### PR TITLE
fix(auxiliary): preserve auto fallback model after auth failure

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3623,7 +3623,7 @@ def resolve_provider_client(
     # main_model also empty), the branches still hit their own
     # missing-credentials returns and ``_resolve_auto`` falls through to
     # the Step-2 chain as before.
-    if not model:
+    if not model and provider != "auto":
         model = _get_aux_model_for_provider(provider) or _read_main_model() or model
 
     def _needs_codex_wrap(client_obj, base_url_str: str, model_str: str) -> bool:

--- a/tests/agent/test_auxiliary_main_first.py
+++ b/tests/agent/test_auxiliary_main_first.py
@@ -118,6 +118,44 @@ class TestResolveAutoMainFirst:
         assert client is chain_client
         assert model == "google/gemini-3-flash-preview"
 
+    def test_public_auto_fallback_uses_chain_model_not_main_model(self, monkeypatch):
+        """resolve_provider_client('auto') must not send main gpt-5.5 to fallback OpenRouter.
+
+        Regression for Codex-auth failures: _resolve_auto correctly returns the
+        fallback chain model (Gemini Flash), but the public wrapper previously
+        re-applied the main model and routed OpenRouter requests as gpt-5.5.
+        """
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        chain_client = MagicMock()
+
+        with patch(
+            "agent.auxiliary_client._build_codex_client",
+            return_value=(None, None),
+        ), patch(
+            "agent.auxiliary_client._read_codex_access_token",
+            return_value=None,
+        ), patch(
+            "agent.auxiliary_client._read_main_model",
+            return_value="gpt-5.5",
+        ), patch(
+            "agent.auxiliary_client._try_openrouter",
+            return_value=(chain_client, "google/gemini-3-flash-preview"),
+        ):
+            from agent.auxiliary_client import resolve_provider_client
+
+            client, model = resolve_provider_client(
+                "auto",
+                main_runtime={
+                    "provider": "openai-codex",
+                    "model": "gpt-5.5",
+                    "base_url": "https://chatgpt.com/backend-api/codex",
+                    "api_mode": "codex_responses",
+                },
+            )
+
+        assert client is chain_client
+        assert model == "google/gemini-3-flash-preview"
+
     def test_main_unavailable_uses_task_fallback_chain_before_builtin_chain(self):
         """Auto aux resolution honors auxiliary.<task>.fallback_chain before built-ins."""
         task_client = MagicMock()


### PR DESCRIPTION
## Summary

`resolve_provider_client("auto")` already lets `_resolve_auto()` select a fallback-chain model when the selected main provider is unavailable. However, the public wrapper then filled a missing `model` argument from `_read_main_model()` before returning the auto resolution result.

That meant a Codex-auth failure path could correctly resolve OpenRouter/Gemini Flash internally, but still hand back the stale main model (`gpt-5.5`) to the caller.

This keeps the existing provider-specific defaulting behaviour, but skips that prefill for `provider == "auto"` so `_resolve_auto()` can preserve the model it selected.

## Why

Follow-up to #36759 / #50954. The dangerous #36759 leak path is mostly fixed by the fallback-policy changes, but this narrower wrapper regression still reproduced on current `origin/main`: `resolve_provider_client("auto", main_runtime={...openai-codex/gpt-5.5...})` returned `gpt-5.5` after the OpenRouter fallback selected `google/gemini-3-flash-preview`.

## Tests

```bash
venv/bin/python -m pytest -q -o 'addopts=' tests/agent/test_auxiliary_main_first.py::TestResolveAutoMainFirst::test_public_auto_fallback_uses_chain_model_not_main_model
# 1 passed

scripts/run_tests.sh tests/agent/test_auxiliary_main_first.py
# 19 passed

venv/bin/python scripts/check-windows-footguns.py --diff origin/main...HEAD
# No Windows footguns found
```
