### PR TITLE
fix(model-metadata): retry transient OpenRouter fetch + quiet warning on cache fallback

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -132,6 +132,46 @@ _model_metadata_cache_time: float = 0
 _novita_metadata_cache: Dict[str, Dict[str, Any]] = {}
 _novita_metadata_cache_time: float = 0
 _MODEL_CACHE_TTL = 3600
+
+# OpenRouter metadata is best-effort: a flaky network blip should retry briefly
+# and otherwise fall back to cached metadata without alarming the user (#50770).
+_MODEL_METADATA_FETCH_ATTEMPTS = 2
+_MODEL_METADATA_FETCH_BACKOFF = 0.5  # seconds, multiplied by attempt number
+# ``requests`` is imported lazily (see ``_ensure_requests``), so its exception
+# classes can't be referenced at module load. Resolve the transient-error tuple
+# on demand — the fetch loop has already called ``_ensure_requests`` by the time
+# an ``except`` clause needs it.
+_TRANSIENT_FETCH_ERROR_NAMES = (
+    "SSLError",
+    "ConnectionError",
+    "Timeout",
+    "ChunkedEncodingError",
+)
+
+
+def _transient_fetch_errors() -> tuple:
+    exceptions = _ensure_requests().exceptions
+    return tuple(getattr(exceptions, name) for name in _TRANSIENT_FETCH_ERROR_NAMES)
+
+
+def _is_retryable_fetch_error(error: Exception) -> bool:
+    """False for deterministic failures that a retry would only reproduce.
+
+    A broken certificate chain (TLS-inspecting proxy, missing custom CA,
+    expired/self-signed cert) fails the handshake identically every time, so
+    retrying just adds a second doomed request. The repo already draws this
+    line in agent/error_classifier.py — reuse its patterns rather than
+    re-deriving them here. Everything else in _TRANSIENT_FETCH_ERROR_NAMES (EOF-style
+    SSL blips, connection resets, timeouts) stays retryable.
+    """
+    try:
+        from agent.error_classifier import _SSL_CERT_VERIFY_PATTERNS
+    except Exception:
+        return True
+
+    error_msg = str(error).lower()
+    return not any(p in error_msg for p in _SSL_CERT_VERIFY_PATTERNS)
+
 _endpoint_model_metadata_cache: Dict[str, Dict[str, Dict[str, Any]]] = {}
 _endpoint_model_metadata_cache_time: Dict[str, float] = {}
 _ENDPOINT_MODEL_CACHE_TTL = 300
@@ -1054,49 +1094,69 @@ def fetch_model_metadata(force_refresh: bool = False) -> Dict[str, Dict[str, Any
                 _model_metadata_cache_time = time.time() - disk_age
                 return _model_metadata_cache
 
-    try:
-        _ensure_requests()
-        # Tuple (connect, read) — flat timeout=10 means urllib3 can block 10s per
-        # retry stage through proxies that 403 CONNECT, ballooning to minutes
-        # (#46620). 5s connect / 10s read fails fast on unreachable hosts.
-        response = requests.get(OPENROUTER_MODELS_URL, timeout=(5, 10), verify=_resolve_requests_verify())
-        response.raise_for_status()
-        data = response.json()
+    last_error: Optional[Exception] = None
+    for attempt in range(_MODEL_METADATA_FETCH_ATTEMPTS):
+        try:
+            _ensure_requests()
+            # Tuple (connect, read) — flat timeout=10 means urllib3 can block 10s per
+            # retry stage through proxies that 403 CONNECT, ballooning to minutes
+            # (#46620). 5s connect / 10s read fails fast on unreachable hosts.
+            response = requests.get(OPENROUTER_MODELS_URL, timeout=(5, 10), verify=_resolve_requests_verify())
+            response.raise_for_status()
+            data = response.json()
 
-        cache = {}
-        for model in data.get("data", []):
-            model_id = model.get("id", "")
-            entry = {
-                "context_length": model.get("context_length", 128000),
-                "max_completion_tokens": model.get("top_provider", {}).get("max_completion_tokens", 4096),
-                "name": model.get("name", model_id),
-                "pricing": model.get("pricing", {}),
-            }
-            _add_model_aliases(cache, model_id, entry)
-            canonical = model.get("canonical_slug", "")
-            if canonical and canonical != model_id:
-                _add_model_aliases(cache, canonical, entry)
+            cache = {}
+            for model in data.get("data", []):
+                model_id = model.get("id", "")
+                entry = {
+                    "context_length": model.get("context_length", 128000),
+                    "max_completion_tokens": model.get("top_provider", {}).get("max_completion_tokens", 4096),
+                    "name": model.get("name", model_id),
+                    "pricing": model.get("pricing", {}),
+                }
+                _add_model_aliases(cache, model_id, entry)
+                canonical = model.get("canonical_slug", "")
+                if canonical and canonical != model_id:
+                    _add_model_aliases(cache, canonical, entry)
 
-        _model_metadata_cache = cache
-        _model_metadata_cache_time = time.time()
-        _save_model_metadata_disk_cache(cache)
-        logger.debug("Fetched metadata for %s models from OpenRouter", len(cache))
-        return cache
+            _model_metadata_cache = cache
+            _model_metadata_cache_time = time.time()
+            _save_model_metadata_disk_cache(cache)
+            logger.debug("Fetched metadata for %s models from OpenRouter", len(cache))
+            return cache
 
-    except Exception as e:
-        logger.warning("Failed to fetch model metadata from OpenRouter: %s", e)
-        if _model_metadata_cache:
-            return _model_metadata_cache
-        disk_cache = _load_model_metadata_disk_cache()
-        if disk_cache:
-            _model_metadata_cache = disk_cache
-            disk_age = _model_metadata_disk_cache_age_seconds()
-            if disk_age is not None:
-                _model_metadata_cache_time = time.time() - min(disk_age, _MODEL_CACHE_TTL)
-            else:
-                _model_metadata_cache_time = time.time() - _MODEL_CACHE_TTL + 1
-            return _model_metadata_cache
-        return {}
+        except _transient_fetch_errors() as e:
+            # Network/SSL blip — retry briefly before giving up. A certificate
+            # verification failure is deterministic, so it falls through to the
+            # cache path on the first attempt instead of burning a second request.
+            last_error = e
+            if attempt + 1 < _MODEL_METADATA_FETCH_ATTEMPTS and _is_retryable_fetch_error(e):
+                time.sleep(_MODEL_METADATA_FETCH_BACKOFF * (attempt + 1))
+                continue
+        except Exception as e:
+            last_error = e
+        break
+
+    # Fetch failed (transient retries exhausted, or a non-transient error).
+    # Fall back to cached metadata so a flaky network doesn't degrade the run.
+    # When a cache is available the user still has working metadata, so log at
+    # DEBUG instead of alarming them with a WARNING for a non-problem (#50770).
+    if _model_metadata_cache:
+        logger.debug("Could not refresh model metadata from OpenRouter (%s); using in-memory cache", last_error)
+        return _model_metadata_cache
+    disk_cache = _load_model_metadata_disk_cache()
+    if disk_cache:
+        logger.debug("Could not refresh model metadata from OpenRouter (%s); using disk cache", last_error)
+        _model_metadata_cache = disk_cache
+        disk_age = _model_metadata_disk_cache_age_seconds()
+        if disk_age is not None:
+            _model_metadata_cache_time = time.time() - min(disk_age, _MODEL_CACHE_TTL)
+        else:
+            _model_metadata_cache_time = time.time() - _MODEL_CACHE_TTL + 1
+        return _model_metadata_cache
+    # No cache to fall back on — this genuinely degrades the run, so warn.
+    logger.warning("Failed to fetch model metadata from OpenRouter: %s", last_error)
+    return {}
 
 
 def fetch_endpoint_model_metadata(

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -10,6 +10,7 @@ Coverage levels:
   Persistent cache       — save/load, corruption, update, provider isolation
 """
 
+import logging
 import time
 
 import pytest
@@ -1358,3 +1359,122 @@ class TestFallbackWarning:
             if r.levelno == logging.WARNING and "falling back" in r.getMessage()
         ]
         assert len(fallback_warnings) == 0
+
+
+class TestFetchModelMetadataResilience:
+    """fetch_model_metadata should survive transient OpenRouter outages: retry
+    briefly, fall back to cached metadata, and not alarm the user with a
+    WARNING when a usable cache is available (#50770).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolate(self, monkeypatch, tmp_path):
+        import agent.model_metadata as mm
+        # Point the disk cache at an isolated dir and reset in-memory cache so
+        # tests don't read/write the user's real ~/.hermes cache.
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(mm, "_model_metadata_cache", {}, raising=False)
+        monkeypatch.setattr(mm, "_model_metadata_cache_time", 0, raising=False)
+        monkeypatch.setattr(mm, "_save_model_metadata_disk_cache", lambda data: None)
+        monkeypatch.setattr(mm.time, "sleep", lambda *_a, **_k: None)
+        return mm
+
+    @staticmethod
+    def _ok_response(models):
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.json.return_value = {"data": models}
+        return resp
+
+    def test_retries_transient_error_then_succeeds(self, _isolate, monkeypatch):
+        import requests
+        mm = _isolate
+        calls = {"n": 0}
+
+        def fake_get(*_a, **_k):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise requests.exceptions.SSLError("EOF in violation of protocol")
+            return self._ok_response([{"id": "vendor/model-x", "context_length": 64000}])
+
+        monkeypatch.setattr(mm.requests, "get", fake_get)
+        result = mm.fetch_model_metadata(force_refresh=True)
+        assert calls["n"] == 2  # one failure, one success
+        assert "vendor/model-x" in result
+
+    def test_certificate_verify_failure_is_not_retried(self, _isolate, monkeypatch):
+        # A broken cert chain is deterministic — the handshake fails identically
+        # on every attempt, so retrying only adds a second doomed request. The
+        # repo draws this line in error_classifier; the fetch must honor it.
+        import requests
+        mm = _isolate
+        calls = {"n": 0}
+
+        def fake_get(*_a, **_k):
+            calls["n"] += 1
+            raise requests.exceptions.SSLError(
+                "HTTPSConnectionPool(host='openrouter.ai', port=443): "
+                "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: "
+                "unable to get local issuer certificate (_ssl.c:1006)"
+            )
+
+        monkeypatch.setattr(mm.requests, "get", fake_get)
+        mm.fetch_model_metadata(force_refresh=True)
+        assert calls["n"] == 1  # exactly one request, no retry
+
+    def test_gives_up_after_max_attempts(self, _isolate, monkeypatch):
+        import requests
+        mm = _isolate
+        calls = {"n": 0}
+
+        def fake_get(*_a, **_k):
+            calls["n"] += 1
+            raise requests.exceptions.SSLError("EOF in violation of protocol")
+
+        monkeypatch.setattr(mm.requests, "get", fake_get)
+        mm.fetch_model_metadata(force_refresh=True)
+        assert calls["n"] == mm._MODEL_METADATA_FETCH_ATTEMPTS
+
+    def test_falls_back_to_memory_cache_without_warning(self, _isolate, monkeypatch, caplog):
+        import requests
+        mm = _isolate
+        monkeypatch.setattr(mm, "_model_metadata_cache", {"cached/model": {"context_length": 1234}}, raising=False)
+
+        def fake_get(*_a, **_k):
+            raise requests.exceptions.SSLError("EOF in violation of protocol")
+
+        monkeypatch.setattr(mm.requests, "get", fake_get)
+        with caplog.at_level(logging.WARNING, logger="agent.model_metadata"):
+            result = mm.fetch_model_metadata(force_refresh=True)
+        assert result == {"cached/model": {"context_length": 1234}}
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+    def test_falls_back_to_disk_cache_without_warning(self, _isolate, monkeypatch, caplog):
+        import requests
+        mm = _isolate
+        monkeypatch.setattr(mm, "_load_model_metadata_disk_cache", lambda: {"disk/model": {"context_length": 5678}})
+
+        def fake_get(*_a, **_k):
+            raise requests.exceptions.ConnectionError("connection reset")
+
+        monkeypatch.setattr(mm.requests, "get", fake_get)
+        with caplog.at_level(logging.WARNING, logger="agent.model_metadata"):
+            result = mm.fetch_model_metadata(force_refresh=True)
+        assert result == {"disk/model": {"context_length": 5678}}
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+    def test_warns_only_when_no_cache_available(self, _isolate, monkeypatch, caplog):
+        import requests
+        mm = _isolate
+        monkeypatch.setattr(mm, "_load_model_metadata_disk_cache", lambda: {})
+
+        def fake_get(*_a, **_k):
+            raise requests.exceptions.SSLError("EOF in violation of protocol")
+
+        monkeypatch.setattr(mm.requests, "get", fake_get)
+        with caplog.at_level(logging.WARNING, logger="agent.model_metadata"):
+            result = mm.fetch_model_metadata(force_refresh=True)
+        assert result == {}
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert len(warnings) == 1
+        assert "Failed to fetch model metadata" in warnings[0].message


### PR DESCRIPTION
## What does this PR do?

`fetch_model_metadata()` logged a `WARNING` with a full SSL/connection stack on **every** transient failure to reach `openrouter.ai` — even though it immediately falls back to the in-memory or on-disk metadata cache and the run continues unaffected. On a flaky network this surfaces as alarming noise for a non-problem:

```
WARNING agent.model_metadata: Failed to fetch model metadata from OpenRouter: HTTPSConnectionPool(host='openrouter.ai', port=443): Max retries exceeded with url: /api/v1/models (Caused by SSLError(SSLEOFError(8, '[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1016)')))
```

## Fix

- **Retry briefly on transient errors.** A single dropped TLS handshake now retries (2 attempts, short backoff) for `SSLError`, `ConnectionError`, `Timeout`, and `ChunkedEncodingError` before giving up, so a momentary blip recovers on its own.
- **Quiet the warning when a cache is available.** If the fetch ultimately fails but cached metadata (memory or disk) can serve the request, log at `DEBUG` ("could not refresh, using cached metadata") instead of `WARNING`. The `WARNING` is reserved for the genuinely degraded case where there is no cache to fall back on.

Non-transient errors (HTTP 4xx/5xx via `raise_for_status`, JSON decode, etc.) still fail fast — only the listed connectivity errors are retried.

## Related Issue

Fixes #50770

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactor / cleanup
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- `agent/model_metadata.py`
  - Add `_MODEL_METADATA_FETCH_ATTEMPTS`, `_MODEL_METADATA_FETCH_BACKOFF`, and a `_TRANSIENT_FETCH_ERRORS` tuple.
  - Wrap the OpenRouter `/api/v1/models` fetch in a retry loop; classify transient connectivity errors separately from hard failures.
  - On exhausted fetch, log at `DEBUG` when a memory/disk cache serves the result; keep `WARNING` only when no fallback exists.
- `tests/agent/test_model_metadata.py`
  - `TestFetchModelMetadataResilience`: retry-then-succeed, give-up-after-max-attempts, memory-cache fallback (no warning), disk-cache fallback (no warning), and warn-only-when-no-cache.

## Testing

```
uv run pytest tests/agent/test_model_metadata.py tests/agent/test_model_metadata_ssl.py -q
```

`119 passed`. `ruff check` clean.