### PR TITLE
feat: tool policy hook API + MCP Accept header fix (from arifOS federation)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1128,6 +1128,27 @@ def init_agent(
                 _agent_cfg.get("tool_loop_guardrails", {})
             )
         )
+        # Auto-register user-supplied policy hooks from config.
+        #
+        # Config schema (optional):
+        #     tool_loop_guardrails:
+        #       policy_hooks:
+        #         - "agent.policy_hooks.example_policy_guardrail:risk_policy_guardrail"
+        #         - "my_pkg.my_module:my_hook"
+        #
+        # Each entry is a "module:callable" import path. Failures are logged
+        # and skipped — never break agent init on a missing optional hook.
+        for _hook_path in _agent_cfg.get("tool_loop_guardrails", {}).get("policy_hooks", []) or []:
+            try:
+                _mod_name, _attr = _hook_path.split(":", 1)
+                _mod = __import__(_mod_name, fromlist=[_attr])
+                _hook = getattr(_mod, _attr)
+                agent._tool_guardrails.register_policy_hook(_hook)
+                _ra().logger.info("Registered tool guardrail policy hook: %s", _hook_path)
+            except Exception as _ph_err:
+                _ra().logger.warning(
+                    "Could not register policy hook %s: %s", _hook_path, _ph_err,
+                )
     except Exception as _tlg_err:
         _ra().logger.warning("Tool loop guardrail config ignored: %s", _tlg_err)
     # Cache only the derived auxiliary compression context override that is

--- a/agent/policy_hooks/__init__.py
+++ b/agent/policy_hooks/__init__.py
@@ -1,0 +1,12 @@
+r"""Reference implementations for tool-call policy hooks.
+
+Modules here are optional examples for use with the
+\`ToolCallGuardrailController.register_policy_hook()\` extension API.
+
+To register an example at runtime, point your config at it with a
+"module:callable" import path:
+
+    tool_loop_guardrails:
+      policy_hooks:
+        - "agent.policy_hooks.example_policy_guardrail:risk_policy_guardrail"
+"""

--- a/agent/policy_hooks/example_policy_guardrail.py
+++ b/agent/policy_hooks/example_policy_guardrail.py
@@ -1,0 +1,108 @@
+"""
+example_policy_guardrail.py
+
+Reference implementation of a tool-call policy guardrail that integrates with
+the ToolCallGuardrailController.register_policy_hook() API.
+
+Demonstrates a 3-tier risk classification (READ / WRITE / PRIVILEGED) that
+matches the well-established principle of least authority for browser and
+side-effecting tool calls. Project-specific deployments can adapt the
+risk table to their own threat model.
+
+Hook signature
+--------------
+    def policy_hook(tool_name: str, args: dict | None) -> ToolGuardrailDecision | None
+
+Returning None means "no opinion, fall through to the built-in guardrail logic."
+Returning a ToolGuardrailDecision short-circuits the chain.
+
+Registration
+------------
+    from agent.tool_guardrails import ToolCallGuardrailController
+    from agent.policy_hooks.example_policy_guardrail import risk_policy_guardrail
+
+    controller.register_policy_hook(risk_policy_guardrail)
+
+Or, via config (see agent/policy_hooks/__init__.py for the import-path format):
+    tool_loop_guardrails:
+      policy_hooks:
+        - "agent.policy_hooks.example_policy_guardrail:risk_policy_guardrail"
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Mapping
+
+from agent.tool_guardrails import ToolCallSignature, ToolGuardrailDecision
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Risk classification — adapt to your deployment's threat model
+# ---------------------------------------------------------------------------
+
+RISK_TABLE: dict[str, str] = {
+    # READ — no side effects, no approval needed by default
+    "browser_navigate": "R",
+    "browser_snapshot": "R",
+    "browser_scroll": "R",
+    "browser_back": "R",
+    "browser_get_images": "R",
+    "web_search": "R",
+    # WRITE — mutates remote state; needs explicit allow-list or policy check
+    "browser_click": "W",
+    "browser_type": "W",
+    "browser_press": "W",
+    "browser_vision": "W",
+    # PRIVILEGED — high-blast-radius; require operator approval (e.g. 888_HOLD)
+    "browser_cdp": "P",
+    "browser_dialog": "P",
+    "browser_console": "P",
+}
+
+
+def _operator_approval_required(risk: str, tool_name: str, args: Mapping[str, Any]) -> ToolGuardrailDecision:
+    """Block the call and surface a verdict that downstream code can route to a human."""
+    return ToolGuardrailDecision(
+        action="block",
+        code="POLICY_OPERATOR_APPROVAL_REQUIRED",
+        message=(
+            f"Blocked by policy: {tool_name} is risk class {risk}. "
+            "Operator approval required before execution."
+        ),
+        tool_name=tool_name,
+    )
+
+
+def risk_policy_guardrail(
+    tool_name: str,
+    args: dict[str, Any] | None,
+) -> ToolGuardrailDecision | None:
+    """Policy hook implementing the 3-tier risk table above.
+
+    Returns None for tool calls that are not in the risk table so the built-in
+    guardrail logic can take over. Returns a ToolGuardrailDecision to block.
+    """
+    args = args or {}
+    risk = RISK_TABLE.get(tool_name)
+    if risk is None:
+        # Not a classified tool — let the chain continue.
+        return None
+
+    if risk == "R":
+        # Read-only — pass through, do not consume the policy slot.
+        return None
+
+    if risk in ("W", "P"):
+        # Default-deny for write/privileged actions. Projects should replace
+        # this with their own approval workflow (allow-list, signed token,
+        # operator confirmation, etc.).
+        logger.info(
+            "risk_policy_guardrail: %s class %s blocked — awaiting operator approval",
+            tool_name, risk,
+        )
+        return _operator_approval_required(risk, tool_name, args)
+
+    return None

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -233,13 +233,29 @@ class ToolCallGuardrailController:
         self._same_tool_failure_counts: dict[str, int] = {}
         self._no_progress: dict[ToolCallSignature, tuple[str, int]] = {}
         self._halt_decision: ToolGuardrailDecision | None = None
+        self._policy_hooks: list[callable] = []
 
     @property
     def halt_decision(self) -> ToolGuardrailDecision | None:
         return self._halt_decision
 
+    def register_policy_hook(self, hook: callable) -> None:
+        """Register a policy hook that runs before the built-in checks.
+
+        Each hook receives (tool_name: str, args: dict|None) and must return
+        a ToolCallGuardrailDecision or None. If None is returned by all hooks,
+        the normal guardrail logic proceeds.
+        """
+        if callable(hook) and hook not in self._policy_hooks:
+            self._policy_hooks.append(hook)
+
     def before_call(self, tool_name: str, args: Mapping[str, Any] | None) -> ToolGuardrailDecision:
         signature = ToolCallSignature.from_call(tool_name, _coerce_args(args))
+        # arifOS policy hooks run first — short-circuit if any returns a decision
+        for _hook in self._policy_hooks:
+            _result = _hook(tool_name, args)
+            if _result is not None:
+                return _result
         if not self.config.hard_stop_enabled:
             return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1968,6 +1968,14 @@ class MCPServerTask:
         # case-insensitive so conventional casing is preserved.
         if not any(key.lower() == "mcp-protocol-version" for key in headers):
             headers["mcp-protocol-version"] = LATEST_PROTOCOL_VERSION
+        # MCP Streamable HTTP / SSE servers REQUIRE the Accept header to
+        # declare both `application/json` and `text/event-stream` per the
+        # MCP spec (2025-11-25). Servers return `-32600 "Not Acceptable"`
+        # without it (caught on af-forge 2026-06-18 against minimax-code
+        # on :18091 — and ~10 other servers in the same gateway boot).
+        # Seed as default so user-configured headers can still override.
+        if not any(key.lower() == "accept" for key in headers):
+            headers["Accept"] = "application/json, text/event-stream"
         connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
         ssl_verify = config.get("ssl_verify", True)
         client_cert = _resolve_client_cert(self.name, config)


### PR DESCRIPTION
## Context

Three small, separable improvements harvested from running Hermes in production inside the [arifOS federation](https://github.com/ariffazil/arifos). Each commit is independently reviewable.

## Changes

### 1. `fix(mcp): seed Accept header for Streamable HTTP / SSE servers` (`tools/mcp_tool.py`, +8)

MCP spec (2025-11-25) requires the `Accept` header to declare both `application/json` and `text/event-stream` on the streamable HTTP transport. Without it, servers return `-32600 "Not Acceptable"` and the gateway boot fails for that server.

Mirrors the existing `MCP-Protocol-Version` seeding pattern right above. User-configured headers still override.

### 2. `feat(tool_guardrails): add register_policy_hook() extension API` (`agent/tool_guardrails.py`, +16)

Lets deployments register callables that run before the built-in guardrail checks:

```python
def hook(tool_name: str, args: dict | None) -> ToolGuardrailDecision | None: ...
```

Returning `None` = fall through to built-in logic. Returning a `ToolGuardrailDecision` short-circuits the chain. Enables project-specific policy layers without forking the controller.

### 3. `feat(agent): auto-register tool policy hooks from config` (`agent/agent_init.py`, +21, +108 new file +12 new file)

Reads `tool_loop_guardrails.policy_hooks` (a list of `module:callable` import paths) and registers each at agent init. Failures are logged and skipped — never break init on a missing optional hook.

Includes a neutral reference implementation at `agent/policy_hooks/example_policy_guardrail.py` showing a 3-tier risk classification (READ / WRITE / PRIVILEGED) for browser and side-effecting tool calls. Deployments can either use it as-is or copy it as a template.

## Why this is safe

- **Zero deletions.** All 165 added lines are additive.
- **No behavior change by default.** With no `policy_hooks` configured, the controller behaves identically to before.
- **Backward compatible.** Existing code that doesn't import `register_policy_hook` is unaffected.
- **Neutral scope.** The included example guardrail is doctrine-free — projects wire in their own approval workflow.

## Testing

```bash
# Run from the repo root
python -c "
import sys; sys.path.insert(0, '.')
from agent.tool_guardrails import ToolCallGuardrailController, ToolCallGuardrailConfig
from agent.policy_hooks.example_policy_guardrail import risk_policy_guardrail

c = ToolCallGuardrailController(ToolCallGuardrailConfig.from_mapping({}))
c.register_policy_hook(risk_policy_guardrail)
print(c.before_call('browser_click', {}).code)  # -> POLICY_OPERATOR_APPROVAL_REQUIRED
print(c.before_call('terminal', {}).action)     # -> allow
"
```

## Notes

The example guardrail is intentionally minimal — it returns a block decision with a clear code (`POLICY_OPERATOR_APPROVAL_REQUIRED`) that downstream code can route to whatever approval workflow makes sense (allow-list, signed token, operator prompt, etc.). It does NOT bake in any specific policy framework.

Happy to split this into multiple PRs if maintainers prefer — each commit is independent.