### PR TITLE
fix(ssh): skip ControlMaster multiplexing on native Windows OpenSSH (#50707)

### DIFF
--- a/tests/tools/test_ssh_environment.py
+++ b/tests/tools/test_ssh_environment.py
@@ -66,6 +66,31 @@ class TestBuildSSHCommand:
         env = SSHEnvironment(host="h", user="u")
         assert env._build_ssh_command()[-1] == "u@h"
 
+    def test_windows_skips_controlmaster_flags(self, monkeypatch):
+        # Native Windows OpenSSH cannot create the ControlMaster AF_UNIX
+        # socket, so the three multiplexing -o flags must be omitted there;
+        # the remaining hardening flags stay on every platform.
+        monkeypatch.setattr("tools.environments.ssh._IS_WINDOWS", True)
+        cmd = " ".join(SSHEnvironment(host="h", user="u")._build_ssh_command())
+        for token in ("ControlMaster", "ControlPersist", "ControlPath"):
+            assert token not in cmd
+        assert "BatchMode=yes" in cmd
+        assert "StrictHostKeyChecking=accept-new" in cmd
+
+    def test_scp_omits_controlpath_on_windows(self, monkeypatch):
+        monkeypatch.setattr("tools.environments.ssh._IS_WINDOWS", True)
+        calls = []
+
+        def _capture(cmd, *a, **k):
+            calls.append(cmd)
+            return subprocess.CompletedProcess([], 0)
+
+        monkeypatch.setattr("tools.environments.ssh.subprocess.run", _capture)
+        SSHEnvironment(host="h", user="u")._scp_upload("/local/f", "/remote/f")
+        scp_calls = [c for c in calls if c and c[0] == "scp"]
+        assert scp_calls, "scp should have been invoked"
+        assert "ControlPath" not in " ".join(scp_calls[0])
+
 
 class TestControlSocketPath:
     """Regression tests for issue #11840.

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -20,6 +20,13 @@ from tools.environments.file_sync import (
 
 logger = logging.getLogger(__name__)
 
+# Native Windows OpenSSH cannot create the AF_UNIX control socket that
+# ControlMaster multiplexing requires (every ssh/scp call fails with
+# "getsockname failed: Not a socket"). ControlMaster is pure connection-
+# reuse perf; session state persists via in-band stdout markers, so on
+# Windows we just skip multiplexing and use a fresh connection per call.
+_IS_WINDOWS = os.name == "nt"
+
 
 def _ensure_ssh_available() -> None:
     """Fail fast with a clear error when the SSH client is unavailable."""
@@ -82,9 +89,10 @@ class SSHEnvironment(BaseEnvironment):
 
     def _build_ssh_command(self, extra_args: list | None = None) -> list:
         cmd = ["ssh"]
-        cmd.extend(["-o", f"ControlPath={self.control_socket}"])
-        cmd.extend(["-o", "ControlMaster=auto"])
-        cmd.extend(["-o", "ControlPersist=300"])
+        if not _IS_WINDOWS:
+            cmd.extend(["-o", f"ControlPath={self.control_socket}"])
+            cmd.extend(["-o", "ControlMaster=auto"])
+            cmd.extend(["-o", "ControlPersist=300"])
         cmd.extend(["-o", "BatchMode=yes"])
         cmd.extend(["-o", "StrictHostKeyChecking=accept-new"])
         cmd.extend(["-o", "ConnectTimeout=10"])
@@ -169,7 +177,9 @@ class SSHEnvironment(BaseEnvironment):
             stdin=subprocess.DEVNULL,
         )
 
-        scp_cmd = ["scp", "-o", f"ControlPath={self.control_socket}"]
+        scp_cmd = ["scp"]
+        if not _IS_WINDOWS:
+            scp_cmd.extend(["-o", f"ControlPath={self.control_socket}"])
         if self.port != 22:
             scp_cmd.extend(["-P", str(self.port)])
         if self.key_path:

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -313,7 +313,7 @@ Every key under `terminal:` has an env-var override of the form `TERMINAL_<KEY_U
 
 ### SSH Backend
 
-Runs commands on a remote server over SSH. Uses ControlMaster for connection reuse (5-minute idle keepalive). Persistent shell is enabled by default — state (cwd, env vars) survives across commands.
+Runs commands on a remote server over SSH. On Unix-like hosts, it uses ControlMaster for connection reuse (5-minute idle keepalive). Native Windows OpenSSH uses a fresh SSH connection per command because ControlMaster's Unix-domain sockets are unavailable. Persistent shell is enabled by default — state (cwd, env vars) survives across commands.
 
 ```yaml
 terminal:

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
@@ -168,7 +168,7 @@ terminal:
 
 ### SSH 后端
 
-通过 SSH 在远程服务器上运行命令。使用 ControlMaster 进行连接复用（5 分钟空闲保活）。默认启用持久 shell —— 状态（cwd、环境变量）在命令之间保持。
+通过 SSH 在远程服务器上运行命令。在类 Unix 主机上使用 ControlMaster 进行连接复用（5 分钟空闲保活）。原生 Windows OpenSSH 不支持 ControlMaster 所需的 Unix 域套接字，因此每条命令都会建立新的 SSH 连接。默认启用持久 shell —— 状态（cwd、环境变量）在命令之间保持。
 
 ```yaml
 terminal:


### PR DESCRIPTION
## Problem

Closes #50707.

The SSH terminal backend builds every `ssh`/`scp` command with ControlMaster connection multiplexing unconditionally:

- `_build_ssh_command` (`tools/environments/ssh.py`) always adds `-o ControlPath=…`, `-o ControlMaster=auto`, `-o ControlPersist=300`
- `_scp_upload` always adds `-o ControlPath=…`

Native **Windows OpenSSH** cannot create the AF_UNIX control socket that ControlMaster requires, so on Windows **every** ssh/scp call dies with `getsockname failed: Not a socket`. The result is a 100% failure rate for the SSH backend on Windows desktop — no terminal tool call can run.

## Fix

Guard the four multiplexing flags behind a platform check:

```python
_IS_WINDOWS = os.name == "nt"
...
if not _IS_WINDOWS:
    cmd.extend(["-o", f"ControlPath={self.control_socket}"])
    cmd.extend(["-o", "ControlMaster=auto"])
    cmd.extend(["-o", "ControlPersist=300"])
```

ControlMaster is **pure connection-reuse perf** — session `cwd`/env state persists via the in-band stdout markers documented in this module's docstring, not via the control socket. So on Windows we simply use a fresh connection per command (slower, not broken); the reporter validated this exact workaround. Unix behaviour is byte-for-byte unchanged (the flags are still emitted first, in the same order).

The cleanup path (`-O exit`) is already gated by `if self.control_socket.exists():`, so it correctly no-ops on Windows where the socket is never created — no further change needed there.

This matches CONTRIBUTING priority #2 (cross-platform compatibility).

## Tests

Two regression tests in `tests/tools/test_ssh_environment.py` patch `_IS_WINDOWS=True` and assert no `ControlMaster`/`ControlPersist`/`ControlPath` tokens are emitted by `_build_ssh_command` or `_scp_upload`, while the hardening flags (`BatchMode`, `StrictHostKeyChecking`) stay. The existing `test_base_flags` keeps the Unix path green.
