### PR TITLE
fix(cli): use is_truthy_value for remaining config boolean coercion

### DIFF
--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -33,6 +33,7 @@ from hermes_cli.browser_connect import (
     is_browser_debug_ready,
     manual_chrome_debug_command,
 )
+from utils import is_truthy_value
 
 
 class CLICommandsMixin:
@@ -1983,7 +1984,7 @@ class CLICommandsMixin:
 
         cfg = load_config() or {}
         footer_cfg = ((cfg.get("display") or {}).get("runtime_footer") or {})
-        current = bool(footer_cfg.get("enabled", False))
+        current = is_truthy_value(footer_cfg.get("enabled"), default=False)
         fields = footer_cfg.get("fields") or ["model", "context_pct", "cwd"]
 
         if arg in {"status", "?"}:

--- a/hermes_cli/model_catalog.py
+++ b/hermes_cli/model_catalog.py
@@ -53,7 +53,7 @@ from pathlib import Path
 from typing import Any
 
 from hermes_cli import __version__ as _HERMES_VERSION
-from utils import atomic_replace
+from utils import atomic_replace, is_truthy_value
 
 logger = logging.getLogger(__name__)
 
@@ -104,7 +104,7 @@ def _load_catalog_config() -> dict[str, Any]:
         raw = {}
 
     return {
-        "enabled": bool(raw.get("enabled", True)),
+        "enabled": is_truthy_value(raw.get("enabled"), default=True),
         "url": str(raw.get("url") or DEFAULT_CATALOG_URL),
         "ttl_hours": float(raw.get("ttl_hours") or DEFAULT_TTL_HOURS),
         "providers": raw.get("providers") if isinstance(raw.get("providers"), dict) else {},

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -76,7 +76,7 @@ from gateway.status import (
     parse_active_agents,
     read_runtime_status,
 )
-from utils import env_var_enabled
+from utils import env_var_enabled, is_truthy_value
 
 try:
     from fastapi import (
@@ -4920,7 +4920,7 @@ def _messaging_platform_payload(
             plat_cfg = platforms_cfg.get(platform_id)
             if not isinstance(plat_cfg, dict):
                 plat_cfg = {}
-            enabled = bool(plat_cfg.get("enabled"))
+            enabled = is_truthy_value(plat_cfg.get("enabled"))
             hc = plat_cfg.get("home_channel")
             home_channel = hc if isinstance(hc, dict) else None
         except Exception:


### PR DESCRIPTION
## Summary

`bool("false")` returns `True` in Python. Replace remaining `bool(config.get("enabled"))` calls with `is_truthy_value()` in 3 CLI files:

- `cli_commands_mixin.py`: runtime_footer enabled toggle
- `web_server.py`: platform enabled check
- `model_catalog.py`: catalog enabled default

Companion to PR #50604 which fixed gateway/ + webhook + secrets_cli.

## Test plan

- [ ] CI passes