### PR TITLE
fix: hide compressed summaries in desktop transcripts

### DIFF
--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -69,6 +69,28 @@ describe('toChatMessages', () => {
     expect(chatMessageText(assistantMessages[0])).toContain('Now let me check git status and commit.')
   })
 
+  it('hides compressed summary metadata rows from loaded transcripts', () => {
+    const messages = toChatMessages([
+      { role: 'user', content: 'real prompt', timestamp: 1 },
+      {
+        role: 'assistant',
+        content: 'internal summary',
+        timestamp: 2,
+        _compressed_summary: true
+      },
+      {
+        role: 'user',
+        content: 'legacy internal summary',
+        timestamp: 3,
+        compressed_summary: 1
+      },
+      { role: 'assistant', content: 'visible reply', timestamp: 4 }
+    ])
+
+    expect(messages).toHaveLength(2)
+    expect(messages.map(message => chatMessageText(message))).toEqual(['real prompt', 'visible reply'])
+  })
+
   it('hides attached context payloads from user message display', () => {
     const [message] = toChatMessages([
       {

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -178,6 +178,10 @@ function displayContentForMessage(role: SessionMessage['role'], content: unknown
   return [refs.join('\n'), visibleText].filter(Boolean).join('\n\n') || visibleText
 }
 
+function isCompressedSummaryMessage(message: SessionMessage): boolean {
+  return Boolean(message._compressed_summary || message.compressed_summary)
+}
+
 const STREAM_PART: Record<'reasoning' | 'text', (text: string) => ChatMessagePart> = {
   reasoning: reasoningPart,
   text: textPart
@@ -735,6 +739,10 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
   }
 
   messages.forEach((message, index) => {
+    if (isCompressedSummaryMessage(message)) {
+      return
+    }
+
     if (message.role === 'tool') {
       const updatedPendingToolParts = applyStoredToolResultToParts(pendingToolParts, message)
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -350,7 +350,9 @@ export interface SessionInfo {
 }
 
 export interface SessionMessage {
+  _compressed_summary?: boolean | number
   codex_reasoning_items?: unknown
+  compressed_summary?: boolean | number
   content: unknown
   context?: unknown
   name?: string

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -116,7 +116,16 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 16
+SCHEMA_VERSION = 17
+
+# Keep in sync with agent.context_compressor.COMPRESSED_SUMMARY_METADATA_KEY.
+# Duplicated here to avoid importing the agent package from the state layer.
+COMPRESSED_SUMMARY_METADATA_KEY = "_compressed_summary"
+COMPRESSED_SUMMARY_PREFIXES = (
+    "[CONTEXT COMPACTION",
+    "[CONTEXT SUMMARY]:",
+    "[Your active task list was preserved across context compression]",
+)
 
 # ---------------------------------------------------------------------------
 # WAL-compatibility fallback
@@ -576,7 +585,8 @@ CREATE TABLE IF NOT EXISTS messages (
     platform_message_id TEXT,
     observed INTEGER DEFAULT 0,
     active INTEGER NOT NULL DEFAULT 1,
-    compacted INTEGER NOT NULL DEFAULT 0
+    compacted INTEGER NOT NULL DEFAULT 0,
+    compressed_summary INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS state_meta (
@@ -1300,6 +1310,22 @@ class SessionDB:
                         "            WHERE m.session_id = sessions.id AND m.role = 'tool') "
                         "AND NOT EXISTS (SELECT 1 FROM sessions ch "
                         "                WHERE ch.parent_session_id = sessions.id)"
+                    )
+                except sqlite3.OperationalError:
+                    pass
+            if current_version < 17:
+                # v17: persist the in-process compressed-summary marker so
+                # Desktop/TUI transcript replay can hide internal compaction
+                # handoff rows instead of rendering them as user messages.
+                # Backfill the legacy prefix shapes that were already stored
+                # before the metadata column existed.
+                try:
+                    cursor.execute(
+                        "UPDATE messages SET compressed_summary = 1 "
+                        "WHERE compressed_summary = 0 AND content IS NOT NULL "
+                        "AND (content LIKE '[CONTEXT COMPACTION%' "
+                        "OR content LIKE '[CONTEXT SUMMARY]:%' "
+                        "OR content LIKE '[Your active task list was preserved across context compression]%')"
                     )
                 except sqlite3.OperationalError:
                     pass
@@ -2505,6 +2531,7 @@ class SessionDB:
         platform_message_id: str = None,
         observed: bool = False,
         timestamp: Any = None,
+        compressed_summary: bool = False,
     ) -> int:
         """
         Append a message to a session. Returns the message row ID.
@@ -2535,6 +2562,7 @@ class SessionDB:
         # Multimodal content (list of parts) must be JSON-encoded: sqlite3
         # cannot bind list/dict parameters directly.
         stored_content = self._encode_content(content)
+        is_compressed_summary = compressed_summary or self._looks_like_compressed_summary(content)
 
         message_timestamp = time.time()
         if timestamp is not None:
@@ -2556,8 +2584,8 @@ class SessionDB:
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   codex_message_items, platform_message_id, observed, compressed_summary)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -2575,6 +2603,7 @@ class SessionDB:
                     codex_message_items_json,
                     platform_message_id,
                     1 if observed else 0,
+                    1 if is_compressed_summary else 0,
                 ),
             )
             msg_id = cursor.lastrowid
@@ -2642,13 +2671,18 @@ class SessionDB:
             platform_msg_id = (
                 msg.get("platform_message_id") or msg.get("message_id")
             )
+            compressed_summary = bool(
+                msg.get(COMPRESSED_SUMMARY_METADATA_KEY)
+                or msg.get("compressed_summary")
+                or self._looks_like_compressed_summary(msg.get("content"))
+            )
 
             conn.execute(
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   codex_message_items, platform_message_id, observed, compressed_summary)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -2666,6 +2700,7 @@ class SessionDB:
                     codex_message_items_json,
                     platform_msg_id,
                     1 if msg.get("observed") else 0,
+                    1 if compressed_summary else 0,
                 ),
             )
             inserted += 1
@@ -2675,6 +2710,13 @@ class SessionDB:
                 )
             now_ts = max(now_ts + 1e-6, message_timestamp + 1e-6)
         return inserted, tool_calls_total
+
+    @staticmethod
+    def _looks_like_compressed_summary(content: Any) -> bool:
+        if not isinstance(content, str):
+            return False
+        text = content.lstrip()
+        return any(text.startswith(prefix) for prefix in COMPRESSED_SUMMARY_PREFIXES)
 
     def replace_messages(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
         """Atomically replace every message for a session.
@@ -3099,7 +3141,8 @@ class SessionDB:
             rows = self._conn.execute(
                 "SELECT role, content, tool_call_id, tool_calls, tool_name, "
                 "finish_reason, reasoning, reasoning_content, reasoning_details, "
-                "codex_reasoning_items, codex_message_items, platform_message_id, observed, timestamp "
+                "codex_reasoning_items, codex_message_items, platform_message_id, "
+                "observed, compressed_summary, timestamp "
                 f"FROM messages WHERE session_id IN ({placeholders})"
                 f"{active_clause} ORDER BY timestamp, id",
                 tuple(session_ids),
@@ -3132,6 +3175,8 @@ class SessionDB:
                 msg["message_id"] = row["platform_message_id"]
             if row["observed"]:
                 msg["observed"] = True
+            if row["compressed_summary"]:
+                msg[COMPRESSED_SUMMARY_METADATA_KEY] = True
             # Restore reasoning fields on assistant messages so providers
             # that replay reasoning (OpenRouter, OpenAI, Nous) receive
             # coherent multi-turn reasoning context.

--- a/tests/agent/test_compressed_summary_metadata.py
+++ b/tests/agent/test_compressed_summary_metadata.py
@@ -20,6 +20,7 @@ from agent.context_compressor import (
     COMPRESSED_SUMMARY_METADATA_KEY,
     ContextCompressor,
 )
+from hermes_state import SessionDB
 
 
 def _make_compressor():
@@ -91,3 +92,63 @@ class TestMetadataFlagNeverReachesWire:
             isinstance(m, dict) and m.get(COMPRESSED_SUMMARY_METADATA_KEY)
             for m in out
         )
+
+
+class TestMetadataFlagPersistence:
+    def test_replace_messages_round_trips_compressed_summary_flag(self, tmp_path):
+        db = SessionDB(tmp_path / "state.db")
+        try:
+            db.create_session("session-1", source="test")
+            db.replace_messages(
+                "session-1",
+                [
+                    {"role": "user", "content": "real prompt"},
+                    {
+                        "role": "assistant",
+                        "content": "internal summary",
+                        COMPRESSED_SUMMARY_METADATA_KEY: True,
+                    },
+                    {
+                        "role": "user",
+                        "content": "[Your active task list was preserved across context compression]\n- [>] 1. keep going (in_progress)",
+                    },
+                    {"role": "assistant", "content": "visible reply"},
+                ],
+            )
+
+            raw = db.get_messages("session-1")
+            assert raw[1]["compressed_summary"] == 1
+            assert raw[2]["compressed_summary"] == 1
+            assert raw[0]["compressed_summary"] == 0
+
+            replay = db.get_messages_as_conversation("session-1")
+            assert replay[1][COMPRESSED_SUMMARY_METADATA_KEY] is True
+            assert replay[2][COMPRESSED_SUMMARY_METADATA_KEY] is True
+            assert COMPRESSED_SUMMARY_METADATA_KEY not in replay[0]
+        finally:
+            db.close()
+
+    def test_schema_upgrade_backfills_legacy_summary_prefixes(self, tmp_path):
+        db_path = tmp_path / "state.db"
+        db = SessionDB(db_path)
+        try:
+            db.create_session("session-1", source="test")
+            db.append_message(
+                "session-1",
+                role="user",
+                content="[Your active task list was preserved across context compression]\n- [>] 1. keep going (in_progress)",
+            )
+            db._conn.execute("UPDATE messages SET compressed_summary = 0")
+            db._conn.execute("UPDATE schema_version SET version = 16")
+            db._conn.commit()
+        finally:
+            db.close()
+
+        upgraded = SessionDB(db_path)
+        try:
+            raw = upgraded.get_messages("session-1")
+            assert raw[0]["compressed_summary"] == 1
+            replay = upgraded.get_messages_as_conversation("session-1")
+            assert replay[0][COMPRESSED_SUMMARY_METADATA_KEY] is True
+        finally:
+            upgraded.close()

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -71,6 +71,27 @@ def test_err_envelope(server):
     }
 
 
+def test_history_to_messages_hides_compressed_summary_rows(server):
+    messages = server._history_to_messages(
+        [
+            {"role": "user", "content": "real prompt"},
+            {
+                "role": "assistant",
+                "content": "internal summary",
+                "_compressed_summary": True,
+            },
+            {
+                "role": "user",
+                "content": "legacy internal summary",
+                "compressed_summary": 1,
+            },
+            {"role": "assistant", "content": "visible reply"},
+        ]
+    )
+
+    assert [m["text"] for m in messages] == ["real prompt", "visible reply"]
+
+
 # ── write_json ───────────────────────────────────────────────────────
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4129,6 +4129,8 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
         role = m.get("role")
         if role not in {"user", "assistant", "tool", "system"}:
             continue
+        if m.get("_compressed_summary") or m.get("compressed_summary"):
+            continue
         content_text = _coerce_message_text(m.get("content"))
         if role == "assistant" and m.get("tool_calls"):
             for tc in m["tool_calls"]:


### PR DESCRIPTION
## Summary
- persist compressed-summary metadata in SQLite as `messages.compressed_summary`
- restore `_compressed_summary` during conversation replay so gateway/desktop can distinguish internal compaction handoff rows from real turns
- backfill legacy summary prefixes, including the todo-tool block `[Your active task list was preserved across context compression]`
- hide flagged rows in TUI gateway history conversion and Desktop loaded transcript conversion

## Why
Desktop can currently render internal context-compression/task-preservation rows as normal user/assistant chat bubbles after a compressed session is resumed. This makes it look like the user typed messages they never wrote.

## Tests
- `./scripts/run_tests.sh tests/agent/test_compressed_summary_metadata.py tests/tui_gateway/test_protocol.py`
- `./scripts/run_tests.sh tests/run_agent/test_in_place_compaction.py tests/hermes_state/test_resolve_resume_session_id.py tests/hermes_cli/test_web_server.py`
- `./scripts/run_tests.sh tests/run_agent/test_compression_persistence.py tests/run_agent/test_compression_boundary_hook.py tests/gateway/test_compression_concurrent_sessions.py tests/cli/test_manual_compress.py tests/agent/test_compression_rotation_state.py`
- `npm --workspace apps/desktop run test:ui -- src/lib/chat-messages.test.ts`
- `npm --workspace apps/desktop run typecheck`
- `uv run ruff check hermes_state.py tui_gateway/server.py tests/agent/test_compressed_summary_metadata.py tests/tui_gateway/test_protocol.py`
