### PR TITLE
feat(providers): add PleumRouter model-provider plugin

### DIFF
--- a/plugins/model-providers/pleumrouter/__init__.py
+++ b/plugins/model-providers/pleumrouter/__init__.py
@@ -1,0 +1,23 @@
+"""PleumRouter provider profile."""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+pleumrouter = ProviderProfile(
+    name="pleumrouter",
+    aliases=("pleum",),
+    display_name="PleumRouter",
+    description="Korea-region OpenAI-compatible multi-provider LLM gateway",
+    signup_url="https://router.pleum.ai",
+    env_vars=("PLEUMROUTER_API_KEY",),
+    base_url="https://router.pleum.ai/v1",
+    # models_url falls back to {base_url}/models — PleumRouter exposes a public
+    # GET /v1/models (no key required), so model discovery works out of the box.
+    fallback_models=(
+        "claude-sonnet-4-6",
+        "gpt-5.5",
+        "gemini-2.5-pro",
+    ),
+)
+
+register_provider(pleumrouter)

--- a/plugins/model-providers/pleumrouter/plugin.yaml
+++ b/plugins/model-providers/pleumrouter/plugin.yaml
@@ -1,0 +1,5 @@
+name: pleumrouter-provider
+kind: model-provider
+version: 1.0.0
+description: PleumRouter — Korea-region OpenAI-compatible LLM gateway
+author: AIrouter Dev


### PR DESCRIPTION
## What does this PR do?

Adds **PleumRouter** (https://router.pleum.ai) as a built-in model-provider plugin. PleumRouter is a Korea-region, OpenAI-compatible multi-provider LLM gateway (one key → many providers). It follows the self-contained plugin pattern documented in `plugins/model-providers/README.md`, mirroring the existing **OpenRouter / StepFun** gateway plugins.

## Related Issue

No issue — new provider addition via the documented `plugins/model-providers/` path. (Searched open PRs + code for `pleum`: no duplicates.)

Fixes #

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/model-providers/pleumrouter/__init__.py` — `ProviderProfile` (name `pleumrouter`, alias `pleum`, `auth_type` api_key default, `base_url=https://router.pleum.ai/v1`, env `PLEUMROUTER_API_KEY`, fallback models) + `register_provider()`.
- `plugins/model-providers/pleumrouter/plugin.yaml` — manifest.

Model discovery uses the standard `{base_url}/models` fallback — PleumRouter serves a public `GET /v1/models` (no key needed for listing), so the picker populates automatically, same as the other OpenAI-compatible gateways.

## How to Test

1. `export PLEUMROUTER_API_KEY=plm_...` (key from https://router.pleum.ai)
2. `hermes` → setup/picker → select **PleumRouter** (or alias `pleum`); models load from `/v1/models`.
3. Run a turn against e.g. `claude-sonnet-4-6` — chat + tool calls work via the OpenAI-compatible endpoint.

## Checklist

- [x] Followed the `plugins/model-providers/README.md` "Adding a new provider" steps (self-contained plugin; no core files touched)
- [x] Mirrors the existing `openrouter` / `stepfun` provider plugins
- [x] Searched existing PRs/issues/code for duplicates (none)

Happy to add a docs entry (`website/docs/integrations/providers.md`) or tweak the fallback models / aliases to your preference.