### PR TITLE
feat(desktop): show profile-scoped Codex quota

### DIFF
--- a/apps/desktop/src/app/chat/composer/codex-quota-card.test.tsx
+++ b/apps/desktop/src/app/chat/composer/codex-quota-card.test.tsx
@@ -1,0 +1,49 @@
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  useQuery: vi.fn()
+}))
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: (options: unknown) => mocks.useQuery(options)
+}))
+
+vi.mock('@/hermes', () => ({
+  getCodexUsage: vi.fn()
+}))
+
+import { CodexQuotaCard } from './codex-quota-card'
+
+describe('CodexQuotaCard', () => {
+  beforeEach(() => {
+    mocks.useQuery.mockReturnValue({ data: null, isPending: true })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('keys quota fetches by profile and provider so different Codex auth pools never share cache', () => {
+    render(<CodexQuotaCard enabled profile="acewill-dev" provider="openai-codex" />)
+
+    expect(mocks.useQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: true,
+        queryKey: ['codex-usage', 'acewill-dev', 'openai-codex']
+      })
+    )
+  })
+
+  it('does not fetch Codex quota for non-Codex providers', () => {
+    render(<CodexQuotaCard enabled profile="default" provider="anthropic" />)
+
+    expect(mocks.useQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: false,
+        queryKey: ['codex-usage', 'default', 'anthropic']
+      })
+    )
+  })
+})

--- a/apps/desktop/src/app/chat/composer/codex-quota-card.tsx
+++ b/apps/desktop/src/app/chat/composer/codex-quota-card.tsx
@@ -1,0 +1,179 @@
+import { useQuery } from '@tanstack/react-query'
+import type { FC } from 'react'
+
+import { getCodexUsage } from '@/hermes'
+import { cn } from '@/lib/utils'
+import type { CodexUsageResponse } from '@/types/hermes'
+
+interface CodexQuotaCardProps {
+  /** Only fetch when the popover is open (lazy). */
+  enabled: boolean
+  /** Active Hermes profile; part of the cache key because Codex auth is per-profile. */
+  profile: string
+  /** Current model provider; only OpenAI Codex exposes this quota surface. */
+  provider: string
+}
+
+const CODEX_PROVIDER = 'openai-codex'
+
+/** Hover card body showing live OpenAI Codex rate-limit / quota. */
+export const CodexQuotaCard: FC<CodexQuotaCardProps> = ({ enabled, profile, provider }) => {
+  const normalizedProfile = normalizeProfile(profile)
+  const normalizedProvider = normalizeProvider(provider)
+  const canFetch = enabled && normalizedProvider === CODEX_PROVIDER
+
+  const usage = useQuery<CodexUsageResponse>({
+    queryKey: ['codex-usage', normalizedProfile, normalizedProvider],
+    queryFn: getCodexUsage,
+    enabled: canFetch,
+    staleTime: 60_000, // cache 1 min — quota doesn't move that fast
+    refetchOnWindowFocus: false
+  })
+
+  if (!enabled || normalizedProvider !== CODEX_PROVIDER) {
+    return null
+  }
+
+  if (usage.isPending) {
+    return (
+      <div className="flex items-center gap-2 px-3 py-2 text-xs text-(--ui-text-tertiary)">
+        <span className="inline-block size-3 animate-spin rounded-full border-2 border-(--ui-stroke-tertiary) border-t-(--ui-text-secondary)" />
+        Loading quota…
+      </div>
+    )
+  }
+
+  const data = usage.data
+
+  if (!data?.available) {
+    return <div className="px-3 py-2 text-xs text-(--ui-text-tertiary)">{data?.error || 'Codex quota unavailable'}</div>
+  }
+
+  const windows = data.windows ?? []
+  const plan = data.plan ? ` · ${data.plan}` : ''
+
+  return (
+    <div className="min-w-52 max-w-64 select-none px-3 py-2.5 text-xs">
+      {/* Header */}
+      <div className="mb-2 flex items-center gap-1.5 text-(--ui-text-secondary)">
+        <span className="font-medium">OpenAI Codex{plan}</span>
+      </div>
+
+      {/* Rate-limit windows */}
+      {windows.length === 0 ? (
+        <div className="text-(--ui-text-tertiary)">No rate-limit data</div>
+      ) : (
+        <div className="space-y-2">
+          {windows.map(w => {
+            const used = clampPercent(w.used_percent ?? 0)
+            // Codex IDE shows remaining quota, while the backend reports used_percent.
+            const remaining = clampPercent(w.remaining_percent ?? 100 - used)
+
+            const colorClass = remaining <= 15 ? 'bg-red-500' : remaining <= 40 ? 'bg-amber-400' : 'bg-emerald-500'
+
+            return (
+              <div key={w.label}>
+                <div className="mb-0.5 flex items-center justify-between gap-3">
+                  <span className="text-(--ui-text-tertiary)">{w.label}</span>
+                  <span className="tabular-nums text-(--ui-text-secondary)">{remaining}% left</span>
+                </div>
+                {/* Remaining-quota bar, matching Codex IDE semantics. */}
+                <div className="h-1.5 w-full overflow-hidden rounded-full bg-(--ui-control-background)">
+                  <div
+                    className={cn('h-full rounded-full transition-all', colorClass)}
+                    style={{ width: `${remaining}%` }}
+                  />
+                </div>
+                <div className="mt-0.5 text-[0.65rem] leading-none text-(--ui-text-tertiary)">
+                  {used}% used{w.reset_at ? ` · resets ${formatReset(new Date(w.reset_at))}` : ''}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      {/* Details (credits, reset credits, etc.) */}
+      {(data.details?.length ?? 0) > 0 && (
+        <div className="mt-2 space-y-0.5 border-t border-(--ui-stroke-tertiary) pt-2">
+          {data.details!.map((d, i) => (
+            <div className="text-[0.65rem] leading-snug text-(--ui-text-tertiary)" key={i}>
+              {d}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function normalizeProfile(value: string): string {
+  const trimmed = String(value || '').trim()
+
+  return trimmed || 'default'
+}
+
+function normalizeProvider(value: string): string {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+}
+
+function clampPercent(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0
+  }
+
+  return Math.max(0, Math.min(100, Math.round(value)))
+}
+
+/** Human-friendly relative + absolute local time for quota reset. */
+function formatReset(date: Date): string {
+  const absolute = formatAbsoluteDateTime(date)
+  const now = Date.now()
+  const diff = date.getTime() - now
+
+  if (diff <= 0) {
+    return `now · ${absolute}`
+  }
+
+  const mins = Math.floor(diff / 60_000)
+  const hours = Math.floor(mins / 60)
+  const days = Math.floor(hours / 24)
+
+  let relative: string
+
+  if (days > 0) {
+    relative = `in ${days}d ${hours % 24}h`
+  } else if (hours > 0) {
+    relative = `in ${hours}h ${mins % 60}m`
+  } else {
+    relative = `in ${mins}m`
+  }
+
+  return `${relative} · ${absolute}`
+}
+
+function formatAbsoluteDateTime(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0')
+  const yyyy = date.getFullYear()
+  const mm = pad(date.getMonth() + 1)
+  const dd = pad(date.getDate())
+  const hh = pad(date.getHours())
+  const min = pad(date.getMinutes())
+  const tz = formatShortTimeZone(date)
+
+  return `${yyyy}-${mm}-${dd} ${hh}:${min}${tz ? ` ${tz}` : ''}`
+}
+
+function formatShortTimeZone(date: Date): string {
+  try {
+    const tz = new Intl.DateTimeFormat(undefined, { timeZoneName: 'short' })
+      .formatToParts(date)
+      .find(part => part.type === 'timeZoneName')?.value
+
+    return tz ?? ''
+  } catch {
+    return ''
+  }
+}

--- a/apps/desktop/src/app/chat/composer/model-pill.test.tsx
+++ b/apps/desktop/src/app/chat/composer/model-pill.test.tsx
@@ -1,0 +1,95 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  quotaCard: vi.fn(),
+  setModelPickerOpen: vi.fn()
+}))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      shell: {
+        statusbar: {
+          modelNone: 'No model',
+          modelTitle: (provider: string, model: string) => `${provider} · ${model}`,
+          openModelPicker: 'Open model picker',
+          switchModel: 'Switch model'
+        }
+      }
+    }
+  })
+}))
+
+vi.mock('./codex-quota-card', () => ({
+  CodexQuotaCard: (props: { enabled: boolean; profile: string; provider: string }) => {
+    mocks.quotaCard(props)
+
+    return (
+      <div data-testid="quota-card">
+        {String(props.enabled)}|{props.profile}|{props.provider}
+      </div>
+    )
+  }
+}))
+
+vi.mock('@/store/session', async () => {
+  const actual = await vi.importActual('@/store/session')
+
+  return {
+    ...(actual as object),
+    setModelPickerOpen: (open: boolean) => mocks.setModelPickerOpen(open)
+  }
+})
+
+import { $activeGatewayProfile } from '@/store/profile'
+import { $currentFastMode, $currentModel, $currentProvider, $currentReasoningEffort } from '@/store/session'
+
+import { ModelPill } from './model-pill'
+
+function resetStores({ profile = 'acewill-dev', provider = 'openai-codex' } = {}) {
+  $activeGatewayProfile.set(profile)
+  $currentModel.set('gpt-5.5')
+  $currentProvider.set(provider)
+  $currentFastMode.set(false)
+  $currentReasoningEffort.set('')
+}
+
+describe('ModelPill Codex quota hover', () => {
+  beforeEach(() => {
+    resetStores()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('shows the Codex quota card on hover and passes the active gateway profile', async () => {
+    render(
+      <ModelPill
+        disabled={false}
+        model={{ canSwitch: true, model: 'gpt-5.5', modelMenuContent: <div>models</div>, provider: 'openai-codex' }}
+      />
+    )
+
+    fireEvent.mouseEnter(screen.getByRole('button', { name: 'openai-codex · gpt-5.5' }))
+
+    await waitFor(() => expect(screen.queryByTestId('quota-card')).toBeTruthy())
+    expect(screen.getByTestId('quota-card').textContent).toBe('true|acewill-dev|openai-codex')
+  })
+
+  it('does not show Codex quota for non-Codex providers', () => {
+    resetStores({ profile: 'default', provider: 'anthropic' })
+    render(
+      <ModelPill
+        disabled={false}
+        model={{ canSwitch: true, model: 'gpt-5.5', modelMenuContent: <div>models</div>, provider: 'openai-codex' }}
+      />
+    )
+
+    fireEvent.mouseEnter(screen.getByRole('button', { name: 'anthropic · gpt-5.5' }))
+
+    expect(screen.queryByTestId('quota-card')).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/model-pill.tsx
+++ b/apps/desktop/src/app/chat/composer/model-pill.tsx
@@ -1,14 +1,16 @@
 import { useStore } from '@nanostores/react'
-import { useState } from 'react'
+import { type ReactElement, useEffect, useRef, useState } from 'react'
 
 import { ModelMenuCloseContext } from '@/app/shell/model-menu-panel'
 import { Button } from '@/components/ui/button'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import { GlyphSpinner } from '@/components/ui/glyph-spinner'
+import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
 import { useI18n } from '@/i18n'
 import { ChevronDown } from '@/lib/icons'
 import { formatModelStatusLabel } from '@/lib/model-status-label'
 import { cn } from '@/lib/utils'
+import { $activeGatewayProfile } from '@/store/profile'
 import {
   $currentFastMode,
   $currentModel,
@@ -17,12 +19,16 @@ import {
   setModelPickerOpen
 } from '@/store/session'
 
+import { CodexQuotaCard } from './codex-quota-card'
 import type { ChatBarState } from './types'
 
 const PILL = cn(
   'h-(--composer-control-size) max-w-40 shrink-0 gap-1 rounded-md px-2 text-xs font-normal',
   'text-(--ui-text-tertiary) hover:bg-(--chrome-action-hover) hover:text-foreground'
 )
+
+const CODEX_PROVIDER = 'openai-codex'
+const QUOTA_CLOSE_DELAY_MS = 120
 
 /**
  * Composer model selector — the relocated status-bar pill. Reuses the live
@@ -41,9 +47,12 @@ export function ModelPill({
   const copy = useI18n().t.shell.statusbar
   const currentModel = useStore($currentModel)
   const currentProvider = useStore($currentProvider)
+  const activeGatewayProfile = useStore($activeGatewayProfile)
   const fastMode = useStore($currentFastMode)
   const reasoningEffort = useStore($currentReasoningEffort)
   const [open, setOpen] = useState(false)
+  const [quotaOpen, setQuotaOpen] = useState(false)
+  const quotaCloseTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // The model resolves a beat after the gateway/session comes up. Rather than
   // flash a literal "No model", show a quiet loader (inherits the pill text
@@ -71,9 +80,87 @@ export function ModelPill({
     : PILL
 
   const title = currentProvider ? copy.modelTitle(currentProvider, currentModel || copy.modelNone) : copy.switchModel
+  const normalizedProvider = currentProvider.trim().toLowerCase()
+  const quotaProfile = activeGatewayProfile.trim() || 'default'
+  const quotaSupported = normalizedProvider === CODEX_PROVIDER
+  const quotaEnabled = quotaSupported && !disabled && !open
+
+  const clearQuotaCloseTimer = () => {
+    if (quotaCloseTimer.current) {
+      clearTimeout(quotaCloseTimer.current)
+      quotaCloseTimer.current = null
+    }
+  }
+
+  const openQuota = () => {
+    if (!quotaEnabled) {
+      return
+    }
+
+    clearQuotaCloseTimer()
+    setQuotaOpen(true)
+  }
+
+  const closeQuotaSoon = () => {
+    clearQuotaCloseTimer()
+    quotaCloseTimer.current = setTimeout(() => {
+      setQuotaOpen(false)
+      quotaCloseTimer.current = null
+    }, QUOTA_CLOSE_DELAY_MS)
+  }
+
+  useEffect(
+    () => () => {
+      clearQuotaCloseTimer()
+    },
+    []
+  )
+
+  const handleMenuOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen)
+
+    if (nextOpen) {
+      clearQuotaCloseTimer()
+      setQuotaOpen(false)
+    }
+  }
+
+  const withQuotaHover = (content: ReactElement) => {
+    if (!quotaSupported) {
+      return content
+    }
+
+    return (
+      <Popover open={quotaOpen && quotaEnabled}>
+        <PopoverAnchor asChild>
+          <span
+            className="inline-flex"
+            onBlur={closeQuotaSoon}
+            onFocus={openQuota}
+            onMouseEnter={openQuota}
+            onMouseLeave={closeQuotaSoon}
+          >
+            {content}
+          </span>
+        </PopoverAnchor>
+        {quotaOpen && quotaEnabled && (
+          <PopoverContent
+            align="end"
+            className="w-auto p-0"
+            onMouseEnter={openQuota}
+            onMouseLeave={closeQuotaSoon}
+            side="top"
+            sideOffset={8}
+          >
+            <CodexQuotaCard enabled profile={quotaProfile} provider={currentProvider} />
+          </PopoverContent>
+        )}
+      </Popover>
+    )
+  }
 
   if (!model.modelMenuContent) {
-    return (
+    return withQuotaHover(
       <Button
         aria-label={copy.openModelPicker}
         className={pillClass}
@@ -88,8 +175,8 @@ export function ModelPill({
     )
   }
 
-  return (
-    <DropdownMenu onOpenChange={setOpen} open={open}>
+  return withQuotaHover(
+    <DropdownMenu onOpenChange={handleMenuOpenChange} open={open}>
       <DropdownMenuTrigger asChild>
         <Button
           aria-label={title}

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { getSessionMessages, listAllProfileSessions, listSessions } from './hermes'
+import { getCodexUsage, getSessionMessages, listAllProfileSessions, listSessions, setApiRequestProfile } from './hermes'
 
 const emptySessionsResponse = {
   limit: 0,
@@ -55,6 +55,18 @@ describe('Hermes REST session helpers', () => {
     expect(api).toHaveBeenCalledWith({
       path: '/api/sessions/session-1/messages?profile=xiaoxuxu',
       profile: 'xiaoxuxu'
+    })
+  })
+
+  it('routes Codex usage through the active profile backend', async () => {
+    api.mockResolvedValue({ available: false, details: [], provider: 'openai-codex', windows: [] })
+    setApiRequestProfile('acewill-dev')
+
+    await getCodexUsage()
+
+    expect(api).toHaveBeenCalledWith({
+      path: '/api/codex/usage',
+      profile: 'acewill-dev'
     })
   })
 })

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -8,6 +8,7 @@ import type {
   AudioTranscriptionResponse,
   AuxiliaryModelsResponse,
   BackendUpdateCheckResponse,
+  CodexUsageResponse,
   ConfigSchemaResponse,
   CronJob,
   CronJobCreatePayload,
@@ -59,6 +60,7 @@ export type {
   AudioTranscriptionResponse,
   AuxiliaryModelsResponse,
   BackendUpdateCheckResponse,
+  CodexUsageResponse,
   ConfigFieldSchema,
   ConfigSchemaResponse,
   CronJob,
@@ -266,6 +268,13 @@ export function getGlobalModelInfo(): Promise<ModelInfoResponse> {
   })
 }
 
+export function getCodexUsage(): Promise<CodexUsageResponse> {
+  return window.hermesDesktop.api<CodexUsageResponse>({
+    ...profileScoped(),
+    path: '/api/codex/usage'
+  })
+}
+
 export function getStatus(): Promise<StatusResponse> {
   return window.hermesDesktop.api<StatusResponse>({
     path: '/api/status'
@@ -347,10 +356,7 @@ export function getMemoryProviderConfig(provider: string): Promise<MemoryProvide
   })
 }
 
-export function saveMemoryProviderConfig(
-  provider: string,
-  values: Record<string, string>
-): Promise<{ ok: boolean }> {
+export function saveMemoryProviderConfig(provider: string, values: Record<string, string>): Promise<{ ok: boolean }> {
   return window.hermesDesktop.api<{ ok: boolean }>({
     path: `/api/memory/providers/${encodeURIComponent(provider)}/config`,
     method: 'PUT',

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -231,6 +231,26 @@ export interface ModelInfoResponse {
   provider: string
 }
 
+export interface CodexUsageWindow {
+  detail?: null | string
+  label: string
+  remaining_percent?: null | number
+  reset_at?: null | string
+  used_percent?: null | number
+}
+
+export interface CodexUsageResponse {
+  available: boolean
+  details: string[]
+  error?: null | string
+  fetched_at?: null | string
+  plan?: null | string
+  provider: string
+  source?: null | string
+  title?: string
+  windows: CodexUsageWindow[]
+}
+
 export interface ModelPricing {
   /** Formatted $/Mtok input price, e.g. "$3.00", or "free", or "" if unknown. */
   input: string

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -20,6 +20,7 @@ import hmac
 import importlib.util
 import json
 import logging
+import math
 import mimetypes
 import os
 import re
@@ -3480,6 +3481,90 @@ _EMPTY_MODEL_INFO: dict = {
     "effective_context_length": 0,
     "capabilities": {},
 }
+
+
+def _iso_z(dt: Optional[datetime]) -> Optional[str]:
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _finite_float(value: Any) -> Optional[float]:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    numeric = float(value)
+    return numeric if math.isfinite(numeric) else None
+
+
+def _clamp_percent(value: float) -> float:
+    return max(0.0, min(100.0, value))
+
+
+def _serialize_account_usage_window(window: Any) -> dict:
+    used = _finite_float(getattr(window, "used_percent", None))
+    remaining = None if used is None else _clamp_percent(100.0 - _clamp_percent(used))
+    return {
+        "label": str(getattr(window, "label", "") or ""),
+        "used_percent": None if used is None else _clamp_percent(used),
+        "remaining_percent": remaining,
+        "reset_at": _iso_z(getattr(window, "reset_at", None)),
+        "detail": getattr(window, "detail", None),
+    }
+
+
+def _serialize_account_usage(snapshot: Any, *, provider: str = "openai-codex") -> dict:
+    if snapshot is None:
+        return {
+            "available": False,
+            "details": [],
+            "error": "Codex quota unavailable",
+            "fetched_at": None,
+            "plan": None,
+            "provider": provider,
+            "source": None,
+            "title": "OpenAI Codex quota",
+            "windows": [],
+        }
+
+    unavailable_reason = getattr(snapshot, "unavailable_reason", None)
+    return {
+        "available": bool(getattr(snapshot, "available", False)),
+        "details": list(getattr(snapshot, "details", ()) or ()),
+        "error": unavailable_reason,
+        "fetched_at": _iso_z(getattr(snapshot, "fetched_at", None)),
+        "plan": getattr(snapshot, "plan", None),
+        "provider": str(getattr(snapshot, "provider", provider) or provider),
+        "source": getattr(snapshot, "source", None),
+        "title": str(getattr(snapshot, "title", "OpenAI Codex quota") or "OpenAI Codex quota"),
+        "windows": [
+            _serialize_account_usage_window(window)
+            for window in (getattr(snapshot, "windows", ()) or ())
+        ],
+    }
+
+
+@app.get("/api/codex/usage")
+def get_codex_usage(profile: Optional[str] = None):
+    """Return OpenAI Codex quota for the requested profile's auth store.
+
+    OpenAI Codex OAuth credentials are profile-local. The desktop normally
+    routes this request to the active profile backend process; the query param
+    keeps the endpoint safe for local profile-scoped tests / direct dashboard
+    calls by swapping HERMES_HOME for the duration of the fetch.
+    """
+    try:
+        from agent import account_usage
+
+        with _profile_scope(profile):
+            snapshot = account_usage.fetch_account_usage("openai-codex")
+        return _serialize_account_usage(snapshot, provider="openai-codex")
+    except HTTPException:
+        raise
+    except Exception:
+        _log.exception("GET /api/codex/usage failed")
+        return _serialize_account_usage(None, provider="openai-codex")
 
 
 @app.get("/api/model/info")

--- a/tests/hermes_cli/test_dashboard_codex_usage.py
+++ b/tests/hermes_cli/test_dashboard_codex_usage.py
@@ -1,0 +1,110 @@
+from datetime import datetime, timezone
+
+import pytest
+
+
+def _client():
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:
+        pytest.skip("fastapi/starlette not installed")
+
+    from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+    client = TestClient(app)
+    client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+    return client
+
+
+@pytest.fixture
+def isolated_profiles(tmp_path, monkeypatch, _isolate_hermes_home):
+    from hermes_constants import get_hermes_home
+    from hermes_cli import profiles
+
+    default_home = get_hermes_home()
+    profiles_root = default_home / "profiles"
+    worker_home = profiles_root / "worker_alpha"
+    for home in (default_home, worker_home):
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "config.yaml").write_text("{}\n", encoding="utf-8")
+
+    monkeypatch.setattr(profiles, "_get_default_hermes_home", lambda: default_home)
+    monkeypatch.setattr(profiles, "_get_profiles_root", lambda: profiles_root)
+    return {"default": default_home, "worker_alpha": worker_home}
+
+
+def test_codex_usage_serializes_account_snapshot(monkeypatch, _isolate_hermes_home):
+    from agent import account_usage
+    from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
+
+    fetched_at = datetime(2026, 6, 22, 12, 0, tzinfo=timezone.utc)
+    reset_at = datetime(2026, 6, 23, 12, 0, tzinfo=timezone.utc)
+
+    def fake_fetch(provider, *, base_url=None, api_key=None):
+        assert provider == "openai-codex"
+        assert base_url is None
+        assert api_key is None
+        return AccountUsageSnapshot(
+            provider="openai-codex",
+            source="usage_api",
+            fetched_at=fetched_at,
+            title="OpenAI Codex quota",
+            plan="Plus",
+            windows=(
+                AccountUsageWindow(
+                    label="Weekly",
+                    used_percent=25.0,
+                    reset_at=reset_at,
+                ),
+            ),
+            details=("Credits balance: unlimited",),
+        )
+
+    monkeypatch.setattr(account_usage, "fetch_account_usage", fake_fetch)
+
+    resp = _client().get("/api/codex/usage")
+
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "available": True,
+        "details": ["Credits balance: unlimited"],
+        "error": None,
+        "fetched_at": "2026-06-22T12:00:00Z",
+        "plan": "Plus",
+        "provider": "openai-codex",
+        "source": "usage_api",
+        "title": "OpenAI Codex quota",
+        "windows": [
+            {
+                "detail": None,
+                "label": "Weekly",
+                "remaining_percent": 75.0,
+                "reset_at": "2026-06-23T12:00:00Z",
+                "used_percent": 25.0,
+            }
+        ],
+    }
+
+
+def test_codex_usage_profile_param_switches_hermes_home(monkeypatch, isolated_profiles):
+    from agent import account_usage
+    from agent.account_usage import AccountUsageSnapshot
+    from hermes_constants import get_hermes_home
+
+    homes = []
+
+    def fake_fetch(provider, *, base_url=None, api_key=None):
+        homes.append(get_hermes_home())
+        return AccountUsageSnapshot(
+            provider="openai-codex",
+            source="usage_api",
+            fetched_at=datetime(2026, 6, 22, 12, 0, tzinfo=timezone.utc),
+            details=("profile scoped",),
+        )
+
+    monkeypatch.setattr(account_usage, "fetch_account_usage", fake_fetch)
+
+    resp = _client().get("/api/codex/usage", params={"profile": "worker_alpha"})
+
+    assert resp.status_code == 200
+    assert homes == [isolated_profiles["worker_alpha"]]


### PR DESCRIPTION
## Summary
- Add a profile-scoped `/api/codex/usage` endpoint that reads Codex quota from the requested profile's `HERMES_HOME`
- Add a desktop `getCodexUsage()` API wrapper routed through the active gateway profile
- Show OpenAI Codex quota in the composer model pill hover card with React Query cache keys isolated by profile/provider
- Add frontend and backend tests for routing, profile-aware caching, hover behavior, and response serialization

## Test Plan
- `npm run test:ui -- src/hermes.test.ts src/app/chat/composer/codex-quota-card.test.tsx src/app/chat/composer/model-pill.test.tsx`
- `npm run typecheck`
- `npx eslint src/hermes.ts src/hermes.test.ts src/types/hermes.ts src/app/chat/composer/model-pill.tsx src/app/chat/composer/codex-quota-card.tsx src/app/chat/composer/model-pill.test.tsx src/app/chat/composer/codex-quota-card.test.tsx`
- `uv run --extra dev ruff check hermes_cli/web_server.py tests/hermes_cli/test_dashboard_codex_usage.py`
- `uv run --extra dev python -m pytest tests/hermes_cli/test_dashboard_codex_usage.py tests/hermes_cli/test_dashboard_admin_endpoints.py -q -o 'addopts='`
- `git diff --check`
