### PR TITLE
fix(voice): use is_truthy_value for beep_enabled config coercion

### DIFF
--- a/hermes_cli/voice.py
+++ b/hermes_cli/voice.py
@@ -219,6 +219,7 @@ from tools.voice_mode import (
     play_audio_file,
     transcribe_recording,
 )
+from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
 
@@ -251,7 +252,7 @@ def _beeps_enabled() -> bool:
 
         voice_cfg = load_config().get("voice", {})
         if isinstance(voice_cfg, dict):
-            return bool(voice_cfg.get("beep_enabled", True))
+            return is_truthy_value(voice_cfg.get("beep_enabled"), default=True)
     except Exception:
         pass
     return True


### PR DESCRIPTION
## Summary

`bool("false")` returns `True` in Python. Replace `bool(voice_cfg.get("beep_enabled", True))` with `is_truthy_value()` to correctly handle quoted YAML values.

Companion to PRs #50604 and #50646.

## Test plan

- [ ] CI passes