### PR TITLE
fix(dashboard): move sync I/O off the event loop to prevent desktop timeouts

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -27,13 +27,73 @@ import shutil
 import stat
 import subprocess
 import sys
+import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath, PureWindowsPath
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from agent.skill_utils import is_excluded_skill_path
 
 _PROFILE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+# find_alias_for_profile scans ~/.local/bin/ to reverse-lookup wrapper aliases.
+# With ~3774 files in that directory (common on dev machines), every call that
+# triggers list_profiles → find_alias_for_profile reads every file — and
+# concurrent async requests (cron/profiles/sessions endpoints) all do it in
+# parallel. Cache the scan for 2s with a lock so only one thread scans at a time.
+_WRAPPER_CACHE: Dict[str, Tuple[float, Dict[str, Optional[str]]]] = {}
+_WRAPPER_SCAN_TTL_S = 2.0
+_WRAPPER_SCAN_LOCK = threading.Lock()
+
+def _scan_wrapper_dir() -> Dict[str, Optional[str]]:
+    """Scan ~/.local/bin/ for `hermes -p <name>` wrappers.
+    Returns {needle: alias} preferring custom aliases over profile-named ones."""
+    wrapper_dir = _get_wrapper_dir()
+    if not wrapper_dir.is_dir():
+        return {}
+    is_windows = sys.platform == "win32"
+    # Track (custom_alias, profile_named_alias) per needle; custom wins.
+    pairs: Dict[str, Tuple[Optional[str], Optional[str]]] = {}
+    for entry in sorted(wrapper_dir.iterdir()):
+        if is_windows and entry.suffix != ".bat":
+            continue
+        if not is_windows and entry.suffix:
+            continue
+        if not entry.is_file():
+            continue
+        try:
+            content = entry.read_text()
+        except (OSError, UnicodeDecodeError):
+            continue
+        import re as _re
+        for m in _re.finditer(r"hermes -p (\S+)", content):
+            needle = f"hermes -p {m.group(1)}"
+            alias = entry.stem if is_windows else entry.name
+            custom, named = pairs.get(needle, (None, None))
+            if alias == m.group(1):
+                named = alias
+            else:
+                custom = alias
+            pairs[needle] = (custom, named)
+    return {needle: (custom or named) for needle, (custom, named) in pairs.items()}
+
+def _get_wrapper_scan() -> Dict[str, Optional[str]]:
+    """Thread-safe cached wrapper scan. Only one thread scans at a time;
+    concurrent callers wait for the first result and share it."""
+    wrapper_dir = _get_wrapper_dir()
+    cache_key = str(wrapper_dir.resolve())
+    now = time.monotonic()
+    cached = _WRAPPER_CACHE.get(cache_key)
+    if cached and (now - cached[0]) < _WRAPPER_SCAN_TTL_S:
+        return cached[1]
+    with _WRAPPER_SCAN_LOCK:
+        cached = _WRAPPER_CACHE.get(cache_key)
+        if cached and (now - cached[0]) < _WRAPPER_SCAN_TTL_S:
+            return cached[1]
+        result = _scan_wrapper_dir()
+        _WRAPPER_CACHE[cache_key] = (time.monotonic(), result)
+        return result
 
 # Directories bootstrapped inside every new profile
 _PROFILE_DIRS = [
@@ -506,28 +566,8 @@ def find_alias_for_profile(profile_name: str) -> Optional[str]:
     is_windows = sys.platform == "win32"
     needle = f"hermes -p {canon}"
 
-    custom: Optional[str] = None
-    profile_named: Optional[str] = None
-    for entry in sorted(wrapper_dir.iterdir()):
-        if not entry.is_file():
-            continue
-        # Only our own wrappers are named with the alias and (on Windows) .bat.
-        if is_windows and entry.suffix != ".bat":
-            continue
-        if not is_windows and entry.suffix:
-            continue
-        try:
-            content = entry.read_text()
-        except (OSError, UnicodeDecodeError):
-            continue
-        if needle not in content:
-            continue
-        alias = entry.stem if is_windows else entry.name
-        if alias == canon:
-            profile_named = alias
-        elif custom is None:
-            custom = alias
-    return custom if custom is not None else profile_named
+    needle_map = _get_wrapper_scan()
+    return needle_map.get(needle)
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1783,12 +1783,12 @@ async def get_status(profile: Optional[str] = None):
         # Try local PID check first (same-host).  If that fails and a remote
         # GATEWAY_HEALTH_URL is configured, probe the gateway over HTTP so the
         # dashboard works when the gateway runs in a separate container.
-        gateway_pid = get_running_pid()
+        loop = asyncio.get_running_loop()
+        gateway_pid = await loop.run_in_executor(None, get_running_pid)
         gateway_running = gateway_pid is not None
         remote_health_body: dict | None = None
 
         if not gateway_running and _GATEWAY_HEALTH_URL:
-            loop = asyncio.get_running_loop()
             alive, remote_health_body = await loop.run_in_executor(
                 None, _probe_gateway_health
             )
@@ -3031,8 +3031,9 @@ async def get_profiles_sessions(
         name, home = _cron_profile_home(profile)
         targets.append((name, home))
     else:
+        loop = asyncio.get_running_loop()
         try:
-            infos = profiles_mod.list_profiles()
+            infos = await loop.run_in_executor(None, profiles_mod.list_profiles)
             targets = [(info.name, info.path) for info in infos]
         except Exception:
             _log.exception("GET /api/profiles/sessions: list_profiles failed")
@@ -7661,16 +7662,23 @@ def _find_cron_job_profile(job_id: str) -> Optional[str]:
 @app.get("/api/cron/jobs")
 async def list_cron_jobs(profile: str = "all"):
     requested = (profile or "all").strip()
+    loop = asyncio.get_running_loop()
     if requested.lower() != "all":
-        return _call_cron_for_profile(requested, "list_jobs", True)
+        return await loop.run_in_executor(
+            None, _call_cron_for_profile, requested, "list_jobs", True
+        )
 
+    profile_dicts = await loop.run_in_executor(None, _cron_profile_dicts)
     jobs: List[Dict[str, Any]] = []
-    for item in _cron_profile_dicts():
+    for item in profile_dicts:
         name = str(item.get("name") or "")
         if not name:
             continue
         try:
-            jobs.extend(_call_cron_for_profile(name, "list_jobs", True))
+            profile_jobs = await loop.run_in_executor(
+                None, _call_cron_for_profile, name, "list_jobs", True
+            )
+            jobs.extend(profile_jobs)
         except Exception:
             _log.exception("Failed to list cron jobs for profile %s", name)
     return jobs
@@ -7678,10 +7686,11 @@ async def list_cron_jobs(profile: str = "all"):
 
 @app.get("/api/cron/jobs/{job_id}")
 async def get_cron_job(job_id: str, profile: Optional[str] = None):
-    selected = profile or _find_cron_job_profile(job_id)
+    loop = asyncio.get_running_loop()
+    selected = profile or await loop.run_in_executor(None, _find_cron_job_profile, job_id)
     if not selected:
         raise HTTPException(status_code=404, detail="Job not found")
-    job = _call_cron_for_profile(selected, "get_job", job_id)
+    job = await loop.run_in_executor(None, _call_cron_for_profile, selected, "get_job", job_id)
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
     return job
@@ -9795,8 +9804,10 @@ def _disable_unselected_skills(profile_dir: Path, keep: List[str]) -> int:
 @app.get("/api/profiles")
 async def list_profiles_endpoint():
     from hermes_cli import profiles as profiles_mod
+    loop = asyncio.get_running_loop()
     try:
-        return {"profiles": [_profile_to_dict(p) for p in profiles_mod.list_profiles()]}
+        infos = await loop.run_in_executor(None, profiles_mod.list_profiles)
+        return {"profiles": [_profile_to_dict(p) for p in infos]}
     except Exception:
         _log.exception("GET /api/profiles failed; falling back to profile directory scan")
         return {"profiles": _fallback_profile_dicts(profiles_mod)}


### PR DESCRIPTION

The desktop renderer calls `/api/cron/jobs`, `/api/profiles`, `/api/profiles/sessions`, and `/api/status` in parallel during boot. These endpoints run synchronous file I/O (`list_profiles`, `get_running_pid`, `_cron_profile_dicts`, `_call_cron_for_profile`) directly in async def handlers, blocking the event loop for seconds and causing the desktop's 15s `hermes:api` timeout.

Fix the root cause in two ways:

1. **Wrap synchronous endpoint work in `loop.run_in_executor()`** so the event loop stays responsive:
   - `/api/cron/jobs` (`list_cron_jobs`)
   - `/api/cron/jobs/{job_id}` (`get_cron_job`)
   - `/api/profiles` (`list_profiles_endpoint`)
   - `/api/profiles/sessions` (`get_profiles_sessions`)
   - `/api/status` (`get_status`)

2. **Cache the `~/.local/bin/` wrapper-directory scan** used by `find_alias_for_profile`. With 3774+ files in that directory on a dev machine, every `list_profiles()` call reads every file — and concurrent async requests all do it in parallel. A 2-second TTL cache with a threading lock ensures only one thread scans at a time and all callers share the result.

Related: #45072, #44032

```
hermes_cli/profiles.py   | 86 +++++++++++++++++++++++++++++++-----------
hermes_cli/web_server.py | 29 +++++++++++-----
2 files changed, 83 insertions(+), 32 deletions(-)
```
