### PR TITLE
feat(opencode-go): support GLM-5 reasoning controls (#49279)

### DIFF
--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -31,6 +31,18 @@ def _is_deepseek_thinking_model(model: str | None) -> bool:
     return m == "deepseek-reasoner"
 
 
+def _is_glm_thinking_model(model: str | None) -> bool:
+    """Return True for GLM models that expose reasoning controls on OpenCode Go.
+
+    GLM-5 model IDs currently route through this profile, but Hermes was
+    treating them like generic chat-completions models and silently dropping
+    `/reasoning`. Reuse the existing DeepSeek-style mapping so GLM-5 requests
+    can forward ``reasoning_effort`` or the fallback ``extra_body.thinking``
+    fields instead of falling through this gate.
+    """
+    return _flat_model_name(model).startswith("glm-5")
+
+
 class OpenCodeGoProfile(ProviderProfile):
     """OpenCode Go - model-specific reasoning controls."""
 
@@ -80,7 +92,10 @@ class OpenCodeGoProfile(ProviderProfile):
                 extra_body["thinking"] = {"type": "enabled"}
             return extra_body, top_level
 
-        if not _is_deepseek_thinking_model(model):
+        if not (
+            _is_deepseek_thinking_model(model)
+            or _is_glm_thinking_model(model)
+        ):
             return extra_body, top_level
 
         enabled = True

--- a/tests/plugins/model_providers/test_opencode_go_profile.py
+++ b/tests/plugins/model_providers/test_opencode_go_profile.py
@@ -122,13 +122,59 @@ class TestOpenCodeGoDeepSeekThinking:
             assert top_level == {"reasoning_effort": "max"}
 
 
+class TestOpenCodeGoGLMThinking:
+    """GLM-5 models use the same thinking contract on OpenCode Go."""
+
+    def test_high_effort_emits_thinking_and_effort(self, opencode_go_profile):
+        extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="glm-5.1",
+        )
+        assert extra_body == {}
+        assert top_level == {"reasoning_effort": "high"}
+
+    def test_disabled_emits_thinking_disabled_without_effort(self, opencode_go_profile):
+        extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            model="glm-5.1",
+        )
+        assert extra_body == {"thinking": {"type": "disabled"}}
+        assert top_level == {}
+
+    def test_no_config_emits_thinking_enabled_without_effort(self, opencode_go_profile):
+        extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
+            reasoning_config=None,
+            model="glm-5.1",
+        )
+        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert top_level == {}
+
+    def test_minimal_effort_enables_thinking_without_effort(self, opencode_go_profile):
+        extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "minimal"},
+            model="zai/glm-5.2",
+        )
+        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert top_level == {}
+
+    def test_xhigh_and_max_normalize_to_max(self, opencode_go_profile):
+        for effort in ("xhigh", "max"):
+            extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
+                reasoning_config={"enabled": True, "effort": effort},
+                model="z-ai/glm-5.2",
+            )
+            assert extra_body == {}
+            assert top_level == {"reasoning_effort": "max"}
+
+
 class TestOpenCodeGoModelGating:
-    """Other OpenCode Go models must not receive Kimi/DeepSeek controls."""
+    """Other OpenCode Go models must not receive Kimi/DeepSeek/GLM controls."""
 
     @pytest.mark.parametrize(
         "model",
         [
-            "glm-5.1",
+            "glm-4.5",
+            "glm-4.5-flash",
             "qwen3.6-plus",
             "minimax-m2.7",
             "deepseek-v3.1",
@@ -170,6 +216,20 @@ class TestOpenCodeGoFullKwargsIntegration:
 
         kwargs = ChatCompletionsTransport().build_kwargs(
             model="deepseek-v4-pro",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=opencode_go_profile,
+            reasoning_config={"enabled": True, "effort": "high"},
+            base_url="https://opencode.ai/zen/go/v1",
+        )
+        assert "extra_body" not in kwargs
+        assert kwargs["reasoning_effort"] == "high"
+
+    def test_glm_thinking_reaches_extra_body_and_top_level(self, opencode_go_profile):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="glm-5.1",
             messages=[{"role": "user", "content": "ping"}],
             tools=None,
             provider_profile=opencode_go_profile,


### PR DESCRIPTION
## What does this PR do?

Adds GLM-5 reasoning support to the `opencode-go` profile so Hermes stops silently dropping `/reasoning` for GLM-5 model IDs routed through `plugins/model-providers/opencode-zen/__init__.py`.

Before this change, `OpenCodeGoProfile.build_api_kwargs_extras()` only applied reasoning controls to Kimi K2 and DeepSeek thinking models. `glm-5*` IDs fell through the gate entirely, so `/reasoning high`, `/reasoning off`, and related settings had no effect on GLM-5 requests on this provider path.

This PR adds a GLM-5 model gate and reuses the existing DeepSeek-style mapping already used on OpenCode Go:
- recognized efforts forward as top-level `reasoning_effort`
- disabled reasoning emits `extra_body.thinking={"type":"disabled"}`
- unrecognized/no explicit effort falls back to `extra_body.thinking={"type":"enabled"}`

## Related Issue

Fixes #49279

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `_is_glm_thinking_model()` to `plugins/model-providers/opencode-zen/__init__.py`
- Routed GLM-5 IDs through the existing OpenCode Go reasoning-control branch
- Added GLM-specific unit coverage in `tests/plugins/model_providers/test_opencode_go_profile.py`
- Extended model-gating tests to keep `glm-4.5` and `glm-4.5-flash` excluded
- Added transport integration coverage to verify `reasoning_effort` reaches final kwargs for GLM-5

## How to Test

1. On `main`, call `OpenCodeGoProfile.build_api_kwargs_extras(..., model="glm-5.1")` with a reasoning config and observe that it returns no GLM reasoning controls.
2. On this branch, repeat the same call and verify that GLM-5 models now emit the same reasoning fields as the existing DeepSeek branch.
3. Run:
   - `./.venv/bin/python -m pytest tests/plugins/model_providers/test_opencode_go_profile.py -q`
   - `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7.7

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted validation run:

```text
$ ./.venv/bin/python -m pytest tests/plugins/model_providers/test_opencode_go_profile.py -q
28 passed, 3 warnings in 3.70s

$ git diff --check
(no output)
```
