### PR TITLE
chore(security-guidance): sync forked patterns

### DIFF
--- a/plugins/security-guidance/NOTICE
+++ b/plugins/security-guidance/NOTICE
@@ -7,7 +7,7 @@ licensed under the Apache License, Version 2.0.
 
     Source:    https://github.com/anthropics/claude-plugins-official
     Subpath:   plugins/security-guidance/hooks/patterns.py
-    Commit:    0bde168 (2026-05-26)
+    Commit:    12a5376 (2026-05-29)
     License:   Apache License 2.0 (see LICENSE in this directory)
 
 Forked content

--- a/plugins/security-guidance/README.md
+++ b/plugins/security-guidance/README.md
@@ -81,7 +81,7 @@ not a substitute for code review, SAST, dependency scanning, or pen testing.
 
 * `patterns.py` is a verbatim fork from
   [`anthropics/claude-plugins-official`](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/security-guidance/hooks)
-  (commit `0bde168`, 2026-05-26), licensed under the
+  (commit `12a5376`, 2026-05-29), licensed under the
   [Apache License 2.0](./LICENSE). See [NOTICE](./NOTICE) for the full
   attribution.
 * `__init__.py`, `plugin.yaml`, `README.md`, and tests are original work by

--- a/plugins/security-guidance/patterns.py
+++ b/plugins/security-guidance/patterns.py
@@ -24,7 +24,7 @@ Forked verbatim from Anthropic's claude-plugins-official repository
 
 Modifications by NousResearch for the Hermes Agent plugin port:
   - none to the pattern data itself; this file is byte-for-byte the upstream
-    patterns.py at commit 0bde168 (2026-05-26). Hermes-side wiring lives in
+    patterns.py at commit 12a5376 (2026-05-29). Hermes-side wiring lives in
     __init__.py.
 """
 from enum import IntEnum
@@ -117,6 +117,9 @@ Only use exec() if you absolutely need shell features and the input is guarantee
     },
     {
         "ruleName": "new_function_injection",
+        # JS-only construct: gate to JS/TS files so docs/.md and other prose
+        # mentioning "new Function" don't trip the warning.
+        "path_filter": lambda p: p.endswith(_JS_EXTS),
         "substrings": ["new Function"],
         "reminder": "\u26a0\ufe0f Security Warning: Using new Function() with string interpolation is a CODE INJECTION vulnerability. If any variable is concatenated or interpolated into the function body string, an attacker controlling that variable can execute arbitrary code. Use safe alternatives: for property access use obj[key] or array.reduce((o, k) => o[k], root); for computation use a safe expression parser. NEVER interpolate untrusted strings into new Function() bodies.",
     },
@@ -130,16 +133,24 @@ Only use exec() if you absolutely need shell features and the input is guarantee
     },
     {
         "ruleName": "react_dangerously_set_html",
+        # JS/TS-only (React); gate so .md docs / .py / .go files don't trip.
+        "path_filter": lambda p: p.endswith(_JS_EXTS),
         "substrings": ["dangerouslySetInnerHTML"],
         "reminder": "⚠️ Security Warning: dangerouslySetInnerHTML can lead to XSS vulnerabilities if used with untrusted content. Ensure all content is properly sanitized using an HTML sanitizer library like DOMPurify, or use safe alternatives.",
     },
     {
         "ruleName": "document_write_xss",
+        # Browser DOM API: only meaningful in JS/TS source.
+        "path_filter": lambda p: p.endswith(_JS_EXTS),
         "substrings": ["document.write"],
         "reminder": "⚠️ Security Warning: document.write() can be exploited for XSS attacks and has performance issues. Use DOM manipulation methods like createElement() and appendChild() instead.",
     },
     {
         "ruleName": "innerHTML_xss",
+        # Browser DOM API: only meaningful in JS/TS source. Closes FPs like
+        # docs/example HTML, playground/self-contained skills that hardcode
+        # innerHTML strings with zero user input (#410).
+        "path_filter": lambda p: p.endswith(_JS_EXTS),
         "substrings": [".innerHTML =", ".innerHTML="],
         "reminder": "⚠️ Security Warning: Setting innerHTML with untrusted content can lead to XSS vulnerabilities. Use textContent for plain text or safe DOM methods for HTML content. If you need HTML support, consider using an HTML sanitizer library such as DOMPurify.",
     },
@@ -240,11 +251,15 @@ Additionally, validate user inputs:
     },
     {
         "ruleName": "outerHTML_xss",
+        # Browser DOM API: only meaningful in JS/TS source.
+        "path_filter": lambda p: p.endswith(_JS_EXTS),
         "substrings": [".outerHTML =", ".outerHTML="],
         "reminder": "⚠️ Security Warning: Use textContent or sanitize with DOMPurify. outerHTML assignment is an XSS sink equivalent to innerHTML.",
     },
     {
         "ruleName": "insertAdjacentHTML_xss",
+        # Browser DOM API: only meaningful in JS/TS source.
+        "path_filter": lambda p: p.endswith(_JS_EXTS),
         "substrings": [".insertAdjacentHTML("],
         "reminder": "⚠️ Security Warning: Use insertAdjacentText() or sanitize with DOMPurify. insertAdjacentHTML is an XSS sink.",
     },

--- a/tests/plugins/test_security_guidance_plugin.py
+++ b/tests/plugins/test_security_guidance_plugin.py
@@ -157,6 +157,27 @@ class TestScanContent:
         )
         assert "react_dangerously_set_html" in [n for n, _ in findings]
 
+    @pytest.mark.parametrize(
+        ("rule_name", "content"),
+        [
+            ("new_function_injection", "const f = new Function(src)"),
+            ("react_dangerously_set_html", "<div dangerouslySetInnerHTML={{__html: x}} />"),
+            ("document_write_xss", "document.write(userHtml)"),
+            ("innerHTML_xss", "el.innerHTML = userHtml"),
+            ("outerHTML_xss", "el.outerHTML = userHtml"),
+            ("insertAdjacentHTML_xss", "el.insertAdjacentHTML('beforeend', userHtml)"),
+        ],
+    )
+    def test_js_xss_rules_are_gated_to_js_family_paths(self, rule_name, content):
+        """Upstream 12a5376 gates JS-only XSS substrings away from prose/docs."""
+        mod = _load_plugin_init()
+
+        js_findings = mod._scan_content("/tmp/component.tsx", content)
+        assert rule_name in [n for n, _ in js_findings]
+
+        markdown_findings = mod._scan_content("/tmp/security-notes.md", content)
+        assert rule_name not in [n for n, _ in markdown_findings]
+
     def test_github_workflow_path_check_fires_on_path_alone(self):
         """github_actions_workflow has no regex/substring — fires on path."""
         mod = _load_plugin_init()


### PR DESCRIPTION
## Summary
- Syncs Hermes' forked `plugins/security-guidance/patterns.py` from Anthropic's `claude-plugins-official` commit `0bde168` (2026-05-26) to `12a5376` (2026-05-29).
- Brings in upstream's JS-family path filters for six XSS/browser-DOM rules so Markdown/prose and non-JS files that merely mention these APIs do not trigger warnings.
- Updates attribution refs in README/NOTICE and adds regression coverage for the JS path-gating behavior.

## Upstream sources checked
- `anthropics/claude-plugins-official`, subpath `plugins/security-guidance/hooks/patterns.py`
  - Before: `0bde168` (recorded in Hermes)
  - Latest relevant upstream path commit: `12a5376e205c8c519a53ee06115bd279a1e121d1` (2026-05-29), `security-guidance: gate XSS pattern rules to JS-family files`
- `PCinkusz/hermes-achievements`
  - Latest main observed: `3964b95b00c4b78a20ea4e4827c569ff77ef733c` (2026-05-26), base-path/reverse-proxy dashboard fix. Not included here because the vendored Hermes dashboard has local modifications and this is a separate coherent sync.
- `spectrum-ts` npm package used by Photon sidecar
  - Latest npm observed: `5.2.0`; not included in this PR because it is a dependency/runtime adapter update, not part of the security-guidance fork sync.
- `trycua/cua` for `cua-driver`
  - Latest release observed: `agent-v0.8.3` (2026-06-22). Hermes does not pin/vendor the driver binary; installer/update flows fetch latest, so no repo change was needed here.
- PR #19432 was checked and confirmed unrelated to vendored/forked tool syncs (auxiliary Anthropic explicit API-key propagation only).

## Validation
- `scripts/run_tests.sh tests/plugins/test_security_guidance_plugin.py`
  - Result: 33 passed in 2.2s
- Focused body diff against upstream `patterns.py` after Hermes attribution docstring: no differences.

## Follow-ups / risks
- `plugins/hermes-achievements/` has upstream drift from `PCinkusz/hermes-achievements`; syncing it should be handled in a separate focused PR because Hermes carries local bundled-dashboard modifications.
- Photon `spectrum-ts` has newer versions available; that should be evaluated separately with adapter/sidecar validation.
