### PR TITLE
fix(desktop): keep streamed text when GPT-5.5 sends an empty final_response

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -556,6 +556,17 @@ export function useMessageStream({
 
         const replaceTextPart = (parts: ChatMessagePart[]) => {
           const visibleFinalText = stripGeneratedImageEchoes(finalText, generatedImageEchoSources(parts)).trim()
+
+          // Responses-API reasoning models (GPT-5.5 / Codex) frequently ship an
+          // empty aggregated final_response even though the answer streamed
+          // token-by-token via message.delta. Erasing the streamed text parts
+          // here (and re-adding nothing) is what blanked out completed GPT-5.5
+          // turns. When there's no visible final text but we already streamed
+          // text, keep the streamed parts untouched.
+          if (!visibleFinalText && parts.some(part => part.type === 'text')) {
+            return parts
+          }
+
           const dedupeReference = normalize(visibleFinalText)
 
           const kept = parts.filter(part => {
@@ -627,8 +638,22 @@ export function useMessageStream({
         const hasInlineError = nextMessages.some(m => m.role === 'assistant' && m.error && !m.hidden)
         const lastVisible = [...nextMessages].reverse().find(m => !m.hidden)
         const unresolvedUserTail = lastVisible?.role === 'user'
+
+        // Does the finalized assistant bubble still hold visible streamed text?
+        // If so, an empty final_response must NOT trigger a hydrate: the stored
+        // session can lag (or, on a history_version desync, never received this
+        // turn at all), so reloading would blank the answer the user can see.
+        const finalizedAssistant = streamId
+          ? nextMessages.find(m => m.id === streamId)
+          : [...nextMessages].reverse().find(m => m.role === 'assistant' && !m.hidden)
+        const finalizedHasText = finalizedAssistant ? chatMessageText(finalizedAssistant).trim().length > 0 : false
+
         shouldHydrate =
-          !completionError && !hasInlineError && !unresolvedUserTail && (!state.sawAssistantPayload || !finalText)
+          !completionError &&
+          !hasInlineError &&
+          !unresolvedUserTail &&
+          !finalizedHasText &&
+          (!state.sawAssistantPayload || !finalText)
 
         return {
           ...state,


### PR DESCRIPTION
## Symptom

On the desktop app, a **GPT-5.5** (and Codex / any Responses-API reasoning model) turn streams a visible answer token-by-token, then the **entire response text disappears** the instant the turn completes. Chat-completions models (Claude, etc.) are unaffected.

## Root cause

Responses-API reasoning models frequently emit an **empty aggregated `final_response`** even though the answer streamed fine via `message.delta`. The gateway puts that empty string into `message.complete`'s `text` (`tui_gateway/server.py` → `result["final_response"]`).

In `apps/desktop/src/app/session/hooks/use-message-stream.ts`, `completeAssistantMessage` then does two destructive things on an empty final:

1. **`replaceTextPart`** strips every existing `text` part and only re-adds one when `visibleFinalText` is non-empty:
   ```ts
   return visibleFinalText ? [...kept, assistantTextPart(visibleFinalText)] : kept
   ```
   Empty final ⇒ streamed text removed, nothing re-added ⇒ **blank bubble**.

2. **`shouldHydrate`** is forced true by the empty `finalText`, reloading the bubble from stored session history. On a `history_version` desync (server.py warns *"the response above is visible but was not saved to session history"*) the reload comes back **without** the answer, cementing the wipe.

## Fix

Both changes in `apps/desktop/src/app/session/hooks/use-message-stream.ts`:

- **`replaceTextPart`**: when there's no visible final text but the bubble already holds streamed `text` parts, keep them untouched instead of dropping them.
- **`shouldHydrate`**: skip the destructive hydrate whenever the finalized assistant bubble still holds visible streamed text.

Chat-completions models return a populated final string, so they continue through the existing dedupe/replace path unchanged — no behavior change for them.

## Verification

- `tsc -p apps/desktop --noEmit` → clean.
- `vite build` → succeeds.
- UI suite (`vitest run --environment jsdom`): the failing-file/test counts are **identical with this change stashed in or out** (pre-existing environment failures unrelated to this hook) — zero new regressions.
- Manually traced the GPT-5.5 event sequence (`message.delta` → `reasoning.delta` → `message.complete` with empty `text`) against the patched logic.