### PR TITLE
fix(computer-use): delete broken pre-install asset probe; trust the upstream installer

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -648,52 +648,31 @@ def _pip_install(
 
 
 
-def _check_cua_driver_asset_for_arch() -> bool:
-    """Check whether the latest CUA release ships an asset for this architecture.
-
-    Returns True if the asset likely exists (or if we cannot determine it).
-    Returns False and prints a warning when the asset is confirmed missing,
-    so callers can skip the install attempt and avoid a raw 404.
-    """
-    import platform as _plat
-    import urllib.request
-
-    machine = _plat.machine()  # "x86_64" or "arm64"
-    if machine == "arm64":
-        # arm64 (Apple Silicon) assets are always published.
-        return True
-
-    # x86_64 / Intel — probe the latest release for an architecture-specific
-    # asset before falling through to the upstream installer.
-    api_url = (
-        "https://api.github.com/repos/trycua/cua/releases/latest"
-    )
-    try:
-        req = urllib.request.Request(api_url, headers={"Accept": "application/vnd.github+json"})
-        with urllib.request.urlopen(req, timeout=10) as resp:
-            release = _json.loads(resp.read().decode())
-        tag = release.get("tag_name", "")
-        assets = release.get("assets", [])
-        arch_names = {"x86_64", "amd64"}
-        has_asset = any(
-            any(a in a_info.get("name", "").lower() for a in arch_names)
-            for a_info in assets
-        )
-        if not has_asset:
-            _print_warning(
-                f"    Latest CUA release ({tag}) has no Intel (x86_64) asset."
-            )
-            _print_info(
-                "    CUA Driver currently only ships Apple Silicon builds."
-            )
-            _print_info(
-                "    See: https://github.com/trycua/cua/issues/1493"
-            )
-            return False
-    except Exception:
-        # Network / API failure — proceed and let the installer handle it.
-        pass
-    return True
+# The asset-probe that lived here used to hit `/releases/latest` on
+# trycua/cua and inspect the release's asset list before piping the
+# installer to bash. It was broken in two places:
+#
+#   1. cua-driver-rs releases are marked **prerelease** on every cut,
+#      and GitHub's `/releases/latest` endpoint explicitly skips
+#      prereleases. On the live trycua/cua repo today, `/releases/latest`
+#      returns the Python `cua-agent v0.8.3` package (zero binary
+#      assets) instead of `cua-driver-rs-v0.6.0` (19 binary assets).
+#      The probe then reported "no asset for this arch" and skipped the
+#      install on every non-arm64 host — Linux x86_64, Windows, macOS
+#      Intel, Linux arm64 — even when the upstream installer would have
+#      succeeded.
+#   2. Even with the right endpoint, we'd be duplicating tag-resolution
+#      logic the upstream installer already does correctly via
+#      `CUA_DRIVER_RS_BAKED_VERSION` (auto-baked by CD on every release,
+#      with an API fallback). Drift between our probe and theirs is a
+#      maintenance hazard.
+#
+# Resolution: trust the upstream installer. For fresh installs, run
+# install.sh directly — it errors clean if the target arch has no
+# asset. For the upgrade path, `cua_driver_update_check()` (which calls
+# `cua-driver check-update --json`) gives us the canonical update
+# answer from the binary itself — same tag-resolution as the installer,
+# no Python-side duplication.
 
 
 def install_cua_driver(upgrade: bool = False) -> bool:
@@ -734,8 +713,9 @@ def install_cua_driver(upgrade: bool = False) -> bool:
             _print_warning("    curl not found — install manually:")
             _print_info("      https://github.com/trycua/cua/blob/main/libs/cua-driver/README.md")
             return False
-        if not _check_cua_driver_asset_for_arch():
-            return False
+        # Pre-install asset probe deleted — see comment near the top of
+        # tools_config.py for why. install.sh has CUA_DRIVER_RS_BAKED_VERSION
+        # baked in by CD and errors cleanly on missing-arch assets.
         return _run_cua_driver_installer(label="Installing")
 
     # Already installed and caller didn't ask to upgrade → just confirm.
@@ -758,8 +738,10 @@ def install_cua_driver(upgrade: bool = False) -> bool:
         _print_warning("    curl not found — cannot refresh cua-driver.")
         return bool(binary)
 
-    if not _check_cua_driver_asset_for_arch():
-        return bool(binary)
+    # Pre-install asset probe deleted (see top-of-file comment). The
+    # `cua_driver_update_check()` call further down asks the installed
+    # cua-driver binary itself whether an update exists — same
+    # tag-resolution as the installer, no duplication.
 
     if binary:
         # Show before/after version when we have a baseline. Best-effort.

--- a/tests/hermes_cli/test_install_cua_driver.py
+++ b/tests/hermes_cli/test_install_cua_driver.py
@@ -1,4 +1,4 @@
-"""Tests for ``install_cua_driver`` upgrade semantics and architecture pre-check.
+"""Tests for ``install_cua_driver`` upgrade semantics.
 
 The cua-driver upstream installer always pulls the latest release tag, so
 re-running it is the canonical upgrade path. ``install_cua_driver(upgrade=True)``
@@ -10,14 +10,18 @@ must:
   fix for the "we only pulled cua-driver once on enable" complaint).
 * Preserve original ``upgrade=False`` behaviour for the toolset-enable flow:
   skip if installed, install otherwise, warn on non-macOS.
-* Pre-check architecture compatibility before downloading to avoid raw 404
-  errors on Intel macOS when the upstream release lacks x86_64 assets.
+
+The pre-install arch probe that used to live alongside this function was
+deleted (see top-of-file comment in tools_config.py) — the upstream
+installer has CUA_DRIVER_RS_BAKED_VERSION baked in by CD and errors
+cleanly on missing-arch assets, and the upgrade path uses
+``cua_driver_update_check()`` (which shells `cua-driver check-update
+--json` against the already-installed binary).
 """
 
 from __future__ import annotations
 
-import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 
 class TestInstallCuaDriverUpgrade:
@@ -44,8 +48,6 @@ class TestInstallCuaDriverUpgrade:
              patch.object(tools_config.shutil, "which",
                           side_effect=lambda n: "/usr/local/bin/" + n
                                                  if n in {"cua-driver", "curl"} else None), \
-             patch.object(tools_config, "_check_cua_driver_asset_for_arch",
-                          return_value=True), \
              patch.object(tools_config, "_run_cua_driver_installer",
                           return_value=True) as runner, \
              patch("subprocess.run"):
@@ -60,8 +62,6 @@ class TestInstallCuaDriverUpgrade:
         with patch("platform.system", return_value="Darwin"), \
              patch.object(tools_config.shutil, "which",
                           side_effect=lambda n: "/usr/bin/curl" if n == "curl" else None), \
-             patch.object(tools_config, "_check_cua_driver_asset_for_arch",
-                          return_value=True), \
              patch.object(tools_config, "_run_cua_driver_installer",
                           return_value=True) as runner:
             assert tools_config.install_cua_driver(upgrade=True) is True
@@ -85,128 +85,75 @@ class TestInstallCuaDriverUpgrade:
         with patch("platform.system", return_value="Darwin"), \
              patch.object(tools_config.shutil, "which",
                           side_effect=lambda n: "/usr/bin/curl" if n == "curl" else None), \
-             patch.object(tools_config, "_check_cua_driver_asset_for_arch",
-                          return_value=True), \
              patch.object(tools_config, "_run_cua_driver_installer",
                           return_value=True) as runner:
             assert tools_config.install_cua_driver(upgrade=False) is True
+            runner.assert_called_once()
 
 
-class TestCheckCuaDriverAssetForArch:
-    def test_arm64_always_returns_true(self):
+class TestArchProbeRemoval:
+    """Regression tests for the deletion of `_check_cua_driver_asset_for_arch`.
+
+    The old probe queried ``/releases/latest`` on trycua/cua and inspected
+    asset names. That was wrong in two ways:
+
+    1. cua-driver-rs releases are marked **prerelease** on every cut, so
+       ``/releases/latest`` returns the Python ``cua-agent`` / ``cua-computer``
+       package instead — a release with zero binary assets. The probe then
+       reported "no asset for $arch" on Linux x86_64, Windows, macOS Intel,
+       Linux arm64 — every non-Apple-Silicon host.
+    2. Even with the right endpoint, it duplicated tag-resolution the upstream
+       installer already does correctly via ``CUA_DRIVER_RS_BAKED_VERSION``
+       (auto-baked by CD on every release).
+
+    The fix: stop probing. Trust the upstream installer for fresh installs
+    (it has the baked version + correct API fallback) and the
+    ``cua-driver check-update --json`` MCP-binary native command for the
+    upgrade path.
+    """
+
+    def test_probe_function_is_gone(self):
         from hermes_cli import tools_config
+        assert not hasattr(tools_config, "_check_cua_driver_asset_for_arch")
+        assert not hasattr(tools_config, "_latest_cua_driver_rs_release")
 
-        with patch("platform.machine", return_value="arm64"):
-            assert tools_config._check_cua_driver_asset_for_arch() is True
-
-    def test_x86_64_with_asset_returns_true(self):
+    def test_fresh_install_does_not_call_github_api(self):
+        """Pre-install no longer probes the GitHub API — the upstream
+        ``install.sh`` resolves the tag from its baked CUA_DRIVER_RS_BAKED_VERSION
+        line. install.sh errors cleanly when the arch has no asset, so the
+        probe was duplicate gatekeeping.
+        """
         from hermes_cli import tools_config
-
-        release = {
-            "tag_name": "cua-driver-v0.1.6",
-            "assets": [
-                {"name": "cua-driver-0.1.6-darwin-arm64.tar.gz"},
-                {"name": "cua-driver-0.1.6-darwin-x86_64.tar.gz"},
-            ],
-        }
-        mock_resp = MagicMock()
-        mock_resp.read.return_value = json.dumps(release).encode()
-        mock_resp.__enter__ = lambda s: s
-        mock_resp.__exit__ = MagicMock(return_value=False)
-
-        with patch("platform.machine", return_value="x86_64"), \
-             patch("urllib.request.urlopen", return_value=mock_resp):
-            assert tools_config._check_cua_driver_asset_for_arch() is True
-
-    def test_x86_64_without_asset_returns_false(self):
-        from hermes_cli import tools_config
-
-        release = {
-            "tag_name": "cua-driver-v0.1.6",
-            "assets": [
-                {"name": "cua-driver-0.1.6-darwin-arm64.tar.gz"},
-                {"name": "cua-driver.tar.gz"},
-            ],
-        }
-        mock_resp = MagicMock()
-        mock_resp.read.return_value = json.dumps(release).encode()
-        mock_resp.__enter__ = lambda s: s
-        mock_resp.__exit__ = MagicMock(return_value=False)
-
-        with patch("platform.machine", return_value="x86_64"), \
-             patch("urllib.request.urlopen", return_value=mock_resp), \
-             patch.object(tools_config, "_print_warning") as warn, \
-             patch.object(tools_config, "_print_info"):
-            assert tools_config._check_cua_driver_asset_for_arch() is False
-            warn.assert_called_once()
-            assert "no Intel" in warn.call_args[0][0].lower() or "x86_64" in warn.call_args[0][0]
-
-    def test_x86_64_api_failure_returns_true(self):
-        """Network failure should fail open — let the installer handle it."""
-        from hermes_cli import tools_config
-
-        with patch("platform.machine", return_value="x86_64"), \
-             patch("urllib.request.urlopen", side_effect=Exception("timeout")):
-            assert tools_config._check_cua_driver_asset_for_arch() is True
-
-    def test_fresh_install_x86_64_no_asset_skips_installer(self):
-        """When the latest release has no Intel asset, skip the installer."""
-        from hermes_cli import tools_config
-
-        release = {
-            "tag_name": "cua-driver-v0.1.6",
-            "assets": [{"name": "cua-driver-0.1.6-darwin-arm64.tar.gz"}],
-        }
-        mock_resp = MagicMock()
-        mock_resp.read.return_value = json.dumps(release).encode()
-        mock_resp.__enter__ = lambda s: s
-        mock_resp.__exit__ = MagicMock(return_value=False)
 
         with patch("platform.system", return_value="Darwin"), \
              patch.object(tools_config.shutil, "which",
                           side_effect=lambda n: "/usr/bin/curl" if n == "curl" else None), \
-             patch("platform.machine", return_value="x86_64"), \
-             patch("urllib.request.urlopen", return_value=mock_resp), \
-             patch.object(tools_config, "_print_warning"), \
-             patch.object(tools_config, "_print_info"), \
-             patch.object(tools_config, "_run_cua_driver_installer") as runner:
-            assert tools_config.install_cua_driver(upgrade=False) is False
-            runner.assert_not_called()
+             patch("urllib.request.urlopen") as urlopen, \
+             patch.object(tools_config, "_run_cua_driver_installer",
+                          return_value=True) as runner:
+            assert tools_config.install_cua_driver(upgrade=False) is True
+            runner.assert_called_once()
+            urlopen.assert_not_called()
 
-    def test_upgrade_x86_64_no_asset_returns_existing_status(self):
-        """On upgrade with no Intel asset, return whether binary existed."""
+    def test_upgrade_with_binary_does_not_call_github_api_directly(self):
+        """The upgrade path no longer hits GitHub from Python — it delegates
+        to the upstream ``install.sh`` (which has the baked release tag and
+        the proper API fallback). When cua-driver is already installed,
+        ``cua_driver_update_check()`` (added in a separate change) further
+        short-circuits the network re-install via the binary's native
+        ``check-update --json`` verb.
+        """
         from hermes_cli import tools_config
 
-        release = {
-            "tag_name": "cua-driver-v0.1.6",
-            "assets": [{"name": "cua-driver-0.1.6-darwin-arm64.tar.gz"}],
-        }
-        mock_resp = MagicMock()
-        mock_resp.read.return_value = json.dumps(release).encode()
-        mock_resp.__enter__ = lambda s: s
-        mock_resp.__exit__ = MagicMock(return_value=False)
-
-        # With binary installed — returns True (binary exists)
         with patch("platform.system", return_value="Darwin"), \
              patch.object(tools_config.shutil, "which",
                           side_effect=lambda n: "/usr/local/bin/" + n
                                                  if n in ("cua-driver", "curl") else None), \
-             patch("platform.machine", return_value="x86_64"), \
-             patch("urllib.request.urlopen", return_value=mock_resp), \
-             patch.object(tools_config, "_print_warning"), \
-             patch.object(tools_config, "_print_info"), \
-             patch.object(tools_config, "_run_cua_driver_installer") as runner:
+             patch("urllib.request.urlopen") as urlopen, \
+             patch("subprocess.run"), \
+             patch.object(tools_config, "_run_cua_driver_installer",
+                          return_value=True) as runner:
             assert tools_config.install_cua_driver(upgrade=True) is True
-            runner.assert_not_called()
-
-        # Without binary — returns False
-        with patch("platform.system", return_value="Darwin"), \
-             patch.object(tools_config.shutil, "which",
-                          side_effect=lambda n: "/usr/bin/curl" if n == "curl" else None), \
-             patch("platform.machine", return_value="x86_64"), \
-             patch("urllib.request.urlopen", return_value=mock_resp), \
-             patch.object(tools_config, "_print_warning"), \
-             patch.object(tools_config, "_print_info"), \
-             patch.object(tools_config, "_run_cua_driver_installer") as runner:
-            assert tools_config.install_cua_driver(upgrade=True) is False
-            runner.assert_not_called()
+            runner.assert_called_once()
+            # Probe deleted — no direct GitHub API call from Python.
+            urlopen.assert_not_called()


### PR DESCRIPTION
## Summary

`hermes computer-use install` refused to install on **Linux, Windows, and macOS x86_64** because the pre-install asset probe was hitting the wrong GitHub endpoint AND duplicating tag-resolution logic the upstream installer already does correctly. Fix: **delete the probe** rather than mirror upstream's logic in Python.

## Root cause

`_check_cua_driver_asset_for_arch()` in `hermes_cli/tools_config.py` queried `https://api.github.com/repos/trycua/cua/releases/latest`. On `trycua/cua`:

- cua-driver-rs releases (the binary the installer fetches) are marked **prerelease** on every cut. GitHub's `/releases/latest` explicitly skips prereleases.
- The Python package releases (`cua-agent`, `cua-computer`, `cua-train`) are non-prerelease and end up as the "latest" instead.

Live verification today:

```
$ curl -sf https://api.github.com/repos/trycua/cua/releases/latest | jq '{tag:.tag_name, asset_count: (.assets|length)}'
{ "tag": "agent-v0.8.3", "asset_count": 0 }
```

The probe sees zero assets, prints "Latest CUA release has no Linux x86_64 asset", and skips the install on every Linux / Windows / macOS-x86_64 host — even though `cua-driver-rs-v0.6.0` (further down the same release list) ships 19 binary assets covering all those platforms.

## Why delete rather than fix the endpoint

Filtering `/releases?per_page=N` for the `cua-driver-rs-v*` prefix fixes the bug, but it duplicates tag-resolution logic the upstream `_install-rust.sh` already does correctly via `CUA_DRIVER_RS_BAKED_VERSION` — a constant auto-baked by CD on every release, with a `/releases?per_page=N` API fallback for dev checkouts. The right answer is to trust that contract instead of mirroring it in Python where it can drift.

Two paths get the same outcome without the probe:

1. **Fresh install** — run `install.sh` directly. It has the baked release tag, fetches the right asset, and errors with a clear message on missing-arch downloads. No preflight needed.
2. **Upgrade path** — `cua_driver_update_check()` (added separately) shells `cua-driver check-update --json` against the installed binary, which returns the canonical update answer from the same source the installer uses.

## Changes

- `hermes_cli/tools_config.py` — delete `_check_cua_driver_asset_for_arch` and its two call sites in `install_cua_driver`. Replace with a comment explaining the rationale.
- `tests/hermes_cli/test_install_cua_driver.py` — drop the obsolete `TestCheckCuaDriverAssetForArch` block. Add `TestArchProbeRemoval` with three regressions:
  - `test_probe_function_is_gone` — asserts the deleted helpers stay deleted (catches accidental re-introduction).
  - `test_fresh_install_does_not_call_github_api` — asserts the fresh-install path doesn't hit GitHub directly from Python anymore.
  - `test_upgrade_with_binary_does_not_call_github_api_directly` — same for the upgrade path.

Net diff: `+91 / -162` lines.

## Test plan

- [x] `pytest tests/hermes_cli/test_install_cua_driver.py -v` — 9 passed, 0 failed
- [x] Live-verified `/releases/latest` returns `agent-v0.8.3` (zero binary assets), confirming the bug
- [x] Live-verified `cua-driver check-update --json` returns the correct `current_version` / `latest_version` for the cua-driver-rs release on a host with cua-driver already installed
- [ ] Run `hermes computer-use install` on a Linux x86_64 host (no longer skipped — needs follow-up smoke on a clean install)

## Context

Caught by @teknium1 while testing computer-use on a headed Ubuntu host. Surfaced separately from PR #50507 (the cross-platform supersede). Could go into 50507 instead — open to either landing path.

Earlier draft of this PR mirrored `_install-rust.sh`'s tag-resolution in Python (option A from the original triage); this revision is option B (delete the probe, trust the upstream installer) per maintainer feedback about not duplicating tag logic across Hermes and cua-driver.