### PR TITLE
fix(signal): detect RIFF/WAVE attachments as .wav so they route to STT

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -97,6 +97,12 @@ def _guess_extension(data: bytes) -> str:
         return ".gif"
     if len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WEBP":
         return ".webp"
+    # RIFF/WAVE shares the ``RIFF`` chunk header with WebP; the form-type at
+    # bytes 8-11 disambiguates. Without this, an inbound WAV voice note fell
+    # through to ``.bin`` (octet-stream) and was cached as a document, so STT
+    # never saw it — even though ``.wav`` is in the audio allowlist + MIME map.
+    if len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WAVE":
+        return ".wav"
     if data[:4] == b"%PDF":
         return ".pdf"
     if len(data) >= 8 and data[4:8] == b"ftyp":

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -164,6 +164,43 @@ class TestSignalHelpers:
         from gateway.platforms.signal import _guess_extension
         assert _guess_extension(b"\x00\x00\x00\x18ftypisom" + b"\x00" * 100) == ".mp4"
 
+    def test_guess_extension_wav(self):
+        """RIFF/WAVE must be detected as ``.wav`` (regression for the WAV gap).
+
+        WAV shares the ``RIFF`` chunk header with WebP; only the form-type at
+        bytes 8-11 (``WAVE`` vs ``WEBP``) distinguishes them. Before the fix the
+        sniffer only handled ``WEBP`` and a WAV file fell through to ``.bin``.
+        """
+        from gateway.platforms.signal import _guess_extension
+        # Canonical WAV header: 'RIFF' <size> 'WAVE' 'fmt '...
+        wav = b"RIFF\x24\x08\x00\x00WAVEfmt " + b"\x00" * 100
+        assert _guess_extension(wav) == ".wav"
+
+    def test_guess_extension_wav_not_misread_as_webp(self):
+        """A RIFF container that is NOT WebP must not be returned as ``.webp``."""
+        from gateway.platforms.signal import _guess_extension
+        wav = b"RIFF\x24\x08\x00\x00WAVEfmt " + b"\x00" * 100
+        assert _guess_extension(wav) != ".webp"
+
+    def test_guess_extension_wav_routes_to_audio_cache(self):
+        """A detected WAV must route to the audio cache, not the document cache.
+
+        ``.wav`` is already in ``_is_audio_ext``; the bug was purely that
+        ``_guess_extension`` never produced ``.wav`` for raw bytes, so the
+        attachment was treated as a document and STT never received it.
+        """
+        from gateway.platforms.signal import _is_audio_ext, _guess_extension
+        wav = b"RIFF\x24\x08\x00\x00WAVEfmt " + b"\x00" * 100
+        ext = _guess_extension(wav)
+        assert ext == ".wav"
+        assert _is_audio_ext(ext) is True
+
+    def test_guess_extension_webp_still_detected(self):
+        """Guard that adding WAVE detection didn't break the WebP branch."""
+        from gateway.platforms.signal import _guess_extension
+        webp = b"RIFF\x24\x08\x00\x00WEBPVP8 " + b"\x00" * 100
+        assert _guess_extension(webp) == ".webp"
+
     def test_guess_extension_aac_adts_unprotected(self):
         """ADTS AAC, MPEG-4, no CRC (the canonical Android Signal voice note).
 


### PR DESCRIPTION
## Problem

Inbound **WAV** attachments on Signal are silently treated as opaque
documents instead of audio. `_guess_extension()` sniffs magic bytes to
label downloaded attachments, but it only recognised the `RIFF` container
in its **WebP** form (`RIFF…WEBP`) — it had no branch for `RIFF…WAVE`.

A WAV file therefore fell through to the final `return ".bin"`, so:
- `_is_audio_ext(".bin")` is `False` → the attachment was cached via
  `cache_document_from_bytes()` (document) rather than
  `cache_audio_from_bytes()` (audio),
- STT never saw it, even though `.wav` is already present in both
  `_is_audio_ext()` and the `_EXT_TO_MIME` map (`audio/wav`).

So the rest of the adapter is fully wired for WAV — only the byte sniffer
never produced `.wav`.

## Root cause

`gateway/platforms/signal.py::_guess_extension()` had:

```python
if len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WEBP":
    return ".webp"
```

WAV and WebP share the `RIFF` chunk header; the 4-byte form-type at offset
8 (`WAVE` vs `WEBP`) is what distinguishes them. The `WAVE` case was missing.

## Fix

Add the sibling branch right after the WebP check:

```python
if len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WAVE":
    return ".wav"
```

+6 lines in source (1 branch + comment), no behavior change for any other
type. WebP detection is unaffected (still matched first by its own form-type).

## Tests

Added 4 tests to `tests/gateway/test_signal.py::TestSignalHelpers`
mirroring the existing `_guess_extension_*` cases:
- `test_guess_extension_wav` — `RIFF…WAVE` → `.wav`
- `test_guess_extension_wav_not_misread_as_webp`
- `test_guess_extension_wav_routes_to_audio_cache` — asserts `_is_audio_ext` is True
- `test_guess_extension_webp_still_detected` — regression guard for the WebP branch

The first and third **fail without the fix** (they get `.bin`):

```
>       assert ext == ".wav"
E       AssertionError: assert '.bin' == '.wav'
E         - .wav
E         + .bin
tests/gateway/test_signal.py:195: AssertionError
2 failed, 1 passed, 137 deselected
```

Full suite with the fix:

```
$ .venv/bin/python -m pytest tests/gateway/test_signal.py -q
140 passed in 3.14s
```

## Real behavior proof

Captured from a real run on this branch:

```
detected ext   : .wav
is_audio_ext   : True
mime           : audio/wav
routes to      : audio cache (STT)
webp still     : .webp
```

Before the fix `detected ext` was `.bin` → `is_audio_ext: False` →
`routes to: document cache`.

## Notes

- `plugins/platforms/simplex/adapter.py` carries the same `_guess_extension`
  shape and the same WAV gap; I'll send that as a separate focused PR rather
  than bundling two adapters here.
