### PR TITLE
fix(docs): use python instead of python3 in GitHub skill shell examples for Windows compat

### DIFF
--- a/skills/github/github-auth/scripts/gh-env.sh
+++ b/skills/github/github-auth/scripts/gh-env.sh
@@ -39,7 +39,7 @@ fi
 if [ "$GH_AUTH_METHOD" = "curl" ] && [ -z "$GH_USER" ]; then
     GH_USER=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
         https://api.github.com/user 2>/dev/null \
-        | python3 -c "import sys,json; print(json.load(sys.stdin).get('login',''))" 2>/dev/null)
+        | python -c "import sys,json; print(json.load(sys.stdin).get('login',''))" 2>/dev/null)
 fi
 
 # --- Repo detection (if inside a git repo with a GitHub remote) ---

--- a/skills/github/github-code-review/SKILL.md
+++ b/skills/github/github-code-review/SKILL.md
@@ -144,7 +144,7 @@ PR_NUMBER=123
 curl -s \
   -H "Authorization: token $GITHUB_TOKEN" \
   https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER \
-  | python3 -c "
+  | python -c "
 import sys, json
 pr = json.load(sys.stdin)
 print(f\"Title: {pr['title']}\")
@@ -157,7 +157,7 @@ print(f\"Body:\n{pr['body']}\")"
 curl -s \
   -H "Authorization: token $GITHUB_TOKEN" \
   https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER/files \
-  | python3 -c "
+  | python -c "
 import sys, json
 for f in json.load(sys.stdin):
     print(f\"{f['status']:10} +{f['additions']:-4} -{f['deletions']:-4}  {f['filename']}\")"
@@ -224,7 +224,7 @@ gh api repos/$OWNER/$REPO/pulls/123/comments \
 HEAD_SHA=$(curl -s \
   -H "Authorization: token $GITHUB_TOKEN" \
   https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['head']['sha'])")
+  | python -c "import sys,json; print(json.load(sys.stdin)['head']['sha'])")
 
 curl -s -X POST \
   -H "Authorization: token $GITHUB_TOKEN" \
@@ -254,7 +254,7 @@ gh pr review 123 --comment --body "Some suggestions, nothing blocking."
 HEAD_SHA=$(curl -s \
   -H "Authorization: token $GITHUB_TOKEN" \
   https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['head']['sha'])")
+  | python -c "import sys,json; print(json.load(sys.stdin)['head']['sha'])")
 
 curl -s -X POST \
   -H "Authorization: token $GITHUB_TOKEN" \
@@ -419,7 +419,7 @@ gh pr review $PR_NUMBER --request-changes --body "Found a few issues — see inl
 ```bash
 HEAD_SHA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
   https://api.github.com/repos/$GH_OWNER/$GH_REPO/pulls/$PR_NUMBER \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['head']['sha'])")
+  | python -c "import sys,json; print(json.load(sys.stdin)['head']['sha'])")
 
 # Build the review JSON — event is APPROVE, REQUEST_CHANGES, or COMMENT
 curl -s -X POST \

--- a/skills/github/github-issues/SKILL.md
+++ b/skills/github/github-issues/SKILL.md
@@ -63,7 +63,7 @@ gh issue view 42
 curl -s \
   -H "Authorization: token $GITHUB_TOKEN" \
   "https://api.github.com/repos/$OWNER/$REPO/issues?state=open&per_page=20" \
-  | python3 -c "
+  | python -c "
 import sys, json
 for i in json.load(sys.stdin):
     if 'pull_request' not in i:  # GitHub API returns PRs in /issues too
@@ -74,7 +74,7 @@ for i in json.load(sys.stdin):
 curl -s \
   -H "Authorization: token $GITHUB_TOKEN" \
   "https://api.github.com/repos/$OWNER/$REPO/issues?state=open&labels=bug&per_page=20" \
-  | python3 -c "
+  | python -c "
 import sys, json
 for i in json.load(sys.stdin):
     if 'pull_request' not in i:
@@ -84,7 +84,7 @@ for i in json.load(sys.stdin):
 curl -s \
   -H "Authorization: token $GITHUB_TOKEN" \
   https://api.github.com/repos/$OWNER/$REPO/issues/42 \
-  | python3 -c "
+  | python -c "
 import sys, json
 i = json.load(sys.stdin)
 labels = ', '.join(l['name'] for l in i['labels'])
@@ -98,7 +98,7 @@ print(f\"\n{i['body']}\")"
 curl -s \
   -H "Authorization: token $GITHUB_TOKEN" \
   "https://api.github.com/search/issues?q=authentication+error+repo:$OWNER/$REPO" \
-  | python3 -c "
+  | python -c "
 import sys, json
 for i in json.load(sys.stdin)['items']:
     print(f\"#{i['number']}  {i['state']:6}  {i['title']}\")"
@@ -206,7 +206,7 @@ curl -s -X DELETE \
 curl -s \
   -H "Authorization: token $GITHUB_TOKEN" \
   https://api.github.com/repos/$OWNER/$REPO/labels \
-  | python3 -c "
+  | python -c "
 import sys, json
 for l in json.load(sys.stdin):
     print(f\"  {l['name']:30}  {l.get('description', '')}\")"
@@ -312,7 +312,7 @@ gh issue list --label "needs-triage" --state open
 curl -s \
   -H "Authorization: token $GITHUB_TOKEN" \
   "https://api.github.com/repos/$OWNER/$REPO/issues?labels=needs-triage&state=open" \
-  | python3 -c "
+  | python -c "
 import sys, json
 for i in json.load(sys.stdin):
     if 'pull_request' not in i:
@@ -346,7 +346,7 @@ gh issue list --label "wontfix" --json number --jq '.[].number' | \
 curl -s \
   -H "Authorization: token $GITHUB_TOKEN" \
   "https://api.github.com/repos/$OWNER/$REPO/issues?labels=wontfix&state=open" \
-  | python3 -c "import sys,json; [print(i['number']) for i in json.load(sys.stdin)]" \
+  | python -c "import sys,json; [print(i['number']) for i in json.load(sys.stdin)]" \
   | while read num; do
     curl -s -X PATCH \
       -H "Authorization: token $GITHUB_TOKEN" \

--- a/skills/github/github-pr-workflow/SKILL.md
+++ b/skills/github/github-pr-workflow/SKILL.md
@@ -173,7 +173,7 @@ SHA=$(git rev-parse HEAD)
 curl -s \
   -H "Authorization: token $GITHUB_TOKEN" \
   https://api.github.com/repos/$OWNER/$REPO/commits/$SHA/status \
-  | python3 -c "
+  | python -c "
 import sys, json
 data = json.load(sys.stdin)
 print(f\"Overall: {data['state']}\")
@@ -184,7 +184,7 @@ for s in data.get('statuses', []):
 curl -s \
   -H "Authorization: token $GITHUB_TOKEN" \
   https://api.github.com/repos/$OWNER/$REPO/commits/$SHA/check-runs \
-  | python3 -c "
+  | python -c "
 import sys, json
 data = json.load(sys.stdin)
 for cr in data.get('check_runs', []):
@@ -200,7 +200,7 @@ for i in $(seq 1 20); do
   STATUS=$(curl -s \
     -H "Authorization: token $GITHUB_TOKEN" \
     https://api.github.com/repos/$OWNER/$REPO/commits/$SHA/status \
-    | python3 -c "import sys,json; print(json.load(sys.stdin)['state'])")
+    | python -c "import sys,json; print(json.load(sys.stdin)['state'])")
   echo "Check $i: $STATUS"
   if [ "$STATUS" = "success" ] || [ "$STATUS" = "failure" ] || [ "$STATUS" = "error" ]; then
     break
@@ -234,7 +234,7 @@ BRANCH=$(git branch --show-current)
 curl -s \
   -H "Authorization: token $GITHUB_TOKEN" \
   "https://api.github.com/repos/$OWNER/$REPO/actions/runs?branch=$BRANCH&per_page=5" \
-  | python3 -c "
+  | python -c "
 import sys, json
 runs = json.load(sys.stdin)['workflow_runs']
 for r in runs:
@@ -319,7 +319,7 @@ Merge methods: `"merge"` (merge commit), `"squash"`, `"rebase"`
 PR_NODE_ID=$(curl -s \
   -H "Authorization: token $GITHUB_TOKEN" \
   https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['node_id'])")
+  | python -c "import sys,json; print(json.load(sys.stdin)['node_id'])")
 
 curl -s -X POST \
   -H "Authorization: token $GITHUB_TOKEN" \

--- a/skills/github/github-repo-management/SKILL.md
+++ b/skills/github/github-repo-management/SKILL.md
@@ -39,7 +39,7 @@ fi
 if [ "$AUTH" = "gh" ]; then
   GH_USER=$(gh api user --jq '.login')
 else
-  GH_USER=$(curl -s -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/user | python3 -c "import sys,json; print(json.load(sys.stdin)['login'])")
+  GH_USER=$(curl -s -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/user | python -c "import sys,json; print(json.load(sys.stdin)['login'])")
 fi
 ```
 
@@ -213,7 +213,7 @@ gh search repos "machine learning" --language python --sort stars
 curl -s \
   -H "Authorization: token $GITHUB_TOKEN" \
   https://api.github.com/repos/$OWNER/$REPO \
-  | python3 -c "
+  | python -c "
 import sys, json
 r = json.load(sys.stdin)
 print(f\"Name: {r['full_name']}\")
@@ -226,7 +226,7 @@ print(f\"Language: {r['language']}\")"
 curl -s \
   -H "Authorization: token $GITHUB_TOKEN" \
   "https://api.github.com/user/repos?per_page=20&sort=updated" \
-  | python3 -c "
+  | python -c "
 import sys, json
 for r in json.load(sys.stdin):
     vis = 'private' if r['private'] else 'public'
@@ -235,7 +235,7 @@ for r in json.load(sys.stdin):
 # Search repos
 curl -s \
   "https://api.github.com/search/repositories?q=machine+learning+language:python&sort=stars&per_page=10" \
-  | python3 -c "
+  | python -c "
 import sys, json
 for r in json.load(sys.stdin)['items']:
     print(f\"  {r['full_name']:40}  ★{r['stargazers_count']:6}  {r['description'][:60] if r['description'] else ''}\")"
@@ -321,7 +321,7 @@ curl -s \
   https://api.github.com/repos/$OWNER/$REPO/actions/secrets/public-key
 
 # Encrypt and set (requires Python with PyNaCl)
-python3 -c "
+python -c "
 from base64 import b64encode
 from nacl import encoding, public
 import json, sys
@@ -349,7 +349,7 @@ curl -s -X PUT \
 curl -s \
   -H "Authorization: token $GITHUB_TOKEN" \
   https://api.github.com/repos/$OWNER/$REPO/actions/secrets \
-  | python3 -c "
+  | python -c "
 import sys, json
 for s in json.load(sys.stdin)['secrets']:
     print(f\"  {s['name']:30}  updated: {s['updated_at']}\")"
@@ -389,7 +389,7 @@ curl -s -X POST \
 curl -s \
   -H "Authorization: token $GITHUB_TOKEN" \
   https://api.github.com/repos/$OWNER/$REPO/releases \
-  | python3 -c "
+  | python -c "
 import sys, json
 for r in json.load(sys.stdin):
     tag = r.get('tag_name', 'no tag')
@@ -426,7 +426,7 @@ gh workflow run deploy.yml -f environment=staging
 curl -s \
   -H "Authorization: token $GITHUB_TOKEN" \
   https://api.github.com/repos/$OWNER/$REPO/actions/workflows \
-  | python3 -c "
+  | python -c "
 import sys, json
 for w in json.load(sys.stdin)['workflows']:
     print(f\"  {w['id']:10}  {w['name']:30}  {w['state']}\")"
@@ -435,7 +435,7 @@ for w in json.load(sys.stdin)['workflows']:
 curl -s \
   -H "Authorization: token $GITHUB_TOKEN" \
   "https://api.github.com/repos/$OWNER/$REPO/actions/runs?per_page=10" \
-  | python3 -c "
+  | python -c "
 import sys, json
 for r in json.load(sys.stdin)['workflow_runs']:
     print(f\"  Run {r['id']}  {r['name']:30}  {r['conclusion'] or r['status']}\")"
@@ -494,7 +494,7 @@ curl -s -X POST \
 curl -s \
   -H "Authorization: token $GITHUB_TOKEN" \
   https://api.github.com/gists \
-  | python3 -c "
+  | python -c "
 import sys, json
 for g in json.load(sys.stdin):
     files = ', '.join(g['files'].keys())


### PR DESCRIPTION
## Problem

Skills that declare `platforms: [linux, macos, windows]` use `python3` in shell command examples. On Windows, `python3` does not exist — only `python` is available. This means copy-pasted examples fail on Windows.

## Fix

Replace `python3` with `python` in shell pipeline commands across 4 GitHub skill files:

- `skills/github/github-issues/SKILL.md` (7 occurrences)
- `skills/github/github-code-review/SKILL.md` (5 occurrences)
- `skills/github/github-repo-management/SKILL.md` (10 occurrences)
- `skills/github/github-pr-workflow/SKILL.md` (5 occurrences)

All instances are `python3 -c "..."` used in shell pipelines to parse JSON. `python` works on all three platforms (Linux, macOS, Windows).

## Scope

This PR covers the 4 GitHub-related skills. A follow-up PR can address the remaining ~12 affected skills (maps, airtable, arxiv, comfyui, ascii-art, etc.).

Fixes #50606 (partial)