### PR TITLE
fix(acp): emit tool completion updates from progress callback (#50723)

### DIFF
--- a/acp_adapter/events.py
+++ b/acp_adapter/events.py
@@ -127,11 +127,41 @@ def make_tool_progress_cb(
 
     Emits ``ToolCallStart`` for ``tool.started`` events and tracks IDs in a FIFO
     queue per tool name so duplicate/parallel same-name calls still complete
-    against the correct ACP tool call.  Other event types (``tool.completed``,
-    ``reasoning.available``) are silently ignored.
+    against the correct ACP tool call.  ``tool.completed`` events pop the
+    oldest pending ID and emit a matching ``ToolCallUpdate`` so the ACP card
+    transitions out of "running" state without depending on the derived
+    step_callback path.  Other event types (``reasoning.available``) are
+    silently ignored.
     """
 
     def _tool_progress(event_type: str, name: str = None, preview: str = None, args: Any = None, **kwargs) -> None:
+        if event_type == "tool.completed":
+            if not name:
+                return
+            queue = tool_call_ids.get(name)
+            if not queue:
+                # No pending start for this name — likely the step callback
+                # already drained the queue, or the callback was attached
+                # after the tool started. Nothing to do.
+                return
+            tc_id = queue.popleft()
+            if not queue:
+                tool_call_ids.pop(name, None)
+            meta = tool_call_meta.pop(tc_id, {})
+            result = kwargs.get("result")
+            update = build_tool_complete(
+                tc_id,
+                name,
+                result=str(result) if result is not None else None,
+                function_args=meta.get("args"),
+                snapshot=meta.get("snapshot"),
+            )
+            _send_update(conn, session_id, loop, update)
+            if name == "todo":
+                plan_update = _build_plan_update_from_todo_result(result)
+                if plan_update is not None:
+                    _send_update(conn, session_id, loop, plan_update)
+            return
         # Only emit ACP ToolCallStart for tool.started; ignore other event types
         if event_type != "tool.started":
             return

--- a/tests/acp/test_events.py
+++ b/tests/acp/test_events.py
@@ -126,6 +126,122 @@ class TestToolProgressCallback:
             step_cb(2, [{"name": "terminal", "result": "ok-2"}])
             assert "terminal" not in tool_call_ids
 
+    def test_tool_completed_event_pops_fifo_and_emits_finish_update(self, mock_conn, event_loop_fixture):
+        """Regression for #50723: a tool.completed event must emit a matching
+        ToolCallUpdate so the ACP card transitions out of 'running' state.
+
+        Previously, the progress callback dropped tool.completed silently,
+        leaving some tool cards stuck. The fix pops the FIFO and emits
+        build_tool_complete via _send_update.
+        """
+        from collections import deque
+
+        tool_call_ids = {"terminal": deque(["tc-finish-1"])}
+        tool_call_meta = {"tc-finish-1": {"args": {"command": "ls"}, "snapshot": None}}
+        loop = event_loop_fixture
+
+        cb = make_tool_progress_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
+
+        with patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts, \
+             patch("acp_adapter.events._send_update") as mock_send:
+            future = MagicMock(spec=Future)
+            future.result.return_value = None
+            mock_rcts.return_value = future
+
+            cb("tool.completed", "terminal", None, None,
+               duration=0.42, is_error=False, result="ok")
+
+        # FIFO must be drained for this tool name
+        assert "terminal" not in tool_call_ids
+        # build_tool_complete path must have been called via _send_update
+        assert mock_send.call_count == 1
+        sent_update = mock_send.call_args.args[3]
+        # Update must be a tool_call_update (not a tool_call_start)
+        assert getattr(sent_update, "session_update", None) == "tool_call_update"
+
+    def test_tool_completed_event_pops_oldest_fifo_entry(self, mock_conn, event_loop_fixture):
+        """When several same-name tools are in flight, tool.completed must
+        pop the OLDEST pending ID (FIFO order), matching the start side.
+        """
+        from collections import deque
+
+        tool_call_ids = {"terminal": deque(["tc-first", "tc-second"])}
+        tool_call_meta = {
+            "tc-first": {"args": {"command": "ls"}, "snapshot": None},
+            "tc-second": {"args": {"command": "pwd"}, "snapshot": None},
+        }
+        loop = event_loop_fixture
+
+        cb = make_tool_progress_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
+
+        with patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts, \
+             patch("acp_adapter.events._send_update"):
+            future = MagicMock(spec=Future)
+            future.result.return_value = None
+            mock_rcts.return_value = future
+
+            cb("tool.completed", "terminal", None, None,
+               duration=0.1, is_error=False, result="ls-output")
+
+        # Oldest entry consumed; second entry still pending
+        assert list(tool_call_ids["terminal"]) == ["tc-second"]
+
+    def test_tool_completed_without_pending_id_is_safe(self, mock_conn, event_loop_fixture):
+        """If tool.completed arrives with no preceding tool.started (e.g. the
+        callback was attached after the tool already started, or the FIFO
+        was already drained by the step callback), the progress callback
+        must not crash and must not emit a finish update.
+        """
+        tool_call_ids: dict = {}
+        tool_call_meta: dict = {}
+        loop = event_loop_fixture
+
+        cb = make_tool_progress_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
+
+        with patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts, \
+             patch("acp_adapter.events._send_update") as mock_send:
+            future = MagicMock(spec=Future)
+            future.result.return_value = None
+            mock_rcts.return_value = future
+
+            # No prior tool.started; this should be a no-op
+            cb("tool.completed", "missing_tool", None, None,
+               duration=0.0, is_error=False, result="late")
+
+        assert "missing_tool" not in tool_call_ids
+        mock_send.assert_not_called()
+
+    def test_failed_tool_completion_forwards_result_for_failure_inference(self, mock_conn, event_loop_fixture):
+        """A failed tool's result string is forwarded to build_tool_complete;
+        build_tool_complete already infers the failed status from the result
+        content via _tool_result_failed(result, tool_name), so we just need
+        to thread `result` through.
+        """
+        from collections import deque
+
+        tool_call_ids = {"terminal": deque(["tc-fail-1"])}
+        tool_call_meta = {"tc-fail-1": {"args": {"command": "false"}, "snapshot": None}}
+        loop = event_loop_fixture
+
+        cb = make_tool_progress_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
+
+        with patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts, \
+             patch("acp_adapter.events.build_tool_complete") as mock_btc, \
+             patch("acp_adapter.events._send_update"):
+            future = MagicMock(spec=Future)
+            future.result.return_value = None
+            mock_rcts.return_value = future
+
+            cb("tool.completed", "terminal", None, None,
+               duration=0.5, is_error=True, result="Error: command not found")
+
+        mock_btc.assert_called_once_with(
+            "tc-fail-1", "terminal",
+            result="Error: command not found",
+            function_args={"command": "false"},
+            snapshot=None,
+        )
+
 
 # ---------------------------------------------------------------------------
 # Thinking callback


### PR DESCRIPTION
## What

The ACP progress callback in `make_tool_progress_cb()` only handled `tool.started` events and silently dropped `tool.completed` events. In some flows the step callback's derived view arrives too late (or not at all), leaving tool cards stuck in a "running" state in ACP clients even though the underlying Hermes tool has already finished.

## Root Cause

`acp_adapter/events.py::_tool_progress()` had:
```python
if event_type != "tool.started":
    return
```

This early-return dropped `tool.completed` events that `agent/tool_executor.py` invokes with `result=function_result`, `is_error=is_error` kwargs.

## Fix

Added a `tool.completed` branch to `_tool_progress` that:

1. **Pops the oldest pending tc_id** from the per-name FIFO (`popleft()`), matching the start side's append order — correct for parallel same-name tool calls.
2. **Emits a matching ToolCallUpdate** via `build_tool_complete()` + `_send_update()`, preserving the captured args/snapshot from `tool_call_meta`.
3. **Handles the todo special case** — emits a plan update on todo completion, mirroring `make_step_cb`.
4. **Defensive no-op** — if the FIFO is empty (step callback already drained it, or callback was attached after the tool started), the completion is silently skipped.

No double-emission risk: both the progress callback and the step callback share the same FIFO drain pattern — whichever fires first empties the queue.

## Verification

- **RED phase**: 3 of 4 new regression tests fail on upstream/main (proving the bug exists).
- **GREEN phase**: all 23 tests in `tests/acp/test_events.py` pass with the fix.
- **Rebased** onto latest `upstream/main` — clean, exactly 1 commit ahead.

### Tests added (`tests/acp/test_events.py`)
- `test_tool_completed_event_pops_fifo_and_emits_finish_update` — basic completion emission
- `test_tool_completed_event_pops_oldest_fifo_entry` — FIFO order on parallel same-name calls
- `test_tool_completed_without_pending_id_is_safe` — defensive no-op when no start was seen
- `test_failed_tool_completion_forwards_result_for_failure_inference` — result forwarding for failure state

```
23 passed, 8 warnings in 0.17s
```

Closes #50723.

---

*Auto-published by Moonsong via Path B automated pipeline.*