### PR TITLE
fix(api): wait for MCP discovery before REST agent snapshots

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1104,6 +1104,17 @@ class APIServerAdapter(BasePlatformAdapter):
 
         max_iterations = _current_max_iterations()
 
+        # If API-server startup kicked off MCP discovery in the background,
+        # briefly join it before constructing AIAgent. AIAgent snapshots tools
+        # during construction, so this bounded wait lets slow/cold MCP servers
+        # that are already starting register in time for the first REST turn
+        # while preserving prompt-cache safety and never blocking indefinitely.
+        try:
+            from hermes_cli.mcp_startup import wait_for_mcp_discovery
+            wait_for_mcp_discovery()
+        except Exception:
+            logger.debug("[%s] MCP discovery wait failed", self.name, exc_info=True)
+
         # Load fallback provider chain so the API server platform has the
         # same fallback behaviour as Telegram/Discord/Slack (fixes #4954).
         fallback_model = GatewayRunner._load_fallback_model()
@@ -4370,26 +4381,6 @@ class APIServerAdapter(BasePlatformAdapter):
             logger.warning("[%s] aiohttp not installed", self.name)
             return False
 
-        # Load configured MCP servers so REST/API sessions expose MCP tools,
-        # matching the TUI/gateway/ACP/CLI entrypoints which all kick off MCP
-        # discovery at startup (#50248). Without this, an API server started
-        # outside the full gateway-run path (e.g. as a standalone service)
-        # never connects MCP servers, so sessions created via POST
-        # /api/sessions and /v1/chat/completions get no MCP tools even when
-        # the mcp toolset is enabled. start_background_mcp_discovery is
-        # idempotent per-process and runs in a daemon thread, so it never
-        # blocks the asyncio loop and is a no-op when MCP discovery already
-        # ran (e.g. via gateway run) or no MCP servers are configured.
-        try:
-            from hermes_cli.mcp_startup import start_background_mcp_discovery
-            start_background_mcp_discovery(
-                logger=logger, thread_name=f"{self.name}-mcp-discovery"
-            )
-        except Exception:
-            logger.debug(
-                "[%s] MCP discovery kickoff failed", self.name, exc_info=True
-            )
-
         try:
             mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
             self._app = web.Application(middlewares=mws, client_max_size=MAX_REQUEST_BYTES)
@@ -4520,6 +4511,24 @@ class APIServerAdapter(BasePlatformAdapter):
                 return False
             except (ConnectionRefusedError, OSError):
                 pass  # port is free
+
+            # Load configured MCP servers so REST/API sessions expose MCP tools,
+            # matching the TUI/gateway/ACP/CLI entrypoints which all kick off
+            # MCP discovery at startup (#50248). Do this only after startup
+            # refusal gates pass so a missing/weak API_SERVER_KEY cannot spawn
+            # configured MCP subprocesses or open remote MCP connections. The
+            # bounded pre-agent wait in _create_agent() gives fast/cold servers
+            # a chance to register before AIAgent snapshots tools without
+            # blocking startup indefinitely.
+            try:
+                from hermes_cli.mcp_startup import start_background_mcp_discovery
+                start_background_mcp_discovery(
+                    logger=logger, thread_name=f"{self.name}-mcp-discovery"
+                )
+            except Exception:
+                logger.debug(
+                    "[%s] MCP discovery kickoff failed", self.name, exc_info=True
+                )
 
             self._runner = web.AppRunner(self._app)
             await self._runner.setup()

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4370,6 +4370,26 @@ class APIServerAdapter(BasePlatformAdapter):
             logger.warning("[%s] aiohttp not installed", self.name)
             return False
 
+        # Load configured MCP servers so REST/API sessions expose MCP tools,
+        # matching the TUI/gateway/ACP/CLI entrypoints which all kick off MCP
+        # discovery at startup (#50248). Without this, an API server started
+        # outside the full gateway-run path (e.g. as a standalone service)
+        # never connects MCP servers, so sessions created via POST
+        # /api/sessions and /v1/chat/completions get no MCP tools even when
+        # the mcp toolset is enabled. start_background_mcp_discovery is
+        # idempotent per-process and runs in a daemon thread, so it never
+        # blocks the asyncio loop and is a no-op when MCP discovery already
+        # ran (e.g. via gateway run) or no MCP servers are configured.
+        try:
+            from hermes_cli.mcp_startup import start_background_mcp_discovery
+            start_background_mcp_discovery(
+                logger=logger, thread_name=f"{self.name}-mcp-discovery"
+            )
+        except Exception:
+            logger.debug(
+                "[%s] MCP discovery kickoff failed", self.name, exc_info=True
+            )
+
         try:
             mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
             self._app = web.Application(middlewares=mws, client_max_size=MAX_REQUEST_BYTES)

--- a/tests/gateway/test_api_server_toolset.py
+++ b/tests/gateway/test_api_server_toolset.py
@@ -124,3 +124,28 @@ class TestApiServerAdapterToolset:
             call_kwargs = mock_agent_cls.call_args
             toolsets = call_kwargs.kwargs.get("enabled_toolsets")
             assert sorted(toolsets) == ["terminal", "web"]
+
+    @patch("gateway.platforms.api_server.AIOHTTP_AVAILABLE", True)
+    def test_connect_triggers_mcp_discovery(self):
+        """connect() kicks off MCP discovery so REST/API sessions get MCP tools.
+
+        Regression for #50248: API sessions had no MCP tools because the
+        api_server adapter never loaded configured MCP servers, unlike the
+        TUI/gateway/ACP/CLI entrypoints which all run MCP discovery at startup.
+        The adapter must call start_background_mcp_discovery() from connect()
+        (idempotent + non-blocking)."""
+        import asyncio
+        from gateway.platforms.api_server import APIServerAdapter
+        from gateway.config import PlatformConfig
+
+        adapter = APIServerAdapter(PlatformConfig())
+        # Empty API key makes connect() return early AFTER the MCP discovery
+        # kickoff, so no real web server binds during the test.
+        adapter._api_key = ""
+        with patch("hermes_cli.mcp_startup.start_background_mcp_discovery") as mock_disc:
+            result = asyncio.run(adapter.connect())
+
+        assert result is False
+        mock_disc.assert_called_once()
+        assert mock_disc.call_args.kwargs.get("logger") is not None
+        assert "mcp" in mock_disc.call_args.kwargs.get("thread_name", "")

--- a/tests/gateway/test_api_server_toolset.py
+++ b/tests/gateway/test_api_server_toolset.py
@@ -1,5 +1,5 @@
 """Tests for hermes-api-server toolset and API server tool availability."""
-from unittest.mock import patch, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 
 from toolsets import resolve_toolset, get_toolset, validate_toolset
@@ -126,26 +126,91 @@ class TestApiServerAdapterToolset:
             assert sorted(toolsets) == ["terminal", "web"]
 
     @patch("gateway.platforms.api_server.AIOHTTP_AVAILABLE", True)
-    def test_connect_triggers_mcp_discovery(self):
-        """connect() kicks off MCP discovery so REST/API sessions get MCP tools.
+    def test_create_agent_waits_for_mcp_discovery_before_tool_snapshot(self):
+        """Agent construction waits briefly for MCP discovery before tools snapshot.
 
-        Regression for #50248: API sessions had no MCP tools because the
-        api_server adapter never loaded configured MCP servers, unlike the
-        TUI/gateway/ACP/CLI entrypoints which all run MCP discovery at startup.
-        The adapter must call start_background_mcp_discovery() from connect()
-        (idempotent + non-blocking)."""
+        Regression: connect() starts MCP discovery in the background, but the
+        first REST request can call _create_agent() immediately. AIAgent
+        snapshots tools during construction, so the API path must perform the
+        same bounded wait as the CLI before constructing the agent.
+        """
+        from gateway.platforms.api_server import APIServerAdapter
+        from gateway.config import PlatformConfig
+
+        adapter = APIServerAdapter(PlatformConfig())
+        calls = []
+
+        def _wait():
+            calls.append("wait")
+
+        def _make_agent(*args, **kwargs):
+            calls.append("agent")
+            return MagicMock()
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs") as mock_kwargs, \
+             patch("gateway.run._resolve_gateway_model") as mock_model, \
+             patch("gateway.run._load_gateway_config") as mock_config, \
+             patch("hermes_cli.mcp_startup.wait_for_mcp_discovery", side_effect=_wait) as mock_wait, \
+             patch("run_agent.AIAgent", side_effect=_make_agent) as mock_agent_cls:
+
+            mock_kwargs.return_value = {"api_key": "test-key", "base_url": None,
+                                        "provider": None, "api_mode": None,
+                                        "command": None, "args": []}
+            mock_model.return_value = "test/model"
+            mock_config.return_value = {}
+
+            adapter._create_agent()
+
+        mock_wait.assert_called_once()
+        mock_agent_cls.assert_called_once()
+        assert calls == ["wait", "agent"]
+
+    @patch("gateway.platforms.api_server.AIOHTTP_AVAILABLE", True)
+    def test_connect_missing_api_key_does_not_trigger_mcp_discovery(self):
+        """Rejected API-server startup must not spawn MCP subprocesses/connections."""
         import asyncio
         from gateway.platforms.api_server import APIServerAdapter
         from gateway.config import PlatformConfig
 
         adapter = APIServerAdapter(PlatformConfig())
-        # Empty API key makes connect() return early AFTER the MCP discovery
-        # kickoff, so no real web server binds during the test.
         adapter._api_key = ""
         with patch("hermes_cli.mcp_startup.start_background_mcp_discovery") as mock_disc:
             result = asyncio.run(adapter.connect())
 
         assert result is False
+        mock_disc.assert_not_called()
+
+    @patch("gateway.platforms.api_server.AIOHTTP_AVAILABLE", True)
+    def test_connect_valid_api_key_triggers_mcp_discovery(self):
+        """connect() kicks off MCP discovery only after API key startup gates pass.
+
+        Regression for #50248: API sessions had no MCP tools because the
+        api_server adapter never loaded configured MCP servers, unlike the
+        TUI/gateway/ACP/CLI entrypoints which all run MCP discovery at startup.
+        The adapter must call start_background_mcp_discovery() from connect()
+        for a valid keyed server, while refused startups must not create MCP
+        subprocess/remote side effects.
+        """
+        import asyncio
+        from gateway.platforms.api_server import APIServerAdapter
+        from gateway.config import PlatformConfig
+
+        adapter = APIServerAdapter(PlatformConfig())
+        adapter._api_key = "valid-test-key"
+        adapter._host = "127.0.0.1"
+        with patch("socket.socket") as mock_socket_cls, \
+             patch("hermes_cli.mcp_startup.start_background_mcp_discovery") as mock_disc, \
+             patch("gateway.platforms.api_server.web.AppRunner") as mock_runner_cls, \
+             patch("gateway.platforms.api_server.web.TCPSite") as mock_site_cls:
+            mock_socket_cls.return_value.__enter__.return_value.connect.side_effect = ConnectionRefusedError
+            mock_runner_cls.return_value.setup = AsyncMock()
+            mock_runner_cls.return_value.cleanup = AsyncMock()
+            mock_site_cls.return_value.start = AsyncMock()
+            mock_site_cls.return_value.stop = AsyncMock()
+
+            result = asyncio.run(adapter.connect())
+
+        assert result is True
         mock_disc.assert_called_once()
         assert mock_disc.call_args.kwargs.get("logger") is not None
         assert "mcp" in mock_disc.call_args.kwargs.get("thread_name", "")


### PR DESCRIPTION
## Summary
- Corrective follow-up for #50587 after Kanban review found API MCP discovery readiness blockers.
- Moves API-server MCP discovery kickoff after API key / weak-key startup gates so refused startup does not spawn MCP subprocesses or remote MCP connections.
- Adds a bounded `wait_for_mcp_discovery()` before API-server REST agent construction so the first REST agent snapshots MCP tools after discovery has had a chance to finish.
- Adds regression coverage for valid startup discovery, missing-key no-discovery, and pre-agent wait ordering.

## Provenance
- Based on PR #50587 head `e675ac78847b4ca83c2b8e7fb7520796f246ecb4`.
- Local approved commit: `c53f914d5` (`fix(api): wait for MCP discovery before REST agent snapshots`).
- Kanban source task: `t_fee9cfec`; reviewer gate: `t_7b86a27b` APPROVED/PASS.
- Direct push to `trevorgordon981/hermes-agent:fix/50248-mcp-rest-sessions` was previously denied with GitHub 403 despite `maintainerCanModify=true`, so this PR publishes the approved local corrective commit from an authorized fork without force-pushing to the contributor branch.

## Test plan
- `python -m pytest tests/gateway/test_api_server_toolset.py::TestApiServerAdapterToolset::test_create_agent_waits_for_mcp_discovery_before_tool_snapshot tests/gateway/test_api_server_toolset.py::TestApiServerAdapterToolset::test_connect_missing_api_key_does_not_trigger_mcp_discovery tests/gateway/test_api_server_toolset.py::TestApiServerAdapterToolset::test_connect_valid_api_key_triggers_mcp_discovery -q -o 'addopts='` -> 3 passed, 4 warnings
- `python -m py_compile gateway/platforms/api_server.py tests/gateway/test_api_server_toolset.py` -> passed
