### PR TITLE
fix(redact): mask Cookie / Set-Cookie session tokens

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -142,6 +142,24 @@ _SECRET_HEADER_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Cookie / Set-Cookie headers carry session tokens — account-takeover
+# credentials that the Authorization / x-api-key rules above do not cover, so a
+# logged request or echoed ``curl`` would otherwise leak a live session. Mask
+# every cookie VALUE while preserving the cookie name and the non-secret
+# Set-Cookie attributes (Path/Domain/Expires/Max-Age/SameSite + HttpOnly/Secure
+# flags) so logs stay debuggable.
+_COOKIE_ATTR_NAMES = frozenset({
+    "path", "domain", "expires", "max-age", "samesite",
+    "secure", "httponly", "partitioned", "priority", "version", "comment",
+})
+# Header value runs to end-of-line or a closing quote (so an inline
+# ``curl -H 'Cookie: …' https://host`` doesn't swallow the trailing URL).
+_COOKIE_HEADER_RE = re.compile(
+    r"((?:Set-)?Cookie:\s*)([^\r\n'\"]+)",
+    re.IGNORECASE,
+)
+_COOKIE_PAIR_RE = re.compile(r"([^\s=;,]+)(\s*=\s*)([^;,]+)")
+
 # Telegram bot tokens: bot<digits>:<token> or <digits>:<token>,
 # where token part is restricted to [-A-Za-z0-9_] and length >= 30
 _TELEGRAM_RE = re.compile(
@@ -406,6 +424,18 @@ def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = F
             lambda m: m.group(1) + _mask_token(m.group(2)),
             text,
         )
+
+    # Cookie / Set-Cookie headers — mask each cookie value, keeping the cookie
+    # name and the non-secret Set-Cookie attributes.
+    if ":" in text:
+        def _redact_cookie(m):
+            def _mask_pair(pm):
+                name, eq, val = pm.group(1), pm.group(2), pm.group(3)
+                if name.strip().lower() in _COOKIE_ATTR_NAMES:
+                    return pm.group(0)
+                return f"{name}{eq}{_mask_token(val.strip())}"
+            return m.group(1) + _COOKIE_PAIR_RE.sub(_mask_pair, m.group(2))
+        text = _COOKIE_HEADER_RE.sub(_redact_cookie, text)
 
     # Telegram bot tokens — pattern requires ":<token>" with digits prefix
     if ":" in text:

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -190,6 +190,35 @@ class TestApiKeyHeaders:
         assert "anotherOpaqueSecret" not in result
 
 
+class TestCookieHeaders:
+    """Cookie / Set-Cookie headers carry session tokens (account-takeover
+    credentials) and must be masked like Authorization / x-api-key."""
+
+    def test_cookie_header_values_masked_names_preserved(self):
+        text = "Cookie: sessionid=abcdef123456FAKESESSION7890; csrftoken=xyzFAKECSRF"
+        result = redact_sensitive_text(text)
+        assert "FAKESESSION7890" not in result
+        assert "xyzFAKECSRF" not in result
+        # Cookie names stay for debuggability.
+        assert "sessionid=" in result
+        assert "csrftoken=" in result
+
+    def test_set_cookie_value_masked_attributes_preserved(self):
+        text = "Set-Cookie: session=topFAKEsecretvalue12345; HttpOnly; Path=/; Max-Age=3600"
+        result = redact_sensitive_text(text)
+        assert "topFAKEsecretvalue12345" not in result
+        # Non-secret Set-Cookie attributes survive.
+        assert "HttpOnly" in result
+        assert "Path=/" in result
+        assert "Max-Age=3600" in result
+
+    def test_cookie_in_curl_command_masked_url_preserved(self):
+        text = "curl -H 'Cookie: auth=superFAKEsecrettok123' https://api.example.com/v1/x"
+        result = redact_sensitive_text(text)
+        assert "superFAKEsecrettok123" not in result
+        assert "https://api.example.com/v1/x" in result
+
+
 class TestTelegramTokens:
     def test_bot_token(self):
         text = "bot123456789:ABCDEfghij-KLMNopqrst_UVWXyz12345"


### PR DESCRIPTION
## Summary

Follow-up to `6f0ecf37d` ("mask all Authorization schemes and x-api-key style headers").

`redact_sensitive_text` masks `Authorization` / `Proxy-Authorization` and the `x-api-key` / `api-key` header family — the threat model that commit names is *a logged request or echoed `curl` leaking live credentials*. But **`Cookie` / `Set-Cookie` headers were left untouched**, so a session token — an account-takeover credential — leaks verbatim into logs, transcripts, and tool output.

Reproduced against current `main`:

```python
>>> redact_sensitive_text("Cookie: sessionid=abcdef123456SECRET7890; csrftoken=xyz", force=True)
'Cookie: sessionid=abcdef123456SECRET7890; csrftoken=xyz'   # ← leaked
>>> redact_sensitive_text("Set-Cookie: session=topsecretvalue12345; HttpOnly; Path=/", force=True)
'Set-Cookie: session=topsecretvalue12345; HttpOnly; Path=/' # ← leaked
>>> redact_sensitive_text("authorization: Bearer sk-x", force=True)
'authorization: Bearer ***'                                  # (already masked)
```

`Cookie` carries arbitrarily many secret pairs (`sessionid`, `csrftoken`, auth tokens); `Set-Cookie` carries the cookie plus non-secret attributes (`Path`, `HttpOnly`, …). Neither is covered by the Authorization or x-api-key rules, and `cookie` is not in the JSON/query secret-key set.

## Fix

Add a Cookie/Set-Cookie rule alongside the existing header rules. It masks **each** cookie value via `_mask_token` (the same masker used for Authorization/x-api-key, so the partial-reveal policy is consistent) while preserving cookie names and the non-secret `Set-Cookie` attributes (Path/Domain/Expires/Max-Age/SameSite + the HttpOnly/Secure flags) for debuggability. The value run stops at end-of-line or a closing quote so an inline `curl -H 'Cookie: …' https://host` doesn't swallow the trailing URL.

After the fix:
```
Cookie: sessionid=abcdef...7890; csrftoken=***
Set-Cookie: session=topsec...2345; HttpOnly; Path=/
curl -H 'Cookie: auth=***' https://api.example.com/v1/x
```

## Tests

`tests/agent/test_redact.py::TestCookieHeaders` — Cookie multi-pair masking (names preserved), Set-Cookie value masked with attributes preserved, and a curl-command case (URL preserved). **All three fail without the rule**; the full suite (85 tests) passes with it.