### PR TITLE
fix(installer): re-resolve Python fallback at venv stage on Windows (#50769)

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -139,6 +139,11 @@ foreach ($tmpVar in @('TEMP', 'TMP')) {
 $RepoUrlSsh = "git@github.com:NousResearch/hermes-agent.git"
 $RepoUrlHttps = "https://github.com/NousResearch/hermes-agent.git"
 $PythonVersion = "3.11"
+# Minor versions the installer accepts when the requested $PythonVersion isn't
+# available, in preference order.  uv discovers both uv-managed and system
+# interpreters, so this list also matches a pre-existing system Python.  Single
+# source of truth shared by Test-Python's fallback and Resolve-AvailablePythonVersion.
+$PythonFallbackVersions = @("3.12", "3.13", "3.10")
 $NodeVersion = "22"
 
 # Stage-protocol version.  Bumped only for genuinely breaking changes to the
@@ -511,6 +516,31 @@ function Resolve-UvCmd {
     throw "uv is not installed. Run install.ps1 -Stage uv first."
 }
 
+function Resolve-AvailablePythonVersion {
+    # Return the first Python minor version uv can actually find, preferring the
+    # requested $PythonVersion and then $PythonFallbackVersions.  Returns $null
+    # when none are available.
+    #
+    # This is the cross-process-safe counterpart to Test-Python's in-memory
+    # ``$script:PythonVersion = $fallbackVer`` mutation.  Under Hermes-Setup.exe
+    # each ``-Stage NAME`` runs in a *fresh* powershell.exe, so the fallback the
+    # ``python`` stage settled on (e.g. 3.12 when 3.11 is absent) does NOT
+    # survive into the ``venv`` stage's process -- there $PythonVersion is back
+    # at its "3.11" default.  Consumers re-resolve here instead of trusting that
+    # default, which is exactly the propagation gap behind issue #50769.
+    $candidates = @($PythonVersion) + $PythonFallbackVersions
+    $seen = @{}
+    foreach ($ver in $candidates) {
+        if (-not $ver -or $seen.ContainsKey($ver)) { continue }
+        $seen[$ver] = $true
+        try {
+            $found = & $UvCmd python find $ver 2>$null
+            if ($found) { return $ver }
+        } catch { }
+    }
+    return $null
+}
+
 function Test-Python {
     Write-Info "Checking Python $PythonVersion..."
     
@@ -567,7 +597,7 @@ function Test-Python {
 
     # Fallback: check if ANY Python 3.10+ is already available on the system
     Write-Info "Trying to find any existing Python 3.10+..."
-    foreach ($fallbackVer in @("3.12", "3.13", "3.10")) {
+    foreach ($fallbackVer in $PythonFallbackVersions) {
         try {
             $pythonPath = & $UvCmd python find $fallbackVer 2>$null
             if ($pythonPath) {
@@ -1514,7 +1544,19 @@ function Install-Venv {
         Write-Info "Skipping virtual environment (-NoVenv)"
         return
     }
-    
+
+    # Re-resolve the interpreter before creating the venv.  Under Hermes-Setup.exe
+    # each stage runs in its own powershell.exe, so the fallback the `python`
+    # stage picked (e.g. 3.12 when 3.11 is absent) did NOT propagate into this
+    # fresh process -- $PythonVersion is back at its "3.11" default.  Trusting it
+    # here made `uv venv venv --python 3.11` fail with exit 2 on machines without
+    # 3.11 even though the `python` stage reported success (issue #50769).
+    $resolved = Resolve-AvailablePythonVersion
+    if ($resolved -and $resolved -ne $PythonVersion) {
+        Write-Info "Python $PythonVersion not available; using detected Python $resolved"
+        $script:PythonVersion = $resolved
+    }
+
     Write-Info "Creating virtual environment with Python $PythonVersion..."
     
     Push-Location $InstallDir

--- a/tests/test_install_ps1_python_fallback_venv.py
+++ b/tests/test_install_ps1_python_fallback_venv.py
@@ -1,0 +1,113 @@
+"""Regression: the Windows installer must honor its Python fallback at venv time.
+
+A user on Windows 11 reported (#50769) that the installer correctly detected a
+Python 3.12 fallback when 3.11 was absent::
+
+    [OK] Found fallback: Python 3.12.8
+    ...
+    -> Creating virtual environment with Python 3.11...
+
+and then failed with ``Failed to create virtual environment (uv venv exited
+with 2)``.
+
+Root cause: ``Test-Python`` records the fallback via an in-memory
+``$script:PythonVersion = $fallbackVer`` mutation, but under Hermes-Setup.exe
+each ``-Stage NAME`` runs in its *own* fresh ``powershell.exe`` process.  The
+``venv`` stage therefore starts with ``$PythonVersion`` back at its ``"3.11"``
+default, so ``uv venv venv --python 3.11`` runs on a machine that has no 3.11.
+
+The fix re-resolves the interpreter inside ``Install-Venv`` (via the
+cross-process-safe ``Resolve-AvailablePythonVersion`` helper) before creating
+the venv, so the venv stage uses whatever interpreter is actually present.
+These tests lock that contract at the source level (the script only runs on
+Windows, so there's no runner to execute it on Linux CI).
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+_INSTALL_PS1 = Path(__file__).resolve().parents[1] / "scripts" / "install.ps1"
+
+
+@pytest.fixture(scope="module")
+def source() -> str:
+    return _INSTALL_PS1.read_text(encoding="utf-8")
+
+
+def _function_body(source: str, name: str) -> str:
+    """Return the text of a PowerShell ``function <name> { ... }`` block."""
+    start = source.index(f"function {name}")
+    brace = source.index("{", start)
+    depth = 0
+    for i in range(brace, len(source)):
+        if source[i] == "{":
+            depth += 1
+        elif source[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[brace : i + 1]
+    raise AssertionError(f"unterminated function body for {name}")
+
+
+def test_resolver_helper_is_defined(source: str):
+    """A cross-process-safe Python-version resolver must exist."""
+    assert "function Resolve-AvailablePythonVersion" in source, (
+        "expected a Resolve-AvailablePythonVersion helper that re-resolves the "
+        "interpreter independently of the in-memory $script:PythonVersion mutation"
+    )
+
+
+def test_install_venv_reresolves_before_creating_venv(source: str):
+    """Install-Venv must re-resolve the interpreter BEFORE `uv venv`.
+
+    Otherwise the venv stage's fresh process trusts the stale "3.11" default
+    and fails on machines where only the fallback (e.g. 3.12) is installed.
+    """
+    body = _function_body(source, "Install-Venv")
+    resolve_at = body.find("Resolve-AvailablePythonVersion")
+    assert resolve_at != -1, (
+        "Install-Venv must call Resolve-AvailablePythonVersion so the venv "
+        "stage doesn't trust the stale $PythonVersion default across processes"
+    )
+    create_at = body.find("Creating virtual environment with Python")
+    assert create_at != -1, "expected the venv-creation log line in Install-Venv"
+    assert resolve_at < create_at, (
+        "the interpreter must be re-resolved BEFORE the 'Creating virtual "
+        "environment' step (and before `uv venv` runs)"
+    )
+
+
+def test_fallback_list_is_single_source_of_truth(source: str):
+    """The fallback versions live in one shared constant, used by both paths.
+
+    A drifting second copy of the list is how detection and venv creation
+    disagree in the first place.
+    """
+    assert re.search(r"\$PythonFallbackVersions\s*=", source), (
+        "expected a shared $PythonFallbackVersions constant"
+    )
+    # Test-Python's fallback loop must iterate the shared constant, not an
+    # inline literal list.
+    test_python = _function_body(source, "Test-Python")
+    assert "foreach ($fallbackVer in $PythonFallbackVersions)" in test_python, (
+        "Test-Python must iterate the shared $PythonFallbackVersions constant"
+    )
+    # The resolver must seed its candidate list from the same constant.
+    resolver = _function_body(source, "Resolve-AvailablePythonVersion")
+    assert "$PythonFallbackVersions" in resolver, (
+        "Resolve-AvailablePythonVersion must reuse the shared fallback constant"
+    )
+
+
+def test_resolver_prefers_requested_version_then_fallbacks(source: str):
+    """The resolver tries the requested version first, then the fallbacks."""
+    resolver = _function_body(source, "Resolve-AvailablePythonVersion")
+    assert "@($PythonVersion) + $PythonFallbackVersions" in resolver, (
+        "resolver candidate order must be: requested $PythonVersion first, "
+        "then the shared fallbacks"
+    )
+    assert "uv" in resolver and "python find" in resolver, (
+        "resolver must probe availability via `uv python find`"
+    )


### PR DESCRIPTION
## Summary

Fixes #50769 — on Windows, the installer detects a Python fallback (e.g. 3.12 when 3.11 is absent) but then still tries to create the venv with 3.11 and fails:

```
[OK] Found fallback: Python 3.12.8
...
-> Creating virtual environment with Python 3.11...
Failed to create virtual environment (uv venv exited with 2)
```

## Root cause

Under `Hermes-Setup.exe`, each `-Stage NAME` runs in its **own** `powershell.exe` process (the script even documents this for `HasNode`). `Test-Python` records the fallback via an **in-memory** `$script:PythonVersion = $fallbackVer` mutation in the `python` stage's process. That mutation dies when the process exits, so the fresh `venv`-stage process starts with `$PythonVersion` back at its `"3.11"` default — and runs `uv venv venv --python 3.11`, which fails on a machine that only has the fallback installed.

Installing Python 3.11 manually "fixes" it because then the default `3.11` is actually present — matching the reporter's workaround.

## Fix

- Add a cross-process-safe `Resolve-AvailablePythonVersion` helper that returns the first interpreter `uv python find` can actually locate, preferring the requested `$PythonVersion` then the shared `$PythonFallbackVersions` list.
- Call it at the top of `Install-Venv` **before** the venv-creation log line, so the venv stage uses whatever interpreter is actually present instead of the stale default.
- Factor the fallback list into one `$PythonFallbackVersions` constant shared by both `Test-Python` and the resolver, so detection and venv creation can't drift.

The single-process interactive install path is unaffected (the in-memory mutation still works there); this only adds robustness for the cross-process desktop installer path where the bug occurs.

## Testing

- New source-level regression guard `tests/test_install_ps1_python_fallback_venv.py` (the script only runs on Windows, so there's no Linux CI runner — matching the existing `test_install_ps1_uv_powershell_host.py` pattern). Asserts the resolver exists, that `Install-Venv` re-resolves before creating the venv, and that both paths share the one fallback constant.
- `pytest tests/test_install_ps1_python_fallback_venv.py` → 4 passed.

Two commits: the installer fix, then the regression test.
