### PR TITLE
fix(subdirectory-hints): avoid crash when HOME is unavailable

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -144,7 +144,7 @@ class SubdirectoryHintTracker:
                 if parent == p:
                     break  # filesystem root
                 p = parent
-        except (OSError, ValueError):
+        except (OSError, ValueError, RuntimeError):
             pass
 
     def _extract_paths_from_command(self, cmd: str, candidates: Set[Path]):

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -252,6 +252,17 @@ class TestSubdirectoryHintTracker:
 class TestPermissionErrorHandling:
     """Regression tests for PermissionError in filesystem checks (ref #6214)."""
 
+    def test_check_tool_call_survives_expanduser_runtime_error(self, project):
+        """check_tool_call should not crash when Path.expanduser cannot resolve HOME."""
+        tracker = SubdirectoryHintTracker(working_dir=str(project))
+        with patch.object(
+            Path,
+            "expanduser",
+            side_effect=RuntimeError("Could not determine home directory."),
+        ):
+            result = tracker.check_tool_call("read_file", {"path": "~/backend/src/main.py"})
+        assert result is None
+
     def test_is_valid_subdir_permission_error(self, tmp_path):
         """_is_valid_subdir should return False when is_dir() raises PermissionError."""
         tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))


### PR DESCRIPTION
## What happened
In restricted service environments (cron/systemd/container), `Path.expanduser()` can raise:

`RuntimeError: Could not determine home directory.`

When that happened inside `SubdirectoryHintTracker._add_path_candidate()`, it bubbled out and interrupted tool-call execution.

## Why this is a bug
Subdirectory hints are best-effort context enrichment. They should never crash the agent/tool path when a path token cannot be resolved.

## Fix
Treat `RuntimeError` from `Path.expanduser()` the same as existing path-resolution errors (`OSError`, `ValueError`) and skip that candidate path.

## Tests
Added regression test in `tests/agent/test_subdirectory_hints.py` to force `Path.expanduser()` to raise `RuntimeError("Could not determine home directory.")` and verify `check_tool_call()` returns safely.

## Commits
1. `fix(subdirectory-hints): ignore expanduser runtime failure when HOME is missing`
2. `test(subdirectory-hints): cover expanduser RuntimeError with missing HOME`