### PR TITLE
fix(web): allow explicit Firecrawl keyless mode

### DIFF
--- a/plugins/web/firecrawl/plugin.yaml
+++ b/plugins/web/firecrawl/plugin.yaml
@@ -1,6 +1,6 @@
 name: web-firecrawl
 version: 1.0.0
-description: "Firecrawl web search + content extraction. Supports direct API and Nous-hosted tool-gateway routing for subscribers. Requires FIRECRAWL_API_KEY (or FIRECRAWL_API_URL for self-hosted), or an active Nous subscription with FIRECRAWL_GATEWAY_URL."
+description: "Firecrawl web search + content extraction. Supports keyless cloud, direct API, and Nous-hosted tool-gateway routing for subscribers."
 author: NousResearch
 kind: backend
 provides_web_providers:

--- a/plugins/web/firecrawl/provider.py
+++ b/plugins/web/firecrawl/provider.py
@@ -50,10 +50,14 @@ import logging
 import os
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
+import httpx
+
 from agent.web_search_provider import WebSearchProvider
 from tools.website_policy import check_website_access
 
 logger = logging.getLogger(__name__)
+
+_FIRECRAWL_CLOUD_API_URL = "https://api.firecrawl.dev"
 
 
 # ---------------------------------------------------------------------------
@@ -120,11 +124,17 @@ Firecrawl = _FirecrawlProxy()
 
 
 def _get_direct_firecrawl_config() -> Optional[tuple]:
-    """Return explicit direct Firecrawl kwargs + cache key, or None when unset."""
+    """Return direct Firecrawl mode/kwargs/cache key, or None when unavailable."""
     api_key = os.getenv("FIRECRAWL_API_KEY", "").strip()
     api_url = os.getenv("FIRECRAWL_API_URL", "").strip().rstrip("/")
 
     if not api_key and not api_url:
+        if _is_explicit_firecrawl_selection():
+            return (
+                "keyless",
+                {"api_url": _FIRECRAWL_CLOUD_API_URL},
+                ("direct-keyless", _FIRECRAWL_CLOUD_API_URL, None),
+            )
         return None
 
     kwargs: Dict[str, str] = {}
@@ -133,7 +143,41 @@ def _get_direct_firecrawl_config() -> Optional[tuple]:
     if api_url:
         kwargs["api_url"] = api_url
 
-    return kwargs, ("direct", api_url or None, api_key or None)
+    return "sdk", kwargs, ("direct", api_url or None, api_key or None)
+
+
+def _is_explicit_firecrawl_selection() -> bool:
+    """Return True when config explicitly selects Firecrawl for web tools."""
+    import tools.web_tools as _wt
+
+    cfg = _wt._load_web_config()
+    return any(
+        (cfg.get(key) or "").lower().strip() == "firecrawl"
+        for key in ("backend", "search_backend", "extract_backend")
+    )
+
+
+class _KeylessFirecrawlClient:
+    """Minimal REST client for Firecrawl's keyless cloud mode."""
+
+    def __init__(self, api_url: str = _FIRECRAWL_CLOUD_API_URL):
+        self.api_url = api_url.rstrip("/")
+
+    def _post(self, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        response = httpx.post(
+            f"{self.api_url}{path}",
+            json=payload,
+            headers={"Content-Type": "application/json"},
+            timeout=60.0,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def search(self, *, query: str, limit: int = 5) -> Dict[str, Any]:
+        return self._post("/v2/search", {"query": query, "limit": limit})
+
+    def scrape(self, *, url: str, formats: List[str]) -> Dict[str, Any]:
+        return self._post("/v2/scrape", {"url": url, "formats": formats})
 
 
 def _get_firecrawl_gateway_url() -> str:
@@ -160,7 +204,7 @@ def _is_tool_gateway_ready() -> bool:
 
 
 def _has_direct_firecrawl_config() -> bool:
-    """Return True when direct Firecrawl config is explicitly configured."""
+    """Return True when a direct or explicit-keyless Firecrawl path is available."""
     return _get_direct_firecrawl_config() is not None
 
 
@@ -191,8 +235,10 @@ def _raise_web_backend_configuration_error() -> None:
 
     message = (
         "Web tools are not configured. "
-        "Set FIRECRAWL_API_KEY for cloud Firecrawl or set FIRECRAWL_API_URL "
-        "for a self-hosted Firecrawl instance."
+        "Set FIRECRAWL_API_KEY for authenticated cloud Firecrawl, set "
+        "FIRECRAWL_API_URL for a self-hosted Firecrawl instance, or explicitly "
+        "select Firecrawl in web.backend/search_backend/extract_backend to use "
+        "cloud keyless mode."
     )
     if _wt.managed_nous_tools_enabled():
         message += (
@@ -228,7 +274,7 @@ def _get_firecrawl_client() -> Any:
 
     direct_config = _get_direct_firecrawl_config()
     if direct_config is not None and not _wt.prefers_gateway("web"):
-        kwargs, client_config = direct_config
+        client_mode, kwargs, client_config = direct_config
     else:
         managed_gateway = _wt.resolve_managed_tool_gateway(
             "firecrawl", token_reader=_wt._read_nous_access_token
@@ -244,6 +290,7 @@ def _get_firecrawl_client() -> Any:
             "api_key": managed_gateway.nous_user_token,
             "api_url": managed_gateway.gateway_origin,
         }
+        client_mode = "sdk"
         client_config = (
             "tool-gateway",
             kwargs["api_url"],
@@ -257,7 +304,10 @@ def _get_firecrawl_client() -> Any:
 
     # Construct via the re-exported Firecrawl proxy on tools.web_tools so
     # unit tests patching ``tools.web_tools.Firecrawl`` see their mock.
-    _wt._firecrawl_client = _wt.Firecrawl(**kwargs)
+    if client_mode == "keyless":
+        _wt._firecrawl_client = _KeylessFirecrawlClient(api_url=kwargs["api_url"])
+    else:
+        _wt._firecrawl_client = _wt.Firecrawl(**kwargs)
     _wt._firecrawl_client_config = client_config
     return _wt._firecrawl_client
 
@@ -579,15 +629,15 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
     def get_setup_schema(self) -> Dict[str, Any]:
         return {
             "name": "Firecrawl",
-            "badge": "paid · optional gateway",
+            "badge": "keyless/paid · optional gateway",
             "tag": (
-                "Full search + extract; supports direct API and "
+                "Full search + extract; supports keyless cloud, direct API, and "
                 "Nous tool-gateway routing."
             ),
             "env_vars": [
                 {
                     "key": "FIRECRAWL_API_KEY",
-                    "prompt": "Firecrawl API key (or leave blank for self-hosted)",
+                    "prompt": "Firecrawl API key (optional; blank = keyless cloud or self-hosted)",
                     "url": "https://docs.firecrawl.dev/introduction",
                 },
             ],

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -219,6 +219,23 @@ class TestIsAvailable:
         monkeypatch.setenv("FIRECRAWL_API_URL", "http://localhost:3002")
         assert p.is_available() is True
 
+    def test_firecrawl_explicit_config_allows_keyless_cloud(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("firecrawl")
+        assert p is not None
+        assert p.is_available() is False
+
+        monkeypatch.setattr(
+            "tools.web_tools._load_web_config",
+            lambda: {"backend": "firecrawl"},
+            raising=False,
+        )
+        assert p.is_available() is True
+
     def test_ddgs_always_available_when_package_importable(self) -> None:
         """DDGS is the always-on fallback — no API key required.
 

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -240,6 +240,82 @@ class TestFirecrawlClientConfig:
                     with pytest.raises(ValueError):
                         _get_firecrawl_client()
 
+    def test_explicit_firecrawl_config_without_creds_uses_keyless_client(self):
+        """Explicit Firecrawl config should build the keyless cloud client."""
+        from plugins.web.firecrawl import provider as firecrawl_provider
+
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "firecrawl"}):
+            with patch("tools.web_tools._read_nous_access_token", return_value=None):
+                with patch("tools.web_tools.Firecrawl", side_effect=AssertionError("SDK path should not run")):
+                    from tools.web_tools import _get_firecrawl_client
+
+                    result = _get_firecrawl_client()
+
+        assert isinstance(result, firecrawl_provider._KeylessFirecrawlClient)
+        assert result.api_url == "https://api.firecrawl.dev"
+
+    def test_keyless_firecrawl_search_omits_authorization_header(self, monkeypatch):
+        """Keyless Firecrawl search must not send a bearer header."""
+        from plugins.web.firecrawl import provider as firecrawl_provider
+
+        captured = {}
+
+        class _Response:
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return {"success": True, "data": {"web": []}}
+
+        def _fake_post(url, *, json, headers, timeout):
+            captured["url"] = url
+            captured["json"] = json
+            captured["headers"] = headers
+            captured["timeout"] = timeout
+            return _Response()
+
+        monkeypatch.setattr(firecrawl_provider.httpx, "post", _fake_post)
+
+        client = firecrawl_provider._KeylessFirecrawlClient()
+        result = client.search(query="firecrawl", limit=1)
+
+        assert result["success"] is True
+        assert captured["url"] == "https://api.firecrawl.dev/v2/search"
+        assert captured["json"] == {"query": "firecrawl", "limit": 1}
+        assert captured["headers"] == {"Content-Type": "application/json"}
+        assert "Authorization" not in captured["headers"]
+
+    def test_keyless_firecrawl_scrape_omits_authorization_header(self, monkeypatch):
+        """Keyless Firecrawl scrape must not send a bearer header."""
+        from plugins.web.firecrawl import provider as firecrawl_provider
+
+        captured = {}
+
+        class _Response:
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return {"success": True, "data": {"markdown": "# ok"}}
+
+        def _fake_post(url, *, json, headers, timeout):
+            captured["url"] = url
+            captured["json"] = json
+            captured["headers"] = headers
+            captured["timeout"] = timeout
+            return _Response()
+
+        monkeypatch.setattr(firecrawl_provider.httpx, "post", _fake_post)
+
+        client = firecrawl_provider._KeylessFirecrawlClient()
+        result = client.scrape(url="https://example.com", formats=["markdown"])
+
+        assert result["success"] is True
+        assert captured["url"] == "https://api.firecrawl.dev/v2/scrape"
+        assert captured["json"] == {"url": "https://example.com", "formats": ["markdown"]}
+        assert captured["headers"] == {"Content-Type": "application/json"}
+        assert "Authorization" not in captured["headers"]
+
 
 class TestBackendSelection:
     """Test suite for _get_backend() backend selection logic.


### PR DESCRIPTION
## Summary
- treat explicitly selected Firecrawl as a valid direct backend even without `FIRECRAWL_API_KEY` or `FIRECRAWL_API_URL`
- route that path through a minimal keyless REST client that never sends an `Authorization` header
- update Firecrawl setup copy and add regression coverage for availability and error messaging

## Testing
- `uv run --frozen pytest -q tests/tools/test_web_tools_config.py::TestFirecrawlClientConfig::test_no_config_raises_with_helpful_message tests/tools/test_web_tools_config.py::TestFirecrawlClientConfig::test_explicit_firecrawl_config_without_creds_uses_keyless_client tests/tools/test_web_tools_config.py::TestFirecrawlClientConfig::test_keyless_firecrawl_search_omits_authorization_header tests/tools/test_web_tools_config.py::TestFirecrawlClientConfig::test_keyless_firecrawl_scrape_omits_authorization_header tests/tools/test_web_tools_config.py::TestCheckWebApiKey::test_firecrawl_key_only tests/tools/test_web_tools_config.py::TestCheckWebApiKey::test_firecrawl_url_only tests/tools/test_web_tools_config.py::TestCheckWebApiKey::test_no_keys_returns_false tests/plugins/web/test_web_search_provider_plugins.py::TestIsAvailable::test_firecrawl_requires_either_key_or_url tests/plugins/web/test_web_search_provider_plugins.py::TestIsAvailable::test_firecrawl_explicit_config_allows_keyless_cloud tests/plugins/web/test_web_search_provider_plugins.py::TestErrorResponseShapes::test_firecrawl_extract_returns_per_url_errors_when_unconfigured tests/plugins/web/test_web_search_provider_plugins.py::TestErrorResponseShapes::test_firecrawl_config_error_points_paid_users_to_nous_subscription tests/plugins/web/test_web_search_provider_plugins.py::TestErrorResponseShapes::test_firecrawl_config_error_uses_entitlement_message_when_not_paid tests/tools/test_web_providers.py::TestUnconfiguredErrorEnvelopeParity::test_unconfigured_search_emits_top_level_error`
- `uv run --frozen ruff check plugins/web/firecrawl/provider.py tests/tools/test_web_tools_config.py tests/plugins/web/test_web_search_provider_plugins.py tests/tools/test_web_providers.py`
- `git diff --check`

## Notes
- A broader file-level pytest invocation also touched optional `parallel-web` dependency tests in a fresh `uv` environment; those failures were preexisting and unrelated to this Firecrawl-specific diff, so proof stayed on targeted Firecrawl coverage.

Fixes #49912
