### PR TITLE
fix(slack): allow configured mention user aliases

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2274,7 +2274,15 @@ class SlackAdapter(BasePlatformAdapter):
                 return
             elif allow_bots == "mentions":
                 text_check = event.get("text", "")
-                if self._bot_user_id and f"<@{self._bot_user_id}>" not in text_check:
+                team_id_check = event.get("team") or event.get("team_id") or ""
+                bot_uid_check = self._team_bot_user_ids.get(
+                    team_id_check, self._bot_user_id
+                )
+                mention_user_ids = self._slack_mention_user_ids(bot_uid_check)
+                if not any(
+                    f"<@{mention_user_id}>" in text_check
+                    for mention_user_id in mention_user_ids
+                ):
                     return
             # "all" falls through to process the message
             # Always ignore our own messages to prevent echo loops
@@ -2483,8 +2491,12 @@ class SlackAdapter(BasePlatformAdapter):
         #   3. The message is in a thread where the bot was previously @mentioned, OR
         #   4. There's an existing session for this thread (survives restarts)
         bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
+        mention_user_ids = self._slack_mention_user_ids(bot_uid)
         routing_text = original_text or ""
-        is_mentioned = bot_uid and f"<@{bot_uid}>" in routing_text
+        is_mentioned = any(
+            f"<@{mention_user_id}>" in routing_text
+            for mention_user_id in mention_user_ids
+        )
         event_thread_ts = event.get("thread_ts")
         is_thread_reply = bool(event_thread_ts and event_thread_ts != ts)
 
@@ -2524,8 +2536,10 @@ class SlackAdapter(BasePlatformAdapter):
                     return
 
         if is_mentioned:
-            # Strip the bot mention from the text
-            text = text.replace(f"<@{bot_uid}>", "").strip()
+            # Strip accepted bot/alias mentions from the text.
+            for mention_user_id in mention_user_ids:
+                text = text.replace(f"<@{mention_user_id}>", "")
+            text = text.strip()
             # Register this thread so all future messages auto-trigger the bot.
             # Skipped in strict mode: strict_mention=true bots must be
             # re-mentioned every turn, so remembering the thread would
@@ -3777,6 +3791,23 @@ class SlackAdapter(BasePlatformAdapter):
             "on",
         }
 
+    def _slack_mention_user_ids(self, bot_uid: Optional[str]) -> set:
+        """Return Slack user IDs that count as a direct bot mention."""
+        raw = self.config.extra.get("mention_user_ids")
+        if raw is None:
+            raw = os.getenv("SLACK_MENTION_USER_IDS", "")
+        if isinstance(raw, list):
+            alias_ids = {str(part).strip() for part in raw if str(part).strip()}
+        else:
+            alias_ids = {
+                part.strip()
+                for part in str(raw or "").split(",")
+                if part.strip()
+            }
+        if bot_uid:
+            alias_ids.add(bot_uid)
+        return alias_ids
+
     def _slack_free_response_channels(self) -> set:
         """Return channel IDs where no @mention is required."""
         raw = self.config.extra.get("free_response_channels")
@@ -4036,6 +4067,11 @@ def _apply_yaml_config(yaml_cfg: dict, slack_cfg: dict) -> dict | None:
         os.environ["SLACK_REQUIRE_MENTION"] = str(slack_cfg["require_mention"]).lower()
     if "strict_mention" in slack_cfg and not os.getenv("SLACK_STRICT_MENTION"):
         os.environ["SLACK_STRICT_MENTION"] = str(slack_cfg["strict_mention"]).lower()
+    mention_ids = slack_cfg.get("mention_user_ids")
+    if mention_ids is not None and not os.getenv("SLACK_MENTION_USER_IDS"):
+        if isinstance(mention_ids, list):
+            mention_ids = ",".join(str(v) for v in mention_ids)
+        os.environ["SLACK_MENTION_USER_IDS"] = str(mention_ids)
     if "allow_bots" in slack_cfg and not os.getenv("SLACK_ALLOW_BOTS"):
         os.environ["SLACK_ALLOW_BOTS"] = str(slack_cfg["allow_bots"]).lower()
     frc = slack_cfg.get("free_response_channels")
@@ -4085,7 +4121,7 @@ def register(ctx) -> None:
         # and the static _PLATFORMS["slack"] dict in hermes_cli/gateway.py.
         setup_fn=interactive_setup,
         # YAML→env config bridge — owns the translation of config.yaml slack:
-        # keys (require_mention, strict_mention, allow_bots,
+        # keys (require_mention, strict_mention, mention_user_ids, allow_bots,
         # free_response_channels, reactions, allowed_channels) into SLACK_*
         # env vars that the adapter reads via os.getenv(). Replaces the
         # hardcoded block in gateway/config.py. Hook contract: #24849.

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -118,6 +118,14 @@ def adapter():
 @pytest.fixture(autouse=True)
 def _redirect_cache(tmp_path, monkeypatch):
     """Point document cache to tmp_path so tests don't touch ~/.hermes."""
+    for var in (
+        "SLACK_ALLOWED_CHANNELS",
+        "SLACK_FREE_RESPONSE_CHANNELS",
+        "SLACK_MENTION_USER_IDS",
+        "SLACK_REQUIRE_MENTION",
+        "SLACK_STRICT_MENTION",
+    ):
+        monkeypatch.delenv(var, raising=False)
     monkeypatch.setattr(
         "gateway.platforms.base.DOCUMENT_CACHE_DIR", tmp_path / "doc_cache"
     )
@@ -1789,17 +1797,58 @@ class TestMessageRouting:
     @pytest.mark.asyncio
     async def test_channel_mention_strips_bot_id(self, adapter):
         """When mentioned in a channel, the bot mention should be stripped."""
+        adapter._team_bot_user_ids["T123"] = "U_BOT"
         event = {
             "text": "<@U_BOT> what's the weather?",
             "user": "U_USER",
             "channel": "C123",
             "channel_type": "channel",
+            "team": "T123",
             "ts": "1234567890.000001",
         }
         await adapter._handle_slack_message(event)
         msg_event = adapter.handle_message.call_args[0][0]
         assert msg_event.text == "what's the weather?"
         assert "<@U_BOT>" not in msg_event.text
+
+    @pytest.mark.asyncio
+    async def test_channel_alias_mention_strips_all_accepted_ids(self, adapter):
+        """Configured mention aliases should route and be stripped in real dispatch."""
+        adapter.config.extra["mention_user_ids"] = ["U_ALIAS"]
+        adapter._team_bot_user_ids["T123"] = "U_BOT"
+        event = {
+            "text": "<@U_ALIAS> <@U_BOT> status",
+            "user": "U_USER",
+            "channel": "C123",
+            "channel_type": "channel",
+            "team": "T123",
+            "ts": "1234567890.000001",
+        }
+        await adapter._handle_slack_message(event)
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "status"
+        assert "<@U_ALIAS>" not in msg_event.text
+        assert "<@U_BOT>" not in msg_event.text
+
+    @pytest.mark.asyncio
+    async def test_bot_message_allow_mentions_accepts_alias_mention(self, adapter):
+        """allow_bots=mentions should honor configured mention aliases too."""
+        adapter.config.extra["allow_bots"] = "mentions"
+        adapter.config.extra["mention_user_ids"] = ["U_ALIAS"]
+        adapter._team_bot_user_ids["T123"] = "U_BOT"
+        event = {
+            "text": "<@U_ALIAS> status",
+            "bot_id": "B_OTHER",
+            "user": "U_OTHER_BOT",
+            "channel": "C123",
+            "channel_type": "channel",
+            "team": "T123",
+            "ts": "1234567890.000002",
+        }
+        await adapter._handle_slack_message(event)
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "status"
+        assert "<@U_ALIAS>" not in msg_event.text
 
     @pytest.mark.asyncio
     async def test_bot_messages_ignored(self, adapter):

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -7,6 +7,8 @@ Follows the same pattern as test_whatsapp_group_gating.py.
 import sys
 from unittest.mock import MagicMock
 
+import pytest
+
 from gateway.config import Platform, PlatformConfig
 
 
@@ -46,6 +48,19 @@ _slack_mod.SLACK_AVAILABLE = True
 from plugins.platforms.slack.adapter import SlackAdapter  # noqa: E402
 
 
+@pytest.fixture(autouse=True)
+def _clear_slack_gating_env(monkeypatch):
+    """Keep mention-gating unit tests isolated from the real Hermes profile env."""
+    for var in (
+        "SLACK_ALLOWED_CHANNELS",
+        "SLACK_FREE_RESPONSE_CHANNELS",
+        "SLACK_MENTION_USER_IDS",
+        "SLACK_REQUIRE_MENTION",
+        "SLACK_STRICT_MENTION",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -55,7 +70,13 @@ CHANNEL_ID = "C0AQWDLHY9M"
 OTHER_CHANNEL_ID = "C9999999999"
 
 
-def _make_adapter(require_mention=None, strict_mention=None, free_response_channels=None, allowed_channels=None):
+def _make_adapter(
+    require_mention=None,
+    strict_mention=None,
+    free_response_channels=None,
+    allowed_channels=None,
+    mention_user_ids=None,
+):
     extra = {}
     if require_mention is not None:
         extra["require_mention"] = require_mention
@@ -65,6 +86,8 @@ def _make_adapter(require_mention=None, strict_mention=None, free_response_chann
         extra["free_response_channels"] = free_response_channels
     if allowed_channels is not None:
         extra["allowed_channels"] = allowed_channels
+    if mention_user_ids is not None:
+        extra["mention_user_ids"] = mention_user_ids
 
     adapter = object.__new__(SlackAdapter)
     adapter.platform = Platform.SLACK
@@ -181,6 +204,49 @@ def test_strict_mention_env_var_fallback(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Tests: _slack_mention_user_ids
+# ---------------------------------------------------------------------------
+
+def test_mention_user_ids_defaults_to_bot_uid(monkeypatch):
+    monkeypatch.delenv("SLACK_MENTION_USER_IDS", raising=False)
+    adapter = _make_adapter()
+    assert adapter._slack_mention_user_ids(BOT_USER_ID) == {BOT_USER_ID}
+
+
+def test_mention_user_ids_includes_config_aliases():
+    adapter = _make_adapter(mention_user_ids=["U_ALIAS", " U_OTHER ", ""])
+    assert adapter._slack_mention_user_ids(BOT_USER_ID) == {
+        BOT_USER_ID,
+        "U_ALIAS",
+        "U_OTHER",
+    }
+
+
+def test_mention_user_ids_env_csv_fallback(monkeypatch):
+    monkeypatch.setenv("SLACK_MENTION_USER_IDS", "U_ALIAS, U_OTHER")
+    adapter = _make_adapter()
+    assert adapter._slack_mention_user_ids(BOT_USER_ID) == {
+        BOT_USER_ID,
+        "U_ALIAS",
+        "U_OTHER",
+    }
+
+
+def test_alias_mention_passes_require_mention_gate():
+    adapter = _make_adapter(require_mention=True, mention_user_ids=["U_ALIAS"])
+    assert _would_process(adapter, text="<@U_ALIAS> status") is True
+
+
+def test_alias_mention_stripping_removes_all_accepted_mentions():
+    adapter = _make_adapter(mention_user_ids=["U_ALIAS"])
+    mention_user_ids = adapter._slack_mention_user_ids(BOT_USER_ID)
+    text = "<@U_ALIAS> <@U_BOT_123> status"
+    for mention_user_id in mention_user_ids:
+        text = text.replace(f"<@{mention_user_id}>", "")
+    assert text.strip() == "status"
+
+
+# ---------------------------------------------------------------------------
 # Tests: _slack_free_response_channels
 # ---------------------------------------------------------------------------
 
@@ -249,7 +315,8 @@ def _would_process(adapter, *, is_dm=False, channel_id=CHANNEL_ID,
     bot_uid = adapter._team_bot_user_ids.get("T1", adapter._bot_user_id)
     if mentioned:
         text = f"<@{bot_uid}> {text}"
-    is_mentioned = bot_uid and f"<@{bot_uid}>" in text
+    mention_user_ids = adapter._slack_mention_user_ids(bot_uid)
+    is_mentioned = any(f"<@{user_id}>" in text for user_id in mention_user_ids)
 
     if not is_dm and bot_uid:
         # allowed_channels check (whitelist — must pass before other gating)
@@ -514,6 +581,48 @@ def test_config_bridges_slack_strict_mention(monkeypatch, tmp_path):
     assert config is not None
     import os as _os
     assert _os.environ["SLACK_STRICT_MENTION"] == "true"
+
+
+def test_config_bridges_slack_mention_user_ids(monkeypatch, tmp_path):
+    from gateway.config import load_gateway_config
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "slack:\n"
+        "  mention_user_ids:\n"
+        "    - U_ALIAS\n"
+        "    - U_OTHER\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("SLACK_MENTION_USER_IDS", raising=False)
+
+    load_gateway_config()
+
+    import os as _os
+    assert _os.environ["SLACK_MENTION_USER_IDS"] == "U_ALIAS,U_OTHER"
+
+
+def test_config_bridges_slack_mention_user_ids_env_takes_precedence(monkeypatch, tmp_path):
+    from gateway.config import load_gateway_config
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "slack:\n"
+        "  mention_user_ids: U_ALIAS\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("SLACK_MENTION_USER_IDS", "U_ENV")
+
+    load_gateway_config()
+
+    import os as _os
+    assert _os.environ["SLACK_MENTION_USER_IDS"] == "U_ENV"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Allow configured Slack `mention_user_ids` aliases to count as direct bot mentions.
- Use the same accepted mention IDs when stripping mention tokens before dispatch.
- Bridge `slack.mention_user_ids` from YAML config to `SLACK_MENTION_USER_IDS` while preserving explicit env precedence.
- Add regression coverage for normal channel mentions, alias mention stripping, and `allow_bots=mentions` bot-message routing.

## Problem
Slack routing previously checked only the primary bot user ID for direct mentions. Deployments that need an additional accepted mention user ID could ignore valid mentions or leave the alias mention token in the message sent downstream.

## Tests
- `python3 -m py_compile plugins/platforms/slack/adapter.py tests/gateway/test_slack.py tests/gateway/test_slack_mention.py`
- `pytest -q tests/gateway/test_slack_mention.py tests/gateway/test_slack.py::TestMessageRouting::test_channel_mention_strips_bot_id tests/gateway/test_slack.py::TestMessageRouting::test_channel_alias_mention_strips_all_accepted_ids tests/gateway/test_slack.py::TestMessageRouting::test_bot_message_allow_mentions_accepts_alias_mention`
- `git diff --check origin/main...HEAD`
- `gitleaks git --log-opts="origin/main..HEAD" --no-banner --redact`
- Local regex scan over the PR diff: no private paths, tokens, or local-context terms found
