### PR TITLE
fix(mem0): mark api_key as optional in config schema for self-hosted

### DIFF
--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -170,7 +170,7 @@ class Mem0MemoryProvider(MemoryProvider):
 
     def get_config_schema(self):
         return [
-            {"key": "api_key", "description": "Mem0 API key (cloud or self-hosted)", "secret": True, "required": True, "env_var": "MEM0_API_KEY", "url": "https://app.mem0.ai"},
+            {"key": "api_key", "description": "Mem0 API key (cloud or self-hosted)", "secret": True, "required": False, "env_var": "MEM0_API_KEY", "url": "https://app.mem0.ai"},
             {"key": "host", "description": "Self-hosted Mem0 URL (e.g. http://localhost:24220)", "default": "", "env_var": "MEM0_HOST"},
             {"key": "user_id", "description": "User identifier", "default": "hermes-user"},
             {"key": "agent_id", "description": "Agent identifier", "default": "hermes"},


### PR DESCRIPTION
## Summary

- PR #50479 added self-hosted support via `MEM0_HOST` — `is_available()` and `_get_client()` both accept host-only (no api_key)
- But `get_config_schema()` still declares `api_key` with `required: True`, misrepresenting the runtime contract
- Any downstream consumer of the schema (dashboard config UI, setup wizard validation, third-party tooling) would incorrectly flag a host-only install as misconfigured

## Fix

Change `required: True` → `required: False` on the `api_key` field. The runtime validation in `_get_client()` already enforces the real constraint: either `api_key` or `host` must be present.

## Test plan

- [x] `pytest tests/agent/test_memory_provider.py tests/agent/test_memory_user_id.py` — 105 passed
- [x] Schema verified: `api_key: required=False`