### PR TITLE
fix(gateway): make voice transcript echo configurable

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17608,18 +17608,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                         pending_text = _enriched
                                         if _transcripts:
                                             _echo_meta = {"thread_id": source.thread_id} if source.thread_id else None
-                                            for _tx in _transcripts:
-                                                try:
-                                                    await _adapter.send(
-                                                        source.chat_id,
-                                                        f'🎙️ "{_tx}"',
-                                                        metadata=_echo_meta,
-                                                    )
-                                                except Exception as _echo_exc:
-                                                    logger.debug(
-                                                        "Voice-interrupt echo failed (non-fatal): %s",
-                                                        _echo_exc,
-                                                    )
+                                            await self._echo_voice_transcripts(
+                                                source,
+                                                _transcripts,
+                                                metadata=_echo_meta,
+                                            )
                                     except Exception as _trans_exc:
                                         logger.warning(
                                             "Voice-interrupt transcription failed: %s", _trans_exc,
@@ -18028,17 +18021,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             pending = _enriched or None
                             if _transcripts:
                                 _echo_meta = {"thread_id": source.thread_id} if source.thread_id else None
-                                for _tx in _transcripts:
-                                    try:
-                                        await adapter.send(
-                                            source.chat_id,
-                                            f'🎙️ "{_tx}"',
-                                            metadata=_echo_meta,
-                                        )
-                                    except Exception as _echo_exc:
-                                        logger.debug(
-                                            "Voice-drain echo failed (non-fatal): %s", _echo_exc,
-                                        )
+                                await self._echo_voice_transcripts(
+                                    source,
+                                    _transcripts,
+                                    metadata=_echo_meta,
+                                )
                         except Exception as _trans_exc:
                             logger.warning(
                                 "Voice-drain transcription failed: %s", _trans_exc,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9611,24 +9611,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     message_text,
                     audio_paths,
                 )
-                # Echo each successful transcript back to the user immediately,
-                # before the agent loop runs. Lets the user verify STT quality
-                # in real-time and see the raw whisper output verbatim.
+                # Optionally echo each successful transcript back to the user
+                # immediately, before the agent loop runs. The transcript is
+                # always prepended to the model input; this user-visible echo is
+                # controlled by gateway.echo_voice_transcripts.
                 if _successful_transcripts:
-                    _echo_adapter = self.adapters.get(source.platform)
                     _echo_meta = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
-                    if _echo_adapter:
-                        for _tx in _successful_transcripts:
-                            try:
-                                await _echo_adapter.send(
-                                    source.chat_id,
-                                    f'🎙️ "{_tx}"',
-                                    metadata=_echo_meta,
-                                )
-                            except Exception as _echo_exc:
-                                logger.debug(
-                                    "Transcript echo failed (non-fatal): %s", _echo_exc,
-                                )
+                    await self._echo_voice_transcripts(source, _successful_transcripts, metadata=_echo_meta)
                 # NOTE: Previously, when transcription failed (e.g. no STT
                 # provider configured), the gateway also emitted a hardcoded
                 # English notice via `_stt_adapter.send()`. That bypassed the
@@ -13979,6 +13968,43 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return prefix
         return user_text
 
+    async def _echo_voice_transcripts(
+        self,
+        source,
+        transcripts: List[str],
+        *,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Echo successful STT transcripts to the user when configured.
+
+        The transcript is always included in the agent's input by
+        _enrich_message_with_transcription(); this controls only the extra
+        user-visible confirmation message.
+        """
+        if not transcripts:
+            return
+        cfg = _load_gateway_config()
+        raw_enabled = cfg_get(cfg, "gateway", "echo_voice_transcripts", default=True)
+        if isinstance(raw_enabled, str):
+            echo_enabled = raw_enabled.strip().lower() not in {"0", "false", "no", "off", ""}
+        else:
+            echo_enabled = bool(raw_enabled)
+        if not echo_enabled:
+            return
+
+        echo_adapter = self.adapters.get(source.platform)
+        if not echo_adapter:
+            return
+        for transcript in transcripts:
+            try:
+                await echo_adapter.send(
+                    source.chat_id,
+                    f'🎙️ "{transcript}"',
+                    metadata=metadata,
+                )
+            except Exception as echo_exc:
+                logger.debug("Transcript echo failed (non-fatal): %s", echo_exc)
+
     async def _enrich_message_with_transcription(
         self,
         user_text: str,
@@ -14110,23 +14136,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             enriched_text, successful_transcripts = await self._enrich_message_with_transcription(
                 text, audio_paths,
             )
-            # Echo raw transcripts back to the user so voice interrupts
-            # feel identical to fresh voice messages.
+            # Keep queued voice interrupts aligned with fresh voice messages:
+            # transcripts are always included in the agent input, while the
+            # separate user-visible echo obeys gateway.echo_voice_transcripts.
             if successful_transcripts:
-                echo_adapter = self.adapters.get(source.platform)
                 echo_meta = {"thread_id": source.thread_id} if source.thread_id else None
-                if echo_adapter:
-                    for tx in successful_transcripts:
-                        try:
-                            await echo_adapter.send(
-                                source.chat_id,
-                                f'🎙️ "{tx}"',
-                                metadata=echo_meta,
-                            )
-                        except Exception as echo_exc:
-                            logger.debug(
-                                "Transcript echo failed (non-fatal): %s", echo_exc,
-                            )
+                await self._echo_voice_transcripts(source, successful_transcripts, metadata=echo_meta)
             return enriched_text or None
 
         # Non-audio fallback: preserve original _dequeue_pending_text semantics.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2728,6 +2728,13 @@ DEFAULT_CONFIG = {
             "enabled": False,
         },
 
+        # Echo each successfully transcribed voice/audio message back to the
+        # user as a separate "🎙️ ..." chat message. The transcript is always
+        # included in the agent's context when STT succeeds; disabling this only
+        # hides the extra user-visible confirmation message. Default preserves
+        # existing behavior.
+        "echo_voice_transcripts": True,
+
         # Maximum bytes for an inbound image / audio / video payload the
         # gateway will buffer into memory and cache to disk. Inbound media is
         # read fully into RAM before being written, so an unbounded upload

--- a/tests/gateway/test_voice_transcript_echo_config.py
+++ b/tests/gateway/test_voice_transcript_echo_config.py
@@ -1,3 +1,4 @@
+import inspect
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -57,3 +58,14 @@ async def test_voice_transcript_echo_accepts_string_false_from_yaml_or_env_bridg
         await runner._echo_voice_transcripts(source, ["hidden from chat"])
 
     adapter.send.assert_not_awaited()
+
+
+def test_all_voice_transcript_echo_paths_use_configured_helper():
+    source = inspect.getsource(GatewayRunner)
+
+    assert "Voice-interrupt echo failed" not in source
+    assert "Voice-drain echo failed" not in source
+    assert "_echo_voice_transcripts(\n                                                source," in source
+    assert "_echo_voice_transcripts(\n                                    source," in source
+    assert source.count("f'🎙️ \"{transcript}\"'") == 1
+    assert "f'🎙️ \"{_tx}\"'" not in source

--- a/tests/gateway/test_voice_transcript_echo_config.py
+++ b/tests/gateway/test_voice_transcript_echo_config.py
@@ -1,0 +1,59 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gateway.run import GatewayRunner
+
+
+@pytest.mark.asyncio
+async def test_voice_transcript_echo_defaults_to_enabled():
+    runner = GatewayRunner.__new__(GatewayRunner)
+    adapter = SimpleNamespace(send=AsyncMock())
+    runner.adapters = {"telegram": adapter}
+    source = SimpleNamespace(platform="telegram", chat_id="123")
+
+    with patch("gateway.run._load_gateway_config", return_value={}):
+        await runner._echo_voice_transcripts(
+            source,
+            ["hello from voice"],
+            metadata={"thread_id": 99},
+        )
+
+    adapter.send.assert_awaited_once_with(
+        "123",
+        '🎙️ "hello from voice"',
+        metadata={"thread_id": 99},
+    )
+
+
+@pytest.mark.asyncio
+async def test_voice_transcript_echo_can_be_disabled_without_disabling_stt():
+    runner = GatewayRunner.__new__(GatewayRunner)
+    adapter = SimpleNamespace(send=AsyncMock())
+    runner.adapters = {"telegram": adapter}
+    source = SimpleNamespace(platform="telegram", chat_id="123")
+
+    with patch(
+        "gateway.run._load_gateway_config",
+        return_value={"gateway": {"echo_voice_transcripts": False}},
+    ):
+        await runner._echo_voice_transcripts(source, ["hidden from chat"])
+
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_voice_transcript_echo_accepts_string_false_from_yaml_or_env_bridge():
+    runner = GatewayRunner.__new__(GatewayRunner)
+    adapter = SimpleNamespace(send=AsyncMock())
+    runner.adapters = {"telegram": adapter}
+    source = SimpleNamespace(platform="telegram", chat_id="123")
+
+    with patch(
+        "gateway.run._load_gateway_config",
+        return_value={"gateway": {"echo_voice_transcripts": "false"}},
+    ):
+        await runner._echo_voice_transcripts(source, ["hidden from chat"])
+
+    adapter.send.assert_not_awaited()

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -358,6 +358,15 @@ Voice messages you send on Telegram are automatically transcribed by Hermes's co
 - `groq` uses Groq Whisper and requires `GROQ_API_KEY`
 - `openai` uses OpenAI Whisper and requires `VOICE_TOOLS_OPENAI_KEY`
 
+By default, Hermes also sends a separate confirmation message containing the raw transcript (for example `🎙️ "..."`) before the agent replies. If you want STT to keep working but do not want that extra chat message, disable only the echo:
+
+```yaml
+gateway:
+  echo_voice_transcripts: false
+```
+
+The transcript is still injected into the agent's context when STT succeeds; this setting only controls the user-visible confirmation message.
+
 #### Skipping STT: pass the raw audio file to the agent
 
 If you'd rather have the **agent itself** handle audio — for diarization, a custom transcription tool, or just archiving the recording — set `stt.enabled: false` in `~/.hermes/config.yaml`:


### PR DESCRIPTION
## Summary
- adds `gateway.echo_voice_transcripts` so STT can stay enabled while suppressing the extra `🎙️ "..."` confirmation message
- applies the setting to both fresh Telegram voice messages and queued voice interrupts
- documents the Telegram config option and preserves the existing default behavior

## Tests
- `python3 -m py_compile gateway/run.py hermes_cli/config.py tests/gateway/test_voice_transcript_echo_config.py`
- `scripts/run_tests.sh tests/gateway/test_voice_transcript_echo_config.py`

## Security
- Changed-file secret scan passed (`cached_secret_scan=clean`).