### PR TITLE
feat(agy-cli): register agy-cli provider in auth registry + runtime resolver

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -225,6 +225,16 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
+    "agy-cli": ProviderConfig(
+        id="agy-cli",
+        name="Antigravity CLI (agy)",
+        auth_type="external_process",
+        # Internal marker URL, never sent over HTTP. The agy binary at
+        # ~/.local/bin/agy handles its own OAuth + cloudcode-pa transport.
+        # See agent/agy_cli_client.py + plugins/model-providers/agy-cli/.
+        inference_base_url="agy://antigravity",
+        base_url_env_var="HERMES_AGY_COMMAND",  # actually a command override, not URL
+    ),
     "gemini": ProviderConfig(
         id="gemini",
         name="Google AI Studio",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1641,6 +1641,23 @@ def resolve_runtime_provider(
             "requested_provider": requested_provider,
         }
 
+    if provider == "agy-cli":
+        # Antigravity CLI: auth is fully internal to the `agy` binary
+        # (~/.local/bin/agy + its own OAuth/cloudcode-pa session). Hermes
+        # has nothing to resolve; we just hand back the marker base_url so
+        # init_agent's "if api_key and base_url" branch takes over and
+        # routes the request to AgyCliClient via agent_runtime_helpers.
+        return {
+            "provider": "agy-cli",
+            "api_mode": "agy_cli",
+            "base_url": "agy://antigravity",
+            # Placeholder api_key: AgyCliClient doesn't use it but the
+            # init path requires non-empty creds to reach the client builder.
+            "api_key": "agy-cli-external-process",
+            "source": "process",
+            "requested_provider": requested_provider,
+        }
+
     # Anthropic (native Messages API)
     if provider == "anthropic":
         # Allow base URL override from config.yaml model.base_url, but only


### PR DESCRIPTION
## Summary

Registers the **agy-cli** (Antigravity CLI) provider in the two core auth/runtime seams, so the agy-cli model provider is wired into Hermes' resolution path. This is the **auth/runtime registration half** of the agy-cli provider; the client (`agent/agy_cli_client.py`), plugin, and tests live in the sibling PR #50555.

### Changes (+27 lines, 2 files)

1. **`hermes_cli/auth.py`** — adds the `agy-cli` entry to `PROVIDER_REGISTRY`:
   ```python
   "agy-cli": ProviderConfig(
       id="agy-cli",
       name="Antigravity CLI (agy)",
       auth_type="external_process",
       inference_base_url="agy://antigravity",   # internal marker, never sent over HTTP
       base_url_env_var="HERMES_AGY_COMMAND",
   ),
   ```

2. **`hermes_cli/runtime_provider.py`** — adds the `if provider == "agy-cli":` branch in `resolve_runtime_provider()`, mirroring the existing `copilot-acp` external-process pattern. Returns `api_mode="agy_cli"` + the marker `base_url` so `init_agent` routes to `AgyCliClient`. Auth is fully internal to the `agy` binary (its own OAuth/cloudcode-pa session), so there's nothing for Hermes to resolve.

### Verification
- Applies clean on current `main` (+27 lines).
- Compiles; **0 new test failures** (the 39 pre-existing `tests/hermes_cli/` failures are identical with and without this change — they're upstream environment/isolation issues, not from this PR).
- Functional: `resolve_runtime_provider(requested="agy-cli")` → `api_mode='agy_cli'`, `base_url='agy://antigravity'`; `PROVIDER_REGISTRY["agy-cli"].auth_type == "external_process"`.

### Relationship to #50555
#50555 carries the agy-cli client + plugin + tests (currently a stale-base WIP draft). This PR carries the small, current-main-clean auth/runtime registration that #50555's stale base can't host without a rebase. The two together complete the agy-cli provider; they can be consolidated at #50555's upgrade.

Draft (agy-cli is WIP per the project's isolate-agy-cli policy).
