### PR TITLE
feat: add meeting prep brief helper

### DIFF
--- a/docs/plans/2026-06-23-nightly-meeting-prep-brief.md
+++ b/docs/plans/2026-06-23-nightly-meeting-prep-brief.md
@@ -1,0 +1,52 @@
+# Nightly Meeting Prep Brief Helper
+
+## Goal
+
+Add a small local-first helper script that turns a human-maintained JSON/YAML meeting queue into a compact Markdown prep brief for upcoming meetings. This is aimed at Joe's personal operating system: reduce morning context-switching by surfacing who he is meeting, why it matters, what to prepare, and stale/missing prep fields.
+
+## Non-goals
+
+- No calendar API access.
+- No emails/messages sent.
+- No live deployment or background service.
+- No mutation of source files.
+
+## Input contract
+
+`scripts/meeting_prep_brief.py` accepts one or more local files containing either:
+
+- a top-level list of meeting records, or
+- a mapping with a `meetings` list.
+
+Supported file types: `.json`, `.yaml`, `.yml`.
+
+Meeting fields are intentionally flexible for hand-written notes:
+
+- Required-ish: `title` or `name`; `date` or `datetime`.
+- Optional: `time`, `timezone`, `attendees`, `goals`, `prep`, `questions`, `materials`, `notes`, `link`, `source`, `status`.
+- `attendees`, `goals`, `prep`, `questions`, and `materials` may be strings or lists.
+
+## Output contract
+
+Default output is Markdown:
+
+- `# Meeting Prep Brief`
+- one section per upcoming meeting, sorted by date/time
+- explicit missing-prep warnings for records without goals/prep/questions/materials
+- a `## Quick Actions` section with deterministic next actions
+
+If no active meetings are due in the window and there are no data-hygiene quick actions, output exactly `[SILENT]`.
+
+`--json` emits structured JSON with `generated_for`, `window_days`, `meetings`, and `quick_actions`.
+
+## Selection logic
+
+- Include meetings whose date/datetime is between `--today` and `--today + --days` inclusive.
+- Default `--days`: 7.
+- Skip statuses: `done`, `cancelled`, `canceled`, `archived`.
+- If a record has no parseable date, exclude it from the main brief but include a quick-action warning.
+
+## Verification plan
+
+- Unit tests for JSON input, YAML input when PyYAML is available, status/date filtering, flexible list parsing, missing-prep warnings, JSON output, and exact `[SILENT]` behavior.
+- Smoke check with a temporary sample file.

--- a/scripts/meeting_prep_brief.py
+++ b/scripts/meeting_prep_brief.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Build a local-first Markdown prep brief from JSON/YAML meeting notes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from datetime import date, datetime, time, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+SKIP_STATUSES = {"done", "cancelled", "canceled", "archived"}
+PREP_FIELDS = ("goals", "prep", "questions", "materials")
+
+
+@dataclass(order=True)
+class Meeting:
+    sort_key: tuple[date, str] = field(init=False, repr=False)
+    title: str
+    day: date
+    time_text: str = ""
+    timezone_text: str = ""
+    attendees: list[str] = field(default_factory=list)
+    goals: list[str] = field(default_factory=list)
+    prep: list[str] = field(default_factory=list)
+    questions: list[str] = field(default_factory=list)
+    materials: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+    link: str = ""
+    source: str = ""
+    missing_fields: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.sort_key = (self.day, self.time_text or "99:99")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "title": self.title,
+            "date": self.day.isoformat(),
+            "time": self.time_text,
+            "timezone": self.timezone_text,
+            "attendees": self.attendees,
+            "goals": self.goals,
+            "prep": self.prep,
+            "questions": self.questions,
+            "materials": self.materials,
+            "notes": self.notes,
+            "link": self.link,
+            "source": self.source,
+            "missing_fields": self.missing_fields,
+        }
+
+
+def _coerce_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    if isinstance(value, tuple):
+        return [str(item).strip() for item in value if str(item).strip()]
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return []
+        if "," in text and "\n" not in text:
+            return [part.strip() for part in text.split(",") if part.strip()]
+        return [line.strip(" -\t") for line in text.splitlines() if line.strip(" -\t")]
+    return [str(value).strip()] if str(value).strip() else []
+
+
+def _parse_date(record: dict[str, Any]) -> tuple[date | None, str]:
+    raw_datetime = record.get("datetime")
+    if raw_datetime:
+        text = str(raw_datetime).strip()
+        normalized = text.replace("Z", "+00:00")
+        try:
+            parsed = datetime.fromisoformat(normalized)
+            time_text = parsed.strftime("%H:%M") if parsed.time() != time(0, 0) else ""
+            return parsed.date(), time_text
+        except ValueError:
+            return None, ""
+
+    raw_date = record.get("date")
+    if not raw_date:
+        return None, ""
+    text = str(raw_date).strip()
+    try:
+        parsed_day = date.fromisoformat(text[:10])
+    except ValueError:
+        return None, ""
+    return parsed_day, str(record.get("time") or "").strip()
+
+
+def _load_file(path: Path) -> list[dict[str, Any]]:
+    text = path.read_text(encoding="utf-8")
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        payload = json.loads(text)
+    elif suffix in {".yaml", ".yml"}:
+        try:
+            import yaml  # type: ignore
+        except ImportError as exc:  # pragma: no cover - depends on optional env
+            raise SystemExit("PyYAML is required for YAML meeting files") from exc
+        payload = yaml.safe_load(text) or []
+    else:
+        raise ValueError(f"Unsupported file type: {path}")
+
+    if isinstance(payload, dict):
+        records = payload.get("meetings", [])
+    else:
+        records = payload
+    if not isinstance(records, list):
+        raise ValueError(f"Expected a list of meetings in {path}")
+    return [record for record in records if isinstance(record, dict)]
+
+
+def _normalize_record(record: dict[str, Any], source_path: Path) -> tuple[Meeting | None, str | None]:
+    title = str(record.get("title") or record.get("name") or "Untitled meeting").strip()
+    status = str(record.get("status") or "").strip().lower()
+    if status in SKIP_STATUSES:
+        return None, None
+
+    meeting_day, parsed_time = _parse_date(record)
+    if meeting_day is None:
+        return None, f"Add an ISO date for `{title}` in {source_path.name}."
+
+    fields = {field: _coerce_list(record.get(field)) for field in PREP_FIELDS}
+    missing_fields = [field for field, values in fields.items() if not values]
+    meeting = Meeting(
+        title=title,
+        day=meeting_day,
+        time_text=parsed_time,
+        timezone_text=str(record.get("timezone") or "").strip(),
+        attendees=_coerce_list(record.get("attendees")),
+        goals=fields["goals"],
+        prep=fields["prep"],
+        questions=fields["questions"],
+        materials=fields["materials"],
+        notes=_coerce_list(record.get("notes")),
+        link=str(record.get("link") or "").strip(),
+        source=str(record.get("source") or source_path.name).strip(),
+        missing_fields=missing_fields,
+    )
+    return meeting, None
+
+
+def collect_meetings(paths: list[Path], today: date, days: int) -> tuple[list[Meeting], list[str]]:
+    end_day = today + timedelta(days=days)
+    meetings: list[Meeting] = []
+    quick_actions: list[str] = []
+
+    for path in paths:
+        for record in _load_file(path):
+            meeting, warning = _normalize_record(record, path)
+            if warning:
+                quick_actions.append(warning)
+            if meeting is None:
+                continue
+            if today <= meeting.day <= end_day:
+                meetings.append(meeting)
+
+    meetings.sort()
+    for meeting in meetings:
+        if meeting.missing_fields:
+            quick_actions.append(
+                f"Fill {', '.join(meeting.missing_fields)} for `{meeting.title}` before {meeting.day.isoformat()}."
+            )
+    return meetings, quick_actions
+
+
+def build_payload(paths: list[Path | str], today: str | None = None, days: int = 7) -> dict[str, Any]:
+    generated_for = date.fromisoformat(today) if today else datetime.now(timezone.utc).date()
+    normalized_paths = [Path(path).expanduser() for path in paths]
+    meetings, quick_actions = collect_meetings(normalized_paths, generated_for, days)
+    return {
+        "generated_for": generated_for.isoformat(),
+        "window_days": days,
+        "meetings": [meeting.to_dict() for meeting in meetings],
+        "quick_actions": quick_actions,
+    }
+
+
+def _append_list(lines: list[str], label: str, values: list[str]) -> None:
+    if not values:
+        return
+    lines.append(f"- **{label}:**")
+    for value in values:
+        lines.append(f"  - {value}")
+
+
+def format_markdown(payload: dict[str, Any]) -> str:
+    meetings = payload["meetings"]
+    quick_actions = payload["quick_actions"]
+    if not meetings and not quick_actions:
+        return "[SILENT]"
+
+    lines = [
+        "# Meeting Prep Brief",
+        "",
+        f"Window: {payload['generated_for']} + {payload['window_days']} days",
+        "",
+    ]
+    if meetings:
+        for meeting in meetings:
+            when = meeting["date"]
+            if meeting.get("time"):
+                when += f" {meeting['time']}"
+            if meeting.get("timezone"):
+                when += f" {meeting['timezone']}"
+            lines.extend([f"## {meeting['title']}", "", f"- **When:** {when}"])
+            if meeting.get("attendees"):
+                lines.append(f"- **Attendees:** {', '.join(meeting['attendees'])}")
+            if meeting.get("source"):
+                lines.append(f"- **Source:** {meeting['source']}")
+            if meeting.get("link"):
+                lines.append(f"- **Link:** {meeting['link']}")
+            if meeting.get("missing_fields"):
+                lines.append(f"- **Warning:** Missing prep fields: {', '.join(meeting['missing_fields'])}")
+            _append_list(lines, "Goals", meeting.get("goals", []))
+            _append_list(lines, "Prep", meeting.get("prep", []))
+            _append_list(lines, "Questions", meeting.get("questions", []))
+            _append_list(lines, "Materials", meeting.get("materials", []))
+            _append_list(lines, "Notes", meeting.get("notes", []))
+            lines.append("")
+    else:
+        lines.extend(["No dated meetings are due in the selected window.", ""])
+
+    if quick_actions:
+        lines.extend(["## Quick Actions", ""])
+        for action in quick_actions:
+            lines.append(f"- {action}")
+    return "\n".join(lines).rstrip()
+
+
+def build_brief(paths: list[Path | str], today: str | None = None, days: int = 7) -> str:
+    return format_markdown(build_payload(paths, today=today, days=days))
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="+", type=Path, help="JSON/YAML meeting files")
+    parser.add_argument("--today", help="ISO date for deterministic runs, e.g. 2026-06-23")
+    parser.add_argument("--days", type=int, default=7, help="Inclusive lookahead window in days")
+    parser.add_argument("--json", action="store_true", help="Emit structured JSON instead of Markdown")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = build_payload(args.paths, today=args.today, days=args.days)
+    if args.json:
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+    else:
+        print(format_markdown(payload))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_meeting_prep_brief.py
+++ b/tests/test_meeting_prep_brief.py
@@ -1,0 +1,126 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "meeting_prep_brief.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("meeting_prep_brief", MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_json(path: Path, payload):
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_markdown_brief_filters_and_sorts_upcoming_json_meetings(tmp_path):
+    module = load_module()
+    source = tmp_path / "meetings.json"
+    write_json(
+        source,
+        {
+            "meetings": [
+                {
+                    "title": "Later call",
+                    "date": "2026-06-27",
+                    "time": "16:00",
+                    "attendees": ["Finn"],
+                    "goals": ["Book Japan hotels"],
+                    "prep": "Check passport dates",
+                },
+                {
+                    "name": "Earlier BD sync",
+                    "datetime": "2026-06-24T09:30:00+08:00",
+                    "attendees": "Daniel, Yuki",
+                    "questions": ["Any blockers?"],
+                    "materials": ["Pipeline notes"],
+                },
+                {"title": "Done meeting", "date": "2026-06-25", "status": "done"},
+                {"title": "Too far", "date": "2026-07-10"},
+            ]
+        },
+    )
+
+    brief = module.build_brief([source], today="2026-06-23", days=7)
+
+    assert brief.startswith("# Meeting Prep Brief")
+    assert brief.index("Earlier BD sync") < brief.index("Later call")
+    assert "Daniel" in brief and "Yuki" in brief
+    assert "Done meeting" not in brief
+    assert "Too far" not in brief
+    assert "Missing prep fields" in brief
+    assert "## Quick Actions" in brief
+
+
+def test_silent_when_no_active_meetings_in_window(tmp_path):
+    module = load_module()
+    source = tmp_path / "meetings.json"
+    write_json(source, [{"title": "Future", "date": "2026-07-15"}])
+
+    assert module.build_brief([source], today="2026-06-23", days=7) == "[SILENT]"
+
+
+def test_json_output_includes_unparseable_date_warning(tmp_path):
+    module = load_module()
+    source = tmp_path / "meetings.json"
+    write_json(
+        source,
+        [
+            {"title": "No date", "date": "next tuesday"},
+            {"title": "Investor chat", "date": "2026-06-25", "goals": "Thesis check"},
+        ],
+    )
+
+    payload = module.build_payload([source], today="2026-06-23", days=7)
+
+    assert [meeting["title"] for meeting in payload["meetings"]] == ["Investor chat"]
+    assert any("No date" in action for action in payload["quick_actions"])
+
+
+def test_yaml_mapping_input_when_pyyaml_available(tmp_path):
+    yaml = pytest.importorskip("yaml")
+    module = load_module()
+    source = tmp_path / "meetings.yaml"
+    source.write_text(
+        yaml.safe_dump(
+            {
+                "meetings": [
+                    {
+                        "title": "House ops",
+                        "date": "2026-06-23",
+                        "prep": ["AC filter status"],
+                        "questions": "Who owns the next cleaning?",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    brief = module.build_brief([source], today="2026-06-23", days=0)
+
+    assert "House ops" in brief
+    assert "AC filter status" in brief
+    assert "Who owns the next cleaning?" in brief
+
+
+def test_cli_json_flag_outputs_valid_json(tmp_path, capsys):
+    module = load_module()
+    source = tmp_path / "meetings.json"
+    write_json(source, [{"title": "Review", "date": "2026-06-23", "prep": "Open PR"}])
+
+    exit_code = module.main([str(source), "--today", "2026-06-23", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["generated_for"] == "2026-06-23"
+    assert payload["meetings"][0]["title"] == "Review"


### PR DESCRIPTION
## Summary

- add `scripts/meeting_prep_brief.py`, a local-first JSON/YAML meeting queue to Markdown/JSON prep brief helper
- include a spec/plan under `docs/plans/`
- add focused tests for filtering, sorting, flexible parsing, YAML support, JSON output, and exact `[SILENT]` behavior

## Why

This gives a low-friction personal-ops primitive: Joe can keep a simple meeting prep file and get a deterministic morning brief without granting calendar or email access.

## Tests

- `scripts/run_tests.sh tests/test_meeting_prep_brief.py`
- smoke: `python scripts/meeting_prep_brief.py /tmp/meeting-prep-sample.json --today 2026-06-23 --days 3`

## Safety

- local files only
- read-only against inputs
- no messages/emails/calendar/API calls
- no deployment
