### PR TITLE
fix: add CLI history autosuggest toggle

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -454,6 +454,9 @@ def load_cli_config() -> Dict[str, Any]:
             "show_reasoning": False,
             "reasoning_full": False,
             "streaming": True,
+            # Inline ghost text from previously submitted prompts. This does
+            # not affect persisted history or explicit Up-arrow recall.
+            "cli_history_autosuggest": True,
             "busy_input_mode": "interrupt",
             "persistent_output": True,
             "persistent_output_max_lines": 200,
@@ -719,6 +722,18 @@ def load_cli_config() -> Dict[str, Any]:
 
 # Load configuration at module startup
 CLI_CONFIG = load_cli_config()
+
+
+def _cli_history_autosuggest_enabled(config: Dict[str, Any]) -> bool:
+    """Return whether free-text prompt history should appear as ghost text."""
+    display = config.get("display", {}) if isinstance(config, dict) else {}
+    if not isinstance(display, dict):
+        return True
+
+    value = display.get("cli_history_autosuggest", True)
+    if isinstance(value, str):
+        return value.strip().lower() not in {"0", "false", "no", "off"}
+    return bool(value)
 
 
 # Initialize centralized logging early — agent.log + errors.log in ~/.hermes/logs/.
@@ -13228,6 +13243,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             command_filter=cli_ref._command_available,
             skill_bundles_provider=lambda: get_skill_bundles(),
         )
+        history_suggest = (
+            AutoSuggestFromHistory()
+            if _cli_history_autosuggest_enabled(self.config)
+            else None
+        )
         input_area = TextArea(
             height=Dimension(min=1, max=8, preferred=1),
             prompt=get_prompt,
@@ -13245,7 +13265,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             completer=ThreadedCompleter(_completer),
             complete_while_typing=True,
             auto_suggest=SlashCommandAutoSuggest(
-                history_suggest=AutoSuggestFromHistory(),
+                history_suggest=history_suggest,
                 completer=_completer,
             ),
         )

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1881,7 +1881,8 @@ class SlashCommandAutoSuggest(AutoSuggest):
     """Inline ghost-text suggestions for slash commands and their subcommands.
 
     Shows the rest of a command or subcommand in dim text as you type.
-    Falls back to history-based suggestions for non-slash input.
+    Falls back to history-based suggestions for non-slash input only when a
+    history suggester is provided by the CLI config.
     """
 
     def __init__(

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1577,6 +1577,9 @@ DEFAULT_CONFIG = {
         # collapses long thinking to the first 10 lines. Set true to print the
         # complete thinking text uncollapsed (live streaming is always full).
         "reasoning_full": False,
+        # Classic CLI: show inline ghost-text completions from prior submitted
+        # prompts. Does not affect writing history or explicit Up-arrow recall.
+        "cli_history_autosuggest": True,
         # Background self-improvement review notifications surfaced in chat.
         #   "off"     — no chat notification (the review still runs and writes)
         #   "on"      — generic "💾 Memory updated" line (default)

--- a/tests/cli/test_resume_display.py
+++ b/tests/cli/test_resume_display.py
@@ -715,6 +715,7 @@ class TestResumeDisplayConfig:
         display = DEFAULT_CONFIG.get("display", {})
         assert "resume_display" in display
         assert display["resume_display"] == "full"
+        assert display.get("cli_history_autosuggest") is True
 
     def test_cli_defaults_have_resume_display(self):
         """cli.py load_cli_config defaults include resume_display."""
@@ -728,3 +729,19 @@ class TestResumeDisplayConfig:
 
         display = config.get("display", {})
         assert display.get("resume_display") == "full"
+        assert display.get("cli_history_autosuggest") is True
+
+    def test_cli_history_autosuggest_config_parser(self):
+        """cli_history_autosuggest accepts bools and common off strings."""
+        from cli import _cli_history_autosuggest_enabled
+
+        assert _cli_history_autosuggest_enabled({"display": {}}) is True
+        assert _cli_history_autosuggest_enabled(
+            {"display": {"cli_history_autosuggest": False}}
+        ) is False
+        assert _cli_history_autosuggest_enabled(
+            {"display": {"cli_history_autosuggest": "off"}}
+        ) is False
+        assert _cli_history_autosuggest_enabled(
+            {"display": {"cli_history_autosuggest": "yes"}}
+        ) is True

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1377,6 +1377,7 @@ display:
   resume_display: full    # full (show previous messages on resume) | minimal (one-liner only)
   bell_on_complete: false # Play terminal bell when agent finishes (great for long tasks)
   show_reasoning: false   # Show model reasoning/thinking above each response (toggle with /reasoning show|hide)
+  cli_history_autosuggest: true  # Classic CLI: show prior prompts as inline ghost-text suggestions
   streaming: false        # Stream tokens to terminal as they arrive (real-time output)
   show_cost: false        # Show estimated $ cost in the CLI status bar
   timestamps: false       # When true, prefixes user and assistant labels with [HH:MM] timestamps in the CLI / TUI transcript


### PR DESCRIPTION
## Summary
- add display.cli_history_autosuggest to gate free-text prompt history ghost suggestions
- preserve existing default behavior by defaulting the setting to true
- keep prompt history, Up-arrow recall, slash command suggestions, and completion plumbing intact
- document the setting and add focused config parser/default tests

## Tests
- uv run --extra dev python -m pytest tests/cli/test_resume_display.py::TestResumeDisplayConfig -q
- uv run python -m py_compile cli.py hermes_cli/config.py hermes_cli/commands.py tests/cli/test_resume_display.py
- git diff --check