### PR TITLE
cron: enforce ORBIT worker isolation guards

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -116,9 +116,9 @@ WORKSPACE_ALLOWLIST_VIOLATION = "WORKSPACE_ALLOWLIST_VIOLATION"
 WORKER_ATTRIBUTION_MISMATCH = "WORKER_ATTRIBUTION_MISMATCH"
 
 _DEFAULT_ORBIT_ALLOWED_REPOS = frozenset({
-    "orbit-governance",
-    "orbitgrc-ui",
-    "orbit-docs",
+    "adavidson510/orbit-governance",
+    "adavidson510/orbitgrc-ui",
+    "adavidson510/orbit-docs",
 })
 
 
@@ -162,13 +162,20 @@ def _path_is_relative_to(child: Path, parent: Path) -> bool:
         return False
 
 
-def _normalize_allowed_repo_names(raw) -> set[str]:
+def _normalize_allowed_repo_names(raw) -> tuple[set[str], set[str]]:
+    """Return qualified and explicit-bare allowed repo names.
+
+    Fully-qualified allowlist entries pin owner/repo and must not silently
+    loosen to bare-name matches. Bare repo-name entries are preserved only as an
+    explicit opt-in compatibility path.
+    """
     if raw is None or raw is False or raw == "":
-        return set(_DEFAULT_ORBIT_ALLOWED_REPOS)
+        return set(_DEFAULT_ORBIT_ALLOWED_REPOS), set()
     items = raw
     if isinstance(raw, str):
         items = re.split(r"[,\s]+", raw)
-    allowed: set[str] = set()
+    qualified: set[str] = set()
+    bare_allowed: set[str] = set()
     for item in items or []:
         text = str(item or "").strip().lower()
         if not text:
@@ -176,10 +183,13 @@ def _normalize_allowed_repo_names(raw) -> set[str]:
         text = text.rstrip("/")
         if text.endswith(".git"):
             text = text[:-4]
-        # Accept either "owner/repo" or bare "repo" allowlist entries.
-        allowed.add(text)
-        allowed.add(text.rsplit("/", 1)[-1])
-    return allowed or set(_DEFAULT_ORBIT_ALLOWED_REPOS)
+        if "/" in text:
+            qualified.add(text)
+        else:
+            bare_allowed.add(text)
+    if not qualified and not bare_allowed:
+        return set(_DEFAULT_ORBIT_ALLOWED_REPOS), set()
+    return qualified, bare_allowed
 
 
 def _repo_name_from_remote(url: str) -> Optional[str]:
@@ -240,18 +250,9 @@ def _observed_github_actor() -> Optional[str]:
     """Best-effort current GitHub write actor for attribution preflight.
 
     Cron should not require GitHub for unrelated jobs, so this is only called
-    inside the opt-in ORBIT guard. Env overrides make the helper cheap and easy
-    to test; falling back to `gh api user` mirrors the write identity used by
-    GitHub CLI driven comment/review/receipt scripts.
+    inside the opt-in ORBIT guard. The observed actor must come from the real
+    write credential. Spoofable environment variables are deliberately ignored.
     """
-    for name in (
-        "HERMES_GITHUB_ACTOR",
-        "GITHUB_ACTOR",
-        "GH_ACTOR",
-    ):
-        value = os.environ.get(name)
-        if value and value.strip():
-            return value.strip()
     gh = shutil.which("gh")
     if not gh:
         return None
@@ -349,7 +350,7 @@ def _check_orbit_worker_guards(job: dict) -> None:
         logger.error("%s: %s", WORKSPACE_ALLOWLIST_VIOLATION, details)
         raise CronWorkerIsolationViolation(WORKSPACE_ALLOWLIST_VIOLATION, details)
 
-    allowed = _normalize_allowed_repo_names(
+    allowed_qualified, allowed_bare = _normalize_allowed_repo_names(
         job.get("allowed_repos") or job.get("orbit_allowed_repos")
     )
     repo_root = _git_toplevel_for_guard(effective_cwd)
@@ -368,10 +369,10 @@ def _check_orbit_worker_guards(job: dict) -> None:
         for remote in remotes:
             repo_name = _repo_name_from_remote(remote)
             bare = repo_name.rsplit("/", 1)[-1] if repo_name else None
-            if repo_name not in allowed and bare not in allowed:
+            if repo_name not in allowed_qualified and bare not in allowed_bare:
                 details["observed_remote"] = remote
                 details["observed_repo"] = repo_name or ""
-                details["allowed_repos"] = ",".join(sorted(allowed))
+                details["allowed_repos"] = ",".join(sorted([*allowed_qualified, *allowed_bare]))
                 details["reason"] = "git remote is outside ORBIT allowlist"
                 logger.error("%s: %s", WORKSPACE_ALLOWLIST_VIOLATION, details)
                 raise CronWorkerIsolationViolation(WORKSPACE_ALLOWLIST_VIOLATION, details)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -112,6 +112,287 @@ class CronPromptInjectionBlocked(Exception):
     """
 
 
+WORKSPACE_ALLOWLIST_VIOLATION = "WORKSPACE_ALLOWLIST_VIOLATION"
+WORKER_ATTRIBUTION_MISMATCH = "WORKER_ATTRIBUTION_MISMATCH"
+
+_DEFAULT_ORBIT_ALLOWED_REPOS = frozenset({
+    "orbit-governance",
+    "orbitgrc-ui",
+    "orbit-docs",
+})
+
+
+class CronWorkerIsolationViolation(RuntimeError):
+    """Raised when an ORBIT/control-plane worker invariant fails closed."""
+
+    def __init__(self, code: str, details: dict):
+        self.code = code
+        self.details = details
+        rendered = ", ".join(
+            f"{key}={value!r}" for key, value in sorted(details.items())
+        )
+        super().__init__(f"{code}: {rendered}")
+
+
+def _job_is_orbit_guarded(job: dict) -> bool:
+    """Return True when a cron job has opted into ORBIT worker invariants.
+
+    The guard is deliberately opt-in so ordinary personal cron jobs are not
+    retroactively constrained to ORBIT repositories. ORBIT schedulers can set
+    any of the explicit fields below on the job record; hand-edited legacy jobs
+    keep their previous behavior.
+    """
+    truthy_fields = (
+        "orbit_worker_guard",
+        "orbit_worker",
+        "worker_isolation_guard",
+        "workspace_allowlist_guard",
+    )
+    if any(bool(job.get(field)) for field in truthy_fields):
+        return True
+    board = str(job.get("board") or job.get("kanban_board") or "").strip().lower()
+    return board == "orbit"
+
+
+def _path_is_relative_to(child: Path, parent: Path) -> bool:
+    try:
+        child.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def _normalize_allowed_repo_names(raw) -> set[str]:
+    if raw is None or raw is False or raw == "":
+        return set(_DEFAULT_ORBIT_ALLOWED_REPOS)
+    items = raw
+    if isinstance(raw, str):
+        items = re.split(r"[,\s]+", raw)
+    allowed: set[str] = set()
+    for item in items or []:
+        text = str(item or "").strip().lower()
+        if not text:
+            continue
+        text = text.rstrip("/")
+        if text.endswith(".git"):
+            text = text[:-4]
+        # Accept either "owner/repo" or bare "repo" allowlist entries.
+        allowed.add(text)
+        allowed.add(text.rsplit("/", 1)[-1])
+    return allowed or set(_DEFAULT_ORBIT_ALLOWED_REPOS)
+
+
+def _repo_name_from_remote(url: str) -> Optional[str]:
+    text = str(url or "").strip()
+    if not text:
+        return None
+    text = text.rstrip("/")
+    if text.endswith(".git"):
+        text = text[:-4]
+    # git@github.com:owner/repo -> owner/repo; https://.../owner/repo -> owner/repo
+    if ":" in text and "/" in text and not text.startswith(("http://", "https://")):
+        text = text.split(":", 1)[1]
+    parts = [part for part in text.split("/") if part]
+    if len(parts) >= 2:
+        return "/".join(parts[-2:]).lower()
+    if parts:
+        return parts[-1].lower()
+    return None
+
+
+def _git_output(args: list[str], cwd: Path) -> Optional[str]:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    return (result.stdout or "").strip()
+
+
+def _git_toplevel_for_guard(cwd: Path) -> Optional[Path]:
+    out = _git_output(["rev-parse", "--show-toplevel"], cwd)
+    if not out:
+        return None
+    return Path(out).expanduser().resolve(strict=False)
+
+
+def _git_remote_urls_for_guard(repo_root: Path) -> list[str]:
+    out = _git_output(["remote", "-v"], repo_root)
+    if not out:
+        return []
+    urls: list[str] = []
+    for line in out.splitlines():
+        parts = line.split()
+        if len(parts) >= 2 and parts[1] not in urls:
+            urls.append(parts[1])
+    return urls
+
+
+def _observed_github_actor() -> Optional[str]:
+    """Best-effort current GitHub write actor for attribution preflight.
+
+    Cron should not require GitHub for unrelated jobs, so this is only called
+    inside the opt-in ORBIT guard. Env overrides make the helper cheap and easy
+    to test; falling back to `gh api user` mirrors the write identity used by
+    GitHub CLI driven comment/review/receipt scripts.
+    """
+    for name in (
+        "HERMES_GITHUB_ACTOR",
+        "GITHUB_ACTOR",
+        "GH_ACTOR",
+    ):
+        value = os.environ.get(name)
+        if value and value.strip():
+            return value.strip()
+    gh = shutil.which("gh")
+    if not gh:
+        return None
+    try:
+        result = subprocess.run(
+            [gh, "api", "user", "--jq", ".login"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    actor = (result.stdout or "").strip()
+    return actor or None
+
+
+def _expected_github_actor(job: dict) -> Optional[str]:
+    explicit = job.get("expected_github_actor") or job.get("github_actor")
+    if explicit:
+        return str(explicit).strip() or None
+    profile = str(job.get("profile") or job.get("run_profile") or "").strip()
+    mapping = job.get("profile_github_actors") or job.get("github_actor_map") or {}
+    if profile and isinstance(mapping, dict) and mapping.get(profile):
+        return str(mapping[profile]).strip() or None
+    # Default invariant: a scheduled profile must write as itself unless the
+    # job carries an explicit credential mapping above.
+    return profile or None
+
+
+def _build_worker_violation_doc(job: dict, violation: CronWorkerIsolationViolation) -> str:
+    details = violation.details
+    lines = [
+        f"# Cron Job: {job.get('name') or job.get('id') or 'cron job'} (BLOCKED)",
+        "",
+        f"**Job ID:** {job.get('id', 'unknown')}",
+        f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}",
+        f"**Status:** {violation.code}",
+        "",
+        "The ORBIT worker/control-plane isolation guard failed closed before the job ran.",
+        "",
+        "## Guard receipt",
+    ]
+    for key in sorted(details):
+        lines.append(f"- **{key}:** `{details[key]}`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _check_orbit_worker_guards(job: dict) -> None:
+    """Fail closed before an ORBIT worker job can read/write out of lane."""
+    if not _job_is_orbit_guarded(job):
+        return
+
+    job_id = str(job.get("id") or "unknown")
+    task_id = str(job.get("task_id") or job.get("kanban_task") or job_id)
+    run_id = str(job.get("run_id") or job.get("current_run_id") or "")
+    profile = str(job.get("profile") or job.get("run_profile") or "").strip()
+
+    workdir_raw = str(job.get("workdir") or "").strip()
+    assigned_raw = str(
+        job.get("assigned_workspace")
+        or job.get("workspace_path")
+        or workdir_raw
+        or ""
+    ).strip()
+    details = {
+        "job_id": job_id,
+        "task_id": task_id,
+        "run_id": run_id,
+        "profile": profile,
+        "workspace_path": assigned_raw,
+    }
+
+    if not assigned_raw:
+        details["reason"] = "missing assigned workspace/workdir"
+        logger.error("%s: %s", WORKSPACE_ALLOWLIST_VIOLATION, details)
+        raise CronWorkerIsolationViolation(WORKSPACE_ALLOWLIST_VIOLATION, details)
+
+    assigned = Path(assigned_raw).expanduser().resolve(strict=False)
+    if workdir_raw:
+        effective_cwd = Path(workdir_raw).expanduser().resolve(strict=False)
+    else:
+        effective_cwd = Path.cwd().resolve(strict=False)
+    details["workspace_path"] = str(assigned)
+    details["effective_cwd"] = str(effective_cwd)
+    if not effective_cwd.is_absolute() or not _path_is_relative_to(effective_cwd, assigned):
+        details["reason"] = "effective cwd is outside assigned workspace"
+        logger.error("%s: %s", WORKSPACE_ALLOWLIST_VIOLATION, details)
+        raise CronWorkerIsolationViolation(WORKSPACE_ALLOWLIST_VIOLATION, details)
+    if not assigned.exists() or not assigned.is_dir():
+        details["reason"] = "assigned workspace missing or not a directory"
+        logger.error("%s: %s", WORKSPACE_ALLOWLIST_VIOLATION, details)
+        raise CronWorkerIsolationViolation(WORKSPACE_ALLOWLIST_VIOLATION, details)
+
+    allowed = _normalize_allowed_repo_names(
+        job.get("allowed_repos") or job.get("orbit_allowed_repos")
+    )
+    repo_root = _git_toplevel_for_guard(effective_cwd)
+    if repo_root is not None:
+        details["git_root"] = str(repo_root)
+        if not _path_is_relative_to(repo_root, assigned):
+            details["reason"] = "git root is outside assigned workspace"
+            logger.error("%s: %s", WORKSPACE_ALLOWLIST_VIOLATION, details)
+            raise CronWorkerIsolationViolation(WORKSPACE_ALLOWLIST_VIOLATION, details)
+        remotes = _git_remote_urls_for_guard(repo_root)
+        details["git_remotes"] = ",".join(remotes)
+        if not remotes:
+            details["reason"] = "git root has no configured remotes"
+            logger.error("%s: %s", WORKSPACE_ALLOWLIST_VIOLATION, details)
+            raise CronWorkerIsolationViolation(WORKSPACE_ALLOWLIST_VIOLATION, details)
+        for remote in remotes:
+            repo_name = _repo_name_from_remote(remote)
+            bare = repo_name.rsplit("/", 1)[-1] if repo_name else None
+            if repo_name not in allowed and bare not in allowed:
+                details["observed_remote"] = remote
+                details["observed_repo"] = repo_name or ""
+                details["allowed_repos"] = ",".join(sorted(allowed))
+                details["reason"] = "git remote is outside ORBIT allowlist"
+                logger.error("%s: %s", WORKSPACE_ALLOWLIST_VIOLATION, details)
+                raise CronWorkerIsolationViolation(WORKSPACE_ALLOWLIST_VIOLATION, details)
+
+    expected_actor = _expected_github_actor(job)
+    if expected_actor:
+        observed_actor = _observed_github_actor()
+        attr_details = {
+            "job_id": job_id,
+            "task_id": task_id,
+            "run_id": run_id,
+            "profile": profile,
+            "expected_writer_identity": expected_actor,
+            "observed_writer_identity": observed_actor or "<unknown>",
+            "workspace_path": str(assigned),
+        }
+        if not observed_actor or observed_actor != expected_actor:
+            logger.error("%s: %s", WORKER_ATTRIBUTION_MISMATCH, attr_details)
+            raise CronWorkerIsolationViolation(WORKER_ATTRIBUTION_MISMATCH, attr_details)
+
+
 def _resolve_cron_disabled_toolsets(cfg: dict) -> list[str]:
     """Toolsets a cron-spawned agent must never receive.
 
@@ -1611,6 +1892,12 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     """
     job_id = job["id"]
     job_name = str(job.get("name") or job.get("prompt") or job_id or "cron job")
+
+    try:
+        _check_orbit_worker_guards(job)
+    except CronWorkerIsolationViolation as violation:
+        doc = _build_worker_violation_doc(job, violation)
+        return False, doc, "", str(violation)
 
     # ---------------------------------------------------------------
     # no_agent short-circuit — the script IS the job, no LLM involvement.

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -250,8 +250,10 @@ def _observed_github_actor() -> Optional[str]:
     """Best-effort current GitHub write actor for attribution preflight.
 
     Cron should not require GitHub for unrelated jobs, so this is only called
-    inside the opt-in ORBIT guard. The observed actor must come from the real
-    write credential. Spoofable environment variables are deliberately ignored.
+    inside the opt-in ORBIT guard. The observed writer must come from the real
+    GitHub credential, not spoofable job environment variables; `gh api user`
+    mirrors the write identity used by GitHub CLI driven comment/review/receipt
+    scripts.
     """
     gh = shutil.which("gh")
     if not gh:
@@ -372,7 +374,10 @@ def _check_orbit_worker_guards(job: dict) -> None:
             if repo_name not in allowed_qualified and bare not in allowed_bare:
                 details["observed_remote"] = remote
                 details["observed_repo"] = repo_name or ""
-                details["allowed_repos"] = ",".join(sorted([*allowed_qualified, *allowed_bare]))
+                allowed_rendered = sorted(allowed_qualified) + [
+                    f"bare:{name}" for name in sorted(allowed_bare)
+                ]
+                details["allowed_repos"] = ",".join(allowed_rendered)
                 details["reason"] = "git remote is outside ORBIT allowlist"
                 logger.error("%s: %s", WORKSPACE_ALLOWLIST_VIOLATION, details)
                 raise CronWorkerIsolationViolation(WORKSPACE_ALLOWLIST_VIOLATION, details)

--- a/tests/cron/test_orbit_worker_guards.py
+++ b/tests/cron/test_orbit_worker_guards.py
@@ -1,0 +1,80 @@
+"""Regression tests for ORBIT worker isolation cron guards (#497)."""
+
+from __future__ import annotations
+
+import subprocess
+
+
+def _git(*args: str, cwd):
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def test_orbit_worker_rejects_non_allowlisted_git_remote_before_script(tmp_path):
+    import cron.scheduler as sched
+
+    workspace = tmp_path / "t_orbit"
+    workspace.mkdir()
+    _git("init", cwd=workspace)
+    _git("remote", "add", "origin", "https://github.com/adavidson510/glucapet.git", cwd=workspace)
+
+    job = {
+        "id": "job-workspace-guard",
+        "name": "orbit guarded worker",
+        "no_agent": True,
+        "script": "would-run-if-guard-failed.sh",
+        "workdir": str(workspace),
+        "orbit_worker_guard": True,
+        "task_id": "t_1ecf7ff4",
+        "run_id": "4303",
+        # No profile here: this test is about workspace confinement, and should
+        # fail before any attribution/GitHub actor lookup is needed.
+    }
+
+    success, output, response, error = sched.run_job(job)
+
+    assert success is False
+    assert response == ""
+    assert sched.WORKSPACE_ALLOWLIST_VIOLATION in (error or "")
+    assert sched.WORKSPACE_ALLOWLIST_VIOLATION in output
+    assert "glucapet" in output
+    assert "t_1ecf7ff4" in output
+    # The guard must fire before the script path is resolved/executed.
+    assert "script failed" not in output.lower()
+
+
+def test_orbit_worker_rejects_profile_actor_mismatch_before_mutation(tmp_path, monkeypatch):
+    import cron.scheduler as sched
+
+    workspace = tmp_path / "t_attr"
+    workspace.mkdir()
+    monkeypatch.setattr(sched, "_observed_github_actor", lambda: "orbitrivet")
+
+    job = {
+        "id": "job-attr-guard",
+        "name": "orbit attribution worker",
+        "no_agent": True,
+        "script": "would-post-if-guard-failed.sh",
+        "workdir": str(workspace),
+        "orbit_worker_guard": True,
+        "task_id": "t_1ecf7ff4",
+        "run_id": "4303",
+        "profile": "orbitcommand",
+    }
+
+    success, output, response, error = sched.run_job(job)
+
+    assert success is False
+    assert response == ""
+    assert sched.WORKER_ATTRIBUTION_MISMATCH in (error or "")
+    assert sched.WORKER_ATTRIBUTION_MISMATCH in output
+    assert "orbitcommand" in output
+    assert "orbitrivet" in output
+    assert "4303" in output
+    # The guard must fire before the script/comment/receipt mutation path.
+    assert "script failed" not in output.lower()

--- a/tests/cron/test_orbit_worker_guards.py
+++ b/tests/cron/test_orbit_worker_guards.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+from types import SimpleNamespace
 
 
 def _git(*args: str, cwd):
@@ -46,6 +47,57 @@ def test_orbit_worker_rejects_non_allowlisted_git_remote_before_script(tmp_path)
     assert "t_1ecf7ff4" in output
     # The guard must fire before the script path is resolved/executed.
     assert "script failed" not in output.lower()
+
+
+def test_orbit_worker_rejects_same_repo_name_wrong_owner_before_script(tmp_path):
+    import cron.scheduler as sched
+
+    workspace = tmp_path / "t_wrong_owner"
+    workspace.mkdir()
+    _git("init", cwd=workspace)
+    _git(
+        "remote",
+        "add",
+        "origin",
+        "https://github.com/not-orbit/orbit-governance.git",
+        cwd=workspace,
+    )
+
+    job = {
+        "id": "job-owner-guard",
+        "name": "orbit guarded worker",
+        "no_agent": True,
+        "script": "would-run-if-owner-guard-failed.sh",
+        "workdir": str(workspace),
+        "orbit_worker_guard": True,
+        "task_id": "t_owner_guard",
+        "run_id": "4304",
+    }
+
+    success, output, response, error = sched.run_job(job)
+
+    assert success is False
+    assert response == ""
+    assert sched.WORKSPACE_ALLOWLIST_VIOLATION in (error or "")
+    assert sched.WORKSPACE_ALLOWLIST_VIOLATION in output
+    assert "not-orbit/orbit-governance" in output
+    assert "script failed" not in output.lower()
+
+
+def test_observed_github_actor_ignores_spoofable_env(monkeypatch):
+    import cron.scheduler as sched
+
+    monkeypatch.setenv("HERMES_GITHUB_ACTOR", "expected-spoof")
+    monkeypatch.setenv("GITHUB_ACTOR", "expected-spoof")
+    monkeypatch.setenv("GH_ACTOR", "expected-spoof")
+    monkeypatch.setattr(sched.shutil, "which", lambda name: "/usr/bin/gh")
+
+    def fake_run(*args, **kwargs):
+        return SimpleNamespace(returncode=0, stdout="real-token-user\n", stderr="")
+
+    monkeypatch.setattr(sched.subprocess, "run", fake_run)
+
+    assert sched._observed_github_actor() == "real-token-user"
 
 
 def test_orbit_worker_rejects_profile_actor_mismatch_before_mutation(tmp_path, monkeypatch):

--- a/tests/cron/test_orbit_worker_guards.py
+++ b/tests/cron/test_orbit_worker_guards.py
@@ -22,7 +22,13 @@ def test_orbit_worker_rejects_non_allowlisted_git_remote_before_script(tmp_path)
     workspace = tmp_path / "t_orbit"
     workspace.mkdir()
     _git("init", cwd=workspace)
-    _git("remote", "add", "origin", "https://github.com/adavidson510/glucapet.git", cwd=workspace)
+    _git(
+        "remote",
+        "add",
+        "origin",
+        "https://github.com/adavidson510/glucapet.git",
+        cwd=workspace,
+    )
 
     job = {
         "id": "job-workspace-guard",
@@ -81,7 +87,37 @@ def test_orbit_worker_rejects_same_repo_name_wrong_owner_before_script(tmp_path)
     assert sched.WORKSPACE_ALLOWLIST_VIOLATION in (error or "")
     assert sched.WORKSPACE_ALLOWLIST_VIOLATION in output
     assert "not-orbit/orbit-governance" in output
+    assert "adavidson510/orbit-governance" in output
     assert "script failed" not in output.lower()
+
+
+def test_orbit_worker_allows_bare_repo_name_only_when_explicitly_configured(tmp_path):
+    import cron.scheduler as sched
+
+    workspace = tmp_path / "t_bare_opt_in"
+    workspace.mkdir()
+    _git("init", cwd=workspace)
+    _git(
+        "remote",
+        "add",
+        "origin",
+        "https://github.com/not-orbit/orbit-governance.git",
+        cwd=workspace,
+    )
+
+    job = {
+        "id": "job-bare-opt-in",
+        "name": "orbit guarded worker",
+        "no_agent": True,
+        "script": "would-run-if-guard-failed.sh",
+        "workdir": str(workspace),
+        "orbit_worker_guard": True,
+        "allowed_repos": ["orbit-governance"],
+    }
+
+    # The guard itself should permit explicitly configured bare-name matching;
+    # the no_agent script path is intentionally not executed in this unit check.
+    sched._check_orbit_worker_guards(job)
 
 
 def test_observed_github_actor_ignores_spoofable_env(monkeypatch):


### PR DESCRIPTION
## Summary

Implements ORBIT #497 worker/control-plane guardrails in the cron scheduler path:

- adds opt-in ORBIT worker guard fields (`orbit_worker_guard`, `orbit_worker`, `worker_isolation_guard`, `workspace_allowlist_guard`, or `board=orbit`)
- fails closed with `WORKSPACE_ALLOWLIST_VIOLATION` before a guarded worker runs from a missing/out-of-workspace/non-ORBIT git remote
- fails closed with `WORKER_ATTRIBUTION_MISMATCH` when a scheduled profile would write as a different GitHub actor unless an explicit profile→actor mapping is configured
- emits guard receipts/audit logs with job id, task id, run id, profile, workspace path, observed remote/actor, and expected actor
- adds regression tests for both negative controls

ORBIT tracker: adavidson510/orbit-governance#497
Master plan: adavidson510/orbit-governance#589

## Tests

- `uv run --with pytest pytest -q tests/cron/test_orbit_worker_guards.py tests/cron/test_cron_workdir.py tests/cron/test_run_one_job.py`
- `uv run --with pytest pytest -q tests/cron/test_scheduler.py`
