### PR TITLE
fix(web): gate dashboard API docs under /api/ prefix (close unauth Swagger/OpenAPI exposure)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -232,7 +232,21 @@ def _get_chat_argv_lock(app: "FastAPI") -> asyncio.Lock:
         return app.state.chat_argv_lock
 
 
-app = FastAPI(title="Hermes Agent", version=__version__, lifespan=_lifespan)
+app = FastAPI(
+    title="Hermes Agent",
+    version=__version__,
+    lifespan=_lifespan,
+    # Relocate FastAPI's auto-generated API docs under the auth-gated ``/api/``
+    # prefix. At the default root paths (``/docs``, ``/redoc``,
+    # ``/openapi.json``) they bypass ``auth_middleware`` — which only gates
+    # ``/api/*`` — exposing the interactive API explorer and full schema
+    # unauthenticated on any 0.0.0.0 / reverse-proxied bind. Moving all three
+    # (Swagger UI fetches the schema from ``openapi_url``) puts them behind the
+    # same gate as every other ``/api/*`` route.
+    docs_url="/api/docs",
+    redoc_url="/api/redoc",
+    openapi_url="/api/openapi.json",
+)
 
 # ---------------------------------------------------------------------------
 # Session token for protecting sensitive endpoints (reveal).

--- a/tests/hermes_cli/test_dashboard_docs_prefix.py
+++ b/tests/hermes_cli/test_dashboard_docs_prefix.py
@@ -1,0 +1,72 @@
+"""FastAPI's auto-generated API docs must live under the auth-gated ``/api/``
+prefix.
+
+By default FastAPI serves Swagger UI at ``/docs``, ReDoc at ``/redoc`` and the
+raw OpenAPI schema at ``/openapi.json`` — all at the root, where the dashboard's
+``auth_middleware`` (which only gates ``/api/*``) does not reach them. On a bind
+to ``0.0.0.0`` or behind a reverse proxy that exposes the full interactive API
+explorer and schema to anyone who can reach the host.
+
+``web_server.app`` is constructed with ``docs_url``/``redoc_url``/``openapi_url``
+relocated under ``/api/`` so all three sit behind the same gate as every other
+``/api/*`` route. These tests assert the root paths are gone (404) and that the
+relocated paths are now subject to the dashboard auth gate.
+"""
+import pytest
+
+
+@pytest.fixture
+def client():
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:  # pragma: no cover - exercised only when extras missing
+        pytest.skip("fastapi/starlette not installed")
+
+    from hermes_cli.web_server import app
+
+    return TestClient(app)
+
+
+@pytest.mark.parametrize("path", ["/docs", "/redoc", "/openapi.json"])
+def test_docs_not_served_at_root(client, path):
+    """The interactive docs and schema are no longer exposed at the root.
+
+    The root paths fall outside the ``/api/*`` gate, so leaving them mapped
+    would serve the API explorer and schema unauthenticated. They must 404.
+    """
+    resp = client.get(path)
+    assert resp.status_code == 404
+
+
+@pytest.mark.parametrize(
+    "path", ["/api/docs", "/api/redoc", "/api/openapi.json"]
+)
+def test_docs_gated_under_api_prefix_without_token(client, path):
+    """Under the ``/api/`` prefix the docs are gated by ``auth_middleware``.
+
+    Without a valid session token the gate returns 401 — the security win:
+    the docs and schema are no longer reachable unauthenticated. They are
+    deliberately absent from the public-paths allowlist.
+    """
+    from hermes_cli.dashboard_auth.public_paths import PUBLIC_API_PATHS
+
+    assert path not in PUBLIC_API_PATHS
+
+    resp = client.get(path, headers={"X-Hermes-Session-Token": "wrong-token"})
+    assert resp.status_code == 401
+
+
+@pytest.mark.parametrize(
+    "path", ["/api/docs", "/api/redoc", "/api/openapi.json"]
+)
+def test_docs_reachable_under_api_prefix_with_token(client, path):
+    """With a valid session token the relocated docs/schema are served.
+
+    Confirms the relocation didn't break the docs for an authenticated caller
+    (e.g. the dashboard SPA / desktop shell): the route still exists, it's just
+    behind the gate now.
+    """
+    from hermes_cli.web_server import _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+    resp = client.get(path, headers={_SESSION_HEADER_NAME: _SESSION_TOKEN})
+    assert resp.status_code == 200


### PR DESCRIPTION
## Problem

The dashboard web server (`hermes_cli/web_server.py`) builds a module-level `FastAPI(...)` app with no doc-URL overrides, so FastAPI serves its interactive docs at the **root**: Swagger UI `/docs`, ReDoc `/redoc`, and the raw OpenAPI schema `/openapi.json`.

The dashboard's `auth_middleware` (and the OAuth `gated_auth_middleware`) only gate paths under **`/api/*`**. So these three doc endpoints sit *outside* the gate — served **unauthenticated**. On any dashboard bound to `0.0.0.0` or behind a reverse proxy, that exposes the full interactive API explorer and complete schema to anyone who can reach the host.

## Fix

Relocate all three doc endpoints under the auth-gated `/api/` prefix:

```python
app = FastAPI(
    title="Hermes Agent", version=__version__, lifespan=_lifespan,
    docs_url="/api/docs", redoc_url="/api/redoc", openapi_url="/api/openapi.json",
)
```

All three matter: the Swagger UI fetches the schema from `openapi_url`, so moving only `docs_url`/`redoc_url` would still leave `/openapi.json` (the full API surface) exposed at root. Under `/api/`, all three are gated by the same middleware as every other `/api/*` route, under both loopback/session and OAuth modes (they're deliberately not in `dashboard_auth/public_paths.py`).

No frontend impact: the SPA's client-side `/docs` route (a React "Documentation" page served by the catch-all SPA mount) is unrelated to FastAPI's backend doc endpoints; nothing in the frontend references `/openapi.json` or the FastAPI `/docs`/`/redoc` endpoints.

## Tests

New `tests/hermes_cli/test_dashboard_docs_prefix.py` (9 cases): root `/docs` `/redoc` `/openapi.json` → 404; the relocated `/api/*` paths → 401 without a token (and absent from `PUBLIC_API_PATHS`) and reachable with a valid session token. Existing `tests/hermes_cli/test_web_server.py` stays green (313 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
