### PR TITLE
fix(desktop): split fallback-chain model options

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -109,6 +109,29 @@ def _check_hermes_model_warning(model_name: str) -> str:
     return ""
 
 
+def _append_declared_model_ids(models: list[str], *sources: object) -> None:
+    """Append configured model ids, splitting comma-chain defaults into entries.
+
+    Some provider configs store ``default_model`` as a comma-separated fallback
+    chain (for example ``volcengine-agent-plan``). The desktop picker and
+    ``/model`` menus need individually selectable model ids, not the raw chain.
+    """
+    for source in sources:
+        if isinstance(source, dict):
+            entries = source.keys()
+        elif isinstance(source, list):
+            entries = source
+        else:
+            entries = [source]
+
+        for entry in entries:
+            if not isinstance(entry, str):
+                continue
+            for model_id in (part.strip() for part in entry.split(",")):
+                if model_id and model_id not in models:
+                    models.append(model_id)
+
+
 # ---------------------------------------------------------------------------
 # Model aliases -- short names -> (vendor, family) with NO version numbers.
 # Resolved dynamically against the live models.dev catalog.
@@ -1769,22 +1792,13 @@ def list_authenticated_providers(
             default_model = ep_cfg.get("default_model", "") or ep_cfg.get("model", "")
 
             # Build models list from both default_model and full models array
-            models_list = []
-            if default_model:
-                models_list.append(default_model)
-            # Also include the full models list from config.
-            # Hermes writes ``models:`` as a dict keyed by model id
-            # (see hermes_cli/main.py::_save_custom_provider); older
-            # configs or hand-edited files may still use a list.
+            models_list: list[str] = []
+            # Also include the full models list from config. Hermes writes
+            # ``models:`` as a dict keyed by model id (see
+            # hermes_cli/main.py::_save_custom_provider); older configs or
+            # hand-edited files may still use a list.
             cfg_models = ep_cfg.get("models", [])
-            if isinstance(cfg_models, dict):
-                for m in cfg_models:
-                    if m and m not in models_list:
-                        models_list.append(m)
-            elif isinstance(cfg_models, list):
-                for m in cfg_models:
-                    if m and m not in models_list:
-                        models_list.append(m)
+            _append_declared_model_ids(models_list, default_model, cfg_models)
 
             # Official OpenAI API rows in providers: often have base_url but no
             # explicit models: dict — avoid a misleading zero count in /model.
@@ -1970,18 +1984,8 @@ def list_authenticated_providers(
             # downstream readers (agent/models_dev.py, gateway/run.py,
             # run_agent.py, hermes_cli/config.py) already consume that dict.
             default_model = (entry.get("model") or "").strip()
-            if default_model and default_model not in groups[group_key]["models"]:
-                groups[group_key]["models"].append(default_model)
-
             cfg_models = entry.get("models", {})
-            if isinstance(cfg_models, dict):
-                for m in cfg_models:
-                    if m and m not in groups[group_key]["models"]:
-                        groups[group_key]["models"].append(m)
-            elif isinstance(cfg_models, list):
-                for m in cfg_models:
-                    if m and m not in groups[group_key]["models"]:
-                        groups[group_key]["models"].append(m)
+            _append_declared_model_ids(groups[group_key]["models"], default_model, cfg_models)
 
         _section4_emitted_slugs: set = set()
         _current_base_url_norm = str(current_base_url or "").strip().rstrip("/").lower()

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -291,6 +291,34 @@ def test_list_enumerates_dict_format_models_without_singular_model(monkeypatch):
     assert thor_rows[0]["total_models"] == 3
 
 
+def test_list_splits_comma_chain_custom_provider_model(monkeypatch):
+    """A comma-separated custom-provider ``model:`` chain should be split.
+
+    Regression: desktop picker rows are fed from ``list_authenticated_providers``
+    and previously rendered the whole fallback chain as one entry.
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="openai-codex",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "Volcengine Agent Plan",
+                "base_url": "https://ark.cn-beijing.volces.com/api/v3",
+                "model": "deepseek-v4-flash, deepseek-v4-pro, glm-5.2, deepseek-v4-flash",
+            }
+        ],
+        max_models=50,
+    )
+
+    rows = [p for p in providers if p["name"] == "Volcengine Agent Plan"]
+    assert len(rows) == 1
+    assert rows[0]["models"] == ["deepseek-v4-flash", "deepseek-v4-pro", "glm-5.2"]
+    assert rows[0]["total_models"] == 3
+
+
 def test_list_dedupes_dict_model_matching_singular_default(monkeypatch):
     """When the singular ``model:`` is also a key in the ``models:`` dict,
     it must appear exactly once in the picker."""

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -246,6 +246,41 @@ def test_list_authenticated_providers_dict_models_dedupe_with_default(monkeypatc
     assert user_prov["models"].count("model-a") == 1
 
 
+def test_list_authenticated_providers_splits_comma_default_model_chain(monkeypatch):
+    """Comma-separated ``default_model`` chains should surface as individual rows.
+
+    Desktop ``model.options`` consumes this picker payload directly, so a raw
+    fallback chain string would otherwise render as one unselectable dropdown
+    entry.
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    user_providers = {
+        "volcengine-agent-plan": {
+            "name": "VOLCENGINE-AGENT-PLAN",
+            "base_url": "https://ark.cn-beijing.volces.com/api/v3",
+            "default_model": "deepseek-v4-flash, deepseek-v4-pro, glm-5.2, deepseek-v4-flash",
+        }
+    }
+
+    providers = list_authenticated_providers(
+        current_provider="volcengine-agent-plan",
+        user_providers=user_providers,
+        custom_providers=[],
+        max_models=50,
+    )
+
+    user_prov = next(
+        (p for p in providers if p.get("is_user_defined") and p["slug"] == "volcengine-agent-plan"),
+        None,
+    )
+
+    assert user_prov is not None
+    assert user_prov["models"] == ["deepseek-v4-flash", "deepseek-v4-pro", "glm-5.2"]
+    assert user_prov["total_models"] == 3
+
+
 def test_openai_native_curated_catalog_is_non_empty():
     """Regression: built-in openai must have a static catalog for picker totals."""
     from hermes_cli.models import _PROVIDER_MODELS


### PR DESCRIPTION
Closes #50557.

## Summary
- split comma-separated configured fallback chains into individual model ids before feeding picker payloads
- apply the same normalization to both `providers:` and `custom_providers:` entries
- add regressions covering the desktop `model.options` feed path for both config styles

## Testing
- /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/hermes_cli/test_user_providers_model_switch.py tests/hermes_cli/test_model_switch_custom_providers.py
- /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m ruff check hermes_cli/model_switch.py tests/hermes_cli/test_user_providers_model_switch.py tests/hermes_cli/test_model_switch_custom_providers.py
- git diff --check