### PR TITLE
fix(telegram): cap a single rich send at the visible message limit

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1128,12 +1128,31 @@ class TelegramAdapter(BasePlatformAdapter):
             and self._bot_supports_rich()
         )
 
+    def _content_fits_visible_limit(self, content: str) -> bool:
+        """True when content fits Telegram's normal visible message limit.
+
+        The raw rich endpoint accepts up to ``RICH_MESSAGE_MAX_CHARS`` (32,768),
+        but a single non-streamed rich send of a very long body still renders
+        poorly on clients and can appear truncated. A fresh ``send`` therefore
+        caps rich delivery at the regular 4,096-UTF-16-unit visible limit and
+        lets longer bodies fall back to the legacy MarkdownV2 chunking path.
+
+        This is deliberately *only* applied on the fresh-send gate
+        (:meth:`_should_attempt_rich`). The streaming-accumulation paths — rich
+        draft previews (:meth:`_should_attempt_rich_draft`) and the in-place
+        ``editMessageText`` finalize (:meth:`_try_edit_rich`) — keep using the
+        full 32,768 cap via :meth:`_content_fits_rich_limits`, so a long table
+        streamed to its final form is still delivered as one rich message.
+        """
+        return utf16_len(content) <= self.MAX_MESSAGE_LENGTH
+
     def _should_attempt_rich(
         self, content: str, metadata: Optional[Dict[str, Any]] = None
     ) -> bool:
         return bool(
             not (metadata or {}).get("expect_edits")
             and self._rich_eligible(content)
+            and self._content_fits_visible_limit(content)
         )
 
     def prefers_fresh_final_streaming(

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -301,25 +301,48 @@ async def test_oversized_content_skips_rich_and_chunks():
     assert adapter._bot.send_message.await_count > 1
 
 
-@pytest.mark.asyncio
-async def test_rich_limit_is_characters_not_bytes():
-    """Telegram's rich limit is UTF-8 characters, not encoded bytes."""
+def test_rich_limit_is_characters_not_bytes():
+    """The 32,768 rich cap is counted in UTF-8 characters, not encoded bytes.
+
+    Exercised at the predicate level: an accented body of 20k chars / 40k UTF-8
+    bytes is over the byte count but under the character cap, so the cap that
+    governs the streaming-accumulation paths still admits it. (A *fresh* send of
+    this length is separately capped at the visible message limit — see
+    :func:`test_long_single_rich_send_over_visible_limit_chunks`.)
+    """
     adapter = _make_adapter()
-    # Rich-eligible (table) so the content takes the rich path; the accented
-    # body is 20k chars / 40k UTF-8 bytes — over the byte count, under the
-    # character cap. CJK is intentionally avoided here because affected
-    # Telegram Desktop clients render CJK rich drafts incorrectly.
-    accented = "| a | b |\n|---|---|\n" + "é" * 20000
+    accented = "é" * 20000
     assert len(accented.encode("utf-8")) > TelegramAdapter.RICH_MESSAGE_MAX_BYTES
     assert len(accented) <= TelegramAdapter.RICH_MESSAGE_MAX_CHARS
 
-    result = await adapter.send("12345", accented)
+    assert adapter._content_fits_rich_limits(accented) is True
+
+
+@pytest.mark.asyncio
+async def test_long_single_rich_send_over_visible_limit_chunks():
+    """A fresh rich send over the visible message limit falls back to chunking.
+
+    The raw rich endpoint accepts up to 32,768 chars, but a single non-streamed
+    send of a long body renders poorly / appears truncated on clients, so the
+    fresh-send gate caps rich delivery at the normal 4,096-UTF-16-unit visible
+    limit. The streaming-accumulation paths (drafts, in-place finalize) are NOT
+    affected — see ``test_finalize_edit_rich_over_markdownv2_limit_not_split``.
+    """
+    adapter = _make_adapter()
+    big_table = "| a | b |\n|---|---|\n" + "\n".join(
+        f"| {'x' * 50} | {'y' * 50} |" for _ in range(40)
+    )
+    assert adapter.message_len_fn(big_table) > TelegramAdapter.MAX_MESSAGE_LENGTH
+    assert len(big_table) <= TelegramAdapter.RICH_MESSAGE_MAX_CHARS
+
+    result = await adapter.send("12345", big_table)
 
     assert result.success is True
     bot = adapter._bot
     assert bot is not None
-    bot.do_api_request.assert_awaited_once()
-    bot.send_message.assert_not_called()
+    # Not sent as one oversized rich blob; split onto the legacy chunking path.
+    bot.do_api_request.assert_not_called()
+    assert bot.send_message.await_count > 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Focused follow-up to #46124. That PR was closed because it also changed `streaming_overflow_limit` (returning `None` unconditionally), which re-fragmented long rich tables back into 4,096-char chunks and rolled back intentional streaming accumulation. This PR keeps **only** the defensible half: cap a *single, non-streamed* rich send at Telegram's normal visible message limit.

- A fresh `sendRichMessage` of a very long body still renders poorly on clients and can appear truncated, even though the raw rich endpoint accepts up to `RICH_MESSAGE_MAX_CHARS` (32,768).
- The fresh-send gate now also requires `utf16_len(content) <= MAX_MESSAGE_LENGTH` (4,096); longer bodies fall back to the legacy MarkdownV2 chunking path.
- `streaming_overflow_limit` is **unchanged** — no behavioral rollback this time.

## A note on placement (the one deviation from the review)

The close comment suggested touching only `_content_fits_rich_limits`. On current `main`, that predicate is shared via `_rich_eligible` by three paths:

1. fresh send (`send` → `_should_attempt_rich`)
2. rich draft previews (`_should_attempt_rich_draft`)
3. the in-place `editMessageText` finalize (`edit_message(finalize=True)` → `_rich_eligible`)

Putting the visible-limit cap inside `_content_fits_rich_limits` therefore also caps (2) and (3), which **breaks `test_finalize_edit_rich_over_markdownv2_limit_not_split`** — the long-table streaming accumulation that is load-bearing and exactly what we want to preserve:

```
FAILED tests/gateway/test_telegram_rich_messages.py::test_finalize_edit_rich_over_markdownv2_limit_not_split
```

To honor the intent ("cap a single rich send while keeping streaming accumulation intact"), the cap lives on the fresh-send gate `_should_attempt_rich` via a small `_content_fits_visible_limit` helper. The draft and finalize paths keep using the full 32,768 cap via `_content_fits_rich_limits`, so a long table streamed to its final form is still delivered as one rich message. Happy to fold it directly into `_content_fits_rich_limits` instead if you'd prefer a parameterized variant.

## Tests

- Added `test_long_single_rich_send_over_visible_limit_chunks` — a fresh rich send over the visible limit (but under the 32,768 cap) chunks instead of sending one oversized rich blob.
- Reworked `test_rich_limit_is_characters_not_bytes` into a predicate-level char-vs-byte check (a fresh 20k send is now capped, so the char-vs-byte property is asserted on `_content_fits_rich_limits`, which still governs the streaming paths).
- Streaming/finalize/draft tests are unchanged and stay green.

```
venv/bin/pytest tests/gateway/test_telegram_rich_messages.py \
  tests/gateway/test_telegram_format.py tests/gateway/test_stream_consumer_draft.py
# 184 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)