### PR TITLE
fix: add explicit encoding to read_text in root files

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1352,7 +1352,7 @@ def _setup_worktree(repo_root: str = None, sync_base: bool = True) -> Optional[D
     gitignore = Path(repo_root) / ".gitignore"
     _ignore_entry = ".worktrees/"
     try:
-        existing = gitignore.read_text() if gitignore.exists() else ""
+        existing = gitignore.read_text(encoding="utf-8") if gitignore.exists() else ""
         if _ignore_entry not in existing.splitlines():
             with open(gitignore, "a", encoding="utf-8") as f:
                 if existing and not existing.endswith("\n"):
@@ -1402,7 +1402,7 @@ def _setup_worktree(repo_root: str = None, sync_base: bool = True) -> Optional[D
         try:
             repo_root_resolved = Path(repo_root).resolve()
             wt_path_resolved = wt_path.resolve()
-            for line in include_file.read_text().splitlines():
+            for line in include_file.read_text(encoding="utf-8").splitlines():
                 entry = line.strip()
                 if not entry or entry.startswith("#"):
                     continue

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -82,7 +82,7 @@ def get_hermes_home() -> Path:
         try:
             fallback_home = _get_platform_default_hermes_home()
             active_path = fallback_home / "active_profile"
-            active = active_path.read_text().strip() if active_path.exists() else ""
+            active = active_path.read_text(encoding="utf-8").strip() if active_path.exists() else ""
         except (UnicodeDecodeError, OSError):
             active = ""
         if active and active != "default":


### PR DESCRIPTION
## Summary

Final companion to PRs #50655, #50660, #50666, #50679, #50689. Add `encoding="utf-8"` to remaining `read_text()` calls in root-level files.

- `hermes_constants.py`: 1 call
- `cli.py`: 2 calls

Completes the encoding fix series across the entire codebase (171 total calls fixed).

## Test plan

- [ ] CI passes