### PR TITLE
feat(messenger): add Facebook Messenger platform plugin

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -537,6 +537,14 @@ class GatewayAuthorizationMixin:
                 ),
                 Platform.QQBOT: ("QQ_GROUP_ALLOWED_USERS",),
             }
+            if platform not in platform_env_map:
+                try:
+                    from gateway.platform_registry import platform_registry
+                    entry = platform_registry.get(platform.value)
+                    if entry and entry.allowed_users_env:
+                        platform_env_map[platform] = entry.allowed_users_env
+                except Exception:
+                    pass
             if os.getenv(platform_env_map.get(platform, ""), "").strip():
                 return "ignore"
             for env_key in platform_group_env_map.get(platform, ()):

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -360,7 +360,7 @@ def _prompt_plugin_env_vars(manifest: dict, console) -> None:
         name = spec["name"]
         desc = spec.get("description", "")
         url = spec.get("url", "")
-        secret = spec.get("secret", False)
+        secret = bool(spec.get("secret", False) or spec.get("password", False))
 
         label = f"  {name}"
         if desc:

--- a/plugins/platforms/messenger/__init__.py
+++ b/plugins/platforms/messenger/__init__.py
@@ -1,0 +1,3 @@
+from .adapter import register
+
+__all__ = ["register"]

--- a/plugins/platforms/messenger/adapter.py
+++ b/plugins/platforms/messenger/adapter.py
@@ -71,6 +71,8 @@ DEFAULT_WEBHOOK_PATH = "/messenger/webhook"
 MAX_MESSAGE_LENGTH = 2000
 WEBHOOK_BODY_MAX_BYTES = 1_048_576
 DEDUP_MAX_SIZE = 2048
+RESERVED_WEBHOOK_PATHS = frozenset({"/messenger/health"})
+_YAML_BRIDGED_ENV_KEYS: set[str] = set()
 
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\((https?://[^\s)]+)\)")
 _MARKDOWN_CODE_BLOCK_RE = re.compile(r"```[a-zA-Z0-9_+-]*\n?(.*?)```", re.DOTALL)
@@ -148,6 +150,21 @@ def _normalise_webhook_path(path: Any) -> str:
 def _normalise_api_version(value: Any) -> str:
     text = str(value or DEFAULT_API_VERSION).strip() or DEFAULT_API_VERSION
     return text if text.startswith("v") else f"v{text}"
+
+
+def _bridge_yaml_env(key: str, value: Any) -> None:
+    """Bridge YAML-only plugin auth keys to env without stale reload values."""
+    if value in (None, ""):
+        if key in _YAML_BRIDGED_ENV_KEYS:
+            os.environ.pop(key, None)
+            _YAML_BRIDGED_ENV_KEYS.discard(key)
+        return
+
+    existing = _env_value(key)
+    if existing and key not in _YAML_BRIDGED_ENV_KEYS:
+        return
+    os.environ[key] = str(value)
+    _YAML_BRIDGED_ENV_KEYS.add(key)
 
 
 def _read_secret_file(path_value: Any) -> str:
@@ -344,8 +361,27 @@ def parse_accounts(extra: Optional[Dict[str, Any]]) -> Dict[str, MessengerAccoun
     return accounts
 
 
-def _has_complete_account(extra: Optional[Dict[str, Any]]) -> bool:
-    return any(account.complete for account in parse_accounts(extra).values())
+def _webhook_path_error(accounts: Iterable[MessengerAccount]) -> Optional[str]:
+    route_paths: Dict[str, MessengerAccount] = {}
+    for account in accounts:
+        if account.webhook_path in RESERVED_WEBHOOK_PATHS:
+            return (
+                f"Messenger webhook path {account.webhook_path} for account "
+                f"{account.account_id} is reserved"
+            )
+        previous = route_paths.get(account.webhook_path)
+        if previous is not None:
+            return (
+                f"Duplicate Messenger webhook path {account.webhook_path} for "
+                f"accounts {previous.account_id} and {account.account_id}"
+            )
+        route_paths[account.webhook_path] = account
+    return None
+
+
+def _has_valid_complete_accounts(extra: Optional[Dict[str, Any]]) -> bool:
+    accounts = [account for account in parse_accounts(extra).values() if account.complete]
+    return bool(accounts) and _webhook_path_error(accounts) is None
 
 
 def _message_type_for_attachment(kind: str) -> MessageType:
@@ -398,6 +434,7 @@ class _MessageDeduplicator:
 class MessengerAdapter(BasePlatformAdapter):
     """Facebook Messenger webhook adapter."""
 
+    SUPPORTS_MESSAGE_EDITING = False
     splits_long_messages = True
     supports_code_blocks = False
 
@@ -442,18 +479,11 @@ class MessengerAdapter(BasePlatformAdapter):
             return False
 
         app = web.Application(client_max_size=WEBHOOK_BODY_MAX_BYTES)
-        route_paths: Dict[str, MessengerAccount] = {}
+        path_error = _webhook_path_error(self._complete_accounts.values())
+        if path_error:
+            logger.error(path_error)
+            return False
         for account in self._complete_accounts.values():
-            previous = route_paths.get(account.webhook_path)
-            if previous is not None:
-                logger.error(
-                    "Duplicate Messenger webhook path %s for accounts %s and %s",
-                    account.webhook_path,
-                    previous.account_id,
-                    account.account_id,
-                )
-                return False
-            route_paths[account.webhook_path] = account
             app.router.add_get(account.webhook_path, self._build_verify_handler(account))
             app.router.add_post(account.webhook_path, self._build_webhook_handler(account))
 
@@ -503,7 +533,12 @@ class MessengerAdapter(BasePlatformAdapter):
         account, recipient_id = self._resolve_outbound_account(chat_id, metadata)
         if account is None or not recipient_id:
             return SendResult(success=False, error="Missing Messenger account or recipient ID")
-        return await self._send_text_chunks(account, recipient_id, self.format_message(content or ""))
+        return await self._send_text_chunks(
+            account,
+            recipient_id,
+            self.format_message(content or ""),
+            metadata=metadata,
+        )
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         account, recipient_id = self._resolve_outbound_account(chat_id, metadata)
@@ -527,7 +562,13 @@ class MessengerAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Missing Messenger account or recipient ID")
         if not str(image_url).startswith(("http://", "https://")):
             return SendResult(success=False, error="Messenger image sending requires a public http(s) URL")
-        image_result = await self._send_attachment_url(account, recipient_id, "image", image_url)
+        image_result = await self._send_attachment_url(
+            account,
+            recipient_id,
+            "image",
+            image_url,
+            metadata=metadata,
+        )
         if not image_result.success or not caption:
             return image_result
         caption_result = await self.send(chat_id, caption, reply_to=reply_to, metadata=metadata)
@@ -570,21 +611,44 @@ class MessengerAdapter(BasePlatformAdapter):
                 payload = json.loads(body.decode("utf-8"))
             except (UnicodeDecodeError, json.JSONDecodeError):
                 return web.Response(status=400, text="Invalid JSON")
-            asyncio.create_task(self._process_webhook_payload(account, payload))
+            self._track_background_task(self._process_webhook_payload(account, payload))
             return web.json_response({"status": "ok"})
 
         return handler
+
+    def _track_background_task(self, coro) -> Optional[asyncio.Task]:
+        task = asyncio.create_task(coro)
+        try:
+            self._background_tasks.add(task)
+        except TypeError:
+            return task
+        if hasattr(task, "add_done_callback"):
+            task.add_done_callback(self._background_tasks.discard)
+            task.add_done_callback(self._expected_cancelled_tasks.discard)
+        return task
 
     async def _health(self, request):
         return web.json_response({"ok": True, "platform": "messenger"})
 
     async def _process_webhook_payload(self, account: MessengerAccount, payload: Dict[str, Any]) -> None:
+        if not isinstance(payload, dict):
+            logger.debug("Ignoring malformed Messenger webhook payload: %r", type(payload).__name__)
+            return
         if payload.get("object") != "page":
             logger.debug("Ignoring non-page Messenger webhook object: %r", payload.get("object"))
             return
         for entry in payload.get("entry") or []:
+            if not isinstance(entry, dict):
+                logger.debug("Ignoring malformed Messenger webhook entry: %r", type(entry).__name__)
+                continue
             messaging_events = entry.get("messaging") or []
+            if not isinstance(messaging_events, list):
+                logger.debug("Ignoring malformed Messenger messaging list: %r", type(messaging_events).__name__)
+                continue
             for event in messaging_events:
+                if not isinstance(event, dict):
+                    logger.debug("Ignoring malformed Messenger messaging event: %r", type(event).__name__)
+                    continue
                 try:
                     await self._process_messaging_event(account, event)
                 except Exception:
@@ -608,8 +672,8 @@ class MessengerAdapter(BasePlatformAdapter):
             logger.debug("Messenger DM policy disabled; dropping message from %s", sender_id or "?")
             return
         if sender_id:
-            asyncio.create_task(self._best_effort_sender_action(account, sender_id, "mark_seen"))
-            asyncio.create_task(self._best_effort_sender_action(account, sender_id, "typing_on"))
+            self._track_background_task(self._best_effort_sender_action(account, sender_id, "mark_seen"))
+            self._track_background_task(self._best_effort_sender_action(account, sender_id, "typing_on"))
 
         event_obj = await self._to_message_event(account, event)
         if event_obj is not None:
@@ -679,7 +743,7 @@ class MessengerAdapter(BasePlatformAdapter):
             chat_id=chat_id,
             chat_name=sender_id,
             chat_type="dm",
-            user_id=sender_id,
+            user_id=chat_id,
             user_name=sender_id,
             message_id=message_id,
         )
@@ -697,7 +761,7 @@ class MessengerAdapter(BasePlatformAdapter):
     async def _download_attachment(self, url: str, kind: str):
         if not HTTPX_AVAILABLE or not self._http:
             return None
-        if not is_safe_url(url):
+        if not await asyncio.to_thread(is_safe_url, url):
             logger.warning("Blocked unsafe Messenger attachment URL: %s", safe_url_for_log(url))
             return None
         media_type = "media"
@@ -773,27 +837,69 @@ class MessengerAdapter(BasePlatformAdapter):
             return sender_id
         return f"{account.account_id}:{sender_id}"
 
-    async def _send_text_chunks(self, account: MessengerAccount, recipient_id: str, text: str) -> SendResult:
+    def _messaging_metadata(self, metadata: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        metadata = metadata or {}
+        messaging_type = str(
+            metadata.get("messenger_messaging_type")
+            or metadata.get("messaging_type")
+            or "RESPONSE"
+        ).strip().upper()
+        if messaging_type not in {"RESPONSE", "UPDATE", "MESSAGE_TAG", "UTILITY"}:
+            messaging_type = "RESPONSE"
+        result: Dict[str, Any] = {"messaging_type": messaging_type}
+        tag = str(metadata.get("messenger_tag") or metadata.get("tag") or "").strip()
+        if tag:
+            result["tag"] = tag
+        return result
+
+    def _base_send_payload(
+        self,
+        recipient_id: str,
+        metadata: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        send_meta = self._messaging_metadata(metadata)
+        payload = {
+            "recipient": {"id": recipient_id},
+            "messaging_type": send_meta["messaging_type"],
+        }
+        if send_meta.get("tag"):
+            payload["tag"] = send_meta["tag"]
+        return payload
+
+    async def _send_text_chunks(
+        self,
+        account: MessengerAccount,
+        recipient_id: str,
+        text: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
         chunks = split_for_messenger(text) or [""]
         message_ids: List[str] = []
         responses: List[Any] = []
         for chunk in chunks:
-            payload = {
-                "recipient": {"id": recipient_id},
-                "messaging_type": "RESPONSE",
-                "message": {"text": chunk},
-            }
+            payload = self._base_send_payload(recipient_id, metadata)
+            payload["message"] = {"text": chunk}
             try:
                 data = await self._post_graph(account, "/me/messages", payload)
             except MessengerGraphError as exc:
+                delivered = bool(message_ids)
                 return SendResult(
                     success=False,
                     error=str(exc),
-                    raw_response=exc.detail,
-                    retryable=exc.retryable,
+                    raw_response={
+                        "error": exc.detail,
+                        "delivered_message_ids": message_ids,
+                    } if delivered else exc.detail,
+                    retryable=exc.retryable and not delivered,
                 )
             except Exception as exc:
-                return SendResult(success=False, error=str(exc), retryable=True)
+                delivered = bool(message_ids)
+                return SendResult(
+                    success=False,
+                    error=str(exc),
+                    raw_response={"delivered_message_ids": message_ids} if delivered else None,
+                    retryable=not delivered,
+                )
             responses.append(data)
             mid = data.get("message_id") if isinstance(data, dict) else None
             if mid:
@@ -811,15 +917,13 @@ class MessengerAdapter(BasePlatformAdapter):
         recipient_id: str,
         attachment_type: str,
         url: str,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        payload = {
-            "recipient": {"id": recipient_id},
-            "messaging_type": "RESPONSE",
-            "message": {
-                "attachment": {
-                    "type": attachment_type,
-                    "payload": {"url": url, "is_reusable": True},
-                },
+        payload = self._base_send_payload(recipient_id, metadata)
+        payload["message"] = {
+            "attachment": {
+                "type": attachment_type,
+                "payload": {"url": url, "is_reusable": True},
             },
         }
         try:
@@ -883,7 +987,7 @@ def check_requirements() -> bool:
 
 
 def validate_config(config) -> bool:
-    return _has_complete_account(getattr(config, "extra", {}) or {})
+    return _has_valid_complete_accounts(getattr(config, "extra", {}) or {})
 
 
 def is_connected(config) -> bool:
@@ -928,7 +1032,7 @@ def _apply_yaml_config(yaml_cfg: dict, messenger_cfg: dict) -> dict | None:
     """
     seeded: Dict[str, Any] = {}
     extra = messenger_cfg.get("extra") if isinstance(messenger_cfg.get("extra"), dict) else {}
-    for source in (messenger_cfg, extra):
+    for source in (extra, messenger_cfg):
         for key in (
             "page_access_token",
             "pageAccessToken",
@@ -951,6 +1055,10 @@ def _apply_yaml_config(yaml_cfg: dict, messenger_cfg: dict) -> dict | None:
             "apiVersion",
             "dm_policy",
             "dmPolicy",
+            "allow_from",
+            "allowFrom",
+            "allow_all_users",
+            "allowAllUsers",
             "accounts",
         ):
             if key in source and source[key] not in (None, ""):
@@ -962,11 +1070,16 @@ def _apply_yaml_config(yaml_cfg: dict, messenger_cfg: dict) -> dict | None:
                 seeded["port"] = int(source["port"])
             except (TypeError, ValueError):
                 pass
-    if "allow_from" in messenger_cfg and not _env_value("MESSENGER_ALLOWED_USERS"):
-        value = messenger_cfg["allow_from"]
-        os.environ["MESSENGER_ALLOWED_USERS"] = ",".join(_coerce_list(value))
-    if "allow_all_users" in messenger_cfg and not _env_value("MESSENGER_ALLOW_ALL_USERS"):
-        os.environ["MESSENGER_ALLOW_ALL_USERS"] = str(messenger_cfg["allow_all_users"]).lower()
+    allow_from = _get_cfg_value(seeded, "allow_from", "allowFrom")
+    allow_all_users = _get_cfg_value(seeded, "allow_all_users", "allowAllUsers")
+    _bridge_yaml_env(
+        "MESSENGER_ALLOWED_USERS",
+        ",".join(_coerce_list(allow_from)) if allow_from is not None else None,
+    )
+    _bridge_yaml_env(
+        "MESSENGER_ALLOW_ALL_USERS",
+        str(allow_all_users).lower() if allow_all_users is not None else None,
+    )
     return seeded or None
 
 
@@ -994,9 +1107,16 @@ async def _standalone_send(
     try:
         if adapter._http is None:
             return {"error": "Messenger standalone send: httpx is not installed"}
-        result = await adapter.send(chat_id, message)
+        result = await adapter.send(
+            chat_id,
+            message,
+            metadata={"messenger_messaging_type": "UPDATE"},
+        )
         if not result.success:
-            return {"error": result.error or "Messenger send failed"}
+            payload = {"error": result.error or "Messenger send failed"}
+            if result.retryable:
+                payload["retryable"] = True
+            return payload
         if media_files:
             return {
                 "success": True,

--- a/plugins/platforms/messenger/adapter.py
+++ b/plugins/platforms/messenger/adapter.py
@@ -1,0 +1,1078 @@
+"""Facebook Messenger platform adapter for Hermes Agent.
+
+This is a bundled platform plugin, not a core platform. It follows Meta's
+Messenger webhook contract:
+
+* ``GET /messenger/webhook`` handles ``hub.challenge`` verification.
+* ``POST /messenger/webhook`` requires ``X-Hub-Signature-256`` HMAC-SHA256
+  over the raw request body using the Facebook app secret.
+* outbound messages use the Page Send API at ``/{version}/me/messages``.
+
+Access control is intentionally delegated to the gateway-level platform
+authorization layer. Configure ``MESSENGER_ALLOWED_USERS`` /
+``MESSENGER_ALLOW_ALL_USERS`` or use the default pairing flow.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+import logging
+import os
+import re
+import time
+import uuid
+from collections import OrderedDict
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlsplit
+
+try:
+    from aiohttp import web
+
+    AIOHTTP_AVAILABLE = True
+except ImportError:  # pragma: no cover - depends on optional runtime deps
+    web = None  # type: ignore[assignment]
+    AIOHTTP_AVAILABLE = False
+
+try:
+    import httpx
+
+    HTTPX_AVAILABLE = True
+except ImportError:  # pragma: no cover - depends on optional runtime deps
+    httpx = None  # type: ignore[assignment]
+    HTTPX_AVAILABLE = False
+
+from gateway.config import Platform
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+    _ssrf_redirect_guard,
+    cache_media_bytes,
+    safe_url_for_log,
+    validate_inbound_media_size,
+)
+from tools.url_safety import is_safe_url
+
+logger = logging.getLogger(__name__)
+
+
+GRAPH_API_BASE = "https://graph.facebook.com"
+DEFAULT_API_VERSION = "v21.0"
+DEFAULT_WEBHOOK_HOST = "0.0.0.0"
+DEFAULT_WEBHOOK_PORT = 8650
+DEFAULT_WEBHOOK_PATH = "/messenger/webhook"
+MAX_MESSAGE_LENGTH = 2000
+WEBHOOK_BODY_MAX_BYTES = 1_048_576
+DEDUP_MAX_SIZE = 2048
+
+_MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\((https?://[^\s)]+)\)")
+_MARKDOWN_CODE_BLOCK_RE = re.compile(r"```[a-zA-Z0-9_+-]*\n?(.*?)```", re.DOTALL)
+_MARKDOWN_CODE_INLINE_RE = re.compile(r"`([^`]+)`")
+_MARKDOWN_BOLD_RE = re.compile(r"\*\*(.+?)\*\*")
+_MARKDOWN_ITALIC_RE = re.compile(r"(?<!\*)\*(?!\s)(.+?)(?<!\s)\*(?!\*)")
+_MARKDOWN_HEADING_RE = re.compile(r"^#{1,6}\s+", re.MULTILINE)
+_MARKDOWN_BULLET_RE = re.compile(r"^[\s]*[-*+]\s+", re.MULTILINE)
+
+
+def _env_value(key: str) -> str:
+    """Read env values the Hermes way, including ``~/.hermes/.env``."""
+    try:
+        from hermes_cli.config import get_env_value
+
+        return (get_env_value(key) or "").strip()
+    except Exception:
+        return os.getenv(key, "").strip()
+
+
+class MessengerGraphError(RuntimeError):
+    """Raised for failed Meta Graph API calls."""
+
+    def __init__(self, status_code: int, detail: Any):
+        self.status_code = status_code
+        self.detail = detail
+        super().__init__(f"Meta Graph API returned {status_code}: {detail}")
+
+    @property
+    def retryable(self) -> bool:
+        return self.status_code == 429 or self.status_code >= 500
+
+
+@dataclass(frozen=True)
+class MessengerAccount:
+    """One Messenger Page/App credential set."""
+
+    account_id: str
+    name: str
+    page_access_token: str
+    app_secret: str
+    verify_token: str
+    enabled: bool = True
+    webhook_path: str = DEFAULT_WEBHOOK_PATH
+    api_version: str = DEFAULT_API_VERSION
+
+    @property
+    def complete(self) -> bool:
+        return bool(
+            self.enabled
+            and self.page_access_token
+            and self.app_secret
+            and self.verify_token
+        )
+
+
+def _truthy(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "on"}:
+        return True
+    if text in {"0", "false", "no", "off"}:
+        return False
+    return default
+
+
+def _normalise_webhook_path(path: Any) -> str:
+    text = str(path or DEFAULT_WEBHOOK_PATH).strip() or DEFAULT_WEBHOOK_PATH
+    return text if text.startswith("/") else f"/{text}"
+
+
+def _normalise_api_version(value: Any) -> str:
+    text = str(value or DEFAULT_API_VERSION).strip() or DEFAULT_API_VERSION
+    return text if text.startswith("v") else f"v{text}"
+
+
+def _read_secret_file(path_value: Any) -> str:
+    path = str(path_value or "").strip()
+    if not path:
+        return ""
+    try:
+        return Path(path).expanduser().read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        logger.warning("Failed to read Messenger secret file %s: %s", path, exc)
+        return ""
+
+
+def _get_cfg_value(data: Dict[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if key in data and data[key] not in (None, ""):
+            return data[key]
+    return None
+
+
+def _get_secret(
+    data: Dict[str, Any],
+    snake_key: str,
+    camel_key: str,
+    file_snake_key: str,
+    file_camel_key: str,
+    env_key: str = "",
+) -> str:
+    env_value = _env_value(env_key) if env_key else ""
+    direct = _get_cfg_value(data, snake_key, camel_key)
+    file_value = _get_cfg_value(data, file_snake_key, file_camel_key)
+    return env_value or str(direct or "").strip() or _read_secret_file(file_value)
+
+
+def verify_messenger_signature(body: bytes, signature_header: str, app_secret: str) -> bool:
+    """Return True when ``signature_header`` matches ``body`` for ``app_secret``."""
+    if not body or not signature_header or not app_secret:
+        return False
+    header = signature_header.strip()
+    if not header.startswith("sha256="):
+        return False
+    expected = "sha256=" + hmac.new(
+        app_secret.encode("utf-8"),
+        body,
+        hashlib.sha256,
+    ).hexdigest()
+    return hmac.compare_digest(header, expected)
+
+
+def strip_markdown_for_messenger(text: str) -> str:
+    """Convert common Markdown to Messenger-friendly plain text."""
+    if not text:
+        return ""
+
+    text = _MARKDOWN_CODE_BLOCK_RE.sub(lambda m: m.group(1).rstrip("\n"), text)
+    text = _MARKDOWN_CODE_INLINE_RE.sub(r"\1", text)
+    text = _MARKDOWN_LINK_RE.sub(lambda m: f"{m.group(1)} ({m.group(2)})", text)
+    text = _MARKDOWN_BOLD_RE.sub(r"\1", text)
+    text = _MARKDOWN_ITALIC_RE.sub(r"\1", text)
+    text = _MARKDOWN_HEADING_RE.sub("", text)
+    text = _MARKDOWN_BULLET_RE.sub("• ", text)
+    return text
+
+
+def split_for_messenger(text: str, max_chars: int = MAX_MESSAGE_LENGTH) -> List[str]:
+    """Split text into Messenger's 2000-character Send API chunks."""
+    if text is None:
+        return [""]
+    text = str(text)
+    if len(text) <= max_chars:
+        return [text]
+
+    chunks: List[str] = []
+    remaining = text
+    while remaining:
+        if len(remaining) <= max_chars:
+            chunks.append(remaining)
+            break
+
+        window = remaining[:max_chars]
+        split_at = max(window.rfind("\n\n"), window.rfind("\n"), window.rfind(" "))
+        if split_at < int(max_chars * 0.65):
+            split_at = max_chars
+        chunk = remaining[:split_at].rstrip()
+        chunks.append(chunk)
+        remaining = remaining[split_at:].lstrip()
+    return chunks or [""]
+
+
+def _coerce_list(value: Any) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [part.strip() for part in value.split(",") if part.strip()]
+    if isinstance(value, Iterable):
+        return [str(part).strip() for part in value if str(part).strip()]
+    return [str(value).strip()] if str(value).strip() else []
+
+
+def _default_account_from_extra(extra: Dict[str, Any]) -> Optional[MessengerAccount]:
+    page_token = _get_secret(
+        extra,
+        "page_access_token",
+        "pageAccessToken",
+        "token_file",
+        "tokenFile",
+        "MESSENGER_PAGE_ACCESS_TOKEN",
+    )
+    app_secret = _get_secret(
+        extra,
+        "app_secret",
+        "appSecret",
+        "secret_file",
+        "secretFile",
+        "MESSENGER_APP_SECRET",
+    )
+    verify_token = _get_secret(
+        extra,
+        "verify_token",
+        "verifyToken",
+        "verify_token_file",
+        "verifyTokenFile",
+        "MESSENGER_VERIFY_TOKEN",
+    )
+    if not any((page_token, app_secret, verify_token)):
+        return None
+
+    return MessengerAccount(
+        account_id=str(extra.get("account_id") or extra.get("accountId") or "default"),
+        name=str(extra.get("name") or "Messenger"),
+        enabled=_truthy(extra.get("enabled"), True),
+        page_access_token=page_token,
+        app_secret=app_secret,
+        verify_token=verify_token,
+        webhook_path=_normalise_webhook_path(
+            _env_value("MESSENGER_WEBHOOK_PATH") or extra.get("webhook_path") or extra.get("webhookPath")
+        ),
+        api_version=_normalise_api_version(
+            _env_value("MESSENGER_API_VERSION") or extra.get("api_version") or extra.get("apiVersion")
+        ),
+    )
+
+
+def _account_from_mapping(account_id: str, data: Dict[str, Any], defaults: Dict[str, Any]) -> MessengerAccount:
+    merged = dict(defaults)
+    merged.update(data)
+    return MessengerAccount(
+        account_id=str(data.get("id") or data.get("account_id") or data.get("accountId") or account_id),
+        name=str(data.get("name") or account_id),
+        enabled=_truthy(data.get("enabled"), True),
+        page_access_token=_get_secret(merged, "page_access_token", "pageAccessToken", "token_file", "tokenFile"),
+        app_secret=_get_secret(merged, "app_secret", "appSecret", "secret_file", "secretFile"),
+        verify_token=_get_secret(merged, "verify_token", "verifyToken", "verify_token_file", "verifyTokenFile"),
+        webhook_path=_normalise_webhook_path(
+            data.get("webhook_path") or data.get("webhookPath") or defaults.get("webhook_path")
+        ),
+        api_version=_normalise_api_version(
+            data.get("api_version") or data.get("apiVersion") or defaults.get("api_version")
+        ),
+    )
+
+
+def parse_accounts(extra: Optional[Dict[str, Any]]) -> Dict[str, MessengerAccount]:
+    """Parse single- or multi-page Messenger account config."""
+    extra = dict(extra or {})
+    defaults = {
+        "webhook_path": _env_value("MESSENGER_WEBHOOK_PATH")
+        or extra.get("webhook_path")
+        or extra.get("webhookPath")
+        or DEFAULT_WEBHOOK_PATH,
+        "api_version": _env_value("MESSENGER_API_VERSION")
+        or extra.get("api_version")
+        or extra.get("apiVersion")
+        or DEFAULT_API_VERSION,
+    }
+
+    accounts: Dict[str, MessengerAccount] = {}
+    configured = extra.get("accounts")
+    if isinstance(configured, dict):
+        for key, value in configured.items():
+            if isinstance(value, dict):
+                account = _account_from_mapping(str(key), value, defaults)
+                accounts[account.account_id] = account
+    elif isinstance(configured, list):
+        for index, value in enumerate(configured, start=1):
+            if isinstance(value, dict):
+                account = _account_from_mapping(str(value.get("id") or index), value, defaults)
+                accounts[account.account_id] = account
+
+    default_account = _default_account_from_extra(extra)
+    if default_account is not None:
+        accounts.setdefault(default_account.account_id, default_account)
+
+    return accounts
+
+
+def _has_complete_account(extra: Optional[Dict[str, Any]]) -> bool:
+    return any(account.complete for account in parse_accounts(extra).values())
+
+
+def _message_type_for_attachment(kind: str) -> MessageType:
+    return {
+        "image": MessageType.PHOTO,
+        "video": MessageType.VIDEO,
+        "audio": MessageType.VOICE,
+        "file": MessageType.DOCUMENT,
+        "fallback": MessageType.TEXT,
+    }.get(kind, MessageType.TEXT)
+
+
+def _extension_from_url(url: str) -> str:
+    try:
+        path = urlsplit(url).path
+    except Exception:
+        return ""
+    suffix = Path(path).suffix.lower()
+    return suffix if suffix and len(suffix) <= 12 else ""
+
+
+def _filename_from_url(url: str, fallback: str) -> str:
+    try:
+        name = Path(urlsplit(url).path).name
+    except Exception:
+        name = ""
+    return name or fallback
+
+
+class _MessageDeduplicator:
+    """Bounded inbound message/postback de-duplicator."""
+
+    def __init__(self, max_size: int = DEDUP_MAX_SIZE):
+        self._max_size = max_size
+        self._seen: OrderedDict[str, float] = OrderedDict()
+
+    def is_duplicate(self, key: str) -> bool:
+        if not key:
+            return False
+        now = time.time()
+        if key in self._seen:
+            self._seen.move_to_end(key)
+            return True
+        self._seen[key] = now
+        while len(self._seen) > self._max_size:
+            self._seen.popitem(last=False)
+        return False
+
+
+class MessengerAdapter(BasePlatformAdapter):
+    """Facebook Messenger webhook adapter."""
+
+    splits_long_messages = True
+    supports_code_blocks = False
+
+    def __init__(self, config):
+        super().__init__(config, Platform("messenger"))
+        extra = getattr(config, "extra", {}) or {}
+        self.webhook_host = _env_value("MESSENGER_HOST") or extra.get("host") or DEFAULT_WEBHOOK_HOST
+        try:
+            self.webhook_port = int(
+                _env_value("MESSENGER_PORT") or extra.get("port") or DEFAULT_WEBHOOK_PORT
+            )
+        except (TypeError, ValueError):
+            self.webhook_port = DEFAULT_WEBHOOK_PORT
+        self._dm_policy = str(
+            _env_value("MESSENGER_DM_POLICY")
+            or extra.get("dm_policy")
+            or extra.get("dmPolicy")
+            or "pairing"
+        ).strip().lower()
+        self.dm_policy = self._dm_policy
+        self.accounts = parse_accounts(extra)
+        self._complete_accounts = {
+            account_id: account
+            for account_id, account in self.accounts.items()
+            if account.complete
+        }
+        self._runner = None
+        self._site = None
+        self._http = None
+        self._dedup = _MessageDeduplicator()
+
+    @property
+    def name(self) -> str:
+        return "messenger"
+
+    async def connect(self) -> bool:
+        if not AIOHTTP_AVAILABLE or not HTTPX_AVAILABLE:
+            logger.error("Messenger requires aiohttp and httpx")
+            return False
+        if not self._complete_accounts:
+            logger.error("Messenger is missing page access token, app secret, or verify token")
+            return False
+
+        app = web.Application(client_max_size=WEBHOOK_BODY_MAX_BYTES)
+        route_paths: Dict[str, MessengerAccount] = {}
+        for account in self._complete_accounts.values():
+            previous = route_paths.get(account.webhook_path)
+            if previous is not None:
+                logger.error(
+                    "Duplicate Messenger webhook path %s for accounts %s and %s",
+                    account.webhook_path,
+                    previous.account_id,
+                    account.account_id,
+                )
+                return False
+            route_paths[account.webhook_path] = account
+            app.router.add_get(account.webhook_path, self._build_verify_handler(account))
+            app.router.add_post(account.webhook_path, self._build_webhook_handler(account))
+
+        app.router.add_get("/messenger/health", self._health)
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        try:
+            self._site = web.TCPSite(self._runner, self.webhook_host, self.webhook_port)
+            await self._site.start()
+        except OSError as exc:
+            await self._runner.cleanup()
+            self._runner = None
+            logger.error("Failed to start Messenger webhook on %s:%s: %s", self.webhook_host, self.webhook_port, exc)
+            return False
+
+        self._http = httpx.AsyncClient(
+            timeout=30.0,
+            follow_redirects=True,
+            event_hooks={"response": [_ssrf_redirect_guard]},
+        )
+        self._mark_connected()
+        logger.info(
+            "Messenger webhook listening on %s:%s for %d account(s)",
+            self.webhook_host,
+            self.webhook_port,
+            len(self._complete_accounts),
+        )
+        return True
+
+    async def disconnect(self) -> None:
+        if self._http is not None:
+            await self._http.aclose()
+            self._http = None
+        if self._runner is not None:
+            await self._runner.cleanup()
+            self._runner = None
+            self._site = None
+        self._mark_disconnected()
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        account, recipient_id = self._resolve_outbound_account(chat_id, metadata)
+        if account is None or not recipient_id:
+            return SendResult(success=False, error="Missing Messenger account or recipient ID")
+        return await self._send_text_chunks(account, recipient_id, self.format_message(content or ""))
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        account, recipient_id = self._resolve_outbound_account(chat_id, metadata)
+        if account is None or not recipient_id:
+            return
+        try:
+            await self._send_sender_action(account, recipient_id, "typing_on")
+        except Exception:
+            logger.debug("Failed to send Messenger typing indicator", exc_info=True)
+
+    async def send_image(
+        self,
+        chat_id: str,
+        image_url: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        account, recipient_id = self._resolve_outbound_account(chat_id, metadata)
+        if account is None or not recipient_id:
+            return SendResult(success=False, error="Missing Messenger account or recipient ID")
+        if not str(image_url).startswith(("http://", "https://")):
+            return SendResult(success=False, error="Messenger image sending requires a public http(s) URL")
+        image_result = await self._send_attachment_url(account, recipient_id, "image", image_url)
+        if not image_result.success or not caption:
+            return image_result
+        caption_result = await self.send(chat_id, caption, reply_to=reply_to, metadata=metadata)
+        return caption_result if not caption_result.success else image_result
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        account, recipient_id = self._resolve_outbound_account(chat_id, None)
+        return {
+            "name": recipient_id or chat_id,
+            "type": "dm",
+            "chat_id": chat_id,
+            "account_id": account.account_id if account else None,
+        }
+
+    def format_message(self, content: str) -> str:
+        return strip_markdown_for_messenger(content or "")
+
+    def _build_verify_handler(self, account: MessengerAccount):
+        async def handler(request):
+            mode = request.query.get("hub.mode")
+            token = request.query.get("hub.verify_token")
+            challenge = request.query.get("hub.challenge")
+            if mode == "subscribe" and token == account.verify_token and challenge is not None:
+                return web.Response(text=challenge)
+            return web.Response(status=403, text="Verification failed")
+
+        return handler
+
+    def _build_webhook_handler(self, account: MessengerAccount):
+        async def handler(request):
+            body = await request.read()
+            if len(body) > WEBHOOK_BODY_MAX_BYTES:
+                return web.Response(status=413, text="Webhook body too large")
+            signature = request.headers.get("X-Hub-Signature-256", "")
+            if not signature:
+                return web.Response(status=400, text="Missing signature")
+            if not verify_messenger_signature(body, signature, account.app_secret):
+                return web.Response(status=401, text="Invalid signature")
+            try:
+                payload = json.loads(body.decode("utf-8"))
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                return web.Response(status=400, text="Invalid JSON")
+            asyncio.create_task(self._process_webhook_payload(account, payload))
+            return web.json_response({"status": "ok"})
+
+        return handler
+
+    async def _health(self, request):
+        return web.json_response({"ok": True, "platform": "messenger"})
+
+    async def _process_webhook_payload(self, account: MessengerAccount, payload: Dict[str, Any]) -> None:
+        if payload.get("object") != "page":
+            logger.debug("Ignoring non-page Messenger webhook object: %r", payload.get("object"))
+            return
+        for entry in payload.get("entry") or []:
+            messaging_events = entry.get("messaging") or []
+            for event in messaging_events:
+                try:
+                    await self._process_messaging_event(account, event)
+                except Exception:
+                    logger.exception("Failed to process Messenger webhook event")
+
+    async def _process_messaging_event(self, account: MessengerAccount, event: Dict[str, Any]) -> None:
+        message = event.get("message") or {}
+        if message.get("is_echo"):
+            return
+        if event.get("delivery") or event.get("read"):
+            return
+        if not (message or event.get("postback")):
+            return
+
+        dedup_key = self._dedup_key(account, event)
+        if self._dedup.is_duplicate(dedup_key):
+            return
+
+        sender_id = str((event.get("sender") or {}).get("id") or "")
+        if self._dm_policy == "disabled":
+            logger.debug("Messenger DM policy disabled; dropping message from %s", sender_id or "?")
+            return
+        if sender_id:
+            asyncio.create_task(self._best_effort_sender_action(account, sender_id, "mark_seen"))
+            asyncio.create_task(self._best_effort_sender_action(account, sender_id, "typing_on"))
+
+        event_obj = await self._to_message_event(account, event)
+        if event_obj is not None:
+            await self.handle_message(event_obj)
+
+    def _dedup_key(self, account: MessengerAccount, event: Dict[str, Any]) -> str:
+        message = event.get("message") or {}
+        postback = event.get("postback") or {}
+        sender_id = str((event.get("sender") or {}).get("id") or "")
+        if message.get("mid"):
+            return f"{account.account_id}:mid:{message['mid']}"
+        if postback.get("mid"):
+            return f"{account.account_id}:mid:{postback['mid']}"
+        return f"{account.account_id}:evt:{sender_id}:{event.get('timestamp')}:{postback.get('payload') or postback.get('title')}"
+
+    async def _to_message_event(self, account: MessengerAccount, event: Dict[str, Any]) -> Optional[MessageEvent]:
+        sender_id = str((event.get("sender") or {}).get("id") or "")
+        if not sender_id:
+            return None
+        message = event.get("message") or {}
+        postback = event.get("postback") or {}
+        message_id = str(message.get("mid") or postback.get("mid") or uuid.uuid4().hex)
+
+        text_parts: List[str] = []
+        message_type = MessageType.TEXT
+        media_urls: List[str] = []
+        media_types: List[str] = []
+
+        if message.get("text"):
+            text_parts.append(str(message.get("text") or ""))
+        if postback:
+            title = str(postback.get("title") or "").strip()
+            payload = str(postback.get("payload") or "").strip()
+            text_parts.append(payload or title or "[postback]")
+
+        for attachment in message.get("attachments") or []:
+            kind = str(attachment.get("type") or "file").lower()
+            payload = attachment.get("payload") or {}
+            if kind == "location":
+                coordinates = payload.get("coordinates") or {}
+                lat = coordinates.get("lat")
+                long = coordinates.get("long")
+                title = attachment.get("title") or "location"
+                text_parts.append(f"[location: {title} {lat},{long}]")
+                message_type = MessageType.LOCATION
+                continue
+
+            url = str(payload.get("url") or "").strip()
+            if not url:
+                text_parts.append(f"[{kind} attachment]")
+                if message_type == MessageType.TEXT:
+                    message_type = _message_type_for_attachment(kind)
+                continue
+
+            cached = await self._download_attachment(url, kind)
+            if cached is not None:
+                media_urls.append(cached.path)
+                media_types.append(cached.media_type)
+                text_parts.append(cached.context_note())
+            else:
+                text_parts.append(f"[{kind} attachment: {url}]")
+            if message_type == MessageType.TEXT:
+                message_type = _message_type_for_attachment(kind)
+
+        chat_id = self._scoped_chat_id(account, sender_id)
+        source = self.build_source(
+            chat_id=chat_id,
+            chat_name=sender_id,
+            chat_type="dm",
+            user_id=sender_id,
+            user_name=sender_id,
+            message_id=message_id,
+        )
+        text = "\n".join(part for part in text_parts if part).strip() or "[message]"
+        return MessageEvent(
+            text=text,
+            message_type=message_type,
+            source=source,
+            raw_message=event,
+            message_id=message_id,
+            media_urls=media_urls,
+            media_types=media_types,
+        )
+
+    async def _download_attachment(self, url: str, kind: str):
+        if not HTTPX_AVAILABLE or not self._http:
+            return None
+        if not is_safe_url(url):
+            logger.warning("Blocked unsafe Messenger attachment URL: %s", safe_url_for_log(url))
+            return None
+        media_type = "media"
+        if kind in {"image", "video", "audio", "file"}:
+            media_type = kind
+        try:
+            async with self._http.stream(
+                "GET",
+                url,
+                headers={
+                    "User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)",
+                    "Accept": "*/*",
+                },
+            ) as response:
+                response.raise_for_status()
+                content_type = response.headers.get("content-type", "").split(";", 1)[0].strip()
+                content_length = response.headers.get("content-length")
+                if content_length:
+                    try:
+                        validate_inbound_media_size(int(content_length), media_type=media_type)
+                    except ValueError:
+                        raise
+                    except Exception:
+                        pass
+                chunks: List[bytes] = []
+                total = 0
+                async for chunk in response.aiter_bytes():
+                    total += len(chunk)
+                    validate_inbound_media_size(total, media_type=media_type)
+                    chunks.append(chunk)
+            filename = _filename_from_url(url, f"messenger-{kind}{_extension_from_url(url)}")
+            return cache_media_bytes(
+                b"".join(chunks),
+                filename=filename,
+                mime_type=content_type,
+                default_kind=kind if kind in {"image", "video", "audio"} else "document",
+            )
+        except Exception as exc:
+            logger.warning("Failed to cache Messenger attachment %s: %s", safe_url_for_log(url), exc)
+            return None
+
+    def _resolve_outbound_account(
+        self,
+        chat_id: str,
+        metadata: Optional[Dict[str, Any]],
+    ) -> Tuple[Optional[MessengerAccount], str]:
+        metadata = metadata or {}
+        account_id = str(metadata.get("account_id") or metadata.get("messenger_account_id") or "").strip()
+        recipient_id = str(metadata.get("recipient_id") or metadata.get("messenger_recipient_id") or chat_id or "").strip()
+
+        if account_id:
+            account = self._complete_accounts.get(account_id)
+            if account and recipient_id.startswith(f"{account_id}:"):
+                recipient_id = recipient_id.split(":", 1)[1]
+            return account, recipient_id
+
+        if ":" in recipient_id:
+            prefix, rest = recipient_id.split(":", 1)
+            account = self._complete_accounts.get(prefix)
+            if account is not None:
+                return account, rest
+
+        account = self._complete_accounts.get("default")
+        if account is not None:
+            return account, recipient_id
+        if len(self._complete_accounts) == 1:
+            only_account = next(iter(self._complete_accounts.values()))
+            return only_account, recipient_id
+        return None, recipient_id
+
+    def _scoped_chat_id(self, account: MessengerAccount, sender_id: str) -> str:
+        if account.account_id == "default":
+            return sender_id
+        return f"{account.account_id}:{sender_id}"
+
+    async def _send_text_chunks(self, account: MessengerAccount, recipient_id: str, text: str) -> SendResult:
+        chunks = split_for_messenger(text) or [""]
+        message_ids: List[str] = []
+        responses: List[Any] = []
+        for chunk in chunks:
+            payload = {
+                "recipient": {"id": recipient_id},
+                "messaging_type": "RESPONSE",
+                "message": {"text": chunk},
+            }
+            try:
+                data = await self._post_graph(account, "/me/messages", payload)
+            except MessengerGraphError as exc:
+                return SendResult(
+                    success=False,
+                    error=str(exc),
+                    raw_response=exc.detail,
+                    retryable=exc.retryable,
+                )
+            except Exception as exc:
+                return SendResult(success=False, error=str(exc), retryable=True)
+            responses.append(data)
+            mid = data.get("message_id") if isinstance(data, dict) else None
+            if mid:
+                message_ids.append(str(mid))
+        return SendResult(
+            success=True,
+            message_id=message_ids[-1] if message_ids else None,
+            raw_response=responses,
+            continuation_message_ids=tuple(message_ids[:-1]),
+        )
+
+    async def _send_attachment_url(
+        self,
+        account: MessengerAccount,
+        recipient_id: str,
+        attachment_type: str,
+        url: str,
+    ) -> SendResult:
+        payload = {
+            "recipient": {"id": recipient_id},
+            "messaging_type": "RESPONSE",
+            "message": {
+                "attachment": {
+                    "type": attachment_type,
+                    "payload": {"url": url, "is_reusable": True},
+                },
+            },
+        }
+        try:
+            data = await self._post_graph(account, "/me/messages", payload)
+        except MessengerGraphError as exc:
+            return SendResult(
+                success=False,
+                error=str(exc),
+                raw_response=exc.detail,
+                retryable=exc.retryable,
+            )
+        except Exception as exc:
+            return SendResult(success=False, error=str(exc), retryable=True)
+        return SendResult(
+            success=True,
+            message_id=str(data.get("message_id") or "") if isinstance(data, dict) else None,
+            raw_response=data,
+        )
+
+    async def _send_sender_action(
+        self,
+        account: MessengerAccount,
+        recipient_id: str,
+        action: str,
+    ) -> None:
+        payload = {
+            "recipient": {"id": recipient_id},
+            "sender_action": action,
+        }
+        await self._post_graph(account, "/me/messages", payload)
+
+    async def _best_effort_sender_action(self, account: MessengerAccount, recipient_id: str, action: str) -> None:
+        try:
+            await self._send_sender_action(account, recipient_id, action)
+        except Exception:
+            logger.debug("Messenger sender action failed: %s", action, exc_info=True)
+
+    async def _post_graph(self, account: MessengerAccount, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        if self._http is None:
+            raise RuntimeError("Messenger HTTP client is not connected")
+        url = f"{GRAPH_API_BASE}/{account.api_version}{path}"
+        response = await self._http.post(
+            url,
+            headers={
+                "Authorization": f"Bearer {account.page_access_token}",
+                "Content-Type": "application/json",
+            },
+            json=payload,
+        )
+        try:
+            data = response.json()
+        except Exception:
+            data = response.text
+        if response.status_code >= 400:
+            raise MessengerGraphError(response.status_code, data)
+        return data if isinstance(data, dict) else {"response": data}
+
+
+def check_requirements() -> bool:
+    return AIOHTTP_AVAILABLE and HTTPX_AVAILABLE
+
+
+def validate_config(config) -> bool:
+    return _has_complete_account(getattr(config, "extra", {}) or {})
+
+
+def is_connected(config) -> bool:
+    return validate_config(config)
+
+
+def _env_enablement() -> Optional[Dict[str, Any]]:
+    if not (
+        _env_value("MESSENGER_PAGE_ACCESS_TOKEN")
+        and _env_value("MESSENGER_APP_SECRET")
+        and _env_value("MESSENGER_VERIFY_TOKEN")
+    ):
+        return None
+    seeded: Dict[str, Any] = {
+        "dm_policy": _env_value("MESSENGER_DM_POLICY") or "pairing",
+    }
+    host = _env_value("MESSENGER_HOST")
+    port = _env_value("MESSENGER_PORT")
+    webhook_path = _env_value("MESSENGER_WEBHOOK_PATH")
+    api_version = _env_value("MESSENGER_API_VERSION")
+    home_channel = _env_value("MESSENGER_HOME_CHANNEL")
+    if host:
+        seeded["host"] = host
+    if port:
+        try:
+            seeded["port"] = int(port)
+        except ValueError:
+            pass
+    if webhook_path:
+        seeded["webhook_path"] = _normalise_webhook_path(webhook_path)
+    if api_version:
+        seeded["api_version"] = _normalise_api_version(api_version)
+    if home_channel:
+        seeded["home_channel"] = {"chat_id": home_channel, "name": "Messenger"}
+    return seeded
+
+
+def _apply_yaml_config(yaml_cfg: dict, messenger_cfg: dict) -> dict | None:
+    """Translate ``messenger:`` / ``platforms.messenger:`` YAML into extras.
+
+    Env vars remain higher priority because ``parse_accounts`` reads env first.
+    """
+    seeded: Dict[str, Any] = {}
+    extra = messenger_cfg.get("extra") if isinstance(messenger_cfg.get("extra"), dict) else {}
+    for source in (messenger_cfg, extra):
+        for key in (
+            "page_access_token",
+            "pageAccessToken",
+            "token_file",
+            "tokenFile",
+            "app_secret",
+            "appSecret",
+            "secret_file",
+            "secretFile",
+            "verify_token",
+            "verifyToken",
+            "verify_token_file",
+            "verifyTokenFile",
+            "account_id",
+            "accountId",
+            "name",
+            "webhook_path",
+            "webhookPath",
+            "api_version",
+            "apiVersion",
+            "dm_policy",
+            "dmPolicy",
+            "accounts",
+        ):
+            if key in source and source[key] not in (None, ""):
+                seeded[key] = source[key]
+        if "host" in source:
+            seeded["host"] = source["host"]
+        if "port" in source:
+            try:
+                seeded["port"] = int(source["port"])
+            except (TypeError, ValueError):
+                pass
+    if "allow_from" in messenger_cfg and not _env_value("MESSENGER_ALLOWED_USERS"):
+        value = messenger_cfg["allow_from"]
+        os.environ["MESSENGER_ALLOWED_USERS"] = ",".join(_coerce_list(value))
+    if "allow_all_users" in messenger_cfg and not _env_value("MESSENGER_ALLOW_ALL_USERS"):
+        os.environ["MESSENGER_ALLOW_ALL_USERS"] = str(messenger_cfg["allow_all_users"]).lower()
+    return seeded or None
+
+
+async def _standalone_send(
+    pconfig,
+    chat_id: str,
+    message: str,
+    *,
+    thread_id: Optional[str] = None,
+    media_files: Optional[List[str]] = None,
+    force_document: bool = False,
+) -> Dict[str, Any]:
+    extra = getattr(pconfig, "extra", {}) or {}
+    accounts = {
+        account_id: account
+        for account_id, account in parse_accounts(extra).items()
+        if account.complete
+    }
+    if not accounts:
+        return {"error": "Messenger standalone send: missing credentials"}
+
+    adapter = MessengerAdapter(pconfig)
+    adapter._complete_accounts = accounts
+    adapter._http = httpx.AsyncClient(timeout=30.0) if HTTPX_AVAILABLE else None
+    try:
+        if adapter._http is None:
+            return {"error": "Messenger standalone send: httpx is not installed"}
+        result = await adapter.send(chat_id, message)
+        if not result.success:
+            return {"error": result.error or "Messenger send failed"}
+        if media_files:
+            return {
+                "success": True,
+                "message_id": result.message_id,
+                "warning": "Messenger standalone media delivery requires public URLs; sent text only",
+            }
+        return {"success": True, "message_id": result.message_id}
+    finally:
+        if adapter._http is not None:
+            await adapter._http.aclose()
+            adapter._http = None
+
+
+def interactive_setup() -> None:
+    print()
+    print("Facebook Messenger setup")
+    print("------------------------")
+    print("Use a Meta app with Messenger enabled, then paste the Page token, app secret,")
+    print("and webhook verify token. Set the Meta webhook URL to:")
+    print("  https://<public-host>/messenger/webhook")
+    print()
+
+    try:
+        from hermes_cli.config import get_env_value, save_env_value
+        from hermes_cli.secret_prompt import masked_secret_prompt
+    except ImportError:
+        print("hermes_cli.config not available; set MESSENGER_* vars manually in ~/.hermes/.env")
+        return
+
+    def prompt_secret(var: str, label: str) -> None:
+        existing = get_env_value(var)
+        suffix = " [keep current]" if existing else ""
+        try:
+            value = masked_secret_prompt(f"{label}{suffix}: ")
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return
+        if value:
+            save_env_value(var, value)
+
+    prompt_secret("MESSENGER_PAGE_ACCESS_TOKEN", "Page access token")
+    prompt_secret("MESSENGER_APP_SECRET", "App secret")
+    prompt_secret("MESSENGER_VERIFY_TOKEN", "Webhook verify token")
+    print("Done.")
+
+
+def register(ctx) -> None:
+    ctx.register_platform(
+        name="messenger",
+        label="Messenger",
+        adapter_factory=lambda cfg: MessengerAdapter(cfg),
+        check_fn=check_requirements,
+        validate_config=validate_config,
+        is_connected=is_connected,
+        required_env=[
+            "MESSENGER_PAGE_ACCESS_TOKEN",
+            "MESSENGER_APP_SECRET",
+            "MESSENGER_VERIFY_TOKEN",
+        ],
+        install_hint="pip install aiohttp httpx",
+        setup_fn=interactive_setup,
+        env_enablement_fn=_env_enablement,
+        apply_yaml_config_fn=_apply_yaml_config,
+        cron_deliver_env_var="MESSENGER_HOME_CHANNEL",
+        standalone_sender_fn=_standalone_send,
+        allowed_users_env="MESSENGER_ALLOWED_USERS",
+        allow_all_env="MESSENGER_ALLOW_ALL_USERS",
+        max_message_length=MAX_MESSAGE_LENGTH,
+        emoji="💬",
+        pii_safe=False,
+        allow_update_command=True,
+        platform_hint=(
+            "You are chatting through Facebook Messenger Page DMs. Messenger "
+            "does not render Markdown reliably, so send concise plain text with "
+            "bare URLs. Each text message is capped at 2000 characters; the "
+            "adapter chunks longer replies. Image sending requires a public "
+            "http(s) URL."
+        ),
+    )

--- a/plugins/platforms/messenger/plugin.yaml
+++ b/plugins/platforms/messenger/plugin.yaml
@@ -1,0 +1,58 @@
+name: messenger-platform
+label: Messenger
+kind: platform
+version: 1.0.0
+description: >
+  Facebook Messenger gateway adapter for Hermes Agent. Runs an aiohttp webhook
+  server for Meta Messenger webhooks, verifies X-Hub-Signature-256, and relays
+  Page DMs between Messenger and Hermes.
+author: Hermes Agent contributors
+requires_env:
+  - name: MESSENGER_PAGE_ACCESS_TOKEN
+    description: "Facebook Page access token with Messenger permissions"
+    prompt: "Messenger Page access token"
+    url: "https://developers.facebook.com/apps/"
+    password: true
+  - name: MESSENGER_APP_SECRET
+    description: "Facebook app secret used for webhook HMAC-SHA256 verification"
+    prompt: "Messenger app secret"
+    url: "https://developers.facebook.com/apps/"
+    password: true
+  - name: MESSENGER_VERIFY_TOKEN
+    description: "Webhook verify token you configure in the Meta app dashboard"
+    prompt: "Messenger webhook verify token"
+    url: "https://developers.facebook.com/apps/"
+    password: true
+optional_env:
+  - name: MESSENGER_HOST
+    description: "Webhook bind host (default: 0.0.0.0)"
+    prompt: "Webhook host"
+    password: false
+  - name: MESSENGER_PORT
+    description: "Webhook listen port (default: 8650)"
+    prompt: "Webhook port"
+    password: false
+  - name: MESSENGER_WEBHOOK_PATH
+    description: "Webhook path (default: /messenger/webhook)"
+    prompt: "Webhook path"
+    password: false
+  - name: MESSENGER_API_VERSION
+    description: "Meta Graph API version (default: v21.0)"
+    prompt: "Graph API version"
+    password: false
+  - name: MESSENGER_ALLOWED_USERS
+    description: "Comma-separated Messenger PSIDs allowed to DM Hermes; blank uses gateway pairing"
+    prompt: "Allowed PSIDs"
+    password: false
+  - name: MESSENGER_ALLOW_ALL_USERS
+    description: "Allow any Messenger user to talk to Hermes (dev only)"
+    prompt: "Allow all users? (true/false)"
+    password: false
+  - name: MESSENGER_HOME_CHANNEL
+    description: "Default Messenger PSID for cron / notification delivery"
+    prompt: "Home channel PSID"
+    password: false
+  - name: MESSENGER_DM_POLICY
+    description: "Unauthorized DM behavior: pairing sends pairing codes; disabled drops inbound DMs (default: pairing)"
+    prompt: "DM policy"
+    password: false

--- a/tests/gateway/test_messenger_plugin.py
+++ b/tests/gateway/test_messenger_plugin.py
@@ -1,0 +1,247 @@
+"""Tests for the Facebook Messenger platform plugin."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from tests.gateway._plugin_adapter_loader import load_plugin_adapter
+
+
+_messenger = load_plugin_adapter("messenger")
+
+MessengerAdapter = _messenger.MessengerAdapter
+MessageType = _messenger.MessageType
+_MessageDeduplicator = _messenger._MessageDeduplicator
+_apply_yaml_config = _messenger._apply_yaml_config
+_env_enablement = _messenger._env_enablement
+parse_accounts = _messenger.parse_accounts
+register = _messenger.register
+split_for_messenger = _messenger.split_for_messenger
+strip_markdown_for_messenger = _messenger.strip_markdown_for_messenger
+validate_config = _messenger.validate_config
+verify_messenger_signature = _messenger.verify_messenger_signature
+
+
+def _signature(body: bytes, secret: str) -> str:
+    return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+def test_verify_messenger_signature_accepts_valid_header():
+    body = b'{"object":"page"}'
+    assert verify_messenger_signature(body, _signature(body, "secret"), "secret")
+
+
+def test_verify_messenger_signature_rejects_tampered_body():
+    body = b'{"object":"page"}'
+    assert not verify_messenger_signature(body + b" ", _signature(body, "secret"), "secret")
+
+
+def test_verify_messenger_signature_rejects_missing_sha256_prefix():
+    body = b"{}"
+    assert not verify_messenger_signature(body, _signature(body, "secret").removeprefix("sha256="), "secret")
+
+
+def test_split_for_messenger_respects_2000_char_cap():
+    chunks = split_for_messenger("a" * 1999 + " " + "b" * 1999)
+    assert len(chunks) == 2
+    assert all(len(chunk) <= 2000 for chunk in chunks)
+
+
+def test_strip_markdown_preserves_links_as_plain_urls():
+    text = strip_markdown_for_messenger("**bold** [OpenAI](https://openai.com) `code`")
+    assert "**" not in text
+    assert "`" not in text
+    assert "OpenAI (https://openai.com)" in text
+
+
+def test_parse_accounts_reads_default_env(monkeypatch):
+    monkeypatch.setenv("MESSENGER_PAGE_ACCESS_TOKEN", "page-token")
+    monkeypatch.setenv("MESSENGER_APP_SECRET", "app-secret")
+    monkeypatch.setenv("MESSENGER_VERIFY_TOKEN", "verify-token")
+    accounts = parse_accounts({})
+    assert accounts["default"].page_access_token == "page-token"
+    assert accounts["default"].complete
+
+
+def test_validate_config_accepts_yaml_only_credentials(monkeypatch):
+    monkeypatch.delenv("MESSENGER_PAGE_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("MESSENGER_APP_SECRET", raising=False)
+    monkeypatch.delenv("MESSENGER_VERIFY_TOKEN", raising=False)
+    config = PlatformConfig(
+        enabled=True,
+        extra={
+            "page_access_token": "page-token",
+            "app_secret": "app-secret",
+            "verify_token": "verify-token",
+        },
+    )
+    assert validate_config(config)
+
+
+def test_env_enablement_seeds_runtime_options(monkeypatch):
+    monkeypatch.setenv("MESSENGER_PAGE_ACCESS_TOKEN", "page-token")
+    monkeypatch.setenv("MESSENGER_APP_SECRET", "app-secret")
+    monkeypatch.setenv("MESSENGER_VERIFY_TOKEN", "verify-token")
+    monkeypatch.setenv("MESSENGER_PORT", "9999")
+    monkeypatch.setenv("MESSENGER_WEBHOOK_PATH", "messenger/custom")
+    seeded = _env_enablement()
+    assert seeded["port"] == 9999
+    assert seeded["webhook_path"] == "/messenger/custom"
+    assert seeded["dm_policy"] == "pairing"
+
+
+def test_apply_yaml_config_translates_direct_and_extra_keys():
+    seeded = _apply_yaml_config(
+        {},
+        {
+            "host": "127.0.0.1",
+            "extra": {
+                "pageAccessToken": "page-token",
+                "appSecret": "app-secret",
+                "verifyToken": "verify-token",
+            },
+        },
+    )
+    assert seeded["host"] == "127.0.0.1"
+    assert seeded["pageAccessToken"] == "page-token"
+    assert seeded["appSecret"] == "app-secret"
+    assert seeded["verifyToken"] == "verify-token"
+
+
+def test_deduplicator_tracks_repeated_mid():
+    dedup = _MessageDeduplicator(max_size=2)
+    assert not dedup.is_duplicate("m1")
+    assert dedup.is_duplicate("m1")
+    assert not dedup.is_duplicate("")
+    assert not dedup.is_duplicate("")
+
+
+def test_register_metadata():
+    class FakeCtx:
+        def __init__(self):
+            self.kwargs = None
+
+        def register_platform(self, **kwargs):
+            self.kwargs = kwargs
+
+    ctx = FakeCtx()
+    register(ctx)
+    assert ctx.kwargs["name"] == "messenger"
+    assert ctx.kwargs["allowed_users_env"] == "MESSENGER_ALLOWED_USERS"
+    assert ctx.kwargs["allow_all_env"] == "MESSENGER_ALLOW_ALL_USERS"
+    assert ctx.kwargs["cron_deliver_env_var"] == "MESSENGER_HOME_CHANNEL"
+
+
+def test_adapter_exposes_gateway_dm_policy_name(monkeypatch):
+    monkeypatch.delenv("MESSENGER_DM_POLICY", raising=False)
+    config = PlatformConfig(
+        enabled=True,
+        extra={
+            "dm_policy": "disabled",
+            "page_access_token": "page-token",
+            "app_secret": "app-secret",
+            "verify_token": "verify-token",
+        },
+    )
+    adapter = MessengerAdapter(config)
+    assert adapter._dm_policy == "disabled"
+    assert adapter.dm_policy == "disabled"
+
+
+def test_package_exports_register():
+    module_name = "plugin_package_messenger_test"
+    init_path = Path(__file__).resolve().parents[2] / "plugins" / "platforms" / "messenger" / "__init__.py"
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        init_path,
+        submodule_search_locations=[str(init_path.parent)],
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+        assert callable(module.register)
+    finally:
+        sys.modules.pop(module_name, None)
+
+
+@pytest.mark.asyncio
+async def test_to_message_event_builds_scoped_source_and_attachment_note(monkeypatch):
+    config = PlatformConfig(
+        enabled=True,
+        extra={
+            "accounts": {
+                "work": {
+                    "page_access_token": "page-token",
+                    "app_secret": "app-secret",
+                    "verify_token": "verify-token",
+                }
+            }
+        },
+    )
+    adapter = MessengerAdapter(config)
+    account = adapter._complete_accounts["work"]
+
+    cached = type(
+        "Cached",
+        (),
+        {
+            "path": "/tmp/messenger-photo.jpg",
+            "media_type": "image/jpeg",
+            "context_note": lambda self: "[image saved at: /tmp/messenger-photo.jpg]",
+        },
+    )()
+    monkeypatch.setattr(adapter, "_download_attachment", AsyncMock(return_value=cached))
+    event = await adapter._to_message_event(
+        account,
+        {
+            "sender": {"id": "PSID123"},
+            "recipient": {"id": "PAGE"},
+            "message": {
+                "mid": "mid.1",
+                "text": "hello",
+                "attachments": [{"type": "image", "payload": {"url": "https://example.com/a.jpg"}}],
+            },
+        },
+    )
+
+    assert event.source.chat_id == "work:PSID123"
+    assert event.source.user_id == "PSID123"
+    assert event.message_type is MessageType.PHOTO
+    assert event.media_urls == ["/tmp/messenger-photo.jpg"]
+    assert "hello" in event.text
+
+
+@pytest.mark.asyncio
+async def test_disabled_dm_policy_drops_inbound_before_dispatch(monkeypatch):
+    config = PlatformConfig(
+        enabled=True,
+        extra={
+            "dm_policy": "disabled",
+            "page_access_token": "page-token",
+            "app_secret": "app-secret",
+            "verify_token": "verify-token",
+        },
+    )
+    adapter = MessengerAdapter(config)
+    account = adapter._complete_accounts["default"]
+    handle_message = AsyncMock()
+    monkeypatch.setattr(adapter, "handle_message", handle_message)
+    await adapter._process_messaging_event(
+        account,
+        {
+            "sender": {"id": "PSID123"},
+            "recipient": {"id": "PAGE"},
+            "message": {"mid": "mid.1", "text": "hello"},
+        },
+    )
+
+    handle_message.assert_not_called()

--- a/tests/gateway/test_messenger_plugin.py
+++ b/tests/gateway/test_messenger_plugin.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import hmac
 import importlib.util
+import json
+import os
 import sys
 from pathlib import Path
 from unittest.mock import AsyncMock
@@ -18,8 +21,10 @@ from tests.gateway._plugin_adapter_loader import load_plugin_adapter
 _messenger = load_plugin_adapter("messenger")
 
 MessengerAdapter = _messenger.MessengerAdapter
+MessengerGraphError = _messenger.MessengerGraphError
 MessageType = _messenger.MessageType
 _MessageDeduplicator = _messenger._MessageDeduplicator
+_YAML_BRIDGED_ENV_KEYS = _messenger._YAML_BRIDGED_ENV_KEYS
 _apply_yaml_config = _messenger._apply_yaml_config
 _env_enablement = _messenger._env_enablement
 parse_accounts = _messenger.parse_accounts
@@ -62,6 +67,10 @@ def test_strip_markdown_preserves_links_as_plain_urls():
     assert "OpenAI (https://openai.com)" in text
 
 
+def test_adapter_disables_streaming_message_editing():
+    assert MessengerAdapter.SUPPORTS_MESSAGE_EDITING is False
+
+
 def test_parse_accounts_reads_default_env(monkeypatch):
     monkeypatch.setenv("MESSENGER_PAGE_ACCESS_TOKEN", "page-token")
     monkeypatch.setenv("MESSENGER_APP_SECRET", "app-secret")
@@ -86,10 +95,53 @@ def test_validate_config_accepts_yaml_only_credentials(monkeypatch):
     assert validate_config(config)
 
 
+def test_validate_config_rejects_duplicate_or_reserved_webhook_paths(monkeypatch):
+    monkeypatch.delenv("MESSENGER_PAGE_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("MESSENGER_APP_SECRET", raising=False)
+    monkeypatch.delenv("MESSENGER_VERIFY_TOKEN", raising=False)
+    monkeypatch.delenv("MESSENGER_WEBHOOK_PATH", raising=False)
+    duplicate = PlatformConfig(
+        enabled=True,
+        extra={
+            "accounts": {
+                "a": {
+                    "page_access_token": "page-a",
+                    "app_secret": "secret-a",
+                    "verify_token": "verify-a",
+                    "webhook_path": "/messenger/page",
+                },
+                "b": {
+                    "page_access_token": "page-b",
+                    "app_secret": "secret-b",
+                    "verify_token": "verify-b",
+                    "webhook_path": "/messenger/page",
+                },
+            },
+        },
+    )
+    reserved = PlatformConfig(
+        enabled=True,
+        extra={
+            "accounts": {
+                "a": {
+                    "page_access_token": "page",
+                    "app_secret": "secret",
+                    "verify_token": "verify",
+                    "webhook_path": "/messenger/health",
+                }
+            },
+        },
+    )
+
+    assert not validate_config(duplicate)
+    assert not validate_config(reserved)
+
+
 def test_env_enablement_seeds_runtime_options(monkeypatch):
     monkeypatch.setenv("MESSENGER_PAGE_ACCESS_TOKEN", "page-token")
     monkeypatch.setenv("MESSENGER_APP_SECRET", "app-secret")
     monkeypatch.setenv("MESSENGER_VERIFY_TOKEN", "verify-token")
+    monkeypatch.delenv("MESSENGER_DM_POLICY", raising=False)
     monkeypatch.setenv("MESSENGER_PORT", "9999")
     monkeypatch.setenv("MESSENGER_WEBHOOK_PATH", "messenger/custom")
     seeded = _env_enablement()
@@ -114,6 +166,37 @@ def test_apply_yaml_config_translates_direct_and_extra_keys():
     assert seeded["pageAccessToken"] == "page-token"
     assert seeded["appSecret"] == "app-secret"
     assert seeded["verifyToken"] == "verify-token"
+
+
+def test_apply_yaml_config_bridges_nested_auth_and_direct_overrides_extra(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.delenv("MESSENGER_ALLOWED_USERS", raising=False)
+    monkeypatch.delenv("MESSENGER_ALLOW_ALL_USERS", raising=False)
+    _YAML_BRIDGED_ENV_KEYS.clear()
+
+    seeded = _apply_yaml_config(
+        {},
+        {
+            "pageAccessToken": "direct-page-token",
+            "allow_from": ["outer-user"],
+            "allow_all_users": False,
+            "extra": {
+                "pageAccessToken": "extra-page-token",
+                "allow_from": ["inner-user"],
+                "allow_all_users": True,
+            },
+        },
+    )
+
+    assert seeded["pageAccessToken"] == "direct-page-token"
+    assert seeded["allow_from"] == ["outer-user"]
+    assert seeded["allow_all_users"] is False
+    assert os.environ["MESSENGER_ALLOWED_USERS"] == "outer-user"
+    assert os.environ["MESSENGER_ALLOW_ALL_USERS"] == "false"
+
+    _apply_yaml_config({}, {"extra": {"pageAccessToken": "new-token"}})
+    assert "MESSENGER_ALLOWED_USERS" not in os.environ
+    assert "MESSENGER_ALLOW_ALL_USERS" not in os.environ
 
 
 def test_deduplicator_tracks_repeated_mid():
@@ -214,14 +297,146 @@ async def test_to_message_event_builds_scoped_source_and_attachment_note(monkeyp
     )
 
     assert event.source.chat_id == "work:PSID123"
-    assert event.source.user_id == "PSID123"
+    assert event.source.user_id == "work:PSID123"
     assert event.message_type is MessageType.PHOTO
     assert event.media_urls == ["/tmp/messenger-photo.jpg"]
     assert "hello" in event.text
 
 
 @pytest.mark.asyncio
+async def test_process_webhook_payload_skips_malformed_entries(monkeypatch):
+    config = PlatformConfig(
+        enabled=True,
+        extra={
+            "page_access_token": "page-token",
+            "app_secret": "app-secret",
+            "verify_token": "verify-token",
+        },
+    )
+    adapter = MessengerAdapter(config)
+    account = adapter._complete_accounts["default"]
+    process = AsyncMock()
+    monkeypatch.setattr(adapter, "_process_messaging_event", process)
+
+    await adapter._process_webhook_payload(
+        account,
+        {
+            "object": "page",
+            "entry": [
+                "bad-entry",
+                {"messaging": "bad-events"},
+                {"messaging": ["bad-event", {"message": {"text": "hello"}}]},
+            ],
+        },
+    )
+
+    process.assert_awaited_once_with(account, {"message": {"text": "hello"}})
+
+
+@pytest.mark.asyncio
+async def test_webhook_handler_tracks_post_processing_task(monkeypatch):
+    if _messenger.web is None:
+        pytest.skip("aiohttp is not installed")
+
+    config = PlatformConfig(
+        enabled=True,
+        extra={
+            "page_access_token": "page-token",
+            "app_secret": "app-secret",
+            "verify_token": "verify-token",
+        },
+    )
+    adapter = MessengerAdapter(config)
+    account = adapter._complete_accounts["default"]
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def wait_payload(_account, _payload):
+        started.set()
+        await release.wait()
+
+    monkeypatch.setattr(adapter, "_process_webhook_payload", wait_payload)
+    body = json.dumps({"object": "page"}).encode("utf-8")
+
+    class Request:
+        headers = {"X-Hub-Signature-256": _signature(body, "app-secret")}
+
+        async def read(self):
+            return body
+
+    response = await adapter._build_webhook_handler(account)(Request())
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    assert response.status == 200
+    assert [task for task in adapter._background_tasks if not task.done()]
+
+    release.set()
+    await asyncio.gather(*list(adapter._background_tasks), return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_send_uses_metadata_messaging_type(monkeypatch):
+    config = PlatformConfig(
+        enabled=True,
+        extra={
+            "page_access_token": "page-token",
+            "app_secret": "app-secret",
+            "verify_token": "verify-token",
+        },
+    )
+    adapter = MessengerAdapter(config)
+    post_graph = AsyncMock(return_value={"message_id": "mid.1"})
+    monkeypatch.setattr(adapter, "_post_graph", post_graph)
+
+    result = await adapter.send(
+        "PSID123",
+        "hello",
+        metadata={"messenger_messaging_type": "UPDATE"},
+    )
+
+    assert result.success is True
+    assert post_graph.await_args.args[2]["messaging_type"] == "UPDATE"
+
+    utility_result = await adapter.send(
+        "PSID123",
+        "utility",
+        metadata={"messenger_messaging_type": "UTILITY"},
+    )
+
+    assert utility_result.success is True
+    assert post_graph.await_args.args[2]["messaging_type"] == "UTILITY"
+
+
+@pytest.mark.asyncio
+async def test_chunked_send_partial_failure_is_not_retryable(monkeypatch):
+    config = PlatformConfig(
+        enabled=True,
+        extra={
+            "page_access_token": "page-token",
+            "app_secret": "app-secret",
+            "verify_token": "verify-token",
+        },
+    )
+    adapter = MessengerAdapter(config)
+    post_graph = AsyncMock(
+        side_effect=[
+            {"message_id": "mid.1"},
+            MessengerGraphError(500, {"error": "temporary"}),
+        ]
+    )
+    monkeypatch.setattr(adapter, "_post_graph", post_graph)
+    account = adapter._complete_accounts["default"]
+
+    result = await adapter._send_text_chunks(account, "PSID123", "a" * 2001)
+
+    assert result.success is False
+    assert result.retryable is False
+    assert result.raw_response["delivered_message_ids"] == ["mid.1"]
+
+
+@pytest.mark.asyncio
 async def test_disabled_dm_policy_drops_inbound_before_dispatch(monkeypatch):
+    monkeypatch.delenv("MESSENGER_DM_POLICY", raising=False)
     config = PlatformConfig(
         enabled=True,
         extra={

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -203,6 +203,41 @@ def test_simplex_allowlist_denies_unlisted(monkeypatch):
     assert runner._is_user_authorized(source) is False
 
 
+def test_plugin_platform_allowlist_makes_unauthorized_dm_ignored(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.delenv("MESSENGER_ALLOWED_USERS", raising=False)
+    monkeypatch.setenv("MESSENGER_ALLOWED_USERS", "page-a:12345678901234567")
+
+    from gateway.platform_registry import PlatformEntry, platform_registry
+
+    previous = platform_registry.get("messenger")
+    platform_registry.unregister("messenger")
+    platform_registry.register(PlatformEntry(
+        name="messenger",
+        label="Messenger",
+        adapter_factory=lambda cfg: None,
+        check_fn=lambda: True,
+        allowed_users_env="MESSENGER_ALLOWED_USERS",
+        allow_all_env="MESSENGER_ALLOW_ALL_USERS",
+    ))
+
+    try:
+        messenger = Platform("messenger")
+        from gateway.authz_mixin import GatewayAuthorizationMixin
+
+        class Runner(GatewayAuthorizationMixin):
+            pass
+
+        runner = Runner()
+        runner.config = GatewayConfig(platforms={messenger: PlatformConfig(enabled=True)})
+
+        assert runner._get_unauthorized_dm_behavior(messenger) == "ignore"
+    finally:
+        platform_registry.unregister("messenger")
+        if previous is not None:
+            platform_registry.register(previous)
+
+
 def test_star_wildcard_in_allowlist_authorizes_any_user(monkeypatch):
     """WHATSAPP_ALLOWED_USERS=* should act as allow-all wildcard."""
     _clear_auth_env(monkeypatch)

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -705,6 +705,24 @@ class TestPromptPluginEnvVars:
 
         mock_prompt.assert_called_once()
 
+    def test_password_alias_uses_masked_prompt(self):
+        from hermes_cli.plugins_cmd import _prompt_plugin_env_vars
+        from unittest.mock import MagicMock, patch
+
+        console = MagicMock()
+        manifest = {
+            "name": "test",
+            "requires_env": [{"name": "SECRET_KEY", "password": True}],
+        }
+
+        with patch("hermes_cli.config.get_env_value", return_value=None), \
+             patch("builtins.input", side_effect=AssertionError("secret should be masked")), \
+             patch("hermes_cli.plugins_cmd.masked_secret_prompt", return_value="s3cret") as mock_prompt, \
+             patch("hermes_cli.config.save_env_value"):
+            _prompt_plugin_env_vars(manifest, console)
+
+        mock_prompt.assert_called_once()
+
     def test_empty_input_skips(self):
         from hermes_cli.plugins_cmd import _prompt_plugin_env_vars
         from unittest.mock import MagicMock, patch

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -231,6 +231,23 @@ class TestSendMessageTool:
         assert thread_id is None
         assert is_explicit is True
 
+    def test_messenger_account_scoped_target_is_explicit(self):
+        chat_id, thread_id, is_explicit = _parse_target_ref(
+            "messenger",
+            "page-a:12345678901234567",
+        )
+
+        assert chat_id == "page-a:12345678901234567"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_messenger_named_channel_still_resolves_via_directory(self):
+        chat_id, thread_id, is_explicit = _parse_target_ref("messenger", "team-page")
+
+        assert chat_id is None
+        assert thread_id is None
+        assert is_explicit is False
+
     def test_ntfy_topic_target_bypasses_channel_directory(self):
         ntfy_platform = Platform("ntfy")
         ntfy_cfg = SimpleNamespace(enabled=True, token=None, extra={"topic": "hermes-in"})
@@ -2761,6 +2778,37 @@ class TestSendViaAdapterStandaloneFallback:
         assert recorded["chat_id"] == "alerts-channel"
         assert recorded["content"] == "done"
         assert recorded["metadata"] == {"publish_topic": "alerts-channel"}
+
+    @pytest.mark.asyncio
+    async def test_live_messenger_adapter_receives_update_messaging_type(self, monkeypatch):
+        from tools.send_message_tool import _send_via_adapter
+
+        platform = _FakePlatform("messenger")
+        recorded = {}
+
+        class Adapter:
+            async def send(self, *, chat_id, content, metadata=None):
+                recorded["chat_id"] = chat_id
+                recorded["content"] = content
+                recorded["metadata"] = metadata
+                return SimpleNamespace(success=True, message_id="mid.1")
+
+        runner = SimpleNamespace(adapters={platform: Adapter()})
+        fake_gateway_run = ModuleType("gateway.run")
+        fake_gateway_run._gateway_runner_ref = lambda: runner
+        monkeypatch.setitem(sys.modules, "gateway.run", fake_gateway_run)
+
+        result = await _send_via_adapter(
+            platform,
+            SimpleNamespace(extra={}),
+            "page-a:12345678901234567",
+            "done",
+        )
+
+        assert result == {"success": True, "message_id": "mid.1"}
+        assert recorded["chat_id"] == "page-a:12345678901234567"
+        assert recorded["content"] == "done"
+        assert recorded["metadata"] == {"messenger_messaging_type": "UPDATE"}
 
     @pytest.mark.asyncio
     async def test_standalone_sender_fn_called_when_no_adapter(self, monkeypatch):

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -31,6 +31,7 @@ _SLACK_TARGET_RE = re.compile(r"^\s*([CGDU][A-Z0-9]{8,})\s*$")
 _SLACK_THREAD_TARGET_RE = re.compile(r"^\s*([CGD][A-Z0-9]{8,}):([^\s:]+)\s*$")
 _WEIXIN_TARGET_RE = re.compile(r"^\s*((?:wxid|gh|v\d+|wm|wb)_[A-Za-z0-9_-]+|[A-Za-z0-9._-]+@chatroom|filehelper)\s*$")
 _YUANBAO_TARGET_RE = re.compile(r"^\s*((?:group|direct):[^:]+)\s*$")
+_MESSENGER_SCOPED_TARGET_RE = re.compile(r"^\s*([A-Za-z0-9_.-]+:[^\s:][^\s]*)\s*$")
 # Discord snowflake IDs are numeric, same regex pattern as Telegram topic targets.
 _NUMERIC_TOPIC_RE = _TELEGRAM_TOPIC_TARGET_RE
 # Platforms that address recipients by phone number and accept E.164 format
@@ -158,7 +159,7 @@ SEND_MESSAGE_SCHEMA = {
             },
             "target": {
                 "type": "string",
-                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or 'platform:chat_id:thread_id' for Telegram topics and Discord threads. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:999888777:555444333', 'discord:#bot-home', 'slack:#engineering', 'signal:+155****4567', 'matrix:!roomid:server.org', 'matrix:@user:server.org', 'ntfy:alerts-channel' (explicit ntfy topic), 'yuanbao:direct:<account_id>' (DM), 'yuanbao:group:<group_code>' (group chat)"
+                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or 'platform:chat_id:thread_id' for Telegram topics and Discord threads. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:999888777:555444333', 'discord:#bot-home', 'slack:#engineering', 'signal:+155****4567', 'matrix:!roomid:server.org', 'matrix:@user:server.org', 'messenger:page-a:12345678901234567' (Messenger account-id:PSID), 'ntfy:alerts-channel' (explicit ntfy topic), 'yuanbao:direct:<account_id>' (DM), 'yuanbao:group:<group_code>' (group chat)"
             },
             "message": {
                 "type": "string",
@@ -516,6 +517,10 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         if target_ref.strip().isdigit():
             return f"group:{target_ref.strip()}", None, True
         return None, None, False
+    if platform_name == "messenger":
+        match = _MESSENGER_SCOPED_TARGET_RE.fullmatch(target_ref)
+        if match:
+            return match.group(1), None, True
     if platform_name == "ntfy":
         topic = target_ref.strip()
         if topic:
@@ -659,6 +664,8 @@ async def _send_via_adapter(
                     metadata["thread_id"] = thread_id
                 if platform_name == "ntfy" and chat_id:
                     metadata["publish_topic"] = chat_id
+                if platform_name == "messenger":
+                    metadata["messenger_messaging_type"] = "UPDATE"
                 if not metadata:
                     metadata = None
                 result = await adapter.send(chat_id=chat_id, content=chunk, metadata=metadata)

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -23,7 +23,7 @@ Bots need both a model provider and tool providers (TTS, web). A [Nous Portal](/
 | Slack | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Google Chat | — | ✅ | ✅ | ✅ | — | ✅ | — |
 | WhatsApp | — | ✅ | ✅ | — | — | ✅ | ✅ |
-| Messenger | — | ✅ | ✅ | — | — | ✅ | — |
+| Messenger | — | ✅ | Inbound | — | — | ✅ | — |
 | Signal | — | ✅ | ✅ | — | — | ✅ | ✅ |
 | SMS | — | — | — | — | — | — | — |
 | Email | — | ✅ | ✅ | ✅ | — | — | — |
@@ -43,7 +43,7 @@ Bots need both a model provider and tool providers (TTS, web). A [Nous Portal](/
 | ntfy | — | — | — | — | — | — | — |
 | Raft | — | — | — | — | — | — | — |
 
-**Voice** = TTS audio replies and/or voice message transcription. **Images** = send/receive images. **Files** = send/receive file attachments. **Threads** = threaded conversations. **Reactions** = emoji reactions on messages. **Typing** = typing indicator while processing. **Streaming** = progressive message updates via editing.
+**Voice** = TTS audio replies and/or voice message transcription. **Images** = send/receive images. **Files** = send/receive file attachments. **Inbound** = receives but does not send native files. **Threads** = threaded conversations. **Reactions** = emoji reactions on messages. **Typing** = typing indicator while processing. **Streaming** = progressive message updates via editing.
 
 ## Architecture
 
@@ -497,6 +497,7 @@ Each platform has its own toolset:
 | WhatsApp | `hermes-whatsapp` | Full tools including terminal |
 | WhatsApp Cloud API | `hermes-whatsapp` | Full tools including terminal (shares toolset with the Baileys bridge) |
 | Slack | `hermes-slack` | Full tools including terminal |
+| Messenger | `hermes-messenger` | Full tools including terminal |
 | Google Chat | `hermes-google_chat` | Full tools including terminal |
 | Signal | `hermes-signal` | Full tools including terminal |
 | SMS | `hermes-sms` | Full tools including terminal |

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 1
 title: "Messaging Gateway"
-description: "Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Yuanbao, Microsoft Teams, LINE, Raft, Webhooks, or any OpenAI-compatible frontend via the API server — architecture and setup overview"
+description: "Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Messenger, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Yuanbao, Microsoft Teams, LINE, Raft, Webhooks, or any OpenAI-compatible frontend via the API server — architecture and setup overview"
 ---
 
 # Messaging Gateway
 
-Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Feishu/Lark, WeCom, Weixin, BlueBubbles (iMessage), QQ, Yuanbao, Microsoft Teams, LINE, ntfy, or your browser. The gateway is a single background process that connects to all your configured platforms, handles sessions, runs cron jobs, and delivers voice messages.
+Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Facebook Messenger, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Feishu/Lark, WeCom, Weixin, BlueBubbles (iMessage), QQ, Yuanbao, Microsoft Teams, LINE, ntfy, or your browser. The gateway is a single background process that connects to all your configured platforms, handles sessions, runs cron jobs, and delivers voice messages.
 
 For the full voice feature set — including CLI microphone mode, spoken replies in messaging, and Discord voice-channel conversations — see [Voice Mode](/user-guide/features/voice-mode) and [Use Voice Mode with Hermes](/guides/use-voice-mode-with-hermes).
 
@@ -23,6 +23,7 @@ Bots need both a model provider and tool providers (TTS, web). A [Nous Portal](/
 | Slack | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Google Chat | — | ✅ | ✅ | ✅ | — | ✅ | — |
 | WhatsApp | — | ✅ | ✅ | — | — | ✅ | ✅ |
+| Messenger | — | ✅ | ✅ | — | — | ✅ | — |
 | Signal | — | ✅ | ✅ | — | — | ✅ | ✅ |
 | SMS | — | — | — | — | — | — | — |
 | Email | — | ✅ | ✅ | ✅ | — | — | — |
@@ -56,6 +57,7 @@ flowchart TB
             sl[Slack]
             gc[Google Chat]
             sig[Signal]
+            fb[Messenger]
             sms[SMS]
             em[Email]
             ha[Home Assistant]
@@ -84,6 +86,7 @@ flowchart TB
     wa --> store
     sl --> store
     gc --> store
+    fb --> store
     sig --> store
     sms --> store
     em --> store
@@ -624,6 +627,7 @@ Defaults to `false`. Only platforms whose adapter implements `delete_message` ho
 - [Google Chat Setup](google_chat.md)
 - [WhatsApp Setup](whatsapp.md)
 - [WhatsApp Business Cloud API Setup](whatsapp-cloud.md)
+- [Messenger Setup](messenger.md)
 - [Signal Setup](signal.md)
 - [SMS Setup (Twilio)](sms.md)
 - [Email Setup](email.md)

--- a/website/docs/user-guide/messaging/messenger.md
+++ b/website/docs/user-guide/messaging/messenger.md
@@ -17,11 +17,12 @@ Messenger is webhook-based: Meta sends inbound Page messages to a public HTTPS U
 3. Generate a Page Access Token for your Page.
 4. Copy the App Secret from **App Settings > Basic**.
 5. Generate a secure verify token, for example `openssl rand -hex 32`.
-6. Add the credentials to `~/.hermes/.env`.
-7. Start the Hermes gateway.
-8. Configure the Meta webhook callback URL as `https://<public-host>/messenger/webhook`.
-9. Subscribe the Page to `messages` and `messaging_postbacks`.
-10. DM the Page and approve the pairing code for the sender, or preconfigure `MESSENGER_ALLOWED_USERS`.
+6. Add the three credential values to `~/.hermes/.env`.
+7. Put Messenger behavior settings in `~/.hermes/config.yaml`.
+8. Start the Hermes gateway.
+9. Configure the Meta webhook callback URL as `https://<public-host>/messenger/webhook`.
+10. Subscribe the Page to `messages` and `messaging_postbacks`.
+11. DM the Page and approve the pairing code for the sender, or preconfigure `allow_from`.
 
 ## Requirements
 
@@ -40,24 +41,38 @@ Add the default-account credentials to `~/.hermes/.env`:
 MESSENGER_PAGE_ACCESS_TOKEN=EA...
 MESSENGER_APP_SECRET=...
 MESSENGER_VERIFY_TOKEN=...
-
-# Defaults shown for clarity.
-MESSENGER_HOST=0.0.0.0
-MESSENGER_PORT=8650
-MESSENGER_WEBHOOK_PATH=/messenger/webhook
-MESSENGER_API_VERSION=v21.0
-MESSENGER_DM_POLICY=pairing
 ```
 
-`MESSENGER_DM_POLICY=pairing` is the safe default. Unknown senders receive a pairing code and cannot talk to the agent until you approve it.
+Put non-secret behavior settings in `~/.hermes/config.yaml`:
+
+```yaml
+gateway:
+  platforms:
+    messenger:
+      enabled: true
+      dm_policy: pairing
+      extra:
+        host: 0.0.0.0
+        port: 8650
+        webhook_path: /messenger/webhook
+        api_version: v21.0
+```
+
+`dm_policy: pairing` is the safe default. Unknown senders receive a pairing code and cannot talk to the agent until you approve it.
 
 For a private deployment, pre-allow the Messenger PSIDs that may talk to Hermes:
 
-```env
-MESSENGER_ALLOWED_USERS=12345678901234567,98765432109876543
+```yaml
+gateway:
+  platforms:
+    messenger:
+      enabled: true
+      allow_from:
+        - "12345678901234567"
+        - "98765432109876543"
 ```
 
-Use `MESSENGER_ALLOW_ALL_USERS=true` only for tightly controlled development Pages.
+Use `allow_all_users: true` only for tightly controlled development Pages.
 
 ## Meta Developer Setup
 
@@ -146,23 +161,28 @@ Development-mode apps only work for app admins, developers, and testers. To let 
 
 ## Configuration Reference
 
-Default-account credentials can be set by environment variable:
+Default-account credentials are secrets and belong in `~/.hermes/.env`:
 
 | Variable | Description |
 |----------|-------------|
 | `MESSENGER_PAGE_ACCESS_TOKEN` | Facebook Page access token with Messenger permissions. |
 | `MESSENGER_APP_SECRET` | Meta app secret used for webhook HMAC-SHA256 verification. |
 | `MESSENGER_VERIFY_TOKEN` | Webhook verify token you configure in the Meta dashboard. |
-| `MESSENGER_HOST` | Webhook bind host. Defaults to `0.0.0.0`. |
-| `MESSENGER_PORT` | Webhook listen port. Defaults to `8650`. |
-| `MESSENGER_WEBHOOK_PATH` | Webhook path. Defaults to `/messenger/webhook`. |
-| `MESSENGER_API_VERSION` | Meta Graph API version. Defaults to `v21.0`. |
-| `MESSENGER_ALLOWED_USERS` | Comma-separated Messenger PSIDs allowed to DM Hermes. |
-| `MESSENGER_ALLOW_ALL_USERS` | Allow any Messenger sender. Use only for controlled development. |
-| `MESSENGER_HOME_CHANNEL` | Default Messenger PSID for cron or notification delivery. |
-| `MESSENGER_DM_POLICY` | Unauthorized DM behavior. `pairing` sends pairing codes; `disabled` drops inbound DMs. |
 
-Hermes can also read credentials from YAML under `gateway.platforms.messenger.extra`, including file-backed secrets:
+Non-secret behavior belongs in `config.yaml`:
+
+| Key | Description |
+|-----|-------------|
+| `gateway.platforms.messenger.extra.host` | Webhook bind host. Defaults to `0.0.0.0`. |
+| `gateway.platforms.messenger.extra.port` | Webhook listen port. Defaults to `8650`. |
+| `gateway.platforms.messenger.extra.webhook_path` | Webhook path. Defaults to `/messenger/webhook`. |
+| `gateway.platforms.messenger.extra.api_version` | Meta Graph API version. Defaults to `v21.0`. |
+| `gateway.platforms.messenger.allow_from` | Messenger PSIDs allowed to DM Hermes. |
+| `gateway.platforms.messenger.allow_all_users` | Allow any Messenger sender. Use only for controlled development. |
+| `gateway.platforms.messenger.home_channel.chat_id` | Default Messenger PSID for cron or notification delivery. |
+| `gateway.platforms.messenger.dm_policy` | Unauthorized DM behavior. `pairing` sends pairing codes; `disabled` drops inbound DMs. |
+
+Hermes can also read credentials from file-backed YAML references:
 
 ```yaml
 gateway:
@@ -170,12 +190,9 @@ gateway:
     messenger:
       enabled: true
       extra:
-        page_access_token: "EA..."
-        app_secret: "..."
-        verify_token: "verify-token"
-        # Or keep secrets in files:
-        # token_file: "~/.hermes/secrets/messenger-page-token"
-        # secret_file: "~/.hermes/secrets/messenger-app-secret"
+        token_file: "~/.hermes/secrets/messenger-page-token"
+        secret_file: "~/.hermes/secrets/messenger-app-secret"
+        verify_token_file: "~/.hermes/secrets/messenger-verify-token"
 ```
 
 Environment variables take priority over YAML values for the default account.
@@ -192,14 +209,14 @@ gateway:
       extra:
         accounts:
           page-a:
-            page_access_token: "EA..."
-            app_secret: "..."
-            verify_token: "verify-a"
+            token_file: "~/.hermes/secrets/page-a-token"
+            secret_file: "~/.hermes/secrets/page-a-app-secret"
+            verify_token_file: "~/.hermes/secrets/page-a-verify-token"
             webhook_path: "/messenger/webhook/page-a"
           page-b:
-            page_access_token: "EA..."
-            app_secret: "..."
-            verify_token: "verify-b"
+            token_file: "~/.hermes/secrets/page-b-token"
+            secret_file: "~/.hermes/secrets/page-b-app-secret"
+            verify_token_file: "~/.hermes/secrets/page-b-verify-token"
             webhook_path: "/messenger/webhook/page-b"
 ```
 
@@ -230,7 +247,7 @@ Messenger users can type text commands such as `/new`, `/reset`, `/status`, and 
 
 **Webhook verification returns 502 or times out**
 
-- The public tunnel or reverse proxy is not reaching `MESSENGER_PORT`.
+- The public tunnel or reverse proxy is not reaching the configured `gateway.platforms.messenger.extra.port`.
 - The gateway must be running before clicking **Verify and Save**.
 - Meta requires HTTPS for the public callback URL.
 
@@ -250,12 +267,12 @@ Messenger users can type text commands such as `/new`, `/reset`, `/status`, and 
 
 - Generate a long-lived Page token or System User token for production.
 - Confirm the token belongs to the connected Page.
-- Test the token with `curl "https://graph.facebook.com/me?access_token=<token>"`.
+- Test the token with `curl -H "Authorization: Bearer $MESSENGER_PAGE_ACCESS_TOKEN" https://graph.facebook.com/v21.0/me`.
 
 **Unknown sender gets a pairing code**
 
 - Approve the code with `hermes pairing approve messenger <code>`.
-- Or add the sender PSID to `MESSENGER_ALLOWED_USERS`.
+- Or add the sender PSID to `gateway.platforms.messenger.allow_from`.
 
 **Bot replies but the user cannot see messages**
 

--- a/website/docs/user-guide/messaging/messenger.md
+++ b/website/docs/user-guide/messaging/messenger.md
@@ -1,0 +1,263 @@
+---
+sidebar_position: 18
+title: "Messenger"
+description: "Set up Hermes Agent as a Facebook Messenger Page bot"
+---
+
+# Facebook Messenger Setup
+
+Run Hermes Agent as a Facebook Messenger bot for Page DMs through Meta's Graph API. The adapter is a bundled platform plugin under `plugins/platforms/messenger/`, so it is discovered at gateway startup without adding a core platform enum.
+
+Messenger is webhook-based: Meta sends inbound Page messages to a public HTTPS URL, and Hermes replies through the Page Send API.
+
+## Quick Setup
+
+1. Create a Meta Developer account and app at [developers.facebook.com](https://developers.facebook.com/).
+2. Add the Messenger product to your app and connect a Facebook Page.
+3. Generate a Page Access Token for your Page.
+4. Copy the App Secret from **App Settings > Basic**.
+5. Generate a secure verify token, for example `openssl rand -hex 32`.
+6. Add the credentials to `~/.hermes/.env`.
+7. Start the Hermes gateway.
+8. Configure the Meta webhook callback URL as `https://<public-host>/messenger/webhook`.
+9. Subscribe the Page to `messages` and `messaging_postbacks`.
+10. DM the Page and approve the pairing code for the sender, or preconfigure `MESSENGER_ALLOWED_USERS`.
+
+## Requirements
+
+- A Meta app with the Messenger product enabled.
+- A Facebook Page connected to that app.
+- A Page access token with `pages_messaging`.
+- The app secret from **App Settings > Basic**.
+- A webhook verify token that you choose.
+- A public HTTPS route to the local Messenger webhook port.
+
+## Configure Hermes
+
+Add the default-account credentials to `~/.hermes/.env`:
+
+```env
+MESSENGER_PAGE_ACCESS_TOKEN=EA...
+MESSENGER_APP_SECRET=...
+MESSENGER_VERIFY_TOKEN=...
+
+# Defaults shown for clarity.
+MESSENGER_HOST=0.0.0.0
+MESSENGER_PORT=8650
+MESSENGER_WEBHOOK_PATH=/messenger/webhook
+MESSENGER_API_VERSION=v21.0
+MESSENGER_DM_POLICY=pairing
+```
+
+`MESSENGER_DM_POLICY=pairing` is the safe default. Unknown senders receive a pairing code and cannot talk to the agent until you approve it.
+
+For a private deployment, pre-allow the Messenger PSIDs that may talk to Hermes:
+
+```env
+MESSENGER_ALLOWED_USERS=12345678901234567,98765432109876543
+```
+
+Use `MESSENGER_ALLOW_ALL_USERS=true` only for tightly controlled development Pages.
+
+## Meta Developer Setup
+
+Meta's developer dashboard requires several manual steps before webhooks are delivered.
+
+### 1. Create a Meta Developer App
+
+1. Open [developers.facebook.com](https://developers.facebook.com/).
+2. Click **My Apps > Create App**.
+3. Select a business-capable app type or the Messenger use case.
+4. Fill in the app name and contact email, then create the app.
+
+### 2. Add Messenger and Connect a Page
+
+1. In the app dashboard, add or open the **Messenger** product.
+2. Under **Access Tokens**, click **Add or Remove Pages**.
+3. Connect the Facebook Page Hermes should answer from.
+4. Generate a Page Access Token for that Page and save it as `MESSENGER_PAGE_ACCESS_TOKEN`.
+
+### 3. Copy the App Secret
+
+1. Go to **App Settings > Basic**.
+2. Click **Show** next to **App Secret**.
+3. Save that value as `MESSENGER_APP_SECRET`.
+
+Hermes uses this secret to verify the `X-Hub-Signature-256` header on every inbound POST.
+
+### 4. Expose the Webhook
+
+Meta requires a public HTTPS callback URL. Use a fixed reverse proxy, Cloudflare Tunnel, ngrok, or another HTTPS tunnel for development.
+
+Example ingress target:
+
+```text
+https://messenger.example.com/messenger/webhook -> http://localhost:8650/messenger/webhook
+```
+
+Start the gateway before verifying the callback:
+
+```bash
+hermes gateway
+```
+
+The gateway log should include:
+
+```text
+Messenger webhook listening on 0.0.0.0:8650 for 1 account(s)
+```
+
+You can test the public GET verification path with the same verify token configured in Meta:
+
+```bash
+curl "https://<public-host>/messenger/webhook?hub.mode=subscribe&hub.verify_token=<verify-token>&hub.challenge=ok"
+```
+
+It should return exactly:
+
+```text
+ok
+```
+
+### 5. Configure the Meta Webhook
+
+1. In the Meta Developer Portal, open **Messenger > Settings > Webhooks**.
+2. Click **Add Callback URL**.
+3. Enter `https://<public-host>/messenger/webhook`.
+4. Enter the exact `MESSENGER_VERIFY_TOKEN` value.
+5. Click **Verify and Save**.
+
+Meta sends a GET request with `hub.verify_token` and `hub.challenge`. Hermes must be running and reachable for this step to pass.
+
+### 6. Subscribe to Webhook Fields
+
+After verifying the callback, subscribe the Page to:
+
+| Field | Required | Purpose |
+|-------|----------|---------|
+| `messages` | Yes | Receives text messages and media attachments from users. |
+| `messaging_postbacks` | Recommended | Receives postback payloads when users tap structured message buttons. |
+| `message_reads` | Optional | Read receipts; ignored by Hermes. |
+| `message_deliveries` | Optional | Delivery confirmations; ignored by Hermes. |
+
+### 7. Go Live
+
+Development-mode apps only work for app admins, developers, and testers. To let arbitrary Facebook users message the Page, request App Review for `pages_messaging` and switch the app to Live mode after approval.
+
+## Configuration Reference
+
+Default-account credentials can be set by environment variable:
+
+| Variable | Description |
+|----------|-------------|
+| `MESSENGER_PAGE_ACCESS_TOKEN` | Facebook Page access token with Messenger permissions. |
+| `MESSENGER_APP_SECRET` | Meta app secret used for webhook HMAC-SHA256 verification. |
+| `MESSENGER_VERIFY_TOKEN` | Webhook verify token you configure in the Meta dashboard. |
+| `MESSENGER_HOST` | Webhook bind host. Defaults to `0.0.0.0`. |
+| `MESSENGER_PORT` | Webhook listen port. Defaults to `8650`. |
+| `MESSENGER_WEBHOOK_PATH` | Webhook path. Defaults to `/messenger/webhook`. |
+| `MESSENGER_API_VERSION` | Meta Graph API version. Defaults to `v21.0`. |
+| `MESSENGER_ALLOWED_USERS` | Comma-separated Messenger PSIDs allowed to DM Hermes. |
+| `MESSENGER_ALLOW_ALL_USERS` | Allow any Messenger sender. Use only for controlled development. |
+| `MESSENGER_HOME_CHANNEL` | Default Messenger PSID for cron or notification delivery. |
+| `MESSENGER_DM_POLICY` | Unauthorized DM behavior. `pairing` sends pairing codes; `disabled` drops inbound DMs. |
+
+Hermes can also read credentials from YAML under `gateway.platforms.messenger.extra`, including file-backed secrets:
+
+```yaml
+gateway:
+  platforms:
+    messenger:
+      enabled: true
+      extra:
+        page_access_token: "EA..."
+        app_secret: "..."
+        verify_token: "verify-token"
+        # Or keep secrets in files:
+        # token_file: "~/.hermes/secrets/messenger-page-token"
+        # secret_file: "~/.hermes/secrets/messenger-app-secret"
+```
+
+Environment variables take priority over YAML values for the default account.
+
+## Multi-Account
+
+Use `gateway.platforms.messenger.extra.accounts` for multiple Facebook Pages. Each account needs its own webhook path and matching Meta callback URL.
+
+```yaml
+gateway:
+  platforms:
+    messenger:
+      enabled: true
+      extra:
+        accounts:
+          page-a:
+            page_access_token: "EA..."
+            app_secret: "..."
+            verify_token: "verify-a"
+            webhook_path: "/messenger/webhook/page-a"
+          page-b:
+            page_access_token: "EA..."
+            app_secret: "..."
+            verify_token: "verify-b"
+            webhook_path: "/messenger/webhook/page-b"
+```
+
+For named accounts, route cron or manual sends to `account-id:psid`, for example `page-a:12345678901234567`.
+
+## Capabilities
+
+| Feature | Support |
+|---------|---------|
+| Text DMs | ✅ |
+| Postbacks | ✅ |
+| Inbound images/video/audio/files | ✅ |
+| Outbound text | ✅ |
+| Outbound image URL | ✅ |
+| Typing indicator | ✅ |
+| Threads/groups | — |
+
+Outbound text is chunked to Messenger's 2000-character limit. Messenger does not reliably render Markdown, so Hermes strips common Markdown markers and keeps bare URLs.
+
+Messenger users can type text commands such as `/new`, `/reset`, `/status`, and `/model` as regular messages. The gateway handles them the same way it handles text commands on other messaging platforms.
+
+## Troubleshooting
+
+**Webhook verification returns 403**
+
+- The verify token in Meta does not exactly match `MESSENGER_VERIFY_TOKEN`.
+- Confirm you are verifying the same callback path Hermes is listening on.
+
+**Webhook verification returns 502 or times out**
+
+- The public tunnel or reverse proxy is not reaching `MESSENGER_PORT`.
+- The gateway must be running before clicking **Verify and Save**.
+- Meta requires HTTPS for the public callback URL.
+
+**POST returns 401**
+
+- `MESSENGER_APP_SECRET` does not match the Meta app secret.
+- A proxy may be modifying the raw request body before Hermes verifies the signature.
+
+**No messages arrive**
+
+- Confirm the Page is subscribed to `messages`.
+- In Development mode, confirm the sender is an app admin, developer, or tester.
+- In Live mode, confirm the app has `pages_messaging` approval.
+- Check logs with `hermes logs --follow` and look for `messenger` entries.
+
+**Token errors**
+
+- Generate a long-lived Page token or System User token for production.
+- Confirm the token belongs to the connected Page.
+- Test the token with `curl "https://graph.facebook.com/me?access_token=<token>"`.
+
+**Unknown sender gets a pairing code**
+
+- Approve the code with `hermes pairing approve messenger <code>`.
+- Or add the sender PSID to `MESSENGER_ALLOWED_USERS`.
+
+**Bot replies but the user cannot see messages**
+
+- Confirm the Page Access Token has `pages_messaging`.
+- Confirm the recipient is allowed by the app's Development/Live mode.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -609,6 +609,7 @@ const sidebars: SidebarsConfig = {
             'user-guide/messaging/slack',
             'user-guide/messaging/whatsapp',
             'user-guide/messaging/whatsapp-cloud',
+            'user-guide/messaging/messenger',
             'user-guide/messaging/signal',
             'user-guide/messaging/email',
             'user-guide/messaging/sms',


### PR DESCRIPTION
## What does this PR do?

Adds Facebook Messenger Page DM support as a bundled Hermes platform plugin.

This is the platform-plugin path, not a core-tool or core-platform expansion: Messenger lives under `plugins/platforms/messenger/`, registers via `ctx.register_platform(...)`, and is discovered like the other bundled platform plugins.

## Related Issue

N/A — I searched existing open/closed issues and PRs for Facebook Messenger / Meta Messenger / `pages_messaging` / `messaging_postbacks` / Page Send API and did not find an existing Facebook Messenger implementation. Related precedent: WhatsApp Cloud uses the same Meta Graph webhook family, but this PR is Messenger/Page-DM specific.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `plugins/platforms/messenger/plugin.yaml` with `kind: platform` and setup/env metadata.
- Added `plugins/platforms/messenger/adapter.py`:
  - `GET /messenger/webhook` verification with `hub.challenge`.
  - `POST /messenger/webhook` processing with `X-Hub-Signature-256` HMAC-SHA256 validation.
  - Meta Graph API outbound text sends via `/v21.0/me/messages`.
  - 2000-character message chunking and Messenger-friendly Markdown stripping.
  - Text, postback, location-note, and inbound media attachment handling.
  - Echo/read/delivery filtering to avoid loops.
  - URL-safety and media-size checks before caching inbound attachments.
  - Multi-account support with per-account webhook paths.
  - Gateway integration hooks for env/YAML config, allowlists, pairing, cron delivery, standalone sends, setup, status, and platform hints.
- Added `plugins/platforms/messenger/__init__.py` package export.
- Added `tests/gateway/test_messenger_plugin.py` coverage for signatures, config parsing, env/YAML hooks, chunking, markdown conversion, registration metadata, source scoping, attachment notes, and disabled DM policy behavior.
- Added `website/docs/user-guide/messaging/messenger.md` setup guide.
- Updated `website/docs/user-guide/messaging/index.md` and `website/sidebars.ts` so Messenger appears in the messaging guide, comparison table, architecture diagram, next steps, and sidebar.

## How to Test

1. Configure Messenger credentials in `~/.hermes/.env`:

   ```env
   MESSENGER_PAGE_ACCESS_TOKEN=...
   MESSENGER_APP_SECRET=...
   MESSENGER_VERIFY_TOKEN=...
   ```

2. Start the gateway and verify the webhook route:

   ```bash
   hermes gateway
   curl "https://<public-host>/messenger/webhook?hub.mode=subscribe&hub.verify_token=<verify-token>&hub.challenge=ok"
   ```

   Expected: the response body is exactly `ok`.

3. In the Meta Developer Portal, set the callback URL to `https://<public-host>/messenger/webhook`, then subscribe the Page to `messages` and `messaging_postbacks`.

4. Send a Page DM from an allowed/paired sender and verify Hermes responds in Messenger.

## Security Impact

New network surface: a local aiohttp webhook server for Meta Messenger callbacks.

Mitigations:

- POST requests require `X-Hub-Signature-256` and are verified with `hmac.compare_digest`.
- App secret and Page token are treated as secrets and are never logged.
- Unknown senders use existing gateway pairing by default.
- `MESSENGER_ALLOWED_USERS` and `MESSENGER_ALLOW_ALL_USERS` integrate with existing gateway authorization.
- Echo/read/delivery events are ignored to avoid loops.
- Inbound media URLs pass URL-safety checks and size validation before caching.
- Outbound image sending requires a public `http(s)` URL.

No personal credentials, page IDs, PSIDs, callback hosts, allowlists, Cloudflare routes, or local deployment data are included in this PR.

## Pattern Match

Checked against `gateway/platforms/ADDING_A_PLATFORM.md` and existing bundled platform plugins:

- [x] `plugin.yaml` uses `kind: platform`.
- [x] Adapter subclasses `BasePlatformAdapter`.
- [x] Plugin exposes `register(ctx)` and calls `ctx.register_platform(...)`.
- [x] Uses `env_enablement_fn` and `apply_yaml_config_fn` instead of growing core config boilerplate.
- [x] Uses `allowed_users_env` / `allow_all_env` for gateway authz.
- [x] Uses `cron_deliver_env_var` and `standalone_sender_fn` for cron delivery.
- [x] Adds docs and tests.
- [x] Does not add a new core model tool.
- [x] Does not add a core platform enum.
- [x] Does not modify existing platform behavior.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
  - Attempted in Docker. First run failed during collection because the ephemeral image venv lacked `setuptools`; rerun with `setuptools` installed progressed to ~41% with broad unrelated failures and then produced no output for 10+ minutes. The hung ephemeral test container was stopped after ~33 minutes. Focused CI-parity wrapper and docs build are listed below.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux/Docker, plus live Meta Messenger smoke test with private credentials

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
  - N/A: new setup metadata lives in the platform plugin manifest and the user-facing docs include env/YAML config examples; no core default config schema was changed.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
  - N/A: this follows the existing platform-plugin architecture.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - The adapter uses Python async HTTP libraries and `pathlib`; no POSIX-only process/signal APIs. `scripts/check-windows-footguns.py plugins/platforms/messenger/adapter.py` passed.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
  - N/A: no model tool behavior changed.

## Validation

- `docker run --rm --entrypoint /bin/sh -v "$PWD":/src -w /src hermes-agent -lc 'uv pip install --python /opt/hermes/.venv/bin/python pytest==9.0.2 pytest-asyncio==1.3.0 >/tmp/pytest-install.log && /opt/hermes/.venv/bin/python -m pytest -q tests/gateway/test_messenger_plugin.py'`
  - `15 passed`
- `docker run --rm --entrypoint /bin/sh -v "$PWD":/src -w /src hermes-agent -lc 'set -e; uv pip install --python /opt/hermes/.venv/bin/python pytest==9.0.2 pytest-asyncio==1.3.0 >/tmp/pytest-install.log; ln -s /opt/hermes/.venv /src/.venv; trap "rm -f /src/.venv" EXIT; scripts/run_tests.sh tests/gateway/test_messenger_plugin.py'`
  - `15 passed`
- `python3 scripts/check-windows-footguns.py plugins/platforms/messenger/adapter.py`
  - `✓ No Windows footguns found`
- `cd website && npm ci && npm run build`
  - completed successfully
  - Docusaurus reported existing broken-link/anchor warnings unrelated to this Messenger page, mostly in zh-Hans docs and pre-existing pages
- Local live smoke test with private Meta credentials:
  - public webhook challenge returned the expected challenge
  - signed POST returned `{"status":"ok"}`
  - inbound Page DM routed into Hermes
  - outbound reply delivered back to Messenger

- `docker run --rm --entrypoint /bin/sh -v "$PWD":/src -w /src hermes-agent -lc 'set -e; uv pip install --python /opt/hermes/.venv/bin/python pytest==9.0.2 pytest-asyncio==1.3.0 setuptools >/tmp/pytest-install.log; /opt/hermes/.venv/bin/python -m pytest tests/ -q'`
  - did not complete: progressed to ~41% with broad unrelated failures, then hung with no output for 10+ minutes; stopped the ephemeral container after ~33 minutes

## Screenshots / Logs

No screenshots included. Live smoke testing used private Page credentials and deployment-specific identifiers, which are intentionally omitted from the PR.

