### PR TITLE
fix(skills): catch PermissionError in _delete_skill for read-only bundled skills (#50938)

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -1028,3 +1028,20 @@ class TestDeleteSkillRmtreeGuard:
         assert result["success"] is False
         assert "skills root" in result["error"].lower()
         assert outside.exists()
+
+
+class TestDeleteSkillPermissionError:
+    """Read-only bundled skills must return a clear error, not crash."""
+
+    def test_readonly_skill_returns_error(self, tmp_path):
+        """When shutil.rmtree raises PermissionError, _delete_skill returns
+        a non-retryable error instead of propagating the exception."""
+        with _skill_dir(tmp_path):
+            _create_skill("bundled-skill", VALID_SKILL_CONTENT)
+            import shutil as _shutil
+            with patch.object(_shutil, "rmtree",
+                              side_effect=PermissionError("Permission denied")):
+                result = _delete_skill("bundled-skill", absorbed_into="")
+        assert result["success"] is False
+        assert "permission denied" in result["error"].lower()
+        assert "bundled" in result["error"].lower() or "read-only" in result["error"].lower()

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -814,7 +814,17 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
     if unsafe:
         return {"success": False, "error": unsafe}
 
-    shutil.rmtree(skill_dir)
+    try:
+        shutil.rmtree(skill_dir)
+    except PermissionError:
+        return {
+            "success": False,
+            "error": (
+                f"Cannot delete skill '{name}': permission denied. "
+                f"The skill directory is read-only (bundled skill in the base image). "
+                f"Bundled skills cannot be removed."
+            ),
+        }
 
     # Clean up empty category directories (don't remove the skills root itself)
     parent = skill_dir.parent


### PR DESCRIPTION
## What does this PR do?

Fixes a crash in `_delete_skill` when attempting to delete a bundled skill with read-only permissions (e.g. `dr-xr-xr-x` in Docker images). Previously, `shutil.rmtree()` raised an unhandled `PermissionError`, causing the agent to retry indefinitely until the loop warning fired. Now the error is caught and returned as a clear, non-retryable message.

## Related Issue

Fixes #50938

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skill_manager_tool.py`: Wrapped `shutil.rmtree(skill_dir)` in `_delete_skill` with a `try/except PermissionError` block that returns a clear error message identifying the skill as read-only/bundled and non-deletable.
- `tests/tools/test_skill_manager_tool.py`: Added `TestDeleteSkillPermissionError` class with `test_readonly_skill_returns_error` that mocks `shutil.rmtree` to raise `PermissionError` and verifies the function returns `success: False` with an informative error.

## How to Test

**Platform limitation**: The reporter's scenario (bundled skills with `dr-xr-xr-x` in Docker images) cannot be reproduced on this macOS host. The fix is verified via targeted unit test that mocks the PermissionError path directly.

1. Run the targeted test that exercises the PermissionError path in `_delete_skill`:
   ```bash
   python -m pytest tests/tools/test_skill_manager_tool.py::TestDeleteSkillPermissionError -xvs
   ```
   Observed result:
   ```
   tests/tools/test_skill_manager_tool.py::TestDeleteSkillPermissionError::test_readonly_skill_returns_error PASSED
   ```

2. Run all delete-related tests to confirm no regression:
   ```bash
   python -m pytest tests/tools/test_skill_manager_tool.py -xvs -k "delete"
   ```
   Observed result: All 19 delete-related tests pass (including the new one).

3. Code-level verification: Before this fix, `_delete_skill` line 817 called `shutil.rmtree(skill_dir)` with no exception handling. After the fix, a `try/except PermissionError` block catches the error and returns `{"success": False, "error": "Cannot delete skill '...': permission denied. The skill directory is read-only (bundled skill in the base image). Bundled skills cannot be removed."}`. This prevents the agent retry loop described in #50938.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
