### PR TITLE
fix(tui): call discover_plugins() in _make_agent to enable hook-based plugins (#50776)

### DIFF
--- a/tests/tui/test_tui_plugin_hooks.py
+++ b/tests/tui/test_tui_plugin_hooks.py
@@ -1,0 +1,50 @@
+"""Test that discover_plugins() is called in _make_agent path.
+
+Regression test for #50776: hook-based plugins (Langfuse, etc.) were silently
+inactive in TUI/Web UI because _make_agent() never called discover_plugins().
+"""
+import importlib
+import sys
+import types
+from unittest.mock import patch, MagicMock
+
+
+def test_make_agent_calls_discover_plugins():
+    """_make_agent must call discover_plugins() so hooks are registered."""
+    # We cannot fully instantiate _make_agent (needs real config/model), so
+    # verify the source contains the discover_plugins import + call.
+    import inspect
+    from tui_gateway.server import _make_agent
+
+    src = inspect.getsource(_make_agent)
+    assert "discover_plugins" in src, (
+        "_make_agent does not reference discover_plugins; "
+        "hook-based plugins will remain inactive in TUI path"
+    )
+    # Verify it imports from hermes_cli.plugins (not a stale/different module)
+    assert "from hermes_cli.plugins import discover_plugins" in src, (
+        "_make_agent imports discover_plugins from wrong module"
+    )
+
+
+def test_discover_plugins_is_idempotent():
+    """Calling discover_plugins() multiple times is safe (no double-load)."""
+    from hermes_cli.plugins import discover_plugins, get_plugin_manager
+
+    # First call
+    discover_plugins()
+    mgr = get_plugin_manager()
+    first_discovered = mgr._discovered
+
+    # Second call should be a no-op
+    discover_plugins()
+    assert mgr._discovered is True
+    # If it crashed or duplicated state, the test would fail above.
+
+
+if __name__ == "__main__":
+    test_make_agent_calls_discover_plugins()
+    print("PASS: _make_agent references discover_plugins")
+    test_discover_plugins_is_idempotent()
+    print("PASS: discover_plugins is idempotent")
+    print("ALL TESTS PASSED")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3731,6 +3731,19 @@ def _make_agent(
     except Exception:
         pass
 
+    # Discover Python plugins so hook-based plugins (Langfuse, nemo_relay,
+    # etc.) are registered before the agent checks has_hook().  The gateway
+    # startup path (gateway/run.py) calls discover_plugins() at boot; the
+    # TUI slash_worker only called it conditionally for toolset resolution,
+    # leaving hooks silently inactive for web-UI / dashboard conversations.
+    # discover_plugins() is idempotent (guarded by _discovered flag).
+    try:
+        from hermes_cli.plugins import discover_plugins
+
+        discover_plugins()
+    except Exception:
+        pass
+
     cfg = _load_cfg()
     agent_cfg = cfg.get("agent") or {}
     system_prompt = _prompt_text(agent_cfg.get("system_prompt", ""))


### PR DESCRIPTION
## What does this PR do?

Hook-based plugins (Langfuse, nemo\_relay, security-guidance, and all future hook-based plugins) are silently inactive for conversations conducted through the **web UI / TUI dashboard**.  The plugin is enabled and hooks are registered in the plugin manifest, but `discover_plugins()` is never called in the TUI agent initialization path, so `has_hook()` always returns `False` and no hooks fire.

This fix adds a `discover_plugins()` call in `_make_agent()` after MCP discovery, matching the gateway startup pattern in `gateway/run.py`.

## Related Issue

Fixes #50776

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`tui_gateway/server.py`**: Added `discover_plugins()` call in `_make_agent()` after MCP discovery wait blocks, before agent creation.  The call is idempotent (guarded by `_discovered` flag) and wrapped in try/except to never block agent creation.
- **`tests/tui/test_tui_plugin_hooks.py`**: Added regression tests verifying `_make_agent` references `discover_plugins` and that repeated calls are safe.

## How to Test

### Behavior verification

1. Enable any hook-based plugin (e.g., Langfuse): `hermes plugins enable observability/langfuse`
2. Set required env vars for the plugin
3. Start the web UI: `hermes dashboard`
4. Send a message through the web UI
5. **Before fix**: Zero traces in Langfuse dashboard; `has_hook("pre_api_request")` returns `False` in TUI path
6. **After fix**: Hooks fire correctly; traces appear in Langfuse dashboard for web UI conversations

### Targeted tests

```bash
python -m pytest tests/tui/test_tui_plugin_hooks.py -v
```

**Observed result**: Both tests pass — `_make_agent` contains the `discover_plugins` call, and repeated calls are idempotent.

### Platform tested

macOS (Darwin) — Python 3.14.0.  The fix is platform-independent (plugin discovery is pure Python with no OS-specific behavior).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
