### PR TITLE
feat(telegram): inline query mode with Platform.TELEGRAM_INLINE

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -615,6 +615,9 @@ def discover_all_skill_config_vars() -> List[Dict[str, Any]]:
             skill_name = frontmatter.get("name") or skill_file.parent.name
             if str(skill_name) in disabled:
                 continue
+            # inline_only skills must not appear in the agent's chat-mode context
+            if frontmatter.get("inline_only"):
+                continue
             if not skill_matches_platform(frontmatter):
                 continue
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -165,6 +165,7 @@ class Platform(Enum):
     QQBOT = "qqbot"
     YUANBAO = "yuanbao"
     RELAY = "relay"  # generic relay adapter fronted by the connector (EXPERIMENTAL)
+    TELEGRAM_INLINE = "telegram_inline"  # inline-only Telegram bot (separate token)
     @classmethod
     def _missing_(cls, value):
         """Accept unknown platform names only for known plugin adapters.
@@ -997,6 +998,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["exclusive_bot_mentions"] = platform_cfg["exclusive_bot_mentions"]
                 if plat == Platform.TELEGRAM and "observe_unmentioned_group_messages" in platform_cfg:
                     bridged["observe_unmentioned_group_messages"] = platform_cfg["observe_unmentioned_group_messages"]
+                if plat == Platform.TELEGRAM and "inline" in platform_cfg:
+                    bridged["inline"] = platform_cfg["inline"]
                 if "dm_policy" in platform_cfg:
                     bridged["dm_policy"] = platform_cfg["dm_policy"]
                 if "allow_from" in platform_cfg:
@@ -1172,6 +1175,7 @@ def _validate_gateway_config(config: "GatewayConfig") -> None:
     # won't connect and the cause can be confusing without a log line.
     _token_env_names = {
         Platform.TELEGRAM: "TELEGRAM_BOT_TOKEN",
+        Platform.TELEGRAM_INLINE: "TELEGRAM_BOT_TOKEN_INLINE",
         Platform.DISCORD: "DISCORD_BOT_TOKEN",
         Platform.SLACK: "SLACK_BOT_TOKEN",
         Platform.MATTERMOST: "MATTERMOST_TOKEN",
@@ -1241,7 +1245,14 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if telegram_token:
         telegram_config = _enable_from_env(Platform.TELEGRAM)
         telegram_config.token = telegram_token
-    
+
+    # Telegram inline-only bot (separate token, handles only inline_query updates)
+    telegram_inline_token = os.getenv("TELEGRAM_BOT_TOKEN_INLINE")
+    if telegram_inline_token:
+        _tgi_cfg = _enable_from_env(Platform.TELEGRAM_INLINE)
+        _tgi_cfg.token = telegram_inline_token
+        _tgi_cfg.extra["inline_only_mode"] = True
+
     # Reply threading mode for Telegram (off/first/all)
     telegram_reply_mode = os.getenv("TELEGRAM_REPLY_TO_MODE", "").lower()
     if telegram_reply_mode in {"off", "first", "all"}:

--- a/gateway/platforms/telegram_inline_router.py
+++ b/gateway/platforms/telegram_inline_router.py
@@ -1,0 +1,189 @@
+"""Dispatch layer for Telegram inline queries.
+
+Loads ``inline_tools.yaml`` from the Hermes config directory to determine which
+executor handles each query.  The framework ships the dispatch surface only —
+concrete tool implementations are user-space concerns.
+
+Registry format (inline_tools.yaml)::
+
+    version: 1
+    tools:
+      - id: my_tool
+        type: direct          # "direct" skips LLM; "llm" routes through a model
+        executor: my_executor # name passed to TelegramInlineRouter.register_executor()
+        match:
+          - pattern: "https?://example\\.com/"
+            type: url          # url | prefix | search (catch-all)
+            priority: 0        # lower = higher precedence
+          - pattern: ".*"
+            type: search
+            priority: 99
+        timeout_sec: 25
+        cache:
+          backend: memory
+          ttl_sec: 3600
+        staging_chat_env: TELEGRAM_INLINE_STAGING_CHAT  # env var naming the staging chat id
+        enabled: true
+
+``staging_chat_env`` names an environment variable that holds the chat ID where
+the executor should stage files to obtain a ``file_id``.  The recommended env var
+name is ``TELEGRAM_INLINE_STAGING_CHAT``; set it to any chat or channel the inline
+bot has access to.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from abc import ABC, abstractmethod
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _default_registry_path() -> str:
+    try:
+        from hermes_cli.config import get_hermes_home
+        return str(get_hermes_home() / "inline_tools.yaml")
+    except Exception:
+        return os.path.join(os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes")), "inline_tools.yaml")
+
+
+# ---------------------------------------------------------------------------
+# Registry loader
+# ---------------------------------------------------------------------------
+
+class InlineToolRegistry:
+    """Loads and caches inline_tools.yaml; provides pattern matching."""
+
+    def __init__(self, path: str) -> None:
+        self._path = path
+        self._tools: List[Dict[str, Any]] = []
+        self._load()
+
+    def _load(self) -> None:
+        try:
+            import yaml
+            with open(self._path) as fh:
+                data = yaml.safe_load(fh) or {}
+            self._tools = data.get("tools", [])
+            logger.info("[inline_router] loaded %d tools from %s", len(self._tools), self._path)
+        except FileNotFoundError:
+            logger.warning("[inline_router] registry not found at %s — all inline queries will be dropped", self._path)
+        except Exception as exc:
+            logger.error("[inline_router] registry load error: %s", exc)
+
+    def match(self, query: str) -> Optional[Dict[str, Any]]:
+        """Return the first enabled tool whose match patterns fit query, or None."""
+        enabled = [t for t in self._tools if t.get("enabled", False)]
+
+        def _min_prio(tool: Dict[str, Any]) -> int:
+            return min((m.get("priority", 0) for m in tool.get("match", [])), default=0)
+
+        for tool in sorted(enabled, key=_min_prio):
+            for matcher in tool.get("match", []):
+                mtype = matcher.get("type", "search")
+                pattern = matcher.get("pattern", "")
+                try:
+                    if mtype == "url" and re.search(pattern, query):
+                        return tool
+                    elif mtype == "prefix" and re.match(pattern, query):
+                        return tool
+                    elif mtype == "search":
+                        return tool  # catch-all
+                except re.error:
+                    pass
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Executor interface
+# ---------------------------------------------------------------------------
+
+class InlineExecutor(ABC):
+    """Base class for inline query executors.
+
+    Subclass this in user-space and register with
+    ``TelegramInlineRouter.register_executor()``.
+
+    ``execute()`` must return within the adapter's ``INLINE_RESPONSE_DEADLINE``
+    (default 6.5 s) or it will be cancelled.  Executors that need longer may
+    return a stub result (e.g. ``InlineQueryResultArticle("Processing...")``)
+    immediately and manage their own background state.
+    """
+
+    @abstractmethod
+    async def execute(self, user_id: int, query: str) -> List[Any]:
+        """Run the tool and return a list of InlineQueryResult objects.
+
+        Args:
+            user_id: Telegram user ID of the query sender.
+            query: The full inline query text after tool matching.
+
+        Returns:
+            List of ``InlineQueryResult`` objects passed directly to
+            ``answerInlineQuery``.  Return an empty list to show nothing.
+
+        Raises:
+            Exception: Propagated to the adapter, which answers with an empty
+                result list and logs a warning.
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+class TelegramInlineRouter:
+    """Dispatch router for Telegram inline queries.  One instance per adapter.
+
+    Usage::
+
+        router = TelegramInlineRouter(bot)
+        router.register_executor("my_executor", MyExecutor)
+
+    Executors are looked up by the ``executor`` field in inline_tools.yaml.
+    The framework ships no concrete executors; implementations are user-space.
+    Result lifecycle (caching, stubs, retries) is entirely the executor's concern.
+    """
+
+    def __init__(self, bot: Any, registry_path: Optional[str] = None) -> None:
+        self._bot = bot
+        _path = registry_path if registry_path is not None else _default_registry_path()
+        self._registry = InlineToolRegistry(_path)
+        self._executors: Dict[str, Callable[[Dict[str, Any], Any], InlineExecutor]] = {}
+
+    def register_executor(
+        self,
+        name: str,
+        factory: Callable[[Dict[str, Any], Any], InlineExecutor],
+    ) -> None:
+        """Register an executor factory for tools that declare ``executor: <name>``.
+
+        The factory is called as ``factory(tool_config, bot)`` and must return an
+        ``InlineExecutor`` instance.  Call this before the first inline query arrives
+        (e.g. right after ``TelegramInlineRouter.__init__``).
+
+        Example::
+
+            router.register_executor("audio_dl", MyAudioDownloader)
+        """
+        self._executors[name] = factory
+
+    async def dispatch(self, user_id: int, query: str) -> List[Any]:
+        """Match query to a tool, call its executor, return InlineQueryResult list."""
+        tool = self._registry.match(query)
+        if tool is None:
+            logger.debug("[inline_router] no enabled tool matched %r", query[:60])
+            return []
+
+        executor_name = tool.get("executor", "")
+        factory = self._executors.get(executor_name)
+        if factory is None:
+            logger.warning("[inline_router] no executor registered for %r", executor_name)
+            return []
+
+        executor = factory(tool, self._bot)
+        return await executor.execute(user_id, query)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -31,6 +31,7 @@ try:
         Application,
         CommandHandler,
         CallbackQueryHandler,
+        InlineQueryHandler,
         MessageHandler as TelegramMessageHandler,
         ContextTypes,
         filters,
@@ -49,6 +50,7 @@ except ImportError:
     Application = Any
     CommandHandler = Any
     CallbackQueryHandler = Any
+    InlineQueryHandler = Any
     TelegramMessageHandler = Any
     HTTPXRequest = Any
     filters = None
@@ -110,6 +112,9 @@ _TELEGRAM_IMAGE_EXT_TO_MIME = {
 
 MAX_COMMANDS_PER_SCOPE = 30
 
+# Hard deadline for answerInlineQuery — Telegram drops responses after ~10 s empirically.
+INLINE_RESPONSE_DEADLINE = 6.5
+
 
 def check_telegram_requirements() -> bool:
     """Check if Telegram dependencies are available.
@@ -121,7 +126,7 @@ def check_telegram_requirements() -> bool:
     """
     global TELEGRAM_AVAILABLE, Update, Bot, Message, InlineKeyboardButton
     global InlineKeyboardMarkup, LinkPreviewOptions, Application
-    global CommandHandler, CallbackQueryHandler, TelegramMessageHandler
+    global CommandHandler, CallbackQueryHandler, InlineQueryHandler, TelegramMessageHandler
     global ContextTypes, filters, ParseMode, ChatType, HTTPXRequest
     if TELEGRAM_AVAILABLE:
         return True
@@ -140,6 +145,7 @@ def check_telegram_requirements() -> bool:
         from telegram.ext import (
             Application as _App, CommandHandler as _CH,
             CallbackQueryHandler as _CQH,
+            InlineQueryHandler as _IQH,
             MessageHandler as _MH,
             ContextTypes as _CT, filters as _filters,
         )
@@ -156,6 +162,7 @@ def check_telegram_requirements() -> bool:
     Application = _App
     CommandHandler = _CH
     CallbackQueryHandler = _CQH
+    InlineQueryHandler = _IQH
     TelegramMessageHandler = _MH
     ContextTypes = _CT
     filters = _filters
@@ -604,6 +611,8 @@ class TelegramAdapter(BasePlatformAdapter):
         # Tracks status bubbles owned by this adapter so subsequent calls with the
         # same key edit the same message instead of appending new ones (#30045).
         self._status_message_ids: Dict[tuple, str] = {}
+        # inline query router (initialised in connect() once self._bot is available)
+        self._inline_router: Optional[Any] = None
 
     def _notification_kwargs(
         self, metadata: Optional[Dict[str, Any]]
@@ -2204,27 +2213,39 @@ class TelegramAdapter(BasePlatformAdapter):
             builder = builder.request(request).get_updates_request(get_updates_request)
             self._app = builder.build()
             self._bot = self._app.bot
-            
+
+            # Inline router — reads inline_tools.yaml from the Hermes config directory
+            try:
+                from gateway.platforms.telegram_inline_router import TelegramInlineRouter
+                self._inline_router = TelegramInlineRouter(self._bot)
+            except Exception as _irt_err:
+                logger.warning("[%s] inline router init failed: %s", self.name, _irt_err)
+
             # Register handlers
-            self._app.add_handler(TelegramMessageHandler(
-                filters.TEXT & ~filters.COMMAND,
-                self._handle_text_message
-            ))
-            self._app.add_handler(TelegramMessageHandler(
-                filters.COMMAND,
-                self._handle_command
-            ))
-            self._app.add_handler(TelegramMessageHandler(
-                filters.LOCATION | getattr(filters, "VENUE", filters.LOCATION),
-                self._handle_location_message
-            ))
-            self._app.add_handler(TelegramMessageHandler(
-                filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL | filters.Sticker.ALL,
-                self._handle_media_message
-            ))
-            # Handle inline keyboard button callbacks (update prompts)
-            self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
-            
+            _inline_only = self.config.extra.get("inline_only_mode", False) if getattr(self.config, "extra", None) else False
+            if not _inline_only:
+                self._app.add_handler(TelegramMessageHandler(
+                    filters.TEXT & ~filters.COMMAND,
+                    self._handle_text_message
+                ))
+                self._app.add_handler(TelegramMessageHandler(
+                    filters.COMMAND,
+                    self._handle_command
+                ))
+                self._app.add_handler(TelegramMessageHandler(
+                    filters.LOCATION | getattr(filters, "VENUE", filters.LOCATION),
+                    self._handle_location_message
+                ))
+                self._app.add_handler(TelegramMessageHandler(
+                    filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL | filters.Sticker.ALL,
+                    self._handle_media_message
+                ))
+                # Handle inline keyboard button callbacks (update prompts)
+                self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
+            # Handle inline queries (@botname <query>)
+            self._app.add_handler(InlineQueryHandler(self._handle_inline_query))
+
+
             # Start polling — retry initialize() for transient TLS resets
             try:
                 from telegram.error import NetworkError, TimedOut
@@ -6096,6 +6117,37 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         return getattr(update, "effective_message", None) or getattr(update, "message", None)
 
+    async def _handle_inline_query(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Deadline-enforced dispatch wrapper for inline queries."""
+        import asyncio as _asyncio
+        iq = getattr(update, "inline_query", None)
+        if not iq:
+            return
+
+        _inline_cfg = self.config.extra.get("inline", {}) if getattr(self.config, "extra", None) else {}
+        if isinstance(_inline_cfg, dict) and not _inline_cfg.get("enabled", True):
+            logger.debug("[%s] inline queries disabled in config — dropping", self.name)
+            return
+
+        query = (iq.query or "").strip()
+        if not query or not self._inline_router:
+            await iq.answer([], cache_time=0)
+            return
+
+        try:
+            results = await _asyncio.wait_for(
+                self._inline_router.dispatch(iq.from_user.id, query),
+                timeout=INLINE_RESPONSE_DEADLINE,
+            )
+            await iq.answer(results or [], cache_time=0)
+        except _asyncio.TimeoutError:
+            logger.debug("[%s] inline dispatch timed out for %r", self.name, query[:60])
+            await iq.answer([], cache_time=0)
+        except Exception as exc:
+            logger.warning("[%s] inline dispatch error: %s", self.name, exc)
+            await iq.answer([], cache_time=0)
+
+
     async def _handle_text_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming text messages.
 
@@ -7143,6 +7195,21 @@ def _build_adapter(config):
     return adapter
 
 
+def _build_inline_adapter(config):
+    """Factory for the inline-only Telegram adapter (TELEGRAM_BOT_TOKEN_INLINE).
+
+    Creates a TelegramAdapter with inline_only_mode=True so connect() only
+    registers InlineQueryHandler — no chat, command, or callback handlers.
+    """
+    config.extra["inline_only_mode"] = True
+    adapter = TelegramAdapter(config)
+    try:
+        adapter._notifications_mode = _resolve_notifications_mode()
+    except Exception:
+        adapter._notifications_mode = "important"
+    return adapter
+
+
 def _is_connected(config) -> bool:
     """Telegram is connected when a bot token is configured.
 
@@ -7317,4 +7384,15 @@ def register(ctx) -> None:
         max_message_length=4096,
         emoji="✈️",
         allow_update_command=True,
+    )
+    ctx.register_platform(
+        name="telegram_inline",
+        label="Telegram Inline Bot",
+        adapter_factory=_build_inline_adapter,
+        check_fn=check_telegram_requirements,
+        is_connected=_is_connected,
+        required_env=["TELEGRAM_BOT_TOKEN_INLINE"],
+        install_hint="Set TELEGRAM_BOT_TOKEN_INLINE in your Hermes .env file",
+        max_message_length=4096,
+        emoji="🎵",
     )


### PR DESCRIPTION
## Why this PR

### 1. Guest mode and inline mode are distinct API surfaces that conflict on a shared token

Telegram Bot API 10.0 introduced *guest mode*: bots can receive \`guest_message\` updates from groups without being a member.  That surface is text-only — any attempt to send media returns \`guest_chat_no_media\`.  The solution for media delivery is *inline mode* (\`@botname <query>\`), where the **user** sends the result, not the bot, so group membership is irrelevant.

These two surfaces cannot share one \`python-telegram-bot\` \`Application\` without race conditions on the update-routing loop.  A second \`Application\` instance running on \`TELEGRAM_BOT_TOKEN_INLINE\` isolates the inline polling loop completely.  \`Platform.TELEGRAM_INLINE\` gives that second adapter a first-class enum value, separate env-var, and its own lifecycle in the platform registry — exactly the same pattern already used for \`Platform.RELAY\`.

### 2. Inline tool registry: explicit whitelist, \`type: direct\` vs \`type: llm\`

\`InlineToolRegistry\` reads \`inline_tools.yaml\` from the Hermes config directory.  Every tool that can be reached via inline query must be listed and have \`enabled: true\`.  Unlisted executors cannot be dispatched — the router returns an empty result list.

Two tool types are defined:

| \`type\`   | LLM calls | Primary use case |
|----------|-----------|-----------------|
| \`direct\` | zero      | media/file fetching, deterministic lookups |
| \`llm\`    | one       | short text answers, search summaries |

\`type\` is metadata the executor can inspect from its \`tool_config\`; the router dispatches identically in both cases.

### 3. Speed constraint — adapter enforces a 6.5 s deadline

Telegram drops \`answerInlineQuery\` calls that arrive after ~10 s empirically (the documented limit is higher but unreliable in practice).  The adapter wraps every dispatch in \`asyncio.wait_for(..., timeout=INLINE_RESPONSE_DEADLINE)\` (default 6.5 s).  If the executor doesn't return in time, the adapter answers with an empty result list and logs a debug line.

Executors own their own result lifecycle.  An executor that needs longer than the deadline should return a stub result immediately (e.g. \`InlineQueryResultArticle("Processing...")\`) and manage its own background state and caching — the adapter has no opinion on this.

### 4. \`file_id\` caching is the correct Telegram primitive for repeated delivery

Once a file is uploaded to Telegram via \`send_audio\`, the returned \`audio.file_id\` is permanent on Telegram's servers.  Executors can cache this ID and return \`InlineQueryResultCachedAudio\` for instant redelivery on subsequent queries.  The framework has no cache — that is executor state.

The \`staging_chat_env\` key in \`inline_tools.yaml\` names an environment variable (\`TELEGRAM_INLINE_STAGING_CHAT\`) that holds the chat ID where the executor stages uploads.  This is an executor-level concern; the router never reads it.

### 5. \`platforms.telegram.inline.enabled\` — fail-open gate

\`\`\`yaml
platforms:
  telegram:
    inline:
      enabled: false   # set to disable; omit to enable (default: true)
\`\`\`

\`_handle_inline_query\` checks this at the top and returns silently if disabled.  The gate is fail-open (missing key → enabled) so existing deployments without the key are unaffected.

### 6. What this PR does NOT include

No specific inline tool implementation ships upstream.  \`InlineExecutor\` is an abstract base class; \`register_executor()\` on \`TelegramInlineRouter\` accepts user-space factories.  The \`inline_tools.yaml\` registry schema is documented in the module docstring.  Concrete executors (media downloaders, search handlers, etc.) are user-space concerns and are intentionally absent.

## Files changed

| File | Change |
|------|--------|
| \`gateway/config.py\` | \`Platform.TELEGRAM_INLINE\` enum; \`TELEGRAM_BOT_TOKEN_INLINE\` env pickup; \`inline\` config key bridge |
| \`gateway/platforms/telegram_inline_router.py\` | **new** — \`InlineToolRegistry\`, \`InlineExecutor\` ABC, \`TelegramInlineRouter\` |
| \`plugins/platforms/telegram/adapter.py\` | \`INLINE_RESPONSE_DEADLINE\`; \`inline_only_mode\` handler gating; \`_handle_inline_query\` deadline wrapper; \`_build_inline_adapter\`; second \`register_platform\` |
| \`agent/skill_utils.py\` | Skip \`inline_only: true\` skills from chat-mode context |

## Test plan

- [ ] Set \`TELEGRAM_BOT_TOKEN_INLINE\` to a second bot token and start the gateway — confirm \`telegram_inline\` platform connects
- [ ] Type \`@botname query\` in any Telegram chat — confirm the bot responds within the deadline
- [ ] Register a mock executor that sleeps 10 s — confirm the adapter times out and answers with an empty list
- [ ] With no executor registered, confirm inline query returns an empty list and does not crash the adapter
- [ ] Confirm primary \`telegram\` platform chat handlers are unaffected (no regression on text, command, media, callback flows)
- [ ] Set \`platforms.telegram.inline.enabled: false\` in config — confirm inline queries are silently dropped
- [ ] Add a skill with \`inline_only: true\` frontmatter — confirm it does not appear in agent chat completions

🤖 Generated with [Claude Code](https://claude.com/claude-code)