### PR TITLE
fix(agent, cron): handle final reports at iteration limits

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -122,10 +122,14 @@ def finalize_turn(
                 )
 
     # Determine if conversation completed successfully
+    normal_text_response = str(_turn_exit_reason).startswith("text_response(")
     completed = (
         final_response is not None
-        and api_call_count < agent.max_iterations
         and not failed
+        and (
+            api_call_count < agent.max_iterations
+            or normal_text_response
+        )
     )
 
     # Post-loop cleanup must never lose the response.  Trajectory save,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2189,13 +2189,27 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # would otherwise be delivered as if it were the agent's reply and the
         # job's `last_status` set to "ok". Raise so the except handler below
         # builds the proper failure tuple. (issue #17855)
-        if result.get("failed") is True or result.get("completed") is False:
+        turn_exit_reason = str(result.get("turn_exit_reason") or "")
+        final_response_text = (result.get("final_response") or "").strip()
+        max_iteration_summary = (
+            result.get("failed") is not True
+            and result.get("completed") is False
+            and turn_exit_reason.startswith("max_iterations_reached(")
+            and bool(final_response_text)
+        )
+        if result.get("failed") is True or (result.get("completed") is False and not max_iteration_summary):
             _err_text = (
                 result.get("error")
-                or (result.get("final_response") or "").strip()
+                or final_response_text
                 or "agent reported failure"
             )
             raise RuntimeError(_err_text)
+        if max_iteration_summary:
+            logger.warning(
+                "Job '%s' reached the iteration limit but produced a final fallback response; "
+                "delivering the response instead of failing the cron run",
+                job_name,
+            )
 
         final_response = result.get("final_response", "") or ""
         # Strip leaked placeholder text that upstream may inject on empty completions.

--- a/tests/agent/test_turn_finalizer_cleanup_guard.py
+++ b/tests/agent/test_turn_finalizer_cleanup_guard.py
@@ -100,7 +100,13 @@ class _StubAgent:
         pass
 
 
-def _run(agent):
+def _run(
+    agent,
+    *,
+    final_response=None,
+    api_call_count=3,
+    turn_exit_reason="unknown",
+):
     messages = [
         {"role": "user", "content": "do a thing"},
         {
@@ -114,8 +120,8 @@ def _run(agent):
     ]
     return finalize_turn(
         agent,
-        final_response=None,  # forces the max-iterations summary path
-        api_call_count=3,
+        final_response=final_response,
+        api_call_count=api_call_count,
         interrupted=False,
         failed=False,
         messages=messages,
@@ -125,7 +131,7 @@ def _run(agent):
         user_message="do a thing",
         original_user_message="do a thing",
         _should_review_memory=False,
-        _turn_exit_reason="unknown",
+        _turn_exit_reason=turn_exit_reason,
     )
 
 
@@ -162,4 +168,17 @@ def test_clean_turn_has_no_cleanup_errors_key():
     agent = _StubAgent(raise_in=())
     result = _run(agent)
     assert result["final_response"] == "PARTIAL SUMMARY FROM MODEL"
+    assert result["completed"] is False
     assert "cleanup_errors" not in result
+
+
+def test_text_response_on_last_allowed_call_is_completed():
+    agent = _StubAgent(raise_in=())
+    result = _run(
+        agent,
+        final_response="final report",
+        api_call_count=agent.max_iterations,
+        turn_exit_reason="text_response(finish_reason=stop)",
+    )
+    assert result["final_response"] == "final report"
+    assert result["completed"] is True

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1394,6 +1394,52 @@ class TestRunJobSessionPersistence:
         assert error is None
         assert final_response == "all good"
 
+    def test_run_job_delivers_max_iteration_fallback_summary(self, tmp_path):
+        """Cron should deliver a usable max-iteration fallback summary.
+
+        A cron run can exhaust the iteration budget, get a final text summary
+        from the no-tools fallback call, and still have ``completed=False`` in
+        the generic agent result. That should not make cron raise the report
+        text as a RuntimeError.
+        """
+        job = {
+            "id": "summary-job",
+            "name": "summary",
+            "prompt": "finish the report",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {
+                "final_response": "final fallback report",
+                "completed": False,
+                "failed": False,
+                "turn_exit_reason": "max_iterations_reached(60/60)",
+            }
+            mock_agent_cls.return_value = mock_agent
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "final fallback report"
+        assert "final fallback report" in output
+        assert "(FAILED)" not in output
+
     def test_tick_marks_empty_response_as_error(self, tmp_path):
         """When run_job returns success=True but final_response is empty,
         tick() should mark the job as error so last_status != 'ok'.


### PR DESCRIPTION
## What does this PR do?

Fixes two completion-state boundary cases where Hermes can produce usable final text at the iteration limit, but downstream code still treats the turn as incomplete.

First, `agent.turn_finalizer.finalize_turn()` now treats a normal final `text_response(...)` as completed even when it lands on exactly the last allowed API call. The previous predicate required `api_call_count < max_iterations`, so a successful `text_response(finish_reason=stop)` at `api_call_count == max_iterations` returned `completed=False`.

Second, cron now handles the related but distinct max-iteration fallback-summary path. A cron run can hit `max_iterations_reached(...)`, receive a non-empty fallback report from the no-tools summary call, and still have `completed=False` in the generic agent result. Cron should deliver that report instead of raising `RuntimeError(<full report>)`.

The generic max-iteration semantics stay intact for interactive and worker paths. The cron-specific exception only applies when `failed` is not true, the exit reason is `max_iterations_reached(...)`, and the fallback response is non-empty.

## Related Issue

Discord support thread: https://discord.com/channels/1053877538025386074/1518634271122784427

Supersedes #50980; the cron fallback-summary fix has been consolidated here so the support thread has a single review target.

Separate related PR:

- #50890 covers the Discord slash-command cap error later in the same attached log. It does not cover the cron RuntimeError.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/turn_finalizer.py`: treat `text_response(...)` exits with a final response as completed even when they happen on the last allowed API call.
- `cron/scheduler.py`: let cron deliver a non-empty `max_iterations_reached(...)` fallback response instead of raising it as an error when `completed=False`.
- `tests/agent/test_turn_finalizer_cleanup_guard.py`: add regression coverage for a final text response at the max-iteration boundary, while keeping true max-iteration summary turns incomplete.
- `tests/cron/test_scheduler.py`: add regression coverage for cron delivering a non-empty max-iteration fallback report.

## How to Test

1. Run the focused finalizer and scheduler suites:
   `scripts/run_tests.sh -j 4 tests/agent/test_turn_finalizer_cleanup_guard.py tests/cron/test_scheduler.py`
2. Confirm normal final text at the max API-call boundary returns `completed=True`.
3. Confirm generic max-iteration summary turns still return `completed=False`.
4. Confirm cron delivers a non-empty `max_iterations_reached(...)` fallback response instead of failing the run.
5. Confirm real agent failure paths with `failed=True`, empty incomplete output, or explicit errors still fail.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL/Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Focused test run:

`scripts/run_tests.sh -j 4 tests/agent/test_turn_finalizer_cleanup_guard.py tests/cron/test_scheduler.py`

Result: 169 tests passed.

