### PR TITLE
fix(desktop): keep floating composer on-screen, scoped to the thread area

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-popout-drag.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-popout-drag.ts
@@ -10,6 +10,7 @@ import {
 import {
   POPOUT_ESTIMATED_HEIGHT,
   POPOUT_WIDTH_REM,
+  readPopoutBounds,
   setComposerPopoutPosition,
   type PopoutPosition,
   type PopoutSize
@@ -147,7 +148,7 @@ export function useComposerPopoutGestures({
   const beginFloatDrag = useCallback(
     (state: PressState, clientX: number, clientY: number, next: PopoutPosition, size?: PopoutSize) => {
       clearTimer()
-      const clamped = setComposerPopoutPosition(next, { size })
+      const clamped = setComposerPopoutPosition(next, { area: readPopoutBounds(composerRef.current), size })
       liveRef.current = clamped
 
       state.mode = 'float'
@@ -159,7 +160,7 @@ export function useComposerPopoutGestures({
 
       setDragging(true)
     },
-    [clearTimer]
+    [clearTimer, composerRef]
   )
 
   const peelOffFromDock = useCallback(
@@ -265,7 +266,7 @@ export function useComposerPopoutGestures({
           bottom: state.startBottom - (pending.y - state.startY),
           right: state.startRight - (pending.x - state.startX)
         },
-        { size }
+        { area: readPopoutBounds(composer), size }
       )
 
       if (composer) {
@@ -327,7 +328,7 @@ export function useComposerPopoutGestures({
         } else {
           // Persist the resting position once, on release — never per move.
           const size = composer ? { height: composer.offsetHeight, width: composer.offsetWidth } : undefined
-          setComposerPopoutPosition(liveRef.current, { persist: true, size })
+          setComposerPopoutPosition(liveRef.current, { area: readPopoutBounds(composer), persist: true, size })
         }
       }
 

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -44,6 +44,7 @@ import {
   $composerPopoutPosition,
   $composerPoppedOut,
   POPOUT_WIDTH_REM,
+  readPopoutBounds,
   setComposerPoppedOut,
   setComposerPopoutPosition
 } from '@/store/composer-popout'
@@ -553,7 +554,7 @@ export function ChatBar({
     const reclamp = (persist: boolean) => {
       const el = composerRef.current
       const size = el ? { height: el.offsetHeight, width: el.offsetWidth } : undefined
-      setComposerPopoutPosition($composerPopoutPosition.get(), { persist, size })
+      setComposerPopoutPosition($composerPopoutPosition.get(), { area: readPopoutBounds(el), persist, size })
     }
 
     reclamp(true)

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -12,6 +12,7 @@ import {
   useRef,
   useState
 } from 'react'
+import { createPortal } from 'react-dom'
 
 import { hermesDirectiveFormatter, type SlashChipKind } from '@/components/assistant-ui/directive-text'
 import { composerFill, composerSurfaceGlass } from '@/components/chat/composer-dock'
@@ -1923,7 +1924,7 @@ export function ChatBar({
     </div>
   )
 
-  return (
+  const composerOverlay = (
     <>
       {dragging && poppedOut && (
         <div
@@ -2106,6 +2107,19 @@ export function ChatBar({
           </div>
         </ComposerPrimitive.Root>
       </ComposerPrimitive.Unstable_TriggerPopoverRoot>
+    </>
+  )
+
+  return (
+    <>
+      {/* Floating: portal to <body> so position:fixed resolves against the
+          viewport. The chat content wrapper sets `contain: layout paint`, which
+          makes it a containing block for (and clips) fixed descendants — left
+          inline, the popped-out composer is positioned/clipped relative to the
+          chat column (which shifts with the sidebars), not the viewport, so the
+          viewport-based clamp can't keep it on-screen. Docked stays inline: it's
+          `absolute` within that column by design. */}
+      {poppedOut ? createPortal(composerOverlay, document.body) : composerOverlay}
 
       <UrlDialog
         inputRef={urlInputRef}

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -12,7 +12,6 @@ import {
   useRef,
   useState
 } from 'react'
-import { createPortal } from 'react-dom'
 
 import { hermesDirectiveFormatter, type SlashChipKind } from '@/components/assistant-ui/directive-text'
 import { composerFill, composerSurfaceGlass } from '@/components/chat/composer-dock'
@@ -1924,7 +1923,7 @@ export function ChatBar({
     </div>
   )
 
-  const composerOverlay = (
+  return (
     <>
       {dragging && poppedOut && (
         <div
@@ -2107,19 +2106,6 @@ export function ChatBar({
           </div>
         </ComposerPrimitive.Root>
       </ComposerPrimitive.Unstable_TriggerPopoverRoot>
-    </>
-  )
-
-  return (
-    <>
-      {/* Floating: portal to <body> so position:fixed resolves against the
-          viewport. The chat content wrapper sets `contain: layout paint`, which
-          makes it a containing block for (and clips) fixed descendants — left
-          inline, the popped-out composer is positioned/clipped relative to the
-          chat column (which shifts with the sidebars), not the viewport, so the
-          viewport-based clamp can't keep it on-screen. Docked stays inline: it's
-          `absolute` within that column by design. */}
-      {poppedOut ? createPortal(composerOverlay, document.body) : composerOverlay}
 
       <UrlDialog
         inputRef={urlInputRef}

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -543,9 +543,12 @@ export function ChatBar({
     syncComposerMetrics()
   }, [poppedOut, syncComposerMetrics])
 
-  // Keep the floating box on-screen: re-clamp (with the real measured size) when
-  // it pops out and whenever the window resizes — so a position persisted on a
-  // bigger/other monitor, or a shrunk window, can never strand it out of reach.
+  // Keep the floating box on-screen: re-clamp (with the real measured size +
+  // thread bounds) when it pops out and on every window resize — so a position
+  // persisted on a bigger/other monitor, a shrunk window, or now-wider sidebar
+  // can never strand it. The rAF pass re-clamps after layout settles (sidebar
+  // widths, fonts), so anyone loading in out of bounds is pulled back + saved
+  // even if the first measure was premature.
   useEffect(() => {
     if (!poppedOut) {
       return undefined
@@ -558,10 +561,14 @@ export function ChatBar({
     }
 
     reclamp(true)
+    const raf = requestAnimationFrame(() => reclamp(true))
     const onResize = () => reclamp(false)
     window.addEventListener('resize', onResize)
 
-    return () => window.removeEventListener('resize', onResize)
+    return () => {
+      cancelAnimationFrame(raf)
+      window.removeEventListener('resize', onResize)
+    }
   }, [poppedOut])
 
   useEffect(() => {

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -443,6 +443,7 @@ export function ChatView({
       >
         <div
           className="relative min-h-0 max-w-full flex-1 overflow-hidden bg-(--ui-chat-surface-background) contain-[layout_paint]"
+          data-slot="composer-bounds"
           {...dropHandlers}
         >
           <Thread

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -433,17 +433,17 @@ export function ChatView({
 
       <PromptOverlays />
 
-      <div
-        className="relative min-h-0 max-w-full flex-1 overflow-hidden bg-(--ui-chat-surface-background) contain-[layout_paint]"
-        {...dropHandlers}
+      <ChatRuntimeBoundary
+        busy={busy}
+        onCancel={onCancel}
+        onEdit={onEdit}
+        onReload={onReload}
+        onThreadMessagesChange={onThreadMessagesChange}
+        suppressMessages={routeSessionMismatch}
       >
-        <ChatRuntimeBoundary
-          busy={busy}
-          onCancel={onCancel}
-          onEdit={onEdit}
-          onReload={onReload}
-          onThreadMessagesChange={onThreadMessagesChange}
-          suppressMessages={routeSessionMismatch}
+        <div
+          className="relative min-h-0 max-w-full flex-1 overflow-hidden bg-(--ui-chat-surface-background) contain-[layout_paint]"
+          {...dropHandlers}
         >
           <Thread
             clampToComposer={showChatBar}
@@ -458,54 +458,62 @@ export function ChatView({
             sessionId={activeSessionId}
             sessionKey={threadKey}
           />
-          {showChatBar && (
-            <Suspense fallback={<ChatBarFallback />}>
-              <ChatBar
-                busy={busy}
-                cwd={currentCwd}
-                disabled={!gatewayOpen}
-                focusKey={activeSessionId}
-                gateway={gateway}
-                maxRecordingSeconds={maxVoiceRecordingSeconds}
-                onAddContextRef={onAddContextRef}
-                onAddUrl={onAddUrl}
-                onAttachDroppedItems={onAttachDroppedItems}
-                onAttachImageBlob={onAttachImageBlob}
-                onCancel={onCancel}
-                onPasteClipboardImage={onPasteClipboardImage}
-                onPickFiles={onPickFiles}
-                onPickFolders={onPickFolders}
-                onPickImages={onPickImages}
-                onRemoveAttachment={onRemoveAttachment}
-                onSteer={onSteer}
-                onSubmit={onSubmit}
-                onTranscribeAudio={onTranscribeAudio}
-                queueSessionKey={selectedSessionId}
-                sessionId={activeSessionId}
-                state={chatBarState}
-              />
-            </Suspense>
+          {resumeExhausted && routedSessionId && (
+            <div className="absolute inset-0 z-10 grid place-items-center bg-(--ui-chat-surface-background) px-8 py-10">
+              <ErrorState
+                className="max-w-sm"
+                description={t.desktop.resumeStrandedBody}
+                title={t.desktop.resumeStrandedTitle}
+              >
+                <div className="grid justify-items-center">
+                  <Button onClick={() => onRetryResume(routedSessionId)} size="sm" variant="outline">
+                    {t.desktop.resumeRetry}
+                  </Button>
+                </div>
+              </ErrorState>
+            </div>
           )}
-        </ChatRuntimeBoundary>
-        {resumeExhausted && routedSessionId && (
-          <div className="absolute inset-0 z-10 grid place-items-center bg-(--ui-chat-surface-background) px-8 py-10">
-            <ErrorState
-              className="max-w-sm"
-              description={t.desktop.resumeStrandedBody}
-              title={t.desktop.resumeStrandedTitle}
-            >
-              <div className="grid justify-items-center">
-                <Button onClick={() => onRetryResume(routedSessionId)} size="sm" variant="outline">
-                  {t.desktop.resumeRetry}
-                </Button>
-              </div>
-            </ErrorState>
-          </div>
+          {showChatBar && <ScrollToBottomButton />}
+          <ChatDropOverlay kind={dragKind} />
+          <ChatSwapOverlay profile={gatewaySwapTarget} />
+        </div>
+        {/* Composer renders OUTSIDE the contain:[layout paint] wrapper above:
+            that wrapper is a containing block for — and clips — position:fixed
+            descendants, so the popped-out (fixed) composer would anchor to the
+            chat column (which shifts/resizes with the sidebars) and get clipped
+            off-screen instead of floating against the viewport. As a sibling it
+            anchors to the outer relative container instead: docked is absolute
+            (identical placement), floating resolves against the viewport. Both
+            states stay mounted here, so dock⇄float never remounts the editor. */}
+        {showChatBar && (
+          <Suspense fallback={<ChatBarFallback />}>
+            <ChatBar
+              busy={busy}
+              cwd={currentCwd}
+              disabled={!gatewayOpen}
+              focusKey={activeSessionId}
+              gateway={gateway}
+              maxRecordingSeconds={maxVoiceRecordingSeconds}
+              onAddContextRef={onAddContextRef}
+              onAddUrl={onAddUrl}
+              onAttachDroppedItems={onAttachDroppedItems}
+              onAttachImageBlob={onAttachImageBlob}
+              onCancel={onCancel}
+              onPasteClipboardImage={onPasteClipboardImage}
+              onPickFiles={onPickFiles}
+              onPickFolders={onPickFolders}
+              onPickImages={onPickImages}
+              onRemoveAttachment={onRemoveAttachment}
+              onSteer={onSteer}
+              onSubmit={onSubmit}
+              onTranscribeAudio={onTranscribeAudio}
+              queueSessionKey={selectedSessionId}
+              sessionId={activeSessionId}
+              state={chatBarState}
+            />
+          </Suspense>
         )}
-        {showChatBar && <ScrollToBottomButton />}
-        <ChatDropOverlay kind={dragKind} />
-        <ChatSwapOverlay profile={gatewaySwapTarget} />
-      </div>
+      </ChatRuntimeBoundary>
     </div>
   )
 }

--- a/apps/desktop/src/store/composer-popout.ts
+++ b/apps/desktop/src/store/composer-popout.ts
@@ -49,18 +49,28 @@ export interface PopoutSize {
   width: number
 }
 
+/** Viewport-space rect the floating composer is confined to. Defaults to the
+ *  whole window; pass the thread area so the box can't slide under a pinned
+ *  sidebar or behind the header. */
+export interface PopoutBounds {
+  bottom: number
+  left: number
+  right: number
+  top: number
+}
+
 interface SetPositionOptions {
+  /** Thread-area rect to confine the box to; falls back to the full window. */
+  area?: PopoutBounds
   persist?: boolean
   /** Measured box size; falls back to the compact width + a min height so the
    *  box stays grabbable even when the caller can't measure it. */
   size?: PopoutSize
 }
 
-// Keep at least this much of every edge between the box and the viewport, so the
+// Keep at least this much between the box and every edge of its bounds, so the
 // floating composer can never be dragged (or restored) out of reach.
 const EDGE_MARGIN = 8
-const TITLEBAR_HEIGHT_FALLBACK = 34
-const TITLEBAR_CLEARANCE_REM = 0.75
 // Height floor used when the real box height is unknown (init / load / peel-off).
 export const POPOUT_ESTIMATED_HEIGHT = 56
 const MIN_VISIBLE_HEIGHT = POPOUT_ESTIMATED_HEIGHT
@@ -69,24 +79,32 @@ const clampRange = (value: number, lo: number, hi: number) => Math.min(Math.max(
 
 const rootFontSize = () => parseFloat(getComputedStyle(document.documentElement).fontSize) || 16
 
-function titlebarTopMargin() {
-  const raw = getComputedStyle(document.documentElement).getPropertyValue('--titlebar-height').trim()
-  const titlebarHeight = Number.parseFloat(raw)
-  const breathingRoom = TITLEBAR_CLEARANCE_REM * rootFontSize()
+/** The thread area's viewport rect (excludes a pinned sidebar + the header), or
+ *  undefined before it mounts — callers then fall back to the full window. */
+export function readPopoutBounds(composer: Element | null): PopoutBounds | undefined {
+  const el = (composer?.parentElement ?? document).querySelector('[data-slot="composer-bounds"]')
 
-  return Math.max(EDGE_MARGIN, (Number.isFinite(titlebarHeight) ? titlebarHeight : TITLEBAR_HEIGHT_FALLBACK) + breathingRoom)
+  if (!el) {
+    return undefined
+  }
+
+  const { bottom, left, right, top } = el.getBoundingClientRect()
+
+  return { bottom, left, right, top }
 }
 
-// Bound the bottom-right inset so the WHOLE box stays on-screen — the corner
-// anchor alone would let the box's width/height push it past the left/top edges.
-function clampPosition({ bottom, right }: PopoutPosition, size?: PopoutSize): PopoutPosition {
+// Bound the bottom/right inset so the WHOLE box stays inside `area` (the thread
+// region, or the window by default) — the corner anchor alone would let the
+// box's width/height push it past the opposite edges.
+function clampPosition({ bottom, right }: PopoutPosition, size?: PopoutSize, area?: PopoutBounds): PopoutPosition {
   const width = size?.width || POPOUT_WIDTH_REM * rootFontSize()
   const height = size?.height || MIN_VISIBLE_HEIGHT
-  const topMargin = titlebarTopMargin()
+  const { innerHeight: vh, innerWidth: vw } = window
+  const a = area ?? { bottom: vh, left: 0, right: vw, top: 0 }
 
   return {
-    bottom: clampRange(bottom, EDGE_MARGIN, window.innerHeight - height - topMargin),
-    right: clampRange(right, EDGE_MARGIN, window.innerWidth - width - EDGE_MARGIN)
+    bottom: clampRange(bottom, vh - a.bottom + EDGE_MARGIN, vh - a.top - height - EDGE_MARGIN),
+    right: clampRange(right, vw - a.right + EDGE_MARGIN, vw - a.left - width - EDGE_MARGIN)
   }
 }
 
@@ -102,8 +120,8 @@ export function setComposerPoppedOut(value: boolean) {
  *  unless `persist`. Returns the clamped position so callers can sync their live
  *  ref. Pass the measured `size` for exact bounds; otherwise a fallback keeps it
  *  on-screen. */
-export function setComposerPopoutPosition(position: PopoutPosition, { persist, size }: SetPositionOptions = {}): PopoutPosition {
-  const next = clampPosition(position, size)
+export function setComposerPopoutPosition(position: PopoutPosition, { area, persist, size }: SetPositionOptions = {}): PopoutPosition {
+  const next = clampPosition(position, size, area)
   $composerPopoutPosition.set(next)
 
   if (persist) {

--- a/apps/desktop/src/store/composer-popout.ts
+++ b/apps/desktop/src/store/composer-popout.ts
@@ -88,9 +88,11 @@ export function readPopoutBounds(composer: Element | null): PopoutBounds | undef
     return undefined
   }
 
-  const { bottom, left, right, top } = el.getBoundingClientRect()
+  const { bottom, height, left, right, top, width } = el.getBoundingClientRect()
 
-  return { bottom, left, right, top }
+  // Pre-layout (mount before first layout) the rect is empty — fall back to the
+  // window rather than clamping the box into a collapsed area.
+  return width > 0 && height > 0 ? { bottom, left, right, top } : undefined
 }
 
 // Bound the bottom/right inset so the WHOLE box stays inside `area` (the thread


### PR DESCRIPTION
## Summary

Second fast-follow to the composer pop-out (#49488, bounds #50466). Users on the latest build still reported **losing** the floating composer off-screen even after #50466 made the bounds clamp account for the box size.

### Root cause
The popped-out composer is `position: fixed`, but its ancestor — the chat content wrapper — sets `contain: layout paint`:

```
relative min-h-0 max-w-full flex-1 overflow-hidden ... contain-[layout_paint]
```

`contain: layout`/`paint` makes that element a **containing block for fixed descendants** and `paint` **clips** them to its box. So the floating composer was positioned/clipped relative to the **chat column**, not the viewport. That column resizes/shifts with the sidebars, so the viewport-based clamp measured a different rectangle than the box lived in, and anything outside the column got clipped → invisible. Matches the field report + the earlier "sidebars hidden" symptom.

### Fix
1. **Escape the containing block.** Render `ChatBar` as a sibling of the contained wrapper, inside the same `ChatRuntimeBoundary` (pure context, no DOM). Its nearest positioned ancestor becomes the outer `relative isolate` container (no transform/contain/filter), so docked stays `absolute` (identical placement) and floating `fixed` resolves against the viewport. The composer stays mounted across dock⇄float — no remount, no portal. (Verified `PaneMain` + the shell chain above `ChatView` use no transform/contain/filter.)
2. **Clamp to the thread area, not the window.** The thread wrapper is tagged `data-slot="composer-bounds"`; the clamp confines the box to that rect (which already excludes a pinned sidebar and the header), falling back to the full window before it's measured. Threaded through every entry point: mount, resize, per-frame drag, peel-off, release-persist. This subsumes the old titlebar top-margin.
3. **Self-heal on load.** On pop-out we re-clamp immediately and again on the next frame (after sidebar/font layout settles), persisting the corrected position — so anyone who loads in with a stranded position (saved on another monitor/layout, or from before this fix) is pulled back on-screen automatically. A degenerate pre-layout bounds rect is treated as unknown so the box is never clamped into a collapsed area.

## Test plan
- [ ] Pop out, open/close both sidebars → composer stays put and fully visible; never slides under a pinned sidebar.
- [ ] Drag to each edge with sidebars open and hidden → stops at the thread edges in both.
- [ ] Seed a far-off `hermes.desktop.composerPopout.position` in localStorage, reload → snaps back on-screen and the value is rewritten.
- [ ] Toggle dock ⇄ float repeatedly with text in the editor → no remount; draft + caret preserved.
- [ ] Docked placement/centering unchanged with sidebars open/closed.
- [ ] Secondary window (Ctrl+Shift+N) / subagent view → composer stays docked.
- [ ] macOS + Windows + WSLg.

Related: #50466, #49903.