### PR TITLE
fix(desktop): add source='desktop' to session.create/resume calls

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -465,7 +465,8 @@ export function useSessionActions({
           ...(newChatProfile ? { profile: newChatProfile } : {}),
           ...(uiModel ? { model: uiModel, ...(uiProvider ? { provider: uiProvider } : {}) } : {}),
           ...(uiEffort ? { reasoning_effort: uiEffort } : {}),
-          ...(uiFast ? { fast: true } : {})
+          ...(uiFast ? { fast: true } : {}),
+          source: "desktop"
         })
 
         const stored = created.stored_session_id ?? null
@@ -707,7 +708,8 @@ export function useSessionActions({
           session_id: storedSessionId,
           cols: 96,
           ...(watchWindow ? { lazy: true } : {}),
-          ...(sessionProfile ? { profile: sessionProfile } : {})
+          ...(sessionProfile ? { profile: sessionProfile } : {}),
+          source: "desktop"
         })
         // The rejection is consumed by the `await` below; this guard only
         // keeps it from surfacing as unhandled while the prefetch settles.


### PR DESCRIPTION
Desktop app sessions (new chat, resume, branch) are stored with `source = "tui"` instead of `source = "desktop"` because the `requestGateway` calls don't pass the source parameter.

This makes Desktop sessions indistinguishable from terminal TUI sessions, preventing filtering/grouping by platform.

Fix: add `source: 'desktop'` to all three `requestGateway` calls:
- Session.create (main chat) — line 462
- Session.resume — line 706
- Branch session.create — line 899

Closes #50932