### PR TITLE
fix(models): fall back to canonical provider for context window on custom endpoints

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -326,7 +326,15 @@ def lookup_models_dev_context(provider: str, model: str) -> Optional[int]:
     """
     mdev_provider_id = PROVIDER_TO_MODELS_DEV.get(provider)
     if not mdev_provider_id:
-        return None
+        # For custom OpenAI-compatible endpoints serving a known model family,
+        # fall back to the canonical provider lookup so users get accurate
+        # context windows instead of the 200k default (e.g. Claude Opus 1M,
+        # Sonnet 200k) when running through LiteLLM or similar proxies.
+        model_lower = model.lower()
+        if "claude" in model_lower:
+            mdev_provider_id = "anthropic"
+        else:
+            return None
 
     data = fetch_models_dev()
     provider_data = data.get(mdev_provider_id)


### PR DESCRIPTION
## Problem

`lookup_models_dev_context()` returns `None` for `provider=custom` because it is not in `PROVIDER_TO_MODELS_DEV`. This causes hermes to use the 200k default context window even for models with much larger windows (e.g. Claude Opus 4 = 1M tokens, Claude Sonnet = 200k).

Users on custom OpenAI-compatible endpoints (LiteLLM, local proxies, Bedrock gateways) see truncated context estimates and incorrect hygiene/compression thresholds.

## Fix

When `provider=custom` has no mapping, check the model name for a known family and fall back to the canonical provider lookup:

- model name contains `claude` → look up under `anthropic`

This is intentionally narrow (only Claude for now) to avoid false positives for unknown custom models.

## Result

Claude Opus 4 via LiteLLM shows 1M context instead of 200k. Sonnet shows 200k (correct). Unknown custom models still return `None` and use the safe default.

## Related

Same root cause as #50946 (custom provider caching).