### PR TITLE
fix(tui): submit slash commands on first Enter

### DIFF
--- a/ui-tui/src/__tests__/completionApply.test.ts
+++ b/ui-tui/src/__tests__/completionApply.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { applyCompletion, completionToApplyOnSubmit } from '../domain/slash.js'
+import { applyCompletion, completionToApplyOnSubmit, valueToDispatchOnSubmit } from '../domain/slash.js'
 
 describe('applyCompletion', () => {
   it('replaces from compReplace and drops the leading slash from the row', () => {
@@ -47,5 +47,19 @@ describe('completionToApplyOnSubmit', () => {
   it('returns null when there is no row text', () => {
     expect(completionToApplyOnSubmit('/exit', undefined, 1)).toBeNull()
     expect(completionToApplyOnSubmit('/exit', '', 1)).toBeNull()
+  })
+})
+
+describe('valueToDispatchOnSubmit', () => {
+  it('dispatches the completed slash command on the same Enter press', () => {
+    expect(valueToDispatchOnSubmit('/ex', 'exit', 1)).toBe('/exit')
+  })
+
+  it('dispatches the completed argument on the same Enter press', () => {
+    expect(valueToDispatchOnSubmit('/cron ad', 'add', 6)).toBe('/cron add')
+  })
+
+  it('keeps the current value when the completion only adds trailing space', () => {
+    expect(valueToDispatchOnSubmit('/exit', 'exit ', 1)).toBe('/exit')
   })
 })

--- a/ui-tui/src/app/useSubmission.ts
+++ b/ui-tui/src/app/useSubmission.ts
@@ -2,7 +2,7 @@ import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 
 import { TYPING_IDLE_MS } from '../config/timing.js'
 import { attachedImageNotice } from '../domain/messages.js'
-import { completionToApplyOnSubmit, looksLikeSlashCommand } from '../domain/slash.js'
+import { looksLikeSlashCommand, valueToDispatchOnSubmit } from '../domain/slash.js'
 import type { GatewayClient } from '../gatewayClient.js'
 import type {
   InputDetectDropResponse,
@@ -352,16 +352,15 @@ export function useSubmission(opts: UseSubmissionOptions) {
 
   const submit = useCallback(
     (value: string) => {
-      if (composerState.completions.length) {
-        const row = composerState.completions[composerState.compIdx]
-        const next = completionToApplyOnSubmit(value, row?.text, composerState.compReplace)
+      const submitValue = composerState.completions.length
+        ? valueToDispatchOnSubmit(
+            value,
+            composerState.completions[composerState.compIdx]?.text,
+            composerState.compReplace
+          )
+        : value
 
-        if (next !== null) {
-          return composerActions.setInput(next)
-        }
-      }
-
-      if (!value.trim() && !composerState.inputBuf.length) {
+      if (!submitValue.trim() && !composerState.inputBuf.length) {
         const live = getUiState()
         const now = Date.now()
         const doubleTap = now - lastEmptyAt.current < DOUBLE_ENTER_MS
@@ -397,7 +396,7 @@ export function useSubmission(opts: UseSubmissionOptions) {
         return composerActions.setInput('')
       }
 
-      dispatchSubmission([...composerState.inputBuf, value].join('\n'))
+      dispatchSubmission([...composerState.inputBuf, submitValue].join('\n'))
     },
     [appendMessage, composerActions, composerRefs, composerState, dispatchSubmission, gw, sys]
   )

--- a/ui-tui/src/domain/slash.ts
+++ b/ui-tui/src/domain/slash.ts
@@ -48,3 +48,16 @@ export const completionToApplyOnSubmit = (
 
   return next !== value && next.trimEnd() !== value.trimEnd() ? next : null
 }
+
+/**
+ * Resolve the text Enter should dispatch from the TUI composer.
+ *
+ * Enter always submits immediately, but when a highlighted completion would
+ * materially extend the current slash token, we inline that completion into
+ * the submitted text instead of forcing a separate "accept completion" keypress.
+ */
+export const valueToDispatchOnSubmit = (
+  value: string,
+  rowText: string | undefined,
+  compReplace: number
+): string => completionToApplyOnSubmit(value, rowText, compReplace) ?? value


### PR DESCRIPTION
## Summary
- dispatch slash-command completions on the same Enter press instead of only rewriting the composer
- keep the trailing-space guard so fully completed commands still submit immediately
- add regression coverage for partial command and argument completion submits

Closes #50639

## Testing
- npm test -- --run src/__tests__/completionApply.test.ts
- npx eslint src/app/useSubmission.ts src/domain/slash.ts src/__tests__/completionApply.test.ts
- git diff --check

## Notes
- `npm run typecheck` is currently not a truthful local gate in this checkout because the ui-tui environment is missing a clean dependency/type baseline; broad missing-module/tsconfig failures are preexisting and unrelated to this diff.