### PR TITLE
fix(discord): inherit VoiceMixer from discord.AudioSource for vc.play() (#50899)

### DIFF
--- a/plugins/platforms/discord/voice_mixer.py
+++ b/plugins/platforms/discord/voice_mixer.py
@@ -46,6 +46,8 @@ import logging
 import threading
 from typing import TYPE_CHECKING, List, Optional
 
+import discord
+
 if TYPE_CHECKING:  # numpy is an optional ("voice" extra) dep — never import at runtime top-level
     import numpy as np
 
@@ -145,7 +147,7 @@ class MixerChild:
         return samples
 
 
-class VoiceMixer:
+class VoiceMixer(discord.AudioSource):
     """A continuous ``discord.AudioSource`` that mixes N child streams.
 
     Use :meth:`set_ambient` to install/replace the looping idle bed and

--- a/tests/gateway/conftest.py
+++ b/tests/gateway/conftest.py
@@ -110,6 +110,11 @@ def _ensure_discord_mock() -> None:
     discord_mod.ForumChannel = type("ForumChannel", (), {})
     discord_mod.Interaction = object
     discord_mod.Message = type("Message", (), {})
+    discord_mod.AudioSource = type("AudioSource", (), {
+        "is_opus": lambda self: False,
+        "read": lambda self: b"",
+        "cleanup": lambda self: None,
+    })
 
     # Embed: accept the kwargs production code / tests use
     # (title, description, color). MagicMock auto-attributes work too,

--- a/tests/gateway/test_discord_voice_mixer.py
+++ b/tests/gateway/test_discord_voice_mixer.py
@@ -51,6 +51,12 @@ class TestVoiceMixerCore:
         # discord.py sends raw PCM when is_opus() is False.
         assert vm.VoiceMixer().is_opus() is False
 
+    def test_isinstance_audio_source(self):
+        # VoiceMixer must be a discord.AudioSource so vc.play(mixer) accepts it.
+        import discord
+        mx = vm.VoiceMixer()
+        assert isinstance(mx, discord.AudioSource)
+
     def test_ambient_loops_and_is_quiet(self):
         mx = vm.VoiceMixer(ambient_gain=0.2)
         amb = vm.synth_ambient_pcm(seconds=0.5)


### PR DESCRIPTION
## What does this PR do?

Inherits `VoiceMixer` from `discord.AudioSource` so that `VoiceClient.play(mixer)` accepts it. The class already implements the full AudioSource interface (`is_opus`, `read`, `cleanup`) but was declared without a base class, causing discord.py's `isinstance(source, AudioSource)` guard to reject it.

## Related Issue

Fixes #50899

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`plugins/platforms/discord/voice_mixer.py`**: Added `import discord` and changed `class VoiceMixer:` to `class VoiceMixer(discord.AudioSource):`.
- **`tests/gateway/conftest.py`**: Added `AudioSource` to the discord mock (a real type with stub methods) so `VoiceMixer` can inherit from it in test environments where discord.py is not installed.
- **`tests/gateway/test_discord_voice_mixer.py`**: Added `test_isinstance_audio_source` to verify `VoiceMixer` is a proper `discord.AudioSource` subclass.

## How to Test

1. **Targeted regression test** (verifies the isinstance fix):
   ```bash
   cd /path/to/hermes-agent
   python -m pytest tests/gateway/test_discord_voice_mixer.py::TestVoiceMixerCore::test_isinstance_audio_source -v
   ```
   Observed result: `PASSED`

2. **Full voice mixer test suite** (verifies no regressions):
   ```bash
   python -m pytest tests/gateway/test_discord_voice_mixer.py -v
   ```
   Observed result: `20 passed in 0.54s`

3. **Manual verification** (requires a running Discord bot in a voice channel):
   - Configure `voice_fx` with `enabled: true` in the Hermes config.
   - Join a Discord voice channel with the bot.
   - Trigger a tool call — the ambient "thinking" pad should start playing.
   - Verify no `source must be an AudioSource not VoiceMixer` warning in gateway logs.

   **Platform limitation**: Steps 1–2 are the regression tests run from this cron host (macOS). Step 3 requires a live Discord voice connection and cannot be automated here. The `isinstance` check is the root cause gate — if it passes, `vc.play(mixer)` will accept the mixer.

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.5

## Code Intelligence

- Root cause: `plugins/platforms/discord/voice_mixer.py:148` — `class VoiceMixer:` missing base class
- The `isinstance(source, AudioSource)` check lives in discord.py's `VoiceClient.play()` (`discord/player.py`)
- `VoiceMixer` implements `is_opus()` at line 158, `read()` at line 244, `cleanup()` at line 292 — the complete AudioSource contract
- Search used: `rg "class VoiceMixer" plugins/platforms/discord/voice_mixer.py`
