### PR TITLE
fix(desktop): show all of a provider's models when searching the composer picker

### DIFF
--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -326,8 +326,10 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
 }
 
 // Collapsed we show the user's chosen models (or the curated default); typing
-// spans every available model so anything is reachable past the cut.
-const PER_PROVIDER_SEARCH = 12
+// spans every available model so anything is reachable past the cut. A search
+// is itself a narrowing action, so we do NOT cap per-provider matches — a
+// provider serving 19 models (e.g. opencode-go) must show all 19 when the user
+// searches for it, not a truncated subset. (#47077 follow-up)
 
 function groupModels(
   providers: ModelOptionProvider[],
@@ -374,11 +376,7 @@ function groupModels(
         ? allFamilies.find(family => family.id === current.model || family.fastId === current.model)?.id
         : undefined
 
-    let families = allFamilies.filter(family => shown.has(family.id) || family.id === activeId)
-
-    if (q) {
-      families = families.slice(0, PER_PROVIDER_SEARCH)
-    }
+    const families = allFamilies.filter(family => shown.has(family.id) || family.id === activeId)
 
     if (families.length > 0) {
       groups.push({ families, provider })


### PR DESCRIPTION
## Summary
Searching the desktop composer model picker for a provider now shows **all** of that provider's matching models, not a truncated subset. Previously a provider serving more than 12 models (e.g. opencode-go with 19) showed only the first 12 when you typed its name — the exact models you searched for got cut off, even though Edit Models listed them all.

Root cause: `groupModels` capped each provider's search results at `PER_PROVIDER_SEARCH = 12`. Edit Models doesn't apply that cap, hence the mismatch ("enabled in Edit Models, missing in the composer").

## Changes
- `apps/desktop/src/app/shell/model-menu-panel.tsx`: remove the per-provider 12-row cap on search results. A search is already a narrowing action; the no-search default still shows the curated top-N per provider via the visibility set.

## Validation
| | Before | After |
|---|---|---|
| Search "opencode go" (19 models) | 12 shown | all 19 shown |
| No-search default | curated top-N | curated top-N (unchanged) |

`apps/desktop` typecheck: clean. Visibility/presets store tests: 23 passed. (The one pre-existing `model-edit-submenu.test.tsx` jsdom `scrollIntoView` failure reproduces identically on clean `main` — unrelated.)

Follow-up to #47077 / #50809 (backend dedup). This closes the remaining frontend truncation in the composer picker.

## Infographic

![nous-badge](https://v3b.fal.media/files/b/0a9f5213/bdqVWbpY8Wq61q8JpxZ7a_6bnGdtll.png)
