### PR TITLE
fix(skills): add explicit encoding to read_text/write_text calls

### DIFF
--- a/skills/creative/comfyui/scripts/auto_fix_deps.py
+++ b/skills/creative/comfyui/scripts/auto_fix_deps.py
@@ -158,7 +158,7 @@ def main(argv: list[str] | None = None) -> int:
     sources: dict[str, str] = {}
     if args.models_from_file:
         try:
-            sources = json.loads(Path(args.models_from_file).read_text())
+            sources = json.loads(Path(args.models_from_file).read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as e:
             log(f"Could not read --models-from-file: {e}")
 

--- a/skills/creative/comfyui/scripts/extract_schema.py
+++ b/skills/creative/comfyui/scripts/extract_schema.py
@@ -303,7 +303,7 @@ def main(argv: list[str] | None = None) -> int:
         out = json.dumps(schema, indent=2, default=str)
 
     if args.output:
-        Path(args.output).write_text(out)
+        Path(args.output).write_text(out, encoding="utf-8")
         print(f"Schema written to {args.output}", file=sys.stderr)
     else:
         print(out)

--- a/skills/creative/comfyui/scripts/run_workflow.py
+++ b/skills/creative/comfyui/scripts/run_workflow.py
@@ -620,7 +620,7 @@ def main(argv: list[str] | None = None) -> int:
     args_str = args.args
     if args_str.startswith("@"):
         try:
-            args_str = Path(args_str[1:]).read_text()
+            args_str = Path(args_str[1:]).read_text(encoding="utf-8")
         except OSError as e:
             emit_json({"error": f"Cannot read args file: {e}"})
             return 1

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -70,7 +70,7 @@ def _ensure_authenticated():
 
 def _stored_token_scopes() -> list[str]:
     try:
-        data = json.loads(TOKEN_PATH.read_text())
+        data = json.loads(TOKEN_PATH.read_text(encoding="utf-8"))
     except Exception:
         return list(SCOPES)
     scopes = data.get("scopes")
@@ -192,7 +192,8 @@ def get_credentials():
             json.dumps(
                 _normalize_authorized_user_payload(json.loads(creds.to_json())),
                 indent=2,
-            )
+            ),
+            encoding="utf-8",
         )
     if not creds.valid:
         print("Token is invalid. Re-run setup.", file=sys.stderr)

--- a/skills/productivity/google-workspace/scripts/gws_bridge.py
+++ b/skills/productivity/google-workspace/scripts/gws_bridge.py
@@ -69,7 +69,8 @@ def refresh_token(token_data: dict) -> dict:
     ).isoformat()
 
     get_token_path().write_text(
-        json.dumps(_normalize_authorized_user_payload(token_data), indent=2)
+        json.dumps(_normalize_authorized_user_payload(token_data), indent=2),
+        encoding="utf-8",
     )
     return token_data
 
@@ -81,7 +82,7 @@ def get_valid_token() -> str:
         print("ERROR: No Google token found. Run setup.py --auth-url first.", file=sys.stderr)
         sys.exit(1)
 
-    token_data = json.loads(token_path.read_text())
+    token_data = json.loads(token_path.read_text(encoding="utf-8"))
 
     expiry = token_data.get("expiry", "")
     if expiry:

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -71,7 +71,7 @@ def _normalize_authorized_user_payload(payload: dict) -> dict:
 
 def _load_token_payload(path: Path = TOKEN_PATH) -> dict:
     try:
-        return json.loads(path.read_text())
+        return json.loads(path.read_text(encoding="utf-8"))
     except Exception:
         return {}
 
@@ -220,7 +220,8 @@ def check_auth(quiet: bool = False):
                 json.dumps(
                     _normalize_authorized_user_payload(json.loads(creds.to_json())),
                     indent=2,
-                )
+                ),
+                encoding="utf-8",
             )
             missing_scopes = _missing_scopes_from_payload(_load_token_payload(TOKEN_PATH))
             if missing_scopes:
@@ -260,7 +261,7 @@ def store_client_secret(path: str):
         sys.exit(1)
 
     try:
-        data = json.loads(src.read_text())
+        data = json.loads(src.read_text(encoding="utf-8"))
     except json.JSONDecodeError:
         print("ERROR: File is not valid JSON.")
         sys.exit(1)
@@ -270,7 +271,7 @@ def store_client_secret(path: str):
         print("Download the correct file from: https://console.cloud.google.com/apis/credentials")
         sys.exit(1)
 
-    CLIENT_SECRET_PATH.write_text(json.dumps(data, indent=2))
+    CLIENT_SECRET_PATH.write_text(json.dumps(data, indent=2), encoding="utf-8")
     print(f"OK: Client secret saved to {CLIENT_SECRET_PATH}")
 
 
@@ -284,7 +285,8 @@ def _save_pending_auth(*, state: str, code_verifier: str):
                 "redirect_uri": REDIRECT_URI,
             },
             indent=2,
-        )
+        ),
+        encoding="utf-8",
     )
 
 
@@ -295,7 +297,7 @@ def _load_pending_auth() -> dict:
         sys.exit(1)
 
     try:
-        data = json.loads(PENDING_AUTH_PATH.read_text())
+        data = json.loads(PENDING_AUTH_PATH.read_text(encoding="utf-8"))
     except Exception as e:
         print(f"ERROR: Could not read pending OAuth session: {e}")
         print("Run --auth-url again to start a fresh OAuth session.")
@@ -410,7 +412,7 @@ def exchange_auth_code(code: str):
         print(f"WARNING: Token missing some Google Workspace scopes: {', '.join(missing_scopes)}")
         print("Some services may not be available.")
 
-    TOKEN_PATH.write_text(json.dumps(token_payload, indent=2))
+    TOKEN_PATH.write_text(json.dumps(token_payload, indent=2), encoding="utf-8")
     PENDING_AUTH_PATH.unlink(missing_ok=True)
     print(f"OK: Authenticated. Token saved to {TOKEN_PATH}")
     print(f"Profile-scoped token location: {display_hermes_home()}/google_token.json")


### PR DESCRIPTION
## Summary

Companion to PRs #50655 (hermes_cli/) and #50660 (tools/agent/). Add `encoding="utf-8"` to remaining `read_text()`/`write_text()` calls in skill scripts.

6 files, 14 calls fixed:
- `google-workspace/google_api.py`: 1 write_text
- `google-workspace/setup.py`: 4 read + 3 write
- `google-workspace/gws_bridge.py`: 1 read + 1 write
- `comfyui/auto_fix_deps.py`: 1 read
- `comfyui/run_workflow.py`: 1 read
- `comfyui/extract_schema.py`: 1 write

## Test plan

- [ ] CI passes