### PR TITLE
fix: catch PermissionError in _delete_skill for read-only bundled skills

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -436,6 +436,34 @@ class TestDeleteSkill:
             result = _delete_skill("my-skill")
         assert result["success"] is True
 
+    def test_delete_readonly_skill_returns_structured_error(self, tmp_path):
+        """Deleting a read-only (bundled) skill must return a structured,
+        non-retryable error instead of crashing with ``PermissionError``
+        (#50938).
+
+        The read-only condition is simulated by patching ``shutil.rmtree`` to
+        raise ``PermissionError`` rather than by chmod'ing the directory. A
+        chmod-based test is non-deterministic under CI/containers that run as
+        root, because root bypasses the write bit and ``rmtree`` succeeds — so
+        the test would silently pass without exercising the except branch.
+        Patching the call keeps the assertion deterministic regardless of the
+        UID the suite runs as.
+        """
+        with _skill_dir(tmp_path):
+            _create_skill("bundled-skill", VALID_SKILL_CONTENT)
+            with patch(
+                "tools.skill_manager_tool.shutil.rmtree",
+                side_effect=PermissionError(13, "Permission denied"),
+            ):
+                result = _delete_skill("bundled-skill", absorbed_into="")
+            # Structured failure, not a raised exception.
+            assert result["success"] is False
+            err = result["error"].lower()
+            assert "permission denied" in err
+            assert "bundled-skill" in result["error"]
+            # The skill dir is untouched (rmtree was intercepted).
+            assert (tmp_path / "bundled-skill").exists()
+
 
 # ---------------------------------------------------------------------------
 # write_file / remove_file

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1112,7 +1112,17 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
             message += f" Content absorbed into '{absorbed_target}'."
         return {"success": True, "message": message, "_archived": True}
 
-    shutil.rmtree(skill_dir)
+    try:
+        shutil.rmtree(skill_dir)
+    except PermissionError:
+        return {
+            "success": False,
+            "error": (
+                f"Cannot delete skill '{name}': permission denied. "
+                "This is likely a bundled read-only skill installed as part of the base image. "
+                "It cannot be removed."
+            ),
+        }
 
     # Clean up empty category directories (don't remove the skills root itself)
     parent = skill_dir.parent

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -814,7 +814,43 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
     if unsafe:
         return {"success": False, "error": unsafe}
 
-    shutil.rmtree(skill_dir)
+    # During the curator consolidation pass, a verified consolidation must be
+    # RECOVERABLE: archival into ~/.hermes/skills/.archive/ is documented as
+    # the maximum destructive action the curator may take, and
+    # `hermes curator restore` promises the skill can be brought back. Route
+    # through the recoverable archive primitive instead of permanent rmtree so
+    # a misjudged consolidation can be undone (#29912). Foreground,
+    # user-directed deletes keep their existing hard-delete semantics.
+    try:
+        from tools.skill_provenance import is_background_review
+        curator_pass = is_background_review()
+    except Exception:
+        curator_pass = False
+
+    if curator_pass:
+        try:
+            from tools.skill_usage import archive_skill
+            ok, archive_msg = archive_skill(name)
+        except Exception as e:
+            return {"success": False, "error": f"failed to archive '{name}': {e}"}
+        if not ok:
+            return {"success": False, "error": archive_msg}
+        message = f"Skill '{name}' archived ({archive_msg})."
+        if is_consolidation:
+            message += f" Content absorbed into '{absorbed_target}'."
+        return {"success": True, "message": message, "_archived": True}
+
+    try:
+        shutil.rmtree(skill_dir)
+    except PermissionError:
+        return {
+            "success": False,
+            "error": (
+                f"Cannot delete skill '{name}': permission denied. "
+                "This is likely a bundled read-only skill installed as part of the base image. "
+                "It cannot be removed."
+            ),
+        }
 
     # Clean up empty category directories (don't remove the skills root itself)
     parent = skill_dir.parent


### PR DESCRIPTION
## Problem

When an agent tries to delete a bundled skill installed as part of the image (`dr-xr-xr-x` permissions), `shutil.rmtree()` raises `PermissionError`. The tool returns an error, the agent retries the same call, and the session gets stuck in a tool loop.

Seen in production with skills: `simplify-code`, `test-driven-development`, `requesting-code-review`.

## Fix

Wrap `shutil.rmtree(skill_dir)` in a `try/except PermissionError` and return a clear, descriptive error message. This stops the retry loop immediately and tells the agent why the deletion failed.

## Fixes

Closes #50939