### PR TITLE
fix(cli): handle xAI setup in noninteractive runners

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1126,6 +1126,14 @@ def _run_post_setup(post_setup_key: str):
             _print_success("    xAI will use your existing XAI_API_KEY")
             return
 
+        if os.environ.get("HERMES_NONINTERACTIVE") == "1" or not sys.stdin.isatty():
+            raise RuntimeError(
+                "xAI credentials are not configured. This setup step cannot "
+                "prompt from the Desktop/Dashboard background runner. Run "
+                "`hermes auth add xai-oauth` in a terminal, or save XAI_API_KEY "
+                "from Settings / ~/.hermes/.env, then retry."
+            )
+
         _print_info("    xAI needs credentials. Choose one:")
         try:
             from hermes_cli.setup import (

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -1492,6 +1492,27 @@ def test_apply_provider_selection_does_not_prompt_or_post_setup(monkeypatch):
 #    reported as added/removed by `hermes tools` ──────────────────────────
 
 
+def test_xai_grok_post_setup_noninteractive_without_credentials_fails_cleanly(monkeypatch):
+    """Desktop/Dashboard post-setup runs without stdin; xAI setup must not prompt."""
+    from hermes_cli import tools_config
+
+    monkeypatch.setenv("HERMES_NONINTERACTIVE", "1")
+    monkeypatch.setattr(tools_config, "get_env_value", lambda key, default=None: None)
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_xai_oauth_auth_status",
+        lambda: {"logged_in": False},
+    )
+
+    with pytest.raises(RuntimeError) as exc:
+        tools_config._run_post_setup("xai_grok")
+
+    msg = str(exc.value)
+    assert "xAI credentials are not configured" in msg
+    assert "cannot prompt" in msg
+    assert "hermes auth add xai-oauth" in msg
+    assert "XAI_API_KEY" in msg
+
+
 def test_checklist_toolset_keys_excludes_kanban():
     """``kanban`` is check_fn-gated and never appears in the checklist, so it
     must not be in the checklist's offered universe for any platform."""


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Fixes Desktop/Dashboard setup failures for xAI-backed toolsets.

The `xai_grok` post-setup hook previously attempted to launch the interactive OAuth/API-key picker even when executed from non-interactive background setup tasks. This caused Desktop/Dashboard setup runs to fail when xAI credentials were not configured.

This PR detects non-interactive execution environments and returns actionable credential setup instructions instead of launching the interactive prompt. Interactive CLI behavior remains unchanged.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #50486

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

### `hermes_cli/tools_config.py`

- Detect `HERMES_NONINTERACTIVE=1` or non-TTY stdin before opening the xAI credential picker.
- Continue setup normally when xAI OAuth or `XAI_API_KEY` is already configured.
- Return a clear error message when credentials are missing, instructing users to run `hermes auth add xai-oauth` or configure `XAI_API_KEY`.

### `tests/hermes_cli/test_tools_config.py`

- Added regression coverage for the non-interactive `xai_grok` setup path.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Run the targeted regression test:
```bash
python -m pytest tests/hermes_cli/test_tools_config.py -q -k xai_grok
```
2. Reproduce the Desktop/Dashboard non-interactive path without credentials:

```bash
HERMES_NONINTERACTIVE=1 python -m hermes_cli.main tools post-setup xai_grok
```

Expected: clear credential setup error, no interactive prompt.

3. Verify configured credentials still pass:

```bash
HERMES_NONINTERACTIVE=1 XAI_API_KEY=xai-test python -m hermes_cli.main tools post-setup xai_grok
```

Expected: setup succeeds using the existing `XAI_API_KEY`.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11<!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->
Targeted test:

```text
python -m pytest tests/hermes_cli/test_tools_config.py -q -k xai_grok
1 passed, 97 deselected
```

Non-interactive missing-credentials path now reports:

```text
Running post-setup hook: xai_grok
Post-setup failed: xAI credentials are not configured. This setup step cannot prompt from the Desktop/Dashboard
background runner. Run `hermes auth add xai-oauth` in a terminal, or save XAI_API_KEY from Settings / ~/.hermes/.env, then retry.
```
