### PR TITLE
fix: route Telegram NWE callbacks to wellness handler

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3951,6 +3951,32 @@ class TelegramAdapter(BasePlatformAdapter):
         query_thread_id = getattr(query_message, "message_thread_id", None)
         query_user_name = getattr(query.from_user, "first_name", None)
 
+        logger.info(
+            "[TG_CALLBACK_HANDLER_ENTER] data=%s chat_id=%s message_id=%s pid=%s",
+            data,
+            query_chat_id,
+            getattr(query_message, "message_id", None),
+            os.getpid(),
+        )
+        logger.info(
+            "[TG_CALLBACK_ROUTE_CHECK] data=%s chat_id=%s message_id=%s pid=%s",
+            data,
+            query_chat_id,
+            getattr(query_message, "message_id", None),
+            os.getpid(),
+        )
+
+        if data.startswith(("w:", "s:", "m:", "mr:")):
+            await self._handle_nwe_callback(
+                query,
+                data,
+                query_chat_id=query_chat_id,
+                query_chat_type=query_chat_type,
+                query_thread_id=query_thread_id,
+                query_user_name=query_user_name,
+            )
+            return
+
         # --- Model picker callbacks ---
         if data.startswith(("mp:", "mpg:", "mm:", "mc:", "mb", "mx", "mg:")):
             chat_id = str(query.message.chat_id) if query.message else None
@@ -6900,7 +6926,102 @@ class TelegramAdapter(BasePlatformAdapter):
 # hermes_cli/{setup,gateway}.py, and the _send_telegram dispatch in
 # tools/send_message_tool.py).  Telegram uses the generic token connected
 # check, so no is_connected override is needed.
-# ──────────────────────────────────────────────────────────────────────────
+        return None
+
+    async def _handle_nwe_callback(
+        self,
+        query,
+        data: str,
+        *,
+        query_chat_id,
+        query_chat_type,
+        query_thread_id,
+        query_user_name,
+    ) -> None:
+        query_message = getattr(query, "message", None)
+        chat_id = query_chat_id or getattr(getattr(query_message, "chat", None), "id", None)
+        message_id = getattr(query_message, "message_id", None)
+
+        if data.startswith("w:"):
+            logger.info("[NWE_WATER_ROUTE_MATCH] data=%s chat_id=%s message_id=%s", data, chat_id, message_id)
+        elif data.startswith("s:"):
+            logger.info("[NWE_SUPP_ROUTE_SEEN] data=%s message_id=%s", data, message_id)
+        elif data.startswith("m:"):
+            logger.info("[NWE_MEAL_ROUTE_SEEN] data=%s message_id=%s", data, message_id)
+        elif data.startswith("mr:"):
+            logger.info("[NWE_MEAL_RESOLUTION_ROUTE_SEEN] data=%s message_id=%s", data, message_id)
+
+        ack_text = None
+        if data.startswith("w:"):
+            ack_text = "💧 Água"
+        elif data.startswith("s:"):
+            ack_text = "💊 Suplementos"
+        elif data.startswith(("m:", "mr:")):
+            ack_text = "🍽️ Refeição"
+
+        logger.info("[NWE_CALLBACK_BEFORE_ANSWER] data=%s chat_id=%s message_id=%s", data, chat_id, message_id)
+        try:
+            await query.answer(text=ack_text)
+            logger.info("[NWE_CALLBACK_AFTER_ANSWER] data=%s chat_id=%s message_id=%s", data, chat_id, message_id)
+        except Exception as exc:
+            logger.warning("[TG_ANSWER_CALLBACK_ERROR] data=%s error=%s", data, exc, exc_info=True)
+
+        logger.info("[NWE_CALLBACK_BEFORE_PROCESS] data=%s chat_id=%s message_id=%s", data, chat_id, message_id)
+        result = await self._run_nwe_callback(
+            chat_id=str(chat_id),
+            message_id=str(message_id),
+            callback_data=data,
+        )
+        logger.info("[NWE_CALLBACK_AFTER_PROCESS] data=%s ok=%s duplicate=%s", data, result.get("ok"), result.get("duplicate"))
+
+        confirmation_text = result.get("confirmation_text") or result.get("answer_text")
+        if confirmation_text:
+            await self._bot.send_message(
+                chat_id=chat_id,
+                text=confirmation_text,
+                message_thread_id=query_thread_id,
+            )
+
+    async def _run_nwe_callback(self, *, chat_id: str, message_id: str, callback_data: str) -> dict:
+        hermes_home = _Path(os.environ.get("HERMES_HOME") or _Path.home() / ".hermes")
+        handle_script = hermes_home / "scripts" / "reminders" / "wellness_v2" / "handle_poc_callback.py"
+
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable,
+            str(handle_script),
+            str(chat_id),
+            str(message_id),
+            str(callback_data),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout_b, stderr_b = await proc.communicate()
+        stdout = stdout_b.decode("utf-8", errors="replace").strip()
+        stderr = stderr_b.decode("utf-8", errors="replace").strip()
+
+        logger.info(
+            "[NWE_SCRIPT_RESULT] returncode=%s stdout_len=%s stderr_len=%s stdout_prefix=%r stderr_prefix=%r",
+            proc.returncode,
+            len(stdout),
+            len(stderr),
+            stdout[:500],
+            stderr[:500],
+        )
+
+        if stderr:
+            logger.warning("[NWE_SCRIPT_STDERR] %s", stderr[:1000])
+
+        try:
+            result = json.loads(stdout) if stdout else {}
+        except Exception:
+            logger.exception("[NWE_SCRIPT_JSON_ERROR] stdout=%r", stdout[:1000])
+            result = {"ok": False, "error": "invalid_json", "raw_stdout": stdout[:1000]}
+
+        if proc.returncode != 0:
+            result.setdefault("ok", False)
+            result.setdefault("error", f"nwe_script_returncode_{proc.returncode}")
+
+        return result
 
 
 def _resolve_notifications_mode() -> str:


### PR DESCRIPTION
## Summary

Routes Telegram inline callback data for Wellness/NWE flows through the existing wellness callback handler.

This patch updates `plugins/platforms/telegram/adapter.py` to intercept:

- `w:*`
- `s:*`
- `m:*`
- `mr:*`

The adapter now acknowledges callback queries early, delegates business logic to the existing `handle_poc_callback.py` script, and sends the returned confirmation text separately.

## Scope

Changed file:

- `plugins/platforms/telegram/adapter.py`

Out of scope:

- no changes to `poc_core.py`
- no changes to wellness business rules
- no changes to `hermes_cli/config.py`
- no changes to `tools/tts_tool.py`
- no SKILL.md/self-improvement change included

## Validation

### Static/local validation

- `git diff --check`: passed
- `py_compile plugins/platforms/telegram/adapter.py`: passed
- `py_compile` passed for the relevant NWE scripts:
  - `storage.py`
  - `poc_core.py`
  - `handle_poc_callback.py`
  - `send_poc_meal.py`
  - `reset_poc_day.py`

### Local NWE validation after patch restore

POC message:

- `message_id=1624`

Validated locally:

- `w:view`: view-only, no mutation
- `w:500`: created `water_logged`
- duplicate `w:500`: deduplicated
- `w:300`: created second `water_logged`
- final `water_ml=800`
- `s:view`: view-only, no mutation
- `s:cre:ok`: created `supplement_confirmed`
- `s:ba:ok`: created `supplement_confirmed`
- `s:ma:ok`: created magnesium A confirmation
- `s:mb:ok` after `s:ma:ok`: blocked by magnesium conflict
- `m:0930:wm`: created `meal_confirmed`
- duplicate `m:0930:wm`: deduplicated
- final meal state:
  - `message_instances.status=confirmed`
  - `protein_g=28`
  - `carbs_g=24`

### Runtime Telegram validation

Gateway restarted with:

```text
./venv/Scripts/hermes.exe gateway restart
```

Runtime PID:

```text
18528
```

POC message:

```text
message_id=1626
```

Validated in real Telegram runtime:

#### `s:view`

Observed in `gateway.log`:

* `TG_CALLBACK_HANDLER_ENTER`
* `NWE_CALLBACK_BEFORE_ANSWER`
* `NWE_CALLBACK_AFTER_ANSWER`
* `NWE_CALLBACK_BEFORE_PROCESS`
* `NWE_SCRIPT_RESULT returncode=0`
* `NWE_CALLBACK_AFTER_PROCESS`

Result:

* ACK occurred before processing
* view-only response worked
* no mutating event was created
* Telegram UX was visible

#### `m:0930:wm`

First click:

* `duplicate=false`
* created `meal_confirmed`

Second click:

* `duplicate=true`
* no duplicate event created

Final persisted state:

* `message_instances.status=confirmed`
* `protein_g=28.0`
* `carbs_g=24.0`
* `meals_confirmed=1`

No `TG_ANSWER_CALLBACK_ERROR` appeared during the final runtime validation.

## Coverage notes

| Callback                  | Local  | Runtime                                                        | Result                          |
| ------------------------- | ------ | -------------------------------------------------------------- | ------------------------------- |
| `w:view`                  | passed | historical runtime before restore / not retested after restore | view-only, no mutation          |
| `w:500`                   | passed | historical runtime before restore / not retested after restore | records and deduplicates        |
| `s:view`                  | passed | passed                                                         | view-only, no mutation          |
| `s:cre:ok`                | passed | not required in final runtime                                  | records supplement confirmation |
| `s:ba:ok`                 | passed | not required in final runtime                                  | records supplement confirmation |
| `s:ma:ok`                 | passed | not required in final runtime                                  | records magnesium A             |
| `s:mb:ok` after `s:ma:ok` | passed | not required in final runtime                                  | blocks magnesium conflict       |
| `m:0930:wm`               | passed | passed                                                         | records and deduplicates        |

## Risks / follow-ups

* Water callbacks were validated locally after restore and had historical runtime evidence before the recovery, but were not re-clicked in the final runtime pass.
* There was earlier Desktop/gateway instability and stale process history. The final validation used an official gateway restart and considered only the current runtime PID.
* Earlier `TG_ANSWER_CALLBACK_ERROR` appeared on older/tardy water clicks, but did not appear in the final runtime validation.
