### PR TITLE
fix(gateway): reconcile previewed final responses

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9719,8 +9719,65 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)
                 _footer_line = ""
-            if _footer_line and response and not agent_result.get("already_sent") and not _intentional_silence:
-                response = f"{response}\n\n{_footer_line}"
+
+            _preview_delivery_confirmed = bool(
+                agent_result.get("preview_delivery_confirmed")
+            )
+            _previewed_content = agent_result.get("previewed_content")
+            _previewed_message_id = agent_result.get("previewed_message_id")
+            _preview_adapter = self.adapters.get(source.platform)
+            _previewed_final_text = (
+                f"{response}\n\n{_footer_line}"
+                if _footer_line and response and not _intentional_silence
+                else response
+            )
+            if (
+                not agent_result.get("already_sent")
+                and not _intentional_silence
+                and response
+                and _preview_delivery_confirmed
+                and isinstance(_previewed_content, str)
+            ):
+                _preview_matches_final = _previewed_content == _previewed_final_text
+                _preview_editable = bool(
+                    _previewed_message_id
+                    and _preview_adapter is not None
+                    and getattr(_preview_adapter, "SUPPORTS_MESSAGE_EDITING", True)
+                )
+                if _preview_matches_final:
+                    agent_result["already_sent"] = True
+                    response = _previewed_final_text
+                    _footer_line = ""
+                    logger.info(
+                        "Suppressing normal final send for session %s: preview already matches final response.",
+                        session_key or "?",
+                    )
+                elif _preview_editable:
+                    try:
+                        await _preview_adapter.edit_message(
+                            source.chat_id,
+                            _previewed_message_id,
+                            _previewed_final_text,
+                        )
+                        agent_result["already_sent"] = True
+                        response = _previewed_final_text
+                        _footer_line = ""
+                        logger.info(
+                            "Edited previewed message %s for session %s to reflect final response.",
+                            _previewed_message_id,
+                            session_key or "?",
+                        )
+                    except Exception as _preview_edit_err:
+                        logger.warning(
+                            "Failed to edit previewed message for session %s: %s",
+                            session_key or "?",
+                            _preview_edit_err,
+                        )
+                        response = _previewed_final_text
+                else:
+                    response = _previewed_final_text
+            elif _footer_line and response and not agent_result.get("already_sent") and not _intentional_silence:
+                response = _previewed_final_text
 
             # Emit agent:end hook
             await self.hooks.emit("agent:end", {
@@ -15125,6 +15182,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         result_holder = [None]  # Mutable container for the result
         tools_holder = [None]   # Mutable container for the tool definitions
         stream_consumer_holder = [None]  # Mutable container for stream consumer
+        preview_delivery = {
+            "message_id": None,
+            "content": None,
+            "future": None,
+            "confirmed": False,
+        }
         
         # Bridge sync step_callback → async hooks.emit for agent:step events
         _loop_for_step = asyncio.get_running_loop()
@@ -15360,6 +15423,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 except Exception as _sc_err:
                     logger.debug("Could not set up stream consumer: %s", _sc_err)
 
+            async def _send_tracked_interim_assistant(text: str) -> None:
+                send_result = await _status_adapter.send(
+                    _status_chat_id,
+                    text,
+                    metadata=_status_thread_metadata,
+                )
+                if getattr(send_result, "success", False):
+                    preview_delivery["message_id"] = getattr(send_result, "message_id", None)
+                    preview_delivery["content"] = text
+                    preview_delivery["confirmed"] = True
+
             def _interim_assistant_cb(text: str, *, already_streamed: bool = False) -> None:
                 if not _run_still_current():
                     return
@@ -15371,12 +15445,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     return
                 if already_streamed or not _status_adapter or not str(text or "").strip():
                     return
-                safe_schedule_threadsafe(
-                    _status_adapter.send(
-                        _status_chat_id,
-                        text,
-                        metadata=_status_thread_metadata,
-                    ),
+                preview_delivery["content"] = text
+                preview_delivery["future"] = safe_schedule_threadsafe(
+                    _send_tracked_interim_assistant(text),
                     _loop_for_step,
                     logger=logger,
                     log_message="interim_assistant_callback scheduling error",
@@ -16190,6 +16261,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "session_id": effective_session_id,
                 "response_previewed": result.get("response_previewed", False),
                 "response_transformed": result.get("response_transformed", False),
+                "preview_delivery_confirmed": bool(preview_delivery.get("confirmed")),
+                "previewed_content": preview_delivery.get("content"),
+                "previewed_message_id": preview_delivery.get("message_id"),
             }
         
         # Start progress message sender if enabled
@@ -16967,9 +17041,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _streamed = bool(
                 _sc and getattr(_sc, "final_response_sent", False)
             )
-            # response_previewed means the interim_assistant_callback already
-            # sent the final text via the adapter (non-streaming path).
-            _previewed = bool(response.get("response_previewed"))
+            _preview_future = preview_delivery.get("future")
+            if _preview_future is not None and not _preview_future.done():
+                try:
+                    await asyncio.wait_for(asyncio.wrap_future(_preview_future), timeout=1.0)
+                except Exception:
+                    pass
             _content_delivered = bool(
                 _sc and getattr(_sc, "final_content_delivered", False)
             )
@@ -16977,12 +17054,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # after streaming finished — when the response was transformed, always
             # send the final version so the appended content reaches the client.
             _transformed = bool(response.get("response_transformed"))
-            if not _is_empty_sentinel and not _transformed and (_streamed or _previewed or _content_delivered):
+            if not _is_empty_sentinel and not _transformed and (
+                _streamed
+                or _content_delivered
+            ):
                 logger.info(
-                    "Suppressing normal final send for session %s: final delivery already confirmed (streamed=%s previewed=%s content_delivered=%s).",
+                    "Suppressing normal final send for session %s: final delivery already confirmed (streamed=%s content_delivered=%s).",
                     session_key or "?",
                     _streamed,
-                    _previewed,
                     _content_delivered,
                 )
                 response["already_sent"] = True

--- a/tests/gateway/test_duplicate_reply_suppression.py
+++ b/tests/gateway/test_duplicate_reply_suppression.py
@@ -13,17 +13,20 @@ Covers four fix paths:
 """
 
 import asyncio
+from datetime import datetime
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from gateway.config import Platform, PlatformConfig
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
     SendResult,
 )
-from gateway.session import SessionSource, build_session_key
+from gateway.session import SessionEntry, SessionSource, build_session_key
 
 
 # ---------------------------------------------------------------------------
@@ -64,6 +67,115 @@ def _make_event(text="hello", chat_id="c1", user_id="u1"):
             user_id=user_id,
         ),
         message_id="m1",
+    )
+
+
+class PreviewAdapter(BasePlatformAdapter):
+    """Telegram-like adapter that records sends and edits."""
+
+    def __init__(self, *, supports_editing=True):
+        super().__init__(PlatformConfig(enabled=True, token="fake"), Platform.TELEGRAM)
+        self.SUPPORTS_MESSAGE_EDITING = supports_editing
+        self.sent = []
+        self.edits = []
+
+    async def connect(self):
+        return True
+
+    async def disconnect(self):
+        pass
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.sent.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id="preview-msg")
+
+    async def edit_message(self, chat_id, message_id, content):
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+            }
+        )
+        return SendResult(success=True, message_id=message_id)
+
+    async def send_typing(self, chat_id, metadata=None):
+        pass
+
+    async def stop_typing(self, chat_id):
+        pass
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+
+def _preview_runner(monkeypatch, tmp_path, adapter):
+    runner = gateway_run.GatewayRunner(GatewayConfig())
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._handle_active_session_busy_message = AsyncMock(return_value=False)
+    runner._session_db = MagicMock()
+    runner._recover_telegram_topic_thread_id = lambda _source: None
+    runner._cache_session_source = lambda _key, _source: None
+    runner._is_session_run_current = lambda _key, _gen: True
+    runner._begin_session_run_generation = lambda _key: 1
+    runner._reply_anchor_for_event = lambda _event: None
+    runner._get_guild_id = lambda _event: None
+    runner._should_send_voice_reply = lambda *_a, **_kw: False
+    runner._show_reasoning = False
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key="agent:main:telegram:group:-1001:12345",
+        session_id="sess-preview",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+    )
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"}
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100_000,
+    )
+    return runner
+
+
+def _preview_source():
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        user_id="12345",
+    )
+
+
+def _preview_event():
+    return MessageEvent(
+        text="hello world",
+        source=_preview_source(),
+        message_id="msg-42",
     )
 
 
@@ -375,6 +487,123 @@ class TestQueuedMessageAlreadyStreamed:
         )
 
         assert _already_streamed is False
+
+
+# ===================================================================
+# Test 3b: previewed final response reconciliation
+# ===================================================================
+
+@pytest.mark.asyncio
+async def test_previewed_final_is_suppressed_when_it_already_matches(monkeypatch, tmp_path):
+    adapter = PreviewAdapter()
+    runner = _preview_runner(monkeypatch, tmp_path, adapter)
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "You're welcome.",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+            "api_calls": 1,
+            "failed": False,
+            "response_previewed": True,
+            "preview_delivery_confirmed": True,
+            "previewed_content": "You're welcome.",
+            "previewed_message_id": "preview-msg",
+        }
+    )
+
+    response = await runner._handle_message_with_agent(
+        _preview_event(),
+        _preview_source(),
+        "agent:main:telegram:group:-1001:12345",
+        1,
+    )
+
+    assert response is None
+    assert adapter.edits == []
+
+
+@pytest.mark.asyncio
+async def test_previewed_final_edits_in_reasoning_prefix_before_suppressing(
+    monkeypatch, tmp_path
+):
+    (tmp_path / "config.yaml").write_text(
+        "display:\n  show_reasoning: true\n",
+        encoding="utf-8",
+    )
+    adapter = PreviewAdapter()
+    runner = _preview_runner(monkeypatch, tmp_path, adapter)
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "You're welcome.",
+            "last_reasoning": "Check the stored reasoning from this turn.",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+            "api_calls": 1,
+            "failed": False,
+            "response_previewed": True,
+            "preview_delivery_confirmed": True,
+            "previewed_content": "You're welcome.",
+            "previewed_message_id": "preview-msg",
+        }
+    )
+
+    response = await runner._handle_message_with_agent(
+        _preview_event(),
+        _preview_source(),
+        "agent:main:telegram:group:-1001:12345",
+        1,
+    )
+
+    assert response is None
+    assert len(adapter.edits) == 1
+    assert adapter.edits[0]["message_id"] == "preview-msg"
+    assert adapter.edits[0]["content"].startswith("💭 **Reasoning:**\n```")
+    assert "Check the stored reasoning from this turn." in adapter.edits[0]["content"]
+    assert adapter.edits[0]["content"].endswith("\n\nYou're welcome.")
+
+
+@pytest.mark.asyncio
+async def test_previewed_final_falls_back_to_normal_send_when_not_editable(
+    monkeypatch, tmp_path
+):
+    (tmp_path / "config.yaml").write_text(
+        "display:\n  show_reasoning: true\n",
+        encoding="utf-8",
+    )
+    adapter = PreviewAdapter(supports_editing=False)
+    runner = _preview_runner(monkeypatch, tmp_path, adapter)
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "You're welcome.",
+            "last_reasoning": "Check the stored reasoning from this turn.",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+            "api_calls": 1,
+            "failed": False,
+            "response_previewed": True,
+            "preview_delivery_confirmed": True,
+            "previewed_content": "You're welcome.",
+            "previewed_message_id": "preview-msg",
+        }
+    )
+
+    response = await runner._handle_message_with_agent(
+        _preview_event(),
+        _preview_source(),
+        "agent:main:telegram:group:-1001:12345",
+        1,
+    )
+
+    assert response.startswith("💭 **Reasoning:**\n```")
+    assert "Check the stored reasoning from this turn." in response
+    assert response.endswith("\n\nYou're welcome.")
+    assert adapter.edits == []
 
 
 # ===================================================================

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -586,22 +586,6 @@ class CommentaryAgent:
         }
 
 
-class PreviewedResponseAgent:
-    def __init__(self, **kwargs):
-        self.interim_assistant_callback = kwargs.get("interim_assistant_callback")
-        self.tools = []
-
-    def run_conversation(self, message, conversation_history=None, task_id=None):
-        if self.interim_assistant_callback:
-            self.interim_assistant_callback("You're welcome.", already_streamed=False)
-        return {
-            "final_response": "You're welcome.",
-            "response_previewed": True,
-            "messages": [],
-            "api_calls": 1,
-        }
-
-
 class StreamingRefineAgent:
     def __init__(self, **kwargs):
         self.stream_delta_callback = kwargs.get("stream_delta_callback")
@@ -903,20 +887,6 @@ async def test_run_agent_bluebubbles_uses_commentary_send_path_for_quick_replies
     assert result.get("already_sent") is not True
     assert [call["content"] for call in adapter.sent] == ["I'll inspect the repo first."]
     assert adapter.edits == []
-
-
-@pytest.mark.asyncio
-async def test_run_agent_previewed_final_marks_already_sent(monkeypatch, tmp_path):
-    adapter, result = await _run_with_agent(
-        monkeypatch,
-        tmp_path,
-        PreviewedResponseAgent,
-        session_id="sess-previewed",
-        config_data={"display": {"interim_assistant_messages": True}},
-    )
-
-    assert result.get("already_sent") is True
-    assert [call["content"] for call in adapter.sent] == ["You're welcome."]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Fixes the Telegram `show_reasoning` delivery gap when Hermes preview-sends a quick final reply before the gateway finishes assembling the real final message.

Before this change, the previewed `"You're welcome."` style reply could be marked as already delivered inside `_run_agent_inner()`. Later, `_handle_message_with_agent()` prepended the `💭 Reasoning:` block and optional footer, but the normal final send was already suppressed, so Telegram users never saw the reasoning even though it was present in `agent_result["last_reasoning"]`.

This PR defers preview reconciliation until the final response text is fully assembled. The gateway now:

- tracks whether a previewed interim send actually succeeded and which message id it used
- compares the delivered preview text against the fully assembled final response
- suppresses only exact matches
- edits the existing preview bubble in place when the final response gained reasoning/footer content
- falls back to a normal final send when the preview cannot be edited

## Related Issue

Fixes #50193

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`
  - record preview-send confirmation, content, and message id for interim assistant replies
  - stop treating preview delivery as final delivery inside `_run_agent_inner()`
  - reconcile previewed replies only after `_handle_message_with_agent()` has added reasoning/footer text
  - edit the previewed message in place when the assembled final response differs
- `tests/gateway/test_duplicate_reply_suppression.py`
  - add `_handle_message_with_agent()` coverage for previewed-final suppression, preview edit with reasoning, and fallback when editing is unavailable
- `tests/gateway/test_run_progress_topics.py`
  - remove preview assertions from the `_run_agent()`-only test surface so the behavior is verified at the real final-send layer instead

## How to Test

1. Run:
   `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/gateway/test_duplicate_reply_suppression.py -q`
2. Run:
   `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/gateway/test_run_progress_topics.py -k 'commentary or matrix_streaming or transformed_response or rolls_progress_bubble' -q`
3. Confirm the new previewed-final tests show:
   - exact preview match -> final send suppressed without edit
   - reasoning-added final -> preview message edited in place
   - non-editable preview path -> full final response returned for normal delivery

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `pytest tests/gateway/test_duplicate_reply_suppression.py -q` -> `27 passed in 2.41s`
- `pytest tests/gateway/test_run_progress_topics.py -k 'commentary or matrix_streaming or transformed_response or rolls_progress_bubble' -q` -> `12 passed, 20 deselected in 4.15s`
