### PR TITLE
fix(gateway): suppress compression noise across chat platforms

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -68,8 +68,8 @@ _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
-_TELEGRAM_NOISY_STATUS_RE = re.compile(
-    r"("  # transient/auxiliary status that should stay in logs, not Telegram chat
+_GATEWAY_NOISY_STATUS_RE = re.compile(
+    r"("  # transient/auxiliary status that should stay in logs, not gateway chats
     r"auxiliary\s+.+\s+failed"
     r"|compression\s+summary\s+failed"
     r"|fallback\s+context\s+marker"
@@ -388,17 +388,26 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
 
 
 def _prepare_gateway_status_message(platform: Any, event_type: str, message: str) -> Optional[str]:
-    """Filter/sanitize agent status callbacks before platform delivery."""
+    """Filter/sanitize agent status callbacks before platform delivery.
+
+    Local/CLI sessions keep the raw diagnostic stream. Messaging gateway
+    surfaces should not receive transient auxiliary/compression chatter: those
+    events are useful in logs, but in chat they look like assistant replies and
+    leak raw provider errors (for example OpenRouter 402 bodies during
+    auto-detected compression fallback).
+    """
     text = str(message or "").strip()
     if not text:
         return None
-    if _gateway_platform_value(platform) != "telegram":
+
+    platform_value = _gateway_platform_value(platform)
+    if platform_value == "local":
         return text
 
     text = _redact_gateway_user_facing_secrets(text)
-    if _TELEGRAM_NOISY_STATUS_RE.search(text):
+    if _GATEWAY_NOISY_STATUS_RE.search(text):
         return None
-    if _looks_like_gateway_provider_error(text):
+    if platform_value == "telegram" and _looks_like_gateway_provider_error(text):
         return _gateway_provider_error_reply(text)
     return text
 

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -7,12 +7,13 @@ from gateway.run import (
 )
 
 
-def test_telegram_status_suppresses_auxiliary_and_retry_noise():
-    """Auxiliary failures and retry backoff chatter should not hit Telegram."""
+def test_gateway_status_suppresses_auxiliary_and_retry_noise_on_chat_platforms():
+    """Auxiliary failures and retry backoff chatter should not hit gateway chats."""
     noisy_messages = [
         "⚠ Auxiliary title generation failed: HTTP 400: Operation contains cybersecurity risk",
-        "⚠ Compression summary failed: upstream error. Inserted a fallback context marker.",
+        "⚠ Compression summary failed: Error code: 402 - {'message': This request requires more credits, or fewer max_tokens. You requested up to 65536 tokens, but can only afford 612. To increase, visit https://openrouter.ai/settings/credits ...}. Inserted a fallback context marker.",
         "🗜️ Compacting context — summarizing earlier conversation so I can continue...",
+        "📦 Preflight compression: ~237,261 tokens >= 231,200 threshold. This may take a moment.",
         "ℹ Configured compression model 'small-model' failed (timeout). Recovered using main model — check auxiliary.compression.model in config.yaml.",
         "⏳ Retrying in 4.2s (attempt 1/3)...",
         "⏱️ Rate limited. Waiting 30.0s (attempt 2/3)...",
@@ -21,14 +22,22 @@ def test_telegram_status_suppresses_auxiliary_and_retry_noise():
 
     for message in noisy_messages:
         assert _prepare_gateway_status_message(Platform.TELEGRAM, "warn", message) is None
+        assert _prepare_gateway_status_message(Platform.DISCORD, "warn", message) is None
+        assert _prepare_gateway_status_message(Platform.SLACK, "warn", message) is None
 
 
-def test_non_telegram_status_is_unchanged():
-    """The Telegram quieting policy must not hide CLI/Discord diagnostics."""
+def test_local_status_is_unchanged():
+    """CLI/local diagnostics should keep raw status chatter for debugging."""
     message = "⏳ Retrying in 4.2s (attempt 1/3)..."
 
-    assert _prepare_gateway_status_message(Platform.DISCORD, "lifecycle", message) == message
     assert _prepare_gateway_status_message("local", "lifecycle", message) == message
+
+
+def test_non_noisy_discord_status_is_unchanged():
+    """Normal non-Telegram status messages should still be delivered."""
+    message = "✅ Gateway restarted successfully."
+
+    assert _prepare_gateway_status_message(Platform.DISCORD, "lifecycle", message) == message
 
 
 def test_telegram_status_sanitizes_raw_provider_security_errors():


### PR DESCRIPTION
## What
Suppress transient auxiliary/compression status chatter across messaging gateway platforms, not just Telegram.

This keeps messages like:
- `Compacting context — summarizing earlier conversation...`
- `Preflight compression: ...`
- `Compression summary failed: Error code: 402 ... openrouter.ai ... Inserted a fallback context marker.`

out of Discord/Slack/etc. chat channels while preserving raw diagnostics for local/CLI sessions and gateway logs.

## Why
The existing noise filter was Telegram-only. On Discord and other gateway channels, internal compression lifecycle messages could appear as chat messages and leak raw provider error bodies from auxiliary-provider fallback, e.g. OpenRouter 402 credit errors during compression even when the user's main chat provider is not OpenRouter.

## How to test
- `uv run --extra dev pytest tests/gateway/test_telegram_noise_filter.py tests/gateway/test_session_hygiene.py tests/run_agent/test_413_compression.py -q`
- `uv run --extra dev ruff check gateway/run.py tests/gateway/test_telegram_noise_filter.py`

## Platforms tested
Linux.