### PR TITLE
fix(cli): validate enum config values in set_config_value (#50710)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -6801,15 +6801,49 @@ def set_config_value(key: str, value: str):
     # _set_nested which preserves list-typed nodes; before #17876 the
     # inline navigation here silently overwrote lists with dicts.
 
-    # Convert value to appropriate type
-    if value.lower() in {'true', 'yes', 'on'}:
-        value = True
-    elif value.lower() in {'false', 'no', 'off'}:
-        value = False
-    elif value.isdigit():
-        value = int(value)
-    elif value.replace('.', '', 1).isdigit():
-        value = float(value)
+    # Enumerated config keys that must be validated against a fixed set of
+    # string values. The CLI has always accepted these as raw strings, so a
+    # typo like `display.tool_progress none` would silently land in
+    # config.yaml and never reach the runtime gate (`mode != "off"`), with no
+    # error to the user — see #50710. The runtime check in
+    # gateway/display_config.py + the interactive wizard in hermes_cli/setup.py
+    # both already agree on these sets, so the writer must enforce them too.
+    # We validate *before* the bool/int/float coercion below, otherwise the
+    # 'off' string would silently turn into the bool `False` and the check
+    # would never match the documented string set.
+    _ENUM_CONFIG_KEYS = {
+        "display.tool_progress": ("off", "new", "all", "verbose"),
+    }
+    if key in _ENUM_CONFIG_KEYS:
+        allowed = _ENUM_CONFIG_KEYS[key]
+        if not isinstance(value, str) or value not in allowed:
+            allowed_str = "|".join(allowed)
+            print(
+                f"Error: '{key}' must be one of {{{allowed_str}}}, got {value!r}.",
+                file=sys.stderr,
+            )
+            print(
+                f"  e.g. hermes config set {key} {allowed[0]}",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        # Pass the validated string through unchanged — skip the bool/int
+        # coercion below so that "off" stays the string "off", not the bool
+        # False.
+        _skip_type_coercion = True
+    else:
+        _skip_type_coercion = False
+
+    # Convert value to appropriate type (skipped for enum keys, see above)
+    if not _skip_type_coercion:
+        if value.lower() in {'true', 'yes', 'on'}:
+            value = True
+        elif value.lower() in {'false', 'no', 'off'}:
+            value = False
+        elif value.isdigit():
+            value = int(value)
+        elif value.replace('.', '', 1).isdigit():
+            value = float(value)
 
     _set_nested(user_config, key, value)
     # Normalize the api_base → base_url alias at set-time too (issue #8919),

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -301,3 +301,54 @@ class TestSecretRedactionInDisplay:
 
         captured = capsys.readouterr()
         assert "Set model.reasoning_effort = high" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Enum validation — regression tests for #50710
+# ---------------------------------------------------------------------------
+
+class TestEnumValidation:
+    """`hermes config set display.tool_progress <value>` must reject values
+    outside the documented enum (off|new|all|verbose) — see #50710. Before
+    the fix, ``set_config_value`` wrote the raw string into config.yaml with
+    no validation, so a user setting ``none`` (or any typo) got a green
+    "✓ Set" echo, but the gateway kept streaming tool progress because
+    ``tool_progress_enabled = mode != "off"``.
+    """
+
+    _VALID_MODES = {"off", "new", "all", "verbose"}
+
+    @pytest.mark.parametrize("mode", ["off", "new", "all", "verbose"])
+    def test_valid_mode_is_accepted(self, mode, _isolated_hermes_home):
+        set_config_value("display.tool_progress", mode)
+        config = _read_config(_isolated_hermes_home)
+        import yaml
+        loaded = yaml.safe_load(config) if config.strip() else {}
+        assert loaded.get("display", {}).get("tool_progress") == mode
+
+    @pytest.mark.parametrize("bogus", ["none", "NONE", "true", "false", "0", "1", "always", "Verbose"])
+    def test_invalid_mode_rejected(self, bogus, _isolated_hermes_home, capsys):
+        """Unknown values must exit non-zero and must NOT be written to config."""
+        with pytest.raises(SystemExit) as excinfo:
+            set_config_value("display.tool_progress", bogus)
+        assert excinfo.value.code != 0
+
+        # Nothing was written to config.yaml
+        config = _read_config(_isolated_hermes_home)
+        assert bogus not in config
+        # And we should have told the user why
+        captured = capsys.readouterr()
+        err = (captured.err or "") + (captured.out or "")
+        assert "tool_progress" in err
+        # Help text lists the valid options
+        assert "off" in err and "verbose" in err
+
+    def test_invalid_value_does_not_clobber_existing(self, _isolated_hermes_home):
+        """A bad `set` call must not overwrite a previously-good value."""
+        set_config_value("display.tool_progress", "off")
+        with pytest.raises(SystemExit):
+            set_config_value("display.tool_progress", "none")
+        # The earlier 'off' should still be in config.yaml
+        import yaml
+        loaded = yaml.safe_load(_read_config(_isolated_hermes_home)) or {}
+        assert loaded.get("display", {}).get("tool_progress") == "off"


### PR DESCRIPTION
## Summary

`hermes config set display.tool_progress <value>` previously accepted **any** string and wrote it to `config.yaml` verbatim. The runtime gate (`gateway/run.py`: `tool_progress_enabled = mode != "off"`) treats only the exact string `"off"` as disabled, so a typo like `none` produced a green *✓ Set* echo and a config that **appears** to disable tool progress but leaves it enabled.

This enforces the documented enum (`off|new|all|verbose`) at write-time, matching the interactive wizard in `hermes_cli/setup.py` and the runtime normaliser in `gateway/display_config.py`. The validator runs **before** the existing bool/int/float coercion, otherwise `off` would silently turn into the bool `False` and the check would never match.

## Repro (before the fix)

```bash
hermes config set display.tool_progress none
# → ✓ Set display.tool_progress = none in /home/.../config.yaml  (lie: tool progress still streams)
hermes config set display.tool_progress Verbose
# → ✓ Set display.tool_progress = Verbose in /home/.../config.yaml  (case-sensitive, never matches)
```

## Behaviour (after the fix)

```bash
hermes config set display.tool_progress none
# → Error: 'display.tool_progress' must be one of {off|new|all|verbose}, got 'none'.
# → e.g. hermes config set display.tool_progress off
# → (exit code 2, nothing written to config.yaml)

hermes config set display.tool_progress off
# → ✓ Set display.tool_progress = off in /home/.../config.yaml  (string, not bool False)
```

## Tests

- 13 new regression tests in `tests/hermes_cli/test_set_config_value.py::TestEnumValidation`:
  - 4 valid modes (off|new|all|verbose) → accepted, written as the right type
  - 8 invalid values (none, NONE, true, false, 0, 1, always, Verbose) → rejected with `SystemExit(2)`, nothing written
  - A bad `set` call does **not** clobber a previously-good value
- 37 existing tests in the same file remain green (no regressions)

## Related

- Issue: #50710
- Cross-reference: `gateway/display_config.py::_normalise` + `hermes_cli/setup.py:1509` (interactive wizard) already agree on this set
- Follow-up opportunity: `display.show_reasoning`, `display.busy_ack_detail`, and `display.tool_progress_grouping` are also documented as enums in `gateway/display_config.py` and would benefit from the same writer-side check. Out of scope here, but a registry is in place to extend.

## Checklist

- [x] Reproduced on current `main`
- [x] Fix is in the writer, not in a downstream normaliser
- [x] 13 regression tests added + all 37 existing tests green
- [x] No public API change (only rejects values that were never valid)
- [x] Followed repo commit convention (`fix(scope): subject`)
