### PR TITLE
fix(honcho): make local memory migration retry-safe

### DIFF
--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -831,12 +831,82 @@ class HonchoSessionManager:
 
         return "\n".join(lines).encode("utf-8")
 
+    _MEMORY_MIGRATION_MARKER = "hermes_memory_files_migrated"
+    _MEMORY_MIGRATION_SOURCE = "local_memory"
+
+    @staticmethod
+    def _metadata_dict(obj: Any) -> dict[str, Any]:
+        """Return a plain metadata dict from a Honcho SDK object."""
+        metadata = {}
+        getter = getattr(obj, "get_metadata", None)
+        if callable(getter):
+            try:
+                metadata = getter() or {}
+            except Exception as e:
+                logger.debug("Honcho metadata read failed: %s", e)
+        if not metadata:
+            metadata = getattr(obj, "metadata", {}) or {}
+        if isinstance(metadata, dict):
+            return dict(metadata)
+        return {}
+
+    def _mark_memory_files_migrated(
+        self,
+        honcho_session: Any,
+        *,
+        reason: str,
+        uploaded_files: list[str] | None = None,
+    ) -> None:
+        """Persist an idempotency marker on the Honcho session metadata."""
+        metadata = self._metadata_dict(honcho_session)
+        metadata[self._MEMORY_MIGRATION_MARKER] = True
+        metadata["hermes_memory_files_migrated_reason"] = reason
+        if uploaded_files is not None:
+            metadata["hermes_memory_files_migrated_files"] = sorted(uploaded_files)
+        setter = getattr(honcho_session, "set_metadata", None)
+        if callable(setter):
+            try:
+                setter(metadata)
+            except Exception as e:
+                logger.debug("Honcho memory migration marker write failed: %s", e)
+
+    def _memory_files_already_migrated(self, honcho_session: Any) -> bool:
+        """Return True if local MEMORY/USER/SOUL files were already uploaded."""
+        metadata = self._metadata_dict(honcho_session)
+        if metadata.get(self._MEMORY_MIGRATION_MARKER):
+            return True
+
+        # Backfill protection for deployments created before the marker existed.
+        # Honcho v3 supports metadata filters on Session.messages(); using the
+        # SDK avoids private SQL and follows the documented Messages primitive.
+        messages = getattr(honcho_session, "messages", None)
+        if callable(messages):
+            try:
+                page = messages(filters={"metadata": {"source": self._MEMORY_MIGRATION_SOURCE}})
+                items = list(getattr(page, "items", []) or [])
+                if any(
+                    (getattr(item, "metadata", {}) or {}).get("source") == self._MEMORY_MIGRATION_SOURCE
+                    for item in items
+                ):
+                    self._mark_memory_files_migrated(
+                        honcho_session,
+                        reason="existing_local_memory_messages",
+                    )
+                    return True
+            except Exception as e:
+                logger.debug("Honcho local memory migration marker probe failed: %s", e)
+
+        return False
+
     def migrate_memory_files(self, session_key: str, memory_dir: str) -> bool:
         """
-        Upload MEMORY.md and USER.md to Honcho as files.
+        Upload MEMORY.md, USER.md, and SOUL.md to Honcho as files once.
 
         Used when Honcho activates on an instance that already has locally
-        consolidated memory. Backwards compatible -- skips if files don't exist.
+        consolidated memory. The upload is idempotent because session.context()
+        can return no recent messages for an existing per-directory session,
+        which otherwise makes Hermes treat every startup as a fresh session and
+        flood Honcho with duplicate <prior_memory_file> messages.
 
         Args:
             session_key: The session key to associate files with.
@@ -861,10 +931,15 @@ class HonchoSessionManager:
             logger.warning("No Honcho session cached for '%s', skipping memory migration", session_key)
             return False
 
+        if self._memory_files_already_migrated(honcho_session):
+            logger.debug("Honcho local memory files already migrated for %s", session_key)
+            return False
+
         user_peer = self._get_or_create_peer(session.user_peer_id)
         assistant_peer = self._get_or_create_peer(session.assistant_peer_id)
 
         uploaded = False
+        uploaded_files: list[str] = []
         files = [
             (
                 "MEMORY.md",
@@ -925,8 +1000,16 @@ class HonchoSessionManager:
                     target_kind,
                 )
                 uploaded = True
+                uploaded_files.append(filename)
             except Exception as e:
                 logger.error("Failed to upload %s to Honcho: %s", filename, e)
+
+        if uploaded:
+            self._mark_memory_files_migrated(
+                honcho_session,
+                reason="uploaded_local_memory_files",
+                uploaded_files=uploaded_files,
+            )
 
         return uploaded
 

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -856,10 +856,18 @@ class HonchoSessionManager:
         *,
         reason: str,
         uploaded_files: list[str] | None = None,
+        complete: bool = True,
     ) -> None:
-        """Persist an idempotency marker on the Honcho session metadata."""
+        """Persist migration state on the Honcho session metadata.
+
+        ``complete=True`` writes the idempotency marker that stops future
+        migration attempts. ``complete=False`` records only which files made
+        it up, so a partially-failed run can retry the missing files on the
+        next startup without re-uploading the ones that succeeded.
+        """
         metadata = self._metadata_dict(honcho_session)
-        metadata[self._MEMORY_MIGRATION_MARKER] = True
+        if complete:
+            metadata[self._MEMORY_MIGRATION_MARKER] = True
         metadata["hermes_memory_files_migrated_reason"] = reason
         if uploaded_files is not None:
             metadata["hermes_memory_files_migrated_files"] = sorted(uploaded_files)
@@ -875,6 +883,14 @@ class HonchoSessionManager:
         metadata = self._metadata_dict(honcho_session)
         if metadata.get(self._MEMORY_MIGRATION_MARKER):
             return True
+
+        # A files list WITHOUT the marker is the partial-failure state: a
+        # previous run uploaded some files and failed on others. Report "not
+        # migrated" so the retry runs — the upload loop skips the recorded
+        # files, and the message-probe backfill below must not misread the
+        # partial run's messages as a completed migration.
+        if metadata.get("hermes_memory_files_migrated_files"):
+            return False
 
         # Backfill protection for deployments created before the marker existed.
         # Honcho v3 supports metadata filters on Session.messages(); using the
@@ -938,8 +954,17 @@ class HonchoSessionManager:
         user_peer = self._get_or_create_peer(session.user_peer_id)
         assistant_peer = self._get_or_create_peer(session.assistant_peer_id)
 
+        # Files a previous partial run already uploaded — skip them so a retry
+        # only sends what is missing (no duplicate <prior_memory_file> floods).
+        previously_uploaded = set(
+            self._metadata_dict(honcho_session).get(
+                "hermes_memory_files_migrated_files"
+            )
+            or []
+        )
         uploaded = False
-        uploaded_files: list[str] = []
+        uploaded_files: list[str] = sorted(previously_uploaded)
+        failed_files: list[str] = []
         files = [
             (
                 "MEMORY.md",
@@ -965,6 +990,8 @@ class HonchoSessionManager:
         ]
 
         for filename, upload_name, description, target_peer, target_kind in files:
+            if filename in previously_uploaded:
+                continue
             filepath = memory_path / filename
             if not filepath.exists():
                 continue
@@ -1003,8 +1030,24 @@ class HonchoSessionManager:
                 uploaded_files.append(filename)
             except Exception as e:
                 logger.error("Failed to upload %s to Honcho: %s", filename, e)
+                failed_files.append(filename)
 
-        if uploaded:
+        if failed_files:
+            # Do NOT write the completion marker: it would permanently skip
+            # the failed files. Record what did make it up so the next
+            # startup retries only the missing ones.
+            if uploaded:
+                self._mark_memory_files_migrated(
+                    honcho_session,
+                    reason="partial_local_memory_upload",
+                    uploaded_files=uploaded_files,
+                    complete=False,
+                )
+            logger.warning(
+                "Honcho memory migration incomplete (failed: %s); retrying on next startup",
+                ", ".join(failed_files),
+            )
+        elif uploaded or previously_uploaded:
             self._mark_memory_files_migrated(
                 honcho_session,
                 reason="uploaded_local_memory_files",

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -923,6 +923,69 @@ class TestToolsModeInitBehavior:
         assert mock_manager_cls.call_args.kwargs["runtime_user_peer_name_alt"] == "union-id"
 
 
+class TestMemoryFileMigrationIdempotency:
+    def _make_manager(self, honcho_session):
+        mgr = HonchoSessionManager()
+        session = HonchoSession(
+            key="test-session",
+            user_peer_id="joel",
+            assistant_peer_id="default",
+            honcho_session_id="test-session",
+        )
+        mgr._cache["test-session"] = session
+        mgr._sessions_cache["test-session"] = honcho_session
+        mgr._peers_cache["joel"] = MagicMock(name="user_peer")
+        mgr._peers_cache["default"] = MagicMock(name="assistant_peer")
+        return mgr
+
+    def test_existing_local_memory_messages_skip_upload_and_set_marker(self, tmp_path):
+        (tmp_path / "MEMORY.md").write_text("durable memory", encoding="utf-8")
+        honcho_session = MagicMock()
+        honcho_session.get_metadata.return_value = {}
+        honcho_session.messages.return_value = SimpleNamespace(
+            items=[SimpleNamespace(metadata={"source": "local_memory", "original_file": "MEMORY.md"})]
+        )
+        mgr = self._make_manager(honcho_session)
+
+        assert mgr.migrate_memory_files("test-session", str(tmp_path)) is False
+
+        honcho_session.upload_file.assert_not_called()
+        honcho_session.set_metadata.assert_called_once()
+        written = honcho_session.set_metadata.call_args.args[0]
+        assert written["hermes_memory_files_migrated"] is True
+        assert written["hermes_memory_files_migrated_reason"] == "existing_local_memory_messages"
+
+    def test_marker_skips_upload_without_scanning_messages(self, tmp_path):
+        (tmp_path / "MEMORY.md").write_text("durable memory", encoding="utf-8")
+        honcho_session = MagicMock()
+        honcho_session.get_metadata.return_value = {"hermes_memory_files_migrated": True}
+        mgr = self._make_manager(honcho_session)
+
+        assert mgr.migrate_memory_files("test-session", str(tmp_path)) is False
+
+        honcho_session.messages.assert_not_called()
+        honcho_session.upload_file.assert_not_called()
+
+    def test_upload_marks_session_after_success(self, tmp_path):
+        (tmp_path / "MEMORY.md").write_text("memory", encoding="utf-8")
+        (tmp_path / "USER.md").write_text("user", encoding="utf-8")
+        (tmp_path / "SOUL.md").write_text("soul", encoding="utf-8")
+        honcho_session = MagicMock()
+        honcho_session.get_metadata.return_value = {"existing": "kept"}
+        honcho_session.messages.return_value = SimpleNamespace(items=[])
+        mgr = self._make_manager(honcho_session)
+
+        assert mgr.migrate_memory_files("test-session", str(tmp_path)) is True
+
+        assert honcho_session.upload_file.call_count == 3
+        honcho_session.set_metadata.assert_called_once()
+        written = honcho_session.set_metadata.call_args.args[0]
+        assert written["existing"] == "kept"
+        assert written["hermes_memory_files_migrated"] is True
+        assert written["hermes_memory_files_migrated_reason"] == "uploaded_local_memory_files"
+        assert written["hermes_memory_files_migrated_files"] == ["MEMORY.md", "SOUL.md", "USER.md"]
+
+
 class TestPerSessionMigrateGuard:
     """Verify migrate_memory_files is skipped under per-session strategy.
 

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -985,6 +985,57 @@ class TestMemoryFileMigrationIdempotency:
         assert written["hermes_memory_files_migrated_reason"] == "uploaded_local_memory_files"
         assert written["hermes_memory_files_migrated_files"] == ["MEMORY.md", "SOUL.md", "USER.md"]
 
+    def test_partial_upload_failure_does_not_set_completion_marker(self, tmp_path):
+        # One failing upload must NOT mark the migration complete — the
+        # completion marker would permanently skip the failed file on every
+        # later startup. Only the files that made it up are recorded.
+        (tmp_path / "MEMORY.md").write_text("memory", encoding="utf-8")
+        (tmp_path / "USER.md").write_text("user", encoding="utf-8")
+        (tmp_path / "SOUL.md").write_text("soul", encoding="utf-8")
+        honcho_session = MagicMock()
+        honcho_session.get_metadata.return_value = {}
+        honcho_session.messages.return_value = SimpleNamespace(items=[])
+
+        def _upload(file, peer, metadata):
+            if metadata["original_file"] == "SOUL.md":
+                raise RuntimeError("upload exploded")
+
+        honcho_session.upload_file.side_effect = _upload
+        mgr = self._make_manager(honcho_session)
+
+        assert mgr.migrate_memory_files("test-session", str(tmp_path)) is True
+
+        assert honcho_session.upload_file.call_count == 3
+        honcho_session.set_metadata.assert_called_once()
+        written = honcho_session.set_metadata.call_args.args[0]
+        assert "hermes_memory_files_migrated" not in written
+        assert written["hermes_memory_files_migrated_reason"] == "partial_local_memory_upload"
+        assert written["hermes_memory_files_migrated_files"] == ["MEMORY.md", "USER.md"]
+
+    def test_retry_after_partial_failure_uploads_only_missing_files(self, tmp_path):
+        # Second startup after a partial run: the files list without the
+        # completion marker means "retry", and only the missing file is
+        # re-uploaded (no duplicate floods for the ones that succeeded).
+        (tmp_path / "MEMORY.md").write_text("memory", encoding="utf-8")
+        (tmp_path / "USER.md").write_text("user", encoding="utf-8")
+        (tmp_path / "SOUL.md").write_text("soul", encoding="utf-8")
+        honcho_session = MagicMock()
+        honcho_session.get_metadata.return_value = {
+            "hermes_memory_files_migrated_reason": "partial_local_memory_upload",
+            "hermes_memory_files_migrated_files": ["MEMORY.md", "USER.md"],
+        }
+        mgr = self._make_manager(honcho_session)
+
+        assert mgr.migrate_memory_files("test-session", str(tmp_path)) is True
+
+        honcho_session.messages.assert_not_called()
+        assert honcho_session.upload_file.call_count == 1
+        uploaded_meta = honcho_session.upload_file.call_args.kwargs["metadata"]
+        assert uploaded_meta["original_file"] == "SOUL.md"
+        written = honcho_session.set_metadata.call_args.args[0]
+        assert written["hermes_memory_files_migrated"] is True
+        assert written["hermes_memory_files_migrated_files"] == ["MEMORY.md", "SOUL.md", "USER.md"]
+
 
 class TestPerSessionMigrateGuard:
     """Verify migrate_memory_files is skipped under per-session strategy.


### PR DESCRIPTION
## Summary

- Make local MEMORY.md, USER.md, and SOUL.md migration idempotent.
- Record successfully uploaded filenames without marking a partial run complete.
- Retry only files that are still missing.
- Write the completion marker only after every eligible file has uploaded.
- Backfill the marker when existing local-memory messages prove an older migration already happened.

## Current main alignment

Current main now contains the observer-resolution and bounded first-turn wait work from the original branch. Those obsolete hunks were removed during the rebase. This PR now contains only the retry-safe memory migration change.

## Verification

- tests/honcho_plugin/test_session.py passed with 146 tests.
- Coverage includes an upload failure followed by a retry that uploads only the missing file.
- Coverage verifies the final marker contains the union of successful files.
- Ruff and git diff check passed.
