### PR TITLE
fix: skip nested desktop rebuild during self-update

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -2049,6 +2049,10 @@ async function applyUpdatesPosixInApp() {
   // Node lives directly under %LOCALAPPDATA%\hermes\node, not node\bin.
   const env = {
     HERMES_HOME,
+    // Desktop self-update owns the GUI rebuild below. Prevent the nested
+    // `hermes update` step from running its own desktop build first, which
+    // otherwise burns CPU and can leave the update overlay looking stuck.
+    HERMES_UPDATE_SKIP_DESKTOP_REBUILD: '1',
     PATH: pathWithHermesManagedNode(path.join(updateRoot, 'venv', 'bin'))
   }
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9287,11 +9287,14 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # an existing packaged executable or desktop dist); people who have
         # never run ``hermes desktop`` shouldn't be forced into a full
         # Electron build by ``hermes update``.
+        skip_desktop_rebuild = os.getenv("HERMES_UPDATE_SKIP_DESKTOP_REBUILD") == "1"
         desktop_dir = PROJECT_ROOT / "apps" / "desktop"
         has_desktop_app = _desktop_packaged_executable(desktop_dir) is not None or _desktop_dist_exists(desktop_dir)
         from hermes_constants import find_node_executable
 
-        if (desktop_dir / "package.json").exists() and find_node_executable("npm") and has_desktop_app:
+        if skip_desktop_rebuild:
+            print("→ Skipping desktop app rebuild (handled by Desktop updater)")
+        elif (desktop_dir / "package.json").exists() and find_node_executable("npm") and has_desktop_app:
             print("→ Checking if desktop app needs rebuilding...")
             _desktop_build_cmd = [sys.executable, "-m", "hermes_cli.main", "desktop", "--build-only"]
             # Stream the build output live (long Electron builds otherwise

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -220,6 +220,7 @@ class TestCmdUpdateBranchFallback:
         import subprocess as _subprocess
         build_ok = _subprocess.CompletedProcess([], 0, stdout="", stderr="")
         with patch.object(hm, "_is_termux_env", return_value=False), \
+             patch.object(hm, "_web_ui_build_needed", return_value=True), \
              patch.object(hm, "_run_with_idle_timeout", return_value=build_ok) as mock_idle:
             cmd_update(mock_args)
 
@@ -300,6 +301,30 @@ class TestCmdUpdateBranchFallback:
                 "repo-root npm install must stream output "
                 "(no capture_output) so postinstall progress is visible"
             )
+
+    @patch("shutil.which")
+    @patch("subprocess.run")
+    def test_desktop_spawned_update_skips_nested_desktop_rebuild(
+        self, mock_run, mock_which, mock_args, monkeypatch, capsys
+    ):
+        from hermes_cli import main as hm
+
+        mock_which.side_effect = {"uv": "/usr/bin/uv", "npm": "/usr/bin/npm"}.get
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="1"
+        )
+        monkeypatch.setenv("HERMES_UPDATE_SKIP_DESKTOP_REBUILD", "1")
+        build_ok = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+
+        with patch.object(hm, "_is_termux_env", return_value=False), \
+             patch.object(hm, "_run_with_idle_timeout", return_value=build_ok), \
+             patch.object(hm, "_desktop_packaged_executable", return_value=PROJECT_ROOT / "apps/desktop/release/mac-arm64/Hermes.app"), \
+             patch.object(hm, "_desktop_dist_exists", return_value=True):
+            cmd_update(mock_args)
+
+        commands = [" ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list if c.args]
+        assert not any("desktop --build-only" in command for command in commands)
+        assert "Skipping desktop app rebuild (handled by Desktop updater)" in capsys.readouterr().out
 
     def test_update_non_interactive_runs_safe_config_migrations(self, mock_args, capsys):
         """Dashboard/web updates apply non-interactive migrations before restart."""


### PR DESCRIPTION
## Summary
- pass `HERMES_UPDATE_SKIP_DESKTOP_REBUILD=1` from the Desktop in-app updater when it invokes `hermes update`
- make the CLI updater skip its own desktop rebuild when that flag is set, leaving the Electron updater as the single owner of the GUI rebuild/retry flow
- add regression coverage so Desktop-spawned updates do not run nested `desktop --build-only` commands

## Why
Desktop self-update currently invokes `hermes update`, and the CLI update path can run `desktop --build-only` itself. After that returns, the Electron updater runs its own rebuild step too. On macOS this can make the update overlay look stuck while duplicate Electron/npm build work burns CPU.

## Tests
- `./scripts/run_tests.sh tests/hermes_cli/test_cmd_update.py`
- `uv run ruff check hermes_cli/main.py tests/hermes_cli/test_cmd_update.py`
- `node --test apps/desktop/electron/update-rebuild.test.cjs apps/desktop/electron/update-relaunch.test.cjs apps/desktop/electron/update-marker.test.cjs`