### PR TITLE
fix(gateway): stop orphaned typing indicator on /new reset

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -91,6 +91,19 @@ class GatewaySlashCommandsMixin:
                 self._cleanup_agent_resources(_old_agent)
         self._evict_cached_agent(session_key)
 
+        # Stop any orphaned typing indicator / _keep_typing task from the
+        # previous run.  Without this, /new dispatched via the normal command
+        # path (no agent in _running_agents) skips _interrupt_and_clear_session,
+        # and a surviving _keep_typing loop keeps sending typing indicators
+        # indefinitely (#50766).
+        _adapters = getattr(self, "adapters", None)
+        adapter = _adapters.get(source.platform) if _adapters else None
+        if adapter and hasattr(adapter, "interrupt_session_activity"):
+            try:
+                await adapter.interrupt_session_activity(session_key, source.chat_id)
+            except Exception:
+                pass
+
         # Discard any /queue overflow for this session — /new is a
         # conversation-boundary operation, queued follow-ups from the
         # previous conversation must not bleed into the new one.

--- a/tests/gateway/test_session_model_reset.py
+++ b/tests/gateway/test_session_model_reset.py
@@ -139,3 +139,22 @@ async def test_new_command_only_clears_own_session():
     assert other_key in runner._session_reasoning_overrides
     assert session_key not in runner._pending_model_notes
     assert other_key in runner._pending_model_notes
+
+
+@pytest.mark.asyncio
+async def test_new_command_stops_typing_indicator():
+    """/new must call adapter.interrupt_session_activity() to stop any
+    orphaned _keep_typing task from the previous run (#50766)."""
+    runner = _make_runner()
+    adapter = runner.adapters[Platform.TELEGRAM]
+    adapter.interrupt_session_activity = AsyncMock()
+
+    await runner._handle_reset_command(_make_event("/new"))
+
+    adapter.interrupt_session_activity.assert_awaited_once()
+    call_args = adapter.interrupt_session_activity.call_args
+    assert call_args is not None
+    # First positional arg is the session key, second is the chat_id
+    args, _ = call_args
+    assert len(args) == 2
+    assert args[1] == "c1"  # chat_id from _make_source()


### PR DESCRIPTION
## Summary

`_handle_reset_command` never calls `adapter.interrupt_session_activity()`, so `/new` dispatched via the normal command path (no agent in `_running_agents`) leaves orphaned `_keep_typing` tasks that keep sending typing indicators indefinitely.

Closes #50766.

## Root cause

There are two code paths to `/new`:

**Path A (quick path, agent running)** — `run.py:7117-7127`:
```python
if _cmd_def_inner.name == "new":
    await self._interrupt_and_clear_session(...)  # ← stops typing ✅
    return await self._handle_reset_command(event)
```

**Path B (normal dispatch, no running agent)** — `run.py:7508-7517`:
```python
if canonical == "new":
    async def _do_reset():
        return await self._handle_reset_command(event)  # ← no typing cleanup ❌
    return await self._maybe_confirm_destructive_slash(...)
```

`_handle_reset_command` (`slash_commands.py:64-143`) cleans up agent state, cache, and queue — but never touches the platform adapter's typing indicator. When a `_keep_typing` task survives a response (race condition, slow LLM response), Path B lets it continue as an orphan.

## Changes

- `gateway/slash_commands.py`: Call `adapter.interrupt_session_activity()` after `_evict_cached_agent` in `_handle_reset_command`. Guarded with `hasattr` + `try/except`, matching the pattern already used in the same method for `env_passthrough`, `credential_files`, and plugin hooks.
- `tests/gateway/test_session_model_reset.py`: Added `test_new_command_stops_typing_indicator` — asserts `/new` calls `interrupt_session_activity` with correct session_key and chat_id.

## Sibling-site audit

- **Path A** (`run.py:7117`): wraps `_handle_reset_command` with `_interrupt_and_clear_session` → already calls `interrupt_session_activity` → my fix calls it again → **idempotent, harmless** (just sets an `asyncio.Event` and calls `stop_typing`).
- **Path B** (`run.py:7508`): calls `_handle_reset_command` directly → **was missing typing cleanup → now fixed**.
- **`/stop`** (`slash_commands.py:700-744`): uses `_interrupt_and_clear_session` independently → **unaffected**.
- No other call sites to `_handle_reset_command` exist.

## Validation

| | Result |
|---|---|
| `test_session_model_reset.py` (4 tests) | ✅ 4 passed |
| ruff (diff vs main) | ✅ clean |
| Negative check: new test on main without fix | ✅ fails — `AssertionError: Expected interrupt_session_activity to have been awaited once. Awaited 0 times.` |

## Related

- #50766 — this bug (detailed analysis)
- #47539 — Telegram typing stuck (orphaned `_keep_typing`)
- #28004 — Telegram typing stuck (`_keep_typing` race condition)
- #26854 — Discord typing stuck (same family)
