### PR TITLE
fix(acp): emit tool.completed updates immediately via progress callback (#50723)

### DIFF
--- a/acp_adapter/events.py
+++ b/acp_adapter/events.py
@@ -127,12 +127,38 @@ def make_tool_progress_cb(
 
     Emits ``ToolCallStart`` for ``tool.started`` events and tracks IDs in a FIFO
     queue per tool name so duplicate/parallel same-name calls still complete
-    against the correct ACP tool call.  Other event types (``tool.completed``,
-    ``reasoning.available``) are silently ignored.
+    against the correct ACP tool call.  Also handles ``tool.completed`` to
+    emit immediate completion updates so ACP clients do not show stale
+    "running" state.  The step callback's ``prev_tools`` completion path
+    remains as a safety net — it skips tools already completed here because
+    their queue entry was already popped.
     """
 
     def _tool_progress(event_type: str, name: str = None, preview: str = None, args: Any = None, **kwargs) -> None:
-        # Only emit ACP ToolCallStart for tool.started; ignore other event types
+        if event_type == "tool.completed":
+            queue = tool_call_ids.get(name)
+            if isinstance(queue, str):
+                queue = deque([queue])
+                tool_call_ids[name] = queue
+            if not queue:
+                return
+            tc_id = queue.popleft()
+            if not queue:
+                tool_call_ids.pop(name, None)
+            meta = tool_call_meta.pop(tc_id, {})
+            update = build_tool_complete(
+                tc_id,
+                name,
+                result=str(kwargs.get("result")) if kwargs.get("result") is not None else None,
+                function_args=meta.get("args"),
+                snapshot=meta.get("snapshot"),
+            )
+            _send_update(conn, session_id, loop, update)
+            if name == "todo":
+                plan_update = _build_plan_update_from_todo_result(kwargs.get("result"))
+                if plan_update is not None:
+                    _send_update(conn, session_id, loop, plan_update)
+            return
         if event_type != "tool.started":
             return
         if isinstance(args, str):

--- a/tests/acp/test_events.py
+++ b/tests/acp/test_events.py
@@ -126,6 +126,60 @@ class TestToolProgressCallback:
             step_cb(2, [{"name": "terminal", "result": "ok-2"}])
             assert "terminal" not in tool_call_ids
 
+    def test_tool_completed_emits_immediate_update(self, mock_conn, event_loop_fixture):
+        """tool.completed should emit ToolCallUpdate immediately via progress callback."""
+        tool_call_ids = {}
+        tool_call_meta = {}
+        loop = event_loop_fixture
+
+        cb = make_tool_progress_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
+
+        with patch("acp_adapter.events.make_tool_call_id", return_value="tc-complete"), \
+             patch("acp_adapter.events._send_update") as mock_send:
+            cb("tool.started", "terminal", "$ ls", {"command": "ls"})
+            assert "terminal" in tool_call_ids
+
+            cb("tool.completed", "terminal", None, None, result="file1.txt\nfile2.txt")
+
+        # Queue should be drained and tool removed
+        assert "terminal" not in tool_call_ids
+        assert "tc-complete" not in tool_call_meta
+        # Two calls: one for start, one for complete
+        assert mock_send.call_count == 2
+
+    def test_tool_completed_ignores_unmatched_name(self, mock_conn, event_loop_fixture):
+        """tool.completed for a name with no tracked IDs should be silently ignored."""
+        tool_call_ids = {}
+        tool_call_meta = {}
+        loop = event_loop_fixture
+
+        cb = make_tool_progress_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
+
+        with patch("acp_adapter.events._send_update") as mock_send:
+            cb("tool.completed", "unknown_tool", None, None, result="ok")
+
+        mock_send.assert_not_called()
+
+    def test_step_cb_skips_already_completed_tool(self, mock_conn, event_loop_fixture):
+        """Step callback should not double-complete tools finished by progress callback."""
+        tool_call_ids = {}
+        tool_call_meta = {}
+        loop = event_loop_fixture
+
+        progress_cb = make_tool_progress_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
+        step_cb = make_step_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
+
+        with patch("acp_adapter.events.make_tool_call_id", return_value="tc-fifo"), \
+             patch("acp_adapter.events._send_update") as mock_send:
+            progress_cb("tool.started", "terminal", "$ ls", {"command": "ls"})
+            progress_cb("tool.completed", "terminal", None, None, result="ok")
+
+            # Step callback should see empty queue and skip
+            step_cb(1, [{"name": "terminal", "result": "ok"}])
+
+        # Only 2 sends (start + complete), not 3
+        assert mock_send.call_count == 2
+
 
 # ---------------------------------------------------------------------------
 # Thinking callback


### PR DESCRIPTION
## What does this PR do?

Fixes missing ACP tool completion updates.

ACP clients can receive `tool.started` updates immediately, but `tool.completed` events were ignored by `make_tool_progress_cb()`. That meant the client could keep a tool card in a running state until the next agent step flushed completions through the step callback. This PR handles `tool.completed` in the progress callback, emits the completion update immediately, and leaves the existing step callback path as a no-duplicate safety net.

## Related Issue

Fixes #50723

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `acp_adapter/events.py`: handles `tool.completed` in `_tool_progress()`, pops the tracked FIFO tool call id, emits `build_tool_complete()`, and sends todo plan updates when the completed tool is `todo`.
- `tests/acp/test_events.py`: adds coverage for immediate `tool.completed` completion, unmatched completed events, and avoiding duplicate completion from the step callback after the progress callback already completed the tool.

## How to Test

1. From a disposable worktree checked out at this PR head, run `pytest tests/acp/test_events.py -xvs`.
2. Run a minimal behavior probe that calls the production `make_tool_progress_cb()` with `tool.started` followed by `tool.completed`.
3. Observed result: the targeted ACP event tests pass, and the behavior probe emits both the start update and immediate completion update while draining the tool tracking queues.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1, disposable local PR worktree

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) -- or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys -- or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows -- or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) -- or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior -- or N/A

## Screenshots / Logs

Targeted test run:

```text
$ pytest tests/acp/test_events.py -xvs
collected 22 items
tests/acp/test_events.py::TestToolProgressCallback::test_tool_completed_emits_immediate_update PASSED
tests/acp/test_events.py::TestToolProgressCallback::test_tool_completed_ignores_unmatched_name PASSED
tests/acp/test_events.py::TestToolProgressCallback::test_step_cb_skips_already_completed_tool PASSED
...
======================== 22 passed, 9 warnings in 0.50s ========================
```

Behavior probe output:

```text
$ python -c "<calls make_tool_progress_cb with tool.started then tool.completed>"
updates_count= 2
update_types= ['ToolCallStart', 'ToolCallProgress']
remaining_tool_call_ids= {}
remaining_tool_call_meta= {}
```

The probe uses the production callback from `acp_adapter.events`, so it verifies that `tool.completed` no longer waits for the next step callback to clear the ACP tool card.
