### PR TITLE
fix(server): offload cron job listing from dashboard event loop

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7662,15 +7662,21 @@ def _find_cron_job_profile(job_id: str) -> Optional[str]:
 async def list_cron_jobs(profile: str = "all"):
     requested = (profile or "all").strip()
     if requested.lower() != "all":
-        return _call_cron_for_profile(requested, "list_jobs", True)
+        return await asyncio.to_thread(
+            _call_cron_for_profile, requested, "list_jobs", True
+        )
 
     jobs: List[Dict[str, Any]] = []
-    for item in _cron_profile_dicts():
+    for item in await asyncio.to_thread(_cron_profile_dicts):
         name = str(item.get("name") or "")
         if not name:
             continue
         try:
-            jobs.extend(_call_cron_for_profile(name, "list_jobs", True))
+            jobs.extend(
+                await asyncio.to_thread(
+                    _call_cron_for_profile, name, "list_jobs", True
+                )
+            )
         except Exception:
             _log.exception("Failed to list cron jobs for profile %s", name)
     return jobs

--- a/tests/hermes_cli/test_web_server_cron_profiles.py
+++ b/tests/hermes_cli/test_web_server_cron_profiles.py
@@ -187,6 +187,111 @@ async def test_cron_delete_with_profile_deletes_only_target_profile(isolated_pro
 
 
 @pytest.mark.asyncio
+async def test_list_cron_jobs_does_not_block_event_loop_when_sync_io_is_slow(
+    isolated_profiles, monkeypatch
+):
+    """Regression test for #45072: slow synchronous sub-functions must NOT
+    block the asyncio event loop.
+
+    Before the fix, ``_cron_profile_dicts()`` and ``_call_cron_for_profile()``
+    were called directly in the ``async def list_cron_jobs()`` handler, which
+    freezes the event loop for the duration of every synchronous I/O call.
+
+    After the fix, these calls are offloaded via ``asyncio.to_thread()`` so
+    the event loop stays responsive.
+
+    The test injects slow sync functions (time.sleep) and runs a concurrent
+    heartbeat coroutine. If the event loop were blocked, the heartbeat would
+    stall; with the fix, it continues ticking.
+    """
+    import asyncio
+    import time as time_mod
+
+    from hermes_cli import web_server
+
+    SLEEP_PER_CALL = 0.2  # seconds per monkeypatched sync function
+    TICK_INTERVAL = 0.01  # heartbeat granularity
+    EXPECTED_TICKS = 10   # generous lower bound
+
+    original_dicts = web_server._cron_profile_dicts
+    original_call = web_server._call_cron_for_profile
+
+    def slow_dicts():
+        time_mod.sleep(SLEEP_PER_CALL)
+        return original_dicts()
+
+    def slow_call(profile, func_name, *args, **kwargs):
+        time_mod.sleep(SLEEP_PER_CALL)
+        return original_call(profile, func_name, *args, **kwargs)
+
+    monkeypatch.setattr(web_server, "_cron_profile_dicts", slow_dicts)
+    monkeypatch.setattr(web_server, "_call_cron_for_profile", slow_call)
+
+    start = time_mod.monotonic()
+    deadline = start + 1.0  # plenty of room for 3× slow calls
+
+    ticks = 0
+
+    async def heartbeat():
+        nonlocal ticks
+        while time_mod.monotonic() < deadline:
+            ticks += 1
+            await asyncio.sleep(TICK_INTERVAL)
+
+    await asyncio.gather(
+        web_server.list_cron_jobs(profile="all"),
+        heartbeat(),
+    )
+
+    # If the event loop were blocked by synchronous calls, ticks would be
+    # very low (~0-2). With async.offloaded to thread pool it should be
+    # well above EXPECTED_TICKS.
+    assert ticks > EXPECTED_TICKS, (
+        f"Heartbeat only ticked {ticks} times (expected >{EXPECTED_TICKS}). "
+        "This means synchronous cron/profile functions blocked the event loop."
+    )
+
+    # Also verify that the single-profile path is non-blocking
+    ticks2 = 0
+    start2 = time_mod.monotonic()
+    deadline2 = start2 + 0.4
+
+    async def heartbeat2():
+        nonlocal ticks2
+        while time_mod.monotonic() < deadline2:
+            ticks2 += 1
+            await asyncio.sleep(TICK_INTERVAL)
+
+    await asyncio.gather(
+        web_server.list_cron_jobs(profile="default"),
+        heartbeat2(),
+    )
+
+    assert ticks2 > 5, (
+        f"Single-profile heartbeat only ticked {ticks2} times "
+        "(expected >5). The sync offload for single-profile path is broken."
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_cron_jobs_preserves_exceptions_from_sync_functions(
+    isolated_profiles, monkeypatch
+):
+    """Verify that exceptions raised inside asyncio.to_thread still
+    propagate correctly with the original error type and message."""
+    from hermes_cli import web_server
+
+    def broken_dicts():
+        msg = "simulated sync crash"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(web_server, "_cron_profile_dicts", broken_dicts)
+
+    with pytest.raises(RuntimeError, match="simulated sync crash"):
+        await web_server.list_cron_jobs(profile="all")
+
+
+@pytest.mark.asyncio
 async def test_cron_profile_validation_errors(isolated_profiles):
     from hermes_cli import web_server
 


### PR DESCRIPTION
## Summary

`GET /api/cron/jobs` is an async dashboard endpoint, but it performs synchronous profile enumeration and per-profile cron file I/O directly on the event loop thread.

If those filesystem operations become slow, the dashboard event loop is blocked for the duration of the sync call, starving other HTTP requests and WebSocket traffic.

This PR offloads only the synchronous cron/profile work to `asyncio.to_thread(...)`:

- `_cron_profile_dicts()` — profile enumeration
- `_call_cron_for_profile(...)` — per-profile cron module calls, for both the single-profile and all-profiles paths

The handler shape, response format, profile parameter behavior, error handling, and per-profile sequential processing order are preserved.

## Related Issue

Relates to #45072.

This addresses only the `/api/cron/jobs` portion of the broader event-loop blocking issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill

## Changes Made

- `hermes_cli/web_server.py`
  - Wrapped `_cron_profile_dicts()` and both `_call_cron_for_profile(...)` calls in `list_cron_jobs()` with `await asyncio.to_thread(...)`.
  - Only the synchronous I/O-bound calls are offloaded; the handler loop, response assembly, and parameter handling stay on the event loop.
  - Per-profile processing remains sequential.

- `tests/hermes_cli/test_web_server_cron_profiles.py`
  - Added a regression test that monkeypatches slow synchronous cron/profile functions and verifies a concurrent heartbeat continues ticking.
  - Added a test verifying exceptions from the thread-pool calls preserve the existing behavior.

## How to Test

Targeted tests:

```bash
pytest tests/hermes_cli/test_web_server_cron_profiles.py -v
pytest tests/hermes_cli/test_web_server.py -k "cron"
pytest tests/hermes_cli/test_cron*.py -q
```

Results:

- `tests/hermes_cli/test_web_server_cron_profiles.py`: 9 passed
- `tests/hermes_cli/test_web_server.py -k "cron"`: 6 passed
- `tests/hermes_cli/test_cron*.py -q`: 19 passed

Broader filtered run (`pytest tests -q -k "cron or web_server"`) has pre-existing
failures on `origin/main`, unrelated to this change:

- `tests/cron/test_scheduler.py::test_all_token_case_insensitive`
- `tests/hermes_cli/test_web_server.py::TestPtyWebSocket` (3 tests)

The cron/event-loop tests added by this PR pass.

## Regression Proof

Before this change, the slow-sync regression test failed: a concurrent 10ms
heartbeat received 0 ticks while `list_cron_jobs()` was running with simulated
synchronous I/O.

After this change, the heartbeat continues ticking while the cron/profile work
runs in the thread pool.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits (`fix(server): offload cron job listing from event loop`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass

  Not checked: broader filtered runs have pre-existing failures on `origin/main`, documented above.

- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS, Apple Silicon, Python 3.11.14

### Documentation & Housekeeping

- [x] N/A — No documentation changes needed
- [x] N/A — No config key changes
- [x] N/A — No architecture or workflow changes
- [x] N/A — No tool behavior changes
