### PR TITLE
feat(auth): Codex OAuth write-through to global root (multi-profile parity with xAI #43589)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3428,12 +3428,78 @@ def _sync_codex_pool_entries(
         entry["last_error_reset_at"] = None
 
 
+def _profile_has_own_codex_oauth_state(auth_store: Dict[str, Any]) -> bool:
+    """True when this store has its OWN ``providers.openai-codex`` block.
+
+    Distinguishes a profile that genuinely shadows the root Codex/ChatGPT
+    grant from one that only *reads* root via ``_load_provider_state``'s
+    fallback. Only the latter needs the refresh write-through below. Mirrors
+    ``_profile_has_own_xai_oauth_state`` for the Codex provider key.
+    """
+    providers = auth_store.get("providers")
+    return isinstance(providers, dict) and isinstance(providers.get("openai-codex"), dict)
+
+
+def _write_through_codex_oauth_to_global_root(state: Dict[str, Any]) -> None:
+    """Persist a rotated Codex OAuth ``state`` into the global-root auth.json.
+
+    Best-effort write-through for the multi-profile rotation hazard: Codex
+    (ChatGPT) OAuth refresh_tokens are single-use/rotating, so when a profile
+    session refreshes a grant it resolved from the root fallback, the rotated
+    chain must land back in root. Otherwise root keeps a now-consumed refresh
+    token and every other profile reading the stale root grant dies with a
+    "refresh token consumed by another client" error once its access token
+    expires. xAI already does this (#43589); this brings Codex to parity.
+
+    Only updates ``providers.openai-codex`` in the root store; never touches
+    the profile store (the caller already saved that) and preserves every
+    other provider already present in the root file. Swallows all errors — a
+    failed write-through degrades to the pre-existing behavior (root stale),
+    it must never break the profile's own successful save.
+    """
+    global_path = _global_auth_file_path()
+    if global_path is None:
+        # Classic mode (profile == root); the profile save already hit root.
+        return
+    # Seat belt: under pytest, refuse to write the real user's
+    # ~/.hermes/auth.json even when HERMES_HOME points at a profile path
+    # (mirrors the read-side guard in _load_global_auth_store). Uses the
+    # unmodified HOME env, not Path.home() which fixtures may monkeypatch.
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        real_home_env = os.environ.get("HOME", "")
+        if real_home_env:
+            real_root = Path(real_home_env) / ".hermes" / "auth.json"
+            try:
+                if global_path.resolve(strict=False) == real_root.resolve(strict=False):
+                    return
+            except Exception:
+                return
+    try:
+        if global_path.exists():
+            global_store = _load_auth_store(global_path)
+        else:
+            global_store = {}
+        if not isinstance(global_store, dict):
+            return
+        _store_provider_state(global_store, "openai-codex", dict(state), set_active=False)
+        _save_auth_store(global_store, global_path)
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.debug("Codex OAuth: write-through to global root failed: %s", exc)
+
+
 def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: str = None) -> None:
     """Save Codex OAuth tokens to Hermes auth store (~/.hermes/auth.json)."""
     if last_refresh is None:
         last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
     with _auth_store_lock():
         auth_store = _load_auth_store()
+        # A profile that lacks its own openai-codex block is reading the root
+        # grant through _load_provider_state's fallback. When such a profile
+        # refreshes the (rotating, single-use) grant, we must write the rotated
+        # chain back to root too, or root is left holding a consumed refresh
+        # token and siblings die with "refresh token consumed by another
+        # client". Mirrors the xAI write-through (#43589).
+        write_through_to_root = not _profile_has_own_codex_oauth_state(auth_store)
         state = _load_provider_state(auth_store, "openai-codex") or {}
         # Capture the previous singleton tokens BEFORE overwriting them.  The
         # pool-sync step uses this to distinguish legacy singleton-aliases
@@ -3454,6 +3520,8 @@ def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: 
             previous_singleton_tokens=previous_singleton_tokens,
         )
         _save_auth_store(auth_store)
+        if write_through_to_root:
+            _write_through_codex_oauth_to_global_root(state)
 
 
 def _recover_codex_tokens_from_cli(reason: str) -> Optional[Dict[str, str]]:

--- a/tests/hermes_cli/test_codex_oauth_writethrough.py
+++ b/tests/hermes_cli/test_codex_oauth_writethrough.py
@@ -1,0 +1,247 @@
+"""Regression tests for Codex OAuth refresh write-through to the global root.
+
+Companion to the xAI write-through tests (``test_xai_oauth_writethrough.py``).
+They cover the same WRITE-side hazard for the Codex/ChatGPT provider: when a
+profile that has no own ``providers.openai-codex`` block refreshes the
+(rotating, single-use) grant it resolved from the root fallback, the rotated
+tokens must be written back to the global root too. Codex OAuth refresh tokens
+are single-use, so otherwise root keeps a now-consumed refresh token and every
+other profile reading root's stale grant dies with "refresh token consumed by
+another client" once its access token expires. xAI already does this (#43589);
+this brings Codex to parity.
+
+The READ fallback (profile -> credential pool -> global root) is already
+generic via ``_load_provider_state``; these tests assert a sibling profile sees
+the rotated token after a write-through, but the read side needs no change.
+
+The tests drive the real ``_save_codex_tokens`` against real on-disk auth
+stores (profile + root under ``tmp_path``) rather than mocking the save
+boundary, so they exercise the actual atomic write path.
+"""
+
+import json
+
+import pytest
+
+from hermes_cli import auth
+
+
+def _write_store(path, store):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(store), encoding="utf-8")
+
+
+def _read_store(path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+@pytest.fixture
+def profile_and_root(tmp_path, monkeypatch):
+    """Wire a profile auth store + a distinct global-root auth store on disk.
+
+    Returns (profile_path, root_path). The pytest seat belt in
+    ``_write_through_codex_oauth_to_global_root`` only refuses the *real*
+    user's ``$HOME/.hermes/auth.json``; a tmp_path root is allowed, so we point
+    HOME away from the tmp root to keep the guard from tripping on these
+    fixtures.
+    """
+    profile_path = tmp_path / "profiles" / "work" / "auth.json"
+    root_path = tmp_path / "root" / "auth.json"
+
+    monkeypatch.setattr(auth, "_auth_file_path", lambda: profile_path)
+    monkeypatch.setattr(auth, "_global_auth_file_path", lambda: root_path)
+    # Keep the pytest write seat belt from matching our tmp root.
+    monkeypatch.setenv("HOME", str(tmp_path / "not-the-root"))
+    return profile_path, root_path
+
+
+def test_refresh_writes_through_to_root_when_profile_has_no_own_state(profile_and_root):
+    """Profile reading root's grant must push rotated tokens back to root."""
+    profile_path, root_path = profile_and_root
+    # Profile has NO own openai-codex block (reads root via fallback).
+    _write_store(profile_path, {"version": 1, "providers": {}})
+    _write_store(
+        root_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "old-access",
+                        "refresh_token": "old-refresh",
+                    }
+                }
+            },
+        },
+    )
+
+    rotated = {
+        "access_token": "new-access",
+        "refresh_token": "new-refresh",
+        "token_type": "Bearer",
+    }
+    auth._save_codex_tokens(rotated)
+
+    # Profile got the rotated chain (existing behavior).
+    profile = _read_store(profile_path)
+    assert profile["providers"]["openai-codex"]["tokens"]["refresh_token"] == "new-refresh"
+
+    # AND the global root no longer holds the consumed refresh token.
+    root = _read_store(root_path)
+    assert root["providers"]["openai-codex"]["tokens"]["access_token"] == "new-access"
+    assert root["providers"]["openai-codex"]["tokens"]["refresh_token"] == "new-refresh"
+
+
+def test_refresh_does_not_touch_root_when_profile_has_own_state(profile_and_root):
+    """A profile that genuinely shadows root must NOT clobber the root grant."""
+    profile_path, root_path = profile_and_root
+    # Profile has its OWN openai-codex block: it shadows root legitimately.
+    _write_store(
+        profile_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "profile-old",
+                        "refresh_token": "profile-old-refresh",
+                    }
+                }
+            },
+        },
+    )
+    _write_store(
+        root_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "root-untouched",
+                        "refresh_token": "root-untouched-refresh",
+                    }
+                }
+            },
+        },
+    )
+
+    auth._save_codex_tokens(
+        {"access_token": "profile-new", "refresh_token": "profile-new-refresh"}
+    )
+
+    profile = _read_store(profile_path)
+    assert profile["providers"]["openai-codex"]["tokens"]["refresh_token"] == "profile-new-refresh"
+
+    # Root is a separate grant chain — must be left exactly as-is.
+    root = _read_store(root_path)
+    assert root["providers"]["openai-codex"]["tokens"]["access_token"] == "root-untouched"
+    assert root["providers"]["openai-codex"]["tokens"]["refresh_token"] == "root-untouched-refresh"
+
+
+def test_write_through_preserves_other_providers_in_root(profile_and_root):
+    """Writing Codex through to root must not drop sibling providers (e.g. xai)."""
+    profile_path, root_path = profile_and_root
+    _write_store(profile_path, {"version": 1, "providers": {}})
+    _write_store(
+        root_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "old-access",
+                        "refresh_token": "old-refresh",
+                    }
+                },
+                "xai-oauth": {
+                    "tokens": {
+                        "access_token": "xai-access",
+                        "refresh_token": "xai-refresh",
+                    }
+                },
+            },
+        },
+    )
+
+    auth._save_codex_tokens(
+        {"access_token": "new-access", "refresh_token": "new-refresh"}
+    )
+
+    root = _read_store(root_path)
+    # Codex rotated...
+    assert root["providers"]["openai-codex"]["tokens"]["refresh_token"] == "new-refresh"
+    # ...and the unrelated xAI grant is preserved untouched.
+    assert root["providers"]["xai-oauth"]["tokens"]["access_token"] == "xai-access"
+    assert root["providers"]["xai-oauth"]["tokens"]["refresh_token"] == "xai-refresh"
+
+
+def test_sibling_profile_reads_rotated_token_after_write_through(profile_and_root):
+    """The single-use-RT race: a sibling must read the fresh token, not the consumed one."""
+    profile_path, root_path = profile_and_root
+    # Profile A has no own block; reads root via fallback.
+    _write_store(profile_path, {"version": 1, "providers": {}})
+    _write_store(
+        root_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "old-access",
+                        "refresh_token": "old-refresh",
+                    }
+                }
+            },
+        },
+    )
+
+    # Profile A refreshes and write-through rotates the root grant.
+    auth._save_codex_tokens(
+        {"access_token": "new-access", "refresh_token": "new-refresh"}
+    )
+
+    # A sibling profile B (also no own block) now resolves Codex state. It must
+    # see the ROTATED token from root, not the consumed "old-refresh".
+    sibling_store = {"version": 1, "providers": {}}
+    sibling_state = auth._load_provider_state(sibling_store, "openai-codex")
+    assert sibling_state is not None
+    assert sibling_state["tokens"]["refresh_token"] == "new-refresh"
+    assert sibling_state["tokens"]["access_token"] == "new-access"
+
+
+def test_write_through_is_noop_in_classic_mode(tmp_path, monkeypatch):
+    """Classic mode (profile == root) already saves to root; no double write."""
+    profile_path = tmp_path / "auth.json"
+    monkeypatch.setattr(auth, "_auth_file_path", lambda: profile_path)
+    # Classic mode: _global_auth_file_path returns None.
+    monkeypatch.setattr(auth, "_global_auth_file_path", lambda: None)
+    _write_store(profile_path, {"version": 1, "providers": {}})
+
+    # Should not raise and should persist to the single store.
+    auth._save_codex_tokens(
+        {"access_token": "a", "refresh_token": "r"}
+    )
+    store = _read_store(profile_path)
+    assert store["providers"]["openai-codex"]["tokens"]["refresh_token"] == "r"
+
+
+def test_write_through_failure_does_not_break_profile_save(profile_and_root, monkeypatch):
+    """A failed root write-through must not break the profile's own save."""
+    profile_path, root_path = profile_and_root
+    _write_store(profile_path, {"version": 1, "providers": {}})
+    _write_store(root_path, {"version": 1, "providers": {}})
+
+    # Make the root write blow up; the profile save must still succeed.
+    real_save = auth._save_auth_store
+
+    def _exploding_save(store, target_path=None):
+        if target_path is not None and target_path == root_path:
+            raise OSError("simulated root write failure")
+        return real_save(store, target_path)
+
+    monkeypatch.setattr(auth, "_save_auth_store", _exploding_save)
+
+    auth._save_codex_tokens({"access_token": "a", "refresh_token": "r"})
+
+    profile = _read_store(profile_path)
+    assert profile["providers"]["openai-codex"]["tokens"]["refresh_token"] == "r"


### PR DESCRIPTION
## Problem

Codex (ChatGPT) OAuth refresh tokens are single-use / rotating. Hermes already lets multiple profiles share one subscription by reading a grant from the global-root `~/.hermes/auth.json` (`_load_provider_state` falls back to root generically). But the **write** side is missing for Codex: when a profile that resolved the grant from root refreshes it, the rotated chain is saved only to that profile. Root keeps the now-consumed refresh token, and every *other* profile reading the stale root grant fails with **"refresh token consumed by another client"** once its access token expires.

## Fix

Mirror the existing **xAI OAuth write-through** (#43589) for `openai-codex`:

- `_profile_has_own_codex_oauth_state(auth_store)` — distinguishes a profile that genuinely shadows root from one that only reads root via fallback.
- `_write_through_codex_oauth_to_global_root(state)` — best-effort write of the rotated `providers.openai-codex` state back into the global-root store (no-op in classic mode; preserves all other providers; never breaks the profile's own save).
- Invoked from `_save_codex_tokens` when the active profile lacks its own `openai-codex` block — which also covers `_refresh_codex_auth_tokens` and the CLI self-heal path, since both persist through `_save_codex_tokens`.

The read side already resolves cross-profile reads from root, so **no read-side change is needed**.

## Tests

New `tests/hermes_cli/test_codex_oauth_writethrough.py` (6 tests), mirroring the xAI write-through suite: writes through when the profile has no own block; does **not** when it does; preserves other providers in root; a sibling profile reads the rotated token (the single-use-RT race); no-op in classic mode; failed root write-through doesn't break the profile save. Existing auth/credential-pool suites stay green.

---

Supersedes #47221 (which took a separate shared-auth-file approach and conflicts) — this version reuses the already-merged xAI mechanism for consistency and a minimal footprint (one file, +68 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
