### PR TITLE
fix(terminal): bridge docker_extra_args to TERMINAL_DOCKER_EXTRA_ARGS in CLI + gateway

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -621,6 +621,7 @@ def load_cli_config() -> Dict[str, Any]:
         "container_persistent": "TERMINAL_CONTAINER_PERSISTENT",
         "docker_volumes": "TERMINAL_DOCKER_VOLUMES",
         "docker_env": "TERMINAL_DOCKER_ENV",
+        "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
         "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
         "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
         "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1464,6 +1464,7 @@ if _config_path.exists():
                 "container_persistent": "TERMINAL_CONTAINER_PERSISTENT",
                 "docker_volumes": "TERMINAL_DOCKER_VOLUMES",
                 "docker_env": "TERMINAL_DOCKER_ENV",
+                "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
                 "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
                 "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
                 "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",

--- a/tests/tools/test_terminal_config_env_sync.py
+++ b/tests/tools/test_terminal_config_env_sync.py
@@ -233,6 +233,27 @@ def test_docker_env_is_bridged_everywhere():
     assert "TERMINAL_DOCKER_ENV" in _terminal_tool_env_var_names()
 
 
+def test_docker_extra_args_is_bridged_everywhere():
+    """Regression pin for docker_extra_args config key being silently ignored.
+
+    ``terminal.docker_extra_args`` in config.yaml passes extra flags verbatim
+    to ``docker run`` (e.g. ``--gpus=all``, ``--shm-size=16g``).  The key was
+    present in DEFAULT_CONFIG, TERMINAL_CONFIG_ENV_MAP (so ``hermes config
+    set`` bridged it), terminal_tool._get_env_config (reads
+    TERMINAL_DOCKER_EXTRA_ARGS), and DockerEnvironment (applies extra_args) --
+    but it was MISSING from cli.py's env_mappings and gateway/run.py's
+    _terminal_env_map.  So a user who hand-edited config.yaml had their GPU /
+    shm-size flags silently dropped on the CLI and gateway/desktop paths,
+    while ``image``/``volumes`` (which were in those maps) bridged fine --
+    producing the "Hermes partially reads the Docker config" symptom.  Guard
+    all four bridging points so this cannot regress.
+    """
+    assert "docker_extra_args" in _cli_env_map_keys()
+    assert "docker_extra_args" in _gateway_env_map_keys()
+    assert "docker_extra_args" in _save_config_env_sync_keys()
+    assert "TERMINAL_DOCKER_EXTRA_ARGS" in _terminal_tool_env_var_names()
+
+
 def test_docker_persist_across_processes_is_bridged_everywhere():
     """Regression pin for the cross-process container reuse toggle.
 


### PR DESCRIPTION
## Summary

`terminal.docker_extra_args` passes flags verbatim to `docker run` (e.g. `--gpus=all`, `--shm-size=16g`). It is wired into:

- `DEFAULT_CONFIG["terminal"]` (`hermes_cli/config.py`)
- `TERMINAL_CONFIG_ENV_MAP` — so `hermes config set terminal.docker_extra_args …` bridges it to `.env`
- `tools/terminal_tool.py::_get_env_config()` — reads `TERMINAL_DOCKER_EXTRA_ARGS`
- `tools/environments/docker.py` — applies `extra_args` to the `docker run` command

…but it was **missing from the other two yaml→env bridges**: `cli.py`'s `env_mappings` and `gateway/run.py`'s `_terminal_env_map`.

## Symptom

A user reported (Hermes Desktop on Windows, `terminal.backend=docker`) that Hermes "partially reads the Docker config": `image` and `volume` are honored, but `--gpus=all` and `--shm-size=16g` are silently dropped from the generated `docker run` command.

Root cause: the user **hand-edited `config.yaml`** rather than running `hermes config set`. On the CLI and gateway/desktop startup paths, `docker_extra_args` never reaches `os.environ` because neither bridge maps it — while `docker_image`/`docker_volumes` (which *are* in those maps) bridge fine. `_get_env_config()` reads only `TERMINAL_*` env vars at runtime, so the flags vanish before `DockerEnvironment` ever sees them.

This is the **same bridge-coverage bug class** that already shipped twice — `docker_run_as_host_user` (missing from cli + gateway) and `docker_mount_cwd_to_workspace` (missing from gateway).

## Fix

- Add `"docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS"` to `cli.py`'s `env_mappings` and `gateway/run.py`'s `_terminal_env_map`.
- Add `test_docker_extra_args_is_bridged_everywhere` to `tests/tools/test_terminal_config_env_sync.py`, mirroring the existing `test_docker_*_is_bridged_everywhere` regression pins (asserts the key is present in all three bridge maps **and** consumed by `terminal_tool`).

## Test plan

- [x] `pytest tests/tools/test_terminal_config_env_sync.py` — 10 passed
- [x] **Mutation-tested**: removed the key from both maps → the new pin fails (`AssertionError: 'docker_extra_args' not in _cli_env_map_keys()`); restored → green. (Note: the pre-existing `test_cli_and_gateway_env_maps_agree` could not catch this, since both maps "agreed" by both omitting the key.)

## Workaround for affected users (pre-fix)

`hermes config set terminal.docker_extra_args '["--gpus=all","--shm-size=16g"]'` — the `config set` bridge writes `.env`, which the gateway/desktop reads regardless of the missing startup bridges.

## Infographic

![docker-extra-args-bridge](https://v3b.fal.media/files/b/0a9f474e/D2VRxZ-9iJ4h4oRWsUhGs_DOJy0CE0.png)
