### PR TITLE
fix(cli): validate enum values for config set command

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -6745,6 +6745,13 @@ def edit_config():
     subprocess.run([editor, str(config_path)])
 
 
+# Known enumerated config keys and their valid values.
+# Keys not in this dict accept any value.
+_ENUM_CONFIG_VALUES = {
+    "display.tool_progress": {"off", "new", "all", "verbose"},
+}
+
+
 def set_config_value(key: str, value: str):
     """Set a configuration value."""
     if is_managed():
@@ -6784,6 +6791,20 @@ def set_config_value(key: str, value: str):
         print(f"✓ Set {key} in {get_env_path()}")
         return
     
+    # Validate enum values before writing
+    key_lower = key.strip().lower()
+    if key_lower in _ENUM_CONFIG_VALUES:
+        valid = _ENUM_CONFIG_VALUES[key_lower]
+        if value.lower() not in valid:
+            print(
+                f"✗ Invalid value '{value}' for {key}. "
+                f"Valid options: {'|'.join(sorted(valid))}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        # Normalize to lowercase
+        value = value.lower()
+
     # Otherwise it goes to config.yaml
     # Read the raw user config (not merged with defaults) to avoid
     # dumping all default values back to the file


### PR DESCRIPTION
## Summary

`hermes config set display.tool_progress none` was silently accepted but had no effect.

## Motivation

Fixes #50710

The gateway only recognizes `off|new|all|verbose` for `display.tool_progress`. Passing `none` was written to config.yaml verbatim and reported as success, but the gateway treated it as a non-"off" value, leaving tool-progress enabled.

## Changes

- **fix**: Added enum validation for known enumerated config keys
- Invalid values are rejected with an error message listing valid options
- Valid values are normalized to lowercase

## Validation

- `hermes config set display.tool_progress none` now rejects with: `✗ Invalid value 'none' for display.tool_progress. Valid options: all|new|off|verbose`
- `hermes config set display.tool_progress off` still works as expected

## Checklist

- [x] Code follows the project's style guidelines
- [x] No unrelated changes included
- [x] Commit message follows Conventional Commits format