### PR TITLE
fix(agent): use monotonic clock in chat_completion_helpers

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -352,7 +352,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
         agent._codex_stream_last_event_ts = None
         agent._codex_stream_last_progress_ts = None
 
-    _call_start = time.time()
+    _call_start = time.monotonic()
     agent._touch_activity("waiting for non-streaming API response")
 
     t = threading.Thread(target=_call, daemon=True)
@@ -365,12 +365,12 @@ def interruptible_api_call(agent, api_kwargs: dict):
         # Touch activity every ~30s so the gateway's inactivity
         # monitor knows we're alive while waiting for the response.
         if _poll_count % 100 == 0:  # 100 × 0.3s = 30s
-            _elapsed = time.time() - _call_start
+            _elapsed = time.monotonic() - _call_start
             agent._touch_activity(
                 f"waiting for non-streaming response ({int(_elapsed)}s elapsed)"
             )
 
-        _elapsed = time.time() - _call_start
+        _elapsed = time.monotonic() - _call_start
 
         # TTFB detector: the Codex stream has produced no event at all and
         # we're past the first-byte cutoff → the backend opened the
@@ -437,9 +437,9 @@ def interruptible_api_call(agent, api_kwargs: dict):
         if (
             _codex_idle_enabled
             and _last_codex_event_ts is not None
-            and (time.time() - _last_codex_event_ts) > _codex_idle_timeout
+            and (time.monotonic() - _last_codex_event_ts) > _codex_idle_timeout
         ):
-            _event_stale_elapsed = time.time() - _last_codex_event_ts
+            _event_stale_elapsed = time.monotonic() - _last_codex_event_ts
             logger.warning(
                 "Codex stream produced no SSE events for %.0fs after first byte "
                 "(threshold %.0fs, model=%s, context=~%s tokens). Killing "
@@ -1767,7 +1767,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     # Wall-clock timestamp of the last real streaming chunk.  The outer
     # poll loop uses this to detect stale connections that keep receiving
     # SSE keep-alive pings but no actual data.
-    last_chunk_time = {"t": time.time()}
+    last_chunk_time = {"t": time.monotonic()}
     # Stale-stream patience, shared between the httpx socket read timeout
     # (built in ``_call_chat_completions`` below) and the stale-stream detector
     # (computed further down, before the worker thread starts).  Initialized
@@ -1854,7 +1854,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         )
         # Reset stale-stream timer so the detector measures from this
         # attempt's start, not a previous attempt's last chunk.
-        last_chunk_time["t"] = time.time()
+        last_chunk_time["t"] = time.monotonic()
         agent._touch_activity("waiting for provider response (streaming)")
         # Initialize per-attempt stream diagnostics so the retry block can
         # reach for them after the stream dies.  Lives on
@@ -1891,7 +1891,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         reasoning_parts: list = []
         usage_obj = None
         for chunk in stream:
-            last_chunk_time["t"] = time.time()
+            last_chunk_time["t"] = time.monotonic()
             agent._touch_activity("receiving stream response")
 
             # Update per-attempt diagnostic counters.  Best-effort —
@@ -2170,7 +2170,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         has_tool_use = False
 
         # Reset stale-stream timer for this attempt
-        last_chunk_time["t"] = time.time()
+        last_chunk_time["t"] = time.monotonic()
         # Per-attempt diagnostic dict for the retry block to consume.
         _diag = agent._stream_diag_init()
         request_client_holder["diag"] = _diag
@@ -2201,7 +2201,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 # Opus streams after 180 s even when events are
                 # actively arriving (the chat_completions path
                 # already does this at the top of its chunk loop).
-                last_chunk_time["t"] = time.time()
+                last_chunk_time["t"] = time.monotonic()
                 agent._touch_activity("receiving stream response")
 
                 # Update per-attempt diagnostic counters (best-effort).
@@ -2564,7 +2564,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
 
     t = threading.Thread(target=_call, daemon=True)
     t.start()
-    _last_heartbeat = time.time()
+    _last_heartbeat = time.monotonic()
     _HEARTBEAT_INTERVAL = 30.0  # seconds between gateway activity touches
     while t.is_alive():
         t.join(timeout=0.3)
@@ -2577,7 +2577,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # activity on each chunk, but the gap between API call start
         # and first chunk can exceed the gateway timeout — especially
         # when the stale-stream timeout is disabled (local providers).
-        _hb_now = time.time()
+        _hb_now = time.monotonic()
         if _hb_now - _last_heartbeat >= _HEARTBEAT_INTERVAL:
             _last_heartbeat = _hb_now
             _waiting_secs = int(_hb_now - last_chunk_time["t"])
@@ -2588,7 +2588,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # Detect stale streams: connections kept alive by SSE pings
         # but delivering no real chunks.  Kill the client so the
         # inner retry loop can start a fresh connection.
-        _stale_elapsed = time.time() - last_chunk_time["t"]
+        _stale_elapsed = time.monotonic() - last_chunk_time["t"]
         if _stale_elapsed > _stream_stale_timeout:
             _est_ctx = estimate_request_context_tokens(api_kwargs)
             logger.warning(
@@ -2615,7 +2615,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 pass
             # Reset the timer so we don't kill repeatedly while
             # the inner thread processes the closure.
-            last_chunk_time["t"] = time.time()
+            last_chunk_time["t"] = time.monotonic()
             agent._touch_activity(
                 f"stale stream detected after {int(_stale_elapsed)}s, reconnecting"
             )


### PR DESCRIPTION
## Summary

`time.time()` is affected by system clock adjustments (NTP sync, manual changes) which can cause negative or inflated elapsed measurements.

Replace all 14 instances in `agent/chat_completion_helpers.py` with `time.monotonic()`.

Affected patterns:
- API call duration tracking (`_call_start`, `_elapsed`)
- Codex idle timeout detection (`_codex_idle_timeout`)
- Stream chunk staleness tracking (`last_chunk_time`)
- Heartbeat interval tracking (`_last_heartbeat`)

## Why this matters

Same rationale as PR #50584 (conversation_loop.py). System clock jumps during NTP corrections can break timeout detection and produce misleading metrics. `time.monotonic()` is the correct clock for all relative time measurements.

## Test plan

- [ ] CI passes
- [ ] Codex idle timeout detection still works
- [ ] Stream heartbeat still fires correctly