### PR TITLE
fix(tui_gateway): add /goal wait and /goal unwait command parity

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7946,3 +7946,109 @@ def test_start_agent_build_passes_session_model_override(monkeypatch):
         assert session["agent"].model == "claude-sonnet-4.6"
     finally:
         server._sessions.clear()
+
+
+# ---------------------------------------------------------------------------
+# /goal wait + /goal unwait parity
+# ---------------------------------------------------------------------------
+
+
+def _goal_dispatch(arg, mgr_class=None, session_extra=None):
+    """Helper: dispatch ``/goal <arg>`` through command.dispatch and return the
+    response dict.  Patches GoalManager with *mgr_class* (if given) and injects
+    a minimal session so the handler doesn't bail on "no active session"."""
+    session = _session(**(session_extra or {}))
+    server._sessions["gsid"] = session
+    ctx = patch("hermes_cli.goals.GoalManager", mgr_class) if mgr_class else patch(
+        "hermes_cli.goals.GoalManager",
+        lambda **kw: types.SimpleNamespace(
+            wait_on=lambda *a, **k: None,
+            stop_waiting=lambda: False,
+            has_goal=lambda: False,
+            status_line=lambda: "",
+            set=lambda t: types.SimpleNamespace(goal=t, max_turns=20),
+            pause=lambda **k: None,
+            resume=lambda: None,
+            clear=lambda: None,
+        ),
+    )
+    try:
+        with ctx:
+            return server.handle_request({
+                "id": "1",
+                "method": "command.dispatch",
+                "params": {"name": "goal", "arg": arg, "session_id": "gsid"},
+            })
+    finally:
+        server._sessions.pop("gsid", None)
+
+
+def test_goal_wait_parks_on_valid_pid():
+    calls = {}
+
+    class FakeMgr:
+        def __init__(self, **kw):
+            pass
+
+        def wait_on(self, pid, reason=""):
+            calls["pid"] = pid
+            calls["reason"] = reason
+
+    resp = _goal_dispatch("wait 1234 CI running", mgr_class=FakeMgr)
+    assert "result" in resp
+    assert resp["result"]["type"] == "exec"
+    assert "1234" in resp["result"]["output"]
+    assert "⏳" in resp["result"]["output"]
+    assert calls["pid"] == 1234
+    assert calls["reason"] == "CI running"
+
+
+def test_goal_wait_no_arg_shows_usage():
+    resp = _goal_dispatch("wait")
+    assert "result" in resp
+    assert "Usage" in resp["result"]["output"]
+
+
+def test_goal_wait_invalid_pid_shows_error():
+    resp = _goal_dispatch("wait abc")
+    assert "result" in resp
+    assert "integer" in resp["result"]["output"]
+
+
+def test_goal_wait_runtime_error_surfaces():
+    class FakeMgr:
+        def __init__(self, **kw):
+            pass
+
+        def wait_on(self, pid, reason=""):
+            raise RuntimeError("no active goal to park")
+
+    resp = _goal_dispatch("wait 999", mgr_class=FakeMgr)
+    assert "result" in resp
+    assert "no active goal" in resp["result"]["output"]
+
+
+def test_goal_unwait_clears_barrier():
+    class FakeMgr:
+        def __init__(self, **kw):
+            pass
+
+        def stop_waiting(self):
+            return True
+
+    resp = _goal_dispatch("unwait", mgr_class=FakeMgr)
+    assert "result" in resp
+    assert "barrier cleared" in resp["result"]["output"]
+
+
+def test_goal_unwait_no_barrier():
+    class FakeMgr:
+        def __init__(self, **kw):
+            pass
+
+        def stop_waiting(self):
+            return False
+
+    resp = _goal_dispatch("unwait", mgr_class=FakeMgr)
+    assert "result" in resp
+    assert "No wait barrier" in resp["result"]["output"]

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9036,6 +9036,32 @@ def _(rid, params: dict) -> dict:
                 },
             )
 
+        # /goal wait <pid> [reason] — park the loop on a background process.
+        if lower == "wait" or lower.startswith("wait "):
+            wait_arg = arg[len("wait"):].strip()
+            if not wait_arg:
+                return _ok(rid, {"type": "exec", "output": "Usage: /goal wait <pid> [reason]"})
+            wtokens = wait_arg.split(None, 1)
+            try:
+                pid = int(wtokens[0])
+            except ValueError:
+                return _ok(rid, {"type": "exec", "output": "/goal wait: <pid> must be an integer process id."})
+            reason = wtokens[1].strip() if len(wtokens) > 1 else ""
+            try:
+                mgr.wait_on(pid, reason=reason)
+            except (RuntimeError, ValueError) as exc:
+                return _ok(rid, {"type": "exec", "output": f"/goal wait: {exc}"})
+            rtxt = f" ({reason})" if reason else ""
+            return _ok(
+                rid, {"type": "exec", "output": f"⏳ Goal parked on pid {pid}{rtxt}. Loop pauses until it exits."},
+            )
+
+        # /goal unwait — clear the wait barrier.
+        if lower == "unwait":
+            if mgr.stop_waiting():
+                return _ok(rid, {"type": "exec", "output": "▶ Wait barrier cleared — goal loop resumes."})
+            return _ok(rid, {"type": "exec", "output": "No wait barrier set."})
+
         # Otherwise — treat the remaining text as the new goal.
         try:
             state = mgr.set(arg)


### PR DESCRIPTION
## Summary

- `/goal wait <pid>` and `/goal unwait` were added to both the CLI (`cli_commands_mixin.py`) and gateway (`slash_commands.py`) in #50503, but the TUI gateway's `/goal` dispatcher was not updated.
- In the TUI, `/goal wait 1234` falls through to the default "set new goal" branch and silently creates a goal named `"wait 1234"` instead of parking the loop on PID 1234.
- `/goal unwait` similarly creates a goal named `"unwait"`.

## Fix

Add the same `wait` / `unwait` subcommand parsing to `tui_gateway/server.py`, using the existing `GoalManager.wait_on()` and `stop_waiting()` methods and the TUI handler's `_ok(rid, {type: exec, output: ...})` response convention. Logic mirrors `gateway/slash_commands.py` line-for-line.

## Test plan

- [ ] Open a TUI session, set a goal (`/goal build the project`)
- [ ] Run `/goal wait <pid>` with a valid PID — verify "⏳ Goal parked" output
- [ ] Run `/goal wait` with no argument — verify usage hint
- [ ] Run `/goal wait abc` — verify "<pid> must be an integer" error
- [ ] Run `/goal unwait` — verify "▶ Wait barrier cleared" output
- [ ] Run `/goal unwait` with no barrier set — verify "No wait barrier set" output
- [ ] Verify existing subcommands still work: `/goal status`, `/goal pause`, `/goal resume`, `/goal clear`