### PR TITLE
fix(gateway): compact Codex startup timeout errors

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2800,6 +2800,13 @@ def _normalize_empty_agent_response(
                 "Use /compact to compress the conversation, or "
                 "/reset to start fresh."
             )
+        if _is_codex_app_server_startup_timeout(error_detail):
+            # Positively identified thread/start startup timeout: the raw
+            # error is a multi-line transport dump that reads like a crash.
+            # Every OTHER failure keeps the transport's diagnostic text
+            # (including its redacted stderr tail) — that contract is
+            # deliberate, see _format_error_with_stderr.
+            return f"⚠️ {_compact_codex_startup_timeout_error()}"
         return (
             f"The request failed: {str(error_detail)[:300]}\n"
             "Try again or use /reset to start a fresh session."
@@ -2826,6 +2833,8 @@ def _normalize_empty_agent_response(
             return ""
         if agent_result.get("partial"):
             err = agent_result.get("error", "processing incomplete")
+            if _is_codex_app_server_startup_timeout(err):
+                return f"⚠️ {_compact_codex_startup_timeout_error()}"
             return f"⚠️ Processing stopped: {str(err)[:200]}. Try again."
         return (
             "⚠️ Processing completed but no response was generated. "
@@ -2873,6 +2882,28 @@ def _is_gateway_hidden_reasoning_incomplete_turn(agent_result: dict) -> bool:
         return False
     final_response = str(agent_result.get("final_response") or "").strip()
     return not final_response or final_response == error_text
+
+
+def _is_codex_app_server_startup_timeout(error_detail: object) -> bool:
+    """Positively identify a Codex app-server thread/start startup timeout.
+
+    All three markers are required so ordinary Codex failures (which carry a
+    deliberately retained diagnostic stderr tail) are never compacted.
+    """
+    text = str(error_detail or "").lower()
+    return (
+        "codex app-server startup failed" in text
+        and "thread/start" in text
+        and "timed out" in text
+    )
+
+
+def _compact_codex_startup_timeout_error() -> str:
+    """One-line user message for the identified startup-timeout case."""
+    return (
+        "Codex app-server startup timed out while starting a thread. "
+        "Try again; if it repeats, switch back with /codex-runtime auto."
+    )
 
 
 def _should_clear_resume_pending_after_turn(agent_result: dict) -> bool:

--- a/tests/test_lazy_session_regressions.py
+++ b/tests/test_lazy_session_regressions.py
@@ -347,6 +347,81 @@ class TestGatewaySurfacesNullResponse:
         assert response != "", "Null response with api_calls>0 must be surfaced"
         assert "nonexistent_tool" in response
 
+    # Runtime-produced error shape for a Codex app-server thread/start
+    # startup timeout (see _format_error_with_stderr): base error + the
+    # deliberately retained redacted stderr tail.
+    _CODEX_STARTUP_TIMEOUT_ERROR = (
+        "codex app-server startup failed: codex method 'thread/start' timed "
+        "out after 45s\n"
+        "codex stderr (last 3 lines):\n"
+        "WARN codex_core::config: profile fallback engaged\n"
+        "ERROR codex_app_server: handshake stalled\n"
+        "thread 'main' waiting on thread/start"
+    )
+
+    def test_failed_codex_startup_timeout_is_compacted(self):
+        """A positively identified thread/start timeout gets the one-liner,
+        not the multi-line transport dump."""
+        from gateway.run import _normalize_empty_agent_response
+
+        agent_result = {
+            "final_response": None,
+            "api_calls": 0,
+            "failed": True,
+            "partial": False,
+            "interrupted": False,
+            "error": self._CODEX_STARTUP_TIMEOUT_ERROR,
+        }
+
+        response = _normalize_empty_agent_response(agent_result, "", history_len=10)
+
+        assert "startup timed out while starting a thread" in response
+        assert "/codex-runtime auto" in response
+        assert "codex stderr" not in response
+
+    def test_partial_codex_startup_timeout_is_compacted(self):
+        """Same timeout surfacing through the partial path (api_calls > 0)."""
+        from gateway.run import _normalize_empty_agent_response
+
+        agent_result = {
+            "final_response": None,
+            "api_calls": 2,
+            "failed": False,
+            "partial": True,
+            "interrupted": False,
+            "error": self._CODEX_STARTUP_TIMEOUT_ERROR,
+        }
+
+        response = _normalize_empty_agent_response(agent_result, "", history_len=10)
+
+        assert "startup timed out while starting a thread" in response
+        assert "codex stderr" not in response
+
+    def test_other_codex_failures_keep_their_stderr_diagnostics(self):
+        """Generic Codex failures keep the transport's diagnostic text —
+        compaction is limited to the identified startup-timeout case."""
+        from gateway.run import _normalize_empty_agent_response
+
+        agent_result = {
+            "final_response": None,
+            "api_calls": 1,
+            "failed": True,
+            "partial": False,
+            "interrupted": False,
+            "error": (
+                "codex turn failed: Internal error\n"
+                "codex stderr (last 2 lines):\n"
+                "ERROR codex_core::auth: credential refresh rejected"
+            ),
+        }
+
+        response = _normalize_empty_agent_response(agent_result, "", history_len=10)
+
+        assert "The request failed:" in response
+        assert "codex stderr" in response
+        assert "credential refresh rejected" in response
+        assert "startup timed out while starting a thread" not in response
+
     def test_interrupted_response_stays_empty(self):
         """Interrupted agent → response stays empty (platform handles UX)."""
         from gateway.run import _normalize_empty_agent_response


### PR DESCRIPTION
## Summary

- Compact only the positively identified Codex app-server thread/start startup timeout.
- Require all three startup-timeout markers before compaction.
- Apply the same handling to failed results and runtime-produced partial results.
- Preserve the transport diagnostic text, including the redacted stderr tail, for every other Codex failure.

## Verification

- tests/test_lazy_session_regressions.py passed with 21 tests.
- Coverage pins both failed and partial result shapes.
- Coverage proves non-timeout stderr diagnostics remain visible.
- Ruff and git diff check passed.
