### PR TITLE
feat(tools): expand command TTS output_format allowlist (m4a/aac/amr/opus)

### DIFF
--- a/tests/tools/test_tts_command_providers.py
+++ b/tests/tools/test_tts_command_providers.py
@@ -201,10 +201,19 @@ class TestConfigGetters:
         assert _get_command_tts_output_format({"format": "ogg"}, "/tmp/clip.xyz") == "ogg"
 
     def test_output_format_rejects_unknown(self):
-        assert _get_command_tts_output_format({"format": "m4a"}) == DEFAULT_COMMAND_TTS_OUTPUT_FORMAT
+        assert _get_command_tts_output_format({"format": "midi"}) == DEFAULT_COMMAND_TTS_OUTPUT_FORMAT
 
     def test_output_format_supported_set(self):
-        assert COMMAND_TTS_OUTPUT_FORMATS == frozenset({"mp3", "wav", "ogg", "flac"})
+        assert COMMAND_TTS_OUTPUT_FORMATS == frozenset(
+            {"mp3", "wav", "ogg", "flac", "m4a", "aac", "amr", "opus"}
+        )
+
+    def test_output_format_accepts_extended_formats(self):
+        # m4a/aac/amr/opus are common ffmpeg-producible containers/codecs;
+        # honored both via explicit config and via the output path suffix.
+        for fmt in ("m4a", "aac", "amr", "opus"):
+            assert _get_command_tts_output_format({"format": fmt}) == fmt
+            assert _get_command_tts_output_format({}, f"/tmp/clip.{fmt}") == fmt
 
     def test_voice_compatible_boolean(self):
         assert _is_command_tts_voice_compatible({"voice_compatible": True}) is True

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -395,7 +395,9 @@ BUILTIN_TTS_PROVIDERS = frozenset({
 
 DEFAULT_COMMAND_TTS_TIMEOUT_SECONDS = 120
 DEFAULT_COMMAND_TTS_OUTPUT_FORMAT = "mp3"
-COMMAND_TTS_OUTPUT_FORMATS = frozenset({"mp3", "wav", "ogg", "flac"})
+COMMAND_TTS_OUTPUT_FORMATS = frozenset(
+    {"mp3", "wav", "ogg", "flac", "m4a", "aac", "amr", "opus"}
+)
 DEFAULT_COMMAND_TTS_MAX_TEXT_LENGTH = 5000
 
 

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -266,6 +266,8 @@ tts:
       output_format: wav
 ```
 
+**Supported `output_format` values:** `mp3` (default), `wav`, `ogg`, `flac`, `m4a`, `aac`, `amr`, `opus`. Your command must actually produce that format (e.g. via `ffmpeg`); Hermes only validates the declared value and names the output file accordingly. An unknown value falls back to `mp3`. The chosen format is also exposed to the command as the `{format}` placeholder.
+
 #### Example: Doubao (Chinese seed-tts-2.0)
 
 For high-quality Chinese TTS via ByteDance's [seed-tts-2.0](https://www.volcengine.com/docs/6561/1257544) bidirectional-streaming API, install the [`doubao-speech`](https://pypi.org/project/doubao-speech/) PyPI package and wire it in as a command provider:


### PR DESCRIPTION
## What does this PR do?

Command-type TTS providers (`tts.providers.<name>`, `type: command`) validated `output_format` against a hardcoded `{mp3,wav,ogg,flac}` allowlist; any other value was silently coerced back to `mp3`, which then mismatched the output path the post-run existence check expects. This blocked common ffmpeg-producible containers/codecs — notably **m4a (AAC)**, the portable choice for WeChat/iOS/mobile voice files — with no config-only path (only a local source patch, lost on every `hermes update`).

This widens `COMMAND_TTS_OUTPUT_FORMATS` to add `m4a`, `aac`, `amr`, `opus`. It only *permits* a command provider to declare these; the command still produces the file (e.g. via `ffmpeg`). No built-in provider behavior changes and no new required config.

## Related Issue

Closes #50612

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/tts_tool.py`: add `m4a`, `aac`, `amr`, `opus` to `COMMAND_TTS_OUTPUT_FORMATS`.
- `tests/tools/test_tts_command_providers.py`: update the two tests that pinned the old set (`test_output_format_supported_set`, `test_output_format_rejects_unknown`), add `test_output_format_accepts_extended_formats`.
- `website/docs/user-guide/features/tts.md`: document the supported `output_format` values under the command-provider section.

## How to Test

1. Declare a command provider with `output_format: m4a` whose command emits AAC via ffmpeg.
2. Call `text_to_speech`; confirm the file is a valid `.m4a` (AAC-LC) instead of coerced `.mp3`.
3. `pytest tests/tools/test_tts_command_providers.py -q` -> 53 passed.

## Checklist

- [x] Read the Contributing Guide
- [x] Conventional Commits (`feat(tools):`)
- [x] Searched existing PRs (closest #37337 is orthogonal)
- [x] PR contains only changes related to this feature
- [x] Ran `pytest tests/tools/test_tts_command_providers.py -q`, all 53 pass
- [x] Added tests
- [x] Tested on macOS 15 (Apple Silicon), end-to-end valid AAC-LC .m4a
- [x] Updated docs (`tts.md`)
