### PR TITLE
fix: repair Yuanbao setup guide link in desktop messaging

### DIFF
--- a/apps/desktop/src/app/messaging/index.test.tsx
+++ b/apps/desktop/src/app/messaging/index.test.tsx
@@ -1,0 +1,59 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import type { MessagingPlatformInfo } from '@/types/hermes'
+
+import { PlatformDetail } from './index'
+
+function platform(patch: Partial<MessagingPlatformInfo> = {}): MessagingPlatformInfo {
+  return {
+    configured: false,
+    description: 'Connect Hermes to Tencent Yuanbao.',
+    docs_url: '',
+    enabled: false,
+    env_vars: [],
+    gateway_running: true,
+    id: 'yuanbao',
+    name: 'Yuanbao (元宝)',
+    state: 'not_configured',
+    ...patch
+  }
+}
+
+function renderPlatformDetail(value: MessagingPlatformInfo) {
+  return render(
+    <I18nProvider configClient={null} initialLocale="en">
+      <PlatformDetail
+        edits={{}}
+        onClear={vi.fn()}
+        onEdit={vi.fn()}
+        onSave={vi.fn()}
+        onToggle={vi.fn()}
+        platform={value}
+        saving={null}
+      />
+    </I18nProvider>
+  )
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('PlatformDetail', () => {
+  it('hides the setup guide button when no docs URL is configured', () => {
+    renderPlatformDetail(platform({ docs_url: '   ' }))
+
+    expect(screen.queryByRole('link', { name: 'Open setup guide' })).toBeNull()
+  })
+
+  it('renders the setup guide button with the configured docs URL', () => {
+    renderPlatformDetail(
+      platform({ docs_url: 'https://hermes-agent.nousresearch.com/docs/user-guide/messaging/yuanbao/' })
+    )
+
+    const link = screen.getByRole('link', { name: 'Open setup guide' })
+    expect(link.getAttribute('href')).toBe('https://hermes-agent.nousresearch.com/docs/user-guide/messaging/yuanbao/')
+  })
+})

--- a/apps/desktop/src/app/messaging/index.tsx
+++ b/apps/desktop/src/app/messaging/index.tsx
@@ -339,7 +339,7 @@ function PlatformRow({
   )
 }
 
-function PlatformDetail({
+export function PlatformDetail({
   edits,
   onClear,
   onEdit,
@@ -359,6 +359,7 @@ function PlatformDetail({
   const { t } = useI18n()
   const m = t.messaging
   const [showAdvanced, setShowAdvanced] = useState(false)
+  const docsUrl = platform.docs_url.trim()
 
   const hasEdits = Object.keys(trimEdits(edits)).length > 0
   const requiredFields = platform.env_vars.filter(field => field.required)
@@ -401,14 +402,16 @@ function PlatformDetail({
             <p className="mt-1 text-[length:var(--conversation-caption-font-size)] leading-(--conversation-caption-line-height) text-(--ui-text-tertiary)">
               {introCopy(platform, m)}
             </p>
-            <div className="mt-3">
-              <Button asChild size="sm" variant="textStrong">
-                <a href={platform.docs_url} rel="noreferrer" target="_blank">
-                  {m.openSetupGuide}
-                  <ExternalLink className="size-3.5" />
-                </a>
-              </Button>
-            </div>
+            {docsUrl && (
+              <div className="mt-3">
+                <Button asChild size="sm" variant="textStrong">
+                  <a href={docsUrl} rel="noreferrer" target="_blank">
+                    {m.openSetupGuide}
+                    <ExternalLink className="size-3.5" />
+                  </a>
+                </Button>
+              </div>
+            )}
           </section>
 
           <section>

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4511,7 +4511,7 @@ _PLATFORM_OVERRIDES: dict[str, dict[str, Any]] = {
     "yuanbao": {
         "name": "Yuanbao (元宝)",
         "description": "Connect Hermes to Tencent Yuanbao.",
-        "docs_url": "",
+        "docs_url": "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/yuanbao/",
         "required_env": (),
     },
     "api_server": {

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1647,6 +1647,20 @@ class TestWebServerEndpoints:
             assert "QR login" in fields[key]["description"]
             assert "Official Account" not in fields[key]["description"]
 
+    def test_yuanbao_messaging_metadata_exposes_setup_guide(self):
+        resp = self.client.get("/api/messaging/platforms")
+
+        assert resp.status_code == 200
+        yuanbao = next(
+            platform
+            for platform in resp.json()["platforms"]
+            if platform["id"] == "yuanbao"
+        )
+        assert yuanbao["name"] == "Yuanbao (元宝)"
+        assert yuanbao["docs_url"] == (
+            "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/yuanbao/"
+        )
+
     def test_messaging_catalog_covers_gateway_platforms(self):
         """Catalog is derived from the Platform enum, so every built-in shows up."""
         from gateway.config import Platform


### PR DESCRIPTION
Fixes #50597

## Summary
- add the Yuanbao messaging docs URL to the desktop/web messaging catalog
- hide the desktop setup-guide button when a platform has no docs URL, so blank links cannot resolve back to the packaged `index.html`
- add targeted backend and desktop regression tests for the setup-guide path

## Local proof
- `uv run --frozen pytest tests/hermes_cli/test_web_server.py -k yuanbao_messaging_metadata_exposes_setup_guide`
- `uv run --frozen ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_server.py`
- `npm run test:ui -- src/app/messaging/index.test.tsx`
- `npx eslint src/app/messaging/index.tsx src/app/messaging/index.test.tsx`
- `git diff --check`
