### PR TITLE
fix(tui): split DEL control bytes in termio tokenizer

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts
@@ -40,6 +40,17 @@ describe('parseMultipleKeypresses bracketed paste recovery', () => {
   })
 })
 
+describe('parseMultipleKeypresses control-byte boundaries', () => {
+  it('preserves DEL as a standalone backspace between adjacent IME text chunks', () => {
+    const [keys] = parseMultipleKeypresses(INITIAL_STATE, 'ㅎ\x7fㅏ')
+
+    expect(keys).toHaveLength(3)
+    expect(keys[0]).toMatchObject({ kind: 'key', raw: 'ㅎ' })
+    expect(keys[1]).toMatchObject({ kind: 'key', name: 'backspace', raw: '\x7f' })
+    expect(keys[2]).toMatchObject({ kind: 'key', raw: 'ㅏ' })
+  })
+})
+
 describe('mouse wheel modifier decoding', () => {
   // SGR mouse format: ESC [ < button ; col ; row M
   // Wheel up = 64 (0x40), wheel down = 65 (0x41).

--- a/ui-tui/packages/hermes-ink/src/ink/termio/tokenize.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/termio/tokenize.test.ts
@@ -64,6 +64,29 @@ describe('tokenizer state-aware flush', () => {
   })
 })
 
+describe('tokenizer control-byte boundaries', () => {
+  it('splits DEL out of surrounding text so backspace stays parseable', () => {
+    const tokenizer = createTokenizer()
+
+    expect(tokenizer.feed('ㅎ\x7fㅏ')).toEqual([
+      { type: 'text', value: 'ㅎ' },
+      { type: 'text', value: '\x7f' },
+      { type: 'text', value: 'ㅏ' }
+    ])
+  })
+
+  it('keeps escape sequences intact while splitting adjacent control bytes', () => {
+    const tokenizer = createTokenizer()
+
+    expect(tokenizer.feed(`ab\x7f\x1b[Acd`)).toEqual([
+      { type: 'text', value: 'ab' },
+      { type: 'text', value: '\x7f' },
+      { type: 'sequence', value: '\x1b[A' },
+      { type: 'text', value: 'cd' }
+    ])
+  })
+})
+
 // Battle-test: prove the leak class is structurally impossible, not just that
 // the known cases are patched. We hammer the tokenizer with the worst stalls a
 // terminal can produce (split + flush at every byte) and assert the two hard

--- a/ui-tui/packages/hermes-ink/src/ink/termio/tokenize.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/termio/tokenize.ts
@@ -6,7 +6,7 @@
  * identifies boundaries for use by keyboard input parsing.
  */
 
-import { C0, ESC_TYPE, isEscFinal } from './ansi.js'
+import { C0, ESC_TYPE, isC0, isEscFinal } from './ansi.js'
 import { isCSIFinal, isCSIIntermediate, isCSIParam } from './csi.js'
 
 export type Token = { type: 'text'; value: string } | { type: 'sequence'; value: string }
@@ -154,6 +154,10 @@ function tokenize(
           seqStart = i
           result.state = 'escape'
           i++
+        } else if (isC0(code)) {
+          flushText()
+          i++
+          flushText()
         } else {
           i++
         }


### PR DESCRIPTION
## Summary
- split non-ESC C0 bytes out of tokenizer text chunks so DEL (0x7f) stays parseable as backspace
- add tokenizer and parse-keypress regressions for Korean IME-style `ㅎㅏ` input
- cover the dashboard fast-echo path with the existing `textInputFastEcho` regression run

## Why
Issue #50067 already documents #50061 as a temporary dashboard-only workaround. This change fixes the shared hermes-ink input path the issue called out: DEL no longer gets merged into adjacent text, so backspace survives from termio tokenization into key parsing.

## Testing
- `npm test -- --run packages/hermes-ink/src/ink/termio/tokenize.test.ts packages/hermes-ink/src/ink/parse-keypress.test.ts src/__tests__/textInputFastEcho.test.ts`
- `npx eslint packages/hermes-ink/src/ink/termio/tokenize.ts packages/hermes-ink/src/ink/termio/tokenize.test.ts packages/hermes-ink/src/ink/parse-keypress.test.ts`
- `git diff --check`
