### PR TITLE
fix(tools): convert Windows native CWD to MSYS format for bash cd

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -4,6 +4,7 @@ Tests _wrap_command(), _extract_cwd_from_output(), _embed_stdin_heredoc(),
 init_session() failure handling, and the CWD marker contract.
 """
 
+import sys
 from unittest.mock import MagicMock
 
 from tools.environments.base import BaseEnvironment
@@ -194,3 +195,44 @@ class TestCwdMarker:
         env1 = _TestableEnv()
         env2 = _TestableEnv()
         assert env1._cwd_marker != env2._cwd_marker
+
+
+class TestWindowsToMsysPath:
+    def test_noop_on_non_windows(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "linux")
+        assert (
+            BaseEnvironment._windows_to_msys_path(r"C:\Users\x")
+            == r"C:\Users\x"
+        )
+
+    def test_converts_drive_path_on_windows(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "win32")
+        assert (
+            BaseEnvironment._windows_to_msys_path(r"C:\Users\NVIDIA")
+            == "/c/Users/NVIDIA"
+        )
+
+    def test_converts_forward_slash_variant(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "win32")
+        assert (
+            BaseEnvironment._windows_to_msys_path("D:/Projects/foo")
+            == "/d/Projects/foo"
+        )
+
+    def test_noop_on_already_msys_path(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "win32")
+        assert (
+            BaseEnvironment._windows_to_msys_path("/c/Users/NVIDIA")
+            == "/c/Users/NVIDIA"
+        )
+
+    def test_noop_on_empty_string(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "win32")
+        assert BaseEnvironment._windows_to_msys_path("") == ""
+
+    def test_preserves_trailing_slash(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "win32")
+        assert (
+            BaseEnvironment._windows_to_msys_path("C:\\Users\\NVIDIA\\")
+            == "/c/Users/NVIDIA/"
+        )

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -10,9 +10,11 @@ import codecs
 import json
 import logging
 import os
+import re
 import select
 import shlex
 import subprocess
+import sys
 import threading
 import time
 import uuid
@@ -359,7 +361,8 @@ class BaseEnvironment(ABC):
         # Restore configured cwd after login shell profile scripts, which may
         # change the working directory (e.g. bashrc `cd ~`).  Without this,
         # pwd -P captures the profile's directory, not terminal.cwd.
-        _quoted_cwd = shlex.quote(self.cwd)
+        _cwd_for_bash = self._windows_to_msys_path(self.cwd)
+        _quoted_cwd = shlex.quote(_cwd_for_bash)
         # Quote the snapshot / cwd-file paths so Git Bash on Windows handles
         # ``C:/Users/...``-shaped paths without glob-splitting the colon or
         # tripping on drive letters.  On POSIX this is a no-op (no colons /
@@ -404,6 +407,26 @@ class BaseEnvironment(ABC):
     # ------------------------------------------------------------------
 
     @staticmethod
+    def _windows_to_msys_path(cwd: str) -> str:
+        """Convert a Windows native path to Git Bash / MSYS form for ``cd``.
+
+        ``C:\\Users\\x`` → ``/c/Users/x``.  No-op on non-Windows hosts or
+        paths that are already in MSYS format.
+
+        ``_msys_to_windows_path`` (in ``local.py``) handles the reverse
+        translation for ``os.path.isdir`` / ``subprocess.Popen(cwd=...)``.
+        This helper closes the gap for the bash-script side.
+        """
+        if sys.platform != "win32" or not cwd:
+            return cwd
+        m = re.match(r'^([a-zA-Z]):[\\/](.*)$', cwd)
+        if not m:
+            return cwd
+        drive = m.group(1).lower()
+        rest = m.group(2).replace('\\', '/')
+        return f"/{drive}/{rest}"
+
+    @staticmethod
     def _quote_cwd_for_cd(cwd: str) -> str:
         """Quote a ``cd`` target while preserving ``~`` expansion."""
         if cwd == "~":
@@ -441,7 +464,8 @@ class BaseEnvironment(ABC):
 
         # Preserve bare ``~`` expansion, but rewrite ``~/...`` through
         # ``$HOME`` so suffixes with spaces remain a single shell word.
-        quoted_cwd = self._quote_cwd_for_cd(cwd)
+        _cwd_for_bash = self._windows_to_msys_path(cwd)
+        quoted_cwd = self._quote_cwd_for_cd(_cwd_for_bash)
         # ``--`` keeps hyphen-prefixed directory names from being parsed as options.
         parts.append(f"builtin cd -- {quoted_cwd} || exit 126")
 

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -379,7 +379,7 @@ class BaseEnvironment(ABC):
             f"echo 'shopt -s expand_aliases' >> {_quoted_snap}\n"
             f"echo 'set +e' >> {_quoted_snap}\n"
             f"echo 'set +u' >> {_quoted_snap}\n"
-            f"builtin cd {_quoted_cwd} 2>/dev/null || true\n"
+            f"builtin cd -- {_quoted_cwd} 2>/dev/null || true\n"
             f"pwd -P > {_quoted_cwd_file} 2>/dev/null || true\n"
             f"printf '\\n{self._cwd_marker}%s{self._cwd_marker}\\n' \"$(pwd -P)\"\n"
         )


### PR DESCRIPTION
## What does this PR do?

When Hermes is started from PowerShell or cmd.exe on Windows, `os.getcwd()` returns a Windows native path (`C:\Users\...`) which gets stored as the session working directory. Both `init_session()` and `_wrap_command()` embed this path directly into bash scripts via `cd`, but Git Bash cannot parse Windows drive-letter paths.

**Impact:** Every terminal tool call fails with exit code 126 the first time any command runs. The agent cannot write files, search, or execute shell commands. It wastes tokens diagnosing the failure, may produce incorrect results, and can fail entirely on tasks requiring shell execution. This affects ALL Windows users launching Hermes from non-Msys terminals (PowerShell, cmd.exe).

The existing `_msys_to_windows_path()` in `local.py` handles reverse conversion (bash output -> Python `Popen` cwd). No forward helper existed.

This PR adds `_windows_to_msys_path()` to `BaseEnvironment` and applies it in both `init_session()` and `_wrap_command()`.

## Related Issue

Fixes #50594

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/environments/base.py` — Added `_windows_to_msys_path()` static method: `C:\Users\x` -> `/c/Users/x`. No-op on non-Windows or already-Msys paths
- `tools/environments/base.py` — `init_session()`: convert `self.cwd` via `_windows_to_msys_path()` before `shlex.quote()`
- `tools/environments/base.py` — `_wrap_command()`: convert `cwd` via `_windows_to_msys_path()` before `_quote_cwd_for_cd()`
- Added `import re` and `import sys` to module imports

## How to Test

1. Open PowerShell (not Git Bash)
2. `cd C:\Users\YourName`
3. `hermes`
4. Ask agent: list files in current directory
5. Command should succeed instead of failing with exit code 126

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] pytest 55 passed (1 pre-existing failure on Windows — POSIX root test)
- [x] I have added tests for my changes
- [x] I have tested on my platform: Windows 10, PowerShell

### Documentation & Housekeeping

- [x] N/A — no docs or config keys affected
- [x] Cross-platform: `_windows_to_msys_path()` is a no-op on non-Windows
