### PR TITLE
fix(auxiliary): accept legacy fallback_provider/fallback_model in auxiliary task fallback chain

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3158,6 +3158,10 @@ def _try_configured_fallback_chain(
     entry in order.  Each entry must have at least ``provider``; ``model``,
     ``base_url``, and ``api_key`` are optional.
 
+    Also supports the legacy singular ``fallback_provider`` /
+    ``fallback_model`` fields: when ``fallback_chain`` is absent, a
+    single-entry chain is built from those fields.
+
     Returns:
         (client, model, provider_label) or (None, None, "") if no fallback.
     """
@@ -3167,7 +3171,16 @@ def _try_configured_fallback_chain(
     task_config = _get_auxiliary_task_config(task)
     chain = task_config.get("fallback_chain")
     if not chain or not isinstance(chain, list):
-        return None, None, ""
+        # Support legacy singular fallback_provider / fallback_model fields.
+        # When fallback_chain is absent, build a single-entry chain from
+        # the singular fields so users with the old config form still get
+        # fallback coverage.
+        fb_provider = str(task_config.get("fallback_provider", "") or "").strip()
+        fb_model = str(task_config.get("fallback_model", "") or "").strip()
+        if fb_provider:
+            chain = [{"provider": fb_provider, "model": fb_model}]
+        else:
+            return None, None, ""
 
     skip = failed_provider.lower().strip()
     tried = []

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1937,6 +1937,117 @@ class TestTryMainAgentModelFallback:
         assert client is None
 
 
+class TestConfiguredFallbackChainLegacyFields:
+    """_try_configured_fallback_chain accepts legacy singular fallback_provider / fallback_model."""
+
+    def test_legacy_singular_fields_build_single_entry_chain(self):
+        """When fallback_chain is absent but fallback_provider is set, a single-entry chain is built."""
+        from agent.auxiliary_client import _try_configured_fallback_chain
+
+        fake_client = MagicMock()
+        task_config = {
+            "provider": "bailian",
+            "model": "qwen3.7-plus",
+            "fallback_provider": "minimax-oai",
+            "fallback_model": "MiniMax-M3",
+        }
+
+        with patch("agent.auxiliary_client._get_auxiliary_task_config",
+                    return_value=task_config), \
+             patch("agent.auxiliary_client._resolve_fallback_entry",
+                    return_value=(fake_client, "MiniMax-M3")):
+            client, model, label = _try_configured_fallback_chain(
+                "vision", "bailian", reason="429 rate limit")
+
+        assert client is fake_client
+        assert model == "MiniMax-M3"
+        assert "minimax-oai" in label
+
+    def test_legacy_singular_fields_no_model_still_works(self):
+        """fallback_provider without fallback_model should still create a chain entry."""
+        from agent.auxiliary_client import _try_configured_fallback_chain
+
+        fake_client = MagicMock()
+        task_config = {
+            "provider": "bailian",
+            "model": "qwen3.7-plus",
+            "fallback_provider": "minimax-oai",
+        }
+
+        with patch("agent.auxiliary_client._get_auxiliary_task_config",
+                    return_value=task_config), \
+             patch("agent.auxiliary_client._resolve_fallback_entry",
+                    return_value=(fake_client, "minimax-default")):
+            client, model, label = _try_configured_fallback_chain(
+                "vision", "bailian", reason="429 rate limit")
+
+        assert client is fake_client
+        assert "minimax-oai" in label
+
+    def test_chain_list_takes_precedence_over_legacy_fields(self):
+        """When fallback_chain (list) is present, legacy singular fields are ignored."""
+        from agent.auxiliary_client import _try_configured_fallback_chain
+
+        chain_client = MagicMock()
+        task_config = {
+            "provider": "bailian",
+            "model": "qwen3.7-plus",
+            "fallback_provider": "minimax-oai",
+            "fallback_model": "MiniMax-M3",
+            "fallback_chain": [
+                {"provider": "openrouter", "model": "gpt-4o-mini"},
+            ],
+        }
+
+        with patch("agent.auxiliary_client._get_auxiliary_task_config",
+                    return_value=task_config), \
+             patch("agent.auxiliary_client._resolve_fallback_entry",
+                    return_value=(chain_client, "gpt-4o-mini")):
+            client, model, label = _try_configured_fallback_chain(
+                "vision", "bailian", reason="429 rate limit")
+
+        assert client is chain_client
+        assert "openrouter" in label
+        assert "minimax" not in label
+
+    def test_no_chain_no_legacy_returns_none(self):
+        """When neither fallback_chain nor fallback_provider is set, returns (None, None, '')."""
+        from agent.auxiliary_client import _try_configured_fallback_chain
+
+        task_config = {
+            "provider": "bailian",
+            "model": "qwen3.7-plus",
+        }
+
+        with patch("agent.auxiliary_client._get_auxiliary_task_config",
+                    return_value=task_config):
+            client, model, label = _try_configured_fallback_chain(
+                "vision", "bailian", reason="429 rate limit")
+
+        assert client is None
+        assert model is None
+        assert label == ""
+
+    def test_legacy_fields_skip_failed_provider(self):
+        """Legacy fallback_provider matching the failed provider should be skipped."""
+        from agent.auxiliary_client import _try_configured_fallback_chain
+
+        task_config = {
+            "provider": "bailian",
+            "model": "qwen3.7-plus",
+            "fallback_provider": "bailian",
+            "fallback_model": "qwen-turbo",
+        }
+
+        with patch("agent.auxiliary_client._get_auxiliary_task_config",
+                    return_value=task_config):
+            client, model, label = _try_configured_fallback_chain(
+                "vision", "bailian", reason="429 rate limit")
+
+        assert client is None
+        assert label == ""
+
+
 # ---------------------------------------------------------------------------
 # Gate: _resolve_api_key_provider must skip anthropic when not configured
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

When the primary auxiliary provider (e.g. vision) fails, `_try_configured_fallback_chain` only reads the plural `fallback_chain` list key. Users who configure the legacy singular `fallback_provider` / `fallback_model` fields get **silently no fallback** — the vision call fails outright instead of trying the configured fallback provider.

This PR accepts both forms: when `fallback_chain` is absent, a single-entry chain is built from `fallback_provider` / `fallback_model`, mirroring the pattern already used by `get_fallback_chain()` in `hermes_cli/fallback_config.py` for the main agent fallback chain.

## Related Issue

Fixes #50995

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`agent/auxiliary_client.py`**: In `_try_configured_fallback_chain`, when `fallback_chain` is not found or is not a list, check for legacy `fallback_provider` / `fallback_model` fields and construct a single-entry chain from them. Updated docstring to document the dual-form support.
- **`tests/agent/test_auxiliary_client.py`**: Added `TestConfiguredFallbackChainLegacyFields` with 5 tests covering: legacy singular fields build chain, missing model still works, plural chain takes precedence, no fields returns none, and failed provider is skipped.

## How to Test

Reproduce the exact scenario from the issue — legacy singular config:

```python
from unittest.mock import patch, MagicMock
from agent.auxiliary_client import _try_configured_fallback_chain

task_config = {
    "provider": "bailian",
    "model": "qwen3.7-plus",
    "fallback_provider": "minimax-oai",
    "fallback_model": "MiniMax-M3",
}

fake_client = MagicMock()
with patch("agent.auxiliary_client._get_auxiliary_task_config", return_value=task_config), \
     patch("agent.auxiliary_client._resolve_fallback_entry", return_value=(fake_client, "MiniMax-M3")):
    client, model, label = _try_configured_fallback_chain("vision", "bailian", reason="429 rate limit")

print(f"client={client is not None}, model={model}, label={label}")
```

Observed output:
```
client=True, model=MiniMax-M3, label=fallback_chain[0](minimax-oai)
```

Before this fix, the same code returned `client=None, model=None, label=""` because `fallback_chain` (plural list key) was absent and the legacy singular fields were silently ignored.

Run the targeted test class:

```
python -m pytest tests/agent/test_auxiliary_client.py::TestConfiguredFallbackChainLegacyFields -v
```

Observed output:
```
tests/agent/test_auxiliary_client.py::TestConfiguredFallbackChainLegacyFields::test_legacy_singular_fields_build_single_entry_chain PASSED
tests/agent/test_auxiliary_client.py::TestConfiguredFallbackChainLegacyFields::test_legacy_singular_fields_no_model_still_works PASSED
tests/agent/test_auxiliary_client.py::TestConfiguredFallbackChainLegacyFields::test_chain_list_takes_precedence_over_legacy_fields PASSED
tests/agent/test_auxiliary_client.py::TestConfiguredFallbackChainLegacyFields::test_no_chain_no_legacy_returns_none PASSED
tests/agent/test_auxiliary_client.py::TestConfiguredFallbackChainLegacyFields::test_legacy_fields_skip_failed_provider PASSED
5 passed in 0.44s
```

Run existing fallback layering tests to verify no regression:

```
python -m pytest tests/agent/test_auxiliary_client.py::TestAuxiliaryFallbackLayering tests/agent/test_auxiliary_client.py::TestTryMainAgentModelFallback -v
```

Observed result: All 8 existing tests passed, no regression.

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.5
