### PR TITLE
fix(gateway): prevent duplicate chunks when send() splits a draft-streamed final reply

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -2224,6 +2224,13 @@ class GatewayStreamConsumer:
                         # Record this (and any continuation fragments from an
                         # oversized first send) for fresh-final cleanup.
                         self._track_preview_ids_from_result(result)
+                        # When send() split content across multiple 4096-char
+                        # chunks (legacy path), treat it like an edit overflow:
+                        # the content was fully delivered so the got_done block
+                        # must not fire a second finalize edit (which would
+                        # re-split into a duplicate chunk).
+                        if getattr(result, "continuation_message_ids", None):
+                            self._last_edit_overflowed = True
                     else:
                         self._edit_supported = False
                     self._already_sent = True

--- a/gateway/stream_consumer_transport.py
+++ b/gateway/stream_consumer_transport.py
@@ -428,6 +428,13 @@ class StreamTransportMixin:
         if result.message_id:
             self._adopt_message_id(result.message_id)
             self._track_preview_ids_from_result(result)
+            # When send() split content across multiple 4096-char
+            # chunks (legacy path), treat it like an edit overflow:
+            # the content was fully delivered so the got_done block
+            # must not fire a second finalize edit (which would
+            # re-split into a duplicate chunk).
+            if getattr(result, "continuation_message_ids", None):
+                self._last_edit_overflowed = True
         else:
             # No editable id: fallback mode + sentinel so we don't re-enter first-send.
             self._enter_fallback_mode(self._visible_prefix())

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3363,6 +3363,7 @@ class TelegramAdapter(BasePlatformAdapter):
             await self._retrigger_typing(chat_id, metadata)
             return SendResult(
                 success=True, message_id=message_ids[0] if message_ids else None,
+                continuation_message_ids=tuple(message_ids[1:]) if len(message_ids) > 1 else (),
                 raw_response={
                     "message_ids": message_ids, "requested_thread_id": requested_thread_id, "thread_fallback": used_thread_fallback})
         except Exception as e:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4609,13 +4609,14 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(
                 success=True,
                 message_id=message_ids[0] if message_ids else None,
+                continuation_message_ids=tuple(message_ids[1:]) if len(message_ids) > 1 else (),
                 raw_response={
                     "message_ids": message_ids,
                     "requested_thread_id": requested_thread_id,
                     "thread_fallback": used_thread_fallback,
                 },
             )
-            
+
         except Exception as e:
             safe_error = _redact_telegram_error_text(e)
             logger.error("[%s] Failed to send Telegram message: %s", self.name, safe_error)

--- a/tests/gateway/test_stream_consumer_draft.py
+++ b/tests/gateway/test_stream_consumer_draft.py
@@ -141,6 +141,77 @@ class TestDraftStreamingHappyPath:
         assert "expect_edits" not in final_metadata
 
     @pytest.mark.asyncio
+    async def test_overflow_split_on_first_send_does_not_trigger_redundant_finalize_edit(self):
+        """Regression (#51010): in draft-streaming mode, _message_id stays
+        None throughout streaming. At got_done, the run loop's own
+        should_edit tick (line ~751, finalize=(got_done or got_segment_break))
+        reaches _send_or_edit's "First message" branch first and calls
+        adapter.send() with the full reply.
+
+        The text here is deliberately short — well under the consumer's own
+        pre-split threshold (gateway/stream_consumer.py's "Split overflow"
+        branch, which pre-chunks anything over ~4000 chars *before* this
+        code is ever reached, and is a separate mechanism from the one this
+        test targets). What's being simulated is the *adapter's own*
+        internal decision to split (e.g. Telegram's legacy 4096-char path),
+        signalled purely through the mocked continuation_message_ids on the
+        SendResult — real length is irrelevant to the bug.
+
+        Once send() reports continuation_message_ids, the very next line in
+        the got_done block (the "elif current_update_visible and (...
+        _last_edit_overflowed)" gate) must recognize the reply as fully
+        delivered and must NOT fall through to its "elif self._message_id"
+        branch, which would call _send_or_edit(finalize=True) a second time
+        — and since _message_id is now set, that second call takes the EDIT
+        branch, calling adapter.edit_message(finalize=True) and re-splitting
+        the same content into a duplicate chunk on screen.
+
+        Verified by temporarily disabling the fix locally: without it, this
+        exact scenario produces adapter.edit_message being awaited once
+        (the redundant call); with the fix, zero.
+        """
+        adapter = _make_draft_capable_adapter()
+        adapter.REQUIRES_EDIT_FINALIZE = True
+        adapter.send = AsyncMock(return_value=SimpleNamespace(
+            success=True, message_id="msg_1", continuation_message_ids=("msg_2",),
+        ))
+        cfg = StreamConsumerConfig(
+            transport="auto", chat_type="dm",
+            edit_interval=0.01, buffer_threshold=5, cursor="",
+        )
+        consumer = GatewayStreamConsumer(adapter, "12345", cfg)
+
+        consumer.on_delta("Hello world!")
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.05)
+        consumer.finish()
+        await task
+
+        adapter.send.assert_awaited_once()
+        adapter.edit_message.assert_not_awaited()
+        assert consumer._last_edit_overflowed is True
+
+    @pytest.mark.asyncio
+    async def test_group_chat_skips_draft_path(self):
+        adapter = _make_draft_capable_adapter()
+        cfg = StreamConsumerConfig(
+            transport="auto", chat_type="group",
+            edit_interval=0.01, buffer_threshold=5, cursor="",
+        )
+        consumer = GatewayStreamConsumer(adapter, "67890", cfg)
+
+        consumer.on_delta("Group message")
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.05)
+        consumer.finish()
+        await task
+
+        # Group chats skip drafts entirely — no send_draft calls at all.
+        assert adapter.draft_calls == []
+        # Edit-based path delivered via send (first message).
+        adapter.send.assert_awaited()
+
+    @pytest.mark.asyncio
     async def test_stream_is_message_preserves_cumulative_text_across_tool_boundaries(self):
         """Slack native streams accept cumulative frames. A tool boundary must
         not clear the consumer accumulator, otherwise every next segment is a

--- a/tests/gateway/test_stream_consumer_draft.py
+++ b/tests/gateway/test_stream_consumer_draft.py
@@ -137,6 +137,77 @@ class TestDraftStreamingHappyPath:
         )
         assert sent_content == "Hello world!"
 
+    @pytest.mark.asyncio
+    async def test_overflow_split_on_first_send_does_not_trigger_redundant_finalize_edit(self):
+        """Regression (#51010): in draft-streaming mode, _message_id stays
+        None throughout streaming. At got_done, the run loop's own
+        should_edit tick (line ~751, finalize=(got_done or got_segment_break))
+        reaches _send_or_edit's "First message" branch first and calls
+        adapter.send() with the full reply.
+
+        The text here is deliberately short — well under the consumer's own
+        pre-split threshold (gateway/stream_consumer.py's "Split overflow"
+        branch, which pre-chunks anything over ~4000 chars *before* this
+        code is ever reached, and is a separate mechanism from the one this
+        test targets). What's being simulated is the *adapter's own*
+        internal decision to split (e.g. Telegram's legacy 4096-char path),
+        signalled purely through the mocked continuation_message_ids on the
+        SendResult — real length is irrelevant to the bug.
+
+        Once send() reports continuation_message_ids, the very next line in
+        the got_done block (the "elif current_update_visible and (...
+        _last_edit_overflowed)" gate) must recognize the reply as fully
+        delivered and must NOT fall through to its "elif self._message_id"
+        branch, which would call _send_or_edit(finalize=True) a second time
+        — and since _message_id is now set, that second call takes the EDIT
+        branch, calling adapter.edit_message(finalize=True) and re-splitting
+        the same content into a duplicate chunk on screen.
+
+        Verified by temporarily disabling the fix locally: without it, this
+        exact scenario produces adapter.edit_message being awaited once
+        (the redundant call); with the fix, zero.
+        """
+        adapter = _make_draft_capable_adapter()
+        adapter.REQUIRES_EDIT_FINALIZE = True
+        adapter.send = AsyncMock(return_value=SimpleNamespace(
+            success=True, message_id="msg_1", continuation_message_ids=("msg_2",),
+        ))
+        cfg = StreamConsumerConfig(
+            transport="auto", chat_type="dm",
+            edit_interval=0.01, buffer_threshold=5, cursor="",
+        )
+        consumer = GatewayStreamConsumer(adapter, "12345", cfg)
+
+        consumer.on_delta("Hello world!")
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.05)
+        consumer.finish()
+        await task
+
+        adapter.send.assert_awaited_once()
+        adapter.edit_message.assert_not_awaited()
+        assert consumer._last_edit_overflowed is True
+
+    @pytest.mark.asyncio
+    async def test_group_chat_skips_draft_path(self):
+        adapter = _make_draft_capable_adapter()
+        cfg = StreamConsumerConfig(
+            transport="auto", chat_type="group",
+            edit_interval=0.01, buffer_threshold=5, cursor="",
+        )
+        consumer = GatewayStreamConsumer(adapter, "67890", cfg)
+
+        consumer.on_delta("Group message")
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.05)
+        consumer.finish()
+        await task
+
+        # Group chats skip drafts entirely — no send_draft calls at all.
+        assert adapter.draft_calls == []
+        # Edit-based path delivered via send (first message).
+        adapter.send.assert_awaited()
+
 
 class TestDraftFallbackOnFailure:
     """When a draft frame fails, the consumer disables drafts for the rest


### PR DESCRIPTION
## Problem

In Telegram DM chats (where native draft streaming is active), long responses
(> 4096 chars) appeared **4–5 times** in the chat — each copy ending with
`(1/2)`, the final one in plain text.

### Root cause

In draft-streaming mode `_message_id` stays `None` throughout streaming
(drafts have no message id). At `got_done` the stream consumer therefore
always reaches the **"First message"** path and calls `adapter.send()` with
the full response text.

When that text exceeds 4096 UTF-16 chars, `send()` takes the legacy split
path, delivers **M1 "(1/2)"** + **M2 "(2/2)"**, but returned only
`message_ids[0]` without populating `continuation_message_ids`. As a result
`_last_edit_overflowed` was never set.

Because `REQUIRES_EDIT_FINALIZE = True` for Telegram and
`_last_edit_overflowed` was `False`, the `got_done` block unconditionally
fired a **second** `_send_or_edit` that tried to edit M1 — triggering
`_edit_overflow_split` and producing a third **M3 "(2/2)"** chunk. With
multiple tool-call iterations this compounded into 4–5 visible copies.

### Relationship to prior fixes

`4ed293b38` (feat: native draft streaming, 2026-05-10) introduced the
condition. The companion commit `bf1f40996` (fix: split-and-deliver oversized
edits) wired `continuation_message_ids` for the **edit** overflow path
(`_edit_overflow_split`) but left the **send()** return without it, creating
the gap closed here.

## Fix

**`plugins/platforms/telegram/adapter.py`** — `send()` now populates
`continuation_message_ids` from any extra chunks the legacy 4096-split path
delivers, symmetric with what `_edit_overflow_split` already does.

**`gateway/stream_consumer.py`** — The "First message" success path detects a
non-empty `continuation_message_ids` and sets `_last_edit_overflowed = True`,
causing the `got_done` condition to recognise full delivery and skip the
redundant second finalize edit.

## Scope

- No behaviour change for non-DM chats (edit path, `_message_id` always set
  during streaming — `_edit_overflow_split` already handled this correctly).
- No behaviour change for responses ≤ 4096 chars (single chunk,
  `continuation_message_ids` stays empty).
- No behaviour change for other platforms (the `getattr` guard is
  backwards-compatible with adapters that pre-date the field).

## Test plan

- [ ] Send a Telegram DM that produces a response > 4096 chars (e.g. ask for
  a detailed explanation of a complex topic). Confirm it arrives as two
  `(1/2)` / `(2/2)` messages **exactly once**, not repeated.
- [ ] Send a short DM response (< 4096 chars). Confirm single message,
  no regression.
- [ ] Group chat with a long response. Confirm no change (edit path unaffected).
- [x] Run existing stream consumer tests: `pytest tests/gateway/test_stream_consumer.py`
- [x] New regression test added (see update below) — `test_overflow_split_on_first_send_does_not_trigger_redundant_finalize_edit`

## Update: added the missing regression test (addresses hermes-sweeper review)

Also rebased onto `origin/main` (663 commits behind); applied cleanly, no conflicts.

sweeper correctly flagged that this PR shipped no regression test — the existing draft-streaming test's mocked `send()` result had no `continuation_message_ids`, so it couldn't have caught this bug. Added one, with `REQUIRES_EDIT_FINALIZE=True` and a final `send()` result carrying `continuation_message_ids`, asserting no redundant `edit_message(finalize=True)` call occurs.

Getting the test right took tracing the actual call path rather than guessing at it: `gateway/stream_consumer.py` has its own independent "Split overflow" pre-chunking (in the main should-edit tick handling, well before `_send_or_edit` is ever reached) that fires for genuinely long accumulated text and has nothing to do with this bug — my first attempt used 5000 characters of text and tripped that unrelated path instead, producing a misleading two-calls-to-`send()` result with no `edit_message` call either way. The actual bug lives entirely in `_send_or_edit`'s "First message" branch and the `got_done` block's redundant-finalize gate around it, so the fix only needs the *mocked* `send()` result to carry `continuation_message_ids` — real text length is irrelevant. Verified by temporarily disabling the fix locally: without it, this exact scenario produces a second `_send_or_edit` call with `_message_id` now set (taking the edit branch, calling `adapter.edit_message(finalize=True)`); with the fix, that call never happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
