### PR TITLE
fix: close cron session db on script short-circuit

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1338,6 +1338,20 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
     except Exception as e:
         logger.debug("Job '%s': SQLite session store not available: %s", job.get("id", "?"), e)
 
+    def _close_unstarted_session_db() -> None:
+        """Close the cron SessionDB on paths that return before AIAgent owns it.
+
+        Jobs with a data-collection script can short-circuit before the agent
+        session is created (empty script output, wakeAgent=false, prompt block).
+        Those paths still constructed SessionDB above, so close it explicitly
+        rather than leaking state.db/state.db-wal fds in the long-lived gateway.
+        """
+        if _session_db:
+            try:
+                _session_db.close()
+            except (Exception, KeyboardInterrupt) as e:
+                logger.debug("Job '%s': failed to close unused SQLite session store: %s", job_id, e)
+
     # Wake-gate: if this job has a pre-check script, run it BEFORE building
     # the prompt so a ``{"wakeAgent": false}`` response can short-circuit
     # the whole agent run. We pass the result into _build_job_prompt so
@@ -1358,6 +1372,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
                 "Script gate returned `wakeAgent=false` — agent skipped.\n"
             )
+            _close_unstarted_session_db()
             return True, silent_doc, SILENT_MARKER, None
 
     try:
@@ -1384,9 +1399,11 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             "and the match is a false positive, rephrase the content to avoid "
             "the threat pattern (`tools/cronjob_tools.py::_CRON_THREAT_PATTERNS`)."
         )
+        _close_unstarted_session_db()
         return False, blocked_doc, "", str(block_exc)
     if prompt is None:
         logger.info("Job '%s': script produced no output, skipping AI call.", job_name)
+        _close_unstarted_session_db()
         return True, "", SILENT_MARKER, None
     origin = _resolve_origin(job)
     _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -11,6 +11,7 @@ import json
 import os
 import sys
 import textwrap
+import types
 from pathlib import Path
 
 import pytest
@@ -171,6 +172,41 @@ class TestRunJobScript:
         assert success is True
         parsed = json.loads(output)
         assert parsed["new_prs"][0]["number"] == 42
+
+    def test_llm_job_empty_script_output_closes_unused_session_db(self, cron_env, monkeypatch):
+        """LLM jobs with empty script output skip the agent without leaking state.db fds."""
+        from cron import scheduler as sched_mod
+
+        class FakeSessionDB:
+            closed = False
+
+            def close(self):
+                self.closed = True
+
+        fake_db = FakeSessionDB()
+        monkeypatch.setitem(
+            sys.modules,
+            "run_agent",
+            types.SimpleNamespace(AIAgent=object),
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "hermes_state",
+            types.SimpleNamespace(SessionDB=lambda: fake_db),
+        )
+        monkeypatch.setattr(sched_mod, "_run_job_script", lambda _path: (True, ""))
+
+        success, _doc, final_response, error = sched_mod._run_job_impl({
+            "id": "job123",
+            "name": "empty-script-job",
+            "prompt": "Report only if there is data.",
+            "script": "empty.py",
+        })
+
+        assert success is True
+        assert final_response == sched_mod.SILENT_MARKER
+        assert error is None
+        assert fake_db.closed is True
 
 
 class TestBuildJobPromptWithScript:


### PR DESCRIPTION
## Summary
- close the cron SessionDB when data-collection script paths short-circuit before AIAgent is created
- covers empty script output, wakeAgent=false, and prompt-injection block paths
- add regression test for empty script output closing the unused SessionDB

Fixes TSA-375.

## Tests
- python -m pytest tests/cron/test_cron_script.py -q -o 'addopts='
- python -m pytest tests/cron -q -o 'addopts='