### PR TITLE
fix(agent): backfill session counters from SessionDB on agent rebuild

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -151,6 +151,41 @@ def _merge_custom_provider_extra_body(agent, custom_providers: List[Dict[str, An
     agent.request_overrides = overrides
 
 
+def backfill_session_counters_from_row(agent, row: Dict[str, Any]) -> None:
+    """Seed an agent's in-memory session counters from a persisted session row.
+
+    Used when a gateway AIAgent is *rebuilt* for an existing session (agent-cache
+    invalidation, #50675): the rebuilt instance starts every counter at 0, but
+    the SessionDB row already holds the correct cumulative totals. Mirror them
+    back so ``/usage`` keeps reporting whole-session figures instead of only the
+    activity since the rebuild.
+
+    The ``sessions`` table has no separate prompt/completion/total columns, so
+    total is derived as input+output and the prompt/completion split mirrors the
+    input/output split. Missing/NULL values default to 0 / existing defaults.
+    """
+    if not row:
+        return
+    _in = int(row.get("input_tokens") or 0)
+    _out = int(row.get("output_tokens") or 0)
+    agent.session_input_tokens = _in
+    agent.session_output_tokens = _out
+    agent.session_cache_read_tokens = int(row.get("cache_read_tokens") or 0)
+    agent.session_cache_write_tokens = int(row.get("cache_write_tokens") or 0)
+    agent.session_reasoning_tokens = int(row.get("reasoning_tokens") or 0)
+    agent.session_api_calls = int(row.get("api_call_count") or 0)
+    agent.session_total_tokens = _in + _out
+    agent.session_prompt_tokens = _in
+    agent.session_completion_tokens = _out
+    _prior_cost = row.get("estimated_cost_usd")
+    if _prior_cost is not None:
+        agent.session_estimated_cost_usd = float(_prior_cost)
+    if row.get("cost_status"):
+        agent.session_cost_status = row["cost_status"]
+    if row.get("cost_source"):
+        agent.session_cost_source = row["cost_source"]
+
+
 def init_agent(
     agent,
     base_url: str = None,
@@ -1663,7 +1698,27 @@ def init_agent(
     agent.session_estimated_cost_usd = 0.0
     agent.session_cost_status = "unknown"
     agent.session_cost_source = "none"
-    
+
+    # Backfill cumulative counters from the SessionDB row when this AIAgent is
+    # a *rebuild* of an existing session (gateway agent-cache invalidation).
+    # The gateway rebuilds AIAgent for the same session_id when its cached
+    # message_count snapshot goes stale (large flushes, compression). Without
+    # this, the fresh instance starts every counter at 0, so /usage reports
+    # only the calls/tokens since the rebuild and silently undercounts the
+    # session totals (#50675). The on-disk row already holds the correct
+    # cumulative totals (per-call increments survive the rebuild), so seed the
+    # in-memory counters from it. Brand-new sessions have no row yet (or an
+    # all-zero one), so this is a no-op for them. Fail-open: never let a DB
+    # read break agent construction.
+    if session_db is not None and getattr(agent, "session_id", None):
+        try:
+            _prior = session_db.get_session(agent.session_id)
+        except Exception as _bf_err:
+            _prior = None
+            _ra().logger.debug("Session counter backfill read failed: %s", _bf_err)
+        if _prior:
+            backfill_session_counters_from_row(agent, _prior)
+
     # ── Ollama num_ctx injection ──
     # Ollama defaults to 2048 context regardless of the model's capabilities.
     # When running against an Ollama server, detect the model's max context

--- a/tests/agent/test_session_counter_backfill.py
+++ b/tests/agent/test_session_counter_backfill.py
@@ -1,0 +1,125 @@
+"""Regression tests for session-counter backfill on agent rebuild (#50675).
+
+When the gateway invalidates its agent cache mid-session (stale message_count
+after a large flush / context compression), it rebuilds the ``AIAgent`` for the
+same ``session_id``. The rebuilt instance initializes every session counter to
+0, so ``/usage`` reported only the activity since the rebuild and silently
+undercounted the whole-session totals. The SessionDB row already holds the
+correct cumulative totals, so the rebuild now backfills the in-memory counters
+from it.
+"""
+import sys
+import types
+from pathlib import Path
+
+# Ensure repo root is importable
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+# Stub optional heavy deps not installed in the test environment so importing
+# agent.agent_init does not pull in network/SDK packages.
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+from agent.agent_init import backfill_session_counters_from_row  # noqa: E402
+from hermes_state import SessionDB  # noqa: E402
+
+
+def _zeroed_agent():
+    """A bare object with all session counters initialized to their defaults."""
+    agent = types.SimpleNamespace()
+    agent.session_prompt_tokens = 0
+    agent.session_completion_tokens = 0
+    agent.session_total_tokens = 0
+    agent.session_api_calls = 0
+    agent.session_input_tokens = 0
+    agent.session_output_tokens = 0
+    agent.session_cache_read_tokens = 0
+    agent.session_cache_write_tokens = 0
+    agent.session_reasoning_tokens = 0
+    agent.session_estimated_cost_usd = 0.0
+    agent.session_cost_status = "unknown"
+    agent.session_cost_source = "none"
+    return agent
+
+
+def test_backfill_restores_cumulative_counters_from_row():
+    """A persisted row's totals are mirrored back onto a freshly-zeroed agent."""
+    agent = _zeroed_agent()
+    row = {
+        "input_tokens": 35_000,
+        "output_tokens": 10_000,
+        "cache_read_tokens": 5_000,
+        "cache_write_tokens": 2_000,
+        "reasoning_tokens": 1_500,
+        "api_call_count": 7,
+        "estimated_cost_usd": 0.42,
+        "cost_status": "estimated",
+        "cost_source": "pricing_table",
+    }
+
+    backfill_session_counters_from_row(agent, row)
+
+    assert agent.session_input_tokens == 35_000
+    assert agent.session_output_tokens == 10_000
+    assert agent.session_cache_read_tokens == 5_000
+    assert agent.session_cache_write_tokens == 2_000
+    assert agent.session_reasoning_tokens == 1_500
+    assert agent.session_api_calls == 7
+    # total / prompt / completion are derived from input+output (no DB columns)
+    assert agent.session_total_tokens == 45_000
+    assert agent.session_prompt_tokens == 35_000
+    assert agent.session_completion_tokens == 10_000
+    assert agent.session_estimated_cost_usd == 0.42
+    assert agent.session_cost_status == "estimated"
+    assert agent.session_cost_source == "pricing_table"
+
+
+def test_backfill_tolerates_null_and_missing_fields():
+    """NULL/absent columns fall back to 0 / existing defaults (no crash)."""
+    agent = _zeroed_agent()
+    row = {"input_tokens": None, "output_tokens": 5}  # cost fields absent
+
+    backfill_session_counters_from_row(agent, row)
+
+    assert agent.session_input_tokens == 0
+    assert agent.session_output_tokens == 5
+    assert agent.session_total_tokens == 5
+    assert agent.session_api_calls == 0
+    # Untouched because the row carried no cost data.
+    assert agent.session_estimated_cost_usd == 0.0
+    assert agent.session_cost_status == "unknown"
+    assert agent.session_cost_source == "none"
+
+
+def test_backfill_matches_db_accumulated_totals(tmp_path):
+    """End-to-end: per-call increments in SessionDB are recovered on rebuild.
+
+    This reproduces the #50675 scenario: a session accrues several API calls,
+    the agent is rebuilt (counters reset to 0), and the rebuild must recover the
+    cumulative totals from the persisted row.
+    """
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(session_id="s1", source="whatsapp")
+    # Simulate three API calls' worth of per-call increments (the CLI/gateway
+    # persistence path, update_token_counts in increment mode).
+    for _ in range(3):
+        db.update_token_counts(
+            "s1",
+            input_tokens=1_000,
+            output_tokens=400,
+            cache_read_tokens=200,
+            reasoning_tokens=50,
+            api_call_count=1,
+        )
+
+    # Rebuilt agent starts at zero, then backfills from the row.
+    agent = _zeroed_agent()
+    backfill_session_counters_from_row(agent, db.get_session("s1"))
+
+    assert agent.session_api_calls == 3
+    assert agent.session_input_tokens == 3_000
+    assert agent.session_output_tokens == 1_200
+    assert agent.session_cache_read_tokens == 600
+    assert agent.session_reasoning_tokens == 150
+    assert agent.session_total_tokens == 4_200


### PR DESCRIPTION
## Summary

- Backfill an `AIAgent`'s in-memory session counters from the persisted `SessionDB` row when the gateway **rebuilds** an agent for an existing session.
- `/usage` now reports cumulative whole-session token/API-call totals again, instead of only the activity since the most recent cache rebuild.

## Motivation

Closes #50675.

In gateway mode the agent cache is invalidated intermittently when the cached `message_count` snapshot goes stale (most reliably after large multi-tool flushes or context compression — the slow-DB-flush window). When that happens a fresh `AIAgent` is built for the **same** `session_id`, and `agent_init` initialized every session counter (`session_api_calls`, `session_input_tokens`, `session_output_tokens`, `session_total_tokens`, ...) to `0`. Since `/usage` reads those in-memory counters, it then severely under-reported the session — counting only calls/tokens accrued since the rebuild.

CLI mode uses a single agent instance per session and was unaffected.

The persisted row in the `sessions` table already holds the correct cumulative totals: token persistence in `conversation_loop` calls `update_token_counts(..., api_call_count=1)` per API call in **increment** mode, so the per-call deltas survive the in-memory rebuild. The fix simply re-seeds the rebuilt agent's counters from that row.

## Root cause

- `agent/agent_init.py` set `agent.session_* = 0` unconditionally during init.
- A rebuild for an existing `session_id` therefore discarded the cumulative figures held only in the previous (evicted) agent instance.

## Fix

- New pure helper `backfill_session_counters_from_row(agent, row)` mirrors the persisted totals back onto the agent. `session_total_tokens`/`prompt`/`completion` are derived from `input + output` (the `sessions` table has no separate columns); NULL/missing values fall back to `0`/existing defaults.
- During `init_agent`, when a `session_db` is present and a row already exists for `agent.session_id`, call the helper. Brand-new sessions have no row yet → no-op. The DB read is wrapped fail-open so it can never break agent construction.
- The `/clear` / `/new` reset path (`reset_session_state` in `run_agent.py`) is **untouched** — those intentionally start a fresh session at `0` and never call the new helper.

## Verification

- `python3 -m pytest tests/agent/test_session_counter_backfill.py -q` — 3 passed
- `python3 -m pytest tests/run_agent/test_session_reset_fix.py tests/gateway/test_usage_command.py tests/test_hermes_state.py -q` — 290 passed (reset path + /usage + state DB all green)

## Real behavior proof

- **Behavior addressed:** after an agent-cache rebuild mid-session, `/usage` counters reset to 0 and undercount the session.
- **Real environment:** local repo on fresh `origin/main`, Python 3.13.
- **Exact commands run after the patch:** the end-to-end test `test_backfill_matches_db_accumulated_totals` accrues 3 API calls' worth of per-call increments into a real `SessionDB`, zeroes a fresh agent (the rebuild), then backfills.
- **Captured output AFTER fix:**
  ```
  $ python3 -m pytest tests/agent/test_session_counter_backfill.py -q
  ...
  3 passed in 0.59s
  ```
  Recovered counters on the rebuilt agent: `api_calls=3, input=3000, output=1200, cache_read=600, reasoning=150, total=4200` — matching the DB row, where before the fix every value was `0`.
- **Regression test:** `tests/agent/test_session_counter_backfill.py` — asserts the recovered (non-zero) totals; it fails without the backfill (helper no-op leaves counters at 0).
- **What was NOT tested:** the live gateway cache-invalidation trigger itself (covered by existing gateway tests); this PR targets the counter-recovery contract.
