### PR TITLE
fix(gateway): apply profile override in ephemeral agent threads (background, preview-restart)

### DIFF
--- a/tests/tui_gateway/test_ephemeral_profile_override.py
+++ b/tests/tui_gateway/test_ephemeral_profile_override.py
@@ -1,0 +1,158 @@
+"""Regression tests: profile HERMES_HOME override in ephemeral agent threads (#50233).
+
+Why: normal prompt turns bind ``session['profile_home']`` via
+``set_hermes_home_override`` before ``run_conversation`` so the turn runs against
+the correct profile home. The two ephemeral RPC paths — ``prompt.background`` and
+``preview.restart`` — spawn a fresh ``AIAgent`` on a NEW thread, and the
+``HERMES_HOME`` ContextVar set on the session-create thread does NOT propagate to
+those threads. Without an explicit re-bind, a background/preview-restart turn under
+a non-default profile would run against the wrong home. This module locks in:
+
+  1. ``prompt.background`` re-binds ``profile_home`` for the ephemeral turn.
+  2. ``preview.restart`` re-binds ``profile_home`` for the ephemeral turn AND does
+     NOT close the ephemeral agent (a task-wide ``AIAgent.close()`` would kill the
+     background server the restart just started — maintainer problem #1).
+  3. Both paths RESTORE the override after the turn (reset token from set), exactly
+     like the normal prompt turn, and skip the bind entirely when no profile is set.
+
+How to test: run this module with pytest; each test drives the real RPC handler
+from ``tui_gateway.server._methods`` with ``threading.Thread`` patched to run the
+target inline, then asserts on the recorded override set/reset calls and the agent.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tui_gateway import server as srv
+
+
+PROFILE_HOME = "/home/user/.hermes/profiles/work"
+
+
+class _InlineThread:
+    """Drop-in for ``threading.Thread`` that runs the target synchronously.
+
+    Why: the ephemeral RPC handlers do their real work inside ``run()`` on a
+    spawned thread; running it inline makes the override set/reset observable
+    within the test without racing a real background thread.
+    """
+
+    def __init__(self, target=None, daemon=None, **_kwargs):
+        self._target = target
+
+    def start(self):
+        if self._target is not None:
+            self._target()
+
+
+@pytest.fixture
+def fake_session():
+    """A minimal session carrying a non-default ``profile_home``."""
+    agent = MagicMock()
+    return {"agent": agent, "session_key": "sess_k", "profile_home": PROFILE_HOME}
+
+
+@pytest.fixture
+def override_calls():
+    """Patch set/reset override + AIAgent + emit/context helpers; record calls.
+
+    Returns a dict with the mocks so each test can assert on set/reset ordering
+    and on whether the ephemeral agent was closed.
+    """
+    agent_instance = MagicMock()
+    # run_conversation returns a plain dict like the real agent does.
+    agent_instance.run_conversation.return_value = {"final_response": "done"}
+
+    with patch("tui_gateway.server.threading.Thread", _InlineThread), \
+        patch("tui_gateway.server.set_hermes_home_override", return_value="TOK") as m_set, \
+        patch("tui_gateway.server.reset_hermes_home_override") as m_reset, \
+        patch("tui_gateway.server._background_agent_kwargs", return_value={}), \
+        patch("tui_gateway.server._ephemeral_preview_agent_kwargs", return_value={}), \
+        patch("tui_gateway.server._preview_restart_callbacks", return_value={}), \
+        patch("tui_gateway.server._preview_restart_history", return_value=[]), \
+        patch("tui_gateway.server._set_session_context", return_value=None), \
+        patch("tui_gateway.server._clear_session_context"), \
+        patch("tui_gateway.server._session_cwd", return_value="/tmp"), \
+        patch("tui_gateway.server._emit"), \
+        patch("run_agent.AIAgent", return_value=agent_instance) as m_agent:
+        yield {
+            "set": m_set,
+            "reset": m_reset,
+            "agent_cls": m_agent,
+            "agent": agent_instance,
+        }
+
+
+def _run(method_name, params, session):
+    """Invoke a registered RPC handler with ``_sess`` patched to our session."""
+    handler = srv._methods[method_name]
+    with patch("tui_gateway.server._sess", return_value=(session, None)):
+        return handler("rid1", params)
+
+
+class TestBackgroundProfileOverride:
+    def test_background_binds_and_restores_profile_home(self, fake_session, override_calls):
+        """prompt.background binds profile_home for the ephemeral turn and restores it."""
+        _run("prompt.background", {"text": "hi", "session_id": "ui1"}, fake_session)
+
+        override_calls["set"].assert_called_once_with(PROFILE_HOME)
+        override_calls["reset"].assert_called_once_with("TOK")
+        override_calls["agent"].run_conversation.assert_called_once()
+
+    def test_background_no_profile_skips_override(self, override_calls):
+        """With no profile_home the background path never touches the override."""
+        session = {"agent": MagicMock(), "session_key": "sess_k", "profile_home": None}
+        _run("prompt.background", {"text": "hi", "session_id": "ui1"}, session)
+
+        override_calls["set"].assert_not_called()
+        override_calls["reset"].assert_not_called()
+        override_calls["agent"].run_conversation.assert_called_once()
+
+    def test_background_restores_override_on_error(self, fake_session, override_calls):
+        """A failing turn must still restore the override (finally-block parity)."""
+        override_calls["agent"].run_conversation.side_effect = RuntimeError("boom")
+        _run("prompt.background", {"text": "hi", "session_id": "ui1"}, fake_session)
+
+        override_calls["set"].assert_called_once_with(PROFILE_HOME)
+        override_calls["reset"].assert_called_once_with("TOK")
+
+
+class TestPreviewRestartProfileOverride:
+    def test_preview_binds_and_restores_profile_home(self, fake_session, override_calls):
+        """preview.restart binds profile_home for the ephemeral turn and restores it."""
+        _run(
+            "preview.restart",
+            {"url": "http://localhost:5173", "cwd": "", "session_id": "ui1"},
+            fake_session,
+        )
+
+        override_calls["set"].assert_called_once_with(PROFILE_HOME)
+        override_calls["reset"].assert_called_once_with("TOK")
+        override_calls["agent"].run_conversation.assert_called_once()
+
+    def test_preview_does_not_close_agent(self, fake_session, override_calls):
+        """The restarted preview server must survive: the ephemeral agent is NOT
+        closed via task-wide process cleanup (maintainer problem #1)."""
+        _run(
+            "preview.restart",
+            {"url": "http://localhost:5173", "cwd": "", "session_id": "ui1"},
+            fake_session,
+        )
+
+        # A task-wide AIAgent.close() would kill every process for this task_id,
+        # tearing down the very background server the restart just launched.
+        override_calls["agent"].close.assert_not_called()
+
+    def test_preview_no_profile_skips_override(self, override_calls):
+        """With no profile_home the preview path never touches the override."""
+        session = {"agent": MagicMock(), "session_key": "sess_k", "profile_home": None}
+        _run(
+            "preview.restart",
+            {"url": "http://localhost:5173", "cwd": "", "session_id": "ui1"},
+            session,
+        )
+
+        override_calls["set"].assert_not_called()
+        override_calls["reset"].assert_not_called()
+        override_calls["agent"].close.assert_not_called()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10084,12 +10084,28 @@ def _(rid, params: dict) -> dict:
         try:
             from run_agent import AIAgent
 
-            result = AIAgent(
-                **_background_agent_kwargs(session["agent"], task_id)
-            ).run_conversation(
-                user_message=text,
-                task_id=task_id,
+            # Bug #50233: ephemeral agent threads don't inherit the session's
+            # HERMES_HOME override (the ContextVar set on the session-create
+            # thread doesn't propagate here), so a background turn under a
+            # non-default profile would run against the wrong home. Re-bind the
+            # override for the duration of this turn, exactly as the normal
+            # prompt turn does, and restore it afterward.
+            _profile_home_str = session.get("profile_home")
+            home_token = (
+                set_hermes_home_override(_profile_home_str)
+                if _profile_home_str
+                else None
             )
+            try:
+                result = AIAgent(
+                    **_background_agent_kwargs(session["agent"], task_id)
+                ).run_conversation(
+                    user_message=text,
+                    task_id=task_id,
+                )
+            finally:
+                if home_token is not None:
+                    reset_hermes_home_override(home_token)
             _emit(
                 "background.complete",
                 parent,
@@ -10195,14 +10211,33 @@ def _(rid, params: dict) -> dict:
                 parent,
                 {"task_id": task_id, "text": f"Starting hidden restart agent{history_note}"},
             )
-            result = AIAgent(
-                **_ephemeral_preview_agent_kwargs(session["agent"], task_id),
-                **_preview_restart_callbacks(parent, task_id),
-            ).run_conversation(
-                user_message=prompt,
-                task_id=task_id,
-                conversation_history=parent_history or None,
+            # Bug #50233: ephemeral preview-restart agent threads don't inherit
+            # the session's HERMES_HOME override (the ContextVar set on the
+            # session-create thread doesn't propagate here). Re-bind it for the
+            # duration of the turn, mirroring the normal prompt turn, then
+            # restore it. NOTE: we deliberately do NOT close this agent through
+            # task-wide process cleanup — the whole point of preview.restart is
+            # to leave a background server running under this task_id, and
+            # AIAgent.close() would kill every process for the task_id and tear
+            # down the very server the restart just started.
+            _profile_home_str = session.get("profile_home")
+            home_token = (
+                set_hermes_home_override(_profile_home_str)
+                if _profile_home_str
+                else None
             )
+            try:
+                result = AIAgent(
+                    **_ephemeral_preview_agent_kwargs(session["agent"], task_id),
+                    **_preview_restart_callbacks(parent, task_id),
+                ).run_conversation(
+                    user_message=prompt,
+                    task_id=task_id,
+                    conversation_history=parent_history or None,
+                )
+            finally:
+                if home_token is not None:
+                    reset_hermes_home_override(home_token)
             text = (
                 result.get("final_response", str(result))
                 if isinstance(result, dict)


### PR DESCRIPTION
## Summary

Fixes #50233. Normal prompt turns bind `session['profile_home']` via `set_hermes_home_override` before `run_conversation`, so the turn runs against the correct profile `HERMES_HOME`. The two **ephemeral** RPC paths — `prompt.background` and `preview.restart` — spawn a fresh `AIAgent` on a **new thread**, where the `HERMES_HOME` ContextVar set on the session-create thread does **not** propagate. As a result, a background or preview-restart turn under a non-default profile ran against the wrong home.

## Scope (reworked per review)

- **(a) Profile-override binding in both ephemeral agent paths.** `prompt.background` and `preview.restart` now re-bind the session's `profile_home` via `set_hermes_home_override` for the duration of the ephemeral turn and restore it in a `finally` block — modelled exactly on the normal prompt-turn binding. When the session has no `profile_home`, the override is left untouched (no-op).
- **(b) Preview server RETAINED — no task-wide close.** The `preview.restart` path deliberately does **not** close its ephemeral agent. The ephemeral agent uses `task_id` as its session id, and `AIAgent.close()` kills **all** processes for that id — which would tear down the very background server the restart just launched. The restarted preview server survives.
- **(c) Four unrelated skills removed / split out.** The `bug-pipeline` and `simplicio-*` skills that were bundled here have been dropped from this PR; they will be modernized independently to meet the `AGENTS.md` metadata standards.
- **(d) Regression tests.** New `tests/tui_gateway/test_ephemeral_profile_override.py` asserts, for **both** RPC paths: the override is bound with `profile_home` and restored after the turn (including on error), the no-profile case is a no-op, and `preview.restart` never closes the ephemeral agent (background server survives).

## Verification

- New tests: `6 passed`.
- Related `tui_gateway` suites (`slash_worker_profile_home`, `delegation_session_lifecycle`, `protocol`, `finalize_session_persist`): `113 passed`.
- Fail-without-binding check: temporarily reverting a binding makes the binding-assertion tests fail (`set_hermes_home_override ... Called 0 times`); restoring it makes them pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
