### PR TITLE
feat(cron): add script_args support for no_agent scripts

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -738,6 +738,7 @@ def create_job(
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
     no_agent: bool = False,
+    script_args: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -812,6 +813,14 @@ def create_job(
     normalized_base_url = normalized_base_url or None
     normalized_script = str(script).strip() if isinstance(script, str) else None
     normalized_script = normalized_script or None
+    if script_args is None:
+        normalized_script_args: List[str] = []
+    elif isinstance(script_args, list):
+        normalized_script_args = [str(a) for a in script_args]
+    else:
+        raise TypeError(
+            f"script_args must be a list of strings, got {type(script_args).__name__}"
+        )
     normalized_toolsets = [str(t).strip() for t in enabled_toolsets if str(t).strip()] if enabled_toolsets else None
     normalized_toolsets = normalized_toolsets or None
     normalized_workdir = _normalize_workdir(workdir)
@@ -846,6 +855,7 @@ def create_job(
         "provider": normalized_provider,
         "base_url": normalized_base_url,
         "script": normalized_script,
+        "script_args": normalized_script_args,
         "no_agent": normalized_no_agent,
         "context_from": context_from,
         "schedule": parsed_schedule,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -918,6 +918,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                         loop,
                     )
                     if future is None:
+                        logger.warning(
+                            "Job '%s': live adapter schedule failed for %s:%s, falling back to standalone",
+                            job["id"], platform_name, chat_id,
+                        )
                         adapter_ok = False
                         target_errors.append("live adapter event loop scheduling failed")
                     else:
@@ -1067,6 +1071,16 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     job["id"], err_msg,
                 )
 
+        elif runtime_adapter is not None:
+            # Gateway is running (adapter exists) but the event loop is
+            # unavailable — this is unexpected and means live delivery
+            # can't be attempted.  Fall through to standalone.
+            reason = "loop is None" if loop is None else "loop is not running"
+            logger.warning(
+                "Job '%s': live adapter exists for %s but %s, falling back to standalone",
+                job["id"], platform_name, reason,
+            )
+
         if not delivered:
             # Standalone path: run the async send in a fresh event loop (safe from any thread)
             coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
@@ -1140,7 +1154,7 @@ def _get_script_timeout() -> int:
     return _DEFAULT_SCRIPT_TIMEOUT
 
 
-def _run_job_script(script_path: str) -> tuple[bool, str]:
+def _run_job_script(script_path: str, script_args: Optional[list[str]] = None) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
     Scripts must reside within HERMES_HOME/scripts/.  Both relative and
@@ -1171,6 +1185,9 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         (success, output) — on failure *output* contains the error message so the
         LLM can report the problem to the user.
     """
+    if not script_path:
+        return False, "Script path is empty or None"
+
     scripts_dir = _get_hermes_home() / "scripts"
     scripts_dir.mkdir(parents=True, exist_ok=True)
     scripts_dir_resolved = scripts_dir.resolve()
@@ -1221,6 +1238,9 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         argv = [_bash, str(path)]
     else:
         argv = [sys.executable, str(path)]
+
+    if script_args:
+        argv.extend(script_args)
 
     try:
         from tools.environments.local import _sanitize_subprocess_env
@@ -1311,11 +1331,12 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
 
     # Run data-collection script if configured, inject output as context.
     script_path = job.get("script")
+    script_args = job.get("script_args")
     if script_path:
         if prerun_script is not None:
             success, script_output = prerun_script
         else:
-            success, script_output = _run_job_script(script_path)
+            success, script_output = _run_job_script(script_path, script_args)
         if success:
             if script_output:
                 prompt = (
@@ -1591,6 +1612,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     #                               is no agent to wake
     if job.get("no_agent"):
         script_path = job.get("script")
+        script_args = job.get("script_args")
         if not script_path:
             err = "no_agent=True but no script is set for this job"
             logger.error("Job '%s': %s", job_id, err)
@@ -1609,7 +1631,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 _prior_cwd = None
 
         try:
-            ok, output = _run_job_script(script_path)
+            ok, output = _run_job_script(script_path, script_args)
         finally:
             if _prior_cwd is not None:
                 try:
@@ -1697,8 +1719,9 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     # the script is only executed once.
     prerun_script = None
     script_path = job.get("script")
+    script_args = job.get("script_args")
     if script_path:
-        prerun_script = _run_job_script(script_path)
+        prerun_script = _run_job_script(script_path, script_args)
         _ran_ok, _script_output = prerun_script
         if _ran_ok and not _parse_wake_gate(_script_output):
             logger.info(

--- a/tests/cron/test_cron_script_args.py
+++ b/tests/cron/test_cron_script_args.py
@@ -1,0 +1,377 @@
+"""Tests for cron script_args feature — B class tests.
+
+Covers _run_job_script() argv construction, create_job() validation,
+and _format_job() echo-back of the script_args field.
+
+See: /Users/x/.hermes/tmp/cc-fix-plan-dual-bug-v2.md
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure project root is importable
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+@pytest.fixture
+def cron_env(tmp_path, monkeypatch):
+    """Isolated cron environment with temp HERMES_HOME."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "cron").mkdir()
+    (hermes_home / "cron" / "output").mkdir()
+    (hermes_home / "scripts").mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    import cron.jobs as jobs_mod
+    monkeypatch.setattr(jobs_mod, "HERMES_DIR", hermes_home)
+    monkeypatch.setattr(jobs_mod, "CRON_DIR", hermes_home / "cron")
+    monkeypatch.setattr(jobs_mod, "JOBS_FILE", hermes_home / "cron" / "jobs.json")
+    monkeypatch.setattr(jobs_mod, "OUTPUT_DIR", hermes_home / "cron" / "output")
+
+    import cron.scheduler as sched_mod
+    monkeypatch.setattr(sched_mod, "_hermes_home", hermes_home)
+
+    return hermes_home
+
+
+def _fake_subprocess_run(returncode=0, stdout="ok", stderr=""):
+    """Return a side_effect for subprocess.run that captures argv."""
+    captured = {}
+
+    def fake_run(argv, **kwargs):
+        captured["argv"] = list(argv)
+        return MagicMock(returncode=returncode, stdout=stdout, stderr=stderr)
+
+    return captured, fake_run
+
+
+class TestRunJobScriptArgs:
+    """B: _run_job_script argv construction with script_args."""
+
+    def test_no_args(self, cron_env):
+        """script_args not passed → argv contains only interpreter + script."""
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "test.py"
+        script.write_text('print("hello")\n')
+
+        captured, fake_run = _fake_subprocess_run()
+        with patch("subprocess.run", side_effect=fake_run):
+            success, output = _run_job_script("test.py")
+
+        assert success is True
+        assert output == "ok"
+        argv = captured["argv"]
+        assert argv[0] == sys.executable
+        assert argv[1].endswith("test.py")
+        assert len(argv) == 2
+
+    def test_single_arg(self, cron_env):
+        """script_args=["--mode", "close"] → both appended to argv."""
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "test.py"
+        script.write_text('print("hello")\n')
+
+        captured, fake_run = _fake_subprocess_run()
+        with patch("subprocess.run", side_effect=fake_run):
+            success, output = _run_job_script("test.py", script_args=["--mode", "close"])
+
+        assert success is True
+        argv = captured["argv"]
+        assert argv[-2] == "--mode"
+        assert argv[-1] == "close"
+
+    def test_multiple_args(self, cron_env):
+        """Multiple items in script_args → all appended in order."""
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "test.py"
+        script.write_text('print("hello")\n')
+
+        captured, fake_run = _fake_subprocess_run()
+        with patch("subprocess.run", side_effect=fake_run):
+            success, output = _run_job_script(
+                "test.py",
+                script_args=["--verbose", "--output", "/tmp/out", "--retries", "3"],
+            )
+
+        assert success is True
+        argv = captured["argv"]
+        args_slice = argv[2:]  # after interpreter + script
+        assert args_slice == ["--verbose", "--output", "/tmp/out", "--retries", "3"]
+
+    def test_script_none_script_args(self):
+        """script=None → early return with error, no subprocess call."""
+        from cron.scheduler import _run_job_script
+
+        with patch("cron.scheduler.subprocess.run") as mock_run:
+            success, output = _run_job_script(None)
+
+        assert success is False
+        assert "Script path is empty or None" == output
+        mock_run.assert_not_called()
+
+    def test_script_empty_string(self):
+        """script="" → early return with error, no subprocess call."""
+        from cron.scheduler import _run_job_script
+
+        with patch("cron.scheduler.subprocess.run") as mock_run:
+            success, output = _run_job_script("")
+
+        assert success is False
+        assert "Script path is empty or None" == output
+        mock_run.assert_not_called()
+
+    def test_empty_script_args_list(self, cron_env):
+        """script_args=[] → same argv length as no script_args."""
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "test.py"
+        script.write_text('print("hello")\n')
+
+        captured, fake_run = _fake_subprocess_run()
+        with patch("subprocess.run", side_effect=fake_run):
+            success, output = _run_job_script("test.py", script_args=[])
+
+        assert success is True
+        argv = captured["argv"]
+        assert len(argv) == 2  # just interpreter + script
+
+    def test_script_path_with_spaces(self, cron_env):
+        """Filename with spaces is NOT split — script stays one path, not two tokens."""
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "my script.py"
+        script.write_text('print("ok")\n')
+
+        captured, fake_run = _fake_subprocess_run()
+        with patch("subprocess.run", side_effect=fake_run):
+            success, output = _run_job_script("my script.py", script_args=["--flag"])
+
+        assert success is True
+        argv = captured["argv"]
+        # The script path must be a single argv entry, not split on space
+        assert argv[1].endswith("my script.py")
+        assert "--flag" in argv
+
+    def test_path_traversal_rejected(self, cron_env):
+        """Path traversal (../../etc/passwd) is blocked by containment check."""
+        from cron.scheduler import _run_job_script
+
+        success, output = _run_job_script("../../etc/passwd")
+        assert success is False
+        assert "blocked" in output.lower()
+
+    def test_shell_script_with_args(self, cron_env):
+        """.sh script uses bash interpreter and appends script_args correctly."""
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "backup.sh"
+        script.write_text("#!/bin/bash\necho done\n")
+
+        captured, fake_run = _fake_subprocess_run()
+        with patch("subprocess.run", side_effect=fake_run):
+            success, output = _run_job_script("backup.sh", script_args=["--force", "--dest", "/tmp/out"])
+
+        assert success is True
+        assert output == "ok"
+        argv = captured["argv"]
+        # argv[0] must be bash, not python
+        assert argv[0].endswith("bash")
+        assert argv[1].endswith("backup.sh")
+        args_slice = argv[2:]
+        assert args_slice == ["--force", "--dest", "/tmp/out"]
+
+    def test_bash_script_with_args(self, cron_env):
+        """.bash script also uses bash interpreter and appends script_args."""
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "deploy.bash"
+        script.write_text("#!/bin/bash\necho done\n")
+
+        captured, fake_run = _fake_subprocess_run()
+        with patch("subprocess.run", side_effect=fake_run):
+            success, output = _run_job_script("deploy.bash", script_args=["--env", "prod"])
+
+        assert success is True
+        argv = captured["argv"]
+        assert argv[0].endswith("bash")
+        assert argv[1].endswith("deploy.bash")
+        assert argv[2:] == ["--env", "prod"]
+
+
+class TestCreateJobScriptArgsValidation:
+    """B: create_job() script_args input validation."""
+
+    def test_non_list_rejected(self, cron_env):
+        """script_args must be a list — non-list values raise TypeError."""
+        from cron.jobs import create_job
+
+        with pytest.raises(TypeError, match="script_args must be a list"):
+            create_job(
+                prompt="test",
+                schedule="every 1h",
+                script="test.py",
+                script_args="not_a_list",
+            )
+
+    def test_non_list_rejected_in_cronjob_update(self, cron_env, monkeypatch):
+        """cronjob() update with non-list script_args returns error."""
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        create_res = json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="test",
+            script="test.py",
+        ))
+        job_id = create_res["job_id"]
+
+        update_res = json.loads(cronjob(
+            action="update",
+            job_id=job_id,
+            script_args="not_a_list",
+        ))
+        assert update_res["success"] is False
+        assert "must be a list" in update_res["error"].lower()
+
+    def test_update_script_args_success(self, cron_env, monkeypatch):
+        """cronjob() update with valid script_args persists and echoes them back."""
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        create_res = json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="test",
+            script="test.py",
+        ))
+        job_id = create_res["job_id"]
+
+        update_res = json.loads(cronjob(
+            action="update",
+            job_id=job_id,
+            script_args=["--mode", "full", "--verbose"],
+        ))
+        assert update_res["success"] is True
+        assert update_res["job"]["script_args"] == ["--mode", "full", "--verbose"]
+
+        # Verify persisted by reading back via list
+        list_res = json.loads(cronjob(action="list"))
+        for j in list_res["jobs"]:
+            if j["job_id"] == job_id:
+                assert j["script_args"] == ["--mode", "full", "--verbose"]
+                break
+        else:
+            pytest.fail(f"Job {job_id} not found in list")
+
+    def test_update_script_args_clear(self, cron_env, monkeypatch):
+        """cronjob() update with script_args=[] clears the field."""
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        create_res = json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="test",
+            script="test.py",
+            script_args=["--original"],
+        ))
+        job_id = create_res["job_id"]
+
+        update_res = json.loads(cronjob(
+            action="update",
+            job_id=job_id,
+            script_args=[],
+        ))
+        assert update_res["success"] is True
+        assert update_res["job"]["script_args"] == []
+
+        # Verify persisted as empty
+        list_res = json.loads(cronjob(action="list"))
+        for j in list_res["jobs"]:
+            if j["job_id"] == job_id:
+                assert j["script_args"] == []
+                break
+        else:
+            pytest.fail(f"Job {job_id} not found in list")
+
+    def test_update_script_args_retain(self, cron_env, monkeypatch):
+        """cronjob() update without script_args field retains existing value."""
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        create_res = json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="test",
+            script="test.py",
+            script_args=["--original"],
+        ))
+        job_id = create_res["job_id"]
+
+        # Update only the name — script_args should be retained
+        update_res = json.loads(cronjob(
+            action="update",
+            job_id=job_id,
+            name="renamed-job",
+        ))
+        assert update_res["success"] is True
+        assert update_res["job"]["script_args"] == ["--original"]
+
+    def test_non_string_elements_normalized(self, cron_env):
+        """script_args with int, bool, float → all normalised to str via str()."""
+        from cron.jobs import create_job
+        from tools.cronjob_tools import _format_job
+
+        job = create_job(
+            prompt="test",
+            schedule="every 1h",
+            script="test.py",
+            script_args=[1, True, 3.14, 0, False],
+        )
+
+        formatted = _format_job(job)
+        assert formatted["script_args"] == ["1", "True", "3.14", "0", "False"]
+
+
+class TestFormatJobScriptArgs:
+    """B: _format_job() echo-back of script_args."""
+
+    def test_format_job_includes_script_args(self, cron_env):
+        """_format_job echoes script_args when present on the job."""
+        from cron.jobs import create_job
+        from tools.cronjob_tools import _format_job
+
+        job = create_job(
+            prompt="analyze",
+            schedule="every 1h",
+            script="collector.py",
+            script_args=["--mode", "full", "--since", "yesterday"],
+        )
+
+        formatted = _format_job(job)
+        assert "script_args" in formatted
+        assert formatted["script_args"] == ["--mode", "full", "--since", "yesterday"]
+
+    def test_format_job_no_script_args(self, cron_env):
+        """_format_job echoes empty script_args list when not supplied."""
+        from cron.jobs import create_job
+        from tools.cronjob_tools import _format_job
+
+        job = create_job(
+            prompt="analyze",
+            schedule="every 1h",
+            script="collector.py",
+        )
+
+        formatted = _format_job(job)
+        assert "script_args" in formatted
+        assert formatted["script_args"] == []

--- a/tests/cron/test_scheduler_delivery_logging.py
+++ b/tests/cron/test_scheduler_delivery_logging.py
@@ -1,0 +1,161 @@
+"""Tests for cron/scheduler.py _deliver_result — live adapter delivery logging (A.1 & A.2).
+
+Covers the warning-logging behaviour added in the dual-bug fix:
+
+A.1 — safe_schedule_threadsafe returns None → WARNING logged, falls back to standalone
+A.2 — runtime_adapter exists but loop is None / not running → WARNING logged
+Also verifies the normal path (no adapter) does NOT emit spurious warnings.
+"""
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cron.scheduler import _deliver_result
+
+
+def _make_job(platform="telegram", chat_id="12345"):
+    return {
+        "id": "test-job-abc",
+        "name": "test-job",
+        "deliver": "origin",
+        "origin": {"platform": platform, "chat_id": chat_id},
+    }
+
+
+def _make_pconfig():
+    pconfig = MagicMock()
+    pconfig.enabled = True
+    return pconfig
+
+
+def _make_gateway_config(platform, pconfig):
+    from gateway.config import Platform
+    mock_cfg = MagicMock()
+    mock_cfg.platforms = {Platform(platform): pconfig}
+    return mock_cfg
+
+
+class TestLiveAdapterDeliveryLogging:
+    """A.1 & A.2: Verify warning logs when live adapter delivery can't proceed."""
+
+    def test_safe_schedule_threadsafe_returns_none_logs_warning(self, caplog):
+        """A.1: safe_schedule_threadsafe returns None → WARNING with 'live adapter schedule failed'."""
+        from gateway.config import Platform
+
+        adapter = MagicMock()
+        adapter.send.return_value = MagicMock(success=True)
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        pconfig = _make_pconfig()
+        mock_cfg = _make_gateway_config("telegram", pconfig)
+        job = _make_job()
+
+        mock_send = AsyncMock(return_value={"success": True})
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=mock_send), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("agent.async_utils.safe_schedule_threadsafe", return_value=None):
+            with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+                result = _deliver_result(
+                    job, "Test content",
+                    adapters={Platform.TELEGRAM: adapter},
+                    loop=loop,
+                )
+
+        assert result is None
+        assert any(
+            "live adapter schedule failed" in r.message
+            for r in caplog.records
+        ), f"Expected 'live adapter schedule failed' warning, got: {[r.message for r in caplog.records]}"
+        mock_send.assert_called_once()
+
+    def test_live_adapter_loop_none_logs_warning(self, caplog):
+        """A.2: runtime_adapter exists but loop is None → WARNING with 'loop is None'."""
+        from gateway.config import Platform
+
+        adapter = AsyncMock()
+        pconfig = _make_pconfig()
+        mock_cfg = _make_gateway_config("telegram", pconfig)
+        job = _make_job()
+
+        mock_send = AsyncMock(return_value={"success": True})
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=mock_send), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+                result = _deliver_result(
+                    job, "Test content",
+                    adapters={Platform.TELEGRAM: adapter},
+                    loop=None,
+                )
+
+        assert result is None
+        assert any(
+            "loop is None" in r.message
+            for r in caplog.records
+        ), f"Expected 'loop is None' warning, got: {[r.message for r in caplog.records]}"
+        mock_send.assert_called_once()
+        adapter.send.assert_not_called()
+
+    def test_live_adapter_loop_not_running_logs_warning(self, caplog):
+        """A.2: runtime_adapter exists but loop.is_running() is False → WARNING with 'loop is not running'."""
+        from gateway.config import Platform
+
+        adapter = AsyncMock()
+        loop = MagicMock()
+        loop.is_running.return_value = False
+
+        pconfig = _make_pconfig()
+        mock_cfg = _make_gateway_config("telegram", pconfig)
+        job = _make_job()
+
+        mock_send = AsyncMock(return_value={"success": True})
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=mock_send), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+                result = _deliver_result(
+                    job, "Test content",
+                    adapters={Platform.TELEGRAM: adapter},
+                    loop=loop,
+                )
+
+        assert result is None
+        assert any(
+            "loop is not running" in r.message
+            for r in caplog.records
+        ), f"Expected 'loop is not running' warning, got: {[r.message for r in caplog.records]}"
+        mock_send.assert_called_once()
+        adapter.send.assert_not_called()
+
+    def test_no_runtime_adapter_no_warning(self, caplog):
+        """Normal path: no adapter for the platform → no loop-related warning logged."""
+        pconfig = _make_pconfig()
+        mock_cfg = _make_gateway_config("telegram", pconfig)
+        job = _make_job()
+
+        mock_send = AsyncMock(return_value={"success": True})
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=mock_send), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+                result = _deliver_result(
+                    job, "Test content",
+                    adapters={},  # no adapter for telegram
+                    loop=None,
+                )
+
+        assert result is None
+        loop_warnings = [
+            r.message for r in caplog.records
+            if "loop" in r.message.lower() and "live adapter" in r.message.lower()
+        ]
+        assert not loop_warnings, (
+            f"Expected no loop-related live-adapter warnings when no adapter is present, "
+            f"got: {loop_warnings}"
+        )
+        mock_send.assert_called_once()

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -471,6 +471,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    if "script_args" in job:
+        result["script_args"] = job["script_args"]
     return result
 
 
@@ -539,6 +541,7 @@ def cronjob(
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
+    script_args: Optional[List[str]] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -605,6 +608,7 @@ def cronjob(
                 enabled_toolsets=enabled_toolsets or None,
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
+                script_args=script_args,
             )
             _notify_provider_jobs_changed_safe()
             return json.dumps(
@@ -771,6 +775,14 @@ def cronjob(
                             success=False,
                         )
                 updates["no_agent"] = target_no_agent
+            if script_args is not None:
+                if isinstance(script_args, list):
+                    updates["script_args"] = [str(a) for a in script_args]
+                else:
+                    return tool_error(
+                        f"script_args must be a list of strings, got {type(script_args).__name__}",
+                        success=False,
+                    )
             if repeat is not None:
                 # Normalize: treat 0 or negative as None (infinite)
                 normalized_repeat = None if repeat <= 0 else repeat
@@ -871,6 +883,11 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "string",
                 "description": f"Optional path to a script that runs each tick. In the default mode its stdout is injected into the agent's prompt as context (data-collection / change-detection pattern). With no_agent=True, the script IS the job and its stdout is delivered verbatim (classic watchdog pattern). Relative paths resolve under {display_hermes_home()}/scripts/. ``.sh``/``.bash`` extensions run via bash, everything else via Python. On update, pass empty string to clear."
             },
+            "script_args": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional list of string arguments to pass to the script. When set, these are appended to the subprocess argv after the script path (e.g. ['--mode', 'close']). When omitted or empty, the script runs with no extra arguments."
+            },
             "no_agent": {
                 "type": "boolean",
                 "default": False,
@@ -966,6 +983,7 @@ registry.register(
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
+        script_args=args.get("script_args"),
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,


### PR DESCRIPTION
## Summary

Adds `script_args` field support for `no_agent` cron scripts, allowing users to pass arguments to their script executables scheduled via cron jobs.

## Changes

### `cron/scheduler.py`
- `_run_job_script`: accept `script_args` parameter, extend subprocess argv
- `_run_job_script`: guard against empty/None `script_path`
- `_build_job_prompt`: read and pass `script_args` to script execution
- `_run_job_impl`: pass `script_args` in both `no_agent` and agent paths
- `_deliver_result`: warning when live adapter schedule fails + loop-unavailable fallback log

### `tools/cronjob_tools.py`
- `_format_job`: include `script_args` in display output
- `cronjob()`: add `script_args` parameter to signature
- `cronjob()` create: pass `script_args` to `create_job()`
- `cronjob()` update: validate and normalize `script_args`
- `CRONJOB_SCHEMA`: add `script_args` array field
- `registry.register`: wire `script_args` from args

### Tests
- `tests/cron/test_cron_script_args.py`: 377 lines
- `tests/cron/test_scheduler_delivery_logging.py`: 161 lines