### PR TITLE
fix(cron): ensure cron session title is never blank on failure

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2270,7 +2270,15 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 _cron_title = f"{_title_base} · {_hermes_now().strftime('%b %d %H:%M')}"
                 _session_db.set_session_title(_cron_session_id, _cron_title)
             except (Exception, KeyboardInterrupt) as e:
-                logger.debug("Job '%s': failed to set cron session title: %s", job_id, e)
+                # Title conflict or DB error — retry with a unique fallback so
+                # the session is never left blank.  Append the session suffix
+                # (includes seconds) to guarantee uniqueness.
+                logger.warning("Job '%s': failed to set cron session title: %s", job_id, e)
+                try:
+                    _fallback_title = f"{_title_base} · {_cron_session_id.split('_')[-1]}"
+                    _session_db.set_session_title(_cron_session_id, _fallback_title)
+                except Exception:
+                    logger.debug("Job '%s': fallback title also failed", job_id, exc_info=True)
             try:
                 _session_db.end_session(_cron_session_id, "cron_complete")
             except (Exception, KeyboardInterrupt) as e:


### PR DESCRIPTION
## Summary

When `set_session_title` raises (e.g. title conflict with another session), the cron session was left with no title. The error was only logged at DEBUG level, making it invisible by default.

## Motivation

Fixes #50535

When a cron job runs and the title-setting fails (DB error, title conflict), the cron session ends up with a blank title in the session sidebar/history.

## Changes

- **fix**: Retry with a fallback title that includes the session's timestamp suffix (seconds) to guarantee uniqueness
- **logging**: Log the initial failure at WARNING level instead of DEBUG so operators can see it

## Validation

The fallback title format: `{job_name} · {session_suffix}` where session_suffix is the timestamp portion of the session ID (e.g. `080045`), guaranteed unique.

## Checklist

- [x] Code follows the project's style guidelines
- [x] No unrelated changes included
- [x] Commit message follows Conventional Commits format