### PR TITLE
fix(tests): pin DEFAULT_DB_PATH in hermetic fixture to prevent production state.db leak (#50681)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -360,6 +360,17 @@ def _hermetic_environment(tmp_path, monkeypatch):
     (fake_hermes_home / "skills").mkdir()
     monkeypatch.setenv("HERMES_HOME", str(fake_hermes_home))
 
+    # 3b. Pin DEFAULT_DB_PATH so ``SessionDB()`` without an explicit path
+    #     uses the tempdir, not the real ``~/.hermes/state.db``.
+    #     ``DEFAULT_DB_PATH`` is a module-level constant evaluated at
+    #     import time — before this fixture runs — so it freezes to the
+    #     production path.  See #50681.
+    import hermes_state
+    monkeypatch.setattr(
+        hermes_state, "DEFAULT_DB_PATH",
+        fake_hermes_home / "state.db", raising=False,
+    )
+
     # 4. Deterministic locale / timezone / hashseed. CI runs in UTC with
     #    C.UTF-8 locale; local dev often doesn't. Pin everything.
     monkeypatch.setenv("TZ", "UTC")

--- a/tests/test_default_db_path_isolation.py
+++ b/tests/test_default_db_path_isolation.py
@@ -1,0 +1,47 @@
+"""Regression test: DEFAULT_DB_PATH must not leak into the real state.db.
+
+``DEFAULT_DB_PATH`` is a module-level constant evaluated at import time.
+The ``_hermetic_environment`` autouse fixture monkeypatches it to a tempdir
+so ``SessionDB()`` without an explicit *db_path* cannot write to the
+production ``~/.hermes/state.db``.  See #50681.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import hermes_state
+
+
+def test_default_db_path_points_to_tempdir(tmp_path: Path) -> None:
+    """DEFAULT_DB_PATH must resolve to the test-scoped tempdir, not ``~/.hermes``."""
+    # The _hermetic_environment autouse fixture sets HERMES_HOME to tmp_path
+    # and monkeypatches DEFAULT_DB_PATH accordingly.
+    resolved = hermes_state.DEFAULT_DB_PATH
+    assert tmp_path in resolved.parents or resolved.parent == tmp_path, (
+        f"DEFAULT_DB_PATH {resolved} should be under tmp_path {tmp_path}"
+    )
+    assert ".hermes" not in str(resolved), (
+        f"DEFAULT_DB_PATH {resolved} still points at the real ~/.hermes"
+    )
+
+
+def test_sessiondb_uses_tempdir_by_default(tmp_path: Path) -> None:
+    """SessionDB() with no explicit path must use the tempdir, not production."""
+    db = hermes_state.SessionDB()
+    try:
+        assert tmp_path in db.db_path.parents or db.db_path.parent == tmp_path, (
+            f"SessionDB().db_path {db.db_path} should be under tmp_path {tmp_path}"
+        )
+    finally:
+        db.close()
+
+
+def test_default_db_path_survives_reload(tmp_path: Path) -> None:
+    """After reloading hermes_state, DEFAULT_DB_PATH must still be patched."""
+    importlib.reload(hermes_state)
+    resolved = hermes_state.DEFAULT_DB_PATH
+    assert tmp_path in resolved.parents or resolved.parent == tmp_path, (
+        f"After reload, DEFAULT_DB_PATH {resolved} should still be under tmp_path"
+    )


### PR DESCRIPTION
## What does this PR do?

Pins `DEFAULT_DB_PATH` in the `_hermetic_environment` autouse fixture so tests that create `SessionDB()` without an explicit path write to the test tempdir instead of the production `~/.hermes/state.db`.

## Related Issue

Fixes #50681

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tests/conftest.py`: Add `monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", ...)` in `_hermetic_environment` so the frozen module-level constant is overridden for every test.
- `tests/test_default_db_path_isolation.py`: 3 regression tests verifying `DEFAULT_DB_PATH` points to the tempdir, `SessionDB()` uses it, and the patch survives `importlib.reload`.

## How to Test

**Reproduction (before this patch):**

1. Run `python -m pytest tests/gateway/test_session.py::TestSessionStoreEntriesAttribute -v` — this test creates `SessionDB()` instances without an explicit path.
2. After the test completes, inspect `~/.hermes/state.db`:
   ```bash
   sqlite3 ~/.hermes/state.db "SELECT count(*) FROM sessions WHERE title LIKE '%test%' OR title = ''"
   ```
3. Observe phantom sessions written to the production database by the test run.

**Verification (after this patch):**

1. Run the same test suite: `python -m pytest tests/gateway/test_session.py -v`
2. Check `~/.hermes/state.db` — no new phantom sessions should appear.
3. Run the regression tests: `python -m pytest tests/test_default_db_path_isolation.py -v` — all 3 pass, confirming `DEFAULT_DB_PATH` points to the per-test tempdir.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_state.DEFAULT_DB_PATH` (module-level constant), `SessionDB.__init__`, `tests/conftest.py::_hermetic_environment`
- Blast radius: LOW — test infrastructure only; no production code paths changed
- Related patterns: Several test files already monkeypatch `DEFAULT_DB_PATH` individually (e.g., `test_session.py`, `test_session_dm_thread_seeding.py`). This fix centralizes the patch in the autouse fixture so it covers ALL tests.
