### PR TITLE
Fix desktop model selection across profiles

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -5095,6 +5095,7 @@ async function startHermes() {
         source: remote.source,
         authMode: remote.authMode || 'token',
         token: remote.token,
+        profile: primaryProfileKey(),
         wsUrl: remote.wsUrl,
         logs: hermesLog.slice(-80),
         ...getWindowState()
@@ -5232,6 +5233,7 @@ async function startHermes() {
       source: 'local',
       authMode: 'token',
       token: authToken,
+      profile: primaryProfileKey(),
       wsUrl: `ws://127.0.0.1:${port}/api/ws?token=${encodeURIComponent(authToken)}`,
       logs: hermesLog.slice(-80),
       ...getWindowState()

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -7,7 +7,7 @@ import {
 import { useStore } from '@nanostores/react'
 import { useQuery } from '@tanstack/react-query'
 import type * as React from 'react'
-import { Suspense, useCallback, useMemo, useRef } from 'react'
+import { Suspense, useCallback, useEffect, useMemo, useRef } from 'react'
 import { useLocation } from 'react-router-dom'
 
 import { Thread } from '@/components/assistant-ui/thread'
@@ -19,7 +19,7 @@ import { ErrorState } from '@/components/ui/error-state'
 import { getGlobalModelOptions, type HermesGateway } from '@/hermes'
 import { useI18n } from '@/i18n'
 import type { ChatMessage } from '@/lib/chat-messages'
-import { quickModelOptions, sessionTitle, toRuntimeMessage } from '@/lib/chat-runtime'
+import { quickModelOptions, resolveModelSelection, sessionTitle, toRuntimeMessage } from '@/lib/chat-runtime'
 import { useIncrementalExternalStoreRuntime } from '@/lib/incremental-external-store-runtime'
 import { cn } from '@/lib/utils'
 import type { ComposerAttachment } from '@/store/composer'
@@ -43,7 +43,9 @@ import {
   $resumeExhaustedSessionId,
   $selectedStoredSessionId,
   $sessions,
-  sessionPinId
+  sessionPinId,
+  setCurrentModel,
+  setCurrentProvider
 } from '@/store/session'
 import { isSecondaryWindow } from '@/store/windows'
 import type { ModelOptionsResponse } from '@/types/hermes'
@@ -361,6 +363,24 @@ export function ChatView({
     () => quickModelOptions(modelOptionsQuery.data, currentProvider, currentModel),
     [currentModel, currentProvider, modelOptionsQuery.data]
   )
+
+  useEffect(() => {
+    if (activeSessionId || !currentModel || !currentProvider || !modelOptionsQuery.data) {
+      return
+    }
+
+    const resolved = resolveModelSelection(modelOptionsQuery.data, {
+      model: currentModel,
+      provider: currentProvider
+    })
+
+    if (!resolved.repaired) {
+      return
+    }
+
+    setCurrentModel(resolved.model)
+    setCurrentProvider(resolved.provider)
+  }, [activeSessionId, currentModel, currentProvider, modelOptionsQuery.data])
 
   const chatBarState = useMemo<ChatBarState>(
     () => ({

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -5,7 +5,17 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { getSessionMessages } from '@/hermes'
 import { $activeGatewayProfile, $newChatProfile } from '@/store/profile'
-import { $currentCwd, $messages, $resumeFailedSessionId, setMessages, setResumeFailedSessionId } from '@/store/session'
+import {
+  $currentCwd,
+  $currentModel,
+  $currentProvider,
+  $messages,
+  $resumeFailedSessionId,
+  setCurrentModel,
+  setCurrentProvider,
+  setMessages,
+  setResumeFailedSessionId
+} from '@/store/session'
 
 import type { ClientSessionState } from '../../types'
 
@@ -84,6 +94,8 @@ describe('createBackendSessionForSend profile routing', () => {
     cleanup()
     $newChatProfile.set(null)
     $activeGatewayProfile.set('default')
+    setCurrentModel('')
+    setCurrentProvider('')
     vi.restoreAllMocks()
   })
 
@@ -116,6 +128,58 @@ describe('createBackendSessionForSend profile routing', () => {
     })
 
     expect(params).toMatchObject({ profile: 'default' })
+  })
+
+  it('repairs a stale model/provider pair before creating a profile chat', async () => {
+    let createParams: Record<string, unknown> | undefined
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'model.options') {
+        return {
+          model: 'grok-composer-2.5-fast',
+          provider: 'xai-oauth',
+          providers: [
+            {
+              name: 'xAI Grok OAuth',
+              slug: 'xai-oauth',
+              models: ['grok-composer-2.5-fast']
+            },
+            {
+              name: 'OpenAI Codex',
+              slug: 'openai-codex',
+              models: ['gpt-5.5']
+            }
+          ]
+        } as never
+      }
+
+      if (method === 'session.create') {
+        createParams = params
+
+        return { session_id: RUNTIME_SESSION_ID, stored_session_id: null } as never
+      }
+
+      return {} as never
+    })
+
+    $currentCwd.set('')
+    $activeGatewayProfile.set('job-hunting')
+    $newChatProfile.set(null)
+    setCurrentModel('gpt-5.5')
+    setCurrentProvider('xai-oauth')
+
+    let create: ((preview?: string | null) => Promise<string | null>) | null = null
+    render(<Harness onReady={c => (create = c)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(create).not.toBeNull())
+    await create!()
+
+    expect(createParams).toMatchObject({
+      model: 'grok-composer-2.5-fast',
+      profile: 'job-hunting',
+      provider: 'xai-oauth'
+    })
+    expect($currentModel.get()).toBe('grok-composer-2.5-fast')
+    expect($currentProvider.get()).toBe('xai-oauth')
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -5,7 +5,7 @@ import type { NavigateFunction } from 'react-router-dom'
 import { deleteSession, getSession, getSessionMessages, setSessionArchived } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { type ChatMessage, chatMessageText, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
-import { normalizePersonalityValue } from '@/lib/chat-runtime'
+import { normalizePersonalityValue, resolveModelSelection } from '@/lib/chat-runtime'
 import { embeddedImageUrls, textWithoutEmbeddedImages } from '@/lib/embedded-images'
 import { setSessionYolo } from '@/lib/yolo-session'
 import { clearQueuedPrompts } from '@/store/composer-queue'
@@ -51,7 +51,14 @@ import {
 import { broadcastSessionsChanged } from '@/store/session-sync'
 import { reportBackendContract } from '@/store/updates'
 import { isWatchWindow } from '@/store/windows'
-import type { SessionCreateResponse, SessionInfo, SessionResumeResponse, SessionRuntimeInfo, UsageStats } from '@/types/hermes'
+import type {
+  ModelOptionsResponse,
+  SessionCreateResponse,
+  SessionInfo,
+  SessionResumeResponse,
+  SessionRuntimeInfo,
+  UsageStats
+} from '@/types/hermes'
 
 import { NEW_CHAT_ROUTE, sessionRoute, SETTINGS_ROUTE } from '../../routes'
 import type { ClientSessionState, SidebarNavItem } from '../../types'
@@ -454,10 +461,26 @@ export function useSessionActions({
         // with every session.create so the new chat opens on whatever the picker
         // shows — applied as per-session overrides, never written to the profile
         // default (that lives in Settings → Model).
-        const uiModel = $currentModel.get().trim()
-        const uiProvider = $currentProvider.get().trim()
+        let uiModel = $currentModel.get().trim()
+        let uiProvider = $currentProvider.get().trim()
         const uiEffort = $currentReasoningEffort.get().trim()
         const uiFast = $currentFastMode.get()
+
+        if (uiModel && uiProvider) {
+          try {
+            const options = await requestGateway<ModelOptionsResponse>('model.options')
+            const resolved = resolveModelSelection(options, { model: uiModel, provider: uiProvider })
+
+            if (resolved.repaired) {
+              uiModel = resolved.model
+              uiProvider = resolved.provider
+              setCurrentModel(resolved.model)
+              setCurrentProvider(resolved.provider)
+            }
+          } catch {
+            // If options are unavailable, let the backend handle session.create.
+          }
+        }
 
         const created = await requestGateway<SessionCreateResponse>('session.create', {
           cols: 96,

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -250,6 +250,82 @@ export function parseCommandDispatch(raw: unknown): CommandDispatchResponse | nu
   }
 }
 
+interface ModelSelection {
+  model: string
+  provider: string
+}
+
+export interface ResolvedModelSelection extends ModelSelection {
+  repaired: boolean
+}
+
+function modelSelectionAvailable(data: ModelOptionsResponse | undefined, selection: ModelSelection): boolean {
+  if (!selection.provider || !selection.model) {
+    return false
+  }
+
+  const provider = data?.providers?.find(row => row.slug === selection.provider)
+
+  return Boolean(
+    provider &&
+      provider.models?.includes(selection.model) &&
+      !provider.unavailable_models?.includes(selection.model)
+  )
+}
+
+function firstAvailableModel(data: ModelOptionsResponse | undefined, providerSlug?: string): ModelSelection | null {
+  const providers = data?.providers ?? []
+  const orderedProviders = providerSlug
+    ? [...providers].sort((a, b) => {
+        if (a.slug === providerSlug) {
+          return -1
+        }
+
+        if (b.slug === providerSlug) {
+          return 1
+        }
+
+        return 0
+      })
+    : providers
+
+  for (const provider of orderedProviders) {
+    const model = provider.models?.find(candidate => !provider.unavailable_models?.includes(candidate))
+
+    if (model) {
+      return { model, provider: provider.slug }
+    }
+  }
+
+  return null
+}
+
+export function resolveModelSelection(
+  data: ModelOptionsResponse | undefined,
+  selection: ModelSelection
+): ResolvedModelSelection {
+  if (!data?.providers?.length || modelSelectionAvailable(data, selection)) {
+    return { ...selection, repaired: false }
+  }
+
+  const configuredDefault = {
+    model: data.model?.trim() || '',
+    provider: data.provider?.trim() || ''
+  }
+
+  if (modelSelectionAvailable(data, configuredDefault)) {
+    return { ...configuredDefault, repaired: true }
+  }
+
+  const fallback = firstAvailableModel(data, selection.provider)
+
+  if (fallback) {
+    return { ...fallback, repaired: true }
+  }
+
+  return { ...selection, repaired: false }
+}
+
 export function quickModelOptions(
   data: ModelOptionsResponse | undefined,
   currentProvider: string,
@@ -289,7 +365,11 @@ export function quickModelOptions(
     options.push({ provider, providerName, model })
   }
 
-  if (currentProvider && currentModel) {
+  if (
+    currentProvider &&
+    currentModel &&
+    (!data?.providers?.length || modelSelectionAvailable(data, { model: currentModel, provider: currentProvider }))
+  ) {
     add(currentProvider, currentProvider, currentModel)
   }
 

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -7,12 +7,17 @@ import {
   $attentionSessionIds,
   $connection,
   $currentCwd,
+  $currentModel,
+  $currentProvider,
   $workingSessionIds,
   applyConfiguredDefaultProjectDir,
   getRecentlySettledSessionIds,
   mergeSessionPage,
   sessionPinId,
+  setConnection,
   setCurrentCwd,
+  setCurrentModel,
+  setCurrentProvider,
   setSessionAttention,
   setSessionWorking,
   workspaceCwdForNewSession
@@ -186,7 +191,7 @@ describe('mergeSessionPage', () => {
 describe('workspaceCwdForNewSession', () => {
   afterEach(() => {
     applyConfiguredDefaultProjectDir(null)
-    $connection.set(null)
+    setConnection(null)
     $currentCwd.set('')
     $activeSessionId.set(null)
     window.localStorage.removeItem('hermes.desktop.workspace-cwd')
@@ -240,6 +245,40 @@ describe('workspaceCwdForNewSession', () => {
 
     $connection.set(null)
     expect(workspaceCwdForNewSession()).toBe('/local/project')
+  })
+})
+
+describe('composer model storage', () => {
+  afterEach(() => {
+    $activeSessionId.set(null)
+    $connection.set(null)
+    setCurrentModel('')
+    setCurrentProvider('')
+    window.localStorage.removeItem('hermes.desktop.composer.model.local.default')
+    window.localStorage.removeItem('hermes.desktop.composer.provider.local.default')
+    window.localStorage.removeItem('hermes.desktop.composer.model.local.job-hunting')
+    window.localStorage.removeItem('hermes.desktop.composer.provider.local.job-hunting')
+  })
+
+  it('keeps sticky model/provider selections scoped to the active profile', () => {
+    setConnection({ baseUrl: 'http://local', mode: 'local', profile: 'default' } as never)
+    setCurrentModel('gpt-5.5')
+    setCurrentProvider('openai-codex')
+
+    setConnection({ baseUrl: 'http://local', mode: 'local', profile: 'job-hunting' } as never)
+    expect($currentModel.get()).toBe('')
+    expect($currentProvider.get()).toBe('')
+
+    setCurrentModel('grok-composer-2.5-fast')
+    setCurrentProvider('xai-oauth')
+
+    setConnection({ baseUrl: 'http://local', mode: 'local', profile: 'default' } as never)
+    expect($currentModel.get()).toBe('gpt-5.5')
+    expect($currentProvider.get()).toBe('openai-codex')
+
+    setConnection({ baseUrl: 'http://local', mode: 'local', profile: 'job-hunting' } as never)
+    expect($currentModel.get()).toBe('grok-composer-2.5-fast')
+    expect($currentProvider.get()).toBe('xai-oauth')
   })
 })
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -14,8 +14,8 @@ const WORKSPACE_CWD_KEY = 'hermes.desktop.workspace-cwd'
 // The composer's model/effort/fast is sticky UI state, NOT the profile default
 // (that lives in Settings → Model). Persisting it in localStorage makes a pick
 // follow across Cmd+N and app restarts instead of snapping back to the default.
-// It's deliberately global (not per-profile): a profile switch force-reseeds to
-// that profile's default, while within a profile new chats keep your last pick.
+// Keep the sticky slot scoped to the active profile so an OpenAI pick in one
+// profile can't become an impossible xAI pick in another.
 const COMPOSER_MODEL_KEY = 'hermes.desktop.composer.model'
 const COMPOSER_PROVIDER_KEY = 'hermes.desktop.composer.provider'
 const COMPOSER_EFFORT_KEY = 'hermes.desktop.composer.reasoning-effort'
@@ -31,6 +31,38 @@ function workspaceCwdKey(connection: HermesConnection | null = $connection.get()
   const base = encodeURIComponent(connection.baseUrl || 'remote')
   const profile = encodeURIComponent(connection.profile || 'default')
   return `${WORKSPACE_CWD_KEY}.remote.${base}.${profile}`
+}
+
+function composerStorageScope(connection: HermesConnection | null = $connection.get()): string {
+  const profile = encodeURIComponent(connection?.profile?.trim() || 'default')
+
+  if (connection?.mode === 'remote') {
+    const base = encodeURIComponent(connection.baseUrl || 'remote')
+
+    return `remote.${base}.${profile}`
+  }
+
+  return `local.${profile}`
+}
+
+function composerStorageKey(baseKey: string, connection: HermesConnection | null = $connection.get()): string {
+  return `${baseKey}.${composerStorageScope(connection)}`
+}
+
+function getRememberedComposerModel(connection: HermesConnection | null = $connection.get()): string {
+  return storedString(composerStorageKey(COMPOSER_MODEL_KEY, connection))?.trim() || ''
+}
+
+function getRememberedComposerProvider(connection: HermesConnection | null = $connection.get()): string {
+  return storedString(composerStorageKey(COMPOSER_PROVIDER_KEY, connection))?.trim() || ''
+}
+
+function getRememberedComposerReasoningEffort(connection: HermesConnection | null = $connection.get()): string {
+  return storedString(composerStorageKey(COMPOSER_EFFORT_KEY, connection))?.trim() || ''
+}
+
+function getRememberedComposerFastMode(connection: HermesConnection | null = $connection.get()): boolean {
+  return storedBoolean(composerStorageKey(COMPOSER_FAST_KEY, connection), false)
 }
 
 export const getRememberedWorkspaceCwd = (): string => storedString(workspaceCwdKey())?.trim() || ''
@@ -235,11 +267,11 @@ export const $resumeFailedSessionId = atom<string | null>(null)
 // clears it and resets the retry counter. Null whenever the active route has a
 // healthy, in-flight, or still-auto-retrying resume.
 export const $resumeExhaustedSessionId = atom<string | null>(null)
-export const $currentModel = atom(storedString(COMPOSER_MODEL_KEY) ?? '')
-export const $currentProvider = atom(storedString(COMPOSER_PROVIDER_KEY) ?? '')
-export const $currentReasoningEffort = atom(storedString(COMPOSER_EFFORT_KEY) ?? '')
+export const $currentModel = atom(getRememberedComposerModel())
+export const $currentProvider = atom(getRememberedComposerProvider())
+export const $currentReasoningEffort = atom(getRememberedComposerReasoningEffort())
 export const $currentServiceTier = atom('')
-export const $currentFastMode = atom(storedBoolean(COMPOSER_FAST_KEY, false))
+export const $currentFastMode = atom(getRememberedComposerFastMode())
 // Effective approval-bypass state mirrored from the gateway (session.info).
 // Persistence lives in the backend config (approvals.mode), so this is a plain
 // reflection of the truth the gateway reports rather than its own store.
@@ -262,7 +294,18 @@ export const $contextSuggestions = atom<ContextSuggestion[]>([])
 export const $modelPickerOpen = atom(false)
 export const $sessionPickerOpen = atom(false)
 
-export const setConnection = (next: Updater<HermesConnection | null>) => updateAtom($connection, next)
+export const setConnection = (next: Updater<HermesConnection | null>) => {
+  const previousComposerScope = composerStorageScope($connection.get())
+  updateAtom($connection, next)
+  const nextComposerScope = composerStorageScope($connection.get())
+
+  if (previousComposerScope !== nextComposerScope && !$activeSessionId.get()) {
+    $currentModel.set(getRememberedComposerModel($connection.get()))
+    $currentProvider.set(getRememberedComposerProvider($connection.get()))
+    $currentReasoningEffort.set(getRememberedComposerReasoningEffort($connection.get()))
+    $currentFastMode.set(getRememberedComposerFastMode($connection.get()))
+  }
+}
 export const setGatewayState = (next: Updater<string>) => updateAtom($gatewayState, next)
 export const setSessions = (next: Updater<SessionInfo[]>) => updateAtom($sessions, next)
 export const setSessionsTotal = (next: Updater<number>) => updateAtom($sessionsTotal, next)
@@ -286,24 +329,24 @@ export const setAwaitingResponse = (next: Updater<boolean>) => updateAtom($await
 
 export const setCurrentModel = (next: Updater<string>) => {
   updateAtom($currentModel, next)
-  persistString(COMPOSER_MODEL_KEY, $currentModel.get() || null)
+  persistString(composerStorageKey(COMPOSER_MODEL_KEY), $currentModel.get() || null)
 }
 
 export const setCurrentProvider = (next: Updater<string>) => {
   updateAtom($currentProvider, next)
-  persistString(COMPOSER_PROVIDER_KEY, $currentProvider.get() || null)
+  persistString(composerStorageKey(COMPOSER_PROVIDER_KEY), $currentProvider.get() || null)
 }
 
 export const setCurrentReasoningEffort = (next: Updater<string>) => {
   updateAtom($currentReasoningEffort, next)
-  persistString(COMPOSER_EFFORT_KEY, $currentReasoningEffort.get() || null)
+  persistString(composerStorageKey(COMPOSER_EFFORT_KEY), $currentReasoningEffort.get() || null)
 }
 
 export const setCurrentServiceTier = (next: Updater<string>) => updateAtom($currentServiceTier, next)
 
 export const setCurrentFastMode = (next: Updater<boolean>) => {
   updateAtom($currentFastMode, next)
-  persistBoolean(COMPOSER_FAST_KEY, $currentFastMode.get())
+  persistBoolean(composerStorageKey(COMPOSER_FAST_KEY), $currentFastMode.get())
 }
 
 export const setYoloActive = (next: Updater<boolean>) => updateAtom($yoloActive, next)


### PR DESCRIPTION
## Summary
- Scope sticky desktop composer model/provider settings by active profile instead of sharing one global localStorage slot.
- Validate the current provider/model pair against model.options before creating a new desktop session and repair invalid pairs to the profile default/fallback.
- Include the primary desktop profile in renderer connection descriptors so a profile-launched primary backend uses the correct scoped composer storage.

## Verification
- npm --workspace apps/desktop run test:ui -- src/store/session.test.ts src/app/session/hooks/use-session-actions.test.tsx
- npm --workspace apps/desktop run typecheck

## Local repro checked
A stale desktop state could combine an OpenAI model (gpt-5.5) with the xAI provider in a non-default profile. New job-hunting desktop sessions now resolve to the profile's xAI Grok model instead of sending xai-oauth:gpt-5.5.