### PR TITLE
fix(telegram): recover from stale DM topic sends

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2593,6 +2593,7 @@ class TelegramAdapter(BasePlatformAdapter):
             thread_id = self._metadata_thread_id(metadata)
             requested_thread_id = self._message_thread_id_for_send(thread_id)
             used_thread_fallback = False
+            dm_topic_plain_fallback = False
             
             try:
                 from telegram.error import NetworkError as _NetErr
@@ -2623,30 +2624,40 @@ class TelegramAdapter(BasePlatformAdapter):
                     and self._reply_to_mode == "off"
                     and bool(metadata and metadata.get("telegram_dm_topic_reply_fallback"))
                 )
-                reply_to_source = reply_to or (
-                    str(metadata_reply_to) if private_dm_topic_send and metadata_reply_to is not None else None
-                )
-                if private_dm_topic_send:
-                    should_thread = (
-                        reply_to_source is not None
-                        and self._reply_to_mode != "off"
-                    )
+                if dm_topic_plain_fallback and private_dm_topic_send:
+                    # Telegram can continue surfacing user messages from a
+                    # stale/deleted private DM topic while rejecting bot sends
+                    # with "Message thread not found". Once that happens, keep
+                    # the processed reply deliverable by sending subsequent
+                    # text chunks as plain DM messages instead of looping
+                    # through the same dead topic metadata.
+                    reply_to_id = None
+                    thread_kwargs = {}
                 else:
-                    should_thread = self._should_thread_reply(reply_to_source, i)
-                reply_to_id = int(reply_to_source) if should_thread and reply_to_source else None
-                if private_dm_topic_send and reply_to_id is None and not dm_topic_reply_to_off:
-                    return SendResult(
-                        success=False,
-                        error=self._dm_topic_missing_anchor_error(),
-                        retryable=False,
+                    reply_to_source = reply_to or (
+                        str(metadata_reply_to) if private_dm_topic_send and metadata_reply_to is not None else None
                     )
-                thread_kwargs = self._thread_kwargs_for_send(
-                    chat_id,
-                    thread_id,
-                    metadata,
-                    reply_to_message_id=reply_to_id,
-                    reply_to_mode=self._reply_to_mode,
-                )
+                    if private_dm_topic_send:
+                        should_thread = (
+                            reply_to_source is not None
+                            and self._reply_to_mode != "off"
+                        )
+                    else:
+                        should_thread = self._should_thread_reply(reply_to_source, i)
+                    reply_to_id = int(reply_to_source) if should_thread and reply_to_source else None
+                    if private_dm_topic_send and reply_to_id is None and not dm_topic_reply_to_off:
+                        return SendResult(
+                            success=False,
+                            error=self._dm_topic_missing_anchor_error(),
+                            retryable=False,
+                        )
+                    thread_kwargs = self._thread_kwargs_for_send(
+                        chat_id,
+                        thread_id,
+                        metadata,
+                        reply_to_message_id=reply_to_id,
+                        reply_to_mode=self._reply_to_mode,
+                    )
                 if used_thread_fallback and thread_kwargs.get("message_thread_id") is not None:
                     thread_kwargs = dict(thread_kwargs)
                     thread_kwargs["message_thread_id"] = None
@@ -2690,7 +2701,19 @@ class TelegramAdapter(BasePlatformAdapter):
                         # specific cases instead of blindly retrying.
                         if _BadReq and isinstance(send_err, _BadReq):
                             if self._is_thread_not_found_error(send_err) and effective_thread_id is not None:
-                                if private_dm_topic_send or (metadata and metadata.get("telegram_dm_topic_created_for_send")):
+                                if private_dm_topic_send:
+                                    logger.warning(
+                                        "[%s] Telegram DM topic thread %s not found, retrying as plain DM",
+                                        self.name,
+                                        effective_thread_id,
+                                    )
+                                    dm_topic_plain_fallback = True
+                                    used_thread_fallback = True
+                                    reply_to_id = None
+                                    effective_thread_id = None
+                                    thread_kwargs = {}
+                                    continue
+                                if metadata and metadata.get("telegram_dm_topic_created_for_send"):
                                     return SendResult(
                                         success=False,
                                         error=str(send_err),

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -627,6 +627,44 @@ async def test_send_uses_reply_anchor_when_direct_topic_fallback_metadata_exists
 
 
 @pytest.mark.asyncio
+async def test_send_dm_topic_thread_not_found_retries_plain_dm():
+    """Deleted Hermes DM topics must not black-hole completed text replies."""
+    adapter = _make_adapter()
+    call_log = []
+
+    async def mock_send_message(**kwargs):
+        call_log.append(dict(kwargs))
+        if len(call_log) == 1:
+            raise FakeBadRequest("Message thread not found")
+        return SimpleNamespace(message_id=781)
+
+    adapter._bot = SimpleNamespace(send_message=mock_send_message)
+
+    result = await adapter.send(
+        chat_id="123",
+        content="test message",
+        metadata={
+            "thread_id": "20197",
+            "telegram_dm_topic_reply_fallback": True,
+            "direct_messages_topic_id": "20197",
+            "telegram_reply_to_message_id": "462",
+        },
+    )
+
+    assert result.success is True
+    assert result.message_id == "781"
+    assert result.raw_response["requested_thread_id"] == 20197
+    assert result.raw_response["thread_fallback"] is True
+    assert len(call_log) == 2
+    assert call_log[0]["reply_to_message_id"] == 462
+    assert call_log[0]["message_thread_id"] == 20197
+    assert "direct_messages_topic_id" not in call_log[0]
+    assert call_log[1]["reply_to_message_id"] is None
+    assert "message_thread_id" not in call_log[1]
+    assert "direct_messages_topic_id" not in call_log[1]
+
+
+@pytest.mark.asyncio
 async def test_send_created_private_topic_uses_message_thread_without_anchor():
     """Topics created via createForumTopic are addressable by message_thread_id directly."""
     adapter = _make_adapter()


### PR DESCRIPTION
## Summary
- retry Telegram DM-topic sends as plain DMs when stale topic metadata returns `Message thread not found`
- preserve fail-closed behaviour for created/private topics that must not leak to root DMs
- add regression coverage for stale DM-topic send recovery

## Verification
- `uv run --extra dev pytest tests/gateway/test_telegram_thread_fallback.py -q`