### PR TITLE
fix(cli): respect active sidecar venv paths

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -77,6 +77,66 @@ def _safe_which(cmd: str) -> str | None:
         return None
 
 
+def _runtime_venv_root() -> Path | None:
+    """Return the active runtime virtualenv when Hermes is running inside one."""
+    if sys.prefix != sys.base_prefix:
+        venv_root = Path(sys.prefix)
+        if venv_root.is_dir():
+            return venv_root
+
+    virtual_env = os.environ.get("VIRTUAL_ENV", "").strip()
+    if virtual_env:
+        venv_root = Path(virtual_env)
+        if venv_root.is_dir():
+            return venv_root
+
+    return None
+
+
+def _venv_bin_dir(venv_root: Path) -> Path:
+    return venv_root / ("Scripts" if sys.platform == "win32" else "bin")
+
+
+def _find_hermes_entrypoint(project_root: Path) -> Path | None:
+    runtime_venv = _runtime_venv_root()
+    if runtime_venv is not None:
+        candidate = _venv_bin_dir(runtime_venv) / ("hermes.exe" if sys.platform == "win32" else "hermes")
+        if candidate.exists():
+            return candidate
+
+    for venv_name in ("venv", ".venv"):
+        candidate = project_root / venv_name / ("Scripts" if sys.platform == "win32" else "bin") / (
+            "hermes.exe" if sys.platform == "win32" else "hermes"
+        )
+        if candidate.exists():
+            return candidate
+
+    return None
+
+
+def _display_project_path(path: Path, project_root: Path) -> str:
+    try:
+        return str(path.relative_to(project_root))
+    except ValueError:
+        return str(path)
+
+
+def _reinstall_entrypoint_command(project_root: Path) -> str:
+    runtime_venv = _runtime_venv_root()
+    if runtime_venv is not None:
+        venv_python = _venv_bin_dir(runtime_venv) / ("python.exe" if sys.platform == "win32" else "python")
+        if venv_python.exists():
+            if runtime_venv.parent == project_root and runtime_venv.name in {"venv", ".venv"}:
+                rel = _display_project_path(runtime_venv, project_root)
+                activate = "Scripts\\activate" if sys.platform == "win32" else "bin/activate"
+                return f"cd {project_root} && source {rel}/{activate} && pip install -e '.[all]'"
+            return (
+                f"cd {project_root} && uv pip install --python {venv_python} --editable '.[all]'"
+            )
+
+    return f"cd {project_root} && source venv/bin/activate && pip install -e '.[all]'"
+
+
 def _termux_browser_setup_steps(node_installed: bool) -> list[str]:
     steps: list[str] = []
     step = 1
@@ -1282,13 +1342,7 @@ def run_doctor(args):
 
     if sys.platform != "win32":
         _section("Command Installation")
-        # Determine the venv entry point location
-        _venv_bin = None
-        for _venv_name in ("venv", ".venv"):
-            _candidate = PROJECT_ROOT / _venv_name / "bin" / "hermes"
-            if _candidate.exists():
-                _venv_bin = _candidate
-                break
+        _venv_bin = _find_hermes_entrypoint(PROJECT_ROOT)
 
         # Determine the expected command link directory (mirrors install.sh logic)
         _prefix = os.environ.get("PREFIX", "")
@@ -1304,13 +1358,13 @@ def run_doctor(args):
         if _venv_bin is None:
             check_warn(
                 "Venv entry point not found",
-                "(hermes not in venv/bin/ or .venv/bin/ — reinstall with pip install -e '.[all]')"
+                "(could not resolve a hermes entry point from the active runtime or common project venv locations)"
             )
             manual_issues.append(
-                f"Reinstall entry point: cd {PROJECT_ROOT} && source venv/bin/activate && pip install -e '.[all]'"
+                f"Reinstall entry point: {_reinstall_entrypoint_command(PROJECT_ROOT)}"
             )
         else:
-            check_ok(f"Venv entry point exists ({_venv_bin.relative_to(PROJECT_ROOT)})")
+            check_ok(f"Venv entry point exists ({_display_project_path(_venv_bin, PROJECT_ROOT)})")
 
             # Check the symlink at the command link location
             if _cmd_link.is_symlink():

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6148,7 +6148,7 @@ def _update_via_zip(args):
     if not uv_bin:
         uv_bin = _ensure_uv_for_termux(pip_cmd)
     if uv_bin:
-        uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+        uv_env = {**os.environ, "VIRTUAL_ENV": str(_preferred_install_venv_root())}
         if _is_termux_env(uv_env):
             uv_env.pop("PYTHONPATH", None)
             uv_env.pop("PYTHONHOME", None)
@@ -6877,7 +6877,7 @@ def _recover_from_interrupted_install() -> None:
 
             uv_bin = ensure_uv()
             if uv_bin:
-                uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+                uv_env = {**os.environ, "VIRTUAL_ENV": str(_preferred_install_venv_root())}
                 if _is_termux_env(uv_env):
                     uv_env.pop("PYTHONPATH", None)
                     uv_env.pop("PYTHONHOME", None)
@@ -7673,6 +7673,27 @@ def _resolve_install_target_python(
             return first
 
     return None
+
+
+def _preferred_install_venv_root() -> Path:
+    """Prefer the active runtime venv, but fall back to the checkout venv names."""
+    if sys.prefix != sys.base_prefix:
+        venv_root = Path(sys.prefix)
+        if venv_root.is_dir():
+            return venv_root
+
+    virtual_env = os.environ.get("VIRTUAL_ENV", "").strip()
+    if virtual_env:
+        venv_root = Path(virtual_env)
+        if venv_root.is_dir():
+            return venv_root
+
+    for venv_name in ("venv", ".venv"):
+        candidate = PROJECT_ROOT / venv_name
+        if candidate.is_dir():
+            return candidate
+
+    return PROJECT_ROOT / "venv"
 
 
 def _is_termux_env(env: dict[str, str] | None = None) -> bool:
@@ -9121,7 +9142,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         install_group = "all"
 
         if uv_bin:
-            uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+            uv_env = {**os.environ, "VIRTUAL_ENV": str(_preferred_install_venv_root())}
             if _is_termux_env(uv_env):
                 uv_env.pop("PYTHONPATH", None)
                 uv_env.pop("PYTHONHOME", None)

--- a/tests/hermes_cli/test_doctor_command_install.py
+++ b/tests/hermes_cli/test_doctor_command_install.py
@@ -29,6 +29,8 @@ def _setup_doctor_env(monkeypatch, tmp_path, venv_name="venv"):
     monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
     monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
     monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setattr(sys, "prefix", "/usr")
+    monkeypatch.setattr(sys, "base_prefix", "/usr")
 
     # Stub model_tools so doctor doesn't fail on import
     fake_model_tools = types.SimpleNamespace(
@@ -167,6 +169,8 @@ class TestDoctorCommandInstallation:
         monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
         monkeypatch.setattr(doctor_mod, "_DHH", str(home))
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(sys, "prefix", "/usr")
+        monkeypatch.setattr(sys, "base_prefix", "/usr")
 
         fake_model_tools = types.SimpleNamespace(
             check_tool_availability=lambda *a, **kw: ([], []),
@@ -206,6 +210,60 @@ class TestDoctorCommandInstallation:
         out = _run_doctor(fix=False)
         assert "Venv entry point exists" in out
         assert ".venv/bin/hermes" in out
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Symlink check is Unix-only")
+    def test_active_sidecar_venv_is_preferred_over_project_venv(self, monkeypatch, tmp_path):
+        """Doctor should trust the running sidecar venv, not just PROJECT_ROOT/venv."""
+        home = tmp_path / ".hermes"
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+
+        project = tmp_path / "project"
+        project.mkdir(exist_ok=True)
+
+        sidecar = tmp_path / ".venv-bma-sidecar"
+        sidecar_bin = sidecar / "bin"
+        sidecar_bin.mkdir(parents=True, exist_ok=True)
+        hermes_bin = sidecar_bin / "hermes"
+        hermes_bin.write_text("#!/usr/bin/env python\n# sidecar entry point\n")
+        hermes_bin.chmod(0o755)
+        python_bin = sidecar_bin / "python"
+        python_bin.write_text("#!/usr/bin/env python\n")
+        python_bin.chmod(0o755)
+
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+        monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(sys, "prefix", str(sidecar))
+        monkeypatch.setattr(sys, "base_prefix", "/usr")
+
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: ([], []),
+            TOOLSET_REQUIREMENTS={},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+        try:
+            from hermes_cli import auth as _auth_mod
+            monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        except Exception:
+            pass
+        try:
+            import httpx
+            monkeypatch.setattr(httpx, "get", lambda *a, **kw: types.SimpleNamespace(status_code=200))
+        except Exception:
+            pass
+
+        cmd_link_dir = tmp_path / ".local" / "bin"
+        cmd_link_dir.mkdir(parents=True)
+        cmd_link = cmd_link_dir / "hermes"
+        cmd_link.symlink_to(hermes_bin)
+
+        out = _run_doctor(fix=False)
+        assert "Venv entry point exists" in out
+        assert str(hermes_bin) in out
+        assert "correct target" in out
 
     @pytest.mark.skipif(sys.platform == "win32", reason="Symlink check is Unix-only")
     def test_non_symlink_regular_file_shows_ok(self, monkeypatch, tmp_path):

--- a/tests/hermes_cli/test_update_interrupted_recovery.py
+++ b/tests/hermes_cli/test_update_interrupted_recovery.py
@@ -97,6 +97,36 @@ def test_recovery_runs_install_and_clears_marker(tmp_path, monkeypatch):
     assert not m._update_marker_path().exists(), "marker cleared on success"
 
 
+def test_recovery_uv_install_uses_active_sidecar_virtualenv(tmp_path, monkeypatch):
+    monkeypatch.setattr(m, "PROJECT_ROOT", tmp_path)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+    m._write_update_incomplete_marker()
+
+    sidecar = tmp_path / ".venv-bma-sidecar"
+    sidecar.mkdir()
+    monkeypatch.setattr(m.sys, "prefix", str(sidecar))
+    monkeypatch.setattr(m.sys, "base_prefix", "/usr")
+    monkeypatch.setattr(m, "_is_termux_env", lambda *a, **k: False)
+    monkeypatch.setattr("hermes_cli.managed_uv.ensure_uv", lambda: "/usr/bin/uv")
+
+    class R:
+        returncode = 0
+
+    seen = {}
+    monkeypatch.setattr(m.subprocess, "run", lambda *a, **k: R())
+    monkeypatch.setattr(
+        m,
+        "_install_python_dependencies_with_optional_fallback",
+        lambda *a, **k: seen.update({"cmd": a[0], "env": k.get("env")}),
+    )
+
+    m._recover_from_interrupted_install()
+
+    assert seen["cmd"] == ["/usr/bin/uv", "pip"]
+    assert seen["env"]["VIRTUAL_ENV"] == str(sidecar)
+    assert not m._update_marker_path().exists()
+
+
 def test_recovery_keeps_marker_on_failure(tmp_path, monkeypatch):
     # If the install itself blows up, the marker must survive so the next
     # launch retries — and recovery must not raise.


### PR DESCRIPTION
## Summary
- let `hermes doctor` resolve the active runtime hermes entry point instead of only probing `PROJECT_ROOT/venv` and `.venv`
- point uv-driven reinstall/update flows at the active sidecar virtualenv when Hermes is running from one
- add targeted regressions for doctor command-install checks and interrupted-install recovery in sidecar layouts

Fixes #50581.

## Proof
- `proof SHA`: `da5a9d35619c3c21fafe10fdd23270353cec2054`
- `proof path`: `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/fix-50581-doctor-sidecar-venv/.paperclip_artifacts/quality-gate/proof-da5a9d35619c3c21fafe10fdd23270353cec2054.json`
- targeted commands:
  - `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/hermes_cli/test_doctor_command_install.py tests/hermes_cli/test_update_interrupted_recovery.py`
  - `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m ruff check hermes_cli/doctor.py hermes_cli/main.py tests/hermes_cli/test_doctor_command_install.py tests/hermes_cli/test_update_interrupted_recovery.py`
  - `git diff --check`
