### PR TITLE
feat: inline keyboard support for Telegram

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6116,10 +6116,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         send_metadata: Dict[str, Any] = {}
         if effective_thread_id:
             send_metadata["thread_id"] = effective_thread_id
+
+        # Parse inline keyboard from agent response
+        # Agent can include buttons using format:
+        #   ---\n[buttons: [{"text": "Label", "callback_data": "data"}, ...]]
+        # The block is stripped from the message text and passed via metadata.
+        _parsed_text = response_text
+        try:
+            import re as _re, json as _json
+            _btn_match = _re.search(r'\n---\n\[buttons:\s*(\[.*?\])\]\s*$', response_text, _re.DOTALL)
+            if _btn_match:
+                _btn_data = _json.loads(_btn_match.group(1))
+                if isinstance(_btn_data, list) and _btn_data:
+                    send_metadata["inline_keyboard"] = _btn_data
+                    _parsed_text = response_text[:_btn_match.start()]
+        except Exception:
+            pass  # Malformed button block — send without buttons
+
         try:
             result = await adapter.send(
                 chat_id=str(home.chat_id),
-                content=response_text,
+                content=_parsed_text,
                 metadata=send_metadata or None,
             )
         except Exception as exc:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1300,6 +1300,11 @@ class TelegramAdapter(BasePlatformAdapter):
         # which must not be sent as a stray field on the raw endpoint.
         payload.update({k: v for k, v in thread_kwargs.items() if v is not None})
         payload.update(self._notification_kwargs(metadata))
+        # Inline keyboard support: extract from metadata
+        if metadata and metadata.get("inline_keyboard"):
+            payload["reply_markup"] = {
+                "inline_keyboard": metadata["inline_keyboard"]
+            }
         if getattr(self, "_disable_link_previews", False):
             payload["link_preview_options"] = {"is_disabled": True}
         if reply_to_id is not None:
@@ -2614,11 +2619,14 @@ class TelegramAdapter(BasePlatformAdapter):
                     try:
                         # Try Markdown first, fall back to plain text if it fails
                         try:
+                            _inline_kb = metadata.get("inline_keyboard") if metadata else None
+                            _reply_markup = {"inline_keyboard": _inline_kb} if _inline_kb else None
                             msg = await self._bot.send_message(
                                 chat_id=int(chat_id),
                                 text=chunk,
                                 parse_mode=ParseMode.MARKDOWN_V2,
                                 reply_to_message_id=reply_to_id,
+                                reply_markup=_reply_markup,
                                 **thread_kwargs,
                                 **self._link_preview_kwargs(),
                                 **self._notification_kwargs(metadata),
@@ -2628,11 +2636,14 @@ class TelegramAdapter(BasePlatformAdapter):
                             if "parse" in str(md_error).lower() or "markdown" in str(md_error).lower():
                                 logger.warning("[%s] MarkdownV2 parse failed, falling back to plain text: %s", self.name, md_error)
                                 plain_chunk = _strip_mdv2(chunk)
+                                _inline_kb = metadata.get("inline_keyboard") if metadata else None
+                                _reply_markup = {"inline_keyboard": _inline_kb} if _inline_kb else None
                                 msg = await self._bot.send_message(
                                     chat_id=int(chat_id),
                                     text=plain_chunk,
                                     parse_mode=None,
                                     reply_to_message_id=reply_to_id,
+                                    reply_markup=_reply_markup,
                                     **thread_kwargs,
                                     **self._link_preview_kwargs(),
                                     **self._notification_kwargs(metadata),
@@ -4376,6 +4387,34 @@ class TelegramAdapter(BasePlatformAdapter):
                         clarify_id,
                     )
             return
+
+        # --- Fallback: unhandled callback -> forward to agent as message ---
+        logger.info("[telegram] Unhandled callback, forwarding to agent: %s", data)
+        try:
+            await query.answer()
+        except Exception:
+            pass
+        try:
+            from gateway.platforms.base import MessageEvent, MessageType, SessionSource
+            event = MessageEvent(
+                text=f"🔘 Button clicked: {data}",
+                message_type=MessageType.TEXT,
+                message_id=str(getattr(query.message, "message_id", "")) if query.message else None,
+                source=SessionSource(
+                    platform=self.platform,
+                    chat_id=str(query.message.chat_id) if query.message else str(query_chat_id),
+                    user_id=str(getattr(query.from_user, "id", "")),
+                    user_name=getattr(query.from_user, "first_name", "User"),
+                ),
+                raw_message={
+                    "callback_data": data,
+                    "callback_type": data.split(":")[0] if ":" in data else data,
+                    "original_message_id": str(getattr(query.message, "message_id", "")) if query.message else None,
+                },
+            )
+            await self.handle_message(event)
+        except Exception as cb_err:
+            logger.error("[telegram] Failed to forward callback: %s", cb_err)
 
         # --- Update prompt callbacks ---
         if not data.startswith("update_prompt:"):

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -171,6 +171,10 @@ SEND_MESSAGE_SCHEMA = {
             "message_id": {
                 "type": "string",
                 "description": "For action='react'/'unreact': id of the message to react to. Omit to target the most recent message received in that chat (usually the one being replied to)."
+            },
+            "inline_keyboard": {
+                "type": "string",
+                "description": "Inline keyboard markup as a JSON array of button rows for Telegram. Each row is an array of button objects with 'text' and either 'callback_data' or 'url'. Example: '[[{\"text\":\"Yes\",\"callback_data\":\"yes\"},{\"text\":\"No\",\"callback_data\":\"no\"}]]'. Only supported for Telegram."
             }
         },
         "required": []
@@ -299,6 +303,7 @@ def _handle_send(args):
     """Send a message to a platform target."""
     target = args.get("target", "")
     message = args.get("message", "")
+    inline_keyboard = args.get("inline_keyboard", "")
     if not target or not message:
         return tool_error("Both 'target' and 'message' are required when action='send'")
 
@@ -441,6 +446,7 @@ def _handle_send(args):
                 thread_id=thread_id,
                 media_files=media_files,
                 force_document=force_document_attachments,
+                inline_keyboard=inline_keyboard,
             )
         )
         if used_home_channel and isinstance(result, dict) and result.get("success"):
@@ -713,7 +719,7 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False):
+async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False, inline_keyboard=""):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -791,6 +797,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 thread_id=thread_id,
                 disable_link_previews=disable_link_previews,
                 force_document=force_document,
+                inline_keyboard=inline_keyboard,
             )
             if isinstance(result, dict) and result.get("error"):
                 return result
@@ -980,7 +987,7 @@ def _is_telegram_thread_not_found(error: Exception) -> bool:
     return "thread not found" in str(error).lower()
 
 
-async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False):
+async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False, inline_keyboard=""):
     """Send via Telegram Bot API (one-shot, no polling needed).
 
     Applies markdown→MarkdownV2 formatting (same as the gateway adapter)
@@ -1065,6 +1072,25 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         text_kwargs = dict(thread_kwargs)
         if disable_link_previews:
             text_kwargs["disable_web_page_preview"] = True
+
+        reply_markup = None
+        if inline_keyboard:
+            try:
+                from telegram import InlineKeyboardMarkup, InlineKeyboardButton
+                import json as _json
+                parsed = _json.loads(inline_keyboard)
+                if isinstance(parsed, list):
+                    button_rows = []
+                    for row in parsed:
+                        buttons = []
+                        for btn in row:
+                            buttons.append(InlineKeyboardButton(**btn))
+                        button_rows.append(buttons)
+                    reply_markup = InlineKeyboardMarkup(button_rows)
+            except Exception as e:
+                logger.warning("Failed to parse inline_keyboard: %s", e)
+        if reply_markup is not None:
+            text_kwargs["reply_markup"] = reply_markup
 
         last_msg = None
         warnings = []


### PR DESCRIPTION
## Summary

Add native inline keyboard support to the Hermes Telegram integration.

## Changes

- **Gateway runner** parses `---\n[buttons: [...]]` blocks from agent responses, extracting `inline_keyboard` into send metadata
- **TelegramAdapter.send()** passes `inline_keyboard` from metadata as `reply_markup` to both Bot API 10.1 rich and legacy Markdown sends
- **Fallback callback handler** forwards unhandled button clicks to the agent as MessageEvent with callback metadata
- **send_message CLI tool** accepts `inline_keyboard` parameter for programmatic keyboard sends

## Usage

Agent response format for buttons:
```
Your message text here.

---
[buttons: [{"text": "Yes", "callback_data": "yes"}, {"text": "No", "callback_data": "no"}]]
```

## Testing

- [x] Syntax validation passed for all modified files
- [x] Rich send path includes reply_markup
- [x] Legacy Markdown path includes reply_markup
- [x] Plain text fallback path includes reply_markup
- [x] Callback handler forwards unhandled clicks to agent
- [x] send_message tool accepts inline_keyboard parameter