### PR TITLE
feat(skills): add spec-driven-dev

### DIFF
--- a/skills/software-development/spec-driven-dev/SKILL.md
+++ b/skills/software-development/spec-driven-dev/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: spec-driven-dev
+description: "Spec-Driven Development: constitution, spec, plan, tasks."
+version: 0.1.0
+author: Hermes Agent (adapted from github/spec-kit pattern)
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [planning, specification, spec-kit, design, constitution, acceptance-criteria, workflow]
+    related_skills: [plan, spike, subagent-driven-development, test-driven-development, requesting-code-review]
+---
+
+# Spec-Driven Development
+
+A Hermes-native port of the GitHub Spec Kit flow. Five-stage pipeline that
+front-loads the *why* before the *what* and the *how*:
+
+```
+constitution  ->  spec  ->  plan  ->  tasks  ->  implement
+   (why)        (what)    (how)    (slices)    (code)
+```
+
+Load this skill when the user wants to design a feature before coding it,
+or when an existing plan is too thin to hand to `subagent-driven-development`.
+
+## Core principle
+
+Specs are **executable artifacts**, not documentation. Each stage produces a
+file the next stage can read without re-deriving intent. If a stage needs
+human judgment, it stops and asks — it does not guess.
+
+## Pipeline at a glance
+
+| Stage | Output file (under `.spec/<feature>/`) | Purpose |
+|-------|----------------------------------------|---------|
+| 1. Constitution | `constitution.md` | Non-negotiable project invariants. Frozen unless amended. |
+| 2. Spec | `spec.md` | WHAT the feature does. User stories + acceptance criteria. |
+| 3. Plan | `plan.md` | HOW we will build it. Architecture, tech choices, file layout. |
+| 4. Tasks | `tasks.md` | Bite-sized 2-5 min slices with TDD cycles, ready for `subagent-driven-development`. |
+| 5. Implement | (no file) | Hand tasks.md to `subagent-driven-development`. Updates each task inline as it lands. |
+
+`.spec/` is the working tree of this skill. It is **read-mostly** after the
+spec stage freezes — anything past spec.md should not mutate earlier stages.
+
+## When to load this skill
+
+**Load when:**
+- User says "I want to design X before building it"
+- User asks for a "spec", "specification", "design doc", or "PRD"
+- A feature crosses 3+ files or spans multiple sessions
+- Multiple profiles (coder, reviewer, orchestrator) will touch the work
+- The work is ambiguous enough that plan-only would invent the answer
+
+**Do NOT load when:**
+- The task is a single-file bug fix or trivial refactor — use `systematic-debugging`
+- The user wants raw feasibility exploration — use `spike`
+- The user already has a good plan — use `plan` or `subagent-driven-development`
+- The work is one-shot throwaway — use `sketch`
+
+## How to run
+
+1. Confirm scope: 1-3 sentences on what is being designed and why. Ask if unclear.
+2. Load `references/constitution-template.md`. If `.spec/constitution.md`
+   exists for the project, reuse it; otherwise scaffold one.
+3. Load `references/spec-template.md`. Write `.spec/<slug>/spec.md`.
+   Freeze, then move on.
+4. Load `references/implementation-flow.md`. Write `.spec/<slug>/plan.md`.
+5. Load `references/tasks-template.md`. Write `.spec/<slug>/tasks.md`.
+6. Hand `tasks.md` to `subagent-driven-development`. Do not re-plan inline.
+7. After implementation, append an outcome section to `spec.md`
+   (acceptance-criteria checklist marked done + deviations).
+
+See `references/implementation-flow.md` for the full gating logic between
+stages, what counts as "frozen", and the amend-vs-revise rules.
+
+## Tools referenced (Hermes-native)
+
+This skill uses only built-in tools:
+
+- `read_file`, `write_file`, `patch`, `search_files`
+- `terminal` (read-only inspection commands)
+- `todo` (to track stage transitions)
+- `delegate_task` (via `subagent-driven-development` at stage 5)
+
+No MCP server, no new dependency, no shell pipeline.
+
+## Pitfalls
+
+- **Skipping constitution.** Without invariants, spec debates reopen every stage.
+- **Vague acceptance criteria.** "Works correctly" is not testable. Each criterion
+  must be expressible as a yes/no check a reviewer can run in under 30 seconds.
+- **Tasks larger than 5 minutes.** If a task is bigger, split it before handing
+  off to `subagent-driven-development` — that skill assumes bite-size.
+- **Mutating constitution to fix a plan.** Amend only when the invariant itself
+  was wrong; otherwise fix the plan to honor the invariant.
+- **Mixing stages.** A spec is not a plan. A plan is not tasks. If you find
+  yourself writing implementation steps in `spec.md`, the scope leaked.

--- a/skills/software-development/spec-driven-dev/SKILL.md
+++ b/skills/software-development/spec-driven-dev/SKILL.md
@@ -2,7 +2,7 @@
 name: spec-driven-dev
 description: "Spec-Driven Development: constitution, spec, plan, tasks."
 version: 0.1.0
-author: Hermes Agent (adapted from github/spec-kit pattern)
+author: Juan Ramon Gros (@jrgros-ops); Hermes Agent (adapted from github/spec-kit pattern)
 license: MIT
 platforms: [linux, macos, windows]
 metadata:
@@ -11,88 +11,141 @@ metadata:
     related_skills: [plan, spike, subagent-driven-development, test-driven-development, requesting-code-review]
 ---
 
-# Spec-Driven Development
+# Spec-Driven Development Skill
 
-A Hermes-native port of the GitHub Spec Kit flow. Five-stage pipeline that
-front-loads the *why* before the *what* and the *how*:
+A Hermes-native port of the GitHub Spec Kit flow. Use it to produce executable
+artifacts that carry a feature from project invariants through validated work:
 
 ```
 constitution  ->  spec  ->  plan  ->  tasks  ->  implement
-   (why)        (what)    (how)    (slices)    (code)
+   (why)        (what)    (how)    (slices)    (validated execution)
 ```
 
-Load this skill when the user wants to design a feature before coding it,
-or when an existing plan is too thin to hand to `subagent-driven-development`.
+Each stage produces a file the next stage can read without re-deriving intent.
+If a stage needs human judgment, it stops and asks; it does not guess.
 
-## Core principle
+## When to Use
 
-Specs are **executable artifacts**, not documentation. Each stage produces a
-file the next stage can read without re-deriving intent. If a stage needs
-human judgment, it stops and asks — it does not guess.
+Load this skill when the user wants to design a feature before coding it, or
+when an existing plan is too thin to hand to `subagent-driven-development`.
 
-## Pipeline at a glance
+Use when:
 
-| Stage | Output file (under `.spec/<feature>/`) | Purpose |
-|-------|----------------------------------------|---------|
-| 1. Constitution | `constitution.md` | Non-negotiable project invariants. Frozen unless amended. |
-| 2. Spec | `spec.md` | WHAT the feature does. User stories + acceptance criteria. |
-| 3. Plan | `plan.md` | HOW we will build it. Architecture, tech choices, file layout. |
-| 4. Tasks | `tasks.md` | Bite-sized 2-5 min slices with TDD cycles, ready for `subagent-driven-development`. |
-| 5. Implement | (no file) | Hand tasks.md to `subagent-driven-development`. Updates each task inline as it lands. |
+- User says "I want to design X before building it".
+- User asks for a "spec", "specification", "design doc", or "PRD".
+- A feature crosses 3+ files or spans multiple sessions.
+- Multiple profiles (coder, reviewer, orchestrator) will touch the work.
+- The work is ambiguous enough that plan-only would invent the answer.
 
-`.spec/` is the working tree of this skill. It is **read-mostly** after the
-spec stage freezes — anything past spec.md should not mutate earlier stages.
+Do not use when:
 
-## When to load this skill
+- The task is a single-file bug fix or trivial refactor; use `systematic-debugging`.
+- The user wants raw feasibility exploration; use `spike`.
+- The user already has a good plan; use `plan` or `subagent-driven-development`.
+- The work is one-shot throwaway; use `sketch`.
 
-**Load when:**
-- User says "I want to design X before building it"
-- User asks for a "spec", "specification", "design doc", or "PRD"
-- A feature crosses 3+ files or spans multiple sessions
-- Multiple profiles (coder, reviewer, orchestrator) will touch the work
-- The work is ambiguous enough that plan-only would invent the answer
+## Prerequisites
 
-**Do NOT load when:**
-- The task is a single-file bug fix or trivial refactor — use `systematic-debugging`
-- The user wants raw feasibility exploration — use `spike`
-- The user already has a good plan — use `plan` or `subagent-driven-development`
-- The work is one-shot throwaway — use `sketch`
+- Access to the repository or workspace being designed.
+- A clear feature name that can become the `.spec/<feature>/` directory.
+- Permission to create or update files under `.spec/`.
+- The project constitution at `.spec/constitution.md`, if it already exists.
 
-## How to run
+The constitution is project-scoped. It captures why the project exists, its
+principles, and non-negotiable invariants reused across features. Feature
+artifacts live under `.spec/<feature>/`, but the constitution stays at
+`.spec/constitution.md` and is frozen unless explicitly amended.
 
-1. Confirm scope: 1-3 sentences on what is being designed and why. Ask if unclear.
-2. Load `references/constitution-template.md`. If `.spec/constitution.md`
-   exists for the project, reuse it; otherwise scaffold one.
-3. Load `references/spec-template.md`. Write `.spec/<slug>/spec.md`.
-   Freeze, then move on.
-4. Load `references/implementation-flow.md`. Write `.spec/<slug>/plan.md`.
-5. Load `references/tasks-template.md`. Write `.spec/<slug>/tasks.md`.
-6. Hand `tasks.md` to `subagent-driven-development`. Do not re-plan inline.
-7. After implementation, append an outcome section to `spec.md`
-   (acceptance-criteria checklist marked done + deviations).
-
-See `references/implementation-flow.md` for the full gating logic between
-stages, what counts as "frozen", and the amend-vs-revise rules.
-
-## Tools referenced (Hermes-native)
-
-This skill uses only built-in tools:
+This skill uses only built-in Hermes tools:
 
 - `read_file`, `write_file`, `patch`, `search_files`
-- `terminal` (read-only inspection commands)
-- `todo` (to track stage transitions)
-- `delegate_task` (via `subagent-driven-development` at stage 5)
+- `terminal` for read-only inspection commands
+- `todo` to track stage transitions
+- `delegate_task` through `subagent-driven-development` at stage 5
 
-No MCP server, no new dependency, no shell pipeline.
+No MCP server, new dependency, or shell pipeline is required.
+
+## How to Run
+
+1. Confirm scope in 1-3 sentences: what is being designed and why. Ask if
+   unclear; completion means the user-facing feature boundary is explicit.
+2. Load `references/constitution-template.md`. Reuse `.spec/constitution.md`
+   when it exists; otherwise scaffold it as the project-scoped constitution.
+   Completion means the project invariants are available to every later stage.
+3. Load `references/spec-template.md`. Write `.spec/<feature>/spec.md`.
+   Completion means the feature's user stories and acceptance criteria are
+   frozen enough to plan against.
+4. Load `references/implementation-flow.md`. Write `.spec/<feature>/plan.md`.
+   Completion means the implementation approach, architecture, tech choices,
+   and expected file layout are documented.
+5. Load `references/tasks-template.md`. Write `.spec/<feature>/tasks.md`.
+   Completion means the plan is split into executable 2-5 minute slices.
+6. Hand `.spec/<feature>/tasks.md` to `subagent-driven-development`. Do not
+   re-plan inline. Completion means tasks have been executed and validated.
+7. After implementation, append an outcome section to `.spec/<feature>/spec.md`
+   with the acceptance-criteria checklist marked done and any deviations noted.
+
+See `references/implementation-flow.md` for the full gating logic between
+stages, what counts as frozen, and the amend-vs-revise rules.
+
+## Quick Reference
+
+| Stage | Output file | Purpose |
+|-------|-------------|---------|
+| 1. Constitution | `.spec/constitution.md` | WHY the project exists; principles and invariants reused across features. |
+| 2. Spec | `.spec/<feature>/spec.md` | WHAT the feature must achieve; user stories and acceptance criteria. |
+| 3. Plan | `.spec/<feature>/plan.md` | HOW the feature will be implemented; architecture, choices, and file layout. |
+| 4. Tasks | `.spec/<feature>/tasks.md` | Executable work breakdown; bite-sized TDD-ready slices. |
+| 5. Implement | No new spec file | Validated execution of the tasks, updating task state as work lands. |
+
+`.spec/` is the working tree of this skill. After `spec.md` freezes, later
+stages should not mutate earlier stages unless the user explicitly chooses an
+amendment path.
+
+## Procedure
+
+1. Constitution: capture the project's why, principles, and invariants in
+   `.spec/constitution.md`. Reuse it between features. Amend only when an
+   invariant itself is wrong or incomplete, not to make a difficult plan easier.
+2. Spec: capture what the feature must accomplish in `.spec/<feature>/spec.md`.
+   Keep implementation details out. Acceptance criteria must be checkable as
+   yes/no outcomes a reviewer can evaluate quickly.
+3. Plan: capture how the feature will be implemented in `.spec/<feature>/plan.md`.
+   Include architecture, key files, data flow, testing strategy, and constraints
+   inherited from `.spec/constitution.md`.
+4. Tasks: split the plan into `.spec/<feature>/tasks.md`. Each task should be
+   small enough for a focused implementation pass and should identify its
+   expected validation.
+5. Implement: execute the tasks, preferably with `subagent-driven-development`
+   when delegation fits. Mark tasks as complete only after the relevant tests,
+   checks, or manual verification have actually run.
 
 ## Pitfalls
 
-- **Skipping constitution.** Without invariants, spec debates reopen every stage.
-- **Vague acceptance criteria.** "Works correctly" is not testable. Each criterion
+- Skipping constitution. Without project invariants, spec debates reopen every
+  stage.
+- Treating constitution as feature-scoped. The constitution belongs at
+  `.spec/constitution.md` and is reused across features; feature work gets
+  `spec.md`, `plan.md`, and `tasks.md` under `.spec/<feature>/`.
+- Vague acceptance criteria. "Works correctly" is not testable. Each criterion
   must be expressible as a yes/no check a reviewer can run in under 30 seconds.
-- **Tasks larger than 5 minutes.** If a task is bigger, split it before handing
-  off to `subagent-driven-development` — that skill assumes bite-size.
-- **Mutating constitution to fix a plan.** Amend only when the invariant itself
-  was wrong; otherwise fix the plan to honor the invariant.
-- **Mixing stages.** A spec is not a plan. A plan is not tasks. If you find
-  yourself writing implementation steps in `spec.md`, the scope leaked.
+- Tasks larger than 5 minutes. If a task is bigger, split it before handing off
+  to `subagent-driven-development`; that skill assumes bite-size work.
+- Mutating constitution to fix a plan. Amend only when the invariant itself was
+  wrong; otherwise fix the plan to honor the invariant.
+- Mixing stages. A spec is not a plan. A plan is not tasks. If implementation
+  steps appear in `spec.md`, the scope leaked.
+
+## Verification
+
+- Confirm `.spec/constitution.md` exists or was intentionally scaffolded as the
+  project-scoped source of principles and invariants.
+- Confirm `.spec/<feature>/spec.md` states what the feature must accomplish and
+  has checkable acceptance criteria.
+- Confirm `.spec/<feature>/plan.md` explains how the feature will be built and
+  honors the constitution.
+- Confirm `.spec/<feature>/tasks.md` breaks work into executable slices with
+  validation expectations.
+- Confirm implementation tasks were executed and validated before marking them
+  complete.
+- Confirm any post-implementation deviations are recorded in the feature spec.

--- a/skills/software-development/spec-driven-dev/SKILL.md
+++ b/skills/software-development/spec-driven-dev/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: spec-driven-dev
+description: "Spec-Driven Development: constitution, spec, plan, tasks."
+version: 0.1.0
+author: Juan Ramon Gros (@jrgros-ops); Hermes Agent (adapted from github/spec-kit pattern)
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [planning, specification, spec-kit, design, constitution, acceptance-criteria, workflow]
+    related_skills: [plan, spike, subagent-driven-development, test-driven-development, requesting-code-review]
+---
+
+# Spec-Driven Development Skill
+
+A Hermes-native port of the GitHub Spec Kit flow. Use it to produce executable
+artifacts that carry a feature from project invariants through validated work:
+
+```
+constitution  ->  spec  ->  plan  ->  tasks  ->  implement
+   (why)        (what)    (how)    (slices)    (validated execution)
+```
+
+Each stage produces a file the next stage can read without re-deriving intent.
+If a stage needs human judgment, it stops and asks; it does not guess.
+
+## When to Use
+
+Load this skill when the user wants to design a feature before coding it, or
+when an existing plan is too thin to hand to `subagent-driven-development`.
+
+Use when:
+
+- User says "I want to design X before building it".
+- User asks for a "spec", "specification", "design doc", or "PRD".
+- A feature crosses 3+ files or spans multiple sessions.
+- Multiple profiles (coder, reviewer, orchestrator) will touch the work.
+- The work is ambiguous enough that plan-only would invent the answer.
+
+Do not use when:
+
+- The task is a single-file bug fix or trivial refactor; use `systematic-debugging`.
+- The user wants raw feasibility exploration; use `spike`.
+- The user already has a good plan; use `plan` or `subagent-driven-development`.
+- The work is one-shot throwaway; use `sketch`.
+
+## Prerequisites
+
+- Access to the repository or workspace being designed.
+- A clear feature name that can become the `.spec/<feature>/` directory.
+- Permission to create or update files under `.spec/`.
+- The project constitution at `.spec/constitution.md`, if it already exists.
+
+The constitution is project-scoped. It captures why the project exists, its
+principles, and non-negotiable invariants reused across features. Feature
+artifacts live under `.spec/<feature>/`, but the constitution stays at
+`.spec/constitution.md` and is frozen unless explicitly amended.
+
+This skill uses only built-in Hermes tools:
+
+- `read_file`, `write_file`, `patch`, `search_files`
+- `terminal` for read-only inspection commands
+- `todo` to track stage transitions
+- `delegate_task` through `subagent-driven-development` at stage 5
+
+No MCP server, new dependency, or shell pipeline is required.
+
+## How to Run
+
+1. Confirm scope in 1-3 sentences: what is being designed and why. Ask if
+   unclear; completion means the user-facing feature boundary is explicit.
+2. Load `references/constitution-template.md`. Reuse `.spec/constitution.md`
+   when it exists; otherwise scaffold it as the project-scoped constitution.
+   Completion means the project invariants are available to every later stage.
+3. Load `references/spec-template.md`. Write `.spec/<feature>/spec.md`.
+   Completion means the feature's user stories and acceptance criteria are
+   frozen enough to plan against.
+4. Load `references/implementation-flow.md`. Write `.spec/<feature>/plan.md`.
+   Completion means the implementation approach, architecture, tech choices,
+   and expected file layout are documented.
+5. Load `references/tasks-template.md`. Write `.spec/<feature>/tasks.md`.
+   Completion means the plan is split into executable 2-5 minute slices.
+6. Hand `.spec/<feature>/tasks.md` to `subagent-driven-development`. Do not
+   re-plan inline. Completion means tasks have been executed and validated.
+7. After implementation, append an outcome section to `.spec/<feature>/spec.md`
+   with the acceptance-criteria checklist marked done and any deviations noted.
+
+See `references/implementation-flow.md` for the full gating logic between
+stages, what counts as frozen, and the amend-vs-revise rules.
+
+## Quick Reference
+
+| Stage | Output file | Purpose |
+|-------|-------------|---------|
+| 1. Constitution | `.spec/constitution.md` | WHY the project exists; principles and invariants reused across features. |
+| 2. Spec | `.spec/<feature>/spec.md` | WHAT the feature must achieve; user stories and acceptance criteria. |
+| 3. Plan | `.spec/<feature>/plan.md` | HOW the feature will be implemented; architecture, choices, and file layout. |
+| 4. Tasks | `.spec/<feature>/tasks.md` | Executable work breakdown; bite-sized TDD-ready slices. |
+| 5. Implement | No new spec file | Validated execution of the tasks, updating task state as work lands. |
+
+`.spec/` is the working tree of this skill. After `spec.md` freezes, later
+stages should not mutate earlier stages unless the user explicitly chooses an
+amendment path.
+
+## Procedure
+
+1. Constitution: capture the project's why, principles, and invariants in
+   `.spec/constitution.md`. Reuse it between features. Amend only when an
+   invariant itself is wrong or incomplete, not to make a difficult plan easier.
+2. Spec: capture what the feature must accomplish in `.spec/<feature>/spec.md`.
+   Keep implementation details out. Acceptance criteria must be checkable as
+   yes/no outcomes a reviewer can evaluate quickly.
+3. Plan: capture how the feature will be implemented in `.spec/<feature>/plan.md`.
+   Include architecture, key files, data flow, testing strategy, and constraints
+   inherited from `.spec/constitution.md`.
+4. Tasks: split the plan into `.spec/<feature>/tasks.md`. Each task should be
+   small enough for a focused implementation pass and should identify its
+   expected validation.
+5. Implement: execute the tasks, preferably with `subagent-driven-development`
+   when delegation fits. Mark tasks as complete only after the relevant tests,
+   checks, or manual verification have actually run.
+
+## Pitfalls
+
+- Skipping constitution. Without project invariants, spec debates reopen every
+  stage.
+- Treating constitution as feature-scoped. The constitution belongs at
+  `.spec/constitution.md` and is reused across features; feature work gets
+  `spec.md`, `plan.md`, and `tasks.md` under `.spec/<feature>/`.
+- Vague acceptance criteria. "Works correctly" is not testable. Each criterion
+  must be expressible as a yes/no check a reviewer can run in under 30 seconds.
+- Tasks larger than 5 minutes. If a task is bigger, split it before handing off
+  to `subagent-driven-development`; that skill assumes bite-size work.
+- Mutating constitution to fix a plan. Amend only when the invariant itself was
+  wrong; otherwise fix the plan to honor the invariant.
+- Mixing stages. A spec is not a plan. A plan is not tasks. If implementation
+  steps appear in `spec.md`, the scope leaked.
+
+## Verification
+
+- Confirm `.spec/constitution.md` exists or was intentionally scaffolded as the
+  project-scoped source of principles and invariants.
+- Confirm `.spec/<feature>/spec.md` states what the feature must accomplish and
+  has checkable acceptance criteria.
+- Confirm `.spec/<feature>/plan.md` explains how the feature will be built and
+  honors the constitution.
+- Confirm `.spec/<feature>/tasks.md` breaks work into executable slices with
+  validation expectations.
+- Confirm implementation tasks were executed and validated before marking them
+  complete.
+- Confirm any post-implementation deviations are recorded in the feature spec.

--- a/skills/software-development/spec-driven-dev/references/constitution-template.md
+++ b/skills/software-development/spec-driven-dev/references/constitution-template.md
@@ -1,0 +1,30 @@
+# Constitution Template
+
+The constitution is **frozen** once accepted. Amendments require an explicit
+note in the file (see `## Amendment log` at the bottom).
+
+## Sections
+
+### 1. Purpose
+Why this project exists. 2-4 sentences. Should not change often.
+
+### 2. Core invariants
+Non-negotiable rules the implementation must always honor. Each line is a
+single rule with a one-line rationale.
+
+### 3. Quality gates
+Hard checks that block merge: coverage baselines, dependency pinning, lint.
+
+### 4. Out of scope
+Things this project explicitly does NOT do. Prevents scope creep at spec time.
+
+### 5. Amendment log
+| Date | Section | What changed | Why |
+|------|---------|--------------|-----|
+
+## Authoring notes
+
+- Keep it under 60 lines total.
+- Each invariant must be verifiable in <30 seconds by a reviewer with `read_file` or `terminal`.
+- Do not include implementation specifics (those belong in plan.md).
+- If you cannot write a verification step, the invariant is too vague — reword it.

--- a/skills/software-development/spec-driven-dev/references/implementation-flow.md
+++ b/skills/software-development/spec-driven-dev/references/implementation-flow.md
@@ -1,0 +1,57 @@
+# Implementation Flow
+
+The orchestration logic that connects the 5 stages. Use this as the
+authoritative gating table; if a stage is unclear, re-read its section here.
+
+## Stage gates
+
+| Stage | Produces | Freeze rule | May amend later? |
+|-------|----------|-------------|------------------|
+| 1. Constitution | `constitution.md` | User accepts in writing | Yes, via Amendment log only |
+| 2. Spec | `spec.md` | All Open questions resolved or moved out; AC list final | Only if AC prove un-testable; record reason |
+| 3. Plan | `plan.md` | All spec acceptance criteria mapped to implementation steps | Yes, before tasks freeze |
+| 4. Tasks | `tasks.md` | Each task is 2-5 min and TDD-complete | Until stage 5 starts |
+| 5. Implement | git history + AC checkmarks | When `subagent-driven-development` reports all tasks green | N/A |
+
+## When to stop and ask the user
+
+- Spec stage: any criterion you cannot make binary. Do NOT write "TBD" -- ask.
+- Plan stage: a tech choice with no clear winner. Do NOT pick arbitrarily.
+- Tasks stage: a slice cannot be made under 5 min without dropping a step.
+  Ask whether to merge or split.
+
+## When NOT to stop
+
+- Constitution stage: trivial wording tweaks. Edit inline.
+- Spec stage: renaming a user story, tightening a criterion. Edit inline.
+- Plan stage: reordering file layout, swapping a non-load-bearing lib.
+- Tasks stage: typo fixes, command-line flag corrections.
+
+## Hand-off to implementation
+
+Once `tasks.md` is frozen:
+
+1. Load `optional-skills/software-development/subagent-driven-development`.
+2. Dispatch the first task per that skill protocol.
+3. After each task lands, mark the corresponding AC in `spec.md`.
+4. On spec deviation: stop, append a `## Deviations` section to `spec.md`,
+   surface the deviation to the user before proceeding.
+
+## Failure recovery
+
+- **Implementer asks a clarifying question:** answer in writing; update
+  `plan.md` if the answer changes a tech choice.
+- **Reviewer flags spec gap:** add an acceptance criterion to `spec.md` and
+  re-derive affected tasks in `tasks.md` before re-dispatching.
+- **Constitution violation discovered mid-implement:** STOP. Surface the
+  violation. Either amend the constitution (with rationale) or fix the plan.
+  Never silently violate.
+
+## Anti-patterns
+
+- Skipping straight from spec to implementation ("the plan is obvious").
+  A plan is rarely obvious once you write tasks.
+- Letting tasks.md drift from spec.md. If AC-3 changes, update the tasks
+  that reference AC-3 before the next subagent dispatch.
+- Reopening constitution mid-feature. Amendments are expensive; verify
+  before freezing.

--- a/skills/software-development/spec-driven-dev/references/spec-template.md
+++ b/skills/software-development/spec-driven-dev/references/spec-template.md
@@ -1,0 +1,55 @@
+# Spec Template (`spec.md`)
+
+The spec describes **WHAT** the feature does — observable behavior and
+acceptance criteria. It is **frozen** after sign-off. No code, no file paths,
+no implementation tactics.
+
+## Sections
+
+### 1. Title & one-sentence summary
+Single sentence describing the feature from the user perspective.
+
+### 2. User stories
+Given/When/Then. One paragraph per story. Number them (`US-1`, `US-2`, ...).
+Stories are testable by hand without code knowledge.
+
+### 3. Acceptance criteria
+A numbered, **checkable** list. Each criterion is one yes/no question a
+reviewer can answer in under 30 seconds by reading the diff or running one
+command. Format:
+
+```
+AC-1: [criterion]
+  Verify: [exact command or observation]
+```
+
+Bad: "The feature is fast."  
+Good: "AC-3: P95 latency on the new endpoint <= 200ms with 100 concurrent
+users. Verify: `locust -u 100 -r 10 --headless --run-time 60s` shows p95 <= 200ms."
+
+### 4. Edge cases & error states
+What happens when inputs are malformed, concurrent, or adversarial. Each
+edge case maps to at least one acceptance criterion.
+
+### 5. Out of scope
+Bullet list.
+
+### 6. Open questions
+Numbered list of questions that block planning. If empty by spec-freeze, delete
+the section.
+
+## Authoring notes
+
+- **No file paths.** File paths are a planning concern.
+- **No API shapes.** API shapes belong in `plan.md`.
+- **No tests.** Tests belong in `tasks.md` per slice.
+- **Each acceptance criterion is binary.** If it cannot be yes/no, split it.
+- **Reject "works correctly", "is intuitive", "performs well".** Replace with
+  measurable language.
+
+## Anti-patterns
+
+- Acceptance criteria that read like a tutorial — those are user stories.
+- Spec that names specific classes or functions — that leaked from planning.
+- "TBD" as a placeholder — block spec-freeze until resolved, or move to
+  `Open questions` and freeze the rest.

--- a/skills/software-development/spec-driven-dev/references/tasks-template.md
+++ b/skills/software-development/spec-driven-dev/references/tasks-template.md
@@ -1,0 +1,87 @@
+# Tasks Template (`tasks.md`)
+
+`tasks.md` is the contract handed to `subagent-driven-development`. Each task
+is a 2-5 minute slice with full TDD cycle, exact paths, exact commands,
+exact expected output. If a slice is bigger than 5 minutes, split it.
+
+## Sections
+
+### 1. Header (required)
+
+```markdown
+# [Feature] Implementation Tasks
+
+> Source spec: `.spec/<slug>/spec.md`
+> Source plan: `.spec/<slug>/plan.md`
+
+**Goal:** [one sentence from spec section 1]
+**Estimated tasks:** N
+**Execution skill:** `subagent-driven-development`
+```
+
+### 2. Task list
+
+Each task uses this exact structure:
+
+```markdown
+### Task N: <verb-first descriptive name>
+
+**Spec reference:** AC-1, AC-4
+**Plan reference:** Plan section 3 "Module X"
+
+**Files:**
+- Create: `path/to/new_file.py`
+- Modify: `path/to/existing.py:45-67`
+- Test: `tests/path/test_file.py`
+
+**Step 1 -- Write failing test**
+
+[code block]
+
+**Step 2 -- Run test, verify FAIL**
+
+Run: `pytest tests/path/test_file.py::test_specific_behavior -v`
+Expected: FAIL with "function not defined" or assertion mismatch.
+
+**Step 3 -- Minimal implementation**
+
+[code block]
+
+**Step 4 -- Run test, verify PASS**
+
+Run: `pytest tests/path/test_file.py::test_specific_behavior -v`
+Expected: PASS.
+
+**Step 5 -- Regression sweep**
+
+Run: `pytest tests/ -q`
+Expected: no new failures (baseline pass count + 1).
+
+**Step 6 -- Commit**
+
+```bash
+git add <files>
+git commit -m "<type>: <description>"
+```
+```
+
+### 3. Task ordering principles
+
+1. Tests first, code second. Every code-creating task starts with a failing test.
+2. Independence where possible. Tasks should not require re-reading prior tasks.
+3. Verify before commit. Never commit on red.
+4. Reuse the `plan` skill bite-size rules. 2-5 minutes per task.
+
+### 4. Definition of done
+
+- [ ] All N tasks committed.
+- [ ] `pytest tests/ -q` green.
+- [ ] `git diff main --stat` shows only expected files.
+- [ ] Spec acceptance criteria re-checked: all AC-N marked done in spec.md.
+
+## Anti-patterns
+
+- "Implement and test X" with no test code -- split into two tasks.
+- Tasks that depend on a previous task uncommitted state -- merge them.
+- "Verify it works" with no exact command -- replace with the actual line.
+- Tasks over 5 minutes -- split.

--- a/tests/skills/test_spec_driven_dev_skill.py
+++ b/tests/skills/test_spec_driven_dev_skill.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_PATH = REPO_ROOT / "skills" / "software-development" / "spec-driven-dev" / "SKILL.md"
+REQUIRED_SECTION_ORDER = [
+    "When to Use",
+    "Prerequisites",
+    "How to Run",
+    "Quick Reference",
+    "Procedure",
+    "Pitfalls",
+    "Verification",
+]
+
+
+def _skill_text() -> str:
+    return SKILL_PATH.read_text(encoding="utf-8")
+
+
+def _frontmatter() -> dict[str, object]:
+    text = _skill_text()
+    match = re.match(r"^---\n(.*?)\n---\n", text, re.DOTALL)
+    assert match is not None
+    parsed = yaml.safe_load(match.group(1))
+    assert isinstance(parsed, dict)
+    return parsed
+
+
+def test_spec_driven_dev_frontmatter_credits_external_contributor_first():
+    author = str(_frontmatter()["author"])
+
+    assert author.startswith("Juan Ramon Gros (@jrgros-ops)")
+
+
+def test_spec_driven_dev_title_ends_with_skill():
+    text = _skill_text()
+    title = next(line for line in text.splitlines() if line.startswith("# "))
+
+    assert title == "# Spec-Driven Development Skill"
+
+
+def test_spec_driven_dev_required_section_order():
+    headings = re.findall(r"^## (.+)$", _skill_text(), flags=re.MULTILINE)
+
+    assert headings == REQUIRED_SECTION_ORDER
+
+
+def test_spec_driven_dev_uses_project_scoped_constitution():
+    text = _skill_text()
+
+    assert ".spec/constitution.md" in text
+    assert ".spec/<feature>/constitution.md" not in text
+    assert ".spec/<feature>/spec.md" in text
+    assert ".spec/<feature>/plan.md" in text
+    assert ".spec/<feature>/tasks.md" in text
+
+
+def test_spec_driven_dev_description_matches_skill_contract():
+    description = str(_frontmatter()["description"])
+
+    assert len(description) <= 60
+    assert description.endswith(".")


### PR DESCRIPTION
Adds a new spec-driven-dev skill implementing a 5-stage constitution/spec/plan/tasks/implement workflow with progressive-disclosure references.

The PR is isolated from the unrelated local self-improvement work.

Commit `65f208da` addresses the review feedback by:

- crediting Juan Ramon Gros (@jrgros-ops) first;
- adopting the required modern skill section structure;
- standardizing the project-scoped `.spec/constitution.md` path;
- adding the dedicated skill contract test.

Local validation: 5 tests passed and `git diff --check` passed.