### PR TITLE
fix(installer): use detected Python fallback for venv creation

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1514,11 +1514,16 @@ function Install-Venv {
         Write-Info "Skipping virtual environment (-NoVenv)"
         return
     }
-    
-    Write-Info "Creating virtual environment with Python $PythonVersion..."
-    
+
+    # Read the detected Python version from script scope.  Test-Python may
+    # have updated $script:PythonVersion to a fallback (e.g. "3.12") when the
+    # preferred version was unavailable.  Using $script: explicitly avoids any
+    # scope-chain ambiguity.
+    $detectedPy = $script:PythonVersion
+    Write-Info "Creating virtual environment with Python $detectedPy..."
+
     Push-Location $InstallDir
-    
+
     if (Test-Path "venv") {
         Write-Info "Virtual environment already exists, recreating..."
         # On Windows, native Python extensions (e.g. _bcrypt.pyd) are loaded as
@@ -1532,12 +1537,12 @@ function Install-Venv {
         }
         Remove-Item -Recurse -Force "venv"
     }
-    
+
     # uv creates the venv and pins the Python version in one step.  uv emits
     # normal progress such as "Using CPython ..." on stderr; under Windows
     # PowerShell 5.1 with EAP=Stop that stderr is a NativeCommandError unless
     # we temporarily relax EAP and trust $LASTEXITCODE for real failures.
-    Invoke-NativeWithRelaxedErrorAction { & $UvCmd venv venv --python $PythonVersion }
+    Invoke-NativeWithRelaxedErrorAction { & $UvCmd venv venv --python $detectedPy }
     # Relaxing EAP above means a *genuine* uv-venv failure (exit != 0) no longer
     # aborts on its own. Capture $LASTEXITCODE immediately and fail fast, so the
     # `venv` stage can't falsely report success (and Invoke-Stage can't emit
@@ -1561,8 +1566,8 @@ function Install-Venv {
     }
 
     Pop-Location
-    
-    Write-Success "Virtual environment ready (Python $PythonVersion)"
+
+    Write-Success "Virtual environment ready (Python $detectedPy)"
 }
 
 function Install-Dependencies {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -586,11 +586,23 @@ check_python() {
         PYTHON_PATH="$("$UV_CMD" python find "$PYTHON_VERSION")"
         PYTHON_FOUND_VERSION="$("$PYTHON_PATH" --version 2>/dev/null)"
         log_success "Python installed: $PYTHON_FOUND_VERSION"
-    else
-        log_error "Failed to install Python $PYTHON_VERSION"
-        log_info "Install Python $PYTHON_VERSION manually, then re-run this script"
-        exit 1
+        return 0
     fi
+
+    # Fallback: check if ANY Python 3.10+ is already available on the system
+    log_info "Trying to find any existing Python 3.10+..."
+    for _fallback_ver in 3.12 3.13 3.10; do
+        if PYTHON_PATH="$("$UV_CMD" python find "$_fallback_ver" 2>/dev/null)"; then
+            PYTHON_FOUND_VERSION="$("$PYTHON_PATH" --version 2>/dev/null)"
+            log_success "Found fallback: $PYTHON_FOUND_VERSION"
+            PYTHON_VERSION="$_fallback_ver"
+            return 0
+        fi
+    done
+
+    log_error "Failed to find or install Python $PYTHON_VERSION"
+    log_info "Install Python 3.11+ manually, then re-run this script"
+    exit 1
 }
 
 # Best-effort automatic git provisioning, mirroring install.ps1's Install-Git


### PR DESCRIPTION
## Summary

When Python 3.11 is not available, the installer detects a fallback (e.g. Python 3.12) but the venv creation step still used the hardcoded 3.11 version, causing installation to fail.

## Motivation

Fixes #50769

The PowerShell installer's `Test-Python` function correctly detects a fallback Python version (3.12, 3.13, or 3.10) and updates `$script:PythonVersion`. However, `Install-Venv` reads `$PythonVersion` without the `$script:` qualifier, which in some PowerShell scope contexts may not resolve to the updated script-level variable.

The bash installer had NO fallback logic at all — it would hard-fail if Python 3.11 was unavailable.

## Changes

### Windows (`install.ps1`)
- `Install-Venv` now reads `$script:PythonVersion` explicitly into a local variable `$detectedPy` before using it
- This avoids any scope-chain ambiguity that could cause the fallback value to be missed

### Linux/macOS (`install.sh`)
- Added fallback loop (3.12, 3.13, 3.10) to `check_python()`, matching the logic that `install.ps1` already had
- Updates `PYTHON_VERSION` on success so `setup_venv()` uses the correct version

## Validation

- The fix is defensive — it ensures the detected fallback version propagates correctly to the venv creation step
- Both installers now have consistent fallback behavior

## Checklist

- [x] Code follows the project's style guidelines
- [x] No unrelated changes included
- [x] Commit message follows Conventional Commits format