### PR TITLE
fix(matrix): use correct ❌ emoji for deny reaction in approval prompt

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1923,7 +1923,7 @@ class MatrixAdapter(BasePlatformAdapter):
             "`!approve always` to approve permanently, or `!deny` to cancel.\n\n"
             "You can also click the reaction to approve:\n"
             "✅ = approve\n"
-            "❎ = deny"
+            "❌ = deny"
         )
 
         result = await self.send(chat_id, text, metadata=metadata)


### PR DESCRIPTION
## Summary

The approval prompt was using the wrong emoji for the deny reaction.

## Motivation

Fixes #50429

The approval prompt was using ❎ (negative squared cross mark) for the deny reaction, but the Matrix bot expects ❌ (cross mark) for deny.

## Changes

- **fix**: Change ❎ to ❌ in the deny reaction emoji

## Files Modified

1. `plugins/platforms/matrix/adapter.py` - Fix deny reaction emoji

## Related Issues

Fixes #50429

## Checklist

- [x] Code follows the project's style guidelines
- [x] No unrelated changes included
- [x] Commit message follows Conventional Commits format