### PR TITLE
fix(auxiliary): classify z.ai plan-limit 429 as payment, not transient (salvage #13234)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2326,6 +2326,11 @@ def _is_payment_error(exc: Exception) -> bool:
             "credits", "insufficient funds",
             "can only afford", "billing",
             "payment required",
+            # z.ai returns 429 code 1311 when the plan lacks access to the
+            # requested model (e.g. GLM-5V-Turbo on the coding plan). Permanent,
+            # not transient -- treat as billing so the payment-fallback chain
+            # picks a different backend instead of a useless cooldown.
+            "subscription plan", "does not yet include", "plan does not include",
             "out of funds", "run out of funds",
             "balance_depleted", "no usable credits",
             "model_not_supported_on_free_tier",

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1261,6 +1261,27 @@ class TestIsPaymentError:
         exc = Exception("connection reset")
         assert _is_payment_error(exc) is False
 
+    def test_zai_1311_subscription_plan_is_payment(self):
+        """z.ai returns HTTP 429 code 1311 when the plan lacks the model
+        (e.g. GLM-5V-Turbo on the coding plan). Permanent -- must route to
+        payment fallback, not transient rate-limit handling."""
+        exc = Exception(
+            "{'error': {'code': '1311', 'message': "
+            "'Your current subscription plan does not yet include access to GLM-5V-Turbo'}}"
+        )
+        exc.status_code = 429
+        assert _is_payment_error(exc) is True
+
+    def test_zai_1305_overloaded_is_not_payment(self):
+        """Transient overload must NOT be classified as payment -- it will
+        recover, and misclassifying it skips retry/cooldown paths."""
+        exc = Exception(
+            "{'error': {'code': '1305', 'message': "
+            "'The service may be temporarily overloaded, please try again later'}}"
+        )
+        exc.status_code = 429
+        assert _is_payment_error(exc) is False
+
     # ── Daily / monthly quota exhaustion (#26803) ────────────────────────────
 
     def test_429_quota_exceeded(self):


### PR DESCRIPTION
Salvage of #13234 by @thapecroth. Re-applied the core classification fix to the
current `_is_payment_error` keyword list (which has grown since the original PR)
and ported the two regression tests.

## Bug

`_is_payment_error()` in `agent/auxiliary_client.py` decides whether an
auxiliary-model failure is a **billing/quota** problem (? route to the
payment-fallback chain, pick a different backend) or a **transient** one
(? cool down and retry the same backend).

z.ai returns **HTTP 429 code 1311** when the subscription plan simply doesn''t
include the requested model, e.g.:

```
{'error': {'code': '1311', 'message':
  "Your current subscription plan does not yet include access to GLM-5V-Turbo"}}
```

This is **permanent** - the plan will never include that model without an
upgrade - but `_is_payment_error` doesn''t recognise the wording, so it falls
through to transient rate-limit handling. The aux chain then sits in a useless
cooldown on a backend that can never serve the request, instead of failing over
to a working one.

## Fix

Add the z.ai plan-limit phrasings to the billing keyword set:

```python
"subscription plan", "does not yet include", "plan does not include",
```

Now a 1311 plan-limit error classifies as payment ? the fallback chain engages
with credential/backend rotation.

## Tests (ported from #13234)

`tests/agent/test_auxiliary_client.py`:
- `test_zai_1311_subscription_plan_is_payment` - 429/1311 plan-limit ? payment.
- `test_zai_1305_overloaded_is_not_payment` - 429/1305 transient overload stays
  **not** payment, so genuine rate limits still cool down and retry.

## Scope

The original PR also added a `_log_400_diag` HTTP-400 diagnostic helper. That
part has drifted against the current `call_llm` / `async_call_llm` structure and
is an independent diagnostics improvement, so this PR keeps to the classification
bug fix + its tests. The 400-diagnostics can be a separate change.

## Verification

- Confirmed on current `main`: `_is_payment_error`''s keyword set does **not**
  contain `subscription plan` / `does not yet include` / `plan does not include`.
- The transient-overload test guards against over-classifying real rate limits
  as billing.

Credit to @thapecroth for the original fix, tests, and analysis (#13234).