### PR TITLE
fix(achievements): keep lifetime progress monotonic after session cleanup

### DIFF
--- a/plugins/hermes-achievements/dashboard/plugin_api.py
+++ b/plugins/hermes-achievements/dashboard/plugin_api.py
@@ -763,6 +763,28 @@ def evaluate_definition(definition: Dict[str, Any], aggregate: Dict[str, Any]) -
     return evaluate_boolean(definition, aggregate)
 
 
+def _merge_lifetime_aggregate(state: Dict[str, Any], scanned: Dict[str, Any]) -> Dict[str, Any]:
+    """Persist achievement aggregate counters monotonically.
+
+    Session rows are operational history and can be pruned. Achievement
+    progress is lifetime state, so numeric aggregate counters should never
+    decrease just because old sessions disappeared from state.db.
+    """
+    persisted = state.setdefault("lifetime_aggregate", {})
+    merged: Dict[str, Any] = {}
+    for key in set(persisted) | set(scanned):
+        old = persisted.get(key)
+        new = scanned.get(key)
+        if isinstance(old, (int, float)) or isinstance(new, (int, float)):
+            merged[key] = max(int(old or 0), int(new or 0))
+        elif new is not None:
+            merged[key] = new
+        else:
+            merged[key] = old
+    state["lifetime_aggregate"] = dict(merged)
+    return merged
+
+
 def evidence_for(definition: Dict[str, Any], sessions: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
     if not sessions:
         return None
@@ -794,8 +816,11 @@ def _compute_from_scan(scan: Dict[str, Any], *, is_partial: bool = False) -> Dic
     """
     aggregate = scan.get("aggregate", {})
     state = load_state() if not is_partial else {"unlocks": {}}
+    if not is_partial:
+        aggregate = _merge_lifetime_aggregate(state, aggregate)
     unlocks = state.setdefault("unlocks", {})
     now = int(time.time())
+
     evaluated = []
     for definition in ACHIEVEMENTS:
         result = evaluate_definition(definition, aggregate)
@@ -1059,3 +1084,4 @@ async def reset_state():
     except Exception:
         pass
     return {"ok": True}
+

--- a/tests/plugins/test_achievements_plugin.py
+++ b/tests/plugins/test_achievements_plugin.py
@@ -376,3 +376,34 @@ def test_partial_snapshots_do_not_persist_unlock_timestamps(plugin_api):
         "partial scans must not record unlock timestamps — a later session "
         "could change whether the badge deserves to be unlocked yet"
     )
+
+
+def test_full_scans_persist_lifetime_aggregate_monotonically(plugin_api):
+    """Lifetime achievement progress must not regress when old sessions are pruned.
+
+    A full scan with high historical totals should seed state.json. A later full
+    scan over fewer remaining sessions should still evaluate achievements using
+    the higher persisted aggregate.
+    """
+    plugin_api.save_state({"unlocks": {}})
+
+    high_scan = {
+        "sessions": [{"session_id": "old", "title": "old", "tool_call_count": 5000}],
+        "aggregate": {"session_count": 500, "total_tool_calls": 5000, "max_tool_calls_in_session": 200},
+        "scan_meta": {"mode": "full"},
+    }
+    high = plugin_api._compute_from_scan(high_scan, is_partial=False)
+
+    assert high["aggregate"]["total_tool_calls"] == 5000
+    assert plugin_api.load_state()["lifetime_aggregate"]["total_tool_calls"] == 5000
+
+    low_scan = {
+        "sessions": [{"session_id": "new", "title": "new", "tool_call_count": 1}],
+        "aggregate": {"session_count": 1, "total_tool_calls": 1, "max_tool_calls_in_session": 1},
+        "scan_meta": {"mode": "full"},
+    }
+    low = plugin_api._compute_from_scan(low_scan, is_partial=False)
+
+    assert low["aggregate"]["total_tool_calls"] == 5000
+    assert low["aggregate"]["session_count"] == 500
+    assert plugin_api.load_state()["lifetime_aggregate"]["total_tool_calls"] == 5000


### PR DESCRIPTION
## Summary
- persist achievement lifetime aggregate counters in state.json
- merge future scans monotonically so pruned/deleted sessions do not lower lifetime progress
- add regression coverage for a high-history scan followed by a reduced-session scan

Closes #28661

## Test Plan
- python -m pytest tests/plugins/test_achievements_plugin.py plugins/hermes-achievements/tests/test_achievement_engine.py -q -o 'addopts='