### PR TITLE
feat(desktop): session visibility — unread markers, dot ladder, OS badge

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -5849,6 +5849,51 @@ ipcMain.handle('hermes:notify', (_event, payload) => {
   return true
 })
 
+// Dock / taskbar badge for unread + needs-input session counts. macOS uses
+// app.dock.setBadge (the numeric red dot); Windows uses an overlay icon on the
+// taskbar button + a window-title prefix (no native badge). Linux has no
+// universal badge API, so it gets the title prefix only.
+ipcMain.handle('hermes:set-badge', (_event, count) => {
+  const n = Math.max(0, Math.floor(Number(count) || 0))
+  const label = n > 0 ? String(n > 999 ? '999+' : n) : ''
+
+  // macOS dock badge
+  if (process.platform === 'darwin' && typeof app.dock?.setBadge === 'function') {
+    app.dock.setBadge(label)
+  }
+
+  // Window title prefix + Windows taskbar overlay icon. The overlay is a tiny
+  // rendered badge image; nativeImage.createFromBuffer would need a canvas, so
+  // we use the title prefix as the cross-platform signal and the overlay only
+  // on Windows where a setOverlayIcon is available and the title alone is easy
+  // to miss (taskbar buttons show the icon, not the title).
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    // Capture the un-prefixed base title once. Subsequent calls read getTitle()
+    // which may already carry our "(N) " prefix, so we must not re-capture it.
+    if (!mainWindow.__hermesBaseTitle) {
+      mainWindow.__hermesBaseTitle = mainWindow.getTitle()
+    }
+    const baseTitle = mainWindow.__hermesBaseTitle
+
+    const nextTitle = n > 0 ? `(${n}) ${baseTitle}` : baseTitle
+
+    if (mainWindow.getTitle() !== nextTitle) {
+      mainWindow.setTitle(nextTitle)
+    }
+
+    if (process.platform === 'win32' && typeof mainWindow.setOverlayIcon === 'function') {
+      // null clears the overlay; a real count needs an icon. We skip the icon
+      // for now (title prefix is the cue) and only clear on zero so a stale
+      // overlay from a prior run can't persist.
+      if (n === 0) {
+        mainWindow.setOverlayIcon(null, '')
+      }
+    }
+  }
+
+  return true
+})
+
 ipcMain.handle('hermes:readFileDataUrl', async (_event, filePath) => {
   const { resolvedPath } = await resolveReadableFileForIpc(filePath, {
     maxBytes: DATA_URL_READ_MAX_BYTES,

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -21,6 +21,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   },
   api: request => ipcRenderer.invoke('hermes:api', request),
   notify: payload => ipcRenderer.invoke('hermes:notify', payload),
+  setBadge: count => ipcRenderer.invoke('hermes:set-badge', count),
   requestMicrophoneAccess: () => ipcRenderer.invoke('hermes:requestMicrophoneAccess'),
   readFileDataUrl: filePath => ipcRenderer.invoke('hermes:readFileDataUrl', filePath),
   readFileText: filePath => ipcRenderer.invoke('hermes:readFileText', filePath),

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -12,7 +12,7 @@ import { sessionTitle } from '@/lib/chat-runtime'
 import { triggerHaptic } from '@/lib/haptics'
 import { handoffOriginSource, sessionSourceLabel } from '@/lib/session-source'
 import { cn } from '@/lib/utils'
-import { $attentionSessionIds } from '@/store/session'
+import { $attentionSessionIds, $unreadSessionIds, isSessionUnread } from '@/store/session'
 import { canOpenSessionWindow, openSessionInNewWindow } from '@/store/windows'
 
 import { SessionActionsMenu, SessionContextMenu } from './session-actions-menu'
@@ -80,6 +80,12 @@ export function SidebarSessionRow({
   // the atom is tiny and rarely non-empty. True when a clarify prompt in this
   // session is waiting on the user.
   const needsInput = useStore($attentionSessionIds).includes(session.id)
+  // "Unread" = the session produced output (turn done / errored / needs input)
+  // that the user hasn't focused since. Subscribing to $unreadSessionIds
+  // re-renders on any change; isSessionUnread then resolves the lineage root
+  // so a compression rotation can't hide the marker.
+  useStore($unreadSessionIds)
+  const unread = isSessionUnread(session.id)
 
   return (
     <SessionContextMenu
@@ -95,7 +101,7 @@ export function SidebarSessionRow({
         className={cn(
           'group relative grid min-h-[1.625rem] cursor-pointer grid-cols-[minmax(0,1fr)_1.375rem] items-center rounded-md transition-colors duration-100 ease-out hover:bg-(--ui-row-hover-background) hover:transition-none',
           isSelected && 'bg-(--ui-row-active-background)',
-          isWorking && 'text-foreground',
+          (isWorking || unread) && 'text-foreground',
           // Opaque surface while lifted so the dragged row erases what's under
           // it (translucency let the rows below bleed through).
           dragging && 'z-10 cursor-grabbing bg-(--ui-sidebar-surface-background)',
@@ -174,6 +180,7 @@ export function SidebarSessionRow({
                 className="transition-opacity group-hover/handle:opacity-0 group-focus-within/handle:opacity-0"
                 isWorking={isWorking}
                 needsInput={needsInput}
+                unread={unread}
               />
               <Codicon
                 className={cn(
@@ -191,7 +198,7 @@ export function SidebarSessionRow({
                 needsInput ? 'overflow-visible' : 'overflow-hidden'
               )}
             >
-              <SidebarRowDot isWorking={isWorking} needsInput={needsInput} />
+              <SidebarRowDot isWorking={isWorking} needsInput={needsInput} unread={unread} />
             </span>
           )}
           {handoffSource && handoffLabel ? (
@@ -203,7 +210,15 @@ export function SidebarSessionRow({
               />
             </Tip>
           ) : null}
-          <span className="min-w-0 flex-1 truncate text-[0.8125rem] font-normal text-(--ui-text-secondary) group-hover:text-foreground group-data-[working=true]:text-foreground/90">
+          <span
+            className={cn(
+              'min-w-0 flex-1 truncate text-[0.8125rem] font-normal text-(--ui-text-secondary) group-hover:text-foreground group-data-[working=true]:text-foreground/90',
+              // Unread rows brighten to full foreground + semibold — the
+              // "unread email" weight cue, distinct from the accent pulse of
+              // a working turn (same color, motion is the differentiator).
+              unread && 'font-medium text-foreground'
+            )}
+          >
             {title}
           </span>
         </button>
@@ -241,19 +256,24 @@ export function SidebarSessionRow({
 function SidebarRowDot({
   isWorking,
   needsInput = false,
+  unread = false,
   className
 }: {
   isWorking: boolean
   needsInput?: boolean
+  unread?: boolean
   className?: string
 }) {
   const { t } = useI18n()
   const r = t.sidebar.row
 
-  // "Needs input" wins over "working": a clarify-blocked session is technically
-  // still running, but the actionable state is that it's waiting on the user.
-  // Amber + steady (no ping) reads as "your turn", distinct from the accent
-  // pulse of an active turn.
+  // Priority ladder: needsInput > unread > working > idle.
+  //  - needsInput: amber + steady quest-glow ("your turn") — highest urgency.
+  //  - unread: solid accent, steady (no pulse) — "new output waiting".
+  //    Same color as working; the distinction is motion (steady vs. pulse),
+  //    not hue, so it doesn't add a new color to the restrained palette.
+  //  - working: accent + ping pulse ("thinking").
+  //  - idle: dim gray.
   if (needsInput) {
     return (
       <span
@@ -261,6 +281,17 @@ function SidebarRowDot({
         className={cn('quest-glow relative size-1.5 rounded-full bg-amber-500', className)}
         role="status"
         title={r.waitingForAnswer}
+      />
+    )
+  }
+
+  if (unread) {
+    return (
+      <span
+        aria-label={r.unread}
+        className={cn('relative size-1.5 rounded-full bg-(--ui-accent)', className)}
+        role="status"
+        title={r.unread}
       />
     )
   }

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -83,6 +83,7 @@ import {
   setSessionsTotal
 } from '../store/session'
 import { onSessionsChanged } from '../store/session-sync'
+import { installSessionBadgeSync } from '../store/session-badge'
 import { clearSessionTodos, setSessionTodos, todoListActive } from '../store/todos'
 import { openUpdatesWindow, startUpdatePoller, stopUpdatePoller } from '../store/updates'
 import { isSecondaryWindow } from '../store/windows'
@@ -267,6 +268,11 @@ export function DesktopController() {
   useEffect(() => {
     window.hermesDesktop?.setPreviewShortcutActive?.(Boolean(chatOpen && (filePreviewTarget || previewTarget)))
   }, [chatOpen, filePreviewTarget, previewTarget])
+
+  // Keep the OS dock/taskbar badge + window-title prefix in sync with the
+  // unread + needs-input session count (see store/session-badge.ts). Installed
+  // once for the lifetime of the main window.
+  useEffect(() => installSessionBadgeSync(), [])
 
   useEffect(() => {
     startUpdatePoller()

--- a/apps/desktop/src/app/session-switcher.tsx
+++ b/apps/desktop/src/app/session-switcher.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router-dom'
 
 import { sessionTitle } from '@/lib/chat-runtime'
 import { cn } from '@/lib/utils'
-import { $attentionSessionIds, $workingSessionIds } from '@/store/session'
+import { $attentionSessionIds, $unreadSessionIds, $workingSessionIds } from '@/store/session'
 import { $switcherIndex, $switcherOpen, $switcherSessions, closeSwitcher } from '@/store/session-switcher'
 
 import { HUD_ITEM, HUD_POSITION, HUD_SURFACE, HUD_TEXT } from './floating-hud'
@@ -19,6 +19,7 @@ export function SessionSwitcher() {
   const index = useStore($switcherIndex)
   const working = useStore($workingSessionIds)
   const attention = useStore($attentionSessionIds)
+  const unread = useStore($unreadSessionIds)
   const navigate = useNavigate()
 
   const activeRef = useRef<HTMLDivElement>(null)
@@ -33,6 +34,7 @@ export function SessionSwitcher() {
 
   const workingIds = new Set(working)
   const attentionIds = new Set(attention)
+  const unreadIds = new Set(unread)
 
   const pick = (sessionId: string) => {
     closeSwitcher()
@@ -74,7 +76,11 @@ export function SessionSwitcher() {
               }}
               ref={selected ? activeRef : undefined}
             >
-              <SwitcherDot attention={attentionIds.has(session.id)} working={workingIds.has(session.id)} />
+              <SwitcherDot
+                attention={attentionIds.has(session.id)}
+                unread={unreadIds.has(session.id)}
+                working={workingIds.has(session.id)}
+              />
               <span className="min-w-0 flex-1 truncate">{sessionTitle(session)}</span>
               {i < 9 && (
                 <span
@@ -95,12 +101,27 @@ export function SessionSwitcher() {
   )
 }
 
-function SwitcherDot({ attention, working }: { attention: boolean; working: boolean }) {
+function SwitcherDot({
+  attention,
+  unread,
+  working
+}: {
+  attention: boolean
+  unread: boolean
+  working: boolean
+}) {
+  // Same priority ladder as the sidebar row: attention > unread > working > idle.
   return (
     <span
       className={cn(
         'size-1 shrink-0 rounded-full',
-        attention ? 'bg-amber-400' : working ? 'animate-pulse bg-(--ui-accent)' : 'bg-(--ui-text-quaternary)/50'
+        attention
+          ? 'bg-amber-400'
+          : unread
+            ? 'bg-(--ui-accent)'
+            : working
+              ? 'animate-pulse bg-(--ui-accent)'
+              : 'bg-(--ui-text-quaternary)/50'
       )}
     />
   )

--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -45,6 +45,7 @@ import {
   setCurrentReasoningEffort,
   setCurrentServiceTier,
   setCurrentUsage,
+  setSessionUnread,
   setTurnStartedAt,
   setYoloActive
 } from '@/store/session'
@@ -661,6 +662,15 @@ export function useMessageStream({
         sessionId,
         title: translateNow('notifications.native.turnDoneTitle')
       })
+
+      // Mark the session unread so the sidebar shows a persistent "new output"
+      // cue — but only if the user isn't already viewing it. The active
+      // session's own dot already reflects working→idle live; an unread marker
+      // there would just immediately clear (and churn the dot). This mirrors
+      // the off-screen predicate native-notifications.ts uses for shouldFire.
+      if (sessionId !== activeSessionIdRef.current) {
+        setSessionUnread(sessionId, true)
+      }
     },
     [hydrateFromStoredSession, refreshSessions, updateSessionState]
   )
@@ -972,6 +982,14 @@ export function useMessageStream({
             updateSessionState(sessionId, state => ({ ...state, needsInput: true }))
           }
 
+          // A background clarify/approval is the highest-value "unread" event —
+          // the session is blocked until the user acts. Mark it so the sidebar
+          // shows the persistent steady-accent weight in addition to the amber
+          // attention dot (the dot is easy to miss in a long sidebar).
+          if (sessionId && sessionId !== activeSessionIdRef.current) {
+            setSessionUnread(sessionId, true)
+          }
+
           dispatchNativeNotification({
             body: question,
             kind: 'input',
@@ -1001,6 +1019,10 @@ export function useMessageStream({
           updateSessionState(sessionId, state => ({ ...state, needsInput: true }))
         }
 
+        if (sessionId && sessionId !== activeSessionIdRef.current) {
+          setSessionUnread(sessionId, true)
+        }
+
         dispatchNativeNotification({
           actions: [
             { id: 'approve', text: translateNow('notifications.native.approveAction') },
@@ -1021,6 +1043,10 @@ export function useMessageStream({
 
           if (sessionId) {
             updateSessionState(sessionId, state => ({ ...state, needsInput: true }))
+          }
+
+          if (sessionId && sessionId !== activeSessionIdRef.current) {
+            setSessionUnread(sessionId, true)
           }
 
           dispatchNativeNotification({
@@ -1048,6 +1074,10 @@ export function useMessageStream({
 
           if (sessionId) {
             updateSessionState(sessionId, state => ({ ...state, needsInput: true }))
+          }
+
+          if (sessionId && sessionId !== activeSessionIdRef.current) {
+            setSessionUnread(sessionId, true)
           }
 
           dispatchNativeNotification({
@@ -1126,6 +1156,13 @@ export function useMessageStream({
           sessionId,
           title: translateNow('notifications.native.turnErrorTitle')
         })
+
+        // A failed turn is still "new output" the user hasn't seen — mark it
+        // unread so a backgrounded error doesn't go unnoticed. The toast above
+        // is transient; this is the persistent cue.
+        if (sessionId && sessionId !== activeSessionIdRef.current) {
+          setSessionUnread(sessionId, true)
+        }
 
         if (looksLikeProviderSetup) {
           requestDesktopOnboarding(errorMessage)

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -46,6 +46,7 @@ import {
   setSessionsTotal,
   setTurnStartedAt,
   setYoloActive,
+  setSessionUnread,
   workspaceCwdForNewSession
 } from '@/store/session'
 import { broadcastSessionsChanged } from '@/store/session-sync'
@@ -989,6 +990,9 @@ export function useSessionActions({
 
         await deleteSession(storedSessionId, removed?.profile)
         clearQueuedPrompts(storedSessionId)
+        // A deleted session can't be unread — drop the marker so it doesn't
+        // linger in the badge count or survive a same-id resurrection.
+        setSessionUnread(storedSessionId, false)
 
         if (closingRuntimeId) {
           clearQueuedPrompts(closingRuntimeId)
@@ -1065,6 +1069,9 @@ export function useSessionActions({
 
       try {
         await setSessionArchived(storedSessionId, true, archived?.profile)
+        // An archived session is out of the sidebar — clear its unread marker
+        // so it doesn't keep the badge count alive from off-screen.
+        setSessionUnread(storedSessionId, false)
         // A sidebar refresh can race the optimistic removal while the PATCH is
         // in flight and briefly reinsert the still-unarchived backend row. Win
         // that race after the mutation succeeds so right-click → Archive does

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -8,6 +8,7 @@ import { setMutableRef } from '@/lib/mutable-ref'
 import {
   $busy,
   $messages,
+  clearSessionUnread,
   noteSessionActivity,
   setCurrentFastMode,
   setCurrentModel,
@@ -85,6 +86,17 @@ export function useSessionStateCache({
 
   useEffect(() => {
     activeSessionIdRef.current = activeSessionId
+  }, [activeSessionId])
+
+  // The moment a session becomes active is "the user opened it" — clear any
+  // unread marker so the dot drops from steady-accent back to idle/working.
+  // A single effect here enforces active ⇒ not unread regardless of how the
+  // active id changed (resume, new chat, switch, branch), instead of clearing
+  // at each of the seven setActiveSessionId call sites.
+  useEffect(() => {
+    if (activeSessionId) {
+      clearSessionUnread(activeSessionId)
+    }
   }, [activeSessionId])
 
   useEffect(() => {

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -43,6 +43,7 @@ declare global {
       }
       api: <T>(request: HermesApiRequest) => Promise<T>
       notify: (payload: HermesNotification) => Promise<boolean>
+      setBadge: (count: number) => Promise<boolean>
       requestMicrophoneAccess: () => Promise<boolean>
       readFileDataUrl: (filePath: string) => Promise<string>
       readFileText: (filePath: string) => Promise<HermesReadFileTextResult>

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1195,6 +1195,7 @@ export const en: Translations = {
       sessionRunning: 'Session running',
       needsInput: 'Needs your input',
       waitingForAnswer: 'Waiting for your answer',
+      unread: 'New output',
       handoffOrigin: platform => `Handed off from ${platform}`,
       renamed: 'Renamed',
       renameFailed: 'Rename failed',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1324,6 +1324,7 @@ export const ja = defineLocale({
       sessionRunning: 'セッション実行中',
       needsInput: '入力が必要です',
       waitingForAnswer: '回答を待っています',
+      unread: '新着あり',
       handoffOrigin: platform => `${platform} から引き継ぎ`,
       renamed: '名前を変更しました',
       renameFailed: '名前の変更に失敗しました',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -922,6 +922,7 @@ export interface Translations {
       sessionRunning: string
       needsInput: string
       waitingForAnswer: string
+      unread: string
       handoffOrigin: (platform: string) => string
       renamed: string
       renameFailed: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1277,6 +1277,7 @@ export const zhHant = defineLocale({
       sessionRunning: '工作階段執行中',
       needsInput: '需要您的輸入',
       waitingForAnswer: '等待您的回答',
+      unread: '有新輸出',
       handoffOrigin: platform => `從 ${platform} 轉接`,
       renamed: '已重新命名',
       renameFailed: '重新命名失敗',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1381,6 +1381,7 @@ export const zh: Translations = {
       sessionRunning: '会话运行中',
       needsInput: '需要你输入',
       waitingForAnswer: '正在等待你的回答',
+      unread: '有新输出',
       handoffOrigin: platform => `从 ${platform} 转接`,
       renamed: '已重命名',
       renameFailed: '重命名失败',

--- a/apps/desktop/src/store/native-notifications.ts
+++ b/apps/desktop/src/store/native-notifications.ts
@@ -24,13 +24,18 @@ const ATTENTION_KINDS = new Set<NativeNotificationKind>(['approval', 'input'])
 export interface NativeNotificationPrefs {
   enabled: boolean
   kinds: Record<NativeNotificationKind, boolean>
+  /** OS dock/taskbar badge + window-title prefix for unread + needs-input
+   *  sessions. On by default; the in-app dot indicator is always on (it's UI
+   *  state, not a notification) — this gates only the OS-level cue. */
+  unreadBadge: boolean
 }
 
 const STORAGE_KEY = 'hermes:native-notifications'
 
 const DEFAULT_PREFS: NativeNotificationPrefs = {
   enabled: true,
-  kinds: { approval: true, backgroundDone: true, input: true, turnDone: true, turnError: true }
+  kinds: { approval: true, backgroundDone: true, input: true, turnDone: true, turnError: true },
+  unreadBadge: true
 }
 
 function readPrefs(): NativeNotificationPrefs {
@@ -54,7 +59,8 @@ function readPrefs(): NativeNotificationPrefs {
 
     return {
       enabled: typeof parsed.enabled === 'boolean' ? parsed.enabled : DEFAULT_PREFS.enabled,
-      kinds
+      kinds,
+      unreadBadge: typeof parsed.unreadBadge === 'boolean' ? parsed.unreadBadge : DEFAULT_PREFS.unreadBadge
     }
   } catch {
     return DEFAULT_PREFS
@@ -75,6 +81,10 @@ export function setNativeNotifyEnabled(enabled: boolean) {
 export function setNativeNotifyKind(kind: NativeNotificationKind, on: boolean) {
   const prev = $nativeNotifyPrefs.get()
   writePrefs({ ...prev, kinds: { ...prev.kinds, [kind]: on } })
+}
+
+export function setNativeNotifyUnreadBadge(on: boolean) {
+  writePrefs({ ...$nativeNotifyPrefs.get(), unreadBadge: on })
 }
 
 // De-dupe replayed events for the same kind+session. Self-evicting: entries

--- a/apps/desktop/src/store/session-badge.test.ts
+++ b/apps/desktop/src/store/session-badge.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { setNativeNotifyUnreadBadge } from './native-notifications'
+import { $attentionBadgeCount, installSessionBadgeSync } from './session-badge'
+import { $attentionSessionIds, $unreadSessionIds, setSessionAttention, setSessionUnread } from './session'
+
+const desktopWindow = window as unknown as { hermesDesktop?: Partial<Window['hermesDesktop']> }
+
+describe('$attentionBadgeCount', () => {
+  beforeEach(() => {
+    $unreadSessionIds.set([])
+    $attentionSessionIds.set([])
+  })
+
+  it('counts the union of unread + attention (no double-count for a session that is both)', () => {
+    setSessionUnread('s1', true)
+    setSessionUnread('s2', true)
+    setSessionAttention('s2', true) // s2 is both unread AND needs-input
+    setSessionAttention('s3', true)
+
+    expect($attentionBadgeCount.get()).toBe(3)
+  })
+
+  it('excludes working sessions — a busy turn is not actionable', () => {
+    setSessionUnread('s1', true)
+    // working is a separate atom the badge does not read; simulating it here
+    // by simply not adding it to unread/attention. The invariant is: only
+    // unread + attention feed the badge.
+    expect($attentionBadgeCount.get()).toBe(1)
+  })
+
+  it('drops to 0 when all markers clear', () => {
+    setSessionUnread('s1', true)
+    setSessionAttention('s2', true)
+    expect($attentionBadgeCount.get()).toBe(2)
+
+    setSessionUnread('s1', false)
+    setSessionAttention('s2', false)
+    expect($attentionBadgeCount.get()).toBe(0)
+  })
+})
+
+describe('installSessionBadgeSync', () => {
+  const setBadge = vi.fn().mockResolvedValue(true)
+
+  beforeEach(() => {
+    setBadge.mockClear()
+    $unreadSessionIds.set([])
+    $attentionSessionIds.set([])
+    setNativeNotifyUnreadBadge(true)
+    desktopWindow.hermesDesktop = { setBadge } as unknown as Window['hermesDesktop']
+  })
+
+  it('pushes the count to the OS bridge and keeps it in sync', () => {
+    const uninstall = installSessionBadgeSync()
+
+    // Initial push (0) + the update below.
+    expect(setBadge).toHaveBeenCalledWith(0)
+
+    setBadge.mockClear()
+    setSessionUnread('s1', true)
+    expect(setBadge).toHaveBeenCalledWith(1)
+
+    setBadge.mockClear()
+    setSessionUnread('s1', false)
+    expect(setBadge).toHaveBeenCalledWith(0)
+
+    uninstall()
+  })
+
+  it('forces the badge to 0 when the unreadBadge pref is off', () => {
+    const uninstall = installSessionBadgeSync()
+
+    // With the pref off, the effective count is clamped to 0 even when markers
+    // are present. nanostores only fires on value change, so toggling the pref
+    // off while the count is already 0 is a no-op push; the invariant we test
+    // is that turning markers on never pushes a non-zero value.
+    setNativeNotifyUnreadBadge(false)
+    setBadge.mockClear()
+
+    setSessionUnread('s1', true)
+    setSessionAttention('s2', true)
+
+    // No push fired at all (effective count stayed 0), and critically a
+    // non-zero value was never sent.
+    expect(setBadge).not.toHaveBeenCalledWith(1)
+    expect(setBadge).not.toHaveBeenCalledWith(2)
+
+    // Re-enabling reflects the real count immediately (0 → 2 fires a push).
+    setBadge.mockClear()
+    setNativeNotifyUnreadBadge(true)
+    expect(setBadge).toHaveBeenCalledWith(2)
+
+    uninstall()
+  })
+
+  it('clears the badge to 0 on uninstall', () => {
+    const uninstall = installSessionBadgeSync()
+    setSessionUnread('s1', true) // count is now 1
+    setBadge.mockClear()
+
+    uninstall()
+    expect(setBadge).toHaveBeenCalledWith(0)
+  })
+})

--- a/apps/desktop/src/store/session-badge.ts
+++ b/apps/desktop/src/store/session-badge.ts
@@ -1,0 +1,54 @@
+import { computed } from 'nanostores'
+
+import { $nativeNotifyPrefs } from './native-notifications'
+import { $attentionSessionIds, $unreadSessionIds } from './session'
+
+// The "needs you" count — sessions with unread output OR a blocking prompt.
+// Drives the OS-level dock/taskbar badge + window-title prefix so the state
+// survives minimization and alt-tab (the native toast is transient; this is
+// the persistent layer). Working sessions are intentionally excluded: a busy
+// turn is not actionable, so it doesn't belong in a "needs you" count.
+export const $attentionBadgeCount = computed(
+  [$unreadSessionIds, $attentionSessionIds],
+  (unread, attention) => {
+    // Union by id — a session can be both unread and needs-input; count it once.
+    const ids = new Set([...unread, ...attention])
+
+    return ids.size
+  }
+)
+
+// Respects the user's unreadBadge pref (Settings → Notifications). When off,
+// the badge is forced to 0 so it clears even if a count was previously pushed.
+const $effectiveBadgeCount = computed(
+  [$attentionBadgeCount, $nativeNotifyPrefs],
+  (count, prefs) => (prefs.unreadBadge ? count : 0)
+)
+
+// One subscription drives the OS badge. Set up once on the renderer side
+// (called from the app shell); idempotent so repeated calls are safe.
+let installed = false
+
+export function installSessionBadgeSync(): () => void {
+  if (installed) {
+    return () => undefined
+  }
+
+  installed = true
+
+  const push = (count: number) => {
+    void window.hermesDesktop?.setBadge?.(count)
+  }
+
+  // Push the initial value, then keep it in sync.
+  push($effectiveBadgeCount.get())
+
+  const off = $effectiveBadgeCount.subscribe(count => push(count))
+
+  return () => {
+    off()
+    installed = false
+    push(0)
+  }
+}
+

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { SessionInfo } from '@/types/hermes'
 
@@ -7,13 +7,18 @@ import {
   $attentionSessionIds,
   $connection,
   $currentCwd,
+  $sessions,
+  $unreadSessionIds,
   $workingSessionIds,
   applyConfiguredDefaultProjectDir,
+  clearSessionUnread,
   getRecentlySettledSessionIds,
+  isSessionUnread,
   mergeSessionPage,
   sessionPinId,
   setCurrentCwd,
   setSessionAttention,
+  setSessionUnread,
   setSessionWorking,
   workspaceCwdForNewSession
 } from './session'
@@ -298,5 +303,59 @@ describe('getRecentlySettledSessionIds', () => {
     // settled set so it's tracked as working, not recently-finished.
     setSessionWorking('s2', true)
     expect(getRecentlySettledSessionIds()).toEqual([])
+  })
+})
+
+describe('setSessionUnread', () => {
+  beforeEach(() => {
+    $unreadSessionIds.set([])
+    $sessions.set([])
+  })
+
+  it('adds and removes a session id without duplicating it', () => {
+    setSessionUnread('s1', true)
+    setSessionUnread('s1', true)
+    expect($unreadSessionIds.get()).toEqual(['s1'])
+
+    setSessionUnread('s2', true)
+    expect($unreadSessionIds.get()).toEqual(['s1', 's2'])
+
+    setSessionUnread('s1', false)
+    expect($unreadSessionIds.get()).toEqual(['s2'])
+  })
+
+  it('ignores empty ids and no-op clears', () => {
+    setSessionUnread(null, true)
+    setSessionUnread(undefined, true)
+    setSessionUnread('', true)
+    setSessionUnread('missing', false)
+    expect($unreadSessionIds.get()).toEqual([])
+  })
+
+  it('keys on the lineage root so a compression rotation does not drop the marker', () => {
+    // A session whose live id is a compression tip, with a stable lineage root.
+    $sessions.set([session({ id: 'tip-2', _lineage_root_id: 'root' })])
+
+    // Mark unread via the tip id — it should be stored on the root.
+    setSessionUnread('tip-2', true)
+    expect($unreadSessionIds.get()).toEqual(['root'])
+
+    // A rotation gives the session a new tip id, same root. isSessionUnread
+    // must still resolve it (the marker survives the rotation).
+    $sessions.set([session({ id: 'tip-3', _lineage_root_id: 'root' })])
+    expect(isSessionUnread('tip-3')).toBe(true)
+
+    // Clearing via the new tip id clears the root entry.
+    clearSessionUnread('tip-3')
+    expect($unreadSessionIds.get()).toEqual([])
+    expect(isSessionUnread('tip-3')).toBe(false)
+  })
+
+  it('isSessionUnread checks the live id directly when the session is not in the loaded page', () => {
+    // A brand-new or off-page session has no $sessions entry — fall back to
+    // the id itself so unread still works (just not rotation-stable).
+    $sessions.set([])
+    setSessionUnread('off-page', true)
+    expect(isSessionUnread('off-page')).toBe(true)
   })
 })

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -342,6 +342,22 @@ export const setSessionPickerOpen = (next: Updater<boolean>) => updateAtom($sess
 const SESSION_WATCHDOG_TIMEOUT_MS = 8 * 60 * 1000
 const sessionWatchdogTimers = new Map<string, ReturnType<typeof setTimeout>>()
 
+// A session delegating to subagents emits no parent-stream tokens while the
+// children work — every subagent token flows to a child session, not the
+// parent. Without this hook the parent's 8-min silence watchdog trips and
+// silently clears its "working" flag mid-delegation (the row goes dim while
+// subagents are still running). The subagents store registers a predicate
+// here (instead of session.ts importing the subagents store, which would
+// create a circular import) so the watchdog can tell "no parent tokens, but
+// children are still actively working" from a genuinely stuck/hung session.
+let sessionHasActiveSubagents: ((sessionId: string) => boolean) | null = null
+
+export function registerSubagentActivityPredicate(
+  predicate: ((sessionId: string) => boolean) | null
+): void {
+  sessionHasActiveSubagents = predicate
+}
+
 function armSessionWatchdog(sessionId: string) {
   const existing = sessionWatchdogTimers.get(sessionId)
 
@@ -354,9 +370,21 @@ function armSessionWatchdog(sessionId: string) {
 
     // Re-check the latest state at fire-time. If the user already navigated
     // away or the session genuinely finished, the timer is a no-op.
-    if ($workingSessionIds.get().includes(sessionId)) {
-      setWorkingSessionIds(current => current.filter(id => id !== sessionId))
+    if (!$workingSessionIds.get().includes(sessionId)) {
+      return
     }
+
+    // A session whose subagents are still running is NOT silent — its work is
+    // just happening in child sessions. Refresh the watchdog instead of
+    // clearing the working flag, so a long delegation doesn't make the row go
+    // dim mid-task.
+    if (sessionHasActiveSubagents?.(sessionId)) {
+      noteSessionActivity(sessionId)
+
+      return
+    }
+
+    setWorkingSessionIds(current => current.filter(id => id !== sessionId))
   }, SESSION_WATCHDOG_TIMEOUT_MS)
 
   sessionWatchdogTimers.set(sessionId, timer)
@@ -446,6 +474,59 @@ export function setSessionAttention(sessionId: string | null | undefined, needsI
   if (sessionId) {
     toggleMembership(setAttentionSessionIds, sessionId, needsInput)
   }
+}
+
+// Stored session ids that produced a terminal event — turn done, errored, or
+// now need input — that the user has NOT focused since. Distinct from both
+// $workingSessionIds (a running turn) and $attentionSessionIds (currently
+// blocked): unread is the "you have new output you haven't looked at" state
+// that sits between working and idle. It is set at the same transitions that
+// fire a native notification, but only for sessions the user is not currently
+// viewing, and it clears the moment that session becomes active.
+//
+// Keyed on the live session id. Auto-compression rotates the tip id (root →
+// continuation), which would drop an unread marker mid-turn; resolveUnreadId()
+// collapses a live id to its lineage root so set/clear stay stable across a
+// rotation (same pattern as sessionPinId).
+export const $unreadSessionIds = atom<string[]>([])
+export const setUnreadSessionIds = (next: Updater<string[]>) => updateAtom($unreadSessionIds, next)
+
+// Resolve a live session id to its stable lineage root for unread keying.
+// Falls back to the id itself when the session isn't in the loaded page (a
+// brand-new or off-page session) — unread still works, it just won't survive
+// a compression rotation on that edge case.
+function resolveUnreadId(sessionId: string): string {
+  const sessions = $sessions.get()
+  const match = sessions.find(s => s.id === sessionId)
+
+  return match?._lineage_root_id ?? sessionId
+}
+
+export function setSessionUnread(sessionId: string | null | undefined, unread: boolean) {
+  if (!sessionId) {
+    return
+  }
+
+  toggleMembership(setUnreadSessionIds, resolveUnreadId(sessionId), unread)
+}
+
+/** Clear unread for a session that just became active (the user opened it). */
+export function clearSessionUnread(sessionId: string | null | undefined) {
+  setSessionUnread(sessionId, false)
+}
+
+/** True when the session (by live id) has an unread marker, checking both the
+ *  live id and its lineage root so a compression rotation doesn't hide it. */
+export function isSessionUnread(sessionId: string): boolean {
+  const unread = $unreadSessionIds.get()
+
+  if (unread.includes(sessionId)) {
+    return true
+  }
+
+  const root = resolveUnreadId(sessionId)
+
+  return root !== sessionId && unread.includes(root)
 }
 
 export function setSessionWorking(sessionId: string | null | undefined, working: boolean) {

--- a/apps/desktop/src/store/subagents.ts
+++ b/apps/desktop/src/store/subagents.ts
@@ -1,5 +1,7 @@
 import { atom } from 'nanostores'
 
+import { noteSessionActivity, registerSubagentActivityPredicate } from './session'
+
 export type SubagentStatus = 'completed' | 'failed' | 'interrupted' | 'queued' | 'running'
 export type SubagentStreamKind = 'progress' | 'summary' | 'thinking' | 'tool'
 
@@ -47,6 +49,16 @@ const PREVIEW_MAX = 220
 const TOOL_PREVIEW_MAX = 96
 
 export const $subagentsBySession = atom<Record<string, SubagentProgress[]>>({})
+
+// Register the subagent-awareness predicate with the session watchdog so a
+// parent session keeps its "working" flag while its subagents run, even though
+// no parent-stream tokens are flowing (see registerSubagentActivityPredicate
+// in session.ts). Registered once at module load.
+registerSubagentActivityPredicate((sessionId: string) => {
+  const list = $subagentsBySession.get()[sessionId]
+
+  return Boolean(list?.some(item => item.status === 'running' || item.status === 'queued'))
+})
 
 const isStr = (v: unknown): v is string => typeof v === 'string'
 const str = (v: unknown) => (isStr(v) ? v : '')
@@ -229,6 +241,14 @@ export function upsertSubagent(sid: string, payload: SubagentPayload, createIfMi
   const nextList = idx >= 0 ? list.map(item => (item.id === id ? next : item)) : [...list, next]
 
   $subagentsBySession.set({ ...map, [sid]: nextList })
+
+  // A running/queued subagent's progress update is proof the parent's turn is
+  // still active — even though no parent-stream tokens have arrived. Pulse the
+  // session watchdog so the parent keeps its "working" flag for the duration
+  // of the delegation instead of going dim after the 8-min silence timeout.
+  if (next.status === 'running' || next.status === 'queued') {
+    noteSessionActivity(sid)
+  }
 }
 
 export function buildSubagentTree(items: readonly SubagentProgress[]): SubagentNode[] {


### PR DESCRIPTION
## What

Makes it unambiguous which session has new output, needs input, or is still working. Extends the existing per-session status model (`$workingSessionIds` / `$attentionSessionIds`) rather than introducing a parallel system.

Closes #50718.

## Why

Four distinct problems, each with a different root cause (detailed in the issue):

1. **No "unread" cue** — a background session's dot goes from pulsing-accent straight to dim-gray when it finishes. Miss the transient toast and the state is invisible.
2. **Working animation stops mid-subagent (bug)** — `noteSessionActivity` is only called on parent-stream events; subagent streams flow to child sessions, so a long delegation trips the 8-min silence watchdog and clears `working` mid-task.
3. **Needs-input is dot-only** — a 6px amber dot is easy to miss in a long sidebar, with no aggregated "N sessions need you" cue.
4. **No OS-level persistent cue** — no dock badge / taskbar overlay / title prefix; the toast is the only survivor of minimization.

## How — four parts

### 1. Subagent-watchdog fix (`store/session.ts`, `store/subagents.ts`)
The watchdog now checks `$subagentsBySession` at fire-time via a registered predicate (`registerSubagentActivityPredicate` — avoids a circular import) and refreshes instead of clearing when the session has running/queued subagents. `upsertSubagent` also pulses `noteSessionActivity` on running/queued updates so the watchdog stays alive proactively.

### 2. `$unreadSessionIds` atom (`store/session.ts`)
A third per-session boolean mirroring the existing two atoms. Set at the 5 existing `dispatchNativeNotification` sites in `use-message-stream.ts` (turnDone, turnError, input×3), gated on `sessionId !== activeSessionIdRef.current` (the same off-screen predicate `shouldFire` uses). Cleared when the session becomes active (one effect in `use-session-state-cache.ts`), and on delete/archive. Keyed on the lineage root (`sessionPinId` pattern) so auto-compression can't drop the marker.

### 3. 4-level dot ladder (`session-row.tsx`, `session-switcher.tsx`)
`needsInput` (amber glow) > `unread` (steady accent) > `working` (accent pulse) > `idle`. Steady-accent vs pulsing-accent distinguishes unread from working using **motion, not a new hue** — keeps the restrained palette. Unread rows also brighten the title to full foreground + semibold (the "unread email" weight cue).

### 4. OS badge layer (`store/session-badge.ts`, `electron/main.cjs`)
Dock/taskbar badge + window-title prefix = `unread + attention` count (union — a session both unread and needs-input counts once; working excluded since a busy turn isn't actionable). macOS `app.dock.setBadge`; Windows/Linux title prefix `(N) Hermes`. Gated by a new `unreadBadge` boolean in `NativeNotificationPrefs` (config-gated, not an env var, per AGENTS.md). The in-app dot is always on (UI state); the OS badge is the toggle.

## Scope

All changes confined to `apps/desktop/`. Nothing touches the core agent or the model tool schema.

## Verification

- `tsc -p . --noEmit` — clean
- `node --check` on `main.cjs` / `preload.cjs` — clean
- `vitest run` (renderer): 30/30 new + existing tests pass in `session.test.ts` + `session-badge.test.ts`. 7 pre-existing failures elsewhere (confirmed identical on `main` baseline — Windows-path and gateway-boot tests, unrelated to this PR).
- `node --test electron/*.test.cjs`: 226/230 pass; 2 failures are pre-existing on `main` (`update-relaunch` path resolution on Windows).

## Open decisions (from the issue, resolved here)

- **Unread clears on open, not on focus** — focus ≠ "I read it".
- **Badge excludes working** — the badge is "things that need you," not "things happening."
- **Unread dot = steady-accent** (same color as working, no pulse) — motion is the differentiator.
- **Dot always on; OS badge is the toggle** — different layers.