### PR TITLE
fix(discord): inherit VoiceMixer from discord.AudioSource for voice_fx playback

### DIFF
--- a/plugins/platforms/discord/voice_mixer.py
+++ b/plugins/platforms/discord/voice_mixer.py
@@ -46,6 +46,8 @@ import logging
 import threading
 from typing import TYPE_CHECKING, List, Optional
 
+import discord
+
 if TYPE_CHECKING:  # numpy is an optional ("voice" extra) dep — never import at runtime top-level
     import numpy as np
 
@@ -145,7 +147,7 @@ class MixerChild:
         return samples
 
 
-class VoiceMixer:
+class VoiceMixer(discord.AudioSource):
     """A continuous ``discord.AudioSource`` that mixes N child streams.
 
     Use :meth:`set_ambient` to install/replace the looping idle bed and

--- a/tests/gateway/conftest.py
+++ b/tests/gateway/conftest.py
@@ -110,6 +110,11 @@ def _ensure_discord_mock() -> None:
     discord_mod.ForumChannel = type("ForumChannel", (), {})
     discord_mod.Interaction = object
     discord_mod.Message = type("Message", (), {})
+    discord_mod.AudioSource = type("AudioSource", (), {
+        "read": lambda self: b"",
+        "is_opus": lambda self: False,
+        "cleanup": lambda self: None,
+    })
 
     # Embed: accept the kwargs production code / tests use
     # (title, description, color). MagicMock auto-attributes work too,

--- a/tests/gateway/test_discord_voice_mixer.py
+++ b/tests/gateway/test_discord_voice_mixer.py
@@ -51,6 +51,11 @@ class TestVoiceMixerCore:
         # discord.py sends raw PCM when is_opus() is False.
         assert vm.VoiceMixer().is_opus() is False
 
+    def test_isinstance_audio_source(self):
+        # VoiceMixer must pass discord.py's isinstance guard in VoiceClient.play().
+        import discord
+        assert isinstance(vm.VoiceMixer(), discord.AudioSource)
+
     def test_ambient_loops_and_is_quiet(self):
         mx = vm.VoiceMixer(ambient_gain=0.2)
         amb = vm.synth_ambient_pcm(seconds=0.5)


### PR DESCRIPTION
## What does this PR do?

Fixes `VoiceMixer` not inheriting from `discord.AudioSource`, which causes discord.py's `isinstance(source, AudioSource)` guard in `VoiceClient.play()` to reject the mixer — breaking the entire `voice_fx` system (ambient pad, audio ducking, verbal acknowledgements).

## Related Issue

Fixes #50899

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/discord/voice_mixer.py`: Added `import discord` and changed `class VoiceMixer:` to `class VoiceMixer(discord.AudioSource):` so the class passes discord.py's `isinstance` check in `VoiceClient.play()`. The class already implements all three abstract methods (`is_opus`, `read`, `cleanup`).
- `tests/gateway/conftest.py`: Added `AudioSource` as a real class (not MagicMock) in the discord mock so tests that subclass or isinstance-check against it work correctly.
- `tests/gateway/test_discord_voice_mixer.py`: Added `test_isinstance_audio_source` to verify `VoiceMixer` is a proper `discord.AudioSource` subclass.

## How to Test

1. Run the voice mixer test suite:
   ```bash
   python -m pytest tests/gateway/test_discord_voice_mixer.py -v
   ```
2. All 20 tests should pass, including the new `test_isinstance_audio_source`.
3. The key assertion is `isinstance(VoiceMixer(), discord.AudioSource)` returns `True` — this is what discord.py checks internally before starting playback.
4. **Platform note**: Full voice_fx end-to-end testing requires a Discord bot with voice channel permissions and the `voice` extra installed. The targeted isinstance regression above exercises the exact code path that was broken (the `isinstance` guard in `VoiceClient.play()`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_discord_voice_mixer.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

⚠️ GitNexus stale (indexed 6/21, current 6/22) — grep-based fallback used.
- Checked files: `plugins/platforms/discord/voice_mixer.py` (callers: adapter.py voice join path, play_in_voice_channel, play_ack_in_voice)
- Blast radius: LOW — change is additive inheritance only; no method signatures or behavior changed
- Related patterns: `discord.AudioSource` subclass pattern used by discord.py's `PCMVolumeTransformer` and `FFmpegPCMAudio`
