### PR TITLE
fix(cron): allow profile-local cron storage

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -49,7 +49,36 @@ except ImportError:
 # Configuration
 # =============================================================================
 
-HERMES_DIR = get_default_hermes_root().resolve()
+def _cron_storage_scope() -> str:
+    """Return cron storage scope: root (default) or profile.
+
+    Historically cron storage was anchored at the default Hermes root so jobs
+    created from a profile-scoped session were visible to a single
+    profile-less gateway. Isolated profile gateways, however, need their own
+    cron stores: if they read the root store, every persona gateway competes to
+    run the default profile's jobs and misses its own profile-local jobs.
+
+    Keep the old root behavior by default and allow sensitive/isolated
+    profiles to opt into profile-local cron with ``cron.storage_scope:
+    profile`` in that profile's config.yaml.
+    """
+    try:
+        from hermes_cli.config import cfg_get, load_config
+
+        value = cfg_get(load_config(), "cron", "storage_scope", default="root")
+        return str(value or "root").strip().lower().replace("-", "_")
+    except Exception:
+        return "root"
+
+
+def _resolve_cron_storage_home() -> Path:
+    scope = _cron_storage_scope()
+    if scope in {"profile", "profile_local", "local"}:
+        return get_hermes_home().resolve()
+    return get_default_hermes_root().resolve()
+
+
+HERMES_DIR = _resolve_cron_storage_home()
 CRON_DIR = HERMES_DIR / "cron"
 JOBS_FILE = CRON_DIR / "jobs.json"
 # Heartbeat file the in-process ticker touches on every loop iteration. The

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -316,17 +316,19 @@ def _get_hermes_home() -> Path:
 
 
 def _get_lock_paths() -> tuple[Path, Path]:
-    """Resolve cron lock paths at call time so profile/env changes are honored.
+    """Resolve cron lock paths at call time so storage changes are honored.
 
-    Anchored on the DEFAULT ROOT home (not the active profile), matching the
-    jobs store in cron.jobs (which uses get_default_hermes_root). The tick lock
-    is storage-coordination — it must live next to the single jobs.json so that
-    tickers running under different profiles share one lock and can't
-    double-fire the relocated store (#32091). Execution context (.env,
-    config.yaml, scripts) stays profile-aware via _get_hermes_home().
+    The tick lock is storage-coordination, so it must live next to the active
+    jobs.json. Default/root cron keeps the historical root-wide lock; profiles
+    that opt into ``cron.storage_scope: profile`` get an independent lock next
+    to their profile-local cron store so isolated persona gateways do not
+    compete to run each other's jobs.
     """
-    from hermes_constants import get_default_hermes_root
-    lock_dir = (_hermes_home or get_default_hermes_root()) / "cron"
+    if _hermes_home is not None:
+        lock_dir = _hermes_home / "cron"
+    else:
+        from cron.jobs import CRON_DIR
+        lock_dir = CRON_DIR
     return lock_dir, lock_dir / ".tick.lock"
 
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2296,6 +2296,13 @@ DEFAULT_CONFIG = {
         # An unknown or unavailable provider falls back to the built-in, so cron
         # never loses its trigger.
         "provider": "",
+        # Cron storage scope. "root" (default) keeps the historical single
+        # store at <default HERMES_HOME>/cron so jobs created from ordinary
+        # profile-scoped sessions are visible to the root/default gateway.
+        # Isolated persona gateways that own their own schedule can set
+        # "profile" to use <profile HERMES_HOME>/cron instead, preventing
+        # cross-profile gateways from running each other's jobs.
+        "storage_scope": "root",
         # Chronos (NAS-mediated managed cron) settings. Only consulted when
         # provider == "chronos". All non-secret (URLs + the JWT audience): the
         # agent holds NO external-scheduler credentials. For hosted agents, NAS

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "jeevesassistant00@gmail.com": "jeeves-assistant",  # Hermes ops automation PRs
     "21178861+ScotterMonk@users.noreply.github.com": "ScotterMonk",  # PR #50145 salvage (cron output truncation: adapter-aware chunking, #50126)
     "rrandqua@gmail.com": "TutkuEroglu",  # PR #50481 salvage (AGENTS.md stale token-lock adapter path)
     "f@trycua.com": "f-trycua",  # PR #50507 salvage (cross-platform computer_use; supersedes #44221/#30660)

--- a/tests/cron/test_cron_profile_storage.py
+++ b/tests/cron/test_cron_profile_storage.py
@@ -1,58 +1,67 @@
-"""Regression tests for #32091 — profile-scoped cron jobs orphaned.
+"""Regression tests for profile-aware cron storage.
 
-Cron storage (CRON_DIR/JOBS_FILE) must anchor at the *default root* Hermes
-home, not the active profile's home. Otherwise a job created from a
-profile-scoped agent session writes to ~/.hermes/profiles/<p>/cron/jobs.json,
-while the profile-less gateway reads only ~/.hermes/cron/jobs.json — the job
-is silently orphaned (looks healthy in `list`, never fires).
+Default cron storage remains anchored at the root Hermes home so jobs created
+from ordinary profile-scoped sessions are visible to the default/root gateway
+(#32091). Isolated persona gateways can opt into profile-local cron storage with
+``cron.storage_scope: profile`` so they do not run the default profile's jobs and
+miss their own profile-local schedule.
 """
 import importlib
-import os
 from pathlib import Path
 
 
-def test_cron_storage_anchors_at_root_under_profile(tmp_path, monkeypatch):
-    """Under a profile HERMES_HOME (<root>/profiles/<name>), the cron store
-    resolves to <root>/cron, NOT <root>/profiles/<name>/cron."""
+def test_cron_storage_anchors_at_root_under_profile_by_default(tmp_path, monkeypatch):
+    """Under a profile HERMES_HOME, default behavior still stores at root."""
     root = tmp_path / "hermes_home"
     profile_home = root / "profiles" / "myprofile"
     profile_home.mkdir(parents=True)
 
-    # Pretend the platform default root IS our tmp root, and the active
-    # HERMES_HOME is a profile under it (the #32091 scenario).
     import hermes_constants
-    monkeypatch.setattr(hermes_constants, "_get_platform_default_hermes_home",
-                        lambda: root)
+    monkeypatch.setattr(hermes_constants, "_get_platform_default_hermes_home", lambda: root)
     monkeypatch.setenv("HERMES_HOME", str(profile_home))
 
-    # get_default_hermes_root must return the ROOT, not the profile dir.
     assert hermes_constants.get_default_hermes_root().resolve() == root.resolve()
-    # ...while get_hermes_home (used elsewhere) follows the profile override.
     assert hermes_constants.get_hermes_home().resolve() == profile_home.resolve()
 
-    # cron/jobs.py computes HERMES_DIR from get_default_hermes_root at import,
-    # so a fresh import under this env anchors the store at <root>/cron.
     import cron.jobs as jobs
     importlib.reload(jobs)
     try:
         assert jobs.HERMES_DIR.resolve() == root.resolve()
         assert jobs.JOBS_FILE.resolve() == (root / "cron" / "jobs.json").resolve()
-        # The orphan path (<profile>/cron/jobs.json) must NOT be the store.
         assert jobs.JOBS_FILE.resolve() != (profile_home / "cron" / "jobs.json").resolve()
     finally:
-        # Restore module state for other tests (reload under the real env).
+        monkeypatch.undo()
+        importlib.reload(jobs)
+
+
+def test_cron_storage_can_be_profile_local_for_isolated_gateways(tmp_path, monkeypatch):
+    """cron.storage_scope=profile stores jobs next to the active profile."""
+    root = tmp_path / "hermes_home"
+    profile_home = root / "profiles" / "therapist"
+    profile_home.mkdir(parents=True)
+    (profile_home / "config.yaml").write_text("cron:\n  storage_scope: profile\n", encoding="utf-8")
+
+    import hermes_constants
+    monkeypatch.setattr(hermes_constants, "_get_platform_default_hermes_home", lambda: root)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    import cron.jobs as jobs
+    importlib.reload(jobs)
+    try:
+        assert jobs.HERMES_DIR.resolve() == profile_home.resolve()
+        assert jobs.JOBS_FILE.resolve() == (profile_home / "cron" / "jobs.json").resolve()
+        assert jobs.JOBS_FILE.resolve() != (root / "cron" / "jobs.json").resolve()
+    finally:
         monkeypatch.undo()
         importlib.reload(jobs)
 
 
 def test_cron_storage_unaffected_when_no_profile(tmp_path, monkeypatch):
-    """With no profile (HERMES_HOME == root), behavior is unchanged: store at
-    <root>/cron."""
+    """With no profile (HERMES_HOME == root), store at <root>/cron."""
     root = tmp_path / "hermes_home"
     root.mkdir(parents=True)
     import hermes_constants
-    monkeypatch.setattr(hermes_constants, "_get_platform_default_hermes_home",
-                        lambda: root)
+    monkeypatch.setattr(hermes_constants, "_get_platform_default_hermes_home", lambda: root)
     monkeypatch.setenv("HERMES_HOME", str(root))
 
     import cron.jobs as jobs
@@ -64,21 +73,20 @@ def test_cron_storage_unaffected_when_no_profile(tmp_path, monkeypatch):
         importlib.reload(jobs)
 
 
-def test_tick_lock_anchors_at_root_under_profile(tmp_path, monkeypatch):
-    """The cron tick lock must live at <root>/cron/.tick.lock, NOT the profile
-    dir — otherwise tickers under different profiles grab different locks and
-    double-fire the (now root-anchored) jobs store (#32091)."""
-    import importlib
+def test_tick_lock_anchors_at_root_under_profile_by_default(tmp_path, monkeypatch):
+    """Default/root cron uses the root-wide tick lock (#32091)."""
     root = tmp_path / "hermes_home"
     profile_home = root / "profiles" / "p"
     profile_home.mkdir(parents=True)
     import hermes_constants
     monkeypatch.setattr(hermes_constants, "_get_platform_default_hermes_home", lambda: root)
     monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    import cron.jobs as jobs
     import cron.scheduler as sched
+    importlib.reload(jobs)
     importlib.reload(sched)
     try:
-        # _hermes_home override is None -> uses get_default_hermes_root()
         sched._hermes_home = None
         lock_dir, lock_file = sched._get_lock_paths()
         assert lock_dir.resolve() == (root / "cron").resolve()
@@ -86,20 +94,44 @@ def test_tick_lock_anchors_at_root_under_profile(tmp_path, monkeypatch):
         assert lock_dir.resolve() != (profile_home / "cron").resolve()
     finally:
         monkeypatch.undo()
+        importlib.reload(jobs)
+        importlib.reload(sched)
+
+
+def test_tick_lock_follows_profile_local_storage(tmp_path, monkeypatch):
+    """Profile-local cron gets a profile-local tick lock beside jobs.json."""
+    root = tmp_path / "hermes_home"
+    profile_home = root / "profiles" / "therapist"
+    profile_home.mkdir(parents=True)
+    (profile_home / "config.yaml").write_text("cron:\n  storage_scope: profile\n", encoding="utf-8")
+
+    import hermes_constants
+    monkeypatch.setattr(hermes_constants, "_get_platform_default_hermes_home", lambda: root)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    import cron.jobs as jobs
+    import cron.scheduler as sched
+    importlib.reload(jobs)
+    importlib.reload(sched)
+    try:
+        sched._hermes_home = None
+        lock_dir, lock_file = sched._get_lock_paths()
+        assert lock_dir.resolve() == (profile_home / "cron").resolve()
+        assert lock_file.resolve() == (profile_home / "cron" / ".tick.lock").resolve()
+    finally:
+        monkeypatch.undo()
+        importlib.reload(jobs)
         importlib.reload(sched)
 
 
 def test_get_default_hermes_root_docker_layouts(tmp_path, monkeypatch):
-    """get_default_hermes_root resolves the root for Docker/custom HERMES_HOME
-    (outside ~/.hermes), so cron storage works in containers."""
+    """get_default_hermes_root resolves Docker/custom HERMES_HOME roots."""
     import hermes_constants
     native = tmp_path / "native_home"
     monkeypatch.setattr(hermes_constants, "_get_platform_default_hermes_home", lambda: native)
 
-    # Docker custom root (outside native): HERMES_HOME itself IS the root.
     monkeypatch.setenv("HERMES_HOME", "/opt/data")
     assert hermes_constants.get_default_hermes_root() == Path("/opt/data")
 
-    # Docker profile layout: <custom>/profiles/<name> -> <custom>.
     monkeypatch.setenv("HERMES_HOME", "/opt/data/profiles/coder")
     assert hermes_constants.get_default_hermes_root() == Path("/opt/data")


### PR DESCRIPTION
## Summary
- Adds `cron.storage_scope` with default `root` to preserve existing root-wide cron behavior.
- Allows isolated profile gateways to opt into `cron.storage_scope: profile` so they read/write their own `profiles/<name>/cron/jobs.json` instead of competing for the default profile's cron store.
- Moves the tick lock next to the active cron store so root-wide and profile-local schedulers coordinate in the correct scope.

## Why
Multiple resident profile gateways can otherwise all tick the default/root cron store. That makes isolated persona bots try to run default-profile jobs, miss their own profile-local jobs, and emit confusing delivery/auth failures.

## Test Plan
- `python -m py_compile cron/jobs.py cron/scheduler.py hermes_cli/config.py`
- `python -m pytest tests/cron/test_cron_profile_storage.py tests/cron/test_claim_job_for_fire.py -q -o 'addopts='`
- `python -m pytest tests/cron/test_cron_profile_storage.py tests/cron/test_claim_job_for_fire.py tests/cron/test_jobs.py -q -o 'addopts='`
- `python -m pytest tests/cron -q -o 'addopts='`
