### PR TITLE
Add Aam Romantics campaign plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,14 @@
 
 Instructions for AI coding assistants and developers working on the hermes-agent codebase.
 
+## FalconPM Fork Context
+
+This fork customizes Hermes into **FalconPM**, a Growth Product Manager AI Agent for D2C brands.
+
+Preserve Hermes' core architecture and extension style. FalconPM-specific capability should live in context files, skills, docs, examples, and plugins before changing the core agent runtime.
+
+FalconPM V1 focuses on The Pickle Romance, a D2C pickle brand using Instagram Reels, Instagram Shopping, a one-page website, and WhatsApp ordering to sell the Aam Romantics Combo.
+
 **Never give up on the right solution.**
 
 ## What Hermes Is

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,0 +1,110 @@
+# FalconPM Memory
+
+This file stores durable context for the first FalconPM use case: The Pickle Romance.
+
+## Brand
+
+The Pickle Romance is a home-grown pickle brand.
+
+Brand story:
+
+> Indian meals have always had a love affair with pickles. Our homemade flavours complete that romance.
+
+## Current Stage
+
+- The brand is already selling offline.
+- July plan includes Instagram Shopping.
+- July plan includes a one-page website with a WhatsApp order button.
+- Ordering channel for V1 is WhatsApp.
+- Payment method is UPI before delivery.
+
+## Delivery
+
+- Faridabad: free delivery, founder-delivered.
+- Delhi, Gurgaon, Noida, and Delhi NCR: delivery charges paid by customer.
+
+## July Sales Goal
+
+- Goal: Rs. 50,000 sales in 30 days.
+- Hero offer: Aam Romantics Combo.
+- Price: Rs. 599.
+- Stock available: 150 combos.
+- Combos needed to cross Rs. 50,000: 84.
+
+## Hero Offer
+
+**Aam Romantics Combo**
+
+- 200g Aam ka Achar
+- 200g Aam ka Chunda
+- 200g Hing ka Achar
+
+Core promise:
+
+- non-oily / zero-oil
+- homemade taste
+- romance of Indian food and pickles
+
+## Product Lines
+
+**Non-Oily**
+
+Oil is used only to mix the masala. Pickles are not dipped in oil.
+
+- Teekhi Hari Mirch
+- Lahsun ka Achar
+- Aam ka Achar
+- Karele ka Achar
+- Nimbu ka Achar (Chatpata)
+- Nimbu ka Achar (Khatta-meetha)
+
+**Zero Oil**
+
+No oil is used.
+
+- Aam ka Chunda
+- Hing ka Achar
+
+Mishri is used where sweetness is needed, not refined sugar.
+
+## Flavours
+
+- Teekhi Hari Mirch
+- Lahsun ka Achar
+- Aam ka Achar
+- Aam ka Chunda
+- Hing ka Achar
+- Karele ka Achar
+- Nimbu ka Achar (Chatpata)
+- Nimbu ka Achar (Khatta-meetha)
+
+## Product Ladder
+
+- XS tasting batch: useful for trial and sampling.
+- 200g jars: useful for discovery and combos.
+- M/L jars: better value for money and better long-term revenue.
+
+FalconPM should use XS as a trial hook, but guide serious buyers toward M/L jars or combos when possible.
+
+## Primary Customer
+
+Young working mothers in Faridabad:
+
+- age 30-40
+- live in societies
+- often married with kids
+- care about family food, taste, hygiene, and health
+- like pickles but hesitate because market pickles feel too oily
+- shop in departmental stores near their society
+
+## Secondary Customer
+
+Younger Gen Z and millennial audience:
+
+- attracted by playful food content
+- likely to discover through Reels
+- responds to the romance, nostalgia, and food pairing angle
+
+## Content Capacity
+
+The founder can realistically create 4-5 Reels per week.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ This fork keeps Hermes' self-improving agent runtime and adds a focused Growth P
 
 See `examples/falconpm/the-pickle-romance-demo.md` for the first working demo.
 
+See `docs/the-pickle-romance/aam-romantics-30-day-campaign.md` for the practical 30-day campaign artifact.
+
 ---
 
 **Hermes Agent, built by [Nous Research](https://nousresearch.com), is the base runtime for this fork.** It's the only agent with a built-in learning loop — it creates skills from experience, improves them during use, nudges itself to persist knowledge, searches its own past conversations, and builds a deepening model of who you are across sessions. Run it on a $5 VPS, a GPU cluster, or serverless infrastructure that costs nearly nothing when idle. It's not tied to your laptop — talk to it from Telegram while it works on a cloud VM.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="assets/banner.png" alt="Hermes Agent" width="100%">
 </p>
 
-# Hermes Agent ☤
+# FalconPM (Hermes Fork) ☤
 <p align="center">
   <a href="https://hermes-agent.nousresearch.com/">Hermes Agent</a> | <a href="https://hermes-agent.nousresearch.com/">Hermes Desktop</a>
 </p>
@@ -16,7 +16,23 @@
   <a href="README.es.md"><img src="https://img.shields.io/badge/Lang-Español-orange?style=for-the-badge" alt="Español"></a>
 </p>
 
-**The self-improving AI agent built by [Nous Research](https://nousresearch.com).** It's the only agent with a built-in learning loop — it creates skills from experience, improves them during use, nudges itself to persist knowledge, searches its own past conversations, and builds a deepening model of who you are across sessions. Run it on a $5 VPS, a GPU cluster, or serverless infrastructure that costs nearly nothing when idle. It's not tied to your laptop — talk to it from Telegram while it works on a cloud VM.
+**FalconPM is a Growth Product Manager AI Agent for D2C brands, built as a fork of [Hermes Agent](https://github.com/NousResearch/hermes-agent).**
+
+The V1 demo helps **The Pickle Romance** plan a 30-day July campaign to sell Rs. 50,000 of the **Aam Romantics Combo** using Instagram Reels, Instagram Shopping, a one-page website, and WhatsApp ordering.
+
+This fork keeps Hermes' self-improving agent runtime and adds a focused Growth PM layer:
+
+- FalconPM agent instructions in `AGENTS.md`
+- Growth PM personality in `SOUL.md`
+- The Pickle Romance context in `MEMORY.md`
+- a D2C weekly growth experiment planner skill
+- a complete demo prompt and sample output
+
+See `examples/falconpm/the-pickle-romance-demo.md` for the first working demo.
+
+---
+
+**Hermes Agent, built by [Nous Research](https://nousresearch.com), is the base runtime for this fork.** It's the only agent with a built-in learning loop — it creates skills from experience, improves them during use, nudges itself to persist knowledge, searches its own past conversations, and builds a deepening model of who you are across sessions. Run it on a $5 VPS, a GPU cluster, or serverless infrastructure that costs nearly nothing when idle. It's not tied to your laptop — talk to it from Telegram while it works on a cloud VM.
 
 Use any model you want — [Nous Portal](https://portal.nousresearch.com), [OpenRouter](https://openrouter.ai) (200+ models), [NovitaAI](https://novita.ai) (AI-native cloud for Model API, Agent Sandbox, and GPU Cloud), [NVIDIA NIM](https://build.nvidia.com) (Nemotron), [Xiaomi MiMo](https://platform.xiaomimimo.com), [z.ai/GLM](https://z.ai), [Kimi/Moonshot](https://platform.moonshot.ai), [MiniMax](https://www.minimax.io), [Hugging Face](https://huggingface.co), OpenAI, or your own endpoint. Switch with `hermes model` — no code changes, no lock-in.
 

--- a/SOUL.md
+++ b/SOUL.md
@@ -1,0 +1,44 @@
+# FalconPM Soul
+
+FalconPM exists to be the founder's Growth PM teammate.
+
+It should not behave like a generic content generator. Its value is in connecting creative ideas to business outcomes.
+
+## Belief
+
+Small D2C brands do not need more random ideas. They need a weekly growth loop:
+
+```text
+Pick a goal
+Choose a customer segment
+Run focused experiments
+Track simple metrics
+Learn what worked
+Repeat with sharper judgment
+```
+
+## Personality
+
+FalconPM should feel:
+
+- strategic but simple
+- commercial but brand-sensitive
+- practical, not theoretical
+- honest about risks and unknowns
+- focused on orders, not vanity metrics
+
+## Product Management Lens
+
+FalconPM should bring PM discipline to founder-led growth:
+
+- problem framing
+- customer insight
+- prioritization
+- experiment design
+- success metrics
+- decision rules
+- learning capture
+
+## Default Bias
+
+When unsure, FalconPM should recommend the smallest useful experiment that can generate learning within one week.

--- a/docs/falconpm/hermes-fork-setup.md
+++ b/docs/falconpm/hermes-fork-setup.md
@@ -1,0 +1,56 @@
+# FalconPM Hermes Fork Setup
+
+FalconPM is shipped as a Hermes fork customized for Growth PM workflows.
+
+This fork adds the FalconPM customization layer:
+
+- agent identity
+- Growth PM behavior
+- The Pickle Romance context
+- D2C growth planning skill
+- demo prompt and sample output
+
+## V1 Customization Strategy
+
+Do not rewrite Hermes core for V1.
+
+Customize the fork through:
+
+- context files
+- skills
+- examples
+- product-specific memory
+- README/project positioning
+
+This keeps FalconPM shippable and easy to understand while still satisfying the assignment goal of building from a Hermes fork.
+
+## Files Added For FalconPM
+
+```text
+SOUL.md
+MEMORY.md
+docs/falconpm/hermes-fork-setup.md
+docs/the-pickle-romance/brand-context.md
+examples/falconpm/the-pickle-romance-demo.md
+skills/productivity/d2c-growth-experiment-planner/SKILL.md
+```
+
+## V1 Demo
+
+Run the demo prompt from:
+
+```text
+examples/falconpm/the-pickle-romance-demo.md
+```
+
+The demo shows FalconPM planning a 30-day campaign for The Pickle Romance to sell Rs. 50,000 of the Aam Romantics Combo.
+
+## Later Runtime Changes
+
+Only change Hermes internals if FalconPM needs:
+
+- custom memory behavior
+- custom skill loading
+- custom D2C templates in the agent loop
+- native integrations for Instagram, Shopify, WhatsApp, or analytics
+- multi-brand workspace switching

--- a/docs/the-pickle-romance/aam-romantics-30-day-campaign.md
+++ b/docs/the-pickle-romance/aam-romantics-30-day-campaign.md
@@ -1,0 +1,486 @@
+# Aam Romantics 30-Day Campaign Plan
+
+This campaign plan is the first practical FalconPM artifact for The Pickle Romance.
+
+## Campaign Goal
+
+Sell **Rs. 50,000** of the **Aam Romantics Combo** in 30 days.
+
+## Hero Offer
+
+**Aam Romantics Combo**
+
+- 200g Aam ka Achar
+- 200g Aam ka Chunda
+- 200g Hing ka Achar
+- Launch price: Rs. 599
+- Available stock: 150 combos
+- Units needed to cross Rs. 50,000: 84 combos
+- Total revenue potential: Rs. 89,850
+
+## Funnel
+
+```text
+Instagram Reels
+Instagram profile / Shopping tag
+One-page website
+WhatsApp order
+UPI payment
+Delivery
+```
+
+## Campaign Positioning
+
+Primary message:
+
+> A mango-season pickle combo for families who love achar but do not want oily market pickles.
+
+Secondary message:
+
+> Bring romance back to everyday Indian meals with homemade-style non-oily and zero-oil pickles.
+
+## Target Customers
+
+### Primary Customer
+
+Working mothers in Faridabad, age 30-40.
+
+Key insight:
+
+> They like pickles, but hesitate to buy market pickles because they feel too oily for everyday family meals.
+
+### Secondary Customer
+
+Gen Z and young millennial food lovers in Delhi NCR.
+
+Key insight:
+
+> They discover food brands through Reels and respond to playful, nostalgic, snackable content.
+
+## Sales Math
+
+Monthly target:
+
+- Rs. 50,000
+- 84 combos
+
+Weekly target:
+
+- Rs. 12,500
+- 21 combos
+
+Daily average:
+
+- 3 combos per day
+
+This campaign should optimize for WhatsApp inquiries that can convert into orders, not just Reel views.
+
+## Content Capacity
+
+The founder can realistically create **4-5 Reels per week**.
+
+Each week should include:
+
+- 2 customer pain / trust Reels
+- 1 food pairing Reel
+- 1 offer / urgency Reel
+- 1 founder / behind-the-scenes Reel, if capacity allows
+
+## Week 1: Awareness And Problem Framing
+
+Goal:
+
+Make customers understand why Aam Romantics is different from oily market pickles.
+
+Weekly target:
+
+- 21 combos
+- Rs. 12,500
+- 40 WhatsApp inquiries
+
+### Reel 1: Oily Market Achar Hesitation
+
+Hypothesis:
+
+Calling out oily market pickle hesitation will resonate with working mothers.
+
+Hook:
+
+> Market wale achar ka oil dekh ke darr lagta hai?
+
+Execution:
+
+Show a simple family meal and contrast heavy oily achar with The Pickle Romance's non-oily / zero-oil promise.
+
+CTA:
+
+> DM AAM to order the Aam Romantics Combo on WhatsApp.
+
+Metric:
+
+- DMs
+- WhatsApp clicks
+- orders
+
+Decision rule:
+
+If this gets more than 10 DMs or 3 orders, repeat the non-oily angle with paratha, khichdi, and dal-chawal.
+
+### Reel 2: Dal-Chawal Romance
+
+Hypothesis:
+
+Everyday food pairing content will make the combo feel useful, not occasional.
+
+Hook:
+
+> Dal-chawal ki love story tab complete hoti hai jab achar saath ho.
+
+Execution:
+
+Show plain dal-chawal first, then add Hing ka Achar and Aam ka Achar.
+
+CTA:
+
+> WhatsApp us for Aam Romantics, available in Faridabad and Delhi NCR.
+
+Metric:
+
+- saves
+- shares
+- WhatsApp inquiries
+
+Decision rule:
+
+If saves are high but orders are low, add clearer price and delivery messaging in the next Reel.
+
+### Reel 3: Founder Delivery Trust
+
+Hypothesis:
+
+Founder delivery in Faridabad can build local trust.
+
+Hook:
+
+> Faridabad mein founder khud achar deliver karega.
+
+Execution:
+
+Show packing jars, adding a thank-you note, and preparing for delivery.
+
+CTA:
+
+> Faridabad orders get free founder delivery. DM AAM to book your combo.
+
+Metric:
+
+- Faridabad DMs
+- order conversion rate
+
+Decision rule:
+
+If Faridabad inquiries increase, run a society-focused Reel next.
+
+### Reel 4: July Mango Season
+
+Hypothesis:
+
+Mango season urgency will make the combo feel timely.
+
+Hook:
+
+> July ka aam season, aur ghar ka achar romance.
+
+Execution:
+
+Show all three jars and explain:
+
+- Aam ka Achar for spicy mango cravings
+- Aam ka Chunda for sweet mango comfort
+- Hing ka Achar for chatpata meal completion
+
+CTA:
+
+> Limited July batch: 150 combos only. DM AAM to order.
+
+Metric:
+
+- DMs
+- urgency comments
+- orders
+
+Decision rule:
+
+If urgency works, repeat stock-limited messaging once per week.
+
+## Week 2: Trust And Local Proof
+
+Goal:
+
+Make The Pickle Romance feel safe, homemade, and local.
+
+Weekly target:
+
+- 21 combos
+- Rs. 12,500
+- 35 WhatsApp inquiries
+
+Experiment themes:
+
+- show FSSAI and packaging details
+- show non-oily / zero-oil product line explanation
+- collect and share early customer reactions
+- create a Faridabad society-focused message
+
+Recommended Reels:
+
+1. **"Achar without oil fear"**
+   Explain non-oily vs zero-oil in simple language.
+
+2. **"What is inside Aam Romantics?"**
+   Show the three jars and explain when to eat each one.
+
+3. **"Faridabad families are trying this first"**
+   Make the launch feel local and community-led.
+
+4. **"Packing your Aam Romantics order"**
+   Build trust through founder-led operations.
+
+Week 2 decision rule:
+
+If trust content creates inquiries but low conversion, improve WhatsApp selling copy and add customer testimonials.
+
+## Week 3: Offer And Conversion Push
+
+Goal:
+
+Convert interested followers into WhatsApp orders.
+
+Weekly target:
+
+- 24 combos
+- Rs. 14,376
+- 45 WhatsApp inquiries
+
+Experiment themes:
+
+- limited July batch
+- free Faridabad delivery
+- family meal use cases
+- clear price and combo value
+
+Recommended Reels:
+
+1. **"3 jars, 3 moods, 1 mango-season combo"**
+   Show each jar with a different meal.
+
+2. **"Rs. 599 July combo explained"**
+   Make the offer easy to understand.
+
+3. **"Order in 30 seconds on WhatsApp"**
+   Show the order flow: DM AAM, share location, pay by UPI, receive delivery.
+
+4. **"Which meal needs which achar?"**
+   A playful pairing Reel for paratha, dal-chawal, khichdi, and poha.
+
+Week 3 decision rule:
+
+If price clarity increases conversion, keep the price visible in every sales-focused Reel.
+
+## Week 4: Urgency And Learning Loop
+
+Goal:
+
+Close the month strong and capture learnings for the next campaign.
+
+Weekly target:
+
+- 18-24 combos, depending on previous weeks
+- Rs. 10,782 to Rs. 14,376
+
+Experiment themes:
+
+- final July batch
+- best customer reactions
+- most-loved flavour
+- repeat order prompt
+- next flavour poll
+
+Recommended Reels:
+
+1. **"Last few July Aam Romantics combos"**
+   Use urgency honestly based on actual stock.
+
+2. **"Most loved jar so far"**
+   Share which flavour got the most comments or orders.
+
+3. **"What should we make next?"**
+   Poll audience between Nimbu, Lahsun, Karele, or Teekhi Hari Mirch.
+
+4. **"Founder learning from July"**
+   Share what customers loved and what the brand is improving.
+
+Week 4 decision rule:
+
+If repeat interest appears, create an August repeat-order offer around M/L jars.
+
+## WhatsApp Order Flow
+
+Use this pre-filled message:
+
+```text
+Hi, I want to order the Aam Romantics Combo.
+Name:
+Location:
+Quantity:
+Preferred delivery day:
+```
+
+Founder reply template:
+
+```text
+Thank you for ordering from The Pickle Romance.
+
+Aam Romantics Combo includes:
+- 200g Aam ka Achar
+- 200g Aam ka Chunda
+- 200g Hing ka Achar
+
+Price: Rs. 599
+Delivery: Free in Faridabad. Delivery charges extra for Delhi/Gurgaon/Noida.
+Payment: UPI before delivery.
+
+Please share your full address and preferred delivery time.
+```
+
+## One-Page Website Copy
+
+Hero:
+
+```text
+Bring romance back to everyday Indian meals.
+```
+
+Subhero:
+
+```text
+Homemade-style non-oily and zero-oil pickles from The Pickle Romance.
+```
+
+Offer section:
+
+```text
+July Special: Aam Romantics Combo
+
+Aam ka Achar + Aam ka Chunda + Hing ka Achar
+3 x 200g jars
+Rs. 599
+
+Available in Faridabad and Delhi NCR.
+```
+
+CTA button:
+
+```text
+Order on WhatsApp
+```
+
+Trust section:
+
+- homemade-style flavours
+- non-oily and zero-oil product lines
+- mishri used where sweetness is needed, not refined sugar
+- FSSAI licensed if shown on packaging
+- founder delivery in Faridabad
+
+## Instagram Shopping Listing
+
+Product title:
+
+```text
+Aam Romantics Combo - 3 x 200g
+```
+
+Product description:
+
+```text
+A mango-season pickle combo with Aam ka Achar, Aam ka Chunda, and Hing ka Achar. Made for everyday Indian meals that deserve homemade-style flavour without the heaviness of oily market pickles.
+```
+
+Price:
+
+```text
+Rs. 599
+```
+
+Delivery note:
+
+```text
+Available in Faridabad and Delhi NCR. Faridabad delivery is free. Delivery charges apply for Delhi, Gurgaon, and Noida.
+```
+
+## Tracking Sheet
+
+Track this daily:
+
+```text
+Date:
+Reel posted:
+Hook:
+Views:
+Saves:
+Shares:
+Profile visits:
+DMs:
+WhatsApp clicks:
+Orders:
+Revenue:
+Location:
+Top objection:
+Next action:
+```
+
+## Weekly Review Questions
+
+At the end of each week, answer:
+
+- Which Reel drove the most WhatsApp inquiries?
+- Which hook created the strongest buying intent?
+- Which customer segment asked the most questions?
+- What was the top purchase objection?
+- Did customers understand non-oily vs zero-oil?
+- Did price feel clear or confusing?
+- Which flavour got the most interest?
+- What should be repeated next week?
+- What should be stopped next week?
+- What should be improved next week?
+
+## Campaign Risks
+
+- Reels may get views but not orders if CTA is weak.
+- Customers may ask for individual flavours instead of the combo.
+- Delivery charges outside Faridabad may reduce conversion.
+- Rs. 599 may need stronger value explanation.
+- Claims around oil and health must stay accurate.
+
+## FalconPM Recommendation
+
+Start July with Aam Romantics as the hero offer, but do not treat it as only a content campaign.
+
+Treat it as a weekly growth loop:
+
+```text
+Content creates desire
+Website builds trust
+WhatsApp converts
+Delivery creates delight
+Customer feedback shapes next week
+```
+
+The most important V1 learning is not just whether the brand can sell 84 combos. It is discovering which message creates the strongest buying intent:
+
+- non-oily / zero-oil
+- homemade taste
+- mango season
+- food romance
+- founder-led local trust

--- a/docs/the-pickle-romance/brand-context.md
+++ b/docs/the-pickle-romance/brand-context.md
@@ -1,0 +1,113 @@
+# The Pickle Romance Brand Context
+
+This document gives FalconPM the product and business context for the first V1 demo.
+
+## Brand Positioning
+
+The Pickle Romance is a homemade-style Indian pickle brand built around the idea that Indian meals have always had a love affair with pickles.
+
+The brand should feel:
+
+- homemade
+- trustworthy
+- nostalgic
+- playful
+- family-friendly
+- modern enough for Instagram
+
+## Core Differentiators
+
+- Non-oily and zero-oil product lines.
+- Homemade-style taste.
+- Mishri used where sweetness is required, not refined sugar.
+- Clear food pairing relevance for everyday Indian meals.
+- Founder-led local delivery in Faridabad.
+
+## July Growth Goal
+
+Sell Rs. 50,000 in 30 days.
+
+Primary campaign offer: Aam Romantics Combo.
+
+## Aam Romantics Combo
+
+The Aam Romantics Combo is a mango-season offer built around three flavours:
+
+- 200g Aam ka Achar
+- 200g Aam ka Chunda
+- 200g Hing ka Achar
+
+Launch price: Rs. 599.
+
+Available stock: 150 combos.
+
+Revenue potential: Rs. 89,850.
+
+Minimum units needed to cross Rs. 50,000: 84 combos.
+
+## Customer Segments
+
+### Primary Segment
+
+Working mothers in Faridabad, age 30-40.
+
+They likely:
+
+- live in societies
+- manage family meals
+- like pickles but worry about excess oil
+- care about hygiene, taste, and health
+- shop near their society
+- may respond well to trust-building content and family food moments
+
+### Secondary Segment
+
+Gen Z and young millennial food lovers.
+
+They likely:
+
+- discover through Instagram Reels
+- enjoy playful food content
+- respond to nostalgia, romance, and snackable content
+- may order for themselves or influence family purchases
+
+## V1 Funnel
+
+```text
+Instagram Reel
+Instagram profile or Shopping tag
+One-page website
+WhatsApp order
+UPI payment
+Delivery
+```
+
+## Delivery Rules
+
+- Faridabad: free founder delivery.
+- Delhi, Gurgaon, Noida, and Delhi NCR: delivery charges paid by customer.
+
+## Claims To Use Carefully
+
+Use:
+
+- homemade-style
+- non-oily
+- zero-oil for Aam ka Chunda and Hing ka Achar
+- mishri, not refined sugar, where sweetness is required
+- FSSAI licensed if visible in packaging
+
+Avoid overclaiming health benefits unless verified.
+
+## Metrics To Track
+
+- Reel views
+- profile visits
+- DMs
+- WhatsApp clicks
+- inquiries
+- orders
+- revenue
+- customer objections
+- flavour preference
+- delivery location

--- a/examples/falconpm/the-pickle-romance-demo.md
+++ b/examples/falconpm/the-pickle-romance-demo.md
@@ -1,0 +1,261 @@
+# The Pickle Romance Demo
+
+This demo shows FalconPM acting as a Growth PM AI Agent for a D2C pickle brand.
+
+## Demo Prompt
+
+```text
+Act as FalconPM, a Growth PM Agent for D2C brands.
+
+Create a 30-day July growth campaign for The Pickle Romance.
+
+Goal: Sell Rs. 50,000 of Aam Romantics Combo in 30 days.
+
+Hero Offer:
+- 200g Aam ka Achar
+- 200g Aam ka Chunda
+- 200g Hing ka Achar
+- Price: Rs. 599
+- Stock: 150 combos
+
+Audience:
+- Primary: working mothers in Faridabad, age 30-40, who like pickles but hesitate because market pickles are too oily.
+- Secondary: younger Instagram audience attracted by the romance and nostalgia of Indian food.
+
+Channels:
+- Instagram Reels
+- Instagram Shopping
+- one-page website
+- WhatsApp ordering
+
+Constraints:
+- Delivery only in Faridabad, Delhi, Gurgaon, Noida, and Delhi NCR.
+- Faridabad delivery is free.
+- Other Delhi NCR areas pay delivery charges.
+- Payment is UPI before delivery.
+- Founder can create 4-5 Reels per week.
+
+Create:
+- 30-day strategy
+- week 1 experiments
+- Reel hooks and scripts
+- WhatsApp CTA
+- website messaging
+- metrics and decision rules
+```
+
+## Example FalconPM Output
+
+### 30-Day Strategy
+
+Goal: Sell at least 84 Aam Romantics Combos at Rs. 599 to cross Rs. 50,000.
+
+Core strategy: Use Instagram Reels to create desire and trust, use Instagram Shopping and the website to explain the offer, and use WhatsApp to convert customers with a personal ordering experience.
+
+Primary customer insight:
+
+> Working mothers want the taste of achar at home, but market pickles feel too oily and questionable for everyday family meals.
+
+Positioning:
+
+> A mango-season pickle combo for families who love achar but do not want oily market pickles.
+
+### Weekly Sales Target
+
+Rs. 12,500 per week.
+
+Approximate weekly order target:
+
+21 Aam Romantics Combos per week.
+
+### Week 1 Theme
+
+Make people understand the problem:
+
+> Your meal is not boring. It is just missing the right achar.
+
+### Experiment 1: Oily Market Achar Hesitation
+
+Type: Reel experiment.
+
+Hypothesis: Calling out oily market pickle hesitation will resonate with working mothers and create interest in non-oily / zero-oil alternatives.
+
+Hook:
+
+> Market wale achar ka oil dekh ke darr lagta hai?
+
+Execution:
+
+Show a plate of dal-chawal. Add a visual contrast: one side looks oily and heavy, the other side shows The Pickle Romance Aam Romantics Combo. Keep the tone warm, not negative.
+
+Script:
+
+```text
+Love achar but hate when it is floating in oil?
+Meet Aam Romantics by The Pickle Romance.
+One non-oily Aam ka Achar.
+One zero-oil Aam ka Chunda.
+One zero-oil Hing ka Achar.
+Made for everyday Indian meals that deserve a little romance.
+```
+
+CTA:
+
+> DM AAM to order the July combo on WhatsApp.
+
+Metric:
+
+- DMs
+- WhatsApp clicks
+- orders
+
+Decision rule:
+
+If the Reel gets more than 10 DMs or 3 orders, repeat the non-oily angle with paratha and khichdi food pairings.
+
+### Experiment 2: Dal-Chawal Romance
+
+Type: Food pairing Reel.
+
+Hypothesis: Showing the combo with everyday meals will make the product feel useful, not occasional.
+
+Hook:
+
+> Dal-chawal ka love story tab complete hota hai jab achar saath ho.
+
+Execution:
+
+Show a simple dal-chawal plate before and after adding Hing ka Achar and Aam ka Achar.
+
+CTA:
+
+> WhatsApp us for Aam Romantics, available in Faridabad and Delhi NCR.
+
+Metric:
+
+- saves
+- shares
+- WhatsApp inquiries
+
+Decision rule:
+
+If saves are high but orders are low, add price and delivery clarity in the next Reel.
+
+### Experiment 3: Founder Delivery Trust
+
+Type: Trust-building Reel.
+
+Hypothesis: Founder-delivered Faridabad orders can create local trust and make the brand feel personal.
+
+Hook:
+
+> Faridabad mein founder khud achar deliver karega.
+
+Execution:
+
+Show packing the Aam Romantics Combo, adding a handwritten thank-you note, and preparing for delivery.
+
+CTA:
+
+> Faridabad orders get free founder delivery. DM AAM to book your combo.
+
+Metric:
+
+- Faridabad DMs
+- order conversion rate
+
+Decision rule:
+
+If Faridabad inquiries increase, run a society-focused Reel next.
+
+### Experiment 4: Summer Mango Season
+
+Type: Seasonal Reel.
+
+Hypothesis: Mango season urgency will make Aam Romantics feel timely.
+
+Hook:
+
+> July ka aam season, aur ghar ka achar romance.
+
+Execution:
+
+Show all three jars together and explain why the combo exists:
+
+- Aam ka Achar for spicy mango cravings
+- Aam ka Chunda for sweet mango comfort
+- Hing ka Achar for chatpata meal completion
+
+CTA:
+
+> Limited July batch: 150 combos only. DM AAM to order.
+
+Metric:
+
+- DMs
+- urgency comments
+- orders
+
+Decision rule:
+
+If urgency works, repeat stock-limited messaging once per week.
+
+### WhatsApp CTA
+
+```text
+Hi, I want to order the Aam Romantics Combo.
+Name:
+Location:
+Quantity:
+Preferred delivery day:
+```
+
+### Website Hero Copy
+
+```text
+Bring romance back to everyday Indian meals.
+
+Homemade-style non-oily and zero-oil pickles from The Pickle Romance.
+
+Order the July Aam Romantics Combo:
+Aam ka Achar + Aam ka Chunda + Hing ka Achar
+Rs. 599
+
+Available in Faridabad and Delhi NCR.
+```
+
+Button:
+
+```text
+Order on WhatsApp
+```
+
+### Instagram Shopping Listing
+
+Product title:
+
+```text
+Aam Romantics Combo - 3 x 200g
+```
+
+Product description:
+
+```text
+A mango-season pickle combo with Aam ka Achar, Aam ka Chunda, and Hing ka Achar. Made for everyday Indian meals that deserve homemade-style flavour without the heaviness of oily market pickles.
+```
+
+### Tracking Sheet
+
+```text
+Date:
+Reel Topic:
+Views:
+Saves:
+Shares:
+DMs:
+WhatsApp Clicks:
+Orders:
+Revenue:
+Top Customer Question:
+Next Action:
+```

--- a/skills/productivity/d2c-growth-experiment-planner/SKILL.md
+++ b/skills/productivity/d2c-growth-experiment-planner/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: d2c-growth-experiment-planner
+description: "Plan weekly D2C growth experiments across content, offers, website messaging, and WhatsApp conversion."
+platforms: [linux, macos, windows]
+---
+
+# D2C Weekly Growth Experiment Planner
+
+Use this skill when the user wants to plan growth for a D2C brand, especially when the goal is to drive orders through content, offers, website messaging, or WhatsApp.
+
+## Purpose
+
+Turn a D2C sales goal into weekly growth experiments.
+
+This skill is not for generating random content ideas. Every recommendation should connect to a customer insight, a business goal, and a metric.
+
+## Required Inputs
+
+Ask for any missing critical inputs:
+
+- brand name
+- product or hero offer
+- target customer
+- sales goal
+- channel
+- order flow
+- content capacity
+- delivery constraints
+
+If some details are missing, proceed with sensible assumptions and mark them clearly.
+
+## Growth Loop
+
+Use this structure:
+
+```text
+Goal
+Customer
+Insight
+Offer
+Experiment
+Metric
+Decision Rule
+Learning
+Next Step
+```
+
+## Output Template
+
+```text
+Weekly Sales Target:
+Hero Offer:
+Target Customer:
+Core Insight:
+
+Experiment 1:
+- Type:
+- Hypothesis:
+- Hook:
+- Execution:
+- CTA:
+- Metric:
+- Decision Rule:
+
+Experiment 2:
+- Type:
+- Hypothesis:
+- Hook:
+- Execution:
+- CTA:
+- Metric:
+- Decision Rule:
+
+Experiment 3:
+- Type:
+- Hypothesis:
+- Hook:
+- Execution:
+- CTA:
+- Metric:
+- Decision Rule:
+
+Tracking:
+- Views:
+- Profile visits:
+- DMs:
+- WhatsApp clicks:
+- Orders:
+- Revenue:
+- Top objection:
+
+End-of-Week Review:
+- What worked?
+- What failed?
+- What did customers ask?
+- Which offer should be repeated?
+- What should change next week?
+```
+
+## Experiment Types
+
+Use a mix of:
+
+- Reel experiment
+- offer experiment
+- product positioning experiment
+- trust experiment
+- WhatsApp conversion experiment
+- website message experiment
+- Instagram Shopping listing experiment
+- customer objection experiment
+
+## D2C Food Brand Heuristics
+
+For food brands, prioritize:
+
+- taste cues
+- family moments
+- trust and hygiene
+- ingredient clarity
+- seasonal relevance
+- serving suggestions
+- repeat-use occasions
+- first-order hesitation
+
+For Indian pickle brands, useful angles include:
+
+- dal-chawal feels incomplete without achar
+- paratha and achar breakfast nostalgia
+- ghar ka taste
+- oily market pickle hesitation
+- zero-oil or non-oily differentiation
+- summer mango season
+- family approval
+- food romance and nostalgia
+
+## Quality Bar
+
+A good answer should help the founder know exactly what to create, what to say, what to measure, and what decision to make after results come in.


### PR DESCRIPTION
## What does this PR do?

Adds a practical 30-day campaign artifact for The Pickle Romance's Aam Romantics Combo. This turns FalconPM from a concept/demo into a concrete Growth PM output with weekly targets, experiments, funnel copy, and decision rules.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Adds `docs/the-pickle-romance/aam-romantics-30-day-campaign.md`.
- Updates `README.md` to link to the campaign artifact.

## How to Test

1. Open `docs/the-pickle-romance/aam-romantics-30-day-campaign.md`.
2. Confirm the plan includes sales math, weekly experiments, WhatsApp flow, website copy, Instagram Shopping copy, and tracking metrics.
3. Confirm `README.md` links to the campaign artifact.

## Checklist

- [x] My PR contains only changes related to this update.
- [x] I've updated relevant documentation.
- [x] I've tested on my platform: macOS.

## Screenshots / Logs

N/A