### PR TITLE
fix(weixin): split chatty multiline inbound batches (#50093)

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+from dataclasses import replace
 import hashlib
 import json
 import logging
@@ -1465,7 +1466,11 @@ class WeixinAdapter(BasePlatformAdapter):
         )
         logger.info("[%s] inbound from=%s type=%s media=%d", self.name, _safe_id(sender_id), source.chat_type, len(media_paths))
         if event.message_type == MessageType.TEXT:
-            self._enqueue_text_event(event)
+            split_events = self._split_batched_inbound_text_event(event)
+            if len(split_events) > 1:
+                await self._dispatch_split_text_burst(split_events)
+            else:
+                self._enqueue_text_event(event)
         else:
             await self.handle_message(event)
 
@@ -1524,6 +1529,40 @@ class WeixinAdapter(BasePlatformAdapter):
         self._pending_text_batch_tasks[key] = asyncio.create_task(
             self._flush_text_batch(key)
         )
+
+    def _split_batched_inbound_text_event(self, event: MessageEvent) -> List[MessageEvent]:
+        """Expand short chat-like multiline payloads into separate events.
+
+        Weixin/iLink can batch rapid user messages into a single multiline text
+        payload before Hermes receives them. Split only the short chat-style
+        shape so later lines can interrupt the current turn instead of being
+        trapped inside one aggregated prompt.
+        """
+        if event.message_type != MessageType.TEXT or event.media_urls:
+            return [event]
+        if not _should_split_short_chat_block_for_weixin(event.text or ""):
+            return [event]
+
+        lines = [line.strip() for line in (event.text or "").splitlines() if line.strip()]
+        if len(lines) <= 1:
+            return [event]
+
+        base_message_id = event.message_id or ""
+        return [
+            replace(
+                event,
+                text=line,
+                message_id=f"{base_message_id}:part{idx}" if base_message_id else None,
+            )
+            for idx, line in enumerate(lines, start=1)
+        ]
+
+    async def _dispatch_split_text_burst(self, events: List[MessageEvent]) -> None:
+        """Schedule pre-batched chat lines as distinct inbound deliveries."""
+        for idx, event in enumerate(events):
+            asyncio.create_task(self.handle_message(event))
+            if idx < len(events) - 1:
+                await asyncio.sleep(0)
 
     async def _flush_text_batch(self, key: str) -> None:
         """Wait for quiet period then dispatch aggregated text."""

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -1061,6 +1061,60 @@ class TestWeixinTextDebounce:
         asyncio.run(_drive())
         assert dispatched == ["one\ntwo\nthree"]
 
+    def test_inbound_chatty_multiline_batch_splits_into_separate_dispatches(self):
+        adapter = _make_adapter()
+        adapter._poll_session = object()
+        adapter.handle_message = AsyncMock()
+
+        message = {
+            "from_user_id": "wxid_user1",
+            "message_id": "msg-1",
+            "item_list": [{"type": 1, "text_item": {"text": "第一行\n第二行\n第三行"}}],
+        }
+
+        async def _drive():
+            await adapter._process_message(message)
+            await asyncio.sleep(0.05)
+
+        asyncio.run(_drive())
+
+        assert adapter.handle_message.await_count == 3
+        texts = [call.args[0].text for call in adapter.handle_message.await_args_list]
+        message_ids = [call.args[0].message_id for call in adapter.handle_message.await_args_list]
+        assert texts == ["第一行", "第二行", "第三行"]
+        assert message_ids == ["msg-1:part1", "msg-1:part2", "msg-1:part3"]
+
+    def test_inbound_structured_multiline_text_still_batches_as_one_event(self):
+        adapter = _make_adapter()
+        adapter._poll_session = object()
+        adapter.handle_message = AsyncMock()
+        adapter._text_batch_delay_seconds = 0.05
+        adapter._text_batch_split_delay_seconds = 0.05
+
+        message = {
+            "from_user_id": "wxid_user1",
+            "message_id": "msg-1",
+            "item_list": [
+                {
+                    "type": 1,
+                    "text_item": {
+                        "text": "今天结论：\n- 留存下降 3%\n- 转化上涨 8%\n- 主要问题在首日激活"
+                    },
+                }
+            ],
+        }
+
+        async def _drive():
+            await adapter._process_message(message)
+            await asyncio.sleep(0.2)
+
+        asyncio.run(_drive())
+
+        assert adapter.handle_message.await_count == 1
+        assert adapter.handle_message.await_args[0][0].text == (
+            "今天结论：\n- 留存下降 3%\n- 转化上涨 8%\n- 主要问题在首日激活"
+        )
+
 
 class _StubResponse:
     def __init__(self, *, status=200, body="{}", delay=0.0):


### PR DESCRIPTION
## Summary
- split short chat-like multiline Weixin payloads into distinct inbound events
- preserve structured multiline prompts on the existing debounce path
- add regression coverage for the split and non-split cases

## Testing
- uv run --frozen pytest tests/gateway/test_weixin.py -q
- uv run --frozen ruff check gateway/platforms/weixin.py tests/gateway/test_weixin.py
- git diff --check

Fixes #50093