### PR TITLE
fix(qqbot): flag splits_long_messages so cron delivery stops truncating QQ output (follow-up to #50778)

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -157,6 +157,12 @@ class QQAdapter(BasePlatformAdapter):
     # QQ Bot API does not support editing sent messages.
     SUPPORTS_MESSAGE_EDITING = False
     MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
+    # QQ chunks long output natively: send() splits via truncate_message() and
+    # emits every chunk.  Declare splits_long_messages so the delivery router
+    # bypasses its 4000-char cron/automation truncation (which would otherwise
+    # drop everything past the first chunk and append a file-save footer),
+    # matching the 12 sibling native-chunking adapters flagged in #50778.
+    splits_long_messages = True
     _TYPING_INPUT_SECONDS = 60  # input_notify duration reported to QQ
     _TYPING_DEBOUNCE_SECONDS = 50  # refresh before it expires
 

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -97,6 +97,69 @@ class TestQQAdapterInit:
 
 
 # ---------------------------------------------------------------------------
+# splits_long_messages (cron/automation delivery, follow-up to #50778)
+# ---------------------------------------------------------------------------
+
+class TestQQChunkingFlag:
+    """QQ chunks natively, so it must declare splits_long_messages=True or the
+    delivery router truncates QQ cron/automation output at MAX_PLATFORM_OUTPUT."""
+
+    def _make(self, **extra):
+        from gateway.platforms.qqbot import QQAdapter
+        return QQAdapter(_make_config(**extra))
+
+    def test_splits_long_messages_flag_set(self):
+        from gateway.platforms.qqbot import QQAdapter
+        # Class attribute must be True (base default is False); #50778 set this
+        # on the 12 native-chunking adapters but missed QQ.
+        assert QQAdapter.splits_long_messages is True
+
+    @pytest.mark.asyncio
+    async def test_send_emits_every_chunk_in_order_losslessly(self):
+        """The flag is only safe if send() actually emits EVERY chunk of long
+        output. Prove send() iterates all truncate_message() chunks in order and
+        drops nothing, so bypassing the router's truncation is lossless."""
+        import re
+        from gateway.platforms.qqbot import QQAdapter
+
+        adapter = self._make(app_id="a", client_secret="b")
+        # Make is_connected True without a real gateway (same pattern as
+        # TestWaitForReconnection.test_send_succeeds_immediately_when_connected).
+        adapter._running = True
+        adapter._ws = SimpleNamespace(closed=False)
+        adapter._http_client = mock.MagicMock()
+
+        sent = []
+
+        async def fake_send_chunk(chat_id, content, reply_to=None):
+            sent.append({"chat_id": chat_id, "content": content, "reply_to": reply_to})
+            return SimpleNamespace(success=True, error=None)
+
+        adapter._send_chunk = fake_send_chunk
+
+        content = "x" * (QQAdapter.MAX_MESSAGE_LENGTH * 3)
+        result = await adapter.send("openid_1", content, reply_to="anchor_msg")
+        assert result.success
+
+        # send() must emit exactly the chunks truncate_message() produces, in
+        # order — no chunk dropped, duplicated, or reordered.
+        formatted = adapter.format_message(content)
+        expected_chunks = QQAdapter.truncate_message(formatted, QQAdapter.MAX_MESSAGE_LENGTH)
+        assert len(expected_chunks) > 1  # sanity: this content really multi-chunks
+        assert [c["content"] for c in sent] == expected_chunks
+
+        # Losslessness: stripping the per-chunk "(i/total)" indicator and
+        # rejoining reconstructs the full formatted body (nothing lost at the
+        # chunk boundaries).
+        bodies = [re.sub(r" \(\d+/\d+\)$", "", c["content"]) for c in sent]
+        assert "".join(bodies) == formatted
+
+        # Only the first chunk carries the reply anchor; the rest must not.
+        assert sent[0]["reply_to"] == "anchor_msg"
+        assert all(c["reply_to"] is None for c in sent[1:])
+
+
+# ---------------------------------------------------------------------------
 # _coerce_list
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Follow-up to #50778.

#50778 added the `splits_long_messages` capability flag (`gateway/platforms/base.py`, default `False`) and set it `True` on the 12 native-chunking adapters (discord/telegram/slack/matrix/feishu/mattermost/teams/whatsapp/whatsapp_cloud/weixin/bluebubbles/yuanbao), so the delivery router (`gateway/delivery.py`) bypasses its 4000-char cron/automation truncation for those platforms.

`QQAdapter` chunks long output natively the same way — `send()` calls `truncate_message()` and emits every chunk via `_send_chunk` — but was **not** flagged. So QQ cron/automation deliveries still hit the truncation branch: everything past the first ~4000-char chunk is dropped and replaced by a `... [truncated, full output saved to ...]` footer. #50778's body names SMS as the only intentional exclusion; QQ wasn't mentioned (it natively chunks, so it belongs with the 12).

**Fix:** set `splits_long_messages = True` on `QQAdapter`, one class attribute identical to the 12 siblings.

**Test:** `TestQQChunkingFlag` asserts the flag is set, plus a send-path test proving `send()` emits *every* `truncate_message()` chunk in order, losslessly (indicator-stripped reconstruction), with the reply anchor only on the first chunk — so bypassing router truncation stays lossless.

If this has already landed via a separate patch, feel free to close + mark accordingly.