### PR TITLE
fix(desktop): cap remote folder picker list height so long directories scroll

### DIFF
--- a/apps/desktop/src/app/right-sidebar/files/remote-picker.tsx
+++ b/apps/desktop/src/app/right-sidebar/files/remote-picker.tsx
@@ -129,7 +129,7 @@ export function RemoteFolderPicker() {
             ))}
           </div>
 
-          <div className="min-h-0 flex-1 overflow-y-auto p-2">
+          <div className="min-h-0 flex-1 overflow-y-auto p-2 max-h-[55vh]">
             <FolderRow disabled={currentPath === '/'} name=".." onClick={() => setCurrentPath(parentDir(currentPath))} />
             {loading ? (
               <div className="flex items-center gap-2 px-2 py-3 text-xs text-muted-foreground">


### PR DESCRIPTION
## Problem

The RemoteFolderPicker dialog (used when "Open Folder" is clicked in the desktop app's right sidebar) cannot scroll when a directory contains many subfolders. The user sees only the folders that fit on screen and has no way to reach entries further down the list.

## Root cause

The dialog layout is:

```
DialogContent (max-h-[85vh], overflow-hidden)  ← clips, doesn't scroll
  ├── header (fixed height)
  ├── middle container (min-h-[22rem], no max)  ← grows unbounded
  │     ├── breadcrumbs
  │     └── list div (overflow-y-auto, flex-1)  ← never activates
  └── footer (fixed height)
```

The middle container has `min-h-[22rem]` but no max height, so when a directory has many subfolders it grows beyond the dialog's `85vh` cap. Because `DialogContent` has `overflow-hidden`, the excess is silently clipped. The `overflow-y-auto` on the list div never triggers because its flex parent isn't height-constrained — the container just keeps expanding.

## Fix

Add `max-h-[55vh]` to the scrollable list div so it scrolls within the dialog regardless of how many entries the current directory has:

```diff
-          <div className="min-h-0 flex-1 overflow-y-auto p-2">
+          <div className="min-h-0 flex-1 overflow-y-auto p-2 max-h-[55vh]">
```

This caps the list at 55% of viewport height, leaving room for the header (breadcrumbs + title) and footer (path + buttons) within the 85vh dialog. The `overflow-y-auto` now activates as soon as entries exceed this height.

## Verification

- `npm run typecheck` in `apps/desktop` ✅
- `npm run build` in `apps/desktop` ✅
- `npm run lint` in `apps/desktop` is currently red on pre-existing repository lint issues; this PR's touched file only reports existing padding-line warnings, not a new error on the changed line.
