### PR TITLE
fix(security): deny the whole ~/.hermes tree for media delivery (credential auto-attach)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1064,14 +1064,20 @@ def _media_delivery_denied_paths() -> List[Path]:
     home = Path(os.path.expanduser("~"))
     for sub in _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS:
         denied.append(home / sub)
-    # The active Hermes profile and shared Hermes root both contain control
-    # files and credentials. Only cache subdirectories under them are
-    # explicitly allowlisted above.
+    # The active Hermes profile and shared Hermes root hold config, sessions,
+    # memory, databases (state.db, kanban.db), and a growing set of integration
+    # credentials (.env, auth.json, google_token.json, mcp-tokens/, ...). Deny
+    # the WHOLE tree rather than enumerating individual files one at a time:
+    # the only deliverables that legitimately live under ~/.hermes are the
+    # managed cache subdirectories, and those are allowlisted in
+    # MEDIA_DELIVERY_SAFE_ROOTS and matched BEFORE this denylist in
+    # validate_media_delivery_path — so generated images/audio/video/documents
+    # still deliver, while no credential or state file under ~/.hermes can be
+    # emitted as a chat attachment. This closes the whole class (a refreshed
+    # google_token.json was being auto-attached to Slack replies) instead of
+    # leaving sibling files (mcp-tokens, *.db, future tokens) exposed.
     for hermes_root in (_HERMES_HOME, _HERMES_ROOT):
-        denied.append(hermes_root / ".env")
-        denied.append(hermes_root / "auth.json")
-        denied.append(hermes_root / "credentials")
-        denied.append(hermes_root / "config.yaml")
+        denied.append(Path(hermes_root))
     return denied
 
 
@@ -1190,9 +1196,11 @@ def validate_media_delivery_path(path: str) -> Optional[str]:
             return str(resolved)
 
     # Non-strict mode (default): accept anything not on the denylist.
-    # The denylist still blocks /etc, /proc, ~/.ssh, ~/.aws, ~/.hermes/.env,
-    # ~/.hermes/auth.json, etc. — so the obvious prompt-injection sites
-    # (``MEDIA:/etc/passwd``, ``MEDIA:~/.ssh/id_rsa``) remain rejected.
+    # The denylist still blocks /etc, /proc, ~/.ssh, ~/.aws, and the entire
+    # ~/.hermes tree (credentials, tokens, state — only its cache subdirs are
+    # allowlisted above) — so the obvious prompt-injection / credential-exfil
+    # sites (``MEDIA:/etc/passwd``, ``MEDIA:~/.ssh/id_rsa``,
+    # ``MEDIA:~/.hermes/google_token.json``) remain rejected.
     if not _media_delivery_strict_mode():
         if _path_under_denied_prefix(resolved):
             return None

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -967,6 +967,43 @@ class TestMediaDeliveryDefaultMode:
 
         assert BasePlatformAdapter.validate_media_delivery_path(str(config_file)) is None
 
+    def test_denylist_blocks_hermes_integration_tokens(self, tmp_path, monkeypatch):
+        """Integration credentials stored at the HERMES_HOME root (e.g.
+        google_token.json) must never be deliverable, even though they are not
+        the historically-enumerated .env/auth.json/config.yaml files. Regression
+        for a refreshed google_token.json being auto-attached to a Slack reply.
+        """
+        self._patch_roots(monkeypatch)
+
+        fake_home = tmp_path / "home"
+        hermes_dir = fake_home / ".hermes"
+        hermes_dir.mkdir(parents=True)
+        token = hermes_dir / "google_token.json"
+        token.write_text('{"access_token": "ya29.secret"}')
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", hermes_dir)
+        monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_dir)
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(token)) is None
+
+    def test_hermes_cache_still_delivers_under_denied_home(self, tmp_path, monkeypatch):
+        """Denying the whole ~/.hermes tree must not break legitimate cache
+        deliveries: a generated artifact under the allowlisted cache root is
+        matched before the denylist and still delivers.
+        """
+        fake_home = tmp_path / "home"
+        hermes_dir = fake_home / ".hermes"
+        cache_dir = hermes_dir / "cache" / "documents"
+        cache_dir.mkdir(parents=True)
+        artifact = cache_dir / "report.pdf"
+        artifact.write_bytes(b"%PDF-1.4")
+        self._patch_roots(monkeypatch, cache_dir)
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", hermes_dir)
+        monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_dir)
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(artifact)) == str(artifact.resolve())
+
     def test_strict_mode_envvar_restores_legacy_behavior(self, tmp_path, monkeypatch):
         """Setting HERMES_MEDIA_DELIVERY_STRICT=1 reactivates the older
         allowlist+recency logic. A stale file outside the allowlist is


### PR DESCRIPTION
## Summary

A user reported on Slack that Hermes auto-attached their **`google_token.json`** (a Google OAuth credential) to the bot's replies — re-sent on every follow-up turn. This is a real credential-exfiltration hole on `main`, not a misconfiguration.

### Root cause

`google_token.json` is stored at the **HERMES_HOME root** (`~/.hermes/google_token.json` — see `tools/credential_files.py`, relative to `HERMES_HOME`). The media-delivery denylist in `gateway/platforms/base.py::_media_delivery_denied_paths()` only enumerated **four** files under `~/.hermes`:

```python
denied.append(hermes_root / ".env")
denied.append(hermes_root / "auth.json")
denied.append(hermes_root / "credentials")
denied.append(hermes_root / "config.yaml")
```

Everything else under `~/.hermes` fell through:

- **Default (non-strict) mode** — `validate_media_delivery_path()` returns *any* path not on the denylist, so a `.json` token path emitted in the reply is delivered.
- **Strict mode** — the token still slips through the recency window (`trust_recent_files`, 600s default): the Google integration refreshes `google_token.json` each turn, bumping its mtime to "now", so `_file_is_recently_produced()` keeps trusting it. This is exactly why it re-sent every turn.

The code's own comment already stated the intended contract — *"Only cache subdirectories under them are explicitly allowlisted"* — but the implementation never enforced it.

### Fix

Deny the **entire** `_HERMES_HOME` / `_HERMES_ROOT` tree instead of listing files one at a time. The managed cache subdirectories stay deliverable because the allowlist (`MEDIA_DELIVERY_SAFE_ROOTS`) is matched **before** the denylist in `validate_media_delivery_path()` — so generated images/audio/video/documents still ship, while no credential or state file under `~/.hermes` (`google_token.json`, `mcp-tokens/`, `state.db`, `kanban.db`, sessions, memory, …) can be emitted as a chat attachment.

This closes the whole bug class rather than the single reported file, subsuming the per-file patches in #37222 (mcp-tokens) and #41071 (state.db/kanban.db).

## Test plan

- [x] `test_denylist_blocks_hermes_integration_tokens` — `~/.hermes/google_token.json` is rejected in default mode (regression).
- [x] `test_hermes_cache_still_delivers_under_denied_home` — a generated artifact in the allowlisted cache subdir under `~/.hermes` still delivers (allowlist beats denylist).
- [x] Existing `~/.hermes` denial tests (`.env`, `config.yaml`, profile root) still pass.
- [x] `scripts/run_tests.sh tests/gateway/test_platform_base.py` → 157 passed, 0 failed.