### PR TITLE
feat: add configurable gateway context budget guard

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2148,6 +2148,35 @@ def _load_gateway_config() -> dict:
     return raw if isinstance(raw, dict) else {}
 
 
+def _resolve_hygiene_threshold_pct(
+    compression_config: dict | None,
+    *,
+    default: float = 0.85,
+    minimum: float = 0.05,
+    maximum: float = 0.95,
+) -> float:
+    """Resolve the gateway pre-agent hygiene compression threshold.
+
+    ``compression.hygiene_threshold`` is intentionally separate from
+    ``compression.threshold``: the latter controls the in-agent compressor loop,
+    while this value is a higher pre-agent safety guard for long-lived gateway
+    sessions that may otherwise rehydrate an over-budget transcript before the
+    agent can start. Invalid/out-of-range values fail open to the default.
+    """
+    if not isinstance(compression_config, dict):
+        return default
+    raw = compression_config.get("hygiene_threshold")
+    if raw is None:
+        return default
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return default
+    if minimum <= value <= maximum:
+        return value
+    return default
+
+
 def _load_gateway_runtime_config() -> dict:
     """Load gateway config for runtime reads, expanding supported ``${VAR}`` refs.
 
@@ -9105,14 +9134,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         _hyg_provider = _model_cfg.get("provider") or None
                         _hyg_base_url = _model_cfg.get("base_url") or None
 
-                    # Read compression settings — only use enabled flag.
-                    # The threshold is intentionally separate from the agent's
-                    # compression.threshold (hygiene runs higher).
+                    # Read compression settings. ``compression.threshold`` is
+                    # intentionally NOT reused here: it controls the agent's
+                    # in-loop compressor (default 0.50), while gateway hygiene
+                    # is a pre-agent safety guard that should normally fire much
+                    # later (default 0.85) to prevent over-budget rehydration.
                     _comp_cfg = _hyg_data.get("compression", {})
                     if isinstance(_comp_cfg, dict):
                         _hyg_compression_enabled = str(
                             _comp_cfg.get("enabled", True)
                         ).lower() in {"true", "1", "yes"}
+                        _hyg_threshold_pct = _resolve_hygiene_threshold_pct(_comp_cfg)
                         _raw_hard_limit = _comp_cfg.get("hygiene_hard_message_limit")
                         if _raw_hard_limit is not None:
                             try:

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -3,9 +3,10 @@
 Verifies that the gateway detects pathologically large transcripts and
 triggers auto-compression before running the agent.  (#628)
 
-The hygiene system uses the SAME compression config as the agent:
-  compression.threshold × model context length
-so CLI and messaging platforms behave identically.
+The hygiene system uses its own pre-agent guard:
+  compression.hygiene_threshold × model context length
+(default 0.85), intentionally separate from the agent's in-loop
+``compression.threshold`` (default 0.50).
 """
 
 import importlib
@@ -192,6 +193,29 @@ class TestSessionHygieneThresholds:
         # Even with enormous content, < 4 messages should be skipped
         # (the gateway code checks `len(history) >= 4` before evaluating)
         assert len(history) < 4
+
+
+class TestSessionHygieneThresholdConfig:
+    """Config parsing for the gateway's pre-agent context budget guard."""
+
+    def test_default_hygiene_threshold_is_85_percent(self):
+        from gateway.run import _resolve_hygiene_threshold_pct
+
+        assert _resolve_hygiene_threshold_pct({}) == 0.85
+        assert _resolve_hygiene_threshold_pct({"threshold": 0.50}) == 0.85
+        assert _resolve_hygiene_threshold_pct(None) == 0.85
+
+    def test_configured_hygiene_threshold_is_used(self):
+        from gateway.run import _resolve_hygiene_threshold_pct
+
+        assert _resolve_hygiene_threshold_pct({"hygiene_threshold": 0.70}) == 0.70
+        assert _resolve_hygiene_threshold_pct({"hygiene_threshold": "0.60"}) == 0.60
+
+    @pytest.mark.parametrize("bad_value", ["nope", None, 0, 0.01, 1.0, 1.2, -0.5])
+    def test_invalid_hygiene_threshold_falls_back_to_default(self, bad_value):
+        from gateway.run import _resolve_hygiene_threshold_pct
+
+        assert _resolve_hygiene_threshold_pct({"hygiene_threshold": bad_value}) == 0.85
 
 
 class TestSessionHygieneWarnThreshold:


### PR DESCRIPTION
## Summary
- Add configurable gateway session hygiene/context budget threshold.
- Introduce `compression.hygiene_threshold` with validation and safe fallback.
- Keep this separate from the existing `compression.threshold` used for normal compression behavior.

## Motivation
We observed long-running gateway conversations where the session hygiene/context-budget guard needed an operator-tunable threshold rather than relying on a hardcoded value. This keeps the behavioral setting in `config.yaml` instead of `.env`, while preserving the existing default behavior when the setting is absent or invalid.

Opening as a draft to validate whether this configuration surface is acceptable before relying on it operationally.

## Test Plan
- [x] `python -m py_compile gateway/run.py`
- [x] `python -m pytest tests/gateway/test_session_hygiene.py -q`
- [x] `python -m pytest tests/gateway/test_session_hygiene.py::TestSessionHygieneThresholdConfig -q`

## Notes
- This does not add a core model tool.
- This does not introduce a user-facing environment variable for behavioral config.
- Invalid or out-of-range values fall back to the existing safe default.
