### PR TITLE
fix(fallback): honour reasoning effort overrides

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1197,6 +1197,21 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             fb_api_mode = "bedrock_converse"
 
         old_model = agent.model
+        fallback_reasoning = None
+        fallback_reasoning_effort = str(
+            fb.get("reasoning_effort") or fb.get("reasoning") or fb.get("effort") or ""
+        ).strip()
+        if fallback_reasoning_effort:
+            from hermes_constants import parse_reasoning_effort
+
+            fallback_reasoning = parse_reasoning_effort(fallback_reasoning_effort)
+            if fallback_reasoning is None:
+                logger.warning(
+                    "Ignoring unknown fallback reasoning_effort %r for %s/%s",
+                    fallback_reasoning_effort,
+                    fb_provider,
+                    fb_model,
+                )
 
         # Clear the per-config context_length override so the fallback
         # model's actual context window is resolved instead of inheriting
@@ -1206,6 +1221,8 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         agent.provider = fb_provider
         agent.base_url = fb_base_url
         agent.api_mode = fb_api_mode
+        if fallback_reasoning is not None:
+            agent.reasoning_config = fallback_reasoning
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
         agent._fallback_activated = True

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5693,6 +5693,27 @@ class TestFallbackAnthropicProvider:
         assert agent.api_mode == "chat_completions"
         assert agent.client is mock_client
 
+    def test_fallback_entry_can_override_reasoning_effort(self, agent):
+        agent.reasoning_config = {"enabled": True, "effort": "high"}
+        agent._fallback_activated = False
+        agent._fallback_model = {
+            "provider": "openrouter",
+            "model": "anthropic/claude-sonnet-4",
+            "reasoning_effort": "medium",
+        }
+        agent._fallback_chain = [agent._fallback_model]
+        agent._fallback_index = 0
+
+        mock_client = MagicMock()
+        mock_client.base_url = "https://openrouter.ai/api/v1"
+        mock_client.api_key = "sk-or-test"
+
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
+            result = agent._try_activate_fallback()
+
+        assert result is True
+        assert agent.reasoning_config == {"enabled": True, "effort": "medium"}
+
 
 def test_aiagent_uses_copilot_acp_client():
     with (


### PR DESCRIPTION
## Summary
- allow fallback provider entries to override reasoning effort
- parse `reasoning_effort`, `reasoning`, or `effort` from the selected fallback config
- add regression coverage for preserving fallback-specific reasoning settings

## Verification
- `uv run pytest tests/run_agent/test_run_agent.py::TestFallbackAnthropicProvider -q`