### PR TITLE
feat: add Sakana AI provider

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1188,6 +1188,8 @@ _PROVIDER_ALIASES = {
     "arceeai": "arcee",
     "gmi-cloud": "gmi",
     "gmicloud": "gmi",
+    "sakana-ai": "sakana",
+    "fugu": "sakana",
     "minimax-china": "minimax-cn",
     "minimax_cn": "minimax-cn",
     "minimax-portal": "minimax-oauth",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -191,6 +191,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="https://api.gmi-serving.com/v1",
         base_url_env_var="GMI_BASE_URL",
     ),
+    "sakana": HermesOverlay(
+        transport="openai_chat",
+        extra_env_vars=("SAKANA_API_KEY",),
+        base_url_override="https://api.sakana.ai/v1",
+        base_url_env_var="SAKANA_BASE_URL",
+    ),
     "ollama-cloud": HermesOverlay(
         transport="openai_chat",
         base_url_override="https://ollama.com/v1",
@@ -338,6 +344,10 @@ ALIASES: Dict[str, str] = {
     "gmi-cloud": "gmi",
     "gmicloud": "gmi",
 
+    # sakana
+    "sakana-ai": "sakana",
+    "fugu": "sakana",
+
     # Local server aliases → virtual "local" concept (resolved via user config)
     "lmstudio": "lmstudio",
     "lm-studio": "lmstudio",
@@ -361,6 +371,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "stepfun": "StepFun Step Plan",
     "xiaomi": "Xiaomi MiMo",
     "gmi": "GMI Cloud",
+    "sakana": "Sakana AI",
     "tencent-tokenhub": "Tencent TokenHub",
     "lmstudio": "LM Studio",
     "local": "Local endpoint",

--- a/plugins/model-providers/sakana/__init__.py
+++ b/plugins/model-providers/sakana/__init__.py
@@ -1,0 +1,26 @@
+"""Sakana AI Fugu provider profile."""
+
+from hermes_cli import __version__ as _HERMES_VERSION
+from providers import register_provider
+from providers.base import ProviderProfile
+
+sakana = ProviderProfile(
+    name="sakana",
+    aliases=("sakana-ai", "fugu"),
+    display_name="Sakana AI",
+    description="Sakana AI Fugu — multi-agent LLM API",
+    signup_url="https://console.sakana.ai/",
+    env_vars=("SAKANA_API_KEY", "SAKANA_BASE_URL"),
+    base_url="https://api.sakana.ai/v1",
+    auth_type="api_key",
+    # Attribution so Sakana can identify traffic from Hermes Agent.
+    # The generic profile.default_headers fallback in run_agent.py and
+    # agent/auxiliary_client.py picks this up at client construction time.
+    default_headers={"User-Agent": f"HermesAgent/{_HERMES_VERSION}"},
+    fallback_models=(
+        "fugu",
+        "fugu-ultra",
+    ),
+)
+
+register_provider(sakana)

--- a/plugins/model-providers/sakana/plugin.yaml
+++ b/plugins/model-providers/sakana/plugin.yaml
@@ -1,0 +1,5 @@
+name: sakana-provider
+kind: model-provider
+version: 1.0.0
+description: Sakana AI Fugu models
+author: Nous Research

--- a/tests/hermes_cli/test_sakana_provider.py
+++ b/tests/hermes_cli/test_sakana_provider.py
@@ -1,0 +1,87 @@
+"""Tests for Sakana AI Fugu provider support."""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli.auth import (
+    PROVIDER_REGISTRY,
+    get_api_key_provider_status,
+    resolve_api_key_provider_credentials,
+    resolve_provider,
+)
+from hermes_cli.models import _PROVIDER_LABELS, normalize_provider
+
+
+@pytest.fixture(autouse=True)
+def _clear_sakana_env(monkeypatch):
+    for key in (
+        "SAKANA_API_KEY",
+        "SAKANA_BASE_URL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+class TestSakanaProviderProfile:
+    def test_registered_in_provider_registry(self):
+        assert "sakana" in PROVIDER_REGISTRY
+        cfg = PROVIDER_REGISTRY["sakana"]
+        assert cfg.name == "Sakana AI"
+        assert cfg.auth_type == "api_key"
+        assert cfg.inference_base_url == "https://api.sakana.ai/v1"
+        assert cfg.api_key_env_vars == ("SAKANA_API_KEY",)
+        assert cfg.base_url_env_var == "SAKANA_BASE_URL"
+
+    def test_profile_fields(self):
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("sakana")
+        assert profile is not None
+        assert profile.display_name == "Sakana AI"
+        assert profile.base_url == "https://api.sakana.ai/v1"
+        assert profile.fallback_models == ("fugu", "fugu-ultra")
+        assert profile.default_headers["User-Agent"].startswith("HermesAgent/")
+
+
+class TestSakanaAliases:
+    @pytest.mark.parametrize("alias", ["sakana", "sakana-ai", "fugu"])
+    def test_alias_resolves(self, alias, monkeypatch):
+        monkeypatch.setenv("SAKANA_API_KEY", "sakana-test-key")
+        assert resolve_provider(alias) == "sakana"
+
+    def test_models_normalize_provider(self):
+        assert normalize_provider("sakana-ai") == "sakana"
+        assert normalize_provider("fugu") == "sakana"
+
+    def test_providers_normalize_provider(self):
+        from hermes_cli.providers import normalize_provider as normalize_provider_in_providers
+
+        assert normalize_provider_in_providers("sakana-ai") == "sakana"
+        assert normalize_provider_in_providers("fugu") == "sakana"
+
+
+class TestSakanaCredentials:
+    def test_status_configured_from_sakana_api_key(self, monkeypatch):
+        monkeypatch.setenv("SAKANA_API_KEY", "sk-sakana-test")
+        status = get_api_key_provider_status("sakana")
+        assert status["configured"]
+
+    def test_resolve_credentials_default_base_url(self, monkeypatch):
+        monkeypatch.setenv("SAKANA_API_KEY", "sk-sakana-test")
+        creds = resolve_api_key_provider_credentials("sakana")
+        assert creds["api_key"] == "sk-sakana-test"
+        assert creds["base_url"] == "https://api.sakana.ai/v1"
+
+    def test_resolve_credentials_base_url_override(self, monkeypatch):
+        monkeypatch.setenv("SAKANA_API_KEY", "sk-sakana-test")
+        monkeypatch.setenv("SAKANA_BASE_URL", "https://sakana.example/v1")
+        creds = resolve_api_key_provider_credentials("sakana")
+        assert creds["base_url"] == "https://sakana.example/v1"
+
+
+class TestSakanaModelCatalog:
+    def test_static_model_list_fallback(self):
+        from hermes_cli.models import provider_model_ids
+
+        assert _PROVIDER_LABELS["sakana"] == "Sakana AI"
+        assert provider_model_ids("sakana") == ["fugu", "fugu-ultra"]

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -26,6 +26,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **Kimi / Moonshot (China)** | `KIMI_CN_API_KEY` in `~/.hermes/.env` (provider: `kimi-coding-cn`; aliases: `kimi-cn`, `moonshot-cn`) |
 | **Arcee AI** | `ARCEEAI_API_KEY` in `~/.hermes/.env` (provider: `arcee`; aliases: `arcee-ai`, `arceeai`) |
 | **GMI Cloud** | `GMI_API_KEY` in `~/.hermes/.env` (provider: `gmi`; aliases: `gmi-cloud`, `gmicloud`) |
+| **Sakana AI** | `SAKANA_API_KEY` in `~/.hermes/.env` (provider: `sakana`; aliases: `sakana-ai`, `fugu`) |
 | **MiniMax** | `MINIMAX_API_KEY` in `~/.hermes/.env` (provider: `minimax`) |
 | **MiniMax China** | `MINIMAX_CN_API_KEY` in `~/.hermes/.env` (provider: `minimax-cn`) |
 | **xAI (Grok) — Responses API** | `XAI_API_KEY` in `~/.hermes/.env` (provider: `xai`) |
@@ -257,6 +258,11 @@ hermes chat --provider arcee --model trinity-large-thinking
 # Use the exact model ID returned by GMI's /v1/models endpoint.
 hermes chat --provider gmi --model zai-org/GLM-5.1-FP8
 # Requires: GMI_API_KEY in ~/.hermes/.env
+
+# Sakana AI Fugu
+hermes chat --provider sakana --model fugu
+hermes chat --provider sakana --model fugu-ultra
+# Requires: SAKANA_API_KEY in ~/.hermes/.env
 ```
 
 Or set the provider permanently in `config.yaml`:
@@ -266,7 +272,7 @@ model:
   default: "zai-org/GLM-5.1-FP8"
 ```
 
-Base URLs can be overridden with `NOVITA_BASE_URL`, `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `DASHSCOPE_BASE_URL`, `XIAOMI_BASE_URL`, `GMI_BASE_URL`, or `TOKENHUB_BASE_URL` environment variables.
+Base URLs can be overridden with `NOVITA_BASE_URL`, `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `DASHSCOPE_BASE_URL`, `XIAOMI_BASE_URL`, `GMI_BASE_URL`, `SAKANA_BASE_URL`, or `TOKENHUB_BASE_URL` environment variables.
 
 :::note Z.AI Endpoint Auto-Detection
 When using the Z.AI / GLM provider, Hermes automatically probes multiple endpoints (global, China, coding variants) to find one that accepts your API key. You don't need to set `GLM_BASE_URL` manually — the working endpoint is detected and cached automatically.


### PR DESCRIPTION
## Summary
- Add a bundled `sakana` model-provider plugin for Sakana AI Fugu.
- Register `SAKANA_API_KEY` / `FUGU_API_KEY`, `https://api.sakana.ai/v1`, and fallback models `fugu` / `fugu-ultra`.
- Wire Sakana aliases into provider normalization and document setup/usage.

## Testing
- `python -m pytest tests/hermes_cli/test_sakana_provider.py tests/providers/test_provider_profiles.py tests/hermes_cli/test_provider_catalog.py -q`
- `python -m pytest tests/hermes_cli/test_sakana_provider.py tests/hermes_cli/test_runtime_provider_resolution.py tests/hermes_cli/test_api_key_providers.py tests/run_agent/test_provider_attribution_headers.py tests/hermes_cli/test_provider_catalog.py -q`
- `python -m ruff check plugins/model-providers/sakana tests/hermes_cli/test_sakana_provider.py hermes_cli/models.py hermes_cli/providers.py`
- `git diff --check`

No live Sakana API call is required for CI; the provider is covered through registry, alias, credential, and catalog fallback tests.