### PR TITLE
fix(cli): keep streamed text visible across tool-prep

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9997,14 +9997,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
     def _on_tool_gen_start(self, tool_name: str) -> None:
         """Called when the model begins generating tool-call arguments.
 
-        Closes any open streaming boxes (reasoning / response) exactly once,
-        then prints a short status line so the user sees activity instead of
-        a frozen screen while a large payload (e.g. 45 KB write_file) streams.
+        Prints a short status line when tool-call argument generation starts,
+        but only when we are not already actively streaming visible content.
+
+        Interleaving a transient "preparing …" line onto the same
+        prompt_toolkit output channel while the live reasoning/response box is
+        open can visually displace the streamed content on some terminals
+        (notably Windows + StdoutProxy). Once the user can already see the
+        response streaming, prefer preserving that output; the normal spinner
+        and tool-completed progress lines still surface tool activity.
         """
-        if getattr(self, "_stream_box_opened", False):
-            self._flush_stream()
-            self._stream_box_opened = False
-        self._close_reasoning_box()
+        if (
+            getattr(self, "_stream_box_opened", False)
+            or getattr(self, "_reasoning_box_opened", False)
+        ):
+            return
 
         from agent.display import get_tool_emoji
         emoji = get_tool_emoji(tool_name, default="⚡")

--- a/tests/cli/test_tool_gen_stream_interleave.py
+++ b/tests/cli/test_tool_gen_stream_interleave.py
@@ -1,0 +1,36 @@
+from unittest.mock import patch
+
+from cli import HermesCLI
+
+
+def _make_cli():
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj._stream_box_opened = False
+    cli_obj._reasoning_box_opened = False
+    cli_obj._stream_buf = ""
+    return cli_obj
+
+
+def test_tool_gen_start_skips_transient_line_while_response_stream_is_open():
+    cli_obj = _make_cli()
+    cli_obj._stream_box_opened = True
+
+    with patch.object(cli_obj, "_flush_stream") as flush_mock, \
+         patch.object(cli_obj, "_close_reasoning_box") as close_reasoning_mock, \
+         patch("cli._cprint") as cprint_mock:
+        cli_obj._on_tool_gen_start("read_file")
+
+    flush_mock.assert_not_called()
+    close_reasoning_mock.assert_not_called()
+    cprint_mock.assert_not_called()
+    assert cli_obj._stream_box_opened is True
+
+
+def test_tool_gen_start_prints_status_when_no_stream_ui_is_open():
+    cli_obj = _make_cli()
+
+    with patch("agent.display.get_tool_emoji", return_value="📄"), \
+         patch("cli._cprint") as cprint_mock:
+        cli_obj._on_tool_gen_start("read_file")
+
+    cprint_mock.assert_called_once_with("  ┊ 📄 preparing read_file…")


### PR DESCRIPTION
## Summary
- stop injecting the transient `preparing ...` scrollback line while a live reasoning/response stream is already open
- preserve the streamed content box instead of flushing and closing it mid-turn
- add CLI regression tests for tool-gen status behavior with and without an open stream UI

## Testing
- pytest tests/cli/test_tool_gen_stream_interleave.py tests/cli/test_tool_progress_scrollback.py -q
- ruff check cli.py tests/cli/test_tool_gen_stream_interleave.py
- git diff --check

Closes #40693.