### PR TITLE
fix(vision): don't encode non-image files as fake image/jpeg

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -396,11 +396,17 @@ def _sniff_mime_from_bytes(raw: bytes) -> Optional[str]:
     return None
 
 
-def _guess_mime(path: Path, raw: Optional[bytes] = None) -> str:
-    """Return image MIME type for *path*.
+def _guess_mime(path: Path, raw: Optional[bytes] = None) -> Optional[str]:
+    """Return the image MIME type for *path*, or ``None`` when the file is not
+    an image.
 
-    If *raw* bytes are provided, magic-byte sniffing wins (authoritative).
-    Otherwise we fall back to ``mimetypes`` then suffix-based defaults.
+    Resolution order: magic-byte sniffing (authoritative when *raw* is
+    provided) → ``mimetypes`` (only when it reports an ``image/*`` type) →
+    known image suffixes. A non-image file (e.g. an ``.html``/``.markdown``
+    document whose filename merely contains "Image") returns ``None`` so the
+    caller skips it instead of fabricating a fake ``image/jpeg`` payload that
+    providers reject with HTTP 400 (#50793). Magic bytes / declared MIME win
+    over the filename.
     """
     if raw is not None:
         sniffed = _sniff_mime_from_bytes(raw)
@@ -409,8 +415,10 @@ def _guess_mime(path: Path, raw: Optional[bytes] = None) -> str:
     mime, _ = mimetypes.guess_type(str(path))
     if mime and mime.startswith("image/"):
         return mime
-    # mimetypes on some Linux distros mis-maps .jpg; default to jpeg when
-    # the suffix looks imagey.
+    # mimetypes on some Linux distros mis-maps .jpg; keep a tight suffix map so
+    # a real image with a quirky local mimetypes DB still routes. Unknown
+    # suffixes return None (NOT a jpeg default) so non-image documents are not
+    # encoded as images.
     suffix = path.suffix.lower()
     return {
         ".jpg": "image/jpeg",
@@ -419,7 +427,7 @@ def _guess_mime(path: Path, raw: Optional[bytes] = None) -> str:
         ".gif": "image/gif",
         ".webp": "image/webp",
         ".bmp": "image/bmp",
-    }.get(suffix, "image/jpeg")
+    }.get(suffix)
 
 
 def _file_to_data_url(path: Path) -> Optional[str]:
@@ -440,6 +448,15 @@ def _file_to_data_url(path: Path) -> Optional[str]:
         logger.warning("image_routing: failed to read %s — %s", path, exc)
         return None
     mime = _guess_mime(path, raw=raw)
+    if mime is None:
+        # Not a real image (magic bytes + declared MIME + suffix all say
+        # non-image). Skip rather than encode document bytes as a fake
+        # image/jpeg, which providers reject with HTTP 400 (#50793).
+        logger.warning(
+            "image_routing: %s is not a recognized image — skipping native "
+            "image routing", path,
+        )
+        return None
     b64 = base64.b64encode(raw).decode("ascii")
     return f"data:{mime};base64,{b64}"
 

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -11,6 +11,8 @@ from agent.image_routing import (
     _coerce_capability_bool,
     _coerce_mode,
     _explicit_aux_vision_override,
+    _file_to_data_url,
+    _guess_mime,
     _lookup_supports_vision,
     _supports_vision_override,
     build_native_content_parts,
@@ -636,3 +638,55 @@ class TestBuildNativeContentPartsURLs:
         )
         assert parts[0]["type"] == "text"
         assert parts[0]["text"].startswith("What do you see in this image?")
+
+
+# ─── MIME validation: non-image files must not be routed as images (#50793) ──
+
+class TestNonImageRoutingGuard:
+    """A document whose filename merely contains "Image" must not be encoded
+    as a fake image/jpeg — magic bytes / declared MIME win over the filename.
+    """
+
+    _PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+
+    def test_guess_mime_real_png_by_magic_bytes(self, tmp_path):
+        p = tmp_path / "weird_name.dat"
+        p.write_bytes(self._PNG)
+        assert _guess_mime(p, raw=self._PNG) == "image/png"
+
+    def test_guess_mime_html_named_image_is_none(self, tmp_path):
+        p = tmp_path / "Image_2_1.html"
+        raw = b"<!DOCTYPE html>\n<html></html>"
+        p.write_bytes(raw)
+        assert _guess_mime(p, raw=raw) is None
+
+    def test_guess_mime_markdown_named_image_is_none(self, tmp_path):
+        p = tmp_path / "Image_3_1.markdown"
+        raw = b"---\ntitle: x\n---\n# hi"
+        p.write_bytes(raw)
+        assert _guess_mime(p, raw=raw) is None
+
+    def test_guess_mime_known_image_suffix_still_maps(self, tmp_path):
+        # A real image with a corrupt header but a known suffix still routes.
+        p = tmp_path / "photo.jpg"
+        p.write_bytes(b"not-really-jpeg-bytes")
+        assert _guess_mime(p, raw=b"not-really-jpeg-bytes") == "image/jpeg"
+
+    def test_file_to_data_url_skips_non_image(self, tmp_path):
+        p = tmp_path / "Image_2_1.html"
+        p.write_bytes(b"<!DOCTYPE html><html></html>")
+        assert _file_to_data_url(p) is None
+
+    def test_build_parts_skips_non_image_keeps_real_image(self, tmp_path):
+        html = tmp_path / "Image_2_1.html"
+        html.write_bytes(b"<!DOCTYPE html><html></html>")
+        png = tmp_path / "real.png"
+        png.write_bytes(self._PNG)
+        parts, skipped = build_native_content_parts(
+            "look", [str(html), str(png)]
+        )
+        image_parts = [p for p in parts if p.get("type") in ("image_url", "input_image")]
+        assert len(image_parts) == 1
+        assert str(html) in skipped
+        # No fabricated image/jpeg from the HTML bytes.
+        assert all("data:image/jpeg" not in str(p) or "real.png" for p in image_parts)


### PR DESCRIPTION
## Summary

Addresses the attachment-routing half of #50793. When a non-image document is routed into the native-image path — e.g. a Discord `.html`/`.markdown` attachment whose filename merely contains "Image" — Hermes base64-encoded it as `data:image/jpeg;base64,<document bytes>`. Vision providers then rejected the **entire turn** with a non-retryable HTTP 400 (`The image data you provided does not represent a valid image`).

Root cause in `agent/image_routing.py`: `_guess_mime()` fell back to a hard `image/jpeg` default for any unrecognized suffix, so document bytes were happily encoded as a JPEG even though magic-byte sniffing and `mimetypes` both said "not an image".

## Fix

Make magic bytes / declared MIME win over the filename:

- `_guess_mime()` returns `None` when the bytes aren't a recognized image **and** the suffix isn't a known image extension (instead of defaulting to `image/jpeg`).
- `_file_to_data_url()` skips files that aren't real images — the caller already records them in `skipped` — instead of fabricating a JPEG payload.

Real images are unaffected: magic-byte sniffing still catches them (even with a wrong/quirky extension), and known image suffixes (`.jpg/.png/.gif/.webp/.bmp`) still map. This is defense-in-depth at the encoding layer, so even if an upstream adapter misclassifies an attachment, non-image bytes never reach a provider as a fake image.

Scope note: this PR covers Case 1 (attachment routing). Case 2 (oversized Discord video fallback) is a separate adapter concern and not included here.

## Tests

`tests/agent/test_image_routing.py::TestNonImageRoutingGuard`: real PNG detected by magic bytes; `.html`/`.markdown` named `Image_*` return `None`; known image suffix still maps; and `build_native_content_parts` skips the non-image document while keeping a real image (no fabricated `image/jpeg`).
