### PR TITLE
feat(memory): cap prefetch query length before recall embedding

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -23,6 +23,7 @@ move-and-name refactor with no semantic change.
 from __future__ import annotations
 
 import logging
+import os
 import threading
 import uuid
 from dataclasses import dataclass
@@ -32,6 +33,29 @@ from agent.iteration_budget import IterationBudget
 from agent.model_metadata import estimate_request_tokens_rough
 
 logger = logging.getLogger(__name__)
+
+
+def _bound_prefetch_query(query: str) -> str:
+    """Cap a memory-recall query before it is embedded / hybrid-searched.
+
+    Some hosts pack their whole system prompt + tool catalogue into the prompt
+    text, arriving as a 50-100KB "user message". Embedding that blob stalls the
+    memory backend and the signal is boilerplate, not intent. Bound it to
+    ``HERMES_PREFETCH_QUERY_MAX_CHARS`` characters (default 1500); set the env
+    var to ``0`` to disable the cap entirely.
+    """
+    try:
+        cap = int(os.environ.get("HERMES_PREFETCH_QUERY_MAX_CHARS", "1500"))
+    except (TypeError, ValueError):
+        cap = 1500
+    if cap > 0 and len(query) > cap:
+        logger.info(
+            "Memory prefetch query truncated: %d -> %d chars "
+            "(set HERMES_PREFETCH_QUERY_MAX_CHARS to override; 0 disables)",
+            len(query), cap,
+        )
+        return query[:cap]
+    return query
 
 
 def _compression_made_progress(
@@ -419,6 +443,7 @@ def build_turn_context(
     if agent._memory_manager:
         try:
             _query = original_user_message if isinstance(original_user_message, str) else ""
+            _query = _bound_prefetch_query(_query)
             ext_prefetch_cache = agent._memory_manager.prefetch_all(_query) or ""
         except Exception:
             pass

--- a/tests/agent/test_prefetch_query_cap.py
+++ b/tests/agent/test_prefetch_query_cap.py
@@ -1,0 +1,54 @@
+"""Tests for the memory-prefetch query-length cap (HERMES_PREFETCH_QUERY_MAX_CHARS).
+
+A large "user message" (e.g. a host that packs its whole system prompt + tool
+catalogue into the prompt text, arriving as a 50-100KB blob) is bounded before it
+is handed to the memory backend's prefetch_all(), so embedding/hybrid search isn't
+stalled by boilerplate. The env var tunes the cap; 0 disables it.
+
+These tests call the REAL production helper ``agent.turn_context._bound_prefetch_query``.
+"""
+import importlib
+
+import pytest
+
+from agent.turn_context import _bound_prefetch_query
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    monkeypatch.delenv("HERMES_PREFETCH_QUERY_MAX_CHARS", raising=False)
+    yield
+
+
+def test_long_query_truncated_to_default_cap():
+    big = "x" * 60000
+    out = _bound_prefetch_query(big)
+    assert len(out) == 1500
+    assert out == big[:1500]
+
+
+def test_short_query_unchanged():
+    short = "what is the weather where this machine is"
+    assert _bound_prefetch_query(short) == short
+
+
+def test_env_override_changes_cap(monkeypatch):
+    monkeypatch.setenv("HERMES_PREFETCH_QUERY_MAX_CHARS", "10")
+    assert _bound_prefetch_query("y" * 500) == "y" * 10
+
+
+def test_zero_disables_cap(monkeypatch):
+    monkeypatch.setenv("HERMES_PREFETCH_QUERY_MAX_CHARS", "0")
+    big = "z" * 9000
+    assert _bound_prefetch_query(big) == big  # unbounded when disabled
+
+
+def test_malformed_env_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("HERMES_PREFETCH_QUERY_MAX_CHARS", "not-an-int")
+    big = "w" * 4000
+    out = _bound_prefetch_query(big)
+    assert len(out) == 1500  # bad value -> default cap, not a crash
+
+
+def test_empty_query_unchanged():
+    assert _bound_prefetch_query("") == ""


### PR DESCRIPTION
## Summary

Cap the memory-recall query length before it's embedded / hybrid-searched.

Some hosts pack their whole system prompt + tool catalogue into the prompt text, so the
"user message" that reaches the memory-prefetch step can be a 50-100KB blob. Embedding
that whole thing stalls the memory backend, and the signal is boilerplate rather than the
user's actual intent.

This bounds the recall query to `HERMES_PREFETCH_QUERY_MAX_CHARS` characters (default
1500) right before `agent._memory_manager.prefetch_all(...)` in `build_turn_context`.
Set the env var to `0` to disable the cap entirely.

## Implementation

- Extracted the bounding logic into a small pure helper
  `agent.turn_context._bound_prefetch_query(query)` so it's directly unit-testable.
- Malformed env values fall back to the default cap rather than raising.
- Logs once at INFO when a truncation happens, naming the override env var.

## Tests

`tests/agent/test_prefetch_query_cap.py` (6 tests, all green) call the **real** helper:
default-cap truncation, short-query-unchanged, env override, `0`-disables, malformed-env
falls back to default, empty query.

## Scope

Two files, +79 lines, no dependencies on anything outside `agent/turn_context.py`. Draft
pending maintainer review.
