### PR TITLE
t_cd7ce752: wire Kanban model override creation paths

### DIFF
--- a/.factory/tasks/t_0486b4fe/activity.yaml
+++ b/.factory/tasks/t_0486b4fe/activity.yaml
@@ -1,0 +1,49 @@
+schema: hermes-factory-activity/v1
+task:
+  id: t_0486b4fe
+  title: Bootstrap Hermes Agent baseline smoke script for factory platform work
+  board: default
+agent:
+  profile: dev-backend-2
+  role: backend
+  model: gpt-5.5
+timeline:
+  started_at: '2026-06-22T13:30:00Z'
+  completed_at: '2026-06-22T13:51:41Z'
+summary:
+  - Added a root smoke.sh baseline entrypoint for Hermes Agent factory work.
+  - Added a pytest regression covering credential-free execution of bash smoke.sh.
+rationale:
+  - decision: Make smoke.sh self-contained and conservative instead of requiring init.sh or networked services.
+    why: Origin main lacks the factory init/smoke spine, and the prerequisite for blocked platform work is a fast baseline that clean worktrees can run before code changes.
+    rejected_alternative: Start the dashboard server and browse core routes from smoke.sh.
+    why_rejected: That path depends on additional factory init artifacts and optional browser tooling, making it too heavy for the minimal prerequisite gate.
+files_touched:
+  - path: smoke.sh
+    change: added conservative repository/tooling smoke entrypoint
+  - path: tests/test_smoke_entrypoint.py
+    change: added regression that runs bash smoke.sh with a minimal credential-free environment
+  - path: .factory/tasks/t_0486b4fe/activity.yaml
+    change: recorded task activity and verification evidence
+verification:
+  - command: bash smoke.sh
+    exit_code: 0
+    output_summary: pyproject validated as hermes-agent; default config validated; temp state.db PRAGMA quick_check returned ok; smoke passed.
+  - command: PYTHONPATH=. /Users/sanbox-user/.hermes/hermes-agent/.venv/bin/python -m pytest tests/test_smoke_entrypoint.py -q
+    exit_code: 0
+    output_summary: 1 passed in 0.43s.
+  - command: scripts/run_tests.sh tests/test_smoke_entrypoint.py -- -q
+    exit_code: 1
+    output_summary: Existing runner picked /Users/sanbox-user/.hermes/hermes-agent/venv/bin/python, which has no pytest installed; direct pytest was used with the repo dev venv instead.
+acceptance_criteria:
+  - criterion: A clean worktree can run bash smoke.sh successfully.
+    status: met
+    evidence: bash smoke.sh exited 0 from the task worktree.
+  - criterion: No credential access is attempted.
+    status: met
+    evidence: smoke.sh invokes Python under env -i with only PATH, HOME, TMPDIR, HERMES_HOME, PYTHONPATH, and PYTHONDONTWRITEBYTECODE.
+  - criterion: t_f5242992 remains blocked until independently validated.
+    status: met
+    evidence: This task only changed the Hermes Agent worktree and did not unblock or modify t_f5242992.
+prior_attempts: []
+follow_ups: []

--- a/.factory/tasks/t_cd7ce752/activity.yaml
+++ b/.factory/tasks/t_cd7ce752/activity.yaml
@@ -1,0 +1,83 @@
+schema: factory.task-activity.v1
+task:
+  id: t_cd7ce752
+  title: "Recovery lane A: wire Kanban model_override creation paths"
+  tenant: software-factory
+agent:
+  profile: dev-backend-2
+  branch: factory/t_cd7ce752-wire-kanban-model-override
+  workspace: /Users/sanbox-user/.hermes/worktrees/t_cd7ce752-wire-kanban-model-override
+timeline:
+  started_at: "2026-06-22T15:42:23Z"
+  completed_at: "2026-06-22T16:13:23Z"
+summary: >-
+  Wired per-task model overrides through Kanban creation plumbing: kb.create_task
+  now persists tasks.model_override, hermes kanban create exposes --model and JSON
+  output includes model_override, and model-facing kanban_create accepts a model object.
+rationale:
+  - decision: "Use the existing tasks.model_override TEXT column as the single persisted value."
+    why: "Dispatcher/run behavior already consumes task.model_override by appending -m <model> to the worker command, so creation paths only needed to populate the existing field."
+    rejected_alternative: "Add a new provider/model JSON column."
+    why_rejected: "The dispatcher currently accepts one CLI -m value; adding a second storage shape would duplicate state and exceed the code-plumbing scope."
+  - decision: "Expose CLI creation as --model and model-tool creation as a cron-style model object."
+    why: "CLI users need a compact string flag, while model-facing tool calls already represent model overrides as {provider, model} objects."
+    rejected_alternative: "Expose only a raw model_override string in the tool schema."
+    why_rejected: "That would be less consistent with existing model-facing tool conventions."
+files_touched:
+  - path: hermes_cli/kanban_db.py
+    reason: "Added create_task(model_override=...) normalization, persistence, and created-event audit payload."
+  - path: hermes_cli/kanban.py
+    reason: "Added hermes kanban create --model and surfaced model_override in JSON task output."
+  - path: tools/kanban_tools.py
+    reason: "Added kanban_create model object schema and handler propagation to kb.create_task."
+  - path: tests/hermes_cli/test_kanban_core_functionality.py
+    reason: "Added RED/GREEN coverage for create_task persistence/backcompat and CLI creation JSON."
+  - path: tests/tools/test_kanban_tools.py
+    reason: "Added RED/GREEN coverage for model-facing kanban_create schema and persistence."
+verification:
+  - command: "bash smoke.sh"
+    result: "pass before changes: ok: pyproject -> hermes-agent; ok: default config validates; ok: state.db quick_check -> ok; ok: smoke passed"
+  - command: "PYTHONPATH=. pytest tests/hermes_cli/test_kanban_core_functionality.py::test_create_task_persists_model_override tests/hermes_cli/test_kanban_core_functionality.py::test_create_task_defaults_model_override_to_none tests/hermes_cli/test_kanban_core_functionality.py::test_cli_create_model_override_json tests/tools/test_kanban_tools.py::test_create_model_object_persists_model_override tests/tools/test_kanban_tools.py::test_create_model_schema_exposes_model_override -q"
+    result: "RED observed: 4 failed, 1 passed before implementation (create_task unexpected keyword, CLI --model unrecognized, tool schema/handler missing; two tool imports also hit missing yaml in non-venv runner)."
+  - command: "/Users/sanbox-user/.hermes/hermes-agent/.venv/bin/python -m pytest tests/hermes_cli/test_kanban_core_functionality.py::test_create_task_persists_model_override tests/hermes_cli/test_kanban_core_functionality.py::test_create_task_defaults_model_override_to_none tests/hermes_cli/test_kanban_core_functionality.py::test_cli_create_model_override_json tests/tools/test_kanban_tools.py::test_create_model_object_persists_model_override tests/tools/test_kanban_tools.py::test_create_model_schema_exposes_model_override -q"
+    result: "pass: 5 passed in 1.35s"
+  - command: "/Users/sanbox-user/.hermes/hermes-agent/.venv/bin/python -m pytest tests/hermes_cli/test_kanban_core_functionality.py tests/tools/test_kanban_tools.py -q"
+    result: "pass: 261 passed, 1 skipped, 3 warnings in 61.71s"
+  - command: "/Users/sanbox-user/.hermes/hermes-agent/.venv/bin/python -m pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py tests/tools/test_kanban_tools.py -q"
+    result: "pass: 484 passed, 1 skipped, 3 warnings in 110.71s"
+  - command: "/Users/sanbox-user/.hermes/hermes-agent/.venv/bin/python -m pytest -q"
+    result: "failed during collection because optional acp dependency is absent: 9 errors importing acp modules."
+  - command: "/Users/sanbox-user/.hermes/hermes-agent/.venv/bin/python -m pytest -q --ignore=tests/acp --ignore=tests/acp_adapter"
+    result: "failed: 119 failed, 5995 passed, 57 skipped, 59 deselected, 19 warnings, 134 errors; broad suite has unrelated failures/logging resource issues outside this task scope."
+  - command: "bash smoke.sh"
+    result: "pass after changes: ok: pyproject -> hermes-agent; ok: default config validates; ok: state.db quick_check -> ok; ok: smoke passed"
+  - command: "/Users/sanbox-user/.hermes/hermes-agent/.venv/bin/python -m pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py tests/tools/test_kanban_tools.py -q"
+    result: "pass: 484 passed, 1 skipped, 3 warnings in 112.26s"
+  - command: "bash smoke.sh"
+    result: "pass re-run before handoff: ok: pyproject -> hermes-agent; ok: default config validates; ok: state.db quick_check -> ok; ok: smoke passed"
+  - command: "git diff --check"
+    result: "pass: no whitespace errors"
+acceptance_criteria:
+  - criterion: "Make per-task model overrides usable through kanban_db.create_task."
+    status: met
+    evidence: "tests/hermes_cli/test_kanban_core_functionality.py::test_create_task_persists_model_override"
+  - criterion: "Make per-task model overrides usable through model-facing kanban_create."
+    status: met
+    evidence: "tests/tools/test_kanban_tools.py::test_create_model_object_persists_model_override and schema test"
+  - criterion: "Make per-task model overrides usable through hermes kanban create/equivalent."
+    status: met
+    evidence: "tests/hermes_cli/test_kanban_core_functionality.py::test_cli_create_model_override_json"
+  - criterion: "Preserve backward compatibility when model_override is unset."
+    status: met
+    evidence: "test_create_task_defaults_model_override_to_none and existing Kanban suites pass"
+  - criterion: "Dispatcher/run behavior still consumes tasks.model_override and audit surfaces retain/expose value where practical."
+    status: met
+    evidence: "Existing dispatcher code still appends -m task.model_override; created events now include model_override and CLI JSON includes model_override."
+  - criterion: "Run baseline smoke plus targeted tests."
+    status: met
+    evidence: "baseline smoke passed before and after; targeted Kanban tests passed."
+follow_ups: []
+git:
+  base_commit: 3cfe4d47cf1047fb63cd785abefd218968997ab5
+  branch: factory/t_cd7ce752-wire-kanban-model-override
+  commit: null

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -75,6 +75,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "completed_at": t.completed_at,
         "result": t.result,
         "skills": list(t.skills) if t.skills else [],
+        "model_override": t.model_override,
         "max_retries": t.max_retries,
         "session_id": t.session_id,
         "workflow_template_id": t.workflow_template_id,
@@ -342,6 +343,10 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                                "two retries. Omit to use the dispatcher's "
                                "kanban.failure_limit config "
                                f"(default {kb.DEFAULT_FAILURE_LIMIT}).")
+    p_create.add_argument("--model", default=None, dest="model_override",
+                          help="Per-task model override passed to the worker "
+                               "as `hermes -m <model>`. Omit to use the "
+                               "assignee profile's default model.")
     p_create.add_argument("--goal", action="store_true", dest="goal_mode",
                           help="Run the worker in a goal loop: after each "
                                "turn a judge checks the response against the "
@@ -1328,6 +1333,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             max_runtime_seconds=max_runtime,
             skills=getattr(args, "skills", None) or None,
             max_retries=max_retries,
+            model_override=getattr(args, "model_override", None),
             goal_mode=bool(getattr(args, "goal_mode", False)),
             goal_max_turns=getattr(args, "goal_max_turns", None),
             initial_status=getattr(args, "initial_status", "running"),

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2257,6 +2257,7 @@ def create_task(
     max_runtime_seconds: Optional[int] = None,
     skills: Optional[Iterable[str]] = None,
     max_retries: Optional[int] = None,
+    model_override: Optional[str] = None,
     goal_mode: bool = False,
     goal_max_turns: Optional[int] = None,
     initial_status: str = "running",
@@ -2302,6 +2303,8 @@ def create_task(
         branch_name = str(branch_name).strip() or None
     if branch_name and workspace_kind != "worktree":
         raise ValueError("branch_name is only valid for worktree workspaces")
+    if model_override is not None:
+        model_override = str(model_override).strip() or None
     parents = tuple(p for p in parents if p)
 
     # Normalise + validate skills: strip whitespace, drop empties, dedupe
@@ -2425,8 +2428,9 @@ def create_task(
                         id, title, body, assignee, status, priority,
                         created_by, created_at, workspace_kind, workspace_path,
                         branch_name, tenant, idempotency_key, max_runtime_seconds,
-                        skills, max_retries, goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        skills, max_retries, model_override, goal_mode, goal_max_turns,
+                        session_id
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -2445,6 +2449,7 @@ def create_task(
                         int(max_runtime_seconds) if max_runtime_seconds is not None else None,
                         json.dumps(skills_list) if skills_list is not None else None,
                         int(max_retries) if max_retries is not None else None,
+                        model_override,
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
@@ -2466,6 +2471,7 @@ def create_task(
                         "tenant": tenant,
                         "branch_name": branch_name,
                         "skills": list(skills_list) if skills_list else None,
+                        "model_override": model_override,
                         "goal_mode": bool(goal_mode) or None,
                     },
                 )

--- a/smoke.sh
+++ b/smoke.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT"
+
+python_bin=""
+for candidate in \
+  "$ROOT/.venv/bin/python" \
+  "$ROOT/venv/bin/python" \
+  "$HOME/.hermes/hermes-agent/.venv/bin/python" \
+  "$HOME/.hermes/hermes-agent/venv/bin/python" \
+  "$(command -v python3 || true)"; do
+  if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+    python_bin="$candidate"
+    break
+  fi
+done
+
+if [ -z "$python_bin" ]; then
+  echo "error: no Python interpreter found for smoke checks" >&2
+  exit 1
+fi
+
+runtime_root="${HERMES_FACTORY_RUNTIME_DIR:-}"
+if [ -n "$runtime_root" ]; then
+  mkdir -p "$runtime_root"
+  smoke_home="$(mktemp -d "$runtime_root/hermes-smoke.XXXXXX")"
+else
+  smoke_home="$(mktemp -d "${TMPDIR:-/tmp}/hermes-smoke.XXXXXX")"
+fi
+cleanup() {
+  rm -rf "$smoke_home"
+}
+trap cleanup EXIT
+
+# Run with a deliberately tiny environment so the smoke path cannot depend on
+# user credentials or live profile state. PYTHONPATH points at this checkout so
+# editable installs are not required for the baseline repository checks.
+env -i \
+  PATH="$PATH" \
+  HOME="${HOME:-}" \
+  TMPDIR="${TMPDIR:-/tmp}" \
+  HERMES_HOME="$smoke_home" \
+  PYTHONPATH="$ROOT" \
+  PYTHONDONTWRITEBYTECODE=1 \
+  "$python_bin" - <<'PY'
+from __future__ import annotations
+
+import os
+import tempfile
+import tomllib
+from pathlib import Path
+
+root = Path.cwd()
+pyproject = root / "pyproject.toml"
+if not pyproject.exists():
+    raise SystemExit("pyproject.toml missing from repository root")
+
+project = tomllib.loads(pyproject.read_text(encoding="utf-8"))["project"]
+if project.get("name") != "hermes-agent":
+    raise SystemExit(f"unexpected project name: {project.get('name')!r}")
+print("ok: pyproject -> hermes-agent")
+
+import hermes_constants  # noqa: F401
+from hermes_cli.config import load_config_readonly, validate_config_structure
+from hermes_state import SessionDB
+
+home = Path(os.environ["HERMES_HOME"]).resolve()
+tmp_root = Path(tempfile.gettempdir()).resolve()
+factory_runtime = (root / ".factory" / "runtime").resolve()
+if not (home == tmp_root or tmp_root in home.parents or factory_runtime in home.parents):
+    raise SystemExit(f"refusing to smoke against non-temporary HERMES_HOME: {home}")
+
+config = load_config_readonly()
+issues = validate_config_structure(config)
+if issues:
+    raise SystemExit(f"default config validation failed: {issues!r}")
+print("ok: default config validates")
+
+db = SessionDB()
+row = db._conn.execute("PRAGMA quick_check").fetchone()
+value = row[0] if row else None
+if value != "ok":
+    raise SystemExit(f"state.db quick_check failed: {value!r}")
+print(f"ok: state.db quick_check -> {value}")
+PY
+
+echo "ok: smoke passed"

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -89,6 +89,48 @@ def test_no_idempotency_key_never_collides(kanban_home):
         conn.close()
 
 
+def test_create_task_persists_model_override(kanban_home):
+    """kb.create_task(model_override=...) should persist the worker model pin."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="model-pinned task",
+            model_override="openrouter/anthropic/claude-3.5-sonnet",
+        )
+
+        task = kb.get_task(conn, tid)
+
+        assert task is not None
+        assert task.model_override == "openrouter/anthropic/claude-3.5-sonnet"
+    finally:
+        conn.close()
+
+
+def test_create_task_defaults_model_override_to_none(kanban_home):
+    """Existing callers that omit model_override keep using profile defaults."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="default model task")
+
+        task = kb.get_task(conn, tid)
+
+        assert task is not None
+        assert task.model_override is None
+    finally:
+        conn.close()
+
+
+def test_cli_create_model_override_json(kanban_home):
+    """`hermes kanban create --model ... --json` should persist the override."""
+    out = run_slash(
+        "create 'model task' --assignee worker --model openrouter/qwen/qwen3 --json"
+    )
+    data = json.loads(out)
+
+    assert data["model_override"] == "openrouter/qwen/qwen3"
+
+
 # ---------------------------------------------------------------------------
 # Spawn-failure circuit breaker
 # ---------------------------------------------------------------------------

--- a/tests/test_smoke_entrypoint.py
+++ b/tests/test_smoke_entrypoint.py
@@ -1,0 +1,28 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_root_smoke_script_runs_without_credentials(tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    smoke = repo_root / "smoke.sh"
+
+    env = {
+        "HOME": os.environ.get("HOME", ""),
+        "PATH": os.environ.get("PATH", ""),
+        "HERMES_HOME": str(tmp_path / "hermes-home"),
+        "PYTHONDONTWRITEBYTECODE": "1",
+    }
+
+    result = subprocess.run(
+        ["bash", str(smoke)],
+        cwd=repo_root,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=60,
+    )
+
+    assert result.returncode == 0, result.stdout
+    assert "ok: smoke passed" in result.stdout

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -768,6 +768,38 @@ def test_create_happy_path(worker_env):
         conn.close()
 
 
+def test_create_model_object_persists_model_override(worker_env):
+    """Model-facing kanban_create should accept a cron-style model object."""
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    out = kt._handle_create({
+        "title": "model child",
+        "assignee": "peer",
+        "model": {"provider": "openrouter", "model": "anthropic/claude-3.5-sonnet"},
+    })
+    d = json.loads(out)
+
+    assert d["ok"] is True
+    conn = kb.connect()
+    try:
+        child = kb.get_task(conn, d["task_id"])
+        assert child is not None
+        assert child.model_override == "openrouter/anthropic/claude-3.5-sonnet"
+    finally:
+        conn.close()
+
+
+def test_create_model_schema_exposes_model_override():
+    from tools.kanban_tools import KANBAN_CREATE_SCHEMA
+
+    model_schema = KANBAN_CREATE_SCHEMA["parameters"]["properties"]["model"]
+
+    assert model_schema["type"] == "object"
+    assert "provider" in model_schema["properties"]
+    assert "model" in model_schema["required"]
+
+
 def test_create_inherits_worker_dir_workspace(monkeypatch, worker_env):
     """A worker scoped to a dir: task that spawns a child without a
     workspace arg inherits the dir, not scratch (so follow-up code-gen

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -788,6 +788,20 @@ def _handle_create(args: dict, **kw) -> str:
     if goal_bool_error:
         return tool_error(goal_bool_error)
     goal_max_turns = args.get("goal_max_turns")
+    model_override = args.get("model_override")
+    model_arg = args.get("model")
+    if model_arg is not None:
+        if not isinstance(model_arg, dict):
+            return tool_error(
+                f"model must be an object with a model field, got {type(model_arg).__name__}"
+            )
+        model_name = str(model_arg.get("model") or "").strip()
+        if not model_name:
+            return tool_error("model.model is required when model is provided")
+        provider = str(model_arg.get("provider") or "").strip()
+        model_override = f"{provider}/{model_name}" if provider else model_name
+    elif model_override is not None:
+        model_override = str(model_override).strip() or None
     if isinstance(parents, str):
         parents = [parents]
     if not isinstance(parents, (list, tuple)):
@@ -824,6 +838,7 @@ def _handle_create(args: dict, **kw) -> str:
                     if max_runtime_seconds is not None else None
                 ),
                 skills=skills,
+                model_override=model_override,
                 goal_mode=goal_mode,
                 goal_max_turns=(
                     int(goal_max_turns) if goal_max_turns is not None else None
@@ -1388,6 +1403,28 @@ KANBAN_CREATE_SCHEMA = {
                     "task, ['github-code-review'] for a reviewer task. "
                     "The names must match skills installed on the "
                     "assignee's profile."
+                ),
+            },
+            "model": {
+                "type": "object",
+                "properties": {
+                    "provider": {
+                        "type": "string",
+                        "description": (
+                            "Optional provider prefix. When set, the "
+                            "dispatcher passes '<provider>/<model>' via "
+                            "`hermes -m` to the worker."
+                        ),
+                    },
+                    "model": {
+                        "type": "string",
+                        "description": "Model name to pass to the dispatched worker.",
+                    },
+                },
+                "required": ["model"],
+                "description": (
+                    "Optional per-task model override for the dispatched "
+                    "worker. Omit to use the assignee profile's default model."
                 ),
             },
             "goal_mode": {


### PR DESCRIPTION
Closes t_cd7ce752

Summary:
- persist tasks.model_override through kanban_db.create_task
- expose CLI create --model and include model_override in JSON output
- accept model objects in kanban_create and cover the plumbing with focused tests

Verification:
- bash smoke.sh
- /Users/sanbox-user/.hermes/hermes-agent/.venv/bin/python -m pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py tests/tools/test_kanban_tools.py -q