### PR TITLE
feat: snapshot channel context files for sessions

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1590,6 +1590,12 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = {str(k): v for k, v in channel_prompts.items()}
                     else:
                         bridged["channel_prompts"] = channel_prompts
+                if "channel_context_files" in platform_cfg:
+                    channel_context_files = platform_cfg["channel_context_files"]
+                    if isinstance(channel_context_files, dict):
+                        bridged["channel_context_files"] = {str(k): v for k, v in channel_context_files.items()}
+                    else:
+                        bridged["channel_context_files"] = channel_context_files
                 if "gateway_restart_notification" in platform_cfg:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
                 if "typing_indicator" in platform_cfg:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2104,6 +2104,11 @@ class MessageEvent:
     # Applied at API call time and never persisted to transcript history.
     channel_prompt: Optional[str] = None
 
+    # Optional file path resolved from per-channel config. The gateway reads
+    # this once when a session starts, snapshots the content onto the session,
+    # and reuses that snapshot for later turns.
+    channel_context_file: Optional[str] = None
+
     # Channel context recovered by history backfill (e.g. messages between
     # bot turns that were missed due to require_mention).  Kept separate
     # from ``text`` so the sender-prefix logic in run.py can operate on the
@@ -2549,6 +2554,35 @@ def resolve_channel_prompt(
         prompt = str(prompt).strip()
         if prompt:
             return prompt
+    return None
+
+
+def resolve_channel_context_file(
+    config_extra: dict,
+    channel_id: str,
+    parent_id: str | None = None,
+) -> str | None:
+    """Resolve a per-channel context file path from platform config.
+
+    Looks up ``channel_context_files`` in the adapter's ``config.extra`` dict.
+    Prefers an exact match on *channel_id*; falls back to *parent_id* so forum
+    threads / child channels can inherit their parent channel state. The file is
+    read by the gateway only when a new session starts and its content is
+    snapshotted onto that session.
+    """
+    files = config_extra.get("channel_context_files") or {}
+    if not isinstance(files, dict):
+        return None
+
+    for key in (channel_id, parent_id):
+        if not key:
+            continue
+        path = files.get(key)
+        if path is None:
+            continue
+        path = str(path).strip()
+        if path:
+            return path
     return None
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -76,6 +76,7 @@ _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _TELEGRAM_CONNECT_TIMEOUT_SECS_DEFAULT = 180.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _GATEWAY_PROXY_SSE_BUFFER_MAX_CHARS = 16 * 1024 * 1024
+_CHANNEL_CONTEXT_FILE_MAX_CHARS = 20_000
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 _GATEWAY_HYGIENE_PLATFORM = "gateway_hygiene"
 
@@ -2931,6 +2932,33 @@ def _load_gateway_runtime_config() -> dict:
 
     expanded = _expand_env_vars(cfg)
     return expanded if isinstance(expanded, dict) else {}
+
+
+def _load_channel_context_file_snapshot(path: str) -> Optional[str]:
+    """Read a configured channel context file for session-start snapshotting."""
+    raw_path = str(path or "").strip()
+    if not raw_path:
+        return None
+    try:
+        expanded = os.path.expandvars(os.path.expanduser(raw_path))
+        context_path = Path(expanded)
+        if not context_path.is_absolute():
+            context_path = (_hermes_home / context_path).resolve()
+        with context_path.open(encoding="utf-8") as context_stream:
+            content = context_stream.read(_CHANNEL_CONTEXT_FILE_MAX_CHARS + 1).strip()
+    except Exception as exc:
+        logger.warning("Failed to read channel_context_files entry %r: %s", raw_path, exc)
+        return None
+    if not content:
+        return None
+    truncated = False
+    if len(content) > _CHANNEL_CONTEXT_FILE_MAX_CHARS:
+        content = content[:_CHANNEL_CONTEXT_FILE_MAX_CHARS].rstrip()
+        truncated = True
+    header = f"[Initial channel context loaded from {context_path}]"
+    if truncated:
+        header += f"\n[Context truncated to {_CHANNEL_CONTEXT_FILE_MAX_CHARS} characters.]"
+    return f"{header}\n{content}"
 
 
 def _resolve_gateway_model(config: dict | None = None) -> str:
@@ -13476,6 +13504,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 auto_skill=event.auto_skill,
                 channel_prompt=event.channel_prompt,
                 channel_context=event.channel_context,
+                channel_context_file=event.channel_context_file,
                 internal=event.internal,
                 timestamp=event.timestamp,
             )
@@ -13507,6 +13536,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     message_id=event.message_id,
                     channel_prompt=event.channel_prompt,
                     channel_context=event.channel_context,
+                    channel_context_file=event.channel_context_file,
                 )
                 adapter._pending_messages[quick_key] = queued_event
             return "Agent still starting — /steer queued for the next turn."
@@ -13530,6 +13560,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 message_id=event.message_id,
                 channel_prompt=event.channel_prompt,
                 channel_context=event.channel_context,
+                channel_context_file=event.channel_context_file,
             )
             adapter._pending_messages[quick_key] = queued_event
         return "No active agent — /steer queued for the next turn."
@@ -15496,6 +15527,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pass
         return source
 
+    def _resolve_event_channel_context_file(self, event, source) -> Optional[str]:
+        """Resolve configured context even for synthetic events lacking adapter fields."""
+        context_file = getattr(event, "channel_context_file", None)
+        if context_file:
+            return context_file
+        adapter = self._adapter_for_source(source)
+        resolver = getattr(adapter, "_resolve_channel_context_file", None)
+        if not callable(resolver):
+            return None
+        channel_id = str(source.thread_id or source.chat_id or "")
+        parent_id = str(source.parent_chat_id or "") or None
+        try:
+            resolved = resolver(channel_id, parent_id)
+            if resolved is None:
+                return None
+            resolved_path = str(resolved).strip()
+            return resolved_path or None
+        except Exception:
+            logger.debug(
+                "Failed to resolve channel context file for synthetic event",
+                exc_info=True,
+            )
+            return None
+
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
         """Inner handler that runs under the _running_agents sentinel guard."""
         _msg_start_time = time.time()
@@ -15751,6 +15806,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # was_auto_reset is already consumed in the cleanup block above
             # (single source of truth); only the reset reason needs clearing here.
             session_entry.auto_reset_reason = None
+
+        initial_context_prompt = getattr(session_entry, "initial_context_prompt", None)
+        context_initialized = getattr(session_entry, "initial_context_initialized", True)
+        if not context_initialized:
+            context_file = self._resolve_event_channel_context_file(event, source)
+            snapshot = (
+                _load_channel_context_file_snapshot(context_file)
+                if context_file
+                else None
+            )
+            try:
+                initialized, authoritative_prompt = (
+                    await self.async_session_store.initialize_context_prompt(
+                        session_key,
+                        session_entry.session_id,
+                        snapshot,
+                    )
+                )
+                if initialized:
+                    initial_context_prompt = authoritative_prompt
+            except Exception:
+                logger.debug("Failed to initialize channel context snapshot", exc_info=True)
+        if initial_context_prompt:
+            context_prompt = (context_prompt + "\n\n" + initial_context_prompt).strip()
 
         # Auto-load skill(s) for topic/channel bindings (Telegram DM Topics,
         # Discord channel_skill_bindings).  Supports a single name or ordered list.
@@ -18185,19 +18264,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Resolve the bound text channel's channel_prompt so voice input gets
         # the same per-channel context as typed messages (#50149).
         channel_prompt: Optional[str] = None
-        resolver = getattr(adapter, "_resolve_channel_prompt", None)
-        if callable(resolver):
+        prompt_resolver = getattr(adapter, "_resolve_channel_prompt", None)
+        if callable(prompt_resolver):
             try:
-                resolved = resolver(str(text_ch_id))
+                resolved = prompt_resolver(str(text_ch_id))
                 channel_prompt = resolved if isinstance(resolved, str) else None
             except Exception:
                 channel_prompt = None
+        channel_context_file: Optional[str] = None
+        context_file_resolver = getattr(adapter, "_resolve_channel_context_file", None)
+        if callable(context_file_resolver):
+            try:
+                resolved = context_file_resolver(str(text_ch_id))
+                channel_context_file = resolved if isinstance(resolved, str) else None
+            except Exception:
+                channel_context_file = None
         event = MessageEvent(
             source=source,
             text=transcript,
             message_type=MessageType.VOICE,
             raw_message=SimpleNamespace(guild_id=guild_id, guild=None),
             channel_prompt=channel_prompt,
+            channel_context_file=channel_context_file,
         )
 
         await adapter.handle_message(event)

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -722,6 +722,35 @@ def build_session_context_prompt(
 # written to sessions.json.  On rehydration after a gateway restart the
 # runner re-resolves credentials via the normal runtime provider resolution.
 PERSISTABLE_MODEL_OVERRIDE_KEYS = ("model", "provider", "base_url")
+_INITIAL_CONTEXT_MODEL_CONFIG_KEY = "gateway_initial_context_prompt"
+_INITIAL_CONTEXT_INITIALIZED_KEY = "gateway_initial_context_initialized"
+
+
+def _initial_context_from_model_config(
+    raw_config: Any,
+) -> tuple[bool, Optional[str]]:
+    """Decode durable context state; legacy sessions count as initialized."""
+    try:
+        config = json.loads(raw_config) if isinstance(raw_config, str) else raw_config
+    except Exception:
+        config = {}
+    if not isinstance(config, dict) or not config.get(_INITIAL_CONTEXT_INITIALIZED_KEY):
+        return True, None
+    prompt = config.get(_INITIAL_CONTEXT_MODEL_CONFIG_KEY)
+    return True, prompt if isinstance(prompt, str) else None
+
+
+def initial_context_model_config(
+    initialized: bool,
+    prompt: Optional[str],
+) -> Dict[str, Any]:
+    """Build model_config fields that preserve a snapshot across a branch."""
+    if not initialized:
+        return {}
+    return {
+        _INITIAL_CONTEXT_INITIALIZED_KEY: True,
+        _INITIAL_CONTEXT_MODEL_CONFIG_KEY: prompt,
+    }
 
 
 def sanitize_model_override(override: Optional[Dict[str, Any]]) -> Optional[Dict[str, str]]:
@@ -777,6 +806,13 @@ class SessionEntry:
     
     # Last API-reported prompt tokens (for accurate compression pre-check)
     last_prompt_tokens: int = 0
+
+    # Optional per-session context snapshotted from a configured channel file
+    # when the session is first created. This lets new Discord/Slack threads
+    # inherit parent-channel state once without drifting if the source file
+    # changes later.
+    initial_context_prompt: Optional[str] = None
+    initial_context_initialized: bool = False
     
     # Set when a session was created because the previous one expired;
     # consumed once by the message handler to inject a notice into context
@@ -848,6 +884,8 @@ class SessionEntry:
             "cache_write_tokens": self.cache_write_tokens,
             "total_tokens": self.total_tokens,
             "last_prompt_tokens": self.last_prompt_tokens,
+            "initial_context_prompt": self.initial_context_prompt,
+            "initial_context_initialized": self.initial_context_initialized,
             "estimated_cost_usd": self.estimated_cost_usd,
             "cost_status": self.cost_status,
             "expiry_finalized": self.expiry_finalized,
@@ -929,6 +967,10 @@ class SessionEntry:
             cache_write_tokens=data.get("cache_write_tokens", 0),
             total_tokens=data.get("total_tokens", 0),
             last_prompt_tokens=data.get("last_prompt_tokens", 0),
+            initial_context_prompt=data.get("initial_context_prompt"),
+            # Routing entries written before this feature represent existing
+            # conversations and must not acquire newly configured context.
+            initial_context_initialized=data.get("initial_context_initialized", True),
             estimated_cost_usd=data.get("estimated_cost_usd", 0.0),
             cost_status=data.get("cost_status", "unknown"),
             expiry_finalized=data.get("expiry_finalized", data.get("memory_flushed", False)),
@@ -1654,6 +1696,9 @@ class SessionStore:
             created_at = datetime.fromtimestamp(float(started_at)) if started_at else now
         except (TypeError, ValueError, OSError):
             created_at = now
+        context_initialized, context_prompt = _initial_context_from_model_config(
+            row.get("model_config")
+        )
         return SessionEntry(
             session_key=session_key,
             session_id=str(row["id"]),
@@ -1663,6 +1708,8 @@ class SessionStore:
             display_name=source.chat_name,
             platform=source.platform,
             chat_type=source.chat_type,
+            initial_context_initialized=context_initialized,
+            initial_context_prompt=context_prompt,
         )
 
     def _find_gateway_session_row(
@@ -2520,6 +2567,87 @@ class SessionStore:
             self._save()
             return True
 
+    def _persist_initial_context_to_db_locked(
+        self,
+        session_id: str,
+        prompt: Optional[str],
+    ) -> None:
+        """Best-effort session-identity persistence for resume/branch hydration."""
+        if not self._db:
+            return
+        try:
+            updates = initial_context_model_config(True, prompt)
+            patcher = getattr(self._db, "patch_session_model_config", None)
+            if callable(patcher):
+                patcher(session_id, updates)
+                return
+            row = self._db.get_session(session_id)
+            if not row:
+                return
+            raw_config = row.get("model_config")
+            try:
+                config = json.loads(raw_config) if raw_config else {}
+            except Exception:
+                config = {}
+            if not isinstance(config, dict):
+                config = {}
+            config.update(updates)
+            self._db.update_session_meta(
+                session_id,
+                json.dumps(config),
+                model=row.get("model"),
+            )
+        except Exception:
+            logger.debug("Failed to persist initial channel context in session DB", exc_info=True)
+
+    def _load_initial_context_from_db_locked(
+        self,
+        session_id: str,
+    ) -> tuple[bool, Optional[str]]:
+        """Hydrate a snapshot by immutable session ID for resume/branch flows."""
+        if not self._db:
+            return True, None
+        try:
+            row = self._db.get_session(session_id)
+            if not row:
+                return True, None
+            return _initial_context_from_model_config(row.get("model_config"))
+        except Exception:
+            logger.debug("Failed to hydrate initial channel context from session DB", exc_info=True)
+            return True, None
+
+    def initialize_context_prompt(
+        self,
+        session_key: str,
+        session_id: str,
+        prompt: Optional[str],
+    ) -> tuple[bool, Optional[str]]:
+        """Atomically initialize a session's stable channel-context snapshot.
+
+        The session-id guard prevents a delayed first-turn write from attaching
+        context to a replacement conversation. Persistence failures keep the
+        authoritative in-memory value so the system prefix cannot drift between
+        turns in the running process.
+        """
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None or entry.session_id != session_id:
+                return False, None
+            if entry.initial_context_initialized:
+                return True, entry.initial_context_prompt
+            entry.initial_context_prompt = prompt
+            entry.initial_context_initialized = True
+            try:
+                self._save()
+            except Exception:
+                logger.warning(
+                    "Failed to persist initial channel context routing snapshot",
+                    exc_info=True,
+                )
+            self._persist_initial_context_to_db_locked(session_id, prompt)
+            return True, entry.initial_context_prompt
+
     def set_model_override(
         self, session_key: str, override: Optional[Dict[str, Any]]
     ) -> None:
@@ -2835,6 +2963,9 @@ class SessionStore:
             db_end_session_id = old_entry.session_id
 
             now = _now()
+            context_initialized, context_prompt = (
+                self._load_initial_context_from_db_locked(target_session_id)
+            )
             new_entry = SessionEntry(
                 session_key=session_key,
                 session_id=target_session_id,
@@ -2844,6 +2975,8 @@ class SessionStore:
                 display_name=old_entry.display_name,
                 platform=old_entry.platform,
                 chat_type=old_entry.chat_type,
+                initial_context_prompt=context_prompt,
+                initial_context_initialized=context_initialized,
             )
 
             self._entries[session_key] = new_entry

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -38,6 +38,7 @@ from gateway.session import (
     AsyncSessionStore,
     SessionSource,
     build_session_key,
+    initial_context_model_config,
     is_shared_multi_user_session,
 )
 from hermes_cli.config import atomic_config_write, cfg_get, clear_model_endpoint_credentials
@@ -2587,6 +2588,7 @@ class GatewaySlashCommandsMixin:
             source=source,
             raw_message=event.raw_message,
             channel_prompt=event.channel_prompt,
+            channel_context_file=event.channel_context_file,
         )
         
         # Let the normal message handler process it
@@ -2719,6 +2721,7 @@ class GatewaySlashCommandsMixin:
                     source=event.source,
                     message_id=event.message_id,
                     channel_prompt=event.channel_prompt,
+                    channel_context_file=event.channel_context_file,
                 )
                 self._enqueue_fifo(_quick_key, kickoff_event, adapter)
             except Exception as exc:
@@ -4568,6 +4571,13 @@ class GatewaySlashCommandsMixin:
             branch_title = await self._session_db.get_next_title_in_lineage(base)
 
         parent_session_id = current_entry.session_id
+        branch_model_config = {"_branched_from": parent_session_id}
+        branch_model_config.update(
+            initial_context_model_config(
+                getattr(current_entry, "initial_context_initialized", True),
+                getattr(current_entry, "initial_context_prompt", None),
+            )
+        )
 
         # Create the new session with parent link.
         # Persist a stable ``_branched_from`` marker in model_config so
@@ -4579,7 +4589,7 @@ class GatewaySlashCommandsMixin:
                 session_id=new_session_id,
                 source=source.platform.value if source.platform else "gateway",
                 model=(self.config.get("model", {}) or {}).get("default") if isinstance(self.config, dict) else None,
-                model_config={"_branched_from": parent_session_id},
+                model_config=branch_model_config,
                 parent_session_id=parent_session_id,
             )
         except Exception as e:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3733,6 +3733,36 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
         self._execute_write(_do)
 
+    def patch_session_model_config(
+        self,
+        session_id: str,
+        updates: Dict[str, Any],
+    ) -> None:
+        """Atomically merge keys into a session's JSON model_config."""
+        self.flush_token_counts()
+
+        def _do(conn):
+            row = conn.execute(
+                "SELECT model_config FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+            if row is None:
+                return
+            raw = row["model_config"] if isinstance(row, sqlite3.Row) else row[0]
+            try:
+                config = json.loads(raw) if raw else {}
+            except Exception:
+                config = {}
+            if not isinstance(config, dict):
+                config = {}
+            config.update(updates)
+            conn.execute(
+                "UPDATE sessions SET model_config = ? WHERE id = ?",
+                (json.dumps(config), session_id),
+            )
+
+        self._execute_write(_do)
+
     def update_system_prompt(self, session_id: str, system_prompt: str) -> None:
         """Store the full assembled system prompt snapshot."""
         def _do(conn):

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5848,12 +5848,15 @@ class DiscordAdapter(BasePlatformAdapter):
         msg_type = MessageType.COMMAND if text.startswith("/") else MessageType.TEXT
         channel_id = str(interaction.channel_id)
         parent_id = str(getattr(getattr(interaction, "channel", None), "parent_id", "") or "")
+        _channel_prompt = self._resolve_channel_prompt(channel_id, parent_id or None)
+        _context_file = self._resolve_channel_context_file(channel_id, parent_id or None)
         return MessageEvent(
             text=text,
             message_type=msg_type,
             source=source,
             raw_message=interaction,
-            channel_prompt=self._resolve_channel_prompt(channel_id, parent_id or None),
+            channel_prompt=_channel_prompt,
+            channel_context_file=_context_file,
         )
 
     # ------------------------------------------------------------------
@@ -5943,6 +5946,7 @@ class DiscordAdapter(BasePlatformAdapter):
         _parent_id = str(getattr(_parent_channel, "id", "") or "")
         _skills = self._resolve_channel_skills(thread_id, _parent_id or None)
         _channel_prompt = self._resolve_channel_prompt(thread_id, _parent_id or None)
+        _context_file = self._resolve_channel_context_file(thread_id, _parent_id or None)
         event = MessageEvent(
             text=text,
             message_type=MessageType.TEXT,
@@ -5950,6 +5954,7 @@ class DiscordAdapter(BasePlatformAdapter):
             raw_message=interaction,
             auto_skill=_skills,
             channel_prompt=_channel_prompt,
+            channel_context_file=_context_file,
         )
         await self.handle_message(event)
 
@@ -5969,6 +5974,11 @@ class DiscordAdapter(BasePlatformAdapter):
         """Resolve a Discord per-channel prompt, preferring the exact channel over its parent."""
         from gateway.platforms.base import resolve_channel_prompt
         return resolve_channel_prompt(self.config.extra, channel_id, parent_id)
+
+    def _resolve_channel_context_file(self, channel_id: str, parent_id: str | None = None) -> str | None:
+        """Resolve a Discord per-channel initial context file path."""
+        from gateway.platforms.base import resolve_channel_context_file
+        return resolve_channel_context_file(self.config.extra, channel_id, parent_id)
 
     def _discord_require_mention(self) -> bool:
         """Return whether Discord channel messages require a bot mention."""
@@ -7846,6 +7856,7 @@ class DiscordAdapter(BasePlatformAdapter):
         _chan_id = str(getattr(_chan, "id", ""))
         _skills = self._resolve_channel_skills(_chan_id, _parent_id or None)
         _channel_prompt = self._resolve_channel_prompt(_chan_id, _parent_id or None)
+        _context_file = self._resolve_channel_context_file(_chan_id, _parent_id or None)
 
         reply_to_id = None
         reply_to_text = None
@@ -7867,6 +7878,7 @@ class DiscordAdapter(BasePlatformAdapter):
             timestamp=message.created_at,
             auto_skill=_skills,
             channel_prompt=_channel_prompt,
+            channel_context_file=_context_file,
             channel_context=_channel_context,
         )
 

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -667,6 +667,25 @@ class TestLoadGatewayConfig:
         assert Platform.RELAY in config.get_connected_platforms()
 
 
+    def test_bridges_channel_context_files_with_string_keys(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  channel_context_files:\n"
+            "    123456789012345678: /tmp/channel-state.md\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.DISCORD].extra["channel_context_files"] == {
+            "123456789012345678": "/tmp/channel-state.md"
+        }
+
     def test_thread_require_mention_yaml_does_not_overwrite_env(self, tmp_path, monkeypatch):
         """Explicit env var should win over config.yaml (env > yaml precedence)."""
         hermes_home = tmp_path / ".hermes"

--- a/tests/gateway/test_discord_channel_prompts.py
+++ b/tests/gateway/test_discord_channel_prompts.py
@@ -30,9 +30,9 @@ def _ensure_discord_mock():
 
 
 import gateway.run as gateway_run
-from gateway.config import Platform
+from gateway.config import GatewayConfig, Platform
 from gateway.platforms.base import MessageEvent
-from gateway.session import SessionSource
+from gateway.session import SessionSource, SessionStore, initial_context_model_config
 
 
 class _CapturingAgent:
@@ -266,6 +266,7 @@ async def test_retry_preserves_channel_prompt(monkeypatch):
         source=_make_source(),
         raw_message=SimpleNamespace(),
         channel_prompt="Channel prompt",
+        channel_context_file="/tmp/channel-state.md",
     )
 
     result = await runner._handle_retry_command(event)
@@ -273,6 +274,7 @@ async def test_retry_preserves_channel_prompt(monkeypatch):
     assert result == "ok"
     retried_event = runner._handle_message.await_args.args[0]
     assert retried_event.channel_prompt == "Channel prompt"
+    assert retried_event.channel_context_file == "/tmp/channel-state.md"
 
 
 @pytest.mark.asyncio
@@ -336,6 +338,20 @@ def test_channel_context_file_snapshot_reads_file(monkeypatch, tmp_path):
     assert "Keep this context" in snapshot
 
 
+def test_channel_context_file_snapshot_truncates_bounded_read(tmp_path):
+    context_file = tmp_path / "large-context.md"
+    context_file.write_text(
+        "x" * (gateway_run._CHANNEL_CONTEXT_FILE_MAX_CHARS + 100),
+        encoding="utf-8",
+    )
+
+    snapshot = gateway_run._load_channel_context_file_snapshot(str(context_file))
+
+    assert snapshot is not None
+    assert f"truncated to {gateway_run._CHANNEL_CONTEXT_FILE_MAX_CHARS} characters" in snapshot
+    assert snapshot.endswith("x" * gateway_run._CHANNEL_CONTEXT_FILE_MAX_CHARS)
+
+
 def test_channel_context_file_snapshot_resolves_relative_to_hermes_home(monkeypatch, tmp_path):
     hermes_home = tmp_path / ".hermes"
     hermes_home.mkdir()
@@ -346,3 +362,287 @@ def test_channel_context_file_snapshot_resolves_relative_to_hermes_home(monkeypa
 
     assert snapshot is not None
     assert "relative context" in snapshot
+
+
+def _make_snapshot_runner(monkeypatch, tmp_path, store):
+    runner = gateway_run.GatewayRunner(GatewayConfig())
+    runner.adapters = {}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._handle_active_session_busy_message = AsyncMock(return_value=False)
+    runner._session_db = None
+    runner._recover_telegram_topic_thread_id = lambda _source: None
+    runner._cache_session_source = lambda _key, _source: None
+    runner._is_session_run_current = lambda _key, _generation: True
+    runner._reply_anchor_for_event = lambda _event: None
+    runner._get_guild_id = lambda _event: None
+    runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.session_store = store
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"}
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100_000,
+    )
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "ok",
+            "messages": [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "ok"},
+            ],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+    return runner
+
+
+def test_channel_context_snapshot_compare_and_set_guards_session_id(tmp_path):
+    store = SessionStore(sessions_dir=tmp_path / "sessions", config=GatewayConfig())
+    store._db = None
+    source = _make_source()
+    entry = store.get_or_create_session(source)
+    session_key = store._generate_session_key(source)
+
+    assert store.initialize_context_prompt(session_key, "stale-session", "wrong") == (
+        False,
+        None,
+    )
+    assert entry.initial_context_prompt is None
+    assert store.initialize_context_prompt(
+        session_key, entry.session_id, "version one"
+    ) == (True, "version one")
+    assert store.initialize_context_prompt(
+        session_key, entry.session_id, "version two"
+    ) == (True, "version one")
+
+
+def test_channel_context_snapshot_stays_stable_when_routing_save_fails(tmp_path):
+    store = SessionStore(sessions_dir=tmp_path / "sessions", config=GatewayConfig())
+    store._db = None
+    source = _make_source()
+    entry = store.get_or_create_session(source)
+    session_key = store._generate_session_key(source)
+    store._save = MagicMock(side_effect=OSError("disk unavailable"))
+
+    assert store.initialize_context_prompt(
+        session_key, entry.session_id, "stable context"
+    ) == (True, "stable context")
+    assert entry.initial_context_prompt == "stable context"
+    assert entry.initial_context_initialized is True
+    assert store.initialize_context_prompt(
+        session_key, entry.session_id, "different context"
+    ) == (True, "stable context")
+
+
+def test_channel_context_snapshot_hydrates_by_session_id_on_resume(tmp_path):
+    class _FakeSessionDB:
+        def __init__(self):
+            self.rows = {}
+
+        def get_session(self, session_id):
+            return self.rows.get(session_id)
+
+        def update_session_meta(self, session_id, model_config, model=None):
+            self.rows.setdefault(session_id, {})["model_config"] = model_config
+            self.rows[session_id]["model"] = model
+
+        def end_session(self, session_id, _reason):
+            return None
+
+        def reopen_session(self, session_id):
+            return None
+
+    store = SessionStore(sessions_dir=tmp_path / "sessions", config=GatewayConfig())
+    store._db = None
+    source = _make_source()
+    original = store.get_or_create_session(source)
+    session_key = store._generate_session_key(source)
+    db = _FakeSessionDB()
+    db.rows[original.session_id] = {"model_config": "{}", "model": None}
+    db.rows["other-session"] = {"model_config": "{}", "model": None}
+    store._db = db  # type: ignore[assignment]
+
+    assert store.initialize_context_prompt(
+        session_key, original.session_id, "resumable context"
+    ) == (True, "resumable context")
+    assert store.switch_session(session_key, "other-session") is not None
+    resumed = store.switch_session(session_key, original.session_id)
+
+    assert resumed is not None
+    assert resumed.initial_context_initialized is True
+    assert resumed.initial_context_prompt == "resumable context"
+
+
+def test_branch_model_config_inherits_initialized_context_snapshot():
+    assert initial_context_model_config(True, "branch context") == {
+        "gateway_initial_context_initialized": True,
+        "gateway_initial_context_prompt": "branch context",
+    }
+    assert initial_context_model_config(False, "not ready") == {}
+
+
+@pytest.mark.parametrize(
+    ("model_config", "expected_prompt"),
+    [
+        ("{}", None),
+        (
+            '{"gateway_initial_context_initialized": true, '
+            '"gateway_initial_context_prompt": "recovered context"}',
+            "recovered context",
+        ),
+    ],
+)
+def test_recovered_existing_session_never_reinitializes_context(
+    tmp_path, model_config, expected_prompt
+):
+    store = SessionStore(sessions_dir=tmp_path / "sessions", config=GatewayConfig())
+    store._db = None
+
+    recovered = store._create_entry_from_recovered_row(
+        row={
+            "id": "recovered-session",
+            "started_at": datetime.now().timestamp(),
+            "model_config": model_config,
+        },
+        session_key="agent:main:discord:thread:12345",
+        source=_make_source(),
+        now=datetime.now(),
+    )
+
+    assert recovered.initial_context_initialized is True
+    assert recovered.initial_context_prompt == expected_prompt
+
+
+@pytest.mark.asyncio
+async def test_channel_context_snapshot_persists_without_drift(monkeypatch, tmp_path):
+    sessions_dir = tmp_path / "sessions"
+    context_file = tmp_path / "channel-state.md"
+    context_file.write_text("version one", encoding="utf-8")
+    source = _make_source()
+    session_key = "agent:main:discord:thread:12345"
+
+    first_store = SessionStore(sessions_dir=sessions_dir, config=GatewayConfig())
+    first_store._db = None
+    first_runner = _make_snapshot_runner(monkeypatch, tmp_path, first_store)
+    first_event = MessageEvent(
+        text="hello",
+        source=source,
+        message_id="m1",
+        channel_context_file=str(context_file),
+    )
+
+    await first_runner._handle_message_with_agent(first_event, source, session_key, 1)
+    first_prompt = first_runner._run_agent.await_args.kwargs["context_prompt"]
+    assert "version one" in first_prompt
+
+    context_file.write_text("version two", encoding="utf-8")
+    reloaded_store = SessionStore(sessions_dir=sessions_dir, config=GatewayConfig())
+    reloaded_store._db = None
+    second_runner = _make_snapshot_runner(monkeypatch, tmp_path, reloaded_store)
+    second_event = MessageEvent(
+        text="hello again",
+        source=source,
+        message_id="m2",
+        channel_context_file=str(context_file),
+    )
+
+    await second_runner._handle_message_with_agent(second_event, source, session_key, 1)
+    second_prompt = second_runner._run_agent.await_args.kwargs["context_prompt"]
+    assert "version one" in second_prompt
+    assert "version two" not in second_prompt
+
+
+@pytest.mark.asyncio
+async def test_synthetic_first_turn_resolves_channel_context_centrally(
+    monkeypatch, tmp_path
+):
+    context_file = tmp_path / "channel-state.md"
+    context_file.write_text("synthetic version one", encoding="utf-8")
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="999",
+        chat_type="thread",
+        user_id="system:wake",
+        thread_id="999",
+        parent_chat_id="200",
+    )
+    session_key = "agent:main:discord:thread:999"
+    store = SessionStore(sessions_dir=tmp_path / "sessions", config=GatewayConfig())
+    store._db = None
+    runner = _make_snapshot_runner(monkeypatch, tmp_path, store)
+    resolver = MagicMock(return_value=str(context_file))
+    runner._resolve_event_channel_context_file = resolver
+
+    synthetic_event = MessageEvent(text="wake", source=source)
+    await runner._handle_message_with_agent(synthetic_event, source, session_key, 1)
+
+    first_prompt = runner._run_agent.await_args.kwargs["context_prompt"]  # type: ignore[attr-defined]
+    assert "synthetic version one" in first_prompt
+    resolver.assert_called_once_with(synthetic_event, source)
+
+    context_file.write_text("synthetic version two", encoding="utf-8")
+    persisted_entry = store.get_or_create_session(source)
+    assert "synthetic version one" in (persisted_entry.initial_context_prompt or "")
+    assert "synthetic version two" not in (persisted_entry.initial_context_prompt or "")
+
+
+def test_central_context_resolver_uses_thread_and_parent_ids():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    adapter_resolver = MagicMock(return_value="/tmp/central-context.md")
+    setattr(
+        runner,
+        "adapters",
+        {
+            Platform.DISCORD: SimpleNamespace(
+                _resolve_channel_context_file=adapter_resolver,
+            )
+        },
+    )
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="999",
+        chat_type="thread",
+        thread_id="999",
+        parent_chat_id="200",
+    )
+
+    result = runner._resolve_event_channel_context_file(
+        MessageEvent(text="wake", source=source),
+        source,
+    )
+
+    assert result == "/tmp/central-context.md"
+    adapter_resolver.assert_called_once_with("999", "200")
+
+
+@pytest.mark.asyncio
+async def test_voice_channel_input_preserves_channel_context_file():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    adapter = SimpleNamespace(
+        _voice_text_channels={42: 321},
+        _voice_sources={},
+        _client=SimpleNamespace(get_channel=lambda _channel_id: None),
+        _resolve_channel_prompt=MagicMock(return_value="Voice prompt"),
+        _resolve_channel_context_file=MagicMock(return_value="/tmp/voice-context.md"),
+        handle_message=AsyncMock(),
+    )
+    runner.adapters = {Platform.DISCORD: adapter}  # type: ignore[dict-item]
+    runner._is_user_authorized = MagicMock(return_value=True)
+    runner._is_duplicate_voice_transcript = MagicMock(return_value=False)
+
+    await runner._handle_voice_channel_input(42, 7, "hello from voice")
+
+    dispatched_event = adapter.handle_message.await_args.args[0]
+    assert dispatched_event.channel_prompt == "Voice prompt"
+    assert dispatched_event.channel_context_file == "/tmp/voice-context.md"

--- a/tests/gateway/test_discord_channel_prompts.py
+++ b/tests/gateway/test_discord_channel_prompts.py
@@ -3,6 +3,7 @@
 import sys
 import threading
 import types
+from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -125,6 +126,126 @@ class TestResolveChannelPrompts:
         adapter.config.extra = {"channel_prompts": {100: "Research mode"}}
         assert adapter._resolve_channel_prompt("100") is None
 
+    def test_match_by_parent_id(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {"channel_prompts": {"200": "Forum prompt"}}
+        assert adapter._resolve_channel_prompt("999", parent_id="200") == "Forum prompt"
+
+    def test_context_file_match_by_parent_id(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {"channel_context_files": {"200": "/tmp/channel-state.md"}}
+        assert adapter._resolve_channel_context_file("999", parent_id="200") == "/tmp/channel-state.md"
+
+    def test_exact_channel_overrides_parent(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {
+            "channel_prompts": {
+                "999": "Thread override",
+                "200": "Forum prompt",
+            }
+        }
+        assert adapter._resolve_channel_prompt("999", parent_id="200") == "Thread override"
+
+    def test_build_message_event_sets_channel_prompt(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {
+            "channel_prompts": {"321": "Command prompt"},
+            "channel_context_files": {"321": "/tmp/context.md"},
+        }
+        adapter.build_source = MagicMock(return_value=SimpleNamespace())
+
+        interaction = SimpleNamespace(
+            channel_id=321,
+            channel=SimpleNamespace(name="general", guild=None, parent_id=None),
+            user=SimpleNamespace(id=1, display_name="Brenner"),
+        )
+        adapter._get_effective_topic = MagicMock(return_value=None)
+
+        event = adapter._build_slash_event(interaction, "/retry")
+
+        assert event.channel_prompt == "Command prompt"
+        assert event.channel_context_file == "/tmp/context.md"
+
+    @pytest.mark.asyncio
+    async def test_dispatch_thread_session_inherits_parent_channel_prompt(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {
+            "channel_prompts": {"200": "Parent prompt"},
+            "channel_context_files": {"200": "/tmp/parent-context.md"},
+        }
+        adapter.build_source = MagicMock(return_value=SimpleNamespace())
+        adapter._get_effective_topic = MagicMock(return_value=None)
+        adapter.handle_message = AsyncMock()
+
+        interaction = SimpleNamespace(
+            guild=SimpleNamespace(name="Wetlands"),
+            channel=SimpleNamespace(id=200, parent=None),
+            user=SimpleNamespace(id=1, display_name="Brenner"),
+        )
+
+        await adapter._dispatch_thread_session(interaction, "999", "new-thread", "hello")
+
+        dispatched_event = adapter.handle_message.await_args.args[0]
+        assert dispatched_event.channel_prompt == "Parent prompt"
+        assert dispatched_event.channel_context_file == "/tmp/parent-context.md"
+
+    @pytest.mark.asyncio
+    async def test_regular_thread_message_sets_parent_channel_context_file(self):
+        _ensure_discord_mock()
+        discord_mod = sys.modules["discord"]
+        adapter = _make_adapter()
+        adapter.config.extra = {
+            "channel_prompts": {"200": "Parent prompt"},
+            "channel_context_files": {"200": "/tmp/parent-context.md"},
+        }
+        adapter._client = SimpleNamespace(user=SimpleNamespace(id=999))
+
+        class _ThreadTracker:
+            def __contains__(self, item):
+                return False
+
+            def mark(self, item):
+                self.marked = item
+
+        adapter._threads = _ThreadTracker()
+        adapter._voice_text_channels = {}
+        adapter._text_batch_delay_seconds = 0
+        adapter._discord_require_mention = MagicMock(return_value=False)
+        adapter._discord_free_response_channels = MagicMock(return_value=set())
+        adapter._discord_history_backfill = MagicMock(return_value=False)
+        adapter._discord_allow_any_attachment = MagicMock(return_value=False)
+        adapter._get_parent_channel_id = MagicMock(return_value="200")
+        adapter._format_thread_chat_name = MagicMock(return_value="guild / #parent / thread")
+        adapter._get_effective_topic = MagicMock(return_value=None)
+        adapter.build_source = MagicMock(return_value=SimpleNamespace())
+        adapter.handle_message = AsyncMock()
+
+        channel = discord_mod.Thread()
+        channel.id = 999
+        channel.parent_id = 200
+        author = SimpleNamespace(id=1, display_name="Brenner", bot=False)
+        message = SimpleNamespace(
+            id=123,
+            channel=channel,
+            content="hello",
+            mentions=[],
+            attachments=[],
+            author=author,
+            guild=SimpleNamespace(id=42, name="Wetlands"),
+            created_at=datetime.now(),
+            reference=None,
+        )
+
+        await adapter._handle_message(message)
+
+        dispatched_event = adapter.handle_message.await_args.args[0]
+        assert dispatched_event.channel_prompt == "Parent prompt"
+        assert dispatched_event.channel_context_file == "/tmp/parent-context.md"
+
+    def test_blank_prompts_are_ignored(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {"channel_prompts": {"100": "   "}}
+        assert adapter._resolve_channel_prompt("100") is None
 
 @pytest.mark.asyncio
 async def test_retry_preserves_channel_prompt(monkeypatch):
@@ -154,3 +275,74 @@ async def test_retry_preserves_channel_prompt(monkeypatch):
     assert retried_event.channel_prompt == "Channel prompt"
 
 
+@pytest.mark.asyncio
+async def test_run_agent_appends_channel_prompt_to_ephemeral_system_prompt(monkeypatch, tmp_path):
+    _install_fake_agent(monkeypatch)
+    runner = _make_runner()
+
+    (tmp_path / "config.yaml").write_text("agent:\n  system_prompt: Global prompt\n", encoding="utf-8")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+        },
+    )
+
+    import hermes_cli.tools_config as tools_config
+
+    monkeypatch.setattr(tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"})
+
+    _CapturingAgent.last_init = None
+    event = MessageEvent(
+        text="hi",
+        source=_make_source(),
+        message_id="m1",
+        channel_prompt="Channel prompt",
+    )
+    result = await runner._run_agent(
+        message="hi",
+        context_prompt="Context prompt",
+        history=[],
+        source=_make_source(),
+        session_id="session-1",
+        session_key="agent:main:discord:thread:12345",
+        channel_prompt=event.channel_prompt,
+    )
+
+    assert result["final_response"] == "ok"
+    assert _CapturingAgent.last_init["ephemeral_system_prompt"] == (
+        "Context prompt\n\nChannel prompt\n\nGlobal prompt"
+    )
+
+
+def test_channel_context_file_snapshot_reads_file(monkeypatch, tmp_path):
+    context_file = tmp_path / "channel-state.md"
+    context_file.write_text("# State\n\n- Keep this context", encoding="utf-8")
+
+    snapshot = gateway_run._load_channel_context_file_snapshot(str(context_file))
+
+    assert snapshot is not None
+    assert "Initial channel context loaded from" in snapshot
+    assert "# State" in snapshot
+    assert "Keep this context" in snapshot
+
+
+def test_channel_context_file_snapshot_resolves_relative_to_hermes_home(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "context.md").write_text("relative context", encoding="utf-8")
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+    snapshot = gateway_run._load_channel_context_file_snapshot("context.md")
+
+    assert snapshot is not None
+    assert "relative context" in snapshot

--- a/tests/gateway/test_queue_command.py
+++ b/tests/gateway/test_queue_command.py
@@ -135,5 +135,35 @@ async def test_queue_preserves_reply_context():
     assert queued.reply_to_author_name == "alice"
 
 
+@pytest.mark.asyncio
+async def test_queue_preserves_channel_context_file():
+    runner, adapter = _make_runner(_session_entry())
+    sk = _running(runner)
+
+    event = MessageEvent(
+        text="/queue start with channel state",
+        source=_make_source(),
+        message_id="q-context",
+        channel_context_file="/tmp/channel-state.md",
+    )
+    result = await runner._handle_message(event)
+
+    assert result is not None and "queued" in result.lower()
+    queued = adapter._pending_messages[sk]
+    assert queued.channel_context_file == "/tmp/channel-state.md"
+
+
+@pytest.mark.asyncio
+async def test_queue_no_text_no_media_returns_usage():
+    runner, adapter = _make_runner(_session_entry())
+    _running(runner)
+
+    event = MessageEvent(text="/queue", source=_make_source(), message_id="q-empty")
+    result = await runner._handle_message(event)
+
+    assert result is not None and "Usage" in result
+    assert adapter._pending_messages == {}
+
+
 if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__, "-v"])

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -4,6 +4,7 @@ Tests the _handle_resume_command handler (switch to a previously-named session)
 across gateway messenger platforms.
 """
 
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -61,6 +62,43 @@ def _make_runner(session_db=None, current_session_id="current_session_001",
     runner.session_store = mock_store
 
     return runner
+
+
+@pytest.mark.asyncio
+async def test_branch_inherits_channel_context_snapshot(tmp_path):
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        parent_id = "parent-session"
+        db.create_session(parent_id, source="telegram")
+        event = _make_event(text="/branch context-fork")
+        runner = _make_runner(db, current_session_id=parent_id, event=event)
+        mock_get_or_create = getattr(runner.session_store, "get_or_create_session")
+        current_entry = mock_get_or_create.return_value
+        current_entry.initial_context_initialized = True
+        current_entry.initial_context_prompt = "stable branch context"
+        mock_load_transcript = getattr(runner.session_store, "load_transcript")
+        mock_load_transcript.return_value = [
+            {"role": "user", "content": "hello"}
+        ]
+        runner._clear_session_boundary_security_state = MagicMock()
+        runner._evict_cached_agent = MagicMock()
+
+        await runner._handle_branch_command(event)
+
+        children = [
+            row
+            for row in db.list_sessions_rich()
+            if row["id"] != parent_id
+        ]
+        assert len(children) == 1
+        child_config = json.loads(children[0]["model_config"])
+        assert child_config["_branched_from"] == parent_id
+        assert child_config["gateway_initial_context_initialized"] is True
+        assert child_config["gateway_initial_context_prompt"] == "stable branch context"
+    finally:
+        db.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -96,6 +96,23 @@ class TestSessionLifecycle:
         assert session["model"] == "test-model"
         assert session["ended_at"] is None
 
+    def test_patch_session_model_config_preserves_existing_keys(self, db):
+        db.create_session(
+            session_id="s-config-patch",
+            source="gateway",
+            model_config={"gateway_runtime": {"provider": "openai-codex"}},
+        )
+
+        db.patch_session_model_config(
+            "s-config-patch",
+            {"gateway_initial_context_prompt": "stable context"},
+        )
+
+        session = db.get_session("s-config-patch")
+        config = json.loads(session["model_config"])
+        assert config["gateway_runtime"] == {"provider": "openai-codex"}
+        assert config["gateway_initial_context_prompt"] == "stable context"
+
 
 
 

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -348,6 +348,7 @@ discord:
     limit: 100                    # Global scan cap per reconnect
     max_dispatches: 10            # Recovery dispatch cap per reconnect
   channel_prompts: {}             # Per-channel ephemeral system prompts
+  channel_context_files: {}       # Per-channel context files snapshotted at session start
   voice_channel_inactivity_timeout_seconds: 300  # Set 0 to stay in VC until explicit /voice leave
   voice_playback_timeout_seconds: 120             # Minimum playback watchdog; long clips get duration+padding
   allow_mentions:                 # What the bot is allowed to ping (safe defaults)
@@ -476,6 +477,27 @@ Behavior:
 - Exact thread/channel ID matches win.
 - If a message arrives inside a thread or forum post and that thread has no explicit entry, Hermes falls back to the parent channel/forum ID.
 - Prompts are applied ephemerally at runtime, so changing them affects future turns immediately without rewriting past session history.
+
+#### `discord.channel_context_files`
+
+**Type:** mapping — **Default:** `{}`
+
+Per-channel context files that are read once when a new Hermes session starts, then snapshotted onto that session. This is useful for parent channels that spawn many threads and need each new thread to inherit a compact handoff note, project state, or local context file without re-reading it every turn.
+
+```yaml
+discord:
+  channel_context_files:
+    "1234567890": "/Users/alice/notes/agent-state/discord-research.md"
+```
+
+Behavior:
+- Exact thread/channel ID matches win.
+- If a message arrives inside a thread or forum post and that thread has no explicit entry, Hermes falls back to the parent channel/forum ID.
+- The file is read only when the session starts. Later edits to the file affect new sessions, not already-open sessions.
+- Relative paths resolve from `~/.hermes`; `~` and environment variables are expanded.
+- Very large files are truncated before injection, so keep these files compact.
+
+Use `channel_prompts` for live instructions that should update immediately. Use `channel_context_files` for stable initial context that should not drift during a thread.
 
 #### `discord.history_backfill`
 


### PR DESCRIPTION
## Summary
- add `channel_context_files` platform config for per-channel context file paths
- snapshot the configured file once when a gateway session starts and reuse the persisted snapshot for later turns
- wire Discord slash/thread, regular-message, queued, retry, goal, steer-fallback, voice-input, wake, watch, and handoff events to preserve configured context
- inherit parent channel/forum mappings unless a thread has an explicit override
- preserve the initialized snapshot across resume, recovery, and `/branch`
- document the feature and cover config, propagation, persistence, bounded reads, recovery, and non-drift behavior

Example config:

```yaml
discord:
  channel_context_files:
    "123456789012345678": "/Users/alice/notes/research-channel-context.md"
```

Threads inherit their parent channel's context file unless the thread has its own entry:

```yaml
discord:
  channel_context_files:
    "123456789012345678": "/Users/alice/notes/research-channel-context.md"   # parent channel/forum
    "987654321098765432": "/Users/alice/notes/special-thread-context.md"      # specific thread override
```

Relative paths resolve from `~/.hermes`, and `~` / environment variables are expanded:

```yaml
discord:
  channel_context_files:
    "123456789012345678": "contexts/research.md"
    "223456789012345678": "~/notes/ops-handoff.md"
    "323456789012345678": "${HOME}/notes/team-conventions.md"
```

## Why
This gives gateway conversations an `AGENTS.md`-like mechanism per channel: a compact local file can describe the channel's standing context, conventions, or project state, and every new session/thread that starts under that channel can inherit it automatically.

This differs from `channel_prompts`: prompts are live instructions that update on every turn, while `channel_context_files` are stable initial context. The file is snapshotted when the session starts, so already-open threads do not drift if the source file changes later.

## Review follow-up
Rebased onto current `main` and adapted the implementation to current gateway boundaries:

- snapshot persistence uses an awaited, lock-safe compare-and-set guarded by the active session ID
- snapshot and initialization-marker metadata are patched atomically in the session DB
- delayed persistence failures cannot alter the in-memory prompt for later turns
- synthetic first-turn paths preserve or centrally resolve channel context
- resumed and recovered sessions retain the original snapshot, including compatibility for legacy rows without an initialization marker
- `/branch` copies the parent session's initialized snapshot into the child
- file reads are bounded to the 20,000-character injection cap
- restart/non-drift coverage persists version one, changes the source file, reloads the store, and verifies the open session still receives version one

## Tests
- focused suite: 373 passed
- final reviewer suite: 242 passed
- branch/recovery blocker regressions: 6 passed
- Ruff on all touched Python files: passed
- `git diff --check`: passed
- independent blocker-only cross-review: no blockers

## Manual verification
Verified in a real Discord thread under a configured parent channel after gateway restart: new thread sessions load the expected channel context.
