### PR TITLE
fix(dashboard): log startup checkpoints before bind

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12095,8 +12095,17 @@ def cmd_dashboard(args):
         _setup_logging_gui(mode="gui")
     except Exception:
         pass
+    logger.info(
+        "Dashboard startup: begin host=%s port=%s skip_build=%s no_open=%s isolated=%s",
+        getattr(args, "host", None),
+        getattr(args, "port", None),
+        getattr(args, "skip_build", False),
+        getattr(args, "no_open", False),
+        getattr(args, "isolated", False),
+    )
 
     try:
+        logger.info("Dashboard startup: checking web UI dependencies")
         import fastapi  # noqa: F401
         import uvicorn  # noqa: F401
     except ImportError as e:
@@ -12109,20 +12118,25 @@ def cmd_dashboard(args):
         )
         print(f"Import error: {e}")
         sys.exit(1)
+    logger.info("Dashboard startup: web UI dependencies available")
 
     # Seed bundled skills on first dashboard launch so the desktop GUI's
     # skills picker / agent skill discovery sees the bundled library.
     # cmd_chat does this in its own pre-dispatch block; the dashboard
     # backend is the desktop's primary entrypoint and needs the same.
+    logger.info("Dashboard startup: syncing bundled skills")
     _sync_bundled_skills_quietly()
+    logger.info("Dashboard startup: bundled skills synced")
 
     if _headless_backend:
         # Don't build the SPA, and tell mount_spa() (read at web_server import
         # below) to disable it even if a stray dist exists. Set it first.
         os.environ["HERMES_SERVE_HEADLESS"] = "1"
     elif "HERMES_WEB_DIST" not in os.environ and not getattr(args, "skip_build", False):
+        logger.info("Dashboard startup: building web UI")
         if not _build_web_ui(PROJECT_ROOT / "web", fatal=True):
             sys.exit(1)
+        logger.info("Dashboard startup: web UI build complete")
     elif getattr(args, "skip_build", False):
         # --build-mode skip trusts the caller to have pre-built the web UI.
         # Verify the dist actually exists; otherwise the server will start
@@ -12155,6 +12169,7 @@ def cmd_dashboard(args):
         # pass here and still 404 there.
         os.environ["HERMES_WEB_DIST"] = str(_dist_root)
         print(f"→ Using web dist from HERMES_WEB_DIST: {_dist_root}")
+        logger.info("Dashboard startup: using prebuilt web UI dist at %s", _dist_root)
 
     # Discover and load plugins so any DashboardAuthProvider plugin
     # (e.g. plugins/dashboard_auth/nous) registers BEFORE start_server's
@@ -12165,11 +12180,14 @@ def cmd_dashboard(args):
     # providers (image_gen, web, dashboard_auth, …).
     try:
         from hermes_cli.plugins import discover_plugins
+        logger.info("Dashboard startup: discovering plugins")
         discover_plugins()
+        logger.info("Dashboard startup: plugin discovery complete")
     except Exception as exc:
         # Discovery failures must not block dashboard startup outright —
         # log and proceed; the gate's fail-closed branch will surface
         # the missing-provider state if it matters.
+        logger.warning("Dashboard startup: plugin discovery failed", exc_info=True)
         print(f"⚠ Plugin discovery failed: {exc}", file=sys.stderr)
 
     # Desktop chat uses the dashboard's in-process /api/ws gateway, which builds
@@ -12182,10 +12200,12 @@ def cmd_dashboard(args):
     try:
         from hermes_cli.mcp_startup import start_background_mcp_discovery
 
+        logger.info("Dashboard startup: scheduling background MCP discovery")
         start_background_mcp_discovery(
             logger=logger,
             thread_name="dashboard-mcp-discovery",
         )
+        logger.info("Dashboard startup: background MCP discovery scheduled")
     except Exception:
         logger.debug(
             "Background MCP tool discovery failed at dashboard startup",
@@ -12199,11 +12219,19 @@ def cmd_dashboard(args):
     # instead of hard-failing inside start_server. Non-interactive callers
     # (Docker/s6, CI, --no-open pipelines) fall through to start_server's
     # fail-closed SystemExit unchanged.
+    logger.info("Dashboard startup: checking interactive auth setup")
     _maybe_setup_dashboard_auth_interactively(args)
+    logger.info("Dashboard startup: interactive auth setup check complete")
 
     # The in-browser Chat tab (the embedded TUI over PTY/WebSocket) is always
     # available — the desktop app and the dashboard's own Chat tab both rely on
     # the `/api/ws` + `/api/pty` sockets, so there is no reason to gate them.
+    logger.info(
+        "Dashboard startup: entering start_server host=%s port=%s open_browser=%s",
+        args.host,
+        args.port,
+        not args.no_open,
+    )
     start_server(
         host=args.host,
         port=args.port,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17201,16 +17201,24 @@ def start_server(
     async def _serve():
         # Split startup from main_loop so we can read the bound port
         # after the socket is live (ephemeral port discovery).
+        _log.info("Dashboard server startup: loading uvicorn config")
         if not config.loaded:
             config.load()
         server.lifespan = config.lifespan_class(config)
         with server.capture_signals():
+            _log.info("Dashboard server startup: awaiting uvicorn startup")
             await server.startup()
+            _log.info(
+                "Dashboard server startup: uvicorn startup returned should_exit=%s started=%s",
+                server.should_exit,
+                server.started,
+            )
             if server.should_exit:
                 return
 
             actual_port = _read_bound_port(server, fallback=port)
             app.state.bound_port = actual_port
+            _log.info("Dashboard server startup: bound port resolved as %s", actual_port)
 
             _write_dashboard_ready_file(actual_port)
             # Port-discovery sentinel parsed by the desktop spawn. `serve` is a


### PR DESCRIPTION
## Summary
- add dashboard startup checkpoints around dependency checks, bundled skill sync, web build/dist selection, plugin discovery, background MCP discovery, auth setup, and the handoff into `start_server`
- add uvicorn startup checkpoints before config load, before/after `server.startup()`, and after the bound port is resolved
- keep stdout behavior unchanged; the extra signal goes through the existing dashboard/gui logging path

## Why
Refs #50641. The Windows report currently stops after `--skip-build` and never reaches `HERMES_DASHBOARD_READY`, but the available logs do not distinguish whether startup is stuck before `start_server`, inside plugin/MCP/auth setup, or during uvicorn startup. These checkpoints make the next debug report actionable without guessing at a Windows-only root cause from another OS.

## Tests
- `python3 -m py_compile hermes_cli/main.py hermes_cli/web_server.py`
- `python3 -m ruff check hermes_cli/main.py hermes_cli/web_server.py`
- `python3 -m pytest tests/test_web_server.py tests/hermes_cli/test_dashboard_auth_gate.py -q`
- `python3 -m pytest tests/hermes_cli/test_dashboard_unified_launch.py -q`
