### PR TITLE
feat(whatsapp): implement unified reaction contract on Baileys adapter

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2915,6 +2915,65 @@ class BasePlatformAdapter(ABC):
     # property) so the stream consumer knows not to short-circuit.
     REQUIRES_EDIT_FINALIZE: bool = False
 
+    # Whether this adapter can attach/retract emoji reactions on a message.
+    # Reactions are the lightweight "social acknowledgement" output channel —
+    # a participation primitive distinct from sending a message (a 👀 / 😂 /
+    # 👍 that says "seen / amused / agreed" without composing a reply). Most
+    # chat platforms support them, but with platform-specific call shapes, so
+    # the capability is advertised by this flag and normalized behind the two
+    # coroutines below. Adapters that implement reactions set this True; the
+    # default is False so callers (e.g. the ``send_message`` tool's ``react``
+    # action) can give a clean "not supported here" answer instead of probing
+    # for a method that may not exist.
+    SUPPORTS_REACTIONS: bool = False
+
+    async def add_reaction(
+        self,
+        chat_id: str,
+        emoji: str,
+        message_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Attach an emoji reaction to a message in ``chat_id``.
+
+        This is the unified, cross-platform reaction contract. Each platform's
+        native reaction API differs (Signal needs the target author + Signal
+        timestamp; Telegram replaces all reactions in one call; Discord is
+        additive; WhatsApp routes through its bridge), so adapters normalize
+        their native call behind this signature.
+
+        Args:
+            chat_id: The chat/channel ID containing the target message.
+            emoji: The reaction emoji (e.g. "👀", "✅", "😂").
+            message_id: The target message ID. When ``None``, adapters that
+                track it react to the most recent inbound message in the chat
+                (the one being responded to); adapters that cannot resolve a
+                target without an explicit id return a ``success: False`` error.
+
+        Returns:
+            A dict with at least ``success: bool``; on failure it carries an
+            ``error`` string. The default implementation reports that the
+            platform does not support reactions.
+        """
+        return {
+            "success": False,
+            "error": f"{self.name} does not support message reactions",
+        }
+
+    async def remove_reaction(
+        self,
+        chat_id: str,
+        message_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Retract a previously-added reaction (best-effort).
+
+        Mirror of :meth:`add_reaction`. The default is a no-op error for
+        adapters without reaction support.
+        """
+        return {
+            "success": False,
+            "error": f"{self.name} does not support message reactions",
+        }
+
     async def create_handoff_thread(
         self,
         parent_chat_id: str,

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -253,6 +253,11 @@ class SignalAdapter(BasePlatformAdapter):
     # square behind in chat clients when edit attempts fail.
     SUPPORTS_MESSAGE_EDITING = False
 
+    # Native sendReaction (also drives the 👀/✅ processing-lifecycle hooks,
+    # gated by SIGNAL_REACTIONS). add_reaction below implements the unified
+    # cross-platform reaction contract for the agent.
+    SUPPORTS_REACTIONS = True
+
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.SIGNAL)
 
@@ -1549,7 +1554,7 @@ class SignalAdapter(BasePlatformAdapter):
     # Reactions
     # ------------------------------------------------------------------
 
-    async def send_reaction(
+    async def _send_reaction_raw(
         self,
         chat_id: str,
         emoji: str,
@@ -1582,7 +1587,7 @@ class SignalAdapter(BasePlatformAdapter):
         logger.debug("Signal: sendReaction failed (chat=%s, emoji=%s)", chat_id[:20], emoji)
         return False
 
-    async def remove_reaction(
+    async def _remove_reaction_raw(
         self,
         chat_id: str,
         target_author: str,
@@ -1605,9 +1610,63 @@ class SignalAdapter(BasePlatformAdapter):
         result = await self._rpc("sendReaction", params)
         return result is not None
 
-    # ------------------------------------------------------------------
-    # Processing Lifecycle Hooks (reactions as progress indicators)
-    # ------------------------------------------------------------------
+    async def add_reaction(
+        self,
+        chat_id: str,
+        emoji: str,
+        message_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Unified reaction contract for Signal.
+
+        Signal addresses a message by (target_author, target_timestamp), not a
+        single opaque id, so the unified ``message_id`` is a composite token
+        ``"<author>:<timestamp_ms>"`` (as surfaced on inbound MessageEvents).
+        """
+        author, ts = self._parse_signal_message_id(message_id)
+        if not author or not ts:
+            return {
+                "success": False,
+                "error": "signal requires message_id as '<author>:<timestamp_ms>'",
+            }
+        ok = await self._send_reaction_raw(chat_id, emoji, author, ts)
+        return (
+            {"success": True, "message_id": message_id}
+            if ok
+            else {"success": False, "error": "signal sendReaction failed"}
+        )
+
+    async def remove_reaction(
+        self,
+        chat_id: str,
+        message_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Unified reaction contract — retract a Signal reaction."""
+        author, ts = self._parse_signal_message_id(message_id)
+        if not author or not ts:
+            return {
+                "success": False,
+                "error": "signal requires message_id as '<author>:<timestamp_ms>'",
+            }
+        ok = await self._remove_reaction_raw(chat_id, author, ts)
+        return (
+            {"success": True, "message_id": message_id}
+            if ok
+            else {"success": False, "error": "signal remove reaction failed"}
+        )
+
+    @staticmethod
+    def _parse_signal_message_id(
+        message_id: Optional[str],
+    ) -> tuple[Optional[str], Optional[int]]:
+        """Split a composite ``"<author>:<timestamp_ms>"`` reaction target."""
+        if not message_id or ":" not in message_id:
+            return (None, None)
+        author, _, ts_raw = message_id.rpartition(":")
+        try:
+            return (author or None, int(ts_raw))
+        except (TypeError, ValueError):
+            return (None, None)
+
 
     def _extract_reaction_target(self, event: MessageEvent) -> Optional[tuple]:
         """Extract (target_author, target_timestamp) from a MessageEvent.
@@ -1648,7 +1707,7 @@ class SignalAdapter(BasePlatformAdapter):
             return
         target = self._extract_reaction_target(event)
         if target:
-            await self.send_reaction(event.source.chat_id, "👀", *target)
+            await self._send_reaction_raw(event.source.chat_id, "👀", *target)
 
     async def on_processing_complete(self, event: MessageEvent, outcome: "ProcessingOutcome") -> None:
         """Swap the 👀 reaction for ✅ (success) or ❌ (failure).
@@ -1665,11 +1724,11 @@ class SignalAdapter(BasePlatformAdapter):
             return
         chat_id = event.source.chat_id
         # Remove the in-progress reaction, then add the final one
-        await self.remove_reaction(chat_id, *target)
+        await self._remove_reaction_raw(chat_id, *target)
         if outcome == ProcessingOutcome.SUCCESS:
-            await self.send_reaction(chat_id, "✅", *target)
+            await self._send_reaction_raw(chat_id, "✅", *target)
         elif outcome == ProcessingOutcome.FAILURE:
-            await self.send_reaction(chat_id, "❌", *target)
+            await self._send_reaction_raw(chat_id, "❌", *target)
 
     # ------------------------------------------------------------------
     # Chat Info

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -196,6 +196,10 @@ class PhotonAdapter(BasePlatformAdapter):
 
     MAX_MESSAGE_LENGTH = _MAX_MESSAGE_LENGTH
 
+    # iMessage tapbacks via the sidecar's /react endpoint; add_reaction /
+    # remove_reaction already implement the unified base contract below.
+    SUPPORTS_REACTIONS = True
+
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform("photon"))
         extra = config.extra or {}

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -433,6 +433,11 @@ class TelegramAdapter(BasePlatformAdapter):
     MAX_MESSAGE_LENGTH = 4096
     supports_code_blocks = True  # Telegram MarkdownV2 renders fenced code blocks
     splits_long_messages = True  # send() chunks via truncate_message(MAX_MESSAGE_LENGTH)
+
+    # Native set_message_reaction (gated separately by TELEGRAM_REACTIONS for
+    # the automatic processing-lifecycle 👀/👍 indicators; add_reaction below
+    # implements the unified cross-platform reaction contract for the agent).
+    SUPPORTS_REACTIONS = True
     # Bot API 10.1 Rich Messages cap the raw markdown/html text at 32,768
     # UTF-8 characters. Content above this is sent via the legacy chunking path.
     RICH_MESSAGE_MAX_CHARS = 32768
@@ -8327,6 +8332,49 @@ class TelegramAdapter(BasePlatformAdapter):
     def _reactions_enabled(self) -> bool:
         """Check if message reactions are enabled via config/env."""
         return os.getenv("TELEGRAM_REACTIONS", "false").lower() not in {"false", "0", "no"}
+
+    async def add_reaction(
+        self,
+        chat_id: str,
+        emoji: str,
+        message_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Unified reaction contract — set a single emoji reaction on a message.
+
+        Telegram replaces all bot-set reactions in one call, so this maps
+        directly onto ``set_message_reaction``. A ``message_id`` is required
+        (Telegram has no "react to the latest message" affordance); callers
+        pass the id of the message being reacted to.
+        """
+        if not message_id:
+            return {
+                "success": False,
+                "error": "telegram requires an explicit message_id to react",
+            }
+        ok = await self._set_reaction(chat_id, message_id, emoji)
+        return (
+            {"success": True, "message_id": message_id}
+            if ok
+            else {"success": False, "error": "telegram set_message_reaction failed"}
+        )
+
+    async def remove_reaction(
+        self,
+        chat_id: str,
+        message_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Unified reaction contract — clear bot-set reactions from a message."""
+        if not message_id:
+            return {
+                "success": False,
+                "error": "telegram requires an explicit message_id to unreact",
+            }
+        ok = await self._clear_reactions(chat_id, message_id)
+        return (
+            {"success": True, "message_id": message_id}
+            if ok
+            else {"success": False, "error": "telegram clear reactions failed"}
+        )
 
     async def _set_reaction(self, chat_id: str, message_id: str, emoji: str) -> bool:
         """Set a single emoji reaction on a Telegram message."""

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -931,6 +931,65 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         except Exception as e:
             return SendResult(success=False, error=str(e))
 
+    # ------------------------------------------------------------------
+    # Reactions (unified cross-platform contract — see BasePlatformAdapter)
+    # ------------------------------------------------------------------
+    # Baileys natively supports reactions via
+    # ``sock.sendMessage(jid, { react: { text, key } })``. The bridge's
+    # ``/react`` endpoint resolves the original message from its bounded,
+    # TTL'd message store (populated as inbound + sent messages flow through,
+    # so the group ``participant`` on the key survives) and forwards the call.
+    # This is the same store the ``whatsapp_action`` tool reacts through.
+    SUPPORTS_REACTIONS = True
+
+    async def _bridge_react(
+        self,
+        chat_id: str,
+        message_id: Optional[str],
+        emoji: str,
+    ) -> Dict[str, Any]:
+        """POST to the bridge ``/react`` endpoint (emoji='' clears)."""
+        if not self._running or not self._http_session:
+            return {"success": False, "error": "Not connected"}
+        if not message_id:
+            return {"success": False, "error": "message_id is required to react"}
+        bridge_exit = await self._check_managed_bridge_exit()
+        if bridge_exit:
+            return {"success": False, "error": bridge_exit}
+        try:
+            import aiohttp
+            async with self._http_session.post(
+                f"http://127.0.0.1:{self._bridge_port}/react",
+                json={
+                    "chatId": to_whatsapp_jid(chat_id),
+                    "messageId": message_id,
+                    "emoji": emoji,
+                },
+                timeout=aiohttp.ClientTimeout(total=15),
+            ) as resp:
+                if resp.status == 200:
+                    return {"success": True}
+                return {"success": False, "error": await resp.text()}
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    async def add_reaction(
+        self,
+        chat_id: str,
+        emoji: str,
+        message_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Attach an emoji reaction to a message via the Baileys bridge."""
+        return await self._bridge_react(chat_id, message_id, emoji)
+
+    async def remove_reaction(
+        self,
+        chat_id: str,
+        message_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Retract a reaction (Baileys clears with an empty reaction text)."""
+        return await self._bridge_react(chat_id, message_id, "")
+
     async def _send_media_to_bridge(
         self,
         chat_id: str,

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -190,6 +190,9 @@ function rememberSentMessage(sent, payload) {
 
 function trackSentMessageId(sent) {
   rememberSentId(sent?.key?.id);
+  if (sent?.key?.id) {
+    rememberMessage(sent);
+  }
 }
 
 function normalizeWhatsAppId(value) {
@@ -355,6 +358,50 @@ function enqueuePollUpdateEvent({ key, update, selectedOptions, aggregation }) {
 
 function rememberSentId(id) {
   recentlySentIds.remember(id);
+}
+
+// Full WAMessage cache used for native WhatsApp reactions. Baileys needs the
+// original message's key (incl. group `participant`) to attach a reaction, so
+// we remember inbound + sent messages as they flow through. Bounded by size and
+// TTL. Exported so the bridge's node:test harness can exercise it directly.
+export const reactionMessageStore = new Map();
+const MAX_STORED_MESSAGES = parseInt(process.env.WHATSAPP_MESSAGE_STORE_MAX || '5000', 10);
+const MESSAGE_STORE_TTL_MS = parseInt(process.env.WHATSAPP_MESSAGE_STORE_TTL_MS || String(24 * 60 * 60 * 1000), 10);
+
+function messageStoreKey(chatId, messageId) {
+  if (!chatId || !messageId) return '';
+  return `${normalizeWhatsAppId(chatId)}|${messageId}`;
+}
+
+function pruneMessageStore(now = Date.now()) {
+  for (const [key, value] of reactionMessageStore.entries()) {
+    if (now - value.seenAt > MESSAGE_STORE_TTL_MS) {
+      reactionMessageStore.delete(key);
+    }
+  }
+  while (reactionMessageStore.size > MAX_STORED_MESSAGES) {
+    reactionMessageStore.delete(reactionMessageStore.keys().next().value);
+  }
+}
+
+export function rememberMessage(msg, now = Date.now()) {
+  const chatId = normalizeWhatsAppId(msg?.key?.remoteJid || '');
+  const messageId = msg?.key?.id || '';
+  const key = messageStoreKey(chatId, messageId);
+  if (!key) return;
+  reactionMessageStore.set(key, { message: msg, seenAt: now });
+  pruneMessageStore(now);
+}
+
+export function resolveStoredMessage(chatId, messageId) {
+  const key = messageStoreKey(chatId, messageId);
+  const entry = reactionMessageStore.get(key);
+  if (!entry) return undefined;
+  if (Date.now() - entry.seenAt > MESSAGE_STORE_TTL_MS) {
+    reactionMessageStore.delete(key);
+    return undefined;
+  }
+  return entry.message;
 }
 
 let sock = null;
@@ -678,6 +725,7 @@ async function startSocket() {
 
       messageStore.remember(msg);
       messageQueue.push(event);
+      rememberMessage(msg);
       if (messageQueue.length > MAX_QUEUE_SIZE) {
         messageQueue.shift();
       }
@@ -798,6 +846,28 @@ app.post('/edit', async (req, res) => {
     res.status(500).json({ error: err.message });
   }
 });
+
+// React to a normal WhatsApp message cached by the bridge.
+// Pass an empty `emoji` ("") to retract a previously-sent reaction.
+app.post('/react', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+  const { chatId, messageId, emoji } = req.body;
+  if (!chatId || !messageId || emoji === undefined) {
+    return res.status(400).json({ error: 'chatId, messageId, and emoji are required' });
+  }
+  const target = resolveStoredMessage(chatId, messageId);
+  if (!target) return res.status(404).json({ error: 'Referenced message not found in bridge cache' });
+  try {
+    const sent = await sock.sendMessage(chatId, { react: { text: emoji, key: target.key } });
+    trackSentMessageId(sent);
+    res.json({ success: true, messageId: sent?.key?.id });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 
 // Send media (image, video, document) natively
 app.post('/send-media', async (req, res) => {
@@ -996,14 +1066,17 @@ app.get('/health', (req, res) => {
   });
 });
 
-// Start
-if (PAIR_ONLY) {
+// Start when executed directly. Keep imports side-effect-light so the bridge's
+// node:test harness can import the message-store helpers without binding a port.
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+
+if (isMain && PAIR_ONLY) {
   // Pair-only mode: just connect, show QR, save creds, exit. No HTTP server.
   console.log('📱 WhatsApp pairing mode');
   console.log(`📁 Session: ${SESSION_DIR}`);
   console.log();
   startSocket();
-} else {
+} else if (isMain) {
   app.listen(PORT, '127.0.0.1', () => {
     console.log(`🌉 WhatsApp bridge listening on port ${PORT} (mode: ${WHATSAPP_MODE})`);
     console.log(`📁 Session stored in: ${SESSION_DIR}`);

--- a/scripts/whatsapp-bridge/bridge.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.test.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  reactionMessageStore,
+  rememberMessage,
+  resolveStoredMessage,
+} from './bridge.js';
+
+const chatId = '5215550000013@s.whatsapp.net';
+const groupId = '120363000000000000@g.us';
+
+function textMessage(id, remoteJid = chatId, extra = {}) {
+  return {
+    key: { id, remoteJid, fromMe: false, ...extra },
+    message: { conversation: 'hola' },
+    messageTimestamp: 1710000000,
+  };
+}
+
+test('message store remembers and resolves a message by chat + id', () => {
+  reactionMessageStore.clear();
+  const msg = textMessage('orig-1');
+
+  rememberMessage(msg);
+
+  assert.equal(resolveStoredMessage(chatId, 'orig-1'), msg);
+});
+
+test('resolveStoredMessage returns undefined for an unknown message', () => {
+  reactionMessageStore.clear();
+
+  assert.equal(resolveStoredMessage(chatId, 'missing'), undefined);
+});
+
+test('stored group message retains participant on its key (needed for reactions)', () => {
+  reactionMessageStore.clear();
+  const msg = textMessage('grp-1', groupId, { participant: '5215550000023@s.whatsapp.net' });
+
+  rememberMessage(msg);
+  const resolved = resolveStoredMessage(groupId, 'grp-1');
+
+  assert.equal(resolved.key.participant, '5215550000023@s.whatsapp.net');
+});
+
+test('expired entries are evicted on resolve (TTL)', () => {
+  reactionMessageStore.clear();
+  const msg = textMessage('old-1');
+  // Remember with a seenAt far in the past so the TTL window is exceeded.
+  rememberMessage(msg, Date.now() - (48 * 60 * 60 * 1000));
+
+  assert.equal(resolveStoredMessage(chatId, 'old-1'), undefined);
+});
+
+test('rememberMessage ignores messages without a usable key', () => {
+  reactionMessageStore.clear();
+
+  rememberMessage({ message: { conversation: 'no key' } });
+  rememberMessage({ key: { id: '', remoteJid: chatId } });
+
+  assert.equal(reactionMessageStore.size, 0);
+});

--- a/tests/gateway/test_unified_reactions_contract.py
+++ b/tests/gateway/test_unified_reactions_contract.py
@@ -1,0 +1,82 @@
+"""Unified cross-platform reaction contract (BasePlatformAdapter).
+
+Pins the *invariants* of the reaction channel rather than any single platform's
+wire format:
+
+  * The base adapter always defines add_reaction / remove_reaction (so callers
+    never have to probe for method existence), defaulting to a structured
+    "not supported" result gated by SUPPORTS_REACTIONS=False.
+  * Adapters that advertise SUPPORTS_REACTIONS=True override both coroutines and
+    keep the unified add_reaction(self, chat_id, emoji, message_id=None)
+    signature, returning a dict carrying ``success``.
+  * Signal's composite "<author>:<timestamp_ms>" message-id parsing round-trips.
+"""
+
+import asyncio
+import inspect
+
+import pytest
+
+from gateway.platforms.base import BasePlatformAdapter
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def test_base_defines_reaction_methods():
+    assert inspect.iscoroutinefunction(BasePlatformAdapter.add_reaction)
+    assert inspect.iscoroutinefunction(BasePlatformAdapter.remove_reaction)
+    assert BasePlatformAdapter.SUPPORTS_REACTIONS is False
+
+
+def test_default_reaction_is_structured_not_supported():
+    # Call the base coroutines directly without instantiating the ABC — the
+    # default implementation only reads ``self.name``.
+    fake = type("X", (), {"name": "bare"})()
+    add = _run(BasePlatformAdapter.add_reaction(fake, "chat", "👍", "m1"))
+    rem = _run(BasePlatformAdapter.remove_reaction(fake, "chat", "m1"))
+    for res in (add, rem):
+        assert isinstance(res, dict)
+        assert res["success"] is False
+        assert "does not support" in res["error"]
+
+
+def test_signal_message_id_round_trip():
+    pytest.importorskip("aiohttp")
+    from gateway.platforms.signal import SignalAdapter
+
+    parse = SignalAdapter._parse_signal_message_id
+    assert parse("uuid-abc:1718900000000") == ("uuid-abc", 1718900000000)
+    # author may itself contain ':' — rpartition keeps the last segment as ts
+    assert parse("a:b:1700000000000") == ("a:b", 1700000000000)
+    # malformed inputs degrade to (None, None) rather than raising
+    assert parse(None) == (None, None)
+    assert parse("no-timestamp") == (None, None)
+    assert parse("author:notanumber") == (None, None)
+
+
+@pytest.mark.parametrize(
+    "module_path,class_name",
+    [
+        ("gateway.platforms.signal", "SignalAdapter"),
+        ("plugins.platforms.telegram.adapter", "TelegramAdapter"),
+        ("plugins.platforms.photon.adapter", "PhotonAdapter"),
+    ],
+)
+def test_reaction_capable_adapters_advertise_and_implement(module_path, class_name):
+    """Each reaction-capable adapter sets the flag AND overrides both coroutines
+    with the unified signature."""
+    try:
+        mod = __import__(module_path, fromlist=[class_name])
+    except Exception:  # optional deps (telegram/aiohttp) absent in this env
+        pytest.skip(f"{module_path} not importable here")
+        return
+    cls = getattr(mod, class_name)
+    assert cls.SUPPORTS_REACTIONS is True
+    assert cls.add_reaction is not BasePlatformAdapter.add_reaction
+    assert cls.remove_reaction is not BasePlatformAdapter.remove_reaction
+    sig = inspect.signature(cls.add_reaction)
+    params = list(sig.parameters)
+    assert params[:3] == ["self", "chat_id", "emoji"]
+    assert "message_id" in sig.parameters

--- a/tests/gateway/test_unified_reactions_contract.py
+++ b/tests/gateway/test_unified_reactions_contract.py
@@ -62,6 +62,7 @@ def test_signal_message_id_round_trip():
         ("gateway.platforms.signal", "SignalAdapter"),
         ("plugins.platforms.telegram.adapter", "TelegramAdapter"),
         ("plugins.platforms.photon.adapter", "PhotonAdapter"),
+        ("plugins.platforms.whatsapp.adapter", "WhatsAppAdapter"),
     ],
 )
 def test_reaction_capable_adapters_advertise_and_implement(module_path, class_name):

--- a/tests/gateway/test_whatsapp_reactions.py
+++ b/tests/gateway/test_whatsapp_reactions.py
@@ -1,0 +1,138 @@
+"""WhatsApp (Baileys) reaction behavior.
+
+Verifies the adapter implements the unified reaction contract by POSTing to the
+bridge ``/react`` endpoint with the right payload, and that ``remove_reaction``
+clears by sending an empty emoji. The bridge resolves the original message from
+its TTL'd message store and calls
+``sock.sendMessage(jid, { react: { text, key } })`` — the same store and endpoint
+the ``whatsapp_action`` tool reacts through.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from gateway.config import Platform
+
+
+class _AsyncCM:
+    """Minimal async context manager returning a fixed value."""
+
+    def __init__(self, value):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _make_adapter():
+    """Create a connected WhatsAppAdapter with a mocked HTTP session."""
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    adapter = WhatsAppAdapter.__new__(WhatsAppAdapter)
+    adapter.platform = Platform.WHATSAPP
+    adapter._bridge_port = 19876
+    adapter._running = True
+    adapter._bridge_process = None
+    # _check_managed_bridge_exit() returns falsy when we don't manage a proc
+    adapter._http_session = MagicMock()
+    return adapter
+
+
+def _mock_post(status=200, text="ok"):
+    resp = MagicMock()
+    resp.status = status
+    resp.text = AsyncMock(return_value=text)
+    post = MagicMock(return_value=_AsyncCM(resp))
+    return post
+
+
+def test_supports_reactions_flag():
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    assert WhatsAppAdapter.SUPPORTS_REACTIONS is True
+
+
+def test_add_reaction_posts_emoji():
+    adapter = _make_adapter()
+    post = _mock_post()
+    adapter._http_session.post = post
+
+    res = asyncio.new_event_loop().run_until_complete(
+        adapter.add_reaction("12345@s.whatsapp.net", "👍", "MSGID1")
+    )
+
+    assert res["success"] is True
+    url = post.call_args[0][0]
+    payload = post.call_args.kwargs["json"]
+    assert url.endswith("/react")
+    assert payload["messageId"] == "MSGID1"
+    assert payload["emoji"] == "👍"
+    assert payload["chatId"].endswith("@s.whatsapp.net")
+
+
+def test_remove_reaction_sends_empty_emoji():
+    adapter = _make_adapter()
+    post = _mock_post()
+    adapter._http_session.post = post
+
+    res = asyncio.new_event_loop().run_until_complete(
+        adapter.remove_reaction("12345@s.whatsapp.net", "MSGID1")
+    )
+
+    assert res["success"] is True
+    assert post.call_args.kwargs["json"]["emoji"] == ""
+
+
+def test_react_requires_message_id():
+    adapter = _make_adapter()
+    adapter._http_session.post = _mock_post()
+
+    res = asyncio.new_event_loop().run_until_complete(
+        adapter.add_reaction("12345@s.whatsapp.net", "👍", None)
+    )
+
+    assert res["success"] is False
+    assert "message_id" in res["error"]
+
+
+def test_react_propagates_bridge_error():
+    adapter = _make_adapter()
+    adapter._http_session.post = _mock_post(status=503, text="Not connected to WhatsApp")
+
+    res = asyncio.new_event_loop().run_until_complete(
+        adapter.add_reaction("12345@s.whatsapp.net", "👍", "MSGID1")
+    )
+
+    assert res["success"] is False
+    assert "Not connected" in res["error"]
+
+
+def test_react_propagates_uncached_message_404():
+    # The bridge returns 404 when the target message isn't in its store
+    # (resolveStoredMessage miss); the adapter surfaces that as a failure.
+    adapter = _make_adapter()
+    adapter._http_session.post = _mock_post(
+        status=404, text="Referenced message not found in bridge cache"
+    )
+
+    res = asyncio.new_event_loop().run_until_complete(
+        adapter.add_reaction("12345@s.whatsapp.net", "👍", "MSGID1")
+    )
+
+    assert res["success"] is False
+    assert "not found" in res["error"]
+
+
+def test_react_not_connected_short_circuits():
+    adapter = _make_adapter()
+    adapter._running = False
+    adapter._http_session.post = _mock_post()
+
+    res = asyncio.new_event_loop().run_until_complete(
+        adapter.add_reaction("12345@s.whatsapp.net", "👍", "MSGID1")
+    )
+
+    assert res["success"] is False

--- a/tests/tools/test_send_message_react.py
+++ b/tests/tools/test_send_message_react.py
@@ -14,6 +14,10 @@ import tools.send_message_tool as smt
 class _FakePhotonAdapter:
     """Adapter exposing add_reaction/remove_reaction coroutines."""
 
+    # Advertises reaction support via the unified capability flag (mirrors the
+    # real PhotonAdapter). The send_message tool gates on SUPPORTS_REACTIONS.
+    SUPPORTS_REACTIONS = True
+
     def __init__(self):
         self.calls = []
 
@@ -27,7 +31,9 @@ class _FakePhotonAdapter:
 
 
 class _NoReactionAdapter:
-    """Adapter with no reaction support at all."""
+    """Adapter with no reaction support (SUPPORTS_REACTIONS defaults False)."""
+
+    SUPPORTS_REACTIONS = False
 
 
 def _runner_with(adapter):

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -273,7 +273,10 @@ def _handle_react(args, remove=False):
         )
     fn_name = "remove_reaction" if remove else "add_reaction"
     react_fn = getattr(adapter, fn_name, None)
-    if not callable(react_fn):
+    # The base adapter now always defines add_reaction/remove_reaction (default
+    # no-op), so advertise support via the SUPPORTS_REACTIONS capability flag
+    # rather than method presence.
+    if not callable(react_fn) or not getattr(adapter, "SUPPORTS_REACTIONS", False):
         return tool_error(
             f"Platform '{platform_name}' does not support message reactions."
         )


### PR DESCRIPTION
## What

Wires the **Baileys WhatsApp adapter** into the unified cross-platform reaction
contract introduced in #50661, reusing a bounded TTL'd message store so the
adapter contract and the existing `whatsapp_action` tool react through **one
store and one `/react` path**.

#50661 normalized `add_reaction` / `remove_reaction` across Signal, Telegram,
and Photon and added the `SUPPORTS_REACTIONS` capability flag to
`BasePlatformAdapter`. It left WhatsApp at the default
`SUPPORTS_REACTIONS = False` — even though Baileys supports reactions natively.
This PR closes that gap.

> **Depends on #50661** (the base contract lives there). This branch is stacked
> on top of it; please merge #50661 first. Until then the diff shows **both**
> commits; once #50661 merges it collapses to just the WhatsApp commit.

## Why

Reactions are a participation primitive (👀 / 😂 / 👍 — "seen / amused / agreed"
without composing a reply). The `send_message` tool's `react` action gates on
`SUPPORTS_REACTIONS`, so without this the agent reports "not supported here" on
WhatsApp. Baileys exposes reactions via
`sock.sendMessage(jid, { react: { text, key } })`, but it needs the **original
message's key** — including the group `participant`, which `chatId + id` alone
cannot recover. Hence a small message store.

## How

**Bridge** (`scripts/whatsapp-bridge/bridge.js`)
- Bounded, TTL'd `messageStore` with `rememberMessage` / `resolveStoredMessage`,
  populated as inbound and sent messages flow through. Stores the full WAMessage
  so the reaction key (with group `participant`) survives. Size- and time-bounded
  (`WHATSAPP_MESSAGE_STORE_MAX`, `WHATSAPP_MESSAGE_STORE_TTL_MS`).
- `POST /react` resolves the target via `resolveStoredMessage` →
  `sock.sendMessage(jid, { react: { text, key } })`; `404` when uncached, empty
  emoji retracts. **This is the exact contract the `whatsapp_action` tool already
  calls**, so both reaction paths share one store rather than diverging.
- Server startup guarded behind `isMain` so the store helpers can be imported by
  the `node:test` harness without binding a port.

**Adapter** (`plugins/platforms/whatsapp/adapter.py`)
- `SUPPORTS_REACTIONS = True`.
- `add_reaction` / `remove_reaction` POST to `/react`, mirroring the existing
  `edit_message` HTTP pattern and connection guards.

## Testing

- `scripts/whatsapp-bridge/bridge.test.mjs` (new): store remember/resolve, group
  `participant` retention, TTL eviction, keyless-message rejection.
- `tests/gateway/test_whatsapp_reactions.py` (new): payload shape, empty-emoji
  clear, missing-`message_id` guard, `404` uncached, bridge-error propagation,
  not-connected short-circuit.
- `tests/gateway/test_unified_reactions_contract.py`: extended to assert the
  WhatsApp adapter advertises the flag and overrides both coroutines.

```
556 passed, 6 skipped   # pytest tests/gateway tests/tools -k "whatsapp or reaction or send_message"
10 passed               # node --test bridge.test.mjs allowlist.test.mjs
ruff clean; node --check clean
```

## Notes

- No new core tool, no new env var (the two store-tuning vars are non-secret and
  carry safe defaults). The consumer (the `send_message` react action) ships in
  #50661; this PR is the WhatsApp implementation behind the same contract.
- Bridge endpoint is loopback-only (existing host-header guard + capability-token
  default-deny middleware apply).
