### PR TITLE
fix(config): accept api_base as URL alias in custom provider entries

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4063,9 +4063,9 @@ def _normalize_custom_provider_entry(
     if "api_key_env" in entry and "key_env" not in entry:
         entry["key_env"] = entry["api_key_env"]
     _KNOWN_KEYS = {
-        "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
-        "api_mode", "transport", "model", "default_model", "models",
-        "context_length", "rate_limit_delay",
+        "name", "api", "url", "base_url", "api_base", "api_key", "key_env",
+        "api_key_env", "api_mode", "transport", "model", "default_model",
+        "models", "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
         "discover_models", "extra_body",
     }
@@ -4087,7 +4087,7 @@ def _normalize_custom_provider_entry(
     from urllib.parse import urlparse
 
     base_url = ""
-    for url_key in ("base_url", "url", "api"):
+    for url_key in ("base_url", "api_base", "url", "api"):
         raw_url = entry.get(url_key)
         if isinstance(raw_url, str) and raw_url.strip():
             candidate = raw_url.strip()

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -2359,6 +2359,32 @@ class TestProviderEntryApiKeyEnvAlias:
         assert normalized is not None
         assert "extra_body" in _VALID_CUSTOM_PROVIDER_FIELDS
         assert normalized["extra_body"] == entry["extra_body"]
+
+    def test_api_base_alias_resolves_to_base_url(self):
+        """``api_base`` is a common alias used by OpenAI SDK and LiteLLM
+        configs.  The normalizer must accept it as a URL source so imports
+        from those tools work without manual rewriting."""
+        from hermes_cli.config import _normalize_custom_provider_entry
+        entry = {
+            "name": "vendor",
+            "api_base": "https://api.vendor.example.com/v1",
+        }
+        normalized = _normalize_custom_provider_entry(dict(entry), provider_key="vendor")
+        assert normalized is not None
+        assert normalized.get("base_url") == "https://api.vendor.example.com/v1"
+
+    def test_api_base_is_in_known_keys(self):
+        """_KNOWN_KEYS must include api_base so it is not rejected as an
+        unrecognized field during normalization."""
+        from hermes_cli.config import _normalize_custom_provider_entry
+        entry = {
+            "name": "vendor",
+            "api_base": "https://api.vendor.example.com/v1",
+            "api_key": "sk-test",
+        }
+        normalized = _normalize_custom_provider_entry(dict(entry), provider_key="vendor")
+        assert normalized is not None
+
 # =============================================================================
 # Tencent TokenHub — API-key provider runtime resolution
 # =============================================================================


### PR DESCRIPTION
## Summary

- `_normalize_custom_provider_entry()` searches for the provider URL in `("base_url", "url", "api")` but not `"api_base"`
- Users who write `api_base` — the key name used by OpenAI SDK and LiteLLM — get a warning *"unknown config keys ignored: api_base"* and the provider is silently dropped, falling back to default auth → 401
- PR #50385 fixed the same alias at the model config level (`model.api_base` → `base_url`) but the `providers:` block was missed

## Fix

Add `"api_base"` to `_KNOWN_KEYS` and to the URL search tuple.

## Test plan

- [x] `pytest tests/hermes_cli/ -k "config or provider or custom"` — 1037 passed (1 flaky unrelated skip)
- [x] `pytest tests/hermes_cli/test_config_drift.py` — 1 passed
- [x] `python -c "from hermes_cli.config import _normalize_custom_provider_entry"` — no import errors