### PR TITLE
fix(trajectory): lock save_trajectory() appends to prevent concurrent JSONL corruption (salvage of #13218 by @bennytimz)

### DIFF
--- a/agent/trajectory.py
+++ b/agent/trajectory.py
@@ -7,8 +7,12 @@ the file-write logic live here.
 
 import json
 import logging
+import sys
 from datetime import datetime
 from typing import Any, Dict, List
+
+if sys.platform != "win32":
+    import fcntl
 
 logger = logging.getLogger(__name__)
 
@@ -48,9 +52,24 @@ def save_trajectory(trajectory: List[Dict[str, Any]], model: str,
         "completed": completed,
     }
 
+    line = json.dumps(entry, ensure_ascii=False) + "\n"
     try:
         with open(filename, "a", encoding="utf-8") as f:
-            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+            # Serialize concurrent appends so interleaved writes from multiple
+            # gateway sessions (all sharing the default trajectory_samples.jsonl
+            # / failed_trajectories.jsonl) cannot corrupt the JSONL file. An
+            # exclusive advisory lock is held only for the single write+flush,
+            # then released. POSIX-only; Windows falls back to the prior
+            # best-effort append (fcntl is unavailable there).
+            if sys.platform != "win32":
+                fcntl.flock(f, fcntl.LOCK_EX)
+                try:
+                    f.write(line)
+                    f.flush()
+                finally:
+                    fcntl.flock(f, fcntl.LOCK_UN)
+            else:
+                f.write(line)
         logger.info("Trajectory saved to %s", filename)
     except Exception as e:
         logger.warning("Failed to save trajectory: %s", e)

--- a/tests/agent/test_trajectory_file_locking.py
+++ b/tests/agent/test_trajectory_file_locking.py
@@ -1,0 +1,73 @@
+"""Concurrency regression test for save_trajectory() file locking.
+
+Salvage of #13218 by @bennytimz. In gateway mode many sessions (across
+platforms) append to the SAME default trajectory file
+(``trajectory_samples.jsonl`` / ``failed_trajectories.jsonl``). Without an
+exclusive lock around the append, interleaved writes from concurrent threads
+can corrupt the JSONL so individual lines no longer parse. save_trajectory()
+now holds an exclusive advisory lock (POSIX ``fcntl.flock``) for the
+single write+flush.
+"""
+import json
+import sys
+import types
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+# Ensure repo root is importable
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from agent.trajectory import save_trajectory  # noqa: E402
+
+
+def test_concurrent_save_trajectory_produces_valid_jsonl(tmp_path):
+    """Every line written by concurrent appenders must be parseable JSON."""
+    target = tmp_path / "trajectory_samples.jsonl"
+
+    n_writers = 24
+    # A reasonably large per-entry payload makes interleaving (and thus
+    # corruption without locking) far more likely to manifest.
+    big = "x" * 4096
+
+    def _write(i: int) -> None:
+        conv = [
+            {"from": "human", "value": f"q{i} {big}"},
+            {"from": "gpt", "value": f"a{i} {big}"},
+        ]
+        save_trajectory(conv, model=f"m{i}", completed=True, filename=str(target))
+
+    with ThreadPoolExecutor(max_workers=n_writers) as pool:
+        list(pool.map(_write, range(n_writers)))
+
+    lines = target.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == n_writers, f"expected {n_writers} lines, got {len(lines)}"
+    models = set()
+    for ln in lines:
+        obj = json.loads(ln)  # raises if a line was corrupted by interleaving
+        assert obj["completed"] is True
+        assert len(obj["conversations"]) == 2
+        models.add(obj["model"])
+    # No write was lost or overwritten: all distinct model tags survived.
+    assert models == {f"m{i}" for i in range(n_writers)}
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="fcntl lock is POSIX-only")
+def test_save_trajectory_uses_exclusive_lock(tmp_path, monkeypatch):
+    """On POSIX the append is wrapped in LOCK_EX … LOCK_UN exactly once."""
+    import agent.trajectory as traj
+
+    calls = []
+    real_flock = traj.fcntl.flock
+
+    def _spy(fd, op):
+        calls.append(op)
+        return real_flock(fd, op)
+
+    monkeypatch.setattr(traj.fcntl, "flock", _spy)
+
+    save_trajectory([{"from": "human", "value": "hi"}], model="m", completed=False,
+                    filename=str(tmp_path / "failed_trajectories.jsonl"))
+
+    assert calls == [traj.fcntl.LOCK_EX, traj.fcntl.LOCK_UN]


### PR DESCRIPTION
## Summary

- Hold an exclusive advisory lock around `save_trajectory()`'s append so concurrent writers can't corrupt the shared JSONL file.
- Salvage of #13218 by @bennytimz, rebased onto current `main` with a real concurrency test and the unrelated changes dropped.

## Motivation

In gateway mode multiple sessions (across platforms) run concurrently and all append to the **same** default trajectory file — `trajectory_samples.jsonl` (completed) / `failed_trajectories.jsonl` (failed). `save_trajectory()` opened the file in append mode and wrote with no locking:

```python
with open(filename, "a", encoding="utf-8") as f:
    f.write(json.dumps(entry, ensure_ascii=False) + "\n")
```

Under concurrent turns, interleaved writes can split a record across another writer's bytes, leaving individual lines unparseable and silently corrupting the dataset.

## Fix

Wrap the single write+flush in an exclusive advisory lock and release it immediately after:

```python
if sys.platform != "win32":
    fcntl.flock(f, fcntl.LOCK_EX)
    try:
        f.write(line)
        f.flush()
    finally:
        fcntl.flock(f, fcntl.LOCK_UN)
else:
    f.write(line)
```

POSIX-only; Windows keeps the prior best-effort append because `fcntl` is unavailable there.

## Changes from the original PR (#13218)

- **Kept** the `agent/trajectory.py` locking fix (the substantive change), crediting @bennytimz.
- **Dropped** the unrelated `scripts/release.py` author-map edit and the unrelated test-file encoding tweak, so this PR closes exactly one concern.
- **Added** a proper concurrency regression test (the original had none).

## Verification

- `python3 -m pytest tests/agent/test_trajectory_file_locking.py -q` — 2 passed
- `python3 -m pytest tests/test_trajectory_compressor.py tests/test_trajectory_compressor_async.py tests/agent/test_trajectory_file_locking.py -q` — 45 passed

## Real behavior proof

- **Behavior addressed:** concurrent appends to the shared trajectory JSONL corrupt lines.
- **Real environment:** local repo on fresh `origin/main`, Python 3.13, macOS (POSIX `fcntl`).
- **Test:** `test_concurrent_save_trajectory_produces_valid_jsonl` spawns 24 threads each appending a ~4 KB entry to one file, then asserts exactly 24 lines, each parses as JSON, and all 24 distinct model tags survive (no lost/overwritten write). `test_save_trajectory_uses_exclusive_lock` asserts the POSIX lock sequence is exactly `[LOCK_EX, LOCK_UN]`.
- **Captured output AFTER fix:**
  ```
  $ python3 -m pytest tests/agent/test_trajectory_file_locking.py -q
  ..
  2 passed in 0.26s
  ```
- **Fails without the fix:** on current `main` (`agent/trajectory.py` has no `fcntl` import), `test_save_trajectory_uses_exclusive_lock` errors with `AttributeError: module 'agent.trajectory' has no attribute 'fcntl'` — confirmed by checking out main's `trajectory.py` and re-running.
- **What was NOT tested:** true cross-process locking (the test exercises threads in one process); `flock` is advisory and applies per open file description, which is the realistic gateway pattern.

Credit: original fix by @bennytimz in #13218.
