### PR TITLE
fix(openviking): remove incorrect 'peers' segment from memory URI path

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -2795,9 +2795,9 @@ class OpenVikingMemoryProvider(MemoryProvider):
         )
 
     def _build_memory_uri(self, subdir: str) -> str:
-        """Build a viking:// memory URI under the configured peer namespace."""
+        """Build a viking:// memory URI under the configured agent namespace."""
         slug = uuid.uuid4().hex[:12]
-        return f"viking://user/peers/{self._agent}/memories/{subdir}/mem_{slug}.md"
+        return f"viking://user/{self._agent}/memories/{subdir}/mem_{slug}.md"
 
     def on_memory_write(
         self,

--- a/tests/openviking_plugin/test_openviking.py
+++ b/tests/openviking_plugin/test_openviking.py
@@ -824,8 +824,8 @@ class TestOpenVikingBrowse:
 class TestOpenVikingMemoryUriBuilder:
     """Regression tests for _build_memory_uri — fixes #36969.
 
-    OpenViking's current memory layout stores peer-scoped memories under
-    viking://user/peers/{peer_id}/...
+    OpenViking's current memory layout stores agent-scoped memories under
+    viking://user/{agent}/...
     """
 
     def _make_provider(self, user="alice", agent="coder"):
@@ -834,19 +834,19 @@ class TestOpenVikingMemoryUriBuilder:
         p._agent = agent
         return p
 
-    def test_uri_layout_includes_peer_segment(self):
-        """URI must contain /peers/{peer_id}/ between user and memories."""
+    def test_uri_layout_includes_agent_segment(self):
+        """URI must contain /{agent}/ between user and memories."""
         p = self._make_provider(user="alice", agent="coder")
         uri = p._build_memory_uri("preferences")
-        assert uri.startswith("viking://user/peers/coder/memories/preferences/mem_")
+        assert uri.startswith("viking://user/coder/memories/preferences/mem_")
         assert uri.endswith(".md")
 
-    def test_uri_uses_configured_peer_not_default(self):
-        """_agent value is the OpenViking actor peer ID, not hardcoded to 'hermes'."""
+    def test_uri_uses_configured_agent_not_default(self):
+        """_agent value is the OpenViking actor ID, not hardcoded to 'hermes'."""
         p = self._make_provider(user="alice", agent="research-bot")
         uri = p._build_memory_uri("entities")
-        assert "/peers/research-bot/" in uri
-        assert "/peers/hermes/" not in uri
+        assert "/research-bot/" in uri
+        assert "/hermes/" not in uri
 
     def test_uri_slug_is_twelve_hex_chars_and_unique(self):
         """Slug must be 12 hex chars and differ between calls."""

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -2633,7 +2633,7 @@ def test_on_memory_write_uses_content_write_independent_of_session_rotation():
     assert captured_payloads[0]["content"] == "remember this"
     assert captured_payloads[0]["mode"] == "create"
     assert captured_payloads[0]["uri"].startswith(
-        "viking://user/peers/hermes/memories/preferences/mem_"
+        "viking://user/hermes/memories/preferences/mem_"
     )
 
 


### PR DESCRIPTION
## Summary

Fixes the `viking_remember` tool failing with `NOT_FOUND` errors on OpenViking v0.3.23 by correcting the URI path construction.

## Motivation

The `_build_memory_uri()` method was constructing URIs with an incorrect `peers` segment:

```
viking://user/peers/{agent}/memories/...
```

OpenViking v0.3.23 stores memory data at:

```
viking://user/{agent}/memories/...
```

This mismatch caused `viking_remember` to fail with `NOT_FOUND` errors.

## Changes

- **fix**: Remove incorrect `peers` segment from URI path
- **test**: Update test assertions to match new URI format
- **docs**: Update docstring to reflect correct path structure

## Files Modified

1. `plugins/memory/openviking/__init__.py` - Fix URI construction
2. `tests/openviking_plugin/test_openviking.py` - Update test expectations
3. `tests/plugins/memory/test_openviking_provider.py` - Update test expectations

## Related Issues

Fixes #50701

## Checklist

- [x] Code follows the project's style guidelines
- [x] Tests have been updated to reflect the changes
- [x] No unrelated changes included