### PR TITLE
fix(release): add `uv.lock` to PyPI sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include uv.lock
 graft skills
 graft optional-skills
 graft optional-mcps

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -116,6 +116,14 @@ def test_manifest_includes_bundled_skills():
     assert "graft optional-skills" in manifest
 
 
+def test_manifest_includes_uv_lock_for_sdist():
+    manifest_lines = (REPO_ROOT / "MANIFEST.in").read_text(encoding="utf-8").splitlines()
+
+    assert "include uv.lock" in manifest_lines, (
+        "MANIFEST.in must include uv.lock so PyPI sdists ship the lockfile"
+    )
+
+
 def test_bundled_plugin_manifests_ship_in_both_wheel_and_sdist():
     """Regression test for #34034 / #28149.
 

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -116,14 +116,6 @@ def test_manifest_includes_bundled_skills():
     assert "graft optional-skills" in manifest
 
 
-def test_manifest_includes_uv_lock_for_sdist():
-    manifest_lines = (REPO_ROOT / "MANIFEST.in").read_text(encoding="utf-8").splitlines()
-
-    assert "include uv.lock" in manifest_lines, (
-        "MANIFEST.in must include uv.lock so PyPI sdists ship the lockfile"
-    )
-
-
 def test_bundled_plugin_manifests_ship_in_both_wheel_and_sdist():
     """Regression test for #34034 / #28149.
 

--- a/tests/test_wheel_locales_e2e.py
+++ b/tests/test_wheel_locales_e2e.py
@@ -119,7 +119,10 @@ def test_built_sdist_ships_locale_catalogs(tmp_path):
     with tarfile.open(tarballs[0]) as tf:
         # Members are prefixed with the sdist root dir, e.g.
         # hermes_agent-0.15.1/locales/en.yaml — match on the suffix.
-        catalogs = [m for m in tf.getnames() if "/locales/" in m and m.endswith(".yaml")]
+        members = tf.getnames()
+        catalogs = [m for m in members if "/locales/" in m and m.endswith(".yaml")]
+
+    assert any(m.endswith("/uv.lock") for m in members), "sdist missing uv.lock"
 
     # Compare against the canonical language list rather than a hardcoded floor
     # so adding/removing a catalog updates the guard automatically and a dropped


### PR DESCRIPTION
## What does this PR do?

The `*.sigstore.json` bundles attached to each GitHub release are for verifying the PyPI sdist and not the source artifacts attached to the GitHub release artifacts. Users can currently download the sdist from PyPI and verify with cosign using the sigstore json bundle on the GitHub release. The problem is this sdist currently does not include a uv.lock file, which prevents being able to install the exact versions of packages supporting the release.

This change ensures that `uv.lock` is included in the PyPI source distribution. It does not add `uv.lock` to the wheels.

## Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

Add `include uv.lock` to MANIFEST.in so that it'll be included in the sdist. Also added a test to check this line is present in MANIFEST.in.

## How to Test

Run `pytest tests/test_packaging_metadata.py::test_manifest_includes_uv_lock_for_sdist` to verify that the necessary line is included in MANIFEST.in.

Run the following commands if you want to verify the resulting sdist and wheels:
```
uv build --sdist --wheel
tar -tf dist/*.tar.gz | grep '/uv.lock$'
unzip -l dist/*.whl | grep 'uv.lock' || true
```

**Expected result**: present in the .tar.gz, absent from the .whl.

## Checklist

### Code

- [X] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [X] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [X] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [X] I've run `pytest tests/ -q` and all tests pass
- [X] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [X] I've tested on my platform: Fedora 44
