### PR TITLE
fix(discord): check pairing store for component button auth

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5684,7 +5684,8 @@ def _component_check_auth(
 
     Mirrors the gateway's external-surface authorization model: component
     button clicks must be explicitly authorized by a Discord user/role
-    allowlist, a global user allowlist, or an explicit allow-all flag.
+    allowlist, a global user allowlist, an explicit allow-all flag, or
+    the pairing store (``hermes pairing approve``).
 
     Behavior:
 
@@ -5694,6 +5695,7 @@ def _component_check_auth(
       - role allowlist set + interaction.user has no resolvable
         ``roles`` attribute (e.g. DM context with a role policy active)
         -> reject (fail closed)
+      - user is approved in the pairing store -> allow
       - otherwise -> reject
     """
     if os.getenv("DISCORD_ALLOW_ALL_USERS", "").strip().lower() in {"true", "1", "yes"}:
@@ -5715,11 +5717,13 @@ def _component_check_auth(
     if user is None:
         return False
 
+    # Resolve user ID once for both allowlist and pairing checks.
+    try:
+        uid = str(user.id)
+    except AttributeError:
+        uid = ""
+
     if has_users:
-        try:
-            uid = str(user.id)
-        except AttributeError:
-            uid = ""
         if "*" in user_set or (uid and uid in user_set):
             return True
 
@@ -5737,6 +5741,18 @@ def _component_check_auth(
             return False
         if user_role_ids & role_set:
             return True
+
+    # Check pairing store — mirrors ``authz_mixin._check_authorization``
+    # so users approved via ``hermes pairing approve`` can interact with
+    # component buttons even without DISCORD_ALLOWED_USERS set.
+    if uid:
+        try:
+            from gateway.pairing import PairingStore
+            store = PairingStore()
+            if store.is_approved("discord", uid):
+                return True
+        except Exception:
+            pass
 
     return False
 

--- a/tests/gateway/test_discord_component_auth.py
+++ b/tests/gateway/test_discord_component_auth.py
@@ -30,12 +30,21 @@ from plugins.platforms.discord.adapter import (  # noqa: E402
 
 @pytest.fixture(autouse=True)
 def _clear_component_auth_env(monkeypatch):
+    from unittest.mock import MagicMock, patch
+
     for name in (
         "DISCORD_ALLOW_ALL_USERS",
         "GATEWAY_ALLOW_ALL_USERS",
         "GATEWAY_ALLOWED_USERS",
     ):
         monkeypatch.delenv(name, raising=False)
+
+    # Default-mock PairingStore so tests don't hit the filesystem.
+    # Pairing-specific tests override this with explicit mock values.
+    mock_store = MagicMock()
+    mock_store.is_approved.return_value = False
+    with patch("gateway.pairing.PairingStore", return_value=mock_store):
+        yield
 
 
 # ---------------------------------------------------------------------------
@@ -304,3 +313,39 @@ def test_view_empty_allowlists_allow_with_explicit_allow_all(monkeypatch):
     monkeypatch.setenv("DISCORD_ALLOW_ALL_USERS", "true")
     view = ExecApprovalView(session_key="s", allowed_user_ids=set())
     assert view._check_auth(_interaction(99999)) is True
+
+
+# ---------------------------------------------------------------------------
+# Pairing store: users approved via ``hermes pairing approve`` must be
+# authorized even without DISCORD_ALLOWED_USERS / DISCORD_ALLOWED_ROLES.
+# ---------------------------------------------------------------------------
+
+
+def test_component_check_pairing_approved_user_passes(monkeypatch):
+    """User approved in pairing store passes even without allowlists."""
+    from unittest.mock import MagicMock, patch
+
+    mock_store = MagicMock()
+    mock_store.is_approved.return_value = True
+    # Override the autouse fixture's mock with approved=True
+    with patch("gateway.pairing.PairingStore", return_value=mock_store):
+        interaction = _interaction(11111)
+        assert _component_check_auth(interaction, set(), set()) is True
+    mock_store.is_approved.assert_called_once_with("discord", "11111")
+
+
+def test_component_check_pairing_not_approved_user_rejected(monkeypatch):
+    """User NOT in pairing store is still rejected (fail-closed)."""
+    # The autouse fixture already mocks is_approved=False, so this
+    # just verifies the fail-closed path still works.
+    interaction = _interaction(99999)
+    assert _component_check_auth(interaction, set(), set()) is False
+
+
+def test_component_check_pairing_import_error_graceful(monkeypatch):
+    """If PairingStore import fails, fall through to fail-closed."""
+    from unittest.mock import patch
+
+    with patch("gateway.pairing.PairingStore", side_effect=ImportError("simulated")):
+        interaction = _interaction(11111)
+        assert _component_check_auth(interaction, set(), set()) is False


### PR DESCRIPTION
## What does this PR do?

Adds pairing store authorization to Discord component button interactions (`_component_check_auth`). Users approved via `hermes pairing approve` can now click approve/deny buttons, slash confirm buttons, model picker buttons, and clarify choice buttons — even when `DISCORD_ALLOWED_USERS` is not set.

## Related Issue

Fixes #50627

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/discord/adapter.py`: Added `PairingStore.is_approved("discord", uid)` check to `_component_check_auth()`, mirroring `authz_mixin._check_authorization()`. The check runs after all env-var allowlist checks, preserving fail-closed behavior for non-paired users. Also hoisted `uid` resolution above the allowlist checks to avoid duplicate `user.id` access.
- `tests/gateway/test_discord_component_auth.py`: Added 3 new tests (pairing-approved user passes, non-approved user rejected, import error graceful fallback). Updated autouse fixture to mock PairingStore so tests don't hit the filesystem.

## How to Test

1. Set up Hermes with Discord gateway **without** `DISCORD_ALLOWED_USERS` set
2. Pair a user via `hermes pairing approve`
3. Ask the bot to run a command requiring approval (e.g., a dangerous exec)
4. Click the Approve button → should succeed (previously showed "You're not authorized")
5. Run `pytest tests/gateway/test_discord_component_auth.py -v` → all 31 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_discord_component_auth.py -v` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `plugins/platforms/discord/adapter.py::_component_check_auth()` (callers: 5 view classes via `_check_auth()`)
- Blast radius: LOW — adds an additive authorization check after existing allowlist logic; no existing behavior changed
- Related patterns: `gateway/authz_mixin.py::_check_authorization()` already checks `pairing_store.is_approved()` for regular messages; this PR mirrors that pattern for component button clicks
