### PR TITLE
feat(agent): warn near max iterations

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -20,6 +20,7 @@ import contextvars
 import copy
 import json
 import logging
+import math
 import os
 import random
 import re
@@ -1142,6 +1143,34 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         logger.error("Failed to activate fallback %s: %s", fb_model, e)
         return agent._try_activate_fallback()  # try next in chain
 
+
+
+def build_iteration_budget_pressure_message(max_iterations: int, api_call_count: int) -> Optional[str]:
+    """Return an ephemeral warning when the agent is nearing max iterations."""
+    if not isinstance(max_iterations, int) or max_iterations <= 0:
+        return None
+    if not isinstance(api_call_count, int) or api_call_count < 0:
+        return None
+
+    caution_at = max(1, math.ceil(max_iterations * 0.7))
+    warning_at = max(1, math.ceil(max_iterations * 0.9))
+    remaining = max(0, max_iterations - api_call_count)
+
+    if api_call_count >= warning_at:
+        return (
+            f"[BUDGET: Iteration {api_call_count}/{max_iterations}. "
+            f"You have {remaining} iterations left. You MUST provide your final response now. "
+            "Do not call any more tools unless absolutely critical.]"
+        )
+
+    if api_call_count >= caution_at:
+        return (
+            f"[BUDGET: Iteration {api_call_count}/{max_iterations}. "
+            f"You have {remaining} iterations left. Start consolidating your work and prepare "
+            "to provide a final response.]"
+        )
+
+    return None
 
 
 def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -32,6 +32,7 @@ from agent.auxiliary_client import set_runtime_main
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
+from agent.chat_completion_helpers import build_iteration_budget_pressure_message
 from agent.iteration_budget import IterationBudget
 from agent.memory_manager import build_memory_context_block
 from agent.message_sanitization import (
@@ -901,6 +902,14 @@ def run_conversation(
                 cache_ttl=agent._cache_ttl,
                 native_anthropic=agent._use_native_cache_layout,
             )
+
+        budget_pressure_message = build_iteration_budget_pressure_message(
+            agent.max_iterations,
+            api_call_count,
+        )
+        if budget_pressure_message:
+            insert_at = 1 if (api_messages and api_messages[0].get("role") == "system") else 0
+            api_messages.insert(insert_at, {"role": "system", "content": budget_pressure_message})
 
         # Safety net: strip orphaned tool results / add stubs for missing
         # results before sending to the API.  Runs unconditionally — not

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2678,6 +2678,23 @@ class TestHandleMaxIterations:
         ]
 
 
+class TestIterationBudgetPressureMessage:
+    def test_two_tier_pressure_message_thresholds(self):
+        from agent.chat_completion_helpers import build_iteration_budget_pressure_message
+
+        assert build_iteration_budget_pressure_message(10, 6) is None
+
+        caution = build_iteration_budget_pressure_message(10, 7)
+        assert caution is not None
+        assert "Start consolidating" in caution
+        assert "7/10" in caution
+
+        warning = build_iteration_budget_pressure_message(10, 9)
+        assert warning is not None
+        assert "MUST provide your final response now" in warning
+        assert "9/10" in warning
+
+
 class TestRunConversation:
     """Tests for the main run_conversation method.
 


### PR DESCRIPTION
## Summary
- Add an ephemeral budget-pressure system message when iteration count approaches the limit.
- Emit a caution warning at ~70% of max iterations and a stronger warning at ~90%.
- Add unit tests for the threshold helper.

## Test plan
- python -m pytest tests/run_agent/test_run_agent.py::TestIterationBudgetPressureMessage::test_two_tier_pressure_message_thresholds tests/run_agent/test_run_agent.py::TestHandleMaxIterations::test_returns_summary -q
- python -m pytest tests/run_agent/test_run_agent.py::TestRunConversation::test_stop_finish_reason_returns_response -q
- ruff check agent/chat_completion_helpers.py agent/conversation_loop.py tests/run_agent/test_run_agent.py

Closes #414