### PR TITLE
fix(security): validate PID identity before kill in google_meet stop

### DIFF
--- a/plugins/google_meet/process_manager.py
+++ b/plugins/google_meet/process_manager.py
@@ -173,6 +173,14 @@ def start(
         # The subprocess now owns the log fd; we can close ours.
         log_fh.close()
 
+    # Capture the kernel start-time fingerprint so stop() can verify
+    # the PID still belongs to this bot after a potential PID recycle.
+    try:
+        from gateway.status import get_process_start_time
+        _kernel_start = get_process_start_time(proc.pid)
+    except Exception:
+        _kernel_start = None
+
     record = {
         "pid": proc.pid,
         "meeting_id": meeting_id,
@@ -182,6 +190,7 @@ def start(
         "session_id": session_id,
         "log_path": str(log_path),
         "mode": mode,
+        "kernel_start_time": _kernel_start,
     }
     _write_active(record)
     return {"ok": True, **record}
@@ -300,6 +309,21 @@ def stop(*, reason: str = "requested") -> Dict[str, Any]:
     transcript_path = Path(out_dir) / "transcript.txt" if out_dir else None
 
     if pid and _pid_alive(pid):
+        recorded_start = active.get("kernel_start_time")
+        if recorded_start is not None:
+            try:
+                from gateway.status import get_process_start_time
+                current_start = get_process_start_time(pid)
+            except Exception:
+                current_start = None
+            if current_start is not None and current_start != recorded_start:
+                _clear_active()
+                return {
+                    "ok": True,
+                    "reason": "stale PID (recycled), cleared pointer",
+                    "meetingId": active.get("meeting_id"),
+                    "transcriptPath": str(transcript_path) if transcript_path else None,
+                }
         try:
             os.kill(pid, signal.SIGTERM)
         except ProcessLookupError:

--- a/tests/plugins/test_google_meet_plugin.py
+++ b/tests/plugins/test_google_meet_plugin.py
@@ -242,6 +242,33 @@ def test_stop_signals_process_and_clears_pointer(tmp_path):
     assert pm._read_active() is None
 
 
+def test_stop_detects_recycled_pid_and_clears_pointer(tmp_path):
+    """When the recorded kernel_start_time no longer matches the live PID's
+    start time, stop() must treat the PID as recycled — clear the pointer
+    without sending SIGTERM to an unrelated process."""
+    from plugins.google_meet import process_manager as pm
+
+    pm._write_active({
+        "pid": 22222, "meeting_id": "r-e-c",
+        "out_dir": str(tmp_path / "r-e-c"),
+        "url": "https://meet.google.com/r-e-c",
+        "started_at": 0,
+        "kernel_start_time": 1000.0,
+    })
+
+    kills = []
+
+    with patch.object(pm, "_pid_alive", return_value=True), \
+         patch("gateway.status.get_process_start_time", return_value=9999.0), \
+         patch.object(pm.os, "kill", side_effect=lambda *a: kills.append(a)):
+        res = pm.stop()
+
+    assert res["ok"] is True
+    assert "stale" in res.get("reason", "").lower() or "recycled" in res.get("reason", "").lower()
+    assert kills == [], "must not SIGTERM a recycled PID"
+    assert pm._read_active() is None
+
+
 # ---------------------------------------------------------------------------
 # Tool handlers — JSON shape + safety gates
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `stop()` reads the bot PID from `.active.json` and sends SIGTERM/SIGKILL after only a bare liveness check (`_pid_exists`)
- Once the bot exits and the kernel recycles its PID onto an unrelated process, `stop()` kills that process instead
- `start()` triggers the same unguarded kill path when replacing an existing meeting (line 119)
- Same vulnerability class fixed in the process registry (PR #50468), WhatsApp bridge (#50468), and browser daemon (#50417)

## Fix

Record the kernel start-time fingerprint in `.active.json` at spawn via `get_process_start_time()` (the same utility `ProcessRegistry._host_pid_is_ours` uses). Before signalling in `stop()`, compare the recorded fingerprint against the live process — a mismatch means the PID was recycled, so clear the stale pointer without killing.

Legacy `.active.json` files without `kernel_start_time` degrade to the prior best-effort behaviour (bare liveness check).

## Test plan

- [x] `pytest tests/plugins/test_google_meet_plugin.py tests/plugins/test_google_meet_audio.py tests/plugins/test_google_meet_realtime.py tests/plugins/test_google_meet_node.py` — 113 passed
- [x] `python -c "import plugins.google_meet.process_manager"` — no import errors