### PR TITLE
Fix multimodal tool result budgeting

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -24,6 +24,8 @@ import logging
 import os
 from typing import Any, Dict, List, Optional
 
+from agent.tool_dispatch_helpers import _trajectory_normalize_msg
+
 logger = logging.getLogger(__name__)
 
 
@@ -742,11 +744,16 @@ def _run_review_in_thread(
             try:
                 # Routed to a different model -> replay a digest (cache is cold
                 # on that model anyway, so minimise cold-written tokens). Same
-                # model -> replay the full snapshot (warm cache reads).
+                # model -> replay the full snapshot (warm cache reads). In both
+                # cases strip binary image payloads before handing the history to
+                # the review fork.
                 _review_history = (
                     _digest_history(messages_snapshot) if _routed
                     else messages_snapshot
                 )
+                review_history = [
+                    _trajectory_normalize_msg(m) for m in _review_history
+                ]
                 review_agent.run_conversation(
                     user_message=(
                         prompt
@@ -754,7 +761,7 @@ def _run_review_in_thread(
                         "management tools. Other tools will be denied "
                         "at runtime — do not attempt them."
                     ),
-                    conversation_history=_review_history,
+                    conversation_history=review_history,
                 )
             finally:
                 clear_thread_tool_whitelist()

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -43,6 +43,7 @@ from tools.terminal_tool import (
 from tools.thread_context import propagate_context_to_thread
 from tools.tool_result_storage import (
     maybe_persist_tool_result,
+    maybe_persist_tool_result_content,
     enforce_turn_budget,
 )
 from tools.budget_config import BudgetConfig, DEFAULT_BUDGET, budget_for_context_window
@@ -827,6 +828,14 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         # image tool result never poisons canonical session history.
         # String results pass through unchanged.
         _tool_content = agent._tool_result_content_for_active_model(name, function_result)
+        if _is_multimodal_tool_result(function_result):
+            _tool_content = maybe_persist_tool_result_content(
+                content=_tool_content,
+                tool_name=name,
+                tool_use_id=tc.id,
+                env=get_active_env(effective_task_id),
+                config=_tool_budget,
+            )
         messages.append(make_tool_result_message(name, _tool_content, tc.id))
         _flush_session_db_after_tool_progress(
             agent,
@@ -1476,6 +1485,14 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # Unwrap _multimodal dicts to an OpenAI-style content list
         # (see parallel path for rationale). String results pass through.
         _tool_content = agent._tool_result_content_for_active_model(function_name, function_result)
+        if _is_multimodal_tool_result(function_result):
+            _tool_content = maybe_persist_tool_result_content(
+                content=_tool_content,
+                tool_name=function_name,
+                tool_use_id=tool_call.id,
+                env=get_active_env(effective_task_id),
+                config=_tool_budget,
+            )
         messages.append(make_tool_result_message(function_name, _tool_content, tool_call.id))
         _flush_session_db_after_tool_progress(
             agent,

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -194,6 +194,49 @@ def test_background_review_summarizer_receives_captured_messages_after_close(mon
     assert captured["notification_mode"] == "on"
 
 
+def test_background_review_strips_image_payloads_from_review_history(monkeypatch):
+    captured: dict = {}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            captured["history"] = kwargs["conversation_history"]
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    data_url = "data:image/png;base64," + ("A" * 2000)
+    messages_snapshot = [
+        {
+            "role": "tool",
+            "tool_call_id": "call_img",
+            "content": [
+                {"type": "text", "text": "screen"},
+                {"type": "image_url", "image_url": {"url": data_url}},
+            ],
+        }
+    ]
+    agent = _bare_agent()
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=messages_snapshot,
+        review_memory=True,
+    )
+
+    assert "data:image" not in str(captured["history"])
+    assert "[screenshot]" in str(captured["history"])
+    assert "data:image" in str(messages_snapshot)
+
+
 def test_background_review_installs_auto_deny_approval_callback(monkeypatch):
     """Regression guard for #15216.
 

--- a/tests/run_agent/test_tool_call_incremental_persistence.py
+++ b/tests/run_agent/test_tool_call_incremental_persistence.py
@@ -52,7 +52,7 @@ def _make_agent():
     with (
         patch(
             "run_agent.get_tool_definitions",
-            return_value=_make_tool_defs("web_search"),
+            return_value=_make_tool_defs("web_search", "vision_analyze"),
         ),
         patch("run_agent.check_toolset_requirements", return_value={}),
         patch("run_agent.OpenAI"),
@@ -87,6 +87,28 @@ def _mock_response(content="Hello", finish_reason="stop", tool_calls=None):
     msg = SimpleNamespace(content=content, tool_calls=tool_calls)
     choice = SimpleNamespace(message=msg, finish_reason=finish_reason)
     return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+def _oversized_multimodal_result() -> tuple[dict, str]:
+    data_url = "data:image/png;base64," + ("A" * 150_000)
+    return (
+        {
+            "_multimodal": True,
+            "content": [
+                {"type": "text", "text": "screenshot"},
+                {"type": "image_url", "image_url": {"url": data_url}},
+            ],
+            "text_summary": "screenshot",
+        },
+        data_url,
+    )
+
+
+def _assert_multimodal_result_was_bounded(messages: list, data_url: str) -> None:
+    content = messages[0]["content"]
+    assert isinstance(content, str)
+    assert "Truncated" in content
+    assert data_url not in content
 
 
 # ---------------------------------------------------------------------------
@@ -250,3 +272,41 @@ def test_execute_tool_calls_concurrent_flushes_each_tool_result_in_order():
     # production flush call breaks one of these assertions.
     assert flushed_tool_ids == ["c1", "c2"]
     assert flush_lengths == [1, 2]
+
+
+def test_sequential_bounds_oversized_multimodal_result_below_turn_budget():
+    agent = _make_agent()
+    agent._flush_messages_to_session_db = MagicMock()
+    tool_call = _mock_tool_call(name="vision_analyze", call_id="img-sequential")
+    assistant_message = SimpleNamespace(content="", tool_calls=[tool_call])
+    result, data_url = _oversized_multimodal_result()
+    messages: list = []
+
+    with (
+        patch("run_agent.handle_function_call", return_value=result),
+        patch("agent.tool_executor.get_active_env", return_value=None),
+        patch.object(agent, "_model_supports_vision", return_value=True),
+        patch.object(agent, "_provider_supports_vision_tool_messages", return_value=True),
+    ):
+        agent._execute_tool_calls_sequential(assistant_message, messages, "task-1")
+
+    _assert_multimodal_result_was_bounded(messages, data_url)
+
+
+def test_concurrent_bounds_oversized_multimodal_result_below_turn_budget():
+    agent = _make_agent()
+    agent._flush_messages_to_session_db = MagicMock()
+    tool_call = _mock_tool_call(name="vision_analyze", call_id="img-concurrent")
+    assistant_message = SimpleNamespace(content="", tool_calls=[tool_call])
+    result, data_url = _oversized_multimodal_result()
+    messages: list = []
+
+    with (
+        patch.object(agent, "_invoke_tool", return_value=result),
+        patch("agent.tool_executor.get_active_env", return_value=None),
+        patch.object(agent, "_model_supports_vision", return_value=True),
+        patch.object(agent, "_provider_supports_vision_tool_messages", return_value=True),
+    ):
+        agent._execute_tool_calls_concurrent(assistant_message, messages, "task-1")
+
+    _assert_multimodal_result_was_bounded(messages, data_url)

--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -492,6 +492,46 @@ class TestEnforceTurnBudget:
         result = enforce_turn_budget([], env=None, config=BudgetConfig(turn_budget=200_000))
         assert result == []
 
+    def test_multimodal_list_counts_serialized_payload_size(self):
+        env = MagicMock()
+        env.execute.return_value = {"output": "", "returncode": 0}
+        data_url = "data:image/png;base64," + ("A" * 210_000)
+        msgs = [
+            {
+                "role": "tool",
+                "tool_call_id": "img1",
+                "content": [
+                    {"type": "text", "text": "screenshot"},
+                    {"type": "image_url", "image_url": {"url": data_url}},
+                ],
+            }
+        ]
+
+        enforce_turn_budget(msgs, env=env, config=BudgetConfig(turn_budget=200_000))
+
+        assert isinstance(msgs[0]["content"], str)
+        assert PERSISTED_OUTPUT_TAG in msgs[0]["content"]
+        assert data_url in env.execute.call_args[1]["stdin_data"]
+
+    def test_multimodal_list_without_env_truncates_inline(self):
+        data_url = "data:image/png;base64," + ("A" * 210_000)
+        msgs = [
+            {
+                "role": "tool",
+                "tool_call_id": "img1",
+                "content": [
+                    {"type": "text", "text": "screenshot"},
+                    {"type": "image_url", "image_url": {"url": data_url}},
+                ],
+            }
+        ]
+
+        enforce_turn_budget(msgs, env=None, config=BudgetConfig(turn_budget=200_000))
+
+        assert isinstance(msgs[0]["content"], str)
+        assert "Truncated" in msgs[0]["content"]
+        assert len(msgs[0]["content"]) < len(data_url)
+
 
 # ── Per-tool threshold integration ────────────────────────────────────
 

--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -20,6 +20,7 @@ from tools.tool_result_storage import (
     enforce_turn_budget,
     generate_preview,
     maybe_persist_tool_result,
+    maybe_persist_tool_result_content,
 )
 
 
@@ -419,6 +420,29 @@ class TestMaybePersistToolResult:
         )
         # Any non-empty content with threshold=0 should be persisted
         assert PERSISTED_OUTPUT_TAG in result
+
+
+# ── maybe_persist_tool_result_content ────────────────────────────────
+
+class TestMaybePersistToolResultContent:
+    def test_structured_content_under_threshold_stays_native(self):
+        content = [
+            {"type": "text", "text": "screenshot"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64,AAAA"},
+            },
+        ]
+
+        result = maybe_persist_tool_result_content(
+            content=content,
+            tool_name="vision_analyze",
+            tool_use_id="img-small",
+            env=None,
+            config=BudgetConfig(default_result_size=1_000),
+        )
+
+        assert result is content
 
 
 # ── enforce_turn_budget ───────────────────────────────────────────────

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -22,10 +22,12 @@ Defense against context-window overflow operates at three levels:
    where many medium-sized results combine to overflow context.
 """
 
+import json
 import logging
 import os
 import shlex
 import uuid
+from typing import Any
 
 from tools.budget_config import (
     DEFAULT_PREVIEW_SIZE_CHARS,
@@ -66,6 +68,26 @@ def generate_preview(content: str, max_chars: int = DEFAULT_PREVIEW_SIZE_CHARS) 
     if last_nl > max_chars // 2:
         truncated = truncated[:last_nl + 1]
     return truncated, True
+
+
+def _serialize_content_for_budget(content: Any) -> str:
+    """Return the string form used for budget accounting and persistence."""
+    if isinstance(content, str):
+        return content
+    try:
+        return json.dumps(content, ensure_ascii=False, default=str)
+    except Exception:
+        return str(content)
+
+
+def _content_budget_size(content: Any) -> int:
+    """Return the real inline size of string or structured tool content."""
+    return len(_serialize_content_for_budget(content))
+
+
+def _is_persisted_content(content: Any) -> bool:
+    """True when content is already a persisted-output replacement block."""
+    return isinstance(content, str) and PERSISTED_OUTPUT_TAG in content
 
 
 def _heredoc_marker(content: str) -> str:
@@ -195,9 +217,9 @@ def enforce_turn_budget(
     total_size = 0
     for i, msg in enumerate(tool_messages):
         content = msg.get("content", "")
-        size = len(content)
+        size = _content_budget_size(content)
         total_size += size
-        if PERSISTED_OUTPUT_TAG not in content:
+        if not _is_persisted_content(content):
             candidates.append((i, size))
 
     if total_size <= config.turn_budget:
@@ -210,17 +232,18 @@ def enforce_turn_budget(
             break
         msg = tool_messages[idx]
         content = msg["content"]
+        storage_content = _serialize_content_for_budget(content)
         tool_use_id = msg.get("tool_call_id", f"budget_{idx}")
 
         replacement = maybe_persist_tool_result(
-            content=content,
+            content=storage_content,
             tool_name=_BUDGET_TOOL_NAME,
             tool_use_id=tool_use_id,
             env=env,
             config=config,
             threshold=0,
         )
-        if replacement != content:
+        if replacement != storage_content:
             total_size -= size
             total_size += len(replacement)
             tool_messages[idx]["content"] = replacement

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -200,6 +200,43 @@ def maybe_persist_tool_result(
     )
 
 
+def maybe_persist_tool_result_content(
+    content: Any,
+    tool_name: str,
+    tool_use_id: str,
+    env=None,
+    config: BudgetConfig = DEFAULT_BUDGET,
+    threshold: int | float | None = None,
+) -> Any:
+    """Layer 2 for string or structured tool-message content.
+
+    Structured content is measured and persisted using its serialized form,
+    but remains a native list/dict while it is within the per-result limit.
+    This keeps small image parts available to vision-capable models without
+    letting oversized base64 payloads bypass Layer 2.
+    """
+    if isinstance(content, str):
+        return maybe_persist_tool_result(
+            content=content,
+            tool_name=tool_name,
+            tool_use_id=tool_use_id,
+            env=env,
+            config=config,
+            threshold=threshold,
+        )
+
+    storage_content = _serialize_content_for_budget(content)
+    replacement = maybe_persist_tool_result(
+        content=storage_content,
+        tool_name=tool_name,
+        tool_use_id=tool_use_id,
+        env=env,
+        config=config,
+        threshold=threshold,
+    )
+    return content if replacement == storage_content else replacement
+
+
 def enforce_turn_budget(
     tool_messages: list[dict],
     env=None,


### PR DESCRIPTION
## Summary
- account for structured/multimodal tool message content by serialized size during per-turn budget enforcement
- persist or truncate oversized multimodal tool results instead of treating a huge image payload list as a tiny list
- strip image payloads from background review conversation history while keeping the original snapshot for action deduplication

Fixes #50788
Related #28446

## Tests
- `venv/bin/python -m pytest tests/tools/test_tool_result_storage.py tests/run_agent/test_background_review.py -q`
