### PR TITLE
Add Canon messaging platform plugin

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -210,6 +210,14 @@ class GatewayAuthorizationMixin:
                 Platform.TELEGRAM: "TELEGRAM_GROUP_ALLOWED_CHATS",
                 Platform.QQBOT: "QQ_GROUP_ALLOWED_USERS",
             }.get(source.platform, "")
+            if not chat_allowlist_env:
+                try:
+                    from gateway.platform_registry import platform_registry
+                    entry = platform_registry.get(source.platform.value)
+                    if entry and entry.group_allowed_chats_env:
+                        chat_allowlist_env = entry.group_allowed_chats_env
+                except Exception:
+                    pass
             if chat_allowlist_env:
                 raw_chat_allowlist = os.getenv(chat_allowlist_env, "").strip()
                 if raw_chat_allowlist:
@@ -287,6 +295,10 @@ class GatewayAuthorizationMixin:
                         platform_env_map[source.platform] = entry.allowed_users_env
                     if entry.allow_all_env:
                         platform_allow_all_map[source.platform] = entry.allow_all_env
+                    if entry.group_allowed_users_env:
+                        platform_group_user_env_map[source.platform] = entry.group_allowed_users_env
+                    if entry.group_allowed_chats_env:
+                        platform_group_chat_env_map[source.platform] = entry.group_allowed_chats_env
             except Exception:
                 pass
 
@@ -317,7 +329,7 @@ class GatewayAuthorizationMixin:
         platform_allowlist = os.getenv(platform_env_map.get(source.platform, ""), "").strip()
         group_user_allowlist = ""
         group_chat_allowlist = ""
-        if source.chat_type in {"group", "forum"}:
+        if source.chat_type in {"group", "forum", "channel"}:
             group_user_allowlist = os.getenv(platform_group_user_env_map.get(source.platform, ""), "").strip()
             group_chat_allowlist = os.getenv(platform_group_chat_env_map.get(source.platform, ""), "").strip()
         global_allowlist = os.getenv("GATEWAY_ALLOWED_USERS", "").strip()
@@ -364,7 +376,7 @@ class GatewayAuthorizationMixin:
         # Telegram can optionally authorize group traffic by chat ID.
         # Keep this separate from TELEGRAM_GROUP_ALLOWED_USERS, which gates
         # the sender user ID for group/forum messages.
-        if group_chat_allowlist and source.chat_type in {"group", "forum"} and source.chat_id:
+        if group_chat_allowlist and source.chat_type in {"group", "forum", "channel"} and source.chat_id:
             allowed_group_ids = {
                 chat_id.strip() for chat_id in group_chat_allowlist.split(",") if chat_id.strip()
             }
@@ -537,6 +549,25 @@ class GatewayAuthorizationMixin:
                 ),
                 Platform.QQBOT: ("QQ_GROUP_ALLOWED_USERS",),
             }
+            if platform not in platform_env_map:
+                try:
+                    from gateway.platform_registry import platform_registry
+                    entry = platform_registry.get(platform.value)
+                    if entry:
+                        if entry.allowed_users_env:
+                            platform_env_map[platform] = entry.allowed_users_env
+                        group_envs = tuple(
+                            env
+                            for env in (
+                                entry.group_allowed_users_env,
+                                entry.group_allowed_chats_env,
+                            )
+                            if env
+                        )
+                        if group_envs:
+                            platform_group_env_map[platform] = group_envs
+                except Exception:
+                    pass
             if os.getenv(platform_env_map.get(platform, ""), "").strip():
                 return "ignore"
             for env_key in platform_group_env_map.get(platform, ()):

--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -88,6 +88,12 @@ class PlatformEntry:
     allowed_users_env: str = ""
     # E.g. "IRC_ALLOW_ALL_USERS" — if truthy, all users authorized.
     allow_all_env: str = ""
+    # E.g. "IRC_GROUP_ALLOWED_USERS" — checked only for group/forum/channel
+    # sender user IDs.
+    group_allowed_users_env: str = ""
+    # E.g. "IRC_GROUP_ALLOWED_CHATS" — authorizes entire group/forum/channel
+    # conversations by chat/conversation ID, even when no sender user ID exists.
+    group_allowed_chats_env: str = ""
 
     # ── Message limits ──
     # Max message length for smart-chunking.  0 = no limit.

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1614,6 +1614,10 @@ class MessageEvent:
     # completion notifications) that must bypass user authorization checks.
     internal: bool = False
 
+    # Optional platform-level routing preference for messages that arrive while
+    # a turn is already running. Supported values are "queue" and "interrupt".
+    delivery_intent: Optional[str] = None
+
     # Timestamps
     timestamp: datetime = field(default_factory=datetime.now)
     
@@ -2149,6 +2153,9 @@ class BasePlatformAdapter(ABC):
         self._post_delivery_callbacks: Dict[str, Any] = {}
         self._expected_cancelled_tasks: set[asyncio.Task] = set()
         self._busy_session_handler: Optional[Callable[[MessageEvent, str], Awaitable[bool]]] = None
+        self._runtime_control_handler: Optional[Callable[[MessageEvent, str, str], Awaitable[bool]]] = None
+        self._queue_depth_provider: Optional[Callable[[str], int]] = None
+        self._queued_message_delete_handler: Optional[Callable[[str, str], int]] = None
         # Auto-TTS on voice input: ``_auto_tts_default`` is the global default
         # (``voice.auto_tts`` in config.yaml, pushed by GatewayRunner on connect).
         # Per-chat overrides live in two sets populated from ``_voice_mode``:
@@ -2548,6 +2555,24 @@ class BasePlatformAdapter(ABC):
     def set_busy_session_handler(self, handler: Optional[Callable[[MessageEvent, str], Awaitable[bool]]]) -> None:
         """Set an optional handler for messages arriving during active sessions."""
         self._busy_session_handler = handler
+
+    def set_runtime_control_handler(
+        self,
+        handler: Optional[Callable[[MessageEvent, str, str], Awaitable[bool]]],
+    ) -> None:
+        """Set an optional handler for trusted platform runtime controls."""
+        self._runtime_control_handler = handler
+
+    def set_queue_depth_provider(self, provider: Optional[Callable[[str], int]]) -> None:
+        """Set an optional queue-depth provider owned by the gateway runner."""
+        self._queue_depth_provider = provider
+
+    def set_queued_message_delete_handler(
+        self,
+        handler: Optional[Callable[[str, str], int]],
+    ) -> None:
+        """Set an optional handler that removes queued messages by chat/message id."""
+        self._queued_message_delete_handler = handler
     
     def set_session_store(self, session_store: Any) -> None:
         """
@@ -3629,6 +3654,15 @@ class BasePlatformAdapter(ABC):
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Hook called when background processing begins."""
 
+    async def on_gateway_message_accepted(
+        self,
+        event: MessageEvent,
+        session_key: str,
+        *,
+        phase: str = "active",
+    ) -> None:
+        """Hook called after the gateway accepts an authorized inbound event."""
+
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
         """Hook called when background processing completes."""
 
@@ -4411,6 +4445,7 @@ class BasePlatformAdapter(ABC):
         # Track delivery outcomes for the processing-complete hook
         delivery_attempted = False
         delivery_succeeded = False
+        processing_started = False
 
         def _record_delivery(result):
             nonlocal delivery_attempted, delivery_succeeded
@@ -4449,6 +4484,10 @@ class BasePlatformAdapter(ABC):
             )
         
         try:
+            processing_started = True
+            runtime_start = getattr(self, "_on_runtime_turn_start", None)
+            if callable(runtime_start):
+                await runtime_start(event, session_key)
             await self._run_processing_hook("on_processing_start", event)
 
             # Call the handler (this can take a while with tool calls)
@@ -4801,9 +4840,17 @@ class BasePlatformAdapter(ABC):
             outcome = ProcessingOutcome.CANCELLED
             if current_task is None or current_task not in self._expected_cancelled_tasks:
                 outcome = ProcessingOutcome.FAILURE
+            runtime_complete = getattr(self, "_on_runtime_turn_complete", None)
+            if processing_started and callable(runtime_complete):
+                await runtime_complete(event, session_key, outcome)
+                processing_started = False
             await self._run_processing_hook("on_processing_complete", event, outcome)
             raise
         except Exception as e:
+            runtime_complete = getattr(self, "_on_runtime_turn_complete", None)
+            if processing_started and callable(runtime_complete):
+                await runtime_complete(event, session_key, ProcessingOutcome.FAILURE)
+                processing_started = False
             await self._run_processing_hook("on_processing_complete", event, ProcessingOutcome.FAILURE)
             logger.error("[%s] Error handling message: %s", self.name, e, exc_info=True)
             # Send the error to the user so they aren't left with radio silence
@@ -4827,6 +4874,27 @@ class BasePlatformAdapter(ABC):
             # callbacks may perform platform I/O; a stuck callback must not
             # leave the typing refresh task running indefinitely.
             await _stop_typing_task()
+            runtime_complete = getattr(self, "_on_runtime_turn_complete", None)
+            if processing_started and callable(runtime_complete):
+                try:
+                    await runtime_complete(event, session_key, ProcessingOutcome.SUCCESS)
+                except Exception:
+                    logger.debug(
+                        "[%s] Runtime turn completion hook failed",
+                        self.name,
+                        exc_info=True,
+                    )
+                processing_started = False
+            runtime_queue_changed = getattr(self, "_on_runtime_queue_changed", None)
+            if callable(runtime_queue_changed):
+                try:
+                    await runtime_queue_changed(session_key)
+                except Exception:
+                    logger.debug(
+                        "[%s] Runtime queue-change hook failed",
+                        self.name,
+                        exc_info=True,
+                    )
             # Fire any one-shot post-delivery callback registered for this
             # session (e.g. deferred background-review notifications).
             #

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3617,6 +3617,44 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             depth += 1
         return depth
 
+    def _remove_queued_message(self, conversation_id: str, message_id: str) -> int:
+        """Remove queued events by conversation/chat id plus platform message id."""
+        removed = 0
+        if not conversation_id or not message_id:
+            return removed
+
+        for adapter in getattr(self, "adapters", {}).values():
+            pending_slot = getattr(adapter, "_pending_messages", None)
+            if not isinstance(pending_slot, dict):
+                continue
+            for key, event in list(pending_slot.items()):
+                source = getattr(event, "source", None)
+                if (
+                    str(getattr(source, "chat_id", "") or "") == str(conversation_id)
+                    and str(getattr(event, "message_id", "") or "") == str(message_id)
+                ):
+                    pending_slot.pop(key, None)
+                    removed += 1
+
+        queued_events = getattr(self, "_queued_events", None)
+        if isinstance(queued_events, dict):
+            for key, overflow in list(queued_events.items()):
+                kept = [
+                    event for event in overflow
+                    if not (
+                        str(getattr(getattr(event, "source", None), "chat_id", "") or "")
+                        == str(conversation_id)
+                        and str(getattr(event, "message_id", "") or "") == str(message_id)
+                    )
+                ]
+                removed += len(overflow) - len(kept)
+                if kept:
+                    queued_events[key] = kept
+                else:
+                    queued_events.pop(key, None)
+
+        return removed
+
     @staticmethod
     def _is_goal_continuation_event(event_or_text: Any) -> bool:
         """Return True for synthetic /goal continuation turns.
@@ -4207,6 +4245,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         self._enqueue_fifo(session_key, event, adapter)
 
+    async def _notify_adapter_message_accepted(
+        self,
+        event: MessageEvent,
+        session_key: str,
+        *,
+        phase: str = "active",
+    ) -> None:
+        source = getattr(event, "source", None)
+        platform = getattr(source, "platform", None)
+        if platform is None:
+            return
+        adapter = self.adapters.get(platform)
+        if adapter is None:
+            return
+        hook = getattr(adapter, "on_gateway_message_accepted", None)
+        if not callable(hook):
+            return
+        try:
+            result = hook(event, session_key, phase=phase)
+            if inspect.isawaitable(result):
+                await result
+        except Exception:
+            logger.debug("Adapter accepted-message hook failed", exc_info=True)
+
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
         # --- Authorization gate (#17775) ---
         # The cold path (_handle_message) checks _is_user_authorized before
@@ -4274,9 +4336,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         running_agent = self._running_agents.get(session_key)
 
         effective_mode = self._busy_input_mode
+        delivery_intent = str(getattr(event, "delivery_intent", "") or "").strip().lower()
+        if delivery_intent == "queue":
+            effective_mode = "queue"
+        elif delivery_intent == "interrupt":
+            effective_mode = "interrupt"
+
         busy_text_mode = getattr(self, "_busy_text_mode", "interrupt")
         if (
-            event.message_type == MessageType.TEXT
+            not delivery_intent
+            and event.message_type == MessageType.TEXT
             and busy_text_mode == "queue"
             and effective_mode != "steer"
         ):
@@ -4323,6 +4392,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if not steered:
                 # Fall back to queue (merge into pending messages, no interrupt)
                 effective_mode = "queue"
+            else:
+                await self._notify_adapter_message_accepted(
+                    event,
+                    session_key,
+                    phase="steer",
+                )
 
         # Store the message so it's processed as the next turn after the
         # current run finishes (or is interrupted).  Skip this for a
@@ -4340,7 +4415,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # turn in arrival order while still preserving photo-burst / album
         # merge semantics for media.
         if not steered:
-            self._queue_or_replace_pending_event(session_key, event)
+            if delivery_intent == "interrupt":
+                adapter._pending_messages[session_key] = event
+            else:
+                self._queue_or_replace_pending_event(session_key, event)
+            queue_changed = getattr(adapter, "_on_runtime_queue_changed", None)
+            if callable(queue_changed):
+                try:
+                    await queue_changed(session_key)
+                except Exception:
+                    logger.debug("Runtime queue-change hook failed", exc_info=True)
 
         is_queue_mode = effective_mode == "queue"
         is_steer_mode = effective_mode == "steer"
@@ -4475,6 +4559,51 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.debug("Failed to send busy-ack: %s", e)
 
         return True
+
+    async def _handle_runtime_control_signal(
+        self,
+        event: MessageEvent,
+        session_key: str,
+        signal: str,
+    ) -> bool:
+        """Handle trusted platform runtime controls without user-text dispatch."""
+        source = event.source
+        adapter = self.adapters.get(source.platform) if source else None
+        if not source or not session_key:
+            return False
+
+        if signal in {"interrupt", "stop_and_drop"}:
+            if signal == "stop_and_drop":
+                if adapter is not None and hasattr(adapter, "_pending_messages"):
+                    adapter._pending_messages.pop(session_key, None)
+                queued_events = getattr(self, "_queued_events", None)
+                if isinstance(queued_events, dict):
+                    queued_events.pop(session_key, None)
+            await self._interrupt_and_clear_session(
+                session_key,
+                source,
+                interrupt_reason=_INTERRUPT_REASON_STOP,
+                invalidation_reason=f"runtime_control_{signal}",
+                discard_pending=signal == "stop_and_drop",
+            )
+            return True
+
+        if signal == "new_session":
+            if adapter is not None and hasattr(adapter, "_pending_messages"):
+                adapter._pending_messages.pop(session_key, None)
+            queued_events = getattr(self, "_queued_events", None)
+            if isinstance(queued_events, dict):
+                queued_events.pop(session_key, None)
+            await self._interrupt_and_clear_session(
+                session_key,
+                source,
+                interrupt_reason=_INTERRUPT_REASON_RESET,
+                invalidation_reason="runtime_control_new_session",
+            )
+            await self._handle_reset_command(event)
+            return True
+
+        return False
 
     async def _drain_active_agents(self, timeout: float) -> tuple[Dict[str, Any], bool]:
         snapshot = self._snapshot_running_agents()
@@ -5418,6 +5547,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 exc_info=True,
             )
         
+        # Discover Python plugins before inspecting auth env vars so plugin
+        # platforms can contribute allowlist metadata to the startup warning.
+        # The CLI startup path does this via hermes_cli/main.py; the gateway
+        # lazily imports run_agent inside per-request handlers, so the
+        # discover_plugins() side-effect in model_tools.py is not guaranteed
+        # to have run by the time we reach this point.
+        try:
+            from hermes_cli.plugins import discover_plugins
+            discover_plugins()
+        except Exception:
+            logger.warning(
+                "plugin discovery failed at gateway startup", exc_info=True,
+            )
+
         # Warn if no user allowlists are configured and open access is not opted in
         _builtin_allowed_vars = (
             "TELEGRAM_ALLOWED_USERS", "DISCORD_ALLOWED_USERS",
@@ -5461,8 +5604,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         try:
             from gateway.platform_registry import platform_registry
             _plugin_allowed_vars = tuple(
-                e.allowed_users_env for e in platform_registry.plugin_entries()
-                if e.allowed_users_env
+                env
+                for e in platform_registry.plugin_entries()
+                for env in (
+                    e.allowed_users_env,
+                    e.group_allowed_users_env,
+                    e.group_allowed_chats_env,
+                )
+                if env
             )
             _plugin_allow_all_vars = tuple(
                 e.allow_all_env for e in platform_registry.plugin_entries()
@@ -5484,20 +5633,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "or configure platform allowlists (e.g., TELEGRAM_ALLOWED_USERS=your_id)."
             )
         
-        # Discover Python plugins before shell hooks so plugin block
-        # decisions take precedence in tie cases.  The CLI startup path
-        # does this via an explicit call in hermes_cli/main.py; the
-        # gateway lazily imports run_agent inside per-request handlers,
-        # so the discover_plugins() side-effect in model_tools.py is NOT
-        # guaranteed to have run by the time we reach this point.
-        try:
-            from hermes_cli.plugins import discover_plugins
-            discover_plugins()
-        except Exception:
-            logger.warning(
-                "plugin discovery failed at gateway startup", exc_info=True,
-            )
-
         # Register the generic relay adapter when a connector relay URL is
         # configured (GATEWAY_RELAY_URL / gateway.relay_url). No URL -> no-op, so
         # direct/single-tenant deployments are unaffected. When configured, the
@@ -5633,6 +5768,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
             adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
             adapter._busy_text_mode = self._busy_text_mode
+            if hasattr(adapter, "set_runtime_control_handler"):
+                adapter.set_runtime_control_handler(self._handle_runtime_control_signal)
+            if hasattr(adapter, "set_queue_depth_provider"):
+                adapter.set_queue_depth_provider(
+                    lambda session_key, _adapter=adapter: self._queue_depth(
+                        session_key,
+                        adapter=_adapter,
+                    )
+                )
+            if hasattr(adapter, "set_queued_message_delete_handler"):
+                adapter.set_queued_message_delete_handler(self._remove_queued_message)
             
             # Try to connect
             logger.info("Connecting to %s...", platform.value)
@@ -6400,6 +6546,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     adapter.set_busy_session_handler(self._handle_active_session_busy_message)
                     adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
                     adapter._busy_text_mode = self._busy_text_mode
+                    if hasattr(adapter, "set_runtime_control_handler"):
+                        adapter.set_runtime_control_handler(self._handle_runtime_control_signal)
+                    if hasattr(adapter, "set_queue_depth_provider"):
+                        adapter.set_queue_depth_provider(
+                            lambda session_key, _adapter=adapter: self._queue_depth(
+                                session_key,
+                                adapter=_adapter,
+                            )
+                        )
+                    if hasattr(adapter, "set_queued_message_delete_handler"):
+                        adapter.set_queued_message_delete_handler(self._remove_queued_message)
 
                     success = await self._connect_adapter_with_timeout(adapter, platform)
                     if success:
@@ -7060,6 +7217,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
             adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
             adapter._busy_text_mode = self._busy_text_mode
+            if hasattr(adapter, "set_runtime_control_handler"):
+                adapter.set_runtime_control_handler(self._handle_runtime_control_signal)
+            if hasattr(adapter, "set_queue_depth_provider"):
+                adapter.set_queue_depth_provider(
+                    lambda session_key, _adapter=adapter: self._queue_depth(
+                        session_key,
+                        adapter=_adapter,
+                    )
+                )
+            if hasattr(adapter, "set_queued_message_delete_handler"):
+                adapter.set_queued_message_delete_handler(self._remove_queued_message)
 
             try:
                 with _profile_runtime_scope(profile_home):
@@ -7386,6 +7554,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Otherwise control/session commands like /new or /help get silently
         # consumed as update answers instead of being dispatched normally.
         _quick_key = self._session_key_for_source(source)
+        if not is_internal:
+            await self._notify_adapter_message_accepted(
+                event,
+                _quick_key,
+                phase="active",
+            )
+
         _update_prompts = getattr(self, "_update_prompt_pending", {})
         if _update_prompts.get(_quick_key):
             raw = (event.text or "").strip()
@@ -13713,6 +13888,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         interrupt_reason: str,
         invalidation_reason: str,
         release_running_state: bool = True,
+        discard_pending: bool = True,
     ) -> None:
         """Interrupt the current run and clear queued session state consistently."""
         if not session_key:
@@ -13724,9 +13900,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         adapter = self.adapters.get(source.platform)
         if adapter and hasattr(adapter, "interrupt_session_activity"):
             await adapter.interrupt_session_activity(session_key, source.chat_id)
-        if adapter and hasattr(adapter, "get_pending_message"):
+        if discard_pending and adapter and hasattr(adapter, "get_pending_message"):
             adapter.get_pending_message(session_key)  # consume and discard
-        self._pending_messages.pop(session_key, None)
+        if discard_pending:
+            self._pending_messages.pop(session_key, None)
         if release_running_state:
             self._release_running_agent_state(session_key)
 
@@ -14166,6 +14343,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if source.platform == Platform.MATRIX:
                         _effective_cursor = ""
                         _buffer_only = True
+                    _stream_metadata = _thread_metadata
+                    _stream_hook = getattr(_adapter, "prepare_streaming_preview", None)
+                    if callable(_stream_hook):
+                        try:
+                            _stream_overrides = _stream_hook(
+                                metadata=_stream_metadata,
+                                cursor=_effective_cursor,
+                                buffer_only=_buffer_only,
+                            )
+                            if isinstance(_stream_overrides, dict):
+                                if "metadata" in _stream_overrides:
+                                    _stream_metadata = _stream_overrides["metadata"]
+                                if "cursor" in _stream_overrides:
+                                    _effective_cursor = str(_stream_overrides["cursor"] or "")
+                                if "buffer_only" in _stream_overrides:
+                                    _buffer_only = bool(_stream_overrides["buffer_only"])
+                        except Exception:
+                            logger.debug("streaming preview hook failed", exc_info=True)
                     # Fresh-final applies to Telegram only — other
                     # platforms either edit in place cheaply (Discord,
                     # Slack) or don't have the timestamp-on-edit
@@ -14188,7 +14383,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         adapter=_adapter,
                         chat_id=source.chat_id,
                         config=_consumer_cfg,
-                        metadata=_thread_metadata,
+                        metadata=_stream_metadata,
                         on_before_finalize=_pause_typing_before_finalize,
                         initial_reply_to_id=event_message_id,
                     )
@@ -15341,6 +15536,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         if source.platform == Platform.MATRIX:
                             _effective_cursor = ""
                             _buffer_only = True
+                        _stream_metadata = _status_thread_metadata
+                        _stream_hook = getattr(_adapter, "prepare_streaming_preview", None)
+                        if callable(_stream_hook):
+                            try:
+                                _stream_overrides = _stream_hook(
+                                    metadata=_stream_metadata,
+                                    cursor=_effective_cursor,
+                                    buffer_only=_buffer_only,
+                                )
+                                if isinstance(_stream_overrides, dict):
+                                    if "metadata" in _stream_overrides:
+                                        _stream_metadata = _stream_overrides["metadata"]
+                                    if "cursor" in _stream_overrides:
+                                        _effective_cursor = str(_stream_overrides["cursor"] or "")
+                                    if "buffer_only" in _stream_overrides:
+                                        _buffer_only = bool(_stream_overrides["buffer_only"])
+                            except Exception:
+                                logger.debug("streaming preview hook failed", exc_info=True)
                         # Fresh-final applies to Telegram only — other
                         # platforms either edit in place cheaply or don't
                         # have the edit-timestamp-stays-stale problem.
@@ -15363,7 +15576,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             adapter=_adapter,
                             chat_id=source.chat_id,
                             config=_consumer_cfg,
-                            metadata=_status_thread_metadata,
+                            metadata=_stream_metadata,
                             on_new_message=(
                                 (lambda: progress_queue.put(("__reset__",)))
                                 if progress_queue is not None
@@ -16891,6 +17104,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         return result
                     next_message_id = self._reply_anchor_for_event(pending_event)
                     next_channel_prompt = getattr(pending_event, "channel_prompt", None)
+                    await self._notify_adapter_message_accepted(
+                        pending_event,
+                        session_key,
+                        phase="queued_turn",
+                    )
 
                 # Restart typing indicator so the user sees activity while
                 # the follow-up turn runs.  The outer _process_message_background

--- a/plugins/platforms/canon/__init__.py
+++ b/plugins/platforms/canon/__init__.py
@@ -1,0 +1,3 @@
+from .adapter import register
+
+__all__ = ["register"]

--- a/plugins/platforms/canon/adapter.py
+++ b/plugins/platforms/canon/adapter.py
@@ -1,0 +1,1831 @@
+"""
+Canon platform adapter for Hermes Agent.
+
+This bundled plugin connects Hermes to Canon agent conversations using the
+same public surface as Canon's TypeScript SDK.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+import mimetypes
+import os
+import time
+import uuid
+from collections import deque
+from pathlib import Path
+from typing import Any, Deque, Dict, Optional
+from urllib.parse import unquote
+
+from gateway.config import Platform
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+    cache_audio_from_bytes,
+    cache_document_from_bytes,
+    cache_image_from_bytes,
+    cache_video_from_bytes,
+)
+from gateway.session import build_session_key
+
+from plugins.platforms.canon.client import (
+    CanonHttpClient,
+    _is_retryable,
+    _safe_error,
+    _parse_sse_frame,
+)
+from plugins.platforms.canon.constants import (
+    AUDIO_EXTS,
+    DEFAULT_BASE_URL,
+    DEFAULT_HISTORY_LIMIT,
+    DEFAULT_STREAM_URL,
+    FINAL_MESSAGE_HANDOFF_SECONDS,
+    IMAGE_EXTS,
+    MAX_MEDIA_BYTES,
+    MAX_SEEN_MESSAGE_IDS,
+    RUNTIME_APPROVAL_POLL_SECONDS,
+    RUNTIME_INPUT_POLL_SECONDS,
+    RUNTIME_SIGNAL_POLL_SECONDS,
+    RUNTIME_STATUS_INTERVAL_SECONDS,
+    TURN_COMPLETE_METADATA,
+    VIDEO_EXTS,
+)
+from plugins.platforms.canon.models import CanonApiError, CanonStreamFrame
+from plugins.platforms.canon.profiles import (
+    _config_int,
+    _config_value,
+    _get_registration_status,
+    _profile_slug,
+    _resolve_canon_agent,
+    _save_canon_profile,
+    _setup_canon,
+    _wait_for_registration_approval,
+    validate_config,
+)
+from plugins.platforms.canon.runtime import (
+    CANON_HERMES_RUNTIME_DESCRIPTOR,
+    _approval_choice_from_response,
+    _canon_message_metadata,
+    _canon_runtime_choices,
+    _canon_timeout_seconds,
+    _is_canon_control_message,
+    _is_canon_streaming_preview,
+    _runtime_input_response_value,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "CanonAdapter",
+    "CanonApiError",
+    "CanonHttpClient",
+    "CanonStreamFrame",
+    "DEFAULT_BASE_URL",
+    "DEFAULT_STREAM_URL",
+    "TURN_COMPLETE_METADATA",
+    "_canon_timeout_seconds",
+    "_env_enablement",
+    "_get_registration_status",
+    "_parse_sse_frame",
+    "_profile_slug",
+    "_resolve_canon_agent",
+    "_save_canon_profile",
+    "_standalone_send",
+    "_wait_for_registration_approval",
+    "check_requirements",
+    "register",
+    "validate_config",
+]
+
+class CanonAdapter(BasePlatformAdapter):
+    """Hermes gateway adapter for Canon conversations."""
+
+    REQUIRES_EDIT_FINALIZE = True
+    MAX_MESSAGE_LENGTH = 3900
+
+    def __init__(self, config, **_: Any) -> None:
+        super().__init__(config=config, platform=Platform("canon"))
+
+        resolved = _resolve_canon_agent(config, raise_on_error=False)
+        self.api_key = resolved.api_key
+        self.profile_name = resolved.profile
+        self.profile_agent_id = resolved.agent_id
+        self.profile_agent_name = resolved.agent_name
+        if self.profile_agent_name:
+            os.environ.setdefault("HERMES_CANON_AGENT_NAME", self.profile_agent_name)
+
+        self.base_url = (
+            _config_value(config, "base_url", "CANON_BASE_URL", "")
+            or resolved.base_url
+            or DEFAULT_BASE_URL
+        )
+        self.stream_url = (
+            _config_value(config, "stream_url", "CANON_STREAM_URL", "")
+            or resolved.stream_url
+            or DEFAULT_STREAM_URL
+        )
+        self.history_limit = _config_int(
+            config, "history_limit", "CANON_HISTORY_LIMIT", DEFAULT_HISTORY_LIMIT
+        )
+
+        self._client: Optional[CanonHttpClient] = None
+        self._agent_id: Optional[str] = None
+        self._stream_task: Optional[asyncio.Task] = None
+        self._runtime_status_task: Optional[asyncio.Task] = None
+        self._runtime_signal_task: Optional[asyncio.Task] = None
+        self._stream_stop: Optional[asyncio.Event] = None
+        self._last_event_id: Optional[str] = None
+        self._conversation_cache: dict[str, dict[str, Any]] = {}
+        self._seen_message_ids: set[str] = set()
+        self._seen_message_order: Deque[str] = deque()
+        self._hitl_tasks: set[asyncio.Task] = set()
+        self._runtime_turn_ids: dict[str, str] = {}
+        self._runtime_turn_opened_at: dict[str, int] = {}
+        self._session_conversation_ids: dict[str, str] = {}
+
+    @property
+    def name(self) -> str:
+        return "Canon"
+
+    def prepare_streaming_preview(
+        self,
+        *,
+        metadata: Optional[dict[str, Any]] = None,
+        cursor: str = "",
+        buffer_only: bool = False,
+    ) -> dict[str, Any]:
+        preview_metadata = dict(metadata or {})
+        preview_metadata["canon_streaming_preview"] = True
+        return {
+            "metadata": preview_metadata,
+            "cursor": "",
+            "buffer_only": buffer_only,
+        }
+
+    async def connect(self) -> bool:
+        if not self.api_key:
+            self._set_fatal_error(
+                "missing_api_key",
+                "CANON_API_KEY, config.api_key, or CANON_AGENT profile is required for the Canon platform",
+                retryable=False,
+            )
+            return False
+
+        self._client = self._make_client()
+        self._stream_stop = asyncio.Event()
+
+        try:
+            ctx = await self._client.get_me()
+            self._agent_id = _first_string(ctx, "agentId", "id", "userId")
+            agent_display_name = _first_string(ctx, "displayName", "agentName", "name")
+            if agent_display_name:
+                self.profile_agent_name = agent_display_name
+                os.environ["HERMES_CANON_AGENT_NAME"] = agent_display_name
+            await self._refresh_conversations()
+            self._mark_connected()
+            await self._publish_runtime_status()
+            self._runtime_status_task = asyncio.create_task(
+                self._runtime_status_loop(), name="canon-platform-runtime-status"
+            )
+            self._runtime_signal_task = asyncio.create_task(
+                self._runtime_signal_loop(), name="canon-platform-runtime-signals"
+            )
+            self._stream_task = asyncio.create_task(
+                self._stream_loop(), name="canon-platform-stream"
+            )
+            logger.info(
+                "Canon platform connected as agent %s", self._agent_id or "<unknown>"
+            )
+            return True
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            if isinstance(exc, CanonApiError) and exc.status_code in {401, 403}:
+                self._set_fatal_error(
+                    "auth_failed",
+                    "Canon rejected the configured agent credentials. Re-run Canon setup.",
+                    retryable=False,
+                )
+            else:
+                self._set_fatal_error(
+                    "connect_failed", _safe_error(exc), retryable=_is_retryable(exc)
+                )
+            await self._close_client()
+            return False
+
+    async def disconnect(self) -> None:
+        stop = self._stream_stop
+        if stop is not None:
+            stop.set()
+
+        task = self._stream_task
+        if task and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.debug(
+                    "Canon stream task raised during disconnect", exc_info=True
+                )
+
+        status_task = self._runtime_status_task
+        if status_task and not status_task.done():
+            status_task.cancel()
+            try:
+                await status_task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.debug(
+                    "Canon runtime status task raised during disconnect", exc_info=True
+                )
+
+        signal_task = self._runtime_signal_task
+        if signal_task and not signal_task.done():
+            signal_task.cancel()
+            try:
+                await signal_task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.debug(
+                    "Canon runtime signal task raised during disconnect", exc_info=True
+                )
+
+        if self._hitl_tasks:
+            tasks = list(self._hitl_tasks)
+            for hitl_task in tasks:
+                hitl_task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            self._hitl_tasks.clear()
+
+        self._stream_task = None
+        self._runtime_status_task = None
+        self._runtime_signal_task = None
+        self._stream_stop = None
+        await self._close_client()
+        self._mark_disconnected()
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        if not self.api_key:
+            return SendResult(
+                success=False, error="Canon API key is not configured", retryable=False
+            )
+
+        client = self._client or self._make_client()
+        owns_client = self._client is None
+
+        try:
+            if _is_canon_streaming_preview(metadata):
+                turn_id = self._turn_id_for_conversation(chat_id)
+                await client.set_streaming(
+                    chat_id,
+                    text=content,
+                    status="streaming",
+                    turn_id=turn_id,
+                )
+                await self._publish_runtime_turn(
+                    chat_id,
+                    "streaming",
+                    session_key=self._session_key_for_conversation(chat_id),
+                )
+                return SendResult(
+                    success=True,
+                    message_id=turn_id,
+                    raw_response={"streaming": True, "turnId": turn_id},
+                )
+
+            canon_options, message_metadata = _split_canon_metadata(metadata)
+            message_metadata.update(TURN_COMPLETE_METADATA)
+            turn_id = self._active_turn_id_for_conversation(chat_id)
+            if turn_id:
+                message_metadata.setdefault("turnId", turn_id)
+            data = await client.send_message(
+                chat_id,
+                content,
+                reply_to=reply_to,
+                metadata=message_metadata,
+                options=canon_options,
+            )
+            message_id = _first_string(data, "messageId", "id")
+            return SendResult(
+                success=True,
+                message_id=message_id,
+                raw_response=data,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            return SendResult(
+                success=False,
+                error=_safe_error(exc),
+                retryable=_is_retryable(exc),
+            )
+        finally:
+            if owns_client:
+                await client.close()
+
+    async def edit_message(
+        self,
+        chat_id: str,
+        message_id: str,
+        content: str,
+        *,
+        finalize: bool = False,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        if not self.api_key:
+            return SendResult(
+                success=False, error="Canon API key is not configured", retryable=False
+            )
+
+        client = self._client or self._make_client()
+        owns_client = self._client is None
+        turn_id = message_id or self._turn_id_for_conversation(chat_id)
+
+        try:
+            if finalize:
+                canon_options, message_metadata = _split_canon_metadata(metadata)
+                message_metadata.update(TURN_COMPLETE_METADATA)
+                message_metadata.setdefault("turnId", turn_id)
+                data = await client.send_message(
+                    chat_id,
+                    content,
+                    metadata=message_metadata,
+                    options=canon_options,
+                )
+                try:
+                    await asyncio.sleep(FINAL_MESSAGE_HANDOFF_SECONDS)
+                    await client.clear_streaming(chat_id)
+                except Exception:
+                    logger.debug("Canon streaming clear after finalize failed", exc_info=True)
+                return SendResult(
+                    success=True,
+                    message_id=_first_string(data, "messageId", "id"),
+                    raw_response=data,
+                )
+
+            await client.set_streaming(
+                chat_id,
+                text=content,
+                status="streaming",
+                turn_id=turn_id,
+            )
+            await self._publish_runtime_turn(
+                chat_id,
+                "streaming",
+                session_key=self._session_key_for_conversation(chat_id),
+            )
+            return SendResult(
+                success=True,
+                message_id=turn_id,
+                raw_response={"streaming": True, "turnId": turn_id},
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            return SendResult(
+                success=False,
+                error=_safe_error(exc),
+                retryable=_is_retryable(exc),
+            )
+        finally:
+            if owns_client:
+                await client.close()
+
+    async def send_image(
+        self,
+        chat_id: str,
+        image_url: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        raw_url = str(image_url or "").strip()
+        if raw_url.startswith("file://"):
+            return await self.send_image_file(
+                chat_id,
+                unquote(raw_url[7:]),
+                caption=caption,
+                reply_to=reply_to,
+                metadata=metadata,
+            )
+
+        if not self.api_key:
+            return SendResult(
+                success=False, error="Canon API key is not configured", retryable=False
+            )
+
+        client = self._client or self._make_client()
+        owns_client = self._client is None
+        try:
+            image_bytes, response_mime = await client.download_media(raw_url)
+            mime_type = _guess_mime_type(raw_url, response_mime)
+            uploaded = await client.upload_media(
+                chat_id,
+                base64.b64encode(image_bytes).decode("ascii"),
+                mime_type,
+                file_name=Path(raw_url.split("?", 1)[0]).name or "image",
+            )
+            attachment = dict(uploaded.get("attachment") or {})
+            if not attachment:
+                attachment = {
+                    "kind": _canon_attachment_kind_for_mime(mime_type),
+                    "url": uploaded.get("url"),
+                    "mimeType": mime_type,
+                    "fileName": Path(raw_url.split("?", 1)[0]).name or "image",
+                    "sizeBytes": len(image_bytes),
+                }
+            if mime_type.startswith("image/"):
+                attachment["kind"] = "image"
+            return await self._send_attachment(
+                chat_id,
+                caption or "",
+                content_type=str(attachment.get("kind") or "image"),
+                attachment=attachment,
+                reply_to=reply_to,
+                metadata=metadata,
+                client=client,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            return SendResult(
+                success=False,
+                error=_safe_error(exc),
+                retryable=_is_retryable(exc),
+            )
+        finally:
+            if owns_client:
+                await client.close()
+
+    async def send_image_file(
+        self,
+        chat_id: str,
+        image_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        return await self._send_media_file(
+            chat_id,
+            image_path,
+            caption=caption,
+            reply_to=reply_to,
+            metadata=metadata,
+            content_type="image",
+            mime_hint=kwargs.get("mime_type"),
+        )
+
+    async def send_voice(
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        return await self._send_media_file(
+            chat_id,
+            audio_path,
+            caption=caption,
+            reply_to=reply_to,
+            metadata=metadata,
+            content_type="audio",
+            mime_hint=kwargs.get("mime_type"),
+            duration_ms=kwargs.get("duration_ms"),
+        )
+
+    async def send_video(
+        self,
+        chat_id: str,
+        video_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        return await self._send_media_file(
+            chat_id,
+            video_path,
+            caption=caption,
+            reply_to=reply_to,
+            metadata=metadata,
+            content_type="video",
+            mime_hint=kwargs.get("mime_type"),
+        )
+
+    async def send_document(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        return await self._send_media_file(
+            chat_id,
+            file_path,
+            caption=caption,
+            file_name=file_name,
+            reply_to=reply_to,
+            metadata=metadata,
+            content_type="file",
+            mime_hint=kwargs.get("mime_type"),
+        )
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        if not self.api_key:
+            return
+        client = self._client or self._make_client()
+        owns_client = self._client is None
+        try:
+            status = "thinking"
+            if isinstance(metadata, dict) and metadata.get("status") in {
+                "typing",
+                "thinking",
+            }:
+                status = metadata["status"]
+            await client.set_typing(chat_id, True, status)
+        except Exception:
+            logger.debug("Canon typing indicator failed", exc_info=True)
+        finally:
+            if owns_client:
+                await client.close()
+
+    async def stop_typing(self, chat_id: str) -> None:
+        if not self.api_key:
+            return
+        client = self._client or self._make_client()
+        owns_client = self._client is None
+        try:
+            await client.set_typing(chat_id, False)
+        except Exception:
+            logger.debug("Canon typing clear failed", exc_info=True)
+        finally:
+            if owns_client:
+                await client.close()
+
+    async def send_clarify(
+        self,
+        chat_id: str,
+        question: str,
+        choices: Optional[list],
+        clarify_id: str,
+        session_key: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        if self._client is None:
+            return SendResult(success=False, error="Canon adapter is not connected")
+
+        timeout_seconds = _canon_timeout_seconds("HERMES_CLARIFY_TIMEOUT", 300)
+        expires_at = int((time.time() + timeout_seconds) * 1000)
+        canon_choices = _canon_runtime_choices(choices)
+
+        try:
+            data = await self._client.create_runtime_input_request(
+                chat_id,
+                input_id=clarify_id,
+                kind="clarify",
+                expires_at=expires_at,
+                title="Clarification needed",
+                prompt=question,
+                choices=canon_choices,
+                native={
+                    "runtime": "hermes",
+                    "method": "clarify",
+                    "requestId": clarify_id,
+                    "sessionKey": session_key,
+                },
+            )
+            await self._publish_runtime_turn(chat_id, "waiting_input", session_key=session_key)
+            task = asyncio.create_task(
+                self._poll_runtime_input_response(
+                    chat_id,
+                    clarify_id,
+                    session_key=session_key,
+                    expires_at=expires_at,
+                ),
+                name=f"canon-runtime-input-{clarify_id}",
+            )
+            self._track_hitl_task(task)
+            return SendResult(
+                success=True,
+                message_id=_first_string(data, "messageId"),
+                raw_response=data,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            return SendResult(
+                success=False,
+                error=_safe_error(exc),
+                retryable=_is_retryable(exc),
+            )
+
+    async def send_exec_approval(
+        self,
+        chat_id: str,
+        command: str,
+        session_key: str,
+        description: str = "dangerous command",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        if self._client is None:
+            return SendResult(success=False, error="Canon adapter is not connected")
+
+        approval_id = f"hermes-{uuid.uuid4().hex[:20]}"
+        timeout_seconds = _canon_timeout_seconds("HERMES_APPROVAL_TIMEOUT", 300)
+        expires_at = int((time.time() + timeout_seconds) * 1000)
+        command_preview = command[:4000]
+        details = [
+            {"label": "Command", "value": command_preview, "monospace": True},
+            {"label": "Reason", "value": description},
+        ]
+
+        try:
+            data = await self._client.create_runtime_approval_request(
+                chat_id,
+                approval_id=approval_id,
+                tool_name="Command",
+                tool_summary=description or "Command approval required",
+                expires_at=expires_at,
+                details=details,
+                native={
+                    "runtime": "hermes",
+                    "method": "exec_approval",
+                    "requestId": approval_id,
+                    "sessionKey": session_key,
+                    "command": command_preview,
+                },
+                allow_session_rule=True,
+            )
+            await self._publish_runtime_turn(chat_id, "waiting_input", session_key=session_key)
+            task = asyncio.create_task(
+                self._poll_runtime_approval_response(
+                    chat_id,
+                    approval_id,
+                    session_key=session_key,
+                    expires_at=expires_at,
+                ),
+                name=f"canon-runtime-approval-{approval_id}",
+            )
+            self._track_hitl_task(task)
+            return SendResult(
+                success=True,
+                message_id=_first_string(data, "messageId"),
+                raw_response=data,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            return SendResult(
+                success=False,
+                error=_safe_error(exc),
+                retryable=_is_retryable(exc),
+            )
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        convo = self._conversation_cache.get(str(chat_id))
+        if convo is None and self._client is not None:
+            await self._refresh_conversations()
+            convo = self._conversation_cache.get(str(chat_id))
+        return {
+            "id": str(chat_id),
+            "name": _conversation_name(convo) if convo else str(chat_id),
+            "type": _chat_type_from_conversation(convo),
+        }
+
+    def _make_client(self) -> CanonHttpClient:
+        return CanonHttpClient(
+            self.api_key,
+            base_url=self.base_url,
+            stream_url=self.stream_url,
+        )
+
+    async def _close_client(self) -> None:
+        client = self._client
+        self._client = None
+        if client is not None:
+            await client.close()
+
+    async def _publish_runtime_status(self) -> None:
+        if self._client is None:
+            return
+        try:
+            await self._client.update_runtime_status(
+                runtime="hermes",
+                host_mode=True,
+                runtime_descriptor=dict(CANON_HERMES_RUNTIME_DESCRIPTOR),
+            )
+        except Exception:
+            logger.debug("Canon runtime status publish failed", exc_info=True)
+
+    def _queue_depth_for_session(self, session_key: str) -> int:
+        provider = getattr(self, "_queue_depth_provider", None)
+        if callable(provider):
+            try:
+                return max(0, int(provider(session_key)))
+            except Exception:
+                logger.debug("Canon queue depth provider failed", exc_info=True)
+        return 1 if session_key in self._pending_messages else 0
+
+    def _turn_id_for_session(self, session_key: str) -> tuple[str, int]:
+        turn_id = self._runtime_turn_ids.get(session_key)
+        if not turn_id:
+            turn_id = f"hermes-{uuid.uuid4().hex[:20]}"
+            self._runtime_turn_ids[session_key] = turn_id
+            self._runtime_turn_opened_at[session_key] = int(time.time() * 1000)
+        return turn_id, self._runtime_turn_opened_at[session_key]
+
+    def _turn_id_for_conversation(self, conversation_id: str) -> str:
+        if conversation_id in self._runtime_turn_ids:
+            return self._runtime_turn_ids[conversation_id]
+        for session_key, known_conversation_id in self._session_conversation_ids.items():
+            if known_conversation_id == conversation_id:
+                return self._turn_id_for_session(session_key)[0]
+        return self._turn_id_for_session(conversation_id)[0]
+
+    def _active_turn_id_for_conversation(self, conversation_id: str) -> Optional[str]:
+        if conversation_id in self._runtime_turn_ids:
+            return self._runtime_turn_ids[conversation_id]
+        for session_key, known_conversation_id in self._session_conversation_ids.items():
+            if known_conversation_id == conversation_id:
+                return self._runtime_turn_ids.get(session_key)
+        return None
+
+    def _session_key_for_conversation(self, conversation_id: str) -> str:
+        for session_key, known_conversation_id in self._session_conversation_ids.items():
+            if known_conversation_id == conversation_id:
+                return session_key
+        return conversation_id
+
+    async def _publish_runtime_turn(
+        self,
+        conversation_id: str,
+        state: str,
+        *,
+        session_key: Optional[str] = None,
+        active_message_ids: Optional[list[str]] = None,
+    ) -> None:
+        if self._client is None or not conversation_id:
+            return
+        session_key = session_key or conversation_id
+        self._session_conversation_ids[session_key] = conversation_id
+        queue_depth = self._queue_depth_for_session(session_key)
+        open_state = state in {"thinking", "streaming", "tool", "waiting_input"}
+        turn_id: Optional[str] = None
+        opened_at: Optional[int] = None
+        if open_state:
+            turn_id, opened_at = self._turn_id_for_session(session_key)
+        else:
+            turn_id = self._runtime_turn_ids.pop(session_key, None)
+            opened_at = self._runtime_turn_opened_at.pop(session_key, None)
+        capabilities = {
+            "supportsInterrupt": True,
+            "supportsQueue": True,
+            "supportsInputInterrupt": state != "waiting_input",
+            "supportsNonFinalPermanentMessages": False,
+        }
+        try:
+            await self._client.update_runtime_turn(
+                conversation_id,
+                state=state,
+                turn_id=turn_id,
+                queue_depth=queue_depth,
+                active_message_ids=active_message_ids,
+                capabilities=capabilities,
+                opened_at=opened_at,
+                turn_updated_at=int(time.time() * 1000),
+            )
+            if not open_state and queue_depth <= 0:
+                self._session_conversation_ids.pop(session_key, None)
+        except Exception:
+            logger.debug("Canon runtime turn publish failed", exc_info=True)
+
+    async def _on_runtime_turn_start(self, event: MessageEvent, session_key: str) -> None:
+        conversation_id = str(event.source.chat_id)
+        self._session_conversation_ids[session_key] = conversation_id
+        await self._publish_runtime_turn(
+            conversation_id,
+            "thinking",
+            session_key=session_key,
+            active_message_ids=[event.message_id] if event.message_id else None,
+        )
+
+    async def on_gateway_message_accepted(
+        self,
+        event: MessageEvent,
+        session_key: str,
+        *,
+        phase: str = "active",
+    ) -> None:
+        raw_message = getattr(event, "raw_message", None)
+        if not isinstance(raw_message, dict) or not isinstance(raw_message.get("message"), dict):
+            return
+        conversation_id = str(event.source.chat_id)
+        self._session_conversation_ids[session_key] = conversation_id
+        if self._client is None:
+            return
+
+        metadata = _canon_message_metadata(raw_message)
+        if metadata.get("inboundDisposition") == "queued" and event.message_id:
+            try:
+                await self._client.update_message_disposition(
+                    conversation_id,
+                    event.message_id,
+                    "accepted_now",
+                )
+            except Exception:
+                logger.debug("Canon queued disposition update failed", exc_info=True)
+
+        try:
+            await self._client.mark_as_read(conversation_id)
+        except Exception:
+            logger.debug("Canon mark-as-read failed", exc_info=True)
+
+    async def _on_runtime_turn_complete(
+        self,
+        event: MessageEvent,
+        session_key: str,
+        outcome: Any,
+    ) -> None:
+        conversation_id = self._session_conversation_ids.get(session_key) or str(event.source.chat_id)
+        state = "interrupted" if getattr(outcome, "value", outcome) == "cancelled" else "completed"
+        await self._publish_runtime_turn(conversation_id, state, session_key=session_key)
+
+    async def _on_runtime_queue_changed(self, session_key: str) -> None:
+        conversation_id = self._session_conversation_ids.get(session_key)
+        if not conversation_id or session_key in self._runtime_turn_ids:
+            if conversation_id:
+                await self._publish_runtime_turn(conversation_id, "thinking", session_key=session_key)
+            return
+        await self._publish_runtime_turn(conversation_id, "idle", session_key=session_key)
+
+    async def _runtime_status_loop(self) -> None:
+        while self._stream_stop is not None and not self._stream_stop.is_set():
+            try:
+                await asyncio.sleep(RUNTIME_STATUS_INTERVAL_SECONDS)
+                await self._publish_runtime_status()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.debug("Canon runtime status loop failed", exc_info=True)
+
+    async def _runtime_signal_loop(self) -> None:
+        while self._stream_stop is not None and not self._stream_stop.is_set():
+            try:
+                await self._poll_runtime_signals_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.debug("Canon runtime signal poll failed", exc_info=True)
+            await asyncio.sleep(RUNTIME_SIGNAL_POLL_SECONDS)
+
+    async def _poll_runtime_signals_once(self) -> None:
+        if self._client is None:
+            return
+        for conversation_id in list(self._conversation_cache.keys()):
+            try:
+                response = await self._client.consume_runtime_signal(conversation_id)
+            except Exception:
+                logger.debug("Canon runtime signal consume failed", exc_info=True)
+                continue
+            if response.get("status") != "signal":
+                continue
+            signal = str(response.get("signal") or "")
+            if signal in {"interrupt", "stop_and_drop", "new_session"}:
+                await self._handle_runtime_signal(
+                    conversation_id,
+                    signal,
+                    updated_by=_first_string(response, "updatedBy"),
+                )
+
+    async def _handle_runtime_signal(
+        self,
+        conversation_id: str,
+        signal: str,
+        *,
+        updated_by: Optional[str] = None,
+    ) -> None:
+        conversation = self._conversation_cache.get(conversation_id)
+        source = self.build_source(
+            chat_id=conversation_id,
+            chat_name=_conversation_name(conversation),
+            chat_type=_chat_type_from_conversation(conversation),
+            user_id=updated_by or self._agent_id or "canon-runtime-control",
+            user_name="Canon",
+        )
+        session_key = build_session_key(
+            source,
+            group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
+            thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
+        )
+        if signal == "stop_and_drop":
+            self._pending_messages.pop(session_key, None)
+
+        event = MessageEvent(
+            text="",
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message={"canonSignal": signal},
+            message_id=f"canon-control:{signal}:{time.time()}",
+        )
+        handler = getattr(self, "_runtime_control_handler", None)
+        if callable(handler):
+            handled = await handler(event, session_key, signal)
+            if handled:
+                await self._publish_runtime_turn(
+                    conversation_id,
+                    "idle" if signal == "new_session" else "interrupted",
+                    session_key=session_key,
+                )
+                return
+
+        # Backward-compatible fallback for older Hermes gateway runners that do
+        # not expose the runtime-control bridge yet.
+        event.text = "/new" if signal == "new_session" else "/stop"
+        await self.handle_message(event)
+
+        if signal == "stop_and_drop":
+            self._pending_messages.pop(session_key, None)
+
+    async def _poll_runtime_input_response(
+        self,
+        conversation_id: str,
+        input_id: str,
+        *,
+        session_key: str,
+        expires_at: int,
+    ) -> None:
+        if self._client is None:
+            return
+        while time.time() * 1000 <= expires_at:
+            try:
+                response = await self._client.consume_runtime_input_response(
+                    conversation_id,
+                    input_id,
+                )
+            except Exception:
+                logger.debug("Canon runtime input consume failed", exc_info=True)
+                await asyncio.sleep(RUNTIME_INPUT_POLL_SECONDS)
+                continue
+            status = response.get("status")
+            if status == "submitted":
+                await self._publish_runtime_turn(conversation_id, "tool", session_key=session_key)
+                value = _runtime_input_response_value(response)
+                from tools.clarify_gateway import resolve_gateway_clarify
+
+                resolve_gateway_clarify(input_id, value)
+                return
+            if status == "cancelled":
+                await self._publish_runtime_turn(conversation_id, "interrupted", session_key=session_key)
+                from tools.clarify_gateway import resolve_gateway_clarify
+
+                resolve_gateway_clarify(input_id, "[user cancelled the clarification]")
+                return
+            if status == "timeout":
+                await self._publish_runtime_turn(conversation_id, "interrupted", session_key=session_key)
+                from tools.clarify_gateway import resolve_gateway_clarify
+
+                resolve_gateway_clarify(input_id, "[user did not respond within 5m]")
+                return
+            await asyncio.sleep(RUNTIME_INPUT_POLL_SECONDS)
+
+        try:
+            await self._client.consume_runtime_input_response(
+                conversation_id,
+                input_id,
+                cancel=True,
+            )
+        finally:
+            await self._publish_runtime_turn(conversation_id, "interrupted", session_key=session_key)
+            from tools.clarify_gateway import resolve_gateway_clarify
+
+            resolve_gateway_clarify(input_id, "[user did not respond within 5m]")
+
+    async def _poll_runtime_approval_response(
+        self,
+        conversation_id: str,
+        approval_id: str,
+        *,
+        session_key: str,
+        expires_at: int,
+    ) -> None:
+        if self._client is None:
+            return
+        while time.time() * 1000 <= expires_at:
+            try:
+                response = await self._client.consume_runtime_approval_response(
+                    conversation_id,
+                    approval_id,
+                )
+            except Exception:
+                logger.debug("Canon runtime approval consume failed", exc_info=True)
+                await asyncio.sleep(RUNTIME_APPROVAL_POLL_SECONDS)
+                continue
+            status = response.get("status")
+            if status == "allow":
+                await self._publish_runtime_turn(conversation_id, "tool", session_key=session_key)
+                choice = _approval_choice_from_response(response)
+                from tools.approval import resolve_gateway_approval
+
+                resolve_gateway_approval(session_key, choice)
+                return
+            if status in {"deny", "timeout"}:
+                await self._publish_runtime_turn(conversation_id, "interrupted", session_key=session_key)
+                from tools.approval import resolve_gateway_approval
+
+                resolve_gateway_approval(session_key, "deny")
+                return
+            await asyncio.sleep(RUNTIME_APPROVAL_POLL_SECONDS)
+
+        try:
+            await self._client.consume_runtime_approval_response(
+                conversation_id,
+                approval_id,
+                cancel=True,
+            )
+        finally:
+            await self._publish_runtime_turn(conversation_id, "interrupted", session_key=session_key)
+            from tools.approval import resolve_gateway_approval
+
+            resolve_gateway_approval(session_key, "deny")
+
+    def _track_hitl_task(self, task: asyncio.Task) -> None:
+        self._hitl_tasks.add(task)
+
+        def _done(done_task: asyncio.Task) -> None:
+            self._hitl_tasks.discard(done_task)
+            try:
+                done_task.result()
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.debug("Canon HITL poll task failed", exc_info=True)
+
+        task.add_done_callback(_done)
+
+    async def _refresh_conversations(self) -> None:
+        if self._client is None:
+            return
+        conversations = await self._client.get_conversations()
+        for convo in conversations:
+            convo_id = _first_string(convo, "id", "conversationId")
+            if convo_id:
+                self._conversation_cache[convo_id] = convo
+
+    async def _send_media_file(
+        self,
+        chat_id: str,
+        file_path: str,
+        *,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        content_type: str,
+        mime_hint: Optional[str] = None,
+        duration_ms: Optional[int] = None,
+    ) -> SendResult:
+        if not self.api_key:
+            return SendResult(
+                success=False, error="Canon API key is not configured", retryable=False
+            )
+
+        path = Path(file_path).expanduser()
+        if not path.exists():
+            return SendResult(success=False, error=f"Media file not found: {file_path}")
+        if path.stat().st_size > MAX_MEDIA_BYTES:
+            return SendResult(success=False, error="Canon media upload limit is 10MB")
+
+        client = self._client or self._make_client()
+        owns_client = self._client is None
+        try:
+            media_bytes = path.read_bytes()
+            mime_type = _guess_mime_type(str(path), mime_hint)
+            uploaded = await client.upload_media(
+                chat_id,
+                base64.b64encode(media_bytes).decode("ascii"),
+                mime_type,
+                file_name=file_name or path.name,
+            )
+            attachment = dict(uploaded.get("attachment") or {})
+            if not attachment:
+                attachment = {
+                    "kind": _canon_attachment_kind_for_mime(mime_type),
+                    "url": uploaded.get("url"),
+                    "mimeType": mime_type,
+                    "fileName": file_name or path.name,
+                    "sizeBytes": len(media_bytes),
+                }
+            if mime_type.startswith("video/"):
+                attachment["kind"] = "video"
+            if duration_ms and attachment.get("kind") == "audio":
+                attachment["durationMs"] = int(duration_ms)
+            if attachment.get("kind") in {"image", "audio", "video"}:
+                content_type = str(attachment["kind"])
+
+            return await self._send_attachment(
+                chat_id,
+                caption or "",
+                content_type=content_type,
+                attachment=attachment,
+                reply_to=reply_to,
+                metadata=metadata,
+                client=client,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            return SendResult(
+                success=False, error=_safe_error(exc), retryable=_is_retryable(exc)
+            )
+        finally:
+            if owns_client:
+                await client.close()
+
+    async def _send_attachment(
+        self,
+        chat_id: str,
+        text: str,
+        *,
+        content_type: str,
+        attachment: dict[str, Any],
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        client: Optional[CanonHttpClient] = None,
+    ) -> SendResult:
+        if not self.api_key:
+            return SendResult(
+                success=False, error="Canon API key is not configured", retryable=False
+            )
+
+        active_client = client or self._client or self._make_client()
+        owns_client = client is None and self._client is None
+        try:
+            canon_options, message_metadata = _split_canon_metadata(metadata)
+            message_metadata.update(TURN_COMPLETE_METADATA)
+            turn_id = self._active_turn_id_for_conversation(chat_id)
+            if turn_id:
+                message_metadata.setdefault("turnId", turn_id)
+            canon_options.update({
+                "contentType": content_type,
+                "attachments": [attachment],
+            })
+            data = await active_client.send_message(
+                chat_id,
+                text,
+                reply_to=reply_to,
+                metadata=message_metadata,
+                options=canon_options,
+            )
+            return SendResult(
+                success=True,
+                message_id=_first_string(data, "messageId", "id"),
+                raw_response=data,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            return SendResult(
+                success=False, error=_safe_error(exc), retryable=_is_retryable(exc)
+            )
+        finally:
+            if owns_client:
+                await active_client.close()
+
+    async def _stream_loop(self) -> None:
+        assert self._client is not None
+        backoff = 1.0
+
+        while self._stream_stop is not None and not self._stream_stop.is_set():
+            try:
+                async for frame in self._client.stream_events(
+                    last_event_id=self._last_event_id
+                ):
+                    if frame.event_id:
+                        self._last_event_id = frame.event_id
+                    await self._handle_stream_frame(frame)
+                backoff = 1.0
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                if self._stream_stop is not None and self._stream_stop.is_set():
+                    break
+                logger.warning("Canon stream disconnected: %s", _safe_error(exc))
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 30.0)
+
+    async def _handle_stream_frame(self, frame: CanonStreamFrame) -> None:
+        if frame.event == "agent.context" and isinstance(frame.data, dict):
+            self._agent_id = (
+                _first_string(frame.data, "agentId", "id", "userId") or self._agent_id
+            )
+            return
+        if frame.event == "conversation.updated" and isinstance(frame.data, dict):
+            convo_id = _first_string(frame.data, "conversationId", "id")
+            if convo_id:
+                cached = self._conversation_cache.setdefault(convo_id, {"id": convo_id})
+                changes = frame.data.get("changes")
+                if isinstance(changes, dict):
+                    cached.update(changes)
+            return
+        if frame.event == "message.deleted" and isinstance(frame.data, dict):
+            conversation_id = _first_string(frame.data, "conversationId")
+            message_id = _first_string(frame.data, "messageId", "id")
+            handler = getattr(self, "_queued_message_delete_handler", None)
+            if conversation_id and message_id and callable(handler):
+                removed = handler(conversation_id, message_id)
+                if removed:
+                    logger.debug(
+                        "Removed %d queued Canon message(s) after deletion: %s",
+                        removed,
+                        message_id,
+                    )
+                    for session_key, mapped_conversation_id in list(self._session_conversation_ids.items()):
+                        if mapped_conversation_id == conversation_id:
+                            await self._on_runtime_queue_changed(session_key)
+            return
+        if frame.event != "message.created":
+            return
+        if isinstance(frame.data, dict):
+            await self._handle_message_payload(frame.data)
+
+    async def _handle_message_payload(self, payload: dict[str, Any]) -> None:
+        message = payload.get("message")
+        if not isinstance(message, dict):
+            return
+
+        sender_id = _first_string(message, "senderId")
+        if self._agent_id and sender_id == self._agent_id:
+            return
+        if _is_canon_control_message(message):
+            return
+
+        message_id = _first_string(message, "id")
+        if message_id and self._already_seen(message_id):
+            return
+
+        conversation_id = _first_string(payload, "conversationId")
+        if not conversation_id:
+            return
+
+        conversation = payload.get("conversation")
+        if isinstance(conversation, dict):
+            self._conversation_cache[conversation_id] = conversation
+        conversation = self._conversation_cache.get(
+            conversation_id, conversation if isinstance(conversation, dict) else None
+        )
+
+        text = _message_text(message)
+        if not text:
+            return
+
+        (
+            media_urls,
+            media_types,
+            media_message_type,
+        ) = await self._materialize_attachments(message)
+
+        source = self.build_source(
+            chat_id=conversation_id,
+            chat_name=_conversation_name(conversation),
+            chat_type=_chat_type_from_conversation(conversation),
+            user_id=sender_id,
+            user_name=_first_string(message, "senderName"),
+            message_id=message_id,
+        )
+
+        event = MessageEvent(
+            text=text,
+            message_type=_message_type_for_text_and_media(text, media_message_type),
+            source=source,
+            raw_message=payload,
+            message_id=message_id,
+            media_urls=media_urls,
+            media_types=media_types,
+            reply_to_message_id=_first_string(message, "replyTo"),
+            channel_prompt=_canon_channel_prompt(
+                payload,
+                conversation,
+                self._agent_id,
+                self.profile_agent_name,
+            ),
+            delivery_intent=_delivery_intent_from_message(message),
+        )
+        await self.handle_message(event)
+
+    async def _materialize_attachments(
+        self,
+        message: dict[str, Any],
+    ) -> tuple[list[str], list[str], Optional[MessageType]]:
+        attachments = message.get("attachments")
+        if not isinstance(attachments, list) or not attachments:
+            return [], [], None
+        if self._client is None:
+            return [], [], None
+
+        media_urls: list[str] = []
+        media_types: list[str] = []
+        message_type: Optional[MessageType] = None
+
+        for attachment in attachments:
+            if not isinstance(attachment, dict):
+                continue
+            url = _first_string(attachment, "url")
+            if not url:
+                continue
+
+            try:
+                data, response_mime = await self._client.download_media(url)
+                mime_type = _attachment_mime_type(attachment, response_mime)
+                local_path, local_message_type = _cache_canon_media(
+                    attachment, data, mime_type
+                )
+            except Exception:
+                logger.debug(
+                    "Failed to materialize Canon media attachment", exc_info=True
+                )
+                continue
+
+            media_urls.append(local_path)
+            media_types.append(mime_type)
+            message_type = _prefer_media_message_type(message_type, local_message_type)
+
+        return media_urls, media_types, message_type
+
+    def _already_seen(self, message_id: str) -> bool:
+        if message_id in self._seen_message_ids:
+            return True
+        self._seen_message_ids.add(message_id)
+        self._seen_message_order.append(message_id)
+        while len(self._seen_message_order) > MAX_SEEN_MESSAGE_IDS:
+            old = self._seen_message_order.popleft()
+            self._seen_message_ids.discard(old)
+        return False
+
+
+
+
+def _first_string(data: Any, *keys: str) -> Optional[str]:
+    if not isinstance(data, dict):
+        return None
+    for key in keys:
+        value = data.get(key)
+        if value is not None and str(value) != "":
+            return str(value)
+    return None
+
+
+def _conversation_name(conversation: Optional[dict[str, Any]]) -> Optional[str]:
+    if not isinstance(conversation, dict):
+        return None
+    return _first_string(conversation, "name", "topic") or _first_string(
+        conversation, "id"
+    )
+
+
+def _chat_type_from_conversation(conversation: Optional[dict[str, Any]]) -> str:
+    if isinstance(conversation, dict) and conversation.get("type") == "group":
+        return "group"
+    return "dm"
+
+
+def _canon_channel_prompt(
+    payload: dict[str, Any],
+    conversation: Optional[dict[str, Any]],
+    agent_id: Optional[str],
+    agent_name: Optional[str],
+) -> Optional[str]:
+    """Surface Canon's structured group targeting metadata to the model."""
+    message = payload.get("message")
+    if not isinstance(message, dict) or _chat_type_from_conversation(conversation) != "group":
+        return None
+
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, dict):
+        provenance = message.get("provenance") if isinstance(message.get("provenance"), dict) else {}
+
+    mentions = message.get("mentions") or payload.get("mentions") or []
+    if not isinstance(mentions, list):
+        mentions = []
+
+    mentioned_agent = bool(provenance.get("mentionedAgent"))
+    if agent_id and str(agent_id) in {str(item) for item in mentions}:
+        mentioned_agent = True
+
+    name_note = f" ({agent_name})" if agent_name else ""
+    if mentioned_agent:
+        return (
+            f"Canon group metadata: this message explicitly mentioned this agent{name_note}. "
+            "Treat it as addressed to you."
+        )
+
+    return (
+        f"Canon group metadata: this message did not structurally mention this agent{name_note}. "
+        "Answer only if the content clearly asks for your help or your configured group policy says to participate."
+    )
+
+
+def _format_contact_card_text(message: dict[str, Any]) -> str:
+    card = message.get("contactCard")
+    if not isinstance(card, dict):
+        return "[Contact card]"
+
+    display_name = (_first_string(card, "displayName") or "Unknown").strip() or "Unknown"
+    user_id = _first_string(card, "userId")
+    user_type = _first_string(card, "userType")
+    owner_name = _first_string(card, "ownerName")
+    about = _first_string(card, "about")
+
+    parts: list[str] = []
+    if user_type:
+        parts.append(user_type)
+    if user_id:
+        parts.append(f"userId: {user_id}")
+    if owner_name:
+        parts.append(f"owner: {owner_name}")
+    if about:
+        parts.append(f"about: {about}")
+
+    summary = f'[Contact card] "{display_name}"'
+    if parts:
+        summary = f"{summary} - {'; '.join(parts)}"
+
+    text = message.get("text")
+    if isinstance(text, str) and text.strip():
+        return f"{summary}\n{text.strip()}"
+    return summary
+
+
+def _message_text(message: dict[str, Any]) -> str:
+    content_type = message.get("contentType")
+    if content_type == "contact_card":
+        return _format_contact_card_text(message)
+
+    text = message.get("text")
+    if isinstance(text, str) and text.strip():
+        return text
+
+    attachments = message.get("attachments")
+    if isinstance(attachments, list) and attachments:
+        labels: list[str] = []
+        for item in attachments:
+            if not isinstance(item, dict):
+                continue
+            kind = _first_string(item, "kind") or content_type or "file"
+            name = _first_string(item, "fileName", "url")
+            labels.append(
+                f"{kind} attachment: {name}" if name else f"{kind} attachment"
+            )
+        if labels:
+            return "[" + "; ".join(labels) + "]"
+
+    if isinstance(content_type, str) and content_type != "text":
+        return f"[{content_type} message]"
+    return ""
+
+
+def _message_type_for_text_and_media(
+    text: str, media_type: Optional[MessageType]
+) -> MessageType:
+    if text.strip().startswith("/"):
+        return MessageType.COMMAND
+    return media_type or MessageType.TEXT
+
+
+def _delivery_intent_from_message(message: dict[str, Any]) -> Optional[str]:
+    metadata = message.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    intent = str(metadata.get("deliveryIntent") or "").strip().lower()
+    return intent if intent in {"queue", "interrupt"} else None
+
+
+def _prefer_media_message_type(
+    current: Optional[MessageType],
+    candidate: MessageType,
+) -> MessageType:
+    priority = {
+        MessageType.VOICE: 4,
+        MessageType.AUDIO: 4,
+        MessageType.VIDEO: 3,
+        MessageType.PHOTO: 2,
+        MessageType.DOCUMENT: 1,
+    }
+    if current is None:
+        return candidate
+    return (
+        candidate if priority.get(candidate, 0) > priority.get(current, 0) else current
+    )
+
+
+def _guess_mime_type(path_or_name: str, override: Optional[str] = None) -> str:
+    if override:
+        return override.split(";", 1)[0].strip().lower()
+    guessed, _encoding = mimetypes.guess_type(path_or_name)
+    if guessed:
+        return guessed
+    ext = Path(path_or_name.split("?", 1)[0]).suffix.lower()
+    if ext in {".m4a"}:
+        return "audio/mp4"
+    if ext in {".opus"}:
+        return "audio/ogg"
+    if ext in VIDEO_EXTS:
+        return "video/mp4"
+    if ext in IMAGE_EXTS:
+        return "image/jpeg"
+    if ext in AUDIO_EXTS:
+        return "audio/mpeg"
+    return "application/octet-stream"
+
+
+def _canon_attachment_kind_for_mime(mime_type: str) -> str:
+    if mime_type.startswith("image/"):
+        return "image"
+    if mime_type.startswith("audio/"):
+        return "audio"
+    if mime_type.startswith("video/"):
+        return "video"
+    return "file"
+
+
+def _attachment_mime_type(
+    attachment: dict[str, Any],
+    response_mime: Optional[str] = None,
+) -> str:
+    explicit = _first_string(attachment, "mimeType")
+    if explicit:
+        return explicit.split(";", 1)[0].strip().lower()
+    if response_mime:
+        return response_mime.split(";", 1)[0].strip().lower()
+    name = _first_string(attachment, "fileName", "url") or ""
+    return _guess_mime_type(name)
+
+
+def _attachment_file_name(attachment: dict[str, Any], mime_type: str) -> str:
+    name = _first_string(attachment, "fileName")
+    if name:
+        return Path(name).name
+
+    url = _first_string(attachment, "url") or ""
+    url_name = Path(url.split("?", 1)[0]).name
+    if url_name and "." in url_name:
+        return url_name
+
+    ext = mimetypes.guess_extension(mime_type) or ".bin"
+    return f"canon-media{ext}"
+
+
+def _cache_canon_media(
+    attachment: dict[str, Any],
+    data: bytes,
+    mime_type: str,
+) -> tuple[str, MessageType]:
+    ext = Path(_attachment_file_name(attachment, mime_type)).suffix.lower()
+    if not ext:
+        ext = mimetypes.guess_extension(mime_type) or ".bin"
+
+    if mime_type.startswith("image/"):
+        return cache_image_from_bytes(
+            data, ext if ext in IMAGE_EXTS else ".jpg"
+        ), MessageType.PHOTO
+    if mime_type.startswith("audio/"):
+        return cache_audio_from_bytes(
+            data, ext if ext in AUDIO_EXTS else ".ogg"
+        ), MessageType.VOICE
+    if mime_type.startswith("video/"):
+        return cache_video_from_bytes(
+            data, ext if ext in VIDEO_EXTS else ".mp4"
+        ), MessageType.VIDEO
+    return cache_document_from_bytes(
+        data, _attachment_file_name(attachment, mime_type)
+    ), MessageType.DOCUMENT
+
+
+def _media_file_path(item: Any) -> str:
+    if isinstance(item, (list, tuple)) and item:
+        return str(item[0])
+    return str(item)
+
+
+def _split_canon_metadata(
+    metadata: Optional[Dict[str, Any]],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    if not isinstance(metadata, dict):
+        return {}, {}
+
+    options = metadata.get("canon_options")
+    canon_metadata = metadata.get("canon_metadata")
+
+    safe_options = dict(options) if isinstance(options, dict) else {}
+    safe_metadata = dict(canon_metadata) if isinstance(canon_metadata, dict) else {}
+
+    if not safe_metadata and metadata:
+        hermes_metadata = {
+            key: value
+            for key, value in metadata.items()
+            if key != "canon_streaming_preview"
+        }
+        if hermes_metadata:
+            safe_metadata["hermes"] = hermes_metadata
+
+    return safe_options, safe_metadata
+
+
+
+
+def check_requirements() -> bool:
+    """Return true when Canon credentials can be resolved."""
+    return validate_config(None)
+
+
+def validate_config(config) -> bool:
+    try:
+        return bool(_resolve_canon_agent(config).api_key)
+    except Exception:
+        return False
+
+
+def is_connected(config) -> bool:
+    return validate_config(config)
+
+
+def _env_enablement() -> dict | None:
+    try:
+        resolved = _resolve_canon_agent(None)
+    except Exception:
+        return None
+
+    if not resolved.api_key:
+        return None
+
+    seed: dict[str, Any] = {}
+    if resolved.profile:
+        seed["agent"] = resolved.profile
+    else:
+        seed["api_key"] = resolved.api_key
+
+    if os.getenv("CANON_BASE_URL"):
+        seed["base_url"] = os.getenv("CANON_BASE_URL", "").strip()
+    elif resolved.base_url:
+        seed["base_url"] = resolved.base_url
+    if os.getenv("CANON_STREAM_URL"):
+        seed["stream_url"] = os.getenv("CANON_STREAM_URL", "").strip()
+    elif resolved.stream_url:
+        seed["stream_url"] = resolved.stream_url
+    if os.getenv("CANON_HISTORY_LIMIT"):
+        seed["history_limit"] = os.getenv("CANON_HISTORY_LIMIT", "").strip()
+    if os.getenv("CANON_HOME_CHANNEL"):
+        seed["home_channel"] = {
+            "chat_id": os.getenv("CANON_HOME_CHANNEL", "").strip(),
+            "name": os.getenv("CANON_HOME_CHANNEL_NAME", "Canon Home"),
+        }
+    return seed
+
+
+async def _standalone_send(
+    pconfig,
+    chat_id: str,
+    message: str,
+    *,
+    thread_id=None,
+    media_files=None,
+    force_document: bool = False,
+) -> dict:
+    try:
+        resolved = _resolve_canon_agent(pconfig)
+    except Exception as exc:
+        return {"error": f"Canon standalone send failed: {_safe_error(exc)}"}
+
+    if not resolved.api_key:
+        return {
+            "error": "Canon standalone send failed: Canon agent credentials are not configured"
+        }
+
+    target = chat_id or os.getenv("CANON_HOME_CHANNEL", "").strip()
+    if not target:
+        home = getattr(pconfig, "home_channel", None)
+        target = getattr(home, "chat_id", "") or ""
+    if not target:
+        return {"error": "Canon standalone send failed: no conversation ID provided"}
+
+    text = message or ""
+
+    client = CanonHttpClient(
+        resolved.api_key,
+        base_url=(
+            _config_value(pconfig, "base_url", "CANON_BASE_URL", "")
+            or resolved.base_url
+            or DEFAULT_BASE_URL
+        ),
+        stream_url=_config_value(
+            pconfig, "stream_url", "CANON_STREAM_URL", ""
+        )
+        or resolved.stream_url
+        or DEFAULT_STREAM_URL,
+    )
+    try:
+        options: dict[str, Any] = {}
+        if media_files:
+            attachments: list[dict[str, Any]] = []
+            for item in media_files:
+                media_path = _media_file_path(item)
+                path = Path(media_path).expanduser()
+                if not path.exists():
+                    return {
+                        "error": f"Canon standalone send failed: media file not found: {media_path}"
+                    }
+                if path.stat().st_size > MAX_MEDIA_BYTES:
+                    return {
+                        "error": "Canon standalone send failed: Canon media upload limit is 10MB"
+                    }
+                mime_type = _guess_mime_type(str(path))
+                uploaded = await client.upload_media(
+                    target,
+                    base64.b64encode(path.read_bytes()).decode("ascii"),
+                    mime_type,
+                    file_name=path.name,
+                )
+                attachment = dict(uploaded.get("attachment") or {})
+                if not attachment:
+                    attachment = {
+                        "kind": _canon_attachment_kind_for_mime(mime_type),
+                        "url": uploaded.get("url"),
+                        "mimeType": mime_type,
+                        "fileName": path.name,
+                        "sizeBytes": path.stat().st_size,
+                    }
+                attachments.append(attachment)
+
+            if attachments:
+                first_kind = str(attachments[0].get("kind") or "file")
+                options["contentType"] = (
+                    first_kind if first_kind in {"image", "audio", "video"} else "file"
+                )
+                options["attachments"] = attachments
+
+        data = await client.send_message(
+            target,
+            text,
+            reply_to=str(thread_id) if thread_id else None,
+            metadata=dict(TURN_COMPLETE_METADATA),
+            options=options or None,
+        )
+        return {"success": True, "message_id": _first_string(data, "messageId", "id")}
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        return {"error": f"Canon standalone send failed: {_safe_error(exc)}"}
+    finally:
+        await client.close()
+
+
+def register(ctx):
+    """Plugin entry point: called by the Hermes plugin system."""
+    from plugins.platforms.canon.runtime_tool import register_runtime_tool
+
+    register_runtime_tool(ctx)
+    ctx.register_platform(
+        name="canon",
+        label="Canon",
+        adapter_factory=lambda cfg: CanonAdapter(cfg),
+        check_fn=check_requirements,
+        validate_config=validate_config,
+        is_connected=is_connected,
+        required_env=[],
+        install_hint="Run gateway setup to register/reconnect a Canon agent profile",
+        setup_fn=_setup_canon,
+        env_enablement_fn=_env_enablement,
+        cron_deliver_env_var="CANON_HOME_CHANNEL",
+        standalone_sender_fn=_standalone_send,
+        allowed_users_env="CANON_ALLOWED_USERS",
+        allow_all_env="CANON_ALLOW_ALL_USERS",
+        group_allowed_users_env="CANON_GROUP_ALLOWED_USERS",
+        group_allowed_chats_env="CANON_GROUP_ALLOWED_CONVERSATIONS",
+        max_message_length=3900,
+        pii_safe=False,
+        allow_update_command=True,
+        platform_hint=(
+            "You are chatting via Canon. Canon conversations can be direct or group chats. "
+            "Use concise conversational text; slash commands are preserved when users send them. "
+            "Messages sent by Hermes are marked as turn-complete for Canon's UI."
+        ),
+    )

--- a/plugins/platforms/canon/client.py
+++ b/plugins/platforms/canon/client.py
@@ -1,0 +1,493 @@
+"""Canon REST and SSE transport for the Canon platform plugin."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, AsyncIterator, Dict, Optional
+
+import httpx
+
+from gateway.platforms.base import safe_url_for_log, _ssrf_redirect_guard
+
+from plugins.platforms.canon.constants import (
+    DEFAULT_BASE_URL,
+    DEFAULT_HISTORY_LIMIT,
+    DEFAULT_STREAM_URL,
+    DEFAULT_TIMEOUT_SECONDS,
+    MAX_MEDIA_BYTES,
+)
+from plugins.platforms.canon.models import CanonApiError, CanonStreamFrame
+
+class CanonHttpClient:
+    """Small async client for the Canon agent REST and SSE APIs."""
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        base_url: str = DEFAULT_BASE_URL,
+        stream_url: str = DEFAULT_STREAM_URL,
+        timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+        self.stream_url = stream_url.rstrip("/")
+        self._client = httpx.AsyncClient(
+            timeout=httpx.Timeout(timeout),
+            event_hooks={"response": [_ssrf_redirect_guard]},
+        )
+
+    def _headers(self, *, accept: Optional[str] = None) -> Dict[str, str]:
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        if accept:
+            headers["Accept"] = accept
+        return headers
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    async def _request_json(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[dict[str, Any]] = None,
+        json_body: Optional[dict[str, Any]] = None,
+    ) -> Any:
+        res = await self._client.request(
+            method,
+            f"{self.base_url}{path}",
+            headers=self._headers(),
+            params=params,
+            json=json_body,
+        )
+        if res.status_code >= 400:
+            raise CanonApiError(res.status_code, res.text)
+        if not res.content:
+            return {}
+        return res.json()
+
+    async def get_me(self) -> dict[str, Any]:
+        data = await self._request_json("GET", "/agents/me")
+        return data if isinstance(data, dict) else {}
+
+    async def get_conversations(self) -> list[dict[str, Any]]:
+        data = await self._request_json("GET", "/conversations")
+        conversations = data.get("conversations") if isinstance(data, dict) else data
+        return conversations if isinstance(conversations, list) else []
+
+    async def get_messages(
+        self, conversation_id: str, *, limit: int = DEFAULT_HISTORY_LIMIT
+    ) -> list[dict[str, Any]]:
+        data = await self._request_json(
+            "GET",
+            f"/conversations/{conversation_id}/messages",
+            params={"limit": str(limit)},
+        )
+        messages = data.get("messages") if isinstance(data, dict) else data
+        return messages if isinstance(messages, list) else []
+
+    async def send_message(
+        self,
+        conversation_id: str,
+        text: str,
+        *,
+        reply_to: Optional[str] = None,
+        metadata: Optional[dict[str, Any]] = None,
+        options: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "conversationId": conversation_id,
+            "text": text,
+        }
+        if options:
+            body.update(options)
+        if reply_to:
+            body["replyTo"] = reply_to
+        if metadata:
+            body["metadata"] = metadata
+
+        data = await self._request_json("POST", "/messages/send", json_body=body)
+        return data if isinstance(data, dict) else {}
+
+    async def upload_media(
+        self,
+        conversation_id: str,
+        data: str,
+        mime_type: str,
+        *,
+        file_name: Optional[str] = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "conversationId": conversation_id,
+            "data": data,
+            "mimeType": mime_type,
+        }
+        if file_name:
+            body["fileName"] = file_name
+        result = await self._request_json("POST", "/media/upload", json_body=body)
+        return result if isinstance(result, dict) else {}
+
+    async def download_media(self, url: str) -> tuple[bytes, Optional[str]]:
+        from tools.url_safety import is_safe_url
+
+        if not is_safe_url(url):
+            raise ValueError(
+                f"Blocked unsafe URL (SSRF protection): {safe_url_for_log(url)}"
+            )
+
+        res = await self._client.get(
+            url,
+            headers={"User-Agent": "HermesAgent/CanonPlatform"},
+            follow_redirects=True,
+        )
+        if res.status_code >= 400:
+            raise CanonApiError(res.status_code, res.text)
+        if len(res.content) > MAX_MEDIA_BYTES:
+            raise ValueError("Canon media attachment exceeds 10MB")
+        return res.content, res.headers.get("content-type")
+
+    async def set_typing(
+        self,
+        conversation_id: str,
+        typing: bool,
+        status: Optional[str] = None,
+    ) -> None:
+        body: dict[str, Any] = {
+            "conversationId": conversation_id,
+            "typing": typing,
+        }
+        if status in {"typing", "thinking"}:
+            body["status"] = status
+        await self._request_json("POST", "/typing", json_body=body)
+
+    async def update_runtime_status(
+        self,
+        *,
+        runtime: str = "hermes",
+        host_mode: bool = False,
+        runtime_descriptor: Optional[dict[str, Any]] = None,
+    ) -> None:
+        body: dict[str, Any] = {
+            "runtime": runtime,
+            "hostMode": host_mode,
+        }
+        if runtime_descriptor:
+            body["runtimeDescriptor"] = runtime_descriptor
+        await self._request_json("POST", "/runtime/status", json_body=body)
+
+    async def update_runtime_turn(
+        self,
+        conversation_id: str,
+        *,
+        state: str,
+        turn_id: Optional[str] = None,
+        queue_depth: int = 0,
+        active_message_ids: Optional[list[str]] = None,
+        capabilities: Optional[dict[str, Any]] = None,
+        opened_at: Optional[int] = None,
+        turn_updated_at: Optional[int] = None,
+    ) -> None:
+        body: dict[str, Any] = {
+            "conversationId": conversation_id,
+            "state": state,
+            "queueDepth": max(0, int(queue_depth)),
+        }
+        if turn_id is not None:
+            body["turnId"] = turn_id
+        if active_message_ids:
+            body["activeMessageIds"] = active_message_ids
+        if capabilities:
+            body["capabilities"] = capabilities
+        if opened_at is not None:
+            body["openedAt"] = opened_at
+        if turn_updated_at is not None:
+            body["turnUpdatedAt"] = turn_updated_at
+        await self._request_json("POST", "/runtime/turn", json_body=body)
+
+    async def set_streaming(
+        self,
+        conversation_id: str,
+        *,
+        text: str,
+        status: str = "streaming",
+        turn_id: Optional[str] = None,
+    ) -> None:
+        body: dict[str, Any] = {
+            "conversationId": conversation_id,
+            "text": text,
+            "status": status,
+        }
+        if turn_id:
+            body["messageId"] = turn_id
+            body["turnId"] = turn_id
+        await self._request_json("POST", "/streaming", json_body=body)
+
+    async def clear_streaming(self, conversation_id: str) -> None:
+        await self._request_json(
+            "POST",
+            "/streaming",
+            json_body={"conversationId": conversation_id, "streaming": False},
+        )
+
+    async def update_message_disposition(
+        self,
+        conversation_id: str,
+        message_id: str,
+        inbound_disposition: str,
+    ) -> None:
+        await self._request_json(
+            "PATCH",
+            f"/conversations/{conversation_id}/messages/{message_id}/disposition",
+            json_body={"inboundDisposition": inbound_disposition},
+        )
+
+    async def mark_as_read(self, conversation_id: str) -> None:
+        await self._request_json("POST", f"/conversations/{conversation_id}/read")
+
+    async def create_runtime_input_request(
+        self,
+        conversation_id: str,
+        *,
+        input_id: str,
+        kind: str,
+        expires_at: int,
+        title: Optional[str] = None,
+        prompt: Optional[str] = None,
+        choices: Optional[list[dict[str, Any]]] = None,
+        questions: Optional[list[dict[str, Any]]] = None,
+        response_user_id: Optional[str] = None,
+        native: Optional[dict[str, Any]] = None,
+        sensitive: Optional[bool] = None,
+        turn_id: Optional[str] = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "conversationId": conversation_id,
+            "inputId": input_id,
+            "kind": kind,
+            "expiresAt": expires_at,
+        }
+        if title:
+            body["title"] = title
+        if prompt:
+            body["prompt"] = prompt
+        if choices:
+            body["choices"] = choices
+        if questions:
+            body["questions"] = questions
+        if response_user_id:
+            body["responseUserId"] = response_user_id
+        if native:
+            body["native"] = native
+        if sensitive is not None:
+            body["sensitive"] = bool(sensitive)
+        if turn_id:
+            body["turnId"] = turn_id
+        data = await self._request_json("POST", "/runtime-input/request", json_body=body)
+        return data if isinstance(data, dict) else {}
+
+    async def consume_runtime_input_response(
+        self,
+        conversation_id: str,
+        input_id: str,
+        *,
+        cancel: bool = False,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "conversationId": conversation_id,
+            "inputId": input_id,
+        }
+        if cancel:
+            body["cancel"] = True
+        data = await self._request_json("POST", "/runtime-input/consume", json_body=body)
+        return data if isinstance(data, dict) else {}
+
+    async def create_runtime_card_request(
+        self,
+        conversation_id: str,
+        *,
+        card: dict[str, Any],
+        card_id: Optional[str] = None,
+        expires_at: Optional[int] = None,
+        response_user_id: Optional[str] = None,
+        runtime_id: Optional[str] = None,
+        turn_id: Optional[str] = None,
+        native: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "conversationId": conversation_id,
+            "card": card,
+        }
+        if card_id:
+            body["cardId"] = card_id
+        if expires_at is not None:
+            body["expiresAt"] = expires_at
+        if response_user_id:
+            body["responseUserId"] = response_user_id
+        if runtime_id:
+            body["runtimeId"] = runtime_id
+        if turn_id:
+            body["turnId"] = turn_id
+        if native:
+            body["native"] = native
+        data = await self._request_json("POST", "/runtime-card/request", json_body=body)
+        return data if isinstance(data, dict) else {}
+
+    async def consume_runtime_card_response(
+        self,
+        conversation_id: str,
+        card_id: str,
+        *,
+        cancel: bool = False,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "conversationId": conversation_id,
+            "cardId": card_id,
+        }
+        if cancel:
+            body["cancel"] = True
+        data = await self._request_json("POST", "/runtime-card/consume", json_body=body)
+        return data if isinstance(data, dict) else {}
+
+    async def create_runtime_approval_request(
+        self,
+        conversation_id: str,
+        *,
+        approval_id: str,
+        tool_name: str,
+        tool_summary: str,
+        expires_at: int,
+        details: Optional[list[dict[str, Any]]] = None,
+        native: Optional[dict[str, Any]] = None,
+        allow_session_rule: bool = True,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "conversationId": conversation_id,
+            "approvalId": approval_id,
+            "toolName": tool_name,
+            "toolSummary": tool_summary,
+            "expiresAt": expires_at,
+            "category": "command",
+            "risk": "high",
+            "riskLevel": "destructive",
+            "allowSessionRule": allow_session_rule,
+        }
+        if details:
+            body["details"] = details
+        if native:
+            body["native"] = native
+        data = await self._request_json("POST", "/runtime-approval/request", json_body=body)
+        return data if isinstance(data, dict) else {}
+
+    async def consume_runtime_approval_response(
+        self,
+        conversation_id: str,
+        approval_id: str,
+        *,
+        cancel: bool = False,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "conversationId": conversation_id,
+            "approvalId": approval_id,
+        }
+        if cancel:
+            body["cancel"] = True
+        data = await self._request_json("POST", "/runtime-approval/consume", json_body=body)
+        return data if isinstance(data, dict) else {}
+
+    async def consume_runtime_signal(self, conversation_id: str) -> dict[str, Any]:
+        data = await self._request_json(
+            "POST",
+            "/runtime/signal/consume",
+            json_body={"conversationId": conversation_id},
+        )
+        return data if isinstance(data, dict) else {}
+
+    async def stream_events(
+        self,
+        *,
+        last_event_id: Optional[str] = None,
+    ) -> AsyncIterator[CanonStreamFrame]:
+        url = f"{self.stream_url}/agents/stream"
+        headers = self._headers(accept="text/event-stream")
+        if last_event_id:
+            headers["Last-Event-ID"] = last_event_id
+
+        async with self._client.stream(
+            "GET",
+            url,
+            headers=headers,
+            params={"events": "messages"},
+            timeout=None,
+        ) as res:
+            if res.status_code >= 400:
+                body = await res.aread()
+                raise CanonApiError(
+                    res.status_code, body.decode("utf-8", errors="replace")
+                )
+
+            buffer = ""
+            async for chunk in res.aiter_text():
+                if not chunk:
+                    continue
+                buffer += chunk.replace("\r\n", "\n").replace("\r", "\n")
+                while "\n\n" in buffer:
+                    frame, buffer = buffer.split("\n\n", 1)
+                    parsed = _parse_sse_frame(frame)
+                    if parsed is not None:
+                        yield parsed
+
+
+
+
+def _parse_sse_frame(frame: str) -> Optional[CanonStreamFrame]:
+    event: Optional[str] = None
+    event_id: Optional[str] = None
+    data_lines: list[str] = []
+
+    for line in frame.split("\n"):
+        if not line or line.startswith(":"):
+            continue
+        if line.startswith("id:"):
+            event_id = line[3:].strip()
+        elif line.startswith("event:"):
+            event = line[6:].strip()
+        elif line.startswith("data:"):
+            data_lines.append(line[5:].strip())
+
+    if not event or not data_lines:
+        return None
+
+    raw_data = "\n".join(data_lines)
+    try:
+        data: Any = json.loads(raw_data)
+    except json.JSONDecodeError:
+        data = raw_data
+    return CanonStreamFrame(event=event, data=data, event_id=event_id)
+
+
+
+
+def _safe_error(exc: Exception) -> str:
+    if isinstance(exc, CanonApiError):
+        return str(exc)
+    return str(exc) or exc.__class__.__name__
+
+
+def _is_retryable(exc: Exception) -> bool:
+    if isinstance(exc, CanonApiError):
+        return exc.retryable
+    return isinstance(
+        exc,
+        (
+            httpx.ConnectError,
+            httpx.ConnectTimeout,
+            httpx.ReadTimeout,
+            httpx.RemoteProtocolError,
+        ),
+    )
+
+

--- a/plugins/platforms/canon/constants.py
+++ b/plugins/platforms/canon/constants.py
@@ -1,0 +1,35 @@
+"""Constants for the Canon platform plugin."""
+
+from __future__ import annotations
+
+DEFAULT_BASE_URL = "https://api-6m6mlelskq-uc.a.run.app"
+DEFAULT_STREAM_URL = "https://canon-agent-stream-195218560334.us-central1.run.app"
+DEFAULT_HISTORY_LIMIT = 50
+DEFAULT_TIMEOUT_SECONDS = 30.0
+MAX_SEEN_MESSAGE_IDS = 1024
+MAX_MEDIA_BYTES = 10 * 1024 * 1024
+RUNTIME_STATUS_INTERVAL_SECONDS = 30.0
+RUNTIME_SIGNAL_POLL_SECONDS = 1.0
+RUNTIME_INPUT_POLL_SECONDS = 1.0
+RUNTIME_APPROVAL_POLL_SECONDS = 1.0
+RUNTIME_HITL_MAX_TIMEOUT_SECONDS = 30 * 60
+FINAL_MESSAGE_HANDOFF_SECONDS = 0.75
+REGISTRATION_POLL_INTERVAL_SECONDS = 3.0
+REGISTRATION_TIMEOUT_SECONDS = 5 * 60.0
+
+AUDIO_EXTS = {".m4a", ".mp3", ".ogg", ".opus", ".wav", ".webm", ".flac"}
+IMAGE_EXTS = {".gif", ".jpeg", ".jpg", ".png", ".webp"}
+VIDEO_EXTS = {".avi", ".mkv", ".mov", ".mp4", ".webm", ".3gp"}
+
+TURN_COMPLETE_METADATA = {
+    "turnSemantics": "turn_complete",
+    "turnComplete": True,
+}
+CANON_AGENTS_JSON_BOOTSTRAP_ENV = "CANON_AGENTS_JSON_BOOTSTRAP"
+
+CONTROL_METADATA_TYPES = {
+    "approval_reply",
+    "approval_outcome",
+    "runtime_input_reply",
+    "runtime_input_outcome",
+}

--- a/plugins/platforms/canon/models.py
+++ b/plugins/platforms/canon/models.py
@@ -1,0 +1,36 @@
+"""Shared data models and errors for the Canon platform plugin."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+class CanonApiError(Exception):
+    """HTTP error from Canon's agent API."""
+
+    def __init__(self, status_code: int, body: str):
+        self.status_code = status_code
+        self.body = body.strip()
+        super().__init__(f"Canon API returned {status_code}: {self.body[:500]}")
+
+    @property
+    def retryable(self) -> bool:
+        return self.status_code in {408, 425, 429} or self.status_code >= 500
+
+
+@dataclass
+class CanonStreamFrame:
+    event: str
+    data: Any
+    event_id: Optional[str] = None
+
+
+@dataclass
+class CanonResolvedAgent:
+    api_key: str = ""
+    profile: Optional[str] = None
+    agent_id: Optional[str] = None
+    agent_name: Optional[str] = None
+    base_url: str = ""
+    stream_url: str = ""

--- a/plugins/platforms/canon/plugin.yaml
+++ b/plugins/platforms/canon/plugin.yaml
@@ -1,0 +1,60 @@
+name: canon-platform
+label: Canon
+kind: platform
+version: 0.1.0
+description: >
+  Canon gateway adapter for Hermes Agent. Connects Hermes to Canon agent
+  conversations over Canon's REST and SSE APIs.
+author: Hermes Agent contributors
+requires_env: []
+provides_tools:
+  - canon_runtime_control
+optional_env:
+  - name: CANON_API_KEY
+    description: "Advanced/headless Canon agent API key override"
+    prompt: "Canon API key override"
+    password: true
+  - name: CANON_AGENT
+    description: "Canon profile name from ~/.canon/agents.json"
+    prompt: "Canon profile"
+    password: false
+  - name: CANON_AGENTS_JSON_BOOTSTRAP
+    description: "Initial agents.json contents for fresh volumes"
+    prompt: "Canon agents.json bootstrap"
+    password: true
+  - name: CANON_HOME
+    description: "Canon profile directory, defaults to ~/.canon"
+    prompt: "Canon home"
+    password: false
+  - name: CANON_BASE_URL
+    description: "Canon agent REST API base URL"
+    prompt: "Canon base URL"
+    password: false
+  - name: CANON_STREAM_URL
+    description: "Canon agent SSE stream base URL"
+    prompt: "Canon stream URL"
+    password: false
+  - name: CANON_HOME_CHANNEL
+    description: "Default Canon conversation ID for cron / notification delivery"
+    prompt: "Canon home conversation ID"
+    password: false
+  - name: CANON_ALLOWED_USERS
+    description: "Comma-separated Canon user IDs allowed to talk to Hermes"
+    prompt: "Allowed Canon user IDs"
+    password: false
+  - name: CANON_ALLOW_ALL_USERS
+    description: "Allow any Canon user to talk to Hermes"
+    prompt: "Allow all users? (true/false)"
+    password: false
+  - name: CANON_GROUP_ALLOWED_USERS
+    description: "Comma-separated Canon user IDs allowed only in group conversations"
+    prompt: "Allowed Canon group user IDs"
+    password: false
+  - name: CANON_GROUP_ALLOWED_CONVERSATIONS
+    description: "Comma-separated Canon group conversation IDs allowed for any sender"
+    prompt: "Allowed Canon group conversation IDs"
+    password: false
+  - name: CANON_HISTORY_LIMIT
+    description: "Messages to fetch when hydrating Canon conversation context"
+    prompt: "Canon history limit"
+    password: false

--- a/plugins/platforms/canon/profiles.py
+++ b/plugins/platforms/canon/profiles.py
@@ -1,0 +1,627 @@
+"""Canon profile resolution, local registration, and setup UX."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+import httpx
+
+from plugins.platforms.canon.client import _safe_error
+from plugins.platforms.canon.constants import (
+    CANON_AGENTS_JSON_BOOTSTRAP_ENV,
+    DEFAULT_BASE_URL,
+    DEFAULT_STREAM_URL,
+    DEFAULT_TIMEOUT_SECONDS,
+    REGISTRATION_POLL_INTERVAL_SECONDS,
+    REGISTRATION_TIMEOUT_SECONDS,
+)
+from plugins.platforms.canon.models import CanonApiError, CanonResolvedAgent
+
+def _config_extra_value(config: Any, *keys: str) -> str:
+    extra = getattr(config, "extra", {}) or {}
+    if not isinstance(extra, dict):
+        return ""
+    for key in keys:
+        value = extra.get(key)
+        if value:
+            return str(value).strip()
+    return ""
+
+
+def _canon_home() -> Path:
+    configured = os.getenv("CANON_HOME", "").strip()
+    if configured:
+        return Path(configured).expanduser()
+    return Path.home() / ".canon"
+
+
+def _canon_agents_path() -> Path:
+    configured = (
+        os.getenv("CANON_AGENTS_FILE", "").strip()
+        or os.getenv("CANON_AGENTS_PATH", "").strip()
+    )
+    if configured:
+        return Path(configured).expanduser()
+    return _canon_home() / "agents.json"
+
+
+def _canon_pending_registrations_path() -> Path:
+    return _canon_home() / "pending-registrations.json"
+
+
+def _load_pending_registrations() -> dict[str, dict[str, Any]]:
+    path = _canon_pending_registrations_path()
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except (json.JSONDecodeError, OSError):
+        return {}
+    if not isinstance(loaded, dict):
+        return {}
+    return {
+        str(name): value
+        for name, value in loaded.items()
+        if isinstance(value, dict)
+    }
+
+
+def _write_pending_registrations(pending: dict[str, dict[str, Any]]) -> None:
+    path = _canon_pending_registrations_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    tmp.write_text(json.dumps(pending, indent=2, sort_keys=True), encoding="utf-8")
+    try:
+        os.chmod(tmp, 0o600)
+    except OSError:
+        pass
+    os.replace(tmp, path)
+
+
+def _pending_registration(profile_name: str) -> dict[str, Any]:
+    pending = _load_pending_registrations()
+    entry = pending.get(profile_name)
+    if not isinstance(entry, dict):
+        entry = {}
+    local_id = str(entry.get("localRegistrationId") or "").strip()
+    if not local_id:
+        local_id = f"hermes-{uuid.uuid4().hex}"
+        entry["localRegistrationId"] = local_id
+        pending[profile_name] = entry
+        _write_pending_registrations(pending)
+    return dict(entry)
+
+
+def _save_pending_registration(profile_name: str, entry: dict[str, Any]) -> None:
+    pending = _load_pending_registrations()
+    pending[profile_name] = dict(entry)
+    _write_pending_registrations(pending)
+
+
+def _clear_pending_registration(profile_name: str) -> None:
+    pending = _load_pending_registrations()
+    if pending.pop(profile_name, None) is not None:
+        _write_pending_registrations(pending)
+
+
+def _parse_agent_profiles(raw: str) -> dict[str, dict[str, Any]]:
+    text = raw.strip()
+    if not text:
+        return {}
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        try:
+            parsed = json.loads(base64.b64decode(text).decode("utf-8"))
+        except Exception as exc:
+            raise ValueError(
+                f"{CANON_AGENTS_JSON_BOOTSTRAP_ENV} must be agents.json JSON or base64 JSON"
+            ) from exc
+    if not isinstance(parsed, dict):
+        raise ValueError(
+            f"{CANON_AGENTS_JSON_BOOTSTRAP_ENV} must be a JSON object keyed by profile name"
+        )
+    profiles: dict[str, dict[str, Any]] = {}
+    for raw_name, value in parsed.items():
+        name = str(raw_name).strip()
+        if not name:
+            raise ValueError(f"{CANON_AGENTS_JSON_BOOTSTRAP_ENV} contains an empty profile name")
+        if not isinstance(value, dict):
+            raise ValueError(
+                f'{CANON_AGENTS_JSON_BOOTSTRAP_ENV} profile "{name}" must be an object'
+            )
+        profiles[name] = value
+    return profiles
+
+
+def _write_agent_profiles(path: Path, profiles: dict[str, dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    tmp.write_text(json.dumps(profiles, indent=2, sort_keys=True), encoding="utf-8")
+    try:
+        os.chmod(tmp, 0o600)
+    except OSError:
+        pass
+    os.replace(tmp, path)
+
+
+def _load_agent_profiles() -> dict[str, dict[str, Any]]:
+    path = _canon_agents_path()
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        loaded = {}
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Could not parse {path}: {exc}") from exc
+    except OSError as exc:
+        raise ValueError(f"Could not read {path}: {exc}") from exc
+
+    if not isinstance(loaded, dict):
+        raise ValueError(f"{path} must be a JSON object keyed by profile name")
+
+    profiles = {
+        str(name): value
+        for name, value in loaded.items()
+        if isinstance(value, dict)
+    }
+
+    bootstrap = os.getenv(CANON_AGENTS_JSON_BOOTSTRAP_ENV, "")
+    if bootstrap:
+        changed = False
+        for name, profile in _parse_agent_profiles(bootstrap).items():
+            if name not in profiles:
+                profiles[name] = profile
+                changed = True
+        if changed or not path.exists():
+            _write_agent_profiles(path, profiles)
+
+    return profiles
+
+
+def _profile_slug(name: str) -> str:
+    slug_chars: list[str] = []
+    prev_dash = False
+    for char in name.strip().lower():
+        if char.isascii() and char.isalnum():
+            slug_chars.append(char)
+            prev_dash = False
+        elif not prev_dash:
+            slug_chars.append("-")
+            prev_dash = True
+    slug = "".join(slug_chars).strip("-")
+    return slug or "hermes"
+
+
+def _profile_matches_client(profile: dict[str, Any], expected: str = "hermes") -> bool:
+    client_type = profile.get("clientType")
+    return not client_type or str(client_type) == expected
+
+
+def _resolved_from_profile(name: str, profile: dict[str, Any]) -> CanonResolvedAgent:
+    if not _profile_matches_client(profile):
+        raise ValueError(f'Canon profile "{name}" is not registered for Hermes')
+    api_key = str(profile.get("apiKey") or "").strip()
+    if not api_key:
+        raise ValueError(f'Canon profile "{name}" is missing apiKey')
+    return CanonResolvedAgent(
+        api_key=api_key,
+        profile=name,
+        agent_id=str(profile.get("agentId") or "").strip() or None,
+        agent_name=str(profile.get("agentName") or "").strip() or None,
+        base_url=str(profile.get("baseUrl") or "").strip(),
+        stream_url=str(profile.get("streamUrl") or "").strip(),
+    )
+
+
+def _resolve_canon_agent(config: Any, *, raise_on_error: bool = True) -> CanonResolvedAgent:
+    api_key = _config_value(config, "api_key", "CANON_API_KEY", "")
+    if api_key:
+        return CanonResolvedAgent(api_key=api_key)
+
+    profile_name = (
+        os.getenv("CANON_AGENT", "").strip()
+        or _config_extra_value(config, "agent", "profile", "canon_agent", "CANON_AGENT")
+    )
+    try:
+        profiles = _load_agent_profiles()
+        if profile_name:
+            profile = profiles.get(profile_name)
+            if not profile:
+                raise ValueError(
+                    f'Canon profile "{profile_name}" not found in {_canon_agents_path()}. '
+                    f"Set {CANON_AGENTS_JSON_BOOTSTRAP_ENV}, set CANON_API_KEY, or re-run registration."
+                )
+            return _resolved_from_profile(profile_name, profile)
+
+        viable = [
+            (name, profile)
+            for name, profile in profiles.items()
+            if _profile_matches_client(profile)
+        ]
+        if len(viable) == 1:
+            return _resolved_from_profile(viable[0][0], viable[0][1])
+        if len(viable) > 1:
+            raise ValueError(
+                "Multiple Canon profiles are available. Set CANON_AGENT to choose one."
+            )
+    except Exception:
+        if raise_on_error:
+            raise
+        return CanonResolvedAgent()
+    return CanonResolvedAgent()
+
+
+def _config_value(config: Any, key: str, env_name: str, default: str = "") -> str:
+    env_value = os.getenv(env_name)
+    if env_value:
+        return env_value.strip()
+
+    if key == "api_key":
+        for attr in ("api_key", "token"):
+            value = getattr(config, attr, None)
+            if value:
+                return str(value).strip()
+
+    extra = getattr(config, "extra", {}) or {}
+    if isinstance(extra, dict):
+        for candidate in (key, env_name.lower(), env_name):
+            value = extra.get(candidate)
+            if value:
+                return str(value).strip()
+    return default
+
+
+def _config_int(config: Any, key: str, env_name: str, default: int) -> int:
+    raw = _config_value(config, key, env_name, "")
+    if raw == "":
+        return default
+    try:
+        return max(1, int(raw))
+    except (TypeError, ValueError):
+        return default
+
+
+def _save_canon_profile(
+    profile_name: str,
+    *,
+    api_key: str,
+    agent_id: str,
+    agent_name: str,
+    base_url: str = "",
+    stream_url: str = "",
+) -> None:
+    profiles = _load_agent_profiles()
+    entry: dict[str, Any] = {
+        "apiKey": api_key,
+        "agentId": agent_id,
+        "agentName": agent_name,
+        "registeredAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "clientType": "hermes",
+    }
+    if base_url and base_url.rstrip("/") != DEFAULT_BASE_URL:
+        entry["baseUrl"] = base_url.rstrip("/")
+    if stream_url and stream_url.rstrip("/") != DEFAULT_STREAM_URL:
+        entry["streamUrl"] = stream_url.rstrip("/")
+    profiles[profile_name] = entry
+    _write_agent_profiles(_canon_agents_path(), profiles)
+
+
+def _post_registration_request(
+    *,
+    base_url: str,
+    name: str,
+    description: str,
+    owner_phone: str,
+    local_registration_id: str,
+    requested_agent_id: Optional[str] = None,
+) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "name": name,
+        "description": description,
+        "ownerPhone": owner_phone,
+        "developerInfo": "Hermes gateway platform adapter",
+        "clientType": "hermes",
+        "localRegistrationId": local_registration_id,
+    }
+    if requested_agent_id:
+        body["requestedAgentId"] = requested_agent_id
+
+    res = httpx.post(
+        f"{base_url.rstrip('/')}/agents/register",
+        headers={"Content-Type": "application/json"},
+        json=body,
+        timeout=DEFAULT_TIMEOUT_SECONDS,
+    )
+    if res.status_code >= 400:
+        raise CanonApiError(res.status_code, res.text)
+    data = res.json()
+    if not isinstance(data, dict) or not data.get("requestId"):
+        raise ValueError("Canon registration did not return a requestId")
+    return data
+
+
+def _get_registration_status(
+    *,
+    base_url: str,
+    request_id: str,
+    poll_token: Optional[str],
+) -> dict[str, Any]:
+    headers = {"x-canon-poll-token": poll_token} if poll_token else None
+    res = httpx.get(
+        f"{base_url.rstrip('/')}/agents/status/{request_id}",
+        headers=headers,
+        timeout=DEFAULT_TIMEOUT_SECONDS,
+    )
+    if res.status_code >= 400:
+        raise CanonApiError(res.status_code, res.text)
+    data = res.json()
+    if not isinstance(data, dict):
+        raise ValueError("Canon registration status response was not an object")
+    return data
+
+
+def _ack_registration_status(
+    *,
+    base_url: str,
+    request_id: str,
+    poll_token: Optional[str],
+) -> None:
+    headers = {"x-canon-poll-token": poll_token} if poll_token else None
+    res = httpx.post(
+        f"{base_url.rstrip('/')}/agents/status/{request_id}/ack",
+        headers=headers,
+        timeout=DEFAULT_TIMEOUT_SECONDS,
+    )
+    if res.status_code >= 400:
+        raise CanonApiError(res.status_code, res.text)
+
+
+def _wait_for_registration_approval(
+    *,
+    base_url: str,
+    request_id: str,
+    poll_token: Optional[str],
+    on_poll: Optional[Callable[[dict[str, Any]], None]] = None,
+    timeout_seconds: float = REGISTRATION_TIMEOUT_SECONDS,
+    poll_interval_seconds: float = REGISTRATION_POLL_INTERVAL_SECONDS,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        time.sleep(poll_interval_seconds)
+        status = _get_registration_status(
+            base_url=base_url,
+            request_id=request_id,
+            poll_token=poll_token,
+        )
+        if on_poll:
+            on_poll(status)
+        if status.get("status") in {"approved", "rejected"}:
+            return status
+    return {"status": "timeout"}
+
+
+def _setup_canon() -> None:
+    from hermes_cli.config import get_env_value, remove_env_value, save_env_value
+    from hermes_cli.setup import (
+        Colors,
+        color,
+        print_error,
+        print_info,
+        print_success,
+        print_warning,
+        prompt,
+        prompt_choice,
+        prompt_yes_no,
+    )
+
+    print()
+    print(color("  --- Canon Setup ---", Colors.CYAN))
+    print()
+    print_info("  Canon can use an existing agent profile or register a new Hermes agent.")
+    print_info("  Registration sends an approval request to the Canon owner app.")
+
+    existing_key = get_env_value("CANON_API_KEY") or ""
+    existing_agent = get_env_value("CANON_AGENT") or ""
+    if existing_key or existing_agent or validate_config(None):
+        print()
+        if existing_agent:
+            print_success(f"Canon is already configured with profile '{existing_agent}'.")
+        else:
+            print_success("Canon is already configured.")
+        if not prompt_yes_no("  Reconfigure Canon?", False):
+            return
+
+    choices = [
+        "Register/reconnect a Hermes agent with Canon (recommended)",
+        "Use an existing Canon profile from ~/.canon/agents.json",
+        "Paste an existing Canon API key (advanced/headless)",
+    ]
+    choice = prompt_choice("  How would you like to configure Canon?", choices, 0)
+
+    if choice == 2:
+        print()
+        print_info("  Use this only for headless deployments that cannot use a saved profile.")
+        api_key = prompt("  Canon API key", password=True)
+        if not api_key:
+            print_warning("  Skipped — Canon needs CANON_API_KEY or CANON_AGENT.")
+            return
+        save_env_value("CANON_API_KEY", api_key)
+        remove_env_value("CANON_AGENT")
+        print_success("  Canon API key saved.")
+        return
+
+    if choice == 1:
+        try:
+            profiles = _load_agent_profiles()
+        except Exception as exc:
+            print_error(f"  Could not read {_canon_agents_path()}: {_safe_error(exc)}")
+            return
+        available = [
+            name
+            for name, profile in sorted(profiles.items())
+            if isinstance(profile, dict) and _profile_matches_client(profile)
+        ]
+        if available:
+            default = existing_agent if existing_agent in available else available[0]
+            profile_name = prompt("  Canon profile", default=default)
+        else:
+            print_warning("  No Hermes-compatible profiles found in ~/.canon/agents.json.")
+            profile_name = prompt("  Canon profile")
+        if not profile_name:
+            print_warning("  Skipped — Canon needs a profile name.")
+            return
+        try:
+            _resolved_from_profile(profile_name, profiles[profile_name])
+        except KeyError:
+            print_error(f"  Profile '{profile_name}' was not found in {_canon_agents_path()}.")
+            return
+        except Exception as exc:
+            print_error(f"  Profile '{profile_name}' is not usable: {_safe_error(exc)}")
+            return
+        save_env_value("CANON_AGENT", profile_name)
+        remove_env_value("CANON_API_KEY")
+        print_success(f"  Canon profile '{profile_name}' saved.")
+        return
+
+    print()
+    agent_name = prompt("  Agent display name", default="Hermes")
+    if not agent_name:
+        print_warning("  Skipped — Canon registration needs an agent name.")
+        return
+    description = prompt(
+        "  Agent description",
+        default="Hermes gateway agent",
+    )
+    owner_phone = prompt("  Canon owner phone number (E.164, exact number from the Canon app)")
+    if not owner_phone:
+        print_warning("  Skipped — Canon registration needs the owner's phone number.")
+        return
+    profile_name = prompt("  Local Canon profile name", default=_profile_slug(agent_name))
+    if not profile_name:
+        print_warning("  Skipped — Canon registration needs a local profile name.")
+        return
+
+    base_url = prompt(
+        "  Canon API base URL",
+        default=get_env_value("CANON_BASE_URL") or DEFAULT_BASE_URL,
+    ).rstrip("/")
+
+    requested_agent_id = None
+    try:
+        requested_agent_id = _load_agent_profiles().get(profile_name, {}).get("agentId")
+    except Exception:
+        requested_agent_id = None
+
+    pending_registration = _pending_registration(profile_name)
+    request_id = str(pending_registration.get("requestId") or "").strip()
+    poll_token = pending_registration.get("pollToken")
+    if request_id:
+        print_info(f"  Reconnecting to pending registration (request ID: {request_id}).")
+    else:
+        local_registration_id = str(pending_registration["localRegistrationId"])
+        try:
+            submitted = _post_registration_request(
+                base_url=base_url,
+                name=agent_name,
+                description=description,
+                owner_phone=owner_phone,
+                local_registration_id=local_registration_id,
+                requested_agent_id=requested_agent_id,
+            )
+        except Exception as exc:
+            print_error(f"  Canon registration failed: {_safe_error(exc)}")
+            return
+
+        request_id = str(submitted.get("requestId") or "")
+        poll_token = submitted.get("pollToken")
+        _save_pending_registration(
+            profile_name,
+            {
+                **pending_registration,
+                "requestId": request_id,
+                "pollToken": poll_token,
+                "baseUrl": base_url,
+                "submittedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            },
+        )
+        print_success(f"  Registration submitted (request ID: {request_id}).")
+    print_info("  Approve the request in the Canon app. Waiting up to 5 minutes...")
+
+    def _poll_update(status: dict[str, Any]) -> None:
+        state = status.get("status", "pending")
+        if state == "pending":
+            print(".", end="", flush=True)
+
+    try:
+        result = _wait_for_registration_approval(
+            base_url=base_url,
+            request_id=request_id,
+            poll_token=str(poll_token) if poll_token else None,
+            on_poll=_poll_update,
+        )
+    except Exception as exc:
+        print()
+        print_error(f"  Canon approval polling failed: {_safe_error(exc)}")
+        return
+
+    print()
+    status = result.get("status")
+    if status == "rejected":
+        _clear_pending_registration(profile_name)
+        print_warning("  Canon registration was rejected.")
+        return
+    if status != "approved":
+        print_warning("  Canon registration timed out. Run setup again to retry.")
+        return
+
+    api_key = str(result.get("apiKey") or "").strip()
+    agent_id = str(result.get("agentId") or "").strip()
+    approved_name = str(result.get("agentName") or agent_name).strip()
+    if not api_key or not agent_id:
+        print_error("  Canon approved the request but did not return a usable API key.")
+        return
+
+    try:
+        _save_canon_profile(
+            profile_name,
+            api_key=api_key,
+            agent_id=agent_id,
+            agent_name=approved_name,
+            base_url=base_url,
+        )
+    except Exception as exc:
+        print_error(f"  Could not save Canon profile: {_safe_error(exc)}")
+        return
+
+    try:
+        _ack_registration_status(
+            base_url=base_url,
+            request_id=request_id,
+            poll_token=str(poll_token) if poll_token else None,
+        )
+    except Exception as exc:
+        print_warning(f"  Canon profile saved, but key-delivery ack failed: {_safe_error(exc)}")
+
+    save_env_value("CANON_AGENT", profile_name)
+    remove_env_value("CANON_API_KEY")
+    if base_url != DEFAULT_BASE_URL:
+        save_env_value("CANON_BASE_URL", base_url)
+    _clear_pending_registration(profile_name)
+
+    print_success(f"  Canon agent '{approved_name}' saved as profile '{profile_name}'.")
+    print_info("  Hermes will use CANON_AGENT for the Canon platform.")
+
+
+
+
+def validate_config(config) -> bool:
+    try:
+        return bool(_resolve_canon_agent(config).api_key)
+    except Exception:
+        return False

--- a/plugins/platforms/canon/runtime.py
+++ b/plugins/platforms/canon/runtime.py
@@ -1,0 +1,154 @@
+"""Canon runtime controls, cards, approvals, and HITL helpers."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Optional
+
+from plugins.platforms.canon.constants import (
+    CONTROL_METADATA_TYPES,
+    RUNTIME_HITL_MAX_TIMEOUT_SECONDS,
+)
+
+CANON_HERMES_RUNTIME_DESCRIPTOR: dict[str, Any] = {
+    "coreControls": [],
+    "runtimeControls": [],
+    "commands": [
+        {
+            "id": "stop",
+            "label": "Stop",
+            "description": "Interrupt the current Hermes turn.",
+            "aliases": ["stop"],
+            "category": "turn",
+            "placements": ["composer_slash", "command_palette"],
+            "availability": ["busy"],
+            "dispatch": {"kind": "signal", "signal": "interrupt"},
+        },
+        {
+            "id": "stop-and-clear-queue",
+            "label": "Stop & clear queue",
+            "description": "Interrupt the current Hermes turn and drop queued Canon prompts.",
+            "aliases": ["stop-clear", "clear-queue"],
+            "category": "turn",
+            "placements": ["composer_slash", "command_palette", "session_strip"],
+            "availability": ["busy_with_queue"],
+            "dispatch": {"kind": "signal", "signal": "stop_and_drop"},
+        },
+        {
+            "id": "new-session",
+            "label": "New session",
+            "description": "Start a fresh Hermes session inside this Canon chat.",
+            "aliases": ["new"],
+            "category": "session",
+            "placements": ["composer_slash", "command_palette", "session_strip"],
+            "availability": ["always"],
+            "dispatch": {"kind": "signal", "signal": "new_session"},
+        },
+    ],
+    "supportsInterrupt": True,
+    "supportsInputInterrupt": True,
+    "streamingTextMode": "delta",
+}
+
+def _is_canon_streaming_preview(metadata: Optional[Dict[str, Any]]) -> bool:
+    return isinstance(metadata, dict) and metadata.get("canon_streaming_preview") is True
+
+
+def _canon_timeout_seconds(env_name: str, default_seconds: int) -> int:
+    raw = os.getenv(env_name, "").strip()
+    try:
+        value = int(raw) if raw else default_seconds
+    except ValueError:
+        value = default_seconds
+    return max(5, min(value, RUNTIME_HITL_MAX_TIMEOUT_SECONDS))
+
+
+def _canon_runtime_choices(choices: Optional[list]) -> Optional[list[dict[str, Any]]]:
+    if not choices:
+        return None
+    normalized: list[dict[str, Any]] = []
+    for choice in choices[:12]:
+        if isinstance(choice, dict):
+            label = str(
+                choice.get("label")
+                or choice.get("text")
+                or choice.get("value")
+                or ""
+            ).strip()
+            value = str(choice.get("value") or label).strip()
+        else:
+            label = str(choice).strip()
+            value = label
+        if not label:
+            continue
+        normalized.append({
+            "label": label[:160],
+            "value": (value or label)[:400],
+        })
+    return normalized or None
+
+
+def _runtime_input_response_value(response: dict[str, Any]) -> str:
+    value = response.get("value")
+    answers = response.get("answers")
+    if isinstance(value, str):
+        if value.strip():
+            return value
+        if not isinstance(answers, dict):
+            return value
+    if isinstance(answers, dict):
+        values: list[str] = []
+        for question_id, item in answers.items():
+            if not isinstance(question_id, str):
+                continue
+            raw_answers = item.get("answers") if isinstance(item, dict) else item
+            if isinstance(raw_answers, list):
+                normalized = [entry.strip() for entry in raw_answers if isinstance(entry, str) and entry.strip()]
+            elif isinstance(raw_answers, str) and raw_answers.strip():
+                normalized = [raw_answers.strip()]
+            else:
+                normalized = []
+            if not normalized:
+                continue
+            if len(answers) == 1:
+                values.append(", ".join(normalized))
+            else:
+                values.append(f"{question_id}: {', '.join(normalized)}")
+        if values:
+            return "\n".join(values)
+    if isinstance(value, str):
+        return value
+    choice = response.get("choice")
+    if isinstance(choice, dict):
+        for key in ("value", "label"):
+            text = choice.get(key)
+            if isinstance(text, str) and text.strip():
+                return text.strip()
+    return ""
+
+
+def _canon_message_metadata(raw_message: Any) -> dict[str, Any]:
+    if not isinstance(raw_message, dict):
+        return {}
+    message = raw_message.get("message")
+    if not isinstance(message, dict):
+        return {}
+    metadata = message.get("metadata")
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _approval_choice_from_response(response: dict[str, Any]) -> str:
+    session_rule = response.get("sessionRule")
+    if isinstance(session_rule, dict):
+        rule_type = session_rule.get("type")
+        if rule_type in {"approve-all", "approve-tool"}:
+            return "session"
+    return "once"
+
+
+def _is_canon_control_message(message: dict[str, Any]) -> bool:
+    metadata = message.get("metadata")
+    if not isinstance(metadata, dict):
+        return False
+    return metadata.get("type") in CONTROL_METADATA_TYPES
+

--- a/plugins/platforms/canon/runtime_tool.py
+++ b/plugins/platforms/canon/runtime_tool.py
@@ -1,0 +1,334 @@
+"""Generic Canon runtime card/input plumbing for Hermes tools.
+
+This module intentionally contains no domain-specific behavior. Domain packs can
+use the helper functions to ask Canon for rich-card actions or structured
+runtime input without copying Canon credential and polling logic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from typing import Any, Optional
+
+from tools.registry import tool_error, tool_result
+
+
+DEFAULT_TIMEOUT_SECONDS = 300
+POLL_SECONDS = 1.0
+
+
+def _safe_timeout_seconds(value: Any, default: int = DEFAULT_TIMEOUT_SECONDS) -> int:
+    try:
+        seconds = int(value)
+    except (TypeError, ValueError):
+        return default
+    return min(30 * 60, max(5, seconds))
+
+
+def resolve_canon_conversation_id(target: Any = None) -> str:
+    """Resolve a Canon conversation id from a tool target or current session."""
+    raw = str(target or "").strip()
+    if raw:
+        if raw.startswith("canon:"):
+            raw = raw.split(":", 1)[1].strip()
+        if raw:
+            return raw
+        raise ValueError("Canon target must include a conversation id")
+
+    try:
+        from gateway.session_context import get_session_env
+
+        platform = get_session_env("HERMES_SESSION_PLATFORM", "").strip().lower()
+        chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "").strip()
+        if platform == "canon" and chat_id:
+            return chat_id
+    except Exception:
+        pass
+
+    home = os.getenv("CANON_HOME_CHANNEL", "").strip()
+    if home:
+        return home
+    raise ValueError(
+        "No Canon conversation id found. Run inside a Canon conversation or pass target='canon:<conversation_id>'."
+    )
+
+
+def _card_has_actions(card: dict[str, Any]) -> bool:
+    blocks = card.get("blocks")
+    if not isinstance(blocks, list):
+        return False
+    return any(
+        isinstance(block, dict)
+        and block.get("kind") == "actions"
+        and isinstance(block.get("actions"), list)
+        and bool(block.get("actions"))
+        for block in blocks
+    )
+
+
+def _new_canon_client():
+    from plugins.platforms.canon.adapter import (
+        DEFAULT_BASE_URL,
+        DEFAULT_STREAM_URL,
+        CanonHttpClient,
+        _resolve_canon_agent,
+    )
+
+    resolved = _resolve_canon_agent(None)
+    if not resolved.api_key:
+        raise RuntimeError("Canon agent credentials are not configured")
+    return CanonHttpClient(
+        resolved.api_key,
+        base_url=os.getenv("CANON_BASE_URL", "").strip()
+        or resolved.base_url
+        or DEFAULT_BASE_URL,
+        stream_url=os.getenv("CANON_STREAM_URL", "").strip()
+        or resolved.stream_url
+        or DEFAULT_STREAM_URL,
+    )
+
+
+async def request_canon_runtime_card(
+    *,
+    target: Any = None,
+    card: dict[str, Any],
+    card_id: Optional[str] = None,
+    response_user_id: Optional[str] = None,
+    runtime_id: Optional[str] = None,
+    turn_id: Optional[str] = None,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+    wait: bool = True,
+    native: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    conversation_id = resolve_canon_conversation_id(target)
+    timeout_seconds = _safe_timeout_seconds(timeout_seconds)
+    expires_at = int((time.time() + timeout_seconds) * 1000)
+    effective_card_id = card_id or str(card.get("cardId") or "")
+
+    client = _new_canon_client()
+    try:
+        request = await client.create_runtime_card_request(
+            conversation_id,
+            card=card,
+            card_id=effective_card_id or None,
+            expires_at=expires_at,
+            response_user_id=response_user_id,
+            runtime_id=runtime_id,
+            turn_id=turn_id,
+            native=native,
+        )
+        effective_card_id = (
+            str(request.get("cardId") or effective_card_id or card.get("cardId") or "").strip()
+        )
+        interactive = request.get("interactive")
+        if interactive is None:
+            interactive = _card_has_actions(card)
+        if not wait or interactive is False:
+            return {
+                "status": "displayed",
+                "conversationId": conversation_id,
+                "cardId": effective_card_id,
+                "request": request,
+            }
+        if not effective_card_id:
+            raise RuntimeError("Canon runtime-card request did not return a card id")
+
+        while time.time() * 1000 <= expires_at:
+            response = await client.consume_runtime_card_response(
+                conversation_id,
+                effective_card_id,
+            )
+            status = response.get("status")
+            if status and status != "pending":
+                response.setdefault("conversationId", conversation_id)
+                return response
+            await asyncio.sleep(POLL_SECONDS)
+
+        try:
+            await client.consume_runtime_card_response(
+                conversation_id,
+                effective_card_id,
+                cancel=True,
+            )
+        finally:
+            return {
+                "status": "timeout",
+                "conversationId": conversation_id,
+                "cardId": effective_card_id,
+            }
+    finally:
+        await client.close()
+
+
+async def request_canon_runtime_input(
+    *,
+    target: Any = None,
+    input_id: str,
+    kind: str = "clarify",
+    title: Optional[str] = None,
+    prompt: Optional[str] = None,
+    choices: Optional[list[dict[str, Any]]] = None,
+    questions: Optional[list[dict[str, Any]]] = None,
+    response_user_id: Optional[str] = None,
+    turn_id: Optional[str] = None,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+    sensitive: Optional[bool] = None,
+    native: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    conversation_id = resolve_canon_conversation_id(target)
+    timeout_seconds = _safe_timeout_seconds(timeout_seconds)
+    expires_at = int((time.time() + timeout_seconds) * 1000)
+
+    client = _new_canon_client()
+    try:
+        await client.create_runtime_input_request(
+            conversation_id,
+            input_id=input_id,
+            kind=kind,
+            expires_at=expires_at,
+            title=title,
+            prompt=prompt,
+            choices=choices,
+            questions=questions,
+            response_user_id=response_user_id,
+            turn_id=turn_id,
+            sensitive=sensitive,
+            native=native,
+        )
+
+        while time.time() * 1000 <= expires_at:
+            response = await client.consume_runtime_input_response(
+                conversation_id,
+                input_id,
+            )
+            status = response.get("status")
+            if status and status != "pending":
+                response.setdefault("conversationId", conversation_id)
+                return response
+            await asyncio.sleep(POLL_SECONDS)
+
+        try:
+            await client.consume_runtime_input_response(
+                conversation_id,
+                input_id,
+                cancel=True,
+            )
+        finally:
+            return {
+                "status": "timeout",
+                "conversationId": conversation_id,
+                "inputId": input_id,
+            }
+    finally:
+        await client.close()
+
+
+async def canon_runtime_control(args: dict[str, Any], **_kwargs) -> str:
+    action = str(args.get("action") or "").strip()
+    try:
+        if action in {"request_card", "send_card"}:
+            card = args.get("card")
+            if not isinstance(card, dict):
+                return tool_error("card must be a canon.card.v1 object", success=False)
+            result = await request_canon_runtime_card(
+                target=args.get("target"),
+                card=card,
+                card_id=args.get("cardId"),
+                response_user_id=args.get("responseUserId"),
+                runtime_id=args.get("runtimeId"),
+                turn_id=args.get("turnId"),
+                timeout_seconds=_safe_timeout_seconds(args.get("timeoutSeconds")),
+                wait=action == "request_card",
+                native=args.get("native") if isinstance(args.get("native"), dict) else None,
+            )
+            return tool_result(success=True, **result)
+        if action == "request_input":
+            input_id = str(args.get("inputId") or "").strip()
+            if not input_id:
+                return tool_error("inputId is required for request_input", success=False)
+            questions = args.get("questions")
+            choices = args.get("choices")
+            result = await request_canon_runtime_input(
+                target=args.get("target"),
+                input_id=input_id,
+                kind=str(args.get("kind") or "clarify"),
+                title=args.get("title"),
+                prompt=args.get("prompt"),
+                choices=choices if isinstance(choices, list) else None,
+                questions=questions if isinstance(questions, list) else None,
+                response_user_id=args.get("responseUserId"),
+                turn_id=args.get("turnId"),
+                timeout_seconds=_safe_timeout_seconds(args.get("timeoutSeconds")),
+                sensitive=args.get("sensitive") if isinstance(args.get("sensitive"), bool) else None,
+                native=args.get("native") if isinstance(args.get("native"), dict) else None,
+            )
+            return tool_result(success=True, **result)
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+    return tool_error("action must be one of request_card, send_card, or request_input", success=False)
+
+
+CANON_RUNTIME_CONTROL_SCHEMA = {
+    "name": "canon_runtime_control",
+    "description": (
+        "Generic Canon runtime card/input request plumbing. Use only for Canon "
+        "runtime-control surfaces; domain-specific cards should be built by the "
+        "owning domain tool first."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["request_card", "send_card", "request_input"],
+            },
+            "target": {
+                "type": "string",
+                "description": "Optional Canon target, formatted as canon:<conversation_id>. Defaults to the active Canon chat.",
+            },
+            "card": {"type": "object"},
+            "cardId": {"type": "string"},
+            "inputId": {"type": "string"},
+            "kind": {"type": "string"},
+            "title": {"type": "string"},
+            "prompt": {"type": "string"},
+            "choices": {"type": "array", "items": {"type": "object"}},
+            "questions": {"type": "array", "items": {"type": "object"}},
+            "responseUserId": {"type": "string"},
+            "runtimeId": {"type": "string"},
+            "turnId": {"type": "string"},
+            "timeoutSeconds": {"type": "integer"},
+            "sensitive": {"type": "boolean"},
+            "native": {"type": "object"},
+        },
+        "required": ["action"],
+    },
+}
+
+
+def check_canon_runtime_requirements() -> bool:
+    try:
+        from plugins.platforms.canon.profiles import _resolve_canon_agent
+
+        return bool(_resolve_canon_agent(None).api_key)
+    except Exception:
+        return False
+
+
+def register_runtime_tool(ctx) -> None:
+    ctx.register_tool(
+        name="canon_runtime_control",
+        toolset="canon",
+        schema=CANON_RUNTIME_CONTROL_SCHEMA,
+        handler=canon_runtime_control,
+        check_fn=check_canon_runtime_requirements,
+        is_async=True,
+        description=CANON_RUNTIME_CONTROL_SCHEMA["description"],
+        emoji="▣",
+    )
+    from tools.registry import registry
+
+    registry.register_toolset_alias("canon_runtime", "canon")

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -240,6 +240,54 @@ class TestBusySessionAck:
         assert "Interrupting" not in content
 
     @pytest.mark.asyncio
+    async def test_delivery_intent_queue_overrides_interrupt_mode(self):
+        """Platform delivery_intent='queue' queues without interrupting."""
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+
+        event = _make_event(text="queue me")
+        event.delivery_intent = "queue"
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        agent._active_children = []
+        runner._running_agents[sk] = agent
+
+        result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is True
+        assert adapter._pending_messages.get(sk) is event
+        agent.interrupt.assert_not_called()
+        content = adapter._send_with_retry.call_args.kwargs.get("content", "")
+        assert "Queued for the next turn" in content
+
+    @pytest.mark.asyncio
+    async def test_delivery_intent_interrupt_overrides_queue_mode(self):
+        """Platform delivery_intent='interrupt' interrupts despite queue mode."""
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "queue"
+        adapter = _make_adapter()
+
+        event = _make_event(text="interrupt now")
+        event.delivery_intent = "interrupt"
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        agent._active_children = []
+        runner._running_agents[sk] = agent
+
+        result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is True
+        assert adapter._pending_messages.get(sk) is event
+        agent.interrupt.assert_called_once_with("interrupt now")
+        content = adapter._send_with_retry.call_args.kwargs.get("content", "")
+        assert "Interrupting current task" in content
+
+    @pytest.mark.asyncio
     async def test_busy_text_mode_queue_delegates_to_adapter_handle_message(self):
         """busy_text_mode=queue lets the adapter debounce text silently."""
         runner, sentinel = _make_runner()

--- a/tests/gateway/test_canon_adapter.py
+++ b/tests/gateway/test_canon_adapter.py
@@ -1,0 +1,1560 @@
+"""Tests for the Canon platform adapter plugin."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+from tests.gateway._plugin_adapter_loader import load_plugin_adapter
+
+_canon = load_plugin_adapter("canon")
+
+CanonAdapter = _canon.CanonAdapter
+CanonApiError = _canon.CanonApiError
+CanonHttpClient = _canon.CanonHttpClient
+CanonStreamFrame = _canon.CanonStreamFrame
+DEFAULT_BASE_URL = _canon.DEFAULT_BASE_URL
+DEFAULT_STREAM_URL = _canon.DEFAULT_STREAM_URL
+TURN_COMPLETE_METADATA = _canon.TURN_COMPLETE_METADATA
+_env_enablement = _canon._env_enablement
+_parse_sse_frame = _canon._parse_sse_frame
+_profile_slug = _canon._profile_slug
+_save_canon_profile = _canon._save_canon_profile
+_standalone_send = _canon._standalone_send
+_resolve_canon_agent = _canon._resolve_canon_agent
+_wait_for_registration_approval = _canon._wait_for_registration_approval
+_canon_timeout_seconds = _canon._canon_timeout_seconds
+check_requirements = _canon.check_requirements
+register = _canon.register
+validate_config = _canon.validate_config
+
+
+def test_core_prompt_and_session_logic_do_not_hardcode_canon():
+    """Canon should integrate through generic platform hooks, not core branches."""
+    for rel_path in ("gateway/run.py", "gateway/session.py"):
+        text = Path(rel_path).read_text(encoding="utf-8")
+        assert "CANON_" not in text
+        assert re.search(r"\b[Cc]anon\b", text) is None
+
+
+def _config(**kwargs):
+    from gateway.config import PlatformConfig
+
+    return PlatformConfig(enabled=True, **kwargs)
+
+
+async def _wait_for(predicate, *, interval: float = 0.01):
+    while not predicate():
+        await asyncio.sleep(interval)
+
+
+class TestCanonConfig:
+    def test_init_from_config_extra(self, monkeypatch):
+        monkeypatch.delenv("CANON_API_KEY", raising=False)
+        cfg = _config(
+            extra={
+                "api_key": "config-key",
+                "base_url": "https://api.example.test",
+                "stream_url": "https://stream.example.test",
+                "history_limit": "25",
+            }
+        )
+
+        adapter = CanonAdapter(cfg)
+
+        assert adapter.api_key == "config-key"
+        assert adapter.base_url == "https://api.example.test"
+        assert adapter.stream_url == "https://stream.example.test"
+        assert adapter.history_limit == 25
+
+    def test_env_overrides_config(self, monkeypatch):
+        monkeypatch.setenv("CANON_API_KEY", "env-key")
+        monkeypatch.setenv("CANON_BASE_URL", "https://api.env.test")
+
+        adapter = CanonAdapter(
+            _config(api_key="config-key", extra={"base_url": "https://api.config.test"})
+        )
+
+        assert adapter.api_key == "env-key"
+        assert adapter.base_url == "https://api.env.test"
+
+    def test_init_from_canon_agent_profile_bootstrap(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("CANON_API_KEY", raising=False)
+        monkeypatch.setenv("CANON_HOME", str(tmp_path))
+        monkeypatch.setenv("CANON_AGENT", "leonardo-2")
+        monkeypatch.setenv(
+            "CANON_AGENTS_JSON_BOOTSTRAP",
+            json.dumps(
+                {
+                    "leonardo-2": {
+                        "apiKey": "profile-key",
+                        "agentId": "agent-leonardo",
+                        "agentName": "Leonardo 2",
+                        "clientType": "hermes",
+                        "baseUrl": "https://api.profile.test",
+                        "streamUrl": "https://stream.profile.test",
+                    }
+                }
+            ),
+        )
+
+        adapter = CanonAdapter(_config())
+
+        assert adapter.api_key == "profile-key"
+        assert adapter.profile_name == "leonardo-2"
+        assert adapter.profile_agent_id == "agent-leonardo"
+        assert adapter.base_url == "https://api.profile.test"
+        assert adapter.stream_url == "https://stream.profile.test"
+        assert (tmp_path / "agents.json").exists()
+
+    def test_direct_key_precedes_malformed_profile_bootstrap(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("CANON_HOME", str(tmp_path))
+        monkeypatch.setenv("CANON_API_KEY", "env-key")
+        monkeypatch.setenv("CANON_AGENT", "leonardo-2")
+        monkeypatch.setenv("CANON_AGENTS_JSON_BOOTSTRAP", "not-json")
+
+        resolved = _resolve_canon_agent(_config())
+
+        assert resolved.api_key == "env-key"
+        assert resolved.profile is None
+
+    def test_validate_config_accepts_env_config_or_profile(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("CANON_HOME", str(tmp_path))
+        monkeypatch.delenv("CANON_API_KEY", raising=False)
+        monkeypatch.delenv("CANON_AGENT", raising=False)
+        monkeypatch.delenv("CANON_AGENTS_JSON_BOOTSTRAP", raising=False)
+        assert not validate_config(_config())
+        assert validate_config(_config(api_key="config-key"))
+
+        monkeypatch.setenv("CANON_API_KEY", "env-key")
+        assert validate_config(_config())
+
+        monkeypatch.delenv("CANON_API_KEY", raising=False)
+        monkeypatch.setenv("CANON_AGENT", "leonardo-2")
+        monkeypatch.setenv(
+            "CANON_AGENTS_JSON_BOOTSTRAP",
+            json.dumps(
+                {
+                    "leonardo-2": {
+                        "apiKey": "profile-key",
+                        "agentId": "agent-leonardo",
+                        "agentName": "Leonardo 2",
+                        "clientType": "hermes",
+                    }
+                }
+            ),
+        )
+        assert validate_config(_config())
+
+    def test_env_enablement_seeds_extra_and_home_channel(self, monkeypatch):
+        monkeypatch.setenv("CANON_API_KEY", "env-key")
+        monkeypatch.setenv("CANON_BASE_URL", "https://api.env.test")
+        monkeypatch.setenv("CANON_STREAM_URL", "https://stream.env.test")
+        monkeypatch.setenv("CANON_HOME_CHANNEL", "convo-home")
+        monkeypatch.setenv("CANON_HISTORY_LIMIT", "75")
+
+        seed = _env_enablement()
+
+        assert seed["api_key"] == "env-key"
+        assert seed["base_url"] == "https://api.env.test"
+        assert seed["stream_url"] == "https://stream.env.test"
+        assert seed["history_limit"] == "75"
+        assert seed["home_channel"]["chat_id"] == "convo-home"
+
+    def test_requirements_follow_canon_credentials(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("CANON_HOME", str(tmp_path))
+        monkeypatch.delenv("CANON_API_KEY", raising=False)
+        monkeypatch.delenv("CANON_AGENT", raising=False)
+        monkeypatch.delenv("CANON_AGENTS_JSON_BOOTSTRAP", raising=False)
+        assert check_requirements() is False
+
+        monkeypatch.setenv("CANON_API_KEY", "env-key")
+        assert check_requirements() is True
+
+    def test_runtime_hitl_timeout_matches_canon_api_limit(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CLARIFY_TIMEOUT", "3600")
+
+        assert _canon_timeout_seconds("HERMES_CLARIFY_TIMEOUT", 300) == 1800
+
+    def test_profile_slug_normalizes_display_name(self):
+        assert _profile_slug("My Hermes Agent!") == "my-hermes-agent"
+        assert _profile_slug("!!!") == "hermes"
+
+    def test_save_canon_profile_writes_resolvable_agents_json(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("CANON_HOME", str(tmp_path))
+        monkeypatch.delenv("CANON_API_KEY", raising=False)
+        monkeypatch.setenv("CANON_AGENT", "my-hermes")
+
+        _save_canon_profile(
+            "my-hermes",
+            api_key="profile-key",
+            agent_id="agent-1",
+            agent_name="My Hermes",
+            base_url="https://api.example.test",
+        )
+
+        resolved = _resolve_canon_agent(_config())
+
+        assert resolved.api_key == "profile-key"
+        assert resolved.profile == "my-hermes"
+        assert resolved.agent_id == "agent-1"
+        assert resolved.base_url == "https://api.example.test"
+
+    def test_pending_registration_reuses_local_registration_id(self, monkeypatch, tmp_path):
+        from plugins.platforms.canon import profiles as canon_profiles
+
+        monkeypatch.setenv("CANON_HOME", str(tmp_path))
+
+        first = canon_profiles._pending_registration("my-hermes")
+        second = canon_profiles._pending_registration("my-hermes")
+
+        assert first["localRegistrationId"].startswith("hermes-")
+        assert second["localRegistrationId"] == first["localRegistrationId"]
+
+    def test_post_registration_uses_stable_local_registration_id(self, monkeypatch):
+        from plugins.platforms.canon import profiles as canon_profiles
+
+        captured = {}
+
+        class Response:
+            status_code = 200
+            text = ""
+
+            @staticmethod
+            def json():
+                return {"requestId": "req-1", "pollToken": "poll-1"}
+
+        def fake_post(url, *, headers, json, timeout):
+            captured.update({
+                "url": url,
+                "headers": headers,
+                "json": json,
+                "timeout": timeout,
+            })
+            return Response()
+
+        monkeypatch.setattr(canon_profiles.httpx, "post", fake_post)
+
+        result = canon_profiles._post_registration_request(
+            base_url="https://api.example.test",
+            name="Hermes",
+            description="Hermes gateway",
+            owner_phone="+15551234567",
+            local_registration_id="local-stable",
+            requested_agent_id="agent-existing",
+        )
+
+        assert result["requestId"] == "req-1"
+        assert captured["json"]["clientType"] == "hermes"
+        assert captured["json"]["localRegistrationId"] == "local-stable"
+        assert captured["json"]["requestedAgentId"] == "agent-existing"
+
+    def test_wait_for_registration_approval_returns_approved(self, monkeypatch):
+        from plugins.platforms.canon import profiles as canon_profiles
+
+        statuses = [
+            {"status": "pending"},
+            {
+                "status": "approved",
+                "apiKey": "agk_live_test",
+                "agentId": "agent-1",
+            },
+        ]
+        seen = []
+
+        def fake_status(**_kwargs):
+            return statuses.pop(0)
+
+        monkeypatch.setattr(canon_profiles, "_get_registration_status", fake_status)
+        monkeypatch.setattr(canon_profiles.time, "sleep", lambda _seconds: None)
+
+        result = _wait_for_registration_approval(
+            base_url=DEFAULT_BASE_URL,
+            request_id="req-1",
+            poll_token="poll-1",
+            on_poll=seen.append,
+            timeout_seconds=10,
+            poll_interval_seconds=0.01,
+        )
+
+        assert result["status"] == "approved"
+        assert result["apiKey"] == "agk_live_test"
+        assert [item["status"] for item in seen] == ["pending", "approved"]
+
+
+class TestCanonHttpClient:
+    @pytest.mark.asyncio
+    async def test_download_media_blocks_unsafe_url(self, monkeypatch):
+        client = CanonHttpClient("key")
+        client._client.get = AsyncMock()
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda _url: False)
+
+        try:
+            with pytest.raises(ValueError, match="SSRF"):
+                await client.download_media("http://127.0.0.1/private")
+
+            client._client.get.assert_not_called()
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_download_media_uses_redirect_guard(self, monkeypatch):
+        client = CanonHttpClient("key")
+        monkeypatch.setattr(
+            "tools.url_safety.is_safe_url",
+            lambda url: url == "https://media.example/voice.m4a",
+        )
+        redirect_response = SimpleNamespace(
+            is_redirect=True,
+            next_request=SimpleNamespace(
+                url="http://169.254.169.254/latest/meta-data"
+            ),
+        )
+
+        try:
+            hooks = client._client.event_hooks["response"]
+            assert hooks
+            with pytest.raises(ValueError, match="Blocked redirect"):
+                await hooks[0](redirect_response)
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_download_media_returns_bytes_for_safe_url(self, monkeypatch):
+        response = SimpleNamespace(
+            status_code=200,
+            content=b"audio-bytes",
+            text="",
+            headers={"content-type": "audio/mp4"},
+        )
+        client = CanonHttpClient("key")
+        client._client.get = AsyncMock(return_value=response)
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda _url: True)
+
+        try:
+            data, content_type = await client.download_media(
+                "https://media.example/voice.m4a"
+            )
+
+            assert data == b"audio-bytes"
+            assert content_type == "audio/mp4"
+            client._client.get.assert_awaited_once_with(
+                "https://media.example/voice.m4a",
+                headers={"User-Agent": "HermesAgent/CanonPlatform"},
+                follow_redirects=True,
+            )
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_runtime_card_and_status_endpoints_use_agent_api(self):
+        client = CanonHttpClient("key")
+        calls = []
+
+        async def fake_request(method, path, *, params=None, json_body=None):
+            calls.append((method, path, params, json_body))
+            if path == "/runtime-input/request":
+                return {"success": True, "messageId": "input-card"}
+            if path == "/runtime-card/request":
+                return {"success": True, "messageId": "runtime-card", "cardId": "card-1"}
+            if path == "/runtime-approval/request":
+                return {"success": True, "messageId": "approval-card"}
+            if path == "/runtime-input/consume":
+                return {"status": "submitted", "inputId": "input-1", "answers": {"field": {"answers": ["supplier"]}}}
+            if path == "/runtime-card/consume":
+                return {"status": "submitted", "cardId": "card-1", "actionId": "approve"}
+            if path == "/runtime-approval/consume":
+                return {"status": "pending", "approvalId": "approval-1"}
+            if path == "/runtime/signal/consume":
+                return {"status": "none"}
+            return {"ok": True}
+
+        client._request_json = fake_request
+
+        try:
+            await client.update_runtime_status(
+                runtime="hermes",
+                runtime_descriptor={"coreControls": []},
+            )
+            await client.update_runtime_turn(
+                "convo-1",
+                state="thinking",
+                turn_id="turn-1",
+                queue_depth=1,
+                capabilities={"supportsQueue": True},
+            )
+            await client.update_message_disposition(
+                "convo-1",
+                "msg-1",
+                "accepted_now",
+            )
+            await client.mark_as_read("convo-1")
+            await client.create_runtime_input_request(
+                "convo-1",
+                input_id="input-1",
+                kind="clarify",
+                expires_at=1234,
+                prompt="Pick one",
+                choices=[{"label": "A", "value": "a"}],
+                questions=[{"id": "field", "question": "Which field?"}],
+                response_user_id="owner-1",
+                turn_id="turn-1",
+            )
+            await client.consume_runtime_input_response("convo-1", "input-1")
+            await client.create_runtime_card_request(
+                "convo-1",
+                card={
+                    "schema": "canon.card.v1",
+                    "title": "Review",
+                    "fallbackText": "Review",
+                    "blocks": [{"kind": "actions", "actions": [{"id": "approve", "label": "Approve"}]}],
+                },
+                card_id="card-1",
+                expires_at=1234,
+                response_user_id="owner-1",
+                runtime_id="hermes",
+                turn_id="turn-1",
+            )
+            await client.consume_runtime_card_response("convo-1", "card-1")
+            await client.create_runtime_approval_request(
+                "convo-1",
+                approval_id="approval-1",
+                tool_name="Command",
+                tool_summary="Run command",
+                expires_at=1234,
+            )
+            await client.consume_runtime_approval_response("convo-1", "approval-1")
+            await client.consume_runtime_signal("convo-1")
+        finally:
+            await client.close()
+
+        assert [call[1] for call in calls] == [
+            "/runtime/status",
+            "/runtime/turn",
+            "/conversations/convo-1/messages/msg-1/disposition",
+            "/conversations/convo-1/read",
+            "/runtime-input/request",
+            "/runtime-input/consume",
+            "/runtime-card/request",
+            "/runtime-card/consume",
+            "/runtime-approval/request",
+            "/runtime-approval/consume",
+            "/runtime/signal/consume",
+        ]
+        assert calls[1][3] == {
+            "conversationId": "convo-1",
+            "state": "thinking",
+            "queueDepth": 1,
+            "turnId": "turn-1",
+            "capabilities": {"supportsQueue": True},
+        }
+        assert calls[2][3] == {"inboundDisposition": "accepted_now"}
+        assert calls[3][3] is None
+        assert calls[4][3] == {
+            "conversationId": "convo-1",
+            "inputId": "input-1",
+            "kind": "clarify",
+            "expiresAt": 1234,
+            "prompt": "Pick one",
+            "choices": [{"label": "A", "value": "a"}],
+            "questions": [{"id": "field", "question": "Which field?"}],
+            "responseUserId": "owner-1",
+            "turnId": "turn-1",
+        }
+        assert calls[6][3] == {
+            "conversationId": "convo-1",
+            "cardId": "card-1",
+            "card": {
+                "schema": "canon.card.v1",
+                "title": "Review",
+                "fallbackText": "Review",
+                "blocks": [{"kind": "actions", "actions": [{"id": "approve", "label": "Approve"}]}],
+            },
+            "expiresAt": 1234,
+            "responseUserId": "owner-1",
+            "runtimeId": "hermes",
+            "turnId": "turn-1",
+        }
+
+
+class TestCanonInbound:
+    def test_message_text_includes_rich_contact_card_identity(self):
+        text = _canon._message_text(
+            {
+                "contentType": "contact_card",
+                "text": "Please meet Moty.",
+                "contactCard": {
+                    "userId": "agent-moty",
+                    "displayName": "Moty",
+                    "userType": "ai_agent",
+                    "ownerName": "Matan",
+                    "about": "Invoice review agent",
+                },
+            }
+        )
+
+        assert text == (
+            '[Contact card] "Moty" - ai_agent; userId: agent-moty; '
+            "owner: Matan; about: Invoice review agent\n"
+            "Please meet Moty."
+        )
+
+    class FakeClient:
+        def __init__(self, *, fail_read: bool = False):
+            self.dispositions = []
+            self.reads = []
+            self.fail_read = fail_read
+
+        async def update_message_disposition(
+            self,
+            conversation_id,
+            message_id,
+            inbound_disposition,
+        ):
+            self.dispositions.append((conversation_id, message_id, inbound_disposition))
+
+        async def mark_as_read(self, conversation_id):
+            if self.fail_read:
+                raise RuntimeError("read failed")
+            self.reads.append(conversation_id)
+
+    @staticmethod
+    def _message_event(*, message_id="msg-1", metadata=None):
+        from gateway.config import Platform
+        from gateway.platforms.base import MessageEvent
+        from gateway.session import SessionSource
+
+        return MessageEvent(
+            text="hello",
+            source=SessionSource(
+                platform=Platform("canon"),
+                chat_id="convo-1",
+                user_id="human-1",
+            ),
+            message_id=message_id,
+            raw_message={"message": {"metadata": metadata or {}}},
+            delivery_intent=(metadata or {}).get("deliveryIntent"),
+        )
+
+    @staticmethod
+    def _gateway_runner(adapter, *, authorized=True):
+        from gateway.config import GatewayConfig, PlatformConfig
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            platforms={adapter.platform: PlatformConfig(enabled=True)}
+        )
+        runner.adapters = {adapter.platform: adapter}
+        runner.session_store = None
+        runner.pairing_store = MagicMock()
+        runner.pairing_store.is_approved.return_value = False
+        runner.pairing_store._is_rate_limited.return_value = False
+        runner._running_agents = {}
+        runner._running_agents_ts = {}
+        runner._pending_messages = {}
+        runner._queued_events = {}
+        runner._busy_ack_ts = {}
+        runner._update_prompt_pending = {}
+        runner._session_run_generation = {}
+        runner._draining = False
+        runner._is_user_authorized = MagicMock(return_value=authorized)
+        runner._get_unauthorized_dm_behavior = MagicMock(return_value="ignore")
+        runner._handle_message_with_agent = AsyncMock(
+            return_value={"final_response": "", "messages": []}
+        )
+        return runner
+
+    @pytest.mark.asyncio
+    async def test_message_created_normalizes_to_message_event(self):
+        from gateway.platforms.base import MessageType
+
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        adapter._agent_id = "agent-1"
+        adapter._conversation_cache["convo-1"] = {
+            "id": "convo-1",
+            "type": "group",
+            "name": "Research",
+        }
+        adapter.handle_message = AsyncMock()
+
+        await adapter._handle_message_payload({
+            "conversationId": "convo-1",
+            "message": {
+                "id": "msg-1",
+                "senderId": "human-1",
+                "senderName": "Ada",
+                "text": "/status please",
+                "contentType": "text",
+                "replyTo": "msg-parent",
+                "metadata": {"deliveryIntent": "queue"},
+            },
+        })
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        assert event.text == "/status please"
+        assert event.message_type == MessageType.COMMAND
+        assert event.message_id == "msg-1"
+        assert event.reply_to_message_id == "msg-parent"
+        assert event.delivery_intent == "queue"
+        assert event.source.platform.value == "canon"
+        assert event.source.chat_id == "convo-1"
+        assert event.source.chat_type == "group"
+        assert event.source.chat_name == "Research"
+        assert event.source.user_id == "human-1"
+        assert event.source.user_name == "Ada"
+        assert "did not structurally mention" in event.channel_prompt
+
+    @pytest.mark.asyncio
+    async def test_group_mentions_surface_in_channel_prompt(self):
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        adapter._agent_id = "agent-1"
+        adapter._conversation_cache["convo-1"] = {
+            "id": "convo-1",
+            "type": "group",
+            "name": "Research",
+        }
+        adapter.handle_message = AsyncMock()
+
+        await adapter._handle_message_payload({
+            "conversationId": "convo-1",
+            "message": {
+                "id": "msg-mention",
+                "senderId": "human-1",
+                "senderName": "Ada",
+                "mentions": ["agent-1"],
+                "text": "@Leonardo can you check this?",
+            },
+        })
+
+        event = adapter.handle_message.await_args.args[0]
+        assert "explicitly mentioned this agent" in event.channel_prompt
+
+    @pytest.mark.asyncio
+    async def test_ignores_self_messages_and_duplicates(self):
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        adapter._agent_id = "agent-1"
+        fake = self.FakeClient()
+        adapter._client = fake
+        adapter.handle_message = AsyncMock()
+
+        payload = {
+            "conversationId": "convo-1",
+            "message": {
+                "id": "msg-1",
+                "senderId": "agent-1",
+                "text": "own echo",
+                "contentType": "text",
+            },
+        }
+        await adapter._handle_message_payload(payload)
+        adapter.handle_message.assert_not_awaited()
+
+        payload["message"]["senderId"] = "human-1"
+        await adapter._handle_message_payload(payload)
+        await adapter._handle_message_payload(payload)
+        adapter.handle_message.assert_awaited_once()
+        assert fake.reads == []
+
+    @pytest.mark.asyncio
+    async def test_attachment_only_message_gets_text_placeholder(self):
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        adapter.handle_message = AsyncMock()
+
+        await adapter._handle_message_payload({
+            "conversationId": "convo-1",
+            "message": {
+                "id": "msg-2",
+                "senderId": "human-1",
+                "contentType": "image",
+                "attachments": [{"kind": "image", "fileName": "plot.png"}],
+            },
+        })
+
+        event = adapter.handle_message.await_args.args[0]
+        assert event.text == "[image attachment: plot.png]"
+        assert event.source.chat_type == "dm"
+
+    @pytest.mark.asyncio
+    async def test_runtime_control_messages_do_not_dispatch_as_user_prompts(self):
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        fake = self.FakeClient()
+        adapter._client = fake
+        adapter.handle_message = AsyncMock()
+
+        await adapter._handle_message_payload({
+            "conversationId": "convo-1",
+            "message": {
+                "id": "msg-control",
+                "senderId": "owner-1",
+                "text": "Approved.",
+                "metadata": {
+                    "type": "approval_reply",
+                    "approvalId": "approval-1",
+                    "decision": "allow",
+                },
+            },
+        })
+
+        adapter.handle_message.assert_not_awaited()
+        assert fake.reads == []
+
+    @pytest.mark.asyncio
+    async def test_runtime_signal_dispatches_hermes_session_command(self):
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        adapter._agent_id = "agent-1"
+        adapter._conversation_cache["convo-1"] = {
+            "id": "convo-1",
+            "type": "dm",
+            "displayName": "Matan",
+        }
+        adapter.handle_message = AsyncMock()
+
+        await adapter._handle_runtime_signal("convo-1", "new_session")
+
+        event = adapter.handle_message.await_args.args[0]
+        assert event.text == "/new"
+        assert event.source.chat_id == "convo-1"
+        assert event.source.user_id == "agent-1"
+
+    @pytest.mark.asyncio
+    async def test_runtime_signal_uses_native_control_handler_when_available(self):
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        adapter._agent_id = "agent-1"
+        adapter._conversation_cache["convo-1"] = {"id": "convo-1", "type": "dm"}
+        adapter.handle_message = AsyncMock()
+        adapter._publish_runtime_turn = AsyncMock()
+        handler = AsyncMock(return_value=True)
+        adapter.set_runtime_control_handler(handler)
+
+        await adapter._handle_runtime_signal("convo-1", "stop_and_drop")
+
+        handler.assert_awaited_once()
+        event, session_key, signal = handler.await_args.args
+        assert event.text == ""
+        assert event.source.chat_id == "convo-1"
+        assert session_key
+        assert signal == "stop_and_drop"
+        adapter.handle_message.assert_not_awaited()
+        adapter._publish_runtime_turn.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_runtime_status_publishes_host_mode(self):
+        class FakeClient:
+            def __init__(self):
+                self.calls = []
+
+            async def update_runtime_status(self, **kwargs):
+                self.calls.append(kwargs)
+
+        client = FakeClient()
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        adapter._client = client
+
+        await adapter._publish_runtime_status()
+
+        assert client.calls[0]["host_mode"] is True
+        descriptor = client.calls[0]["runtime_descriptor"]
+        assert descriptor["supportsInputInterrupt"] is True
+        assert "actions" not in descriptor
+        assert any(command["id"] == "stop-and-clear-queue" for command in descriptor["commands"])
+
+    @pytest.mark.asyncio
+    async def test_runtime_signal_preserves_canon_actor_for_group_sessions(self):
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        adapter._agent_id = "agent-1"
+        adapter._conversation_cache["convo-1"] = {
+            "id": "convo-1",
+            "type": "group",
+            "name": "Research",
+        }
+        adapter.handle_message = AsyncMock()
+
+        await adapter._handle_runtime_signal(
+            "convo-1",
+            "interrupt",
+            updated_by="owner-1",
+        )
+
+        event = adapter.handle_message.await_args.args[0]
+        assert event.text == "/stop"
+        assert event.source.chat_type == "group"
+        assert event.source.user_id == "owner-1"
+
+    @pytest.mark.asyncio
+    async def test_runtime_signal_poll_passes_updated_by(self):
+        class FakeClient:
+            async def consume_runtime_signal(self, conversation_id):
+                assert conversation_id == "convo-1"
+                return {
+                    "status": "signal",
+                    "signal": "new_session",
+                    "updatedBy": "owner-1",
+                }
+
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        adapter._client = FakeClient()
+        adapter._conversation_cache["convo-1"] = {"id": "convo-1", "type": "group"}
+        adapter._handle_runtime_signal = AsyncMock()
+
+        await adapter._poll_runtime_signals_once()
+
+        adapter._handle_runtime_signal.assert_awaited_once_with(
+            "convo-1",
+            "new_session",
+            updated_by="owner-1",
+        )
+
+    @pytest.mark.asyncio
+    async def test_audio_and_video_attachments_are_materialized(self, monkeypatch):
+        from gateway.platforms.base import MessageType
+
+        class FakeClient:
+            async def download_media(self, url):
+                if url.endswith("voice.m4a"):
+                    return b"audio-bytes", "audio/mp4"
+                return b"video-bytes", "video/mp4"
+
+        monkeypatch.setattr(
+            _canon,
+            "cache_audio_from_bytes",
+            lambda data, ext=".ogg": f"/tmp/canon-audio{ext}",
+        )
+        monkeypatch.setattr(
+            _canon,
+            "cache_video_from_bytes",
+            lambda data, ext=".mp4": f"/tmp/canon-video{ext}",
+        )
+
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        adapter._client = FakeClient()
+        adapter.handle_message = AsyncMock()
+
+        await adapter._handle_message_payload({
+            "conversationId": "convo-1",
+            "message": {
+                "id": "msg-media",
+                "senderId": "human-1",
+                "text": "review these",
+                "contentType": "file",
+                "attachments": [
+                    {"kind": "audio", "url": "https://media.example/voice.m4a"},
+                    {"kind": "file", "url": "https://media.example/demo.mp4"},
+                ],
+            },
+        })
+
+        event = adapter.handle_message.await_args.args[0]
+        assert event.message_type == MessageType.VOICE
+        assert event.media_urls == ["/tmp/canon-audio.m4a", "/tmp/canon-video.mp4"]
+        assert event.media_types == ["audio/mp4", "video/mp4"]
+
+    @pytest.mark.asyncio
+    async def test_gateway_message_accepted_marks_accepted_message_read(self):
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        fake = self.FakeClient()
+        adapter._client = fake
+
+        await adapter.on_gateway_message_accepted(
+            self._message_event(metadata={"inboundDisposition": "queued"}),
+            "session-1",
+        )
+
+        assert fake.dispositions == [("convo-1", "msg-1", "accepted_now")]
+        assert fake.reads == ["convo-1"]
+
+    @pytest.mark.asyncio
+    async def test_runtime_turn_start_only_publishes_runtime_turn(self):
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        fake = self.FakeClient()
+        adapter._client = fake
+        adapter._publish_runtime_turn = AsyncMock()
+
+        await adapter._on_runtime_turn_start(
+            self._message_event(metadata={"inboundDisposition": "queued"}),
+            "session-1",
+        )
+
+        assert fake.dispositions == []
+        assert fake.reads == []
+        adapter._publish_runtime_turn.assert_awaited_once_with(
+            "convo-1",
+            "thinking",
+            session_key="session-1",
+            active_message_ids=["msg-1"],
+        )
+
+    @pytest.mark.asyncio
+    async def test_gateway_message_accepted_read_failure_is_non_fatal(self):
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        fake = self.FakeClient(fail_read=True)
+        adapter._client = fake
+
+        await adapter.on_gateway_message_accepted(self._message_event(), "session-1")
+
+        assert fake.dispositions == []
+        assert fake.reads == []
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_gateway_message_does_not_mark_read(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *args, **kwargs: [])
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        fake = self.FakeClient()
+        adapter._client = fake
+        runner = self._gateway_runner(adapter, authorized=False)
+
+        result = await runner._handle_message(self._message_event())
+
+        assert result is None
+        assert fake.dispositions == []
+        assert fake.reads == []
+        runner._handle_message_with_agent.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_pre_gateway_dispatch_skip_does_not_mark_read(self, monkeypatch):
+        def fake_hook(name, **kwargs):
+            if name == "pre_gateway_dispatch":
+                return [{"action": "skip", "reason": "plugin-handled"}]
+            return []
+
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", fake_hook)
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        fake = self.FakeClient()
+        adapter._client = fake
+        runner = self._gateway_runner(adapter, authorized=True)
+
+        result = await runner._handle_message(self._message_event())
+
+        assert result is None
+        assert fake.dispositions == []
+        assert fake.reads == []
+        runner._is_user_authorized.assert_not_called()
+        runner._handle_message_with_agent.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_authorized_gateway_message_marks_read(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *args, **kwargs: [])
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        fake = self.FakeClient()
+        adapter._client = fake
+        runner = self._gateway_runner(adapter, authorized=True)
+
+        result = await runner._handle_message(self._message_event())
+
+        assert result == {"final_response": "", "messages": []}
+        assert fake.dispositions == []
+        assert fake.reads == ["convo-1"]
+        runner._handle_message_with_agent.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_queued_busy_message_waits_until_active_turn_to_mark_read(self, monkeypatch):
+        from gateway.session import build_session_key
+        from gateway.run import GatewayRunner
+
+        monkeypatch.setenv("HERMES_GATEWAY_BUSY_ACK_ENABLED", "false")
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        fake = self.FakeClient()
+        adapter._client = fake
+        runner = self._gateway_runner(adapter, authorized=True)
+        runner._busy_input_mode = "interrupt"
+        event = self._message_event(
+            metadata={"deliveryIntent": "queue", "inboundDisposition": "queued"}
+        )
+        session_key = build_session_key(event.source)
+        runner._running_agents[session_key] = MagicMock()
+
+        result = await GatewayRunner._handle_active_session_busy_message(
+            runner,
+            event,
+            session_key,
+        )
+
+        assert result is True
+        assert adapter._pending_messages[session_key] is event
+        assert fake.dispositions == []
+        assert fake.reads == []
+
+        await adapter.on_gateway_message_accepted(
+            event,
+            session_key,
+            phase="queued_turn",
+        )
+
+        assert fake.dispositions == [("convo-1", "msg-1", "accepted_now")]
+        assert fake.reads == ["convo-1"]
+
+
+class TestCanonOutbound:
+    class FakeClient:
+        def __init__(self):
+            self.sent = []
+            self.streaming = []
+            self.streaming_cleared = []
+            self.runtime_turns = []
+            self.typing = []
+            self.uploads = []
+            self.runtime_inputs = []
+            self.runtime_input_responses = []
+            self.runtime_approvals = []
+            self.runtime_approval_responses = []
+            self.closed = False
+
+        async def send_message(
+            self, conversation_id, text, *, reply_to=None, metadata=None, options=None
+        ):
+            self.sent.append({
+                "conversation_id": conversation_id,
+                "text": text,
+                "reply_to": reply_to,
+                "metadata": metadata,
+                "options": options,
+            })
+            return {"messageId": "msg-out"}
+
+        async def set_streaming(self, conversation_id, *, text, status="streaming", turn_id=None):
+            self.streaming.append((conversation_id, text, status, turn_id))
+
+        async def clear_streaming(self, conversation_id):
+            self.streaming_cleared.append(conversation_id)
+
+        async def update_runtime_turn(self, conversation_id, **kwargs):
+            self.runtime_turns.append((conversation_id, kwargs))
+
+        async def set_typing(self, conversation_id, typing, status=None):
+            self.typing.append((conversation_id, typing, status))
+
+        async def upload_media(
+            self, conversation_id, data, mime_type, *, file_name=None
+        ):
+            self.uploads.append((conversation_id, data, mime_type, file_name))
+            kind = "audio" if mime_type.startswith("audio/") else "file"
+            return {
+                "url": f"https://media.example/{file_name}",
+                "attachment": {
+                    "kind": kind,
+                    "url": f"https://media.example/{file_name}",
+                    "mimeType": mime_type,
+                    "fileName": file_name,
+                },
+            }
+
+        async def download_media(self, url):
+            return b"remote-image-bytes", "image/png"
+
+        async def create_runtime_input_request(self, conversation_id, **kwargs):
+            self.runtime_inputs.append((conversation_id, kwargs))
+            return {"messageId": "input-card"}
+
+        async def consume_runtime_input_response(self, conversation_id, input_id, *, cancel=False):
+            self.runtime_input_responses.append((conversation_id, input_id, cancel))
+            return {
+                "status": "submitted",
+                "inputId": input_id,
+                "kind": "clarify",
+                "value": "Use option B",
+            }
+
+        async def create_runtime_approval_request(self, conversation_id, **kwargs):
+            self.runtime_approvals.append((conversation_id, kwargs))
+            return {"messageId": "approval-card"}
+
+        async def consume_runtime_approval_response(self, conversation_id, approval_id, *, cancel=False):
+            self.runtime_approval_responses.append((conversation_id, approval_id, cancel))
+            return {
+                "status": "allow",
+                "approvalId": approval_id,
+                "sessionRule": {"type": "approve-tool", "toolPattern": "Command"},
+            }
+
+        async def close(self):
+            self.closed = True
+
+    @pytest.mark.asyncio
+    async def test_send_posts_turn_complete_metadata(self):
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        fake = self.FakeClient()
+        adapter._client = fake
+
+        result = await adapter.send(
+            "convo-1",
+            "hello",
+            reply_to="msg-parent",
+            metadata={
+                "canon_metadata": {"source": "test"},
+                "canon_options": {"mentions": ["u1"]},
+            },
+        )
+
+        assert result.success is True
+        assert result.message_id == "msg-out"
+        assert fake.sent[0]["conversation_id"] == "convo-1"
+        assert fake.sent[0]["text"] == "hello"
+        assert fake.sent[0]["reply_to"] == "msg-parent"
+        assert fake.sent[0]["metadata"] == {
+            "source": "test",
+            **TURN_COMPLETE_METADATA,
+        }
+        assert fake.sent[0]["options"] == {"mentions": ["u1"]}
+
+    @pytest.mark.asyncio
+    async def test_streaming_preview_uses_live_snapshot_until_final_edit(self, monkeypatch):
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        fake = self.FakeClient()
+        adapter._client = fake
+        monkeypatch.setattr(_canon.asyncio, "sleep", AsyncMock())
+
+        preview = await adapter.send(
+            "convo-1",
+            "Hel",
+            metadata={"canon_streaming_preview": True},
+        )
+        final = await adapter.edit_message(
+            "convo-1",
+            preview.message_id or "",
+            "Hello",
+            finalize=True,
+            metadata={"canon_streaming_preview": True},
+        )
+
+        assert preview.success is True
+        assert fake.streaming == [
+            ("convo-1", "Hel", "streaming", preview.message_id),
+        ]
+        assert final.success is True
+        assert fake.sent == [
+            {
+                "conversation_id": "convo-1",
+                "text": "Hello",
+                "reply_to": None,
+                "metadata": {**TURN_COMPLETE_METADATA, "turnId": preview.message_id},
+                "options": {},
+            }
+        ]
+        assert fake.streaming_cleared == ["convo-1"]
+
+    @pytest.mark.asyncio
+    async def test_stream_consumer_same_text_finalizes_streaming_preview(self, monkeypatch):
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        fake = self.FakeClient()
+        adapter._client = fake
+        monkeypatch.setattr(_canon.asyncio, "sleep", AsyncMock())
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "convo-1",
+            config=StreamConsumerConfig(cursor=""),
+            metadata={"canon_streaming_preview": True},
+        )
+
+        assert adapter.REQUIRES_EDIT_FINALIZE is True
+        assert await consumer._send_or_edit("Hello") is True
+        assert await consumer._send_or_edit("Hello", finalize=True) is True
+
+        turn_id = fake.streaming[0][3]
+        assert fake.streaming == [
+            ("convo-1", "Hello", "streaming", turn_id),
+        ]
+        assert fake.sent == [
+            {
+                "conversation_id": "convo-1",
+                "text": "Hello",
+                "reply_to": None,
+                "metadata": {**TURN_COMPLETE_METADATA, "turnId": turn_id},
+                "options": {},
+            }
+        ]
+        assert fake.streaming_cleared == ["convo-1"]
+
+    @pytest.mark.asyncio
+    async def test_typing_is_best_effort(self):
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        fake = self.FakeClient()
+        adapter._client = fake
+
+        await adapter.send_typing("convo-1")
+        await adapter.stop_typing("convo-1")
+
+        assert fake.typing == [
+            ("convo-1", True, "thinking"),
+            ("convo-1", False, None),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_send_voice_uploads_audio_attachment(self, tmp_path):
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        fake = self.FakeClient()
+        adapter._client = fake
+        audio_path = tmp_path / "reply.mp3"
+        audio_path.write_bytes(b"audio-bytes")
+
+        result = await adapter.send_voice(
+            "convo-1", str(audio_path), caption="voice reply"
+        )
+
+        assert result.success is True
+        assert fake.uploads[0][2] == "audio/mpeg"
+        sent = fake.sent[0]
+        assert sent["text"] == "voice reply"
+        assert sent["options"]["contentType"] == "audio"
+        assert sent["options"]["attachments"][0]["kind"] == "audio"
+        assert sent["metadata"] == TURN_COMPLETE_METADATA
+
+    @pytest.mark.asyncio
+    async def test_send_remote_image_reuploads_attachment(self):
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        fake = self.FakeClient()
+        adapter._client = fake
+
+        result = await adapter.send_image(
+            "convo-1",
+            "https://cdn.example.test/invoice.png?token=secret",
+            caption="invoice",
+        )
+
+        assert result.success is True
+        assert fake.uploads[0][0] == "convo-1"
+        assert fake.uploads[0][2] == "image/png"
+        sent = fake.sent[0]
+        assert sent["text"] == "invoice"
+        assert sent["options"]["contentType"] == "image"
+        assert sent["options"]["attachments"][0]["kind"] == "image"
+        assert sent["options"]["attachments"][0]["url"].startswith("https://media.example/")
+
+    @pytest.mark.asyncio
+    async def test_send_video_uploads_video_attachment_with_video_mime(self, tmp_path):
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        fake = self.FakeClient()
+        adapter._client = fake
+        video_path = tmp_path / "demo.mp4"
+        video_path.write_bytes(b"video-bytes")
+
+        result = await adapter.send_video("convo-1", str(video_path))
+
+        assert result.success is True
+        assert fake.uploads[0][2] == "video/mp4"
+        sent = fake.sent[0]
+        assert sent["options"]["contentType"] == "video"
+        assert sent["options"]["attachments"][0]["kind"] == "video"
+        assert sent["options"]["attachments"][0]["mimeType"] == "video/mp4"
+
+    @pytest.mark.asyncio
+    async def test_send_clarify_creates_runtime_input_card_and_resolves(self, monkeypatch):
+        resolved = []
+        monkeypatch.setattr(
+            "tools.clarify_gateway.resolve_gateway_clarify",
+            lambda input_id, value: resolved.append((input_id, value)) or True,
+        )
+
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        fake = self.FakeClient()
+        adapter._client = fake
+
+        result = await adapter.send_clarify(
+            "convo-1",
+            "Which branch?",
+            ["main", "backup"],
+            "clarify-1",
+            "session-1",
+        )
+
+        assert result.success is True
+        assert result.message_id == "input-card"
+        assert fake.runtime_inputs[0][0] == "convo-1"
+        assert fake.runtime_inputs[0][1]["kind"] == "clarify"
+        assert fake.runtime_inputs[0][1]["prompt"] == "Which branch?"
+        assert fake.runtime_inputs[0][1]["choices"] == [
+            {"label": "main", "value": "main"},
+            {"label": "backup", "value": "backup"},
+        ]
+        await asyncio.wait_for(_wait_for(lambda: bool(resolved)), timeout=1)
+        assert resolved == [("clarify-1", "Use option B")]
+
+    @pytest.mark.asyncio
+    async def test_send_clarify_resolves_structured_answers(self, monkeypatch):
+        resolved = []
+        monkeypatch.setattr(
+            "tools.clarify_gateway.resolve_gateway_clarify",
+            lambda input_id, value: resolved.append((input_id, value)) or True,
+        )
+
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        fake = self.FakeClient()
+
+        async def structured_response(conversation_id, input_id, *, cancel=False):
+            fake.runtime_input_responses.append((conversation_id, input_id, cancel))
+            return {
+                "status": "submitted",
+                "inputId": input_id,
+                "kind": "clarify",
+                "value": "",
+                "answers": {
+                    "field": {"answers": ["pre_vat_total"]},
+                    "new_value": {"answers": ["900.00"]},
+                },
+            }
+
+        fake.consume_runtime_input_response = structured_response
+        adapter._client = fake
+
+        result = await adapter.send_clarify(
+            "convo-1",
+            "Which field?",
+            [],
+            "clarify-structured",
+            "session-1",
+        )
+
+        assert result.success is True
+        await asyncio.wait_for(_wait_for(lambda: bool(resolved)), timeout=1)
+        assert resolved == [("clarify-structured", "field: pre_vat_total\nnew_value: 900.00")]
+
+    @pytest.mark.asyncio
+    async def test_send_clarify_preserves_blank_legacy_value(self, monkeypatch):
+        resolved = []
+        monkeypatch.setattr(
+            "tools.clarify_gateway.resolve_gateway_clarify",
+            lambda input_id, value: resolved.append((input_id, value)) or True,
+        )
+
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        fake = self.FakeClient()
+
+        async def blank_response(conversation_id, input_id, *, cancel=False):
+            fake.runtime_input_responses.append((conversation_id, input_id, cancel))
+            return {
+                "status": "submitted",
+                "inputId": input_id,
+                "kind": "clarify",
+                "value": "",
+                "choice": {"value": "fallback-choice", "label": "Fallback choice"},
+            }
+
+        fake.consume_runtime_input_response = blank_response
+        adapter._client = fake
+
+        result = await adapter.send_clarify(
+            "convo-1",
+            "Optional note?",
+            [],
+            "clarify-blank",
+            "session-1",
+        )
+
+        assert result.success is True
+        await asyncio.wait_for(_wait_for(lambda: bool(resolved)), timeout=1)
+        assert resolved == [("clarify-blank", "")]
+
+    @pytest.mark.asyncio
+    async def test_send_exec_approval_creates_approval_card_and_resolves_session(self, monkeypatch):
+        resolved = []
+        monkeypatch.setattr(
+            "tools.approval.resolve_gateway_approval",
+            lambda session_key, choice, resolve_all=False: resolved.append((session_key, choice)) or 1,
+        )
+
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        fake = self.FakeClient()
+        adapter._client = fake
+
+        result = await adapter.send_exec_approval(
+            "convo-1",
+            "rm -rf tmp",
+            "session-1",
+            "delete files",
+        )
+
+        assert result.success is True
+        assert result.message_id == "approval-card"
+        assert fake.runtime_approvals[0][0] == "convo-1"
+        request = fake.runtime_approvals[0][1]
+        assert request["tool_name"] == "Command"
+        assert request["tool_summary"] == "delete files"
+        assert request["details"][0] == {
+            "label": "Command",
+            "value": "rm -rf tmp",
+            "monospace": True,
+        }
+        await asyncio.wait_for(_wait_for(lambda: bool(resolved)), timeout=1)
+        assert resolved == [("session-1", "session")]
+
+
+class TestCanonLifecycle:
+    class FakeClient:
+        def __init__(self):
+            self.closed = False
+
+        async def get_me(self):
+            return {"agentId": "agent-1", "displayName": "Hermes"}
+
+        async def get_conversations(self):
+            return [{"id": "convo-1", "type": "direct", "name": "Ada"}]
+
+        async def close(self):
+            self.closed = True
+
+    @pytest.mark.asyncio
+    async def test_connect_hydrates_identity_and_conversations(self, monkeypatch):
+        monkeypatch.delenv("HERMES_CANON_AGENT_NAME", raising=False)
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        fake = self.FakeClient()
+        block = asyncio.Event()
+
+        async def fake_stream_loop():
+            await block.wait()
+
+        adapter._make_client = lambda: fake
+        adapter._stream_loop = fake_stream_loop
+
+        assert await adapter.connect() is True
+        assert adapter.is_connected is True
+        assert adapter._agent_id == "agent-1"
+        assert adapter.profile_agent_name == "Hermes"
+        assert os.environ["HERMES_CANON_AGENT_NAME"] == "Hermes"
+        assert adapter._conversation_cache["convo-1"]["name"] == "Ada"
+
+        block.set()
+        await adapter.disconnect()
+        assert fake.closed is True
+        assert adapter.is_connected is False
+
+    @pytest.mark.asyncio
+    async def test_connect_treats_unauthorized_as_fatal_reconfiguration(self):
+        class UnauthorizedClient:
+            closed = False
+
+            async def get_me(self):
+                raise CanonApiError(401, "bad key")
+
+            async def close(self):
+                self.closed = True
+
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        fake = UnauthorizedClient()
+        adapter._make_client = lambda: fake
+
+        assert await adapter.connect() is False
+        assert fake.closed is True
+        assert adapter.is_connected is False
+        assert adapter.fatal_error_code == "auth_failed"
+        assert adapter.fatal_error_retryable is False
+
+    @pytest.mark.asyncio
+    async def test_stream_frame_dispatches_message_created(self):
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        adapter._handle_message_payload = AsyncMock()
+
+        frame = CanonStreamFrame(
+            event="message.created",
+            data={"conversationId": "convo-1", "message": {"id": "m1"}},
+            event_id="evt-1",
+        )
+        await adapter._handle_stream_frame(frame)
+
+        adapter._handle_message_payload.assert_awaited_once_with(frame.data)
+
+
+class TestCanonSSE:
+    def test_parse_sse_frame(self):
+        frame = _parse_sse_frame(
+            'id: evt-1\nevent: message.created\ndata: {"conversationId":"convo-1"}'
+        )
+
+        assert frame.event == "message.created"
+        assert frame.event_id == "evt-1"
+        assert frame.data == {"conversationId": "convo-1"}
+
+    def test_parse_sse_frame_ignores_comments(self):
+        frame = _parse_sse_frame(": keepalive\nevent: heartbeat\ndata: ok")
+
+        assert frame.event == "heartbeat"
+        assert frame.data == "ok"
+
+
+class TestCanonStandalone:
+    class FakeClient:
+        instances = []
+
+        def __init__(
+            self, api_key, *, base_url=DEFAULT_BASE_URL, stream_url=DEFAULT_STREAM_URL
+        ):
+            self.api_key = api_key
+            self.base_url = base_url
+            self.stream_url = stream_url
+            self.sent = []
+            self.closed = False
+            self.instances.append(self)
+
+        async def send_message(
+            self, conversation_id, text, *, reply_to=None, metadata=None, options=None
+        ):
+            self.sent.append((conversation_id, text, reply_to, metadata, options))
+            return {"messageId": "standalone-1"}
+
+        async def close(self):
+            self.closed = True
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_uses_home_channel_and_closes(self, monkeypatch):
+        self.FakeClient.instances = []
+        monkeypatch.setattr(_canon, "CanonHttpClient", self.FakeClient)
+        monkeypatch.setenv("CANON_API_KEY", "env-key")
+        monkeypatch.setenv("CANON_HOME_CHANNEL", "convo-home")
+
+        result = await _standalone_send(_config(), "", "hello cron")
+
+        client = self.FakeClient.instances[0]
+        assert result == {"success": True, "message_id": "standalone-1"}
+        assert client.api_key == "env-key"
+        assert client.sent == [
+            ("convo-home", "hello cron", None, TURN_COMPLETE_METADATA, None)
+        ]
+        assert client.closed is True
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_errors_without_api_key(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("CANON_HOME", str(tmp_path))
+        monkeypatch.delenv("CANON_API_KEY", raising=False)
+        monkeypatch.delenv("CANON_AGENT", raising=False)
+        monkeypatch.delenv("CANON_AGENTS_JSON_BOOTSTRAP", raising=False)
+
+        result = await _standalone_send(_config(), "convo-1", "hello")
+
+        assert "error" in result
+        assert "credentials" in result["error"]
+
+
+class TestCanonRegister:
+    def test_register_metadata(self):
+        recorded = {}
+        tools = {}
+
+        class Context:
+            def register_tool(self, **kwargs):
+                tools[kwargs["name"]] = kwargs
+
+            def register_platform(self, **kwargs):
+                recorded.update(kwargs)
+
+        register(Context())
+
+        assert "canon_runtime_control" in tools
+        assert recorded["name"] == "canon"
+        assert recorded["label"] == "Canon"
+        assert recorded["required_env"] == []
+        assert callable(recorded["setup_fn"])
+        assert recorded["cron_deliver_env_var"] == "CANON_HOME_CHANNEL"
+        assert recorded["standalone_sender_fn"] is _standalone_send
+        assert recorded["allowed_users_env"] == "CANON_ALLOWED_USERS"
+        assert recorded["allow_all_env"] == "CANON_ALLOW_ALL_USERS"
+        assert recorded["group_allowed_users_env"] == "CANON_GROUP_ALLOWED_USERS"
+        assert recorded["group_allowed_chats_env"] == "CANON_GROUP_ALLOWED_CONVERSATIONS"
+        assert recorded["max_message_length"] == 3900

--- a/tests/gateway/test_config_driven_access_policy.py
+++ b/tests/gateway/test_config_driven_access_policy.py
@@ -261,6 +261,80 @@ def test_non_owning_platform_still_default_denies(monkeypatch):
     assert runner._is_user_authorized(_source(Platform.TELEGRAM)) is False
 
 
+def test_plugin_group_allowed_chats_authorizes_without_sender(monkeypatch):
+    """Plugin-declared group chat allowlists authorize anonymous group traffic."""
+    from gateway.platform_registry import PlatformEntry, platform_registry
+
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("TESTCHAT_GROUP_ALLOWED_CONVERSATIONS", "room-1")
+    platform_registry.register(
+        PlatformEntry(
+            name="testchat",
+            label="Test Chat",
+            adapter_factory=lambda cfg: SimpleNamespace(),
+            check_fn=lambda: True,
+            group_allowed_users_env="TESTCHAT_GROUP_ALLOWED_USERS",
+            group_allowed_chats_env="TESTCHAT_GROUP_ALLOWED_CONVERSATIONS",
+        )
+    )
+    try:
+        platform = Platform("testchat")
+        config = GatewayConfig(platforms={platform: PlatformConfig(enabled=True)})
+        runner, _adapter = _make_runner(platform, config, enforces=False)
+        source = SessionSource(
+            platform=platform,
+            user_id=None,
+            chat_id="room-1",
+            user_name="anonymous",
+            chat_type="group",
+        )
+
+        assert runner._is_user_authorized(source) is True
+    finally:
+        platform_registry.unregister("testchat")
+
+
+def test_plugin_group_allowed_users_authorizes_group_sender(monkeypatch):
+    """Plugin-declared group user allowlists are scoped to group conversations."""
+    from gateway.platform_registry import PlatformEntry, platform_registry
+
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("TESTCHAT_GROUP_ALLOWED_USERS", "group-user")
+    platform_registry.register(
+        PlatformEntry(
+            name="testchat-users",
+            label="Test Chat Users",
+            adapter_factory=lambda cfg: SimpleNamespace(),
+            check_fn=lambda: True,
+            group_allowed_users_env="TESTCHAT_GROUP_ALLOWED_USERS",
+            group_allowed_chats_env="TESTCHAT_GROUP_ALLOWED_CONVERSATIONS",
+        )
+    )
+    try:
+        platform = Platform("testchat-users")
+        config = GatewayConfig(platforms={platform: PlatformConfig(enabled=True)})
+        runner, _adapter = _make_runner(platform, config, enforces=False)
+        group_source = SessionSource(
+            platform=platform,
+            user_id="group-user",
+            chat_id="room-2",
+            user_name="tester",
+            chat_type="group",
+        )
+        dm_source = SessionSource(
+            platform=platform,
+            user_id="group-user",
+            chat_id="dm-1",
+            user_name="tester",
+            chat_type="dm",
+        )
+
+        assert runner._is_user_authorized(group_source) is True
+        assert runner._is_user_authorized(dm_source) is False
+    finally:
+        platform_registry.unregister("testchat-users")
+
+
 def test_env_allowlist_still_takes_precedence_for_own_policy_platform(monkeypatch):
     """When an env allowlist IS set, it governs — adapter trust is a fallback.
 

--- a/tests/tools/test_canon_runtime_tool.py
+++ b/tests/tools/test_canon_runtime_tool.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import pytest
+
+
+class FakeCanonClient:
+    def __init__(self):
+        self.card_requests = []
+        self.card_consumes = []
+        self.input_requests = []
+        self.input_consumes = []
+        self.card_interactive = True
+        self.closed = False
+
+    async def create_runtime_card_request(self, conversation_id, **kwargs):
+        self.card_requests.append((conversation_id, kwargs))
+        return {
+            "success": True,
+            "cardId": kwargs.get("card_id") or "card-1",
+            "interactive": self.card_interactive,
+        }
+
+    async def consume_runtime_card_response(self, conversation_id, card_id, *, cancel=False):
+        self.card_consumes.append((conversation_id, card_id, cancel))
+        return {"status": "submitted", "cardId": card_id, "actionId": "approve"}
+
+    async def create_runtime_input_request(self, conversation_id, **kwargs):
+        self.input_requests.append((conversation_id, kwargs))
+        return {"success": True, "inputId": kwargs["input_id"]}
+
+    async def consume_runtime_input_response(self, conversation_id, input_id, *, cancel=False):
+        self.input_consumes.append((conversation_id, input_id, cancel))
+        return {
+            "status": "submitted",
+            "inputId": input_id,
+            "answers": {"field": "supplier", "new_value": "4018"},
+        }
+
+    async def close(self):
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_runtime_card_helper_requests_and_consumes(monkeypatch):
+    import plugins.platforms.canon.runtime_tool as runtime_tool
+
+    fake = FakeCanonClient()
+    monkeypatch.setattr(runtime_tool, "_new_canon_client", lambda: fake)
+
+    result = await runtime_tool.request_canon_runtime_card(
+        target="canon:convo-1",
+        card={
+            "schema": "canon.card.v1",
+            "cardId": "card-1",
+            "title": "Review",
+            "fallbackText": "Review",
+            "blocks": [{"kind": "actions", "actions": [{"id": "approve", "label": "Approve"}]}],
+        },
+        response_user_id="user-1",
+        runtime_id="hermes",
+        turn_id="turn-1",
+        timeout_seconds=30,
+        native={"runtime": "hermes"},
+    )
+
+    assert result["status"] == "submitted"
+    assert result["actionId"] == "approve"
+    assert fake.card_requests == [
+        (
+            "convo-1",
+            {
+                "card": {
+                    "schema": "canon.card.v1",
+                    "cardId": "card-1",
+                    "title": "Review",
+                    "fallbackText": "Review",
+                    "blocks": [{"kind": "actions", "actions": [{"id": "approve", "label": "Approve"}]}],
+                },
+                "card_id": "card-1",
+                "expires_at": fake.card_requests[0][1]["expires_at"],
+                "response_user_id": "user-1",
+                "runtime_id": "hermes",
+                "turn_id": "turn-1",
+                "native": {"runtime": "hermes"},
+            },
+        )
+    ]
+    assert fake.card_consumes == [("convo-1", "card-1", False)]
+    assert fake.closed is True
+
+
+@pytest.mark.asyncio
+async def test_runtime_card_helper_does_not_poll_display_only_cards(monkeypatch):
+    import plugins.platforms.canon.runtime_tool as runtime_tool
+
+    fake = FakeCanonClient()
+    fake.card_interactive = False
+    monkeypatch.setattr(runtime_tool, "_new_canon_client", lambda: fake)
+
+    result = await runtime_tool.request_canon_runtime_card(
+        target="canon:convo-1",
+        card={
+            "schema": "canon.card.v1",
+            "cardId": "card-1",
+            "title": "Summary",
+            "fallbackText": "Summary",
+            "blocks": [{"kind": "summary", "text": "No action needed."}],
+        },
+        timeout_seconds=30,
+    )
+
+    assert result["status"] == "displayed"
+    assert result["cardId"] == "card-1"
+    assert fake.card_consumes == []
+    assert fake.closed is True
+
+
+@pytest.mark.asyncio
+async def test_runtime_input_helper_supports_questions_response_user_and_answers(monkeypatch):
+    import plugins.platforms.canon.runtime_tool as runtime_tool
+
+    fake = FakeCanonClient()
+    monkeypatch.setattr(runtime_tool, "_new_canon_client", lambda: fake)
+
+    result = await runtime_tool.request_canon_runtime_input(
+        target="canon:convo-2",
+        input_id="input-1",
+        kind="clarify",
+        title="Correction",
+        prompt="Pick a field",
+        questions=[
+            {
+                "id": "field",
+                "question": "Which field?",
+                "choices": [{"label": "Supplier", "value": "supplier"}],
+            }
+        ],
+        response_user_id="user-2",
+        turn_id="turn-2",
+        sensitive=False,
+        timeout_seconds=30,
+    )
+
+    assert result["status"] == "submitted"
+    assert result["answers"] == {"field": "supplier", "new_value": "4018"}
+    assert fake.input_requests == [
+        (
+            "convo-2",
+            {
+                "input_id": "input-1",
+                "kind": "clarify",
+                "expires_at": fake.input_requests[0][1]["expires_at"],
+                "title": "Correction",
+                "prompt": "Pick a field",
+                "choices": None,
+                "questions": [
+                    {
+                        "id": "field",
+                        "question": "Which field?",
+                        "choices": [{"label": "Supplier", "value": "supplier"}],
+                    }
+                ],
+                "response_user_id": "user-2",
+                "turn_id": "turn-2",
+                "sensitive": False,
+                "native": None,
+            },
+        )
+    ]
+    assert fake.input_consumes == [("convo-2", "input-1", False)]
+    assert fake.closed is True
+
+
+def test_runtime_control_is_exposed_on_canon_platform_toolset(monkeypatch, tmp_path):
+    from plugins.platforms.canon.runtime_tool import register_runtime_tool
+    from model_tools import _clear_tool_defs_cache, get_tool_definitions
+    from tools.registry import invalidate_check_fn_cache, registry
+    from toolsets import resolve_toolset
+
+    monkeypatch.setenv("CANON_API_KEY", "dummy")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    class Context:
+        def register_tool(self, **kwargs):
+            registry.register(**kwargs)
+
+    try:
+        registry.deregister("canon_runtime_control")
+        register_runtime_tool(Context())
+        invalidate_check_fn_cache()
+        _clear_tool_defs_cache()
+        schemas = get_tool_definitions(
+            enabled_toolsets=["canon_runtime"],
+            quiet_mode=True,
+        )
+        names = {schema["function"]["name"] for schema in schemas}
+        assert "canon_runtime_control" in names
+        assert "canon_runtime_control" in resolve_toolset("canon_runtime")
+    finally:
+        registry.deregister("canon_runtime_control")
+        invalidate_check_fn_cache()
+        _clear_tool_defs_cache()

--- a/tests/tools/test_send_message_plugin_adapter.py
+++ b/tests/tools/test_send_message_plugin_adapter.py
@@ -1,0 +1,107 @@
+"""Plugin-platform send_message adapter routing tests."""
+
+import asyncio
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+
+class _FakePlatform:
+    """Small stand-in for gateway.config.Platform with just a value."""
+
+    def __init__(self, value):
+        self.value = value
+
+
+@pytest.mark.asyncio
+async def test_live_adapter_send_runs_on_gateway_loop(monkeypatch):
+    """A live plugin adapter is owned by the gateway loop, not the tool loop."""
+    from tools.send_message_tool import _send_via_adapter
+
+    gateway_loop = asyncio.new_event_loop()
+    ready = threading.Event()
+
+    def _run_loop():
+        asyncio.set_event_loop(gateway_loop)
+        ready.set()
+        gateway_loop.run_forever()
+
+    thread = threading.Thread(target=_run_loop, daemon=True)
+    thread.start()
+    assert ready.wait(timeout=2)
+
+    class LoopRecordingAdapter:
+        def __init__(self):
+            self.loop = None
+
+        async def send(self, **kwargs):
+            self.loop = asyncio.get_running_loop()
+            return SimpleNamespace(success=True, message_id="live-1", error=None)
+
+    platform = _FakePlatform("fakeplatform")
+    adapter = LoopRecordingAdapter()
+    runner = SimpleNamespace(
+        adapters={platform: adapter},
+        _gateway_loop=gateway_loop,
+    )
+
+    try:
+        monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: runner)
+
+        result = await _send_via_adapter(
+            platform,
+            SimpleNamespace(extra={}),
+            "chat-1",
+            "hi",
+        )
+    finally:
+        gateway_loop.call_soon_threadsafe(gateway_loop.stop)
+        thread.join(timeout=2)
+        gateway_loop.close()
+
+    assert result == {"success": True, "message_id": "live-1"}
+    assert adapter.loop is gateway_loop
+
+
+@pytest.mark.asyncio
+async def test_live_adapter_media_uses_native_methods(monkeypatch, tmp_path):
+    """MEDIA paths on plugin platforms should not be dropped on the live path."""
+    from tools.send_message_tool import _send_via_adapter
+
+    image_path = tmp_path / "pixel.png"
+    image_path.write_bytes(b"png")
+
+    class MediaAdapter:
+        def __init__(self):
+            self.calls = []
+
+        async def send(self, **kwargs):
+            raise AssertionError("plain send should not handle media files")
+
+        async def send_image_file(self, **kwargs):
+            self.calls.append(("image", kwargs))
+            return SimpleNamespace(success=True, message_id="img-1", error=None)
+
+    platform = _FakePlatform("fakeplatform")
+    adapter = MediaAdapter()
+    runner = SimpleNamespace(adapters={platform: adapter}, _gateway_loop=None)
+    monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: runner)
+
+    result = await _send_via_adapter(
+        platform,
+        SimpleNamespace(extra={}),
+        "chat-1",
+        "caption",
+        thread_id="thread-1",
+        media_files=[(str(image_path), False)],
+    )
+
+    assert result == {"success": True, "message_id": "img-1"}
+    assert len(adapter.calls) == 1
+    kind, kwargs = adapter.calls[0]
+    assert kind == "image"
+    assert kwargs["chat_id"] == "chat-1"
+    assert kwargs["image_path"] == str(image_path)
+    assert kwargs["caption"] == "caption"
+    assert kwargs["metadata"] == {"thread_id": "thread-1"}

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -640,6 +640,83 @@ async def _send_via_adapter(
       3. A descriptive error explaining both options.
     """
     platform_name = platform.value if hasattr(platform, "value") else str(platform)
+
+    async def _await_live_adapter(coro, runner_obj):
+        gateway_loop = getattr(runner_obj, "_gateway_loop", None)
+        if gateway_loop and gateway_loop.is_running():
+            try:
+                current_loop = asyncio.get_running_loop()
+            except RuntimeError:
+                current_loop = None
+            if gateway_loop is not current_loop:
+                future = asyncio.run_coroutine_threadsafe(coro, gateway_loop)
+                return await asyncio.wrap_future(future)
+        return await coro
+
+    def _metadata():
+        metadata = {}
+        if thread_id:
+            metadata["thread_id"] = thread_id
+        if platform_name == "ntfy" and chat_id:
+            metadata["publish_topic"] = chat_id
+        return metadata or None
+
+    def _adapter_result(result):
+        if getattr(result, "success", False):
+            return {"success": True, "message_id": getattr(result, "message_id", None)}
+        return {"error": f"Adapter send failed: {getattr(result, 'error', None)}"}
+
+    async def _send_live_media(adapter, runner_obj):
+        metadata = _metadata()
+        last_result = None
+        for index, (media_path, is_voice) in enumerate(media_files or []):
+            ext = os.path.splitext(str(media_path))[1].lower()
+            caption = chunk if index == 0 and str(chunk or "").strip() else None
+            if force_document:
+                method_name = "send_document"
+                kwargs = {"file_path": media_path}
+            elif is_voice:
+                method_name = "send_voice"
+                kwargs = {"audio_path": media_path}
+            elif ext in _IMAGE_EXTS:
+                method_name = "send_image_file"
+                kwargs = {"image_path": media_path}
+            elif ext in _VIDEO_EXTS:
+                method_name = "send_video"
+                kwargs = {"video_path": media_path}
+            elif ext in _AUDIO_EXTS:
+                method_name = "send_voice"
+                kwargs = {"audio_path": media_path}
+            else:
+                method_name = "send_document"
+                kwargs = {"file_path": media_path}
+
+            method = getattr(adapter, method_name, None)
+            if method is None:
+                if method_name != "send_document":
+                    method = getattr(adapter, "send_document", None)
+                    kwargs = {"file_path": media_path}
+                if method is None:
+                    return {
+                        "error": (
+                            f"Adapter does not support native media delivery for {media_path}"
+                        )
+                    }
+
+            result = await _await_live_adapter(
+                method(
+                    chat_id=chat_id,
+                    caption=caption,
+                    metadata=metadata,
+                    **kwargs,
+                ),
+                runner_obj,
+            )
+            last_result = _adapter_result(result)
+            if not last_result.get("success"):
+                return last_result
+        return last_result or {"success": True, "message_id": None}
+
     runner = None
     try:
         from gateway.run import _gateway_runner_ref
@@ -654,21 +731,17 @@ async def _send_via_adapter(
             adapter = None
         if adapter is not None:
             try:
-                metadata = {}
-                if thread_id:
-                    metadata["thread_id"] = thread_id
-                if platform_name == "ntfy" and chat_id:
-                    metadata["publish_topic"] = chat_id
-                if not metadata:
-                    metadata = None
-                result = await adapter.send(chat_id=chat_id, content=chunk, metadata=metadata)
+                if media_files:
+                    return await _send_live_media(adapter, runner)
+                result = await _await_live_adapter(
+                    adapter.send(chat_id=chat_id, content=chunk, metadata=_metadata()),
+                    runner,
+                )
             except asyncio.CancelledError:
                 raise
             except Exception as e:
                 return {"error": f"Plugin platform send failed: {e}"}
-            if result.success:
-                return {"success": True, "message_id": result.message_id}
-            return {"error": f"Adapter send failed: {result.error}"}
+            return _adapter_result(result)
 
     entry = None
     try:

--- a/website/docs/user-guide/messaging/canon.md
+++ b/website/docs/user-guide/messaging/canon.md
@@ -1,0 +1,84 @@
+# Canon
+
+The Canon platform plugin connects Hermes directly to Canon conversations over
+Canon's REST and SSE APIs. It does not require the legacy Node sidecar bridge.
+
+## Register or Reconnect
+
+Run the gateway setup wizard and select Canon. In the checklist UI, toggle
+Canon with Space, then press Enter to continue:
+
+```bash
+hermes setup gateway
+```
+
+Choose **Register/reconnect a Hermes agent with Canon**. Hermes sends a
+registration request to Canon, the owner approves it in Canon, and Hermes saves
+a named profile in `~/.canon/agents.json`. The gateway then stores `CANON_AGENT`
+so future runs use that profile's `agk_live_...` key.
+
+The saved profile has this shape:
+
+```json
+{
+  "my-agent": {
+    "apiKey": "agk_live_...",
+    "agentId": "agent_...",
+    "agentName": "My Agent",
+    "registeredAt": "2026-06-22T00:00:00Z",
+    "clientType": "hermes"
+  }
+}
+```
+
+If you already have a Hermes-compatible Canon profile, set it directly:
+
+```bash
+CANON_AGENT=my-agent
+```
+
+For headless or managed deployments, `CANON_AGENTS_JSON_BOOTSTRAP` can seed a
+fresh `agents.json` without overwriting existing profiles:
+
+```bash
+CANON_AGENTS_JSON_BOOTSTRAP='{"my-agent":{"apiKey":"agk_live_...","agentId":"agent_...","agentName":"My Agent","registeredAt":"2026-06-22T00:00:00Z","clientType":"hermes"}}'
+CANON_AGENT=my-agent
+```
+
+`CANON_API_KEY=agk_live_...` remains available as an advanced override for
+headless environments. The normal setup path is the owner-approved profile flow.
+
+## Optional Settings
+
+- `CANON_BASE_URL` overrides the Canon REST API base URL.
+- `CANON_STREAM_URL` overrides the Canon SSE stream URL.
+- `CANON_HOME` overrides the Canon profile directory. It defaults to
+  `~/.canon`.
+- `CANON_HOME_CHANNEL` sets the default conversation for cron/send-message
+  delivery.
+- `CANON_ALLOWED_USERS` restricts inbound users. Use this for owner/contact
+  deployments, for example `CANON_ALLOWED_USERS=canon_user_id_1,canon_user_id_2`.
+- `CANON_ALLOW_ALL_USERS=1` allows any Canon user to talk to the agent.
+- `CANON_GROUP_ALLOWED_USERS` allows listed Canon users only when they speak in
+  group conversations.
+- `CANON_GROUP_ALLOWED_CONVERSATIONS` allows every sender in listed Canon group
+  conversations while keeping direct messages restricted.
+
+When `CANON_ALLOWED_USERS` is set, unlisted direct-message senders are ignored
+instead of receiving pairing codes, unless you explicitly configure Canon's
+platform `unauthorized_dm_behavior` back to `pair`.
+
+Canon group mentions are structured. Selecting the agent from Canon's mention
+picker sends the mention metadata to Hermes; typing plain `@Name` text may not.
+Hermes surfaces structured mention state to the model, but Canon can still
+filter delivery before Hermes sees a message when the conversation's behavior
+policy requires mentions.
+
+## Outbound Media
+
+Canon supports native outbound attachments from Hermes. Agents can include
+`MEDIA:<local_path>` in a final response, or in `send_message` text, for files
+under the Hermes media cache or paths allowed by `HERMES_MEDIA_ALLOW_DIRS`.
+Hermes uploads the file through Canon and sends it as an image, audio, video, or
+document attachment. When text is sent with one or more files, Canon uses the
+text as the first attachment's caption.


### PR DESCRIPTION
## What does this PR do?

Adds Canon as an optional Hermes messaging platform plugin.

Canon is implemented as a bundled platform adapter under `plugins/platforms/canon/`, registered through the platform plugin API. The normal connection story is: Hermes registers or reconnects a Canon agent, the owner approves in Canon, Hermes stores a named `~/.canon/agents.json` profile, and runtime calls use that profile's `agk_live_...` key. Raw `CANON_API_KEY` remains available as an advanced/headless override.

This PR also adds the small generic platform hooks Canon needs so the core gateway/session logic stays platform-agnostic: plugin group allowlists, delivery intent, runtime control handling, queue depth callbacks, accepted-message notifications, live streaming-preview metadata, and live/standalone plugin `send_message` media delivery.

## Related Issue

Supersedes #31590 with a clean branch from current `main`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [x] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Added generic gateway/platform hooks in `gateway/run.py`, `gateway/platforms/base.py`, `gateway/platform_registry.py`, and `gateway/authz_mixin.py`.
- Added live plugin adapter media/send support in `tools/send_message_tool.py`.
- Added the Canon platform plugin in `plugins/platforms/canon/`.
- Moved Canon runtime card/input/control plumbing into the Canon plugin via `ctx.register_tool()`.
- Added Canon documentation at `website/docs/user-guide/messaging/canon.md`.
- Added focused regression coverage for Canon config/profile/registration, SSE parsing, inbound/outbound media, runtime cards/input/control, plugin group allowlists, delivery intent, and plugin send-message routing.

## How to Test

1. Enable the `canon-platform` plugin.
2. Run `hermes setup gateway`, select Canon, and choose “Register/reconnect a Hermes agent with Canon”.
3. Approve the registration in Canon, then start the gateway and send a Canon direct message or group mention to the registered agent.
4. For runtime UI paths, exercise clarify, command approval, and `canon_runtime_control` rich-card/input calls.

Focused local verification run on macOS 26.3.1:

- `python3 -m py_compile gateway/run.py gateway/platforms/base.py gateway/authz_mixin.py gateway/platform_registry.py tools/send_message_tool.py plugins/platforms/canon/*.py tests/gateway/test_canon_adapter.py tests/gateway/test_busy_session_ack.py tests/gateway/test_config_driven_access_policy.py tests/tools/test_canon_runtime_tool.py tests/tools/test_send_message_plugin_adapter.py`
- `scripts/run_tests.sh tests/gateway/test_canon_adapter.py tests/tools/test_canon_runtime_tool.py tests/tools/test_send_message_plugin_adapter.py tests/gateway/test_config_driven_access_policy.py tests/gateway/test_busy_session_ack.py` — 134 tests passed.
- `uv run --with ruff ruff check gateway/authz_mixin.py gateway/platform_registry.py gateway/platforms/base.py gateway/run.py tools/send_message_tool.py plugins/platforms/canon/__init__.py plugins/platforms/canon/adapter.py plugins/platforms/canon/client.py plugins/platforms/canon/constants.py plugins/platforms/canon/models.py plugins/platforms/canon/profiles.py plugins/platforms/canon/runtime.py plugins/platforms/canon/runtime_tool.py tests/gateway/test_canon_adapter.py tests/gateway/test_busy_session_ack.py tests/gateway/test_config_driven_access_policy.py tests/tools/test_canon_runtime_tool.py tests/tools/test_send_message_plugin_adapter.py`
- `git diff --check`

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched existing PRs; this supersedes #31590 rather than competing with it.
- [x] My PR contains only changes related to the Canon platform plugin and the generic hooks it needs.
- [ ] I've run full `pytest tests/ -q`; not run locally because this PR was verified with the focused Hermes tests listed above.
- [x] I've added tests for my changes.
- [x] I've tested on my platform: macOS 26.3.1.

### Documentation & Housekeeping

- [x] I've updated relevant documentation.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; Canon uses plugin env metadata and docs.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; this uses existing plugin architecture.
- [x] I've considered cross-platform impact per the compatibility guide.
- [x] I've updated tool descriptions/schemas if I changed tool behavior.

## For New Skills

N/A.

## Screenshots / Logs

No screenshots. The relevant CLI verification output is summarized in “How to Test”.
