### PR TITLE
feat(gateway): opt-in resume-on-message after idle expiry (#43008 proposal #2)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -288,7 +288,14 @@ class SessionResetPolicy:
     idle_minutes: int = 1440  # Minutes of inactivity before reset (24 hours)
     notify: bool = True  # Send a notification to the user when auto-reset occurs
     notify_exclude_platforms: tuple = ("api_server", "webhook")  # Platforms that don't get reset notifications
-    
+    # Opt-in (#43008 proposal #2): when an *idle* expiry would fire, if the next
+    # message lands within resume_grace_minutes of the idle deadline, resume the
+    # existing session instead of starting a blank one. Off = current hard-reset
+    # behavior. Daily resets are never affected (intentional boundaries).
+    resume_on_message: bool = False
+    resume_grace_minutes: int = 60  # Grace window (minutes) after idle expiry during
+    # which the next message resumes; only consulted when resume_on_message is True.
+
     def to_dict(self) -> Dict[str, Any]:
         return {
             "mode": self.mode,
@@ -296,8 +303,10 @@ class SessionResetPolicy:
             "idle_minutes": self.idle_minutes,
             "notify": self.notify,
             "notify_exclude_platforms": list(self.notify_exclude_platforms),
+            "resume_on_message": self.resume_on_message,
+            "resume_grace_minutes": self.resume_grace_minutes,
         }
-    
+
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "SessionResetPolicy":
         # Handle both missing keys and explicit null values (YAML null → None)
@@ -306,12 +315,16 @@ class SessionResetPolicy:
         idle_minutes = data.get("idle_minutes")
         notify = data.get("notify")
         exclude = data.get("notify_exclude_platforms")
+        resume_on_message = data.get("resume_on_message")
+        resume_grace_minutes = data.get("resume_grace_minutes")
         return cls(
             mode=mode if mode is not None else "both",
             at_hour=at_hour if at_hour is not None else 4,
             idle_minutes=idle_minutes if idle_minutes is not None else 1440,
             notify=_coerce_bool(notify, True),
             notify_exclude_platforms=tuple(exclude) if exclude is not None else ("api_server", "webhook"),
+            resume_on_message=_coerce_bool(resume_on_message, False),
+            resume_grace_minutes=resume_grace_minutes if resume_grace_minutes is not None else 60,
         )
 
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -934,21 +934,33 @@ class SessionStore:
         if policy.mode in {"idle", "both"}:
             idle_deadline = entry.updated_at + timedelta(minutes=policy.idle_minutes)
             if now > idle_deadline:
-                return "idle"
-        
+                # Opt-in resume-on-message (#43008 proposal #2): if the first
+                # message lands within the grace window after the idle deadline,
+                # resume the existing session instead of resetting it blank.
+                # Falls through to the daily check below (still enforced for
+                # mode="both"); a real daily boundary still wins.
+                grace = getattr(policy, "resume_grace_minutes", 0)
+                resume_ok = (
+                    getattr(policy, "resume_on_message", False)
+                    and grace > 0
+                    and now <= idle_deadline + timedelta(minutes=grace)
+                )
+                if not resume_ok:
+                    return "idle"
+
         if policy.mode in {"daily", "both"}:
             today_reset = now.replace(
-                hour=policy.at_hour, 
-                minute=0, 
-                second=0, 
+                hour=policy.at_hour,
+                minute=0,
+                second=0,
                 microsecond=0
             )
             if now.hour < policy.at_hour:
                 today_reset -= timedelta(days=1)
-            
+
             if entry.updated_at < today_reset:
                 return "daily"
-        
+
         return None
     
     def has_any_sessions(self) -> bool:
@@ -1020,6 +1032,12 @@ class SessionStore:
                     reset_reason = self._should_reset(entry, source)
                 if not reset_reason:
                     entry.updated_at = now
+                    # A session resumed within the post-idle grace window
+                    # (#43008) was already memory-finalized by the expiry
+                    # watcher; clear the flag so it can be finalized again on
+                    # the next genuine expiry. No-op for normal active sessions.
+                    if getattr(entry, "expiry_finalized", False):
+                        entry.expiry_finalized = False
                     self._save()
                     return entry
                 else:

--- a/tests/gateway/test_resume_on_message.py
+++ b/tests/gateway/test_resume_on_message.py
@@ -1,0 +1,104 @@
+"""Tests for opt-in resume-on-message after idle expiry (issue #43008, proposal #2).
+
+When `session_reset.resume_on_message` is enabled, the first message that lands
+within `resume_grace_minutes` of the idle deadline resumes the existing session
+(same session_id, no auto-reset) instead of starting a blank one. Beyond the
+grace window — or when the option is off — the session hard-resets as before.
+Daily resets are never affected.
+"""
+
+import datetime
+
+import gateway.session as session_mod
+from gateway.config import GatewayConfig, Platform, SessionResetPolicy
+from gateway.session import SessionSource, SessionStore
+
+
+def _store(tmp_path, **policy_kw):
+    cfg = GatewayConfig()
+    cfg.default_reset_policy = SessionResetPolicy(mode="idle", idle_minutes=1, **policy_kw)
+    return SessionStore(sessions_dir=tmp_path, config=cfg)
+
+
+def _source():
+    return SessionSource(platform=Platform.TELEGRAM, chat_id="c1", user_id="u1")
+
+
+def _age_minutes(store, source, minutes):
+    key = store._generate_session_key(source)
+    store._entries[key].updated_at = session_mod._now() - datetime.timedelta(minutes=minutes)
+
+
+# --- Policy round-trips the new fields -------------------------------------
+
+def test_policy_roundtrips_resume_fields():
+    p = SessionResetPolicy.from_dict(
+        {"mode": "idle", "resume_on_message": True, "resume_grace_minutes": 30}
+    )
+    assert p.resume_on_message is True
+    assert p.resume_grace_minutes == 30
+    assert p.to_dict()["resume_on_message"] is True
+    assert p.to_dict()["resume_grace_minutes"] == 30
+
+
+def test_policy_defaults_are_off():
+    p = SessionResetPolicy.from_dict({"mode": "idle"})
+    assert p.resume_on_message is False
+    assert p.resume_grace_minutes == 60
+
+
+# --- Behavior --------------------------------------------------------------
+
+def test_resumes_within_grace_window(tmp_path):
+    store = _store(tmp_path, resume_on_message=True, resume_grace_minutes=60)
+    src = _source()
+    first = store.get_or_create_session(src)
+    sid = first.session_id
+    _age_minutes(store, src, 5)  # past idle(1m), within grace(60m)
+    second = store.get_or_create_session(src)
+    assert second.session_id == sid          # resumed, same session
+    assert second.was_auto_reset is False
+
+
+def test_hard_resets_beyond_grace_window(tmp_path):
+    store = _store(tmp_path, resume_on_message=True, resume_grace_minutes=60)
+    src = _source()
+    first = store.get_or_create_session(src)
+    sid = first.session_id
+    _age_minutes(store, src, 120)  # past idle + grace
+    second = store.get_or_create_session(src)
+    assert second.session_id != sid          # blank reset
+    assert second.was_auto_reset is True
+
+
+def test_off_by_default_still_hard_resets(tmp_path):
+    store = _store(tmp_path)  # resume_on_message defaults False
+    src = _source()
+    first = store.get_or_create_session(src)
+    sid = first.session_id
+    _age_minutes(store, src, 5)  # past idle, within would-be grace
+    second = store.get_or_create_session(src)
+    assert second.session_id != sid          # current behavior preserved
+    assert second.was_auto_reset is True
+
+
+def test_zero_grace_disables_resume(tmp_path):
+    store = _store(tmp_path, resume_on_message=True, resume_grace_minutes=0)
+    src = _source()
+    first = store.get_or_create_session(src)
+    sid = first.session_id
+    _age_minutes(store, src, 5)
+    second = store.get_or_create_session(src)
+    assert second.session_id != sid          # grace=0 → never resumes
+    assert second.was_auto_reset is True
+
+
+def test_resume_clears_expiry_finalized(tmp_path):
+    store = _store(tmp_path, resume_on_message=True, resume_grace_minutes=60)
+    src = _source()
+    store.get_or_create_session(src)
+    key = store._generate_session_key(src)
+    store._entries[key].expiry_finalized = True  # watcher had finalized it
+    _age_minutes(store, src, 5)
+    resumed = store.get_or_create_session(src)
+    assert resumed.expiry_finalized is False     # re-armed for next expiry


### PR DESCRIPTION
Implements **proposal #2** of #43008 (opt-in resume-on-message).

## Context
Proposals **#1** (reset-awareness marker) and **#3** (user-facing reset notice) from #43008 already landed in `main` (`gateway/run.py` injects the `[System note: … previous session expired …]` marker and sends the `◐ Session automatically reset` notice). This PR adds the one remaining piece — **#2**, the opt-in resume.

## What it does
When `session_reset.resume_on_message` is enabled, the first message that arrives within `session_reset.resume_grace_minutes` of the idle deadline **resumes the existing session** (same `session_id`, transcript intact) instead of starting a blank one. So a user who comes back shortly after an idle expiry keeps their thread.

- **Default off** — `resume_on_message: false`, so behavior is unchanged unless opted in.
- **Idle only** — daily resets are never affected (they're intentional boundaries); the daily check still runs for `mode: "both"`.
- **Grace-bounded** — beyond `resume_grace_minutes` (default 60), or with `resume_grace_minutes: 0`, it hard-resets exactly as today.
- On resume, `expiry_finalized` is cleared so the background expiry watcher re-arms for the next genuine expiry.

## Implementation
- `SessionResetPolicy` gains `resume_on_message: bool = False` + `resume_grace_minutes: int = 60` (with `to_dict`/`from_dict` round-trip).
- `SessionStore._should_reset` resumes within the grace window instead of returning `"idle"`.
- `SessionStore.get_or_create_session` clears `expiry_finalized` on the resumed/active path.

## Tests
New `tests/gateway/test_resume_on_message.py` (7 cases): policy round-trip + defaults-off, resume within grace, hard-reset beyond grace, off-by-default, `grace=0` disables, and `expiry_finalized` re-arm. Existing `test_config.py` + `test_fresh_reset_skill_injection.py` (78) remain green.
