### PR TITLE
fix(api-server): construct canonical session_key for delegation routing

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3728,7 +3728,15 @@ class APIServerAdapter(BasePlatformAdapter):
 
             tokens = self._bind_api_server_session(
                 chat_id=session_id or "",
-                session_key=gateway_session_key or session_id or "",
+                # When no X-Hermes-Session-Key header is provided (e.g. no
+                # API_SERVER_KEY configured), construct the canonical gateway
+                # session_key format so async-delegation completion events can
+                # be routed back to this session.  Without this, bare UUID
+                # session_ids cause _parse_session_key() to fail, dropping
+                # delegation results silently.  (#delegation-routing)
+                session_key=gateway_session_key or (
+                    f"agent:main:api_server:dm:{session_id}" if session_id else ""
+                ),
                 session_id=session_id or "",
             )
             try:
@@ -3917,7 +3925,12 @@ class APIServerAdapter(BasePlatformAdapter):
 
         run_id = f"run_{uuid.uuid4().hex}"
         session_id = body.get("session_id") or stored_session_id or run_id
-        approval_session_key = gateway_session_key or session_id or run_id
+        # Construct canonical session_key format when no X-Hermes-Session-Key
+        # header is provided, so async-delegation completion events can be
+        # routed back to this session.  Mirror the fix in _run_agent.
+        approval_session_key = gateway_session_key or (
+            f"agent:main:api_server:dm:{session_id}" if session_id else run_id
+        )
         ephemeral_system_prompt = instructions
         loop = asyncio.get_running_loop()
         q: "asyncio.Queue[Optional[Dict]]" = asyncio.Queue()


### PR DESCRIPTION
## Problem

Async delegation results are **silently lost** for WebUI sessions when `API_SERVER_KEY` is not configured.

### Reproduction

1. Start Hermes gateway with api_server enabled, **no** `API_SERVER_KEY` set
2. Open WebUI, dispatch `delegate_task(background=true)`
3. Subagent completes successfully (logs confirm)
4. Result **never** re-enters the parent session

### Root Cause

**WebUI** (`gateway_chat.py:292`) only sends `X-Hermes-Session-Key` when `api_key` is set:
```python
if api_key:
    headers[X-Hermes-Session-Key] = fagent:main:api_server:dm:{session_id}
```

Without the header, gateway falls back to **bare UUID** as session_key (e.g. `bdee577ef6a1`).

The delegation watcher pipeline then fails:
1. `_parse_session_key('bdee577ef6a1')` → `None` (no `agent:main:` prefix)
2. `_enrich_async_delegation_routing` → returns without enriching
3. `_build_process_event_source` → `None` (no platform/chat_id)
4. `_inject_watch_notification` → **drops event** with 'no routing metadata' warning

**Telegram works** because it always uses canonical format: `agent:main:telegram:dm:{chat_id}`

## Fix

In `_run_agent` and the `/v1/runs` handler, construct the canonical format as fallback:

```python
session_key = gateway_session_key or (
    fagent:main:api_server:dm:{session_id} if session_id else 
)
```

This matches what the WebUI already sends when `API_SERVER_KEY` IS configured, ensuring `_parse_session_key` can extract platform/chat_id for proper event routing.

## Files Changed

- `gateway/platforms/api_server.py` — 2 call sites fixed (`_run_agent` + `/v1/runs` handler)

## Testing

- [x] Verified subagent completes (logs show 3 API calls, text_response)
- [x] Verified completion event was dropped (no injection logs, 'no routing metadata')
- [x] After fix: session_key format is `agent:main:api_server:dm:{id}` → parse succeeds → routing works
