### PR TITLE
fix(auxiliary): add deepseek to _PROVIDERS_WITHOUT_VISION to prevent 401 on vision requests (#50712)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -373,9 +373,15 @@ _PROVIDER_VISION_MODELS: Dict[str, str] = {
 # api.kimi.com/coding (Anthropic Messages wire) which Kimi's own docs
 # describe as having no image_in capability. Vision lives on the separate
 # Kimi Platform (api.moonshot.ai, OpenAI-wire, pay-as-you-go).  See #17076.
+#
+# deepseek: DeepSeek's chat API (api.deepseek.com/v1) returns HTTP 401 on
+# vision requests for all current models (deepseek-chat, deepseek-reasoner).
+# The provider has no vision-capable endpoint, so auto-detection must skip it
+# and fall through to the aggregator chain.  See #50712.
 _PROVIDERS_WITHOUT_VISION: frozenset = frozenset({
     "kimi-coding",
     "kimi-coding-cn",
+    "deepseek",
 })
 
 # OpenRouter app attribution headers (base — always sent).

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3080,6 +3080,45 @@ class TestVisionAutoSkipsKimiCoding:
         assert provider == "openrouter"
         assert client is fake_or_client
 
+    def test_deepseek_skipped_falls_through_to_openrouter(self, monkeypatch):
+        """deepseek as main + vision auto → OpenRouter (not deepseek).
+
+        DeepSeek's chat API returns HTTP 401 on vision requests (#50712).
+        """
+        fake_or_client = MagicMock(name="openrouter_client")
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._read_main_provider", lambda: "deepseek",
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._read_main_model", lambda: "deepseek-chat",
+        )
+        rpc_mock = MagicMock(side_effect=AssertionError(
+            "resolve_provider_client should NOT be called for deepseek "
+            "on the vision auto path"))
+        monkeypatch.setattr(
+            "agent.auxiliary_client.resolve_provider_client", rpc_mock,
+        )
+
+        def fake_strict(provider, model=None):
+            if provider == "openrouter":
+                return fake_or_client, "google/gemini-3-flash-preview"
+            if provider == "nous":
+                return None, None
+            raise AssertionError(
+                f"strict vision backend should not be called for {provider!r} "
+                "when main provider is deepseek"
+            )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._resolve_strict_vision_backend",
+            fake_strict,
+        )
+
+        provider, client, model = resolve_vision_provider_client()
+        assert provider == "openrouter"
+        assert client is fake_or_client
+        assert model == "google/gemini-3-flash-preview"
+
     def test_explicit_override_to_kimi_coding_still_honored(self, monkeypatch):
         """When a user *explicitly* requests kimi-coding for vision (e.g.
         they know what they're doing, or are running a future build that
@@ -3108,6 +3147,7 @@ class TestVisionAutoSkipsKimiCoding:
         assert _PROVIDERS_WITHOUT_VISION == frozenset({
             "kimi-coding",
             "kimi-coding-cn",
+            "deepseek",
         })
 
 


### PR DESCRIPTION
## What does this PR do?

Add `deepseek` to `_PROVIDERS_WITHOUT_VISION` in `auxiliary_client.py` so that the vision auto-detection chain skips DeepSeek and falls through to the aggregator (OpenRouter/Nous) instead of returning a client that produces HTTP 401 on every vision request.

## Related Issue

Fixes #50712

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py`: Added `"deepseek"` to `_PROVIDERS_WITHOUT_VISION` frozenset with a comment referencing #50712. DeepSeek's chat API returns 401 on vision requests for all current models (deepseek-chat, deepseek-reasoner).
- `tests/agent/test_auxiliary_client.py`: Updated `test_skip_set_covers_exactly_known_entries` guard test to include `"deepseek"`. Added `test_deepseek_skipped_falls_through_to_openrouter` that verifies the skip behavior end-to-end via the auto vision path.

## How to Test

1. Configure Hermes with `provider: deepseek` as the main provider.
2. Run `hermes vision_analyze <image>` (or use vision in a chat with an image attached).
3. **Before fix**: vision request returns HTTP 401 from DeepSeek API; no fallback to aggregator.
4. **After fix**: vision request falls through to OpenRouter/Nous aggregator and succeeds.
5. Run targeted tests: `pytest tests/agent/test_auxiliary_client.py::TestVisionAutoSkipsKimiCoding -v` — all 5 tests pass (including the new deepseek test).
6. Run vision routing tests: `pytest tests/agent/test_vision_routing_31179.py -v` — all 12 tests pass.

**Platform tested**: macOS 26.5.1, Python 3.14.0

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (inline comment serves as documentation)
- [x] I've updated `cli-config.yaml.example` — N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (provider-level constant, no platform-specific code)
- [x] I've updated tool descriptions/schemas — N/A

## Code Intelligence

**Files changed**: `agent/auxiliary_client.py` (+6), `tests/agent/test_auxiliary_client.py` (+40)
**Root cause**: `_PROVIDERS_WITHOUT_VISION` frozenset was missing `"deepseek"`, causing the vision auto-detect chain to try DeepSeek's API (which returns 401) instead of falling through to the aggregator chain.
**Pattern**: Matches existing kimi-coding skip pattern (#17076). The `_main_model_supports_vision` fallback does not catch this because `models_dev` has no DeepSeek vision capability data (returns `None` → defaults to `True`).
