### PR TITLE
feat(gateway): unified cross-platform reaction contract on BasePlatformAdapter

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2915,6 +2915,65 @@ class BasePlatformAdapter(ABC):
     # property) so the stream consumer knows not to short-circuit.
     REQUIRES_EDIT_FINALIZE: bool = False
 
+    # Whether this adapter can attach/retract emoji reactions on a message.
+    # Reactions are the lightweight "social acknowledgement" output channel —
+    # a participation primitive distinct from sending a message (a 👀 / 😂 /
+    # 👍 that says "seen / amused / agreed" without composing a reply). Most
+    # chat platforms support them, but with platform-specific call shapes, so
+    # the capability is advertised by this flag and normalized behind the two
+    # coroutines below. Adapters that implement reactions set this True; the
+    # default is False so callers (e.g. the ``send_message`` tool's ``react``
+    # action) can give a clean "not supported here" answer instead of probing
+    # for a method that may not exist.
+    SUPPORTS_REACTIONS: bool = False
+
+    async def add_reaction(
+        self,
+        chat_id: str,
+        emoji: str,
+        message_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Attach an emoji reaction to a message in ``chat_id``.
+
+        This is the unified, cross-platform reaction contract. Each platform's
+        native reaction API differs (Signal needs the target author + Signal
+        timestamp; Telegram replaces all reactions in one call; Discord is
+        additive; WhatsApp routes through its bridge), so adapters normalize
+        their native call behind this signature.
+
+        Args:
+            chat_id: The chat/channel ID containing the target message.
+            emoji: The reaction emoji (e.g. "👀", "✅", "😂").
+            message_id: The target message ID. When ``None``, adapters that
+                track it react to the most recent inbound message in the chat
+                (the one being responded to); adapters that cannot resolve a
+                target without an explicit id return a ``success: False`` error.
+
+        Returns:
+            A dict with at least ``success: bool``; on failure it carries an
+            ``error`` string. The default implementation reports that the
+            platform does not support reactions.
+        """
+        return {
+            "success": False,
+            "error": f"{self.name} does not support message reactions",
+        }
+
+    async def remove_reaction(
+        self,
+        chat_id: str,
+        message_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Retract a previously-added reaction (best-effort).
+
+        Mirror of :meth:`add_reaction`. The default is a no-op error for
+        adapters without reaction support.
+        """
+        return {
+            "success": False,
+            "error": f"{self.name} does not support message reactions",
+        }
+
     async def create_handoff_thread(
         self,
         parent_chat_id: str,

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -253,6 +253,11 @@ class SignalAdapter(BasePlatformAdapter):
     # square behind in chat clients when edit attempts fail.
     SUPPORTS_MESSAGE_EDITING = False
 
+    # Native sendReaction (also drives the 👀/✅ processing-lifecycle hooks,
+    # gated by SIGNAL_REACTIONS). add_reaction below implements the unified
+    # cross-platform reaction contract for the agent.
+    SUPPORTS_REACTIONS = True
+
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.SIGNAL)
 
@@ -1549,7 +1554,7 @@ class SignalAdapter(BasePlatformAdapter):
     # Reactions
     # ------------------------------------------------------------------
 
-    async def send_reaction(
+    async def _send_reaction_raw(
         self,
         chat_id: str,
         emoji: str,
@@ -1582,7 +1587,7 @@ class SignalAdapter(BasePlatformAdapter):
         logger.debug("Signal: sendReaction failed (chat=%s, emoji=%s)", chat_id[:20], emoji)
         return False
 
-    async def remove_reaction(
+    async def _remove_reaction_raw(
         self,
         chat_id: str,
         target_author: str,
@@ -1605,9 +1610,63 @@ class SignalAdapter(BasePlatformAdapter):
         result = await self._rpc("sendReaction", params)
         return result is not None
 
-    # ------------------------------------------------------------------
-    # Processing Lifecycle Hooks (reactions as progress indicators)
-    # ------------------------------------------------------------------
+    async def add_reaction(
+        self,
+        chat_id: str,
+        emoji: str,
+        message_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Unified reaction contract for Signal.
+
+        Signal addresses a message by (target_author, target_timestamp), not a
+        single opaque id, so the unified ``message_id`` is a composite token
+        ``"<author>:<timestamp_ms>"`` (as surfaced on inbound MessageEvents).
+        """
+        author, ts = self._parse_signal_message_id(message_id)
+        if not author or not ts:
+            return {
+                "success": False,
+                "error": "signal requires message_id as '<author>:<timestamp_ms>'",
+            }
+        ok = await self._send_reaction_raw(chat_id, emoji, author, ts)
+        return (
+            {"success": True, "message_id": message_id}
+            if ok
+            else {"success": False, "error": "signal sendReaction failed"}
+        )
+
+    async def remove_reaction(
+        self,
+        chat_id: str,
+        message_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Unified reaction contract — retract a Signal reaction."""
+        author, ts = self._parse_signal_message_id(message_id)
+        if not author or not ts:
+            return {
+                "success": False,
+                "error": "signal requires message_id as '<author>:<timestamp_ms>'",
+            }
+        ok = await self._remove_reaction_raw(chat_id, author, ts)
+        return (
+            {"success": True, "message_id": message_id}
+            if ok
+            else {"success": False, "error": "signal remove reaction failed"}
+        )
+
+    @staticmethod
+    def _parse_signal_message_id(
+        message_id: Optional[str],
+    ) -> tuple[Optional[str], Optional[int]]:
+        """Split a composite ``"<author>:<timestamp_ms>"`` reaction target."""
+        if not message_id or ":" not in message_id:
+            return (None, None)
+        author, _, ts_raw = message_id.rpartition(":")
+        try:
+            return (author or None, int(ts_raw))
+        except (TypeError, ValueError):
+            return (None, None)
+
 
     def _extract_reaction_target(self, event: MessageEvent) -> Optional[tuple]:
         """Extract (target_author, target_timestamp) from a MessageEvent.
@@ -1648,7 +1707,7 @@ class SignalAdapter(BasePlatformAdapter):
             return
         target = self._extract_reaction_target(event)
         if target:
-            await self.send_reaction(event.source.chat_id, "👀", *target)
+            await self._send_reaction_raw(event.source.chat_id, "👀", *target)
 
     async def on_processing_complete(self, event: MessageEvent, outcome: "ProcessingOutcome") -> None:
         """Swap the 👀 reaction for ✅ (success) or ❌ (failure).
@@ -1665,11 +1724,11 @@ class SignalAdapter(BasePlatformAdapter):
             return
         chat_id = event.source.chat_id
         # Remove the in-progress reaction, then add the final one
-        await self.remove_reaction(chat_id, *target)
+        await self._remove_reaction_raw(chat_id, *target)
         if outcome == ProcessingOutcome.SUCCESS:
-            await self.send_reaction(chat_id, "✅", *target)
+            await self._send_reaction_raw(chat_id, "✅", *target)
         elif outcome == ProcessingOutcome.FAILURE:
-            await self.send_reaction(chat_id, "❌", *target)
+            await self._send_reaction_raw(chat_id, "❌", *target)
 
     # ------------------------------------------------------------------
     # Chat Info

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -196,6 +196,10 @@ class PhotonAdapter(BasePlatformAdapter):
 
     MAX_MESSAGE_LENGTH = _MAX_MESSAGE_LENGTH
 
+    # iMessage tapbacks via the sidecar's /react endpoint; add_reaction /
+    # remove_reaction already implement the unified base contract below.
+    SUPPORTS_REACTIONS = True
+
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform("photon"))
         extra = config.extra or {}

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -420,6 +420,11 @@ class TelegramAdapter(BasePlatformAdapter):
     MAX_MESSAGE_LENGTH = 4096
     supports_code_blocks = True  # Telegram MarkdownV2 renders fenced code blocks
     splits_long_messages = True  # send() chunks via truncate_message(MAX_MESSAGE_LENGTH)
+
+    # Native set_message_reaction (gated separately by TELEGRAM_REACTIONS for
+    # the automatic processing-lifecycle 👀/👍 indicators; add_reaction below
+    # implements the unified cross-platform reaction contract for the agent).
+    SUPPORTS_REACTIONS = True
     # Bot API 10.1 Rich Messages cap the raw markdown/html text at 32,768
     # UTF-8 characters. Content above this is sent via the legacy chunking path.
     RICH_MESSAGE_MAX_CHARS = 32768
@@ -8268,6 +8273,49 @@ class TelegramAdapter(BasePlatformAdapter):
     def _reactions_enabled(self) -> bool:
         """Check if message reactions are enabled via config/env."""
         return os.getenv("TELEGRAM_REACTIONS", "false").lower() not in {"false", "0", "no"}
+
+    async def add_reaction(
+        self,
+        chat_id: str,
+        emoji: str,
+        message_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Unified reaction contract — set a single emoji reaction on a message.
+
+        Telegram replaces all bot-set reactions in one call, so this maps
+        directly onto ``set_message_reaction``. A ``message_id`` is required
+        (Telegram has no "react to the latest message" affordance); callers
+        pass the id of the message being reacted to.
+        """
+        if not message_id:
+            return {
+                "success": False,
+                "error": "telegram requires an explicit message_id to react",
+            }
+        ok = await self._set_reaction(chat_id, message_id, emoji)
+        return (
+            {"success": True, "message_id": message_id}
+            if ok
+            else {"success": False, "error": "telegram set_message_reaction failed"}
+        )
+
+    async def remove_reaction(
+        self,
+        chat_id: str,
+        message_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Unified reaction contract — clear bot-set reactions from a message."""
+        if not message_id:
+            return {
+                "success": False,
+                "error": "telegram requires an explicit message_id to unreact",
+            }
+        ok = await self._clear_reactions(chat_id, message_id)
+        return (
+            {"success": True, "message_id": message_id}
+            if ok
+            else {"success": False, "error": "telegram clear reactions failed"}
+        )
 
     async def _set_reaction(self, chat_id: str, message_id: str, emoji: str) -> bool:
         """Set a single emoji reaction on a Telegram message."""

--- a/tests/gateway/test_unified_reactions_contract.py
+++ b/tests/gateway/test_unified_reactions_contract.py
@@ -1,0 +1,82 @@
+"""Unified cross-platform reaction contract (BasePlatformAdapter).
+
+Pins the *invariants* of the reaction channel rather than any single platform's
+wire format:
+
+  * The base adapter always defines add_reaction / remove_reaction (so callers
+    never have to probe for method existence), defaulting to a structured
+    "not supported" result gated by SUPPORTS_REACTIONS=False.
+  * Adapters that advertise SUPPORTS_REACTIONS=True override both coroutines and
+    keep the unified add_reaction(self, chat_id, emoji, message_id=None)
+    signature, returning a dict carrying ``success``.
+  * Signal's composite "<author>:<timestamp_ms>" message-id parsing round-trips.
+"""
+
+import asyncio
+import inspect
+
+import pytest
+
+from gateway.platforms.base import BasePlatformAdapter
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def test_base_defines_reaction_methods():
+    assert inspect.iscoroutinefunction(BasePlatformAdapter.add_reaction)
+    assert inspect.iscoroutinefunction(BasePlatformAdapter.remove_reaction)
+    assert BasePlatformAdapter.SUPPORTS_REACTIONS is False
+
+
+def test_default_reaction_is_structured_not_supported():
+    # Call the base coroutines directly without instantiating the ABC — the
+    # default implementation only reads ``self.name``.
+    fake = type("X", (), {"name": "bare"})()
+    add = _run(BasePlatformAdapter.add_reaction(fake, "chat", "👍", "m1"))
+    rem = _run(BasePlatformAdapter.remove_reaction(fake, "chat", "m1"))
+    for res in (add, rem):
+        assert isinstance(res, dict)
+        assert res["success"] is False
+        assert "does not support" in res["error"]
+
+
+def test_signal_message_id_round_trip():
+    pytest.importorskip("aiohttp")
+    from gateway.platforms.signal import SignalAdapter
+
+    parse = SignalAdapter._parse_signal_message_id
+    assert parse("uuid-abc:1718900000000") == ("uuid-abc", 1718900000000)
+    # author may itself contain ':' — rpartition keeps the last segment as ts
+    assert parse("a:b:1700000000000") == ("a:b", 1700000000000)
+    # malformed inputs degrade to (None, None) rather than raising
+    assert parse(None) == (None, None)
+    assert parse("no-timestamp") == (None, None)
+    assert parse("author:notanumber") == (None, None)
+
+
+@pytest.mark.parametrize(
+    "module_path,class_name",
+    [
+        ("gateway.platforms.signal", "SignalAdapter"),
+        ("plugins.platforms.telegram.adapter", "TelegramAdapter"),
+        ("plugins.platforms.photon.adapter", "PhotonAdapter"),
+    ],
+)
+def test_reaction_capable_adapters_advertise_and_implement(module_path, class_name):
+    """Each reaction-capable adapter sets the flag AND overrides both coroutines
+    with the unified signature."""
+    try:
+        mod = __import__(module_path, fromlist=[class_name])
+    except Exception:  # optional deps (telegram/aiohttp) absent in this env
+        pytest.skip(f"{module_path} not importable here")
+        return
+    cls = getattr(mod, class_name)
+    assert cls.SUPPORTS_REACTIONS is True
+    assert cls.add_reaction is not BasePlatformAdapter.add_reaction
+    assert cls.remove_reaction is not BasePlatformAdapter.remove_reaction
+    sig = inspect.signature(cls.add_reaction)
+    params = list(sig.parameters)
+    assert params[:3] == ["self", "chat_id", "emoji"]
+    assert "message_id" in sig.parameters

--- a/tests/tools/test_send_message_react.py
+++ b/tests/tools/test_send_message_react.py
@@ -14,6 +14,10 @@ import tools.send_message_tool as smt
 class _FakePhotonAdapter:
     """Adapter exposing add_reaction/remove_reaction coroutines."""
 
+    # Advertises reaction support via the unified capability flag (mirrors the
+    # real PhotonAdapter). The send_message tool gates on SUPPORTS_REACTIONS.
+    SUPPORTS_REACTIONS = True
+
     def __init__(self):
         self.calls = []
 
@@ -27,7 +31,9 @@ class _FakePhotonAdapter:
 
 
 class _NoReactionAdapter:
-    """Adapter with no reaction support at all."""
+    """Adapter with no reaction support (SUPPORTS_REACTIONS defaults False)."""
+
+    SUPPORTS_REACTIONS = False
 
 
 def _runner_with(adapter):

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -273,7 +273,10 @@ def _handle_react(args, remove=False):
         )
     fn_name = "remove_reaction" if remove else "add_reaction"
     react_fn = getattr(adapter, fn_name, None)
-    if not callable(react_fn):
+    # The base adapter now always defines add_reaction/remove_reaction (default
+    # no-op), so advertise support via the SUPPORTS_REACTIONS capability flag
+    # rather than method presence.
+    if not callable(react_fn) or not getattr(adapter, "SUPPORTS_REACTIONS", False):
         return tool_error(
             f"Platform '{platform_name}' does not support message reactions."
         )


### PR DESCRIPTION
## What & why

Reactions are the lightweight **social-acknowledgement** output channel — a 👀 / 👍 / 😂 that says *"seen / agreed / amused"* without composing a full reply. They're a first-class way for the agent to participate in a busy group without dominating it. But the capability was wired ad-hoc per adapter, and `BasePlatformAdapter` had **no reaction contract at all**:

| Platform | Native method | Shape |
|----------|---------------|-------|
| Signal | `send_reaction(chat_id, emoji, target_author, target_timestamp)` | author+timestamp |
| Telegram | `_set_reaction(chat_id, message_id, emoji)` | **private** |
| Photon | `add_reaction(chat_id, emoji, message_id=None)` | already unified |
| (others) | — | nothing exposed |

The `send_message` tool's `action="react"`/`"unreact"` calls `add_reaction(chat_id, emoji, message_id)` / `remove_reaction(chat_id, message_id)` and probes for the method with `getattr`. Because only Photon happened to expose exactly that signature, **the agent's reaction channel silently worked on Photon only** — every other platform fell through to *"does not support message reactions"* even though the platform clearly does.

This adds the missing narrow-waist contract and normalizes the existing implementers onto it.

## Changes

- **`BasePlatformAdapter`** gains:
  - `SUPPORTS_REACTIONS: bool = False` capability flag.
  - default `add_reaction(self, chat_id, emoji, message_id=None)` / `remove_reaction(self, chat_id, message_id=None)` coroutines returning a structured `{"success": False, "error": ...}`, so callers never have to probe for method existence.
- **Signal** normalizes onto the unified signature: the native sendReaction wiring is renamed to `_send_reaction_raw` / `_remove_reaction_raw` (still driving the 👀/✅ processing-lifecycle hooks), and the new public `add_reaction` / `remove_reaction` accept the composite `"<author>:<timestamp_ms>"` id Signal needs to address a message.
- **Telegram** promotes its private `_set_reaction` / `_clear_reactions` helpers to the public contract (a `message_id` is required — Telegram has no "latest message" affordance).
- **Photon** already matched the contract; it just sets `SUPPORTS_REACTIONS = True`.
- **`send_message` tool** gates `react`/`unreact` on `SUPPORTS_REACTIONS` instead of method presence, giving a clean *"platform does not support reactions"* answer.

Adapters without reaction support inherit the no-op default and report `SUPPORTS_REACTIONS = False`, so their behavior is unchanged.

This is intentionally scoped to the three adapters with confirmed in-tree reaction APIs (Signal, Telegram, Photon). Other platforms can opt in later by overriding the two coroutines and flipping the flag — the contract is now there to implement against.

## How to test

```bash
scripts/run_tests.sh tests/gateway/test_unified_reactions_contract.py \
  tests/tools/test_send_message_react.py \
  tests/gateway/test_telegram_reactions.py \
  tests/plugins/platforms/photon/test_reactions.py \
  tests/gateway/test_signal.py
```

New `tests/gateway/test_unified_reactions_contract.py` pins the invariants:
- the base class always defines both coroutines and defaults `SUPPORTS_REACTIONS=False`;
- the default is a structured "not supported" result;
- Signal's composite `"<author>:<timestamp_ms>"` id parsing round-trips (incl. malformed-input degradation);
- each reaction-capable adapter advertises the flag **and** overrides both coroutines with the unified signature.

The existing react-dispatch tests were updated to the capability-flag gate.

Locally: 181 reaction-related tests + 208 Signal tests pass; all three adapters import cleanly and the Signal method rename leaves the processing-lifecycle hooks intact.

## Platforms tested

Linux. Changes are pure Python with no OS-specific calls; the Signal/Telegram/Photon paths are exercised by their existing test suites.
