### PR TITLE
fix(cron): deliver final report on last allowed turn instead of failing

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -122,10 +122,14 @@ def finalize_turn(
                 )
 
     # Determine if conversation completed successfully
+    normal_text_response = str(_turn_exit_reason).startswith("text_response(")
     completed = (
         final_response is not None
-        and api_call_count < agent.max_iterations
         and not failed
+        and (
+            api_call_count < agent.max_iterations
+            or normal_text_response
+        )
     )
 
     # Post-loop cleanup must never lose the response.  Trajectory save,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2189,13 +2189,27 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # would otherwise be delivered as if it were the agent's reply and the
         # job's `last_status` set to "ok". Raise so the except handler below
         # builds the proper failure tuple. (issue #17855)
-        if result.get("failed") is True or result.get("completed") is False:
+        turn_exit_reason = str(result.get("turn_exit_reason") or "")
+        final_response_text = (result.get("final_response") or "").strip()
+        max_iteration_summary = (
+            result.get("failed") is not True
+            and result.get("completed") is False
+            and turn_exit_reason.startswith("max_iterations_reached(")
+            and bool(final_response_text)
+        )
+        if result.get("failed") is True or (result.get("completed") is False and not max_iteration_summary):
             _err_text = (
                 result.get("error")
-                or (result.get("final_response") or "").strip()
+                or final_response_text
                 or "agent reported failure"
             )
             raise RuntimeError(_err_text)
+        if max_iteration_summary:
+            logger.warning(
+                "Job '%s' reached the iteration limit but produced a final fallback response; "
+                "delivering the response instead of failing the cron run",
+                job_name,
+            )
 
         final_response = result.get("final_response", "") or ""
         # Strip leaked placeholder text that upstream may inject on empty completions.

--- a/tests/agent/test_turn_finalizer_cleanup_guard.py
+++ b/tests/agent/test_turn_finalizer_cleanup_guard.py
@@ -100,7 +100,13 @@ class _StubAgent:
         pass
 
 
-def _run(agent):
+def _run(
+    agent,
+    *,
+    final_response=None,
+    api_call_count=3,
+    turn_exit_reason="unknown",
+):
     messages = [
         {"role": "user", "content": "do a thing"},
         {
@@ -114,8 +120,8 @@ def _run(agent):
     ]
     return finalize_turn(
         agent,
-        final_response=None,  # forces the max-iterations summary path
-        api_call_count=3,
+        final_response=final_response,
+        api_call_count=api_call_count,
         interrupted=False,
         failed=False,
         messages=messages,
@@ -125,7 +131,7 @@ def _run(agent):
         user_message="do a thing",
         original_user_message="do a thing",
         _should_review_memory=False,
-        _turn_exit_reason="unknown",
+        _turn_exit_reason=turn_exit_reason,
     )
 
 
@@ -162,4 +168,17 @@ def test_clean_turn_has_no_cleanup_errors_key():
     agent = _StubAgent(raise_in=())
     result = _run(agent)
     assert result["final_response"] == "PARTIAL SUMMARY FROM MODEL"
+    assert result["completed"] is False
     assert "cleanup_errors" not in result
+
+
+def test_text_response_on_last_allowed_call_is_completed():
+    agent = _StubAgent(raise_in=())
+    result = _run(
+        agent,
+        final_response="final report",
+        api_call_count=agent.max_iterations,
+        turn_exit_reason="text_response(finish_reason=stop)",
+    )
+    assert result["final_response"] == "final report"
+    assert result["completed"] is True

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1394,6 +1394,52 @@ class TestRunJobSessionPersistence:
         assert error is None
         assert final_response == "all good"
 
+    def test_run_job_delivers_max_iteration_fallback_summary(self, tmp_path):
+        """Cron should deliver a usable max-iteration fallback summary.
+
+        A cron run can exhaust the iteration budget, get a final text summary
+        from the no-tools fallback call, and still have ``completed=False`` in
+        the generic agent result. That should not make cron raise the report
+        text as a RuntimeError.
+        """
+        job = {
+            "id": "summary-job",
+            "name": "summary",
+            "prompt": "finish the report",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {
+                "final_response": "final fallback report",
+                "completed": False,
+                "failed": False,
+                "turn_exit_reason": "max_iterations_reached(60/60)",
+            }
+            mock_agent_cls.return_value = mock_agent
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "final fallback report"
+        assert "final fallback report" in output
+        assert "(FAILED)" not in output
+
     def test_tick_marks_empty_response_as_error(self, tmp_path):
         """When run_job returns success=True but final_response is empty,
         tick() should mark the job as error so last_status != 'ok'.


### PR DESCRIPTION
## Summary
Cron jobs that produce a complete final report no longer fail with a RuntimeError whose text *is* the report.

Two adjacent completion-boundary bugs that share the same user symptom ("cron ran, final message was created, but failed with a runtime error"):

1. A normal final text response landing on the **last allowed** API call was marked `completed=False` (`api_call_count == max_iterations`), so `cron/scheduler.py` raised the response as an error.
2. When the budget was genuinely exhausted but the toolless summary produced a usable report (`max_iterations_reached(...)` + non-empty `final_response`), cron still raised instead of delivering it.

Root cause confirmed against current `main`:
- `agent/conversation_loop.py` increments `api_call_count` to exactly `max_iterations` on the last pass, then captures the final text.
- `agent/turn_finalizer.py`: `completed = ... and api_call_count < agent.max_iterations` → False despite a complete answer.
- `cron/scheduler.py`: `if completed is False: raise RuntimeError(final_response)`.

## Changes
- `agent/turn_finalizer.py`: `completed=True` when the turn exited via `text_response(...)`, regardless of whether it used the last call. Genuine budget-exhaustion (`final_response is None`) stays incomplete.
- `cron/scheduler.py`: deliver a non-empty `max_iterations_reached(...)` summary instead of raising; log a warning.

## Validation
| | Before | After |
|---|---|---|
| Final text on last allowed call | `completed=False` → RuntimeError(report) | `completed=True` → delivered |
| Budget-exhausted summary (non-empty) | RuntimeError(summary) | delivered + warning logged |
| Genuine empty exhaustion | incomplete (raise) | incomplete (raise) — unchanged |

`tests/agent/test_turn_finalizer_cleanup_guard.py` + `tests/cron/test_scheduler.py` → 169 passed.

Salvage of #50967 by @helix4u (both commits cherry-picked, authorship preserved). Reported by NilVaw in Discord. Separate from the Discord slash-command cap error (#50890) later in the same log.

## Infographic

![cron-deliver-final-report](https://v3b.fal.media/files/b/0a9f5aa1/1c9dDg7AWrDILif1hKYzy_DGYfsO0H.png)
