### PR TITLE
fix: preserve comments when using hermes config set

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -6785,21 +6785,7 @@ def set_config_value(key: str, value: str):
         return
     
     # Otherwise it goes to config.yaml
-    # Read the raw user config (not merged with defaults) to avoid
-    # dumping all default values back to the file
     config_path = get_config_path()
-    user_config = {}
-    if config_path.exists():
-        try:
-            with open(config_path, encoding="utf-8") as f:
-                user_config = yaml.safe_load(f) or {}
-        except Exception:
-            user_config = {}
-    
-    # Handle nested keys (e.g., "tts.provider") including numeric list
-    # indices (e.g., "custom_providers.0.api_key").  Delegates to
-    # _set_nested which preserves list-typed nodes; before #17876 the
-    # inline navigation here silently overwrote lists with dicts.
 
     # Convert value to appropriate type
     if value.lower() in {'true', 'yes', 'on'}:
@@ -6811,20 +6797,20 @@ def set_config_value(key: str, value: str):
     elif value.replace('.', '', 1).isdigit():
         value = float(value)
 
-    _set_nested(user_config, key, value)
     # Normalize the api_base → base_url alias at set-time too (issue #8919),
     # so a fresh `hermes config set model.api_base ...` lands on the canonical
     # key the runtime resolver actually reads, instead of being silently
     # ignored. Mirrors the load-time migration in _normalize_root_model_keys.
     _alias_norm = key.strip().lower()
     if _alias_norm in ("model.api_base", "api_base"):
-        user_config = _normalize_root_model_keys(user_config)
         key = "model.base_url"
         print("  (note: 'api_base' is an alias — saved as model.base_url)")
-    # Write only user config back (not the full merged defaults)
+
+    # Preserve comments, ordering, and list-index updates when mutating
+    # user-edited config.yaml in place.
     ensure_hermes_home()
-    from utils import atomic_yaml_write
-    atomic_yaml_write(config_path, user_config, sort_keys=False)
+    from utils import atomic_roundtrip_yaml_update
+    atomic_roundtrip_yaml_update(config_path, key, value)
     
     # Keep .env in sync for keys that terminal_tool reads directly from env vars.
     # config.yaml is authoritative, but terminal_tool only reads TERMINAL_ENV etc.

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -124,6 +124,28 @@ class TestConfigYamlRouting:
             or "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE=True" in env_content
         )
 
+    def test_preserves_comments_when_updating_config(self, _isolated_hermes_home):
+        (_isolated_hermes_home / "config.yaml").write_text(
+            "# global comment\n"
+            "memory:\n"
+            "  # preserve this note\n"
+            "  memory_char_limit: 2200\n"
+            "\n"
+            "# fallback scaffold\n"
+            "# fallback_model:\n"
+            "#   provider: openrouter\n",
+            encoding="utf-8",
+        )
+
+        set_config_value("memory.memory_char_limit", "2300")
+
+        text = _read_config(_isolated_hermes_home)
+        assert "memory_char_limit: 2300" in text
+        assert "# global comment" in text
+        assert "# preserve this note" in text
+        assert "# fallback scaffold" in text
+        assert "# fallback_model:" in text
+
 
 # ---------------------------------------------------------------------------
 # Empty / falsy values — regression tests for #4277
@@ -247,6 +269,27 @@ class TestListNavigation:
         assert isinstance(allowlist, list)
         assert allowlist[0] == {"name": "alice", "role": "admin"}
         assert allowlist[1] == {"name": "bob", "role": "admin"}
+
+    def test_indexed_set_preserves_comments(self, _isolated_hermes_home):
+        """List-index updates must keep unrelated user comments intact."""
+        self._write_config(_isolated_hermes_home, (
+            "# providers\n"
+            "custom_providers:\n"
+            "  # primary\n"
+            "  - name: provider-a\n"
+            "    api_key: old-a\n"
+            "  # backup\n"
+            "  - name: provider-b\n"
+            "    api_key: old-b\n"
+        ))
+
+        set_config_value("custom_providers.0.api_key", "new-a")
+
+        text = _read_config(_isolated_hermes_home)
+        assert "api_key: new-a" in text
+        assert "# providers" in text
+        assert "# primary" in text
+        assert "# backup" in text
 
 
 # ---------------------------------------------------------------------------

--- a/utils.py
+++ b/utils.py
@@ -238,11 +238,12 @@ def atomic_roundtrip_yaml_update(
 
     This is intentionally narrower than :func:`atomic_yaml_write`: it is for
     user-edited config files where comments, ordering, quoting, and Unicode
-    should survive a single setting mutation.  Writes still use the same temp
-    file + fsync + atomic replace pattern.
+    should survive a single setting mutation. Supports dotted dict paths plus
+    numeric list indices (for example ``custom_providers.0.api_key``). Writes
+    still use the same temp file + fsync + atomic replace pattern.
     """
     from ruamel.yaml import YAML
-    from ruamel.yaml.comments import CommentedMap
+    from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -262,15 +263,51 @@ def atomic_roundtrip_yaml_update(
     if not isinstance(config, CommentedMap):
         config = CommentedMap(config)
 
+    def _new_container(next_token: str | None):
+        if next_token is not None and next_token.isdigit():
+            return CommentedSeq()
+        return CommentedMap()
+
+    def _ensure_list_index(seq: CommentedSeq, index: int, next_token: str | None):
+        while len(seq) <= index:
+            seq.append(_new_container(next_token))
+        return seq[index]
+
     current = config
     keys = key_path.split(".")
-    for key in keys[:-1]:
+    for idx, key in enumerate(keys[:-1]):
+        next_token = keys[idx + 1]
+        if isinstance(current, CommentedSeq):
+            if not key.isdigit():
+                raise ValueError(
+                    f"Cannot descend into YAML list with non-numeric path segment {key!r}"
+                )
+            list_index = int(key)
+            next_value = _ensure_list_index(current, list_index, next_token)
+            if not isinstance(next_value, (CommentedMap, CommentedSeq)):
+                next_value = _new_container(next_token)
+                current[list_index] = next_value
+            current = next_value
+            continue
+
         next_value = current.get(key)
-        if not isinstance(next_value, CommentedMap):
-            next_value = CommentedMap()
+        if not isinstance(next_value, (CommentedMap, CommentedSeq)):
+            next_value = _new_container(next_token)
             current[key] = next_value
         current = next_value
-    current[keys[-1]] = value
+
+    leaf = keys[-1]
+    if isinstance(current, CommentedSeq):
+        if not leaf.isdigit():
+            raise ValueError(
+                f"Cannot assign into YAML list with non-numeric path segment {leaf!r}"
+            )
+        leaf_index = int(leaf)
+        while len(current) <= leaf_index:
+            current.append(None)
+        current[leaf_index] = value
+    else:
+        current[leaf] = value
 
     original_mode = _preserve_file_mode(path)
     fd, tmp_path = tempfile.mkstemp(


### PR DESCRIPTION
## What does this PR do?

Fixes `hermes config set` so updating `config.yaml` preserves existing comments, ordering, and commented-out scaffold blocks instead of rewriting the file with a plain YAML dump.

## Related Issue

Fixes #50698

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- route `set_config_value()` through `atomic_roundtrip_yaml_update()` so `config.yaml` edits preserve YAML comments and formatting
- extend the roundtrip updater to handle dotted paths with numeric list indices such as `custom_providers.0.api_key`
- add regression tests covering comment preservation for nested key updates and list-index updates

## How to Test

1. Create a `config.yaml` that contains inline comments and commented-out template blocks.
2. Run `hermes config set memory.memory_char_limit 2300` or update `custom_providers.0.api_key`.
3. Confirm the target value changes while comments and scaffold blocks remain in the file.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x via `uv run`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run --extra dev scripts/run_tests.sh tests/hermes_cli/test_set_config_value.py tests/cli/test_cli_save_config_value.py -- -q`
- `uv run python -m py_compile hermes_cli/config.py utils.py tests/hermes_cli/test_set_config_value.py tests/cli/test_cli_save_config_value.py`
- `git diff --check`
