### PR TITLE
docs(notion): improve ntn CLI skill with -d flag, self-discovery, pitfalls

### DIFF
--- a/skills/productivity/notion/SKILL.md
+++ b/skills/productivity/notion/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: notion
 description: "Notion API + ntn CLI: pages, databases, markdown, Workers."
-version: 2.0.0
+version: 2.1.0
 author: community
 license: MIT
 platforms: [linux, macos, windows]
@@ -83,6 +83,16 @@ Syntax notes:
 - `key[nested]=value` — nested object fields
 - `key:=value` — typed assignment (booleans, numbers, null, arrays)
 
+### Passing JSON bodies with `-d` (preferred for complex payloads)
+```bash
+# Use -d for any JSON body that's too complex for inline key=value syntax
+ntn api v1/data_sources/{id} -X PATCH -d '{"properties":{"Thématique":{"select":{"options":[...]}}}}'
+
+# Or from a file
+ntn api v1/data_sources/{id}/query -X POST --file /tmp/query.json
+```
+The `-d` / `--data <JSON>` flag is the cleanest way to pass structured bodies. It avoids all shell escaping issues that the inline `key=value` syntax can have with nested arrays, unicode, or special characters.
+
 ### Search
 ```bash
 ntn api v1/search query="page title"
@@ -143,10 +153,33 @@ ntn files list
 
 Compare to the 3-step HTTP flow (create upload → PUT bytes → reference).
 
+### Shorthand: `ntn datasources query`
+
+For simple queries without complex filters, use the dedicated subcommand (cleaner than `ntn api`):
+
+```bash
+ntn datasources query <data-source-id> --limit 50
+ntn datasources query <data-source-id> --filter '{"property":"Status","select":{"equals":"Open"}}'
+ntn datasources query <data-source-id> --json   # machine-readable output
+```
+
+For sorts, compound filters, or `filter_properties`, use `ntn api v1/data_sources/{id}/query -X POST` with `-d` or inline `filter:='{...}'` syntax instead.
+
+### Self-discovery: inspect endpoints without leaving the terminal
+
+```bash
+ntn api ls                          # list all public API endpoints
+ntn api v1/data_sources --spec      # reduced OpenAPI fragment for this endpoint
+ntn api v1/data_sources --docs      # full official markdown docs for this endpoint
+ntn api v1/data_sources --docs -X POST   # specify method when ambiguous
+```
+
+Use these when unsure about request/response shapes — faster than guessing or searching the web.
+
 ### Useful env vars
 | Var | Effect |
 |---|---|
-| `NOTION_API_TOKEN` | Auth token (overrides keychain) — set this to your integration token |
+| `NOTION_API_TOKEN` | Auth token (overrides keychain) — set this to your integration token (NOT a `$VAR` reference) |
 | `NOTION_KEYRING=0` | File-based creds at `~/.config/notion/auth.json` instead of OS keychain |
 | `NOTION_WORKSPACE_ID` | Skip the workspace picker prompt |
 
@@ -445,4 +478,59 @@ Headings 5/6 collapse to H4. Multiple `>` lines render as separate quote blocks 
 - Use `"is_inline": true` when creating data sources to embed them in a page.
 - Always pass `-s` to curl to suppress progress bars (cleaner agent output).
 - Pipe JSON through `jq` when reading: `... | jq '.results[0].properties'`.
+- `ntn api` supports `--file /path/to/body.json` as an alternative to `-d` for large JSON payloads.
 - Notion also ships an MCP server now (`Notion MCP`, ~91% more token-efficient on DB ops than the previous version) — wire it via Hermes' MCP support if you want streaming Notion access from inside a session, but the paths above are enough for most one-shot tasks.
+
+## Official Documentation
+
+**When in doubt about Notion CLI behavior, API shapes, or syntax — check the official docs first before guessing.** The `ntn` CLI is also self-documenting via `ntn api ls`, `ntn api <path> --spec`, and `ntn api <path> --docs`.
+
+- **CLI overview:** https://developers.notion.com/cli/get-started/overview
+- **API requests syntax (inline, -d, --file, query params):** https://developers.notion.com/cli/guides/api-requests
+- **Data sources (query, create, update, templates):** https://developers.notion.com/cli/guides/data-sources
+- **Command reference (all ntn commands):** https://developers.notion.com/cli/reference/commands
+- **Authentication (keychain, --no-browser, env vars):** https://developers.notion.com/cli/get-started/authentication
+
+## Common Pitfalls
+
+> **Reference:** See `references/select-option-operations.md` for detailed recipes on renaming select options, deleting properties, and avoiding emoji-duplicate options.
+
+1. **ntn fails with "Failed to build public API request" in Hermes.** `NOTION_API_TOKEN` and `NOTION_KEYRING=0` must be in `~/.hermes/.env` (not just `NOTION_API_KEY`). Without `NOTION_API_TOKEN`, ntn can't find the token. Without `NOTION_KEYRING=0`, it tries the OS keychain which doesn't exist in a headless environment. If only `NOTION_API_KEY` is set, add the other two with the same token value.
+
+2. **ntn shell escaping in terminal tool.** Inline `export VAR=$(...)` with parentheses and quotes gets mangled by the Hermes terminal shell wrapper. **Use `ntn -d '{"key":"value"}'` to pass JSON bodies directly** — this avoids all shell escaping issues and keeps commands as one-liners. Do NOT wrap ntn calls in Python `subprocess.run()` — the user has corrected this reflex multiple times. The CLI is designed to be called directly from the terminal. For complex JSON bodies, write the JSON to a temp file and use `ntn api ... -d @/tmp/body.json`, or use heredoc with `--file`.
+
+3. **ntn fails with "No workspace selected" despite correct token/keyring env vars.** `NOTION_API_TOKEN` and `NOTION_KEYRING=0` are set correctly but ntn still can't resolve the workspace. Fix: set `NOTION_WORKSPACE_ID` in `~/.hermes/.env` (find it in the Notion URL or via `ntn api v1/users` if you can get past the error). If you can't get the workspace ID easily, **fall back to curl immediately** — the curl path (Path B) works perfectly with just `NOTION_API_KEY` and no workspace selection. Don't waste turns trying to fix ntn env when curl works.
+
+4. **DEFAULT TO ntn CLI, NOT MCP TOOLS.** Agents reach for the MCP Notion tools (notion_find, notion_query_data_source, etc.) by reflex because they're function-shaped, but ntn CLI returns compact JSON (~500 chars) vs MCP's 3-5KB wrappers. **Use ntn for ALL standard operations**: search, query, read pages, create/update/delete items, archive blocks. MCP tools should only be used for operations ntn genuinely cannot do (e.g. typed relation creation via notion_create_data_source_item_from_values, schema inspection with notion_inspect_data_source). When in doubt, use ntn.
+
+   Key ntn operations agents forget exist:
+   ```bash
+   # Query a data source
+   ntn api v1/data_sources/{data_source_id}/query -X POST
+
+   # Delete/archive a block (page item)
+   ntn api v1/blocks/{block_id} -X PATCH archived:=true
+
+   # Inspect a data source schema
+   ntn api v1/data_sources/{data_source_id}
+
+   # Search
+   ntn api v1/search query="Objets"
+
+   # Delete a property from a data source (set to null)
+   ntn api v1/data_sources/{data_source_id} -X PATCH 'properties[PropertyName]:=null'
+
+   # Or with -d for clarity:
+   ntn api v1/data_sources/{data_source_id} -X PATCH -d '{"properties":{"PropertyName":null}}'
+   ```
+
+5. **Renaming a select option by ID does NOT work via data_source PATCH.** The Notion API silently ignores name changes to existing select options when you PATCH `/v1/data_sources/{id}` with the option ID + new name. The workaround:
+   1. Add a new option with the desired name: `ntn api v1/data_sources/{id} -X PATCH -d '{"properties":{"Thématique":{"select":{"options":[{"name":"🏙️ Vie terrestre","color":"gray"}]}}}}'`
+   2. Reassign all pages that had the old option to the new one: `ntn api v1/pages/{page_id} -X PATCH -d '{"properties":{"Thématique":{"select":{"name":"🏙️ Vie terrestre"}}}}'`
+   3. Remove the old option by PATCHing the data source with only the desired options list (omitting the old option ID).
+   
+   **WARNING**: If you PATCH the options list to remove an option that pages still reference, those pages lose their select value (it becomes null). Always reassign pages BEFORE removing the old option.
+
+6. **`.env` variable references don't resolve.** If `~/.hermes/.env` contains `NOTION_API_TOKEN=*** `, the `$NOTION_API_KEY` is a literal string, not a variable reference. `.env` files are not shell scripts — they don't expand variables. Always write the actual token value: `NOTION_API_TOKEN=ntn_abc123...`. If `NOTION_API_TOKEN` is missing or invalid, ntn fails with "API token is invalid" even when `NOTION_API_KEY` is correct.
+
+7. **`ntn api -d` for JSON bodies, NOT Python wrappers.** Do NOT wrap `ntn` calls in Python `subprocess.run()` scripts. Call `ntn` directly from the terminal. For complex JSON, use `-d '{"...": "..."}'` or `--file /tmp/body.json`. Python wrappers around ntn are unnecessary indirection — the CLI is designed for direct terminal use.

--- a/skills/productivity/notion/references/select-option-operations.md
+++ b/skills/productivity/notion/references/select-option-operations.md
@@ -1,0 +1,63 @@
+# Select / Multi-select Option Operations
+
+## Renaming a select option (workaround)
+
+The Notion API `PATCH /v1/data_sources/{id}` silently ignores name changes to existing select options when you include the option ID with a new name. The rename does not stick — the option keeps its original name in the response.
+
+### Working procedure (3 steps)
+
+```bash
+# 1. Add a NEW option with the desired name (keep the old one for now)
+ntn api v1/data_sources/{ds_id} -X PATCH \
+  -d '{"properties":{"Thématique":{"select":{"options":[{"name":"🏙️ Vie terrestre","color":"gray"}]}}}}'
+
+# 2. Reassign all pages from old option to new option
+#    First find affected pages:
+ntn api v1/data_sources/{ds_id}/query -X POST > /tmp/pages.json
+#    Then patch each page:
+ntn api v1/pages/{page_id} -X PATCH \
+  -d '{"properties":{"Thématique":{"select":{"name":"🏙️ Vie terrestre"}}}}'
+
+# 3. Remove the old option by PATCHing with only the desired options
+#    Get current options + IDs first:
+ntn api v1/data_sources/{ds_id} > /tmp/schema.json
+#    Build the final options list (excluding old option ID) and PATCH:
+ntn api v1/data_sources/{ds_id} -X PATCH \
+  -d '{"properties":{"Thématique":{"select":{"options":[
+    {"id":"orig-id-1","name":"Option 1","color":"red"},
+    {"id":"orig-id-2","name":"Option 2","color":"blue"}
+  ]}}}}'
+```
+
+### Critical ordering
+
+**Always reassign pages BEFORE removing the old option.** If you remove an option that pages still reference, those pages lose their select value (becomes null). This happened in practice and required re-assigning 13 pages.
+
+## Deleting a property entirely
+
+```bash
+# Inline syntax
+ntn api v1/data_sources/{ds_id} -X PATCH 'properties[PropertyName]:=null'
+
+# Or with -d
+ntn api v1/data_sources/{ds_id} -X PATCH -d '{"properties":{"PropertyName":null}}'
+```
+
+This removes the property and all its values from every page in the database. Irreversible.
+
+## Adding options without duplicates
+
+When adding options via PATCH, the API appends to the existing list. If you include an option with the same name but different emoji (e.g. `🛵 Aventure` vs `🚵 Aventure`), it creates a duplicate. Always check existing options first:
+
+```bash
+ntn api v1/data_sources/{ds_id} | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+for o in d['properties']['Thématique']['select']['options']:
+    print(o['id'], o['name'])
+"
+```
+
+## Emoji precision matters
+
+Notion treats options with different emoji as different options even if the text is identical. `🚵 Aventure` (mountain bike, U+1F6B5) and `🛵 Aventure` (motor scooter, U+1F6F5) are two completely separate options. When assigning values to pages, the emoji in the `select.name` must match exactly.


### PR DESCRIPTION
## Summary

Practical improvements to the Notion skill, learned from real-world  CLI usage during inventory management tasks.

### Changes to SKILL.md

- ** /  flag section**: Document the preferred way to pass JSON bodies for complex payloads (nested arrays, unicode, special characters). Avoids shell escaping issues that inline `key=value` syntax can have.
- **`ntn datasources query` shorthand**: Document the dedicated subcommand for simple queries (cleaner than `ntn api`).
- **Self-discovery section**: `ntn api ls`, `ntn api <path> --spec`, `ntn api <path> --docs` for inspecting endpoints without leaving the terminal.
- **Official Documentation section**: Direct links to 5 Notion CLI doc pages, with explicit instruction to check docs first when in doubt.
- **7 Common Pitfalls**:
  1. `NOTION_API_TOKEN` + `NOTION_KEYRING=0` required in `.env` (not just `NOTION_API_KEY`)
  2. Shell escaping in terminal tool — use `-d`, not Python wrappers
  3. "No workspace selected" error — set `NOTION_WORKSPACE_ID` or fall back to curl
  4. Default to ntn CLI over MCP tools (compact JSON ~500 chars vs MCP 3-5KB wrappers)
  5. Renaming select options by ID doesn't work via data_source PATCH (3-step workaround documented)
  6. `.env` files don't expand variable references (`NOTION_API_TOKEN=$NOTION_API_KEY` is a literal string)
  7. Don't wrap `ntn` in Python `subprocess.run()` — use the CLI directly
- Clarify `NOTION_API_TOKEN` env var note (not a `` reference)
- Bump version to 2.1.0

### New file: `references/select-option-operations.md`

Detailed recipes for:
- Renaming a select option (3-step workaround with critical ordering)
- Deleting a property entirely (`properties[Name]:=null`)
- Adding options without emoji-duplicates
- Emoji precision matters (`🚵` vs `🛵` are different options)

## Rationale

These improvements come from hands-on experience using the `ntn` CLI for Notion database operations. The pitfalls documented here caused multiple failed attempts and wasted turns during a real session. The select-option rename behavior in particular is a subtle API quirk that is not documented in the official Notion docs and cost significant time to diagnose.

## Test Plan

- [ ] Skill loads correctly via `skill_view(name='notion')`
- [ ] All documented commands work as written
- [ ] `references/select-option-operations.md` is accessible via `skill_view(name='notion', file_path='references/select-option-operations.md')`