### PR TITLE
fix(delegation): emit high-concurrency cost warning once per process

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -130,6 +130,12 @@ _SUBAGENT_TOOLSETS = sorted(
 _TOOLSET_LIST_STR = ", ".join(f"'{n}'" for n in _SUBAGENT_TOOLSETS)
 
 _DEFAULT_MAX_CONCURRENT_CHILDREN = 3
+# One-shot guard: the high-concurrency cost advisory is emitted at most once
+# per process. _get_max_concurrent_children() runs on every get_definitions()
+# schema rebuild (via _build_top_level_description / _build_tasks_param_description),
+# so without this flag a config of max_concurrent_children>10 spams the log on
+# every turn / agent spawn even when delegate_task is never called.
+_HIGH_CONCURRENCY_WARNED = False
 MAX_DEPTH = 1  # flat by default: parent (0) -> child (1); grandchild rejected unless max_spawn_depth raised.
 # Configurable depth cap consulted by _get_max_spawn_depth; MAX_DEPTH
 # stays as the default fallback and is still the symbol tests import.
@@ -374,11 +380,14 @@ def _get_max_concurrent_children() -> int:
         try:
             result = max(1, int(val))
             if result > 10:
-                logger.warning(
-                    "delegation.max_concurrent_children=%d: each child consumes API tokens "
-                    "independently. High values multiply cost linearly.",
-                    result,
-                )
+                global _HIGH_CONCURRENCY_WARNED
+                if not _HIGH_CONCURRENCY_WARNED:
+                    _HIGH_CONCURRENCY_WARNED = True
+                    logger.warning(
+                        "delegation.max_concurrent_children=%d: each child consumes API tokens "
+                        "independently. High values multiply cost linearly.",
+                        result,
+                    )
             return result
         except (TypeError, ValueError):
             logger.warning(


### PR DESCRIPTION
## Summary
The `delegation.max_concurrent_children` high-concurrency cost warning now fires at most once per process instead of on every turn / agent spawn.

Root cause: `_get_max_concurrent_children()` is called on **every** `get_definitions()` schema rebuild (via `_build_top_level_description` and `_build_tasks_param_description`), not just when `delegate_task` is actually invoked. With `max_concurrent_children > 10`, the cost advisory logged on every schema assembly across every session — spamming the log even for agents that never delegate.

## Changes
- `tools/delegate_tool.py`: gate the cost warning behind a module-level `_HIGH_CONCURRENCY_WARNED` flag so it emits once per process.

## Validation
| | Before | After |
|---|---|---|
| 50 schema rebuilds (config=15) | 150 warnings | 1 warning |
| resolved limit | 15 | 15 |

E2E: temp `HERMES_HOME` with `max_concurrent_children: 15`, 50 rebuild iterations -> exactly 1 advisory, value still resolves to 15. `tests/tools/test_delegate.py` 140/140 pass.

## Infographic

![delegation-cost-warning-spam-fix](https://v3b.fal.media/files/b/0a9f5384/FjOq7mNhQbPYGgNNSo8UF_thi3Kcw7.png)
