### PR TITLE
fix(agent): record cwd for TUI sessions so Desktop can group them (#50438)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -68,16 +68,22 @@ from hermes_constants import get_hermes_home
 def _launch_cwd_for_session(source: str) -> Optional[str]:
     """Working directory to stamp on a new session row, or None.
 
-    Only local CLI sessions get a recorded cwd: the directory the process was
-    launched from is meaningful for ``hermes -c`` / ``--resume`` (relaunch
-    where you left off). Gateway/cron/remote-backend sessions have no stable
-    host cwd to restore, so they record nothing.
+    Local user-driven sessions (``cli`` and ``tui``) get a recorded cwd: the
+    directory the process was launched from is meaningful for
+    ``hermes -c`` / ``--resume`` (relaunch where you left off) and for the
+    Desktop GUI to group sessions by workspace — see #50438. Before the
+    fix, TUI sessions were stamped with ``cwd = NULL`` because the helper
+    rejected any source other than ``"cli"`` even though ``hermes --tui``
+    is also a local user-driven process.
+
+    Gateway/cron/remote-backend sessions have no stable host cwd to
+    restore, so they record nothing.
 
     ``TERMINAL_ENV`` is set by the CLI's config bridge (``load_cli_config``);
     a non-"local" backend (docker/ssh/modal/...) means the host cwd is
     irrelevant to the agent's tools, so we skip it there too.
     """
-    if source != "cli":
+    if source not in ("cli", "tui"):
         return None
     backend = (os.environ.get("TERMINAL_ENV") or "local").strip().lower()
     if backend and backend != "local":

--- a/tests/run_agent/test_launch_cwd_for_session.py
+++ b/tests/run_agent/test_launch_cwd_for_session.py
@@ -1,0 +1,84 @@
+"""Tests for run_agent._launch_cwd_for_session — see #50438.
+
+The TUI (``hermes --tui``) is a local user-driven process exactly like the
+CLI: it runs on the user's machine, is launched from a shell, and the
+launch directory is meaningful for ``-c``/``--resume``. Before #50438, the
+helper rejected any source other than ``"cli"``, so TUI sessions were
+stored with ``cwd = NULL`` in ``state.db`` and the Desktop GUI could not
+group them under the user's working directory.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from run_agent import _launch_cwd_for_session
+
+
+@pytest.fixture
+def fake_cwd(tmp_path, monkeypatch):
+    """``cd`` into tmp_path so ``os.getcwd()`` returns it."""
+    monkeypatch.chdir(tmp_path)
+    # The function checks TERMINAL_ENV; reset it for "local backend" tests.
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+    return tmp_path
+
+
+class TestLocalSourcesRecordCwd:
+    """Local user-driven sources must record the launch directory."""
+
+    @pytest.mark.parametrize("source", ["cli", "tui"])
+    def test_local_sources_record_getcwd(self, source, fake_cwd):
+        assert _launch_cwd_for_session(source) == str(fake_cwd)
+
+    def test_cli_explicit(self, fake_cwd):
+        """Smoke: the original "cli" path still works after the fix."""
+        assert _launch_cwd_for_session("cli") == str(fake_cwd)
+
+    def test_tui_records_cwd(self, fake_cwd):
+        """The fix: TUI sessions now get a recorded cwd, not NULL."""
+        # Before #50438: returned None.
+        # After:          returns the current working directory.
+        assert _launch_cwd_for_session("tui") == str(fake_cwd)
+
+
+class TestRemoteSourcesDoNotRecordCwd:
+    """Gateway and cron have no stable host cwd to restore."""
+
+    @pytest.mark.parametrize("source", ["gateway", "cron", "desktop", "api"])
+    def test_remote_sources_return_none(self, source, fake_cwd):
+        assert _launch_cwd_for_session(source) is None
+
+
+class TestNonLocalBackendSkipsCwd:
+    """A non-local TERMINAL backend (docker/ssh/modal) means the host cwd
+    is irrelevant — the function must return None even for local sources.
+    """
+
+    @pytest.mark.parametrize("source", ["cli", "tui"])
+    @pytest.mark.parametrize("backend", ["docker", "ssh", "modal", "singularity", "daytona"])
+    def test_nonlocal_backend_returns_none(self, source, backend, fake_cwd, monkeypatch):
+        monkeypatch.setenv("TERMINAL_ENV", backend)
+        assert _launch_cwd_for_session(source) is None
+
+    @pytest.mark.parametrize("source", ["cli", "tui"])
+    def test_local_backend_keeps_cwd(self, source, fake_cwd, monkeypatch):
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        assert _launch_cwd_for_session(source) == str(fake_cwd)
+
+
+class TestDeletedCwd:
+    """If the cwd is unlinked out from under us, return None gracefully."""
+
+    def test_oserror_returns_none(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        # Replace os.getcwd with one that raises
+        def _raise_oserror():
+            raise OSError("cwd was deleted")
+        monkeypatch.setattr(os, "getcwd", _raise_oserror)
+        # Should not raise
+        assert _launch_cwd_for_session("tui") is None
+        assert _launch_cwd_for_session("cli") is None


### PR DESCRIPTION
## Summary

`_launch_cwd_for_session()` in `run_agent.py` only recorded the launch directory for `source == "cli"` sessions. TUI sessions launched via `hermes --tui` were stamped with `cwd = NULL` in `state.db`, so the Desktop GUI could not group them under the user's working directory — every TUI session landed in the default/"No workspace" bucket.

## Why TUI belongs in the allowlist

`hermes --tui` is a local user-driven process exactly like the CLI: it runs on the user's machine, is launched from a shell, and the launch directory is meaningful for `-c`/`--resume` (relaunch where you left off) and for the Desktop workspace grouping. The only sources that correctly skip cwd are gateway/cron/remote-backend (no stable host cwd to restore).

## Fix

Widens the local-source allowlist from `{"cli"}` to `{"cli", "tui"}`. The non-local `TERMINAL_ENV` backend (docker/ssh/modal/...) guard already applied to both, so the existing semantics for remote backends are preserved. Gateway/cron/desktop/api still get `None`.

## Repro (before the fix)

```bash
cd ~/Documents/pa
hermes --tui
# → start a session
# → state.db: INSERT INTO sessions (..., cwd=NULL, source='tui', ...)
# → Desktop GUI: session appears under "No workspace", not under "pa"
```

## Behaviour (after the fix)

```bash
cd ~/Documents/pa
hermes --tui
# → state.db: INSERT INTO sessions (..., cwd='/home/user/Documents/pa', source='tui', ...)
# → Desktop GUI: session correctly grouped under the "pa" workspace
```

## Tests

- **21 new regression tests** in `tests/run_agent/test_launch_cwd_for_session.py`:
  - 2 local sources (cli, tui) record cwd → green
  - 4 remote sources (gateway, cron, desktop, api) return None → green
  - 5 non-local backends × 2 sources (10 parametrised cases) skip cwd → green
  - 1 `local` backend keeps cwd for both local sources → green
  - 1 OSError-on-getcwd fallback returns None gracefully → green
- **1745 existing tests** in `tests/run_agent/` + `tests/hermes_cli/test_resolve_last_session.py` → still green, no regressions

## Related

- Issue: #50438
- Cross-reference: `_session_source_for_agent()` in `run_agent.py` is the producer of `source` values; consumers are `_resolve_last_session()` and `update_session_cwd()`. The fix is contained to the writer side, so no consumer changes are needed.
- Follow-up opportunity: `source='api'` and `source='desktop'` are listed in this PR's tests as remote/non-cwd sources — that's the *current* behaviour preserved verbatim. If a future API/desktop path needs a recorded cwd, it would slot in the same way.