### PR TITLE
fix(terminal): bridge modal_mode config key to TERMINAL_MODAL_MODE in CLI and gateway

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -608,6 +608,7 @@ def load_cli_config() -> Dict[str, Any]:
         "docker_forward_env": "TERMINAL_DOCKER_FORWARD_ENV",
         "singularity_image": "TERMINAL_SINGULARITY_IMAGE",
         "modal_image": "TERMINAL_MODAL_IMAGE",
+        "modal_mode": "TERMINAL_MODAL_MODE",
         "daytona_image": "TERMINAL_DAYTONA_IMAGE",
         # SSH config
         "ssh_host": "TERMINAL_SSH_HOST",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1453,6 +1453,7 @@ if _config_path.exists():
                 "docker_forward_env": "TERMINAL_DOCKER_FORWARD_ENV",
                 "singularity_image": "TERMINAL_SINGULARITY_IMAGE",
                 "modal_image": "TERMINAL_MODAL_IMAGE",
+                "modal_mode": "TERMINAL_MODAL_MODE",
                 "daytona_image": "TERMINAL_DAYTONA_IMAGE",
                 "ssh_host": "TERMINAL_SSH_HOST",
                 "ssh_user": "TERMINAL_SSH_USER",

--- a/tests/tools/test_terminal_config_env_sync.py
+++ b/tests/tools/test_terminal_config_env_sync.py
@@ -322,3 +322,21 @@ def test_docker_forward_env_is_bridged_everywhere():
     assert "docker_forward_env" in _gateway_env_map_keys()
     assert "docker_forward_env" in _save_config_env_sync_keys()
     assert "TERMINAL_DOCKER_FORWARD_ENV" in _terminal_tool_env_var_names()
+
+
+def test_modal_mode_is_bridged_everywhere():
+    """Regression pin for ``terminal.modal_mode`` being silently dropped.
+
+    ``terminal.modal_mode`` selects the Modal credential strategy
+    (auto/direct/managed).  The key was present in DEFAULT_CONFIG
+    (``"modal_mode": "auto"``), TERMINAL_CONFIG_ENV_MAP, and consumed by
+    terminal_tool via ``os.getenv("TERMINAL_MODAL_MODE", "auto")`` — but was
+    missing from cli.py's env_mappings and gateway/run.py's _terminal_env_map.
+    A user who hand-edited ``terminal.modal_mode: direct`` in config.yaml had
+    the setting silently reverted to "auto" on CLI and gateway/desktop paths.
+    Same bug class as docker_extra_args (PR #50631).
+    """
+    assert "modal_mode" in _cli_env_map_keys()
+    assert "modal_mode" in _gateway_env_map_keys()
+    assert "modal_mode" in _save_config_env_sync_keys()
+    assert "TERMINAL_MODAL_MODE" in _terminal_tool_env_var_names()


### PR DESCRIPTION
## Summary

- `terminal.modal_mode` (auto/direct/managed) is defined in `DEFAULT_CONFIG`, present in the canonical `TERMINAL_CONFIG_ENV_MAP`, and consumed by `terminal_tool._get_env_config()` via `os.getenv("TERMINAL_MODAL_MODE", "auto")` — but it was **missing** from `cli.py`'s `env_mappings` and `gateway/run.py`'s `_terminal_env_map`.
- A user who set `terminal.modal_mode: direct` in `config.yaml` had the value silently dropped on CLI and gateway/desktop startup paths, falling back to `"auto"`.
- Same bug class as `docker_extra_args` (#50631).

## Changes

- **cli.py**: add `"modal_mode": "TERMINAL_MODAL_MODE"` to `env_mappings`
- **gateway/run.py**: add `"modal_mode": "TERMINAL_MODAL_MODE"` to `_terminal_env_map`
- **tests/tools/test_terminal_config_env_sync.py**: add `test_modal_mode_is_bridged_everywhere` regression pin (same pattern as the existing `docker_extra_args` / `docker_run_as_host_user` pins)

## Test plan

- [x] All 11 existing `test_terminal_config_env_sync` tests pass
- [x] New `test_modal_mode_is_bridged_everywhere` asserts all four bridging points (cli, gateway, config-set, terminal_tool consumer)
- [x] `ruff check` clean on all changed files