### PR TITLE
feat(dashboard): allowlist trusted Origins for the WebSocket guard behind a reverse proxy

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1772,6 +1772,23 @@ DEFAULT_CONFIG = {
         # falls through to request reconstruction rather than breaking
         # the login flow.
         "public_url": "",
+        # Extra hostnames trusted in the WebSocket Origin header, for a
+        # loopback-bound dashboard fronted by a reverse proxy (cloudflared,
+        # nginx, Caddy) that terminates a public hostname. The proxy rewrites
+        # ``Host`` to the loopback bind so the Host check passes, but the
+        # browser's ``Origin`` (the public hostname) is forwarded verbatim and
+        # otherwise trips the DNS-rebinding guard, refusing every WS upgrade
+        # (``/api/ws``, ``/api/pty``, ``/api/pub``, ``/api/events``) with
+        # ``origin_mismatch``. Declare the proxy's public host(s) here to let
+        # those upgrades through — only these EXACT hosts are allowed, never a
+        # blanket accept-any, so the DNS-rebinding defence still holds.
+        #
+        # Accepts a comma- or semicolon-separated string, or a YAML list, of
+        # bare hosts or full origin URLs (the scheme and port are ignored;
+        # only the host is matched). Env override / extension:
+        # ``HERMES_DASHBOARD_ALLOWED_ORIGINS`` (unioned with this value).
+        # Example: ``dashboard.example.com, https://app.example.com``.
+        "allowed_origins": "",
     },
 
     # Privacy settings

--- a/hermes_cli/dashboard_auth/prefix.py
+++ b/hermes_cli/dashboard_auth/prefix.py
@@ -21,8 +21,9 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import urllib.parse
-from typing import Optional
+from typing import FrozenSet, List, Optional
 
 _log = logging.getLogger(__name__)
 
@@ -199,3 +200,127 @@ def resolve_public_url() -> str:
     if not cfg_clean:
         _warn_if_malformed("dashboard.public_url in config.yaml", cfg_raw)
     return cfg_clean
+
+
+# ---------------------------------------------------------------------------
+# HERMES_DASHBOARD_ALLOWED_ORIGINS / dashboard.allowed_origins
+# ---------------------------------------------------------------------------
+
+# Dedup set for malformed allowed-origin warnings — same rationale as
+# ``_warned_malformed_public_urls``: the resolver runs on every WebSocket
+# upgrade, so an un-deduplicated warning would flood the logs.
+_warned_malformed_origins: set = set()
+
+
+def _warn_if_malformed_origin(source: str, raw: str) -> None:
+    """Warn (once per distinct value) when an allowed-origin entry was
+    rejected by :func:`_normalise_origin_host`.
+
+    Most rejections are a missing/empty token or a value carrying
+    quote/whitespace/control characters (a typo or header-injection
+    attempt). Surfacing it turns a silently-dropped allowlist entry — which
+    would otherwise look like "I allowlisted my proxy host but WebSockets
+    are still refused" — into a self-diagnosing one.
+    """
+    cleaned = raw.strip() if raw else ""
+    if not cleaned:
+        return
+    key = (source, cleaned)
+    if key in _warned_malformed_origins:
+        return
+    _warned_malformed_origins.add(key)
+    _log.warning(
+        "%s contains %r, which was ignored because it is not a valid "
+        "origin host. Use a bare hostname (e.g. dashboard.example.com) or "
+        "a full origin URL (e.g. https://dashboard.example.com); quotes, "
+        "spaces and control characters are rejected.",
+        source,
+        cleaned,
+    )
+
+
+def _parse_origin_list(raw) -> List[str]:
+    """Split a raw allowed-origins value into individual tokens.
+
+    Accepts a string (comma- or semicolon-separated) or a list/tuple — the
+    latter so ``dashboard.allowed_origins`` can be written as a native YAML
+    list in ``config.yaml``. Returns the stripped, non-empty tokens;
+    normalisation to hostnames happens in :func:`_normalise_origin_host`.
+    """
+    if not raw:
+        return []
+    if isinstance(raw, (list, tuple)):
+        items = [str(x) for x in raw]
+    else:
+        items = re.split(r"[;,]", str(raw))
+    return [tok.strip() for tok in items if tok and tok.strip()]
+
+
+def _normalise_origin_host(raw: str) -> str:
+    """Reduce one allowed-origin token to a bare lowercase hostname.
+
+    Accepts ``https://host:443``, ``host:443``, or ``host`` and returns the
+    hostname (no scheme, no port, IPv6 brackets stripped) lowercased, or
+    ``""`` when the token is empty or carries characters that suggest header
+    injection. Matching on the host alone — not scheme or port — mirrors the
+    WS Origin guard, which compares the Origin's ``netloc`` against the bound
+    host with the port suffix removed.
+    """
+    if not raw:
+        return ""
+    tok = raw.strip()
+    if not tok or any(c in tok for c in _REJECT_CHARS):
+        return ""
+    if "://" in tok:
+        tok = urllib.parse.urlparse(tok).netloc
+    tok = tok.strip().lower()
+    if not tok:
+        return ""
+    # Strip the port (IPv6 addresses use [::1]:port bracket notation).
+    if tok.startswith("["):
+        close = tok.find("]")
+        tok = tok[1:close] if close != -1 else tok.strip("[]")
+    elif ":" in tok:
+        tok = tok.rsplit(":", 1)[0]
+    return tok
+
+
+def resolve_allowed_origin_hosts() -> "FrozenSet[str]":
+    """Resolve operator-declared trusted hostnames for the WS Origin guard.
+
+    A loopback-bound dashboard fronted by a reverse proxy (cloudflared,
+    nginx, Caddy) that terminates a public hostname sees that hostname in the
+    browser's WebSocket ``Origin`` header. The proxy rewrites ``Host`` to the
+    loopback bind — so the Host check passes — but ``Origin`` is forwarded
+    verbatim and trips the DNS-rebinding guard, refusing every upgrade with
+    ``origin_mismatch``.
+
+    The union of hostnames declared in ``HERMES_DASHBOARD_ALLOWED_ORIGINS``
+    (env) and ``dashboard.allowed_origins`` (config.yaml) is returned. Both
+    accept a comma- or semicolon-separated list (config may also use a native
+    YAML list) of bare hosts or full origin URLs. Unlike
+    :func:`resolve_public_url`, the two sources are unioned rather than
+    env-overrides-config, so an operator can keep a base list in config and
+    extend it per-deploy via the env var.
+
+    Only these exact hosts are added — never a blanket accept-any — so the
+    DNS-rebinding defence still holds for every undeclared origin.
+    """
+    hosts: set = set()
+    for source, raw in (
+        (
+            "HERMES_DASHBOARD_ALLOWED_ORIGINS env var",
+            os.environ.get("HERMES_DASHBOARD_ALLOWED_ORIGINS", ""),
+        ),
+        (
+            "dashboard.allowed_origins in config.yaml",
+            _load_dashboard_section().get("allowed_origins", ""),
+        ),
+    ):
+        for token in _parse_origin_list(raw):
+            host = _normalise_origin_host(token)
+            if host:
+                hosts.add(host)
+            else:
+                _warn_if_malformed_origin(source, token)
+    return frozenset(hosts)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11031,6 +11031,27 @@ def _ws_client_is_allowed(ws: "WebSocket") -> bool:
     return client_host in _LOOPBACK_HOSTS
 
 
+def _origin_host_is_allowlisted(netloc: str) -> bool:
+    """True if ``netloc``'s host is an operator-declared trusted proxy origin.
+
+    A loopback-bound dashboard behind a reverse proxy (cloudflared, nginx,
+    Caddy) that terminates a public hostname receives that hostname in the
+    browser's WS ``Origin`` header. The proxy rewrites ``Host`` to the
+    loopback bind, so the Host check passes, but ``Origin`` is forwarded
+    verbatim and would otherwise trip the DNS-rebinding guard. Operators
+    declare the trusted host(s) via ``HERMES_DASHBOARD_ALLOWED_ORIGINS`` /
+    ``dashboard.allowed_origins`` so only those exact origins are accepted —
+    never a blanket accept-any. Reuses :func:`_is_accepted_host` so port and
+    bracket stripping match the rest of the Host/Origin guard exactly.
+    """
+    from hermes_cli.dashboard_auth.prefix import resolve_allowed_origin_hosts
+
+    allowed = resolve_allowed_origin_hosts()
+    if not allowed:
+        return False
+    return any(_is_accepted_host(netloc, host) for host in allowed)
+
+
 def _ws_host_origin_reason(ws: "WebSocket") -> Optional[str]:
     """Return a Host/Origin rejection reason, or None when allowed.
 
@@ -11060,7 +11081,9 @@ def _ws_host_origin_reason(ws: "WebSocket") -> Optional[str]:
     if not parsed.netloc:
         return f"origin_mismatch origin={origin} bound={bound_host}"
 
-    if not _is_accepted_host(parsed.netloc, bound_host):
+    if not _is_accepted_host(parsed.netloc, bound_host) and not _origin_host_is_allowlisted(
+        parsed.netloc
+    ):
         return f"origin_mismatch origin={origin} bound={bound_host}"
     return None
 

--- a/tests/hermes_cli/test_dashboard_auth_ws_auth.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_auth.py
@@ -27,6 +27,7 @@ from fastapi.testclient import TestClient
 
 from hermes_cli import web_server
 from hermes_cli.dashboard_auth import clear_providers, register_provider
+from hermes_cli.dashboard_auth import prefix as dash_prefix
 from hermes_cli.dashboard_auth.ws_tickets import (
     _reset_for_tests,
     consume_internal_credential,
@@ -528,6 +529,79 @@ class TestWsHostOriginGuardOrigins:
         # gateway connections — every WS upgrade got HTTP 403 even with a valid
         # ticket.
         ws = self._ws(origin="file://", host="fly-app.fly.dev")
+        assert web_server._ws_host_origin_is_allowed(ws) is True
+
+
+class TestWsHostOriginGuardAllowlist:
+    """Operator-declared HERMES_DASHBOARD_ALLOWED_ORIGINS / dashboard.allowed_origins.
+
+    A loopback-bound dashboard fronted by a reverse proxy (cloudflared, nginx,
+    Caddy) that terminates a public hostname sees that hostname in the browser's
+    WS ``Origin`` header. The proxy rewrites ``Host`` to the loopback bind so the
+    Host check passes, but ``Origin`` is forwarded verbatim and otherwise trips
+    the DNS-rebinding guard. The allowlist lets the declared host(s) — and only
+    those — through, without weakening the guard for any undeclared origin.
+    """
+
+    def _ws(self, *, origin, host="127.0.0.1:9120"):
+        ws = _fake_ws(query={}, path="/api/ws")
+        ws.headers = {"host": host, "origin": origin}
+        return ws
+
+    @pytest.fixture(autouse=True)
+    def _no_config_leak(self, monkeypatch):
+        # Keep the resolver hermetic: the env var is the only allowlist source
+        # under test, so stub the config.yaml fallback to an empty section.
+        monkeypatch.setattr(dash_prefix, "_load_dashboard_section", lambda: {})
+
+    def test_loopback_allowlisted_origin_allowed(self, loopback_app, monkeypatch):
+        monkeypatch.setenv("HERMES_DASHBOARD_ALLOWED_ORIGINS", "dashboard.example.com")
+        ws = self._ws(origin="https://dashboard.example.com")
+        assert web_server._ws_host_origin_is_allowed(ws) is True
+
+    def test_loopback_allowlisted_origin_port_ignored(self, loopback_app, monkeypatch):
+        # Only the host is matched — a port on the Origin must not defeat it.
+        monkeypatch.setenv("HERMES_DASHBOARD_ALLOWED_ORIGINS", "dashboard.example.com")
+        ws = self._ws(origin="https://dashboard.example.com:8443")
+        assert web_server._ws_host_origin_is_allowed(ws) is True
+
+    def test_loopback_full_url_entry_allowed(self, loopback_app, monkeypatch):
+        # The operator may declare a full origin URL; only its host is used.
+        monkeypatch.setenv(
+            "HERMES_DASHBOARD_ALLOWED_ORIGINS", "https://dashboard.example.com"
+        )
+        ws = self._ws(origin="https://dashboard.example.com")
+        assert web_server._ws_host_origin_is_allowed(ws) is True
+
+    def test_loopback_separator_list_allowed(self, loopback_app, monkeypatch):
+        # Comma- and semicolon-separated lists both parse.
+        monkeypatch.setenv(
+            "HERMES_DASHBOARD_ALLOWED_ORIGINS", "a.example.com; b.example.com,c.example.com"
+        )
+        ws = self._ws(origin="https://b.example.com")
+        assert web_server._ws_host_origin_is_allowed(ws) is True
+
+    def test_loopback_unlisted_origin_rejected(self, loopback_app, monkeypatch):
+        # An origin not on the allowlist is still refused (defence intact).
+        monkeypatch.setenv("HERMES_DASHBOARD_ALLOWED_ORIGINS", "dashboard.example.com")
+        ws = self._ws(origin="https://evil.test")
+        assert web_server._ws_host_origin_is_allowed(ws) is False
+
+    def test_loopback_no_allowlist_keeps_default_rejection(self, loopback_app, monkeypatch):
+        # With no allowlist declared, the prior cross-site rejection is unchanged.
+        monkeypatch.delenv("HERMES_DASHBOARD_ALLOWED_ORIGINS", raising=False)
+        ws = self._ws(origin="https://dashboard.example.com")
+        assert web_server._ws_host_origin_is_allowed(ws) is False
+
+    def test_config_yaml_allowlist_allowed(self, loopback_app, monkeypatch):
+        # The config.yaml fallback (here a native YAML list) is honoured too.
+        monkeypatch.delenv("HERMES_DASHBOARD_ALLOWED_ORIGINS", raising=False)
+        monkeypatch.setattr(
+            dash_prefix,
+            "_load_dashboard_section",
+            lambda: {"allowed_origins": ["dashboard.example.com"]},
+        )
+        ws = self._ws(origin="https://dashboard.example.com")
         assert web_server._ws_host_origin_is_allowed(ws) is True
 
     def test_gated_null_origin_allowed(self, gated_app):

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -723,6 +723,15 @@ These go in `~/.hermes/config.yaml` under the `provider_routing` section:
 | `require_parameters` | Only use providers supporting all request params (`true`/`false`) |
 | `data_collection` | `"allow"` (default) or `"deny"` to exclude data-storing providers |
 
+## Dashboard
+
+These configure the [web dashboard](/user-guide/features/web-dashboard). Each env var takes precedence over (or, where noted, is unioned with) the matching `dashboard.*` key in `config.yaml`.
+
+| Variable | Description |
+|----------|-------------|
+| `HERMES_DASHBOARD_ALLOWED_ORIGINS` | Extra hostnames trusted in the WebSocket `Origin` header, for a loopback-bound dashboard behind a reverse proxy (cloudflared, nginx, Caddy) that terminates a public hostname. Without it, the DNS-rebinding guard refuses every WS upgrade whose browser `Origin` doesn't match the bind (`origin_mismatch` in the log; close code `4403`). Comma- or semicolon-separated list of bare hosts or full origin URLs; only the host is matched. **Unioned** with `dashboard.allowed_origins`. Only the exact hosts listed are allowed — never accept-any. See [Behind a reverse proxy](/user-guide/features/web-dashboard#behind-a-reverse-proxy-cloudflared-nginx-caddy). |
+| `HERMES_DASHBOARD_PUBLIC_URL` | Complete public URL (scheme + host + optional path prefix, e.g. `https://example.com/hermes`) the OAuth `redirect_uri` is built from. Set this for deploys behind reverse proxies that don't reliably forward `X-Forwarded-Host`/`-Proto`/`-Prefix`. Overrides `dashboard.public_url`; a value without an `http(s)://` scheme is logged and ignored. |
+
 :::tip
 Use `hermes config set` to set environment variables — it automatically saves them to the right file (`.env` for secrets, `config.yaml` for everything else).
 :::

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -181,6 +181,44 @@ curl -s http://VM_IP:9119/api/status | jq '.auth_required, .auth_providers'
 
 If `/api/status` shows the gate is on with the `"basic"` provider and Desktop *still* fails to connect after signing in, the issue is past basic setup — grab a fresh `desktop.log` (Settings → Gateway → Open logs) plus the dashboard's logs from the same retry window and look for the `/api/ws` close code (4403 = chat WS rejected by the request guard, e.g. Host/peer mismatch; 4401 = the WS ticket didn't authenticate).
 
+#### Behind a reverse proxy (cloudflared, nginx, Caddy)
+
+A common alternative to binding the dashboard on a public address is to keep it on **loopback** (`127.0.0.1`) and put a reverse proxy in front that terminates a public hostname and adds its own auth (Cloudflare Access, an nginx `auth_request`, etc.). The proxy connects to the dashboard over loopback, so the bundled auth gate stays off and the legacy session token remains the app-layer credential.
+
+This works for HTTP out of the box, but the WebSocket upgrade has one extra catch. The browser sends `Origin: https://your-public-host` on the `/api/ws`, `/api/pty`, `/api/pub` and `/api/events` handshakes. Even when the proxy rewrites `Host` to the loopback bind (so the Host check passes), it forwards `Origin` verbatim — and the dashboard's DNS-rebinding guard refuses any `http(s)` Origin whose host doesn't match the bind. The symptom is that the page and its assets load fine but **every WebSocket fails**, with `pty refused: origin_mismatch origin=https://your-public-host bound=127.0.0.1` in the dashboard log and close code `4403` in the browser.
+
+Declare the proxy's public host(s) so those upgrades are accepted — only the exact hosts you list, never a blanket accept-any, so the DNS-rebinding defence still holds for every other origin:
+
+```bash
+# ~/.hermes/.env  (or the LaunchAgent/systemd EnvironmentFile)
+HERMES_DASHBOARD_ALLOWED_ORIGINS="dashboard.example.com"
+# multiple hosts: comma- or semicolon-separated, bare host or full URL
+# HERMES_DASHBOARD_ALLOWED_ORIGINS="dashboard.example.com, https://app.example.com"
+```
+
+or in `~/.hermes/config.yaml`:
+
+```yaml
+dashboard:
+  allowed_origins: "dashboard.example.com"   # string, or a YAML list
+```
+
+The env var and the config value are unioned, so you can keep a base list in `config.yaml` and extend it per-deploy via the env var. Only the **host** is matched (scheme and port are ignored).
+
+For a [cloudflared](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) tunnel fronting the dashboard, the matching ingress keeps `Host` pointed at the loopback bind while the public host flows through in `Origin`:
+
+```yaml
+# ~/.cloudflared/config.yml
+ingress:
+  - hostname: dashboard.example.com
+    service: http://127.0.0.1:9120
+    originRequest:
+      httpHostHeader: "127.0.0.1:9120"   # satisfies the Host check
+  - service: http_status:404
+```
+
+then set `HERMES_DASHBOARD_ALLOWED_ORIGINS=dashboard.example.com` for the dashboard process. After changing it, restart the dashboard and hard-reload the page.
+
 ### Config
 
 A form-based editor for `config.yaml`. All 150+ configuration fields are auto-discovered from `DEFAULT_CONFIG` and organized into tabbed categories:


### PR DESCRIPTION
## Problem

Running the dashboard on **loopback** behind a reverse proxy (cloudflared, nginx, Caddy) that terminates a public hostname and adds its own auth (Cloudflare Access, `auth_request`, …) is a natural remote-access setup — keep the loopback/token surface, let the proxy be the gate. HTTP works, but **every WebSocket fails**.

The browser sends `Origin: https://your-public-host` on the `/api/ws`, `/api/pty`, `/api/pub`, `/api/events` handshakes. The proxy can rewrite `Host` to the loopback bind (so the Host check passes), but it forwards `Origin` verbatim, and the DNS-rebinding guard in `_ws_host_origin_reason` refuses any `http(s)` Origin whose host ≠ the bind. Symptom: page + assets load, chat never connects, log shows

```
pty refused: origin_mismatch origin=https://your-public-host bound=127.0.0.1
```

and the browser sees WS close code `4403`. The only current escape is a non-loopback bind, which **forces the auth gate on** (`should_require_auth`) — redundant when the proxy already authenticates, and it changes the credential model from token to OAuth/password.

## Change

Add an operator-declared allowlist of trusted Origin **hosts**:

- **`HERMES_DASHBOARD_ALLOWED_ORIGINS`** env var, **unioned** with the new **`dashboard.allowed_origins`** `config.yaml` key (so you can keep a base list in config and extend per-deploy via env).
- Accepts a comma-/semicolon-separated string, or a YAML list, of bare hosts or full origin URLs. Only the **host** is matched (scheme/port ignored), reusing `_is_accepted_host` so port/bracket stripping is identical to the rest of the guard.
- Resolution mirrors the existing `resolve_public_url()` (env + config, warn-on-malformed) and lives next to it in `dashboard_auth/prefix.py`.

**Security:** only the exact hosts listed are accepted — never a blanket accept-any — so the DNS-rebinding defence still holds for every undeclared origin. Non-web origins (`file://`, `null`, `app://`) keep their existing pass-through. No change to any bind that doesn't set the new option.

## Tests

`TestWsHostOriginGuardAllowlist` in `tests/hermes_cli/test_dashboard_auth_ws_auth.py` covers: env source, config source (YAML list), full-URL and `host:port` forms, comma/semicolon lists, undeclared-origin rejection, and that the prior cross-site rejection is unchanged when no allowlist is set.

```
pytest tests/hermes_cli/test_dashboard_auth_ws_auth.py tests/hermes_cli/test_web_server_host_header.py
# 68 passed
```

## Docs

- `website/docs/reference/environment-variables.md` — new **Dashboard** section (also fills in the previously-undocumented `HERMES_DASHBOARD_PUBLIC_URL`).
- `website/docs/user-guide/features/web-dashboard.md` — **Behind a reverse proxy (cloudflared, nginx, Caddy)** subsection with a working cloudflared `config.yml` example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
