### PR TITLE
fix(mcp): report a clear error when the OAuth callback port is in use

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -827,3 +827,21 @@ class TestWaitForCallbackSkipIntegration:
                 asyncio.run(_wait_for_callback())
         err = capsys.readouterr().err
         assert "skip" in err.lower()
+
+
+def test_wait_for_callback_port_in_use_reports_clear_error():
+    """A busy loopback callback port surfaces a clear 'already in use' error,
+    not a misleading 'timed out'. Guards the stale-comment fix where the branch
+    also wrongly claimed build_oauth_auth had started a server to poll."""
+    import tools.mcp_oauth as mo
+
+    with patch.object(mo, "_oauth_port", 54321), patch.object(
+        mo, "HTTPServer", side_effect=OSError("address already in use")
+    ):
+        with pytest.raises(mo.OAuthNonInteractiveError) as excinfo:
+            asyncio.run(mo._wait_for_callback())
+
+    msg = str(excinfo.value)
+    assert "54321" in msg
+    assert "already in use" in msg
+    assert "timed out" not in msg

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -481,13 +481,17 @@ async def _wait_for_callback() -> tuple[str, str | None]:
     # Start a temporary server on the known port
     try:
         server = HTTPServer(("127.0.0.1", _oauth_port), handler_cls)
-    except OSError:
-        # Port already in use — the server from build_oauth_auth is running.
-        # Fall back to polling the server started by build_oauth_auth.
+    except OSError as exc:
+        # The loopback callback port is genuinely in use: a concurrent OAuth
+        # flow, a leftover listener, or a fixed `oauth.redirect_port` that
+        # collided. build_oauth_auth does not start its own callback server,
+        # so there is nothing to poll here; surface a clear, actionable error
+        # instead of a misleading "timed out".
         raise OAuthNonInteractiveError(
-            "OAuth callback timed out — could not bind callback port. "
-            "Complete the authorization in a browser first, then retry."
-        )
+            f"OAuth callback port {_oauth_port} is already in use ({exc}). "
+            "Close any other in-progress login, or set a free `oauth.redirect_port` "
+            "in the server config, then retry."
+        ) from exc
 
     server_thread = threading.Thread(target=server.handle_request, daemon=True)
     server_thread.start()


### PR DESCRIPTION
## What does this PR do?

`_wait_for_callback` (tools/mcp_oauth.py) catches `OSError` on bind with a comment claiming the port is held by a server `build_oauth_auth` started, and promising to fall back to polling it. But `build_oauth_auth` never starts a callback server (this `_wait_for_callback` listener is the only one), so there is nothing to poll. The branch just raised a misleading `OAuth callback timed out` when the real cause is a busy port.

This fixes the stale comment and raises an accurate, actionable error, chained from the original `OSError`. Behavior otherwise unchanged.

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `tools/mcp_oauth.py`: correct the `OSError` branch (accurate comment + clear error).
- `tests/tools/test_mcp_oauth.py`: regression test.

## How to Test

`pytest tests/tools/test_mcp_oauth.py -q` -> 68 passed.

## Checklist

### Code

- [x] Contributing Guide
- [x] Conventional Commits
- [x] searched existing PRs
- [x] only related changes
- [x] pytest passes (68)
- [x] added tests
- [x] Linux (Debian, aarch64)

### Documentation & Housekeeping

- [x] docs - N/A
- [x] cli-config.yaml.example - N/A
- [x] CONTRIBUTING/AGENTS - N/A
- [x] cross-platform - N/A
- [x] tool schemas - N/A