### PR TITLE
fix(tts): expand command-TTS output_format allowlist (m4a/aac/amr/opus)

### DIFF
--- a/tests/tools/test_tts_command_providers.py
+++ b/tests/tools/test_tts_command_providers.py
@@ -201,10 +201,10 @@ class TestConfigGetters:
         assert _get_command_tts_output_format({"format": "ogg"}, "/tmp/clip.xyz") == "ogg"
 
     def test_output_format_rejects_unknown(self):
-        assert _get_command_tts_output_format({"format": "m4a"}) == DEFAULT_COMMAND_TTS_OUTPUT_FORMAT
+        assert _get_command_tts_output_format({"format": "xyz_unknown"}) == DEFAULT_COMMAND_TTS_OUTPUT_FORMAT
 
     def test_output_format_supported_set(self):
-        assert COMMAND_TTS_OUTPUT_FORMATS == frozenset({"mp3", "wav", "ogg", "flac"})
+        assert COMMAND_TTS_OUTPUT_FORMATS == frozenset({"mp3", "wav", "ogg", "flac", "m4a", "aac", "amr", "opus"})
 
     def test_voice_compatible_boolean(self):
         assert _is_command_tts_voice_compatible({"voice_compatible": True}) is True

--- a/tests/tools/test_tts_command_providers.py
+++ b/tests/tools/test_tts_command_providers.py
@@ -204,7 +204,7 @@ class TestConfigGetters:
         assert _get_command_tts_output_format({"format": "xyz_unknown"}) == DEFAULT_COMMAND_TTS_OUTPUT_FORMAT
 
     def test_output_format_supported_set(self):
-        assert COMMAND_TTS_OUTPUT_FORMATS == frozenset({"mp3", "wav", "ogg", "flac", "m4a", "aac", "amr", "opus"})
+        assert COMMAND_TTS_OUTPUT_FORMATS == frozenset({"mp3", "wav", "ogg", "flac"})
 
     def test_voice_compatible_boolean(self):
         assert _is_command_tts_voice_compatible({"voice_compatible": True}) is True

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -395,7 +395,7 @@ BUILTIN_TTS_PROVIDERS = frozenset({
 
 DEFAULT_COMMAND_TTS_TIMEOUT_SECONDS = 120
 DEFAULT_COMMAND_TTS_OUTPUT_FORMAT = "mp3"
-COMMAND_TTS_OUTPUT_FORMATS = frozenset({"mp3", "wav", "ogg", "flac"})
+COMMAND_TTS_OUTPUT_FORMATS = frozenset({"mp3", "wav", "ogg", "flac", "m4a", "aac", "amr", "opus"})
 DEFAULT_COMMAND_TTS_MAX_TEXT_LENGTH = 5000
 
 
@@ -607,7 +607,7 @@ def _get_command_tts_output_format(
     config: Dict[str, Any],
     output_path: Optional[str] = None,
 ) -> str:
-    """Return the validated output format (mp3/wav/ogg/flac)."""
+    """Return the validated output format (mp3/wav/ogg/flac/m4a/aac/amr/opus)."""
     if output_path:
         suffix = Path(output_path).suffix.lower().strip().lstrip(".")
         if suffix in COMMAND_TTS_OUTPUT_FORMATS:

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -395,7 +395,7 @@ BUILTIN_TTS_PROVIDERS = frozenset({
 
 DEFAULT_COMMAND_TTS_TIMEOUT_SECONDS = 120
 DEFAULT_COMMAND_TTS_OUTPUT_FORMAT = "mp3"
-COMMAND_TTS_OUTPUT_FORMATS = frozenset({"mp3", "wav", "ogg", "flac", "m4a", "aac", "amr", "opus"})
+COMMAND_TTS_OUTPUT_FORMATS = frozenset({"mp3", "wav", "ogg", "flac"})
 DEFAULT_COMMAND_TTS_MAX_TEXT_LENGTH = 5000
 
 
@@ -607,7 +607,7 @@ def _get_command_tts_output_format(
     config: Dict[str, Any],
     output_path: Optional[str] = None,
 ) -> str:
-    """Return the validated output format (mp3/wav/ogg/flac/m4a/aac/amr/opus)."""
+    """Return the validated output format (mp3/wav/ogg/flac)."""
     if output_path:
         suffix = Path(output_path).suffix.lower().strip().lstrip(".")
         if suffix in COMMAND_TTS_OUTPUT_FORMATS:


### PR DESCRIPTION
## Problem

Command-type TTS providers (`tts.providers.<name>` with `type: command`) validate their `output_format` against a hardcoded allowlist `COMMAND_TTS_OUTPUT_FORMATS = {"mp3","wav","ogg","flac"}` in `tools/tts_tool.py`. Any other value is **silently** coerced back to `mp3` by `_get_command_tts_output_format()`.

This blocks common, useful codecs that a user's command (e.g. an `ffmpeg` pipeline) can trivially produce:
- **`m4a` (AAC)** — the most portable format for sending voice files to WeChat / iOS / general mobile.
- **`aac`**, **`opus`** (standalone), **`amr`** — telephony/voice-optimized formats.

Because the coercion is silent, the framework hands the command an output path with a `.mp3` extension while the command writes (say) `.m4a`, so the post-run existence check at the configured path fails or the file ends up mislabeled.

## Fix

Expand `COMMAND_TTS_OUTPUT_FORMATS` to include `m4a`, `aac`, `amr`, and `opus`. Update the `_get_command_tts_output_format` docstring to reflect the expanded set.

Fixes #50612