### PR TITLE
fix(raft): use is_truthy_value for enabled config coercion

### DIFF
--- a/plugins/platforms/raft/adapter.py
+++ b/plugins/platforms/raft/adapter.py
@@ -47,6 +47,7 @@ from gateway.platforms.base import (
     merge_pending_message_event,
 )
 from gateway.session import build_session_key
+from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
 
@@ -740,7 +741,7 @@ class RaftAdapter(BasePlatformAdapter):
 
 def _is_connected(config: PlatformConfig) -> bool:
     extra = config.extra or {}
-    return bool(extra.get("enabled") or extra.get("bridge_token"))
+    return is_truthy_value(extra.get("enabled")) or bool(extra.get("bridge_token"))
 
 
 def _env_enablement() -> Optional[dict]:


### PR DESCRIPTION
## Summary

`bool("false")` returns `True` in Python. Replace `bool(extra.get("enabled"))` with `is_truthy_value()` in the new raft platform adapter's `_is_connected()` check.

Companion to PRs #50604, #50646, #50650.

## Test plan

- [ ] CI passes