### PR TITLE
fix(tui): discover plugins before creating agent so hooks fire

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3712,6 +3712,18 @@ def _make_agent(
     from run_agent import AIAgent
     from hermes_cli.runtime_provider import resolve_runtime_provider
 
+    # Ensure hook-based plugins (Langfuse, etc.) are discovered and their
+    # hooks registered before the agent starts processing.  The gateway path
+    # (gateway/run.py) already calls discover_plugins() at startup, but the
+    # TUI/dashboard path never did — so has_hook() always returned False and
+    # hooks silently never fired.  discover_plugins() is idempotent (guarded by
+    # a loaded flag internally), so repeated calls are safe.
+    try:
+        from hermes_cli.plugins import discover_plugins
+        discover_plugins()
+    except Exception:
+        pass
+
     # MCP tool discovery runs in a background daemon thread at startup so a
     # dead server can't freeze the shell.  The agent snapshots its tool list
     # once here and never re-reads it, so briefly wait for in-flight discovery


### PR DESCRIPTION
## Summary

Hook-based plugins (Langfuse, etc.) were silently inactive for all conversations conducted through the web UI / TUI dashboard.

## Motivation

Fixes #50776

The plugin was enabled and hooks were registered in the plugin manifest, but `discover_plugins()` was never called in the TUI agent initialization path, so `has_hook()` always returned False and no hooks fired.

## Root Cause

| Path | Plugin loading | Used for |
|------|---------------|----------|
| Gateway (gateway/run.py) | ✅ Calls discover_plugins() at startup | Telegram, Discord, Slack, etc. |
| TUI slash_worker (tui_gateway/server.py) | ❌ Did NOT call discover_plugins() for hooks | Web UI dashboard (port 4860) |

## Changes

- **fix**: Call `discover_plugins()` at the beginning of `_make_agent()` in `tui_gateway/server.py`
- `discover_plugins()` is idempotent (guarded by a loaded flag internally), so repeated calls are safe

## Validation

- The gateway path already calls `discover_plugins()` at startup
- This fix ensures hooks are registered for all conversation paths
- Affects ALL hook-based plugins, not just Langfuse

## Checklist

- [x] Code follows the project's style guidelines
- [x] No unrelated changes included
- [x] Commit message follows Conventional Commits format