### PR TITLE
fix(fireworks): use documented /v1/accounts/{account}/models endpoint and keep /model in sync

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2413,15 +2413,20 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
                     # the top of the picker; live-only entries are appended
                     # afterwards for discovery.  (#46850)
                     curated = list(_PROVIDER_MODELS.get(normalized, []))
-                    if curated:
-                        merged = list(curated)
-                        merged_lower = {m.lower() for m in curated}
-                        for m in live:
-                            if m.lower() not in merged_lower:
-                                merged.append(m)
-                                merged_lower.add(m.lower())
-                        return merged
-                    return live
+                    if normalized in _MODELS_DEV_PREFERRED:
+                        # For providers tracked in models.dev, the CLI setup
+                        # flow (`hermes model`) prefers the models.dev catalog
+                        # (#46850). Keep the same ordering here so `/model`
+                        # surfaces the same models, with live-only and curated
+                        # entries appended afterwards.
+                        return _merge_with_models_dev(normalized, list(curated) + list(live))
+                    merged = list(curated)
+                    merged_lower = {m.lower() for m in curated}
+                    for m in live:
+                        if m.lower() not in merged_lower:
+                            merged.append(m)
+                            merged_lower.add(m.lower())
+                    return merged
             # Use profile's fallback_models if defined
             if _p.fallback_models:
                 return list(_p.fallback_models)

--- a/plugins/model-providers/fireworks/__init__.py
+++ b/plugins/model-providers/fireworks/__init__.py
@@ -1,0 +1,86 @@
+"""Fireworks AI provider profile."""
+
+from typing import Any
+
+from providers import register_provider
+from providers.base import ProviderProfile, _profile_user_agent
+
+
+class FireworksProfile(ProviderProfile):
+    """Fireworks AI provider profile.
+
+    Fireworks exposes its model catalog at ``/v1/accounts/{account}/models``
+    (not the standard OpenAI ``/v1/models`` endpoint under the inference
+    base URL). The response uses ``name`` for the model ID and includes many
+    non-chat / non-tool models, so we filter for public models that support
+    tool use and return only the ``name`` field.
+    """
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Fetch the Fireworks model catalog.
+
+        Falls back to the static ``fallback_models`` if the API call fails.
+        """
+        import json
+        import urllib.request
+
+        url = (self.models_url or "").strip()
+        if not url:
+            return None
+
+        req = urllib.request.Request(url)
+        if api_key:
+            req.add_header("Authorization", f"Bearer {api_key}")
+        req.add_header("Accept", "application/json")
+        req.add_header("User-Agent", _profile_user_agent())
+        for k, v in self.default_headers.items():
+            req.add_header(k, v)
+
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                data = json.loads(resp.read().decode())
+        except Exception:
+            return None
+
+        items = data if isinstance(data, list) else data.get("models", [])
+        result: list[str] = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            name = item.get("name")
+            if not name:
+                continue
+            # Surface only public models that advertise tool support, so the
+            # picker matches the agentic catalog intent.
+            if item.get("public") is False:
+                continue
+            if not item.get("supportsTools"):
+                continue
+            result.append(name)
+        return result
+
+
+fireworks = FireworksProfile(
+    name="fireworks",
+    aliases=("fireworks-ai",),
+    env_vars=("FIREWORKS_API_KEY",),
+    display_name="Fireworks AI",
+    description="Fireworks AI (fast open model hosting)",
+    signup_url="https://fireworks.ai",
+    auth_type="api_key",
+    supports_health_check=True,
+    fallback_models=(
+        "accounts/fireworks/models/llama-v3p1-405b-instruct",
+        "accounts/fireworks/models/deepseek-v3",
+    ),
+    base_url="https://api.fireworks.ai/inference/v1",
+    models_url="https://api.fireworks.ai/v1/accounts/fireworks/models",
+)
+
+register_provider(fireworks)

--- a/plugins/model-providers/fireworks/plugin.yaml
+++ b/plugins/model-providers/fireworks/plugin.yaml
@@ -1,0 +1,5 @@
+name: fireworks-provider
+kind: model-provider
+version: 1.0.0
+description: Fireworks AI provider profile
+author: Nous Research

--- a/tests/hermes_cli/test_provider_live_curated_merge.py
+++ b/tests/hermes_cli/test_provider_live_curated_merge.py
@@ -3,6 +3,11 @@
 Guards the fix for #46850: when a provider's live /v1/models endpoint
 returns a stale or incomplete list, the static curated models from
 ``_PROVIDER_MODELS`` must still appear in the merged result.
+
+These tests use a provider *not* in ``_MODELS_DEV_PREFERRED`` to isolate
+the live+curated merge logic. Providers in ``_MODELS_DEV_PREFERRED`` also
+merge with models.dev; that behavior is covered in
+``test_models_dev_preferred_merge.py``.
 """
 
 from unittest.mock import MagicMock, patch
@@ -25,14 +30,15 @@ class TestGenericProviderLiveCuratedMerge:
     def test_live_models_merged_with_curated(self):
         """Curated models come first; live-only models are appended."""
         live = ["glm-5.2", "glm-5.1", "glm-5"]
-        curated = _PROVIDER_MODELS["zai"]  # includes glm-5.1, glm-5, glm-4.5, etc.
+        curated = ["glm-5.2", "glm-5.1", "glm-5", "glm-4.5", "glm-4.5-flash"]
         profile = self._make_profile(live)
 
         with (
             patch("providers.get_provider_profile", return_value=profile),
             patch("hermes_cli.auth.resolve_api_key_provider_credentials", return_value={"api_key": "k", "base_url": ""}),
+            patch.dict("hermes_cli.models._PROVIDER_MODELS", {"test-provider": curated}),
         ):
-            result = provider_model_ids("zai")
+            result = provider_model_ids("test-provider")
 
         # Curated entries first, in catalog order (keeps newest curated models
         # like glm-5.2 at the top of the picker — see #46309).
@@ -41,10 +47,9 @@ class TestGenericProviderLiveCuratedMerge:
         # Models present in both live and curated are not duplicated.
         assert result.count("glm-5.2") == 1
         assert result.count("glm-5.1") == 1
-        # Curated-only entries are part of the result (e.g. glm-4.5).
-        result_lower = [m.lower() for m in result]
-        assert "glm-4.5" in result_lower
-        assert "glm-4.5-flash" in result_lower
+        # Curated-only entries are part of the result.
+        assert "glm-4.5" in result
+        assert "glm-4.5-flash" in result
 
     def test_no_duplicate_models(self):
         """Models appearing in both live and curated are not duplicated."""
@@ -55,9 +60,9 @@ class TestGenericProviderLiveCuratedMerge:
         with (
             patch("providers.get_provider_profile", return_value=profile),
             patch("hermes_cli.auth.resolve_api_key_provider_credentials", return_value={"api_key": "k", "base_url": ""}),
-            patch.dict("hermes_cli.models._PROVIDER_MODELS", {"zai": curated}),
+            patch.dict("hermes_cli.models._PROVIDER_MODELS", {"test-provider": curated}),
         ):
-            result = provider_model_ids("zai")
+            result = provider_model_ids("test-provider")
 
         assert result.count("glm-5.1") == 1
         assert result.count("glm-5") == 1
@@ -72,9 +77,9 @@ class TestGenericProviderLiveCuratedMerge:
         with (
             patch("providers.get_provider_profile", return_value=profile),
             patch("hermes_cli.auth.resolve_api_key_provider_credentials", return_value={"api_key": "k", "base_url": ""}),
-            patch.dict("hermes_cli.models._PROVIDER_MODELS", {"zai": curated}),
+            patch.dict("hermes_cli.models._PROVIDER_MODELS", {"test-provider": curated}),
         ):
-            result = provider_model_ids("zai")
+            result = provider_model_ids("test-provider")
 
         # Curated-first: curated casing wins for models present in both.
         assert result == ["glm-5.1", "GLM-5", "glm-4.5"]
@@ -87,17 +92,16 @@ class TestGenericProviderLiveCuratedMerge:
         with (
             patch("providers.get_provider_profile", return_value=profile),
             patch("hermes_cli.auth.resolve_api_key_provider_credentials", return_value={"api_key": "k", "base_url": ""}),
-            patch.dict("hermes_cli.models._PROVIDER_MODELS", {"zai": []}),
+            patch.dict("hermes_cli.models._PROVIDER_MODELS", {"test-provider": []}),
         ):
-            result = provider_model_ids("zai")
+            result = provider_model_ids("test-provider")
 
         assert result == ["model-a", "model-b"]
 
     def test_live_empty_falls_back_to_curated(self):
         """When live returns nothing, curated static list is used.
 
-        ZAI is in _MODELS_DEV_PREFERRED so the fallback path merges with
-        models.dev.  We mock _merge_with_models_dev to isolate the test.
+        A non-preferred provider does not call models.dev.
         """
         curated = ["glm-5.1", "glm-5", "glm-4.5"]
         profile = self._make_profile([])
@@ -105,10 +109,9 @@ class TestGenericProviderLiveCuratedMerge:
         with (
             patch("providers.get_provider_profile", return_value=profile),
             patch("hermes_cli.auth.resolve_api_key_provider_credentials", return_value={"api_key": "k", "base_url": ""}),
-            patch.dict("hermes_cli.models._PROVIDER_MODELS", {"zai": curated}),
-            patch("hermes_cli.models._merge_with_models_dev", return_value=curated),
+            patch.dict("hermes_cli.models._PROVIDER_MODELS", {"test-provider": curated}),
         ):
-            result = provider_model_ids("zai")
+            result = provider_model_ids("test-provider")
 
         assert result == curated
 

--- a/tests/plugins/model_providers/test_fireworks_profile.py
+++ b/tests/plugins/model_providers/test_fireworks_profile.py
@@ -1,0 +1,92 @@
+"""Tests for the bundled Fireworks AI provider profile.
+
+Fireworks exposes its catalog at ``/v1/accounts/{account}/models`` with a
+response shape that uses ``name`` instead of ``id`` and includes many
+non-chat / non-tool models. The bundled profile must therefore:
+
+* set ``models_url`` to the documented Fireworks endpoint,
+* override ``fetch_models`` to extract ``name`` and filter for tool support,
+* keep the inference ``base_url`` pointing at the OpenAI-compatible endpoint
+  so the runtime still uses ``https://api.fireworks.ai/inference/v1``.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from providers import get_provider_profile
+from providers.base import ProviderProfile
+
+
+class TestFireworksProfile:
+    def test_profile_is_registered(self):
+        p = get_provider_profile("fireworks")
+        assert p is not None
+        assert p.name == "fireworks"
+
+    def test_profile_has_correct_catalog_and_inference_urls(self):
+        p = get_provider_profile("fireworks")
+        assert p.base_url == "https://api.fireworks.ai/inference/v1"
+        assert p.models_url == "https://api.fireworks.ai/v1/accounts/fireworks/models"
+
+    def test_fetch_models_extracts_name_and_filters_tools(self):
+        """Only public models with supportsTools=True are returned."""
+        p = get_provider_profile("fireworks")
+        fake_response = {
+            "models": [
+                {"name": "accounts/fireworks/models/tool-model", "public": True, "supportsTools": True},
+                {"name": "accounts/fireworks/models/private-tool-model", "public": False, "supportsTools": True},
+                {"name": "accounts/fireworks/models/no-tools-model", "public": True, "supportsTools": False},
+                {"name": "display-name-only", "public": True, "supportsTools": True},
+            ]
+        }
+        with patch("urllib.request.urlopen", return_value=_mock_json_response(fake_response)):
+            models = p.fetch_models(api_key="sk-test", timeout=30)
+
+        assert models == ["accounts/fireworks/models/tool-model", "display-name-only"]
+
+    def test_fetch_models_returns_none_on_network_error(self):
+        """A broken catalog endpoint should not crash the picker."""
+        p = get_provider_profile("fireworks")
+        with patch("urllib.request.urlopen", side_effect=OSError("network down")):
+            assert p.fetch_models(api_key="sk-test", timeout=30) is None
+
+    def test_fetch_models_uses_models_url(self):
+        """The override must hit the Fireworks models endpoint, not base_url/models."""
+        p = get_provider_profile("fireworks")
+        captured = {}
+
+        def capture_request(req, **_kwargs):
+            captured["url"] = req.full_url
+            return _mock_json_response({"models": []})
+
+        with patch("urllib.request.urlopen", side_effect=capture_request):
+            p.fetch_models(api_key="sk-test", timeout=30)
+
+        assert captured["url"] == "https://api.fireworks.ai/v1/accounts/fireworks/models"
+
+
+class _MockFile:
+    """Minimal file-like wrapper for urllib responses."""
+
+    def __init__(self, data):
+        self._data = data
+        self._read = False
+
+    def read(self):
+        if self._read:
+            return b""
+        self._read = True
+        return self._data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+def _mock_json_response(payload):
+    import json
+
+    return _MockFile(json.dumps(payload).encode())


### PR DESCRIPTION
## Problem

The in-session `/model` picker showed only 2 Fireworks models, while `hermes model` showed 15+.

## Root cause

Fireworks exposes its catalog at `GET /v1/accounts/{account}/models` (docs: https://docs.fireworks.ai/api-reference/list-models). The bundled Fireworks `ProviderProfile` had no plugin, and the auto-registered profile used `base_url=https://api.fireworks.ai/inference/v1`, so the generic `fetch_models()` probe hit `/inference/v1/models` which returns HTTP 500. The picker then fell back to the 2-model `fallback_models` list.

## Changes

- Add a bundled `plugins/model-providers/fireworks/` plugin with a `FireworksProfile` subclass:
  - Uses the documented `models_url`.
  - Extracts the `name` field (Fireworks uses `name`, not `id`).
  - Filters for public, tool-capable models.
- In `hermes_cli/models.py`, when a `_MODELS_DEV_PREFERRED` provider has a live catalog, merge the live results with the models.dev catalog so `/model` and `hermes model` surface the same models.
- Add unit tests for the Fireworks profile.

## Verification

- `provider_model_ids('fireworks')` now returns 28 models (15 from models.dev + 13 live-only) instead of 2.
- New Fireworks profile tests: 5 passed.
- models.dev merge tests: 14 passed.
- One pre-existing unrelated failure in `tests/hermes_cli/test_api_key_providers.py::TestResolveApiKeyProviderCredentials::test_resolve_minimax_with_key` (minimax base URL expectation mismatch).
