### PR TITLE
fix(agent): defer preflight compaction until real usage after a compaction (#23767, #36718)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -878,6 +878,18 @@ class ContextCompressor(ContextEngine):
         """
         if rough_tokens < self.threshold_tokens:
             return False
+        # Immediately after a compaction the post-compression path sets
+        # ``awaiting_real_usage_after_compression`` and parks
+        # ``last_prompt_tokens = -1``, but ``last_real_prompt_tokens`` still
+        # holds the STALE pre-compression value (above threshold — that's why
+        # compaction fired).  Without this guard that stale value defeats the
+        # ``last_real_prompt_tokens >= threshold_tokens`` check below, so
+        # preflight fires a SECOND compaction before the provider has reported
+        # real token usage for the now-shorter conversation.  Defer for exactly
+        # one turn; update_from_response() clears the flag when real usage
+        # arrives.  (#36718)
+        if self.awaiting_real_usage_after_compression:
+            return True
         if self.last_real_prompt_tokens <= 0:
             return False
         if self.last_real_prompt_tokens >= self.threshold_tokens:

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -86,6 +86,28 @@ class TestPreflightDeferral:
 
         assert compressor.should_defer_preflight_to_real_usage(93_000) is False
 
+    def test_defers_immediately_after_compaction_with_stale_real_prompt(self, compressor):
+        """#36718: right after a compaction, last_real_prompt_tokens still holds
+        the stale pre-compression value (above threshold). The awaiting flag
+        must force deferral so preflight doesn't fire a SECOND compaction before
+        real post-compaction usage arrives."""
+        compressor.threshold_tokens = 85_000
+        # Stale pre-compression value — would hit the `>= threshold => False`
+        # short-circuit and defeat deferral without the flag guard.
+        compressor.last_real_prompt_tokens = 120_000
+        compressor.awaiting_real_usage_after_compression = True
+        assert compressor.should_defer_preflight_to_real_usage(95_000) is True
+
+    def test_resumes_normal_deferral_after_flag_cleared(self, compressor):
+        """Once update_from_response() clears the flag, the normal baseline/
+        growth deferral logic governs again (no permanent deferral)."""
+        compressor.threshold_tokens = 85_000
+        compressor.last_real_prompt_tokens = 120_000
+        compressor.awaiting_real_usage_after_compression = False
+        # Stale-high real prompt with the flag cleared => the >= threshold
+        # short-circuit applies => no deferral.
+        assert compressor.should_defer_preflight_to_real_usage(95_000) is False
+
 
 
 class TestCompress:


### PR DESCRIPTION
## Summary

After a compaction, preflight could fire a **second** compaction before the provider ever reported real token usage for the now-shorter conversation. `should_defer_preflight_to_real_usage()` — the gate the preflight path consults — short-circuited to `False` on the **stale** `last_real_prompt_tokens` (the pre-compaction value, above threshold), so deferral never engaged. This adds the missing guard: defer while `awaiting_real_usage_after_compression` is set (exactly one turn, until real usage arrives). (Mode F of #23767; hardens #36718.)

## Relationship to #40582 (already merged)

#36718 was closed by #40582, which fixed a **different mechanism** for the same symptom — it stopped `turn_context.py` from clobbering the `last_prompt_tokens = -1` sentinel. That's necessary but **not sufficient**: the preflight gate is `should_defer_preflight_to_real_usage()`, which reads `last_real_prompt_tokens` (a *different* field, still stale-high post-compaction). With only #40582, `should_defer` still returns `False` and `should_compress(rough_estimate)` fires a second compaction. This PR closes that residual gate. Verified: the new regression test **fails on current main** (post-#40582) and passes with this fix.

## Changes

- `agent/context_compressor.py`: early-return `True` from `should_defer_preflight_to_real_usage()` when `awaiting_real_usage_after_compression` is set, placed after the `rough < threshold` cheap-exit (so below-threshold turns never over-defer).
- `tests/agent/test_context_compressor.py`: 2 tests in `TestPreflightDeferral` (defers on stale-real post-compaction; resumes normal logic once the flag clears).

## Validation

| | Result |
|---|---|
| `TestPreflightDeferral` (+2) | 5 passed |
| compressor defer/compress/update_model subset | 114 passed |
| ruff (diff vs main) | clean |
| Negative check | new test fails on main without the fix ✓ |
| E2E (real imports) | defers exactly one turn post-compaction; `update_from_response` clears the flag; below-threshold not over-deferred |

Interaction with #50137 (resets the flag on model switch): orthogonal — a switch deliberately recalibrates, so post-switch the guard correctly doesn't fire on stale post-compaction state.

Part of #23767 (does not close it — mode B still pending).

## Credit

- @ashishpatel26 — #38133 diagnosed the stale-`last_real_prompt_tokens` short-circuit and designed the `should_defer` early-return this implements.
- @Tranquil-Flow — #36769 proposed the same #36718 guard with identical placement.

Both PRs' branches also carried the flag-setting half (now on main via #40582's path) plus stale summary-prompt reverts, so this is a fresh commit of just the still-missing gate, credited above.

Closes #36718.

## Infographic

_Image generation is unavailable in this environment (FAL_KEY unset, no managed-provider credits); to be attached once available._
