### PR TITLE
fix(dingtalk): add circuit breaker to stream reconnect loop to prevent log storm (#24851)

### DIFF
--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -306,26 +306,69 @@ class DingTalkAdapter(BasePlatformAdapter):
             return False
 
     async def _run_stream(self) -> None:
-        """Run the async stream client with auto-reconnection."""
+        """Run the async stream client with auto-reconnection.
+
+        Uses exponential backoff (RECONNECT_BACKOFF) capped at 60 s.
+        A circuit breaker prevents a hot reconnection storm: if the same
+        *type* of error recurs _RECONNECT_CIRCUIT_BREAKER_TRIPS consecutive
+        times without a successful connection, the loop sleeps for
+        _RECONNECT_CIRCUIT_BREAKER_DELAY seconds before trying again so
+        the gateway does not generate hundreds of megabytes of logs.
+        The backoff index is reset after a successful start() call so that
+        a recovered connection is treated as a fresh attempt.
+        """
+        _RECONNECT_CIRCUIT_BREAKER_TRIPS = 5
+        _RECONNECT_CIRCUIT_BREAKER_DELAY = 300  # 5 minutes
         backoff_idx = 0
+        consecutive_same_error = 0
+        last_error_type: type | None = None
         while self._running:
             try:
                 logger.debug("[%s] Starting stream client...", self.name)
                 await self._stream_client.start()
+                # start() returned normally (clean disconnect) — reset state.
+                backoff_idx = 0
+                consecutive_same_error = 0
+                last_error_type = None
             except asyncio.CancelledError:
                 return
             except Exception as e:
                 if not self._running:
                     return
-                logger.warning("[%s] Stream client error: %s", self.name, e)
+                # Circuit breaker: suppress repeated identical errors to
+                # avoid flooding the log with thousands of duplicate lines.
+                error_type = type(e)
+                if error_type is last_error_type:
+                    consecutive_same_error += 1
+                else:
+                    consecutive_same_error = 1
+                    last_error_type = error_type
+                if consecutive_same_error <= _RECONNECT_CIRCUIT_BREAKER_TRIPS:
+                    logger.warning("[%s] Stream client error: %s", self.name, e)
+                elif consecutive_same_error == _RECONNECT_CIRCUIT_BREAKER_TRIPS + 1:
+                    logger.error(
+                        "[%s] Stream client error repeated %d times: %s — "
+                        "entering circuit-breaker pause (%ds). "
+                        "Further attempts suppressed until next pause cycle.",
+                        self.name, consecutive_same_error, e,
+                        _RECONNECT_CIRCUIT_BREAKER_DELAY,
+                    )
+                # else: suppress repeated log line to avoid storm
 
             if not self._running:
                 return
 
-            delay = RECONNECT_BACKOFF[min(backoff_idx, len(RECONNECT_BACKOFF) - 1)]
-            logger.info("[%s] Reconnecting in %ds...", self.name, delay)
-            await asyncio.sleep(delay)
-            backoff_idx += 1
+            if consecutive_same_error > _RECONNECT_CIRCUIT_BREAKER_TRIPS:
+                # Use a long pause to prevent log storms.
+                await asyncio.sleep(_RECONNECT_CIRCUIT_BREAKER_DELAY)
+                # Reset consecutive counter after the pause so we get at least
+                # one fresh warning log on the next attempt.
+                consecutive_same_error = 0
+            else:
+                delay = RECONNECT_BACKOFF[min(backoff_idx, len(RECONNECT_BACKOFF) - 1)]
+                logger.info("[%s] Reconnecting in %ds...", self.name, delay)
+                await asyncio.sleep(delay)
+                backoff_idx += 1
 
     async def disconnect(self) -> None:
         """Disconnect from DingTalk."""

--- a/tests/gateway/test_dingtalk_reconnect_circuit_breaker.py
+++ b/tests/gateway/test_dingtalk_reconnect_circuit_breaker.py
@@ -1,0 +1,166 @@
+"""
+Tests for #24851 — DingTalk reconnection storm causes gateway to hang.
+
+When DingTalkStreamClient.start() raises the same TypeError on every call,
+the reconnection loop must:
+  1. Log the first N failures, then stop logging repeated identical errors.
+  2. After _RECONNECT_CIRCUIT_BREAKER_TRIPS consecutive failures, enter a
+     long pause instead of spinning at the 60 s normal backoff.
+  3. Reset backoff_idx after a clean start() call so a recovered connection
+     is treated as a fresh start.
+"""
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_dingtalk_adapter():
+    """Build a minimal DingTalkAdapter with mocked internals."""
+    try:
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        from gateway.config import Platform
+    except ImportError:
+        pytest.skip("dingtalk-stream not available; skipping")
+
+    # Build a minimal DingTalkAdapter without going through __init__ which
+    # tries to import and configure the real SDK.
+    adapter = DingTalkAdapter.__new__(DingTalkAdapter)
+    # The base class `name` property reads self.platform.value.title()
+    adapter.platform = Platform.DINGTALK
+    adapter._running = True
+    adapter._stream_client = MagicMock()
+    adapter._stream_task = None
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_kicks_in_after_repeated_failures():
+    """After TRIPS consecutive identical errors, loop sleeps CIRCUIT_BREAKER_DELAY, not 60 s."""
+    adapter = _make_dingtalk_adapter()
+    trips = 5  # _RECONNECT_CIRCUIT_BREAKER_TRIPS
+    call_count = 0
+    sleep_durations = []
+
+    async def fake_start():
+        nonlocal call_count
+        call_count += 1
+        if call_count > trips + 1:
+            # Stop the loop after one circuit-breaker sleep
+            adapter._running = False
+            return
+        raise TypeError("'coroutine' object does not support the asynchronous context manager protocol")
+
+    async def fake_sleep(secs):
+        sleep_durations.append(secs)
+
+    adapter._stream_client.start = fake_start
+
+    with patch("asyncio.sleep", side_effect=fake_sleep):
+        await adapter._run_stream()
+
+    # After TRIPS+1 errors we expect a 300 s circuit-breaker sleep (not 60 s)
+    assert any(s >= 300 for s in sleep_durations), (
+        f"Expected at least one >=300 s sleep; got: {sleep_durations}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_first_few_errors_are_logged(caplog):
+    """The first TRIPS errors must be logged at WARNING; later ones must be suppressed."""
+    adapter = _make_dingtalk_adapter()
+    trips = 5
+    call_count = 0
+
+    async def fake_start():
+        nonlocal call_count
+        call_count += 1
+        if call_count > trips + 2:
+            adapter._running = False
+            return
+        raise TypeError("coroutine error")
+
+    async def fake_sleep(secs):
+        pass
+
+    adapter._stream_client.start = fake_start
+
+    with caplog.at_level(logging.WARNING):
+        with patch("asyncio.sleep", side_effect=fake_sleep):
+            await adapter._run_stream()
+
+    warning_lines = [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING and "Stream client error" in r.message
+    ]
+    # The circuit breaker fires after TRIPS consecutive errors; after one
+    # circuit-breaker pause the counter resets so at most one more warning
+    # can appear. Total WARNING lines must be < total calls - 1 (i.e. the
+    # repeated storm of identical lines is suppressed).
+    # We allow up to TRIPS+1 warnings (TRIPS before CB fires, 1 after reset).
+    assert len(warning_lines) <= trips + 1, (
+        f"Too many warning log lines ({len(warning_lines)}); storm suppression not working"
+    )
+
+
+@pytest.mark.asyncio
+async def test_backoff_resets_after_clean_connection():
+    """If start() returns cleanly (no error), backoff_idx should reset."""
+    adapter = _make_dingtalk_adapter()
+    call_count = 0
+    sleep_durations = []
+
+    async def fake_start():
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # First call: raise an error to advance backoff_idx
+            raise ConnectionError("network blip")
+        if call_count == 2:
+            # Second call: succeed (simulate recovered connection)
+            return
+        # Third call: error again (should use backoff index 0 = 2 s, not the advanced index)
+        adapter._running = False
+        raise ConnectionError("network blip again")
+
+    async def fake_sleep(secs):
+        sleep_durations.append(secs)
+
+    adapter._stream_client.start = fake_start
+
+    from plugins.platforms.dingtalk.adapter import RECONNECT_BACKOFF
+
+    with patch("asyncio.sleep", side_effect=fake_sleep):
+        await adapter._run_stream()
+
+    # After the clean connection (call 2), the backoff should reset.
+    # The third error triggers backoff_idx=0 → RECONNECT_BACKOFF[0] = 2 s.
+    assert RECONNECT_BACKOFF[0] in sleep_durations, (
+        f"Backoff did not reset after clean connection; sleep durations: {sleep_durations}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancelled_error_exits_cleanly():
+    """asyncio.CancelledError must cause immediate exit without looping."""
+    adapter = _make_dingtalk_adapter()
+
+    async def fake_start():
+        raise asyncio.CancelledError()
+
+    adapter._stream_client.start = fake_start
+
+    with patch("asyncio.sleep", new=AsyncMock()):
+        # Should return without re-raising or hanging
+        await adapter._run_stream()
+    # If we reach here, exit was clean.


### PR DESCRIPTION
## Summary
- Adds a per-error-type **circuit breaker** to the DingTalk stream-mode reconnect loop so a persistent failure can no longer storm the gateway with logs or hang it.
- User-facing impact: a misbehaving DingTalk connection now pauses (5 min) and stops flooding logs after 5 identical errors, instead of spinning at the 60 s backoff cap forever.

## Motivation
Closes #24851. In `plugins/platforms/dingtalk/adapter.py::_run_stream`, when `start()` raises the same error every cycle (e.g. the known `'coroutine' object does not support the async context manager protocol` TypeError), the loop logs a WARNING and reconnects at the 60 s cap indefinitely — generating hundreds of MB of identical log lines and effectively hanging the gateway.

This adds a circuit breaker: after 5 consecutive **identical-type** errors, the repeated WARNING is suppressed (a single ERROR summarises the situation) and the loop pauses for 300 s instead of spinning. Backoff index and counters reset after a clean `start()` so a recovered connection is treated as a fresh attempt.

## Salvage note
This is a salvage / re-implementation of my own stale PR **#24881**, which targeted the old `gateway/platforms/dingtalk.py`. Current `main` refactored that file to `plugins/platforms/dingtalk/adapter.py`, leaving #24881 CONFLICTING. Same fix logic, rebuilt cleanly on current `main`; the regression test imports the new module path. #24881 will be closed as superseded by this PR.

## Verification
- `pytest tests/gateway/test_dingtalk_reconnect_circuit_breaker.py -q` — **4 passed**.
- Verified the 2 circuit-breaker tests **FAIL on clean `main`** (no breaker) and **PASS with this change** — they genuinely guard the fix.
- Confirmed the bug still exists on current `main`: `_run_stream` had no breaker, just `logger.warning(...)` + reconnect.
- `py_compile` clean on both changed files.

## Changes Made
- `plugins/platforms/dingtalk/adapter.py` — circuit-breaker logic in `_run_stream` (consecutive same-error tracking, suppressed repeated WARNING + one ERROR summary, 300 s pause, state reset on clean start).
- `tests/gateway/test_dingtalk_reconnect_circuit_breaker.py` — 4 tests: breaker trips after N failures, log-storm suppression, backoff reset after clean connection, clean `CancelledError` exit.
