### PR TITLE
fix(slack): honor documented mention_patterns wake words (salvage #50789/#50818)

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2485,7 +2485,10 @@ class SlackAdapter(BasePlatformAdapter):
         #   4. There's an existing session for this thread (survives restarts)
         bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
         routing_text = original_text or ""
-        is_mentioned = bot_uid and f"<@{bot_uid}>" in routing_text
+        is_mentioned = bool(
+            (bot_uid and f"<@{bot_uid}>" in routing_text)
+            or self._slack_message_matches_mention_patterns(routing_text)
+        )
         event_thread_ts = event.get("thread_ts")
         is_thread_reply = bool(event_thread_ts and event_thread_ts != ts)
 
@@ -3811,6 +3814,62 @@ class SlackAdapter(BasePlatformAdapter):
         if isinstance(raw, str) and raw.strip():
             return {part.strip() for part in raw.split(",") if part.strip()}
         return set()
+
+    def _slack_mention_patterns(self) -> List["re.Pattern"]:
+        """Compile optional regex wake-word patterns for channel triggers.
+
+        Parity with the other adapters (Telegram, DingTalk, Mattermost,
+        WhatsApp, BlueBubbles, Photon): when ``require_mention`` is on, a
+        channel message matching one of these patterns triggers the bot even
+        without a literal ``<@BOTUID>`` mention. Reads ``slack.mention_patterns``
+        (a list or single string) or ``SLACK_MENTION_PATTERNS`` (a JSON list, or
+        newline/comma-separated values). Compiled patterns are cached on the
+        instance. Previously this documented field was silently dropped.
+        """
+        cached = getattr(self, "_compiled_mention_patterns", None)
+        if cached is not None:
+            return cached
+
+        patterns = self.config.extra.get("mention_patterns") if self.config.extra else None
+        if patterns is None:
+            raw = os.getenv("SLACK_MENTION_PATTERNS", "").strip()
+            if raw:
+                try:
+                    import json as _json
+                    patterns = _json.loads(raw)
+                except Exception:
+                    patterns = [p.strip() for p in raw.splitlines() if p.strip()] or [
+                        p.strip() for p in raw.split(",") if p.strip()
+                    ]
+
+        if isinstance(patterns, str):
+            patterns = [patterns]
+
+        compiled: List["re.Pattern"] = []
+        if isinstance(patterns, list):
+            for pat in patterns:
+                if not isinstance(pat, str) or not pat.strip():
+                    continue
+                try:
+                    compiled.append(re.compile(pat, re.IGNORECASE))
+                except re.error as exc:
+                    logger.warning("[Slack] Invalid mention pattern %r: %s", pat, exc)
+        elif patterns is not None:
+            logger.warning(
+                "[Slack] mention_patterns must be a list or string; got %s",
+                type(patterns).__name__,
+            )
+
+        if compiled:
+            logger.info("[Slack] Loaded %d mention pattern(s)", len(compiled))
+        self._compiled_mention_patterns = compiled
+        return compiled
+
+    def _slack_message_matches_mention_patterns(self, text: str) -> bool:
+        """Return True when ``text`` matches a configured wake-word pattern."""
+        if not text:
+            return False
+        return any(pattern.search(text) for pattern in self._slack_mention_patterns())
 
 
 # ──────────────────────────────────────────────────────────────────────────

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3838,9 +3838,7 @@ class SlackAdapter(BasePlatformAdapter):
                     import json as _json
                     patterns = _json.loads(raw)
                 except Exception:
-                    patterns = [p.strip() for p in raw.splitlines() if p.strip()] or [
-                        p.strip() for p in raw.split(",") if p.strip()
-                    ]
+                    patterns = [p.strip() for p in raw.replace("\n", ",").split(",") if p.strip()]
 
         if isinstance(patterns, str):
             patterns = [patterns]

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -631,6 +631,7 @@ AUTHOR_MAP = {
     "79389617+txbxxx@users.noreply.github.com": "txbxxx",
     "liuhao03@bilibili.com": "liuhao1024",
     "130918800+devorun@users.noreply.github.com": "devorun",
+    "27793551+iaji@users.noreply.github.com": "iaji",
     "surat.s@itm.kmutnb.ac.th": "beesrsj2500",
     "beesr@bee.localdomain": "beesrsj2500",
     "mind-dragon@nous.research": "Mind-Dragon",

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -735,6 +735,16 @@ def test_mention_patterns_env_var_fallback(monkeypatch):
     assert adapter._slack_message_matches_mention_patterns("hey hermes") is True
 
 
+def test_mention_patterns_env_var_csv_fallback_splits_patterns(monkeypatch):
+    monkeypatch.setenv("SLACK_MENTION_PATTERNS", "hey hermes,hermes,")
+    adapter = _make_adapter()  # no config value -> falls back to env
+
+    patterns = adapter._slack_mention_patterns()
+
+    assert [pattern.pattern for pattern in patterns] == ["hey hermes", "hermes"]
+    assert adapter._slack_message_matches_mention_patterns("hey hermes") is True
+
+
 def test_mention_patterns_trigger_in_channel_without_literal_mention():
     """A wake word triggers the bot in a channel even with require_mention on."""
     adapter = _make_adapter(require_mention=True, mention_patterns=["hey hermes"])

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -55,7 +55,8 @@ CHANNEL_ID = "C0AQWDLHY9M"
 OTHER_CHANNEL_ID = "C9999999999"
 
 
-def _make_adapter(require_mention=None, strict_mention=None, free_response_channels=None, allowed_channels=None):
+def _make_adapter(require_mention=None, strict_mention=None, free_response_channels=None,
+                  allowed_channels=None, mention_patterns=None):
     extra = {}
     if require_mention is not None:
         extra["require_mention"] = require_mention
@@ -65,6 +66,8 @@ def _make_adapter(require_mention=None, strict_mention=None, free_response_chann
         extra["free_response_channels"] = free_response_channels
     if allowed_channels is not None:
         extra["allowed_channels"] = allowed_channels
+    if mention_patterns is not None:
+        extra["mention_patterns"] = mention_patterns
 
     adapter = object.__new__(SlackAdapter)
     adapter.platform = Platform.SLACK
@@ -249,7 +252,10 @@ def _would_process(adapter, *, is_dm=False, channel_id=CHANNEL_ID,
     bot_uid = adapter._team_bot_user_ids.get("T1", adapter._bot_user_id)
     if mentioned:
         text = f"<@{bot_uid}> {text}"
-    is_mentioned = bot_uid and f"<@{bot_uid}>" in text
+    is_mentioned = bool(
+        (bot_uid and f"<@{bot_uid}>" in text)
+        or adapter._slack_message_matches_mention_patterns(text)
+    )
 
     if not is_dm and bot_uid:
         # allowed_channels check (whitelist — must pass before other gating)
@@ -687,3 +693,51 @@ def test_config_bridges_slack_allowed_channels_env_takes_precedence(monkeypatch,
     import os as _os
     # env var must not be overwritten by config.yaml
     assert _os.environ["SLACK_ALLOWED_CHANNELS"] == OTHER_CHANNEL_ID
+
+
+# ---------------------------------------------------------------------------
+# Tests: mention_patterns (wake words) — parity with other adapters (#50732)
+# ---------------------------------------------------------------------------
+
+def test_mention_patterns_default_no_match(monkeypatch):
+    monkeypatch.delenv("SLACK_MENTION_PATTERNS", raising=False)
+    adapter = _make_adapter()
+    assert adapter._slack_mention_patterns() == []
+    assert adapter._slack_message_matches_mention_patterns("hello there") is False
+
+
+def test_mention_patterns_list_matches():
+    adapter = _make_adapter(mention_patterns=["hey hermes", "hermes,"])
+    assert adapter._slack_message_matches_mention_patterns("hey hermes, you there?") is True
+    assert adapter._slack_message_matches_mention_patterns("just chatting") is False
+
+
+def test_mention_patterns_case_insensitive():
+    adapter = _make_adapter(mention_patterns=["hey hermes"])
+    assert adapter._slack_message_matches_mention_patterns("HEY HERMES!") is True
+
+
+def test_mention_patterns_single_string():
+    adapter = _make_adapter(mention_patterns="^hermes")
+    assert adapter._slack_message_matches_mention_patterns("hermes do this") is True
+    assert adapter._slack_message_matches_mention_patterns("ok hermes") is False
+
+
+def test_mention_patterns_invalid_regex_skipped_without_crash():
+    # An invalid pattern is dropped; valid siblings still work.
+    adapter = _make_adapter(mention_patterns=["(unclosed", "hey hermes"])
+    assert adapter._slack_message_matches_mention_patterns("hey hermes") is True
+
+
+def test_mention_patterns_env_var_fallback(monkeypatch):
+    monkeypatch.setenv("SLACK_MENTION_PATTERNS", '["hey hermes", "hermes,"]')
+    adapter = _make_adapter()  # no config value -> falls back to env
+    assert adapter._slack_message_matches_mention_patterns("hey hermes") is True
+
+
+def test_mention_patterns_trigger_in_channel_without_literal_mention():
+    """A wake word triggers the bot in a channel even with require_mention on."""
+    adapter = _make_adapter(require_mention=True, mention_patterns=["hey hermes"])
+    assert _would_process(adapter, text="hey hermes what's the status") is True
+    # Unrelated channel chatter is still ignored.
+    assert _would_process(adapter, text="lunch anyone?") is False


### PR DESCRIPTION
## Summary
Slack now honors the documented `slack.mention_patterns` wake words — a channel message containing a configured pattern triggers the bot under `require_mention`, even without a literal `<@BOTUID>`. Closes #50732.

Root cause: the field is documented (slack.md) and the YAML→config bridge carries it into `config.extra` (gateway/config.py), but the Slack plugin adapter never read it. Every sibling adapter (Telegram, WhatsApp, BlueBubbles, DingTalk, Mattermost, Photon) implements it — Slack was the lone no-op.

## Changes
- `plugins/platforms/slack/adapter.py`: `_slack_mention_patterns()` (compiled + cached) and `_slack_message_matches_mention_patterns()`; channel mention detection now ORs literal-mention with a wake-word match. Reads `slack.mention_patterns` (list or string) or `SLACK_MENTION_PATTERNS` (JSON / newline / comma-separated). Invalid regexes warned and skipped.
- CSV env fallback fix: `'hey hermes,hermes,'` now compiles two patterns. The original `splitlines() or split(",")` short-circuited (`splitlines()` returns a truthy single element), so comma-only input never split.
- `scripts/release.py`: AUTHOR_MAP entry for iaji.

## Validation
- `tests/gateway/test_slack_mention.py`: 63 passed.
- E2E against the real adapter (temp HERMES_HOME, real imports): unset → no match (backward compatible); config.extra wake word matches; CSV env `'a,b,'` → `['a','b']`; newline env → split; config.extra beats env var.

## Credit
Salvage of a duplicate cluster on #50732:
- @kuk1song (#35403, submitted first, May 30) — same fix, but against the pre-plugin-migration `gateway/platforms/slack.py` path.
- @devorun (#50789) — wake-word implementation on the current plugin path (cherry-picked, authorship preserved).
- @iaji (#50818) — CSV-fallback follow-up (cherry-picked, authorship preserved).

## Infographic

![slack-mention-patterns-wake-words](https://v3b.fal.media/files/b/0a9f5357/9cyTeFBrjqnYb6cGFMy6O_CqByufQq.png)
