### PR TITLE
fix(auxiliary): rotate credential pool on connection errors

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -99,7 +99,7 @@ class _OpenAIProxy:
 
 OpenAI = _OpenAIProxy()  # module-level name, resolves lazily on call/isinstance
 
-from agent.credential_pool import load_pool
+from agent.credential_pool import STATUS_CODE_CONNECTION, load_pool
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
 from utils import base_url_host_matches, base_url_hostname, model_forces_max_completion_tokens, normalize_proxy_env_vars
@@ -2771,6 +2771,28 @@ def _recover_provider_pool(provider: str, exc: Exception, *, failed_api_key: str
         if next_entry is not None:
             _evict_cached_clients(normalized)
             return True
+
+    if _is_connection_error(exc):
+        # A connection/stream blip can be account-specific (a stalled stream, a
+        # soft-throttle, or a stale OAuth session that authenticates but is
+        # dead) rather than a global endpoint outage.  When the pool holds more
+        # than one credential, rotate to the next one for this request with a
+        # SHORT cooldown (STATUS_CODE_CONNECTION) — long enough to skip the
+        # failing account on the immediate retry, short enough not to drain the
+        # pool on a string of network blips.  Single-credential pools are left
+        # untouched (rotating to nothing would only penalise the lone account).
+        # The caller bounds this to one rotation: a second connection error on
+        # the rotated account falls through to the cross-provider fallback
+        # instead of rotating again.
+        if len(pool.entries()) > 1:
+            next_entry = pool.mark_exhausted_and_rotate(
+                status_code=STATUS_CODE_CONNECTION,
+                error_context=error_context,
+                api_key_hint=hint,
+            )
+            if next_entry is not None:
+                _evict_cached_clients(normalized)
+                return True
     return False
 
 
@@ -5489,7 +5511,7 @@ def call_llm(
         # between this call and recovery (which leaves current()=None and makes
         # _select_unlocked() return the NEXT key by mistake).
         _client_api_key = str(getattr(client, "api_key", "") or "")
-        if pool_provider and (_is_auth_error(first_err) or _is_payment_error(first_err) or _is_rate_limit_error(first_err)):
+        if pool_provider and (_is_auth_error(first_err) or _is_payment_error(first_err) or _is_rate_limit_error(first_err) or _is_connection_error(first_err)):
             recovery_err = first_err
             # Skip the extra retry for clear payment/quota errors — the endpoint
             # won't accept another request with the same exhausted key.
@@ -5532,6 +5554,11 @@ def call_llm(
                     if (_is_payment_error(retry2_err) or _is_auth_error(retry2_err)
                             or _is_rate_limit_error(retry2_err)):
                         _recover_provider_pool(pool_provider, retry2_err)
+                        first_err = retry2_err
+                    elif _is_connection_error(retry2_err):
+                        # Rotated account also unreachable.  Don't rotate again
+                        # (bounded to one same-provider rotation); fall through
+                        # to the cross-provider connection fallback below.
                         first_err = retry2_err
                     else:
                         raise
@@ -5963,7 +5990,7 @@ async def async_call_llm(
         # ── Same-provider credential-pool recovery (mirrors sync) ─────
         pool_provider = _recoverable_pool_provider(resolved_provider, client, main_runtime=main_runtime)
         _client_api_key = str(getattr(client, "api_key", "") or "")
-        if pool_provider and (_is_auth_error(first_err) or _is_payment_error(first_err) or _is_rate_limit_error(first_err)):
+        if pool_provider and (_is_auth_error(first_err) or _is_payment_error(first_err) or _is_rate_limit_error(first_err) or _is_connection_error(first_err)):
             recovery_err = first_err
             # Skip the extra retry for clear payment/quota errors — the endpoint
             # won't accept another request with the same exhausted key.
@@ -6000,6 +6027,11 @@ async def async_call_llm(
                     if (_is_payment_error(retry2_err) or _is_auth_error(retry2_err)
                             or _is_rate_limit_error(retry2_err)):
                         _recover_provider_pool(pool_provider, retry2_err)
+                        first_err = retry2_err
+                    elif _is_connection_error(retry2_err):
+                        # Rotated account also unreachable.  Don't rotate again
+                        # (bounded to one same-provider rotation); fall through
+                        # to the cross-provider connection fallback below.
                         first_err = retry2_err
                     else:
                         raise

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -62,6 +62,18 @@ STATUS_EXHAUSTED = "exhausted"
 # login) rewrites the tokens.
 STATUS_DEAD = "dead"
 
+# Synthetic status code used to mark a credential after a transient
+# connection/transport failure (DNS blip, connection reset, premature stream
+# close, request timeout).  These errors carry no real HTTP status, and 599 is
+# never returned by a real provider response, so it maps to a short cooldown
+# (``EXHAUSTED_TTL_CONNECTION_SECONDS``).  Rationale: a connection failure can
+# be account-specific (a stalled stream or a stale OAuth session that
+# authenticates but is dead), so rotating to another credential for the
+# immediate retry is worth a try — but the failing account is probably healthy,
+# so it is only skipped briefly rather than treated as quota-exhausted.  A long
+# cooldown here would risk draining the whole pool on a string of network blips.
+STATUS_CODE_CONNECTION = 599
+
 # OAuth error reasons that indicate the credential is permanently invalid
 # server-side and cannot be recovered by retry/refresh.  Sourced from
 # OpenAI Codex Responses API, Anthropic, xAI, and Google OAuth spec.
@@ -111,6 +123,8 @@ SUPPORTED_POOL_STRATEGIES = {
 EXHAUSTED_TTL_401_SECONDS = 5 * 60           # 5 minutes
 EXHAUSTED_TTL_429_SECONDS = 60 * 60          # 1 hour
 EXHAUSTED_TTL_DEFAULT_SECONDS = 60 * 60      # 1 hour
+EXHAUSTED_TTL_CONNECTION_SECONDS = 90        # transient transport blip — skip the
+                                             # account briefly, don't drain the pool
 
 # Pool key prefix for custom OpenAI-compatible endpoints.
 # Custom endpoints all share provider='custom' but are keyed by their
@@ -252,6 +266,8 @@ def _exhausted_ttl(error_code: Optional[int]) -> int:
         return EXHAUSTED_TTL_401_SECONDS
     if error_code == 429:
         return EXHAUSTED_TTL_429_SECONDS
+    if error_code == STATUS_CODE_CONNECTION:
+        return EXHAUSTED_TTL_CONNECTION_SECONDS
     return EXHAUSTED_TTL_DEFAULT_SECONDS
 
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2706,6 +2706,175 @@ class TestAuxiliaryPoolRotationRetry:
         assert pool.rotate_calls[0]["status_code"] == 429
         mock_fallback.assert_not_called()
 
+    def test_call_llm_rotates_explicit_codex_pool_on_connection_error(self):
+        """A connection blip on a multi-account Codex pool rotates to the next
+        account instead of giving up.
+
+        Reporter scenario: ``auxiliary.compression`` runs on ``openai-codex``
+        (also the main provider), so the cross-provider fallback is empty.
+        Before this fix a connection/stream error killed the call even though
+        other pool accounts were available — the same-provider rotation gate
+        only covered auth/payment/rate-limit.  The rotation uses the short
+        ``STATUS_CODE_CONNECTION`` cooldown so a healthy account isn't locked
+        out for the full quota TTL.
+        """
+        from agent.credential_pool import STATUS_CODE_CONNECTION
+
+        conn_err = ConnectionError("transport closed")
+
+        # The stale account must fail TWICE: the initial call plus the
+        # transient-transport retry-once that call_llm runs on the same client
+        # before any rotation.  Only a *persistent* connection failure rotates
+        # to another account — a single blip is retried in place.
+        stale_client = MagicMock()
+        stale_client.base_url = "https://chatgpt.com/backend-api/codex"
+        stale_client.chat.completions.create.side_effect = [conn_err, conn_err]
+
+        fresh_client = MagicMock()
+        fresh_client.base_url = "https://chatgpt.com/backend-api/codex"
+        fresh_client.chat.completions.create.return_value = _DummyResponse("rotated-conn-sync")
+
+        class _Pool:
+            def __init__(self):
+                self.rotate_calls = []
+
+            def has_credentials(self):
+                return True
+
+            def entries(self):
+                return [SimpleNamespace(id="cred-a"), SimpleNamespace(id="cred-b")]
+
+            def try_refresh_current(self):
+                return None
+
+            def mark_exhausted_and_rotate(self, **kwargs):
+                self.rotate_calls.append(kwargs)
+                return SimpleNamespace(id="cred-b")
+
+        pool = _Pool()
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model", return_value=("openai-codex", "gpt-5.4", None, None, None)),
+            patch("agent.auxiliary_client._get_cached_client", side_effect=[(stale_client, "gpt-5.4"), (fresh_client, "gpt-5.4")]),
+            patch("agent.auxiliary_client._refresh_provider_credentials", return_value=False),
+            patch("agent.auxiliary_client.load_pool", return_value=pool),
+            patch("agent.auxiliary_client._try_payment_fallback") as mock_fallback,
+        ):
+            resp = call_llm(
+                task="compression",
+                provider="openai-codex",
+                model="gpt-5.4",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert resp.choices[0].message.content == "rotated-conn-sync"
+        assert stale_client.chat.completions.create.call_count == 2
+        assert fresh_client.chat.completions.create.call_count == 1
+        assert len(pool.rotate_calls) == 1
+        assert pool.rotate_calls[0]["status_code"] == STATUS_CODE_CONNECTION
+        mock_fallback.assert_not_called()
+
+    def test_call_llm_does_not_rotate_single_account_pool_on_connection_error(self):
+        """A single-credential pool must NOT be rotated on a connection error —
+        rotating to nothing only penalises the lone account.  The call falls
+        through to the existing cross-provider connection fallback instead.
+        """
+        conn_err = ConnectionError("transport closed")
+
+        only_client = MagicMock()
+        only_client.base_url = "https://chatgpt.com/backend-api/codex"
+        only_client.chat.completions.create.side_effect = conn_err
+
+        class _Pool:
+            def __init__(self):
+                self.rotate_calls = []
+
+            def has_credentials(self):
+                return True
+
+            def entries(self):
+                return [SimpleNamespace(id="cred-a")]
+
+            def try_refresh_current(self):
+                return None
+
+            def mark_exhausted_and_rotate(self, **kwargs):
+                self.rotate_calls.append(kwargs)
+                return None
+
+        pool = _Pool()
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model", return_value=("openai-codex", "gpt-5.4", None, None, None)),
+            patch("agent.auxiliary_client._get_cached_client", return_value=(only_client, "gpt-5.4")),
+            patch("agent.auxiliary_client._refresh_provider_credentials", return_value=False),
+            patch("agent.auxiliary_client.load_pool", return_value=pool),
+            patch("agent.auxiliary_client._try_payment_fallback", return_value=(None, None, "")),
+        ):
+            with pytest.raises(ConnectionError):
+                call_llm(
+                    task="compression",
+                    provider="openai-codex",
+                    model="gpt-5.4",
+                    messages=[{"role": "user", "content": "hi"}],
+                )
+
+        assert pool.rotate_calls == [], "single-account pool must not be rotated on a connection blip"
+
+    @pytest.mark.asyncio
+    async def test_async_call_llm_rotates_explicit_codex_pool_on_connection_error(self):
+        from agent.credential_pool import STATUS_CODE_CONNECTION
+
+        conn_err = ConnectionError("transport closed")
+
+        stale_client = MagicMock()
+        stale_client.base_url = "https://chatgpt.com/backend-api/codex"
+        stale_client.chat.completions.create = AsyncMock(side_effect=[conn_err, conn_err])
+
+        fresh_client = MagicMock()
+        fresh_client.base_url = "https://chatgpt.com/backend-api/codex"
+        fresh_client.chat.completions.create = AsyncMock(return_value=_DummyResponse("rotated-conn-async"))
+
+        class _Pool:
+            def __init__(self):
+                self.rotate_calls = []
+
+            def has_credentials(self):
+                return True
+
+            def entries(self):
+                return [SimpleNamespace(id="cred-a"), SimpleNamespace(id="cred-b")]
+
+            def try_refresh_current(self):
+                return None
+
+            def mark_exhausted_and_rotate(self, **kwargs):
+                self.rotate_calls.append(kwargs)
+                return SimpleNamespace(id="cred-b")
+
+        pool = _Pool()
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model", return_value=("openai-codex", "gpt-5.4", None, None, None)),
+            patch("agent.auxiliary_client._get_cached_client", side_effect=[(stale_client, "gpt-5.4"), (fresh_client, "gpt-5.4")]),
+            patch("agent.auxiliary_client._refresh_provider_credentials", return_value=False),
+            patch("agent.auxiliary_client.load_pool", return_value=pool),
+            patch("agent.auxiliary_client._try_payment_fallback") as mock_fallback,
+        ):
+            resp = await async_call_llm(
+                task="compression",
+                provider="openai-codex",
+                model="gpt-5.4",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert resp.choices[0].message.content == "rotated-conn-async"
+        assert stale_client.chat.completions.create.await_count == 2
+        assert fresh_client.chat.completions.create.await_count == 1
+        assert len(pool.rotate_calls) == 1
+        assert pool.rotate_calls[0]["status_code"] == STATUS_CODE_CONNECTION
+        mock_fallback.assert_not_called()
+
 
 class TestCodexAdapterReasoningTranslation:
     """Verify _CodexCompletionsAdapter translates extra_body.reasoning
@@ -3414,6 +3583,13 @@ class TestAuxiliaryClientPoisonedCacheEviction:
             _client_cache.clear()
             _client_cache[cache_key] = (poisoned, "gpt-5.5", None)
 
+        # Stub the credential pool to "no credentials" so the same-provider
+        # connection-error rotation path (which now covers connection errors)
+        # bails immediately instead of loading the real on-disk pool and
+        # marking a live account exhausted.  The contract under test is cache
+        # eviction, not rotation.
+        _no_cred_pool = SimpleNamespace(has_credentials=lambda: False)
+
         try:
             with patch(
                 "agent.auxiliary_client._resolve_task_provider_model",
@@ -3421,6 +3597,9 @@ class TestAuxiliaryClientPoisonedCacheEviction:
             ), patch(
                 "agent.auxiliary_client._get_cached_client",
                 return_value=(poisoned, "gpt-5.5"),
+            ), patch(
+                "agent.auxiliary_client.load_pool",
+                return_value=_no_cred_pool,
             ), patch(
                 "agent.auxiliary_client._try_payment_fallback",
                 return_value=(None, None, ""),
@@ -3450,6 +3629,10 @@ class TestAuxiliaryClientPoisonedCacheEviction:
             _client_cache.clear()
             _client_cache[cache_key] = (poisoned, "gpt-5.5", None)
 
+        # See sync counterpart: stub the pool to "no credentials" so the
+        # connection-error rotation path bails without touching the real pool.
+        _no_cred_pool = SimpleNamespace(has_credentials=lambda: False)
+
         try:
             with patch(
                 "agent.auxiliary_client._resolve_task_provider_model",
@@ -3457,6 +3640,9 @@ class TestAuxiliaryClientPoisonedCacheEviction:
             ), patch(
                 "agent.auxiliary_client._get_cached_client",
                 return_value=(poisoned, "gpt-5.5"),
+            ), patch(
+                "agent.auxiliary_client.load_pool",
+                return_value=_no_cred_pool,
             ), patch(
                 "agent.auxiliary_client._try_payment_fallback",
                 return_value=(None, None, ""),


### PR DESCRIPTION
## Problem

Auxiliary calls (compression, memory flush, title-gen, vision) only rotate to another pooled credential on **auth / payment / rate-limit** errors. A **connection / stream** error falls straight through to the cross-provider fallback — which is **empty when the failing provider is also the main agent provider** (the common Codex-on-Codex compression setup, where `auxiliary.compression` runs on `openai-codex` and the fallback chain skips the same provider).

Net effect: a transient connection blip (`APITimeoutError`, premature stream close, "stream exceeded total timeout", `ConnectionError`) on **one** Codex account kills the auxiliary call even though the pool holds **other healthy accounts**. In practice this surfaces as repeated `context compression failed … all fallbacks exhausted` warnings on a multi-account Codex pool.

## Fix

Extend the same-provider credential-pool recovery path in `agent/auxiliary_client.py` to connection errors:

- On a **persistent** connection failure (the existing transient retry-once on the same client still runs first), rotate to the next pool credential and retry once.
- **Bounded to a single rotation** — a second connection error on the rotated account falls through to the existing cross-provider fallback instead of looping.
- **Single-credential pools are left untouched** (rotating to nothing would only penalise the lone account).
- Mirrored across the **sync (`call_llm`)** and **async (`async_call_llm`)** paths.

The rotation marks the failing account with a new **short cooldown** (`STATUS_CODE_CONNECTION` → `EXHAUSTED_TTL_CONNECTION_SECONDS = 90s`) rather than the 1h default. A connection error usually means a healthy account hit a one-off network blip, so it is only briefly skipped — not treated as quota-exhausted, which (with a string of blips and a long TTL) could otherwise drain the whole pool.

## Why a sentinel status code

Exhaustion reset is computed lazily from persisted fields (`last_status_at + _exhausted_ttl(last_error_code)`), so the short TTL has to be derivable from a persisted code that survives a pool reload by another process. Connection errors carry no real HTTP status, and `599` is never returned by a real provider response, so it maps cleanly to the short cooldown in `_exhausted_ttl`. `_is_terminal_auth_failure` only fires for `401`, so the sentinel can never be misclassified as a DEAD credential.

## Tests

`tests/agent/test_auxiliary_client.py`:
- `test_call_llm_rotates_explicit_codex_pool_on_connection_error` (sync) — persistent connection error on a 2-account pool rotates and succeeds; asserts the rotation uses `STATUS_CODE_CONNECTION` and that the cross-provider fallback is **not** reached.
- `test_async_call_llm_rotates_explicit_codex_pool_on_connection_error` (async) — same for `async_call_llm`.
- `test_call_llm_does_not_rotate_single_account_pool_on_connection_error` — a single-credential pool is never rotated; the call raises as before.
- The existing connection-error eviction tests are isolated from the real on-disk pool (the new rotation path would otherwise load it), preserving their original intent.

Both `call_count == 2` on the stale client reflect the existing transient retry-once before rotation — confirming a single blip is retried in place and only a persistent failure rotates.