### PR TITLE
fix(gateway): block launchd restart helper loops

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -57,6 +57,17 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
     # gateway identifier prevents blocking unrelated hermes services (e.g.
     # `launchctl unload ai.hermes.update-checker.plist`).
     r"|(?:launchctl\s+(?:kickstart|unload|load|stop|restart)\b[^\n]*\bhermes[.\-]?gateway)"
+    # Branch B2: launchctl bootstrap/submit of the gateway label or a
+    # restart-helper job. Registering a one-shot "restart the gateway"
+    # helper from inside the gateway is the loop-seeding move the other
+    # branches exist to block — the helper survives the gateway's death and
+    # kicks it over again (observed as self-perpetuating restart loops).
+    r"|(?:launchctl\s+(?:bootstrap|submit)\b[^\n]*(?:\bai\.hermes\.gateway|\brestart-(?:default|hermes)-gateway))"
+    # Branch B3: launchctl bootout of the PRIMARY gateway label/plist.
+    # Deliberately anchored so `ai.hermes.gateway.delayed-restart.<ts>`
+    # does NOT match: removing a runaway one-shot restart helper is the
+    # safe recovery path from chat while the gateway itself stays alive.
+    r"|(?:launchctl\s+bootout\b[^\n]*\bai\.hermes\.gateway(?:\.plist)?(?:\s|$))"
     # Branch C: systemctl ops on a hermes-gateway unit.
     r"|(?:systemctl\s+(?:-\S+\s+)*(?:restart|stop|start)\b[^\n]*\bhermes[.\-]?gateway)"
     # Branch D: pkill / kill targeting the hermes gateway process. Both

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -39,6 +39,10 @@ class TestGatewayLifecyclePattern:
         "launchctl kickstart gui/501/ai.hermes.gateway",
         "launchctl unload ~/Library/LaunchAgents/ai.hermes.gateway.plist",
         "launchctl stop ai.hermes.gateway",
+        "launchctl bootstrap gui/501 ~/Library/LaunchAgents/ai.hermes.gateway.restart-once.plist",
+        "launchctl submit -l ai.hermes.gateway.delayed-restart.20260622213211 -- /bin/sh -lc restart-default-gateway-once.sh",
+        "launchctl bootout gui/501/ai.hermes.gateway",
+        "launchctl bootout ~/Library/LaunchAgents/ai.hermes.gateway.plist",
         "systemctl restart hermes-gateway",
         "systemctl stop hermes-gateway.service",
         "systemctl start hermes-gateway",
@@ -84,6 +88,9 @@ class TestGatewayLifecyclePattern:
         "Monitor the gateway and tell me if a restart is recommended",
         "research how the OpenAI API gateway handles restart after rate limiting",
         "compare AWS API Gateway vs Cloudflare on restart latency",
+        # Removing a runaway one-shot restart helper is the safe recovery path
+        # from Discord/Telegram when the gateway itself is still alive.
+        "launchctl bootout gui/501/ai.hermes.gateway.delayed-restart.20260622213211",
     ])
     def test_safe_commands(self, text):
         assert not _contains_gateway_lifecycle_command(text), f"Should NOT match: {text!r}"
@@ -316,6 +323,9 @@ class TestTerminalToolGatewayLifecycleGuard:
         "systemctl stop hermes-gateway.service",
         "hermes gateway restart",
         "launchctl kickstart gui/501/ai.hermes.gateway",
+        "launchctl bootstrap gui/501 ~/Library/LaunchAgents/ai.hermes.gateway.restart-once.plist",
+        "launchctl submit -l ai.hermes.gateway.delayed-restart.20260622213211 -- /bin/sh -lc restart-default-gateway-once.sh",
+        "launchctl bootout gui/501/ai.hermes.gateway",
         "pkill -f hermes.*gateway",
     ])
     def test_blocks_lifecycle_commands_inside_gateway(self, monkeypatch, cmd):


### PR DESCRIPTION
## Summary

- Block launchd bootstrap and submit restart-helper workarounds from in-gateway lifecycle guards.
- Block primary gateway bootout while preserving safe removal of delayed-restart helper labels.
- Prevent the helper loop that repeatedly killed Discord and Telegram gateways.

## Verification

- tests/hermes_cli/test_gateway_restart_loop.py passed with 73 tests.
- Ruff and git diff check passed.
- The production patch rebased onto current main without alteration.
