### PR TITLE
Clarify profile scope in Desktop statusbar

### DIFF
--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -19,7 +19,13 @@ import {
   ZapFilled
 } from '@/lib/icons'
 import type { RuntimeReadinessResult } from '@/lib/runtime-readiness'
-import { contextBarLabel, LiveDuration, usageContextLabel } from '@/lib/statusbar'
+import {
+  contextBarLabel,
+  LiveDuration,
+  profileScopedStatusLabel,
+  profileScopedStatusTitle,
+  usageContextLabel
+} from '@/lib/statusbar'
 import { cn } from '@/lib/utils'
 import { setGlobalYolo, setSessionYolo } from '@/lib/yolo-session'
 import { $desktopActionTasks } from '@/store/activity'
@@ -29,6 +35,8 @@ import {
   $busy,
   $connection,
   $currentUsage,
+  $selectedStoredSessionId,
+  $sessions,
   $sessionStartedAt,
   $turnStartedAt,
   $workingSessionIds,
@@ -86,6 +94,8 @@ export function useStatusbarItems({
   const { t } = useI18n()
   const copy = t.shell.statusbar
   const activeSessionId = useStore($activeSessionId)
+  const selectedStoredSessionId = useStore($selectedStoredSessionId)
+  const sessions = useStore($sessions)
   const terminalTakeover = useStore($terminalTakeover)
   const yoloActive = useStore($yoloActive)
   const busy = useStore($busy)
@@ -106,6 +116,14 @@ export function useStatusbarItems({
 
   const contextUsage = useMemo(() => usageContextLabel(currentUsage), [currentUsage])
   const contextBar = useMemo(() => contextBarLabel(currentUsage), [currentUsage])
+  const activeSessionProfile = useMemo(() => {
+    const activeStoredId = selectedStoredSessionId ?? activeSessionId
+    const session = activeStoredId
+      ? sessions.find(item => item.id === activeStoredId || item._lineage_root_id === activeStoredId)
+      : null
+
+    return session?.profile ?? connection?.profile ?? null
+  }, [activeSessionId, connection?.profile, selectedStoredSessionId, sessions])
 
   // Per-session approval bypass (same scope as the TUI's Shift+Tab). On a
   // new-chat draft (no runtime session yet) we arm locally; the session-create
@@ -379,8 +397,8 @@ export function useStatusbarItems({
         hidden: !busy || !turnStartedAt,
         icon: <Loader2 className="size-3 animate-spin" />,
         id: 'running-timer',
-        label: copy.turnRunning,
-        title: copy.currentTurnElapsed,
+        label: profileScopedStatusLabel(copy.turnRunning, activeSessionProfile),
+        title: profileScopedStatusTitle(copy.currentTurnElapsed, activeSessionProfile, workingSessionIds.length),
         variant: 'text'
       },
       {
@@ -430,11 +448,13 @@ export function useStatusbarItems({
       contextBar,
       contextUsage,
       copy,
+      activeSessionProfile,
       sessionStartedAt,
       showYoloToggle,
       terminalTakeover,
       toggleYolo,
       turnStartedAt,
+      workingSessionIds.length,
       clientVersionItem,
       backendVersionItem,
       yoloActive

--- a/apps/desktop/src/app/shell/statusbar-controls.tsx
+++ b/apps/desktop/src/app/shell/statusbar-controls.tsx
@@ -156,6 +156,7 @@ function StatusbarItemView({ item, navigate }: { item: StatusbarItem; navigate: 
           'inline-flex h-full items-center gap-1 px-1.5 text-[0.6875rem] text-(--ui-text-tertiary)',
           item.className
         )}
+        title={item.title}
       >
         {content}
       </div>
@@ -164,7 +165,13 @@ function StatusbarItemView({ item, navigate }: { item: StatusbarItem; navigate: 
 
   if (item.href || item.variant === 'link') {
     return (
-      <a className={cn(STATUSBAR_ACTION_CLASS, item.className)} href={item.href} rel="noreferrer" target="_blank">
+      <a
+        className={cn(STATUSBAR_ACTION_CLASS, item.className)}
+        href={item.href}
+        rel="noreferrer"
+        target="_blank"
+        title={item.title}
+      >
         {content}
       </a>
     )
@@ -181,6 +188,7 @@ function StatusbarItemView({ item, navigate }: { item: StatusbarItem; navigate: 
 
         item.onSelect?.({ shiftKey: event.shiftKey })
       }}
+      title={item.title}
       type="button"
     >
       {content}

--- a/apps/desktop/src/lib/statusbar.test.ts
+++ b/apps/desktop/src/lib/statusbar.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { profileScopedStatusLabel, profileScopedStatusTitle } from './statusbar'
+
+describe('profile-scoped statusbar labels', () => {
+  it('keeps default profile labels compact', () => {
+    expect(profileScopedStatusLabel('Running', 'default')).toBe('Running')
+    expect(profileScopedStatusLabel('Running', '')).toBe('Running')
+    expect(profileScopedStatusLabel('Running', null)).toBe('Running')
+  })
+
+  it('includes non-default profile names', () => {
+    expect(profileScopedStatusLabel('Running', 'job-hunting')).toBe('Running · job-hunting')
+  })
+
+  it('describes multi-session running state in titles', () => {
+    expect(profileScopedStatusTitle('Current turn elapsed', 'job-hunting', 3)).toBe(
+      'Current turn elapsed · profile job-hunting · 3 sessions running'
+    )
+  })
+
+  it('omits profile and count noise when there is no ambiguity', () => {
+    expect(profileScopedStatusTitle('Current turn elapsed', 'default', 1)).toBe('Current turn elapsed')
+  })
+})

--- a/apps/desktop/src/lib/statusbar.ts
+++ b/apps/desktop/src/lib/statusbar.ts
@@ -72,6 +72,31 @@ export function contextBarLabel(usage: UsageStats): string {
   return `[${contextBar(usage.context_percent)}] ${pct}%`
 }
 
+export function profileScopedStatusLabel(base: string, profile: string | null | undefined): string {
+  const key = profile?.trim()
+
+  return key && key !== 'default' ? `${base} · ${key}` : base
+}
+
+export function profileScopedStatusTitle(
+  base: string,
+  profile: string | null | undefined,
+  workingSessions: number
+): string {
+  const parts = [base]
+  const key = profile?.trim()
+
+  if (key && key !== 'default') {
+    parts.push(`profile ${key}`)
+  }
+
+  if (workingSessions > 1) {
+    parts.push(`${workingSessions} sessions running`)
+  }
+
+  return parts.join(' · ')
+}
+
 export function LiveDuration({ since }: { since: number | null | undefined }) {
   const [now, setNow] = useState(() => Date.now())
 


### PR DESCRIPTION
## Summary

This is a small Desktop UX hardening patch for multi-profile runs:

- show the active profile name on the bottom `Running` statusbar item when the active turn belongs to a non-default profile
- include the number of running sessions in the statusbar hover title when more than one session is active
- pass `title` through statusbar text/link/button items so existing statusbar tooltips actually render
- add focused unit coverage for the profile-scoped statusbar label helpers

## Why

While diagnosing a local Desktop incident, I had multiple local profile backends alive at once (`job-hunting`, `default`, and `academic-writing`) and two long-running sessions. The UI showed two different running timers:

- an in-chat/session-local running timer around `4:02`
- the bottom statusbar `Running 5:05 89.5k/272.0k`

Those timers were not necessarily tracking the same thing. The app already supports concurrent profile sockets/background workers, but the bottom statusbar only presented a generic global `Running` label. That makes multi-profile foreground/background activity look like a broken timer instead of a scoped foreground status.

This patch does not try to redesign multi-profile execution. It just makes the current statusbar scope visible and restores tooltip plumbing so users can tell which profile the bottom timer belongs to.

## Related issues observed / already filed

This local incident lines up with several existing upstream issues:

- #43071 — statusbar title attributes are not rendered, so hover explanations are missing
- #39324 and #22142 — users need clearer active profile/session identity in Desktop
- #48445 and #50005 — long foreground tasks / WebSocket disconnects can make Desktop confusing or non-functional
- #45403 / #41693 / #44562 — `tapClientLookup: Index out of bounds` renderer failures seen around stale/large sessions

Local evidence from the incident included repeated `ws write slow (loop stalled >10.0s)` log lines during a large `job-hunting` session and concurrent profile dashboard processes. The immediate PR scope here is only the statusbar ambiguity and missing tooltip rendering.

## Validation

- `npm run test:ui -- src/lib/statusbar.test.ts` passes
- targeted ESLint on changed files passes:
  - `src/lib/statusbar.ts`
  - `src/lib/statusbar.test.ts`
  - `src/app/shell/hooks/use-statusbar-items.tsx`
  - `src/app/shell/statusbar-controls.tsx`

Full `npm run typecheck` was attempted but this local checkout is missing `@icons-pack/react-simple-icons`, producing an unrelated existing dependency-resolution error in `src/app/messaging/platform-icon.tsx` before reaching this patch.
