### PR TITLE
fix(discord): authorize requester on component prompts

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12011,6 +12011,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         adapter = self.adapters.get(source.platform)
         metadata = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
+        if getattr(source, "user_id", None):
+            metadata = dict(metadata or {})
+            metadata["requester_user_id"] = str(source.user_id)
 
         used_buttons = False
         if adapter is not None:
@@ -15747,13 +15750,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # false positives from MagicMock auto-attribute creation in tests.
                 if getattr(type(_status_adapter), "send_exec_approval", None) is not None:
                     try:
+                        _approval_metadata = dict(_status_thread_metadata or {})
+                        if getattr(source, "user_id", None):
+                            _approval_metadata["requester_user_id"] = str(source.user_id)
                         _approval_fut = safe_schedule_threadsafe(
                             _status_adapter.send_exec_approval(
                                 chat_id=_status_chat_id,
                                 command=cmd,
                                 session_key=_approval_session_key,
                                 description=desc,
-                                metadata=_status_thread_metadata,
+                                metadata=_approval_metadata or None,
                             ),
                             _loop_for_step,
                             logger=logger,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4714,7 +4714,9 @@ class DiscordAdapter(BasePlatformAdapter):
 
             view = ExecApprovalView(
                 session_key=session_key,
-                allowed_user_ids=self._allowed_user_ids,
+                allowed_user_ids=_merge_component_allowed_user_ids(
+                    self._allowed_user_ids, metadata
+                ),
                 allowed_role_ids=self._allowed_role_ids,
             )
 
@@ -4754,7 +4756,9 @@ class DiscordAdapter(BasePlatformAdapter):
             view = SlashConfirmView(
                 session_key=session_key,
                 confirm_id=confirm_id,
-                allowed_user_ids=self._allowed_user_ids,
+                allowed_user_ids=_merge_component_allowed_user_ids(
+                    self._allowed_user_ids, metadata
+                ),
                 allowed_role_ids=self._allowed_role_ids,
             )
 
@@ -4861,7 +4865,9 @@ class DiscordAdapter(BasePlatformAdapter):
                 view = ClarifyChoiceView(
                     choices=clean_choices,
                     clarify_id=clarify_id,
-                    allowed_user_ids=self._allowed_user_ids,
+                    allowed_user_ids=_merge_component_allowed_user_ids(
+                        self._allowed_user_ids, metadata
+                    ),
                     allowed_role_ids=self._allowed_role_ids,
                 )
             else:
@@ -4906,7 +4912,9 @@ class DiscordAdapter(BasePlatformAdapter):
             )
             view = UpdatePromptView(
                 session_key=session_key,
-                allowed_user_ids=self._allowed_user_ids,
+                allowed_user_ids=_merge_component_allowed_user_ids(
+                    self._allowed_user_ids, metadata
+                ),
                 allowed_role_ids=self._allowed_role_ids,
             )
             msg = await channel.send(embed=embed, view=view)
@@ -4967,7 +4975,9 @@ class DiscordAdapter(BasePlatformAdapter):
                 current_provider=current_provider,
                 session_key=session_key,
                 on_model_selected=on_model_selected,
-                allowed_user_ids=self._allowed_user_ids,
+                allowed_user_ids=_merge_component_allowed_user_ids(
+                    self._allowed_user_ids, metadata
+                ),
                 allowed_role_ids=self._allowed_role_ids,
             )
 
@@ -5739,6 +5749,20 @@ def _component_check_auth(
             return True
 
     return False
+
+
+def _merge_component_allowed_user_ids(
+    allowed_user_ids: Optional[set],
+    metadata: Optional[Dict[str, Any]] = None,
+) -> set[str]:
+    """Merge static component allowlists with the originating requester."""
+    merged = {
+        str(uid).strip() for uid in (allowed_user_ids or set()) if str(uid).strip()
+    }
+    requester_user_id = str((metadata or {}).get("requester_user_id") or "").strip()
+    if requester_user_id:
+        merged.add(requester_user_id)
+    return merged
 
 
 def _define_discord_view_classes() -> None:

--- a/tests/gateway/test_destructive_slash_confirm.py
+++ b/tests/gateway/test_destructive_slash_confirm.py
@@ -153,6 +153,32 @@ async def test_gate_on_pending_confirm_registered(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_button_path_passes_requester_user_id_in_metadata():
+    """Button-capable adapters must receive the originating requester id."""
+    runner = _make_runner()
+    runner._read_user_config = lambda: {"approvals": {"destructive_slash_confirm": True}}
+    runner._session_key_for_source = lambda src: build_session_key(src)
+    runner.adapters[Platform.TELEGRAM].send_slash_confirm = AsyncMock(
+        return_value=SimpleNamespace(success=True)
+    )
+
+    execute = AsyncMock(return_value="should not run yet")
+
+    result = await runner._maybe_confirm_destructive_slash(
+        event=_make_event("/new"),
+        command="new",
+        title="/new",
+        detail="Discards history.",
+        execute=execute,
+    )
+
+    execute.assert_not_awaited()
+    assert result is None
+    kwargs = runner.adapters[Platform.TELEGRAM].send_slash_confirm.await_args.kwargs
+    assert kwargs["metadata"] == {"requester_user_id": "u1"}
+
+
+@pytest.mark.asyncio
 async def test_resolve_once_runs_execute_and_returns_result():
     """Resolving the pending confirm with 'once' runs the destructive
     action and returns its output."""

--- a/tests/gateway/test_discord_component_auth.py
+++ b/tests/gateway/test_discord_component_auth.py
@@ -13,6 +13,7 @@ handling, and fail-closed behavior so the parity cannot regress.
 """
 
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -20,12 +21,14 @@ import pytest
 # importing the production module.
 from plugins.platforms.discord.adapter import (  # noqa: E402
     ClarifyChoiceView,
+    DiscordAdapter,
     ExecApprovalView,
     ModelPickerView,
     SlashConfirmView,
     UpdatePromptView,
     _component_check_auth,
 )
+from gateway.config import PlatformConfig  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
@@ -58,6 +61,14 @@ def _interaction(user_id, role_ids=None, *, drop_user=False, drop_roles=False):
     if not drop_roles:
         user_kwargs["roles"] = [SimpleNamespace(id=r) for r in (role_ids or [])]
     return SimpleNamespace(user=SimpleNamespace(**user_kwargs))
+
+
+def _make_adapter(*, allowed_users=None, allowed_roles=None):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token", extra={}))
+    adapter._client = MagicMock()
+    adapter._allowed_user_ids = set(allowed_users or [])
+    adapter._allowed_role_ids = set(allowed_roles or [])
+    return adapter
 
 
 # ── no policy configured -> deny unless allow-all is explicit ──────────────
@@ -114,6 +125,54 @@ def test_component_check_global_allowlist_without_match_rejects(monkeypatch):
 def test_component_check_wildcard_user_allowlist_passes():
     interaction = _interaction(99999)
     assert _component_check_auth(interaction, {"*"}, set()) is True
+
+
+@pytest.mark.asyncio
+async def test_send_exec_approval_allows_originating_requester_without_global_allowlist():
+    adapter = _make_adapter()
+    channel = MagicMock()
+    sent_msg = MagicMock()
+    sent_msg.id = 123
+    channel.send = AsyncMock(return_value=sent_msg)
+    adapter._client.get_channel = MagicMock(return_value=channel)
+
+    result = await adapter.send_exec_approval(
+        chat_id="9001",
+        command="rm -rf /tmp/demo",
+        session_key="sess-1",
+        metadata={"requester_user_id": "42"},
+    )
+
+    assert result.success is True
+    view = channel.send.call_args.kwargs["view"]
+    assert isinstance(view, ExecApprovalView)
+    assert view._check_auth(_interaction(42)) is True
+    assert view._check_auth(_interaction(99)) is False
+
+
+@pytest.mark.asyncio
+async def test_send_slash_confirm_allows_originating_requester_without_global_allowlist():
+    adapter = _make_adapter()
+    channel = MagicMock()
+    sent_msg = MagicMock()
+    sent_msg.id = 456
+    channel.send = AsyncMock(return_value=sent_msg)
+    adapter._client.get_channel = MagicMock(return_value=channel)
+
+    result = await adapter.send_slash_confirm(
+        chat_id="9001",
+        title="Confirm",
+        message="Apply the change?",
+        session_key="sess-2",
+        confirm_id="confirm-1",
+        metadata={"requester_user_id": "42"},
+    )
+
+    assert result.success is True
+    view = channel.send.call_args.kwargs["view"]
+    assert isinstance(view, SlashConfirmView)
+    assert view._check_auth(_interaction(42)) is True
+    assert view._check_auth(_interaction(99)) is False
 
 
 # ── role allowlist OR semantics ────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- pass the originating requester id into Discord approval and slash-confirm button sends
- merge that requester into the per-view allowlist so paired users can resolve their own prompts even when `DISCORD_ALLOWED_USERS` is unset
- keep the existing fail-closed component policy for unrelated users, and cover the regression with adapter + runner tests

Closes #50627.

## Testing
- `pytest tests/gateway/test_discord_component_auth.py tests/gateway/test_destructive_slash_confirm.py -q`
- `pytest tests/gateway/test_discord_clarify_buttons.py tests/gateway/test_discord_model_picker.py -q`
- `ruff check gateway/run.py plugins/platforms/discord/adapter.py tests/gateway/test_discord_component_auth.py tests/gateway/test_destructive_slash_confirm.py`
- `git diff --check`
