### PR TITLE
fix(pricing): fall back to official-docs snapshot when OpenRouter models API unavailable

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -687,7 +687,24 @@ def get_pricing_entry(
             pricing_version="included-route",
         )
     if route.provider == "openrouter":
-        return _openrouter_pricing_entry(route)
+        entry = _openrouter_pricing_entry(route)
+        if entry is not None:
+            return entry
+        # Fallback: OpenRouter model IDs are "provider/model" (e.g.
+        # "anthropic/claude-sonnet-4-6").  When the models API is unavailable
+        # (disk cache missing + network failure), try the official docs
+        # snapshot for the underlying provider/model rather than returning
+        # None and showing $0.00.
+        if "/" in route.model:
+            sub_provider, sub_model = route.model.split("/", 1)
+            fallback_route = BillingRoute(
+                provider=sub_provider.lower(),
+                model=sub_model,
+                base_url=route.base_url,
+                billing_mode="official_docs_snapshot",
+            )
+            return _lookup_official_docs_pricing(fallback_route)
+        return None
     if route.base_url:
         entry = _pricing_entry_from_metadata(
             fetch_endpoint_model_metadata(route.base_url, api_key=api_key or ""),


### PR DESCRIPTION
## Problem

When the OpenRouter models API disk cache is cold (e.g. `~/.hermes/cache/openrouter_model_metadata.json` doesn't exist) and the network call fails, `_openrouter_pricing_entry()` returns `None`. The existing `_lookup_official_docs_pricing()` fallback was never reached because the `openrouter` branch returned unconditionally:

```python
if route.provider == "openrouter":
    return _openrouter_pricing_entry(route)  # ← early return, never falls through
```

This causes `estimate_usage_cost()` to return `CostResult(amount_usd=None)`, and sessions are saved with `estimated_cost_usd = 0.0` in the state DB. Practically: **all gateway/Mattermost sessions using `anthropic/*` models via OpenRouter show $0.00 in `hermes insights`**.

## Fix

After `_openrouter_pricing_entry()` returns `None`, split the slash-delimited OpenRouter model ID (e.g. `anthropic/claude-sonnet-4-6`) into `sub_provider + sub_model` and look them up in `_OFFICIAL_DOCS_PRICING`. The live API entry still takes precedence when available; the snapshot is a best-effort fallback.

```python
if route.provider == "openrouter":
    entry = _openrouter_pricing_entry(route)
    if entry is not None:
        return entry
    # Fallback for cold cache / network failure
    if "/" in route.model:
        sub_provider, sub_model = route.model.split("/", 1)
        fallback_route = BillingRoute(provider=sub_provider.lower(), model=sub_model, ...)
        return _lookup_official_docs_pricing(fallback_route)
    return None
```

## Testing

```
12 passed in 1.00s  (tests/agent/test_usage_pricing.py)
```

Verified that:
- Cache-miss path now returns correct `PricingEntry` for `anthropic/claude-sonnet-4-6` ($3/$15/$0.30 per million)
- Live API path (when cache warm) is unaffected — `source="provider_models_api"` still takes precedence
- Models without a slash (bare model IDs on custom routes) return `None` as before