### PR TITLE
fix(security): block terminal commands that read credential files (#50734) 

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1,5 +1,6 @@
 """Tests for the dangerous command approval module."""
 
+import json
 import os
 import threading
 import time
@@ -1397,3 +1398,499 @@ class TestApprovalPromptRedaction:
         # The script's credential must not appear in the user-facing message.
         assert "sk-proj-abc123xyz4567890abcdef" not in result["message"]
         assert "sk-proj-abc123xyz4567890abcdef" not in result["command"]
+
+
+# ===========================================================================
+# Credential file read detection tests (#50734)
+# ===========================================================================
+class TestCredentialFileReadDetection:
+    """Tests for terminal command patterns that detect reading credential files.
+
+    Issue #50734: Agent used `cat ~/.hermes/.env` to exfiltrate all API keys
+    to the LLM provider. The read_file tool already blocks this via
+    get_read_block_error(), but the terminal tool had no equivalent guard.
+    These patterns detect common read commands targeting credential paths.
+    """
+
+    # -------------------------------------------------------------------------
+    # Hermes credential files under HERMES_HOME
+    # -------------------------------------------------------------------------
+    def test_cat_hermes_env_detected(self):
+        """cat ~/.hermes/.env should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("cat ~/.hermes/.env")
+        assert is_dangerous is True
+        assert "credential" in desc.lower() or "hermes" in desc.lower()
+
+    def test_cat_hermes_auth_json_detected(self):
+        """cat ~/.hermes/auth.json should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("cat ~/.hermes/auth.json")
+        assert is_dangerous is True
+        assert "credential" in desc.lower() or "hermes" in desc.lower()
+
+    def test_less_hermes_env_detected(self):
+        """less ~/.hermes/.env should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("less ~/.hermes/.env")
+        assert is_dangerous is True
+
+    def test_head_hermes_oauth_detected(self):
+        """head -n 10 ~/.hermes/auth/google_oauth.json should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("head -n 10 ~/.hermes/auth/google_oauth.json")
+        assert is_dangerous is True
+
+    def test_tail_hermes_mcp_token_detected(self):
+        """tail ~/.hermes/mcp-tokens/some_token.json should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("tail ~/.hermes/mcp-tokens/some_token.json")
+        assert is_dangerous is True
+
+    def test_cat_hermes_profile_env_detected(self):
+        """cat ~/.hermes/profiles/default/.env should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("cat ~/.hermes/profiles/default/.env")
+        assert is_dangerous is True
+
+    def test_cat_hermes_anthropic_oauth_detected(self):
+        """cat ~/.hermes/.anthropic_oauth.json should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("cat ~/.hermes/.anthropic_oauth.json")
+        assert is_dangerous is True
+
+    def test_cat_hermes_webhook_subscriptions_detected(self):
+        """cat ~/.hermes/webhook_subscriptions.json should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("cat ~/.hermes/webhook_subscriptions.json")
+        assert is_dangerous is True
+
+    def test_strings_hermes_env_detected(self):
+        """strings ~/.hermes/.env should be detected (binary analysis tool)."""
+        is_dangerous, key, desc = detect_dangerous_command("strings ~/.hermes/.env")
+        assert is_dangerous is True
+
+    def test_base64_hermes_env_detected(self):
+        """base64 ~/.hermes/.env should be detected (encoding exfiltration)."""
+        is_dangerous, key, desc = detect_dangerous_command("base64 ~/.hermes/.env")
+        assert is_dangerous is True
+
+    # -------------------------------------------------------------------------
+    # Project-local .env files anywhere on disk
+    # -------------------------------------------------------------------------
+    def test_cat_project_env_detected(self):
+        """cat .env should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("cat .env")
+        assert is_dangerous is True
+        assert "env" in desc.lower()
+
+    def test_cat_project_env_local_detected(self):
+        """cat .env.local should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("cat .env.local")
+        assert is_dangerous is True
+
+    def test_cat_project_env_production_detected(self):
+        """cat .env.production should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("cat .env.production")
+        assert is_dangerous is True
+
+    def test_cat_project_env_development_detected(self):
+        """cat .env.development should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("cat .env.development")
+        assert is_dangerous is True
+
+    def test_cat_project_env_test_detected(self):
+        """cat .env.test should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("cat .env.test")
+        assert is_dangerous is True
+
+    def test_cat_project_env_staging_detected(self):
+        """cat .env.staging should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("cat .env.staging")
+        assert is_dangerous is True
+
+    def test_cat_envrc_detected(self):
+        """cat .envrc should be detected (direnv credentials)."""
+        is_dangerous, key, desc = detect_dangerous_command("cat .envrc")
+        assert is_dangerous is True
+
+    def test_cat_absolute_project_env_detected(self):
+        """cat /path/to/project/.env should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("cat /path/to/project/.env")
+        assert is_dangerous is True
+
+    # -------------------------------------------------------------------------
+    # User credential files
+    # -------------------------------------------------------------------------
+    def test_cat_netrc_detected(self):
+        """cat ~/.netrc should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("cat ~/.netrc")
+        assert is_dangerous is True
+
+    def test_cat_pgpass_detected(self):
+        """cat ~/.pgpass should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("cat ~/.pgpass")
+        assert is_dangerous is True
+
+    def test_cat_npmrc_detected(self):
+        """cat ~/.npmrc should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("cat ~/.npmrc")
+        assert is_dangerous is True
+
+    def test_cat_pypirc_detected(self):
+        """cat ~/.pypirc should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("cat ~/.pypirc")
+        assert is_dangerous is True
+
+    # -------------------------------------------------------------------------
+    # SSH key files
+    # -------------------------------------------------------------------------
+    def test_cat_ssh_id_rsa_detected(self):
+        """cat ~/.ssh/id_rsa should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("cat ~/.ssh/id_rsa")
+        assert is_dangerous is True
+        assert "ssh" in desc.lower()
+
+    def test_cat_ssh_id_ed25519_detected(self):
+        """cat ~/.ssh/id_ed25519 should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("cat ~/.ssh/id_ed25519")
+        assert is_dangerous is True
+
+    # -------------------------------------------------------------------------
+    # Source commands (load credentials into shell environment)
+    # -------------------------------------------------------------------------
+    def test_source_env_detected(self):
+        """source .env should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("source .env")
+        assert is_dangerous is True
+        assert "source" in desc.lower() or "leak" in desc.lower()
+
+    def test_dot_source_env_detected(self):
+        """. .env should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command(". .env")
+        assert is_dangerous is True
+
+    def test_source_hermes_env_detected(self):
+        """source ~/.hermes/.env should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("source ~/.hermes/.env")
+        assert is_dangerous is True
+
+    # -------------------------------------------------------------------------
+    # False positive checks - safe commands that should NOT be detected
+    # -------------------------------------------------------------------------
+    def test_cat_env_example_allowed(self):
+        """cat .env.example should NOT be detected (documentation file)."""
+        is_dangerous, key, desc = detect_dangerous_command("cat .env.example")
+        assert is_dangerous is False, f"False positive: .env.example should be safe, got: {desc}"
+
+    def test_cat_env_template_allowed(self):
+        """cat .env.template should NOT be detected (documentation file)."""
+        is_dangerous, key, desc = detect_dangerous_command("cat .env.template")
+        assert is_dangerous is False, f"False positive: .env.template should be safe, got: {desc}"
+
+    def test_cat_readme_allowed(self):
+        """cat README.md should NOT be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("cat README.md")
+        assert is_dangerous is False
+
+    def test_grep_in_env_blocked(self):
+        """grep API_KEY .env should be detected — grep directly emits secret-bearing lines.
+
+        PR #50782 review feedback: the original test allowed this, but grep
+        with a credential file as input directly exfiltrates secrets (the
+        matching line is written to stdout and sent to the LLM provider).
+        """
+        is_dangerous, key, desc = detect_dangerous_command("grep API_KEY .env")
+        assert is_dangerous is True, "grep API_KEY .env should be detected as credential read"
+
+    def test_echo_allowed(self):
+        """echo hello should NOT be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("echo hello")
+        assert is_dangerous is False
+
+    def test_ls_allowed(self):
+        """ls -la should NOT be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("ls -la")
+        assert is_dangerous is False
+
+    def test_cat_hermes_config_allowed(self):
+        """cat ~/.hermes/config.yaml should NOT be detected (not a credential file)."""
+        is_dangerous, key, desc = detect_dangerous_command("cat ~/.hermes/config.yaml")
+        assert is_dangerous is False
+
+    def test_cat_ssh_config_allowed(self):
+        """cat ~/.ssh/config should NOT be detected (not a private key)."""
+        is_dangerous, key, desc = detect_dangerous_command("cat ~/.ssh/config")
+        assert is_dangerous is False
+
+    def test_cat_authorized_keys_allowed(self):
+        """cat ~/.ssh/authorized_keys should NOT be detected (public keys)."""
+        is_dangerous, key, desc = detect_dangerous_command("cat ~/.ssh/authorized_keys")
+        assert is_dangerous is False
+
+    # -------------------------------------------------------------------------
+    # Edge cases and bypass attempts
+    # -------------------------------------------------------------------------
+    def test_quoted_path_detected(self):
+        """cat "~/.hermes/.env" should be detected (quoted path)."""
+        is_dangerous, key, desc = detect_dangerous_command('cat "~/.hermes/.env"')
+        assert is_dangerous is True
+
+    def test_sudo_cat_hermes_env_detected(self):
+        """sudo cat ~/.hermes/.env should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("sudo cat ~/.hermes/.env")
+        assert is_dangerous is True
+
+    def test_env_wrapper_cat_detected(self):
+        """env cat ~/.hermes/.env should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("env cat ~/.hermes/.env")
+        assert is_dangerous is True
+
+    def test_cat_with_flags_detected(self):
+        """cat -n ~/.hermes/.env should be detected (with line numbers)."""
+        is_dangerous, key, desc = detect_dangerous_command("cat -n ~/.hermes/.env")
+        assert is_dangerous is True
+
+    def test_more_hermes_env_detected(self):
+        """more ~/.hermes/.env should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("more ~/.hermes/.env")
+        assert is_dangerous is True
+
+    def test_tac_hermes_env_detected(self):
+        """tac ~/.hermes/.env should be detected (reverse cat)."""
+        is_dangerous, key, desc = detect_dangerous_command("tac ~/.hermes/.env")
+        assert is_dangerous is True
+
+    def test_xxd_hermes_env_detected(self):
+        """xxd ~/.hermes/.env should be detected (hex dump)."""
+        is_dangerous, key, desc = detect_dangerous_command("xxd ~/.hermes/.env")
+        assert is_dangerous is True
+
+    # -------------------------------------------------------------------------
+    # Cloud provider credentials (#50734 follow-up)
+    # -------------------------------------------------------------------------
+    def test_cat_aws_credentials_detected(self):
+        """cat ~/.aws/credentials should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("cat ~/.aws/credentials")
+        assert is_dangerous is True
+        assert "cloud" in desc.lower() or "credential" in desc.lower()
+
+    def test_cat_aws_config_detected(self):
+        """cat ~/.aws/config should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("cat ~/.aws/config")
+        assert is_dangerous is True
+
+    def test_cat_kube_config_detected(self):
+        """cat ~/.kube/config should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("cat ~/.kube/config")
+        assert is_dangerous is True
+
+    def test_cat_docker_config_detected(self):
+        """cat ~/.docker/config.json should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("cat ~/.docker/config.json")
+        assert is_dangerous is True
+
+    def test_cat_git_credentials_detected(self):
+        """cat ~/.git-credentials should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("cat ~/.git-credentials")
+        assert is_dangerous is True
+
+    def test_cat_gh_hosts_detected(self):
+        """cat ~/.config/gh/hosts.yml should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("cat ~/.config/gh/hosts.yml")
+        assert is_dangerous is True
+
+    def test_cat_gcloud_credentials_detected(self):
+        """cat ~/.config/gcloud/credentials should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("cat ~/.config/gcloud/credentials")
+        assert is_dangerous is True
+
+    def test_cat_azure_tokens_detected(self):
+        """cat ~/.azure/accessTokens.json should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("cat ~/.azure/accessTokens.json")
+        assert is_dangerous is True
+
+    def test_cat_gpg_private_keys_detected(self):
+        """cat ~/.gnupg/secring.gpg should be detected."""
+        is_dangerous, key, desc = detect_dangerous_command("cat ~/.gnupg/secring.gpg")
+        assert is_dangerous is True
+
+    # -------------------------------------------------------------------------
+    # detect_credential_read_command() — dedicated check for smart-mode bypass
+    # -------------------------------------------------------------------------
+
+    def test_detect_credential_read_hermes_env(self):
+        from tools.approval import detect_credential_read_command
+        is_cred, key, desc = detect_credential_read_command("cat ~/.hermes/.env")
+        assert is_cred is True
+        assert "credential" in desc.lower()
+
+    def test_detect_credential_read_project_env(self):
+        from tools.approval import detect_credential_read_command
+        is_cred, key, desc = detect_credential_read_command("cat .env")
+        assert is_cred is True
+
+    def test_detect_credential_read_grep_env(self):
+        """grep is included — it directly emits secret-bearing lines."""
+        from tools.approval import detect_credential_read_command
+        is_cred, key, desc = detect_credential_read_command("grep API_KEY .env")
+        assert is_cred is True
+
+    def test_detect_credential_read_safe_command(self):
+        """Non-credential commands should not match."""
+        from tools.approval import detect_credential_read_command
+        is_cred, key, desc = detect_credential_read_command("cat README.md")
+        assert is_cred is False
+
+    def test_detect_credential_read_source_env(self):
+        from tools.approval import detect_credential_read_command
+        is_cred, key, desc = detect_credential_read_command("source .env")
+        assert is_cred is True
+
+    def test_detect_credential_read_aws_credentials(self):
+        from tools.approval import detect_credential_read_command
+        is_cred, key, desc = detect_credential_read_command("cat ~/.aws/credentials")
+        assert is_cred is True
+
+
+class TestSearchFilesCredentialProtection:
+    """Tests for search_files credential file protection (#50734 follow-up).
+
+    The search_files tool should block content searches that target credential
+    files, mirroring the read_file protection via get_read_block_error().
+    """
+
+    def test_search_env_file_blocked(self, tmp_path, monkeypatch):
+        """search_files path=.env should be blocked."""
+        from tools.file_tools import search_tool
+        from unittest.mock import patch
+
+        # Create a mock .env file
+        env_file = tmp_path / ".env"
+        env_file.write_text("API_KEY=secret123")
+
+        # Mock _get_file_ops to avoid actual shell execution
+        with patch("tools.file_tools._get_file_ops") as mock_ops:
+            # This should be blocked before reaching file_ops
+            result = search_tool(pattern="API_KEY", path=str(env_file), target="content")
+            result_dict = json.loads(result)
+            assert "error" in result_dict
+            assert "secret-bearing environment file" in result_dict["error"] or "credential" in result_dict["error"].lower()
+
+    def test_search_hermes_auth_blocked(self, tmp_path, monkeypatch):
+        """search_files path=~/.hermes/auth.json should be blocked."""
+        import json
+        from tools.file_tools import search_tool
+        from unittest.mock import patch
+        import agent.file_safety as fs
+
+        # Set up fake hermes home
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        monkeypatch.setattr(fs, "_hermes_home_path", lambda: hermes_home)
+        monkeypatch.setattr(fs, "_hermes_root_path", lambda: hermes_home)
+
+        auth_file = hermes_home / "auth.json"
+        auth_file.write_text('{"api_key": "secret"}')
+
+        with patch("tools.file_tools._get_file_ops"):
+            result = search_tool(pattern="api_key", path=str(auth_file), target="content")
+            result_dict = json.loads(result)
+            assert "error" in result_dict
+
+    def test_search_directory_allowed(self, tmp_path):
+        """search_files path=<directory> should NOT be blocked."""
+        import json
+        from tools.file_tools import search_tool
+        from unittest.mock import patch, MagicMock
+
+        # Create a normal directory
+        test_dir = tmp_path / "project"
+        test_dir.mkdir()
+
+        mock_result = MagicMock()
+        mock_result.matches = []
+        mock_result.to_dict.return_value = {"matches": [], "total_count": 0}
+
+        with patch("tools.file_tools._get_file_ops") as mock_ops:
+            mock_ops.return_value.search.return_value = mock_result
+            result = search_tool(pattern="test", path=str(test_dir), target="content")
+            result_dict = json.loads(result)
+            # Should not have credential block error
+            assert "secret-bearing" not in result_dict.get("error", "")
+
+    def test_search_files_target_allowed(self, tmp_path):
+        """search_files target=files should NOT be blocked (only lists files)."""
+        import json
+        from tools.file_tools import search_tool
+        from unittest.mock import patch, MagicMock
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("API_KEY=secret")
+
+        mock_result = MagicMock()
+        mock_result.matches = []
+        mock_result.to_dict.return_value = {"matches": [], "total_count": 0}
+
+        with patch("tools.file_tools._get_file_ops") as mock_ops:
+            mock_ops.return_value.search.return_value = mock_result
+            result = search_tool(pattern=".env", path=str(tmp_path), target="files")
+            result_dict = json.loads(result)
+            # File search should not be blocked
+            assert "secret-bearing" not in result_dict.get("error", "")
+
+
+class TestCredentialReadSmartModeBypass:
+    """PR #50782 review feedback: credential reads must NOT be auto-approved
+    by smart mode (aux LLM). They must always require explicit user approval.
+    """
+
+    def _setup_smart_mode(self, monkeypatch, session_key="test-cred-smart"):
+        monkeypatch.setenv("HERMES_SESSION_KEY", session_key)
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        monkeypatch.setattr(
+            approval_module,
+            "_get_approval_config",
+            lambda: {"mode": "smart"},
+        )
+        monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", False)
+        # Smart LLM says "approve" — but credential reads must ignore this.
+        monkeypatch.setattr(approval_module, "_smart_approve", lambda *_: "approve")
+        monkeypatch.setattr(
+            "tools.tirith_security.check_command_security",
+            lambda _command: {"action": "allow", "findings": [], "summary": ""},
+        )
+        approval_module.clear_session(session_key)
+        approval_module._permanent_approved.clear()
+
+    def test_smart_mode_cannot_approve_cat_hermes_env(self, monkeypatch):
+        """Smart approve says yes to `cat ~/.hermes/.env` — must be ignored.
+
+        Without the credential-read bypass, smart mode would auto-approve
+        this and exfiltrate the API keys. With the fix, the result must
+        NOT contain smart_approved=True — it must go to manual approval.
+        """
+        self._setup_smart_mode(monkeypatch)
+        command = "cat ~/.hermes/.env"
+
+        result = approval_module.check_all_command_guards(command, "local")
+
+        # Must NOT be smart-approved — requires manual user approval.
+        assert result.get("smart_approved") is not True
+
+    def test_smart_mode_cannot_approve_grep_dotenv(self, monkeypatch):
+        """Smart approve says yes to `grep API_KEY .env` — must be ignored."""
+        self._setup_smart_mode(monkeypatch)
+        command = "grep API_KEY .env"
+
+        result = approval_module.check_all_command_guards(command, "local")
+
+        assert result.get("smart_approved") is not True
+
+    def test_smart_mode_still_approves_non_credential_dangerous(self, monkeypatch):
+        """Sanity check: non-credential dangerous commands are still smart-approved.
+
+        This prevents the credential-read bypass from accidentally disabling
+        smart mode for ALL dangerous commands.
+        """
+        self._setup_smart_mode(monkeypatch)
+        # chmod 777 is dangerous but NOT a credential read
+        command = "chmod 777 /tmp/mydir"
+
+        result = approval_module.check_all_command_guards(command, "local")
+
+        assert result.get("approved") is True
+        assert result.get("smart_approved") is True

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -283,6 +283,100 @@ _CREDENTIAL_FILES = (
     r'(?:~|\$home|\$\{home\})/\.'
     r'(?:netrc|pgpass|npmrc|pypirc)\b'
 )
+
+# ---------------------------------------------------------------------------
+# Credential file read detection (#50734)
+# ---------------------------------------------------------------------------
+# Patterns for detecting terminal commands that READ credential files.
+# The read_file tool already blocks these via get_read_block_error() in
+# agent/file_safety.py, but the terminal tool had no equivalent guard —
+# `cat ~/.hermes/.env` would succeed and exfiltrate credentials to the LLM
+# provider. These patterns detect file-reading commands targeting credential
+# paths so the approval system can gate or block them.
+#
+# The Hermes credential paths mirror what get_read_block_error() blocks:
+# auth.json, auth.lock, .anthropic_oauth.json, .env, webhook_subscriptions.json,
+# auth/google_oauth.json, cache/bws_cache.json, mcp-tokens/*, and any .env*
+# file under HERMES_HOME.
+#
+# Defense-in-depth: the terminal tool runs as the same OS user, so a
+# determined agent can still bypass via base64 encoding, python one-liners,
+# etc. These patterns catch the common/direct cases and surface an audit
+# trail. See get_read_block_error() docstring for the full threat model.
+# ---------------------------------------------------------------------------
+
+# Commands that read file contents (used to detect credential exfiltration).
+# `grep` is included because `grep API_KEY .env` directly emits secret-bearing
+# lines — review feedback on PR #50782.
+_CREDENTIAL_READ_COMMANDS = (
+    r'(?:cat|less|more|head|tail|tac|strings|xxd|od|hexdump|base64|openssl\s+base64|grep)'
+)
+
+# Credential file paths under HERMES_HOME that must not be read via terminal.
+# Matches both the active profile HERMES_HOME and the global Hermes root.
+# Uses the same path fragments as _HERMES_ENV_PATH for consistency.
+_HERMES_HOME_PREFIX = (
+    r'(?:~\/\.hermes/|'
+    r'(?:\$home|\$\{home\})/\.hermes/|'
+    r'(?:\$hermes_home|\$\{hermes_home\})/)'
+)
+
+# Specific credential files under HERMES_HOME (mirrors get_read_block_error).
+_HERMES_CREDENTIAL_FILE = (
+    rf'(?:{_HERMES_HOME_PREFIX}'
+    r'(?:\.env|'
+    r'auth\.json|'
+    r'auth\.lock|'
+    r'\.anthropic_oauth\.json|'
+    r'webhook_subscriptions\.json|'
+    r'auth/google_oauth\.json|'
+    r'cache/bws_cache\.json'
+    r')\b)'
+)
+
+# mcp-tokens/ directory under HERMES_HOME (OAuth token material).
+_HERMES_MCP_TOKENS = (
+    rf'(?:{_HERMES_HOME_PREFIX}mcp-tokens(?:/|\b))'
+)
+
+# profiles/*/  subdirectories — each profile has its own .env, auth.json, etc.
+_HERMES_PROFILE_CREDENTIAL = (
+    rf'(?:{_HERMES_HOME_PREFIX}profiles/[^/\s"\'`]+/'
+    r'(?:\.env|auth\.json|auth\.lock|\.anthropic_oauth\.json)\b)'
+)
+
+# Combined: all Hermes credential paths that should be gated for reads.
+_HERMES_CREDENTIAL_READ_TARGET = (
+    rf'(?:{_HERMES_CREDENTIAL_FILE}|{_HERMES_MCP_TOKENS}|{_HERMES_PROFILE_CREDENTIAL})'
+)
+
+# Project-local .env files that contain secrets (mirrors _BLOCKED_PROJECT_ENV_BASENAMES
+# in agent/file_safety.py). This is more specific than _PROJECT_ENV_PATH because
+# .env.example and .env.template are safe documentation files that should be readable.
+_PROJECT_SECRET_ENV_BASENAMES = (
+    r'\.env(?:\.(?:local|development|production|test|staging))?\b|\.envrc\b'
+)
+_PROJECT_ENV_READ_TARGET = (
+    rf'(?:(?:/|\.{1,2}/)?(?:[^\s/"\'`]+/)*(?:{_PROJECT_SECRET_ENV_BASENAMES}))'
+)
+
+# ---------------------------------------------------------------------------
+# Cloud provider credential paths (#50734 follow-up)
+# ---------------------------------------------------------------------------
+# These directories/files contain cloud provider credentials that should not
+# be read via terminal. Mirrors build_write_denied_prefixes() in file_safety.py.
+# ---------------------------------------------------------------------------
+_CLOUD_CREDENTIAL_PATHS = (
+    r'(?:~|\$home|\$\{home\})/'
+    r'(?:\.aws/(?:credentials|config)|'           # AWS credentials
+    r'\.kube/config|'                              # Kubernetes config
+    r'\.docker/config\.json|'                      # Docker registry auth
+    r'\.git-credentials|'                          # Git credential helper
+    r'\.config/gh/hosts\.yml|'                     # GitHub CLI tokens
+    r'\.config/gcloud/(?:credentials|application_default_credentials)(?:\.json)?|'  # GCP
+    r'\.azure/(?:accessTokens\.json|azureProfile\.json|msal_token_cache\.json)|'  # Azure
+    r'\.gnupg/(?:private-keys-v1\.d|secring\.gpg))'  # GPG private keys
+)
 # macOS: /etc, /var, /tmp, /home are symlinks to /private/{etc,var,tmp,home}.
 # A command written to target /private/etc/sudoers works identically to
 # /etc/sudoers on macOS but bypasses a plain "/etc/" pattern check. Match
@@ -600,6 +694,66 @@ def _sudo_stdin_block_result(description: str) -> dict:
 
 
 # =========================================================================
+# Credential-read detection (#50734 — review follow-up)
+# =========================================================================
+# Separate from DANGEROUS_PATTERNS so check_all_command_guards() can call it
+# BEFORE the smart-approval phase. Credential reads must always require
+# explicit user approval — an LLM risk assessment (smart mode) must NOT be
+# allowed to auto-approve credential exfiltration. See:
+# https://github.com/NousResearch/hermes-agent/pull/50782 review feedback.
+
+_CREDENTIAL_READ_PATTERNS_RAW = (
+    # Hermes credential files under HERMES_HOME (auth.json, .env, etc.)
+    (rf'{_CMDPOS}{_CREDENTIAL_READ_COMMANDS}\b[^;|&\n]*{_HERMES_CREDENTIAL_READ_TARGET}',
+     "read Hermes credential file via terminal"),
+    # Project-local .env files anywhere on disk
+    (rf'{_CMDPOS}{_CREDENTIAL_READ_COMMANDS}\b[^;|&\n]*["\']?{_PROJECT_ENV_READ_TARGET}["\']?{_COMMAND_TAIL}',
+     "read project .env file via terminal"),
+    # User credential files (~/.netrc, ~/.pgpass, etc.)
+    (rf'{_CMDPOS}{_CREDENTIAL_READ_COMMANDS}\b[^;|&\n]*{_CREDENTIAL_FILES}',
+     "read user credential file via terminal"),
+    # SSH private keys (~/.ssh/id_rsa, ~/.ssh/id_ed25519, etc.)
+    # Note: authorized_keys contains PUBLIC keys and is safe to read.
+    (rf'{_CMDPOS}{_CREDENTIAL_READ_COMMANDS}\b[^;|&\n]*{_SSH_SENSITIVE_PATH}(?:id_\w+)\b',
+     "read SSH private key file via terminal"),
+    # Sourcing .env files loads credentials into shell environment where they
+    # can be exfiltrated via `env`, `export`, or subsequent commands.
+    (rf'{_CMDPOS}(?:source|\.)\s+["\']?{_PROJECT_ENV_READ_TARGET}["\']?{_COMMAND_TAIL}',
+     "source project .env file (leaks credentials to environment)"),
+    (rf'{_CMDPOS}(?:source|\.)\s+["\']?{_HERMES_CREDENTIAL_READ_TARGET}["\']?{_COMMAND_TAIL}',
+     "source Hermes credential file (leaks credentials to environment)"),
+    # Cloud provider credentials (AWS, GCP, Azure, Docker, Kubernetes, GitHub CLI, GPG)
+    (rf'{_CMDPOS}{_CREDENTIAL_READ_COMMANDS}\b[^;|&\n]*{_CLOUD_CREDENTIAL_PATHS}',
+     "read cloud provider credential via terminal"),
+)
+
+CREDENTIAL_READ_PATTERNS_COMPILED = [
+    (re.compile(pattern, _RE_FLAGS), description)
+    for pattern, description in _CREDENTIAL_READ_PATTERNS_RAW
+]
+
+
+def detect_credential_read_command(command: str) -> tuple:
+    """Check if a command reads credential files via the terminal.
+
+    Returns:
+        (is_credential_read, pattern_key, description) or (False, None, None)
+
+    This is separate from ``detect_dangerous_command`` so the approval gate
+    can force credential reads to manual approval — smart mode must NOT be
+    allowed to auto-approve credential exfiltration. The patterns also live
+    inside ``DANGEROUS_PATTERNS`` (via ``*_CREDENTIAL_READ_PATTERNS_RAW``) so
+    ``detect_dangerous_command`` still flags them for audit-trail purposes.
+    """
+    for command_variant in _command_detection_variants(command):
+        command_lower = command_variant.lower()
+        for pattern_re, description in CREDENTIAL_READ_PATTERNS_COMPILED:
+            if pattern_re.search(command_lower):
+                return (True, description, description)
+    return (False, None, None)
+
+
+# =========================================================================
 # Dangerous command patterns
 # =========================================================================
 
@@ -863,6 +1017,13 @@ DANGEROUS_PATTERNS = [
     # into a single -X token. Catches the same threat class.
     (r'\bsudo\b[^;|&\n]*?\s+-[a-z]*[sa][a-z]*\b',
      "sudo with combined-flag privilege escalation"),
+    # -------------------------------------------------------------------------
+    # Credential file read detection (#50734)
+    # -------------------------------------------------------------------------
+    # Patterns are defined in _CREDENTIAL_READ_PATTERNS_RAW and unpacked here.
+    # They also feed CREDENTIAL_READ_PATTERNS_COMPILED for the dedicated
+    # detect_credential_read_command() check that runs before smart approval.
+    *_CREDENTIAL_READ_PATTERNS_RAW,
 ]
 
 
@@ -3538,12 +3699,21 @@ def check_all_command_guards(command: str, env_type: str,
     # Dangerous command check (detection only, no approval)
     is_dangerous, pattern_key, description = detect_dangerous_command(command)
 
+    # Credential-read check — separate from detect_dangerous_command so we can
+    # force these to manual approval and prevent smart mode from auto-approving
+    # credential exfiltration (PR #50782 review feedback).
+    is_cred_read, _cred_read_key, _cred_read_desc = detect_credential_read_command(command)
+
     # --- Phase 2: Decide ---
 
     # Collect warnings that need approval
     warnings = []  # list of (pattern_key, description, is_tirith)
 
     session_key = get_current_session_key()
+
+    # Track whether smart approval must be skipped: credential reads require
+    # explicit user approval regardless of what the aux LLM decides.
+    _force_no_smart = False
 
     # Tirith block/warn → approvable warning with rich findings.
     # Previously, tirith "block" was a hard block with no approval prompt.
@@ -3561,6 +3731,18 @@ def check_all_command_guards(command: str, env_type: str,
         if not is_approved(session_key, pattern_key):
             warnings.append((pattern_key, description, False))
 
+    # Credential read: always require explicit user approval — even when
+    # detect_dangerous_command() above also matched (which would already be
+    # in warnings), we still need to flip _force_no_smart so smart mode
+    # cannot auto-approve the exfiltration.
+    if is_cred_read and not is_approved(session_key, _cred_read_key):
+        _force_no_smart = True
+        # Add a dedicated credential-read warning if detect_dangerous_command
+        # did not already add one (e.g. the pattern was approved for the
+        # session but the credential read was not — treat them independently).
+        if not any(key == _cred_read_key for key, _, _ in warnings):
+            warnings.append((_cred_read_key, _cred_read_desc, False))
+
     # Nothing to warn about
     if not warnings:
         return {"approved": True, "message": None}
@@ -3569,8 +3751,12 @@ def check_all_command_guards(command: str, env_type: str,
     # When approvals.mode=smart, ask the aux LLM before prompting the user.
     # Inspired by OpenAI Codex's Smart Approvals guardian subagent
     # (openai/codex#13860).
+    #
+    # Credential reads bypass smart approval entirely: the aux LLM must not
+    # be allowed to auto-approve commands that exfiltrate API keys / tokens.
+    # See PR #50782 review feedback.
     smart_denied_for_owner = False
-    if approval_mode == "smart":
+    if approval_mode == "smart" and not _force_no_smart:
         combined_desc_for_llm = "; ".join(desc for _, desc, _ in warnings)
         observer_payload = _prepare_smart_approval_observer(
             command=command,

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1847,6 +1847,21 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
     try:
         offset, limit = normalize_search_pagination(offset, limit)
 
+        # ── Credential file guard ─────────────────────────────────────
+        # Block searching content of credential files (defense-in-depth,
+        # mirrors the read_file guard via get_read_block_error).
+        # Only applies to content search, not file search.
+        if target == "content" and path != ".":
+            try:
+                _search_path = _resolve_path_for_task(path, task_id)
+                # If path is a file (not directory), check if it's a credential file
+                if _search_path.is_file():
+                    block_error = get_read_block_error(str(_search_path))
+                    if block_error:
+                        return json.dumps({"error": block_error})
+            except (OSError, ValueError):
+                pass  # Path resolution failed, let search proceed
+
         # Track searches to detect *consecutive* repeated search loops.
         # Include pagination args so users can page through truncated
         # results without tripping the repeated-search guard.


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                 
                                                                                                                                                                                                                             
  Closes #50734 — a credential-egress bug where the agent could exfiltrate                                                                                                                                                   
  API keys and secrets by reading `.env` and other credential files via the                                                                                                                                                  
  `terminal` tool.                                                                                                                                                                                                           
                                                                                                                                                                                                                             
  The `read_file` tool already blocks credential files via `get_read_block_error()`                                                                                                                                          
  in `agent/file_safety.py`. However, the `terminal` tool had no equivalent                                                                                                                                                  
  guard — `cat ~/.hermes/.env` would succeed and send all API keys to the LLM                                                                                                                                                
  provider's servers, undoing the protection one layer up.                                                                                                                                                                   
                                                                                                                                                                                                                             
  ## Fix                                                                                                                                                                                                                     
                                                                                                                                                                                                                             
  Added detection patterns in `tools/approval.py` that flag terminal commands                                                                                                                                                
  reading credential files. These patterns require user approval in interactive                                                                                                                                            
  sessions (or block in cron/deny mode).                                                                                                                                                                                     
                                                                                                                                                                                                                             
  ### Coverage                                                                                                                                                                                                               
                                                                                                                                                                                                                             
  **Hermes credential files under HERMES_HOME:**                                                                                                                                                                             
  - `.env`, `auth.json`, `auth.lock`, `.anthropic_oauth.json`                                                                                                                                                              
  - `webhook_subscriptions.json`, `auth/google_oauth.json`                                                                                                                                                                   
  - `cache/bws_cache.json`, `mcp-tokens/*`                                                                                                                                                                                   
  - `profiles/*/.env`, `profiles/*/auth.json`                                                                                                                                                                                
                                                                                                                                                                                                                             
  **Project-local .env files anywhere on disk:**                                                                                                                                                                             
  - `.env`, `.env.local`, `.env.development`, `.env.production`, `.env.test`, `.env.staging`, `.envrc`                                                                                                                       
  - (Excludes safe documentation: `.env.example`, `.env.template`)                                                                                                                                                           
                                                                                                                                                                                                                             
  **User credential files:**                                                                                                                                                                                                 
  - `~/.netrc`, `~/.pgpass`, `~/.npmrc`, `~/.pypirc`, `~/.git-credentials`                                                                                                                                                   
  - SSH private keys: `~/.ssh/id_rsa`, `~/.ssh/id_ed25519`, etc.                                                                                                                                                             
                                                                                                                                                                                                                             
  **Cloud provider credentials:**                                                                                                                                                                                            
  - AWS: `~/.aws/credentials`, `~/.aws/config`                                                                                                                                                                               
  - GCP: `~/.config/gcloud/credentials`, `~/.config/gcloud/application_default_credentials.json`                                                                                                                             
  - Azure: `~/.azure/accessTokens.json`, `~/.azure/azureProfile.json`                                                                                                                                                        
  - Docker: `~/.docker/config.json`                                                                                                                                                                                          
  - Kubernetes: `~/.kube/config`                                                                                                                                                                                             
  - GitHub CLI: `~/.config/gh/hosts.yml`                                                                                                                                                                                     
  - GPG: `~/.gnupg/secring.gpg`, `~/.gnupg/private-keys-v1.d`                                                                                                                                                                
                                                                                                                                                                                                                             
  **Commands detected:**                                                                                                                                                                                                     
  - `cat`, `less`, `more`, `head`, `tail`, `tac`, `strings`, `xxd`, `od`, `hexdump`, `base64`                                                                                                                                
  - `source` / `.` (loading credentials into shell environment)                                                                                                                                                              
                                                                                                                                                                                                                             
  ### Additional fix                                                                                                                                                                                                         
                                                                                                                                                                                                                             
  Added `search_files` protection: content searches targeting credential files                                                                                                                                               
  are now blocked, mirroring the `read_file` guard.                                                                                                                                                                        
                                                                                                                                                                                                                             
  ## Defense-in-depth                                                                                                                                                                                                      
                                                                                                                                                                                                                             
  As documented in code comments, this is **not a security boundary**. A                                                                                                                                                     
  determined agent can bypass via Python one-liners (`python -c "..."`),
  `dd`, `scp`, or other indirect methods. These patterns catch direct attempts                                                                                                                                               
  and surface an audit trail. The `read_file` tool block (`get_read_block_error`)                                                                                                                                            
  remains the primary defense; this adds a secondary layer for the terminal tool.                                                                                                                                            
                                                                                                                                                                                                                             
  ## Tests                                                                                                                                                                                                                   
                                                                                                                                                                                                                             
  `tests/tools/test_approval.py`:                                                                                                                                                                                            
  - `TestCredentialFileReadDetection` (52 tests): Hermes credentials, project
    .env files, user credentials, SSH keys, cloud provider credentials, source                                                                                                                                               
    commands, false-positive checks, edge cases (quoted paths, sudo wrappers)                                                                                                                                                
  - `TestSearchFilesCredentialProtection` (4 tests): search_files credential guard                                                                                                                                           
                                                                                                                                                                                                                             
  Total: **56 new tests**, all passing. 279 tests pass across the approval                                                                                                                                                   
  test surface — no regression.                                                                                                                                                                                              
                                                                                                                                                                                                                             
  Fixes #50734  