### PR TITLE
feat(plugins): add thread_ownership — coordinate Slack replies across multi-agent channels

### DIFF
--- a/plugins/thread_ownership/README.md
+++ b/plugins/thread_ownership/README.md
@@ -1,0 +1,68 @@
+# thread_ownership
+
+Coordinate Slack thread ownership across multiple Hermes agents that share a
+channel — prevents "reply storms" where every bot answers every message.
+
+When a Hermes bot is @-mentioned in a thread, Hermes auto-follows that thread
+(`plugins/platforms/slack/adapter.py` `_mentioned_threads`) and opens a turn on
+every later message. With several bots in one channel they *all* open a turn on
+every follow-up — and an LLM that opens a turn must emit *something*, so the bots
+that weren't addressed blurt out "this isn't for me." This plugin gates that at
+`pre_gateway_dispatch`, **before the model runs** — the non-owner skips the turn
+entirely, no tokens burned.
+
+## How it works
+
+The rule is **"the most-recently @-mentioned bot owns the thread."** Every bot
+following the thread sees every message and runs the same parse, so they all
+converge on the same owner with **zero coordination** — no lock service, no
+shared state, no roster. A bot only needs to know its *own* Slack user id.
+
+| Situation | This bot… |
+|---|---|
+| Message @-mentions me (anywhere in the list) | replies; the **last** mention owns the thread going forward |
+| Message @-mentions other bots, not me | stays silent (skips the turn) |
+| Plain follow-up (no @), I'm the current owner | replies |
+| Plain follow-up, I'm not the owner | stays silent |
+| DM, or top-level message (not in a thread) | replies — Slack's own root @-gating handles those |
+
+The hook returns `{"action": "skip", "reason": …}` for the silent cases, so the
+non-owner never invokes the model.
+
+> **Why parse `raw_message`?** Hermes strips the bot's own `<@id>` from
+> `event.text` before the hook runs, which would make a direct `@me …` look like
+> an un-addressed follow-up. The plugin reads the untouched `raw_message["text"]`
+> so it sees its own mention and the full ordered mention list, falling back to
+> `event.text` only if the raw text is unavailable.
+
+## Setup
+
+Add it to your service's `config.yaml`:
+
+```yaml
+plugins:
+  enabled:
+    - thread_ownership
+```
+
+That's the entire setup — **no operator knobs**, no env vars to configure. The
+plugin reads only:
+
+- `SLACK_BOT_TOKEN` (already required by the Slack platform) — one cached
+  `auth.test` call to learn the bot's own user id.
+- `RAILWAY_SERVICE_NAME` / `HOSTNAME` — identity probe; `HOSTNAME` is the
+  universal fallback.
+
+If it can't resolve the bot's own user id, it **fails open** — it never silences
+a misconfigured bot.
+
+## State & restarts
+
+Ownership is per-process, in-memory (`{channel:thread → am I owner}`). On restart
+a bot goes quiet in a thread until it's @-mentioned again — identical to Hermes's
+own in-memory auto-follow state.
+
+## Compatibility
+
+Pure Python (stdlib + `httpx`), no platform-specific syscalls — runs anywhere
+Hermes runs. Only acts on Slack messages; a no-op for every other platform.

--- a/plugins/thread_ownership/README.md
+++ b/plugins/thread_ownership/README.md
@@ -45,16 +45,16 @@ plugins:
     - thread_ownership
 ```
 
-That's the entire setup — **no operator knobs**, no env vars to configure. The
-plugin reads only:
+That's the entire setup — **no operator knobs, no env vars to configure.** The
+plugin learns its own Slack user id from the running Slack adapter, which already
+authenticates every configured bot token and keeps a per-workspace
+`team_id → bot_user_id` map (`_team_bot_user_ids`). It reads that map keyed by
+each message's own workspace, so multi-workspace deployments (comma-separated
+`SLACK_BOT_TOKEN`, or OAuth-added workspaces) resolve the right identity per
+message rather than assuming a single token.
 
-- `SLACK_BOT_TOKEN` (already required by the Slack platform) — one cached
-  `auth.test` call to learn the bot's own user id.
-- `RAILWAY_SERVICE_NAME` / `HOSTNAME` — identity probe; `HOSTNAME` is the
-  universal fallback.
-
-If it can't resolve the bot's own user id, it **fails open** — it never silences
-a misconfigured bot.
+If it can't resolve the bot's own user id for a message's workspace, it **fails
+open** — it never silences a bot it can't identify.
 
 ## State & restarts
 
@@ -64,5 +64,5 @@ own in-memory auto-follow state.
 
 ## Compatibility
 
-Pure Python (stdlib + `httpx`), no platform-specific syscalls — runs anywhere
-Hermes runs. Only acts on Slack messages; a no-op for every other platform.
+Pure Python (stdlib only), no platform-specific syscalls — runs anywhere Hermes
+runs. Only acts on Slack messages; a no-op for every other platform.

--- a/plugins/thread_ownership/__init__.py
+++ b/plugins/thread_ownership/__init__.py
@@ -16,14 +16,23 @@ Why no lock service / no cluster roster is needed: thread ownership is
 "is the LAST <@id> mention in this message me?", which every bot computes
 independently from the same message text — so they all converge on the same
 owner with zero coordination. Every bot following the thread receives every
-message (Hermes auto-follow), so they stay in sync. Only the bot's OWN Slack
-user_id is needed (auth.test); we never need to know who the other bots are.
+message (Hermes auto-follow), so they stay in sync. We only need to know THIS
+bot's own Slack user_id; we never need to know who the other bots are.
+
+Identity is workspace-scoped. The Slack adapter authenticates each configured
+bot token — comma-separated SLACK_BOT_TOKEN and OAuth-added workspaces — and
+keeps team_id → bot_user_id in ``_team_bot_user_ids``
+(plugins/platforms/slack/adapter.py). We read that live map keyed by the event's
+own workspace, so a multi-workspace deployment resolves the right identity per
+message instead of assuming a single token. An unknown/unresolved workspace
+fails open (see decision 4) — never mute a bot we can't identify. The adapter is
+reached via the ``gateway`` kwarg the hook already receives.
 
 Decision per Slack thread message (this bot = me, my_id = my Slack user_id):
   1. Non-Slack / no channel        → allow.
   2. DM (channel id starts "D")    → allow (1:1; every message is for me).
   3. Top-level msg (no thread_ts)  → allow (Slack's root @-gating handles it).
-  4. my_id unresolved              → allow (never mute a misconfigured bot).
+  4. my_id unresolved              → allow (never mute a bot we can't identify).
   5. Message has <@id> mention(s):
        owner := (last <@id> == me);  I reply ⟺ I'm in the mention list.
        I'm mentioned → allow; not mentioned → skip (yield to whoever was @-ed).
@@ -34,19 +43,14 @@ Ownership state is in-process memory ({channel:thread -> am I owner}); each bot
 keeps its own. A restart drops it (the bot goes quiet until @-mentioned again) —
 same as Hermes' own auto-follow state, which is also in-memory. Acceptable.
 
-Env: RAILWAY_SERVICE_NAME / HOSTNAME (identity, platform-provided) and
-SLACK_BOT_TOKEN (auth.test → own user_id; the Slack platform already requires
-it). No knobs.
+No env knobs: identity comes from the live Slack adapter, not the environment.
 """
 from __future__ import annotations
 
 import logging
-import os
 import re
 import threading
 from typing import Any, Optional
-
-import httpx
 
 logger = logging.getLogger(__name__)
 
@@ -62,56 +66,44 @@ _OWNS_MAX = 5000
 # don't match; lowercase tokens don't match the uppercase id charset.)
 _MENTION_RE = re.compile(r"<@([A-Z0-9]+)(?:\|[^>]*)?>")
 
-# --- identity resolution (platform-provided env only) -----------------------
-_bot_user_id_cache: Optional[str] = None
-_bot_user_id_cache_lock = threading.Lock()
-_BOT_USER_ID_SENTINEL = "<unresolved>"
+# --- identity resolution (from the live Slack adapter) ----------------------
+def _resolve_my_id(gateway: Any, team_id: str, channel_id: str) -> Optional[str]:
+    """This bot's Slack user_id for the event's workspace, or None (fail open).
 
-
-def _resolve_agent_id() -> str:
-    for var in ("RAILWAY_SERVICE_NAME", "HOSTNAME"):
-        v = os.environ.get(var, "").strip()
-        if v:
-            return v
-    return ""
-
-
-def _resolve_bot_user_id() -> Optional[str]:
-    """Resolve this bot's own Slack user_id via auth.test, cached forever
-    (failures cached too, so we don't hammer Slack)."""
-    global _bot_user_id_cache
-    if _bot_user_id_cache is not None:
-        return None if _bot_user_id_cache == _BOT_USER_ID_SENTINEL else _bot_user_id_cache
-    token = os.environ.get("SLACK_BOT_TOKEN", "").strip()
-    if not token:
-        with _bot_user_id_cache_lock:
-            _bot_user_id_cache = _BOT_USER_ID_SENTINEL
+    Reads the Slack adapter's ``_team_bot_user_ids`` (team_id → bot_user_id),
+    the authoritative per-workspace map it builds by auth-testing every
+    configured token. Keying by the event's own workspace is what makes this
+    correct under the adapter's multi-workspace support (comma-separated
+    SLACK_BOT_TOKEN / OAuth-added workspaces); assuming one token would fail
+    open or pick the wrong identity there.
+    """
+    adapters = getattr(gateway, "adapters", None)
+    if not isinstance(adapters, dict):
         return None
-    with _bot_user_id_cache_lock:
-        if _bot_user_id_cache is not None:
-            return None if _bot_user_id_cache == _BOT_USER_ID_SENTINEL else _bot_user_id_cache
-        try:
-            resp = httpx.post(
-                "https://slack.com/api/auth.test",
-                headers={"Authorization": f"Bearer {token}"},
-                timeout=3.0,
-            )
-            data = resp.json()
-            if data.get("ok"):
-                uid = (data.get("user_id") or "").strip()
-                _bot_user_id_cache = uid or _BOT_USER_ID_SENTINEL
-                if uid:
-                    logger.info("thread_ownership: detected bot_user_id=%s", uid)
-                return uid or None
-            logger.warning("thread_ownership: auth.test not-ok: %s", data)
-        except Exception as e:
-            logger.warning("thread_ownership: auth.test failed (%s)", e)
-        _bot_user_id_cache = _BOT_USER_ID_SENTINEL
+    # Exactly one Slack platform (Platform.SLACK = "slack"); match by key.
+    adapter = next((a for k, a in adapters.items() if "slack" in str(k).lower()), None)
+    if adapter is None:
         return None
+    team_map = getattr(adapter, "_team_bot_user_ids", None)
+    if not isinstance(team_map, dict):
+        return None
+    if not team_id:
+        # Event omitted the workspace; the adapter tracks channel → team.
+        team_id = getattr(adapter, "_channel_team", {}).get(channel_id, "")
+    my_id = team_map.get(team_id)
+    if my_id:
+        return my_id
+    # Single workspace: the sole bot id is unambiguous even when the event's
+    # team key differs (e.g. enterprise-grid shapes). Multiple workspaces: an
+    # unknown team must NOT fall back to another workspace's id (the wrong
+    # identity) — stay unresolved and let the caller fail open.
+    if len(team_map) == 1:
+        return next(iter(team_map.values()))
+    return None
 
 
-def _slack_fields(event: Any) -> Optional[tuple[str, Optional[str], str]]:
-    """Return (channel_id, thread_ts, text) or None if not a Slack message."""
+def _slack_fields(event: Any) -> Optional[tuple[str, Optional[str], str, str]]:
+    """Return (channel_id, thread_ts, text, team_id) or None if not Slack."""
     source = getattr(event, "source", None)
     if source is None:
         return None
@@ -133,12 +125,17 @@ def _slack_fields(event: Any) -> Optional[tuple[str, Optional[str], str]]:
     # dict) so we see our own mention AND the full ordered mention list; fall back to
     # event.text only if the raw text is unavailable.
     text = ""
+    team_id = ""
     raw = getattr(event, "raw_message", None)
     if isinstance(raw, dict):
         text = raw.get("text") or ""
+        # Workspace of the message. The adapter resolves per-workspace identity
+        # from the same field (adapter.py: ``event.get("team") or
+        # event.get("team_id")``); mirror it so our id lookup keys match.
+        team_id = raw.get("team") or raw.get("team_id") or ""
     if not text:
         text = getattr(event, "text", "") or ""
-    return channel_id, thread_ts, text
+    return channel_id, thread_ts, text, team_id
 
 
 # --- ownership state --------------------------------------------------------
@@ -163,7 +160,7 @@ def _on_pre_gateway_dispatch(**kwargs: Any) -> Optional[dict[str, Any]]:
     fields = _slack_fields(event)
     if fields is None:
         return None
-    channel_id, thread_ts, text = fields
+    channel_id, thread_ts, text, team_id = fields
 
     # DM: 1:1 — every message is for me.
     if channel_id.startswith("D"):
@@ -171,10 +168,8 @@ def _on_pre_gateway_dispatch(**kwargs: Any) -> Optional[dict[str, Any]]:
     # Top-level message: Slack's root @-gating handles it; we only gate threads.
     if not thread_ts:
         return None
-    # No identity → safe no-op (never mute a misconfigured bot).
-    if not _resolve_agent_id():
-        return None
-    my_id = _resolve_bot_user_id()
+    # My Slack user_id for THIS message's workspace (from the live adapter).
+    my_id = _resolve_my_id(kwargs.get("gateway"), team_id, channel_id)
     if not my_id:
         return None  # can't tell if I'm addressed → fail open
 
@@ -202,8 +197,6 @@ def _on_pre_gateway_dispatch(**kwargs: Any) -> Optional[dict[str, Any]]:
 def register(ctx) -> None:
     """Hermes plugin entry point. Wires the hook into the gateway."""
     ctx.register_hook("pre_gateway_dispatch", _on_pre_gateway_dispatch)
-    agent_id = _resolve_agent_id() or "<unset>"
     logger.info(
-        "thread_ownership: registered as agent_id=%r (local last-mention ownership)",
-        agent_id,
+        "thread_ownership: registered (per-workspace last-mention ownership)",
     )

--- a/plugins/thread_ownership/__init__.py
+++ b/plugins/thread_ownership/__init__.py
@@ -1,0 +1,209 @@
+"""thread_ownership — local Slack thread coordination (no lock service, no LLM).
+
+Problem: when several Hermes agents share a Slack channel, Hermes' "once
+@-mentioned in a thread, auto-follow every later message"
+(plugins/platforms/slack/adapter.py ``_mentioned_threads``) makes every bot open
+a turn on every thread message. An LLM agent that opens a turn MUST emit
+something — so a bot that isn't the intended recipient blurts out "this isn't
+for me, staying out", which is noise.
+
+Solution: a `pre_gateway_dispatch` hook (runs BEFORE the turn) implementing
+"the most-recently @-mentioned bot owns the thread". The owner answers non-@
+follow-ups; everyone else stays silent (we return a skip, so the turn never runs
+and nothing is emitted).
+
+Why no lock service / no cluster roster is needed: thread ownership is
+"is the LAST <@id> mention in this message me?", which every bot computes
+independently from the same message text — so they all converge on the same
+owner with zero coordination. Every bot following the thread receives every
+message (Hermes auto-follow), so they stay in sync. Only the bot's OWN Slack
+user_id is needed (auth.test); we never need to know who the other bots are.
+
+Decision per Slack thread message (this bot = me, my_id = my Slack user_id):
+  1. Non-Slack / no channel        → allow.
+  2. DM (channel id starts "D")    → allow (1:1; every message is for me).
+  3. Top-level msg (no thread_ts)  → allow (Slack's root @-gating handles it).
+  4. my_id unresolved              → allow (never mute a misconfigured bot).
+  5. Message has <@id> mention(s):
+       owner := (last <@id> == me);  I reply ⟺ I'm in the mention list.
+       I'm mentioned → allow; not mentioned → skip (yield to whoever was @-ed).
+  6. No mention (plain follow-up):
+       I'm the current owner → allow; otherwise → skip.
+
+Ownership state is in-process memory ({channel:thread -> am I owner}); each bot
+keeps its own. A restart drops it (the bot goes quiet until @-mentioned again) —
+same as Hermes' own auto-follow state, which is also in-memory. Acceptable.
+
+Env: RAILWAY_SERVICE_NAME / HOSTNAME (identity, platform-provided) and
+SLACK_BOT_TOKEN (auth.test → own user_id; the Slack platform already requires
+it). No knobs.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+import threading
+from typing import Any, Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Per-process per-thread ownership: f"{channel_id}:{thread_ts}" -> am I the owner.
+_owns: dict[str, bool] = {}
+_owns_lock = threading.Lock()
+# Cap memory growth on a long-running process with many threads; drop the
+# oldest half when exceeded.
+_OWNS_MAX = 5000
+
+# Slack canonical mention: <@U0AB12CD> or <@U0AB12CD|name>. Capture user ids in
+# order of appearance. (Special mentions like <!here>/<!channel> use "<!" and
+# don't match; lowercase tokens don't match the uppercase id charset.)
+_MENTION_RE = re.compile(r"<@([A-Z0-9]+)(?:\|[^>]*)?>")
+
+# --- identity resolution (platform-provided env only) -----------------------
+_bot_user_id_cache: Optional[str] = None
+_bot_user_id_cache_lock = threading.Lock()
+_BOT_USER_ID_SENTINEL = "<unresolved>"
+
+
+def _resolve_agent_id() -> str:
+    for var in ("RAILWAY_SERVICE_NAME", "HOSTNAME"):
+        v = os.environ.get(var, "").strip()
+        if v:
+            return v
+    return ""
+
+
+def _resolve_bot_user_id() -> Optional[str]:
+    """Resolve this bot's own Slack user_id via auth.test, cached forever
+    (failures cached too, so we don't hammer Slack)."""
+    global _bot_user_id_cache
+    if _bot_user_id_cache is not None:
+        return None if _bot_user_id_cache == _BOT_USER_ID_SENTINEL else _bot_user_id_cache
+    token = os.environ.get("SLACK_BOT_TOKEN", "").strip()
+    if not token:
+        with _bot_user_id_cache_lock:
+            _bot_user_id_cache = _BOT_USER_ID_SENTINEL
+        return None
+    with _bot_user_id_cache_lock:
+        if _bot_user_id_cache is not None:
+            return None if _bot_user_id_cache == _BOT_USER_ID_SENTINEL else _bot_user_id_cache
+        try:
+            resp = httpx.post(
+                "https://slack.com/api/auth.test",
+                headers={"Authorization": f"Bearer {token}"},
+                timeout=3.0,
+            )
+            data = resp.json()
+            if data.get("ok"):
+                uid = (data.get("user_id") or "").strip()
+                _bot_user_id_cache = uid or _BOT_USER_ID_SENTINEL
+                if uid:
+                    logger.info("thread_ownership: detected bot_user_id=%s", uid)
+                return uid or None
+            logger.warning("thread_ownership: auth.test not-ok: %s", data)
+        except Exception as e:
+            logger.warning("thread_ownership: auth.test failed (%s)", e)
+        _bot_user_id_cache = _BOT_USER_ID_SENTINEL
+        return None
+
+
+def _slack_fields(event: Any) -> Optional[tuple[str, Optional[str], str]]:
+    """Return (channel_id, thread_ts, text) or None if not a Slack message."""
+    source = getattr(event, "source", None)
+    if source is None:
+        return None
+    if "slack" not in str(getattr(source, "platform", "")).lower():
+        return None
+    channel_id = getattr(source, "chat_id", "") or ""
+    if not channel_id:
+        return None
+    thread_ts = (
+        getattr(source, "thread_id", None)
+        or getattr(event, "reply_to_message_id", None)
+        or None
+    )
+    # CRITICAL: Hermes strips THIS bot's own <@id> from event.text before the hook
+    # runs (plugins/platforms/slack/adapter.py does ``text.replace(f"<@{bot_uid}>",
+    # "")`` on a direct @-mention). That would hide our OWN mention from the parser,
+    # so a direct "@me ..." looks like a no-mention follow-up and we'd wrongly skip
+    # it. Parse the ORIGINAL Slack text from raw_message["text"] (the untouched event
+    # dict) so we see our own mention AND the full ordered mention list; fall back to
+    # event.text only if the raw text is unavailable.
+    text = ""
+    raw = getattr(event, "raw_message", None)
+    if isinstance(raw, dict):
+        text = raw.get("text") or ""
+    if not text:
+        text = getattr(event, "text", "") or ""
+    return channel_id, thread_ts, text
+
+
+# --- ownership state --------------------------------------------------------
+def _set_owns(key: str, owns: bool) -> None:
+    with _owns_lock:
+        _owns[key] = owns
+        if len(_owns) > _OWNS_MAX:
+            for k in list(_owns)[: _OWNS_MAX // 2]:
+                _owns.pop(k, None)
+
+
+def _get_owns(key: str) -> bool:
+    with _owns_lock:
+        return _owns.get(key, False)
+
+
+# --- the hook ---------------------------------------------------------------
+def _on_pre_gateway_dispatch(**kwargs: Any) -> Optional[dict[str, Any]]:
+    event = kwargs.get("event")
+    if event is None:
+        return None
+    fields = _slack_fields(event)
+    if fields is None:
+        return None
+    channel_id, thread_ts, text = fields
+
+    # DM: 1:1 — every message is for me.
+    if channel_id.startswith("D"):
+        return None
+    # Top-level message: Slack's root @-gating handles it; we only gate threads.
+    if not thread_ts:
+        return None
+    # No identity → safe no-op (never mute a misconfigured bot).
+    if not _resolve_agent_id():
+        return None
+    my_id = _resolve_bot_user_id()
+    if not my_id:
+        return None  # can't tell if I'm addressed → fail open
+
+    key = f"{channel_id}:{thread_ts}"
+    mentions = _MENTION_RE.findall(text)
+
+    if mentions:
+        # An @-message: the LAST mention owns the thread; I reply iff I'm in the
+        # mention list (any position). Each bot computes the same owner.
+        _set_owns(key, mentions[-1] == my_id)
+        if my_id in mentions:
+            return None
+        reason = f"thread {key}: addressed to another participant — staying silent"
+        logger.info("thread_ownership: %s", reason)
+        return {"action": "skip", "reason": reason}
+
+    # Plain follow-up (no mention): only the current owner replies.
+    if _get_owns(key):
+        return None
+    reason = f"thread {key}: not the current owner — staying silent"
+    logger.info("thread_ownership: %s", reason)
+    return {"action": "skip", "reason": reason}
+
+
+def register(ctx) -> None:
+    """Hermes plugin entry point. Wires the hook into the gateway."""
+    ctx.register_hook("pre_gateway_dispatch", _on_pre_gateway_dispatch)
+    agent_id = _resolve_agent_id() or "<unset>"
+    logger.info(
+        "thread_ownership: registered as agent_id=%r (local last-mention ownership)",
+        agent_id,
+    )

--- a/plugins/thread_ownership/plugin.yaml
+++ b/plugins/thread_ownership/plugin.yaml
@@ -1,0 +1,7 @@
+name: thread_ownership
+version: 1.0.0
+description: "Coordinate Slack thread ownership across multiple Hermes agents that share a channel — prevents reply storms. Gates pre_gateway_dispatch with 'the most-recently @-mentioned bot owns the thread': the owner answers plain follow-ups, everyone else stays silent. Fully local (each bot derives the same owner from the message's mention list), no lock service, no operator knobs."
+author: "CoreSpeed (https://github.com/corespeed-io)"
+kind: standalone
+hooks:
+  - pre_gateway_dispatch

--- a/tests/plugins/test_thread_ownership.py
+++ b/tests/plugins/test_thread_ownership.py
@@ -1,0 +1,223 @@
+"""Tests for the thread_ownership plugin (local last-mention ownership).
+
+We exercise the `pre_gateway_dispatch` hook directly. The plugin reads fields
+off a MessageEvent-shaped object and returns:
+  - None / {"action": "allow"}            → gateway dispatches normally
+  - {"action": "skip", "reason": "..."}   → drop the message (no turn, no output)
+
+Ownership is computed locally from each message's <@id> mention list, so these
+tests need no network — only the bot's own user_id (seeded in the fixture).
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from plugins import thread_ownership
+
+# Realistic Slack user ids: uppercase alphanumeric, no underscore (matches the
+# plugin's <@id> regex, same shape as real ids like U0AQ1AA1HDF).
+MY_ID = "U0GARRY1"
+OTHER_ID = "U0ZEPHYR1"
+
+
+def _slack_event(
+    *,
+    text: str,
+    channel_id: str = "Cabc",
+    thread_ts: str | None = "T1",
+    reply_to_message_id: str | None = None,
+    raw_text: str | None = None,
+) -> SimpleNamespace:
+    """Build a duck-typed MessageEvent matching hermes's shape.
+
+    Real Slack passes the ORIGINAL message text in ``raw_message["text"]``, while
+    ``event.text`` may have this bot's own mention stripped. ``raw_text`` lets a
+    test set the original separately; it defaults to ``text`` (un-stripped).
+    """
+    return SimpleNamespace(
+        text=text,
+        raw_message={"text": raw_text if raw_text is not None else text},
+        reply_to_message_id=reply_to_message_id,
+        source=SimpleNamespace(platform="slack", chat_id=channel_id, thread_id=thread_ts),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_state(monkeypatch):
+    """Reset per-thread ownership + identity caches between tests."""
+    thread_ownership._owns.clear()
+    thread_ownership._bot_user_id_cache = None
+    for key in ("RAILWAY_SERVICE_NAME", "HOSTNAME", "SLACK_BOT_TOKEN"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("RAILWAY_SERVICE_NAME", "garry")
+    thread_ownership._bot_user_id_cache = MY_ID  # seed to skip auth.test
+    yield
+    thread_ownership._owns.clear()
+    thread_ownership._bot_user_id_cache = None
+
+
+# ── identity resolution ──────────────────────────────────────────────────────
+
+
+def test_agent_id_comes_from_railway_service_name(monkeypatch):
+    monkeypatch.setenv("RAILWAY_SERVICE_NAME", "alice")
+    assert thread_ownership._resolve_agent_id() == "alice"
+
+
+def test_agent_id_falls_back_to_hostname(monkeypatch):
+    monkeypatch.delenv("RAILWAY_SERVICE_NAME", raising=False)
+    monkeypatch.setenv("HOSTNAME", "container-abc")
+    assert thread_ownership._resolve_agent_id() == "container-abc"
+
+
+def test_bot_user_id_fetched_from_slack_auth_test(monkeypatch):
+    thread_ownership._bot_user_id_cache = None
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-fake")
+    fake_resp = MagicMock()
+    fake_resp.json.return_value = {"ok": True, "user_id": "U_FROM_API"}
+    with patch.object(thread_ownership.httpx, "post", return_value=fake_resp) as post:
+        assert thread_ownership._resolve_bot_user_id() == "U_FROM_API"
+        assert thread_ownership._resolve_bot_user_id() == "U_FROM_API"  # cached
+    post.assert_called_once()
+
+
+def test_bot_user_id_failure_is_cached(monkeypatch):
+    thread_ownership._bot_user_id_cache = None
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-fake")
+    fake_resp = MagicMock()
+    fake_resp.json.return_value = {"ok": False, "error": "invalid_auth"}
+    with patch.object(thread_ownership.httpx, "post", return_value=fake_resp) as post:
+        assert thread_ownership._resolve_bot_user_id() is None
+        assert thread_ownership._resolve_bot_user_id() is None
+    post.assert_called_once()
+
+
+# ── passthrough / safe no-op cases ───────────────────────────────────────────
+
+
+def test_non_slack_event_passthrough():
+    e = SimpleNamespace(
+        text="hi", reply_to_message_id=None,
+        source=SimpleNamespace(platform="telegram", chat_id="123", thread_id="T1"),
+    )
+    assert thread_ownership._on_pre_gateway_dispatch(event=e) is None
+
+
+def test_top_level_message_passthrough():
+    # No thread_ts → root @-gating handles it; we don't intervene even if it
+    # @-mentions another bot.
+    e = _slack_event(text=f"<@{OTHER_ID}> hi", thread_ts=None)
+    assert thread_ownership._on_pre_gateway_dispatch(event=e) is None
+
+
+def test_dm_always_allows():
+    # DM channel (id starts "D") is 1:1 — never gate, even a mention of another id.
+    e = _slack_event(text=f"<@{OTHER_ID}> hi", channel_id="D999", thread_ts="T1")
+    assert thread_ownership._on_pre_gateway_dispatch(event=e) is None
+
+
+def test_unresolved_bot_id_fails_open():
+    thread_ownership._bot_user_id_cache = thread_ownership._BOT_USER_ID_SENTINEL
+    e = _slack_event(text=f"<@{OTHER_ID}> hi")  # would otherwise skip
+    assert thread_ownership._on_pre_gateway_dispatch(event=e) is None
+
+
+def test_unconfigured_agent_id_is_noop(monkeypatch):
+    monkeypatch.delenv("RAILWAY_SERVICE_NAME", raising=False)
+    monkeypatch.delenv("HOSTNAME", raising=False)
+    e = _slack_event(text=f"<@{OTHER_ID}> hi")
+    assert thread_ownership._on_pre_gateway_dispatch(event=e) is None
+
+
+# ── ownership logic ──────────────────────────────────────────────────────────
+
+
+def test_mention_me_allows_and_takes_ownership():
+    e = _slack_event(text=f"hey <@{MY_ID}> what's up")
+    assert thread_ownership._on_pre_gateway_dispatch(event=e) is None
+    assert thread_ownership._get_owns("Cabc:T1") is True
+
+
+def test_stripped_self_mention_still_detected_via_raw_message():
+    """Regression: hermes strips this bot's own <@id> from event.text on a direct
+    @-mention, so we must read the original from raw_message['text']. Without this
+    the bot ignores a direct @-mention (the prod bug we hit)."""
+    e = _slack_event(text="在吗", raw_text=f"<@{MY_ID}> 在吗")  # event.text already stripped
+    assert thread_ownership._on_pre_gateway_dispatch(event=e) is None
+    assert thread_ownership._get_owns("Cabc:T1") is True
+
+
+def test_mention_other_bot_skips_and_yields_ownership():
+    thread_ownership._set_owns("Cabc:T1", True)  # I used to own it
+    e = _slack_event(text=f"<@{OTHER_ID}> hi")
+    out = thread_ownership._on_pre_gateway_dispatch(event=e)
+    assert isinstance(out, dict) and out["action"] == "skip"
+    assert thread_ownership._get_owns("Cabc:T1") is False  # ownership moved away
+
+
+def test_non_mention_owner_allows():
+    thread_ownership._set_owns("Cabc:T1", True)
+    assert thread_ownership._on_pre_gateway_dispatch(event=_slack_event(text="yes please")) is None
+
+
+def test_non_mention_non_owner_skips():
+    thread_ownership._set_owns("Cabc:T1", False)
+    out = thread_ownership._on_pre_gateway_dispatch(event=_slack_event(text="yes please"))
+    assert isinstance(out, dict) and out["action"] == "skip"
+
+
+def test_non_mention_unknown_thread_skips():
+    # No prior ownership recorded → not the owner → stay silent.
+    out = thread_ownership._on_pre_gateway_dispatch(event=_slack_event(text="lol"))
+    assert isinstance(out, dict) and out["action"] == "skip"
+
+
+def test_last_mention_wins_when_multiple_bots_mentioned():
+    # @OTHER then @ME → I'm last → I own AND reply.
+    e = _slack_event(text=f"<@{OTHER_ID}> <@{MY_ID}> thoughts?")
+    assert thread_ownership._on_pre_gateway_dispatch(event=e) is None
+    assert thread_ownership._get_owns("Cabc:T1") is True
+
+
+def test_mentioned_but_not_last_replies_but_does_not_own():
+    # @ME then @OTHER → I'm mentioned (reply to THIS msg) but OTHER is last (owner).
+    e = _slack_event(text=f"<@{MY_ID}> <@{OTHER_ID}> over to you")
+    assert thread_ownership._on_pre_gateway_dispatch(event=e) is None  # I'm mentioned → reply
+    assert thread_ownership._get_owns("Cabc:T1") is False  # but I don't own follow-ups
+    # subsequent plain follow-up → I stay silent
+    out = thread_ownership._on_pre_gateway_dispatch(event=_slack_event(text="cool"))
+    assert isinstance(out, dict) and out["action"] == "skip"
+
+
+def test_full_transfer_then_followup_is_silent():
+    # I own → someone @s another bot → I yield → plain follow-up → I stay silent.
+    thread_ownership._set_owns("Cabc:T1", True)
+    thread_ownership._on_pre_gateway_dispatch(event=_slack_event(text=f"<@{OTHER_ID}> take this"))
+    out = thread_ownership._on_pre_gateway_dispatch(event=_slack_event(text="thanks"))
+    assert isinstance(out, dict) and out["action"] == "skip"
+
+
+def test_ownership_is_per_thread():
+    thread_ownership._set_owns("Cabc:T1", True)
+    # A different thread I don't own → plain follow-up → skip.
+    out = thread_ownership._on_pre_gateway_dispatch(event=_slack_event(text="hi", thread_ts="T2"))
+    assert isinstance(out, dict) and out["action"] == "skip"
+
+
+def test_human_only_mention_is_treated_as_addressed_elsewhere():
+    # A mention of a human (not me) → I yield, same as any non-self mention.
+    thread_ownership._set_owns("Cabc:T1", True)
+    out = thread_ownership._on_pre_gateway_dispatch(event=_slack_event(text="<@U0HUMAN1> thanks"))
+    assert isinstance(out, dict) and out["action"] == "skip"
+
+
+def test_register_wires_hook_callback():
+    ctx = MagicMock()
+    thread_ownership.register(ctx)
+    ctx.register_hook.assert_called_once()
+    args, _ = ctx.register_hook.call_args
+    assert args[0] == "pre_gateway_dispatch"
+    assert callable(args[1])

--- a/tests/plugins/test_thread_ownership.py
+++ b/tests/plugins/test_thread_ownership.py
@@ -5,13 +5,15 @@ off a MessageEvent-shaped object and returns:
   - None / {"action": "allow"}            → gateway dispatches normally
   - {"action": "skip", "reason": "..."}   → drop the message (no turn, no output)
 
-Ownership is computed locally from each message's <@id> mention list, so these
-tests need no network — only the bot's own user_id (seeded in the fixture).
+Ownership is computed locally from each message's <@id> mention list. Identity
+(this bot's Slack user_id) is read per-workspace from the live Slack adapter's
+``_team_bot_user_ids`` map, reached via the ``gateway`` kwarg the hook receives —
+so these tests seed a fake gateway/adapter instead of hitting the network.
 """
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -21,6 +23,23 @@ from plugins import thread_ownership
 # plugin's <@id> regex, same shape as real ids like U0AQ1AA1HDF).
 MY_ID = "U0GARRY1"
 OTHER_ID = "U0ZEPHYR1"
+TEAM_ID = "T0TEAM1"
+
+
+def _gateway(*, team_bot_user_ids=None, channel_team=None) -> SimpleNamespace:
+    """Fake GatewayRunner exposing a Slack adapter with a per-workspace id map.
+
+    Mirrors the real shape the hook sees: ``gateway.adapters[Platform.SLACK]``
+    carrying ``_team_bot_user_ids`` (team_id → bot_user_id) and ``_channel_team``
+    (channel_id → team_id). Keyed by "slack" — the plugin matches the platform
+    key case-insensitively, and ``str(Platform.SLACK)`` contains "slack".
+    """
+    adapter = SimpleNamespace(
+        platform="slack",
+        _team_bot_user_ids={TEAM_ID: MY_ID} if team_bot_user_ids is None else team_bot_user_ids,
+        _channel_team=channel_team or {},
+    )
+    return SimpleNamespace(adapters={"slack": adapter})
 
 
 def _slack_event(
@@ -30,69 +49,79 @@ def _slack_event(
     thread_ts: str | None = "T1",
     reply_to_message_id: str | None = None,
     raw_text: str | None = None,
+    team_id: str = TEAM_ID,
 ) -> SimpleNamespace:
     """Build a duck-typed MessageEvent matching hermes's shape.
 
-    Real Slack passes the ORIGINAL message text in ``raw_message["text"]``, while
-    ``event.text`` may have this bot's own mention stripped. ``raw_text`` lets a
-    test set the original separately; it defaults to ``text`` (un-stripped).
+    Real Slack passes the ORIGINAL message text in ``raw_message["text"]`` and
+    the workspace in ``raw_message["team"]``, while ``event.text`` may have this
+    bot's own mention stripped. ``raw_text`` lets a test set the original
+    separately; it defaults to ``text`` (un-stripped).
     """
     return SimpleNamespace(
         text=text,
-        raw_message={"text": raw_text if raw_text is not None else text},
+        raw_message={"text": raw_text if raw_text is not None else text, "team": team_id},
         reply_to_message_id=reply_to_message_id,
         source=SimpleNamespace(platform="slack", chat_id=channel_id, thread_id=thread_ts),
     )
 
 
+def _dispatch(event, gateway=None):
+    """Invoke the hook with a default single-workspace gateway unless overridden."""
+    return thread_ownership._on_pre_gateway_dispatch(
+        event=event, gateway=_gateway() if gateway is None else gateway
+    )
+
+
 @pytest.fixture(autouse=True)
-def _clean_state(monkeypatch):
-    """Reset per-thread ownership + identity caches between tests."""
+def _clean_state():
+    """Reset per-thread ownership between tests."""
     thread_ownership._owns.clear()
-    thread_ownership._bot_user_id_cache = None
-    for key in ("RAILWAY_SERVICE_NAME", "HOSTNAME", "SLACK_BOT_TOKEN"):
-        monkeypatch.delenv(key, raising=False)
-    monkeypatch.setenv("RAILWAY_SERVICE_NAME", "garry")
-    thread_ownership._bot_user_id_cache = MY_ID  # seed to skip auth.test
     yield
     thread_ownership._owns.clear()
-    thread_ownership._bot_user_id_cache = None
 
 
-# ── identity resolution ──────────────────────────────────────────────────────
+# ── identity resolution (per-workspace, from the live adapter) ───────────────
 
 
-def test_agent_id_comes_from_railway_service_name(monkeypatch):
-    monkeypatch.setenv("RAILWAY_SERVICE_NAME", "alice")
-    assert thread_ownership._resolve_agent_id() == "alice"
+def test_identity_resolved_per_workspace_from_adapter():
+    gw = _gateway(team_bot_user_ids={TEAM_ID: MY_ID})
+    assert thread_ownership._resolve_my_id(gw, TEAM_ID, "Cabc") == MY_ID
 
 
-def test_agent_id_falls_back_to_hostname(monkeypatch):
-    monkeypatch.delenv("RAILWAY_SERVICE_NAME", raising=False)
-    monkeypatch.setenv("HOSTNAME", "container-abc")
-    assert thread_ownership._resolve_agent_id() == "container-abc"
+def test_identity_multi_workspace_picks_event_workspace():
+    # Two workspaces; the bot has a distinct user id in each. The event's own
+    # workspace must select its id — the bug the review flagged.
+    other_team = "T0OTHER1"
+    gw = _gateway(team_bot_user_ids={TEAM_ID: MY_ID, other_team: "U0ELSEWHERE"})
+    assert thread_ownership._resolve_my_id(gw, TEAM_ID, "Cabc") == MY_ID
+    assert thread_ownership._resolve_my_id(gw, other_team, "Cabc") == "U0ELSEWHERE"
 
 
-def test_bot_user_id_fetched_from_slack_auth_test(monkeypatch):
-    thread_ownership._bot_user_id_cache = None
-    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-fake")
-    fake_resp = MagicMock()
-    fake_resp.json.return_value = {"ok": True, "user_id": "U_FROM_API"}
-    with patch.object(thread_ownership.httpx, "post", return_value=fake_resp) as post:
-        assert thread_ownership._resolve_bot_user_id() == "U_FROM_API"
-        assert thread_ownership._resolve_bot_user_id() == "U_FROM_API"  # cached
-    post.assert_called_once()
+def test_identity_multi_workspace_unknown_team_fails_open():
+    # Unknown workspace must NOT fall back to another workspace's id.
+    gw = _gateway(team_bot_user_ids={TEAM_ID: MY_ID, "T0OTHER1": "U0ELSEWHERE"})
+    assert thread_ownership._resolve_my_id(gw, "T0UNKNOWN", "Cabc") is None
 
 
-def test_bot_user_id_failure_is_cached(monkeypatch):
-    thread_ownership._bot_user_id_cache = None
-    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-fake")
-    fake_resp = MagicMock()
-    fake_resp.json.return_value = {"ok": False, "error": "invalid_auth"}
-    with patch.object(thread_ownership.httpx, "post", return_value=fake_resp) as post:
-        assert thread_ownership._resolve_bot_user_id() is None
-        assert thread_ownership._resolve_bot_user_id() is None
-    post.assert_called_once()
+def test_identity_single_workspace_tolerates_team_key_mismatch():
+    # One workspace → the sole id is unambiguous even if the event's team key
+    # differs (e.g. enterprise-grid payload shapes).
+    gw = _gateway(team_bot_user_ids={TEAM_ID: MY_ID})
+    assert thread_ownership._resolve_my_id(gw, "T0DIFFERENT", "Cabc") == MY_ID
+
+
+def test_identity_falls_back_to_channel_team_when_event_omits_team():
+    gw = _gateway(
+        team_bot_user_ids={TEAM_ID: MY_ID, "T0OTHER1": "U0X"},
+        channel_team={"Cabc": TEAM_ID},
+    )
+    assert thread_ownership._resolve_my_id(gw, "", "Cabc") == MY_ID
+
+
+def test_identity_no_gateway_or_adapter_returns_none():
+    assert thread_ownership._resolve_my_id(None, TEAM_ID, "Cabc") is None
+    assert thread_ownership._resolve_my_id(SimpleNamespace(adapters={}), TEAM_ID, "Cabc") is None
 
 
 # ── passthrough / safe no-op cases ───────────────────────────────────────────
@@ -103,33 +132,33 @@ def test_non_slack_event_passthrough():
         text="hi", reply_to_message_id=None,
         source=SimpleNamespace(platform="telegram", chat_id="123", thread_id="T1"),
     )
-    assert thread_ownership._on_pre_gateway_dispatch(event=e) is None
+    assert _dispatch(e) is None
 
 
 def test_top_level_message_passthrough():
     # No thread_ts → root @-gating handles it; we don't intervene even if it
     # @-mentions another bot.
     e = _slack_event(text=f"<@{OTHER_ID}> hi", thread_ts=None)
-    assert thread_ownership._on_pre_gateway_dispatch(event=e) is None
+    assert _dispatch(e) is None
 
 
 def test_dm_always_allows():
     # DM channel (id starts "D") is 1:1 — never gate, even a mention of another id.
     e = _slack_event(text=f"<@{OTHER_ID}> hi", channel_id="D999", thread_ts="T1")
-    assert thread_ownership._on_pre_gateway_dispatch(event=e) is None
+    assert _dispatch(e) is None
 
 
 def test_unresolved_bot_id_fails_open():
-    thread_ownership._bot_user_id_cache = thread_ownership._BOT_USER_ID_SENTINEL
+    # Adapter can't resolve my id for this event's workspace → fail open.
+    gw = _gateway(team_bot_user_ids={"T0OTHER1": "U0X", "T0OTHER2": "U0Y"})
+    e = _slack_event(text=f"<@{OTHER_ID}> hi", team_id="T0UNKNOWN")  # would otherwise skip
+    assert _dispatch(e, gateway=gw) is None
+
+
+def test_missing_slack_adapter_fails_open():
+    # No Slack adapter reachable (e.g. torn down) → never silence.
     e = _slack_event(text=f"<@{OTHER_ID}> hi")  # would otherwise skip
-    assert thread_ownership._on_pre_gateway_dispatch(event=e) is None
-
-
-def test_unconfigured_agent_id_is_noop(monkeypatch):
-    monkeypatch.delenv("RAILWAY_SERVICE_NAME", raising=False)
-    monkeypatch.delenv("HOSTNAME", raising=False)
-    e = _slack_event(text=f"<@{OTHER_ID}> hi")
-    assert thread_ownership._on_pre_gateway_dispatch(event=e) is None
+    assert _dispatch(e, gateway=SimpleNamespace(adapters={})) is None
 
 
 # ── ownership logic ──────────────────────────────────────────────────────────
@@ -137,7 +166,7 @@ def test_unconfigured_agent_id_is_noop(monkeypatch):
 
 def test_mention_me_allows_and_takes_ownership():
     e = _slack_event(text=f"hey <@{MY_ID}> what's up")
-    assert thread_ownership._on_pre_gateway_dispatch(event=e) is None
+    assert _dispatch(e) is None
     assert thread_ownership._get_owns("Cabc:T1") is True
 
 
@@ -146,71 +175,71 @@ def test_stripped_self_mention_still_detected_via_raw_message():
     @-mention, so we must read the original from raw_message['text']. Without this
     the bot ignores a direct @-mention (the prod bug we hit)."""
     e = _slack_event(text="在吗", raw_text=f"<@{MY_ID}> 在吗")  # event.text already stripped
-    assert thread_ownership._on_pre_gateway_dispatch(event=e) is None
+    assert _dispatch(e) is None
     assert thread_ownership._get_owns("Cabc:T1") is True
 
 
 def test_mention_other_bot_skips_and_yields_ownership():
     thread_ownership._set_owns("Cabc:T1", True)  # I used to own it
     e = _slack_event(text=f"<@{OTHER_ID}> hi")
-    out = thread_ownership._on_pre_gateway_dispatch(event=e)
+    out = _dispatch(e)
     assert isinstance(out, dict) and out["action"] == "skip"
     assert thread_ownership._get_owns("Cabc:T1") is False  # ownership moved away
 
 
 def test_non_mention_owner_allows():
     thread_ownership._set_owns("Cabc:T1", True)
-    assert thread_ownership._on_pre_gateway_dispatch(event=_slack_event(text="yes please")) is None
+    assert _dispatch(_slack_event(text="yes please")) is None
 
 
 def test_non_mention_non_owner_skips():
     thread_ownership._set_owns("Cabc:T1", False)
-    out = thread_ownership._on_pre_gateway_dispatch(event=_slack_event(text="yes please"))
+    out = _dispatch(_slack_event(text="yes please"))
     assert isinstance(out, dict) and out["action"] == "skip"
 
 
 def test_non_mention_unknown_thread_skips():
     # No prior ownership recorded → not the owner → stay silent.
-    out = thread_ownership._on_pre_gateway_dispatch(event=_slack_event(text="lol"))
+    out = _dispatch(_slack_event(text="lol"))
     assert isinstance(out, dict) and out["action"] == "skip"
 
 
 def test_last_mention_wins_when_multiple_bots_mentioned():
     # @OTHER then @ME → I'm last → I own AND reply.
     e = _slack_event(text=f"<@{OTHER_ID}> <@{MY_ID}> thoughts?")
-    assert thread_ownership._on_pre_gateway_dispatch(event=e) is None
+    assert _dispatch(e) is None
     assert thread_ownership._get_owns("Cabc:T1") is True
 
 
 def test_mentioned_but_not_last_replies_but_does_not_own():
     # @ME then @OTHER → I'm mentioned (reply to THIS msg) but OTHER is last (owner).
     e = _slack_event(text=f"<@{MY_ID}> <@{OTHER_ID}> over to you")
-    assert thread_ownership._on_pre_gateway_dispatch(event=e) is None  # I'm mentioned → reply
+    assert _dispatch(e) is None  # I'm mentioned → reply
     assert thread_ownership._get_owns("Cabc:T1") is False  # but I don't own follow-ups
     # subsequent plain follow-up → I stay silent
-    out = thread_ownership._on_pre_gateway_dispatch(event=_slack_event(text="cool"))
+    out = _dispatch(_slack_event(text="cool"))
     assert isinstance(out, dict) and out["action"] == "skip"
 
 
 def test_full_transfer_then_followup_is_silent():
     # I own → someone @s another bot → I yield → plain follow-up → I stay silent.
     thread_ownership._set_owns("Cabc:T1", True)
-    thread_ownership._on_pre_gateway_dispatch(event=_slack_event(text=f"<@{OTHER_ID}> take this"))
-    out = thread_ownership._on_pre_gateway_dispatch(event=_slack_event(text="thanks"))
+    _dispatch(_slack_event(text=f"<@{OTHER_ID}> take this"))
+    out = _dispatch(_slack_event(text="thanks"))
     assert isinstance(out, dict) and out["action"] == "skip"
 
 
 def test_ownership_is_per_thread():
     thread_ownership._set_owns("Cabc:T1", True)
     # A different thread I don't own → plain follow-up → skip.
-    out = thread_ownership._on_pre_gateway_dispatch(event=_slack_event(text="hi", thread_ts="T2"))
+    out = _dispatch(_slack_event(text="hi", thread_ts="T2"))
     assert isinstance(out, dict) and out["action"] == "skip"
 
 
 def test_human_only_mention_is_treated_as_addressed_elsewhere():
     # A mention of a human (not me) → I yield, same as any non-self mention.
     thread_ownership._set_owns("Cabc:T1", True)
-    out = thread_ownership._on_pre_gateway_dispatch(event=_slack_event(text="<@U0HUMAN1> thanks"))
+    out = _dispatch(_slack_event(text="<@U0HUMAN1> thanks"))
     assert isinstance(out, dict) and out["action"] == "skip"
 
 


### PR DESCRIPTION
## What does this PR do?

Adds a `thread_ownership` plugin. When several Hermes agents share a Slack channel, Hermes' auto-follow (`_mentioned_threads`) makes **every** bot open a turn on **every** thread message — and an LLM that opens a turn must emit *something*, so the bots that weren't addressed blurt out "this isn't for me, staying out." That's noise, and it burns tokens.

This plugin gates that at `pre_gateway_dispatch`, **before the model runs** — the bot that isn't addressed returns `{"action": "skip"}` and never invokes the LLM.

The rule is **"the most-recently @-mentioned bot owns the thread"**: the owner answers plain follow-ups; everyone else stays silent. It's **fully local** — every bot following the thread sees every message and runs the same parse, so they all converge on the same owner with zero coordination (no lock service, no shared state, no roster). A bot only needs its own Slack user id (one cached `auth.test`).

## Related Issue

Fixes #50973.

Searched open + closed PRs/issues — related but **distinct** (different platform / mechanism), not duplicates:

- #5756 / #5757 — Telegram `group_topics` config-based filtering
- #9731 — Mattermost sticky thread routing
- #22509 — multi-user Discord bot access control

None addresses Slack multi-agent reply-storm gating at `pre_gateway_dispatch`.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality) — a new opt-in bundled plugin

## Changes Made

- `plugins/thread_ownership/__init__.py` — the `pre_gateway_dispatch` hook + `register(ctx)`
- `plugins/thread_ownership/plugin.yaml` — manifest (`kind: standalone`, opt-in via `plugins.enabled`)
- `plugins/thread_ownership/README.md` — behavior table + setup
- `tests/plugins/test_thread_ownership.py` — 21 unit tests

## How to Test

1. Enable in two or more agents that share a Slack channel — add `- thread_ownership` under `plugins.enabled` in each `config.yaml`.
2. @-mention bot **A** in a thread, then post a plain follow-up → only **A** replies.
3. @-mention bot **B** in the same thread → **B** takes over; **A** stays silent on the next plain follow-up.
4. Unit tests: `PYTHONPATH=. pytest tests/plugins/test_thread_ownership.py` → 21 pass.

## Checklist

- [x] Opt-in via `plugins.enabled` (`kind: standalone`); no operator knobs, no config required
- [x] No new dependencies (stdlib + `httpx`, already a Hermes dep)
- [x] Reads `raw_message["text"]` so it still sees the bot's own mention after the Slack adapter strips `<@bot>` from `event.text`
- [x] Fails open if it can't resolve its own user id (never mutes a misconfigured bot); no-op on non-Slack platforms
- [x] 21 unit tests; `ruff` clean
- [x] Running in production across a 3-bot Slack cluster
