### PR TITLE
fix: handle null tool call arguments

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3815,7 +3815,9 @@ def run_conversation(
                 
                 if agent.verbose_logging:
                     for tc in assistant_message.tool_calls:
-                        logging.debug(f"Tool call: {tc.function.name} with args: {tc.function.arguments[:200]}...")
+                        raw_args = tc.function.arguments
+                        args_preview = raw_args[:200] if isinstance(raw_args, str) else repr(raw_args)[:200]
+                        logging.debug("Tool call: %s with args: %s...", tc.function.name, args_preview)
                 
                 # Validate tool call names - detect model hallucinations
                 # Repair mismatched tool names before validating

--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -112,15 +112,22 @@ def _should_parallelize_tool_batch(tool_calls) -> bool:
     reserved_paths: list[Path] = []
     for tool_call in tool_calls:
         tool_name = tool_call.function.name
-        try:
-            function_args = json.loads(tool_call.function.arguments)
-        except Exception:
-            logging.debug(
-                "Could not parse args for %s — defaulting to sequential; raw=%s",
-                tool_name,
-                tool_call.function.arguments[:200],
-            )
-            return False
+        raw_args = tool_call.function.arguments
+        if isinstance(raw_args, dict):
+            # Already parsed (e.g. direct dispatch) — accept it as-is, like the
+            # executors do, instead of letting json.loads raise and force sequential.
+            function_args = raw_args
+        else:
+            try:
+                function_args = json.loads(raw_args)
+            except Exception:
+                raw_preview = raw_args[:200] if isinstance(raw_args, str) else repr(raw_args)[:200]
+                logging.debug(
+                    "Could not parse args for %s — defaulting to sequential; raw=%s",
+                    tool_name,
+                    raw_preview,
+                )
+                return False
         if not isinstance(function_args, dict):
             logging.debug(
                 "Non-dict args for %s (%s) — defaulting to sequential",

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -292,10 +292,15 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         elif function_name == "skill_manage":
             agent._iters_since_skill = 0
 
-        try:
-            function_args = json.loads(tool_call.function.arguments)
-        except json.JSONDecodeError:
-            function_args = {}
+        # Coerce null/non-string args to {} — see execute_tool_calls_sequential.
+        _raw_args = tool_call.function.arguments
+        if isinstance(_raw_args, dict):
+            function_args = _raw_args
+        else:
+            try:
+                function_args = json.loads(_raw_args) if _raw_args else {}
+            except (json.JSONDecodeError, TypeError):
+                function_args = {}
         if not isinstance(function_args, dict):
             function_args = {}
 
@@ -814,11 +819,18 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
 
         function_name = tool_call.function.name
 
-        try:
-            function_args = json.loads(tool_call.function.arguments)
-        except json.JSONDecodeError as e:
-            logger.warning(f"Unexpected JSON error after validation: {e}")
-            function_args = {}
+        # Some providers return arguments as null/non-string; json.loads then
+        # raises TypeError, not JSONDecodeError. Coerce to {} (matching
+        # sanitize_tool_call_arguments) so a bad arg degrades to a no-arg call.
+        _raw_args = tool_call.function.arguments
+        if isinstance(_raw_args, dict):
+            function_args = _raw_args
+        else:
+            try:
+                function_args = json.loads(_raw_args) if _raw_args else {}
+            except (json.JSONDecodeError, TypeError) as e:
+                logger.warning(f"Unexpected tool_call arguments error after validation: {e}")
+                function_args = {}
         if not isinstance(function_args, dict):
             function_args = {}
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2185,6 +2185,20 @@ class TestExecuteToolCalls:
         assert messages[0]["role"] == "tool"
         assert messages[0]["tool_call_id"] == "c1"
 
+    def test_none_args_defaults_empty(self, agent):
+        tc = _mock_tool_call(name="web_search", arguments=None, call_id="c1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+        with patch("run_agent.handle_function_call", return_value="ok") as mock_hfc:
+            agent._execute_tool_calls(mock_msg, messages, "task-1")
+
+        args, kwargs = mock_hfc.call_args
+        assert args[:3] == ("web_search", {}, "task-1")
+        assert set(kwargs.get("enabled_tools", [])) == agent.valid_tool_names
+        assert len(messages) == 1
+        assert messages[0]["role"] == "tool"
+        assert messages[0]["tool_call_id"] == "c1"
+
     def test_result_truncation_over_100k(self, agent, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
         (tmp_path / ".hermes").mkdir()
@@ -2399,6 +2413,18 @@ class TestConcurrentToolExecution:
                 mock_seq.assert_called_once()
                 mock_con.assert_not_called()
 
+    def test_none_args_batch_forces_sequential(self, agent):
+        """Non-string tool arguments should not crash parallelism gating."""
+        tc1 = _mock_tool_call(name="web_search", arguments='{}', call_id="c1")
+        tc2 = _mock_tool_call(name="web_search", arguments=None, call_id="c2")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2])
+        messages = []
+        with patch.object(agent, "_execute_tool_calls_sequential") as mock_seq:
+            with patch.object(agent, "_execute_tool_calls_concurrent") as mock_con:
+                agent._execute_tool_calls(mock_msg, messages, "task-1")
+                mock_seq.assert_called_once()
+                mock_con.assert_not_called()
+
     def test_non_dict_args_forces_sequential(self, agent):
         """Tool arguments that parse to a non-dict type should fall back to sequential."""
         tc1 = _mock_tool_call(name="web_search", arguments='{}', call_id="c1")
@@ -2410,6 +2436,19 @@ class TestConcurrentToolExecution:
                 agent._execute_tool_calls(mock_msg, messages, "task-1")
                 mock_seq.assert_called_once()
                 mock_con.assert_not_called()
+
+    def test_dict_args_batch_allows_concurrent(self, agent):
+        """Pre-parsed dict arguments should not force sequential — the gate
+        accepts them as-is, like the executors do."""
+        tc1 = _mock_tool_call(name="web_search", arguments={"q": "alpha"}, call_id="c1")
+        tc2 = _mock_tool_call(name="web_search", arguments={"q": "beta"}, call_id="c2")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2])
+        messages = []
+        with patch.object(agent, "_execute_tool_calls_sequential") as mock_seq:
+            with patch.object(agent, "_execute_tool_calls_concurrent") as mock_con:
+                agent._execute_tool_calls(mock_msg, messages, "task-1")
+                mock_con.assert_called_once()
+                mock_seq.assert_not_called()
 
     def test_concurrent_executes_all_tools(self, agent):
         """Concurrent path should execute all tools and append results in order."""
@@ -2439,6 +2478,24 @@ class TestConcurrentToolExecution:
         assert "alpha" in messages[0]["content"]
         assert "beta" in messages[1]["content"]
         assert "gamma" in messages[2]["content"]
+
+    def test_concurrent_none_args_defaults_empty(self, agent):
+        """Concurrent executor should treat arguments=None as an empty object."""
+        tc1 = _mock_tool_call(name="web_search", arguments=None, call_id="c1")
+        tc2 = _mock_tool_call(name="web_search", arguments='{"q":"ok"}', call_id="c2")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2])
+        messages = []
+        seen_args = []
+
+        def fake_handle(name, args, task_id, **kwargs):
+            seen_args.append((kwargs["tool_call_id"], args))
+            return "ok"
+
+        with patch("run_agent.handle_function_call", side_effect=fake_handle):
+            agent._execute_tool_calls_concurrent(mock_msg, messages, "task-1")
+
+        assert sorted(seen_args) == [("c1", {}), ("c2", {"q": "ok"})]
+        assert [m["tool_call_id"] for m in messages] == ["c1", "c2"]
 
     def test_concurrent_preserves_order_despite_timing(self, agent):
         """Even if tools finish in different order, messages should be in original order."""
@@ -3553,6 +3610,25 @@ class TestRunConversation:
         assert result["api_calls"] == 2
         assert mock_handle_function_call.call_args.kwargs["tool_call_id"] == "c1"
         assert mock_handle_function_call.call_args.kwargs["session_id"] == agent.session_id
+
+    def test_tool_call_none_args_verbose_logging_does_not_crash(self, agent):
+        self._setup_agent(agent)
+        agent.verbose_logging = True
+        tc = _mock_tool_call(name="web_search", arguments=None, call_id="c1")
+        resp1 = _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc])
+        resp2 = _mock_response(content="Done searching", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [resp1, resp2]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="search result") as mock_handle_function_call,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("search something")
+
+        assert result["final_response"] == "Done searching"
+        assert mock_handle_function_call.call_args.args[:2] == ("web_search", {})
 
     def test_request_scoped_api_hooks_fire_for_each_api_call(self, agent):
         self._setup_agent(agent)


### PR DESCRIPTION
## Summary

Fixes hard crashes when an OpenAI-compatible provider returns `tool_call.function.arguments` as `null` or another non-string value.

- Make verbose tool-call logging preview non-string arguments safely.
- Teach the parallelization gate to accept pre-parsed dict args and safely fall back for invalid non-string args.
- Coerce null/non-string tool-call args to `{}` in both sequential and concurrent execution paths.
- Add regression coverage for verbose logging, sequential dispatch, concurrent dispatch, and batch parallelization gating.

## Root Cause

Several fresh-response tool-call consumers assumed `function.arguments` was always a JSON string. Providers can pass through `null`, which makes slicing (`arguments[:200]`) raise `TypeError` and makes `json.loads(None)` raise `TypeError` instead of the already-handled `json.JSONDecodeError`.

## Impact

Malformed or provider-specific no-arg tool calls now degrade to an empty argument object instead of aborting the entire conversation turn.

Closes #50892

## Validation

- `scripts/run_tests.sh tests/run_agent/test_run_agent.py -- -q -k 'none_args_defaults_empty or none_args_batch_forces_sequential or dict_args_batch_allows_concurrent or concurrent_none_args_defaults_empty or tool_call_none_args_verbose_logging_does_not_crash'` passed: 5 tests.
- `scripts/run_tests.sh tests/run_agent/test_run_agent.py` was attempted; the file-level runner timed out at 140s after collecting 393 tests and did not report assertion failures before timeout.