### PR TITLE
fix(session_search): use matched message timestamp for 'when' in discover mode

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -297,6 +297,48 @@ class TestRoleFilter:
 
 
 # =========================================================================
+# Discover 'when' / 'started_at' field regression
+# =========================================================================
+
+class TestDiscoverWhenTimestamp:
+    """Regression: 'when' should show matched message time, not session creation time.
+
+    https://github.com/NousResearch/hermes-agent/issues/50900
+    """
+
+    def test_when_shows_message_time_not_session_time(self, db):
+        session_start = 1000000000
+        db.create_session("s1", source="cli")
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (session_start, "s1"),
+        )
+        db.append_message("s1", role="user", content="hello", timestamp=session_start + 10)
+        # This message is 1 day later — the one we'll match
+        msg_ts = session_start + 86400
+        db.append_message("s1", role="user", content="needle in haystack", timestamp=msg_ts)
+        db._conn.commit()
+
+        result = json.loads(session_search(query="needle haystack", db=db))
+        assert result["count"] >= 1
+        hit = result["results"][0]
+
+        # 'when' must reflect the matched message, not session start
+        assert hit["when"] != _format_timestamp(session_start)
+        assert "started_at" in hit
+        assert hit["started_at"] == _format_timestamp(session_start)
+
+    def test_started_always_present_in_discover(self, db):
+        db.create_session("s1", source="cli")
+        db.append_message("s1", role="user", content="needle", timestamp=1000000000)
+        db._conn.commit()
+
+        result = json.loads(session_search(query="needle", db=db))
+        assert result["count"] >= 1
+        assert "started_at" in result["results"][0]
+
+
+# =========================================================================
 # Scroll shape (session_id + around_message_id)
 # =========================================================================
 

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -324,7 +324,7 @@ class TestDiscoverWhenTimestamp:
         hit = result["results"][0]
 
         # 'when' must reflect the matched message, not session start
-        assert hit["when"] != _format_timestamp(session_start)
+        assert hit["when"] == _format_timestamp(msg_ts)
         assert "started_at" in hit
         assert hit["started_at"] == _format_timestamp(session_start)
 

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -588,8 +588,9 @@ def _discover(
         entry = {
             "session_id": hit_sid,
             "when": _format_timestamp(
-                session_meta.get("started_at") or match_info.get("session_started")
+                match_info.get("timestamp") or session_meta.get("started_at")
             ),
+            "started_at": _format_timestamp(session_meta.get("started_at")),
             "source": session_meta.get("source") or match_info.get("source", "unknown"),
             "model": session_meta.get("model") or match_info.get("model") or "unknown",
             "title": session_meta.get("title") or None,

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -478,6 +478,7 @@ def _title_match_result(
     entry = {
         "session_id": session_id,
         "when": _format_timestamp(session_meta.get("started_at")),
+        "started_at": _format_timestamp(session_meta.get("started_at")),
         "source": session_meta.get("source", "unknown"),
         "model": session_meta.get("model") or "unknown",
         "title": session_meta.get("title") or title_query,


### PR DESCRIPTION
## What does this PR do?

`session_search` discovery mode's `when` field was showing session creation time instead of the matched message's actual timestamp. This PR fixes that and adds a `started_at` field for session creation time, consistent with browse mode and the `acp_adapter` consumer.

## Related Issue

Fixes #50900

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/session_search_tool.py`: In `_discover`, changed `when` to use `match_info.get("timestamp")` (message time) instead of `session_meta.get("started_at")` (session time). Added `started_at` field for session creation time.
- `tests/tools/test_session_search.py`: Added `TestDiscoverWhenTimestamp` with 2 regression tests.
- Total: +44/-1 in 2 files, only affects `_discover` mode. scroll/browse/read modes unchanged.

## How to Test

1. Have a session spanning multiple days with conversations on different days
2. Call `session_search` with a query matching a recent message
3. Verify `when` shows the matched message's timestamp (not session creation time), and `started_at` shows the session creation time

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, feat(scope):, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7.7

### Documentation & Housekeeping

- [x] N/A — no docs, config, or schema changes

## Screenshots / Logs

Verified on installed v0.17.0:

**Before fix (bug):**
```
when:       June 22, 2026 at 08:35 PM   ← session creation time
started_at: NOT PRESENT
```

**After fix:**
```
when:       June 22, 2026 at 08:36 PM   ← matched message time ✓
started_at: June 22, 2026 at 08:35 PM   ← session creation time ✓
```
