### PR TITLE
fix: update Anthropic OAuth token endpoint from console.anthropic.com to platform.claude.com

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1297,7 +1297,7 @@ def run_oauth_setup_token() -> Optional[str]:
 # Stores credentials in ~/.hermes/.anthropic_oauth.json (our own file).
 
 _OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
-_OAUTH_TOKEN_URL = "https://console.anthropic.com/v1/oauth/token"
+_OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
 _OAUTH_REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback"
 _OAUTH_SCOPES = "org:create_api_key user:profile user:inference"
 _HERMES_OAUTH_FILE = get_hermes_home() / ".anthropic_oauth.json"

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6049,7 +6049,7 @@ async def disconnect_oauth_provider(
 #          → returns { session_id, flow: "pkce", auth_url }
 #     2. UI opens auth_url in a new tab. User authorizes, copies code.
 #     3. POST /api/providers/oauth/anthropic/submit { session_id, code }
-#          → server exchanges (code + verifier) → tokens at console.anthropic.com
+#          → server exchanges (code + verifier) → tokens at platform.claude.com
 #          → persists to ~/.hermes/.anthropic_oauth.json AND credential pool
 #          → returns { ok: true, status: "approved" }
 #


### PR DESCRIPTION
## Summary

`hermes auth add anthropic --type oauth` fails at the token-exchange step with a 404, so a fresh Claude Pro/Max OAuth login can never complete:

```
Token exchange failed: HTTP Error 404: Not Found
Anthropic OAuth login did not return credentials.
```

## Root cause

Anthropic migrated the OAuth **token** endpoint to `platform.claude.com`. The codebase is inconsistent about this:

- **Login** path — `agent/anthropic_adapter.py`, `run_hermes_oauth_login_pure()` — hardcodes the legacy host via the module constant:
  ```python
  _OAUTH_TOKEN_URL = "https://console.anthropic.com/v1/oauth/token"   # now 404s
  ```
- **Refresh** path — same file (~lines 997–1000) — already does the right thing, trying the new host first and the legacy host as a fallback:
  ```python
  token_endpoints = [
      "https://platform.claude.com/v1/oauth/token",
      "https://console.anthropic.com/v1/oauth/token",
  ]
  ```

So token *refresh* works (which is why credentials created before the migration keep working), but a fresh *login* 404s. `hermes_cli/web_server.py` imports the same `_OAUTH_TOKEN_URL` for the dashboard OAuth flow, so the web login path has the identical bug.

## Evidence

A bare `POST` of the token request to each host:

| Endpoint | HTTP |
|----------|------|
| `console.anthropic.com/v1/oauth/token` | **404** (dead) |
| `platform.claude.com/v1/oauth/token` | **400** (live — rejects the dummy code, i.e. reachable) |

Reproduced on `v0.17.0`; the constant is still `console.anthropic.com` on current `main`.

## Fix

Point the login token exchange at the live host:
```python
_OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
```

This fixes both the CLI login (`run_hermes_oauth_login_pure`) and the dashboard login (`web_server.py`) since both consume the same constant.

Fixes #49821
Related #48534