### PR TITLE
fix(telegram): guest @mention reply shows only final answer, not inter-tool preamble

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -213,6 +213,17 @@ class GatewayStreamConsumer:
         # this response and route through edit-based for graceful degradation.
         self._draft_failures = 0
         self._before_finalize_notified = False
+        # Set when _reset_segment_state is called with preserve_no_edit=True
+        # (segment break on a __no_edit__ platform).  Signals _send_fallback_final
+        # to include "guest_segment_start": True on its first chunk so the
+        # Telegram adapter replaces the guest reply buffer instead of appending —
+        # preventing inter-tool commentary from earlier segments from bleeding
+        # into the answerGuestQuery reply.
+        self._had_no_edit_segment_break = False
+        # Offset into _accumulated where the most-recent segment began.  Updated
+        # by each __no_edit__ segment-break so _send_fallback_final can extract
+        # only the last segment's text when the adapter opts in.
+        self._no_edit_segment_text_start = 0
 
     def _metadata_for_send(
         self,
@@ -333,6 +344,16 @@ class GatewayStreamConsumer:
 
     def _reset_segment_state(self, *, preserve_no_edit: bool = False) -> None:
         if preserve_no_edit and self._message_id == "__no_edit__":
+            # Preserve the __no_edit__ sentinel so _send_fallback_final remains
+            # the final delivery path — resetting to None would re-enter the
+            # first-send path on every segment break and create one platform
+            # message per tool call (the cause of 155 PR comments in #8124).
+            # Track where the current segment begins in _accumulated so
+            # adapters that deliver only the final segment (e.g. Telegram guest
+            # mode via answerGuestQuery) can extract it without accumulating
+            # inter-tool narration from earlier segments.
+            self._had_no_edit_segment_break = True
+            self._no_edit_segment_text_start = len(self._accumulated)
             return
         self._message_id = None
         self._message_created_ts = None
@@ -978,8 +999,25 @@ class GatewayStreamConsumer:
 
         Retries each chunk once on flood-control failures with a short delay.
         """
+        # When the adapter opts in (e.g. Telegram guest mode / answerGuestQuery),
+        # deliver ONLY the last segment's text so inter-tool commentary from
+        # earlier segments does not appear in the reply.  The adapter is then
+        # signalled via "guest_segment_start": True on the first chunk to REPLACE
+        # its buffer (rather than append) so any stale preamble is discarded.
+        _deliver_last_segment_only = (
+            self._had_no_edit_segment_break
+            and getattr(self.adapter, "GUEST_MODE_DROPS_PRIOR_SEGMENTS", False) is True
+        )
         final_text = self._clean_for_display(text)
-        continuation = self._continuation_text(final_text)
+        if _deliver_last_segment_only:
+            continuation = self._clean_for_display(
+                text[self._no_edit_segment_text_start:]
+            ).strip()
+            if not continuation:
+                continuation = final_text  # fallback to full text if last segment empty
+        else:
+            continuation = self._continuation_text(final_text)
+        self._had_no_edit_segment_break = False
         self._fallback_final_send = False
         if not continuation.strip():
             # Nothing new to send — the visible partial already matches final text.
@@ -1032,14 +1070,25 @@ class GatewayStreamConsumer:
         last_message_id: Optional[str] = None
         last_successful_chunk = ""
         sent_any_chunk = False
+        # Signal the first chunk as a "segment start" so adapters that buffer
+        # replies (e.g. Telegram guest mode / answerGuestQuery) replace their
+        # stale inter-tool preamble instead of appending to it.
+        _tag_segment_start = _deliver_last_segment_only
         for chunk in chunks:
             # Try sending with one retry on flood-control errors.
             result = None
+            _base_meta = self._metadata_for_send(final=True)
+            if _tag_segment_start:
+                _chunk_meta: Optional[dict] = dict(_base_meta or {})
+                _chunk_meta["guest_segment_start"] = True
+                _tag_segment_start = False  # only the first chunk gets this flag
+            else:
+                _chunk_meta = _base_meta
             for attempt in range(2):
                 result = await self.adapter.send(
                     chat_id=self.chat_id,
                     content=chunk,
-                    metadata=self._metadata_for_send(final=True),
+                    metadata=_chunk_meta,
                 )
                 if result.success:
                     break

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -13,6 +13,7 @@ import inspect
 import json
 import logging
 import os
+import random
 import html as _html
 import re
 import threading
@@ -151,6 +152,14 @@ async def _shutdown_abandoned_app(app) -> None:
                 await result
         except Exception:
             logger.debug("Abandoned Telegram request shutdown failed", exc_info=True)
+
+try:
+    _tv_ns: dict = {}
+    with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "thinking_verbs.py")) as _tv_f:
+        exec(_tv_f.read(), _tv_ns)
+    _THINKING_VERBS: list = _tv_ns.get("THINKING_VERBS") or ["Thinking"]
+except Exception:
+    _THINKING_VERBS = ["Thinking"]
 
 try:
     from telegram import Update, Bot, Message, InlineKeyboardButton, InlineKeyboardMarkup
@@ -669,6 +678,19 @@ class TelegramAdapter(BasePlatformAdapter):
         # API call (e.g. a set_my_commands stall for certain tokens) cannot
         # blow the gateway's connect timeout (#46298).
         self._post_connect_task: Optional[asyncio.Task] = None
+        # Bot API 10.0 guest mode: chat_id → guest_query_id for answerGuestQuery
+        self._pending_guest_queries: Dict[str, str] = {}
+        # chat IDs that are guest-mode only (bot not a member)
+        self._guest_only_chats: set = set()
+        # accumulated send() content for guest chats; flushed via editMessageText in on_processing_complete
+        self._guest_reply_buffer: Dict[str, str] = {}
+        # inline_message_id returned by the stub answerGuestQuery; used for the follow-up editMessageText
+        self._guest_inline_message_ids: Dict[str, Optional[str]] = {}
+        # Dedup set for guest_message update_ids: PTB resets its polling offset to 0 on restart,
+        # so Telegram re-delivers unacknowledged updates.  We persist the last seen update_id to
+        # _GUEST_UPDATE_ID_FILE and skip updates whose ids we've already processed.
+        self._seen_guest_update_ids: set = set()
+        self._last_guest_update_id: int = 0
 
     def _mark_connected(self) -> None:
         self._drop_delayed_deliveries = False
@@ -3168,7 +3190,10 @@ class TelegramAdapter(BasePlatformAdapter):
             builder = builder.request(request).get_updates_request(get_updates_request)
             self._app = builder.build()
             self._bot = self._app.bot
-            
+
+            # Restore seen guest update_ids so restart doesn't reprocess old updates.
+            self._load_guest_update_ids()
+
             # Register handlers
             self._app.add_handler(TelegramMessageHandler(
                 filters.TEXT & ~filters.COMMAND,
@@ -3188,7 +3213,16 @@ class TelegramAdapter(BasePlatformAdapter):
             ))
             # Handle inline keyboard button callbacks (update prompts)
             self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
-            
+            # Handle guest_message updates (Bot API 10.0 — not yet in PTB typed layer;
+            # the raw payload arrives in update.api_kwargs["guest_message"]).
+            try:
+                from telegram.ext import TypeHandler as _TypeHandler
+                self._app.add_handler(
+                    _TypeHandler(Update, self._handle_guest_message_update), group=1
+                )
+            except Exception as _th_err:
+                logger.warning("[%s] Could not register guest_message TypeHandler: %s", self.name, _th_err)
+
             # Start polling — retry initialize() for transient TLS resets.
             # Each attempt is capped by _init_timeout so a single unreachable
             # fallback-IP chain can't block startup indefinitely.
@@ -3560,9 +3594,99 @@ class TelegramAdapter(BasePlatformAdapter):
 
         # Skip whitespace-only text to prevent Telegram 400 empty-text errors.
         if not content or not content.strip():
+            # Guest streaming: when stream consumer strips the full MEDIA: tag the
+            # adapter receives empty content, but an intermediate chunk ("MEDIA" with
+            # no colon) may already be sitting in the guest reply buffer.  Clear it
+            # so OPC doesn't edit the stub with the raw "MEDIA" fragment.
+            _cid_str_early = str(chat_id)
+            if (bool(metadata and (metadata.get("expect_edits") or metadata.get("notify")))
+                    and (_cid_str_early in self._guest_only_chats
+                         or self._pending_guest_queries.get(_cid_str_early) is not None)):
+                _buf_early = self._guest_reply_buffer.get(_cid_str_early, "")
+                if _buf_early:
+                    _buf_cleaned = re.sub(r"(?i)^MEDIA:?\s*\S*\s*", "", _buf_early).strip()
+                    if _buf_cleaned != _buf_early:
+                        self._guest_reply_buffer[_cid_str_early] = _buf_cleaned
             return SendResult(success=True, message_id=None)
-        
+
         try:
+            # Bot API 10.0 guest reply: buffer content and return immediately.
+            # Must run before the rich/legacy send paths — both use sendMessage
+            # which Telegram rejects with Forbidden when the bot is not a member.
+            # Normalize to string: all guest dicts use str keys (_handle_guest_message_update
+            # stores chat_id_str = str(msg.chat.id)); chat_id here may arrive as int from
+            # the event source, which would silently miss every dict lookup.
+            _cid_str = str(chat_id)
+            if self._pending_guest_queries.get(_cid_str) is not None or _cid_str in self._guest_only_chats:
+                # Tool-use progress blocks (💻 terminal etc.) come through
+                # send() from send_progress_messages().  The stream consumer
+                # always sets expect_edits=True on the first frame and
+                # notify=True on the fallback-final send; tool-progress calls
+                # have neither flag.  Drop anything that isn't from the stream
+                # consumer so the guest reply contains only the LLM response.
+                _is_stream_send = bool(
+                    metadata
+                    and (metadata.get("expect_edits") or metadata.get("notify"))
+                )
+                if not _is_stream_send:
+                    # Tool-progress call from send_progress_messages().  Fire the
+                    # thinking stub on first contact so the user sees immediate
+                    # feedback — no content classification, the stub always fires.
+                    if self._guest_inline_message_ids.get(_cid_str) is False:
+                        await self._guest_fire_text_stub(_cid_str)
+                    return SendResult(success=True, message_id=None)
+
+                # Streaming: fire the stub now if it hasn't fired yet (covers responses
+                # where send_typing() was skipped and no tool-progress call ran).
+                # False = slot open, stub not fired → fire now.
+                # None  = stub fired but Telegram returned no imi → buffer fallback.
+                # str   = real imi → live streaming edits.
+                _imi_val = self._guest_inline_message_ids.get(_cid_str)
+                if _imi_val is False:
+                    await self._guest_fire_text_stub(_cid_str)
+                    _imi_val = self._guest_inline_message_ids.get(_cid_str)
+
+                # Stub fired (imi available or not) — buffer mode: accumulate
+                # content so OPC delivers the full response at once.
+                _cursor = " ▉"
+                _clean = content
+                if _clean.endswith(_cursor):
+                    _clean = _clean[:-len(_cursor)]
+                elif _clean.endswith("▉"):
+                    _clean = _clean[:-1]
+                # Streaming sends cumulative chunks; MEDIA: tags are stripped by the
+                # stream consumer only once the full path (including extension) appears.
+                # Intermediate chunks like "MEDIA:" or "MEDIA:/workspace/file" don't
+                # match the extension-anchored cleanup regex and land in the buffer.
+                # Strip any MEDIA: residuals here so they never appear as text.
+                _raw_clean = _clean  # pre-strip value for cumulative-replace detection below
+                if "MEDIA:" in _clean:
+                    _clean = re.sub(r"MEDIA:\s*\S+", "", _clean).strip()
+
+                _existing = self._guest_reply_buffer.get(_cid_str, "")
+                if metadata and metadata.get("guest_segment_start"):
+                    # Stream consumer had a tool-call segment break on a __no_edit__
+                    # platform: inter-tool commentary was cleared in the consumer and
+                    # this is the start of the final-answer delivery.  Replace the
+                    # buffer so preamble text ("searching...", failed-tool narration)
+                    # from earlier segments does not appear in the answerGuestQuery.
+                    self._guest_reply_buffer[_cid_str] = _clean
+                elif _existing and _raw_clean.startswith(_existing):
+                    # Cumulative streaming update: the raw (pre-strip) frame
+                    # contains all prior content as a prefix → replace so the
+                    # last call wins.  Comparing against _raw_clean (not the
+                    # post-strip _clean) handles the case where a partial "MEDIA"
+                    # chunk landed in the buffer first, and the next cumulative
+                    # frame "MEDIA: /path.ext" strips to "" — the raw frame still
+                    # starts with "MEDIA" so we correctly replace (clearing the
+                    # partial token) rather than appending "" to "MEDIA".
+                    self._guest_reply_buffer[_cid_str] = _clean
+                else:
+                    # Continuation or overflow chunk: content does NOT start
+                    # with what we already have → append.
+                    self._guest_reply_buffer[_cid_str] = _existing + _clean
+                return SendResult(success=True, message_id=None)
+
             # Bot API 10.1 rich fast-path: send the raw agent markdown via
             # sendRichMessage so tables/task lists/etc. render natively. Falls
             # through to the legacy MarkdownV2 path on permanent/capability
@@ -3887,6 +4011,10 @@ class TelegramAdapter(BasePlatformAdapter):
         message in place. If the edit fails (message deleted, too old, etc.)
         we drop the cached id and send fresh.
         """
+        # Guest chats have no existing message to edit and status messages would
+        # consume the one-shot query_id before the real answer is ready.
+        if self._pending_guest_queries.get(str(chat_id)) is not None or str(chat_id) in self._guest_only_chats:
+            return SendResult(success=True, message_id=None)
         key = (str(chat_id), str(status_key))
         cached_id = self._status_message_ids.get(key)
         if cached_id is not None:
@@ -3925,6 +4053,53 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         if not self._bot:
             return SendResult(success=False, error="Not connected")
+
+        # __no_edit__ is the stream consumer's sentinel for "no streaming edits needed".
+        # Guard here so the stream consumer can pass it through without crashing int(message_id).
+        if message_id == "__no_edit__":
+            return SendResult(success=True, message_id=message_id)
+
+        # Guest mode: stream consumer drives progressive edits via inline_message_id.
+        # Intercept before any path that calls int(chat_id)/int(message_id) — the
+        # inline_message_id is a string like "AAMCAgAD..." that cannot be cast to int.
+        _imi = self._guest_inline_message_ids.get(str(chat_id))
+        if isinstance(_imi, str) and message_id == _imi:
+            _text = content
+            for _cur in (" ▉", "▉"):
+                if _text.endswith(_cur):
+                    _text = _text[: -len(_cur)]
+                    break
+            # Strip MEDIA: directives that the stream consumer passes through raw.
+            if "MEDIA:" in _text:
+                _text = re.sub(r"MEDIA:\S+", "", _text).strip()
+                _text = re.sub(r"\n{3,}", "\n\n", _text)
+            # Keep buffer current with the latest raw (pre-format) text so that
+            # on_processing_complete can do a finalize edit if the stream consumer's
+            # own finalize edit fails mid-stream (e.g. API error or truncated chunk).
+            if _text.strip():
+                self._guest_reply_buffer[str(chat_id)] = _text
+            _text = (_strip_mdv2(self.format_message(_text)) if finalize else _text)[:4096]
+            if not _text.strip():
+                return SendResult(success=True, message_id=message_id)
+            try:
+                await self._bot.do_api_request(
+                    "editMessageText",
+                    api_kwargs={"inline_message_id": _imi, "text": _text},
+                )
+                return SendResult(success=True, message_id=message_id)
+            except Exception as _ie:
+                _ie_s = str(_ie).lower()
+                if "not modified" in _ie_s:
+                    return SendResult(success=True, message_id=message_id)
+                logger.warning(
+                    "[%s] guest inline editMessageText failed (imi=%s): %s",
+                    self.name, _imi, _ie,
+                )
+                return SendResult(
+                    success=False,
+                    error=str(_ie),
+                    retryable="retry after" in _ie_s or "flood" in _ie_s,
+                )
 
         # Rich finalize (Bot API 10.1): when the completed content has
         # constructs the legacy MarkdownV2 edit degrades (tables → bullet
@@ -4389,6 +4564,11 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         if not self._bot:
             return SendResult(success=False, error="not_connected")
+
+        # Guest chats: draft streaming requires an existing message to animate;
+        # the bot is not a member, so suppress silently.
+        if self._pending_guest_queries.get(str(chat_id)) is not None or str(chat_id) in self._guest_only_chats:
+            return SendResult(success=True, message_id=None)
 
         # Rich draft fast-path (Bot API 10.1 sendRichMessageDraft): render the
         # streaming preview with the same raw markdown the final
@@ -6414,6 +6594,16 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._bot or self._typing_in_cooldown(chat_id):
             return
 
+        _cid_str = str(chat_id)
+        # For guest-only chats fire the stub unconditionally on the first send_typing()
+        # call.  Platform does no content classification — the stub always fires so the
+        # user sees immediate feedback, and OPC edits it with the final text reply.
+        if (
+            _cid_str in self._guest_only_chats
+            and self._guest_inline_message_ids.get(_cid_str) is False
+        ):
+            await self._guest_fire_text_stub(_cid_str)
+
         _is_dm_topic: bool = False
         message_thread_id: Optional[int] = None
         try:
@@ -7475,6 +7665,206 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         return getattr(update, "effective_message", None) or getattr(update, "message", None)
 
+    async def _guest_fire_text_stub(self, chat_id: str) -> None:
+        """Fire the thinking-verb stub, consuming the answerGuestQuery slot as text.
+
+        Stores the returned inline_message_id (or None on API failure) in
+        _guest_inline_message_ids so send() can drive progressive stream edits and
+        on_processing_complete can update the message with the real reply.
+        Should only be called when _guest_inline_message_ids[chat_id] is False
+        (slot open, stub not yet fired).
+        """
+        _chat_id_str = str(chat_id)
+        _guest_qid = self._pending_guest_queries.get(_chat_id_str)
+        if not _guest_qid or not self._bot:
+            return
+        if self._guest_inline_message_ids.get(_chat_id_str) is not False:
+            return  # already fired or not a guest chat
+        # Claim the slot immediately (before the await) so a concurrent caller that
+        # also passed the `is not False` check above doesn't fire a second stub.
+        self._guest_inline_message_ids[_chat_id_str] = None
+        _verb = random.choice(_THINKING_VERBS)
+        _stub = {
+            "type": "article",
+            "id": "thinking",
+            "title": f"{_verb}...",
+            "input_message_content": {"message_text": f"⏳ {_verb}..."},
+        }
+        # Wrap the API call in a Task so asyncio.shield() can protect it from
+        # _keep_typing's asyncio.wait_for timeout.  When the 1.5 s timeout fires,
+        # _keep_typing cancels send_typing → CancelledError reaches shield → shield
+        # re-raises to us but the inner Task keeps running.  The done_callback
+        # captures the inline_message_id even when the outer await was timed out.
+        _fire_task: "asyncio.Task" = asyncio.ensure_future(
+            self._bot.do_api_request(
+                "answerGuestQuery",
+                api_kwargs={"guest_query_id": _guest_qid, "result": _stub},
+            )
+        )
+
+        def _on_stub_done(fut: "asyncio.Future") -> None:
+            try:
+                _resp = fut.result()
+                _imi = _resp.get("inline_message_id") if isinstance(_resp, dict) else None
+                self._guest_inline_message_ids[_chat_id_str] = _imi
+            except Exception as _e:
+                self._guest_inline_message_ids[_chat_id_str] = None
+                logger.warning(
+                    "[%s] guest stub failed (chat=%s): %s — OPC fallback will run",
+                    self.name, _chat_id_str, _e,
+                )
+
+        _fire_task.add_done_callback(_on_stub_done)
+        try:
+            await asyncio.shield(_fire_task)
+            # Happy path: shield returned normally, callback already fired or will fire.
+        except asyncio.CancelledError:
+            # _keep_typing's asyncio.wait_for timed out (or a genuine task cancel).
+            # _fire_task continues protected by shield; _on_stub_done will set imi.
+            raise
+        except Exception as _stub_err:
+            # The task raised an exception (non-timeout failure).
+            # _on_stub_done already set imi to None; just log for the outer context.
+            logger.warning(
+                "[%s] guest stub task error (chat=%s): %s",
+                self.name, _chat_id_str, _stub_err,
+            )
+
+    def _persist_guest_update_id(self, update_id: int) -> None:
+        """Save the latest processed guest update_id so restarts don't reprocess it."""
+        try:
+            from hermes_constants import get_hermes_home
+            _path = get_hermes_home() / "telegram_guest_update_id.json"
+            import json as _json
+            _path.write_text(_json.dumps({"last_update_id": update_id, "seen_ids": sorted(self._seen_guest_update_ids)[-200:]}))
+        except Exception:
+            pass
+
+    def _load_guest_update_ids(self) -> None:
+        """Restore the seen-update-id set from disk on startup."""
+        try:
+            from hermes_constants import get_hermes_home
+            import json as _json
+            _path = get_hermes_home() / "telegram_guest_update_id.json"
+            if _path.exists():
+                _data = _json.loads(_path.read_text())
+                _ids = _data.get("seen_ids") or []
+                self._seen_guest_update_ids = set(_ids)
+                self._last_guest_update_id = _data.get("last_update_id", 0)
+                logger.info("[%s] Loaded %d seen guest update_ids (last=%s)", self.name, len(_ids), self._last_guest_update_id)
+        except Exception as _e:
+            logger.debug("[%s] Could not load guest update_ids: %s", self.name, _e)
+
+    async def _handle_guest_message_update(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handle guest_message updates (Bot API 10.0 guest bot feature).
+
+        Telegram delivers @mentions from chats the bot hasn't joined via the
+        ``guest_message`` update field.  PTB doesn't know this field yet so it
+        lands in ``update.api_kwargs``.  We parse the raw payload, store the
+        ``guest_query_id`` so ``send()`` can call ``answerGuestQuery``, then
+        route the message through the normal text-processing pipeline.
+        """
+        if not self._telegram_guest_mode():
+            return
+        raw_gm = update.api_kwargs.get("guest_message") if update.api_kwargs else None
+        if not raw_gm or not isinstance(raw_gm, dict):
+            return
+        guest_query_id = raw_gm.get("guest_query_id")
+        _uid = update.update_id or 0
+
+        # Dedup: PTB resets its polling offset to 0 on restart, causing Telegram to redeliver
+        # unacknowledged updates.  Skip any update_id we've already processed.
+        if _uid and _uid in self._seen_guest_update_ids:
+            return
+        if _uid:
+            self._seen_guest_update_ids.add(_uid)
+            if _uid > self._last_guest_update_id:
+                self._last_guest_update_id = _uid
+                self._persist_guest_update_id(_uid)
+            # Trim set to last 500 entries
+            if len(self._seen_guest_update_ids) > 500:
+                _min = min(self._seen_guest_update_ids)
+                self._seen_guest_update_ids.discard(_min)
+
+        if not guest_query_id:
+            logger.warning("[%s] guest_message missing guest_query_id, skipping", self.name)
+            return
+
+        try:
+            msg = Message.de_json(raw_gm, self._bot)
+        except Exception as exc:
+            logger.warning("[%s] Failed to parse guest_message payload: %s", self.name, exc)
+            return
+        if not msg:
+            return
+
+        text = msg.text or getattr(msg, "caption", None) or ""
+        if not text.strip():
+            return
+
+        chat_id_str = str(msg.chat.id) if msg.chat else ""
+        if not chat_id_str:
+            return
+
+        # Register state, fire stub, route to skill layer.
+        self._pending_guest_queries[chat_id_str] = guest_query_id
+        self._guest_only_chats.add(chat_id_str)
+
+        if not self._should_process_message(msg):
+            self._pending_guest_queries.pop(chat_id_str, None)
+            self._guest_only_chats.discard(chat_id_str)
+            return
+
+        # Sentinel: False = slot open, stub not fired yet.
+        # None = stub fired, Telegram returned no imi.  str = real imi.
+        self._guest_inline_message_ids[chat_id_str] = False
+
+        event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
+        event.text = self._clean_bot_trigger_text(event.text)
+
+        # Inject delivery constraint so the LLM knows direct Bot API calls to this
+        # chat will fail (bot is not a member).
+        _guest_delivery_note = (
+            "**Delivery constraint (this session only):** You are responding to "
+            "a @mention in a group chat where the bot is not a member. "
+            "Direct Bot API calls (sendVideo, sendPhoto, sendDocument, sendAudio, "
+            "curl to api.telegram.org, etc.) to this chat will fail with "
+            "\"Forbidden: bot is not a member\" — do NOT attempt them. Media "
+            "delivery is not yet supported in this context; respond with text only."
+        )
+        if event.channel_prompt:
+            event.channel_prompt = event.channel_prompt + "\n\n" + _guest_delivery_note
+        else:
+            event.channel_prompt = _guest_delivery_note
+
+        # Slash commands aren't routed in guest context: command handlers fire
+        # their own answerGuestQuery which creates a second orphaned stub, leaving
+        # an unupdated "⏳" message and a separate "⚠️ Sorry..." reply.
+        # Block them early and reply directly so the user knows why.
+        if event.text.lstrip().startswith("/"):
+            self._pending_guest_queries.pop(chat_id_str, None)
+            self._guest_inline_message_ids.pop(chat_id_str, None)
+            self._guest_only_chats.discard(chat_id_str)
+            _slash_result = {
+                "type": "article",
+                "id": "reply",
+                "title": "Commands not supported",
+                "input_message_content": {
+                    "message_text": "📋 Slash commands aren't supported in this context — just ask me a question!",
+                },
+            }
+            try:
+                await self._bot.do_api_request(
+                    "answerGuestQuery",
+                    api_kwargs={"guest_query_id": guest_query_id, "result": _slash_result},
+                )
+            except Exception as _err:
+                logger.warning("[%s] guest slash-block reply failed (chat=%s): %s", self.name, chat_id_str, _err)
+            return
+
+        event = self._apply_telegram_group_observe_attribution(event)
+        self._enqueue_text_event(event)
+
     async def _handle_text_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming text messages.
 
@@ -8529,6 +8919,68 @@ class TelegramAdapter(BasePlatformAdapter):
         another agent run to swap it to 👍/👎 — which never happens if the
         cancellation was the last activity in the chat.
         """
+        # Guest mode OPC (Bot API 10.0): edit the stub with the final text reply.
+        _gc_id = str(getattr(event.source, "chat_id", None) or "")
+        if _gc_id:
+            _guest_qid = self._pending_guest_queries.pop(_gc_id, None)
+            # Sentinel semantics for _guest_inline_message_ids:
+            #   False  → stub never fired (shouldn't happen — send_typing always fires it)
+            #   None   → stub fired but Telegram returned no inline_message_id
+            #   str    → stub fired, real imi for editMessageText
+            _guest_imi_raw = self._guest_inline_message_ids.pop(_gc_id, False)
+            _guest_imi = _guest_imi_raw if isinstance(_guest_imi_raw, str) else None
+            _buffered = self._guest_reply_buffer.pop(_gc_id, "")
+            self._guest_only_chats.discard(_gc_id)
+            if (_guest_qid or _guest_imi) and self._bot:
+                _plain = _strip_mdv2(self.format_message(_buffered)).strip() if _buffered else ""
+                # Strip any leading MEDIA artifact that escaped stream-consumer cleanup.
+                _plain = re.sub(r"(?i)^MEDIA:?\s*\S*\s*", "", _plain).strip()
+                _reply_text = _plain[:4096] or "⚠️ Sorry, something went wrong. Please try again."
+                logger.warning("[%s] guest OPC flush (chat=%s buffered_len=%d imi=%s)",
+                               self.name, _gc_id, len(_buffered), _guest_imi)
+                try:
+                    if _guest_imi:
+                        # Text result: typewriter then final edit.
+                        _tw_min = 80
+                        _tw_frames = 8
+                        _tw_delay = 0.4
+                        if len(_plain) >= _tw_min:
+                            _tw_chunk = max(40, len(_plain) // _tw_frames)
+                            _tw_pos = _tw_chunk
+                            while _tw_pos < len(_plain):
+                                _tw_frame = _plain[:_tw_pos]
+                                _tw_break = max(_tw_frame.rfind('\n'), _tw_frame.rfind(' '))
+                                if _tw_break > 0:
+                                    _tw_frame = _tw_frame[:_tw_break]
+                                try:
+                                    await self._bot.do_api_request(
+                                        "editMessageText",
+                                        api_kwargs={"inline_message_id": _guest_imi, "text": _tw_frame},
+                                    )
+                                except Exception:
+                                    pass
+                                await asyncio.sleep(_tw_delay)
+                                _tw_pos += _tw_chunk
+                        await self._bot.do_api_request(
+                            "editMessageText",
+                            api_kwargs={"inline_message_id": _guest_imi, "text": _reply_text},
+                        )
+                        logger.warning("[%s] guest OPC text edit (chat=%s imi=%s)", self.name, _gc_id, _guest_imi)
+                    elif _guest_qid:
+                        # No imi (stub API returned nothing) — fall back to a fresh answerGuestQuery.
+                        _fallback = "⛔ Not authorized." if not _buffered else _reply_text
+                        _gq_result = {
+                            "type": "article", "id": "reply", "title": "Reply",
+                            "input_message_content": {"message_text": _fallback},
+                        }
+                        await self._bot.do_api_request(
+                            "answerGuestQuery",
+                            api_kwargs={"guest_query_id": _guest_qid, "result": _gq_result},
+                        )
+                        logger.warning("[%s] guest OPC fallback reply (chat=%s no_imi)", self.name, _gc_id)
+                except Exception as _flush_err:
+                    logger.error("[%s] guest OPC flush failed (chat=%s): %s", self.name, _gc_id, _flush_err)
+
         if not self._reactions_enabled():
             return
         chat_id = getattr(event.source, "chat_id", None)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6001,7 +6001,7 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._bot:
             return SendResult(success=False, error="Not connected")
 
-        if str(chat_id) in self._guest_only_chats:
+        if self._is_guest_chat(chat_id):
             return await self._guest_media_send(str(chat_id), "audio", audio_path, caption)
 
         try:
@@ -6107,7 +6107,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
         # Guest mode: stage each image via _guest_media_send (uploads to home channel
         # to mint a file_id; first image goes to native delivery, rest become notes).
-        if str(chat_id) in self._guest_only_chats:
+        if self._is_guest_chat(chat_id):
             from urllib.parse import unquote as _unquote
             for _img_url, _img_alt in images:
                 _img_path = _unquote(_img_url[7:]) if _img_url.startswith("file://") else _img_url
@@ -6239,7 +6239,7 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._bot:
             return SendResult(success=False, error="Not connected")
 
-        if str(chat_id) in self._guest_only_chats:
+        if self._is_guest_chat(chat_id):
             return await self._guest_media_send(str(chat_id), "photo", image_path, caption)
 
         try:
@@ -6336,7 +6336,7 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._bot:
             return SendResult(success=False, error="Not connected")
 
-        if str(chat_id) in self._guest_only_chats:
+        if self._is_guest_chat(chat_id):
             return await self._guest_media_send(str(chat_id), "document", file_path, caption or file_name)
 
         try:
@@ -6392,7 +6392,7 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._bot:
             return SendResult(success=False, error="Not connected")
 
-        if str(chat_id) in self._guest_only_chats:
+        if self._is_guest_chat(chat_id):
             return await self._guest_media_send(str(chat_id), "video", video_path, caption)
 
         try:
@@ -6453,7 +6453,7 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.warning("[%s] Blocked unsafe image URL (SSRF protection)", self.name)
             return await super().send_image(chat_id, image_url, caption, reply_to, metadata=metadata)
 
-        if str(chat_id) in self._guest_only_chats:
+        if self._is_guest_chat(chat_id):
             # URL-based: try sending from URL to staging directly (Telegram downloads it).
             # Falls back to a local download + _guest_media_send if the URL is a local address.
             _staging = os.environ.get("TELEGRAM_HOME_CHANNEL")

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -7906,6 +7906,24 @@ class TelegramAdapter(BasePlatformAdapter):
         event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
         event.text = self._clean_bot_trigger_text(event.text)
 
+        # Isolate the session per guest caller. build_session_key groups group
+        # participants by user_id, but a guest message carries no from_user
+        # (_build_message_event leaves user_id unset), so without this every
+        # guest turn in a chat collapses onto one shared, chat-keyed session and
+        # a previous caller's context bleeds into the next caller's turn. The
+        # real caller lives in guest_bot_caller_user (captured as
+        # _guest_caller_id at the auth gate above). Stamping it makes guest
+        # sessions key exactly like ordinary group sessions — per-caller when
+        # group_sessions_per_user is on (the default), shared only if the
+        # operator deliberately turned that off. Post-gate the caller is an
+        # authorized user, so this needs no guest-specific isolation branch in
+        # session.py; it just gives the existing group keying the id it lacked.
+        if _guest_caller_id:
+            event.source.user_id = _guest_caller_id
+            _guest_caller_name = _guest_caller.get("first_name") or _guest_caller.get("username")
+            if _guest_caller_name and not getattr(event.source, "user_name", None):
+                event.source.user_name = _guest_caller_name
+
         # Inject delivery constraint so the LLM knows direct Bot API calls to this
         # chat will fail (bot is not a member).
         _guest_delivery_note = (

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -7815,6 +7815,22 @@ class TelegramAdapter(BasePlatformAdapter):
         except Exception as _e:
             logger.debug("[%s] Could not load guest update_ids: %s", self.name, _e)
 
+    def _guest_media_root(self) -> _Path:
+        """Return the resolved root directory guest media staging is confined to.
+
+        The delivery-constraint prompt tells the LLM to stage downloads under
+        ``/cache/<subdir>/`` (translated to ``HERMES_HOME/cache/<subdir>`` on the
+        host by ``_translate_docker_path``), but that is only a prompt-level
+        instruction — nothing enforced it. A guest-triggered turn that is
+        coerced (directly asked, or prompt-injected) into emitting
+        ``MEDIA: /home/hermes/.hermes/auth.json`` or any other host path would
+        otherwise have it staged and made deliverable to the guest chat with no
+        containment at all. This is the hard boundary: any resolved local path
+        outside this root is rejected before ``open()``/upload is ever reached.
+        """
+        from hermes_constants import get_hermes_home
+        return (get_hermes_home() / "cache").resolve()
+
     async def _guest_media_send(self, chat_id: str, tg_type: str, local_path: str, caption: Optional[str] = None) -> "SendResult":
         """Stage media to TELEGRAM_HOME_CHANNEL and record it for OPC delivery.
 
@@ -7840,6 +7856,29 @@ class TelegramAdapter(BasePlatformAdapter):
 
         _is_url = local_path.startswith("http://") or local_path.startswith("https://")
         _resolved_path = local_path if _is_url else self._translate_docker_path(local_path)
+
+        if not _is_url:
+            # Hard containment: reject anything outside the guest media root
+            # before any open()/upload is attempted, regardless of what the
+            # LLM turn was coerced into requesting. Not a soft/advisory check --
+            # this is the only thing standing between a guest chat and reading
+            # an arbitrary file the hermes process can access.
+            try:
+                _abs_resolved = _Path(_resolved_path).resolve()
+                _abs_resolved.relative_to(self._guest_media_root())
+            except ValueError:
+                logger.warning(
+                    "[%s] guest_media_send: rejected path outside staging root "
+                    "(chat=%s requested=%r resolved=%s)",
+                    self.name, _chat_id_str, local_path, _abs_resolved,
+                )
+                return SendResult(
+                    success=False,
+                    error=f"guest_media: path outside the allowed staging directory: {local_path}",
+                )
+            except Exception as _path_err:
+                return SendResult(success=False, error=f"guest_media: path validation failed: {_path_err}")
+            _resolved_path = str(_abs_resolved)
 
         _cache_key = (_resolved_path, tg_type)
         _file_id = self._guest_file_id_cache.get(_cache_key)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -467,6 +467,13 @@ class TelegramAdapter(BasePlatformAdapter):
     # Fixes #25710.
     REQUIRES_EDIT_FINALIZE: bool = True
 
+    # In guest mode (answerGuestQuery), the reply must be a single coherent
+    # answer, not a concatenation of all inter-tool commentary segments.
+    # Setting this True tells stream_consumer._send_fallback_final to deliver
+    # only the last segment's text and tag it with "guest_segment_start" so
+    # the send() buffer replaces instead of appending stale preamble.
+    GUEST_MODE_DROPS_PRIOR_SEGMENTS: bool = True
+
     # Adaptive text-batch ingress: short messages need a tighter delay so the
     # first token reaches the agent fast.  Numbers tuned for "feels instant":
     # ≤320 codepoints (one short paragraph) settles in ~180ms; ≤1024

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -686,6 +686,13 @@ class TelegramAdapter(BasePlatformAdapter):
         self._guest_reply_buffer: Dict[str, str] = {}
         # inline_message_id returned by the stub answerGuestQuery; used for the follow-up editMessageText
         self._guest_inline_message_ids: Dict[str, Optional[str]] = {}
+        # Per-turn staged media: chat_id → {file_id, media_kind}.  Set by send_* wrappers
+        # when a file is staged to TELEGRAM_HOME_CHANNEL during processing; consumed by OPC
+        # which edits the stub to include a deliver_<token> button.  Last-write-wins per turn.
+        self._guest_turn_media: Dict[str, dict] = {}
+        # Cross-turn file_id cache: (resolved_path, tg_type) → telegram file_id.
+        # Prevents re-staging the same file to TELEGRAM_HOME_CHANNEL on repeated delivery attempts.
+        self._guest_file_id_cache: Dict[tuple, str] = {}
         # Dedup set for guest_message update_ids: PTB resets its polling offset to 0 on restart,
         # so Telegram re-delivers unacknowledged updates.  We persist the last seen update_id to
         # _GUEST_UPDATE_ID_FILE and skip updates whose ids we've already processed.
@@ -5993,7 +6000,10 @@ class TelegramAdapter(BasePlatformAdapter):
         """Send audio as a native Telegram voice message or audio file."""
         if not self._bot:
             return SendResult(success=False, error="Not connected")
-        
+
+        if str(chat_id) in self._guest_only_chats:
+            return await self._guest_media_send(str(chat_id), "audio", audio_path, caption)
+
         try:
             if not os.path.exists(audio_path):
                 return SendResult(success=False, error=self._missing_media_path_error("Audio", audio_path))
@@ -6093,6 +6103,15 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._bot:
             return
         if not images:
+            return
+
+        # Guest mode: stage each image via _guest_media_send (uploads to home channel
+        # to mint a file_id; first image goes to native delivery, rest become notes).
+        if str(chat_id) in self._guest_only_chats:
+            from urllib.parse import unquote as _unquote
+            for _img_url, _img_alt in images:
+                _img_path = _unquote(_img_url[7:]) if _img_url.startswith("file://") else _img_url
+                await self._guest_media_send(str(chat_id), "photo", _img_path, _img_alt or None)
             return
 
         try:
@@ -6220,6 +6239,9 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._bot:
             return SendResult(success=False, error="Not connected")
 
+        if str(chat_id) in self._guest_only_chats:
+            return await self._guest_media_send(str(chat_id), "photo", image_path, caption)
+
         try:
             if not os.path.exists(image_path):
                 return SendResult(success=False, error=self._missing_media_path_error("Image", image_path))
@@ -6314,6 +6336,9 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._bot:
             return SendResult(success=False, error="Not connected")
 
+        if str(chat_id) in self._guest_only_chats:
+            return await self._guest_media_send(str(chat_id), "document", file_path, caption or file_name)
+
         try:
             if not os.path.exists(file_path):
                 return SendResult(success=False, error=self._missing_media_path_error("File", file_path))
@@ -6366,6 +6391,9 @@ class TelegramAdapter(BasePlatformAdapter):
         """Send a video natively as a Telegram video message."""
         if not self._bot:
             return SendResult(success=False, error="Not connected")
+
+        if str(chat_id) in self._guest_only_chats:
+            return await self._guest_media_send(str(chat_id), "video", video_path, caption)
 
         try:
             if not os.path.exists(video_path):
@@ -6424,6 +6452,27 @@ class TelegramAdapter(BasePlatformAdapter):
         if not is_safe_url(image_url):
             logger.warning("[%s] Blocked unsafe image URL (SSRF protection)", self.name)
             return await super().send_image(chat_id, image_url, caption, reply_to, metadata=metadata)
+
+        if str(chat_id) in self._guest_only_chats:
+            # URL-based: try sending from URL to staging directly (Telegram downloads it).
+            # Falls back to a local download + _guest_media_send if the URL is a local address.
+            _staging = os.environ.get("TELEGRAM_HOME_CHANNEL")
+            if _staging and self._bot:
+                try:
+                    _staging_id = int(_staging)
+                    _staging_kwargs: Dict[str, Any] = {"photo": image_url, "disable_notification": True}
+                    if caption:
+                        _staging_kwargs["caption"] = caption[:1024]
+                    _smsg = await self._bot.send_photo(_staging_id, **_staging_kwargs)
+                    _file_id = _smsg.photo[-1].file_id if _smsg.photo else None
+                    if _file_id:
+                        _chat_id_str = str(chat_id)
+                        self._guest_turn_media[_chat_id_str] = {"file_id": _file_id, "media_kind": "photo"}
+                        logger.info("[%s] guest URL photo staged for OPC delivery (chat=%s)", self.name, _chat_id_str)
+                        return SendResult(success=True, message_id=str(_smsg.message_id))
+                except Exception as _e:
+                    logger.warning("[%s] guest URL photo staging failed: %s", self.name, _e)
+            return SendResult(success=False, error="guest_no_staging: cannot send image in guest chat without TELEGRAM_HOME_CHANNEL")
 
         try:
             # Telegram can send photos directly from URLs (up to ~5MB)
@@ -7766,6 +7815,67 @@ class TelegramAdapter(BasePlatformAdapter):
         except Exception as _e:
             logger.debug("[%s] Could not load guest update_ids: %s", self.name, _e)
 
+    async def _guest_media_send(self, chat_id: str, tg_type: str, local_path: str, caption: Optional[str] = None) -> "SendResult":
+        """Stage media to TELEGRAM_HOME_CHANNEL and record it for OPC delivery.
+
+        editMessageMedia on an inline message requires a file_id or URL — raw
+        uploads are not accepted.  We upload to the home channel first to mint a
+        file_id, then record {file_id, media_kind} in _guest_turn_media so that
+        on_processing_complete can edit the stub with a deliver_<token> button.
+        Last-write-wins if the skill sends multiple files in one turn.
+
+        tg_type: "photo" | "audio" | "video" | "document"
+        """
+        _chat_id_str = str(chat_id)
+        if not self._bot:
+            return SendResult(success=False, error="guest_media: bot not available")
+
+        _staging = os.environ.get("TELEGRAM_HOME_CHANNEL")
+        if not _staging:
+            return SendResult(success=False, error="guest_no_staging: TELEGRAM_HOME_CHANNEL not configured")
+        try:
+            staging_id = int(_staging)
+        except (ValueError, TypeError):
+            return SendResult(success=False, error="guest_no_staging: TELEGRAM_HOME_CHANNEL is not a valid chat id")
+
+        _is_url = local_path.startswith("http://") or local_path.startswith("https://")
+        _resolved_path = local_path if _is_url else self._translate_docker_path(local_path)
+
+        _cache_key = (_resolved_path, tg_type)
+        _file_id = self._guest_file_id_cache.get(_cache_key)
+
+        if not _file_id:
+            if not _is_url and not os.path.exists(_resolved_path):
+                return SendResult(success=False, error=f"guest_media: file not found: {local_path}")
+            try:
+                _send_map = {
+                    "photo": self._bot.send_photo,
+                    "audio": self._bot.send_audio,
+                    "video": self._bot.send_video,
+                    "document": self._bot.send_document,
+                }
+                _send_fn = _send_map.get(tg_type, self._bot.send_document)
+                _extra: Dict[str, Any] = {"disable_notification": True}
+                if _is_url:
+                    _msg = await _send_fn(staging_id, **{tg_type: _resolved_path, **_extra})
+                else:
+                    with open(_resolved_path, "rb") as _fh:
+                        _msg = await _send_fn(staging_id, **{tg_type: _fh, **_extra})
+                _media_attr = getattr(_msg, tg_type, None)
+                if tg_type == "photo" and _msg.photo:
+                    _media_attr = _msg.photo[-1]
+                _file_id = getattr(_media_attr, "file_id", None)
+                if not _file_id:
+                    return SendResult(success=False, error="guest_media: staging upload returned no file_id")
+                self._guest_file_id_cache[_cache_key] = _file_id
+            except Exception as _stage_err:
+                logger.warning("[%s] guest_media_send staging failed (type=%s): %s", self.name, tg_type, _stage_err)
+                return SendResult(success=False, error=str(_stage_err))
+
+        self._guest_turn_media[_chat_id_str] = {"file_id": _file_id, "media_kind": tg_type}
+        logger.info("[%s] guest media staged for OPC delivery (type=%s chat=%s)", self.name, tg_type, _chat_id_str)
+        return SendResult(success=True, message_id="staged")
+
     async def _handle_guest_message_update(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle guest_message updates (Bot API 10.0 guest bot feature).
 
@@ -7865,6 +7975,53 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             return
 
+        # Branch 2 / Branch 3: deliver_<token> query — no LLM pass, no stub.
+        # Strip the @botname mention before checking so "@bot deliver_<tok>" works.
+        # Dispatched independent of any in-flight Branch-1 turn for this chat —
+        # tapping a "tap to receive" button must work even while another normal
+        # query is still being processed in the same chat. Runs after the caller
+        # gate above, so an unauthorized caller can't redeem a leaked token.
+        _query_text = self._clean_bot_trigger_text(text.strip()).strip()
+        if _query_text.startswith("deliver_"):
+            _token = _query_text[len("deliver_"):]
+            try:
+                from tools.guest_mode_tool import resolve_token as _resolve_token
+                _entry = _resolve_token(_token)
+            except Exception as _imp_err:
+                logger.warning("[%s] guest deliver: import failed: %s", self.name, _imp_err)
+                _entry = None
+            if _entry:
+                # Branch 2 — valid token: answer immediately with the cached media.
+                _mk = _entry["media_kind"]
+                _fid = _entry["file_id"]
+                _fid_key = f"{_mk}_file_id"
+                _cached_result: Dict[str, Any] = {"type": _mk, "id": "delivery", _fid_key: _fid}
+                if _mk in ("audio", "video", "document"):
+                    _cached_result["title"] = _mk.capitalize()
+                try:
+                    await self._bot.do_api_request(
+                        "answerGuestQuery",
+                        api_kwargs={"guest_query_id": guest_query_id, "result": _cached_result},
+                    )
+                    logger.info("[%s] guest deliver branch2 (type=%s chat=%s)", self.name, _mk, chat_id_str)
+                except Exception as _b2_err:
+                    logger.error("[%s] guest deliver branch2 failed: %s", self.name, _b2_err)
+            else:
+                # Branch 3 — invalid / expired token.
+                _err_result = {
+                    "type": "article", "id": "reply", "title": "Something went wrong",
+                    "input_message_content": {"message_text": "⚠️ Sorry, something went wrong. Please try again."},
+                }
+                try:
+                    await self._bot.do_api_request(
+                        "answerGuestQuery",
+                        api_kwargs={"guest_query_id": guest_query_id, "result": _err_result},
+                    )
+                    logger.info("[%s] guest deliver branch3 (expired token=%r chat=%s)", self.name, _token, chat_id_str)
+                except Exception as _b3_err:
+                    logger.error("[%s] guest deliver branch3 failed: %s", self.name, _b3_err)
+            return
+
         # Guest state (_pending_guest_queries, _guest_reply_buffer,
         # _guest_inline_message_ids) is keyed by chat_id, not guest_query_id —
         # a second @mention from the same chat while a turn is still in flight
@@ -7890,7 +8047,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 logger.warning("[%s] guest busy-reply failed (chat=%s): %s", self.name, chat_id_str, _busy_err)
             return
 
-        # Register state, fire stub, route to skill layer.
+        # Branch 1 — normal query.  Register state, fire stub, route to skill layer.
         self._pending_guest_queries[chat_id_str] = guest_query_id
         self._guest_only_chats.add(chat_id_str)
 
@@ -7925,14 +8082,25 @@ class TelegramAdapter(BasePlatformAdapter):
                 event.source.user_name = _guest_caller_name
 
         # Inject delivery constraint so the LLM knows direct Bot API calls to this
-        # chat will fail (bot is not a member).
+        # chat will fail (bot is not a member).  Media must go via MEDIA: tag so the
+        # platform can stage → file_id → editMessageMedia on the stub.
+        try:
+            from hermes_constants import get_hermes_home as _ghh
+            _host_video_dir = str(_ghh() / "cache" / "videos")
+        except Exception:
+            _host_video_dir = "~/.hermes/cache/videos"
         _guest_delivery_note = (
             "**Delivery constraint (this session only):** You are responding to "
             "a @mention in a group chat where the bot is not a member. "
             "Direct Bot API calls (sendVideo, sendPhoto, sendDocument, sendAudio, "
             "curl to api.telegram.org, etc.) to this chat will fail with "
-            "\"Forbidden: bot is not a member\" — do NOT attempt them. Media "
-            "delivery is not yet supported in this context; respond with text only."
+            "\"Forbidden: bot is not a member\" — do NOT attempt them.\n"
+            "To deliver a file:\n"
+            "1. Download it to `/cache/videos/<filename>` "
+            "(this directory is shared with the host).\n"
+            f"2. Output `MEDIA: {_host_video_dir}/<filename>` "
+            "(the host-visible path — NOT `/tmp/` which is container-local). "
+            "The platform will upload it to Telegram and deliver it to the chat automatically."
         )
         if event.channel_prompt:
             event.channel_prompt = event.channel_prompt + "\n\n" + _guest_delivery_note
@@ -9032,16 +9200,38 @@ class TelegramAdapter(BasePlatformAdapter):
             _guest_imi_raw = self._guest_inline_message_ids.pop(_gc_id, False)
             _guest_imi = _guest_imi_raw if isinstance(_guest_imi_raw, str) else None
             _buffered = self._guest_reply_buffer.pop(_gc_id, "")
+            _turn_media = self._guest_turn_media.pop(_gc_id, None)
             self._guest_only_chats.discard(_gc_id)
             if (_guest_qid or _guest_imi) and self._bot:
                 _plain = _strip_mdv2(self.format_message(_buffered)).strip() if _buffered else ""
                 # Strip any leading MEDIA artifact that escaped stream-consumer cleanup.
                 _plain = re.sub(r"(?i)^MEDIA:?\s*\S*\s*", "", _plain).strip()
                 _reply_text = _plain[:4096] or "⚠️ Sorry, something went wrong. Please try again."
-                logger.warning("[%s] guest OPC flush (chat=%s buffered_len=%d imi=%s)",
-                               self.name, _gc_id, len(_buffered), _guest_imi)
+                logger.warning("[%s] guest OPC flush (chat=%s buffered_len=%d turn_media=%s imi=%s)",
+                               self.name, _gc_id, len(_buffered), bool(_turn_media), _guest_imi)
                 try:
-                    if _guest_imi:
+                    if _turn_media and _guest_imi:
+                        # Media result: stage produced a file_id — mint token, edit stub with button.
+                        from tools.guest_mode_tool import mint_token as _mint_token
+                        _token = _mint_token(_turn_media["file_id"], _turn_media["media_kind"])
+                        _inline_q = f"deliver_{_token}"
+                        _ready_text = (_plain[:3900] + "\n\n✅ Ready — tap to receive").strip() if _plain else "✅ Ready — tap to receive"
+                        _markup = {
+                            "inline_keyboard": [[
+                                {"text": "📥 Tap to send here", "switch_inline_query_current_chat": _inline_q}
+                            ]]
+                        }
+                        await self._bot.do_api_request(
+                            "editMessageText",
+                            api_kwargs={
+                                "inline_message_id": _guest_imi,
+                                "text": _ready_text[:4096],
+                                "reply_markup": _markup,
+                            },
+                        )
+                        logger.warning("[%s] guest OPC media button (chat=%s token=%s kind=%s)",
+                                       self.name, _gc_id, _token, _turn_media["media_kind"])
+                    elif _guest_imi:
                         # Text result: typewriter then final edit.
                         _tw_min = 80
                         _tw_frames = 8

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3600,8 +3600,7 @@ class TelegramAdapter(BasePlatformAdapter):
             # so OPC doesn't edit the stub with the raw "MEDIA" fragment.
             _cid_str_early = str(chat_id)
             if (bool(metadata and (metadata.get("expect_edits") or metadata.get("notify")))
-                    and (_cid_str_early in self._guest_only_chats
-                         or self._pending_guest_queries.get(_cid_str_early) is not None)):
+                    and self._is_guest_chat(_cid_str_early)):
                 _buf_early = self._guest_reply_buffer.get(_cid_str_early, "")
                 if _buf_early:
                     _buf_cleaned = re.sub(r"(?i)^MEDIA:?\s*\S*\s*", "", _buf_early).strip()
@@ -3617,7 +3616,7 @@ class TelegramAdapter(BasePlatformAdapter):
             # stores chat_id_str = str(msg.chat.id)); chat_id here may arrive as int from
             # the event source, which would silently miss every dict lookup.
             _cid_str = str(chat_id)
-            if self._pending_guest_queries.get(_cid_str) is not None or _cid_str in self._guest_only_chats:
+            if self._is_guest_chat(_cid_str):
                 # Tool-use progress blocks (💻 terminal etc.) come through
                 # send() from send_progress_messages().  The stream consumer
                 # always sets expect_edits=True on the first frame and
@@ -4013,7 +4012,7 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         # Guest chats have no existing message to edit and status messages would
         # consume the one-shot query_id before the real answer is ready.
-        if self._pending_guest_queries.get(str(chat_id)) is not None or str(chat_id) in self._guest_only_chats:
+        if self._is_guest_chat(chat_id):
             return SendResult(success=True, message_id=None)
         key = (str(chat_id), str(status_key))
         cached_id = self._status_message_ids.get(key)
@@ -4567,7 +4566,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
         # Guest chats: draft streaming requires an existing message to animate;
         # the bot is not a member, so suppress silently.
-        if self._pending_guest_queries.get(str(chat_id)) is not None or str(chat_id) in self._guest_only_chats:
+        if self._is_guest_chat(chat_id):
             return SendResult(success=True, message_id=None)
 
         # Rich draft fast-path (Bot API 10.1 sendRichMessageDraft): render the
@@ -6884,6 +6883,18 @@ class TelegramAdapter(BasePlatformAdapter):
             return bool(configured)
         return os.getenv("TELEGRAM_GUEST_MODE", "false").lower() in {"true", "1", "yes", "on"}
 
+    def _is_guest_chat(self, chat_id: Any) -> bool:
+        """Return whether *chat_id* is currently a guest-mode (non-member) chat.
+
+        True while a guest turn is in flight (``_pending_guest_queries``) or for
+        the remainder of processing after the query has been consumed
+        (``_guest_only_chats``). Shared by every send-path method that must
+        suppress normal ``sendMessage``-family calls in guest chats — the bot
+        isn't a member, so those calls fail with ``Forbidden``.
+        """
+        _cid_str = str(chat_id)
+        return self._pending_guest_queries.get(_cid_str) is not None or _cid_str in self._guest_only_chats
+
     def _telegram_exclusive_bot_mentions(self) -> bool:
         """Return whether explicit @...bot mentions exclusively route group messages."""
         configured = self.config.extra.get("exclusive_bot_mentions")
@@ -7781,8 +7792,10 @@ class TelegramAdapter(BasePlatformAdapter):
             if _uid > self._last_guest_update_id:
                 self._last_guest_update_id = _uid
                 self._persist_guest_update_id(_uid)
-            # Trim set to last 500 entries
-            if len(self._seen_guest_update_ids) > 500:
+            # Trim set to last 200 entries — matches the persisted on-disk cap
+            # in _persist_guest_update_id, so in-memory and reloaded-after-restart
+            # dedup coverage are consistent instead of silently differing (500 vs 200).
+            if len(self._seen_guest_update_ids) > 200:
                 _min = min(self._seen_guest_update_ids)
                 self._seen_guest_update_ids.discard(_min)
 
@@ -7804,6 +7817,31 @@ class TelegramAdapter(BasePlatformAdapter):
 
         chat_id_str = str(msg.chat.id) if msg.chat else ""
         if not chat_id_str:
+            return
+
+        # Guest state (_pending_guest_queries, _guest_reply_buffer,
+        # _guest_inline_message_ids) is keyed by chat_id, not guest_query_id —
+        # a second @mention from the same chat while a turn is still in flight
+        # would otherwise overwrite the first turn's query id and reset its
+        # stub sentinel, orphaning the first stub and letting the two replies'
+        # buffered text cross-contaminate. Reject the new query outright with
+        # its own immediate answer instead of touching in-flight state.
+        if chat_id_str in self._pending_guest_queries:
+            _busy_result = {
+                "type": "article",
+                "id": "busy",
+                "title": "Still working on the previous request",
+                "input_message_content": {
+                    "message_text": "⏳ Still working on a previous request in this chat — please wait for that reply, then ask again.",
+                },
+            }
+            try:
+                await self._bot.do_api_request(
+                    "answerGuestQuery",
+                    api_kwargs={"guest_query_id": guest_query_id, "result": _busy_result},
+                )
+            except Exception as _busy_err:
+                logger.warning("[%s] guest busy-reply failed (chat=%s): %s", self.name, chat_id_str, _busy_err)
             return
 
         # Register state, fire stub, route to skill layer.

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -7819,6 +7819,52 @@ class TelegramAdapter(BasePlatformAdapter):
         if not chat_id_str:
             return
 
+        # Caller authorization (fail-closed). Guest mode lets ANY chat that
+        # @mentions the bot reach it — _should_process_message only gates the
+        # chat/mention, never the person — so without this an unauthorized
+        # stranger who knows the @handle could drive the full LLM + tools from
+        # any group (cost, abuse, prompt-injection surface). Approval gating
+        # only stops dangerous *commands*; it does nothing about this door.
+        #
+        # The human caller for a guest update is carried in the raw
+        # ``guest_bot_caller_user`` field, NOT ``from_user`` (absent/unreliable
+        # for guest messages). PTB's ``Message.de_json`` drops fields it doesn't
+        # model, so this is read from the raw payload, not off ``msg``. Routed
+        # through the same ``_is_callback_user_authorized`` the exec-approval
+        # buttons use, so there is ONE definition of "who's allowed" — the env
+        # allowlists (``TELEGRAM_ALLOWED_USERS`` / group variants /
+        # ``GATEWAY_ALLOWED_USERS``) unioned with the pairing store, with ``*``
+        # as the explicit open-to-everyone opt-out. Empty allowlist or unknown
+        # caller => deny. Placed before the busy-reply, guest-state registration
+        # AND the deliver_<token> branch so token redemption is gated too.
+        _guest_caller = raw_gm.get("guest_bot_caller_user")
+        if not isinstance(_guest_caller, dict):
+            _guest_caller = {}
+        _guest_caller_id = str(_guest_caller.get("id") or "").strip()
+        if not _guest_caller_id:
+            # Defensive fallback; still denies below if neither yields an id.
+            _guest_caller_id = str(
+                getattr(getattr(msg, "from_user", None), "id", "") or ""
+            ).strip()
+        _guest_chat_type = getattr(getattr(msg, "chat", None), "type", None)
+        if not self._is_callback_user_authorized(
+            _guest_caller_id,
+            chat_id=chat_id_str,
+            chat_type=str(_guest_chat_type) if _guest_chat_type is not None else "group",
+            user_name=(_guest_caller.get("username") or _guest_caller.get("first_name")),
+        ):
+            # Loud + diagnostic: if ``guest_bot_caller_user`` is ever absent
+            # (e.g. a Bot API field-name drift), logging the payload keys makes a
+            # silent deny-all instantly traceable to the missing caller field
+            # rather than looking like a backend outage.
+            logger.warning(
+                "[%s] Guest caller not authorized (caller_id=%r chat=%s); denying. "
+                "caller_field_present=%s raw_keys=%s",
+                self.name, _guest_caller_id, chat_id_str,
+                bool(_guest_caller), sorted(raw_gm.keys()),
+            )
+            return
+
         # Guest state (_pending_guest_queries, _guest_reply_buffer,
         # _guest_inline_message_ids) is keyed by chat_id, not guest_query_id —
         # a second @mention from the same chat while a turn is still in flight

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -775,6 +775,43 @@ class TestSegmentBreakOnToolBoundary:
         assert "Phase 3" in final_text
 
     @pytest.mark.asyncio
+    async def test_guest_mode_drops_prior_segments_delivers_only_last_segment(self):
+        """When the adapter sets GUEST_MODE_DROPS_PRIOR_SEGMENTS=True (Telegram guest
+        mode / answerGuestQuery), _send_fallback_final must deliver ONLY the last
+        segment's text and tag it with 'guest_segment_start' so the adapter can
+        replace its buffer instead of concatenating all inter-tool commentary."""
+        adapter = MagicMock()
+        adapter.GUEST_MODE_DROPS_PRIOR_SEGMENTS = True
+        adapter.send = AsyncMock(side_effect=[
+            SimpleNamespace(success=True, message_id=None),
+            SimpleNamespace(success=True, message_id=None),
+        ])
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5)
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        consumer.on_delta("Inter-tool narration 1")
+        consumer.on_delta(None)
+        consumer.on_delta("Inter-tool narration 2")
+        consumer.on_delta(None)
+        consumer.on_delta("Final answer from OSM")
+        consumer.finish()
+
+        await consumer.run()
+
+        assert adapter.send.call_count == 2
+        final_call = adapter.send.call_args_list[1]
+        final_text = final_call[1]["content"]
+        final_meta = final_call[1].get("metadata") or {}
+        # Only the last segment reaches the guest buffer
+        assert "Final answer" in final_text
+        assert "Inter-tool narration" not in final_text
+        # The 'guest_segment_start' flag signals the adapter to replace its buffer
+        assert final_meta.get("guest_segment_start") is True
+
+    @pytest.mark.asyncio
     async def test_fallback_final_splits_long_continuation_without_dropping_text(self):
         """Long continuation tails should be chunked when fallback final-send runs."""
         adapter = MagicMock()

--- a/tests/gateway/test_telegram_guest_reply.py
+++ b/tests/gateway/test_telegram_guest_reply.py
@@ -210,3 +210,51 @@ async def test_guest_allowlisted_caller_via_env_passes(monkeypatch):
         await adapter._handle_guest_message_update(update, MagicMock())
 
     mock_should.assert_called_once()  # real gate allowed the env-allowlisted caller
+
+
+# ---------------------------------------------------------------------------
+# Session isolation per guest caller — different callers in the same chat must
+# not share a session (context bleed). Post-gate the caller is authorized, so
+# stamping the real caller id makes guest sessions key like group sessions.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_guest_session_isolated_per_caller(monkeypatch):
+    from types import SimpleNamespace
+    from gateway.session import SessionSource, build_session_key
+    from gateway.config import Platform
+
+    adapter = _make_adapter()
+    adapter._bot.username = "testbot"
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "999")
+
+    update, _ = _make_guest_update(caller_id="999", chat_id="42")
+    msg = _fake_guest_msg(chat_id="42")
+
+    src = SessionSource(platform=Platform.TELEGRAM, chat_id="42", chat_type="group", user_id=None)
+    ev = SimpleNamespace(source=src, text="hi", channel_prompt=None)
+    captured = {}
+
+    with patch.object(_tg_adapter_mod.Message, "de_json", return_value=msg), \
+         patch.object(adapter, "_build_message_event", return_value=ev), \
+         patch.object(adapter, "_should_process_message", return_value=True), \
+         patch.object(adapter, "_apply_telegram_group_observe_attribution", side_effect=lambda e: e), \
+         patch.object(adapter, "_enqueue_text_event", side_effect=lambda e: captured.update(event=e)):
+        await adapter._handle_guest_message_update(update, MagicMock())
+
+    # The real guest caller id is stamped onto the source...
+    assert captured["event"].source.user_id == "999"
+    # ...so the session key isolates per caller within the chat.
+    key = build_session_key(captured["event"].source, group_sessions_per_user=True)
+    assert key.endswith(":42:999")
+
+    # Two different callers in the same chat get distinct sessions (no bleed).
+    k_a = build_session_key(
+        SessionSource(platform=Platform.TELEGRAM, chat_id="42", chat_type="group", user_id="999"),
+        group_sessions_per_user=True,
+    )
+    k_b = build_session_key(
+        SessionSource(platform=Platform.TELEGRAM, chat_id="42", chat_type="group", user_id="888"),
+        group_sessions_per_user=True,
+    )
+    assert k_a != k_b

--- a/tests/gateway/test_telegram_guest_reply.py
+++ b/tests/gateway/test_telegram_guest_reply.py
@@ -1,0 +1,113 @@
+"""Integration tests for Telegram guest mode reply flow (Bot API 10.0).
+
+This covers the text-only "Branch 1" foundation: a stub fires unconditionally
+on send_typing, the reply is buffered, and on_processing_complete edits the
+stub with the final text via editMessageText(inline_message_id, ...).
+
+Media delivery (deliver_<token> Branch 2/3 dispatch, the media-button OPC
+path) is out of scope here and lands in a follow-up PR.
+"""
+
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+# ---------------------------------------------------------------------------
+# Telegram library mock
+# ---------------------------------------------------------------------------
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+    mod = MagicMock()
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_adapter() -> TelegramAdapter:
+    cfg = PlatformConfig(enabled=True, token="***")
+    cfg.extra = {"guest_mode": True}
+    adapter = TelegramAdapter(cfg)
+    adapter._bot = MagicMock()
+    adapter._bot.do_api_request = AsyncMock(return_value={"inline_message_id": "imi_abc"})
+    return adapter
+
+
+def _register_guest_chat(adapter: TelegramAdapter, chat_id="42") -> None:
+    """Pre-populate state as if branch-1 processing started."""
+    adapter._pending_guest_queries[chat_id] = "gqid_test"
+    adapter._guest_only_chats.add(chat_id)
+    adapter._guest_inline_message_ids[chat_id] = False  # slot open
+
+
+# ---------------------------------------------------------------------------
+# Branch 1 — stub fires unconditionally on send_typing
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_branch1_stub_fires_on_send_typing():
+    """Stub fires on send_typing for any query — no content classification."""
+    adapter = _make_adapter()
+    _register_guest_chat(adapter)
+
+    with patch.object(adapter, "_guest_fire_text_stub", new_callable=AsyncMock) as mock_stub:
+        await adapter.send_typing("42")
+        mock_stub.assert_awaited_once_with("42")
+
+
+@pytest.mark.asyncio
+async def test_branch1_stub_fires_for_media_keyword_query():
+    """No classification suppression — stub fires even for 'download this video'."""
+    adapter = _make_adapter()
+    _register_guest_chat(adapter)
+
+    with patch.object(adapter, "_guest_fire_text_stub", new_callable=AsyncMock) as mock_stub:
+        await adapter.send_typing("42")
+        mock_stub.assert_awaited_once_with("42")
+
+
+# ---------------------------------------------------------------------------
+# Branch 1 OPC — text result: editMessageText on imi
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_branch1_opc_text_result_edits_stub():
+    """OPC text result: editMessageText(inline_message_id, final_text)."""
+    from gateway.platforms.base import ProcessingOutcome
+
+    adapter = _make_adapter()
+    adapter._guest_inline_message_ids["42"] = "imi_abc"
+    adapter._guest_reply_buffer["42"] = "Here is your answer."
+    adapter._guest_only_chats.add("42")
+
+    event = MagicMock()
+    event.source.chat_id = "42"
+    outcome = ProcessingOutcome.SUCCESS
+
+    await adapter.on_processing_complete(event, outcome)
+
+    calls = adapter._bot.do_api_request.await_args_list
+    methods = [c.args[0] for c in calls]
+    assert "editMessageText" in methods
+
+    edit_call = next(c for c in calls if c.args[0] == "editMessageText")
+    kw = edit_call.kwargs["api_kwargs"]
+    assert kw["inline_message_id"] == "imi_abc"
+    assert "Here is your answer." in kw["text"]

--- a/tests/gateway/test_telegram_guest_reply.py
+++ b/tests/gateway/test_telegram_guest_reply.py
@@ -1,14 +1,15 @@
 """Integration tests for Telegram guest mode reply flow (Bot API 10.0).
 
-This covers the text-only "Branch 1" foundation: a stub fires unconditionally
-on send_typing, the reply is buffered, and on_processing_complete edits the
-stub with the final text via editMessageText(inline_message_id, ...).
-
-Media delivery (deliver_<token> Branch 2/3 dispatch, the media-button OPC
-path) is out of scope here and lands in a follow-up PR.
+Branch 1 — normal query: stub fires, skill runs, OPC edits stub with text or
+           media button.
+Branch 2 — deliver_<token> with valid token: answerGuestQuery with cached media,
+           no stub, no edit cycle.
+Branch 3 — deliver_<token> with invalid/expired token: answerGuestQuery with
+           "something went wrong", no stub.
 """
 
 import sys
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -258,3 +259,142 @@ async def test_guest_session_isolated_per_caller(monkeypatch):
         group_sessions_per_user=True,
     )
     assert k_a != k_b
+# Branch 1 OPC — media result: editMessageText with deliver button
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_branch1_opc_media_result_edits_stub_with_button():
+    """OPC media result: editMessageText with switch_inline_query_current_chat button."""
+    import tools.guest_mode_tool as gmt
+    gmt._TOKEN_STORE.clear()
+
+    from gateway.platforms.base import ProcessingOutcome
+
+    adapter = _make_adapter()
+    adapter._guest_inline_message_ids["42"] = "imi_abc"
+    adapter._guest_reply_buffer["42"] = "Here is your video."
+    adapter._guest_turn_media["42"] = {"file_id": "fid_video", "media_kind": "video"}
+    adapter._guest_only_chats.add("42")
+
+    event = MagicMock()
+    event.source.chat_id = "42"
+
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    calls = adapter._bot.do_api_request.await_args_list
+    edit_call = next((c for c in calls if c.args[0] == "editMessageText"), None)
+    assert edit_call is not None
+
+    kw = edit_call.kwargs["api_kwargs"]
+    assert kw["inline_message_id"] == "imi_abc"
+    assert "✅ Ready" in kw["text"]
+    markup = kw.get("reply_markup", {})
+    assert markup, "reply_markup must be present"
+    button = markup["inline_keyboard"][0][0]
+    assert button["switch_inline_query_current_chat"].startswith("deliver_")
+
+    # Token must exist in store
+    token = button["switch_inline_query_current_chat"][len("deliver_"):]
+    assert token in gmt._TOKEN_STORE
+    assert gmt._TOKEN_STORE[token]["media_kind"] == "video"
+
+    gmt._TOKEN_STORE.clear()
+
+
+# ---------------------------------------------------------------------------
+# Branch 2 — valid token: answerGuestQuery with cached media, no stub
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_branch2_valid_token_answers_with_cached_media():
+    """Branch 2: answerGuestQuery fires immediately with InlineQueryResultCachedVideo."""
+    import tools.guest_mode_tool as gmt
+    gmt._TOKEN_STORE.clear()
+
+    token = gmt.mint_token("fid_video", "video")
+
+    adapter = _make_adapter()
+
+    # Simulate _handle_guest_message_update branch dispatch
+    from tools.guest_mode_tool import resolve_token
+    entry = resolve_token(token)
+    assert entry is not None
+
+    mk = entry["media_kind"]
+    fid = entry["file_id"]
+    fid_key = f"{mk}_file_id"
+    cached_result = {"type": mk, "id": "delivery", fid_key: fid, "title": mk.capitalize()}
+
+    await adapter._bot.do_api_request(
+        "answerGuestQuery",
+        api_kwargs={"guest_query_id": "gqid_branch2", "result": cached_result},
+    )
+
+    call = adapter._bot.do_api_request.await_args
+    assert call.args[0] == "answerGuestQuery"
+    payload = call.kwargs["api_kwargs"]
+    assert payload["result"]["type"] == "video"
+    assert payload["result"]["video_file_id"] == "fid_video"
+
+    gmt._TOKEN_STORE.clear()
+
+
+# ---------------------------------------------------------------------------
+# Branch 3 — invalid/expired token: "something went wrong" result
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_branch3_expired_token_answers_with_error():
+    """Branch 3: expired token → answerGuestQuery with 'something went wrong'."""
+    import tools.guest_mode_tool as gmt
+    gmt._TOKEN_STORE.clear()
+
+    token = gmt.mint_token("fid", "video")
+    gmt._TOKEN_STORE[token]["expires_at"] = time.monotonic() - 1  # force expiry
+
+    adapter = _make_adapter()
+
+    from tools.guest_mode_tool import resolve_token
+    entry = resolve_token(token)
+    assert entry is None  # expired
+
+    err_result = {
+        "type": "article", "id": "reply", "title": "Something went wrong",
+        "input_message_content": {"message_text": "⚠️ Sorry, something went wrong. Please try again."},
+    }
+    await adapter._bot.do_api_request(
+        "answerGuestQuery",
+        api_kwargs={"guest_query_id": "gqid_branch3", "result": err_result},
+    )
+
+    call = adapter._bot.do_api_request.await_args
+    assert call.args[0] == "answerGuestQuery"
+    text = call.kwargs["api_kwargs"]["result"]["input_message_content"]["message_text"]
+    assert "wrong" in text.lower()
+
+    gmt._TOKEN_STORE.clear()
+
+
+# ---------------------------------------------------------------------------
+# Callback handler — no delivery attempt, only answerCallbackQuery
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_callback_on_stub_only_dismisses_loading():
+    """Button press on stub produces callback_query — handler must not call answerGuestQuery."""
+    adapter = _make_adapter()
+
+    # The callback handler should only call answerCallbackQuery (dismiss spinner).
+    # Simulate by checking do_api_request is NOT called with answerGuestQuery.
+    cq = MagicMock()
+    cq.id = "cq_123"
+    cq.inline_message_id = "imi_abc"
+    cq.answer = AsyncMock()
+
+    # answerCallbackQuery is the only allowed action
+    await cq.answer()
+
+    cq.answer.assert_awaited_once()
+    # do_api_request should NOT have been called with answerGuestQuery from this path
+    for c in adapter._bot.do_api_request.await_args_list:
+        assert c.args[0] != "answerGuestQuery", "answerGuestQuery must not fire from callback handler"

--- a/tests/gateway/test_telegram_guest_reply.py
+++ b/tests/gateway/test_telegram_guest_reply.py
@@ -47,6 +47,7 @@ def _make_adapter() -> TelegramAdapter:
     cfg.extra = {"guest_mode": True}
     adapter = TelegramAdapter(cfg)
     adapter._bot = MagicMock()
+    adapter._bot.username = "testbot"  # real str so _clean_bot_trigger_text regex works
     adapter._bot.do_api_request = AsyncMock(return_value={"inline_message_id": "imi_abc"})
     return adapter
 
@@ -398,3 +399,63 @@ async def test_callback_on_stub_only_dismisses_loading():
     # do_api_request should NOT have been called with answerGuestQuery from this path
     for c in adapter._bot.do_api_request.await_args_list:
         assert c.args[0] != "answerGuestQuery", "answerGuestQuery must not fire from callback handler"
+
+
+# ---------------------------------------------------------------------------
+# _guest_media_send — hard path containment for the MEDIA: staging flow
+#
+# The delivery-constraint prompt *tells* the LLM to stage under
+# HERMES_HOME/cache/<subdir>, but that was only a prompt-level instruction --
+# nothing enforced it, so a guest-triggered turn coerced into requesting an
+# arbitrary host path (e.g. the credentials store) would previously have had
+# it staged and made deliverable to the guest chat. These tests cover the
+# hard containment check added to _guest_media_send.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_guest_media_send_rejects_path_outside_staging_root(tmp_path, monkeypatch):
+    """A path outside HERMES_HOME/cache is rejected before any open()/upload."""
+    import hermes_constants
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "-100999")
+
+    outside_file = tmp_path / "auth.json"
+    outside_file.write_text('{"api_key": "secret"}')
+
+    adapter = _make_adapter()
+    adapter._translate_docker_path = lambda p: p  # not under test here
+    adapter._bot.send_document = AsyncMock()
+
+    result = await adapter._guest_media_send("42", "document", str(outside_file))
+
+    assert result.success is False
+    assert "outside the allowed staging directory" in result.error
+    adapter._bot.send_document.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_guest_media_send_allows_path_inside_staging_root(tmp_path, monkeypatch):
+    """A path inside HERMES_HOME/cache proceeds to staging as before."""
+    import hermes_constants
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "-100999")
+
+    cache_dir = tmp_path / "cache" / "videos"
+    cache_dir.mkdir(parents=True)
+    video_file = cache_dir / "clip.mp4"
+    video_file.write_bytes(b"fake video bytes")
+
+    adapter = _make_adapter()
+    adapter._translate_docker_path = lambda p: p
+
+    sent_video = MagicMock()
+    sent_video.video = MagicMock(file_id="fid_ok")
+    adapter._bot.send_video = AsyncMock(return_value=sent_video)
+
+    result = await adapter._guest_media_send("42", "video", str(video_file))
+
+    assert result.success is True
+    adapter._bot.send_video.assert_awaited_once()
+    assert adapter._guest_turn_media["42"]["file_id"] == "fid_ok"

--- a/tests/gateway/test_telegram_guest_reply.py
+++ b/tests/gateway/test_telegram_guest_reply.py
@@ -111,3 +111,102 @@ async def test_branch1_opc_text_result_edits_stub():
     kw = edit_call.kwargs["api_kwargs"]
     assert kw["inline_message_id"] == "imi_abc"
     assert "Here is your answer." in kw["text"]
+
+
+# ---------------------------------------------------------------------------
+# Caller authorization gate (fail-closed) — _handle_guest_message_update
+#
+# The human caller for a guest update is in raw guest_bot_caller_user, not
+# from_user. Unauthorized callers are denied before any state registration or
+# API call; empty allowlist / missing caller => deny.
+# ---------------------------------------------------------------------------
+
+import plugins.platforms.telegram.adapter as _tg_adapter_mod  # noqa: E402
+
+
+def _make_guest_update(caller_id="999", chat_id="42", text="@bot hi",
+                       gqid="gq1", update_id=1,
+                       caller_key="guest_bot_caller_user"):
+    raw = {"guest_query_id": gqid, "chat": {"id": int(chat_id), "type": "supergroup"}, "text": text}
+    if caller_id is not None:
+        raw[caller_key] = {"id": int(caller_id), "username": "someone"}
+    update = MagicMock()
+    update.api_kwargs = {"guest_message": raw}
+    update.update_id = update_id
+    return update, raw
+
+
+def _fake_guest_msg(chat_id="42", text="@bot hi", chat_type="supergroup"):
+    msg = MagicMock()
+    msg.text = text
+    msg.caption = None
+    msg.chat.id = int(chat_id)
+    msg.chat.type = chat_type
+    msg.from_user = None  # guest messages carry the caller in guest_bot_caller_user
+    return msg
+
+
+@pytest.mark.asyncio
+async def test_guest_caller_unauthorized_is_denied():
+    """A caller not in any allowlist is denied before state/API — reads the id
+    from guest_bot_caller_user (from_user is None here)."""
+    adapter = _make_adapter()
+    update, _ = _make_guest_update(caller_id="999")
+    msg = _fake_guest_msg()
+
+    with patch.object(_tg_adapter_mod.Message, "de_json", return_value=msg), \
+         patch.object(adapter, "_is_callback_user_authorized", return_value=False) as mock_auth, \
+         patch.object(adapter, "_should_process_message") as mock_should:
+        await adapter._handle_guest_message_update(update, MagicMock())
+
+    mock_auth.assert_called_once()
+    assert mock_auth.call_args.args[0] == "999"  # caller id from the raw field
+    assert adapter._pending_guest_queries == {}
+    adapter._bot.do_api_request.assert_not_called()
+    mock_should.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_guest_caller_authorized_passes_gate():
+    """An authorized caller passes the gate and reaches normal processing."""
+    adapter = _make_adapter()
+    update, _ = _make_guest_update(caller_id="123304346")
+    msg = _fake_guest_msg()
+
+    with patch.object(_tg_adapter_mod.Message, "de_json", return_value=msg), \
+         patch.object(adapter, "_is_callback_user_authorized", return_value=True) as mock_auth, \
+         patch.object(adapter, "_should_process_message", return_value=False) as mock_should:
+        await adapter._handle_guest_message_update(update, MagicMock())
+
+    mock_auth.assert_called_once()
+    mock_should.assert_called_once()  # gate passed → reached processing
+
+
+@pytest.mark.asyncio
+async def test_guest_missing_caller_field_denies_fail_closed():
+    """No guest_bot_caller_user and no from_user => empty caller => real
+    _is_callback_user_authorized denies (no runner, no env allowlist)."""
+    adapter = _make_adapter()
+    update, _ = _make_guest_update(caller_id=None)  # no caller field at all
+    msg = _fake_guest_msg()
+
+    with patch.object(_tg_adapter_mod.Message, "de_json", return_value=msg):
+        await adapter._handle_guest_message_update(update, MagicMock())
+
+    assert adapter._pending_guest_queries == {}
+    adapter._bot.do_api_request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_guest_allowlisted_caller_via_env_passes(monkeypatch):
+    """End-to-end through the real gate: env allowlist authorizes the caller."""
+    adapter = _make_adapter()
+    update, _ = _make_guest_update(caller_id="999")
+    msg = _fake_guest_msg()
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "999")
+
+    with patch.object(_tg_adapter_mod.Message, "de_json", return_value=msg), \
+         patch.object(adapter, "_should_process_message", return_value=False) as mock_should:
+        await adapter._handle_guest_message_update(update, MagicMock())
+
+    mock_should.assert_called_once()  # real gate allowed the env-allowlisted caller

--- a/tests/gateway/test_telegram_reactions.py
+++ b/tests/gateway/test_telegram_reactions.py
@@ -15,6 +15,12 @@ def _make_adapter(**extra_env):
 
     adapter = object.__new__(TelegramAdapter)
     adapter.platform = Platform.TELEGRAM
+    adapter._pending_guest_queries = {}
+    adapter._guest_only_chats = set()
+    adapter._guest_reply_buffer = {}
+    adapter._guest_inline_message_ids = {}
+    adapter._seen_guest_update_ids = set()
+    adapter._last_guest_update_id = 0
     adapter.config = PlatformConfig(enabled=True, token="fake-token")
     adapter._bot = AsyncMock()
     adapter._bot.set_message_reaction = AsyncMock()

--- a/tests/gateway/test_telegram_reactions.py
+++ b/tests/gateway/test_telegram_reactions.py
@@ -19,6 +19,8 @@ def _make_adapter(**extra_env):
     adapter._guest_only_chats = set()
     adapter._guest_reply_buffer = {}
     adapter._guest_inline_message_ids = {}
+    adapter._guest_turn_media = {}
+    adapter._guest_file_id_cache = {}
     adapter._seen_guest_update_ids = set()
     adapter._last_guest_update_id = 0
     adapter.config = PlatformConfig(enabled=True, token="fake-token")

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -136,6 +136,8 @@ def _make_adapter():
     adapter._guest_only_chats = set()
     adapter._guest_reply_buffer = {}
     adapter._guest_inline_message_ids = {}
+    adapter._guest_turn_media = {}
+    adapter._guest_file_id_cache = {}
     adapter._seen_guest_update_ids = set()
     adapter._last_guest_update_id = 0
     adapter.platform = Platform.TELEGRAM

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -132,6 +132,12 @@ def _make_adapter():
     adapter._polling_conflict_count = 0
     adapter._polling_network_error_count = 0
     adapter._polling_error_callback_ref = None
+    adapter._pending_guest_queries = {}
+    adapter._guest_only_chats = set()
+    adapter._guest_reply_buffer = {}
+    adapter._guest_inline_message_ids = {}
+    adapter._seen_guest_update_ids = set()
+    adapter._last_guest_update_id = 0
     adapter.platform = Platform.TELEGRAM
     return adapter
 

--- a/tests/gateway/test_telegram_username_chat_id.py
+++ b/tests/gateway/test_telegram_username_chat_id.py
@@ -173,6 +173,8 @@ def _make_adapter():
     adapter._guest_only_chats = set()
     adapter._guest_reply_buffer = {}
     adapter._guest_inline_message_ids = {}
+    adapter._guest_turn_media = {}
+    adapter._guest_file_id_cache = {}
     adapter._seen_guest_update_ids = set()
     adapter._last_guest_update_id = 0
     adapter.platform = Platform.TELEGRAM

--- a/tests/gateway/test_telegram_username_chat_id.py
+++ b/tests/gateway/test_telegram_username_chat_id.py
@@ -169,6 +169,12 @@ def _make_adapter():
     adapter._polling_conflict_count = 0
     adapter._polling_network_error_count = 0
     adapter._polling_error_callback_ref = None
+    adapter._pending_guest_queries = {}
+    adapter._guest_only_chats = set()
+    adapter._guest_reply_buffer = {}
+    adapter._guest_inline_message_ids = {}
+    adapter._seen_guest_update_ids = set()
+    adapter._last_guest_update_id = 0
     adapter.platform = Platform.TELEGRAM
     return adapter
 

--- a/tests/tools/test_guest_mode_tool.py
+++ b/tests/tools/test_guest_mode_tool.py
@@ -1,0 +1,52 @@
+"""Unit tests for guest_mode_tool — mint_token, resolve_token."""
+
+import time
+
+import tools.guest_mode_tool as gmt
+
+
+def _clear_store():
+    gmt._TOKEN_STORE.clear()
+
+
+class TestTokenStore:
+    def setup_method(self):
+        _clear_store()
+
+    def test_mint_and_resolve(self):
+        token = gmt.mint_token("fid123", "video")
+        entry = gmt.resolve_token(token)
+        assert entry is not None
+        assert entry["file_id"] == "fid123"
+        assert entry["media_kind"] == "video"
+
+    def test_resolve_does_not_consume_token(self):
+        token = gmt.mint_token("fid123", "audio")
+        gmt.resolve_token(token)
+        assert gmt.resolve_token(token) is not None  # still resolvable
+
+    def test_resolve_unknown_token_returns_none(self):
+        assert gmt.resolve_token("nonexistent") is None
+
+    def test_token_expiry(self):
+        token = gmt.mint_token("fid", "video")
+        gmt._TOKEN_STORE[token]["expires_at"] = time.monotonic() - 1
+        assert gmt.resolve_token(token) is None
+
+    def test_expired_token_removed_from_store(self):
+        token = gmt.mint_token("fid", "video")
+        gmt._TOKEN_STORE[token]["expires_at"] = time.monotonic() - 1
+        gmt.resolve_token(token)
+        assert token not in gmt._TOKEN_STORE
+
+    def test_multiple_tokens_are_independent(self):
+        t1 = gmt.mint_token("fid1", "video")
+        t2 = gmt.mint_token("fid2", "audio")
+        assert gmt.resolve_token(t1)["file_id"] == "fid1"
+        assert gmt.resolve_token(t2)["file_id"] == "fid2"
+        assert len(gmt._TOKEN_STORE) == 2  # both still present
+
+    def test_ttl_is_ten_minutes(self):
+        token = gmt.mint_token("fid", "document")
+        entry = gmt._TOKEN_STORE[token]
+        assert entry["expires_at"] - time.monotonic() > 590  # ~10 min

--- a/tools/guest_mode_tool.py
+++ b/tools/guest_mode_tool.py
@@ -1,0 +1,41 @@
+"""Guest mode token store for Telegram guest delivery (Bot API 10.0).
+
+mint_token() / resolve_token() are called by the adapter to track staged
+media across the two-hop deliver_<token> flow.  No LLM involvement.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Optional
+
+_TOKEN_STORE: dict[str, dict] = {}
+_TOKEN_TTL = 600  # 10 minutes
+
+
+def mint_token(file_id: str, media_kind: str) -> str:
+    """Mint a delivery token. Stored for _TOKEN_TTL seconds."""
+    token = uuid.uuid4().hex[:16]
+    _TOKEN_STORE[token] = {
+        "file_id": file_id,
+        "media_kind": media_kind,
+        "expires_at": time.monotonic() + _TOKEN_TTL,
+    }
+    return token
+
+
+def resolve_token(token: str) -> Optional[dict]:
+    """Resolve a delivery token without consuming it.
+
+    Returns None if the token is unknown or expired.  Tokens are kept in the
+    store until natural TTL expiry so repeat taps on the deliver button
+    re-deliver rather than falling through to the invalid-token path.
+    """
+    entry = _TOKEN_STORE.get(token)
+    if entry is None:
+        return None
+    if time.monotonic() > entry["expires_at"]:
+        _TOKEN_STORE.pop(token, None)
+        return None
+    return entry


### PR DESCRIPTION
## Problem

When a bot is @mentioned in a group chat via Bot API 10.0 guest mode, the `answerGuestQuery` reply included **all** inter-tool commentary — every "searching...", "DDG returned empty", "trying another approach" segment the model emitted between tool calls. The final answer was buried at the end of a wall of failed-attempt narration.

## Root cause

On a `__no_edit__` platform (guest mode returns `message_id=None`), `_reset_segment_state(preserve_no_edit=True)` is a no-op. This means `_accumulated` grows across all segments and `_send_fallback_final` delivers the entire concatenation as the `answerGuestQuery` payload.

## Fix

Two-part change that leaves all non-Telegram platforms unchanged:

**`gateway/stream_consumer.py`** — on each `__no_edit__` segment-break, record:
- `_had_no_edit_segment_break = True`
- `_no_edit_segment_text_start = len(self._accumulated)` (start of the current segment)

In `_send_fallback_final`, if the adapter has `GUEST_MODE_DROPS_PRIOR_SEGMENTS is True`, extract only `accumulated[_no_edit_segment_text_start:]` and tag its first chunk with `"guest_segment_start": True`. Adapters without this flag keep the existing all-segments-concatenated behaviour (webhooks, github_comment delivery).

**`plugins/platforms/telegram/adapter.py`** — add `GUEST_MODE_DROPS_PRIOR_SEGMENTS: bool = True`. In the guest buffer `send()` path, handle `metadata["guest_segment_start"]` by **replacing** the buffer instead of appending — discarding stale inter-tool preamble before flushing `answerGuestQuery`.

## Test

Added `test_guest_mode_drops_prior_segments_delivers_only_last_segment` to `tests/gateway/test_stream_consumer.py` verifying: 3-segment stream → only last segment in fallback delivery → `guest_segment_start: True` on first chunk.

## Follow-up to

#49186 (fix(telegram): clean guest reply buffer — drop tool blocks, strip cursor, fix accumulation) — **closed**, superseded by #56476, which this PR's base still targets. This bug is confirmed still live: `_reset_segment_state(preserve_no_edit=True)` in current `gateway/stream_consumer.py` still returns early without clearing `_accumulated` (verified against both `origin/main` and the production `local-patches` copy as of 2026-07-07).

🤖 Generated with [Claude Code](https://claude.com/claude-code)