### PR TITLE
feat(platforms): add Linq iMessage as a bundled platform plugin

### DIFF
--- a/plugins/platforms/linq/README.md
+++ b/plugins/platforms/linq/README.md
@@ -1,0 +1,192 @@
+# Linq iMessage platform plugin
+
+A **Linq iMessage** gateway adapter for Hermes Agent. Send and receive real
+iMessage "blue bubbles" through the hosted [Linq](https://linqapp.com) partner
+API — **no Mac and no BlueBubbles server required**.
+
+This is a bundled platform plugin: it ships in-tree under
+`plugins/platforms/linq/` and sits alongside the bundled **BlueBubbles** and
+**Photon** iMessage channels as a third independent way to reach iMessage.
+
+## How it compares to the other iMessage channels
+
+| | BlueBubbles | Photon | **Linq (this plugin)** |
+|---|---|---|---|
+| Requires a Mac | ✅ yes | ❌ no | ❌ no |
+| Outbound transport | BlueBubbles REST | Node `spectrum-ts` **sidecar** | **direct Linq REST** |
+| Inbound transport | webhook | signed webhook | **signed webhook** |
+| Extra runtime deps | BlueBubbles server | Node 18+ | none beyond Hermes |
+
+Because Linq exposes a public send endpoint, this adapter needs **no Node
+sidecar** — every outbound message, typing indicator, and read receipt is a
+direct `httpx` call.
+
+## Dependencies
+
+The plugin is bundled, so there is nothing to install — the gateway discovers
+it automatically. Its one optional dependency is `aiohttp` (for the inbound
+webhook listener), which ships with the `hermes-agent[messaging]` extra rather
+than the core install. If `hermes linq status` reports it missing:
+
+```bash
+pip install aiohttp
+```
+
+## Setup
+
+Run the one-time setup (stores your token + from-phone in `~/.hermes/auth.json`):
+
+```bash
+hermes linq setup
+```
+
+You'll be asked for:
+
+1. **Linq API token** — from your [linqapp.com](https://linqapp.com) dashboard
+   (or set `LINQ_API_TOKEN` in your environment instead).
+2. **From-phone** (optional) — the Linq number this agent sends from, in E.164
+   (`+15551234567`). Only needed to pin a multi-number account to one line.
+
+Linq also surfaces in the unified wizard:
+
+```bash
+hermes gateway setup        # pick "Linq iMessage"
+```
+
+### Register the inbound webhook
+
+Linq delivers inbound iMessages as webhooks. Point your Linq dashboard at the
+gateway's public URL:
+
+```bash
+hermes linq webhook show --public-url https://your-public-host
+# → register  https://your-public-host/linq/webhook  in the Linq dashboard
+```
+
+Then export the signing secret the dashboard gives you so deliveries are
+verified:
+
+```bash
+export LINQ_WEBHOOK_SECRET=<secret-from-linq-dashboard>
+```
+
+### Start the gateway
+
+```bash
+hermes gateway start --platform linq
+```
+
+Verify any time with:
+
+```bash
+hermes linq status     # credential state + live connectivity probe
+```
+
+## Configuration
+
+Everything is configurable by environment variable, by `~/.hermes/config.yaml`,
+or in `~/.hermes/auth.json`. Precedence is **env → config.yaml → auth.json**.
+
+### `config.yaml`
+
+```yaml
+platforms:
+  linq:
+    enabled: true
+    extra:
+      from_phone: "+15551234567"
+      webhook_port: 8790
+      webhook_path: /linq/webhook
+      send_read_receipts: true
+      require_mention: false
+      mention_patterns:
+        - '(?<![\w@])@?hermes\b[,:\-]?'
+```
+
+### Environment variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `LINQ_API_TOKEN` | — | **Required.** Linq partner API bearer token |
+| `LINQ_FROM_PHONE` | — | Pin a multi-number account to one Linq line (E.164) |
+| `LINQ_WEBHOOK_SECRET` | — | HMAC-SHA256 secret for inbound webhook verification |
+| `LINQ_WEBHOOK_PORT` | `8790` | Local webhook listener port |
+| `LINQ_WEBHOOK_PATH` | `/linq/webhook` | Local webhook listener path |
+| `LINQ_WEBHOOK_BIND` | `0.0.0.0` | Webhook listener bind address |
+| `LINQ_API_BASE` | `https://api.linqapp.com/api/partner/v3` | Linq API base URL |
+| `LINQ_SEND_READ_RECEIPTS` | `true` | Send read receipts + typing on inbound |
+| `LINQ_ALLOWED_USERS` | — | Comma-separated allowlist of E.164 senders |
+| `LINQ_ALLOW_ALL_USERS` | `false` | Allow any sender (dev only) |
+| `LINQ_REQUIRE_MENTION` | `false` | Gate group chats on a wake word |
+| `LINQ_MENTION_PATTERNS` | Hermes wake words | Group mention regexes |
+| `LINQ_HOME_CHANNEL` | — | Default chat id for cron / notification delivery |
+
+## Authorization
+
+The gateway denies unknown senders by default. Authorize them one of two ways
+(same model as every Hermes platform):
+
+1. **DM pairing** — a new sender gets a code; approve it:
+   ```bash
+   hermes pairing approve linq <CODE>
+   ```
+2. **Pre-authorize** — `export LINQ_ALLOWED_USERS=+15551234567,+15557654321`
+
+Set `LINQ_ALLOW_ALL_USERS=true` only for local development.
+
+## Features
+
+- Real iMessage blue bubbles via the Linq API — no Mac
+- Inbound via HMAC-SHA256 signed webhooks (replay-protected, 5-min drift window)
+- At-least-once delivery dedup on `message.id`
+- Outbound text + media-by-URL, typing indicators, read receipts
+- Inbound image attachments downloaded locally for the vision tools
+- Group-chat mention gating (parity with the Photon / BlueBubbles channels)
+- E.164 phone numbers treated as PII and redacted before reaching the LLM
+- Cron / `send_message` delivery, including out-of-process (`standalone_sender`)
+- Unified `hermes gateway setup` onboarding + a dedicated `hermes linq` CLI
+
+## Architecture
+
+```
+Inbound:   iMessage → Linq → signed webhook → aiohttp listener → MessageEvent → agent
+Outbound:  agent → LinqClient (httpx) → Linq REST API → iMessage
+```
+
+- `adapter.py` — `LinqAdapter(BasePlatformAdapter)`, the webhook server, and the
+  `register(ctx)` plugin entry point.
+- `linq_api.py` — async Linq REST client (send / typing / read / reaction / probe).
+- `signing.py` — dependency-free webhook-signature verification, mention gating,
+  and payload parsing (unit-tested in isolation).
+- `auth.py` — credential storage in `~/.hermes/auth.json`.
+- `cli.py` — `hermes linq {setup,status,probe,webhook show}`.
+
+## Development
+
+The security-critical and parsing logic lives in `signing.py` and `auth.py`,
+which import nothing from Hermes, so the test suite runs anywhere:
+
+```bash
+python -m pytest tests/plugins/platforms/linq/ -v
+```
+
+`adapter.py`, `cli.py`, and `linq_api.py` import the host `gateway.*` package
+and Hermes' `BasePlatformAdapter`, so they exercise fully only inside a Hermes
+runtime. Tests for the bundled plugin live at
+`tests/plugins/platforms/linq/` and run under the repo's pytest suite.
+
+## Notes / assumptions to confirm against a live account
+
+- **Group detection.** Linq's documented `message.received` payload (mirrored
+  from the OpenClaw plugin) does not include a first-class chat-type field, so
+  `signing.is_group_chat()` infers group vs. DM from `is_group` / `group_id` /
+  `participants`. Confirm against a real Linq group webhook and tighten if Linq
+  exposes an explicit type.
+- **Outbound media.** Linq sends media by **public URL**, not multipart upload,
+  so `send_image` forwards a URL and the standalone/cron path skips local files
+  with a logged note. If your Linq plan offers an upload endpoint, wire it into
+  `LinqClient.send_message`.
+- **Webhook signature.** Verification matches the OpenClaw plugin's scheme
+  (`hex(hmac_sha256(secret, "{timestamp}.{body}"))`, `X-Webhook-Timestamp` /
+  `X-Webhook-Signature`). Adjust `signing.verify_signature` if your dashboard
+  documents a different header layout.

--- a/plugins/platforms/linq/__init__.py
+++ b/plugins/platforms/linq/__init__.py
@@ -1,0 +1,4 @@
+"""Linq iMessage platform plugin entry point."""
+from .adapter import register
+
+__all__ = ["register"]

--- a/plugins/platforms/linq/adapter.py
+++ b/plugins/platforms/linq/adapter.py
@@ -1,0 +1,634 @@
+"""
+Linq iMessage platform adapter for Hermes Agent.
+
+Linq (https://linqapp.com) delivers real iMessage "blue bubbles" over a hosted
+partner API — no Mac and no BlueBubbles server required.  This adapter plugs
+Linq into the Hermes gateway as a first-class messaging platform, alongside
+the bundled BlueBubbles and Photon iMessage channels.
+
+Inbound:
+    Linq Blue v3 POSTs signed JSON webhooks to a URL you register in the Linq
+    dashboard.  The adapter runs an aiohttp server on ``LINQ_WEBHOOK_PORT``,
+    verifies the ``X-Webhook-Signature`` HMAC (``hex(hmac_sha256(secret,
+    "{ts}.{body}"))``), rejects deliveries with a timestamp drift > 5 minutes,
+    dedupes on ``message.id``, and dispatches a normalized ``MessageEvent`` to
+    the gateway runner via ``BasePlatformAdapter.handle_message``.
+
+Outbound:
+    Linq exposes a public REST API, so — unlike Photon — there is no Node
+    sidecar.  Every ``send`` / ``send_image`` / ``send_typing`` call is a
+    direct ``httpx`` request to ``https://api.linqapp.com/api/partner/v3``.
+
+Configuration precedence is env var → ``config.yaml`` (``platforms.linq.extra``)
+→ ``~/.hermes/auth.json``, matching every other Hermes platform.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+try:
+    import httpx
+    HTTPX_AVAILABLE = True
+except ImportError:  # pragma: no cover - httpx ships with Hermes
+    HTTPX_AVAILABLE = False
+    httpx = None  # type: ignore[assignment]
+
+try:
+    from aiohttp import web
+    AIOHTTP_AVAILABLE = True
+except ImportError:  # pragma: no cover - optional in Hermes core (hermes-agent[messaging])
+    AIOHTTP_AVAILABLE = False
+    web = None  # type: ignore[assignment]
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+)
+
+from . import auth as linq_auth
+from . import signing
+from .linq_api import DEFAULT_API_BASE, LinqClient
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+
+_DEFAULT_WEBHOOK_PORT = 8790
+_DEFAULT_WEBHOOK_PATH = "/linq/webhook"
+_DEFAULT_WEBHOOK_BIND = "0.0.0.0"
+
+# iMessage practical message size is ~16 KB; keep a conservative cap that
+# matches the BlueBubbles and Photon iMessage channels.
+_MAX_MESSAGE_LENGTH = 8000
+
+# Dedup parameters — Linq retries deliveries, so we WILL see a message.id more
+# than once.  Keep a generous buffer pruned by age.
+_DEDUP_MAX_SIZE = 4000
+_DEDUP_WINDOW_SECONDS = 48 * 3600
+
+# Inbound media MIME prefixes we download to a local path for vision tooling.
+_IMAGE_PREFIXES = ("image/",)
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers (also used by check_fn / validate_config / standalone)
+
+def check_requirements() -> bool:
+    """Return True when the adapter's Python deps are importable."""
+    return HTTPX_AVAILABLE and AIOHTTP_AVAILABLE
+
+
+def validate_config(cfg: PlatformConfig) -> bool:
+    extra = cfg.extra or {}
+    token = (
+        os.getenv(linq_auth.ENV_TOKEN)
+        or extra.get("api_token")
+        or linq_auth.load_token()
+    )
+    return bool(token)
+
+
+def is_connected(cfg: PlatformConfig) -> bool:
+    return validate_config(cfg)
+
+
+def _env_enablement() -> Optional[dict]:
+    """Seed ``PlatformConfig.extra`` from env so env-only setups appear in status."""
+    token = linq_auth.load_token()
+    if not token:
+        return None
+    seeded: Dict[str, Any] = {
+        "api_token": token,
+        "webhook_port": signing.coerce_port(os.getenv("LINQ_WEBHOOK_PORT"), _DEFAULT_WEBHOOK_PORT),
+        "webhook_path": os.getenv("LINQ_WEBHOOK_PATH") or _DEFAULT_WEBHOOK_PATH,
+    }
+    phone = linq_auth.load_from_phone()
+    if phone:
+        seeded["from_phone"] = phone
+    return seeded
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+
+class LinqAdapter(BasePlatformAdapter):
+    """Inbound: signed webhook on aiohttp. Outbound: direct Linq REST API."""
+
+    MAX_MESSAGE_LENGTH = _MAX_MESSAGE_LENGTH
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, Platform("linq"))
+        extra = config.extra or {}
+
+        # Credentials (env wins, then config.extra, then auth.json).
+        self._token: str = (
+            os.getenv(linq_auth.ENV_TOKEN)
+            or extra.get("api_token")
+            or linq_auth.load_token()
+            or ""
+        )
+        self._api_base: str = (
+            os.getenv("LINQ_API_BASE")
+            or extra.get("api_base")
+            or DEFAULT_API_BASE
+        )
+        # Optional: only handle inbound addressed to this Linq number (lets a
+        # multi-number account run one adapter per number).
+        self._from_phone: Optional[str] = (
+            os.getenv(linq_auth.ENV_FROM_PHONE)
+            or extra.get("from_phone")
+            or linq_auth.load_from_phone()
+            or None
+        )
+
+        # Webhook receiver.
+        self._webhook_port = signing.coerce_port(
+            extra.get("webhook_port") or os.getenv("LINQ_WEBHOOK_PORT"),
+            _DEFAULT_WEBHOOK_PORT,
+        )
+        self._webhook_path = (
+            extra.get("webhook_path")
+            or os.getenv("LINQ_WEBHOOK_PATH")
+            or _DEFAULT_WEBHOOK_PATH
+        )
+        self._webhook_bind = (
+            extra.get("webhook_bind")
+            or os.getenv("LINQ_WEBHOOK_BIND")
+            or _DEFAULT_WEBHOOK_BIND
+        )
+        self._webhook_secret: str = (
+            os.getenv("LINQ_WEBHOOK_SECRET")
+            or extra.get("webhook_secret")
+            or ""
+        )
+
+        # Send read receipts + typing indicators on inbound (default on, as
+        # with the BlueBubbles channel's send_read_receipts).
+        _srr = extra.get("send_read_receipts")
+        if _srr is None:
+            _srr = os.getenv("LINQ_SEND_READ_RECEIPTS")
+        self._send_read_receipts = signing.coerce_bool(_srr, default=True)
+
+        # Group-chat mention gating (parity with Photon / BlueBubbles).
+        _require_mention = extra.get("require_mention")
+        if _require_mention is None:
+            _require_mention = os.getenv("LINQ_REQUIRE_MENTION")
+        self.require_mention = signing.coerce_bool(_require_mention, default=False)
+        self._mention_patterns = signing.compile_mention_patterns(
+            extra["mention_patterns"]
+            if "mention_patterns" in extra
+            else os.getenv("LINQ_MENTION_PATTERNS")
+        )
+
+        # Runtime state.
+        self._runner: "Optional[web.AppRunner]" = None
+        self._client: Optional[LinqClient] = None
+        self._seen_messages: Dict[str, float] = {}
+
+    # -- Connection lifecycle ---------------------------------------------
+
+    async def connect(self) -> bool:
+        if not AIOHTTP_AVAILABLE:
+            self._set_fatal_error(
+                "MISSING_DEP", "aiohttp not installed. Run: pip install aiohttp", retryable=False
+            )
+            return False
+        if not HTTPX_AVAILABLE:
+            self._set_fatal_error(
+                "MISSING_DEP", "httpx not installed. Run: pip install httpx", retryable=False
+            )
+            return False
+        if not self._token:
+            self._set_fatal_error(
+                "MISSING_CREDENTIALS",
+                "LINQ_API_TOKEN is required. Run: hermes linq setup",
+                retryable=False,
+            )
+            return False
+
+        try:
+            await self._start_webhook_server()
+        except OSError as exc:
+            self._set_fatal_error(
+                "PORT_IN_USE",
+                f"webhook port {self._webhook_port} unavailable: {exc}",
+                retryable=True,
+            )
+            return False
+
+        self._client = LinqClient(self._token, api_base=self._api_base)
+
+        if not self._webhook_secret:
+            logger.warning(
+                "[linq] LINQ_WEBHOOK_SECRET unset — accepting unsigned webhook "
+                "deliveries. Set the signing secret from your Linq dashboard to "
+                "enable HMAC verification."
+            )
+        self._mark_connected()
+        logger.info(
+            "[linq] connected — webhook at %s:%d%s (outbound via %s)",
+            self._webhook_bind, self._webhook_port, self._webhook_path, self._api_base,
+        )
+        return True
+
+    async def disconnect(self) -> None:
+        await self._stop_webhook_server()
+        if self._client is not None:
+            await self._client.close()
+            self._client = None
+        self._mark_disconnected()
+
+    # -- Webhook server ----------------------------------------------------
+
+    async def _start_webhook_server(self) -> None:
+        app = web.Application()
+        app.router.add_post(self._webhook_path, self._handle_webhook)
+        app.router.add_get("/healthz", lambda _req: web.Response(text="ok"))
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, self._webhook_bind, self._webhook_port)
+        await site.start()
+
+    async def _stop_webhook_server(self) -> None:
+        if self._runner is not None:
+            try:
+                await self._runner.cleanup()
+            except Exception:
+                pass
+            self._runner = None
+
+    async def _handle_webhook(self, request: "web.Request") -> "web.Response":
+        body = await request.read()
+        if self._webhook_secret:
+            ts = request.headers.get("X-Webhook-Timestamp", "")
+            sig = request.headers.get("X-Webhook-Signature", "")
+            if not signing.verify_signature(
+                body=body,
+                timestamp_header=ts,
+                signature_header=sig,
+                signing_secret=self._webhook_secret,
+            ):
+                logger.warning("[linq] rejected webhook with bad signature")
+                return web.Response(status=401, text="invalid signature")
+
+        import json
+
+        try:
+            payload = json.loads(body or b"{}")
+        except json.JSONDecodeError:
+            return web.Response(status=400, text="invalid json")
+
+        event_type = payload.get("event_type") or payload.get("event")
+        if event_type != "message.received":
+            # Acknowledge reactions / delivery receipts / future event types
+            # with 200 so Linq doesn't retry them.  Log the interesting ones.
+            if event_type == "reaction.received":
+                data = payload.get("data") or {}
+                if not data.get("is_from_me"):
+                    reaction = data.get("reaction") or {}
+                    logger.debug(
+                        "[linq] reaction %s %s from=%s msg=%s",
+                        reaction.get("operation"), reaction.get("type"),
+                        _redact(data.get("from")), data.get("message_id"),
+                    )
+            elif event_type == "message.delivery_status":
+                data = payload.get("data") or {}
+                logger.debug(
+                    "[linq] delivery %s msg=%s", data.get("status"), data.get("message_id")
+                )
+            return web.Response(text="ok")
+
+        data = payload.get("data") or {}
+        message = data.get("message") or {}
+        msg_id = message.get("id")
+        if not msg_id:
+            return web.Response(status=400, text="missing message.id")
+        if self._is_duplicate(msg_id):
+            return web.Response(text="ok (dup)")
+
+        try:
+            await self._dispatch_inbound(data)
+        except Exception:
+            logger.exception("[linq] inbound dispatch failed")
+            # 200 anyway — we own the dedup; failing here would make Linq retry
+            # the same id we've already recorded.
+        return web.Response(text="ok")
+
+    def _is_duplicate(self, msg_id: str) -> bool:
+        import time
+
+        now = time.time()
+        if len(self._seen_messages) > _DEDUP_MAX_SIZE:
+            cutoff = now - _DEDUP_WINDOW_SECONDS
+            self._seen_messages = {k: v for k, v in self._seen_messages.items() if v > cutoff}
+        if msg_id in self._seen_messages:
+            return True
+        self._seen_messages[msg_id] = now
+        return False
+
+    async def _dispatch_inbound(self, data: Dict[str, Any]) -> None:
+        sender = (data.get("from") or "").strip()
+        if not sender:
+            logger.warning("[linq] inbound missing sender")
+            return
+        if data.get("is_from_me"):
+            return  # never reply to our own echoes
+
+        # Multi-number filter: ignore traffic addressed to a different Linq
+        # number when this adapter is pinned to one.
+        if self._from_phone and data.get("recipient_phone") not in (None, self._from_phone):
+            logger.debug("[linq] skipping message to %s (not %s)", _redact(data.get("recipient_phone")), _redact(self._from_phone))
+            return
+
+        chat_id = str(data.get("chat_id") or "")
+        if not chat_id:
+            logger.warning("[linq] inbound missing chat_id")
+            return
+
+        message = data.get("message") or {}
+        parts = message.get("parts") or []
+        text = signing.extract_text(parts)
+        media = signing.extract_media(parts)
+
+        if not text.strip() and not media:
+            return
+
+        chat_type = "group" if signing.is_group_chat(data) else "dm"
+
+        # Group-mention gating (parity with Photon / BlueBubbles). DMs are
+        # never gated; group messages are dropped unless they hit a wake word,
+        # and the leading wake word is stripped from the ones that do.
+        if chat_type == "group" and self.require_mention:
+            if not signing.message_matches_mention(text, self._mention_patterns):
+                logger.debug("[linq] ignoring group message (require_mention, no match)")
+                return
+            text = signing.clean_mention_text(text, self._mention_patterns)
+
+        # Read receipt + typing indicator (best-effort, fire-and-forget).
+        if self._send_read_receipts and self._client is not None:
+            asyncio.create_task(self._client.mark_read(chat_id))
+            asyncio.create_task(self._client.start_typing(chat_id))
+
+        # Download image attachments to a local path so the vision tools can
+        # read them.  Non-image media is noted inline (the agent at least
+        # knows something was sent and where it lives).
+        media_urls: List[str] = []
+        media_types: List[str] = []
+        mtype = MessageType.TEXT
+        if media:
+            mtype, extra_note = await self._ingest_media(media, media_urls, media_types)
+            if extra_note:
+                text = f"{text}\n{extra_note}" if text else extra_note
+
+        body_text = text.strip()
+        if not body_text and not media_urls:
+            return
+
+        # Timestamp.
+        ts_str = data.get("received_at") or ""
+        try:
+            timestamp = datetime.fromisoformat(str(ts_str).replace("Z", "+00:00"))
+        except (ValueError, TypeError):
+            timestamp = datetime.now(tz=timezone.utc)
+
+        reply_to = (message.get("reply_to") or {}).get("message_id")
+
+        source = self.build_source(
+            chat_id=chat_id,
+            chat_name=sender,
+            chat_type=chat_type,
+            user_id=sender,
+            user_name=sender,
+            message_id=str(message.get("id")) if message.get("id") else None,
+        )
+        event = MessageEvent(
+            text=body_text,
+            message_type=mtype,
+            source=source,
+            message_id=message.get("id"),
+            raw_message=data,
+            timestamp=timestamp,
+            media_urls=media_urls,
+            media_types=media_types,
+            reply_to_message_id=reply_to,
+        )
+        await self.handle_message(event)
+
+    async def _ingest_media(
+        self,
+        media: List[Dict[str, Any]],
+        media_urls: List[str],
+        media_types: List[str],
+    ) -> "tuple[MessageType, str]":
+        """Download image attachments locally; note the rest inline.
+
+        Returns ``(message_type, extra_text_note)``.
+        """
+        notes: List[str] = []
+        mtype = MessageType.TEXT
+        for item in media:
+            url = item.get("url")
+            mime = (item.get("mime_type") or "").lower()
+            if not url:
+                continue
+            if any(mime.startswith(p) for p in _IMAGE_PREFIXES):
+                try:
+                    from gateway.platforms.base import cache_image_from_url
+
+                    local_path = await cache_image_from_url(url)
+                    media_urls.append(local_path)
+                    media_types.append(mime or "image/jpeg")
+                    mtype = MessageType.PHOTO
+                except Exception as exc:
+                    logger.debug("[linq] failed to cache inbound image: %s", exc)
+                    notes.append(f"[image attachment: {url}]")
+            else:
+                label = item.get("filename") or mime or "attachment"
+                notes.append(f"[attachment received: {label} — {url}]")
+        return mtype, "\n".join(notes)
+
+    # -- Outbound ----------------------------------------------------------
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        if self._client is None:
+            return SendResult(success=False, error="Linq adapter not connected")
+        text = content or ""
+        if len(text) > self.MAX_MESSAGE_LENGTH:
+            logger.warning(
+                "[linq] truncating outbound from %d to %d chars", len(text), self.MAX_MESSAGE_LENGTH
+            )
+            text = text[: self.MAX_MESSAGE_LENGTH]
+        try:
+            result = await self._client.send_message(chat_id, text=text, reply_to_message_id=reply_to)
+        except Exception as exc:
+            return SendResult(success=False, error=str(exc), retryable=_is_retryable(exc))
+        return SendResult(success=True, message_id=result.get("message_id"))
+
+    async def send_image(
+        self,
+        chat_id: str,
+        image_url: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        # Linq accepts a public media URL directly — no local caching or
+        # sidecar needed (the key simplification over Photon's outbound path).
+        if self._client is None:
+            return SendResult(success=False, error="Linq adapter not connected")
+        try:
+            result = await self._client.send_message(
+                chat_id, text=caption or None, media_url=image_url, reply_to_message_id=reply_to
+            )
+        except Exception as exc:
+            return SendResult(success=False, error=str(exc), retryable=_is_retryable(exc))
+        return SendResult(success=True, message_id=result.get("message_id"))
+
+    async def send_animation(
+        self,
+        chat_id: str,
+        animation_url: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        # iMessage renders GIFs inline as ordinary image attachments.
+        return await self.send_image(chat_id, animation_url, caption, reply_to, metadata)
+
+    async def send_typing(self, chat_id: str, metadata: Any = None) -> None:
+        if self._client is None:
+            return
+        try:
+            await self._client.start_typing(chat_id)
+        except Exception as exc:
+            logger.debug("[linq] send_typing failed: %s", exc)
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        """Linq chat ids are opaque tokens; surface what we have.
+
+        Linq's inbound payloads identify peers by phone number but address
+        chats by ``chat_id``, so we can't cheaply resolve a display name here.
+        """
+        chat_type = "group" if signing.is_group_chat({"chat_id": chat_id}) else "dm"
+        return {"name": chat_id, "type": chat_type, "id": chat_id}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+
+def _redact(value: Any) -> str:
+    """Mask all but the last 2 digits of a phone-like identifier for logs."""
+    s = str(value or "")
+    if len(s) <= 2:
+        return "***"
+    return "***" + s[-2:]
+
+
+def _is_retryable(exc: Exception) -> bool:
+    text = str(exc).lower()
+    return any(token in text for token in ("connecterror", "connectionerror", "connecttimeout"))
+
+
+# ---------------------------------------------------------------------------
+# Standalone (out-of-process) send for cron deliveries when the gateway is not
+# co-resident.  Opens an ephemeral Linq client, sends, and closes.
+
+async def _standalone_send(
+    pconfig: PlatformConfig,
+    chat_id: str,
+    message: str,
+    *,
+    thread_id: Optional[str] = None,  # noqa: ARG001 - Linq has no threads
+    media_files: Optional[list] = None,
+    force_document: bool = False,  # noqa: ARG001 - iMessage auto-detects file kind
+) -> Dict[str, Any]:
+    if not HTTPX_AVAILABLE:
+        return {"error": "httpx not installed"}
+    extra = (pconfig.extra or {})
+    token = os.getenv(linq_auth.ENV_TOKEN) or extra.get("api_token") or linq_auth.load_token()
+    if not token:
+        return {"error": "Linq standalone send requires LINQ_API_TOKEN"}
+    api_base = os.getenv("LINQ_API_BASE") or extra.get("api_base") or DEFAULT_API_BASE
+
+    last_id: Optional[str] = None
+    try:
+        async with LinqClient(token, api_base=api_base) as client:
+            if message:
+                result = await client.send_message(chat_id, text=message[:_MAX_MESSAGE_LENGTH])
+                last_id = result.get("message_id")
+            # Local media files can't be forwarded: Linq sends media by public
+            # URL, not multipart upload.  Note the omission rather than failing
+            # the whole delivery.
+            if media_files:
+                logger.warning(
+                    "[linq] standalone send skipped %d local media file(s) — "
+                    "Linq sends media by URL, not file upload",
+                    len(media_files),
+                )
+        return {"success": True, "message_id": last_id}
+    except Exception as exc:
+        return {"error": f"Linq standalone send failed: {exc}"}
+
+
+# ---------------------------------------------------------------------------
+# Plugin entry point
+
+def register(ctx) -> None:
+    """Called by the Hermes plugin loader at startup."""
+    from . import cli as _cli
+
+    ctx.register_platform(
+        name="linq",
+        label="Linq iMessage",
+        adapter_factory=lambda cfg: LinqAdapter(cfg),
+        check_fn=check_requirements,
+        validate_config=validate_config,
+        is_connected=is_connected,
+        required_env=["LINQ_API_TOKEN"],
+        install_hint=(
+            "Run: hermes linq setup  (stores your Linq API token + from-phone, "
+            "then register a webhook URL in your Linq dashboard)."
+        ),
+        setup_fn=_cli.gateway_setup,
+        env_enablement_fn=_env_enablement,
+        cron_deliver_env_var="LINQ_HOME_CHANNEL",
+        standalone_sender_fn=_standalone_send,
+        allowed_users_env="LINQ_ALLOWED_USERS",
+        allow_all_env="LINQ_ALLOW_ALL_USERS",
+        max_message_length=_MAX_MESSAGE_LENGTH,
+        emoji="💬",
+        # iMessage carries E.164 phone numbers — treat session descriptions as
+        # PII-sensitive so they get redacted before reaching the LLM (matches
+        # the BlueBubbles and Photon iMessage channels).
+        pii_safe=True,
+        allow_update_command=True,
+        platform_hint=(
+            "You are communicating via Linq (iMessage). Treat replies like "
+            "regular text messages — short, friendly, no markdown rendering. "
+            "Recipient identifiers are E.164 phone numbers; never expose them "
+            "in responses unless the user asked. Inbound images are downloaded "
+            "locally and readable with your vision tools."
+        ),
+    )
+
+    # Register CLI subcommands — `hermes linq ...`
+    ctx.register_cli_command(
+        name="linq",
+        help="Set up and manage the Linq iMessage integration",
+        setup_fn=_cli.register_cli,
+        handler_fn=_cli.dispatch,
+    )

--- a/plugins/platforms/linq/auth.py
+++ b/plugins/platforms/linq/auth.py
@@ -1,0 +1,118 @@
+"""
+Linq credential storage.
+
+The Linq integration needs only two things: an API bearer token and the
+account's "from" phone number (E.164).  Both can be supplied via environment
+variables (``LINQ_API_TOKEN`` / ``LINQ_FROM_PHONE``) or persisted to
+``~/.hermes/auth.json`` under ``credential_pool.linq`` by ``hermes linq
+setup`` — the same file and shape Photon uses for its credentials, so the
+Hermes profile machinery (``hermes_constants.get_hermes_home``) keeps working.
+
+Precedence everywhere is: **env var → auth.json**.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+ENV_TOKEN = "LINQ_API_TOKEN"
+ENV_FROM_PHONE = "LINQ_FROM_PHONE"
+
+
+def _auth_json_path() -> Path:
+    """Resolve ``~/.hermes/auth.json`` honouring the active Hermes profile."""
+    try:
+        from hermes_constants import get_hermes_home  # type: ignore
+
+        return Path(get_hermes_home()) / "auth.json"
+    except Exception:
+        return Path(os.path.expanduser("~/.hermes")) / "auth.json"
+
+
+def _load_auth() -> Dict[str, Any]:
+    path = _auth_json_path()
+    if not path.exists():
+        return {}
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            return json.load(fh) or {}
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("linq: could not read %s: %s", path, exc)
+        return {}
+
+
+def _save_auth(data: Dict[str, Any]) -> None:
+    path = _auth_json_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    with tmp.open("w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2, sort_keys=True)
+    try:
+        os.chmod(tmp, 0o600)
+    except OSError:
+        pass
+    os.replace(tmp, path)
+
+
+def _stored_record() -> Dict[str, Any]:
+    pool = _load_auth().get("credential_pool", {}).get("linq") or []
+    if isinstance(pool, list) and pool and isinstance(pool[0], dict):
+        return pool[0]
+    return {}
+
+
+def load_token() -> Optional[str]:
+    """Return the Linq API token (env wins, then auth.json)."""
+    env = os.getenv(ENV_TOKEN)
+    if env and env.strip():
+        return env.strip()
+    token = _stored_record().get("api_token") or _stored_record().get("access_token")
+    return str(token) if token else None
+
+
+def load_from_phone() -> Optional[str]:
+    """Return the configured Linq "from" phone number (env wins, then auth.json)."""
+    env = os.getenv(ENV_FROM_PHONE)
+    if env and env.strip():
+        return env.strip()
+    phone = _stored_record().get("from_phone")
+    return str(phone) if phone else None
+
+
+def load_credentials() -> Tuple[Optional[str], Optional[str]]:
+    """Return ``(api_token, from_phone)``."""
+    return load_token(), load_from_phone()
+
+
+def store_credentials(api_token: str, from_phone: Optional[str] = None) -> None:
+    """Persist the Linq token (+ optional from-phone) under ``credential_pool.linq``."""
+    auth = _load_auth()
+    record: Dict[str, Any] = {
+        "api_token": api_token,
+        "issued_at": int(time.time()),
+    }
+    if from_phone:
+        record["from_phone"] = from_phone
+    auth.setdefault("credential_pool", {})["linq"] = [record]
+    _save_auth(auth)
+
+
+def print_credential_summary(emit: Callable[[str], None]) -> None:
+    """Render a credential-state table via *emit* (typically ``print``).
+
+    Mirrors Photon's pattern of confining credential-derived strings to a
+    single sink so the CLI module stays free of token taint.
+    """
+    token, phone = load_credentials()
+    token_src = "env" if os.getenv(ENV_TOKEN) else ("auth.json" if token else None)
+    phone_src = "env" if os.getenv(ENV_FROM_PHONE) else ("auth.json" if phone else None)
+    emit("Linq iMessage credentials:")
+    emit(f"  api token           : {'✓ set (' + token_src + ')' if token else '✗ missing — run `hermes linq setup`'}")
+    emit(f"  from phone          : {phone + ' (' + phone_src + ')' if phone else '✗ not set (optional)'}")
+    emit(f"  auth file           : {_auth_json_path()}")

--- a/plugins/platforms/linq/cli.py
+++ b/plugins/platforms/linq/cli.py
@@ -1,0 +1,179 @@
+"""
+``hermes linq ...`` CLI subcommands — registered by the plugin via
+``ctx.register_cli_command()``.
+
+Subcommands::
+
+    setup            store the Linq API token (+ from-phone) and print
+                     webhook-registration instructions
+    status           show credential state and run a connectivity probe
+    webhook show     print the local webhook URL to register in the Linq
+                     dashboard, plus a generated signing-secret reminder
+    probe            hit GET /phonenumbers to confirm the token works
+
+Linq webhooks are registered in the Linq dashboard (Linq POSTs to a URL you
+control), so there is no API-side ``webhook register`` verb the way Photon
+has — the ``webhook show`` helper just tells you exactly what to paste in.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import getpass
+import os
+import sys
+
+from . import auth as linq_auth
+from . import signing
+from .adapter import (
+    _DEFAULT_WEBHOOK_BIND,
+    _DEFAULT_WEBHOOK_PATH,
+    _DEFAULT_WEBHOOK_PORT,
+)
+from .linq_api import DEFAULT_API_BASE, LinqClient
+
+
+# ---------------------------------------------------------------------------
+# argparse wiring
+
+def register_cli(parser: argparse.ArgumentParser) -> None:
+    """Wire up `hermes linq ...` subcommands."""
+    subs = parser.add_subparsers(dest="linq_command", required=False)
+
+    p_setup = subs.add_parser("setup", help="Store Linq API token + from-phone")
+    p_setup.add_argument("--token", default=None, help="Linq API token (omit to be prompted securely)")
+    p_setup.add_argument("--phone", default=None, help="Your Linq from-phone (E.164, e.g. +15551234567)")
+
+    subs.add_parser("status", help="Show credential state and probe connectivity")
+    subs.add_parser("probe", help="Confirm the API token works (GET /phonenumbers)")
+
+    p_hook = subs.add_parser("webhook", help="Webhook registration help")
+    hook_subs = p_hook.add_subparsers(dest="linq_webhook_command", required=False)
+    p_show = hook_subs.add_parser("show", help="Print the webhook URL to register in the Linq dashboard")
+    p_show.add_argument("--public-url", default=None, help="Public base URL the gateway is reachable at")
+
+    parser.set_defaults(func=dispatch)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+
+def dispatch(args: argparse.Namespace) -> int:
+    sub = getattr(args, "linq_command", None)
+    if sub is None:
+        return _cmd_status(args)
+    if sub == "setup":
+        return _cmd_setup(args)
+    if sub == "status":
+        return _cmd_status(args)
+    if sub == "probe":
+        return _cmd_probe(args)
+    if sub == "webhook":
+        return _cmd_webhook(args)
+    print(f"unknown subcommand: {sub}", file=sys.stderr)
+    return 2
+
+
+# ---------------------------------------------------------------------------
+# Subcommand handlers
+
+def _cmd_setup(args: argparse.Namespace) -> int:
+    print("[1/2] Linq API token")
+    token = args.token or os.getenv(linq_auth.ENV_TOKEN) or _prompt(
+        "  Paste your Linq API token (from linqapp.com dashboard): ", secret=True
+    )
+    if not token:
+        print("no token provided — aborting", file=sys.stderr)
+        return 1
+
+    print("[2/2] Linq from-phone (optional)")
+    phone = args.phone or _prompt(
+        "  Linq phone number this agent sends from (E.164, blank to skip): "
+    )
+
+    linq_auth.store_credentials(token, from_phone=phone or None)
+    print(f"  ✓ saved to {linq_auth._auth_json_path()}")
+    print()
+    print("✓ Linq setup complete.")
+    print("  Next: register a webhook URL in your Linq dashboard so inbound")
+    print("        iMessages reach this gateway:")
+    print(f"        hermes linq webhook show --public-url https://YOUR-PUBLIC-HOST")
+    print("  Then start the gateway:")
+    print("        hermes gateway start --platform linq")
+    return 0
+
+
+def _cmd_status(_args: argparse.Namespace) -> int:
+    linq_auth.print_credential_summary(print)
+    return _cmd_probe(_args)
+
+
+def _cmd_probe(_args: argparse.Namespace) -> int:
+    token = linq_auth.load_token()
+    if not token:
+        print("  connectivity         : ✗ no token (run `hermes linq setup`)")
+        return 1
+    api_base = os.getenv("LINQ_API_BASE") or DEFAULT_API_BASE
+
+    async def _run() -> int:
+        async with LinqClient(token, api_base=api_base) as client:
+            try:
+                numbers = await client.list_phone_numbers(timeout=8.0)
+            except Exception as exc:
+                print(f"  connectivity         : ✗ {exc}")
+                return 1
+        count = len(numbers)
+        print(f"  connectivity         : ✓ token valid ({count} number(s) on account)")
+        return 0
+
+    try:
+        return asyncio.run(_run())
+    except RuntimeError as exc:
+        # Already inside an event loop (rare for a CLI) — fall back.
+        print(f"  connectivity         : ? could not run probe: {exc}")
+        return 1
+
+
+def _cmd_webhook(args: argparse.Namespace) -> int:
+    public = getattr(args, "public_url", None) or "https://YOUR-PUBLIC-HOST"
+    path = os.getenv("LINQ_WEBHOOK_PATH") or _DEFAULT_WEBHOOK_PATH
+    port = signing.coerce_port(os.getenv("LINQ_WEBHOOK_PORT"), _DEFAULT_WEBHOOK_PORT)
+    bind = os.getenv("LINQ_WEBHOOK_BIND") or _DEFAULT_WEBHOOK_BIND
+    url = f"{public.rstrip('/')}{path}"
+    print("Linq webhook registration")
+    print(f"  Local listener   : http://{bind}:{port}{path}")
+    print(f"  Register this URL in your Linq dashboard:")
+    print(f"      {url}")
+    print()
+    print("  Then export the signing secret your dashboard shows so the adapter")
+    print("  can verify deliveries:")
+    print("      export LINQ_WEBHOOK_SECRET=<secret-from-linq-dashboard>")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Gateway-setup entry point
+#
+# `hermes gateway setup` discovers platforms via the registry and calls each
+# entry's zero-arg ``setup_fn``.  Linq registers this so it appears in the
+# unified setup wizard alongside every other channel.
+
+def gateway_setup() -> None:
+    """Run Linq first-time setup from the `hermes gateway setup` wizard."""
+    args = argparse.Namespace(linq_command="setup", token=None, phone=None)
+    _cmd_setup(args)
+
+
+# ---------------------------------------------------------------------------
+# Small interactive helper
+
+def _prompt(prompt: str, *, secret: bool = False) -> str:
+    if not sys.stdin.isatty():
+        return ""
+    try:
+        if secret:
+            return getpass.getpass(prompt).strip()
+        return input(prompt).strip()
+    except (KeyboardInterrupt, EOFError):
+        print()
+        return ""

--- a/plugins/platforms/linq/linq_api.py
+++ b/plugins/platforms/linq/linq_api.py
@@ -1,0 +1,239 @@
+"""
+Thin async client for the Linq Blue partner API (v3).
+
+Unlike Photon — which has no public HTTP send endpoint and therefore needs a
+Node ``spectrum-ts`` sidecar — Linq exposes a first-class REST API, so all
+outbound traffic (text, media-by-URL, typing, read receipts, reactions) is a
+direct ``httpx`` call from this process.  No sidecar, no Node dependency.
+
+Endpoints (base: ``https://api.linqapp.com/api/partner/v3``)::
+
+    POST /chats/{chat_id}/messages      send a message (text and/or media parts)
+    POST /chats/{chat_id}/typing        start a typing indicator
+    POST /chats/{chat_id}/read          mark the chat read
+    POST /messages/{message_id}/reactions   add/remove a tapback
+    GET  /phonenumbers                  list the account's Linq numbers (probe)
+
+Auth is a bearer token (``LINQ_API_TOKEN``).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Dict, List, Optional
+
+try:
+    import httpx
+    HTTPX_AVAILABLE = True
+except ImportError:  # pragma: no cover - httpx ships with Hermes
+    HTTPX_AVAILABLE = False
+    httpx = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_API_BASE = "https://api.linqapp.com/api/partner/v3"
+USER_AGENT = "Hermes-Linq/0.1"
+_MAX_RETRIES = 2
+_RETRY_DELAY_MS = 500
+
+# Reactions Linq's tapback API understands.
+REACTION_TYPES = ("love", "like", "dislike", "laugh", "emphasize", "question")
+
+
+class LinqApiError(RuntimeError):
+    """Raised for non-2xx responses from the Linq API."""
+
+    def __init__(self, status: int, body: str):
+        self.status = status
+        self.body = body
+        super().__init__(f"Linq API error {status}: {body[:200]}")
+
+
+class LinqClient:
+    """Async Linq partner API client.
+
+    Holds its own ``httpx.AsyncClient`` so a single client can be shared
+    across an adapter's lifetime; callers must ``await close()`` (or use it
+    as an async context manager) when done.
+    """
+
+    def __init__(
+        self,
+        token: str,
+        *,
+        api_base: str = DEFAULT_API_BASE,
+        timeout: float = 30.0,
+        client: "Optional[httpx.AsyncClient]" = None,
+    ) -> None:
+        if not HTTPX_AVAILABLE:
+            raise RuntimeError("httpx is required for the Linq client. Run: pip install httpx")
+        self._token = token
+        self._api_base = api_base.rstrip("/")
+        self._timeout = timeout
+        self._client = client or httpx.AsyncClient(timeout=timeout)
+        self._owns_client = client is None
+
+    async def __aenter__(self) -> "LinqClient":
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        await self.close()
+
+    async def close(self) -> None:
+        if self._owns_client:
+            try:
+                await self._client.aclose()
+            except Exception:
+                pass
+
+    # -- internals --------------------------------------------------------
+
+    def _headers(self, *, json_body: bool = True) -> Dict[str, str]:
+        headers = {
+            "Authorization": f"Bearer {self._token}",
+            "User-Agent": USER_AGENT,
+        }
+        if json_body:
+            headers["Content-Type"] = "application/json"
+        return headers
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_body: Optional[Dict[str, Any]] = None,
+    ) -> "httpx.Response":
+        url = f"{self._api_base}{path}"
+        for attempt in range(_MAX_RETRIES + 1):
+            resp = await self._client.request(
+                method,
+                url,
+                headers=self._headers(json_body=json_body is not None),
+                json=json_body,
+            )
+            # Honour 429 back-pressure with a bounded exponential backoff.
+            if resp.status_code == 429 and attempt < _MAX_RETRIES:
+                retry_after = 0.0
+                try:
+                    retry_after = float(resp.headers.get("retry-after") or 0)
+                except ValueError:
+                    retry_after = 0.0
+                delay = retry_after if retry_after > 0 else (_RETRY_DELAY_MS / 1000) * (2 ** attempt)
+                await asyncio.sleep(min(delay, 10.0))
+                continue
+            return resp
+        return resp  # pragma: no cover - unreachable, last response returned above
+
+    # -- outbound ---------------------------------------------------------
+
+    async def send_message(
+        self,
+        chat_id: str,
+        *,
+        text: Optional[str] = None,
+        media_url: Optional[str] = None,
+        reply_to_message_id: Optional[str] = None,
+    ) -> Dict[str, str]:
+        """Send a message to a Linq chat. Returns ``{"message_id", "chat_id"}``."""
+        parts: List[Dict[str, Any]] = []
+        if text:
+            parts.append({"type": "text", "value": text})
+        if media_url:
+            parts.append({"type": "media", "url": media_url})
+        if not parts:
+            raise ValueError("send_message requires text or media_url")
+
+        message: Dict[str, Any] = {"parts": parts}
+        if reply_to_message_id:
+            message["reply_to"] = {"message_id": reply_to_message_id}
+
+        resp = await self._request(
+            "POST",
+            f"/chats/{_quote(chat_id)}/messages",
+            json_body={"message": message},
+        )
+        if not resp.is_success:
+            raise LinqApiError(resp.status_code, _safe_text(resp))
+        data = _safe_json(resp)
+        msg = data.get("message") if isinstance(data, dict) else None
+        return {
+            "message_id": (msg or {}).get("id", "unknown") if isinstance(msg, dict) else "unknown",
+            "chat_id": data.get("chat_id", chat_id) if isinstance(data, dict) else chat_id,
+        }
+
+    async def start_typing(self, chat_id: str) -> bool:
+        return await self._fire_and_forget("POST", f"/chats/{_quote(chat_id)}/typing")
+
+    async def stop_typing(self, chat_id: str) -> bool:
+        return await self._fire_and_forget("DELETE", f"/chats/{_quote(chat_id)}/typing")
+
+    async def mark_read(self, chat_id: str) -> bool:
+        return await self._fire_and_forget("POST", f"/chats/{_quote(chat_id)}/read")
+
+    async def send_reaction(
+        self,
+        message_id: str,
+        reaction_type: str,
+        *,
+        operation: str = "add",
+    ) -> bool:
+        if reaction_type not in REACTION_TYPES:
+            raise ValueError(f"unknown reaction type: {reaction_type}")
+        return await self._fire_and_forget(
+            "POST",
+            f"/messages/{_quote(message_id)}/reactions",
+            json_body={"operation": operation, "type": reaction_type},
+        )
+
+    async def list_phone_numbers(self, *, timeout: Optional[float] = None) -> List[str]:
+        """Return the account's Linq phone numbers (used by the connectivity probe)."""
+        resp = await self._client.request(
+            "GET",
+            f"{self._api_base}/phonenumbers",
+            headers=self._headers(json_body=False),
+            timeout=timeout or self._timeout,
+        )
+        if not resp.is_success:
+            raise LinqApiError(resp.status_code, _safe_text(resp))
+        data = _safe_json(resp)
+        numbers = (data or {}).get("phone_numbers") or []
+        return [str(n.get("phone_number")) for n in numbers if isinstance(n, dict) and n.get("phone_number")]
+
+    # -- side-effect helper ----------------------------------------------
+
+    async def _fire_and_forget(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_body: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """POST/DELETE a side-effect call (typing/read/reaction); never raises."""
+        try:
+            resp = await self._request(method, path, json_body=json_body)
+            return resp.is_success
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("[linq] %s %s failed: %s", method, path, exc)
+            return False
+
+
+def _quote(value: str) -> str:
+    from urllib.parse import quote
+
+    return quote(str(value), safe="")
+
+
+def _safe_text(resp: "httpx.Response") -> str:
+    try:
+        return resp.text
+    except Exception:
+        return ""
+
+
+def _safe_json(resp: "httpx.Response") -> Dict[str, Any]:
+    try:
+        data = resp.json()
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}

--- a/plugins/platforms/linq/plugin.yaml
+++ b/plugins/platforms/linq/plugin.yaml
@@ -1,0 +1,71 @@
+name: linq-platform
+label: Linq iMessage
+kind: platform
+version: 0.1.0
+description: >
+  Linq iMessage gateway adapter for Hermes Agent. Sends and receives real
+  iMessage "blue bubbles" through the hosted Linq partner API
+  (https://linqapp.com) — no Mac and no BlueBubbles server required.
+
+  Inbound messages arrive as HMAC-signed webhooks on a local aiohttp server;
+  outbound messages, typing indicators, and read receipts are direct REST
+  calls to the Linq API (no Node sidecar, unlike the Photon channel). The
+  plugin ships a `hermes linq` CLI for one-time token + from-phone setup and
+  persists credentials to ``~/.hermes/auth.json`` under
+  ``credential_pool.linq``.
+author: Linq
+requires_env:
+  - name: LINQ_API_TOKEN
+    description: "Linq partner API bearer token (set by `hermes linq setup`)"
+    prompt: "Linq API token"
+    url: "https://linqapp.com"
+    password: true
+optional_env:
+  - name: LINQ_FROM_PHONE
+    description: "Linq number this agent sends from (E.164). Pins a multi-number account to one line."
+    prompt: "Linq from-phone (E.164)"
+    password: false
+  - name: LINQ_WEBHOOK_SECRET
+    description: "HMAC-SHA256 signing secret from your Linq dashboard webhook config"
+    prompt: "Linq webhook signing secret"
+    password: true
+  - name: LINQ_WEBHOOK_PORT
+    description: "Local port the webhook receiver listens on (default 8790)"
+    prompt: "Webhook receiver port"
+    password: false
+  - name: LINQ_WEBHOOK_PATH
+    description: "Path the webhook receiver listens on (default /linq/webhook)"
+    prompt: "Webhook receiver path"
+    password: false
+  - name: LINQ_WEBHOOK_BIND
+    description: "Bind address for the webhook receiver (default 0.0.0.0)"
+    prompt: "Webhook bind address"
+    password: false
+  - name: LINQ_API_BASE
+    description: "Linq API base URL (default https://api.linqapp.com/api/partner/v3)"
+    prompt: "Linq API base URL"
+    password: false
+  - name: LINQ_SEND_READ_RECEIPTS
+    description: "Send read receipts + typing indicators on inbound (true/false, default true)"
+    prompt: "Send read receipts?"
+    password: false
+  - name: LINQ_ALLOWED_USERS
+    description: "Comma-separated E.164 phone numbers allowed to talk to the bot"
+    prompt: "Allowed users (comma-separated)"
+    password: false
+  - name: LINQ_ALLOW_ALL_USERS
+    description: "Allow any sender to trigger the bot (dev only — disables allowlist)"
+    prompt: "Allow all users? (true/false)"
+    password: false
+  - name: LINQ_REQUIRE_MENTION
+    description: "Ignore group-chat messages unless they match a mention wake word (true/false, default false)"
+    prompt: "Require a mention in group chats?"
+    password: false
+  - name: LINQ_MENTION_PATTERNS
+    description: "Mention wake-word regexes for group chats (JSON list or comma/newline-separated; defaults to Hermes wake words)"
+    prompt: "Group mention patterns"
+    password: false
+  - name: LINQ_HOME_CHANNEL
+    description: "Default Linq chat id for cron / notification delivery"
+    prompt: "Home chat id"
+    password: false

--- a/plugins/platforms/linq/signing.py
+++ b/plugins/platforms/linq/signing.py
@@ -1,0 +1,211 @@
+"""
+Pure, dependency-free helpers for the Linq iMessage platform plugin.
+
+This module deliberately imports **nothing** from the host Hermes package
+(``gateway.*``) and nothing beyond the Python standard library.  Keeping the
+webhook-signature verification, group-mention gating, and small parsing
+helpers here means they can be unit-tested in isolation — ``adapter.py``
+(which *does* import ``gateway.platforms.base``) only runs inside a real
+Hermes runtime, but the security-critical bits below are testable anywhere.
+
+Linq Blue v3 signs outbound webhooks as::
+
+    signature = hex( HMAC_SHA256(secret, f"{timestamp}.{raw_body}") )
+
+delivered in the ``X-Webhook-Signature`` header alongside an
+``X-Webhook-Timestamp`` (unix seconds) header.  This mirrors the scheme used
+by the OpenClaw Linq channel plugin so a single Linq webhook secret verifies
+against both runtimes.
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import re
+import time
+from typing import Any, Optional
+
+# Reject deliveries whose timestamp drifts more than this from now (replay
+# protection).  Matches Photon/BlueBubbles' 5-minute window.
+TIMESTAMP_DRIFT_SECONDS = 300
+
+# Group-chat mention wake words.  When ``require_mention`` is enabled, group
+# messages are ignored unless they match one of these — identical defaults to
+# the Photon and BlueBubbles iMessage adapters so all three iMessage channels
+# gate group chats the same way.
+DEFAULT_MENTION_PATTERNS = [
+    r"(?<![\w@])@?hermes\s+agent\b[,:\-]?",
+    r"(?<![\w@])@?hermes\b[,:\-]?",
+]
+
+
+def coerce_port(value: Any, default: int) -> int:
+    """Best-effort int coercion for port-like env/config values."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def coerce_bool(value: Any, default: bool = False) -> bool:
+    """Parse the truthy strings Hermes accepts in env/config."""
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"true", "1", "yes", "on"}
+
+
+def verify_signature(
+    *,
+    body: bytes,
+    timestamp_header: str,
+    signature_header: str,
+    signing_secret: str,
+    now: Optional[float] = None,
+    drift: int = TIMESTAMP_DRIFT_SECONDS,
+) -> bool:
+    """Constant-time verify a Linq Blue v3 webhook signature.
+
+    Returns ``True`` iff the timestamp is within ``drift`` seconds of *now*
+    AND ``signature_header == hex(hmac_sha256(secret, f"{ts}.{body}"))``.
+
+    The signature header may optionally carry a ``sha256=`` prefix; both
+    shapes are accepted.  Exposed at module scope so tests can exercise it
+    without an adapter instance.
+    """
+    if not timestamp_header or not signature_header or not signing_secret:
+        return False
+    try:
+        ts = int(timestamp_header)
+    except (TypeError, ValueError):
+        return False
+    if abs((now if now is not None else time.time()) - ts) > drift:
+        return False
+    provided = signature_header[7:] if signature_header.startswith("sha256=") else signature_header
+    message = f"{ts}.".encode("utf-8") + body
+    expected = hmac.new(signing_secret.encode("utf-8"), message, hashlib.sha256).hexdigest()
+    try:
+        return hmac.compare_digest(expected, provided)
+    except Exception:
+        return False
+
+
+def compile_mention_patterns(raw: Any) -> "list[re.Pattern]":
+    """Compile group-mention wake words from config/env.
+
+    ``raw`` may be a list (config or env JSON), a string (env var: a JSON
+    list, or comma/newline-separated), or ``None`` (use Hermes defaults).
+    Mirrors the Photon/BlueBubbles implementations so every iMessage channel
+    accepts the same configuration shapes.
+    """
+    if raw is None:
+        patterns: list = list(DEFAULT_MENTION_PATTERNS)
+    elif isinstance(raw, str):
+        text = raw.strip()
+        try:
+            loaded = json.loads(text) if text else []
+        except Exception:
+            loaded = None
+        if isinstance(loaded, list):
+            patterns = loaded
+        else:
+            patterns = [
+                part.strip()
+                for line in text.splitlines()
+                for part in line.split(",")
+            ]
+    elif isinstance(raw, list):
+        patterns = raw
+    else:
+        patterns = [raw]
+
+    compiled: "list[re.Pattern]" = []
+    for pattern in patterns:
+        token = str(pattern).strip()
+        if not token:
+            continue
+        try:
+            compiled.append(re.compile(token, re.IGNORECASE))
+        except re.error:
+            # Skip invalid patterns rather than crashing the adapter; the
+            # adapter logs these at warning level when it compiles them.
+            continue
+    return compiled
+
+
+def message_matches_mention(text: str, patterns: "list[re.Pattern]") -> bool:
+    if not text or not patterns:
+        return False
+    return any(p.search(text) for p in patterns)
+
+
+def clean_mention_text(text: str, patterns: "list[re.Pattern]") -> str:
+    """Strip a single leading wake word before dispatch.
+
+    Custom mention patterns are regexes, so we only strip a *leading* match
+    to avoid deleting ordinary words later in the prompt.
+    """
+    if not text:
+        return text
+    stripped = text.lstrip()
+    for pattern in patterns:
+        match = pattern.match(stripped)
+        if match:
+            cleaned = stripped[match.end():].lstrip(" ,:-")
+            return cleaned or text
+    return text
+
+
+def extract_text(parts: list) -> str:
+    """Join the ``value`` of every ``{"type": "text"}`` part."""
+    out = []
+    for part in parts or []:
+        if isinstance(part, dict) and part.get("type") == "text":
+            value = part.get("value")
+            if value:
+                out.append(str(value))
+    return "\n".join(out)
+
+
+def extract_media(parts: list) -> "list[dict]":
+    """Return ``[{"url": ..., "mime_type": ...}]`` for every media part with a URL."""
+    out = []
+    for part in parts or []:
+        if (
+            isinstance(part, dict)
+            and part.get("type") == "media"
+            and part.get("url")
+        ):
+            out.append(
+                {
+                    "url": str(part["url"]),
+                    "mime_type": str(part.get("mime_type") or ""),
+                    "filename": part.get("filename"),
+                }
+            )
+    return out
+
+
+def is_group_chat(data: dict) -> bool:
+    """Heuristically classify an inbound Linq message as group vs. direct.
+
+    Linq's Blue v3 ``message.received`` payload does not (in the documented
+    shape we mirror from the OpenClaw channel) carry an explicit chat-type
+    discriminator, so we look at the fields a group delivery is known to add:
+    an ``is_group`` flag, a ``group_id``/``group_name``, or a ``participants``
+    list with more than two members.  Everything else is treated as a DM.
+
+    NOTE: confirm against a live Linq group webhook and tighten if the real
+    payload exposes a first-class type field.
+    """
+    if coerce_bool(data.get("is_group")):
+        return True
+    if data.get("group_id") or data.get("group_name"):
+        return True
+    participants = data.get("participants")
+    if isinstance(participants, list) and len(participants) > 2:
+        return True
+    chat_type = str(data.get("chat_type") or "").lower()
+    return chat_type in {"group", "groupchat", "group_chat"}

--- a/tests/plugins/platforms/linq/test_auth.py
+++ b/tests/plugins/platforms/linq/test_auth.py
@@ -1,0 +1,63 @@
+"""Unit tests for credential storage + precedence (stdlib only)."""
+import importlib
+import os
+import tempfile
+import unittest
+
+from plugins.platforms.linq import auth as _linq_auth
+
+
+class AuthTest(unittest.TestCase):
+    def setUp(self):
+        # Point ~/.hermes at a throwaway dir for the duration of each test.
+        self._tmp = tempfile.TemporaryDirectory()
+        self._home = self._tmp.name
+        self._old_home = os.environ.get("HOME")
+        os.environ["HOME"] = self._home
+        for var in ("LINQ_API_TOKEN", "LINQ_FROM_PHONE"):
+            os.environ.pop(var, None)
+        importlib.reload(_linq_auth)
+        self.auth = _linq_auth
+
+    def tearDown(self):
+        if self._old_home is not None:
+            os.environ["HOME"] = self._old_home
+        for var in ("LINQ_API_TOKEN", "LINQ_FROM_PHONE"):
+            os.environ.pop(var, None)
+        self._tmp.cleanup()
+
+    def test_store_and_load_roundtrip(self):
+        self.auth.store_credentials("tok-123", from_phone="+15551112222")
+        self.assertEqual(self.auth.load_token(), "tok-123")
+        self.assertEqual(self.auth.load_from_phone(), "+15551112222")
+        self.assertEqual(self.auth.load_credentials(), ("tok-123", "+15551112222"))
+
+    def test_env_token_wins_over_file(self):
+        self.auth.store_credentials("file-token", from_phone="+1999")
+        os.environ["LINQ_API_TOKEN"] = "env-token"
+        os.environ["LINQ_FROM_PHONE"] = "+1888"
+        self.assertEqual(self.auth.load_token(), "env-token")
+        self.assertEqual(self.auth.load_from_phone(), "+1888")
+
+    def test_missing_returns_none(self):
+        self.assertIsNone(self.auth.load_token())
+        self.assertIsNone(self.auth.load_from_phone())
+
+    def test_auth_file_is_chmod_600(self):
+        self.auth.store_credentials("tok")
+        path = self.auth._auth_json_path()
+        self.assertTrue(path.exists())
+        mode = oct(path.stat().st_mode & 0o777)
+        self.assertEqual(mode, "0o600")
+
+    def test_summary_emits_without_leaking_token(self):
+        self.auth.store_credentials("super-secret-token", from_phone="+15551112222")
+        lines = []
+        self.auth.print_credential_summary(lines.append)
+        joined = "\n".join(lines)
+        self.assertIn("api token", joined)
+        self.assertNotIn("super-secret-token", joined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/plugins/platforms/linq/test_signing.py
+++ b/tests/plugins/platforms/linq/test_signing.py
@@ -1,0 +1,177 @@
+"""Unit tests for the gateway-free signing/parsing helpers.
+
+These use only the standard library so they run anywhere — no Hermes runtime,
+httpx, or aiohttp required.
+"""
+import hashlib
+import hmac
+import time
+import unittest
+
+from plugins.platforms.linq import signing
+
+
+def _sign(secret: str, ts: int, body: bytes) -> str:
+    msg = f"{ts}.".encode("utf-8") + body
+    return hmac.new(secret.encode("utf-8"), msg, hashlib.sha256).hexdigest()
+
+
+class VerifySignatureTest(unittest.TestCase):
+    def setUp(self):
+        self.secret = "s3cr3t"
+        self.body = b'{"event_type":"message.received"}'
+        self.now = 1_700_000_000
+
+    def test_valid_signature(self):
+        ts = self.now
+        sig = _sign(self.secret, ts, self.body)
+        self.assertTrue(
+            signing.verify_signature(
+                body=self.body, timestamp_header=str(ts), signature_header=sig,
+                signing_secret=self.secret, now=self.now,
+            )
+        )
+
+    def test_sha256_prefix_accepted(self):
+        ts = self.now
+        sig = "sha256=" + _sign(self.secret, ts, self.body)
+        self.assertTrue(
+            signing.verify_signature(
+                body=self.body, timestamp_header=str(ts), signature_header=sig,
+                signing_secret=self.secret, now=self.now,
+            )
+        )
+
+    def test_wrong_secret_rejected(self):
+        ts = self.now
+        sig = _sign("other", ts, self.body)
+        self.assertFalse(
+            signing.verify_signature(
+                body=self.body, timestamp_header=str(ts), signature_header=sig,
+                signing_secret=self.secret, now=self.now,
+            )
+        )
+
+    def test_tampered_body_rejected(self):
+        ts = self.now
+        sig = _sign(self.secret, ts, self.body)
+        self.assertFalse(
+            signing.verify_signature(
+                body=b"tampered", timestamp_header=str(ts), signature_header=sig,
+                signing_secret=self.secret, now=self.now,
+            )
+        )
+
+    def test_stale_timestamp_rejected(self):
+        ts = self.now - 10_000
+        sig = _sign(self.secret, ts, self.body)
+        self.assertFalse(
+            signing.verify_signature(
+                body=self.body, timestamp_header=str(ts), signature_header=sig,
+                signing_secret=self.secret, now=self.now,
+            )
+        )
+
+    def test_missing_fields_rejected(self):
+        self.assertFalse(
+            signing.verify_signature(
+                body=self.body, timestamp_header="", signature_header="x",
+                signing_secret=self.secret, now=self.now,
+            )
+        )
+        self.assertFalse(
+            signing.verify_signature(
+                body=self.body, timestamp_header=str(self.now), signature_header="x",
+                signing_secret="", now=self.now,
+            )
+        )
+
+    def test_non_numeric_timestamp_rejected(self):
+        self.assertFalse(
+            signing.verify_signature(
+                body=self.body, timestamp_header="not-a-number",
+                signature_header="x", signing_secret=self.secret, now=self.now,
+            )
+        )
+
+    def test_default_now_uses_wall_clock(self):
+        ts = int(time.time())
+        sig = _sign(self.secret, ts, self.body)
+        self.assertTrue(
+            signing.verify_signature(
+                body=self.body, timestamp_header=str(ts), signature_header=sig,
+                signing_secret=self.secret,
+            )
+        )
+
+
+class MentionGatingTest(unittest.TestCase):
+    def test_defaults_match_hermes_wake_words(self):
+        pats = signing.compile_mention_patterns(None)
+        self.assertTrue(signing.message_matches_mention("hey hermes, what's up", pats))
+        self.assertTrue(signing.message_matches_mention("@hermes agent ping", pats))
+        self.assertFalse(signing.message_matches_mention("just chatting", pats))
+
+    def test_clean_strips_leading_wake_word_only(self):
+        pats = signing.compile_mention_patterns(None)
+        self.assertEqual(signing.clean_mention_text("hermes do the thing", pats), "do the thing")
+        # A later occurrence is left intact.
+        self.assertEqual(
+            signing.clean_mention_text("tell hermes hello", pats), "tell hermes hello"
+        )
+
+    def test_custom_patterns_from_json_string(self):
+        pats = signing.compile_mention_patterns('["@?amos\\\\b"]')
+        self.assertTrue(signing.message_matches_mention("amos ping", pats))
+        self.assertFalse(signing.message_matches_mention("hermes ping", pats))
+
+    def test_custom_patterns_from_csv_string(self):
+        pats = signing.compile_mention_patterns("bot, assistant")
+        self.assertTrue(signing.message_matches_mention("assistant help", pats))
+
+    def test_invalid_regex_skipped(self):
+        pats = signing.compile_mention_patterns(["(", "valid"])
+        # The bad pattern is skipped; the good one still compiles.
+        self.assertEqual(len(pats), 1)
+
+
+class ParsingTest(unittest.TestCase):
+    def test_extract_text_joins_text_parts(self):
+        parts = [
+            {"type": "text", "value": "hello"},
+            {"type": "media", "url": "https://x/y.jpg"},
+            {"type": "text", "value": "world"},
+        ]
+        self.assertEqual(signing.extract_text(parts), "hello\nworld")
+
+    def test_extract_media_returns_urls_and_mime(self):
+        parts = [
+            {"type": "media", "url": "https://x/y.jpg", "mime_type": "image/jpeg"},
+            {"type": "media", "filename": "no-url.pdf"},  # dropped: no url
+            {"type": "text", "value": "hi"},
+        ]
+        media = signing.extract_media(parts)
+        self.assertEqual(len(media), 1)
+        self.assertEqual(media[0]["url"], "https://x/y.jpg")
+        self.assertEqual(media[0]["mime_type"], "image/jpeg")
+
+    def test_is_group_chat_heuristics(self):
+        self.assertTrue(signing.is_group_chat({"is_group": True}))
+        self.assertTrue(signing.is_group_chat({"group_id": "g1"}))
+        self.assertTrue(signing.is_group_chat({"participants": ["a", "b", "c"]}))
+        self.assertTrue(signing.is_group_chat({"chat_type": "group"}))
+        self.assertFalse(signing.is_group_chat({"from": "+15551112222"}))
+        self.assertFalse(signing.is_group_chat({"participants": ["a", "b"]}))
+
+    def test_coerce_helpers(self):
+        self.assertEqual(signing.coerce_port("8790", 1), 8790)
+        self.assertEqual(signing.coerce_port(None, 8790), 8790)
+        self.assertEqual(signing.coerce_port("nope", 8790), 8790)
+        self.assertTrue(signing.coerce_bool("yes"))
+        self.assertTrue(signing.coerce_bool(True))
+        self.assertFalse(signing.coerce_bool("off"))
+        self.assertTrue(signing.coerce_bool(None, default=True))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -6,7 +6,7 @@ description: "Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, 
 
 # Messaging Gateway
 
-Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Feishu/Lark, WeCom, Weixin, BlueBubbles (iMessage), QQ, Yuanbao, Microsoft Teams, LINE, ntfy, or your browser. The gateway is a single background process that connects to all your configured platforms, handles sessions, runs cron jobs, and delivers voice messages.
+Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Feishu/Lark, WeCom, Weixin, BlueBubbles (iMessage), Linq (iMessage), QQ, Yuanbao, Microsoft Teams, LINE, ntfy, or your browser. The gateway is a single background process that connects to all your configured platforms, handles sessions, runs cron jobs, and delivers voice messages.
 
 For the full voice feature set — including CLI microphone mode, spoken replies in messaging, and Discord voice-channel conversations — see [Voice Mode](/user-guide/features/voice-mode) and [Use Voice Mode with Hermes](/guides/use-voice-mode-with-hermes).
 
@@ -35,6 +35,7 @@ Bots need both a model provider and tool providers (TTS, web). A [Nous Portal](/
 | WeCom Callback | — | — | — | — | — | — | — |
 | Weixin | ✅ | ✅ | ✅ | — | — | ✅ | ✅ |
 | BlueBubbles | — | ✅ | ✅ | — | ✅ | ✅ | — |
+| Linq (iMessage) | — | ✅ | ✅ | — | ✅ | ✅ | — |
 | QQ | ✅ | ✅ | ✅ | — | — | ✅ | — |
 | Yuanbao | ✅ | ✅ | ✅ | — | — | ✅ | ✅ |
 | Microsoft Teams | — | ✅ | — | ✅ | — | ✅ | — |
@@ -67,6 +68,7 @@ flowchart TB
     wcb[WeCom Callback]
     wx[Weixin]
     bb[BlueBubbles]
+    lq[Linq iMessage]
     qq[QQ]
     yb[Yuanbao]
     ms[Microsoft Teams]
@@ -96,6 +98,7 @@ flowchart TB
     wcb --> store
     wx --> store
     bb --> store
+    lq --> store
     qq --> store
     yb --> store
     ms --> store
@@ -636,6 +639,7 @@ Defaults to `false`. Only platforms whose adapter implements `delete_message` ho
 - [WeCom Callback Setup](wecom-callback.md)
 - [Weixin Setup (WeChat)](weixin.md)
 - [BlueBubbles Setup (iMessage)](bluebubbles.md)
+- [Linq Setup (iMessage)](linq.md)
 - [QQBot Setup](qqbot.md)
 - [Yuanbao Setup](yuanbao.md)
 - [Microsoft Teams Setup](teams.md)

--- a/website/docs/user-guide/messaging/linq.md
+++ b/website/docs/user-guide/messaging/linq.md
@@ -48,18 +48,17 @@ Outbound:  agent → Linq REST API (httpx) → iMessage
 
 ## Installation
 
-Linq ships as a standalone plugin (the adapter is published separately
-from the Hermes core), so install it once before configuring the
-channel:
+Linq is a **bundled platform plugin** — it ships in-tree with Hermes under
+`plugins/platforms/linq/`, so there is nothing to install. The gateway
+discovers it automatically; you only need to configure it (below).
+
+Its one optional dependency is `aiohttp`, used by the inbound webhook
+listener. It ships with the `hermes-agent[messaging]` extra rather than the
+core install; if `hermes linq status` reports it missing, run:
 
 ```bash
-pip install hermes-linq-plugin
-hermes plugins enable linq-platform
+pip install aiohttp
 ```
-
-Or drop the plugin directory into `~/.hermes/plugins/linq/` and run the
-same `enable`. Source and issues:
-[github.com/linq-team/hermes-linq-plugin][repo].
 
 ## First-time setup
 
@@ -251,4 +250,3 @@ Common issues:
 | `LINQ_MENTION_PATTERNS`   | Hermes wake words                          | JSON list / comma / newline regex patterns for group mentions|
 
 [linq]: https://linqapp.com/
-[repo]: https://github.com/linq-team/hermes-linq-plugin

--- a/website/docs/user-guide/messaging/linq.md
+++ b/website/docs/user-guide/messaging/linq.md
@@ -1,0 +1,254 @@
+---
+sidebar_position: 18
+---
+
+# Linq iMessage
+
+Connect Hermes to **iMessage** through [Linq][linq], a hosted iMessage
+API. Linq runs the Apple line and abuse-prevention layer for you, so
+there's no Mac relay and no BlueBubbles server to maintain — and unlike
+a relay, the channel is fully Apple-native: real **tapback reactions**,
+**typing indicators**, **read receipts**, and blue bubbles.
+
+:::info No Mac required
+Linq hosts the iMessage line. You provide a partner API token and a
+public URL the gateway can receive webhooks on — there is no local
+Apple device or `imessage` daemon in the loop.
+:::
+
+## Architecture
+
+Linq is a **webhook + REST** channel, like the BlueBubbles iMessage
+channel — **not** a persistent gRPC stream like Photon. There is **no
+Node sidecar**; the adapter is pure Python.
+
+- **Inbound** — Linq delivers each iMessage to your gateway as an
+  HMAC-SHA256-signed webhook (`message.received`). The adapter runs a
+  small **aiohttp** listener (default `:8790/linq/webhook`), verifies the
+  signature, dedupes on `message.id`, and dispatches a `MessageEvent` to
+  the agent. Because inbound is a webhook, the listener needs a **public
+  URL** (a tunnel or reverse proxy) registered in your Linq dashboard.
+- **Outbound** — replies go **directly** to the Linq REST API
+  (`https://api.linqapp.com/api/partner/v3`) over `httpx` — send, typing,
+  read receipts, and reactions. No sidecar, no SDK.
+
+```
+Inbound:   iMessage → Linq → signed webhook → aiohttp listener → MessageEvent → agent
+Outbound:  agent → Linq REST API (httpx) → iMessage
+```
+
+## Prerequisites
+
+- A **Linq partner account** with an API token — see [linqapp.com][linq]
+- A **public URL** for the inbound webhook (e.g. a reverse proxy or a
+  tunnel like `cloudflared` / `ngrok` pointed at the listener)
+- **`aiohttp`** on the Python path. It ships with the
+  `hermes-agent[messaging]` extra but is *not* in the core install; if
+  `hermes linq status` reports it missing, run `pip install aiohttp`.
+
+## Installation
+
+Linq ships as a standalone plugin (the adapter is published separately
+from the Hermes core), so install it once before configuring the
+channel:
+
+```bash
+pip install hermes-linq-plugin
+hermes plugins enable linq-platform
+```
+
+Or drop the plugin directory into `~/.hermes/plugins/linq/` and run the
+same `enable`. Source and issues:
+[github.com/linq-team/hermes-linq-plugin][repo].
+
+## First-time setup
+
+Either run the unified gateway wizard and pick **Linq iMessage**:
+
+```bash
+hermes gateway setup
+```
+
+…or run the Linq setup directly (the wizard calls the same flow):
+
+```bash
+hermes linq setup
+```
+
+Setup asks for:
+
+1. **Linq API token** — from your [Linq][linq] dashboard (or set
+   `LINQ_API_TOKEN` in your environment instead).
+2. **From-phone** (optional) — the Linq line this agent sends from, in
+   E.164 (`+15551234567`). Only needed to pin a multi-number account to
+   one line so the adapter ignores traffic to your other numbers.
+
+The token is written to `~/.hermes/auth.json` under
+`credential_pool.linq` — the same place every other channel keeps its
+credentials. `LINQ_API_TOKEN` / `LINQ_FROM_PHONE` in the environment
+take precedence over the stored values.
+
+### Register the inbound webhook
+
+Linq delivers inbound iMessages as webhooks, so it needs a public URL.
+Print the URL to register, then add it in your Linq dashboard:
+
+```bash
+hermes linq webhook show --public-url https://your-public-host
+# → register  https://your-public-host/linq/webhook  in the Linq dashboard
+```
+
+Then export the signing secret the dashboard gives you so deliveries
+are verified (the listener accepts unsigned deliveries with a warning if
+this is unset, which is fine only for local testing):
+
+```bash
+export LINQ_WEBHOOK_SECRET=<secret-from-linq-dashboard>
+```
+
+Signatures are verified as
+`hex(hmac_sha256(secret, "{timestamp}.{body}"))` against the
+`X-Webhook-Timestamp` / `X-Webhook-Signature` headers, with a 5-minute
+timestamp-drift window for replay protection.
+
+## Authorizing users
+
+Linq uses the same authorization model as every other Hermes channel.
+Choose one approach:
+
+**DM pairing (default).** When an unknown number messages your Linq
+line, Hermes replies with a pairing code. Approve it with:
+
+```bash
+hermes pairing approve linq <CODE>
+```
+
+Use `hermes pairing list` to see pending codes and approved users.
+
+**Pre-authorize specific numbers** (in `~/.hermes/.env`):
+
+```bash
+LINQ_ALLOWED_USERS=+15551234567,+15559876543
+```
+
+**Open access** (dev only, in `~/.hermes/.env`):
+
+```bash
+LINQ_ALLOW_ALL_USERS=true
+```
+
+When `LINQ_ALLOWED_USERS` is set, unknown senders are silently ignored
+rather than offered a pairing code (the allowlist signals you
+deliberately restricted access).
+
+### Require mentions in group chats
+
+By default Hermes responds to every authorized DM and group message.
+To make group chats opt-in, enable mention gating (DMs still always
+work):
+
+```yaml
+gateway:
+  platforms:
+    linq:
+      enabled: true
+      require_mention: true
+```
+
+With `require_mention: true`, group-chat messages are ignored unless
+they match a wake-word pattern, and the leading wake word is stripped
+from the ones that do. The defaults match `Hermes` and `@Hermes agent`
+variants. For a custom agent name, set regex patterns:
+
+```yaml
+gateway:
+  platforms:
+    linq:
+      require_mention: true
+      mention_patterns:
+        - '(?<![\w@])@?amos\b[,:\-]?'
+```
+
+Both keys also accept env vars (`LINQ_REQUIRE_MENTION`,
+`LINQ_MENTION_PATTERNS`). This is the same mention-gating model the
+Photon and BlueBubbles iMessage channels use.
+
+## Start the gateway
+
+```bash
+hermes gateway start
+```
+
+You'll see something like:
+
+```
+[linq] connected — webhook at 0.0.0.0:8790/linq/webhook (outbound via https://api.linqapp.com/api/partner/v3)
+```
+
+Send an iMessage to your Linq line and Hermes will reply.
+
+## Status & troubleshooting
+
+```bash
+hermes linq status
+```
+
+Prints saved credentials, the auth-file location, and a live
+connectivity probe against the Linq API:
+
+```
+Linq iMessage credentials:
+  api token           : ✓ stored
+  from phone          : +15551234567
+  auth file           : /Users/you/.hermes/auth.json
+  connectivity        : ✓ reachable
+```
+
+Common issues:
+
+- **`api token : ✗ missing`** — run `hermes linq setup` (or set
+  `LINQ_API_TOKEN`).
+- **`aiohttp not installed`** — the webhook listener dependency is
+  optional in Hermes core. Run `pip install aiohttp`.
+- **`webhook port 8790 unavailable`** — another process holds the port.
+  Set `LINQ_WEBHOOK_PORT` to a free port and update your tunnel.
+- **No inbound messages** — confirm the public URL in your Linq
+  dashboard points at `…/linq/webhook` and that `LINQ_WEBHOOK_SECRET`
+  matches the dashboard secret (a mismatch returns `401` and the
+  delivery is dropped). `hermes linq webhook show` prints the expected
+  URL.
+
+## Limits today
+
+- **Inbound images** are downloaded locally so the vision tools can read
+  them. Non-image attachments are noted inline (the agent learns
+  something was sent and where), not yet read byte-for-byte.
+- **Outbound media is by public URL.** Linq sends media by URL rather
+  than multipart upload, so the agent attaches a publicly reachable
+  image URL; local-file sends on the cron / standalone path are skipped
+  with a logged note.
+- **Reactions, typing, and read receipts** are first-class. Inbound
+  tapbacks arrive as `reaction.received` events; outbound typing and
+  read receipts are sent on inbound (toggle with
+  `LINQ_SEND_READ_RECEIPTS`).
+
+## Env vars
+
+| Variable                  | Default                                    | Notes                                                        |
+|---------------------------|--------------------------------------------|--------------------------------------------------------------|
+| `LINQ_API_TOKEN`          | from `auth.json`                           | **Required.** Linq partner API bearer token; set by setup    |
+| `LINQ_FROM_PHONE`         | (unset)                                    | Pin a multi-number account to one Linq line (E.164)          |
+| `LINQ_WEBHOOK_SECRET`     | (unset)                                    | HMAC-SHA256 secret for inbound signature verification        |
+| `LINQ_WEBHOOK_PORT`       | `8790`                                     | Local webhook listener port                                  |
+| `LINQ_WEBHOOK_PATH`       | `/linq/webhook`                            | Local webhook listener path                                  |
+| `LINQ_WEBHOOK_BIND`       | `0.0.0.0`                                  | Webhook listener bind address                                |
+| `LINQ_API_BASE`           | `https://api.linqapp.com/api/partner/v3`   | Linq REST API base URL                                       |
+| `LINQ_SEND_READ_RECEIPTS` | `true`                                     | Send read receipts + typing indicator on inbound             |
+| `LINQ_HOME_CHANNEL`       | (unset)                                    | Default chat id for cron / notification delivery             |
+| `LINQ_ALLOWED_USERS`      | (unset)                                    | Comma-separated E.164 allowlist                              |
+| `LINQ_ALLOW_ALL_USERS`    | `false`                                    | Dev only — accept any sender                                 |
+| `LINQ_REQUIRE_MENTION`    | `false`                                    | Require a wake word before responding in groups              |
+| `LINQ_MENTION_PATTERNS`   | Hermes wake words                          | JSON list / comma / newline regex patterns for group mentions|
+
+[linq]: https://linqapp.com/
+[repo]: https://github.com/linq-team/hermes-linq-plugin


### PR DESCRIPTION
## What does this PR do?

Adds **Linq** as a bundled iMessage platform plugin, in-tree under
`plugins/platforms/linq/` alongside the existing Photon plugin. Linq reaches
iMessage through the hosted [Linq](https://linqapp.com) partner API — real
tapback reactions, typing indicators, and read receipts — with **no Mac
relay, no BlueBubbles server, and no Node sidecar**. Inbound is an
HMAC‑signed webhook on a small aiohttp listener; outbound is direct `httpx`
calls to the Linq REST API.

It registers through the standard plugin path (`register(ctx)` +
`plugin.yaml`), so it needs **zero changes to core Hermes code**:
`Platform("linq")` resolves via the bundled‑plugin scan, and the entry wires
the full hook set (env enablement, cron home‑channel + standalone sender,
allow‑list envs, PII‑safe redaction, platform hint) exactly like the Photon
plugin.

> **Update:** this PR started as the docs page for Linq and has been expanded
> into the full contribution — it now vendors the plugin itself, plus tests.
> Happy to instead keep Linq external and pip‑installable if you'd prefer it
> not be bundled, but vendoring in‑tree matches how Photon and the other
> iMessage channels ship, so it seemed the natural home.

## Related Issue

N/A — new channel contribution.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/platforms/linq/` — `adapter.py` (`LinqAdapter` + webhook server +
  `register(ctx)`), `cli.py` (`hermes linq {setup,status,probe,webhook}`),
  `auth.py` (credential storage in `~/.hermes/auth.json`), `linq_api.py`
  (async Linq REST client), `signing.py` (webhook HMAC verify + mention
  gating + payload parsing — imports nothing from Hermes), `plugin.yaml`,
  `README.md`.
- `tests/plugins/platforms/linq/` — 22 unit tests: signature verification,
  mention gating, payload/media parsing, and credential storage + precedence.
- `website/docs/user-guide/messaging/linq.md` — full channel setup guide
  (modeled on `photon.md`).
- `website/docs/user-guide/messaging/index.md` — Linq added to the platform
  comparison table, the architecture diagram, and the setup links.

## How to Test

```bash
# 1. New plugin's tests
python -m pytest tests/plugins/platforms/linq/ -q          # 22 passed

# 2. Enum resolves via the bundled-plugin scan (no enum edit needed)
python -c "from gateway.config import Platform; print(Platform('linq'))"
#  -> Platform.LINQ

# 3. The real gateway loader registers it with its hooks
python -c "from hermes_cli.plugins import discover_plugins as d; d(); \
from gateway.platform_registry import platform_registry as r; \
print('linq registered:', r.is_registered('linq'))"
#  -> linq registered: True   (source=plugin, plugin_name=linq-platform)

# 4. Photon's suite is unaffected by the addition
python -m pytest tests/plugins/platforms/photon/ -q        # 102 passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(platforms): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] Ran the affected suites — `tests/plugins/platforms/linq/` (22 pass) and `tests/plugins/platforms/photon/` (102 pass, unaffected). The change is additive and isolated to the new plugin directory; I did not run the full `tests/` suite locally.
- [x] I've added tests for my changes (22 unit tests)
- [x] I've tested on my platform: macOS (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (new `linq.md` + messaging index)
- [x] `cli-config.yaml.example` — N/A (config is env / `plugin.yaml`-driven, same as other plugin platforms)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (uses the existing plugin architecture; no workflow changes)
- [x] Cross-platform: pure Python, no OS-specific calls (httpx + optional aiohttp only)

## Known follow-ups (flagged honestly)

Two behaviors are implemented against Linq's documented webhook shape but not
yet confirmed against a live Linq account; both are called out in the
plugin's README and are easy to tighten if you'd like them nailed down first:

- **Group vs. DM detection** — `signing.is_group_chat()` infers group chats
  from `is_group` / `group_id` / `participants` since the payload has no
  first-class chat-type field.
- **Outbound media** — sent by public URL (Linq's documented mechanism)
  rather than multipart upload; the standalone/cron path skips local files
  with a logged note.
