### PR TITLE
fix(dashboard): route session export through authedFetch for reverse-proxy support

### DIFF
--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -29,7 +29,7 @@ import {
   Check,
   Archive,
 } from "lucide-react";
-import { api } from "@/lib/api";
+import { api, authedFetch } from "@/lib/api";
 import { shouldRefreshSessions } from "@/lib/session-refresh";
 import type {
   SessionInfo,
@@ -1132,14 +1132,7 @@ export default function SessionsPage() {
   const handleExport = useCallback(
     async (id: string) => {
       try {
-        const res = await fetch(api.exportSessionUrl(id), {
-          credentials: "include",
-          headers: {
-            "X-Hermes-Session-Token":
-              (window as unknown as { __HERMES_SESSION_TOKEN__?: string })
-                .__HERMES_SESSION_TOKEN__ ?? "",
-          },
-        });
+        const res = await authedFetch(api.exportSessionUrl(id));
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const blob = await res.blob();
         const url = URL.createObjectURL(blob);


### PR DESCRIPTION
## Summary

- `handleExport` in `SessionsPage.tsx` was the only API call in the dashboard that used raw `fetch()` instead of `authedFetch` / `fetchJSON`, bypassing the `HERMES_BASE_PATH` prefix.
- On reverse-proxy deployments with a URL prefix (e.g. `https://host/hermes/`), session export requests hit `/api/sessions/<id>/export` instead of `/hermes/api/sessions/<id>/export`, returning a 404.
- The raw call also hand-rolled the auth header via a type cast to read `window.__HERMES_SESSION_TOKEN__` instead of using `authedFetch`'s standard handling (loopback-token + gated-cookie modes).

## Fix

Replace the raw `fetch()` + manual auth boilerplate with `authedFetch()`, which already prepends `BASE` and handles auth in both modes — matching every other API call in the dashboard.

## Test plan

- [ ] Deploy dashboard behind a reverse proxy with a non-root prefix (e.g. nginx `location /hermes/`)
- [ ] Navigate to Sessions page, click Export on any session
- [ ] Verify the download triggers (previously 404'd on proxied deployments)
- [ ] Verify export still works on a direct (non-proxied) deployment