### PR TITLE
fix(mcp): extract EmbeddedResource content blocks from tool results

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -907,11 +907,23 @@ class SamplingHandler:
 
     @staticmethod
     def _extract_tool_result_text(block) -> str:
-        """Extract text from a ToolResultContent block."""
+        """Extract text from a ToolResultContent block.
+
+        Handles both TextContent blocks (.text) and EmbeddedResource
+        blocks (.resource.text) per the MCP spec.
+        """
         if not hasattr(block, "content") or block.content is None:
             return ""
         items = block.content if isinstance(block.content, list) else [block.content]
-        return "\n".join(item.text for item in items if hasattr(item, "text"))
+        parts: List[str] = []
+        for item in items:
+            if hasattr(item, "text") and item.text:
+                parts.append(item.text)
+            elif hasattr(item, "resource"):
+                resource = item.resource
+                if hasattr(resource, "text") and resource.text:
+                    parts.append(resource.text)
+        return "\n".join(parts)
 
     def _convert_messages(self, params) -> List[dict]:
         """Convert MCP SamplingMessages to OpenAI format.
@@ -3174,6 +3186,10 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 for block in (result.content or []):
                     if hasattr(block, "text"):
                         error_text += block.text
+                    elif hasattr(block, "resource"):
+                        resource = block.resource
+                        if hasattr(resource, "text") and resource.text:
+                            error_text += resource.text
                 return json.dumps({
                     "error": _sanitize_error(
                         error_text or "MCP tool returned an error"
@@ -3196,6 +3212,12 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 if hasattr(block, "text") and block.text:
                     parts.append(block.text)
                     continue
+                # EmbeddedResource blocks carry payload in .resource.text
+                if hasattr(block, "resource"):
+                    resource = block.resource
+                    if hasattr(resource, "text") and resource.text:
+                        parts.append(resource.text)
+                        continue
                 image_tag = _cache_mcp_image_block(block)
                 if image_tag:
                     parts.append(image_tag)


### PR DESCRIPTION
## Problem

MCP servers that return `type="resource"` content blocks (`EmbeddedResource` in the MCP SDK) have their results silently dropped by Hermes' MCP client. The client only extracts text from `TextContent` and `ImageContent` blocks, ignoring `EmbeddedResource` blocks entirely.

**Affected tools:** GitHub MCP `get_file_contents` (v1.4.0+), Playwright MCP, filesystem servers, and any MCP server that embeds file content as resource blocks.

**Symptom:** `get_file_contents` returns `"successfully downloaded text file (SHA: ...)"` — the metadata text block — but the actual file content in the `resource` block is dropped. The agent sees an empty result.

## Root Cause

`tools/mcp_tool.py` extracts content from tool results in three places, all using `hasattr(block, "text")` only:

1. **Main tool result loop** (~line 3194) — iterates `result.content`, extracts `.text` and image blocks, drops everything else
2. **Error text extraction** (~line 3174) — same pattern for error responses
3. **`_extract_tool_result_text()`** (~line 909) — extracts text from `ToolResultContent` blocks, same gap

The MCP spec defines `EmbeddedResource` with `type="resource"` where the payload lives at `.resource.text` (or `.resource.blob` for binary). These blocks have no top-level `.text` attribute.

## Fix

Patch all three extraction points to also check for `hasattr(block, "resource")` and extract `.resource.text`:

```python
# Added before the image_tag fallback:
if hasattr(block, "resource"):
    resource = block.resource
    if hasattr(resource, "text") and resource.text:
        parts.append(resource.text)
        continue
```

## Verification

Before patch:
```
mcp_github_get_file_contents → {"result": "successfully downloaded text file (SHA: abc123)"}
```

After patch (tested with GitHub MCP v1.4.0):
```
mcp_github_get_file_contents → {"result": "successfully downloaded text file (SHA: abc123)\ninterface:\n  display_name: \"Loop Library\"..."}
```

Content from the `resource` block is now included alongside the metadata text.

## Related

- Fixes #30601
- Supersedes the approach in #26972 (closed without merge)
- Distilled from the fix proposed by @raumzeit77 in #26972