### PR TITLE
docs: fix hermes-agent skill slash command references

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -297,7 +297,6 @@ The registry of record is `hermes_cli/commands.py` — every consumer
 /tools               Manage tools (CLI)
 /toolsets            List toolsets (CLI)
 /skills              Search/install skills (CLI)
-/skill <name>        Load a skill into session
 /reload-skills       Re-scan ~/.hermes/skills/ for added/removed skills
 /reload              Reload .env variables into the running session (CLI)
 /reload-mcp          Reload MCP servers
@@ -343,7 +342,7 @@ The registry of record is `hermes_cli/commands.py` — every consumer
 
 ### Exit
 ```
-/quit (/exit, /q)    Exit CLI
+/quit (/exit)        Exit CLI
 ```
 
 ---

--- a/tests/skills/test_hermes_agent_skill_slash_commands.py
+++ b/tests/skills/test_hermes_agent_skill_slash_commands.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+
+SKILL_PATH = Path("skills/autonomous-ai-agents/hermes-agent/SKILL.md")
+COMMANDS_PATH = Path("hermes_cli/commands.py")
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_skill_docs_do_not_list_phantom_skill_command():
+    skill_text = _read(SKILL_PATH)
+    commands_text = _read(COMMANDS_PATH)
+
+    assert '/skill <name>' not in skill_text
+    assert 'CommandDef("skill"' not in commands_text
+
+
+def test_skill_docs_do_not_claim_q_exits_cli():
+    skill_text = _read(SKILL_PATH)
+    commands_text = _read(COMMANDS_PATH)
+
+    assert '/quit (/exit, /q)' not in skill_text
+    assert '/quit (/exit)' in skill_text
+    assert 'CommandDef("quit", "Exit the CLI (use --delete to also remove session history)", "Exit",' in commands_text
+    assert 'aliases=("exit",), args_hint="[--delete]")' in commands_text
+    assert 'CommandDef("queue", "Queue a prompt for the next turn (doesn\'t interrupt)", "Session",' in commands_text
+    assert 'aliases=("q",), args_hint="<prompt>")' in commands_text


### PR DESCRIPTION
Summary:
- remove the nonexistent /skill slash command from the hermes-agent bundled skill
- stop documenting /q as an alias for /quit now that /q queues prompts
- add a regression test that keeps the skill docs aligned with hermes_cli/commands.py

Testing:
- scripts/run_tests.sh tests/skills/test_hermes_agent_skill_slash_commands.py