### PR TITLE
fix: use is_truthy_value for config boolean coercion

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -720,7 +720,7 @@ def _message_timestamps_enabled(user_config: Optional[dict]) -> bool:
         return False
     mt = gw.get("message_timestamps")
     if isinstance(mt, dict):
-        return bool(mt.get("enabled", False))
+        return is_truthy_value(mt.get("enabled"), default=False)
     # Allow a bare ``message_timestamps: true`` shorthand.
     return bool(mt)
 

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import os
 from typing import Any, Iterable, Optional
+from utils import is_truthy_value
 
 _DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "cwd")
 _SEP = " · "
@@ -70,7 +71,7 @@ def resolve_footer_config(
     global_cfg = cfg.get("runtime_footer")
     if isinstance(global_cfg, dict):
         if "enabled" in global_cfg:
-            resolved["enabled"] = bool(global_cfg.get("enabled"))
+            resolved["enabled"] = is_truthy_value(global_cfg.get("enabled"))
         if isinstance(global_cfg.get("fields"), list) and global_cfg["fields"]:
             resolved["fields"] = [str(f) for f in global_cfg["fields"]]
 
@@ -81,7 +82,7 @@ def resolve_footer_config(
             plat_footer = plat_cfg.get("runtime_footer")
             if isinstance(plat_footer, dict):
                 if "enabled" in plat_footer:
-                    resolved["enabled"] = bool(plat_footer.get("enabled"))
+                    resolved["enabled"] = is_truthy_value(plat_footer.get("enabled"))
                 if isinstance(plat_footer.get("fields"), list) and plat_footer["fields"]:
                     resolved["fields"] = [str(f) for f in plat_footer["fields"]]
 

--- a/hermes_cli/secrets_cli.py
+++ b/hermes_cli/secrets_cli.py
@@ -30,6 +30,7 @@ from hermes_cli.config import (
     save_env_value,
 )
 from hermes_cli.secret_prompt import masked_secret_prompt
+from utils import is_truthy_value
 
 
 # ---------------------------------------------------------------------------
@@ -293,7 +294,7 @@ def cmd_status(args: argparse.Namespace) -> int:
     cfg = load_config()
     bw_cfg = (cfg.get("secrets") or {}).get("bitwarden") or {}
 
-    enabled = bool(bw_cfg.get("enabled"))
+    enabled = is_truthy_value(bw_cfg.get("enabled"))
     token_env = bw_cfg.get("access_token_env", "BWS_ACCESS_TOKEN")
     project_id = bw_cfg.get("project_id", "")
     server_url = str(bw_cfg.get("server_url", "") or "").strip()

--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Dict
 
 from hermes_constants import display_hermes_home
-from utils import atomic_replace
+from utils import atomic_replace, is_truthy_value
 from hermes_cli.config import cfg_get
 
 
@@ -91,7 +91,7 @@ def _get_webhook_config() -> dict:
 
 
 def _is_webhook_enabled() -> bool:
-    return bool(_get_webhook_config().get("enabled"))
+    return is_truthy_value(_get_webhook_config().get("enabled"))
 
 
 def _get_webhook_base_url() -> str:


### PR DESCRIPTION
## Summary

`bool("false")` returns `True` in Python because `"false"` is a non-empty string. Users who quote YAML values (`enabled: "false"`) get wrong behavior.

Replace `bool(config.get("enabled"))` with `is_truthy_value()` which only treats `"1"`, `"true"`, `"yes"`, `"on"` as truthy.

Fixed 4 files:
- `gateway/run.py`: `message_timestamps` enabled check
- `gateway/runtime_footer.py`: global + platform footer enabled
- `hermes_cli/secrets_cli.py`: bitwarden enabled check
- `hermes_cli/webhook.py`: webhook enabled check

## Why this matters

A user who sets `enabled: "false"` in config.yaml (quoting the value) would have the feature silently enabled because `bool("false")` is `True`. This is a common footgun in Python YAML parsing.

## Test plan

- [ ] CI passes
- [ ] `is_truthy_value("false")` returns `False`
- [ ] `is_truthy_value("true")` returns `True`