### PR TITLE
fix(cli): honor explicit workspace cwd for local backends

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -586,14 +586,18 @@ def load_cli_config() -> Dict[str, Any]:
     
     # CWD resolution for CLI/TUI. The gateway has its own config bridge in
     # gateway/run.py but may lazily import cli.py (triggering this code).
-    # Local backend: always os.getcwd(). Use `cd /dir && hermes` to control it.
+    # Local backend: honor an explicit launcher-provided workspace first
+    # (Desktop / embedded TUI set HERMES_CWD), otherwise fall back to the
+    # current process cwd. Use `cd /dir && hermes` to control it when no
+    # launcher workspace is provided.
     # Non-local with placeholder: pop so terminal_tool uses its per-backend default.
     # Non-local with explicit path: keep as-is.
     _CWD_PLACEHOLDERS = (".", "auto", "cwd")
     effective_backend = terminal_config.get("env_type", "local")
 
     if effective_backend == "local":
-        terminal_config["cwd"] = os.getcwd()
+        requested_cwd = os.environ.get("HERMES_CWD") or ""
+        terminal_config["cwd"] = requested_cwd or os.getcwd()
         defaults["terminal"]["cwd"] = terminal_config["cwd"]
     elif terminal_config.get("cwd") in _CWD_PLACEHOLDERS:
         terminal_config.pop("cwd", None)

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -574,6 +574,30 @@ class TestRootLevelProviderOverride:
         assert result["model"]["provider"] == "opencode-go"
         assert result["model"]["base_url"] == "https://example.com/v1"
 
+
+class TestLoadCliConfigCwd:
+    """load_cli_config() must preserve launcher-provided local workspaces."""
+
+    def test_local_backend_prefers_explicit_hermes_cwd(self, tmp_path, monkeypatch):
+        import cli
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HERMES_CWD", str(workspace))
+        monkeypatch.chdir(elsewhere)
+        monkeypatch.setattr(cli, "_hermes_home", hermes_home)
+
+        cfg = cli.load_cli_config()
+
+        assert cfg["terminal"]["cwd"] == str(workspace)
+        assert os.environ["TERMINAL_CWD"] == str(workspace)
+
     def test_normalize_root_model_keys_does_not_override_existing(self):
         """Existing model.provider is never overridden by root-level key."""
         from hermes_cli.config import _normalize_root_model_keys

--- a/tests/cli/test_cwd_env_respect.py
+++ b/tests/cli/test_cwd_env_respect.py
@@ -1,7 +1,7 @@
 """Tests for CLI/TUI CWD resolution in load_cli_config().
 
 Rules:
-- Local backend CLI/TUI: always os.getcwd(), ignoring config and inherited env.
+- Local backend CLI/TUI: prefer explicit HERMES_CWD, else os.getcwd().
 - Non-local with placeholder: pop cwd for backend default.
 - Non-local with explicit path: keep as-is.
 """
@@ -15,7 +15,7 @@ def _resolve_cwd(terminal_config: dict, defaults: dict, env: dict):
     effective_backend = terminal_config.get("env_type", "local")
 
     if effective_backend == "local":
-        terminal_config["cwd"] = "/fake/getcwd"
+        terminal_config["cwd"] = env.get("HERMES_CWD") or "/fake/getcwd"
         defaults["terminal"]["cwd"] = terminal_config["cwd"]
     elif terminal_config.get("cwd") in _CWD_PLACEHOLDERS:
         terminal_config.pop("cwd", None)
@@ -32,7 +32,13 @@ def _resolve_cwd(terminal_config: dict, defaults: dict, env: dict):
 
 
 class TestLocalBackendCli:
-    """Local backend always uses os.getcwd()."""
+    """Local backend uses explicit workspace cwd when provided."""
+
+    def test_explicit_hermes_cwd_wins(self):
+        env = {"HERMES_CWD": "/workspace/project"}
+        tc = {"cwd": ".", "env_type": "local"}
+        d = {"terminal": {"cwd": "."}}
+        assert _resolve_cwd(tc, d, env) == "/workspace/project"
 
     def test_explicit_config_ignored(self):
         env = {}


### PR DESCRIPTION
## Summary
- honor launcher-provided `HERMES_CWD` before falling back to `os.getcwd()` for local backends
- keep exporting the resolved workspace through `TERMINAL_CWD` so Desktop/TUI tool calls follow the selected project
- add cwd regression coverage for the config bridge and the real `load_cli_config()` path

## Testing
- uv run --frozen pytest tests/cli/test_cwd_env_respect.py tests/cli/test_cli_init.py -q
- uv run --frozen ruff check cli.py tests/cli/test_cwd_env_respect.py tests/cli/test_cli_init.py
- git diff --check

Fixes #50017