### PR TITLE
Fix hermes send email subjects

### DIFF
--- a/hermes_cli/send_cmd.py
+++ b/hermes_cli/send_cmd.py
@@ -335,10 +335,12 @@ def cmd_send(args: argparse.Namespace) -> None:
         )
         sys.exit(_USAGE_EXIT)
 
-    # Optional: prepend a subject line. Useful for alerting scripts that
-    # want a consistent header without inlining it into every call.
+    # Optional: pass a transport-native subject when the platform supports it
+    # (email), while preserving the historical header-prepend behavior for
+    # chat platforms that do not have a subject field.
     subject = getattr(args, "subject", None)
-    if subject:
+    target_platform = target.split(":", 1)[0].strip().lower()
+    if subject and target_platform != "email":
         message = f"{subject}\n\n{message.lstrip()}"
 
     # Import lazily so `hermes send --help` stays fast and does not pull in
@@ -355,6 +357,8 @@ def cmd_send(args: argparse.Namespace) -> None:
         "target": target,
         "message": message,
     }
+    if subject and target_platform == "email":
+        tool_args["subject"] = subject
 
     result = send_message_tool(tool_args)
     exit_code = _emit_result(

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -1195,6 +1195,7 @@ async def _standalone_send(
     thread_id=None,
     media_files=None,
     force_document=False,
+    subject=None,
 ):
     """Out-of-process Email delivery via SMTP (one-shot). Implements the
     standalone_sender_fn contract; replaces the legacy _send_email helper."""
@@ -1219,7 +1220,11 @@ async def _standalone_send(
         msg = MIMEText(message, "plain", "utf-8")
         msg["From"] = address
         msg["To"] = chat_id
-        msg["Subject"] = "Hermes Agent"
+        if isinstance(subject, str) and subject.strip():
+            email_subject = subject.replace("\r", " ").replace("\n", " ")
+        else:
+            email_subject = "Hermes Agent"
+        msg["Subject"] = email_subject
         msg["Date"] = formatdate(localtime=True)
 
         server = smtplib.SMTP(smtp_host, smtp_port)

--- a/tests/hermes_cli/test_send_cmd.py
+++ b/tests/hermes_cli/test_send_cmd.py
@@ -116,6 +116,25 @@ def test_subject_prepends_header(fake_tool):
     assert fake_tool.calls[0]["message"] == "[CI]\n\nbody text"
 
 
+def test_email_subject_uses_transport_subject_not_body_header(fake_tool):
+    args = _parse([
+        "--to",
+        "email:andy@example.com",
+        "--subject",
+        "[Hermes][Test] Subject",
+        "body text",
+    ])
+    with pytest.raises(SystemExit) as exc:
+        send_cmd.cmd_send(args)
+    assert exc.value.code == 0
+    assert fake_tool.calls[0] == {
+        "action": "send",
+        "target": "email:andy@example.com",
+        "message": "body text",
+        "subject": "[Hermes][Test] Subject",
+    }
+
+
 def test_json_mode_emits_payload(fake_tool, capsys):
     args = _parse(["--to", "telegram", "--json", "hi"])
     with pytest.raises(SystemExit) as exc:

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -319,6 +319,42 @@ class TestSendMessageTool:
             force_document=False,
         )
 
+    def test_email_subject_reaches_transport(self):
+        email_platform = Platform("email")
+        email_cfg = SimpleNamespace(enabled=True, token=None, extra={})
+        config = SimpleNamespace(
+            platforms={email_platform: email_cfg},
+            get_home_channel=lambda _platform: None,
+        )
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True):
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "email:andy@example.com",
+                        "message": "done",
+                        "subject": "[Hermes][Test] Subject",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        send_mock.assert_awaited_once_with(
+            email_platform,
+            email_cfg,
+            "andy@example.com",
+            "done",
+            thread_id=None,
+            media_files=[],
+            force_document=False,
+            subject="[Hermes][Test] Subject",
+        )
+
     def test_cron_duplicate_target_is_skipped_and_explained(self):
         home = SimpleNamespace(chat_id="-1001")
         config, _telegram_cfg = _make_config()

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -319,18 +319,24 @@ class TestSendMessageTool:
             force_document=False,
         )
 
-    def test_email_subject_reaches_transport(self):
+    def test_email_subject_reaches_smtp_message(self):
         email_platform = Platform("email")
-        email_cfg = SimpleNamespace(enabled=True, token=None, extra={})
+        email_cfg = SimpleNamespace(
+            enabled=True,
+            token=None,
+            extra={"address": "hermes@example.com", "smtp_host": "smtp.example.com"},
+        )
         config = SimpleNamespace(
             platforms={email_platform: email_cfg},
             get_home_channel=lambda _platform: None,
         )
+        smtp = MagicMock()
 
-        with patch("gateway.config.load_gateway_config", return_value=config), \
+        with patch.dict(os.environ, {"EMAIL_PASSWORD": "secret"}), \
+             patch("gateway.config.load_gateway_config", return_value=config), \
              patch("tools.interrupt.is_interrupted", return_value=False), \
              patch("model_tools._run_async", side_effect=_run_async_immediately), \
-             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("smtplib.SMTP", return_value=smtp), \
              patch("gateway.mirror.mirror_to_session", return_value=True):
             result = json.loads(
                 send_message_tool(
@@ -344,16 +350,9 @@ class TestSendMessageTool:
             )
 
         assert result["success"] is True
-        send_mock.assert_awaited_once_with(
-            email_platform,
-            email_cfg,
-            "andy@example.com",
-            "done",
-            thread_id=None,
-            media_files=[],
-            force_document=False,
-            subject="[Hermes][Test] Subject",
-        )
+        sent_message = smtp.send_message.call_args.args[0]
+        assert sent_message["Subject"] == "[Hermes][Test] Subject"
+        assert sent_message.get_payload(decode=True).decode("utf-8") == "done"
 
     def test_cron_duplicate_target_is_skipped_and_explained(self):
         home = SimpleNamespace(chat_id="-1001")

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -788,7 +788,16 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False):
+async def _send_to_platform(
+    platform,
+    pconfig,
+    chat_id,
+    message,
+    thread_id=None,
+    media_files=None,
+    force_document=False,
+    subject=None,
+):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -1077,7 +1086,14 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         elif platform == Platform.SIGNAL:
             result = await _send_signal(pconfig.extra, chat_id, chunk)
         elif platform == Platform.EMAIL:
-            result = await _registry_standalone_send("email", pconfig, chat_id, chunk, thread_id)
+            result = await _registry_standalone_send(
+                "email",
+                pconfig,
+                chat_id,
+                chunk,
+                thread_id,
+                subject=subject,
+            )
         elif platform == Platform.SMS:
             result = await _registry_standalone_send("sms", pconfig, chat_id, chunk, thread_id)
         elif platform == Platform.DINGTALK:
@@ -1449,7 +1465,15 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
 # (plugins/platforms/slack/adapter.py), wired via standalone_sender_fn. #41112.
 
 
-async def _registry_standalone_send(platform_name, pconfig, chat_id, message, thread_id=None):
+async def _registry_standalone_send(
+    platform_name,
+    pconfig,
+    chat_id,
+    message,
+    thread_id=None,
+    *,
+    subject=None,
+):
     """Dispatch a one-shot send through a migrated platform plugin's
     standalone_sender_fn (registry hook).  Used for platforms whose adapter
     moved out of gateway/platforms/ into plugins/platforms/<name>/ (#41112):
@@ -1462,7 +1486,10 @@ async def _registry_standalone_send(platform_name, pconfig, chat_id, message, th
     entry = platform_registry.get(platform_name)
     if entry is None or entry.standalone_sender_fn is None:
         return {"error": f"{platform_name} plugin not registered or missing standalone_sender_fn"}
-    return await entry.standalone_sender_fn(pconfig, chat_id, message, thread_id=thread_id)
+    send_kwargs = {"thread_id": thread_id}
+    if platform_name == "email" and subject is not None:
+        send_kwargs["subject"] = subject
+    return await entry.standalone_sender_fn(pconfig, chat_id, message, **send_kwargs)
 
 
 # _send_whatsapp moved to plugins/platforms/whatsapp/adapter.py::_standalone_send,

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -221,6 +221,10 @@ SEND_MESSAGE_SCHEMA = {
                 "type": "string",
                 "description": "The message text to send. To send an image or file, include MEDIA:<local_path> (e.g. 'MEDIA:/tmp/report.pdf') in the message — the platform will deliver it as a native media attachment."
             },
+            "subject": {
+                "type": "string",
+                "description": "Optional email subject. Honored for target='email:...' and ignored by chat-style platforms."
+            },
             "emoji": {
                 "type": "string",
                 "description": "For action='react': the emoji to react with (e.g. '❤️'). On iMessage, ❤️👍👎😂‼️❓ render as native tapbacks; other emoji use custom-emoji reactions."
@@ -487,17 +491,24 @@ def _handle_send(args):
         except Exception as e:
             return json.dumps({"error": f"Failed to open Slack DM: {e}"})
 
+    subject = args.get("subject") if platform_name == "email" else None
+
     try:
         from model_tools import _run_async
+        send_kwargs = {
+            "thread_id": thread_id,
+            "media_files": media_files,
+            "force_document": force_document_attachments,
+        }
+        if subject:
+            send_kwargs["subject"] = subject
         result = _run_async(
             _send_to_platform(
                 platform,
                 pconfig,
                 chat_id,
                 cleaned_message,
-                thread_id=thread_id,
-                media_files=media_files,
-                force_document=force_document_attachments,
+                **send_kwargs,
             )
         )
         if used_home_channel and isinstance(result, dict) and result.get("success"):


### PR DESCRIPTION
## Summary
- keep the historical `--subject` body-header behavior for chat platforms
- send `hermes send --to email:... --subject ...` as a native MIME `Subject` instead
- carry the subject through the current registry/plugin standalone transport to the email SMTP adapter
- flatten CR/LF before constructing the header
- exercise the actual plugin sender with a mocked SMTP `send_message()` assertion

This is the CLI entry-point half of the outbound-email subject fix. #58564 remains complementary work for the live adapter `send(metadata=...)` path.

## Verification
- `/home/pi/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_send_cmd.py tests/tools/test_send_message_tool.py tests/gateway/test_email.py tests/gateway/test_email_robustness.py -q -o addopts=` — **272 passed**
- `ruff check` on all touched production/test files — passed
- `git diff --check origin/main...HEAD` — passed

Rebased onto current `main` before publication.