### PR TITLE
fix(discord): make voice mixer an audio source

### DIFF
--- a/plugins/platforms/discord/voice_mixer.py
+++ b/plugins/platforms/discord/voice_mixer.py
@@ -49,6 +49,13 @@ from typing import TYPE_CHECKING, List, Optional
 if TYPE_CHECKING:  # numpy is an optional ("voice" extra) dep — never import at runtime top-level
     import numpy as np
 
+try:
+    import discord
+except ImportError:
+    _DiscordAudioSourceBase = object
+else:
+    _DiscordAudioSourceBase = discord.AudioSource
+
 logger = logging.getLogger(__name__)
 
 
@@ -145,7 +152,7 @@ class MixerChild:
         return samples
 
 
-class VoiceMixer:
+class VoiceMixer(_DiscordAudioSourceBase):
     """A continuous ``discord.AudioSource`` that mixes N child streams.
 
     Use :meth:`set_ambient` to install/replace the looping idle bed and

--- a/tests/gateway/test_discord_voice_mixer_audio_source.py
+++ b/tests/gateway/test_discord_voice_mixer_audio_source.py
@@ -1,0 +1,31 @@
+import importlib.util
+import os
+import sys
+import types
+
+
+_DISCORD_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "plugins", "platforms", "discord",
+)
+
+
+def test_voice_mixer_subclasses_discord_audio_source_when_discord_available(monkeypatch):
+    fake_discord = types.ModuleType("discord")
+
+    class _AudioSource:
+        pass
+
+    fake_discord.AudioSource = _AudioSource
+    monkeypatch.setitem(sys.modules, "discord", fake_discord)
+
+    spec = importlib.util.spec_from_file_location(
+        "voice_mixer_with_discord",
+        os.path.join(_DISCORD_DIR, "voice_mixer.py"),
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    assert issubclass(module.VoiceMixer, _AudioSource)
+    assert isinstance(module.VoiceMixer(), _AudioSource)


### PR DESCRIPTION
﻿## What does this PR do?

Fixes #50899 by making `VoiceMixer` inherit from `discord.AudioSource` when `discord.py` is available. The module still imports when Discord is not installed by falling back to `object`.

This also adds a small regression test for the type relationship that `VoiceClient.play()` expects, without requiring a real Discord connection or NumPy.

## Related Issue

Fixes #50899

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- `plugins/platforms/discord/voice_mixer.py`: resolve an optional Discord audio source base and inherit from it.
- `tests/gateway/test_discord_voice_mixer_audio_source.py`: verify `VoiceMixer` is an audio source when Discord is available.

## How to Test

1. `python scripts/run_tests_parallel.py tests\gateway\test_discord_voice_mixer_audio_source.py -- -q`
2. `python -m pytest tests\gateway\test_discord_voice_mixer_audio_source.py -q -p no:cacheprovider --basetemp=C:\tmp\pytest-hermes`

I kept the change focused to make review easier. I’m happy to adjust if you prefer a different approach.
