### PR TITLE
fix(cron): strip code blocks before threat scanning to prevent false positives

### DIFF
--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -193,6 +193,18 @@ def _check_invisible_unicode(prompt: str) -> str:
     return ""
 
 
+def _strip_code_blocks(text: str) -> str:
+    """Strip fenced and inline code blocks, replacing them with a space.
+
+    Without the space replacement, adjacent text across removed regions
+    concatenates and can accidentally match threat-pattern regexes (e.g.
+    ``cat ... .env`` formed from text before and after a code block).
+    """
+    text = re.sub(r"`{3}[\s\S]*?`{3}", " ", text)
+    text = re.sub(r"`[^`]+`", " ", text)
+    return text
+
+
 def _strip_invisible_unicode(prompt: str) -> tuple[str, list[str]]:
     """Strip invisible-unicode characters from *prompt*, preserving the ZWJ
     that lives inside legitimate emoji sequences.
@@ -271,6 +283,10 @@ def _scan_cron_skill_assembled(assembled: str) -> tuple[str, str]:
             "char(s) (%s) from vetted skill content",
             len(removed), ", ".join(removed),
         )
+    # Strip code blocks before scanning so that text across block boundaries
+    # cannot concatenate into a false-positive threat pattern (e.g. "cat … .env"
+    # formed from prose before and after a fenced code block).  See #50754.
+    cleaned = _strip_code_blocks(cleaned)
     prompt_to_scan = _strip_cron_safe_constructs(cleaned)
     for pattern, pid in _CRON_SKILL_ASSEMBLED_PATTERNS:
         if re.search(pattern, prompt_to_scan, re.IGNORECASE):


### PR DESCRIPTION
## Summary

The cron threat scanner produced false-positive `read_secrets` blocks when a job's prompt references skills containing code blocks.

## Motivation

Fixes #50754

`_strip_cron_safe_constructs()` did not strip code blocks, so text across fenced/inline code boundaries could concatenate and accidentally match threat patterns (e.g. `cat ... .env` formed from prose before and after a code block).

8+ cron jobs were blocked that loaded the `auto-issue` skill.

## Changes

- **fix**: Added `_strip_code_blocks()` that replaces code blocks with whitespace
- **fix**: Call `_strip_code_blocks()` in `_scan_cron_skill_assembled()` before pattern matching

## Validation

The fix replaces code blocks with a single space, preventing text concatenation across block boundaries. This matches the approach suggested in the issue.

## Checklist

- [x] Code follows the project's style guidelines
- [x] No unrelated changes included
- [x] Commit message follows Conventional Commits format