### PR TITLE
fix: raise cron fd limit before scheduled work

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -44,6 +44,51 @@ from hermes_cli.config import load_config, _expand_env_vars
 from hermes_time import now as _hermes_now
 
 logger = logging.getLogger(__name__)
+_fd_limit_checked = False
+
+
+def _ensure_cron_fd_limit() -> None:
+    """Raise the scheduler process' soft fd limit for cron workloads.
+
+    macOS launchd services commonly start with RLIMIT_NOFILE soft=256 even
+    when the hard limit is much higher. A busy cron tick can briefly need more
+    descriptors than that while running several jobs in parallel, launching
+    data-collection scripts, opening SQLite handles, and creating HTTP clients.
+    Keep this best-effort so restricted platforms still run normally.
+    """
+    global _fd_limit_checked
+    if _fd_limit_checked:
+        return
+    _fd_limit_checked = True
+
+    try:
+        desired = int(os.getenv("HERMES_CRON_MIN_NOFILE", "1024") or "0")
+    except (TypeError, ValueError):
+        desired = 1024
+    if desired <= 0:
+        return
+
+    try:
+        import resource
+
+        soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+        if soft >= desired:
+            return
+        if hard == resource.RLIM_INFINITY:
+            new_soft = desired
+        else:
+            new_soft = min(desired, hard)
+        if new_soft <= soft:
+            return
+        resource.setrlimit(resource.RLIMIT_NOFILE, (new_soft, hard))
+        logger.info(
+            "Raised cron RLIMIT_NOFILE soft limit from %s to %s (hard=%s)",
+            soft,
+            new_soft,
+            "unlimited" if hard == resource.RLIM_INFINITY else hard,
+        )
+    except Exception as exc:
+        logger.debug("Could not raise cron RLIMIT_NOFILE: %s", exc)
 
 
 def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
@@ -1266,6 +1311,7 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
     try:
         from tools.environments.local import _sanitize_subprocess_env
 
+        _ensure_cron_fd_limit()
         popen_kwargs = {"creationflags": windows_hide_flags()} if sys.platform == "win32" else {}
         result = subprocess.run(
             argv,
@@ -2408,6 +2454,7 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
         Number of jobs executed (0 if another tick is already running)
     """
     lock_dir, lock_file = _get_lock_paths()
+    _ensure_cron_fd_limit()
     lock_dir.mkdir(parents=True, exist_ok=True)
 
     # Cross-platform file locking: fcntl on Unix, msvcrt on Windows

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1732,6 +1732,20 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     except Exception as e:
         logger.debug("Job '%s': SQLite session store not available: %s", job.get("id", "?"), e)
 
+    def _close_unstarted_session_db() -> None:
+        """Close the cron SessionDB on paths that return before AIAgent owns it.
+
+        Jobs with a data-collection script can short-circuit before the agent
+        session is created (empty script output, wakeAgent=false, prompt block).
+        Those paths still constructed SessionDB above, so close it explicitly
+        rather than leaking state.db/state.db-wal fds in the long-lived gateway.
+        """
+        if _session_db:
+            try:
+                _session_db.close()
+            except (Exception, KeyboardInterrupt) as e:
+                logger.debug("Job '%s': failed to close unused SQLite session store: %s", job_id, e)
+
     # Wake-gate: if this job has a pre-check script, run it BEFORE building
     # the prompt so a ``{"wakeAgent": false}`` response can short-circuit
     # the whole agent run. We pass the result into _build_job_prompt so
@@ -1752,6 +1766,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
                 "Script gate returned `wakeAgent=false` — agent skipped.\n"
             )
+            _close_unstarted_session_db()
             return True, silent_doc, SILENT_MARKER, None
 
     try:
@@ -1778,9 +1793,11 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             "and the match is a false positive, rephrase the content to avoid "
             "the threat pattern (`tools/cronjob_tools.py::_CRON_THREAT_PATTERNS`)."
         )
+        _close_unstarted_session_db()
         return False, blocked_doc, "", str(block_exc)
     if prompt is None:
         logger.info("Job '%s': script produced no output, skipping AI call.", job_name)
+        _close_unstarted_session_db()
         return True, "", SILENT_MARKER, None
     origin = _resolve_origin(job)
     _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -221,7 +221,7 @@ class TestRunJobScript:
         )
         monkeypatch.setattr(sched_mod, "_run_job_script", lambda _path: (True, ""))
 
-        success, _doc, final_response, error = sched_mod._run_job_impl({
+        success, _doc, final_response, error = sched_mod.run_job({
             "id": "job123",
             "name": "empty-script-job",
             "prompt": "Report only if there is data.",

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -11,6 +11,7 @@ import json
 import os
 import sys
 import textwrap
+import types
 from pathlib import Path
 
 import pytest
@@ -196,6 +197,41 @@ class TestRunJobScript:
         assert success is True
         parsed = json.loads(output)
         assert parsed["new_prs"][0]["number"] == 42
+
+    def test_llm_job_empty_script_output_closes_unused_session_db(self, cron_env, monkeypatch):
+        """LLM jobs with empty script output skip the agent without leaking state.db fds."""
+        from cron import scheduler as sched_mod
+
+        class FakeSessionDB:
+            closed = False
+
+            def close(self):
+                self.closed = True
+
+        fake_db = FakeSessionDB()
+        monkeypatch.setitem(
+            sys.modules,
+            "run_agent",
+            types.SimpleNamespace(AIAgent=object),
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "hermes_state",
+            types.SimpleNamespace(SessionDB=lambda: fake_db),
+        )
+        monkeypatch.setattr(sched_mod, "_run_job_script", lambda _path: (True, ""))
+
+        success, _doc, final_response, error = sched_mod._run_job_impl({
+            "id": "job123",
+            "name": "empty-script-job",
+            "prompt": "Report only if there is data.",
+            "script": "empty.py",
+        })
+
+        assert success is True
+        assert final_response == sched_mod.SILENT_MARKER
+        assert error is None
+        assert fake_db.closed is True
 
 
 class TestBuildJobPromptWithScript:

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -601,3 +601,76 @@ class TestRunJobEnvVarCleanup:
         assert os.environ.get("HERMES_SESSION_PLATFORM") is None
         assert os.environ.get("HERMES_SESSION_CHAT_ID") is None
         assert os.environ.get("HERMES_SESSION_CHAT_NAME") is None
+
+
+class TestCronFdLimit:
+    def test_ensure_cron_fd_limit_raises_low_soft_limit(self, monkeypatch):
+        import cron.scheduler as scheduler
+
+        calls = []
+
+        class FakeResource:
+            RLIMIT_NOFILE = object()
+            RLIM_INFINITY = -1
+
+            @staticmethod
+            def getrlimit(which):
+                assert which is FakeResource.RLIMIT_NOFILE
+                return (256, 4096)
+
+            @staticmethod
+            def setrlimit(which, limits):
+                assert which is FakeResource.RLIMIT_NOFILE
+                calls.append(limits)
+
+        monkeypatch.setitem(sys.modules, "resource", FakeResource)
+        monkeypatch.setenv("HERMES_CRON_MIN_NOFILE", "1024")
+        monkeypatch.setattr(scheduler, "_fd_limit_checked", False)
+
+        scheduler._ensure_cron_fd_limit()
+
+        assert calls == [(1024, 4096)]
+
+    def test_ensure_cron_fd_limit_clamps_to_hard_limit(self, monkeypatch):
+        import cron.scheduler as scheduler
+
+        calls = []
+
+        class FakeResource:
+            RLIMIT_NOFILE = object()
+            RLIM_INFINITY = -1
+
+            @staticmethod
+            def getrlimit(which):
+                assert which is FakeResource.RLIMIT_NOFILE
+                return (256, 512)
+
+            @staticmethod
+            def setrlimit(which, limits):
+                assert which is FakeResource.RLIMIT_NOFILE
+                calls.append(limits)
+
+        monkeypatch.setitem(sys.modules, "resource", FakeResource)
+        monkeypatch.setenv("HERMES_CRON_MIN_NOFILE", "1024")
+        monkeypatch.setattr(scheduler, "_fd_limit_checked", False)
+
+        scheduler._ensure_cron_fd_limit()
+
+        assert calls == [(512, 512)]
+
+    def test_ensure_cron_fd_limit_noops_when_disabled(self, monkeypatch):
+        import cron.scheduler as scheduler
+
+        class FakeResource:
+            RLIMIT_NOFILE = object()
+            RLIM_INFINITY = -1
+
+            @staticmethod
+            def getrlimit(which):  # pragma: no cover - should not be called
+                raise AssertionError("disabled fd-limit helper imported resource")
+
+        monkeypatch.setitem(sys.modules, "resource", FakeResource)
+        monkeypatch.setenv("HERMES_CRON_MIN_NOFILE", "0")
+        monkeypatch.setattr(scheduler, "_fd_limit_checked", False)
+
+        scheduler._ensure_cron_fd_limit()


### PR DESCRIPTION
## Summary
- Raise the cron scheduler process soft `RLIMIT_NOFILE` to 1024 by default before ticks and script launches.
- Keep the limit change best-effort and configurable with `HERMES_CRON_MIN_NOFILE`.
- Add regression tests for raising, hard-limit clamping, and disabling the helper.

## Test Plan
- `python -m pytest tests/cron/test_cron_script.py -q -o 'addopts='`
- Manual verification: `_run_job_script('pool_proposer.py')` raised soft nofile from 256 to 1024 and returned the expected pool proposal.

Linear: TSA-376