### PR TITLE
feat(desktop): file-path hyperlinks in output with right-click actions

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -6045,6 +6045,49 @@ ipcMain.handle('hermes:logs:reveal', async () => {
   }
 })
 
+// Reveal a file-path hyperlink's target in the OS file manager. Accepts a bare
+// path OR a file:// URL (resolved via resolveRequestedPathForIpc, which also
+// validates against the unsafe-path blocklist). Returns the resolved path so
+// the renderer can show it in the menu label.
+ipcMain.handle('hermes:shell:revealInFolder', (_event, rawPath) => {
+  const localPath = resolveRequestedPathForIpc(String(rawPath || ''), { purpose: 'Reveal in folder' })
+  shell.showItemInFolder(localPath)
+  return { ok: true, path: localPath }
+})
+
+// Open the system "open with" app picker for a file-path hyperlink's target.
+// Windows: rundll32 shell32.dll,OpenAs_RunDLL shows the native picker. macOS:
+// `open -a` with no app argument is ambiguous, so we fall back to openPath
+// (which dispatches to the default handler). Linux: xdg-open is the closest
+// analogue (no standard picker) — we delegate to openPath as best-effort.
+ipcMain.handle('hermes:shell:openWith', (_event, rawPath) => {
+  const localPath = resolveRequestedPathForIpc(String(rawPath || ''), { purpose: 'Open with' })
+
+  if (process.platform === 'win32') {
+    // OpenAs_RunDLL expects a Windows-native path with backslashes.
+    const winPath = localPath.replace(/\//g, '\\')
+    const proc = spawn('rundll32.exe', ['shell32.dll,OpenAs_RunDLL', winPath], {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: false
+    })
+    proc.on('error', error => {
+      rememberLog(`[shell] openWith rundll32 failed: ${error.message}; falling back to openPath`)
+      void shell.openPath(localPath)
+    })
+    proc.unref()
+    return { ok: true, path: localPath }
+  }
+
+  // macOS / Linux: no standard native picker via a single command. Best-effort
+  // is to open with the default handler (the user can then choose another app
+  // from there on macOS via the Open With submenu in Finder, but that's a
+  // follow-up). Log so the behaviour is debuggable.
+  rememberLog(`[shell] openWith on ${process.platform}: delegating to openPath for ${localPath}`)
+  void shell.openPath(localPath)
+  return { ok: true, path: localPath }
+})
+
 ipcMain.handle('hermes:logs:recent', async () => ({ path: DESKTOP_LOG_PATH, lines: hermesLog.slice(-200) }))
 
 function isExecutableFile(filePath) {

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -45,6 +45,13 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   setPreviewShortcutActive: active => ipcRenderer.send('hermes:previewShortcutActive', Boolean(active)),
   openExternal: url => ipcRenderer.invoke('hermes:openExternal', url),
   fetchLinkTitle: url => ipcRenderer.invoke('hermes:fetchLinkTitle', url),
+  // File-path hyperlink shell actions (right-click menu on file:// links in
+  // assistant output). Copy uses writeClipboard above; open-in-default-app
+  // uses openExternal with a file:// URL. These two are reveal + open-with.
+  shell: {
+    revealInFolder: rawPath => ipcRenderer.invoke('hermes:shell:revealInFolder', rawPath),
+    openWith: rawPath => ipcRenderer.invoke('hermes:shell:openWith', rawPath)
+  },
   sanitizeWorkspaceCwd: cwd => ipcRenderer.invoke('hermes:workspace:sanitize', cwd),
   settings: {
     getDefaultProjectDir: () => ipcRenderer.invoke('hermes:setting:defaultProjectDir:get'),

--- a/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
@@ -210,4 +210,77 @@ describe('preprocessMarkdown', () => {
 
     expect(() => preprocessMarkdown(input)).not.toThrow()
   })
+
+  describe('file-path linkification', () => {
+    it('linkifies a Windows drive path in prose', () => {
+      const output = preprocessMarkdown('I updated C:\\Users\\me\\src\\main.ts for you.')
+
+      expect(output).toContain('[C:\\Users\\me\\src\\main.ts](file:///C:/Users/me/src/main.ts)')
+    })
+
+    it('linkifies a Unix absolute path in prose', () => {
+      const output = preprocessMarkdown('See /home/me/src/main.ts for details.')
+
+      expect(output).toContain('[/home/me/src/main.ts](file:///home/me/src/main.ts)')
+    })
+
+    it('linkifies a dot-relative path in prose', () => {
+      expect(preprocessMarkdown('Config at ./config/settings.yaml')).toContain(
+        '[./config/settings.yaml](file://./config/settings.yaml)'
+      )
+      expect(preprocessMarkdown('Parent at ../src/App.tsx')).toContain(
+        '[../src/App.tsx](file://../src/App.tsx)'
+      )
+    })
+
+    it('keeps a line:col suffix in the label but not the href', () => {
+      const output = preprocessMarkdown('Line ref: /home/me/src/main.ts:42:10')
+
+      // The href targets the file only (file:// can't carry line info); the
+      // visible label keeps the :42:10 suffix the model wrote.
+      expect(output).toContain('[/home/me/src/main.ts:42:10](file:///home/me/src/main.ts)')
+    })
+
+    it('peels trailing sentence punctuation off the path', () => {
+      const output = preprocessMarkdown('Sentence end: /home/me/main.ts.')
+
+      expect(output).toContain('[/home/me/main.ts](file:///home/me/main.ts).')
+    })
+
+    it('does not linkify paths inside inline code spans', () => {
+      const output = preprocessMarkdown('See `src/components/App.tsx` for the component.')
+
+      expect(output).not.toContain('file://')
+      expect(output).toContain('`src/components/App.tsx`')
+    })
+
+    it('does not linkify paths inside fenced code blocks', () => {
+      const output = preprocessMarkdown('```ts\nconst p = "/home/me/src/main.ts"\n```')
+
+      expect(output).not.toContain('file://')
+    })
+
+    it('does not linkify bare relative paths without a dot prefix', () => {
+      // Bare relative paths (src/components/App.tsx) are intentionally not
+      // matched — their false-positive rate is too high. Phase 1 links prose
+      // paths only when they start with a drive letter, /, ./, or ../.
+      const output = preprocessMarkdown('The file src/components/App.tsx was changed.')
+
+      expect(output).not.toContain('file://')
+    })
+
+    it('does not linkify http(s) urls as file paths', () => {
+      const output = preprocessMarkdown('Docs at https://example.com/page')
+
+      expect(output).not.toContain('file://')
+      expect(output).toContain('<https://example.com/page>')
+    })
+
+    it('linkifies multiple paths in one message', () => {
+      const output = preprocessMarkdown('See /a/b/c.py and /d/e/f.go for the changes.')
+
+      expect(output).toContain('[/a/b/c.py](file:///a/b/c.py)')
+      expect(output).toContain('[/d/e/f.go](file:///d/e/f.go)')
+    })
+  })
 })

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -12,6 +12,7 @@ import {
   type ComponentProps,
   memo,
   type ReactNode,
+  useCallback,
   useDeferredValue,
   useEffect,
   useMemo,
@@ -23,6 +24,12 @@ import { ExpandableBlock } from '@/components/chat/expandable-block'
 import { PreviewAttachment } from '@/components/chat/preview-attachment'
 import { chunkByLines, SyntaxHighlighter } from '@/components/chat/shiki-highlighter'
 import { ZoomableImage } from '@/components/chat/zoomable-image'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger
+} from '@/components/ui/context-menu'
 import { normalizeExternalUrl, openExternalLink, PrettyLink } from '@/lib/external-link'
 import { createMemoizedMathPlugin } from '@/lib/katex-memo'
 import { preprocessMarkdown } from '@/lib/markdown-preprocess'
@@ -237,6 +244,80 @@ function childrenToText(children: unknown): string {
   return ''
 }
 
+// Resolve a `file://` href (or bare path) to the OS-native absolute path the
+// IPC handlers expect. `window.hermesDesktop.shell.*` accept both forms via
+// resolveRequestedPathForIpc, but we pass the original href through so the
+// main process does the canonical resolution + validation.
+function hrefToShellPath(href: string): string {
+  return href
+}
+
+// A file-path hyperlink rendered from a `file://` markdown link. Left-click
+// opens the file in the OS default app (same as any link); right-click shows a
+// context menu with Copy path / Reveal in Explorer / Open / Open with…
+// (the four actions the feature request specifies). The label retains any
+// `:line:col` suffix the preprocessor captured so the user sees what the model
+// wrote, even though the href targets the file only (file:// can't carry line
+// info — see markdown-preprocess.ts).
+function FilePathLink({
+  children,
+  className,
+  href,
+  ...props
+}: ComponentProps<'a'>) {
+  const path = hrefToShellPath(href ?? '')
+
+  const handleCopyPath = useCallback(() => {
+    void window.hermesDesktop?.writeClipboard?.(path)
+  }, [path])
+
+  const handleRevealInFolder = useCallback(() => {
+    void window.hermesDesktop?.shell?.revealInFolder?.(path)
+  }, [path])
+
+  const handleOpen = useCallback(() => {
+    // openExternal routes file:// through shell.openPath (default app).
+    if (href) {
+      void window.hermesDesktop?.openExternal?.(href)
+    }
+  }, [href])
+
+  const handleOpenWith = useCallback(() => {
+    void window.hermesDesktop?.shell?.openWith?.(path)
+  }, [path])
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <a
+          className={cn(
+            'font-semibold text-foreground underline underline-offset-4 decoration-current/20 wrap-anywhere cursor-pointer',
+            className
+          )}
+          href={href}
+          onClick={event => {
+            // Left-click: open in default app via the IPC bridge (Chromium
+            // blocks file:// navigation from the app origin, so we intercept
+            // and route through openExternal → shell.openPath).
+            event.preventDefault()
+            handleOpen()
+          }}
+          rel="noopener noreferrer"
+          {...props}
+        >
+          {children}
+        </a>
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem onSelect={handleCopyPath}>Copy path</ContextMenuItem>
+        <ContextMenuItem onSelect={handleRevealInFolder}>Open path in Explorer</ContextMenuItem>
+        <ContextMenuItem onSelect={handleOpen}>Open in default app</ContextMenuItem>
+        <ContextMenuItem onSelect={handleOpenWith}>Open with…</ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  )
+}
+
 function MarkdownLink({ children, className, href, ...props }: ComponentProps<'a'>) {
   const mediaPath = mediaPathFromMarkdownHref(href)
 
@@ -248,6 +329,13 @@ function MarkdownLink({ children, className, href, ...props }: ComponentProps<'a
 
   if (previewTarget) {
     return <PreviewAttachment source="explicit-link" target={previewTarget} />
+  }
+
+  // File-path hyperlinks emitted by the preprocessor's linkifyFilePaths()
+  // arrive as `file://` hrefs. Render them with the right-click context menu
+  // (copy / reveal / open / open-with) instead of the generic anchor.
+  if (href && /^file:\/\//i.test(href)) {
+    return <FilePathLink className={className} href={href} {...props}>{children}</FilePathLink>
   }
 
   const target = href ? normalizeExternalUrl(href) : href

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -61,6 +61,13 @@ declare global {
       setPreviewShortcutActive?: (active: boolean) => void
       openExternal: (url: string) => Promise<void>
       fetchLinkTitle: (url: string) => Promise<string>
+      // File-path hyperlink shell actions (right-click menu on file:// links
+      // in assistant output). revealInFolder → OS file manager; openWith →
+      // system "open with" app picker. Both accept a bare path or file:// URL.
+      shell: {
+        revealInFolder: (rawPath: string) => Promise<{ ok: boolean; path: string; error?: string }>
+        openWith: (rawPath: string) => Promise<{ ok: boolean; path: string; error?: string }>
+      }
       sanitizeWorkspaceCwd: (cwd?: null | string) => Promise<{ cwd: string; sanitized: boolean }>
       settings: {
         getDefaultProjectDir: () => Promise<{ defaultLabel: string; dir: null | string; resolvedCwd: string }>

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -16,6 +16,90 @@ const INLINE_CODE_SPLIT_RE = /(`[^`\n]+`)/g
 // and keeps the emphasis run intact. Other trailing punctuation is still peeled
 // off by the final `[^\s<>"'`*.,;:!?]` class.
 const RAW_URL_RE = /https?:\/\/[^\s<>"'`*]+[^\s<>"'`*.,;:!?]/g
+
+// File-path autolink matcher. Wraps filesystem paths the model references in
+// prose as `[path](file://path)` markdown so MarkdownLink can render them as
+// hyperlinks with a right-click context menu (copy / reveal / open / open-with).
+//
+// Scope is deliberately narrow to keep false positives low — this runs on prose
+// only (code fences and inline code spans are carved out by CODE_FENCE_SPLIT_RE
+// / INLINE_CODE_SPLIT_RE before this runs). Four unambiguous path shapes are
+// matched:
+//
+//   1. Windows drive paths  — C:\Users\me\src\main.ts
+//   2. UNC paths            — \\server\share\file.txt
+//   3. Unix absolute paths  — /home/me/src/main.ts
+//   4. Dot-relative paths   — ./config/settings.yaml, ../src/App.tsx
+//
+// Bare relative paths (src/components/App.tsx) are intentionally NOT matched —
+// their false-positive rate against natural language and code-like prose is too
+// high. Models wrap such paths in backticks often enough that the inline-code
+// carve-out is the safer home for a future phase-2 pass.
+//
+// Each branch captures an optional `:line` / `:line:col` suffix (e.g.
+// `src/App.tsx:42:10`); the suffix travels in the visible text but, per the
+// file:// URL spec, is NOT encoded into the href (there's no standard way to
+// carry line info in a file:// URL — Claude Code and the community `termlink`
+// tool handle it the same way). The component keeps the suffix in the label.
+//
+// Lookbehinds keep the path from matching mid-token: a Windows drive letter or
+// Unix root must not be preceded by a path character (so we don't double-link a
+// path that's already part of a URL or another path). The character classes
+// exclude whitespace, quotes, and shell glob/redirect chars (`*?<>|"`) that
+// can't appear in a real path. Trailing punctuation is peeled off so a path at
+// the end of a sentence (`.../main.ts.`) doesn't swallow the period.
+const FILE_PATH_RE =
+  /(?<![\w/\\])(?:([A-Za-z]:[\\/](?:[^\s*?<>|"]*[\\/])+[^\s*?<>|"\\/]+(?:\.[A-Za-z0-9]+))|(\\\\[^\s*?<>|"\\]+(?:\\[^\s*?<>|"\\]+)+)|(\/(?:[^\s*?<>|"]+\/)+[^\s*?<>|"/]+(?:\.[A-Za-z0-9]+))|(\.{1,2}\/(?:[^\s*?<>|"]+\/)*[^\s*?<>|"/]+(?:\.[A-Za-z0-9]+)))(?::(\d+)(?::(\d+))?)?/g
+
+// Trailing punctuation/quote characters that can legitimately end a sentence
+// containing a path but are never part of the path itself. Peeled off after
+// matching so the href stays clean.
+const FILE_PATH_TRAILING_PUNCT = /[.,;:!?)\]"'`*]+$/
+
+// Encode a filesystem path into a `file://` URL. Mirrors Node's
+// `pathToFileURL` for the cases we handle: backslashes → forward slashes,
+// percent-encode spaces and other reserved chars, and keep the leading
+// drive-letter form intact. We don't import url/pathToFileURL here because this
+// module runs in both the renderer bundle and vitest (jsdom) — a hand-rolled
+// encodeURI keeps the behaviour identical across both.
+function pathToFileUrl(filePath: string): string {
+  const forwardSlashed = filePath.replace(/\\/g, '/')
+  // drive-letter paths (C:/...) become file:///C:/... ; UNC (//server/...)
+  // becomes file://server/... ; POSIX (/home/...) becomes file:///home/...
+  const prefix = /^[A-Za-z]:\//.test(forwardSlashed) ? 'file:///' : 'file://'
+  return prefix + encodeURI(forwardSlashed)
+}
+
+function linkifyFilePaths(text: string): string {
+  return text.replace(FILE_PATH_RE, match => {
+    let path = match
+    let trailing = ''
+
+    // Separate the path from its optional :line:col tail so the href targets
+    // the file only, while the label keeps the suffix the model wrote.
+    const lineMatch = path.match(/^(.*?)(?::(\d+)(?::(\d+))?)?$/)
+    if (lineMatch) {
+      path = lineMatch[1]
+    }
+
+    // Peel trailing punctuation that isn't part of the path.
+    const punctMatch = path.match(FILE_PATH_TRAILING_PUNCT)
+    if (punctMatch) {
+      trailing = punctMatch[0]
+      path = path.slice(0, -punctMatch[0].length)
+    }
+
+    if (!path) return match
+
+    const href = pathToFileUrl(path)
+    // Use the original matched text (path + optional :line:col) as the label
+    // so the user sees exactly what the model wrote. Escape any `]` in the
+    // label so it doesn't break the `[label](href)` markdown structure.
+    const label = (path + (match.slice(path.length) || '')).replace(/([[\]])/g, '\\$1')
+
+    return `[${label}](${href})${trailing}`
+  })
+}
 const LOCAL_PREVIEW_URL_RE = /(^|\s)https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::\d+)?\/?[^\s<>"'`]*/gi
 const LOCAL_PREVIEW_ONLY_RE = /^https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::\d+)?\/?$/i
 const URL_ONLY_LINE_RE = /^\s*https?:\/\/\S+\s*$/i
@@ -144,8 +228,10 @@ function normalizeVisibleProse(text: string): string {
     .map(part =>
       part.startsWith('`')
         ? part
-        : autoLinkRawUrls(
-            part.replace(/`{3,}/g, '').replace(LOCAL_PREVIEW_URL_RE, '$1').replace(CITATION_MARKER_RE, '')
+        : linkifyFilePaths(
+            autoLinkRawUrls(
+              part.replace(/`{3,}/g, '').replace(LOCAL_PREVIEW_URL_RE, '$1').replace(CITATION_MARKER_RE, '')
+            )
           )
     )
     .join('')


### PR DESCRIPTION
## Summary

Render filesystem paths the model references in assistant output prose as **hyperlinks**, and show a **right-click context menu** with four actions:

1. **Copy path** — copies the absolute path to the clipboard
2. **Open path in Explorer / Finder** — reveals the file in the OS file manager
3. **Open in default app** — opens with the OS default handler
4. **Open with…** — spawns the system app picker

This leapfrogs Claude Code, which only linkifies file paths in tool-call headers (via OSC 8) and has **no context menu** — file paths in the model's response body are plain colored text there (anthropics/claude-code#13008, #69008).

## Related Issue

Closes #50697

## How it works

**Detection** (`apps/desktop/src/lib/markdown-preprocess.ts`): a `linkifyFilePaths()` step runs on prose alongside the existing `autoLinkRawUrls`, wrapping four unambiguous path shapes (Windows drive, UNC, Unix absolute, dot-relative) in `[path](file://path)` markdown. Bare relative paths are intentionally not matched (high false-positive risk); code fences and inline code spans are already carved out. Optional `:line:col` suffixes are kept in the label but not the href (`file://` can't carry line info — same approach as Claude Code and the community `termlink` tool).

**Rendering** (`apps/desktop/src/components/assistant-ui/markdown-text.tsx`): `MarkdownLink` gains a `file://` branch that renders a `FilePathLink` with the existing radix `ContextMenu` primitive (already used for session rows / profile switcher). Left-click opens the default app; right-click shows the four-item menu.

**IPC** (`apps/desktop/electron/main.cjs` + `preload.cjs` + `global.d.ts`): two new channels. Copy path reuses `hermes:writeClipboard`; open-in-default-app reuses `hermes:openExternal` with a `file://` URL (`shell.openPath`). New: `hermes:shell:revealInFolder` (`shell.showItemInFolder`) and `hermes:shell:openWith` (Windows `rundll32 OpenAs_RunDLL`; macOS/Linux best-effort via `openPath`). All paths validated via the existing `resolveRequestedPathForIpc` (blocklist + `file://` resolution).

## Scope (phase 1)

- Linkify paths in **prose only**; leave backtick-wrapped code-span paths for a possible phase 2 (via the `inlineCode` component override).
- Line:col is parsed and displayed but not used to navigate (no `vscode://`-style editor URIs yet — natural follow-up).
- Cross-platform: Windows, macOS, Linux. The "Open with…" action is richest on Windows; on macOS/Linux it's best-effort.

## How to Test

- [x] `npx vitest run --environment jsdom src/components/assistant-ui/markdown-text.test.ts` — 26 tests pass (16 existing + 10 new)
- [x] `node --test electron/hardening.test.cjs` — 12 tests pass (path validation the IPC handlers reuse)
- [x] `node --check electron/main.cjs` / `preload.cjs` — syntax OK
- [x] `tsc -p apps/desktop --noEmit` — no new errors (one pre-existing missing-dep error on `@icons-pack/react-simple-icons`)
- [ ] Manual: run `npm run dev`, ask the agent something that references a file, right-click the link, exercise all 4 actions

## Checklist

- [x] Conventional Commits (`feat(desktop):`)
- [x] One feature per branch
- [x] Searched existing PRs for duplicates
- [x] Reuses existing infrastructure (radix ContextMenu, `resolveRequestedPathForIpc`, `writeClipboard`, `openExternal`) — no speculative hooks