### PR TITLE
fix(agent): count tokens, not just message rows, as compression progress (#23767, #39550)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3170,7 +3170,7 @@ def run_conversation(
                     if len(messages) < original_len or (new_tokens > 0 and new_tokens < original_tokens * 0.95) or (new_ctx and new_ctx < old_ctx):
                         if len(messages) < original_len:
                             agent._buffer_status(f"🗜️ Compressed {original_len} → {len(messages)} messages, retrying...")
-                        else:
+                        elif new_tokens > 0 and new_tokens < original_tokens * 0.95:
                             agent._buffer_status(f"🗜️ Compressed ~{original_tokens:,} → ~{new_tokens:,} tokens, retrying...")
                         time.sleep(2)  # Brief pause between compression retries
                         _retry.restart_with_compressed_messages = True

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2983,6 +2983,7 @@ def run_conversation(
                     agent._buffer_status(f"⚠️  Request payload too large (413) — compression attempt {compression_attempts}/{max_compression_attempts}...")
 
                     original_len = len(messages)
+                    original_tokens = estimate_messages_tokens_rough(messages)
                     messages, active_system_prompt = agent._compress_context(
                         messages, system_message, approx_tokens=approx_tokens,
                         task_id=effective_task_id,
@@ -2992,8 +2993,18 @@ def run_conversation(
                     # messages to the new session, not skipping them.
                     conversation_history = None
 
-                    if len(messages) < original_len:
-                        agent._buffer_status(f"🗜️ Compressed {original_len} → {len(messages)} messages, retrying...")
+                    # Re-estimate tokens after compression.  Same-message-count
+                    # compression (tool-result pruning, in-place summarization)
+                    # can materially reduce request size without reducing the
+                    # message array.  (#39550)
+                    new_tokens = estimate_messages_tokens_rough(messages)
+                    approx_tokens = new_tokens  # update for downstream logging
+
+                    if len(messages) < original_len or (new_tokens > 0 and new_tokens < original_tokens * 0.95):
+                        if len(messages) < original_len:
+                            agent._buffer_status(f"🗜️ Compressed {original_len} → {len(messages)} messages, retrying...")
+                        else:
+                            agent._buffer_status(f"🗜️ Compressed ~{original_tokens:,} → ~{new_tokens:,} tokens, retrying...")
                         time.sleep(2)  # Brief pause between compression retries
                         _retry.restart_with_compressed_messages = True
                         break
@@ -3139,6 +3150,7 @@ def run_conversation(
                     agent._buffer_status(f"🗜️ Context too large (~{approx_tokens:,} tokens) — compressing ({compression_attempts}/{max_compression_attempts})...")
 
                     original_len = len(messages)
+                    original_tokens = estimate_messages_tokens_rough(messages)
                     messages, active_system_prompt = agent._compress_context(
                         messages, system_message, approx_tokens=approx_tokens,
                         task_id=effective_task_id,
@@ -3148,9 +3160,18 @@ def run_conversation(
                     # messages to the new session, not skipping them.
                     conversation_history = None
 
-                    if len(messages) < original_len or new_ctx and new_ctx < old_ctx:
+                    # Re-estimate tokens after compression.  Same-message-count
+                    # compression (tool-result pruning, in-place summarization)
+                    # can materially reduce request size without reducing the
+                    # message array.  (#39550)
+                    new_tokens = estimate_messages_tokens_rough(messages)
+                    approx_tokens = new_tokens  # update for downstream logging
+
+                    if len(messages) < original_len or (new_tokens > 0 and new_tokens < original_tokens * 0.95) or (new_ctx and new_ctx < old_ctx):
                         if len(messages) < original_len:
                             agent._buffer_status(f"🗜️ Compressed {original_len} → {len(messages)} messages, retrying...")
+                        else:
+                            agent._buffer_status(f"🗜️ Compressed ~{original_tokens:,} → ~{new_tokens:,} tokens, retrying...")
                         time.sleep(2)  # Brief pause between compression retries
                         _retry.restart_with_compressed_messages = True
                         break
@@ -3159,13 +3180,13 @@ def run_conversation(
                         agent._flush_status_buffer()
                         agent._vprint(f"{agent.log_prefix}❌ Context length exceeded and cannot compress further.", force=True)
                         agent._vprint(f"{agent.log_prefix}   💡 The conversation has accumulated too much content. Try /new to start fresh, or /compress to manually trigger compression.", force=True)
-                        logger.error(f"{agent.log_prefix}Context length exceeded: {approx_tokens:,} tokens. Cannot compress further.")
+                        logger.error(f"{agent.log_prefix}Context length exceeded: {new_tokens:,} tokens. Cannot compress further.")
                         agent._persist_session(messages, conversation_history)
                         return {
                             "messages": messages,
                             "completed": False,
                             "api_calls": api_call_count,
-                            "error": f"Context length exceeded ({approx_tokens:,} tokens). Cannot compress further.",
+                            "error": f"Context length exceeded ({new_tokens:,} tokens). Cannot compress further.",
                             "partial": True,
                             "failed": True,
                             "compression_exhausted": True,

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -440,6 +440,48 @@ class TestHTTP413Compression:
         assert result.get("partial") is True
         assert "413" in result["error"]
 
+    def test_413_retries_on_token_only_compression(self, agent):
+        """Same message COUNT but fewer TOKENS must count as progress and retry.
+
+        Regression for #39550/#23767: tool-result pruning / in-place
+        summarization can shrink request size without dropping the message
+        count. The old gate (len(messages) < original_len) treated that as
+        'cannot compress further' and aborted; the fix re-estimates tokens and
+        retries when they drop materially.
+        """
+        err_413 = _make_413_error()
+        ok_resp = _mock_response(content="OK after token-only compaction", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [err_413, ok_resp]
+
+        # 3 large messages in, 3 much smaller messages out (same count, far
+        # fewer tokens) — exactly the token-only-progress case.
+        prefill = [
+            {"role": "user", "content": "x" * 4000},
+            {"role": "assistant", "content": "y" * 4000},
+            {"role": "user", "content": "z" * 4000},
+        ]
+
+        with (
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            # Same message count (3) but ~10x smaller content → token drop.
+            mock_compress.return_value = (
+                [
+                    {"role": "user", "content": "x" * 300},
+                    {"role": "assistant", "content": "y" * 300},
+                    {"role": "user", "content": "z" * 300},
+                ],
+                "compressed prompt",
+            )
+            result = agent.run_conversation("hello", conversation_history=prefill)
+
+        mock_compress.assert_called_once()
+        assert result["completed"] is True
+        assert result["final_response"] == "OK after token-only compaction"
+
 
 class TestPreflightCompression:
     """Preflight compression should compress history before the first API call."""


### PR DESCRIPTION
## Summary

After a context-overflow (413 / "context length exceeded"), Hermes only treated compression as progress if the **message count** dropped — so a pass that reduced request size via tool-result pruning or in-place summarization (same message count, fewer tokens) was judged "cannot compress further" and the turn aborted. The retry path now re-estimates tokens and retries when they drop materially. (Mode D of #23767; also fixes #39550.)

Salvage of #49579 by @davidgut1982, cherry-picked onto current `main` (authorship preserved, both commits) with a maintainer regression test added on top.

## Root cause

In `agent/conversation_loop.py`, both the 413 handler and the context-overflow handler gated retry on `len(messages) < original_len`. The reporter's regressive case (`14→14 messages, 64,186→71,173 tokens`) and the ineffective-but-shrinking case (`65,247→59,610`) both keep the message count, so the loop saw "no progress" and stopped.

## Changes

- `agent/conversation_loop.py` (contributor): capture `original_tokens` before compaction, re-estimate `new_tokens` after, and retry when `new_tokens < original_tokens * 0.95` even if the message count is unchanged. Status/error messages updated to report token deltas. Applied to both overflow handlers.
- `tests/run_agent/test_413_compression.py` (maintainer): `test_413_retries_on_token_only_compression` — same message count, ~10× smaller content → must retry. Verified it **fails on `main` without the fix** and passes with it.

## Sibling-site audit

The third overflow site (Anthropic long-context-tier step-down, ~L2783) gates on context-ceiling reduction, not compression effectiveness, so the token-progress gap does not apply there — correctly left unchanged.

## Validation

| | Result |
|---|---|
| `tests/run_agent/test_413_compression.py` (+1) | 25 passed |
| + `test_1630_context_overflow_loop.py` | 41 passed |
| ruff (diff vs main) | clean |
| Negative check | new test fails on main without the fix ✓ |

Part of #23767 (does not close it — sibling modes tracked separately).

Closes #49579.

Co-authored-by: David Gutowsky <david.gutowsky@gmail.com>

## Infographic

_Image generation is unavailable in this environment (FAL_KEY unset, no managed-provider credits); to be attached once available._
