### PR TITLE
fix(telegram): skip typing re-trigger for cron/automation deliveries (#50791)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2524,7 +2524,9 @@ class TelegramAdapter(BasePlatformAdapter):
                         # the typing refresh loop; re-arming Telegram's ~5s timer
                         # here would leave the "...typing" bubble lingering after
                         # the answer (no Bot API call cancels it). See #48678.
-                        if not (metadata or {}).get("notify"):
+                        # Cron/automation deliveries also carry "job_id" and are
+                        # final user-visible messages — skip re-trigger too.
+                        if not ((metadata or {}).get("notify") or (metadata or {}).get("job_id")):
                             try:
                                 await self.send_typing(chat_id, metadata=metadata)
                             except Exception:
@@ -2758,7 +2760,9 @@ class TelegramAdapter(BasePlatformAdapter):
             # send returns, so re-arming Telegram's ~5s timer here would leave
             # the indicator lingering after the answer with nothing to cancel
             # it (Telegram exposes no stop-typing API). See #48678.
-            if not (metadata or {}).get("notify"):
+            # Cron/automation deliveries also carry "job_id" and are final
+            # user-visible messages — skip re-trigger too.
+            if not ((metadata or {}).get("notify") or (metadata or {}).get("job_id")):
                 try:
                     await self.send_typing(chat_id, metadata=metadata)
                 except Exception:

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -246,6 +246,24 @@ async def test_intermediate_send_still_retriggers_typing(adapter):
     adapter._bot.send_chat_action.assert_awaited()
 
 
+@pytest.mark.asyncio
+async def test_cron_delivery_does_not_retrigger_typing(adapter):
+    """Cron/automation deliveries (metadata['job_id']) are final user-visible
+    messages. They must NOT re-arm Telegram's typing timer, same as the
+    notify case.  See #50791."""
+    adapter._bot = MagicMock()
+    adapter._bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=1))
+    adapter._bot.send_chat_action = AsyncMock()
+    adapter._rich_messages_enabled = False
+
+    result = await adapter.send(
+        "12345", "Morning update.", metadata={"job_id": "cron-abc123"},
+    )
+
+    assert result.success is True
+    adapter._bot.send_chat_action.assert_not_called()
+
+
 # =========================================================================
 # format_message - bold and italic
 # =========================================================================


### PR DESCRIPTION
## What does this PR do?

Fixes Telegram's `...typing` indicator getting stuck after cron/automation message delivery. Cron deliveries carry `metadata["job_id"]` but not `metadata["notify"]`, so the existing notify-only guard let them re-arm Telegram's ~5s typing timer — with no subsequent cancel, the bubble lingered indefinitely.

## Related Issue

Fixes #50791

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`plugins/platforms/telegram/adapter.py`**: Added `job_id` check alongside `notify` at both typing re-trigger sites in `TelegramAdapter.send()` (rich-message fast-path at ~line 2527 and legacy send path at ~line 2761). Cron/automation final messages now skip re-triggering, matching the existing `notify` semantics.
- **`tests/gateway/test_telegram_format.py`**: Added `test_cron_delivery_does_not_retrigger_typing` regression test verifying that `send()` with `metadata={"job_id": "..."}` does not call `send_chat_action`.

## How to Test

### Behavior verification

1. Configure Hermes Gateway with Telegram.
2. Create a cron job that delivers to Telegram (e.g., `hermes cron add --every 1m --deliver telegram --prompt "test ping"`).
3. Let the cron job run.
4. **Before fix**: After the cron message is delivered, Telegram continues showing the bot as `typing...` indefinitely.
5. **After fix**: The typing indicator disappears immediately after cron message delivery.

### Targeted tests

```bash
uv run --with pytest --with pytest-asyncio python -m pytest tests/gateway/test_telegram_format.py -v -o 'addopts=' -k "typing"
```

**Observed result**: All 3 typing-related tests pass:
- `test_final_send_does_not_retrigger_typing` ✅ (existing — notify guard)
- `test_intermediate_send_still_retriggers_typing` ✅ (existing — progress messages)
- `test_cron_delivery_does_not_retrigger_typing` ✅ (new — job_id guard)

Full gateway test suite: `166 passed in 2.32s`.

### Platform tested

macOS (Darwin) — Python 3.11.15. Fix is platform-independent (pure Python metadata check).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

Grep-based fallback (GitNexus stale): the two typing re-trigger sites were located via `grep -n "send_typing\|notify\|job_id" plugins/platforms/telegram/adapter.py`. Cron metadata flow confirmed via `cron/scheduler.py:883` (`route_metadata = {"job_id": job["id"]}`) → `gateway/delivery.py` → `TelegramAdapter.send()`.
