### PR TITLE
fix(photon): recover degraded sidecar streams

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3033,6 +3033,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     async def _connect_adapter_with_timeout(self, adapter, platform) -> bool:
         """Connect an adapter without allowing one platform to block others."""
         timeout = self._platform_connect_timeout_secs()
+        adapter_timeout = getattr(adapter, "connect_timeout_seconds", None)
+        if timeout > 0 and adapter_timeout is not None:
+            try:
+                timeout = max(timeout, float(adapter_timeout))
+            except (TypeError, ValueError):
+                pass
         if timeout <= 0:
             return await adapter.connect()
         try:
@@ -3494,7 +3500,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._failed_platforms[adapter.platform] = {
                     "config": platform_config,
                     "attempts": 0,
-                    "next_retry": time.monotonic() + 30,
+                    "next_retry": time.monotonic(),
                 }
                 logger.info(
                     "%s queued for background reconnection",
@@ -6361,8 +6367,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 for _ in range(30):
                     if not self._running:
                         return
+                    if self._failed_platforms:
+                        break
                     await asyncio.sleep(1)
-                continue
+                if not self._failed_platforms:
+                    continue
 
             now = time.monotonic()
             for platform in list(self._failed_platforms.keys()):

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -91,7 +91,18 @@ _SIDECAR_DIR = Path(__file__).parent / "sidecar"
 _PHOTON_RETRYABLE_PATTERNS = (
     "internal sidecar error",
     "upstream connect error",
+    "upstream unavailable",
+    "connection dropped",
     "reset reason: overflow",
+    "upstream_overflow",
+    "upstream_unavailable",
+)
+_PHOTON_PERMANENT_ERROR_PATTERNS = (
+    "auth_failed",
+    "authentication failed",
+    "invalid credentials",
+    "permission_denied",
+    "permission denied",
 )
 
 # Minimum seconds between typing-indicator calls for the same chat.
@@ -111,6 +122,27 @@ _DEFAULT_MENTION_PATTERNS = [
 
 # ---------------------------------------------------------------------------
 # Module-level helpers — also used by check_fn / standalone send
+
+class PhotonSidecarError(RuntimeError):
+    """Safe sidecar failure surfaced over the loopback control API."""
+
+    def __init__(
+        self,
+        path: str,
+        status_code: int,
+        error: str,
+        *,
+        code: Optional[str] = None,
+        retryable: bool = False,
+    ) -> None:
+        self.path = path
+        self.status_code = status_code
+        self.code = code
+        self.retryable = retryable
+        label = f" ({code})" if code else ""
+        super().__init__(
+            f"Photon sidecar {path} returned {status_code}{label}: {error}"
+        )
 
 def _coerce_port(value: Any, default: int) -> int:
     try:
@@ -1232,6 +1264,8 @@ class PhotonAdapter(BasePlatformAdapter):
         if not error:
             return False
         lowered = error.lower()
+        if any(pat in lowered for pat in _PHOTON_PERMANENT_ERROR_PATTERNS):
+            return False
         return any(pat in lowered for pat in _PHOTON_RETRYABLE_PATTERNS)
 
     async def _send_with_retry(
@@ -1318,6 +1352,8 @@ class PhotonAdapter(BasePlatformAdapter):
             body["format"] = "markdown"
         try:
             data = await self._sidecar_call("/send", body)
+        except PhotonSidecarError as e:
+            return SendResult(success=False, error=str(e), retryable=e.retryable)
         except Exception as e:
             return SendResult(success=False, error=str(e))
         self._record_sent_message(data.get("messageId"))
@@ -1367,6 +1403,8 @@ class PhotonAdapter(BasePlatformAdapter):
             body["caption"] = caption
         try:
             data = await self._sidecar_call("/send-attachment", body)
+        except PhotonSidecarError as e:
+            return SendResult(success=False, error=str(e), retryable=e.retryable)
         except Exception as e:
             return SendResult(success=False, error=str(e))
         self._record_sent_message(data.get("messageId"))
@@ -1386,6 +1424,18 @@ class PhotonAdapter(BasePlatformAdapter):
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.post(url, json=body, headers=headers)
         if resp.status_code != 200:
+            try:
+                data = resp.json() or {}
+            except Exception:
+                data = {}
+            if isinstance(data, dict) and data.get("error"):
+                raise PhotonSidecarError(
+                    path,
+                    resp.status_code,
+                    str(data.get("error")),
+                    code=data.get("code"),
+                    retryable=bool(data.get("retryable")),
+                )
             raise RuntimeError(
                 f"Photon sidecar {path} returned {resp.status_code}: {resp.text[:200]}"
             )

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -93,9 +93,12 @@ _PHOTON_RETRYABLE_PATTERNS = (
     "upstream connect error",
     "upstream unavailable",
     "connection dropped",
+    "catchupevents",
+    "deadline exceeded",
     "reset reason: overflow",
     "upstream_overflow",
     "upstream_unavailable",
+    "upstream_transient",
 )
 _PHOTON_PERMANENT_ERROR_PATTERNS = (
     "auth_failed",
@@ -103,6 +106,8 @@ _PHOTON_PERMANENT_ERROR_PATTERNS = (
     "invalid credentials",
     "permission_denied",
     "permission denied",
+    "target_not_allowed",
+    "target not allowed",
 )
 
 # Minimum seconds between typing-indicator calls for the same chat.
@@ -147,6 +152,13 @@ class PhotonSidecarError(RuntimeError):
 def _coerce_port(value: Any, default: int) -> int:
     try:
         return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_float(value: Any, default: float) -> float:
+    try:
+        return float(value)
     except (TypeError, ValueError):
         return default
 
@@ -257,6 +269,19 @@ class PhotonAdapter(BasePlatformAdapter):
         self._autostart_sidecar = str(
             os.getenv("PHOTON_SIDECAR_AUTOSTART", "true")
         ).lower() not in ("0", "false", "no")
+        self._sidecar_health_interval = max(
+            0.0,
+            _coerce_float(
+                os.getenv("PHOTON_SIDECAR_HEALTH_INTERVAL_SECONDS"), 30.0
+            ),
+        )
+        self._sidecar_start_timeout = max(
+            5.0,
+            _coerce_float(
+                os.getenv("PHOTON_SIDECAR_START_TIMEOUT_SECONDS"), 55.0
+            ),
+        )
+        self.connect_timeout_seconds = self._sidecar_start_timeout + 5.0
         self._node_bin = os.getenv("PHOTON_NODE_BIN") or shutil.which("node") or "node"
 
         # With markdown on, format_message preserves fences and the sidecar's
@@ -267,6 +292,7 @@ class PhotonAdapter(BasePlatformAdapter):
         self._sidecar_proc: Optional[subprocess.Popen] = None
         self._sidecar_supervisor_task: Optional[asyncio.Task] = None
         self._inbound_task: Optional[asyncio.Task] = None
+        self._sidecar_health_task: Optional[asyncio.Task] = None
         self._inbound_running = False
         self._http_client: Optional["httpx.AsyncClient"] = None
         # Lightweight in-memory dedup. The gRPC stream is at-least-once, so we
@@ -402,6 +428,9 @@ class PhotonAdapter(BasePlatformAdapter):
         self._inbound_task = asyncio.get_event_loop().create_task(
             self._inbound_loop()
         )
+        self._sidecar_health_task = asyncio.get_event_loop().create_task(
+            self._monitor_sidecar_health()
+        )
 
         self._mark_connected()
         logger.info(
@@ -412,6 +441,17 @@ class PhotonAdapter(BasePlatformAdapter):
 
     async def disconnect(self) -> None:
         self._inbound_running = False
+        if self._sidecar_health_task is not None:
+            task = self._sidecar_health_task
+            self._sidecar_health_task = None
+            task.cancel()
+            if task is not asyncio.current_task():
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+                except Exception:
+                    pass
         if self._inbound_task is not None:
             self._inbound_task.cancel()
             try:
@@ -471,6 +511,47 @@ class PhotonAdapter(BasePlatformAdapter):
                 )
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, 30.0)
+
+    async def _monitor_sidecar_health(self) -> None:
+        """Promote a degraded upstream Photon stream into gateway reconnect.
+
+        The sidecar can keep its local HTTP server alive while spectrum-ts is
+        repeatedly failing to maintain the upstream message stream. Polling
+        ``/healthz`` keeps that state from being a silent inbound outage.
+        """
+        while self._inbound_running:
+            await asyncio.sleep(self._sidecar_health_interval)
+            if not self._inbound_running:
+                break
+            try:
+                data = await self._sidecar_call("/healthz", {})
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.debug("[photon] sidecar health check failed: %s", exc)
+                continue
+            stream = data.get("stream") if isinstance(data, dict) else None
+            if not isinstance(stream, dict) or stream.get("ok") is not False:
+                continue
+            state = str(stream.get("state") or "unknown")
+            degraded_for_ms = stream.get("degradedForMs")
+            last_issue = str(stream.get("lastIssue") or "unknown stream issue")
+            message = (
+                "Photon upstream stream degraded"
+                f" (state={state}, degradedForMs={degraded_for_ms}): "
+                f"{last_issue}"
+            )
+            logger.error("[photon] %s", message)
+            self._set_fatal_error(
+                "UPSTREAM_STREAM_DEGRADED",
+                message,
+                retryable=True,
+            )
+            try:
+                await self._notify_fatal_error()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("[photon] fatal-error notification failed: %s", exc)
+            break
 
     async def _on_inbound_line(self, line: str) -> None:
         try:
@@ -849,8 +930,10 @@ class PhotonAdapter(BasePlatformAdapter):
             self._supervise_sidecar(self._sidecar_proc)
         )
 
-        # Wait for /healthz to come up — give it up to 15s on cold start.
-        deadline = time.time() + 15.0
+        # Wait for /healthz to come up. Spectrum startup can be slow after
+        # upstream auth/stream turbulence; connect_timeout_seconds tells the
+        # gateway to give this adapter enough room before queueing reconnect.
+        deadline = time.time() + self._sidecar_start_timeout
         last_err: Optional[Exception] = None
         async with httpx.AsyncClient(timeout=2.0) as client:
             while time.time() < deadline:
@@ -870,7 +953,8 @@ class PhotonAdapter(BasePlatformAdapter):
                     last_err = e
                 await asyncio.sleep(0.2)
         raise RuntimeError(
-            f"Photon sidecar did not become ready within 15s: {last_err}"
+            "Photon sidecar did not become ready within "
+            f"{self._sidecar_start_timeout:.1f}s: {last_err}"
         )
 
     async def _supervise_sidecar(self, proc: subprocess.Popen) -> None:
@@ -1353,7 +1437,18 @@ class PhotonAdapter(BasePlatformAdapter):
         try:
             data = await self._sidecar_call("/send", body)
         except PhotonSidecarError as e:
-            return SendResult(success=False, error=str(e), retryable=e.retryable)
+            return SendResult(
+                success=False,
+                error=str(e),
+                retryable=e.retryable,
+                error_kind=(
+                    "transient"
+                    if e.retryable
+                    else "forbidden"
+                    if e.code == "target_not_allowed"
+                    else "unknown"
+                ),
+            )
         except Exception as e:
             return SendResult(success=False, error=str(e))
         self._record_sent_message(data.get("messageId"))
@@ -1404,7 +1499,18 @@ class PhotonAdapter(BasePlatformAdapter):
         try:
             data = await self._sidecar_call("/send-attachment", body)
         except PhotonSidecarError as e:
-            return SendResult(success=False, error=str(e), retryable=e.retryable)
+            return SendResult(
+                success=False,
+                error=str(e),
+                retryable=e.retryable,
+                error_kind=(
+                    "transient"
+                    if e.retryable
+                    else "forbidden"
+                    if e.code == "target_not_allowed"
+                    else "unknown"
+                ),
+            )
         except Exception as e:
             return SendResult(success=False, error=str(e))
         self._record_sent_message(data.get("messageId"))
@@ -1424,25 +1530,32 @@ class PhotonAdapter(BasePlatformAdapter):
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.post(url, json=body, headers=headers)
         if resp.status_code != 200:
+            error_text = resp.text[:200]
+            code = None
+            retryable = False
             try:
                 data = resp.json() or {}
+                if isinstance(data, dict):
+                    error_text = str(data.get("error") or error_text)
+                    code = data.get("code")
+                    retryable = bool(data.get("retryable"))
             except Exception:
-                data = {}
-            if isinstance(data, dict) and data.get("error"):
-                raise PhotonSidecarError(
-                    path,
-                    resp.status_code,
-                    str(data.get("error")),
-                    code=data.get("code"),
-                    retryable=bool(data.get("retryable")),
-                )
-            raise RuntimeError(
-                f"Photon sidecar {path} returned {resp.status_code}: {resp.text[:200]}"
+                pass
+            raise PhotonSidecarError(
+                path,
+                resp.status_code,
+                error_text,
+                code=code,
+                retryable=retryable,
             )
         data = resp.json() or {}
         if not data.get("ok"):
-            raise RuntimeError(
-                f"Photon sidecar {path} reported error: {data.get('error')}"
+            raise PhotonSidecarError(
+                path,
+                resp.status_code,
+                str(data.get("error") or "sidecar reported failure"),
+                code=data.get("code"),
+                retryable=bool(data.get("retryable")),
             )
         return data
 
@@ -1571,6 +1684,65 @@ async def _standalone_send(
         }
     base = f"http://{_DEFAULT_SIDECAR_BIND}:{port}"
     headers = {"X-Hermes-Sidecar-Token": token}
+
+    def _standalone_retryable_error(text: str) -> bool:
+        return any(
+            pat in (text or "").lower() for pat in _PHOTON_RETRYABLE_PATTERNS
+        )
+
+    def _standalone_exception_text(exc: Exception) -> str:
+        return str(exc) or exc.__class__.__name__
+
+    async def _post_with_retry(
+        client: "httpx.AsyncClient",
+        path: str,
+        body: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        last_error = ""
+        for attempt in range(1, 4):
+            retryable = False
+            try:
+                resp = await client.post(f"{base}{path}", json=body, headers=headers)
+                if resp.status_code != 200:
+                    try:
+                        data = resp.json() or {}
+                    except Exception:
+                        data = {}
+                    last_error = str(
+                        data.get("error")
+                        or f"sidecar returned {resp.status_code}: {resp.text[:200]}"
+                    )
+                    retryable = bool(data.get("retryable")) or _standalone_retryable_error(
+                        last_error
+                    )
+                else:
+                    data = resp.json() or {}
+                    if data.get("ok"):
+                        return data
+                    last_error = str(data.get("error") or "sidecar reported failure")
+                    retryable = bool(data.get("retryable")) or _standalone_retryable_error(
+                        last_error
+                    )
+            except Exception as exc:
+                last_error = (
+                    "Photon standalone send failed: "
+                    f"{_standalone_exception_text(exc)}"
+                )
+                retryable = _standalone_retryable_error(last_error)
+
+            if attempt >= 3 or not retryable:
+                break
+            delay = 5 * attempt
+            logger.warning(
+                "[photon] standalone send failed (attempt %d/3, retrying in %ds): %s",
+                attempt,
+                delay,
+                last_error,
+            )
+            await asyncio.sleep(delay)
+
+        return {"error": last_error or "sidecar reported failure"}
+
     last_message_id: Optional[str] = None
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
@@ -1582,14 +1754,9 @@ async def _standalone_send(
                 }
                 if _markdown_enabled():
                     send_body["format"] = "markdown"
-                resp = await client.post(
-                    f"{base}/send", json=send_body, headers=headers,
-                )
-                if resp.status_code != 200:
-                    return {"error": f"sidecar returned {resp.status_code}: {resp.text[:200]}"}
-                data = resp.json() or {}
-                if not data.get("ok"):
-                    return {"error": data.get("error") or "sidecar reported failure"}
+                data = await _post_with_retry(client, "/send", send_body)
+                if data.get("error"):
+                    return data
                 last_message_id = data.get("messageId")
 
             # 2. Each attachment as a separate /send-attachment call.
@@ -1610,14 +1777,9 @@ async def _standalone_send(
                 }
                 if guessed:
                     att_body["mimeType"] = guessed
-                resp = await client.post(
-                    f"{base}/send-attachment", json=att_body, headers=headers,
-                )
-                if resp.status_code != 200:
-                    return {"error": f"sidecar returned {resp.status_code}: {resp.text[:200]}"}
-                data = resp.json() or {}
-                if not data.get("ok"):
-                    return {"error": data.get("error") or "sidecar reported failure"}
+                data = await _post_with_retry(client, "/send-attachment", att_body)
+                if data.get("error"):
+                    return data
                 last_message_id = data.get("messageId") or last_message_id
 
         return {"success": True, "message_id": last_message_id}

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -80,6 +80,110 @@ const E164_RE = /^\+\d{6,}$/;
 const MAX_KNOWN_SPACES = 2048;
 const MAX_KNOWN_MESSAGES = 1024;
 const MAX_REACTION_HANDLES = 512;
+const STREAM_DEGRADED_RESTART_MS =
+  Number(process.env.PHOTON_STREAM_DEGRADED_RESTART_MS) || 90 * 1000;
+const STREAM_INTERRUPTED_DEGRADE_COUNT =
+  Number(process.env.PHOTON_STREAM_INTERRUPTED_DEGRADE_COUNT) || 3;
+
+const streamHealth = {
+  state: "starting",
+  degradedSince: null,
+  lastHealthyAt: null,
+  lastIssueAt: null,
+  lastIssue: null,
+  issueCount: 0,
+};
+let streamRestartTimer = null;
+
+function streamHealthSnapshot() {
+  const now = Date.now();
+  const degradedForMs =
+    streamHealth.degradedSince === null ? 0 : now - streamHealth.degradedSince;
+  return {
+    ok: streamHealth.state !== "degraded",
+    state: streamHealth.state,
+    degradedForMs,
+    restartAfterMs: STREAM_DEGRADED_RESTART_MS,
+    lastHealthyAt: streamHealth.lastHealthyAt,
+    lastIssueAt: streamHealth.lastIssueAt,
+    lastIssue: streamHealth.lastIssue,
+    issueCount: streamHealth.issueCount,
+  };
+}
+
+function markStreamHealthy() {
+  streamHealth.state = "healthy";
+  streamHealth.degradedSince = null;
+  streamHealth.lastHealthyAt = new Date().toISOString();
+  streamHealth.issueCount = 0;
+  if (streamRestartTimer) {
+    clearTimeout(streamRestartTimer);
+    streamRestartTimer = null;
+  }
+}
+
+function scheduleStreamRestart() {
+  if (STREAM_DEGRADED_RESTART_MS <= 0 || streamRestartTimer) return;
+  streamRestartTimer = setTimeout(() => {
+    streamRestartTimer = null;
+    if (streamHealth.state !== "degraded" || streamHealth.degradedSince === null) {
+      return;
+    }
+    const degradedForMs = Date.now() - streamHealth.degradedSince;
+    if (degradedForMs < STREAM_DEGRADED_RESTART_MS) {
+      scheduleStreamRestart();
+      return;
+    }
+    console.error(
+      `photon-sidecar: upstream stream degraded for ${degradedForMs}ms; ` +
+        "exiting so Hermes can restart the Photon adapter"
+    );
+    process.exit(75);
+  }, STREAM_DEGRADED_RESTART_MS + 1000);
+  streamRestartTimer.unref();
+}
+
+function markStreamRecovering(reason) {
+  const now = Date.now();
+  if (streamHealth.state !== "recovering") {
+    streamHealth.issueCount = 0;
+  }
+  streamHealth.state = "recovering";
+  streamHealth.lastIssueAt = new Date(now).toISOString();
+  streamHealth.lastIssue = reason;
+  streamHealth.issueCount += 1;
+  if (streamHealth.issueCount >= STREAM_INTERRUPTED_DEGRADE_COUNT) {
+    markStreamDegraded(reason);
+  }
+}
+
+function markStreamDegraded(reason) {
+  const now = Date.now();
+  if (streamHealth.state !== "degraded") {
+    streamHealth.degradedSince = now;
+  }
+  streamHealth.state = "degraded";
+  streamHealth.lastIssueAt = new Date(now).toISOString();
+  streamHealth.lastIssue = reason;
+  streamHealth.issueCount += 1;
+  scheduleStreamRestart();
+}
+
+const originalConsoleError = console.error.bind(console);
+console.error = (...args) => {
+  const text = args
+    .map((arg) => (arg && arg.stack ? arg.stack : String(arg)))
+    .join(" ");
+  if (text.includes("[spectrum.stream]")) {
+    const reason = text.split("\n", 1)[0];
+    if (text.includes("persistently failing")) {
+      markStreamDegraded(reason);
+    } else if (text.includes("stream interrupted")) {
+      markStreamRecovering(reason);
+    }
+  }
+  originalConsoleError(...args);
+};
 
 if (!projectId || !projectSecret || !sharedToken) {
   console.error(
@@ -353,6 +457,7 @@ async function normalizeEvent(space, message) {
     try {
       for await (const [space, message] of app.messages) {
         backoff = 1000; // healthy traffic — reset
+        markStreamHealthy();
         // Only forward inbound messages (ignore our own outbound echoes).
         if (message && message.direction && message.direction !== "inbound") {
           continue;
@@ -364,11 +469,14 @@ async function normalizeEvent(space, message) {
         await deliver(JSON.stringify(event));
       }
       console.error("photon-sidecar: inbound stream ended — re-subscribing");
+      markStreamRecovering("inbound stream ended");
     } catch (e) {
+      const reason = e && e.message ? e.message : String(e);
       console.error(
         "photon-sidecar: inbound stream errored — restarting: " +
-          (e && e.message ? e.message : String(e))
+          reason
       );
+      markStreamRecovering(reason);
     }
     await new Promise((r) =>
       setTimeout(r, backoff + Math.random() * backoff * 0.2)
@@ -419,8 +527,20 @@ function badRequest(res, msg) {
 function classifyHandlerError(e) {
   const text = e && e.stack ? e.stack : String(e);
   const lowered = text.toLowerCase();
+  if (lowered.includes("target not allowed for this project")) {
+    return {
+      error: "target not allowed for this Photon project",
+      code: "target_not_allowed",
+      retryable: false,
+    };
+  }
   if (
     lowered.includes("invalid credentials") ||
+    lowered.includes("status code 401") ||
+    lowered.includes(" 401") ||
+    lowered.includes("unauthenticated") ||
+    lowered.includes("tokenexpired") ||
+    lowered.includes("token expired") ||
     lowered.includes("authentication failed") ||
     lowered.includes("permission_denied") ||
     lowered.includes("grpccode: 7") ||
@@ -434,19 +554,24 @@ function classifyHandlerError(e) {
   }
   if (lowered.includes("reset reason: overflow")) {
     return {
-      error: "photon upstream overflow",
-      code: "upstream_overflow",
+      error: "Photon upstream connection dropped; retrying may succeed",
+      code: "upstream_transient",
       retryable: true,
     };
   }
   if (
     lowered.includes("connection dropped") ||
+    lowered.includes("catchupevents") ||
+    lowered.includes("service unavailable") ||
     lowered.includes("upstream connect error") ||
-    lowered.includes("unavailable")
+    lowered.includes("unavailable") ||
+    lowered.includes("deadline exceeded") ||
+    lowered.includes("reset reason") ||
+    lowered.includes("overflow")
   ) {
     return {
-      error: "photon upstream unavailable",
-      code: "upstream_unavailable",
+      error: "Photon upstream connection dropped; retrying may succeed",
+      code: "upstream_transient",
       retryable: true,
     };
   }
@@ -513,12 +638,26 @@ async function resolveSpace(spaceId) {
   const phoneTarget = phoneTargetFromSpaceId(spaceId);
   let space = null;
 
+  // Photon represents DM chat ids as `any;-;+1...`. Those ids are already
+  // opaque Spectrum space ids, so after a sidecar restart prefer `space.get(id)`
+  // before falling back to `space.create(phone)`. Creating from the phone first
+  // can be rejected as "Target not allowed for this project" even though
+  // replying to the existing inbound DM space is allowed.
+  if (DM_CHAT_GUID_RE.test(spaceId)) {
+    try {
+      space = await im.space.get(spaceId);
+    } catch (e) {
+      console.error(
+        "photon-sidecar: DM space.get failed: " +
+          (e && e.stack ? e.stack : String(e))
+      );
+    }
+  }
+
   // A bare E.164 phone number addresses a DM, so callers can pass just
-  // "+1..." (e.g. PHOTON_HOME_CHANNEL for cron delivery) instead of an opaque
-  // inbound space id. Photon also represents DM chat ids as `any;-;+1...`;
-  // normalize those through the same path. `space.create` accepts the raw
-  // phone string directly.
-  if (phoneTarget) {
+  // "+1..." (e.g. PHOTON_HOME_CHANNEL for cron delivery). Existing DM chat ids
+  // only fall back here if `space.get(id)` failed.
+  if (!space && phoneTarget) {
     try {
       space = await im.space.create(phoneTarget);
     } catch (e) {
@@ -571,7 +710,7 @@ const server = http.createServer(async (req, res) => {
   }
   try {
     if (req.url === "/healthz") {
-      return ok(res, {});
+      return ok(res, { stream: streamHealthSnapshot() });
     }
     if (req.url === "/shutdown") {
       ok(res, {});

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -416,13 +416,54 @@ function badRequest(res, msg) {
   res.end(JSON.stringify({ ok: false, error: msg }));
 }
 
-function serverError(res) {
+function classifyHandlerError(e) {
+  const text = e && e.stack ? e.stack : String(e);
+  const lowered = text.toLowerCase();
+  if (
+    lowered.includes("invalid credentials") ||
+    lowered.includes("authentication failed") ||
+    lowered.includes("permission_denied") ||
+    lowered.includes("grpccode: 7") ||
+    lowered.includes("code: 7")
+  ) {
+    return {
+      error: "photon authentication failed",
+      code: "auth_failed",
+      retryable: false,
+    };
+  }
+  if (lowered.includes("reset reason: overflow")) {
+    return {
+      error: "photon upstream overflow",
+      code: "upstream_overflow",
+      retryable: true,
+    };
+  }
+  if (
+    lowered.includes("connection dropped") ||
+    lowered.includes("upstream connect error") ||
+    lowered.includes("unavailable")
+  ) {
+    return {
+      error: "photon upstream unavailable",
+      code: "upstream_unavailable",
+      retryable: true,
+    };
+  }
+  return {
+    error: "internal sidecar error",
+    code: "sidecar_internal_error",
+    retryable: false,
+  };
+}
+
+function serverError(res, classified) {
   res.statusCode = 500;
   res.setHeader("Content-Type", "application/json");
-  // Don't leak stack traces or raw exception text to the caller — even
-  // though we listen on loopback, the supervisor logs the real error
-  // and the client only needs a generic failure signal.
-  res.end(JSON.stringify({ ok: false, error: "internal sidecar error" }));
+  // Don't leak stack traces or raw exception text to the caller. Return a
+  // small safe class so Python can distinguish auth/config failures from
+  // transient upstream outages without scraping stderr.
+  res.end(JSON.stringify({ ok: false, ...classified }));
 }
 
 function ok(res, data) {
@@ -661,13 +702,12 @@ const server = http.createServer(async (req, res) => {
     res.setHeader("Content-Type", "application/json");
     return res.end(JSON.stringify({ ok: false, error: "not found" }));
   } catch (e) {
+    const classified = classifyHandlerError(e);
     console.error(
-      "photon-sidecar: handler error: " +
+      `photon-sidecar: handler error (${classified.code}): ` +
         (e && e.stack ? e.stack : String(e))
     );
-    // serverError() intentionally returns a generic message — see its
-    // body for the rationale.
-    return serverError(res);
+    return serverError(res, classified);
   }
 });
 

--- a/plugins/platforms/photon/sidecar/package-lock.json
+++ b/plugins/platforms/photon/sidecar/package-lock.json
@@ -9,16 +9,16 @@
       "version": "0.3.0",
       "hasInstallScript": true,
       "dependencies": {
-        "spectrum-ts": "3.1.0"
+        "spectrum-ts": "5.2.0"
       },
       "engines": {
         "node": ">=18.17"
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
-      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
+      "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@grpc/grpc-js": {
@@ -62,15 +62,6 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
-    "node_modules/@msgpack/msgpack": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.3.tgz",
-      "integrity": "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
@@ -81,9 +72,9 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.216.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.216.0.tgz",
-      "integrity": "sha512-KmGTgvxTJ0J01d4mOeX1wMV5NUTNf9HebIuOOGDfIn0a/IrnXIQbOnlylDyl9tkDv4h0DUpdI/GqCdLzfTkUXg==",
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
+      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
@@ -93,9 +84,9 @@
       }
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.7.1.tgz",
-      "integrity": "sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.8.0.tgz",
+      "integrity": "sha512-/3FIraneMcng67SUJCxvyInk/oxzwsxyadufk0wwfOBLf5wqtAGX4MoQASwSbndBPeARzBryUM9Azr5kHIdWLw==",
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -123,6 +114,7 @@
       "version": "0.218.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.218.0.tgz",
       "integrity": "sha512-Qx+4rpVHzgg89dawcWRHyt+XRXeLnhFz/qBtvggmjkcgPUdr+NAB0/u/eIPA8yAeJV0J80Vz43JZCh/XFvZFGw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api-logs": "0.218.0",
         "@opentelemetry/core": "2.7.1",
@@ -137,38 +129,11 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/api-logs": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
-      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz",
-      "integrity": "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.218.0",
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/resources": "2.7.1",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
       "version": "0.218.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.218.0.tgz",
       "integrity": "sha512-8dqezsmPhtKitIK/eTipZhYl9EX2/gNQ5zUMhaz3uxEURwfkNf8IPvo6yNfrzbxdtpAOybS/+h7wmIWYqFSpiw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "2.7.1",
         "@opentelemetry/otlp-exporter-base": "0.218.0",
@@ -183,69 +148,7 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.218.0.tgz",
-      "integrity": "sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA==",
-      "dependencies": {
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/otlp-transformer": "0.218.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.218.0.tgz",
-      "integrity": "sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.218.0",
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/resources": "2.7.1",
-        "@opentelemetry/sdk-logs": "0.218.0",
-        "@opentelemetry/sdk-metrics": "2.7.1",
-        "@opentelemetry/sdk-trace-base": "2.7.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/api-logs": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
-      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz",
-      "integrity": "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.218.0",
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/resources": "2.7.1",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/resources": {
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/resources": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
       "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
@@ -261,40 +164,7 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.216.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.216.0.tgz",
-      "integrity": "sha512-KB3rcwQuitq0JbbsCcNdqMhRJX3kArAYz/ovb0jGRaBQAIrt2roik3xQXuhYxS37zx0jSkUZcJu1z3Y2UCxbDA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.216.0",
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/resources": "2.7.1",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz",
-      "integrity": "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==",
-      "dependencies": {
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/resources": "2.7.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.9.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-base": {
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
       "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
@@ -309,6 +179,204 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.218.0.tgz",
+      "integrity": "sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-transformer": "0.218.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.218.0.tgz",
+      "integrity": "sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-logs": "0.218.0",
+        "@opentelemetry/sdk-metrics": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
+      "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
+      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz",
+      "integrity": "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz",
+      "integrity": "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+      "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
@@ -369,18 +437,18 @@
       }
     },
     "node_modules/@photon-ai/otel": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@photon-ai/otel/-/otel-0.1.1.tgz",
-      "integrity": "sha512-t/NVepO5+fHOLWDI+Eht+RC8PTik0wi7HQsKhU4yPqBjY5JncXmoBZLnWFvG+/qJ/pn6w+tveabKG9pykfkqKg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@photon-ai/otel/-/otel-1.0.0.tgz",
+      "integrity": "sha512-5fACVHN7BtGS+phglVAxun5QLckNUSS4p750oCxR//m9JNVzFQMoLFWfC6DnWBP/W0/+B2yP75+3NMVLodEJEg==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
-        "@opentelemetry/api-logs": "^0.216.0",
+        "@opentelemetry/api-logs": "^0.218.0",
         "@opentelemetry/context-async-hooks": "^2.7.1",
-        "@opentelemetry/exporter-logs-otlp-http": "^0.216.0",
-        "@opentelemetry/exporter-trace-otlp-http": "^0.216.0",
+        "@opentelemetry/exporter-logs-otlp-http": "^0.218.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
         "@opentelemetry/resources": "^2.7.1",
-        "@opentelemetry/sdk-logs": "^0.216.0",
+        "@opentelemetry/sdk-logs": "^0.218.0",
         "@opentelemetry/sdk-trace-base": "^2.7.1"
       },
       "engines": {
@@ -442,10 +510,122 @@
       }
     },
     "node_modules/@repeaterjs/repeater": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.6.tgz",
-      "integrity": "sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.1.0.tgz",
+      "integrity": "sha512-TaoVksZRSx2KWYYpyLQtMQXXeS98VsgZImzW65xmiVgbYhXLk+aEsmzPLirqVuE4/XuUapH2iMtxUzaBNDzdSQ==",
       "license": "MIT"
+    },
+    "node_modules/@spectrum-ts/core": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-aQSWZ75B9eEiJ00Wa72T/GEEPX9RVIlOPXnsdp0lWWgT5K9+twnL25Kob7L1pgQPbzrgoLH/rjQf3iVktriEwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@photon-ai/otel": "^1.0.0",
+        "@photon-ai/proto": "^0.2.4",
+        "@repeaterjs/repeater": "^3.0.6",
+        "marked": "^18.0.5",
+        "mime-types": "^3.0.1",
+        "open-graph-scraper": "^6.11.0",
+        "vcf": "^2.1.2",
+        "zod": "^4.2.1"
+      },
+      "peerDependencies": {
+        "elysia": "^1",
+        "express": "^4 || ^5",
+        "ffmpeg-static": "^5",
+        "hono": "^4",
+        "typescript": "^5 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "elysia": {
+          "optional": true
+        },
+        "express": {
+          "optional": true
+        },
+        "ffmpeg-static": {
+          "optional": true
+        },
+        "hono": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@spectrum-ts/imessage": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/imessage/-/imessage-5.2.0.tgz",
+      "integrity": "sha512-AZztks7jex8J3dnK7xUdjcN87xsXcZK+LCDlhC/gwZ4defH4mxPVcxFKUVND/CO7W3tN4pBD0LDfKUO7jx9uaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@photon-ai/advanced-imessage": "^0.11.0",
+        "@photon-ai/imessage-kit": "^3.0.0",
+        "@photon-ai/otel": "^1.0.0",
+        "lru-cache": "^11.0.0",
+        "marked": "^18.0.5",
+        "zod": "^4.2.1"
+      },
+      "peerDependencies": {
+        "@spectrum-ts/core": "^5.0.0",
+        "typescript": "^5 || ^6.0.0"
+      }
+    },
+    "node_modules/@spectrum-ts/slack": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/slack/-/slack-5.2.0.tgz",
+      "integrity": "sha512-ql6pHuEOxq7xAd9iIfVV9xXqpdmy5T8kUK+87HE8R87YFJm5L6z7df0wE0g0vpgQ6J7FkmTII0XNw/X7//odiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@photon-ai/slack": "^0.2.0",
+        "zod": "^4.2.1"
+      },
+      "peerDependencies": {
+        "@spectrum-ts/core": "^5.0.0",
+        "typescript": "^5 || ^6.0.0"
+      }
+    },
+    "node_modules/@spectrum-ts/telegram": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/telegram/-/telegram-5.2.0.tgz",
+      "integrity": "sha512-ofG2OKK/63Sxkv3a7MEJWkjtCy3Rs8HLEB2pxHSSlofQmAP7SDkXlBEzfgEr1SeM/mIFvE3gXNpIhb97Nz1Dog==",
+      "license": "MIT",
+      "dependencies": {
+        "@photon-ai/telegram-ts": "10.0.0",
+        "marked": "^18.0.5",
+        "zod": "^4.2.1"
+      },
+      "peerDependencies": {
+        "@spectrum-ts/core": "^5.0.0",
+        "typescript": "^5 || ^6.0.0"
+      }
+    },
+    "node_modules/@spectrum-ts/terminal": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/terminal/-/terminal-5.2.0.tgz",
+      "integrity": "sha512-OHSg4HKOgLXhv3mzm0M9eIPiwxdKel9yZglfUWGfUyafibnpCnF2XI069zc9hkDgdvCHynLfxM+TsPXPzdiMbw==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.1"
+      },
+      "peerDependencies": {
+        "@spectrum-ts/core": "^5.0.0",
+        "typescript": "^5 || ^6.0.0"
+      }
+    },
+    "node_modules/@spectrum-ts/whatsapp-business": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/whatsapp-business/-/whatsapp-business-5.2.0.tgz",
+      "integrity": "sha512-JZJwzug6UviSe7FqWb8y9f1Frq3RJ9IOQ/TgCYhijm5uchXtym/HdC+FAmCG06njcFx+ea7boUhwFs8579V4Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@photon-ai/whatsapp-business": "^0.1.1",
+        "mime-types": "^3.0.1",
+        "zod": "^4.2.1"
+      },
+      "peerDependencies": {
+        "@spectrum-ts/core": "^5.0.0",
+        "typescript": "^5 || ^6.0.0"
+      }
     },
     "node_modules/abort-controller-x": {
       "version": "0.5.0",
@@ -477,15 +657,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/async-mutex": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
-      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -507,29 +678,10 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/better-grpc": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/better-grpc/-/better-grpc-0.3.2.tgz",
-      "integrity": "sha512-e+u6C4zHwjE5g7vOvDpFeMe7Nas7FU+xa6FktiheRTcOpEdD5nag+uoIw7L5bPXdxxg995feBAXLwIay/npEqw==",
-      "license": "MIT",
-      "dependencies": {
-        "@msgpack/msgpack": "^3.1.2",
-        "async-mutex": "^0.5.0",
-        "it-pushable": "^3.2.3",
-        "nice-grpc": "^2.1.13",
-        "zod": "^4.1.12"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5"
-      }
-    },
     "node_modules/better-sqlite3": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
-      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -604,9 +756,9 @@
       }
     },
     "node_modules/chardet": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
-      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
       "license": "MIT"
     },
     "node_modules/cheerio": {
@@ -1008,15 +1160,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/it-pushable": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.2.4.tgz",
-      "integrity": "sha512-WSD7Ss4oCRfDZJT4ldLWr0Bom/muY90xxoJ5PQnU3uSKf0kxCOeehqZtiJX1ARqn+ymXGh1bxpDW9bDNHp2ivQ==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "p-defer": "^4.0.0"
-      }
-    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -1182,18 +1325,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/p-defer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.1.tgz",
-      "integrity": "sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -1275,6 +1406,7 @@
       "version": "8.6.1",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.1.tgz",
       "integrity": "sha512-s4qQPr4pU0W95iYnUInh95skjIg+3aM2sakYsw60QYanU+qWRDY2zQxOAQV6zU7ROJpSNDG9B+VSmk4dqdWWSA==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "long": "^5.3.2"
       },
@@ -1361,9 +1493,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -1421,38 +1553,17 @@
       }
     },
     "node_modules/spectrum-ts": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/spectrum-ts/-/spectrum-ts-3.1.0.tgz",
-      "integrity": "sha512-Dv5rsXATxGUXFnKf3VPK0VpkMPyVkf4HHUYkti0V2AKhz2m+ut3I1UPNMsvZOsiqmF+5hW8Xvrw+u/I82+XcDA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/spectrum-ts/-/spectrum-ts-5.2.0.tgz",
+      "integrity": "sha512-CfHz7ZhKP9Cmunb3i7m4r5stXOGl1HNKOkBp/Fkl1DwDmhnGl+PRDy97FC5JBY+XYxAKxKnMRSbVTl8ldczTNg==",
       "license": "MIT",
       "dependencies": {
-        "@photon-ai/advanced-imessage": "^0.11.0",
-        "@photon-ai/imessage-kit": "^3.0.0",
-        "@photon-ai/otel": "^0.1.1",
-        "@photon-ai/proto": "^0.2.4",
-        "@photon-ai/slack": "^0.2.0",
-        "@photon-ai/telegram-ts": "10.0.0",
-        "@photon-ai/whatsapp-business": "^0.1.1",
-        "@repeaterjs/repeater": "^3.0.6",
-        "better-grpc": "^0.3.2",
-        "lru-cache": "^11.0.0",
-        "marked": "^18.0.5",
-        "mime-types": "^3.0.1",
-        "nice-grpc": "^2.1.16",
-        "nice-grpc-common": "^2.0.2",
-        "open-graph-scraper": "^6.11.0",
-        "type-fest": "^5.4.1",
-        "vcf": "^2.1.2",
-        "zod": "^4.2.1"
-      },
-      "peerDependencies": {
-        "ffmpeg-static": "^5",
-        "typescript": "^5 || ^6.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ffmpeg-static": {
-          "optional": true
-        }
+        "@spectrum-ts/core": "5.2.0",
+        "@spectrum-ts/imessage": "5.2.0",
+        "@spectrum-ts/slack": "5.2.0",
+        "@spectrum-ts/telegram": "5.2.0",
+        "@spectrum-ts/terminal": "5.2.0",
+        "@spectrum-ts/whatsapp-business": "5.2.0"
       }
     },
     "node_modules/string_decoder": {
@@ -1501,18 +1612,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/tagged-tag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
-      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -1549,12 +1648,6 @@
       "integrity": "sha512-tLJxacIQUM82IR7JO1UUkKlYuUTmoY9HBJAmNWFzheSlDS5SPMcNIepejHJa4BpPQLAcbRhRf3GDJzyj6rbKvA==",
       "license": "MIT"
     },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -1568,25 +1661,10 @@
         "node": "*"
       }
     },
-    "node_modules/type-fest": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
-      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
-      "license": "(MIT OR CC0-1.0)",
-      "dependencies": {
-        "tagged-tag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -1598,9 +1676,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.26.0.tgz",
-      "integrity": "sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -1691,9 +1769,9 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",

--- a/plugins/platforms/photon/sidecar/package.json
+++ b/plugins/platforms/photon/sidecar/package.json
@@ -13,7 +13,7 @@
     "node": ">=18.17"
   },
   "dependencies": {
-    "spectrum-ts": "3.1.0"
+    "spectrum-ts": "5.2.0"
   },
   "overrides": {
     "protobufjs": "8.6.1",

--- a/plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs
+++ b/plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs
@@ -101,6 +101,22 @@ function patchInbound(source) {
 }
 
 export function patchSpectrumTs(root = scriptDir()) {
+  const pkgPath = path.join(root, "node_modules", "spectrum-ts", "package.json");
+  if (fs.existsSync(pkgPath)) {
+    try {
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+      const major = Number(String(pkg.version || "0").split(".")[0]);
+      if (major >= 5) {
+        return {
+          patched: false,
+          file: pkgPath,
+          reason: `spectrum-ts ${pkg.version} has the newer inbound mapper`,
+        };
+      }
+    } catch {
+      // Fall through to the structural patch attempt below.
+    }
+  }
   const dist = path.join(root, "node_modules", "spectrum-ts", "dist");
   if (!fs.existsSync(dist)) {
     throw new Error(`spectrum-ts dist not found: ${dist}`);

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -150,6 +150,22 @@ class TestStartupPlatformIsolation:
         with pytest.raises(TimeoutError, match="telegram connect timed out"):
             await runner._connect_adapter_with_timeout(adapter, Platform.TELEGRAM)
 
+    @pytest.mark.asyncio
+    async def test_adapter_connect_timeout_can_extend_global_timeout(self, monkeypatch):
+        """Slow-starting adapters can request a longer startup window."""
+        runner = _make_runner()
+        adapter = StubAdapter()
+        adapter.connect_timeout_seconds = 0.1
+
+        async def slow_success():
+            await asyncio.sleep(0.01)
+            return True
+
+        adapter.connect = slow_success
+        monkeypatch.setenv("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", "0.001")
+
+        assert await runner._connect_adapter_with_timeout(adapter, Platform.TELEGRAM) is True
+
 
 class TestStartupFailureQueuing:
     """Verify that failed platforms are queued during startup."""
@@ -491,6 +507,43 @@ class TestPlatformReconnectWatcher:
         mock_create.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_watcher_wakes_when_runtime_failure_queued_while_idle(self):
+        """A runtime crash should not wait for the idle sleep window."""
+        runner = _make_runner()
+        runner._sync_voice_mode_state_to_adapter = MagicMock()
+        platform_config = PlatformConfig(enabled=True, token="test")
+        adapter = StubAdapter(succeed=True)
+        real_sleep = asyncio.sleep
+        queued = False
+
+        async def fake_sleep(_seconds):
+            nonlocal queued
+            # call 1: initial watcher startup delay.
+            # call 2: first idle tick after observing an empty queue.
+            if not queued and fake_sleep.calls == 1:
+                runner._failed_platforms[Platform.TELEGRAM] = {
+                    "config": platform_config,
+                    "attempts": 0,
+                    "next_retry": time.monotonic() - 1,
+                }
+                queued = True
+            fake_sleep.calls += 1
+            if fake_sleep.calls > 2 and not runner._failed_platforms:
+                runner._running = False
+            await real_sleep(0)
+
+        fake_sleep.calls = 0
+
+        with patch.object(runner, "_create_adapter", return_value=adapter) as mock_create:
+            with patch("gateway.run.build_channel_directory", create=True):
+                with patch("asyncio.sleep", side_effect=fake_sleep):
+                    await runner._platform_reconnect_watcher()
+
+        mock_create.assert_called_once_with(Platform.TELEGRAM, platform_config)
+        assert Platform.TELEGRAM not in runner._failed_platforms
+        assert runner.adapters[Platform.TELEGRAM] is adapter
+
+    @pytest.mark.asyncio
     async def test_adapter_create_returns_none(self):
         """If _create_adapter returns None, remove from queue (missing deps)."""
         runner = _make_runner()
@@ -543,6 +596,24 @@ class TestRuntimeDisconnectQueuing:
 
         assert Platform.TELEGRAM in runner._failed_platforms
         assert runner._failed_platforms[Platform.TELEGRAM]["attempts"] == 0
+
+    @pytest.mark.asyncio
+    async def test_retryable_runtime_error_reconnects_immediately(self):
+        """Runtime crashes should not wait for the startup retry delay."""
+        runner = _make_runner()
+        runner.stop = AsyncMock()
+
+        adapter = StubAdapter(succeed=True)
+        adapter._set_fatal_error("sidecar_crashed", "bridge exited", retryable=True)
+        runner.adapters[Platform.TELEGRAM] = adapter
+
+        before = time.monotonic()
+        await runner._handle_adapter_fatal_error(adapter)
+        after = time.monotonic()
+
+        info = runner._failed_platforms[Platform.TELEGRAM]
+        assert info["attempts"] == 0
+        assert before <= info["next_retry"] <= after
 
     @pytest.mark.asyncio
     async def test_nonretryable_runtime_error_not_queued(self):
@@ -765,4 +836,3 @@ class TestPlatformSlashCommand:
         runner = _make_runner()
         out = await runner._handle_platform_command(self._make_event("/platform"))
         assert "Gateway platforms" in out
-

--- a/tests/plugins/platforms/photon/test_overflow_recovery.py
+++ b/tests/plugins/platforms/photon/test_overflow_recovery.py
@@ -12,16 +12,21 @@ dying (issue #50185):
      ``retryable=True`` fatal so the gateway reconnect watcher revives the
      platform — instead of returning silently and leaving ``_inbound_loop``
      spinning against a dead port.
+  4. ``_monitor_sidecar_health`` promotes a degraded upstream stream reported
+     by ``/healthz`` into the same retryable gateway reconnect path.
 
 No Node sidecar is spawned and no ports are bound.
 """
 from __future__ import annotations
 
+import types
+from pathlib import Path
 from typing import Any, Dict
 
 import pytest
 
 from gateway.config import PlatformConfig
+from plugins.platforms.photon import adapter as photon_adapter
 from plugins.platforms.photon.adapter import PhotonAdapter
 
 
@@ -64,6 +69,16 @@ def test_unrelated_error_not_retryable() -> None:
 )
 def test_auth_failures_are_not_retryable(error: str) -> None:
     assert PhotonAdapter._is_retryable_error(error) is False
+
+
+def test_project_policy_failures_are_not_retryable() -> None:
+    assert (
+        PhotonAdapter._is_retryable_error(
+            "Photon sidecar /send returned 500 (target_not_allowed): "
+            "target not allowed for this Photon project"
+        )
+        is False
+    )
 
 
 def test_base_network_patterns_still_match() -> None:
@@ -240,6 +255,33 @@ async def test_sidecar_send_auth_failure_is_permanent(
 
 
 @pytest.mark.asyncio
+async def test_sidecar_send_project_policy_failure_is_forbidden(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+
+    async def _fake_call(path: str, payload: Dict[str, Any]) -> Any:
+        from plugins.platforms.photon.adapter import PhotonSidecarError
+
+        raise PhotonSidecarError(
+            path,
+            500,
+            "target not allowed for this Photon project",
+            code="target_not_allowed",
+            retryable=False,
+        )
+
+    monkeypatch.setattr(adapter, "_sidecar_call", _fake_call)
+
+    result = await adapter.send("+15551234567", "hello")
+
+    assert result.success is False
+    assert result.retryable is False
+    assert result.error_kind == "forbidden"
+    assert PhotonAdapter._is_retryable_error(result.error) is False
+
+
+@pytest.mark.asyncio
 async def test_clean_shutdown_does_not_raise_fatal(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -259,3 +301,224 @@ async def test_clean_shutdown_does_not_raise_fatal(
 
     assert adapter.has_fatal_error is False
     assert notified == []
+
+
+@pytest.mark.asyncio
+async def test_degraded_stream_health_raises_retryable_fatal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    adapter._inbound_running = True
+    adapter._sidecar_health_interval = 0.0
+
+    async def _fake_call(path: str, payload: Dict[str, Any]) -> Any:
+        assert path == "/healthz"
+        return {
+            "ok": True,
+            "stream": {
+                "ok": False,
+                "state": "degraded",
+                "degradedForMs": 120000,
+                "lastIssue": "[spectrum.stream] stream interrupted; reconnecting",
+            },
+        }
+
+    notified: list[bool] = []
+
+    async def _fake_notify() -> None:
+        notified.append(True)
+
+    monkeypatch.setattr(adapter, "_sidecar_call", _fake_call)
+    monkeypatch.setattr(adapter, "_notify_fatal_error", _fake_notify)
+
+    await adapter._monitor_sidecar_health()
+
+    assert adapter.has_fatal_error is True
+    assert adapter.fatal_error_code == "UPSTREAM_STREAM_DEGRADED"
+    assert adapter.fatal_error_retryable is True
+    assert adapter._running is False
+    assert notified == [True]
+
+
+# -- Gap 5: outbound sidecar send recovery ----------------------------------
+
+class _FakeResponse:
+    def __init__(
+        self,
+        status_code: int,
+        payload: Dict[str, Any] | None = None,
+        text: str = "",
+    ) -> None:
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.text = text
+
+    def json(self) -> Dict[str, Any]:
+        return self._payload
+
+
+class _FakeAsyncClient:
+    calls: list[tuple[str, Dict[str, Any]]] = []
+    responses: list[Any] = []
+
+    def __init__(self, timeout: float | None = None) -> None:
+        self.timeout = timeout
+
+    async def __aenter__(self) -> "_FakeAsyncClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    async def post(
+        self,
+        url: str,
+        json: Dict[str, Any] | None = None,  # noqa: A002 - mirrors httpx
+        headers: Dict[str, str] | None = None,  # noqa: ARG002
+    ) -> _FakeResponse:
+        self.calls.append((url, json or {}))
+        if not self.responses:
+            raise AssertionError("no fake response queued")
+        response = self.responses.pop(0)
+        if isinstance(response, BaseException):
+            raise response
+        return response
+
+
+async def _noop_sleep(delay: float) -> None:  # noqa: ARG001
+    return None
+
+
+@pytest.mark.asyncio
+async def test_photon_standalone_send_retries_transient_sidecar_500(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(photon_adapter, "HTTPX_AVAILABLE", True)
+    monkeypatch.setattr(
+        photon_adapter,
+        "httpx",
+        types.SimpleNamespace(AsyncClient=_FakeAsyncClient),
+    )
+    monkeypatch.setenv("PHOTON_SIDECAR_TOKEN", "token")
+    monkeypatch.setattr(photon_adapter.asyncio, "sleep", _noop_sleep)
+    _FakeAsyncClient.calls = []
+    _FakeAsyncClient.responses = [
+        _FakeResponse(500, {"ok": False}, '{"error":"Connection dropped"}'),
+        _FakeResponse(200, {"ok": True, "messageId": "msg-ok"}),
+    ]
+
+    result = await photon_adapter._standalone_send(
+        PlatformConfig(extra={}),
+        "any;-;+15551234567",
+        "hello",
+    )
+
+    assert result == {"success": True, "message_id": "msg-ok"}
+    assert len(_FakeAsyncClient.calls) == 2
+    assert _FakeAsyncClient.calls[0][1]["spaceId"] == "any;-;+15551234567"
+
+
+@pytest.mark.asyncio
+async def test_photon_standalone_send_uses_sidecar_retryable_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(photon_adapter, "HTTPX_AVAILABLE", True)
+    monkeypatch.setattr(
+        photon_adapter,
+        "httpx",
+        types.SimpleNamespace(AsyncClient=_FakeAsyncClient),
+    )
+    monkeypatch.setenv("PHOTON_SIDECAR_TOKEN", "token")
+    monkeypatch.setattr(photon_adapter.asyncio, "sleep", _noop_sleep)
+    _FakeAsyncClient.calls = []
+    _FakeAsyncClient.responses = [
+        _FakeResponse(
+            500,
+            {
+                "ok": False,
+                "error": "Photon upstream connection dropped",
+                "retryable": True,
+            },
+        ),
+        _FakeResponse(200, {"ok": True, "messageId": "msg-ok"}),
+    ]
+
+    result = await photon_adapter._standalone_send(
+        PlatformConfig(extra={}),
+        "any;-;+15551234567",
+        "hello",
+    )
+
+    assert result == {"success": True, "message_id": "msg-ok"}
+    assert len(_FakeAsyncClient.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_photon_standalone_send_does_not_retry_non_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(photon_adapter, "HTTPX_AVAILABLE", True)
+    monkeypatch.setattr(
+        photon_adapter,
+        "httpx",
+        types.SimpleNamespace(AsyncClient=_FakeAsyncClient),
+    )
+    monkeypatch.setenv("PHOTON_SIDECAR_TOKEN", "token")
+    monkeypatch.setattr(photon_adapter.asyncio, "sleep", _noop_sleep)
+    _FakeAsyncClient.calls = []
+    _FakeAsyncClient.responses = [
+        _FakeResponse(
+            500,
+            {
+                "ok": False,
+                "error": "target not allowed for this Photon project",
+                "retryable": False,
+            },
+        ),
+        _FakeResponse(200, {"ok": True, "messageId": "should-not-send"}),
+    ]
+
+    result = await photon_adapter._standalone_send(
+        PlatformConfig(extra={}),
+        "+15551234567",
+        "hello",
+    )
+
+    assert "target not allowed" in result["error"]
+    assert len(_FakeAsyncClient.calls) == 1
+
+
+class _BlankException(Exception):
+    def __str__(self) -> str:
+        return ""
+
+
+@pytest.mark.asyncio
+async def test_photon_standalone_send_names_blank_exceptions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(photon_adapter, "HTTPX_AVAILABLE", True)
+    monkeypatch.setattr(
+        photon_adapter,
+        "httpx",
+        types.SimpleNamespace(AsyncClient=_FakeAsyncClient),
+    )
+    monkeypatch.setenv("PHOTON_SIDECAR_TOKEN", "token")
+    _FakeAsyncClient.calls = []
+    _FakeAsyncClient.responses = [_BlankException()]
+
+    result = await photon_adapter._standalone_send(
+        PlatformConfig(extra={}),
+        "+15551234567",
+        "hello",
+    )
+
+    assert result == {"error": "Photon standalone send failed: _BlankException"}
+    assert len(_FakeAsyncClient.calls) == 1
+
+
+def test_photon_sidecar_resolves_dm_space_before_phone_create() -> None:
+    source = Path("plugins/platforms/photon/sidecar/index.mjs").read_text()
+    dm_get = source.index("photon-sidecar: DM space.get failed")
+    phone_create = source.index("photon-sidecar: phone->DM space.create failed")
+    assert dm_get < phone_create

--- a/tests/plugins/platforms/photon/test_overflow_recovery.py
+++ b/tests/plugins/platforms/photon/test_overflow_recovery.py
@@ -54,6 +54,18 @@ def test_unrelated_error_not_retryable() -> None:
     assert PhotonAdapter._is_retryable_error(None) is False
 
 
+@pytest.mark.parametrize(
+    "error",
+    [
+        "Photon sidecar /send returned 500 (auth_failed): photon authentication failed",
+        "IMessageError: Invalid credentials",
+        "PERMISSION_DENIED: [upstream] Authentication failed.",
+    ],
+)
+def test_auth_failures_are_not_retryable(error: str) -> None:
+    assert PhotonAdapter._is_retryable_error(error) is False
+
+
 def test_base_network_patterns_still_match() -> None:
     # The override delegates to the base classifier first, so generic
     # network strings keep working.
@@ -173,6 +185,58 @@ async def test_unexpected_sidecar_exit_raises_retryable_fatal(
     assert adapter.fatal_error_retryable is True
     assert adapter._running is False
     assert notified == [True]
+
+
+@pytest.mark.asyncio
+async def test_sidecar_send_preserves_sidecar_retryable_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+
+    async def _fake_call(path: str, payload: Dict[str, Any]) -> Any:
+        from plugins.platforms.photon.adapter import PhotonSidecarError
+
+        raise PhotonSidecarError(
+            path,
+            500,
+            "photon upstream unavailable",
+            code="upstream_unavailable",
+            retryable=True,
+        )
+
+    monkeypatch.setattr(adapter, "_sidecar_call", _fake_call)
+
+    result = await adapter.send("+15551234567", "hello")
+
+    assert result.success is False
+    assert result.retryable is True
+    assert "upstream_unavailable" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_sidecar_send_auth_failure_is_permanent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+
+    async def _fake_call(path: str, payload: Dict[str, Any]) -> Any:
+        from plugins.platforms.photon.adapter import PhotonSidecarError
+
+        raise PhotonSidecarError(
+            path,
+            500,
+            "photon authentication failed",
+            code="auth_failed",
+            retryable=False,
+        )
+
+    monkeypatch.setattr(adapter, "_sidecar_call", _fake_call)
+
+    result = await adapter.send("+15551234567", "hello")
+
+    assert result.success is False
+    assert result.retryable is False
+    assert PhotonAdapter._is_retryable_error(result.error) is False
 
 
 @pytest.mark.asyncio

--- a/tests/plugins/platforms/photon/test_spectrum_patch.py
+++ b/tests/plugins/platforms/photon/test_spectrum_patch.py
@@ -17,6 +17,15 @@ def test_sidecar_applies_spectrum_patch_before_importing_sdk() -> None:
     assert index.index("patchSpectrumTs();") < index.index('await import("spectrum-ts")')
 
 
+def test_sidecar_healthz_reports_stream_health() -> None:
+    """Local process health must include upstream stream health."""
+    index = Path("plugins/platforms/photon/sidecar/index.mjs").read_text(encoding="utf-8")
+    assert "function streamHealthSnapshot()" in index
+    assert 'return ok(res, { stream: streamHealthSnapshot() });' in index
+    assert "STREAM_INTERRUPTED_DEGRADE_COUNT" in index
+    assert "process.exit(75);" in index
+
+
 def test_spectrum_patch_preserves_text_when_single_attachment(tmp_path: Path) -> None:
     """The sidecar dependency patch must turn text+one attachment into group content."""
     dist = tmp_path / "node_modules" / "spectrum-ts" / "dist"


### PR DESCRIPTION
## Summary
- classify Photon sidecar control failures into safe retryable/non-retryable errors, including upstream transient failures, invalid credentials, and Photon project policy failures
- restart/reconnect Photon when the sidecar process crashes or reports degraded upstream stream health, and avoid reporting an idle stream as healthy before real traffic arrives
- make gateway runtime adapter failures queue immediate background reconnection instead of waiting for an inbound message or another startup cycle
- let slow-starting adapters declare a longer connect timeout so Photon sidecar startup is not killed by the generic platform timeout
- resolve restarted Photon DM spaces with `space.get(any;-;+E164)` before falling back to phone-based `space.create`, so established iMessage DMs remain sendable after sidecar restart
- retry standalone Photon sends when the sidecar reports a transient retryable send failure, and avoid blank standalone-send errors when Python/httpx raises an exception with an empty string
- upgrade the Photon sidecar to `spectrum-ts@5.2.0` and skip the mixed-attachment patch when the newer inbound mapper is present

## Related PRs / Expected Merge Path
- #51161 is now the likely maintainer-preferred stream-recovery base: it salvages #51105/#50071 and adds the important `console.log` interception fix for Spectrum WARN/INFO stream logs. If #51161 lands first, this PR should be rebased and duplicate stream-recovery hunks should be dropped.
- #49653 is an older/narrower transport-drop recovery PR. It overlaps with outbound `upstream_connection_dropped` sidecar restart behavior, but does not cover the broader `/healthz` stream-state path, slow Photon startup timeout, DM rehydration, or the `spectrum-ts` upgrade/patch guard here.
- #51075 overlaps on outbound hardening and the `spectrum-ts` upgrade. This PR incorporates the DM-resolution and retry-classification pieces, but still does not include #51075's HEIC/HEIF image transcoding; that remains separable from the gateway/sidecar liveness issue.

After #51161, the intended remaining value of this PR is the live-repro follow-up surface: structured sidecar send classification, adapter-specific Photon startup timeout, DM-space rehydration before phone-based creation, standalone send retry/error clarity, and the `spectrum-ts@5.2.0` upgrade/patch guard if those are not already merged elsewhere.

Happy to split those remaining pieces further if maintainers prefer a narrower review path.

## Validation
- `./scripts/run_tests.sh tests/plugins/platforms/photon/test_overflow_recovery.py tests/plugins/platforms/photon/test_spectrum_patch.py tests/gateway/test_platform_reconnect.py`
- `node --check plugins/platforms/photon/sidecar/index.mjs`
- `node --check plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs`
- `/home/tushar/.hermes/hermes-agent/venv/bin/python -m py_compile plugins/platforms/photon/adapter.py gateway/run.py`
- `git diff --check`
- `/home/tushar/.hermes/hermes-agent/venv/bin/python scripts/check-windows-footguns.py --diff origin/main`

## Live Runtime Check
- restarted the local systemd gateway by SIGTERMing the main process and letting systemd revive it
- reproduced the old failure mode: Photon startup was cut off around the sidecar readiness timeout, leaving systemd green with no Photon sidecar child
- verified the patched gateway gives Photon the longer adapter-specific startup window; local Photon startup took about 35s and then connected
- observed a real inbound Photon text reach Hermes and trigger a gateway response
- upgraded the live sidecar to `spectrum-ts@5.2.0`; gateway restarted and connected with the newer Spectrum runtime
- verified direct sidecar `/send` can return a real Spectrum message id; also observed intermittent upstream send drops now surface as classified `upstream_transient` retryable errors
