### PR TITLE
fix(gateway): pass session_db to hygiene and manual compress agents for proper session rotation

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9305,6 +9305,7 @@ class GatewayRunner:
                                     skip_memory=True,
                                     enabled_toolsets=["memory"],
                                     session_id=session_entry.session_id,
+                                    session_db=self._session_db,
                                 )
                                 try:
                                     _hyg_agent._print_fn = lambda *a, **kw: None
@@ -9330,10 +9331,14 @@ class GatewayRunner:
                                             source, session_entry,
                                             reason="hygiene-compression",
                                         )
-
-                                    self.session_store.rewrite_transcript(
-                                        session_entry.session_id, _compressed
-                                    )
+                                        self.session_store.rewrite_transcript(
+                                            session_entry.session_id, _compressed
+                                        )
+                                    else:
+                                        logger.warning(
+                                            "Session hygiene: session rotation skipped (_session_db unavailable), "                                            "original transcript preserved at session_id=%s",
+                                            session_entry.session_id,
+                                        )
                                     # Reset stored token count — transcript was rewritten
                                     session_entry.last_prompt_tokens = 0
                                     history = _compressed
@@ -13223,6 +13228,7 @@ class GatewayRunner:
                 skip_memory=True,
                 enabled_toolsets=["memory"],
                 session_id=session_entry.session_id,
+                session_db=self._session_db,
             )
             try:
                 tmp_agent._print_fn = lambda *a, **kw: None
@@ -13263,8 +13269,12 @@ class GatewayRunner:
                     self._sync_telegram_topic_binding(
                         source, session_entry, reason="compress-command",
                     )
-
-                self.session_store.rewrite_transcript(new_session_id, compressed)
+                    self.session_store.rewrite_transcript(new_session_id, compressed)
+                else:
+                    logger.warning(
+                        "Manual compress: session rotation skipped (_session_db unavailable), "                        "original transcript preserved at session_id=%s",
+                        session_entry.session_id,
+                    )
                 # Reset stored token count — transcript changed, old value is stale
                 self.session_store.update_session(
                     session_entry.session_key, last_prompt_tokens=0


### PR DESCRIPTION
## Bug

When Gateway Session Hygiene or manual `/compress` creates a temporary `AIAgent` for compression, it does not pass `session_db`. This causes `_compress_context` to skip session rotation (the rotation block is gated on `if agent._session_db:`). Since `rewrite_transcript()` executes unconditionally outside the rotation check, the original session's messages are overwritten with compressed content — **permanent data loss**.

## Fix

Two changes, applied to both the hygiene auto-compress and manual `/compress` paths in `gateway/run.py`:

1. **Pass `session_db=self._session_db`** to the temporary `AIAgent` constructor, so `_compress_context` can perform proper session rotation.
2. **Guard `rewrite_transcript()` on successful session rotation**. When rotation is skipped, log a warning instead of silently destroying the original transcript.

## Related

Fixes #39704. Also related: #39731, #39745, #40112 (prior fix attempts that only addressed the hygiene path; this PR fixes both hygiene and manual `/compress`).