### PR TITLE
fix(matrix): use correct ❌ emoji for deny reaction in approval prompt

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1924,7 +1924,7 @@ class MatrixAdapter(BasePlatformAdapter):
             "`!approve always` to approve permanently, or `!deny` to cancel.\n\n"
             "You can also click the reaction to approve:\n"
             "✅ = approve\n"
-            "❎ = deny"
+            "❌ = deny"
         )
 
         result = await self.send(chat_id, text, metadata=metadata)


### PR DESCRIPTION
## Summary

The approval prompt was using ❎ (negative squared cross mark) for the deny reaction, but the Matrix bot expects ❌ (cross mark) for deny.

## Motivation

Fixes #50429

## Changes

- **fix**: Change ❎ to ❌ in the deny reaction emoji in the approval prompt text

## Validation

The reaction mapping dictionary at line 939 already correctly maps ❌ to "deny". This fix aligns the user-facing prompt text with the actual reaction that will be processed.

## Checklist

- [x] Code follows the project's style guidelines
- [x] No unrelated changes included
- [x] Commit message follows Conventional Commits format