### PR TITLE
fix(credential-pool): handle Ollama Cloud weekly usage caps

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -701,6 +701,11 @@ def recover_with_credential_pool(
                 or "gousagelimit" in context_reason
                 or "usage limit reached" in context_message
                 or "usage limit has been reached" in context_message
+                # Ollama Cloud weekly cap: "you (acct) have reached your weekly
+                # usage limit" — word order misses the matches above, so it
+                # otherwise burns a full two-strikes backoff before rotating.
+                or "weekly usage limit" in context_message
+                or "reached your weekly" in context_message
             )
         if not has_retried_429 and not usage_limit_reached:
             return False, True

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -112,6 +112,14 @@ SUPPORTED_POOL_STRATEGIES = {
 EXHAUSTED_TTL_401_SECONDS = 5 * 60           # 5 minutes
 EXHAUSTED_TTL_429_SECONDS = 60 * 60          # 1 hour
 EXHAUSTED_TTL_DEFAULT_SECONDS = 60 * 60      # 1 hour
+# Ollama Cloud weekly usage caps reset on a rolling ~7-day window and carry no
+# machine-readable reset timestamp. The default 1h 429 cooldown re-enters a
+# capped key every hour and re-hammers it (hundreds of dead 429s/day across
+# cron processes), stacking retry/backoff time until the cron inactivity
+# watchdog kills the job. Bench these ~24h so the pool reports the key
+# unavailable and falls back cleanly, re-probing once a day until the rolling
+# window frees the account.
+EXHAUSTED_TTL_OLLAMA_WEEKLY_SECONDS = 24 * 60 * 60   # 24 hours
 
 # Pool key prefix for custom OpenAI-compatible endpoints.
 # Custom endpoints all share provider='custom' but are keyed by their
@@ -526,6 +534,14 @@ class CredentialPool:
             terminal_status = STATUS_DEAD
         else:
             terminal_status = STATUS_EXHAUSTED
+        reset_at = normalized_error.get("reset_at")
+        # Ollama Cloud weekly cap with no provider reset_at: bench ~24h instead
+        # of the default 1h 429 TTL so a weekly-capped account doesn't re-enter
+        # rotation hourly and re-storm (see EXHAUSTED_TTL_OLLAMA_WEEKLY_SECONDS).
+        if reset_at is None and status_code == 429:
+            _msg = (normalized_error.get("message") or "").lower()
+            if "weekly usage limit" in _msg or "reached your weekly" in _msg:
+                reset_at = time.time() + EXHAUSTED_TTL_OLLAMA_WEEKLY_SECONDS
         updated = replace(
             entry,
             last_status=terminal_status,
@@ -533,7 +549,7 @@ class CredentialPool:
             last_error_code=status_code,
             last_error_reason=normalized_error.get("reason"),
             last_error_message=normalized_error.get("message"),
-            last_error_reset_at=normalized_error.get("reset_at"),
+            last_error_reset_at=reset_at,
         )
         self._replace_entry(entry, updated)
         self._persist()


### PR DESCRIPTION
## Problem

Running a multi-account Ollama Cloud credential pool, the gateway would
appear to "stop rotating" and long-running cron jobs would die. Rotation
was actually working — the issue is how the pool treats Ollama Cloud's
**weekly** usage cap, which returns a 429 worded:

> `you (<account>) have reached your weekly usage limit, upgrade for higher limits: https://ollama.com/upgrade`

Two things made the pool churn on a capped account instead of cleanly
skipping it:

1. **No instant rotation.** `recover_with_credential_pool`'s
   `usage_limit_reached` fast-path matches `"usage limit reached"` /
   `"usage limit has been reached"`. Ollama's wording
   (`"...reached your weekly usage limit"`) misses both, so a weekly cap
   takes the slow two-strikes path and burns a full retry+backoff on the
   dead key before rotating.

2. **Wrong cooldown.** `_mark_exhausted` gives every 429 the 1-hour
   `EXHAUSTED_TTL_429_SECONDS` cooldown, but a weekly cap won't clear for
   days. The capped key re-enters rotation every hour and 429s again —
   in practice hundreds of dead requests/day per capped account across
   cron processes, each restarting the retry/backoff cycle. Enough stack
   up that a job exceeds its inactivity watchdog and is killed:

   ```
   Job 'X' idle for 977s (limit 600s) — last activity: API error recovery (attempt 10/10)
   ```

## Fix

- Add the Ollama weekly-cap wording (`"weekly usage limit"` /
  `"reached your weekly"`) to `usage_limit_reached` so it rotates
  immediately instead of two-strikes.
- Bench Ollama weekly caps for 24h via a new
  `EXHAUSTED_TTL_OLLAMA_WEEKLY_SECONDS` instead of the blanket 1h, so a
  capped key stops re-churning. Once the **whole** pool is capped,
  `has_available()` returns False and the configured fallback provider
  takes over cleanly instead of the loop spinning to a watchdog death;
  capped keys are re-probed daily until their rolling window frees.

Scoped to the Ollama weekly wording + `status_code == 429`, so other
providers' transient 429s keep the existing 1h default. Only fires when
the provider supplies no machine-readable `reset_at` (a real reset
timestamp still wins).

## Notes

- No config/API surface changes; both edits are internal to the pool.
- Verified the wording flows through end-to-end: the real SDK
  `RateLimitError` body `{'error': '...weekly usage limit...'}` lands in
  `error_context["message"]` via `extract_api_error_context`, so both the
  fast-path match and the 24h-bench branch trigger.