### PR TITLE
fix(telegram): don't re-arm typing after cron deliveries

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2524,7 +2524,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         # the typing refresh loop; re-arming Telegram's ~5s timer
                         # here would leave the "...typing" bubble lingering after
                         # the answer (no Bot API call cancels it). See #48678.
-                        if not (metadata or {}).get("notify"):
+                        if not ((metadata or {}).get("notify") or (metadata or {}).get("job_id")):
                             try:
                                 await self.send_typing(chat_id, metadata=metadata)
                             except Exception:
@@ -2758,7 +2758,7 @@ class TelegramAdapter(BasePlatformAdapter):
             # send returns, so re-arming Telegram's ~5s timer here would leave
             # the indicator lingering after the answer with nothing to cancel
             # it (Telegram exposes no stop-typing API). See #48678.
-            if not (metadata or {}).get("notify"):
+            if not ((metadata or {}).get("notify") or (metadata or {}).get("job_id")):
                 try:
                     await self.send_typing(chat_id, metadata=metadata)
                 except Exception:

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -231,6 +231,25 @@ async def test_final_send_does_not_retrigger_typing(adapter):
 
 
 @pytest.mark.asyncio
+async def test_cron_delivery_does_not_retrigger_typing(adapter):
+    """Cron deliveries carry metadata['job_id'] rather than metadata['notify'].
+
+    They are still final user-visible messages, so re-arming Telegram's typing
+    timer after the send leaves a lingering '...typing' bubble after scheduled
+    jobs complete.
+    """
+    adapter._bot = MagicMock()
+    adapter._bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=1))
+    adapter._bot.send_chat_action = AsyncMock()
+    adapter._rich_messages_enabled = False
+
+    result = await adapter.send("12345", "Cronjob Response", metadata={"job_id": "job_123"})
+
+    assert result.success is True
+    adapter._bot.send_chat_action.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_intermediate_send_still_retriggers_typing(adapter):
     """Intermediate/progress sends (no notify marker) keep re-triggering typing
     so the '...typing' bubble survives across progress messages while the agent


### PR DESCRIPTION
## Summary

- Treat Telegram cron deliveries (`metadata["job_id"]`) like final user-visible messages for typing re-arm purposes.
- Prevent `TelegramAdapter.send()` from calling `send_typing()` after cron delivery messages.
- Add a regression test covering cron delivery metadata.

Closes #50791

## Why

Normal final replies already skip the post-send typing re-trigger when `metadata["notify"]` is set. Cron / automation deliveries go through `DeliveryRouter -> TelegramAdapter.send(...)` with `metadata["job_id"]`, but not `metadata["notify"]`.

That means Telegram can receive another `sendChatAction(typing)` after the final cron message, leaving the client showing `typing...` even though the job is complete.

## Test plan

```bash
uv run --with pytest --with pytest-asyncio python -m pytest \
  tests/gateway/test_telegram_format.py \
  tests/gateway/test_delivery.py \
  tests/gateway/test_delivery_silence_filter.py \
  -q -o 'addopts='
```

Result:

```text
166 passed in 2.89s
```
