### PR TITLE
Fix update paths for project .venv installs

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6101,8 +6101,9 @@ def _update_via_zip(args):
                     extracted = candidate
                     break
 
-        # Copy updated files over existing installation, preserving venv/node_modules/.git
-        preserve = {"venv", "node_modules", ".git", ".env"}
+        # Copy updated files over existing installation, preserving the
+        # project's Python env(s), node modules, and local metadata.
+        preserve = {".venv", "venv", "node_modules", ".git", ".env"}
         update_count = 0
         for item in os.listdir(extracted):
             if item in preserve:
@@ -6148,7 +6149,7 @@ def _update_via_zip(args):
     if not uv_bin:
         uv_bin = _ensure_uv_for_termux(pip_cmd)
     if uv_bin:
-        uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+        uv_env = {**os.environ, "VIRTUAL_ENV": str(_project_venv_dir(create_default=True))}
         if _is_termux_env(uv_env):
             uv_env.pop("PYTHONPATH", None)
             uv_env.pop("PYTHONHOME", None)
@@ -6877,7 +6878,10 @@ def _recover_from_interrupted_install() -> None:
 
             uv_bin = ensure_uv()
             if uv_bin:
-                uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+                uv_env = {
+                    **os.environ,
+                    "VIRTUAL_ENV": str(_project_venv_dir(create_default=True)),
+                }
                 if _is_termux_env(uv_env):
                     uv_env.pop("PYTHONPATH", None)
                     uv_env.pop("PYTHONHOME", None)
@@ -6960,9 +6964,36 @@ def _is_windows() -> bool:
     return sys.platform == "win32"
 
 
+def _project_venv_dir(*, create_default: bool = False) -> Path | None:
+    """Resolve the project-local virtualenv directory used by update flows.
+
+    Preference order:
+    1. the active interpreter's env when it is PROJECT_ROOT/{.venv,venv}
+    2. an existing ``.venv`` directory
+    3. an existing ``venv`` directory
+    4. legacy ``PROJECT_ROOT/venv`` when callers need a fallback path
+    """
+    if sys.prefix != sys.base_prefix:
+        try:
+            active_venv = Path(sys.prefix).resolve()
+        except (OSError, ValueError):
+            active_venv = Path(sys.prefix)
+        if active_venv.parent == PROJECT_ROOT and active_venv.name in {".venv", "venv"}:
+            return active_venv
+
+    for name in (".venv", "venv"):
+        candidate = PROJECT_ROOT / name
+        if candidate.is_dir():
+            return candidate
+
+    if create_default:
+        return PROJECT_ROOT / "venv"
+    return None
+
+
 def _venv_scripts_dir() -> Path | None:
     """Return the venv Scripts directory if we're running inside the project venv."""
-    venv_dir = PROJECT_ROOT / "venv"
+    venv_dir = _project_venv_dir()
     if not venv_dir.is_dir():
         return None
     scripts = venv_dir / ("Scripts" if _is_windows() else "bin")
@@ -9121,7 +9152,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
         install_group = "all"
 
         if uv_bin:
-            uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+            uv_env = {
+                **os.environ,
+                "VIRTUAL_ENV": str(_project_venv_dir(create_default=True)),
+            }
             if _is_termux_env(uv_env):
                 uv_env.pop("PYTHONPATH", None)
                 uv_env.pop("PYTHONHOME", None)

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -1,6 +1,8 @@
 """Tests for cmd_update — branch fallback when remote branch doesn't exist."""
 
 import subprocess
+import zipfile
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -107,6 +109,57 @@ class TestCmdUpdatePip:
 
         assert mock_run.call_count == 1
         assert "env" not in mock_run.call_args.kwargs
+
+
+class TestZipFallbackProjectVenv:
+    """ZIP update path should preserve and reuse the active project env."""
+
+    def test_update_via_zip_exports_dotvenv_when_project_uses_dotvenv(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli import main as hm
+
+        project = tmp_path / "repo"
+        project.mkdir()
+        active_venv = project / ".venv"
+        (active_venv / "bin").mkdir(parents=True)
+
+        payload_root = tmp_path / "payload" / "hermes-agent-main"
+        payload_root.mkdir(parents=True)
+        (payload_root / "README.md").write_text("updated\n")
+
+        zip_src = tmp_path / "payload.zip"
+        with zipfile.ZipFile(zip_src, "w") as zf:
+            zf.write(payload_root / "README.md", arcname="hermes-agent-main/README.md")
+
+        captured = {}
+
+        def fake_urlretrieve(_url, dst):
+            Path(dst).write_bytes(zip_src.read_bytes())
+            return dst, None
+
+        def fake_install(_cmd, *, env=None, **_kwargs):
+            captured["env"] = env
+
+        monkeypatch.setattr(hm, "PROJECT_ROOT", project)
+        monkeypatch.setattr(hm, "_clear_bytecode_cache", lambda *_a, **_k: 0)
+        monkeypatch.setattr(hm, "_update_node_dependencies", lambda: None)
+        monkeypatch.setattr(hm, "_build_web_ui", lambda *_a, **_k: None)
+        monkeypatch.setattr(hm, "_install_python_dependencies_with_optional_fallback", fake_install)
+        monkeypatch.setattr(hm, "_print_curator_first_run_notice", lambda: None)
+        monkeypatch.setattr(hm, "_print_curator_recent_run_notice", lambda: None)
+        monkeypatch.setattr(hm, "_kill_stale_dashboard_processes", lambda: None)
+        monkeypatch.setattr(hm.sys, "prefix", str(active_venv))
+        monkeypatch.setattr(hm.sys, "base_prefix", "/usr")
+
+        with patch("urllib.request.urlretrieve", side_effect=fake_urlretrieve), \
+             patch("hermes_cli.managed_uv.update_managed_uv", return_value=None), \
+             patch("hermes_cli.managed_uv.ensure_uv", return_value="/usr/bin/uv"), \
+             patch("tools.skills_sync.sync_skills", return_value={"copied": [], "updated": [], "user_modified": [], "cleaned": []}), \
+             patch("hermes_cli.model_catalog.seed_cache_from_checkout", return_value=False):
+            hm._update_via_zip(SimpleNamespace(branch=None))
+
+        assert captured["env"]["VIRTUAL_ENV"] == str(active_venv)
 
 
 class TestCmdUpdateBranchFallback:

--- a/tests/hermes_cli/test_update_concurrent_quarantine.py
+++ b/tests/hermes_cli/test_update_concurrent_quarantine.py
@@ -119,6 +119,20 @@ def test_detect_concurrent_is_noop_off_windows(_winp, tmp_path):
     assert cli_main._detect_concurrent_hermes_instances(tmp_path) == []
 
 
+def test_venv_scripts_dir_prefers_active_project_dotvenv(monkeypatch, tmp_path):
+    """Update helpers should follow the active project venv, including .venv."""
+    legacy_scripts = tmp_path / "venv" / "bin"
+    legacy_scripts.mkdir(parents=True)
+    active_scripts = tmp_path / ".venv" / "bin"
+    active_scripts.mkdir(parents=True)
+
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(cli_main.sys, "prefix", str(tmp_path / ".venv"))
+    monkeypatch.setattr(cli_main.sys, "base_prefix", "/usr")
+
+    assert cli_main._venv_scripts_dir() == active_scripts
+
+
 # ---------------------------------------------------------------------------
 # Parent-chain exclusion (issue #30768 follow-up — the setuptools .exe
 # launcher on Windows is a separate native process that spawns python.exe;


### PR DESCRIPTION
Closes #49655

## Summary
- follow the active project venv before falling back to legacy hardcoded `venv` paths
- preserve `.venv` on the ZIP fallback path and reuse it for update-time `VIRTUAL_ENV` exports
- add regressions for `.venv` shim lookup and ZIP-fallback dependency reinstalls

## Testing
- pytest tests/hermes_cli/test_update_concurrent_quarantine.py -q -k 'venv_scripts_dir or detect_concurrent'\n- pytest tests/hermes_cli/test_cmd_update.py -q -k 'update_via_zip_exports_dotvenv or update_pip_exports_virtualenv_from_sys_prefix'\n- ruff check hermes_cli/main.py tests/hermes_cli/test_update_concurrent_quarantine.py tests/hermes_cli/test_cmd_update.py\n- git diff --check