### PR TITLE
feat(providers): add xAI display-label override

### DIFF
--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -366,6 +366,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "local": "Local endpoint",
     "bedrock": "AWS Bedrock",
     "ollama-cloud": "Ollama Cloud",
+    "xai": "xAI",
     "xai-oauth": "xAI Grok OAuth (SuperGrok / Premium+)",
 }
 

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -437,6 +437,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "bedrock": "AWS Bedrock",
     "vertex": "Google Vertex AI",
     "ollama-cloud": "Ollama Cloud",
+    "xai": "xAI",
     "xai-oauth": "xAI Grok OAuth (SuperGrok / Premium+)",
     "opencode-free": "OpenCode Free",
 }

--- a/tests/hermes_cli/test_xai_provider_labels.py
+++ b/tests/hermes_cli/test_xai_provider_labels.py
@@ -1,5 +1,7 @@
 """Regression tests for xAI provider label disambiguation."""
 
+import agent.models_dev as models_dev
+import hermes_cli.providers as providers
 from hermes_cli.models import provider_label
 from hermes_cli.providers import get_label
 
@@ -11,3 +13,39 @@ def test_xai_oauth_provider_label_is_not_collapsed_to_api_key_label():
     assert get_label("grok-oauth") == "xAI Grok OAuth (SuperGrok / Premium+)"
 
 
+def test_xai_fallback_without_override_degrades_to_slug(monkeypatch):
+    """Guard the exact regression the override fixes.
+
+    On the catalog-unavailable fallback path ``get_provider`` cannot supply
+    a display name from the live models.dev catalog. WITHOUT the ``xai``
+    entry in ``_LABEL_OVERRIDES`` the label degrades to the raw canonical
+    slug ("xai"). This test pins that failure mode so a future refactor that
+    drops the override is caught.
+    """
+
+    def _unavailable(*args, **kwargs):
+        raise RuntimeError("models.dev catalog unavailable")
+
+    monkeypatch.setattr(models_dev, "get_provider_info", _unavailable)
+
+    overrides = dict(providers._LABEL_OVERRIDES)
+    overrides.pop("xai", None)
+    monkeypatch.setattr(providers, "_LABEL_OVERRIDES", overrides)
+
+    assert get_label("xai") == "xai"
+
+
+def test_xai_label_override_wins_when_models_dev_unavailable(monkeypatch):
+    """The ``_LABEL_OVERRIDES`` entry supplies "xAI" on the fallback path.
+
+    With models.dev unavailable and the override entry present,
+    ``get_label`` consults ``_LABEL_OVERRIDES`` first, so the override must
+    still win and return "xAI" rather than the lowercase slug.
+    """
+
+    def _unavailable(*args, **kwargs):
+        raise RuntimeError("models.dev catalog unavailable")
+
+    monkeypatch.setattr(models_dev, "get_provider_info", _unavailable)
+
+    assert get_label("xai") == "xAI"


### PR DESCRIPTION
## What does this PR do?

The xAI API key provider can fall back to its raw `xai` slug when models.dev metadata is unavailable. This PR gives that provider the stable display label `xAI` while leaving the separate Grok OAuth label unchanged.

## Type of change

Bug fix with fallback regression coverage.

## Changes made

`hermes_cli/providers.py` adds the canonical xAI display override.

`tests/hermes_cli/test_xai_provider_labels.py` proves the previous catalog unavailable fallback degrades to the slug without the override, proves the override returns `xAI`, and keeps the OAuth provider distinct.

## Verification

`scripts/run_tests.sh` passed 147 provider label, model, provider resolution, status, and validation tests across the verified runs. Ruff passes on both changed files.
