### PR TITLE
docs: overnight documentation sweep

### DIFF
--- a/SECURITY.es.md
+++ b/SECURITY.es.md
@@ -173,9 +173,10 @@ modelo de autorización, pero las reglas a continuación se aplican uniformement
 
 **Superficies en Hermes Agent:**
 
-- **Adaptadores de plataforma del gateway.** Integraciones de mensajería en
-  `gateway/platforms/` (Telegram, Discord, Slack, email, SMS, etc.)
-  y adaptadores análogos incluidos como plugins.
+- **Adaptadores de plataforma del gateway.** Las integraciones de mensajería se distribuyen
+  principalmente como adaptadores de plugin en `plugins/platforms/<name>/` (Telegram, Discord,
+  Slack, email, SMS, etc.), con tipos base compartidos en `gateway/platforms/` (por ejemplo
+  `base.py` y adaptadores directos heredados).
 - **Superficies HTTP expuestas en red.** El adaptador del servidor API, el
   plugin del dashboard, los endpoints HTTP del plugin kanban, y cualquier
   otro plugin que vincule un socket de escucha.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -177,9 +177,9 @@ authorization model, but the rules below apply uniformly.
 
 **Surfaces in Hermes Agent:**
 
-- **Gateway platform adapters.** Messaging integrations in
-  `gateway/platforms/` (Telegram, Discord, Slack, email, SMS, etc.)
-  and analogous adapters shipped as plugins.
+- **Gateway platform adapters.** Messaging integrations ship primarily as plugin adapters under
+  `plugins/platforms/<name>/` (Telegram, Discord, Slack, email, SMS, etc.), with shared base
+  types in `gateway/platforms/` (for example `base.py` and legacy direct adapters).
 - **Network-exposed HTTP surfaces.** The API server adapter, the
   dashboard plugin, the kanban plugin's HTTP endpoints, and any
   other plugin that binds a listening socket.

--- a/website/docs/developer-guide/gateway-internals.md
+++ b/website/docs/developer-guide/gateway-internals.md
@@ -21,7 +21,8 @@ The messaging gateway is the long-running process that connects Hermes to 20+ ex
 | `gateway/mirror.py` | Cross-session message mirroring for `send_message` |
 | `gateway/status.py` | Token lock management for profile-scoped gateway instances |
 | `gateway/builtin_hooks/` | Extension point for always-registered hooks (none shipped) |
-| `gateway/platforms/` | Platform adapters (one per messaging platform) |
+| `gateway/platforms/` | Shared platform base types and legacy direct adapters (`base.py`, etc.) |
+| `plugins/platforms/` | Per-platform messaging adapters (Telegram, Discord, Slack, …) |
 
 ## Architecture Overview
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -195,6 +195,8 @@ These variables configure the [Tool Gateway](/user-guide/features/tool-gateway) 
 | `TERMINAL_DOCKER_IMAGE` | Docker image (default: `nikolaik/python-nodejs:python3.11-nodejs20`) |
 | `TERMINAL_DOCKER_FORWARD_ENV` | JSON array of env var names to explicitly forward into Docker terminal sessions. Note: skill-declared `required_environment_variables` are forwarded automatically — you only need this for vars not declared by any skill. |
 | `TERMINAL_DOCKER_VOLUMES` | Additional Docker volume mounts (comma-separated `host:container` pairs) |
+| `TERMINAL_DOCKER_ENV` | JSON object of literal `KEY=value` pairs injected into the Docker terminal sandbox |
+| `TERMINAL_DOCKER_EXTRA_ARGS` | JSON array of extra `docker run` flags (for example `["--gpus=all"]`); mirrors `terminal.docker_extra_args` |
 | `TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE` | Advanced opt-in: mount the launch cwd into Docker `/workspace` (`true`/`false`, default: `false`) |
 | `TERMINAL_SINGULARITY_IMAGE` | Singularity image or `.sif` path |
 | `TERMINAL_MODAL_IMAGE` | Modal container image |
@@ -205,6 +207,17 @@ These variables configure the [Tool Gateway](/user-guide/features/tool-gateway) 
 | `SUDO_PASSWORD` | Enable sudo without interactive prompt |
 
 For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETIME_SECONDS` controls when Hermes cleans up an idle terminal session, and later resumes may recreate the sandbox rather than keep the same live processes running.
+
+## Memory providers (Mem0)
+
+| Variable | Description |
+|----------|-------------|
+| `MEM0_API_KEY` | Mem0 API key for cloud or authenticated self-hosted instances |
+| `MEM0_HOST` | Self-hosted Mem0 base URL (for example `http://localhost:24220`). When set, overrides the default cloud endpoint. |
+| `MEM0_USER_ID` | Mem0 user identifier (default: `hermes-user`) |
+| `MEM0_AGENT_ID` | Mem0 agent identifier (default: `hermes`) |
+
+See [Memory providers](/user-guide/features/memory-providers#mem0) for setup.
 
 ## SSH Backend
 

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -38,7 +38,8 @@ Type `/` in the CLI to open the autocomplete menu. Built-in commands are case-in
 |---------|-------------|
 | `/new [name]` (alias: `/reset`) | Start a new session (fresh session ID + history). Optional `[name]` sets the initial session title — e.g. `/new my-experiment` opens a fresh session already titled `my-experiment` so it's easy to find later with `/resume` or `/sessions`. Append `now`, `--yes`, or `-y` to skip the confirmation modal — e.g. `/reset now`, `/new --yes my-experiment`. |
 | `/clear` | Clear screen and start a new session |
-| `/history` | Show conversation history |
+| `/history` | Show conversation history (respects `/timestamps` when enabled) |
+| `/prompt [initial text]` (alias: `/compose`) | **CLI only.** Open `$EDITOR` to compose your next user message in markdown, then send it on save. Optional initial text seeds the buffer. TUI parity: Ctrl+G submits the edited draft. |
 | `/save` | Save the current conversation |
 | `/retry` | Retry the last message (resend to agent) |
 | `/undo` | Remove the last user/assistant exchange |
@@ -70,7 +71,8 @@ Type `/` in the CLI to open the autocomplete menu. Built-in commands are case-in
 | `/personality` | Set a predefined personality |
 | `/verbose` | Cycle tool progress display: off → new → all → verbose. Can be [enabled for messaging](#notes) via config. |
 | `/fast [normal\|fast\|status]` | Toggle fast mode — OpenAI Priority Processing / Anthropic Fast Mode. Options: `normal`, `fast`, `status`. |
-| `/reasoning` | Manage reasoning effort and display (usage: /reasoning [level\|show\|hide]) |
+| `/reasoning` | Manage reasoning effort and display (usage: `/reasoning [level|show|hide|full|clamp]`). `full` shows the complete thinking trace in `/history` instead of a short clamp. Levels include `none`, `minimal`, `low`, `medium`, `high`, and `xhigh` where the provider supports them. |
+| `/timestamps [on|off|status]` (alias: `/ts`) | **CLI only.** Toggle `[HH:MM]` timestamps on messages and in `/history`. |
 | `/skin` | Show or change the display skin/theme |
 | `/statusbar` (alias: `/sb`) | Toggle the context/model status bar on or off |
 | `/voice [on\|off\|tts\|status]` | Toggle CLI voice mode and spoken playback. Recording uses `voice.record_key` (default: `Ctrl+B`). |
@@ -217,7 +219,7 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 | `/usage` | Show token usage, estimated cost breakdown (input/output), context window state, session duration, and — when available from the active provider — an **Account limits** section with remaining quota / credits pulled live from the provider's API. |
 | `/credits` | Show your Nous credit balance and a top-up link that opens the portal billing page in a browser. |
 | `/insights [days]` | Show usage analytics. |
-| `/reasoning [level\|show\|hide]` | Change reasoning effort or toggle reasoning display. |
+| `/reasoning [level\|show\|hide\|full\|clamp]` | Change reasoning effort or toggle reasoning display. `full` shows the complete thinking trace instead of a short clamp. |
 | `/voice [on\|off\|tts\|join\|channel\|leave\|status]` | Control spoken replies in chat. `join`/`channel`/`leave` manage Discord voice-channel mode. |
 | `/rollback [number]` | List or restore filesystem checkpoints. |
 | `/background <prompt>` | Run a prompt in a separate background session. Results are delivered back to the same chat when the task finishes. See [Messaging Background Sessions](/user-guide/messaging/#background-sessions). |
@@ -245,7 +247,7 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 
 ## Notes
 
-- `/skin`, `/snapshot`, `/reload`, `/tools`, `/toolsets`, `/browser`, `/config`, `/cron`, `/platforms`, `/paste`, `/image`, `/statusbar`, `/plugins`, `/busy`, `/indicator`, `/redraw`, `/clear`, `/history`, `/save`, `/copy`, `/handoff`, `/billing`, and `/quit` are **CLI-only** commands.
+- `/skin`, `/snapshot`, `/reload`, `/tools`, `/toolsets`, `/browser`, `/config`, `/cron`, `/platforms`, `/paste`, `/image`, `/statusbar`, `/plugins`, `/busy`, `/indicator`, `/redraw`, `/clear`, `/history`, `/save`, `/copy`, `/handoff`, `/billing`, `/prompt`, `/timestamps`, and `/quit` are **CLI-only** commands.
 - `/skills` is **CLI-only for search/browse/install**; its write-approval review subcommands (`pending`, `approve`, `reject`, `diff`, `approval`) also work on messaging platforms when `skills.write_approval` is on. `/memory` works on **both** surfaces.
 - `/verbose` is **CLI-only by default**, but can be enabled for messaging platforms by setting `display.tool_progress_command: true` in `config.yaml`. When enabled, it cycles the `display.tool_progress` mode and saves to config.
 - `/sethome`, `/update`, `/restart`, `/approve`, `/deny`, `/topic`, `/platform`, and `/commands` are **messaging-only** commands.

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -320,8 +320,8 @@ Server-side LLM fact extraction with semantic search, reranking, and automatic d
 | | |
 |---|---|
 | **Best for** | Hands-off memory management — Mem0 handles extraction automatically |
-| **Requires** | `pip install mem0ai` + API key |
-| **Data storage** | Mem0 Cloud |
+| **Requires** | `pip install mem0ai` + API key (cloud or self-hosted with auth) |
+| **Data storage** | Mem0 Cloud or a self-hosted Mem0 instance |
 | **Cost** | Mem0 pricing |
 
 **Tools:** `mem0_profile` (all stored memories), `mem0_search` (semantic search + reranking), `mem0_conclude` (store verbatim facts)
@@ -332,14 +332,18 @@ hermes memory setup    # select "mem0"
 # Or manually:
 hermes config set memory.provider mem0
 echo "MEM0_API_KEY=your-key" >> ~/.hermes/.env
+# Self-hosted Mem0 (optional):
+echo "MEM0_HOST=http://localhost:24220" >> ~/.hermes/.env
 ```
 
-**Config:** `$HERMES_HOME/mem0.json`
+**Config:** `$HERMES_HOME/mem0.json` or `memory.providers.mem0` in `config.yaml`
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `user_id` | `hermes-user` | User identifier |
-| `agent_id` | `hermes` | Agent identifier |
+| `api_key` | — | Mem0 API key (`MEM0_API_KEY` in `.env`) |
+| `host` | `https://api.mem0.ai` | Self-hosted Mem0 base URL (`MEM0_HOST` overrides when set) |
+| `user_id` | `hermes-user` | User identifier (`MEM0_USER_ID`) |
+| `agent_id` | `hermes` | Agent identifier (`MEM0_AGENT_ID`) |
 
 ---
 


### PR DESCRIPTION
## Summary
- Reviewed the full codebase for documentation drift against `origin/main` (including recent CLI slash commands, Mem0 self-hosted support, and plugin platform adapter layout).
- Updated documentation to match current implementation.
- Saved run progress in `/tmp/overnight-docs-sweep.md`.

## Sweep window
- From: `2026-06-21 00:00` (local)
- To: `2026-06-22 00:00` (local), plus full drift review on `origin/main` @ `5ff11a689`

## Recent changes reviewed
- `5ff11a689` feat(cli): /timestamps command + timestamps in /history (#50506)
- `9e96e7099` feat(cli): /prompt — compose your next prompt in $EDITOR (#50509)
- `95d53c3bc` feat(cli): /reasoning full — show complete thinking (#50499)
- `b6d2ac176` feat(mem0): add self-hosted support via MEM0_HOST / host config
- `4c1934dd8` docs: repoint remaining stale gateway/platforms adapter refs to plugins/platforms
- (80+ commits in the nightly window on the prior local `main` tip)

## Documentation checked
- `website/docs/reference/slash-commands.md`
- `SECURITY.md`, `SECURITY.es.md`
- `website/docs/user-guide/features/memory-providers.md`
- `website/docs/reference/environment-variables.md`
- `website/docs/developer-guide/gateway-internals.md`
- Cross-checks against `hermes_cli/commands.py`, `plugins/memory/mem0/__init__.py`

## Documentation updated
- `website/docs/reference/slash-commands.md` — document `/prompt`, `/timestamps`, and `/reasoning full|clamp`
- `SECURITY.md`, `SECURITY.es.md` — clarify `plugins/platforms/` vs shared `gateway/platforms/` base
- `website/docs/user-guide/features/memory-providers.md` — Mem0 self-hosted `MEM0_HOST` and config keys
- `website/docs/reference/environment-variables.md` — `TERMINAL_DOCKER_ENV`, `TERMINAL_DOCKER_EXTRA_ARGS`, Mem0 env vars
- `website/docs/developer-guide/gateway-internals.md` — module table lists `plugins/platforms/`

## Verification
- `git diff --check` — passed
- `npm run docs:build` (website/) — skipped: script not configured
- Independent autoreview — dispatched (background subagent)

## Open questions / risks
- PR targets upstream `NousResearch/hermes-agent`; pushed from `virtuadex` fork.
- Local user change to `plugins/platforms/telegram/adapter.py` was stashed before branching (`git stash list`).