### PR TITLE
fix: use platform.win32_ver() for Windows version detection

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -918,7 +918,8 @@ def build_environment_hints() -> str:
         if is_wsl():
             host_lines.append("Host: WSL (Windows Subsystem for Linux)")
         elif sys.platform == "win32":
-            host_lines.append(f"Host: Windows ({platform.release()})")
+            win_ver = platform.win32_ver()[0]
+            host_lines.append(f"Host: Windows ({win_ver or platform.release()})")
         elif sys.platform == "darwin":
             mac_ver = platform.mac_ver()[0]
             host_lines.append(f"Host: macOS ({mac_ver or platform.release()})")


### PR DESCRIPTION
## Problem

`platform.release()` returns the NT kernel version (`"10"`) on Python < 3.12, even on Windows 11 hosts. This causes the system prompt to incorrectly show `Host: Windows (10)` on Windows 11 machines.

## Root Cause

`platform.release()` was only updated in Python 3.12+ to use a Windows API that returns the product version rather than the kernel version. Since Windows 10 and Windows 11 share the same NT 10.0 kernel, older Python versions return `"10"` in both cases.

## Fix

Replace `platform.release()` with `platform.win32_ver()[0]`, which correctly returns the product version (`"10"` or `"11"`) regardless of Python version.

## Change

```diff
-            host_lines.append(f"Host: Windows ({platform.release()})")
+            win_ver = platform.win32_ver()[0]
+            host_lines.append(f"Host: Windows ({win_ver or platform.release()})")
```

## Verified

- Python 3.11 on Windows 11: `release()` → `"10"` ❌, `win32_ver()[0]` → `"11"` ✅
- Python 3.14 on Windows 11: `release()` → `"11"` ✅, `win32_ver()[0]` → `"11"` ✅