### PR TITLE
fix(desktop): escape lone tildes in markdown prose

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
@@ -202,6 +202,22 @@ describe('preprocessMarkdown', () => {
     expect(output).toContain('<https://example.com/a_b/c~d/page>')
   })
 
+  it('escapes lone tildes in prose ranges without touching strikethrough syntax', () => {
+    const output = preprocessMarkdown('Ranges: 1~10,11~20 and ~~deleted~~ text.')
+
+    expect(output).toContain('1\\~10,11\\~20')
+    expect(output).toContain('~~deleted~~')
+  })
+
+  it('does not escape lone tildes inside inline or fenced code', () => {
+    const input = ['Use `1~10` as a literal.', '', '```txt', '1~10,11~20', '```'].join('\n')
+
+    const output = preprocessMarkdown(input)
+
+    expect(output).toContain('`1~10`')
+    expect(output).toContain(['```txt', '1~10,11~20', '```'].join('\n'))
+  })
+
   it('handles a fenced block larger than V8 spread-argument limit', () => {
     // A single huge code block (e.g. a logged minified bundle) used to throw
     // `RangeError: Maximum call stack size exceeded` via `out.push(...lines)`.

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -16,9 +16,11 @@ const INLINE_CODE_SPLIT_RE = /(`[^`\n]+`)/g
 // and keeps the emphasis run intact. Other trailing punctuation is still peeled
 // off by the final `[^\s<>"'`*.,;:!?]` class.
 const RAW_URL_RE = /https?:\/\/[^\s<>"'`*]+[^\s<>"'`*.,;:!?]/g
+const URL_LIKE_SPLIT_RE = /(<https?:\/\/[^>\s]+>|https?:\/\/[^\s<>"'`*]+[^\s<>"'`*.,;:!?])/g
 const LOCAL_PREVIEW_URL_RE = /(^|\s)https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::\d+)?\/?[^\s<>"'`]*/gi
 const LOCAL_PREVIEW_ONLY_RE = /^https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::\d+)?\/?$/i
 const URL_ONLY_LINE_RE = /^\s*https?:\/\/\S+\s*$/i
+const LONE_TILDE_RE = /(?<![\\~])~(?!~)/g
 const CITATION_MARKER_RE = /(?<=[\p{L}\p{N})\].,!?:;"'”’])\[(?:\d+(?:\s*,\s*\d+)*)\](?!\()/gu
 
 /**
@@ -138,14 +140,23 @@ function autoLinkRawUrls(text: string): string {
   })
 }
 
+function escapeLoneTildes(text: string): string {
+  return text
+    .split(URL_LIKE_SPLIT_RE)
+    .map(part => (/^<?https?:\/\//i.test(part) ? part : part.replace(LONE_TILDE_RE, '\\~')))
+    .join('')
+}
+
 function normalizeVisibleProse(text: string): string {
   return text
     .split(INLINE_CODE_SPLIT_RE)
     .map(part =>
       part.startsWith('`')
         ? part
-        : autoLinkRawUrls(
-            part.replace(/`{3,}/g, '').replace(LOCAL_PREVIEW_URL_RE, '$1').replace(CITATION_MARKER_RE, '')
+        : escapeLoneTildes(
+            autoLinkRawUrls(
+              part.replace(/`{3,}/g, '').replace(LOCAL_PREVIEW_URL_RE, '$1').replace(CITATION_MARKER_RE, '')
+            )
           )
     )
     .join('')


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where lone `~` characters in Desktop markdown prose could be interpreted as accidental strikethrough syntax.

For example, ranges like `1~10,11~20` should render with literal tildes, not as `1~~10,11~~20`.

This escapes lone tildes only in visible prose. It preserves intentional `~~deleted~~` strikethrough syntax, inline code, fenced code, and URL paths such as `https://example.com/a_b/c~d/page`.

## Related Issue

Fixes #50871

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/lib/markdown-preprocess.ts`
  - Added escaping for lone `~` characters in prose markdown.
  - Skips URL-like spans so URL paths containing `~` remain unchanged.
  - Leaves inline code and fenced code untouched through the existing preprocessing split.

- `apps/desktop/src/components/assistant-ui/markdown-text.test.ts`
  - Added regression coverage for prose ranges like `1~10,11~20`.
  - Added coverage that intentional `~~deleted~~` syntax still works.
  - Added coverage that inline code and fenced code containing `~` are not escaped.

## How to Test

```bash
npm exec --workspace apps/desktop -- vitest run --environment jsdom src/components/assistant-ui/markdown-text.test.ts
npm exec --workspace apps/desktop -- prettier --check src/lib/markdown-preprocess.ts src/components/assistant-ui/markdown-text.test.ts
npm exec --workspace apps/desktop -- eslint src/lib/markdown-preprocess.ts src/components/assistant-ui/markdown-text.test.ts
git diff --check