### PR TITLE
fix(memory): bound prefetch_all() per-provider with a timeout to prevent ACP hang

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -30,6 +30,7 @@ import re
 import inspect
 import threading
 from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FutureTimeoutError
 from typing import Any, Dict, List, Optional
 
 from agent.memory_provider import MemoryProvider
@@ -449,26 +450,66 @@ class MemoryManager:
         """
         return extract_user_instruction_from_skill_message(text)
 
+    # Hard ceiling on how long a single provider's synchronous prefetch()
+    # can run before we give up on it and move on. prefetch() is documented
+    # as "should be fast" but that's not enforced -- a provider that hangs
+    # on network I/O (or anything else) with no internal timeout would
+    # otherwise block the calling thread indefinitely. On the ACP transport
+    # this manifests as the agent loop hanging silently before the first
+    # API call, since build_turn_context() -> prefetch_all() runs
+    # synchronously on the ACP worker thread before any LLM call is made
+    # or logged (issue #50765).
+    _PREFETCH_TIMEOUT_SECONDS = 8.0
+
     def prefetch_all(self, query: str, *, session_id: str = "") -> str:
         """Collect prefetch context from all providers.
 
         Returns merged context text labeled by provider. Empty providers
-        are skipped. Failures in one provider don't block others.
+        are skipped. Failures in one provider don't block others. Each
+        provider's prefetch() is bounded by _PREFETCH_TIMEOUT_SECONDS --
+        a provider that hangs (no internal timeout of its own) is skipped
+        rather than blocking the turn indefinitely.
         """
         clean_query = self._strip_skill_scaffolding(query)
         if not clean_query:
             return ""
         parts = []
         for provider in self._providers:
+            # One throwaway single-worker executor PER provider call.  A
+            # shared executor would serialize providers behind each other
+            # -- a hung provider would also stall every provider queued
+            # after it for up to its own timeout (e.g. 2 providers each
+            # waiting 8s becomes 16s of total blocking). A dedicated
+            # one-shot executor guarantees one provider's hang costs at
+            # most _PREFETCH_TIMEOUT_SECONDS total, independent of how
+            # many other providers are registered.
+            _one_shot = ThreadPoolExecutor(max_workers=1)
             try:
-                result = provider.prefetch(clean_query, session_id=session_id)
+                future = _one_shot.submit(
+                    provider.prefetch, clean_query, session_id=session_id
+                )
+                result = future.result(timeout=self._PREFETCH_TIMEOUT_SECONDS)
                 if result and result.strip():
                     parts.append(result)
+            except FutureTimeoutError:
+                logger.warning(
+                    "Memory provider '%s' prefetch exceeded %.0fs timeout; "
+                    "skipping for this turn (non-fatal)",
+                    provider.name, self._PREFETCH_TIMEOUT_SECONDS,
+                )
+                # wait=False: do NOT join the abandoned thread. Python
+                # threads cannot be forcibly killed, and waiting here would
+                # re-introduce the exact hang this fix exists to avoid. The
+                # thread is reclaimed once provider.prefetch() eventually
+                # returns on its own, or at interpreter exit.
+                _one_shot.shutdown(wait=False)
+                continue
             except Exception as e:
                 logger.debug(
                     "Memory provider '%s' prefetch failed (non-fatal): %s",
                     provider.name, e,
                 )
+            _one_shot.shutdown(wait=False)
         return "\n\n".join(parts)
 
     def queue_prefetch_all(self, query: str, *, session_id: str = "") -> None:

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1,6 +1,7 @@
 """Tests for the memory provider interface, manager, and builtin provider."""
 
 import json
+import time
 import pytest
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -1491,3 +1492,98 @@ class TestContextEngineToolsetGate:
         """Gate is moot without a context_compressor."""
         tools, names, engine_names = self._run_context_engine_injection(None, None)
         assert tools == []
+
+
+class TestPrefetchAllTimeout:
+    """Regression tests for issue #50765: a provider whose prefetch() hangs
+    (no internal timeout, e.g. blocked network I/O) must not block the
+    calling thread indefinitely. On the ACP transport this manifested as
+    the agent loop hanging silently before the first API call, since
+    build_turn_context() -> prefetch_all() runs synchronously on the ACP
+    worker thread before any LLM call is logged.
+    """
+
+    def test_hanging_provider_does_not_block_indefinitely(self):
+        """A provider whose prefetch() never returns must be abandoned
+        after the timeout rather than hanging the caller forever.
+        """
+        class HangingProvider(MemoryProvider):
+            name = "hanging"
+
+            def initialize(self, session_id, **kwargs):
+                pass
+
+            def is_available(self):
+                return True
+
+            def get_tool_schemas(self):
+                return []
+
+            def prefetch(self, query, *, session_id=""):
+                time.sleep(60)
+                return "should never be returned"
+
+        mgr = MemoryManager()
+        mgr.add_provider(HangingProvider())
+
+        start = time.monotonic()
+        result = mgr.prefetch_all("test query")
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 15, f"prefetch_all blocked for {elapsed:.1f}s"
+        assert result == ""
+
+    def test_hanging_provider_does_not_block_other_providers(self):
+        """One hanging provider must not prevent a healthy provider's
+        result from being collected. Uses name='builtin' for the hanging
+        provider since add_provider() only allows one EXTERNAL provider --
+        'builtin' bypasses that registry restriction so both fakes can
+        coexist for this test of the timeout mechanism itself.
+        """
+        class HangingProvider(MemoryProvider):
+            name = "builtin"
+
+            def initialize(self, session_id, **kwargs):
+                pass
+
+            def is_available(self):
+                return True
+
+            def get_tool_schemas(self):
+                return []
+
+            def prefetch(self, query, *, session_id=""):
+                time.sleep(60)
+                return "should never be returned"
+
+        healthy = FakeMemoryProvider("healthy")
+        healthy._prefetch_result = "healthy provider result"
+
+        mgr = MemoryManager()
+        mgr.add_provider(HangingProvider())
+        mgr.add_provider(healthy)
+
+        start = time.monotonic()
+        result = mgr.prefetch_all("test query")
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 15, f"prefetch_all blocked for {elapsed:.1f}s"
+        assert "healthy provider result" in result
+
+    def test_fast_provider_unaffected_by_timeout_mechanism(self):
+        """A normally-fast provider must not be slowed down or otherwise
+        affected by the timeout-enforcement wrapper.
+        """
+        fast = FakeMemoryProvider("fast")
+        fast._prefetch_result = "fast result"
+
+        mgr = MemoryManager()
+        mgr.add_provider(fast)
+
+        start = time.monotonic()
+        result = mgr.prefetch_all("test query")
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 2.0
+        assert result == "fast result"
+        assert fast.prefetch_queries == ["test query"]


### PR DESCRIPTION
## Problem

MemoryProvider.prefetch() is documented as should be fast but this is not enforced. build_turn_context() calls prefetch_all() synchronously BEFORE the first LLM API call. On ACP this runs on a ThreadPoolExecutor worker thread -- a hung provider means session/prompt never returns and no API call #1 line ever appears (issue #50765, Windows ACP hang, 0.16.0 unaffected).

## Fix

Each providers prefetch() is bounded by an 8s timeout, run on its own dedicated one-shot ThreadPoolExecutor (not a shared executor -- verified empirically that a shared single-worker executor serializes providers behind a hung one, turning 2 providers x 8s timeout into 16s total; one-shot executors keep it under 9s regardless of provider count). Abandoned thread on timeout is never joined (cannot forcibly kill Python threads; joining would reintroduce the hang).

Does not identify the specific provider implementation at fault in the reporters environment -- fix is provider-agnostic, removing the ACP hang regardless of which provider misbehaves.

## Verification

3 new regression tests including empirical proof the per-call executor does not serialize behind another hanging provider (a real bug caught in an earlier iteration of this fix). Full related suites: 100 (memory) + 6 (turn_context) passed, no regressions.

Fixes #50765