### PR TITLE
feat(gateway): add opt-in interrupt debounce to batch rapid messages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -377,6 +377,14 @@ BROWSER_INACTIVITY_TIMEOUT=120
 # HERMES_HUMAN_DELAY_MIN_MS=800   # Min delay in ms (custom mode)
 # HERMES_HUMAN_DELAY_MAX_MS=2500  # Max delay in ms (custom mode)
 
+# Interrupt debounce for busy sessions (interrupt mode only). Default 0 = disabled (upstream
+# behaviour: each message interrupts immediately). When set to a positive number of seconds,
+# rapid follow-up messages are aggregated into a single interrupt + ack after the window
+# expires. Each new message resets the timer, so only the last message in a burst fires.
+# Useful when users type multi-part thoughts and you want to avoid thrashing the running agent.
+# When active, messages in a burst are merged into the pending slot instead of queued separately.
+# HERMES_INTERRUPT_DEBOUNCE_SECONDS=0
+
 # =============================================================================
 # DEBUG OPTIONS
 # =============================================================================

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2591,6 +2591,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._queued_events: Dict[str, List[MessageEvent]] = {}
         self._pending_native_image_paths_by_session: Dict[str, List[str]] = {}
         self._busy_ack_ts: Dict[str, float] = {}  # last busy-ack timestamp per session (debounce)
+        # Pending debounce tasks for interrupt mode (HERMES_INTERRUPT_DEBOUNCE_SECONDS > 0).
+        # Each entry is an asyncio.Task that will fire a single interrupt + ack after the
+        # debounce window expires. Only populated when the opt-in env var is set.
+        self._pending_interrupt_tasks: Dict[str, asyncio.Task] = {}
         self._session_run_generation: Dict[str, int] = {}
         # Startup restore gate: while restart-interrupted sessions are being
         # auto-resumed, real inbound messages are queued instead of competing
@@ -4324,35 +4328,108 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # Fall back to queue (merge into pending messages, no interrupt)
                 effective_mode = "queue"
 
+        # Debounce opt-in: read the env var early so we can decide how to store
+        # the pending message. Default 0 means no debounce (upstream behaviour).
+        # Only relevant for interrupt mode with a real (non-sentinel) running agent.
+        _debounce_seconds = 0.0
+        _debounce_active = False
+        if (
+            not steered
+            and effective_mode == "interrupt"
+            and running_agent is not None
+            and running_agent is not _AGENT_PENDING_SENTINEL
+        ):
+            try:
+                _debounce_seconds = float(
+                    os.environ.get("HERMES_INTERRUPT_DEBOUNCE_SECONDS", "0") or "0"
+                )
+            except ValueError:
+                logger.warning(
+                    "Invalid HERMES_INTERRUPT_DEBOUNCE_SECONDS value %r - defaulting to 0 (no debounce)",
+                    os.environ.get("HERMES_INTERRUPT_DEBOUNCE_SECONDS"),
+                )
+                _debounce_seconds = 0.0
+            _debounce_active = _debounce_seconds > 0
+
         # Store the message so it's processed as the next turn after the
-        # current run finishes (or is interrupted).  Skip this for a
-        # successful steer — the text already landed inside the run and
+        # current run finishes (or is interrupted). Skip this for a
+        # successful steer - the text already landed inside the run and
         # must NOT also be replayed as a next-turn user message.
         #
-        # Route through _queue_or_replace_pending_event (the same FIFO
-        # infrastructure used by busy queue-mode and /queue) rather than a
-        # raw merge_pending_message_event(merge_text=True). The raw merge
-        # newline-joins consecutive TEXT follow-ups into a SINGLE pending
-        # turn, destroying message boundaries — so two separate user
-        # messages sent while the agent was busy (interrupt mode, or a
-        # steer that fell back to queue) arrived as one mashed-together
-        # turn (#43066 sub-bug 2). The FIFO path gives each text its own
-        # turn in arrival order while still preserving photo-burst / album
-        # merge semantics for media.
+        # Two storage strategies, chosen before any interrupt fires:
+        #
+        # DEFAULT (debounce off): route through _queue_or_replace_pending_event
+        # (the same FIFO infrastructure used by busy queue-mode and /queue)
+        # rather than raw merge_pending_message_event(merge_text=True). The raw
+        # merge newline-joins consecutive TEXT follow-ups into a SINGLE pending
+        # turn, destroying message boundaries, so two separate user messages
+        # sent while the agent was busy arrived as one mashed-together turn
+        # (#43066 sub-bug 2). The FIFO path gives each text its own turn in
+        # arrival order while still preserving photo-burst / album merge semantics
+        # for media.
+        #
+        # DEBOUNCE ON: write ONLY to the head pending slot via merge_text=True.
+        # The FIFO enqueue must NOT run - the burst should collapse into a single
+        # turn, not produce overflow entries in _queued_events that would replay
+        # as phantom turns after the interrupt.
         if not steered:
-            self._queue_or_replace_pending_event(session_key, event)
+            if _debounce_active:
+                pending_slot = getattr(adapter, "_pending_messages", None)
+                if isinstance(pending_slot, dict):
+                    merge_pending_message_event(
+                        pending_slot,
+                        session_key,
+                        event,
+                        merge_text=True,
+                    )
+                else:
+                    logger.warning(
+                        "Session %s: adapter._pending_messages is not a dict (%s); "
+                        "falling back to FIFO enqueue (debounce merge skipped).",
+                        session_key, type(pending_slot).__name__,
+                    )
+                    self._queue_or_replace_pending_event(session_key, event)
+            else:
+                self._queue_or_replace_pending_event(session_key, event)
 
         is_queue_mode = effective_mode == "queue"
         is_steer_mode = effective_mode == "steer"
 
-        # If not in queue/steer mode, interrupt the running agent immediately.
-        # This aborts in-flight tool calls and causes the agent loop to exit
-        # at the next check point.
+        # If not in queue/steer mode, interrupt the running agent.
+        # With HERMES_INTERRUPT_DEBOUNCE_SECONDS=0 (default): interrupt immediately,
+        # preserving the existing upstream behaviour exactly.
+        # With HERMES_INTERRUPT_DEBOUNCE_SECONDS>0 (opt-in): aggregate the burst into
+        # a single interrupt + ack after the debounce window. Each new message in the
+        # window cancels the previous timer and reschedules it.
         if effective_mode == "interrupt" and running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
-            try:
-                running_agent.interrupt(event.text)
-            except Exception:
-                pass  # don't let interrupt failure block the ack
+            if not _debounce_active:
+                # Default upstream path: interrupt immediately.
+                try:
+                    running_agent.interrupt(event.text)
+                except Exception:
+                    pass  # don't let interrupt failure block the ack
+            else:
+                # Opt-in debounce path: (re)schedule a single deferred interrupt.
+                # The pending slot was already merged above via merge_text=True.
+                prev_task = self._pending_interrupt_tasks.get(session_key)
+                if prev_task is not None and not prev_task.done():
+                    prev_task.cancel()
+
+                new_task = asyncio.create_task(
+                    self._debounced_interrupt(session_key, event, _debounce_seconds)
+                )
+                self._pending_interrupt_tasks[session_key] = new_task
+
+                def _log_debounce_exc(t: asyncio.Task, _key: str = session_key) -> None:
+                    if not t.cancelled() and t.exception() is not None:
+                        logger.debug(
+                            "Debounced interrupt task for session %s raised: %s",
+                            _key, t.exception(),
+                        )
+
+                new_task.add_done_callback(_log_debounce_exc)
+                # Return True now - the debounce task will send the ack after the window.
+                return True
 
         # Check if busy ack is disabled — skip sending but still process the input.
         # Placed before debounce so we don't stamp a "last ack" timestamp that was
@@ -4475,6 +4552,138 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.debug("Failed to send busy-ack: %s", e)
 
         return True
+
+    def _cancel_pending_interrupt(self, session_key: str) -> None:
+        """Cancel and remove any pending debounce-interrupt task for the given session.
+
+        Safe to call even if the dict does not exist yet (partially-constructed runner)
+        or if there is no pending task for this session.
+        """
+        pending = getattr(self, "_pending_interrupt_tasks", None)
+        if not isinstance(pending, dict):
+            return
+        task = pending.pop(session_key, None)
+        if task is not None and not task.done():
+            task.cancel()
+
+    async def _debounced_interrupt(
+        self,
+        session_key: str,
+        trigger_event: "MessageEvent",
+        debounce_seconds: float,
+    ) -> None:
+        """Fire a single interrupt + ack after the debounce window expires.
+
+        Called as an asyncio.Task. If another message arrives during the window, the
+        previous task is cancelled (via _cancel_pending_interrupt) and a new one is
+        scheduled, so only the last trigger in the burst actually fires.
+
+        When the window expires:
+        - If the agent is no longer running (session finished or was reset), log and return.
+        - Otherwise call running_agent.interrupt() once, then send one busy-ack (subject
+          to the 30-second cooldown, same as the immediate-interrupt path).
+        """
+        try:
+            await asyncio.sleep(debounce_seconds)
+        except asyncio.CancelledError:
+            return
+
+        running_agent = self._running_agents.get(session_key)
+        if running_agent is None or running_agent is _AGENT_PENDING_SENTINEL:
+            logger.debug(
+                "Debounced interrupt fired for session %s but no agent is running; skipping.",
+                session_key,
+            )
+            return
+
+        # Fire the interrupt.
+        try:
+            running_agent.interrupt("user sent additional messages")
+        except Exception as exc:
+            logger.debug("Debounced interrupt call failed for session %s: %s", session_key, exc)
+
+        # Send one ack if not suppressed and cooldown allows.
+        adapter = self.adapters.get(trigger_event.source.platform)
+        if adapter is None:
+            return
+
+        busy_ack_enabled = os.environ.get("HERMES_GATEWAY_BUSY_ACK_ENABLED", "true").lower() == "true"
+        if not busy_ack_enabled:
+            logger.debug("Debounced busy ack suppressed for session %s", session_key)
+            return
+
+        _BUSY_ACK_COOLDOWN = 30
+        now = time.time()
+        last_ack = self._busy_ack_ts.get(session_key, 0)
+        if now - last_ack < _BUSY_ACK_COOLDOWN:
+            return
+
+        # Build status detail using the same pattern as the immediate-interrupt path.
+        from gateway.display_config import resolve_display_setting
+        status_parts: list = []
+        busy_ack_detail_enabled = bool(
+            resolve_display_setting(
+                _load_gateway_config(),
+                _platform_config_key(trigger_event.source.platform),
+                "busy_ack_detail",
+                True,
+            )
+        )
+        if busy_ack_detail_enabled and running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
+            try:
+                summary = running_agent.get_activity_summary()
+                iteration = summary.get("api_call_count", 0)
+                max_iter = summary.get("max_iterations", 0)
+                current_tool = summary.get("current_tool")
+                start_ts = self._running_agents_ts.get(session_key, 0)
+                if start_ts:
+                    elapsed_min = int((now - start_ts) / 60)
+                    if elapsed_min > 0:
+                        status_parts.append(f"{elapsed_min} min elapsed")
+                if max_iter:
+                    status_parts.append(f"iteration {iteration}/{max_iter}")
+                if current_tool:
+                    status_parts.append(f"running: {current_tool}")
+            except Exception:
+                pass
+
+        status_detail = f" ({', '.join(status_parts)})" if status_parts else ""
+        message = (
+            f"Interrupting current task{status_detail}. "
+            f"I'll respond to your message shortly."
+        )
+
+        reply_anchor = self._reply_anchor_for_event(trigger_event)
+        thread_meta = self._thread_metadata_for_source(trigger_event.source, reply_anchor)
+        try:
+            await adapter._send_with_retry(
+                chat_id=trigger_event.source.chat_id,
+                content=message,
+                reply_to=(
+                    reply_anchor
+                    if trigger_event.source.platform == Platform.TELEGRAM
+                    and trigger_event.source.chat_type == "dm"
+                    and trigger_event.source.thread_id
+                    else (
+                        None
+                        if trigger_event.source.platform == Platform.TELEGRAM
+                        and trigger_event.source.thread_id
+                        else trigger_event.message_id
+                    )
+                ),
+                metadata=thread_meta,
+            )
+            # Only stamp the cooldown timestamp after a successful send.
+            self._busy_ack_ts[session_key] = now
+        except Exception as exc:
+            logger.debug("Failed to send debounced busy-ack for session %s: %s", session_key, exc)
+        finally:
+            # Remove ourselves from the pending dict only if we are still the current task.
+            # A new task may have replaced us under a race where cancellation arrived
+            # just as we were executing (cancel delivered between sleep and running_agent check).
+            pending = getattr(self, "_pending_interrupt_tasks", {})
+            if pending.get(session_key) is asyncio.current_task():
+                pending.pop(session_key, None)
 
     async def _drain_active_agents(self, timeout: float) -> tuple[Dict[str, Any], bool]:
         snapshot = self._snapshot_running_agents()
@@ -6686,6 +6895,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             "mark_resume_pending failed for %s: %s",
                             _sk, _e,
                         )
+                # Cancel all pending debounce-interrupt tasks before interrupting agents.
+                # These tasks are no longer needed once the gateway is stopping.
+                _pending_interrupt = getattr(self, "_pending_interrupt_tasks", {})
+                if _pending_interrupt:
+                    _pi_tasks = list(_pending_interrupt.values())
+                    for _pi_t in _pi_tasks:
+                        if not _pi_t.done():
+                            _pi_t.cancel()
+                    _pending_interrupt.clear()
+                    await asyncio.gather(*_pi_tasks, return_exceptions=True)
+
                 self._interrupt_running_agents(
                     _INTERRUPT_REASON_GATEWAY_RESTART if self._restart_requested else _INTERRUPT_REASON_GATEWAY_SHUTDOWN
                 )
@@ -13598,6 +13818,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._running_agents_ts.pop(session_key, None)
         if hasattr(self, "_busy_ack_ts"):
             self._busy_ack_ts.pop(session_key, None)
+        self._cancel_pending_interrupt(session_key)
         # Turn boundary: a running-agent slot was just released.  Persist the
         # new (lower) in-flight count so the dashboard readout stays current
         # between lifecycle transitions.  Preserves gateway_state (see

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -774,3 +774,358 @@ class TestLongRunningNotificationOwnership:
         assert runner._should_emit_long_running_notification(
             "sess", agent, executor_task=live_task
         ) is True
+
+
+# ---------------------------------------------------------------------------
+# Interrupt debounce opt-in (HERMES_INTERRUPT_DEBOUNCE_SECONDS)
+# ---------------------------------------------------------------------------
+
+def _make_runner_for_debounce():
+    """Extend _make_runner with fields required for debounce tests."""
+    from gateway.run import GatewayRunner, _AGENT_PENDING_SENTINEL
+
+    runner = object.__new__(GatewayRunner)
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._busy_ack_ts = {}
+    runner._pending_interrupt_tasks = {}
+    runner._draining = False
+    runner._busy_text_mode = "interrupt"
+    runner._busy_input_mode = "interrupt"
+    runner.adapters = {}
+    runner.config = MagicMock()
+    runner.config.group_sessions_per_user = True
+    runner.config.thread_sessions_per_user = False
+    runner.session_store = None
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = True
+    runner._is_user_authorized = lambda _source: True
+    runner._queued_events = {}
+    return runner, _AGENT_PENDING_SENTINEL
+
+
+class TestInterruptDebounce:
+    """Tests for HERMES_INTERRUPT_DEBOUNCE_SECONDS opt-in debounce feature."""
+
+    @pytest.mark.asyncio
+    async def test_off_by_default_interrupt_is_immediate(self, monkeypatch):
+        """With HERMES_INTERRUPT_DEBOUNCE_SECONDS=0 (default), interrupt fires immediately."""
+        import asyncio
+        from gateway.run import GatewayRunner
+
+        monkeypatch.delenv("HERMES_INTERRUPT_DEBOUNCE_SECONDS", raising=False)
+
+        runner, _sentinel = _make_runner_for_debounce()
+        adapter = _make_adapter()
+        adapter._send_with_retry = AsyncMock()
+
+        event = _make_event(text="interrupt me now")
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {}
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time()
+        runner.adapters[event.source.platform] = adapter
+
+        with (
+            patch("gateway.run._load_gateway_config", return_value={}),
+            patch("gateway.run._platform_config_key", return_value="telegram"),
+            patch("gateway.display_config.resolve_display_setting", return_value=False),
+        ):
+            await GatewayRunner._handle_active_session_busy_message(runner, event, sk)
+
+        # Interrupt must have been called synchronously (no debounce task created).
+        agent.interrupt.assert_called_once()
+        assert sk not in runner._pending_interrupt_tasks
+
+    @pytest.mark.asyncio
+    async def test_off_explicit_zero_interrupt_is_immediate(self, monkeypatch):
+        """With HERMES_INTERRUPT_DEBOUNCE_SECONDS=0 explicitly, behaves same as default."""
+        import asyncio
+        from gateway.run import GatewayRunner
+
+        monkeypatch.setenv("HERMES_INTERRUPT_DEBOUNCE_SECONDS", "0")
+
+        runner, _sentinel = _make_runner_for_debounce()
+        adapter = _make_adapter()
+        adapter._send_with_retry = AsyncMock()
+
+        event = _make_event(text="still immediate")
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {}
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time()
+        runner.adapters[event.source.platform] = adapter
+
+        with (
+            patch("gateway.run._load_gateway_config", return_value={}),
+            patch("gateway.run._platform_config_key", return_value="telegram"),
+            patch("gateway.display_config.resolve_display_setting", return_value=False),
+        ):
+            await GatewayRunner._handle_active_session_busy_message(runner, event, sk)
+
+        agent.interrupt.assert_called_once()
+        assert sk not in runner._pending_interrupt_tasks
+
+    @pytest.mark.asyncio
+    async def test_debounce_on_single_interrupt_and_single_ack(self, monkeypatch):
+        """With debounce>0, a burst of 3 messages produces exactly 1 interrupt and 1 ack."""
+        import asyncio
+        from gateway.run import GatewayRunner
+
+        monkeypatch.setenv("HERMES_INTERRUPT_DEBOUNCE_SECONDS", "0.05")
+
+        runner, _sentinel = _make_runner_for_debounce()
+        adapter = _make_adapter()
+        adapter._send_with_retry = AsyncMock()
+
+        source = MagicMock()
+        source.platform = MagicMock(value="telegram")
+        source.chat_id = "123"
+        source.chat_type = "private"
+        source.user_id = "u1"
+        source.thread_id = None
+
+        def _make_msg(text):
+            e = MessageEvent(
+                text=text,
+                message_type=MessageType.TEXT,
+                source=source,
+                message_id="m1",
+            )
+            return e
+
+        sk = build_session_key(source)
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {}
+        agent.interrupt = MagicMock()
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time()
+        runner.adapters[source.platform] = adapter
+
+        with (
+            patch("gateway.run._load_gateway_config", return_value={}),
+            patch("gateway.run._platform_config_key", return_value="telegram"),
+            patch("gateway.display_config.resolve_display_setting", return_value=False),
+            patch("gateway.run._reply_anchor_for_event", return_value=None, create=True),
+            patch.object(
+                GatewayRunner, "_reply_anchor_for_event", return_value=None
+            ),
+            patch.object(
+                GatewayRunner, "_thread_metadata_for_source", return_value={}
+            ),
+        ):
+            for text in ("msg1", "msg2", "msg3"):
+                await GatewayRunner._handle_active_session_busy_message(
+                    runner, _make_msg(text), sk
+                )
+                # Let the event loop tick so tasks can be scheduled.
+                await asyncio.sleep(0)
+
+            # Wait for the debounce window to expire.
+            await asyncio.sleep(0.15)
+
+        # Exactly one interrupt fired.
+        agent.interrupt.assert_called_once()
+        # Exactly one ack sent.
+        assert adapter._send_with_retry.call_count == 1
+        # Pending slot must contain all 3 texts merged, no overflow turns.
+        pending_text = adapter._pending_messages.get(sk, MagicMock()).text
+        assert "msg1" in pending_text
+        assert "msg2" in pending_text
+        assert "msg3" in pending_text
+        # No phantom turns in the FIFO overflow queue.
+        assert not runner._queued_events.get(sk)
+
+    @pytest.mark.asyncio
+    async def test_debounce_on_agent_gone_before_fire(self, monkeypatch):
+        """If agent finishes before debounce window, no interrupt and no ack are sent."""
+        import asyncio
+        from gateway.run import GatewayRunner
+
+        monkeypatch.setenv("HERMES_INTERRUPT_DEBOUNCE_SECONDS", "0.05")
+
+        runner, _sentinel = _make_runner_for_debounce()
+        adapter = _make_adapter()
+        adapter._send_with_retry = AsyncMock()
+
+        event = _make_event(text="too slow")
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {}
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time()
+        runner.adapters[event.source.platform] = adapter
+
+        with (
+            patch("gateway.run._load_gateway_config", return_value={}),
+            patch("gateway.run._platform_config_key", return_value="telegram"),
+            patch("gateway.display_config.resolve_display_setting", return_value=False),
+            patch.object(GatewayRunner, "_reply_anchor_for_event", return_value=None),
+            patch.object(GatewayRunner, "_thread_metadata_for_source", return_value={}),
+        ):
+            await GatewayRunner._handle_active_session_busy_message(runner, event, sk)
+            await asyncio.sleep(0)
+
+            # Simulate agent finishing before the debounce fires.
+            runner._running_agents.pop(sk, None)
+
+            await asyncio.sleep(0.15)
+
+        agent.interrupt.assert_not_called()
+        adapter._send_with_retry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cancel_pending_interrupt_clears_task(self, monkeypatch):
+        """_cancel_pending_interrupt removes and cancels the pending task."""
+        import asyncio
+        from gateway.run import GatewayRunner
+
+        monkeypatch.setenv("HERMES_INTERRUPT_DEBOUNCE_SECONDS", "10")
+
+        runner, _sentinel = _make_runner_for_debounce()
+        adapter = _make_adapter()
+        adapter._send_with_retry = AsyncMock()
+
+        event = _make_event(text="pending")
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {}
+        runner._running_agents[sk] = agent
+        runner.adapters[event.source.platform] = adapter
+
+        with (
+            patch("gateway.run._load_gateway_config", return_value={}),
+            patch("gateway.run._platform_config_key", return_value="telegram"),
+            patch("gateway.display_config.resolve_display_setting", return_value=False),
+        ):
+            await GatewayRunner._handle_active_session_busy_message(runner, event, sk)
+            await asyncio.sleep(0)
+
+        assert sk in runner._pending_interrupt_tasks
+        task = runner._pending_interrupt_tasks[sk]
+        assert not task.done()
+
+        GatewayRunner._cancel_pending_interrupt(runner, sk)
+
+        assert sk not in runner._pending_interrupt_tasks
+        # After cancel() the task enters "cancelling" state; it becomes done
+        # only after the event loop processes the CancelledError. Allow one tick.
+        await asyncio.sleep(0)
+        assert task.cancelled() or task.done()
+
+    @pytest.mark.asyncio
+    async def test_debounce_finally_does_not_evict_newer_task(self, monkeypatch):
+        """The finally block in _debounced_interrupt must not evict a newer task.
+
+        Simulates the race condition by directly creating two tasks: after the first
+        completes, the second must still be present in _pending_interrupt_tasks.
+        """
+        import asyncio
+        from gateway.run import GatewayRunner
+
+        monkeypatch.setenv("HERMES_INTERRUPT_DEBOUNCE_SECONDS", "0.03")
+        monkeypatch.setenv("HERMES_GATEWAY_BUSY_ACK_ENABLED", "false")
+
+        runner, _sentinel = _make_runner_for_debounce()
+        adapter = _make_adapter()
+        adapter._send_with_retry = AsyncMock()
+
+        event = _make_event(text="first")
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {}
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time()
+        runner.adapters[event.source.platform] = adapter
+
+        with (
+            patch("gateway.run._load_gateway_config", return_value={}),
+            patch("gateway.run._platform_config_key", return_value="telegram"),
+            patch("gateway.display_config.resolve_display_setting", return_value=False),
+            patch.object(GatewayRunner, "_reply_anchor_for_event", return_value=None),
+            patch.object(GatewayRunner, "_thread_metadata_for_source", return_value={}),
+        ):
+            # Directly create first debounce task and register it.
+            first_task = asyncio.create_task(
+                GatewayRunner._debounced_interrupt(runner, sk, event, 0.03)
+            )
+            runner._pending_interrupt_tasks[sk] = first_task
+            await asyncio.sleep(0)
+
+            # Before the first task fires, replace it with a second (simulates new message).
+            first_task.cancel()
+            event2 = _make_event(text="second")
+            second_task = asyncio.create_task(
+                GatewayRunner._debounced_interrupt(runner, sk, event2, 0.03)
+            )
+            runner._pending_interrupt_tasks[sk] = second_task
+            await asyncio.sleep(0)
+
+            assert runner._pending_interrupt_tasks.get(sk) is second_task
+
+            # Wait for the second task to complete.
+            await asyncio.sleep(0.15)
+
+        # Main invariant: agent interrupted exactly once (by the second task).
+        agent.interrupt.assert_called_once()
+        # The second task should have cleaned itself up or left sk absent in the dict;
+        # critically it must NOT be the (cancelled) first_task.
+        remaining = runner._pending_interrupt_tasks.get(sk)
+        assert remaining is not first_task
+
+    @pytest.mark.asyncio
+    async def test_debounce_not_activated_when_demoted_to_queue(self, monkeypatch):
+        """When interrupt mode is demoted to queue (active subagents), debounce must not fire.
+
+        Even with HERMES_INTERRUPT_DEBOUNCE_SECONDS > 0, the demotion sets
+        effective_mode='queue' before the debounce gate runs, so no debounce task
+        is created and no interrupt fires. The message is queued via the normal
+        FIFO path instead.
+        """
+        import asyncio
+        from gateway.run import GatewayRunner
+
+        monkeypatch.setenv("HERMES_INTERRUPT_DEBOUNCE_SECONDS", "0.05")
+
+        runner, _sentinel = _make_runner_for_debounce()
+        adapter = _make_adapter()
+        adapter._send_with_retry = AsyncMock()
+
+        event = _make_event(text="subagent active, should queue not debounce")
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {}
+        agent.interrupt = MagicMock()
+        # Simulate active subagents so the runner demotes interrupt -> queue (#30170).
+        agent._active_children = ["child1"]
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time()
+        runner.adapters[event.source.platform] = adapter
+
+        with (
+            patch("gateway.run._load_gateway_config", return_value={}),
+            patch("gateway.run._platform_config_key", return_value="telegram"),
+            patch("gateway.display_config.resolve_display_setting", return_value=False),
+            # _agent_has_active_subagents must return True for the demotion to happen.
+            patch.object(GatewayRunner, "_agent_has_active_subagents", return_value=True),
+        ):
+            result = await GatewayRunner._handle_active_session_busy_message(runner, event, sk)
+            await asyncio.sleep(0)
+
+        # No debounce task should have been scheduled.
+        assert sk not in runner._pending_interrupt_tasks
+        # No interrupt should have been called (queue mode, not interrupt mode).
+        agent.interrupt.assert_not_called()
+        # Message was stored via FIFO (head pending slot on the adapter).
+        assert sk in adapter._pending_messages


### PR DESCRIPTION
## Problem

In `interrupt` mode, when a user sends several messages in quick succession while an agent is already running, each message triggers a separate `running_agent.interrupt()`. The repeated busy ack is already rate-limited (30s cooldown), but the multiple interrupts themselves are not coalesced. Some setups (personal assistants in particular) would prefer a burst of messages to be handled as a single turn.

## What this adds (opt-in, default off)

A new env var `HERMES_INTERRUPT_DEBOUNCE_SECONDS` (default `0` = disabled). When set above `0`, in `interrupt` mode:

- Rapid messages are aggregated within a debounce window. Each new message cancels and reschedules a per-session timer, so a burst results in a single interrupt and a single ack.
- The burst is merged into one pending turn (`merge_text=True`).

When the value is `0` (default), behavior is unchanged: the FIFO / no-merge path from #43066 is preserved exactly, and the immediate-interrupt path stays equivalent to today.

## Scope and safety

- The debounce is gated strictly inside `interrupt` mode. The `queue` and `steer` modes and the subagent demotion path are untouched.
- The internal-event guard and authorization checks are preserved (the debounce path is reached only after them).
- Per-session cleanup of pending debounce tasks on stop/reset/new/switch/stream-cleanup/eviction (all via `_release_running_agent_state`), plus cancel-and-await on shutdown.
- The `finally` removes the dict entry only if it still points to the current task, avoiding eviction of a newer task under a cancel-during-execution race.
- The busy-ack cooldown timestamp is updated only after a successful send.
- An invalid env value falls back to `0` with a warning, and if the pending store is unexpectedly unavailable the code falls back to the normal FIFO enqueue (no message is dropped silently).

## Tests

Adds tests for: off-by-default (immediate interrupt, no task scheduled), burst batching (single interrupt + single ack, messages merged into the pending turn with no FIFO duplicates), agent finishing within the window (no interrupt / no ack), demotion-to-queue not activating the debounce, and pending-task cleanup. All gateway busy-session tests pass.

## Backward compatibility

Default (`0`) preserves current behavior. Operators opt in by setting `HERMES_INTERRUPT_DEBOUNCE_SECONDS` to a small value such as `1.5`.
