### PR TITLE
feat(telegram): inline query mode with Platform.TELEGRAM_INLINE

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -615,6 +615,9 @@ def discover_all_skill_config_vars() -> List[Dict[str, Any]]:
             skill_name = frontmatter.get("name") or skill_file.parent.name
             if str(skill_name) in disabled:
                 continue
+            # inline_only skills must not appear in the agent's chat-mode context
+            if frontmatter.get("inline_only"):
+                continue
             if not skill_matches_platform(frontmatter):
                 continue
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -165,6 +165,7 @@ class Platform(Enum):
     QQBOT = "qqbot"
     YUANBAO = "yuanbao"
     RELAY = "relay"  # generic relay adapter fronted by the connector (EXPERIMENTAL)
+    TELEGRAM_INLINE = "telegram_inline"  # inline-only Telegram bot (separate token)
     @classmethod
     def _missing_(cls, value):
         """Accept unknown platform names only for known plugin adapters.
@@ -990,6 +991,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["exclusive_bot_mentions"] = platform_cfg["exclusive_bot_mentions"]
                 if plat == Platform.TELEGRAM and "observe_unmentioned_group_messages" in platform_cfg:
                     bridged["observe_unmentioned_group_messages"] = platform_cfg["observe_unmentioned_group_messages"]
+                if plat == Platform.TELEGRAM and "inline" in platform_cfg:
+                    bridged["inline"] = platform_cfg["inline"]
                 if "dm_policy" in platform_cfg:
                     bridged["dm_policy"] = platform_cfg["dm_policy"]
                 if "allow_from" in platform_cfg:
@@ -1165,6 +1168,7 @@ def _validate_gateway_config(config: "GatewayConfig") -> None:
     # won't connect and the cause can be confusing without a log line.
     _token_env_names = {
         Platform.TELEGRAM: "TELEGRAM_BOT_TOKEN",
+        Platform.TELEGRAM_INLINE: "TELEGRAM_BOT_TOKEN_INLINE",
         Platform.DISCORD: "DISCORD_BOT_TOKEN",
         Platform.SLACK: "SLACK_BOT_TOKEN",
         Platform.MATTERMOST: "MATTERMOST_TOKEN",
@@ -1234,7 +1238,14 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if telegram_token:
         telegram_config = _enable_from_env(Platform.TELEGRAM)
         telegram_config.token = telegram_token
-    
+
+    # Telegram inline-only bot (separate token, handles only inline_query updates)
+    telegram_inline_token = os.getenv("TELEGRAM_BOT_TOKEN_INLINE")
+    if telegram_inline_token:
+        _tgi_cfg = _enable_from_env(Platform.TELEGRAM_INLINE)
+        _tgi_cfg.token = telegram_inline_token
+        _tgi_cfg.extra["inline_only_mode"] = True
+
     # Reply threading mode for Telegram (off/first/all)
     telegram_reply_mode = os.getenv("TELEGRAM_REPLY_TO_MODE", "").lower()
     if telegram_reply_mode in {"off", "first", "all"}:

--- a/gateway/platforms/telegram_inline_router.py
+++ b/gateway/platforms/telegram_inline_router.py
@@ -1,0 +1,200 @@
+"""Dispatch layer for Telegram inline queries.
+
+Loads ``inline_tools.yaml`` from the Hermes config directory to determine which
+executor handles each query.  The framework ships the dispatch surface only —
+concrete tool implementations are user-space concerns.
+
+Registry format (inline_tools.yaml)::
+
+    version: 1
+    tools:
+      - id: my_tool
+        type: direct          # "direct" skips LLM; "llm" routes through a model
+        executor: my_executor # name passed to TelegramInlineRouter.register_executor()
+        match:
+          - pattern: "https?://example\\.com/"
+            type: url          # url | prefix | search (catch-all)
+            priority: 0        # lower = higher precedence
+          - pattern: ".*"
+            type: search
+            priority: 99
+        timeout_sec: 25
+        cache:
+          backend: memory
+          ttl_sec: 3600
+        staging_chat_env: TELEGRAM_INLINE_STAGING_CHAT  # env var naming the staging chat id
+        enabled: true
+
+``staging_chat_env`` names an environment variable that holds the chat ID where
+the executor should stage files to obtain a ``file_id``.  The recommended env var
+name is ``TELEGRAM_INLINE_STAGING_CHAT``; set it to any chat or channel the inline
+bot has access to.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+from abc import ABC, abstractmethod
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _default_registry_path() -> str:
+    try:
+        from hermes_cli.config import get_hermes_home
+        return str(get_hermes_home() / "inline_tools.yaml")
+    except Exception:
+        return os.path.join(os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes")), "inline_tools.yaml")
+
+
+# ---------------------------------------------------------------------------
+# Registry loader
+# ---------------------------------------------------------------------------
+
+class InlineToolRegistry:
+    """Loads and caches inline_tools.yaml; provides pattern matching."""
+
+    def __init__(self, path: str) -> None:
+        self._path = path
+        self._tools: List[Dict[str, Any]] = []
+        self._load()
+
+    def _load(self) -> None:
+        try:
+            import yaml
+            with open(self._path) as fh:
+                data = yaml.safe_load(fh) or {}
+            self._tools = data.get("tools", [])
+            logger.info("[inline_router] loaded %d tools from %s", len(self._tools), self._path)
+        except FileNotFoundError:
+            logger.warning("[inline_router] registry not found at %s — all inline queries will be dropped", self._path)
+        except Exception as exc:
+            logger.error("[inline_router] registry load error: %s", exc)
+
+    def match(self, query: str) -> Optional[Dict[str, Any]]:
+        """Return the first enabled tool whose match patterns fit query, or None."""
+        enabled = [t for t in self._tools if t.get("enabled", False)]
+
+        def _min_prio(tool: Dict[str, Any]) -> int:
+            return min((m.get("priority", 0) for m in tool.get("match", [])), default=0)
+
+        for tool in sorted(enabled, key=_min_prio):
+            for matcher in tool.get("match", []):
+                mtype = matcher.get("type", "search")
+                pattern = matcher.get("pattern", "")
+                try:
+                    if mtype == "url" and re.search(pattern, query):
+                        return tool
+                    elif mtype == "prefix" and re.match(pattern, query):
+                        return tool
+                    elif mtype == "search":
+                        return tool  # catch-all
+                except re.error:
+                    pass
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Executor interface
+# ---------------------------------------------------------------------------
+
+class InlineExecutor(ABC):
+    """Base class for inline query executors.
+
+    Subclass this in user-space and register with
+    ``TelegramInlineRouter.register_executor()``.
+
+    ``execute()`` must return a dict that at minimum contains ``"file_id"`` for
+    cached-audio results (the key is passed directly into
+    ``InlineQueryResultCachedAudio``).  Additional keys (``"title"``,
+    ``"performer"``, etc.) are stored in the cache entry but not used by the
+    framework itself.
+    """
+
+    @abstractmethod
+    async def execute(self, user_id: int, query: str) -> Dict[str, Any]:
+        """Run the tool and return a result dict.
+
+        Args:
+            user_id: Telegram user ID of the query sender.
+            query: The full inline query text after tool matching.
+
+        Returns:
+            Dict containing at least ``{"file_id": str}``.
+
+        Raises:
+            Exception: Any exception is caught by the router and stored as a
+                ``"failed"`` cache entry so the user sees an actionable error.
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+class TelegramInlineRouter:
+    """Stateful dispatch router.  One instance per adapter; holds in-flight cache.
+
+    Usage::
+
+        router = TelegramInlineRouter(bot)
+        router.register_executor("my_executor", MyExecutor)
+
+    Executors are looked up by the ``executor`` field in inline_tools.yaml.
+    The framework ships no concrete executors; implementations are user-space.
+    """
+
+    def __init__(self, bot: Any, registry_path: Optional[str] = None) -> None:
+        self._bot = bot
+        _path = registry_path if registry_path is not None else _default_registry_path()
+        self._registry = InlineToolRegistry(_path)
+        self._executors: Dict[str, Callable[[Dict[str, Any], Any], InlineExecutor]] = {}
+        self.cache: Dict[str, Dict[str, Any]] = {}
+
+    def register_executor(
+        self,
+        name: str,
+        factory: Callable[[Dict[str, Any], Any], InlineExecutor],
+    ) -> None:
+        """Register an executor factory for tools that declare ``executor: <name>``.
+
+        The factory is called as ``factory(tool_config, bot)`` and must return an
+        ``InlineExecutor`` instance.  Call this before the first inline query arrives
+        (e.g. right after ``TelegramInlineRouter.__init__``).
+
+        Example::
+
+            router.register_executor("audio_dl", MyAudioDownloader)
+        """
+        self._executors[name] = factory
+
+    def dispatch(self, user_id: int, query: str, cache_key: str) -> None:
+        """Non-blocking: find matching tool, schedule background execution."""
+        tool = self._registry.match(query)
+        if tool is None:
+            self.cache[cache_key] = {"status": "failed", "error": "No enabled tool matched"}
+            return
+
+        executor_name = tool.get("executor", "")
+        factory = self._executors.get(executor_name)
+        if factory is None:
+            logger.warning("[inline_router] no executor registered for %r", executor_name)
+            self.cache[cache_key] = {"status": "failed", "error": f"Executor '{executor_name}' not registered"}
+            return
+
+        executor = factory(tool, self._bot)
+        asyncio.ensure_future(self._run(executor, user_id, query, cache_key))
+
+    async def _run(self, executor: InlineExecutor, user_id: int, query: str, cache_key: str) -> None:
+        try:
+            result = await executor.execute(user_id, query)
+            self.cache[cache_key] = {"status": "ready", **result}
+            logger.info("[inline_router] cached result for %r", cache_key[:60])
+        except Exception as exc:
+            logger.warning("[inline_router] failed for %r: %s", cache_key[:60], exc)
+            self.cache[cache_key] = {"status": "failed", "error": str(exc)[:200]}

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -202,6 +202,17 @@ class GatewayStreamConsumer:
         # this response and route through edit-based for graceful degradation.
         self._draft_failures = 0
         self._before_finalize_notified = False
+        # Set when _reset_segment_state is called with preserve_no_edit=True
+        # (segment break on a __no_edit__ platform).  Signals _send_fallback_final
+        # to include "guest_segment_start": True on its first chunk so the
+        # Telegram adapter replaces the guest reply buffer instead of appending —
+        # preventing inter-tool commentary from earlier segments from bleeding
+        # into the answerGuestQuery reply.
+        self._had_no_edit_segment_break = False
+        # Offset into _accumulated where the most-recent segment began.  Updated
+        # by each __no_edit__ segment-break so _send_fallback_final can extract
+        # only the last segment's text when the adapter opts in.
+        self._no_edit_segment_text_start = 0
 
     def _metadata_for_send(
         self,
@@ -312,6 +323,16 @@ class GatewayStreamConsumer:
 
     def _reset_segment_state(self, *, preserve_no_edit: bool = False) -> None:
         if preserve_no_edit and self._message_id == "__no_edit__":
+            # Preserve the __no_edit__ sentinel so _send_fallback_final remains
+            # the final delivery path — resetting to None would re-enter the
+            # first-send path on every segment break and create one platform
+            # message per tool call (the cause of 155 PR comments in #8124).
+            # Track where the current segment begins in _accumulated so
+            # adapters that deliver only the final segment (e.g. Telegram guest
+            # mode via answerGuestQuery) can extract it without accumulating
+            # inter-tool narration from earlier segments.
+            self._had_no_edit_segment_break = True
+            self._no_edit_segment_text_start = len(self._accumulated)
             return
         self._message_id = None
         self._message_created_ts = None
@@ -876,8 +897,25 @@ class GatewayStreamConsumer:
 
         Retries each chunk once on flood-control failures with a short delay.
         """
+        # When the adapter opts in (e.g. Telegram guest mode / answerGuestQuery),
+        # deliver ONLY the last segment's text so inter-tool commentary from
+        # earlier segments does not appear in the reply.  The adapter is then
+        # signalled via "guest_segment_start": True on the first chunk to REPLACE
+        # its buffer (rather than append) so any stale preamble is discarded.
+        _deliver_last_segment_only = (
+            self._had_no_edit_segment_break
+            and getattr(self.adapter, "GUEST_MODE_DROPS_PRIOR_SEGMENTS", False) is True
+        )
         final_text = self._clean_for_display(text)
-        continuation = self._continuation_text(final_text)
+        if _deliver_last_segment_only:
+            continuation = self._clean_for_display(
+                text[self._no_edit_segment_text_start:]
+            ).strip()
+            if not continuation:
+                continuation = final_text  # fallback to full text if last segment empty
+        else:
+            continuation = self._continuation_text(final_text)
+        self._had_no_edit_segment_break = False
         self._fallback_final_send = False
         if not continuation.strip():
             # Nothing new to send — the visible partial already matches final text.
@@ -930,14 +968,25 @@ class GatewayStreamConsumer:
         last_message_id: Optional[str] = None
         last_successful_chunk = ""
         sent_any_chunk = False
+        # Signal the first chunk as a "segment start" so adapters that buffer
+        # replies (e.g. Telegram guest mode / answerGuestQuery) replace their
+        # stale inter-tool preamble instead of appending to it.
+        _tag_segment_start = _deliver_last_segment_only
         for chunk in chunks:
             # Try sending with one retry on flood-control errors.
             result = None
+            _base_meta = self._metadata_for_send(final=True)
+            if _tag_segment_start:
+                _chunk_meta: Optional[dict] = dict(_base_meta or {})
+                _chunk_meta["guest_segment_start"] = True
+                _tag_segment_start = False  # only the first chunk gets this flag
+            else:
+                _chunk_meta = _base_meta
             for attempt in range(2):
                 result = await self.adapter.send(
                     chat_id=self.chat_id,
                     content=chunk,
-                    metadata=self._metadata_for_send(final=True),
+                    metadata=_chunk_meta,
                 )
                 if result.success:
                     break

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1614,7 +1614,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
             try:
                 await self._app.updater.start_polling(
-                    allowed_updates=Update.ALL_TYPES,
+                    allowed_updates=list(Update.ALL_TYPES) + ["guest_message"],
                     drop_pending_updates=False,
                     error_callback=self._polling_error_callback_ref,
                 )
@@ -2192,7 +2192,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     url_path=webhook_path,
                     webhook_url=webhook_url,
                     secret_token=webhook_secret,
-                    allowed_updates=Update.ALL_TYPES,
+                    allowed_updates=list(Update.ALL_TYPES) + ["guest_message"],
                     drop_pending_updates=True,
                 )
                 self._webhook_mode = True
@@ -2225,7 +2225,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 self._polling_error_callback_ref = _polling_error_callback
 
                 await self._app.updater.start_polling(
-                    allowed_updates=Update.ALL_TYPES,
+                    allowed_updates=list(Update.ALL_TYPES) + ["guest_message"],
                     drop_pending_updates=True,
                     error_callback=_polling_error_callback,
                 )

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -530,6 +530,12 @@ class TelegramAdapter(BasePlatformAdapter):
         # Tracks status bubbles owned by this adapter so subsequent calls with the
         # same key edit the same message instead of appending new ones (#30045).
         self._status_message_ids: Dict[tuple, str] = {}
+        # Bot API 10.0 guest mode: chat_id → guest_query_id for answerGuestQuery
+        self._pending_guest_queries: Dict[str, str] = {}
+        # chat IDs that are guest-mode only (bot not a member)
+        self._guest_only_chats: set = set()
+        # accumulated send() content for guest chats; flushed via answerGuestQuery in on_processing_complete
+        self._guest_reply_buffer: Dict[str, str] = {}
 
     def _notification_kwargs(
         self, metadata: Optional[Dict[str, Any]]
@@ -2115,7 +2121,16 @@ class TelegramAdapter(BasePlatformAdapter):
             ))
             # Handle inline keyboard button callbacks (update prompts)
             self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
-            
+            # Handle guest_message updates (Bot API 10.0 — not yet in PTB typed layer;
+            # the raw payload arrives in update.api_kwargs["guest_message"]).
+            try:
+                from telegram.ext import TypeHandler as _TypeHandler
+                self._app.add_handler(
+                    _TypeHandler(Update, self._handle_guest_message_update), group=1
+                )
+            except Exception as _th_err:
+                logger.warning("[%s] Could not register guest_message TypeHandler: %s", self.name, _th_err)
+
             # Start polling — retry initialize() for transient TLS resets
             try:
                 from telegram.error import NetworkError, TimedOut
@@ -2401,6 +2416,43 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=True, message_id=None)
         
         try:
+            # Bot API 10.0 guest reply: buffer content and return immediately.
+            # Must run before the rich/legacy send paths — both use sendMessage
+            # which Telegram rejects with Forbidden when the bot is not a member.
+            if self._pending_guest_queries.get(chat_id) is not None or chat_id in self._guest_only_chats:
+                # Tool-use progress blocks (💻 terminal etc.) come through
+                # send() from send_progress_messages().  The stream consumer
+                # always sets expect_edits=True on the first frame and
+                # notify=True on the fallback-final send; tool-progress calls
+                # have neither flag.  Drop anything that isn't from the stream
+                # consumer so the guest reply contains only the LLM response.
+                _is_stream_send = bool(
+                    metadata
+                    and (metadata.get("expect_edits") or metadata.get("notify"))
+                )
+                if not _is_stream_send:
+                    return SendResult(success=True, message_id=None)
+
+                # Strip the streaming cursor " ▉" before buffering so it is
+                # never embedded mid-word in the final reply.
+                _cursor = " ▉"
+                _clean = content
+                if _clean.endswith(_cursor):
+                    _clean = _clean[:-len(_cursor)]
+                elif _clean.endswith("▉"):
+                    _clean = _clean[:-1]
+
+                _existing = self._guest_reply_buffer.get(chat_id, "")
+                if _existing and _clean.startswith(_existing):
+                    # Cumulative streaming update: new content contains all
+                    # prior content as a prefix → replace so the last call wins.
+                    self._guest_reply_buffer[chat_id] = _clean
+                else:
+                    # Continuation or overflow chunk: content does NOT start
+                    # with what we already have → append.
+                    self._guest_reply_buffer[chat_id] = _existing + _clean
+                return SendResult(success=True, message_id=None)
+
             # Bot API 10.1 rich fast-path: send the raw agent markdown via
             # sendRichMessage so tables/task lists/etc. render natively. Falls
             # through to the legacy MarkdownV2 path on permanent/capability
@@ -2691,6 +2743,10 @@ class TelegramAdapter(BasePlatformAdapter):
         message in place. If the edit fails (message deleted, too old, etc.)
         we drop the cached id and send fresh.
         """
+        # Guest chats have no existing message to edit and status messages would
+        # consume the one-shot query_id before the real answer is ready.
+        if self._pending_guest_queries.get(str(chat_id)) is not None or str(chat_id) in self._guest_only_chats:
+            return SendResult(success=True, message_id=None)
         key = (str(chat_id), str(status_key))
         cached_id = self._status_message_ids.get(key)
         if cached_id is not None:
@@ -3127,6 +3183,11 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         if not self._bot:
             return SendResult(success=False, error="not_connected")
+
+        # Guest chats: draft streaming requires an existing message to animate;
+        # the bot is not a member, so suppress silently.
+        if self._pending_guest_queries.get(str(chat_id)) is not None or str(chat_id) in self._guest_only_chats:
+            return SendResult(success=True, message_id=None)
 
         # Rich draft fast-path (Bot API 10.1 sendRichMessageDraft): render the
         # streaming preview with the same raw markdown the final
@@ -4452,7 +4513,10 @@ class TelegramAdapter(BasePlatformAdapter):
         """Send audio as a native Telegram voice message or audio file."""
         if not self._bot:
             return SendResult(success=False, error="Not connected")
-        
+
+        if self._pending_guest_queries.get(str(chat_id)) is not None or str(chat_id) in self._guest_only_chats:
+            return SendResult(success=False, error="guest_chat_no_media: bot is not a member of this group so Telegram blocks file uploads. Send the file to the user's private DMs and tell them in the group that the file is in their DMs.")
+
         try:
             if not os.path.exists(audio_path):
                 return SendResult(success=False, error=self._missing_media_path_error("Audio", audio_path))
@@ -4679,6 +4743,9 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._bot:
             return SendResult(success=False, error="Not connected")
 
+        if self._pending_guest_queries.get(str(chat_id)) is not None or str(chat_id) in self._guest_only_chats:
+            return SendResult(success=False, error="guest_chat_no_media: bot is not a member of this group so Telegram blocks file uploads. Send the file to the user's private DMs and tell them in the group that the file is in their DMs.")
+
         try:
             if not os.path.exists(image_path):
                 return SendResult(success=False, error=self._missing_media_path_error("Image", image_path))
@@ -4773,6 +4840,9 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._bot:
             return SendResult(success=False, error="Not connected")
 
+        if self._pending_guest_queries.get(str(chat_id)) is not None or str(chat_id) in self._guest_only_chats:
+            return SendResult(success=False, error="guest_chat_no_media: bot is not a member of this group so Telegram blocks file uploads. Send the file to the user's private DMs and tell them in the group that the file is in their DMs.")
+
         try:
             if not os.path.exists(file_path):
                 return SendResult(success=False, error=self._missing_media_path_error("File", file_path))
@@ -4823,6 +4893,9 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._bot:
             return SendResult(success=False, error="Not connected")
 
+        if self._pending_guest_queries.get(str(chat_id)) is not None or str(chat_id) in self._guest_only_chats:
+            return SendResult(success=False, error="guest_chat_no_media: bot is not a member of this group so Telegram blocks file uploads. Send the file to the user's private DMs and tell them in the group that the file is in their DMs.")
+
         try:
             if not os.path.exists(video_path):
                 return SendResult(success=False, error=self._missing_media_path_error("Video", video_path))
@@ -4866,12 +4939,15 @@ class TelegramAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send an image natively as a Telegram photo.
-        
+
         Tries URL-based send first (fast, works for <5MB images).
         Falls back to downloading and uploading as file (supports up to 10MB).
         """
         if not self._bot:
             return SendResult(success=False, error="Not connected")
+
+        if self._pending_guest_queries.get(str(chat_id)) is not None or str(chat_id) in self._guest_only_chats:
+            return SendResult(success=False, error="guest_chat_no_media: bot is not a member of this group so Telegram blocks file uploads. Send the file to the user's private DMs and tell them in the group that the file is in their DMs.")
 
         from tools.url_safety import is_safe_url
         if not is_safe_url(image_url):
@@ -5960,6 +6036,57 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         return getattr(update, "effective_message", None) or getattr(update, "message", None)
 
+    async def _handle_guest_message_update(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handle guest_message updates (Bot API 10.0 guest bot feature).
+
+        Telegram delivers @mentions from chats the bot hasn't joined via the
+        ``guest_message`` update field.  PTB doesn't know this field yet so it
+        lands in ``update.api_kwargs``.  We parse the raw payload, store the
+        ``guest_query_id`` so ``send()`` can call ``answerGuestQuery``, then
+        route the message through the normal text-processing pipeline.
+        """
+        if not self._telegram_guest_mode():
+            return
+        raw_gm = update.api_kwargs.get("guest_message") if update.api_kwargs else None
+        if not raw_gm or not isinstance(raw_gm, dict):
+            return
+        logger.info("[%s] guest_message update received (update_id=%s)", self.name, update.update_id)
+
+        guest_query_id = raw_gm.get("guest_query_id")
+        if not guest_query_id:
+            logger.warning("[%s] guest_message missing guest_query_id, skipping", self.name)
+            return
+
+        try:
+            msg = Message.de_json(raw_gm, self._bot)
+        except Exception as exc:
+            logger.warning("[%s] Failed to parse guest_message payload: %s", self.name, exc)
+            return
+        if not msg:
+            return
+
+        text = msg.text or getattr(msg, "caption", None) or ""
+        if not text.strip():
+            return
+
+        chat_id_str = str(msg.chat.id) if msg.chat else ""
+        if not chat_id_str:
+            return
+
+        # Store guest_query_id so send() uses answerGuestQuery for the reply.
+        self._pending_guest_queries[chat_id_str] = guest_query_id
+        self._guest_only_chats.add(chat_id_str)
+
+        if not self._should_process_message(msg):
+            self._pending_guest_queries.pop(chat_id_str, None)
+            self._guest_only_chats.discard(chat_id_str)
+            return
+
+        event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
+        event.text = self._clean_bot_trigger_text(event.text)
+        event = self._apply_telegram_group_observe_attribution(event)
+        self._enqueue_text_event(event)
+
     async def _handle_text_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming text messages.
 
@@ -6726,6 +6853,10 @@ class TelegramAdapter(BasePlatformAdapter):
                     break
 
         # Build source
+        # When a user posts "as a channel" in a group, from_user is None but
+        # sender_chat carries the channel identity. Use sender_chat.id so the
+        # auth check can match it and the session key is stable across messages.
+        sender_chat = getattr(message, "sender_chat", None)
         source = self.build_source(
             chat_id=str(chat.id),
             chat_name=chat.title or (chat.full_name if hasattr(chat, "full_name") else None),
@@ -6733,15 +6864,23 @@ class TelegramAdapter(BasePlatformAdapter):
             user_id=(
                 str(user.id)
                 if user
-                else (str(chat.id) if chat_type in {"dm", "channel"} else None)
+                else (
+                    str(sender_chat.id)
+                    if sender_chat
+                    else (str(chat.id) if chat_type in {"dm", "channel"} else None)
+                )
             ),
             user_name=(
                 user.full_name
                 if user
                 else (
-                    chat.full_name
-                    if hasattr(chat, "full_name") and chat_type == "dm"
-                    else (chat.title if chat_type == "channel" else None)
+                    getattr(sender_chat, "title", None) or getattr(sender_chat, "username", None)
+                    if sender_chat
+                    else (
+                        chat.full_name
+                        if hasattr(chat, "full_name") and chat_type == "dm"
+                        else (chat.title if chat_type == "channel" else None)
+                    )
                 )
             ),
             thread_id=thread_id_str,
@@ -6872,6 +7011,36 @@ class TelegramAdapter(BasePlatformAdapter):
         another agent run to swap it to 👍/👎 — which never happens if the
         cancellation was the last activity in the chat.
         """
+        # Flush buffered guest reply via answerGuestQuery (Bot API 10.0).
+        # All send() calls during processing were silently buffered; we fire a
+        # single answerGuestQuery here with the complete response so the user
+        # sees the full answer, not a status fragment.
+        _gc_id = str(getattr(event.source, "chat_id", None) or "")
+        if _gc_id:
+            _guest_qid = self._pending_guest_queries.pop(_gc_id, None)
+            _buffered = self._guest_reply_buffer.pop(_gc_id, "")
+            self._guest_only_chats.discard(_gc_id)
+            if _guest_qid and self._bot:
+                _plain = _strip_mdv2(self.format_message(_buffered)).strip() if _buffered else ""
+                _plain = _plain[:4096] or "​"  # zero-width space if somehow empty
+                _gq_result = {
+                    "type": "article",
+                    "id": "reply",
+                    "title": "Reply",
+                    "input_message_content": {"message_text": _plain},
+                }
+                try:
+                    await self._bot.do_api_request(
+                        "answerGuestQuery",
+                        api_kwargs={"guest_query_id": _guest_qid, "result": _gq_result},
+                    )
+                    logger.info("[%s] answerGuestQuery flushed (chat=%s)", self.name, _gc_id)
+                except Exception as _flush_err:
+                    logger.warning(
+                        "[%s] answerGuestQuery flush failed (chat=%s): %s",
+                        self.name, _gc_id, _flush_err,
+                    )
+
         if not self._reactions_enabled():
             return
         chat_id = getattr(event.source, "chat_id", None)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1487,7 +1487,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
         try:
             await self._app.updater.start_polling(
-                allowed_updates=Update.ALL_TYPES,
+                allowed_updates=list(Update.ALL_TYPES) + ["guest_message"],
                 drop_pending_updates=False,
                 error_callback=self._polling_error_callback_ref,
             )

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -23,6 +23,11 @@ logger = logging.getLogger(__name__)
 
 try:
     from telegram import Update, Bot, Message, InlineKeyboardButton, InlineKeyboardMarkup
+    from telegram import (
+        InlineQueryResultCachedAudio,
+        InlineQueryResultArticle,
+        InputTextMessageContent,
+    )
     try:
         from telegram import LinkPreviewOptions
     except ImportError:
@@ -31,6 +36,7 @@ try:
         Application,
         CommandHandler,
         CallbackQueryHandler,
+        InlineQueryHandler,
         MessageHandler as TelegramMessageHandler,
         ContextTypes,
         filters,
@@ -45,10 +51,14 @@ except ImportError:
     Message = Any
     InlineKeyboardButton = Any
     InlineKeyboardMarkup = Any
+    InlineQueryResultCachedAudio = Any
+    InlineQueryResultArticle = Any
+    InputTextMessageContent = Any
     LinkPreviewOptions = None
     Application = Any
     CommandHandler = Any
     CallbackQueryHandler = Any
+    InlineQueryHandler = Any
     TelegramMessageHandler = Any
     HTTPXRequest = Any
     filters = None
@@ -120,7 +130,8 @@ def check_telegram_requirements() -> bool:
     """
     global TELEGRAM_AVAILABLE, Update, Bot, Message, InlineKeyboardButton
     global InlineKeyboardMarkup, LinkPreviewOptions, Application
-    global CommandHandler, CallbackQueryHandler, TelegramMessageHandler
+    global CommandHandler, CallbackQueryHandler, InlineQueryHandler, TelegramMessageHandler
+    global InlineQueryResultCachedAudio, InlineQueryResultArticle, InputTextMessageContent
     global ContextTypes, filters, ParseMode, ChatType, HTTPXRequest
     if TELEGRAM_AVAILABLE:
         return True
@@ -132,6 +143,11 @@ def check_telegram_requirements() -> bool:
     try:
         from telegram import Update as _Update, Bot as _Bot, Message as _Message
         from telegram import InlineKeyboardButton as _IKB, InlineKeyboardMarkup as _IKM
+        from telegram import (
+            InlineQueryResultCachedAudio as _IQRCA,
+            InlineQueryResultArticle as _IQRArt,
+            InputTextMessageContent as _ITMC,
+        )
         try:
             from telegram import LinkPreviewOptions as _LPO
         except ImportError:
@@ -139,6 +155,7 @@ def check_telegram_requirements() -> bool:
         from telegram.ext import (
             Application as _App, CommandHandler as _CH,
             CallbackQueryHandler as _CQH,
+            InlineQueryHandler as _IQH,
             MessageHandler as _MH,
             ContextTypes as _CT, filters as _filters,
         )
@@ -151,10 +168,14 @@ def check_telegram_requirements() -> bool:
     Message = _Message
     InlineKeyboardButton = _IKB
     InlineKeyboardMarkup = _IKM
+    InlineQueryResultCachedAudio = _IQRCA
+    InlineQueryResultArticle = _IQRArt
+    InputTextMessageContent = _ITMC
     LinkPreviewOptions = _LPO
     Application = _App
     CommandHandler = _CH
     CallbackQueryHandler = _CQH
+    InlineQueryHandler = _IQH
     TelegramMessageHandler = _MH
     ContextTypes = _CT
     filters = _filters
@@ -615,6 +636,8 @@ class TelegramAdapter(BasePlatformAdapter):
         self._guest_only_chats: set = set()
         # accumulated send() content for guest chats; flushed via answerGuestQuery in on_processing_complete
         self._guest_reply_buffer: Dict[str, str] = {}
+        # inline query router (initialised in connect() once self._bot is available)
+        self._inline_router: Optional[Any] = None
 
     def _notification_kwargs(
         self, metadata: Optional[Dict[str, Any]]
@@ -2215,35 +2238,47 @@ class TelegramAdapter(BasePlatformAdapter):
             builder = builder.request(request).get_updates_request(get_updates_request)
             self._app = builder.build()
             self._bot = self._app.bot
-            
-            # Register handlers
-            self._app.add_handler(TelegramMessageHandler(
-                filters.TEXT & ~filters.COMMAND,
-                self._handle_text_message
-            ))
-            self._app.add_handler(TelegramMessageHandler(
-                filters.COMMAND,
-                self._handle_command
-            ))
-            self._app.add_handler(TelegramMessageHandler(
-                filters.LOCATION | getattr(filters, "VENUE", filters.LOCATION),
-                self._handle_location_message
-            ))
-            self._app.add_handler(TelegramMessageHandler(
-                filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL | filters.Sticker.ALL,
-                self._handle_media_message
-            ))
-            # Handle inline keyboard button callbacks (update prompts)
-            self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
-            # Handle guest_message updates (Bot API 10.0 — not yet in PTB typed layer;
-            # the raw payload arrives in update.api_kwargs["guest_message"]).
+
+            # Inline router — reads inline_tools.yaml from the Hermes config directory
             try:
-                from telegram.ext import TypeHandler as _TypeHandler
-                self._app.add_handler(
-                    _TypeHandler(Update, self._handle_guest_message_update), group=1
-                )
-            except Exception as _th_err:
-                logger.warning("[%s] Could not register guest_message TypeHandler: %s", self.name, _th_err)
+                from gateway.platforms.telegram_inline_router import TelegramInlineRouter
+                self._inline_router = TelegramInlineRouter(self._bot)
+            except Exception as _irt_err:
+                logger.warning("[%s] inline router init failed: %s", self.name, _irt_err)
+
+            # Register handlers
+            _inline_only = self.config.extra.get("inline_only_mode", False) if getattr(self.config, "extra", None) else False
+            if not _inline_only:
+                self._app.add_handler(TelegramMessageHandler(
+                    filters.TEXT & ~filters.COMMAND,
+                    self._handle_text_message
+                ))
+                self._app.add_handler(TelegramMessageHandler(
+                    filters.COMMAND,
+                    self._handle_command
+                ))
+                self._app.add_handler(TelegramMessageHandler(
+                    filters.LOCATION | getattr(filters, "VENUE", filters.LOCATION),
+                    self._handle_location_message
+                ))
+                self._app.add_handler(TelegramMessageHandler(
+                    filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL | filters.Sticker.ALL,
+                    self._handle_media_message
+                ))
+                # Handle inline keyboard button callbacks (update prompts)
+                self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
+            # Handle inline queries (e.g. @botname <song name or spotify link>)
+            self._app.add_handler(InlineQueryHandler(self._handle_inline_query))
+            if not _inline_only:
+                # Handle guest_message updates (Bot API 10.0 — not yet in PTB typed layer;
+                # the raw payload arrives in update.api_kwargs["guest_message"]).
+                try:
+                    from telegram.ext import TypeHandler as _TypeHandler
+                    self._app.add_handler(
+                        _TypeHandler(Update, self._handle_guest_message_update), group=1
+                    )
+                except Exception as _th_err:
+                    logger.warning("[%s] Could not register guest_message TypeHandler: %s", self.name, _th_err)
 
             # Start polling — retry initialize() for transient TLS resets
             try:
@@ -6181,6 +6216,83 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         return getattr(update, "effective_message", None) or getattr(update, "message", None)
 
+    async def _handle_inline_query(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Dispatch inline queries via TelegramInlineRouter."""
+        iq = getattr(update, "inline_query", None)
+        if not iq:
+            return
+
+        # Guard: drop if inline disabled in config (platforms.telegram.inline.enabled: false)
+        _inline_cfg = self.config.extra.get("inline", {}) if getattr(self.config, "extra", None) else {}
+        if isinstance(_inline_cfg, dict) and not _inline_cfg.get("enabled", True):
+            logger.debug("[%s] inline queries disabled in config — dropping", self.name)
+            return
+
+        query = (iq.query or "").strip()
+        if not query:
+            try:
+                from telegram import InlineQueryResultsButton as _IQBtn
+                _btn = _IQBtn(text="Type a query to get started", start_parameter="inline_help")
+                await iq.answer([], cache_time=0, button=_btn)
+            except Exception:
+                await iq.answer([], cache_time=0)
+            return
+
+        if not self._inline_router:
+            await iq.answer([], cache_time=0)
+            return
+
+        user_id = iq.from_user.id
+        cache_key = query.lower()
+        cache = self._inline_router.cache
+
+        entry = cache.get(cache_key)
+        if entry:
+            status = entry.get("status")
+            if status == "ready":
+                result = InlineQueryResultCachedAudio(
+                    id=cache_key[:64],
+                    audio_file_id=entry["file_id"],
+                    caption="",
+                )
+                await iq.answer([result], cache_time=300)
+                return
+            if status == "downloading":
+                await iq.answer([InlineQueryResultArticle(
+                    id="preparing",
+                    title="Downloading... try again in a few seconds",
+                    description=query[:80],
+                    input_message_content=InputTextMessageContent(
+                        message_text=f"Downloading: {query[:80]}"
+                    ),
+                )], cache_time=0)
+                return
+            if status == "failed":
+                err_msg = entry.get("error", "unknown error")[:60]
+                cache.pop(cache_key, None)  # evict so retry kicks a fresh download
+                await iq.answer([InlineQueryResultArticle(
+                    id="failed",
+                    title="Download failed — try again",
+                    description=err_msg,
+                    input_message_content=InputTextMessageContent(
+                        message_text=f"Download failed: {err_msg}"
+                    ),
+                )], cache_time=0)
+                return
+
+        # Not cached — record intent and let router dispatch
+        cache[cache_key] = {"status": "downloading", "user_id": user_id}
+        self._inline_router.dispatch(user_id, query, cache_key)
+
+        await iq.answer([InlineQueryResultArticle(
+            id="preparing",
+            title="Downloading...",
+            description=f"Wait ~15 s then type again: {query[:60]}",
+            input_message_content=InputTextMessageContent(
+                message_text=f"Downloading: {query[:80]}"
+            ),
+        )], cache_time=0)
+
     async def _handle_guest_message_update(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle guest_message updates (Bot API 10.0 guest bot feature).
 
@@ -7325,6 +7437,21 @@ def _build_adapter(config):
     return adapter
 
 
+def _build_inline_adapter(config):
+    """Factory for the inline-only Telegram adapter (TELEGRAM_BOT_TOKEN_INLINE).
+
+    Creates a TelegramAdapter with inline_only_mode=True so connect() only
+    registers InlineQueryHandler — no chat, command, or callback handlers.
+    """
+    config.extra["inline_only_mode"] = True
+    adapter = TelegramAdapter(config)
+    try:
+        adapter._notifications_mode = _resolve_notifications_mode()
+    except Exception:
+        adapter._notifications_mode = "important"
+    return adapter
+
+
 def _is_connected(config) -> bool:
     """Telegram is connected when a bot token is configured.
 
@@ -7499,4 +7626,15 @@ def register(ctx) -> None:
         max_message_length=4096,
         emoji="✈️",
         allow_update_command=True,
+    )
+    ctx.register_platform(
+        name="telegram_inline",
+        label="Telegram Inline Bot",
+        adapter_factory=_build_inline_adapter,
+        check_fn=check_telegram_requirements,
+        is_connected=_is_connected,
+        required_env=["TELEGRAM_BOT_TOKEN_INLINE"],
+        install_hint="Set TELEGRAM_BOT_TOKEN_INLINE in your Hermes .env file",
+        max_message_length=4096,
+        emoji="🎵",
     )

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -435,6 +435,13 @@ class TelegramAdapter(BasePlatformAdapter):
     # Fixes #25710.
     REQUIRES_EDIT_FINALIZE: bool = True
 
+    # In guest mode (answerGuestQuery), the reply must be a single coherent
+    # answer, not a concatenation of all inter-tool commentary segments.
+    # Setting this True tells stream_consumer._send_fallback_final to deliver
+    # only the last segment's text and tag it with "guest_segment_start" so
+    # the send() buffer replaces instead of appending stale preamble.
+    GUEST_MODE_DROPS_PRIOR_SEGMENTS: bool = True
+
     # Adaptive text-batch ingress: short messages need a tighter delay so the
     # first token reaches the agent fast.  Numbers tuned for "feels instant":
     # ≤320 codepoints (one short paragraph) settles in ~180ms; ≤1024
@@ -2550,7 +2557,14 @@ class TelegramAdapter(BasePlatformAdapter):
                     _clean = _clean[:-1]
 
                 _existing = self._guest_reply_buffer.get(chat_id, "")
-                if _existing and _clean.startswith(_existing):
+                if metadata and metadata.get("guest_segment_start"):
+                    # Stream consumer had a tool-call segment break on a __no_edit__
+                    # platform: inter-tool commentary was cleared in the consumer and
+                    # this is the start of the final-answer delivery.  Replace the
+                    # buffer so preamble text ("searching...", failed-tool narration)
+                    # from earlier segments does not appear in the answerGuestQuery.
+                    self._guest_reply_buffer[chat_id] = _clean
+                elif _existing and _clean.startswith(_existing):
                     # Cumulative streaming update: new content contains all
                     # prior content as a prefix → replace so the last call wins.
                     self._guest_reply_buffer[chat_id] = _clean

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -775,6 +775,43 @@ class TestSegmentBreakOnToolBoundary:
         assert "Phase 3" in final_text
 
     @pytest.mark.asyncio
+    async def test_guest_mode_drops_prior_segments_delivers_only_last_segment(self):
+        """When the adapter sets GUEST_MODE_DROPS_PRIOR_SEGMENTS=True (Telegram guest
+        mode / answerGuestQuery), _send_fallback_final must deliver ONLY the last
+        segment's text and tag it with 'guest_segment_start' so the adapter can
+        replace its buffer instead of concatenating all inter-tool commentary."""
+        adapter = MagicMock()
+        adapter.GUEST_MODE_DROPS_PRIOR_SEGMENTS = True
+        adapter.send = AsyncMock(side_effect=[
+            SimpleNamespace(success=True, message_id=None),
+            SimpleNamespace(success=True, message_id=None),
+        ])
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5)
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        consumer.on_delta("Inter-tool narration 1")
+        consumer.on_delta(None)
+        consumer.on_delta("Inter-tool narration 2")
+        consumer.on_delta(None)
+        consumer.on_delta("Final answer from OSM")
+        consumer.finish()
+
+        await consumer.run()
+
+        assert adapter.send.call_count == 2
+        final_call = adapter.send.call_args_list[1]
+        final_text = final_call[1]["content"]
+        final_meta = final_call[1].get("metadata") or {}
+        # Only the last segment reaches the guest buffer
+        assert "Final answer" in final_text
+        assert "Inter-tool narration" not in final_text
+        # The 'guest_segment_start' flag signals the adapter to replace its buffer
+        assert final_meta.get("guest_segment_start") is True
+
+    @pytest.mark.asyncio
     async def test_fallback_final_splits_long_continuation_without_dropping_text(self):
         """Long continuation tails should be chunked when fallback final-send runs."""
         adapter = MagicMock()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -541,40 +541,90 @@ def _parse_target_ref(platform_name: str, target_ref: str):
     return None, None, False
 
 
-def _translate_docker_workspace_paths(media_files: list) -> list:
-    """Translate /workspace/ container paths to their host equivalents.
+def _get_docker_mount_table() -> tuple[list[tuple[str, str]], str | None]:
+    """Return ([(container_dest, host_src), ...], container_id) for the active Docker env.
 
-    When the terminal backend is Docker, commands run inside a container where
-    /workspace is a bind-mount of a host directory.  The send_message tool runs
-    on the HOST where /workspace does not exist, so validate_media_delivery_path
-    silently drops those files.  This translator looks up the active Docker
-    environment's workspace host path and rewrites matching paths so the
-    host-side file is found and delivered correctly.
+    Mounts are sorted longest-destination-first so the most specific prefix wins.
+    Returns ([], None) if no active Docker environment is found.
     """
-    if not any(p.startswith("/workspace") for p, _ in media_files):
-        return media_files
-
-    host_workspace: str | None = None
     try:
+        import json
+        import subprocess
         from tools.terminal_tool import _active_environments  # type: ignore[import]
         for env in list(_active_environments.values()):
-            wd = getattr(env, "_workspace_dir", None)
-            if wd:
-                host_workspace = wd
-                break
+            cid = getattr(env, "_container_id", None)
+            if not cid:
+                continue
+            result = subprocess.run(
+                ["docker", "inspect", "--format", "{{json .Mounts}}", cid],
+                capture_output=True, text=True, timeout=5,
+            )
+            if result.returncode != 0:
+                continue
+            mounts = [
+                (m["Destination"].rstrip("/"), m["Source"].rstrip("/"))
+                for m in json.loads(result.stdout)
+                if m.get("Type") == "bind"
+            ]
+            mounts.sort(key=lambda x: len(x[0]), reverse=True)
+            return mounts, cid
     except Exception:
         pass
+    return [], None
 
-    if host_workspace is None:
+
+def _translate_docker_workspace_paths(media_files: list) -> list:
+    """Translate container paths to host equivalents for Docker terminal backends.
+
+    send_message runs on the HOST; files written by the agent inside the Docker
+    container are only reachable if the path falls under a bind-mount or can be
+    copied out.  Strategy:
+      1. Build the mount table from `docker inspect`.
+      2. For each media path, walk mounts longest-first to find a matching prefix
+         and rewrite to the host source path.
+      3. For paths not covered by any mount (e.g. /tmp/), use `docker cp` to
+         extract the file to a temp location the host can read.
+    """
+    import os
+    from pathlib import Path
+
+    if not media_files:
+        return media_files
+
+    mounts, container_id = _get_docker_mount_table()
+    if not mounts and not container_id:
         return media_files
 
     translated = []
     for path, is_voice in media_files:
-        if path == "/workspace":
-            path = host_workspace
-        elif path.startswith("/workspace/"):
-            path = host_workspace + path[len("/workspace"):]
-        translated.append((path, is_voice))
+        host_path = path
+
+        # Try to map via a bind-mount prefix.
+        for dest, src in mounts:
+            if path == dest:
+                host_path = src
+                break
+            if path.startswith(dest + "/"):
+                host_path = src + path[len(dest):]
+                break
+
+        # If still unmapped (e.g. /tmp/) and doesn't exist on host, docker cp it.
+        if host_path == path and not Path(path).exists() and container_id:
+            try:
+                import hashlib
+                import subprocess
+                tag = hashlib.md5(path.encode()).hexdigest()[:8]
+                dest_path = f"/tmp/hermes_docker_media_{tag}{os.path.splitext(path)[1]}"
+                r = subprocess.run(
+                    ["docker", "cp", f"{container_id}:{path}", dest_path],
+                    capture_output=True, timeout=30,
+                )
+                if r.returncode == 0:
+                    host_path = dest_path
+            except Exception:
+                pass
+
+        translated.append((host_path, is_voice))
     return translated
 
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -373,6 +373,7 @@ def _handle_send(args):
     force_document_attachments = "[[as_document]]" in message
 
     media_files, cleaned_message = BasePlatformAdapter.extract_media(message)
+    media_files = _translate_docker_workspace_paths(media_files)
     media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
     mirror_text = cleaned_message.strip() or _describe_media_for_mirror(media_files)
 
@@ -538,6 +539,43 @@ def _parse_target_ref(platform_name: str, target_ref: str):
     if platform_name == "xmpp" and "@" in target_ref:
         return target_ref, None, True
     return None, None, False
+
+
+def _translate_docker_workspace_paths(media_files: list) -> list:
+    """Translate /workspace/ container paths to their host equivalents.
+
+    When the terminal backend is Docker, commands run inside a container where
+    /workspace is a bind-mount of a host directory.  The send_message tool runs
+    on the HOST where /workspace does not exist, so validate_media_delivery_path
+    silently drops those files.  This translator looks up the active Docker
+    environment's workspace host path and rewrites matching paths so the
+    host-side file is found and delivered correctly.
+    """
+    if not any(p.startswith("/workspace") for p, _ in media_files):
+        return media_files
+
+    host_workspace: str | None = None
+    try:
+        from tools.terminal_tool import _active_environments  # type: ignore[import]
+        for env in list(_active_environments.values()):
+            wd = getattr(env, "_workspace_dir", None)
+            if wd:
+                host_workspace = wd
+                break
+    except Exception:
+        pass
+
+    if host_workspace is None:
+        return media_files
+
+    translated = []
+    for path, is_voice in media_files:
+        if path == "/workspace":
+            path = host_workspace
+        elif path.startswith("/workspace/"):
+            path = host_workspace + path[len("/workspace"):]
+        translated.append((path, is_voice))
+    return translated
 
 
 def _describe_media_for_mirror(media_files):


### PR DESCRIPTION
## Why this PR

### 1. Guest mode and inline mode are distinct API surfaces that conflict on a shared token

Telegram Bot API 10.0 introduced *guest mode*: bots can receive `guest_message` updates from groups without being a member.  That surface is text-only — any attempt to send media returns `guest_chat_no_media`.  The solution for media delivery is *inline mode* (`@botname <query>`), where the **user** sends the result, not the bot, so group membership is irrelevant.

These two surfaces cannot share one `python-telegram-bot` `Application` without race conditions on the update-routing loop.  A second `Application` instance running on `TELEGRAM_BOT_TOKEN_INLINE` isolates the inline polling loop completely.  `Platform.TELEGRAM_INLINE` gives that second adapter a first-class enum value, separate env-var, and its own lifecycle in the platform registry — exactly the same pattern already used for `Platform.RELAY`.

### 2. Inline tool registry: explicit whitelist, `type: direct` vs `type: llm`

`InlineToolRegistry` reads `inline_tools.yaml` from the Hermes config directory.  Every tool that can be reached via inline query must be listed and have `enabled: true`.  Unlisted executors cannot be dispatched — the dispatcher logs a warning and returns a "failed" cache entry.

Two tool types are defined:

| `type`   | LLM calls | Primary use case |
|----------|-----------|-----------------|
| `direct` | zero      | media/file fetching, deterministic lookups |
| `llm`    | one       | short text answers, search summaries |

The distinction is load-bearing: Telegram imposes a hard **30-second** timeout on `answerInlineQuery`.  LLM calls on a slow model can easily exceed this; `type: direct` tools never will.  LLM tools are supported in the schema but should use a fast/small model tier.

### 3. Speed constraint — 30 s hard timeout drives the direct-first design

Telegram silently drops `answerInlineQuery` calls that arrive after 30 seconds.  The adapter implements a **two-phase UX** that works around this:

1. First query → cache miss → set `status: downloading` → return `InlineQueryResultArticle("Downloading...")` immediately (within milliseconds)
2. Background task runs the executor
3. Second query (user re-types or waits) → cache hit → return `InlineQueryResultCachedAudio` with the stored `file_id`

The `cache_time=0` on the "Downloading" result forces Telegram to re-query on every keystroke; `cache_time=300` on the ready result lets Telegram cache it locally.

### 4. `file_id` caching is the correct Telegram primitive for repeated delivery

Once a file is uploaded to Telegram via `send_audio`, the returned `audio.file_id` is permanent on Telegram's servers regardless of where the message was sent.  `InlineQueryResultCachedAudio` reuses that ID for instant inline delivery without re-uploading.  The in-memory cache in `TelegramInlineRouter` holds `{query_lower → {status, file_id}}` for the adapter lifetime; entries are evicted on `"failed"` status to allow retries.

The `staging_chat_env` key in `inline_tools.yaml` names an environment variable (`TELEGRAM_INLINE_STAGING_CHAT`) that holds the chat ID where the executor stages uploads.  This is an executor-level concern; the router itself never reads it.

### 5. `platforms.telegram.inline.enabled` — fail-open gate

```yaml
platforms:
  telegram:
    inline:
      enabled: false   # set to disable; omit to enable (default: true)
```

`_handle_inline_query` checks this at the top and returns silently if disabled.  The gate is fail-open (missing key → enabled) so existing deployments without the key are unaffected.

### 6. What this PR does NOT include

No specific inline tool implementation ships upstream.  `InlineExecutor` is an abstract base class; `register_executor()` on `TelegramInlineRouter` accepts user-space factories.  The `inline_tools.yaml` registry schema is documented in the module docstring.  Concrete executors (media downloaders, search handlers, etc.) are user-space concerns and are intentionally absent.

## Files changed

| File | Change |
|------|--------|
| `gateway/config.py` | `Platform.TELEGRAM_INLINE` enum; `TELEGRAM_BOT_TOKEN_INLINE` env pickup; `inline` config key bridge |
| `gateway/platforms/telegram_inline_router.py` | **new** — `InlineToolRegistry`, `InlineExecutor` ABC, `TelegramInlineRouter` |
| `plugins/platforms/telegram/adapter.py` | `inline_only_mode` handler gating; `_handle_inline_query`; `_build_inline_adapter`; second `register_platform` |
| `agent/skill_utils.py` | Skip `inline_only: true` skills from chat-mode context |

## Test plan

- [ ] Set `TELEGRAM_BOT_TOKEN_INLINE` to a second bot token and start the gateway — confirm `telegram_inline` platform connects
- [ ] Type `@botname query` in any Telegram chat — confirm "Downloading..." placeholder appears immediately
- [ ] With no executor registered, confirm inline query returns "Executor not registered" error result and does not crash the adapter
- [ ] Confirm primary `telegram` platform chat handlers are unaffected (no regression on text, command, media, callback flows)
- [ ] Set `platforms.telegram.inline.enabled: false` in config — confirm inline queries are silently dropped
- [ ] Add a skill with `inline_only: true` frontmatter — confirm it does not appear in agent chat completions

🤖 Generated with [Claude Code](https://claude.com/claude-code)