### PR TITLE
fix(feishu): route markdown tables through post+md instead of forcing text

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4374,13 +4374,15 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
-        if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
-        if _MARKDOWN_HINT_RE.search(content):
+        # Markdown content (including tables) is sent via post + tag:md, which
+        # Feishu now renders correctly across all clients. Plain text falls
+        # through to msg_type=text.
+        #
+        # Historical note: this routine used to force msg_type=text for any
+        # content containing a markdown table, because older Feishu/Lark
+        # clients rendered tables inside post+md as blank. That bug has been
+        # fixed upstream — see hermes-agent issues #26658 and #27529.
+        if _MARKDOWN_TABLE_RE.search(content) or _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}
         return "text", json.dumps(text_payload, ensure_ascii=False)

--- a/tests/gateway/test_feishu_outbound_routing.py
+++ b/tests/gateway/test_feishu_outbound_routing.py
@@ -1,0 +1,82 @@
+"""Tests for `FeishuAdapter._build_outbound_payload` routing.
+
+Covers the fix for hermes-agent #26658 / #27529: messages containing markdown
+tables should be sent as ``post`` + ``tag: md`` (which Feishu renders
+correctly across all current clients), not force-downgraded to plain
+``text``.
+"""
+
+import json
+import unittest
+
+
+class TestOutboundPayloadRouting(unittest.TestCase):
+    def _make_adapter(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        return FeishuAdapter(PlatformConfig())
+
+    def test_plain_text_routes_to_text(self):
+        adapter = self._make_adapter()
+        msg_type, payload = adapter._build_outbound_payload("Just a plain line.")
+        self.assertEqual(msg_type, "text")
+        self.assertEqual(json.loads(payload)["text"], "Just a plain line.")
+
+    def test_markdown_without_table_routes_to_post(self):
+        adapter = self._make_adapter()
+        content = "Some **bold** text and a [link](https://example.com)."
+        msg_type, _ = adapter._build_outbound_payload(content)
+        self.assertEqual(msg_type, "post")
+
+    def test_markdown_table_routes_to_post(self):
+        """Regression test for #26658 / #27529.
+
+        Tables must go to ``post`` (not ``text``) so Feishu renders them
+        properly using the ``tag: md`` element. Forcing ``text`` was the
+        old workaround for a Feishu rendering bug that has since been
+        fixed upstream.
+        """
+        adapter = self._make_adapter()
+        content = (
+            "Look at this:\n\n"
+            "| a | b |\n"
+            "|---|---|\n"
+            "| 1 | 2 |\n"
+        )
+        msg_type, payload = adapter._build_outbound_payload(content)
+        self.assertEqual(msg_type, "post")
+        # The post payload should carry the table text verbatim inside a
+        # ``tag: md`` element so Feishu's renderer can format it.
+        decoded = json.loads(payload)
+        rows = decoded["zh_cn"]["content"]
+        rendered = json.dumps(rows, ensure_ascii=False)
+        self.assertIn("| a | b |", rendered)
+        self.assertIn('"tag": "md"', rendered)
+
+    def test_table_only_message_still_routes_to_post(self):
+        """Table-only content (no surrounding prose) also goes to post."""
+        adapter = self._make_adapter()
+        content = (
+            "| col1 | col2 |\n"
+            "|------|------|\n"
+            "| x    | y    |\n"
+        )
+        msg_type, _ = adapter._build_outbound_payload(content)
+        self.assertEqual(msg_type, "post")
+
+    def test_table_with_inline_markdown_routes_to_post(self):
+        adapter = self._make_adapter()
+        content = (
+            "Summary below:\n\n"
+            "| 维度 | 状态 |\n"
+            "|------|------|\n"
+            "| **粗体** | [链接](https://example.com) |\n\n"
+            "End of summary."
+        )
+        msg_type, _ = adapter._build_outbound_payload(content)
+        self.assertEqual(msg_type, "post")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this PR do?

Fixes Feishu markdown table rendering by routing table-containing messages
through the existing `post + tag:md` pipeline instead of force-downgrading
them to plain `text`. The historical workaround caused all formatting
(bold, links, code blocks, lists) to be stripped whenever a message
contained any markdown table — strictly worse than the blank-render bug
it was originally working around, and unnecessary now that Feishu
v1.0.39+ renders tables in `tag:md` correctly.

Before this change, a reply like:
```
Summary:

| Status | Count |
|--------|-------|
| Done   | 12    |

See **details** [here](https://example.com).
```
arrived as raw `| Status | Count |` pipes with the bold, link, and prose
all stripped to plain text. After this change, the same content renders
as a real Feishu table with bold/link/prose preserved.

The net change is **9 lines** in `_build_outbound_payload`: the two
separate branches for "has table" and "has markdown hint" are merged
into one, since both now want the same `post + tag:md` output.

## Related Issue

Fixes #21778

Also addresses #26658 and #27529 (which proposed this exact approach).

Closes-by-implementation (all unmerged, same direction):
- #26108 (closed by author with "open too long, no longer relevant"; three contributors verified the fix worked)
- #33800 (marked duplicate-of-#26108)
- #31410
- #29552
- #31056

Root issue: #9549 (long-standing).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/feishu/adapter.py` — `_build_outbound_payload`: merge the
  markdown-table detection branch into the markdown-hint branch. Both routes
  now return `("post", _build_markdown_post_payload(content))`. Updated the
  surrounding comment to note this is the modern path and link the issues
  that established it.
- `tests/gateway/test_feishu_outbound_routing.py` (new) — 5 regression tests:
  pure text → `text`; markdown without table → `post`; markdown with table → `post`;
  table-only content → `post`; table with inline markdown (`**bold**`, `[link](…)`)
  inside cells → `post`. The third test is the key regression assertion: a
  table-bearing message must NOT downgrade to `text`.

## How to Test

1. Apply this branch.
2. Restart your Feishu gateway (`launchctl kickstart -k gui/$(id -u)/ai.hermes.gateway` on macOS, `systemctl --user restart hermes-gateway` on Linux).
3. Have the agent reply with content that contains a markdown table. Confirm
   it now renders as a real Feishu table rather than raw pipes.
4. Confirm non-table markdown (bold, code blocks, lists, links) and plain
   text still render correctly (those code paths are unchanged but verified
   by the routing tests).
5. Run the new regression tests:
   ```bash
   pytest tests/gateway/test_feishu_outbound_routing.py -q
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit message follows [Conventional Commits](https://www.conventionalcommits.org/) (`fix(feishu): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — there are several in this direction, all unmerged; this re-submission adds broader test coverage and a single-purpose minimal diff. Happy to defer if a maintainer prefers to revive #26108 or fast-track one of the others; will close on request.
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_feishu*.py -q` — `397 passed, 3 failed (pre-existing failures in test_feishu_approval_buttons unrelated to this change, reproduce on main)`
- [x] I've added tests — 5 new regression tests in `tests/gateway/test_feishu_outbound_routing.py`
- [x] I've tested on my platform: macOS 26.4.1 / Feishu v7.x desktop + mobile

### Documentation & Housekeeping

- [x] I've updated relevant documentation — comment in `_build_outbound_payload` rewritten to explain the new routing and link the issues
- [x] N/A — no config keys changed
- [x] N/A — architecture unchanged, just a one-branch consolidation
- [x] Cross-platform — pure routing change, no platform-specific code paths touched
- [x] N/A — tool descriptions/schemas unchanged

## Screenshots / Logs

I verified end-to-end on a live Feishu DM after restarting the gateway with
this branch applied. The same content that previously rendered as raw pipes
now renders as a proper table, with all surrounding markdown intact.

Regression test output:
```
$ pytest tests/gateway/test_feishu_outbound_routing.py -v
test_plain_text_routes_to_text                  PASSED
test_markdown_without_table_routes_to_post      PASSED
test_markdown_table_routes_to_post              PASSED  [key regression assert]
test_table_only_message_still_routes_to_post    PASSED
test_table_with_inline_markdown_routes_to_post  PASSED
5 passed
```
