### PR TITLE
fix(plugins): fire transform_llm_output hooks for non-default profiles

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -46,9 +46,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Set, Union
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_default_hermes_root, get_hermes_home
 from utils import env_var_enabled
-from hermes_cli.config import cfg_get
 from hermes_cli.middleware import OBSERVER_SCHEMA_VERSION, VALID_MIDDLEWARE
 
 
@@ -204,50 +203,76 @@ def _env_enabled(name: str) -> bool:
     return env_var_enabled(name)
 
 
-def _get_disabled_plugins() -> set:
-    """Read the disabled plugins list from config.yaml.
-
-    Kept for backward compat and explicit deny-list semantics. A plugin
-    name in this set will never load, even if it appears in
-    ``plugins.enabled``.
-    """
+def _path_identity(path: Path) -> str:
+    """Return a stable identity for path de-duplication without requiring it to exist."""
     try:
-        from hermes_cli.config import load_config
-        config = load_config()
-        disabled = cfg_get(config, "plugins", "disabled", default=[])
-        return set(disabled) if isinstance(disabled, list) else set()
+        return str(path.expanduser().resolve(strict=False))
     except Exception:
-        return set()
+        return str(path.expanduser())
+
+
+def _ordered_hermes_homes() -> List[Path]:
+    """Return default-root and active Hermes homes, de-duplicated in load order."""
+    homes: List[Path] = []
+    seen: Set[str] = set()
+    for home in (get_default_hermes_root(), get_hermes_home()):
+        key = _path_identity(home)
+        if key in seen:
+            continue
+        seen.add(key)
+        homes.append(home)
+    return homes
+
+
+def _read_plugins_config(home: Path) -> Optional[Dict[str, Any]]:
+    """Read only the ``plugins`` block from a Hermes home config file."""
+    if yaml is None:
+        return None
+    config_path = home / "config.yaml"
+    try:
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return None
+    plugins_cfg = data.get("plugins")
+    return plugins_cfg if isinstance(plugins_cfg, dict) else None
+
+
+def _plugin_config_candidates() -> List[Dict[str, Any]]:
+    """Return root/profile plugin config blocks in increasing precedence order."""
+    configs: List[Dict[str, Any]] = []
+    for home in _ordered_hermes_homes():
+        plugins_cfg = _read_plugins_config(home)
+        if plugins_cfg is not None:
+            configs.append(plugins_cfg)
+    return configs
+
+
+def _get_disabled_plugins() -> set:
+    """Read disabled plugin names from root/profile config.yaml files."""
+    disabled_plugins: Set[Any] = set()
+    for plugins_cfg in _plugin_config_candidates():
+        disabled = plugins_cfg.get("disabled", [])
+        if isinstance(disabled, list):
+            disabled_plugins.update(disabled)
+    return disabled_plugins
 
 
 def _get_enabled_plugins() -> Optional[set]:
     """Read the enabled-plugins allow-list from config.yaml.
 
-    Plugins are opt-in by default — only plugins whose name appears in
-    this set are loaded. Returns:
-
-    * ``None`` — the key is missing or malformed. Callers should treat
-      this as "nothing enabled yet" (the opt-in default); the first
-      ``migrate_config`` run populates the key with a grandfathered set
-      of currently-installed user plugins so existing setups don't
-      break on upgrade.
-    * ``set()`` — an empty list was explicitly set; nothing loads.
-    * ``set(...)`` — the concrete allow-list.
+    Plugins are opt-in by default - only plugins whose name appears in this set
+    are loaded. In profile mode, a profile-local ``plugins.enabled`` list wins;
+    otherwise fresh profiles inherit the default-root allow-list so root-installed
+    hooks still register for ``hermes -p <profile> chat``.
     """
-    try:
-        from hermes_cli.config import load_config
-        config = load_config()
-        plugins_cfg = config.get("plugins")
-        if not isinstance(plugins_cfg, dict):
-            return None
+    for plugins_cfg in reversed(_plugin_config_candidates()):
         if "enabled" not in plugins_cfg:
-            return None
+            continue
         enabled = plugins_cfg.get("enabled")
         if not isinstance(enabled, list):
             return None
         return set(enabled)
-    except Exception:
-        return None
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -1236,13 +1261,14 @@ class PluginManager:
         logger.debug("  bundled/platforms: %d manifest(s)", len(bundled_platforms))
         manifests.extend(bundled_platforms)
 
-        # 2. User plugins (~/.hermes/plugins/)
-        user_dir = get_hermes_home() / "plugins"
-        logger.debug("Scanning user plugins: %s", user_dir)
-        user_manifests = self._scan_directory(user_dir, source="user")
-        logger.debug("  user: %d manifest(s)", len(user_manifests))
-        manifests.extend(user_manifests)
-
+        # 2. User plugins. In profile mode, scan the default root first so
+        # root-installed plugins remain available, then scan the active profile
+        # so profile-local plugins can override by key.
+        for user_dir in (home / "plugins" for home in _ordered_hermes_homes()):
+            logger.debug("Scanning user plugins: %s", user_dir)
+            user_manifests = self._scan_directory(user_dir, source="user")
+            logger.debug("  user: %d manifest(s)", len(user_manifests))
+            manifests.extend(user_manifests)
         # 3. Project plugins (./.hermes/plugins/)
         if _env_enabled("HERMES_ENABLE_PROJECT_PLUGINS"):
             project_dir = Path.cwd() / ".hermes" / "plugins"

--- a/tests/test_transform_llm_output_hook.py
+++ b/tests/test_transform_llm_output_hook.py
@@ -75,6 +75,35 @@ def test_hook_receives_expected_kwargs(tmp_path, monkeypatch):
     assert results == ["hello world|s1|anthropic/claude-sonnet-4.6|cli"]
 
 
+def test_hook_loads_from_default_home_for_named_profile(tmp_path, monkeypatch):
+    """Named profiles should see root-installed output transform hooks."""
+    default_home = tmp_path / ".hermes"
+    profile_home = default_home / "profiles" / "test-profile"
+    default_home.mkdir()
+    profile_home.mkdir(parents=True)
+    _make_enabled_plugin(
+        default_home,
+        "profile_output_hook",
+        register_body=(
+            'ctx.register_hook("transform_llm_output", '
+            'lambda **kw: "HOOK-REPLACED")'
+        ),
+    )
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    mgr = PluginManager()
+    mgr.discover_and_load()
+
+    results = mgr.invoke_hook(
+        "transform_llm_output",
+        response_text="original",
+        session_id="s1",
+        model="m",
+        platform="cli",
+    )
+    assert results == ["HOOK-REPLACED"]
+
 def test_first_non_empty_string_wins_semantics():
     """Simulate the run_agent.py loop: first non-empty string replaces text."""
     # The dispatch contract: invoke_hook returns a list; the caller walks


### PR DESCRIPTION
Fixes #50937.

The root cause was that plugin discovery and plugin enablement were scoped only to the active `HERMES_HOME`. For profiles created with `hermes profile create`, `HERMES_HOME` points at `~/.hermes/profiles/<name>`, so root-installed plugins and the root `plugins.enabled` config were skipped even though they worked on the default profile. As a result, no `transform_llm_output` callback was registered for the named profile.

This fix is limited to the profile/plugin loading path: plugin discovery now considers the default Hermes root before the active profile home, while profile-local plugins/config still take precedence.

Added a regression test proving a root-installed `transform_llm_output` hook fires when `HERMES_HOME` points at a named profile.

Commands run:
- `git fetch upstream main --prune`
- `gh pr list --repo NousResearch/hermes-agent --search "50937 OR transform_llm_output OR non-default profile OR plugin hook"`
- `gh issue view 50937 --repo NousResearch/hermes-agent --comments`
- `python -m pytest tests/test_transform_llm_output_hook.py::test_hook_loads_from_default_home_for_named_profile -q -p no:cacheprovider --basetemp=C:\tmp\pytest-hermes` before fix, confirming the regression failed with `assert [] == ["HOOK-REPLACED"]`
- `git diff --check`
- no-write Python discovery/precedence probes

Note: post-fix pytest reruns in this Codex sandbox were blocked by local temp-directory permissions, and the elevated rerun was blocked by the app usage gate. The no-write probes validated the new discovery behavior and profile allow-list precedence without filesystem writes.