### PR TITLE
fix(agent): use monotonic clock in tool_executor

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -140,7 +140,7 @@ def _emit_cancelled_terminal_post_tool_call(
         result=result,
         effective_task_id=effective_task_id,
         tool_call_id=tool_call_id,
-        duration_ms=int((time.time() - start_time) * 1000),
+        duration_ms=int((time.monotonic() - start_time) * 1000),
         status="cancelled",
         error_type=error_type,
         error_message=f"Tool execution cancelled by {reason}",
@@ -509,7 +509,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         # Approval/sudo callbacks (thread-local) and the agent turn's
         # ContextVars are propagated by propagate_context_to_thread() at the
         # submit site below (GHSA-qg5c-hvr5-hjgr, #13617).
-        start = time.time()
+        start = time.monotonic()
         try:
             try:
                 result = agent._invoke_tool(
@@ -536,14 +536,14 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     start_time=start,
                     middleware_trace=list(middleware_trace),
                 )
-                duration = time.time() - start
+                duration = time.monotonic() - start
                 logger.info("tool %s cancelled (%.2fs)", function_name, duration)
                 results[index] = (function_name, function_args, result, duration, True, False, middleware_trace)
                 return
             except Exception as tool_error:
                 result = f"Error executing tool '{function_name}': {tool_error}"
                 logger.error("_invoke_tool raised for %s: %s", function_name, tool_error, exc_info=True)
-            duration = time.time() - start
+            duration = time.monotonic() - start
             is_error, _ = _detect_tool_failure(function_name, result)
             if is_error:
                 logger.info("tool %s failed (%.2fs): %s", function_name, duration, result[:200])
@@ -595,7 +595,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 # concurrent tool batches. Also check for user interrupts
                 # so we don't block indefinitely when the user sends /stop
                 # or a new message during concurrent tool execution.
-                _conc_start = time.time()
+                _conc_start = time.monotonic()
                 _interrupt_logged = False
                 while True:
                     done, not_done = concurrent.futures.wait(
@@ -624,7 +624,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                         concurrent.futures.wait(not_done, timeout=3.0)
                         break
 
-                    _conc_elapsed = int(time.time() - _conc_start)
+                    _conc_elapsed = int(time.monotonic() - _conc_start)
                     # Heartbeat every ~30s (6 × 5s poll intervals)
                     if _conc_elapsed > 0 and _conc_elapsed % 30 < 6:
                         _still_running = [
@@ -950,7 +950,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             except Exception:
                 pass  # never block tool execution
 
-        tool_start_time = time.time()
+        tool_start_time = time.monotonic()
 
         if _block_msg is not None:
             # Tool blocked by plugin policy — return error without executing.
@@ -1001,7 +1001,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 tool_call_id=getattr(tool_call, "id", "") or "",
                 execute=_execute,
             )
-            tool_duration = time.time() - tool_start_time
+            tool_duration = time.monotonic() - tool_start_time
             if agent._should_emit_quiet_tool_messages():
                 agent._vprint(f"  {_get_cute_tool_message_impl('todo', function_args, tool_duration, result=function_result)}")
         elif function_name == "session_search":
@@ -1030,7 +1030,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 tool_call_id=getattr(tool_call, "id", "") or "",
                 execute=_execute,
             )
-            tool_duration = time.time() - tool_start_time
+            tool_duration = time.monotonic() - tool_start_time
             if agent._should_emit_quiet_tool_messages():
                 agent._vprint(f"  {_get_cute_tool_message_impl('session_search', function_args, tool_duration, result=function_result)}")
         elif function_name == "memory":
@@ -1081,7 +1081,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 tool_call_id=getattr(tool_call, "id", "") or "",
                 execute=_execute,
             )
-            tool_duration = time.time() - tool_start_time
+            tool_duration = time.monotonic() - tool_start_time
             if agent._should_emit_quiet_tool_messages():
                 agent._vprint(f"  {_get_cute_tool_message_impl('memory', function_args, tool_duration, result=function_result)}")
         elif function_name == "clarify":
@@ -1100,7 +1100,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 tool_call_id=getattr(tool_call, "id", "") or "",
                 execute=_execute,
             )
-            tool_duration = time.time() - tool_start_time
+            tool_duration = time.monotonic() - tool_start_time
             if agent._should_emit_quiet_tool_messages():
                 agent._vprint(f"  {_get_cute_tool_message_impl('clarify', function_args, tool_duration, result=function_result)}")
         elif function_name == "read_terminal":
@@ -1119,7 +1119,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 tool_call_id=getattr(tool_call, "id", "") or "",
                 execute=_execute,
             )
-            tool_duration = time.time() - tool_start_time
+            tool_duration = time.monotonic() - tool_start_time
             if agent._should_emit_quiet_tool_messages():
                 agent._vprint(f"  {_get_cute_tool_message_impl('read_terminal', function_args, tool_duration, result=function_result)}")
         elif function_name == "delegate_task":
@@ -1154,7 +1154,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 _delegate_result = function_result
             finally:
                 agent._delegate_spinner = None
-                tool_duration = time.time() - tool_start_time
+                tool_duration = time.monotonic() - tool_start_time
                 cute_msg = _get_cute_tool_message_impl('delegate_task', function_args, tool_duration, result=_delegate_result)
                 if spinner:
                     spinner.stop(cute_msg)
@@ -1186,7 +1186,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 function_result = json.dumps({"error": f"Context engine tool '{function_name}' failed: {tool_error}"})
                 logger.error("context_engine.handle_tool_call raised for %s: %s", function_name, tool_error, exc_info=True)
             finally:
-                tool_duration = time.time() - tool_start_time
+                tool_duration = time.monotonic() - tool_start_time
                 cute_msg = _get_cute_tool_message_impl(function_name, function_args, tool_duration, result=_ce_result)
                 if spinner:
                     spinner.stop(cute_msg)
@@ -1219,7 +1219,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 function_result = json.dumps({"error": f"Memory tool '{function_name}' failed: {tool_error}"})
                 logger.error("memory_manager.handle_tool_call raised for %s: %s", function_name, tool_error, exc_info=True)
             finally:
-                tool_duration = time.time() - tool_start_time
+                tool_duration = time.monotonic() - tool_start_time
                 cute_msg = _get_cute_tool_message_impl(function_name, function_args, tool_duration, result=_mem_result)
                 if spinner:
                     spinner.stop(cute_msg)
@@ -1269,7 +1269,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 function_result = f"Error executing tool '{function_name}': {tool_error}"
                 logger.error("handle_function_call raised for %s: %s", function_name, tool_error, exc_info=True)
             finally:
-                tool_duration = time.time() - tool_start_time
+                tool_duration = time.monotonic() - tool_start_time
                 cute_msg = _get_cute_tool_message_impl(function_name, function_args, tool_duration, result=_spinner_result)
                 if spinner:
                     spinner.stop(cute_msg)
@@ -1308,7 +1308,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             except Exception as tool_error:
                 function_result = f"Error executing tool '{function_name}': {tool_error}"
                 logger.error("handle_function_call raised for %s: %s", function_name, tool_error, exc_info=True)
-            tool_duration = time.time() - tool_start_time
+            tool_duration = time.monotonic() - tool_start_time
 
         if isinstance(function_result, str):
             result_preview = function_result if agent.verbose_logging else (


### PR DESCRIPTION
## Summary

`time.time()` is affected by system clock adjustments (NTP sync, manual changes) which can cause negative or inflated duration measurements.

Replace all 17 instances in `agent/tool_executor.py` with `time.monotonic()`.

Affected patterns:
- Tool execution duration tracking (`start_time`, `tool_duration`)
- Concurrent tool execution timing (`_conc_start`, `_conc_elapsed`)
- Individual tool call timing (`start`, `duration`)

## Why this matters

Same rationale as PRs #50584 and #50593. System clock jumps during NTP corrections can produce negative durations and break timeout logic. `time.monotonic()` is the correct clock for all relative time measurements.

## Test plan

- [ ] CI passes
- [ ] Tool execution timing still works correctly