### PR TITLE
fix(agent): strip timestamp from summary path to avoid strict-provider 400

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1364,7 +1364,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             # bypassing the transport — so mirror that sanitization here:
             # tool_name (SQLite FTS bookkeeping), the codex_* reasoning carriers,
             # and every Hermes-internal underscore-prefixed scaffolding key.
-            for schema_foreign in ("tool_name", "codex_reasoning_items", "codex_message_items"):
+            for schema_foreign in ("tool_name", "codex_reasoning_items", "codex_message_items", "timestamp"):
                 api_msg.pop(schema_foreign, None)
             for internal_key in [k for k in api_msg if isinstance(k, str) and k.startswith("_")]:
                 api_msg.pop(internal_key, None)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3289,6 +3289,24 @@ class TestHandleMaxIterations:
         assert messages[2]["tool_name"] == "execute_code"
         assert messages[1]["codex_reasoning_items"] == [{"id": "rs_1"}]
 
+    def test_summary_strips_timestamp_from_messages(self, agent):
+        """The non-wire 'timestamp' key (display.timestamps, /history) must
+        be stripped before the summary API call — strict gateways reject it
+        the same way they reject tool_name."""
+        agent.client.chat.completions.create.return_value = _mock_response(content="Summary")
+        agent._cached_system_prompt = "You are helpful."
+        messages = [
+            {"role": "user", "content": "hello", "timestamp": 1719000000},
+            {"role": "assistant", "content": "hi", "timestamp": 1719000001},
+        ]
+
+        result = agent._handle_max_iterations(messages, 60)
+
+        assert result == "Summary"
+        sent_msgs = agent.client.chat.completions.create.call_args.kwargs.get("messages", [])
+        for m in sent_msgs:
+            assert "timestamp" not in m, f"timestamp not stripped from {m}"
+
     def test_summary_omits_provider_preferences_for_non_openrouter(self, agent):
         agent.base_url = "https://api.openai.com/v1"
         agent._base_url_lower = agent.base_url.lower()


### PR DESCRIPTION
## Summary

- `handle_max_iterations()` hand-builds API messages and calls `chat.completions.create()` directly, bypassing `ChatCompletionsTransport.convert_messages()`
- The transport strips `timestamp` since PR #47868, but the summary path's inline sanitizer was never updated to match
- On a resumed session whose messages carry timestamps, hitting max iterations on a strict provider (Fireworks, Mistral, Moonshot/Kimi, opencode-go) sends the non-schema field to the wire → HTTP 400 `"Extra inputs are not permitted"`

## Fix

Add `"timestamp"` to the existing `schema_foreign` tuple in the summary path sanitizer — the same field the transport already strips at `chat_completions.py:205`.

## Test plan

- [x] `pytest tests/run_agent/test_run_agent.py -k "max_iter or summary or sanitize or timestamp"` — 13 passed
- [x] `pytest tests/agent/ -k "sanitize or timestamp or strict"` — 43 passed
- [x] `python -c "import agent.chat_completion_helpers"` — no import errors