### PR TITLE
fix(codex): reduce app-server startup noise

### DIFF
--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -193,26 +193,36 @@ def _classify_oauth_failure(*parts: str) -> Optional[str]:
 
 
 def _format_stderr_tail_for_user(lines: list[str]) -> str:
-    """Return a compact, chat-safe diagnostic from Codex stderr lines."""
+    """Return a compact, chat-safe diagnostic from Codex stderr lines.
+
+    Callers pass text already run through redact_sensitive_text(force=True),
+    so lines omitted from the chat copy can be echoed to the module logger —
+    that is what keeps the "see agent.log" pointer below honest.
+    """
     cleaned: list[str] = []
-    omitted = 0
+    omitted: list[str] = []
     for raw_line in lines:
         line = _ANSI_ESCAPE_RE.sub("", str(raw_line)).replace("\x00", "").strip()
         if not line:
             continue
         if any(marker in line for marker in _NOISY_STDERR_SUBSTRINGS):
-            omitted += 1
+            omitted.append(line)
             continue
         if len(line) > _STDERR_USER_MAX_LINE_CHARS:
             line = line[: _STDERR_USER_MAX_LINE_CHARS - 15].rstrip() + " [truncated]"
         if len(cleaned) < _STDERR_USER_MAX_LINES:
             cleaned.append(line)
         else:
-            omitted += 1
+            omitted.append(line)
 
     if omitted:
+        logger.info(
+            "codex stderr omitted from chat (%d line(s)):\n%s",
+            len(omitted),
+            "\n".join(omitted),
+        )
         cleaned.append(
-            f"[{omitted} noisy Codex stderr line(s) omitted; see agent.log]"
+            f"[{len(omitted)} noisy Codex stderr line(s) omitted; see agent.log]"
         )
     return "\n".join(cleaned)
 

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import threading
 import time
 from dataclasses import dataclass, field
@@ -47,6 +48,19 @@ logger = logging.getLogger(__name__)
 # wedge watchdog, etc.). Small enough to keep error messages legible, large
 # enough to surface a config/provider/auth diagnostic.
 _STDERR_TAIL_LINES = 12
+_STDERR_USER_MAX_LINES = 4
+_STDERR_USER_MAX_LINE_CHARS = 280
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+_NOISY_STDERR_SUBSTRINGS = (
+    "sqlx::query",
+    "db.statement",
+    "rows_affected",
+    "rows_returned",
+    "VALUES (?,",
+)
+
+
+_THREAD_START_TIMEOUT_SECONDS = 45.0
 
 
 # Permission profile mapping mirrors the docstring in PR proposal:
@@ -178,6 +192,31 @@ def _classify_oauth_failure(*parts: str) -> Optional[str]:
     return None
 
 
+def _format_stderr_tail_for_user(lines: list[str]) -> str:
+    """Return a compact, chat-safe diagnostic from Codex stderr lines."""
+    cleaned: list[str] = []
+    omitted = 0
+    for raw_line in lines:
+        line = _ANSI_ESCAPE_RE.sub("", str(raw_line)).replace("\x00", "").strip()
+        if not line:
+            continue
+        if any(marker in line for marker in _NOISY_STDERR_SUBSTRINGS):
+            omitted += 1
+            continue
+        if len(line) > _STDERR_USER_MAX_LINE_CHARS:
+            line = line[: _STDERR_USER_MAX_LINE_CHARS - 15].rstrip() + " [truncated]"
+        if len(cleaned) < _STDERR_USER_MAX_LINES:
+            cleaned.append(line)
+        else:
+            omitted += 1
+
+    if omitted:
+        cleaned.append(
+            f"[{omitted} noisy Codex stderr line(s) omitted; see agent.log]"
+        )
+    return "\n".join(cleaned)
+
+
 @dataclass
 class _ServerRequestRouting:
     """Default policies for codex-side approval requests when no interactive
@@ -268,7 +307,11 @@ class CodexAppServerSession:
         # Users who want a write-capable profile configure it in their
         # ~/.codex/config.toml the same way they would for any codex usage.
         params: dict[str, Any] = {"cwd": self._cwd}
-        result = self._client.request("thread/start", params, timeout=15)
+        result = self._client.request(
+            "thread/start",
+            params,
+            timeout=_THREAD_START_TIMEOUT_SECONDS,
+        )
         # Cross-fill thread.id/sessionId — different codex versions have
         # serialized this under either key. Mirrors openclaw beta.8's
         # tolerance fix so future codex drops/renames don't KeyError us
@@ -359,6 +402,9 @@ class CodexAppServerSession:
         if not joined.strip():
             return base
         redacted = redact_sensitive_text(joined, force=True)
+        redacted = _format_stderr_tail_for_user(redacted.splitlines())
+        if not redacted.strip():
+            return base
         return f"{base}\ncodex stderr (last {len(tail)} lines):\n{redacted}"
 
     # ---------- per-turn ----------

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -33,6 +33,7 @@ class FakeClient:
         self.notifications_responses: list[dict] = []
         self.responses: list[tuple[Any, dict]] = []
         self.error_responses: list[tuple[Any, int, str]] = []
+        self.request_timeouts: list[tuple[str, float]] = []
         self._initialized = False
         self._closed = False
         self._notifications: list[dict] = []
@@ -47,6 +48,7 @@ class FakeClient:
 
     def request(self, method: str, params: Optional[dict] = None, timeout: float = 30.0):
         self.requests.append((method, params or {}))
+        self.request_timeouts.append((method, timeout))
         if self._request_handler is not None:
             return self._request_handler(method, params or {})
         # Sensible defaults for protocol methods used by the session
@@ -160,6 +162,17 @@ class TestLifecycle:
         method, params = next(r for r in client.requests if r[0] == "thread/start")
         assert params["cwd"] == "/tmp"
         assert "permissions" not in params  # see session.ensure_started() comment
+
+    def test_thread_start_uses_slower_startup_timeout(self):
+        client = FakeClient()
+        s = make_session(client)
+        s.ensure_started()
+        timeouts = [
+            timeout
+            for method, timeout in client.request_timeouts
+            if method == "thread/start"
+        ]
+        assert timeouts == [session_mod._THREAD_START_TIMEOUT_SECONDS]
 
     def test_close_idempotent(self):
         client = FakeClient()
@@ -383,6 +396,29 @@ class TestRunTurn:
         assert "model_provider 'azure_foundry' not configured" in r.error
         assert r.should_retire is True
         assert r.final_text == ""
+
+    def test_startup_failure_filters_noisy_stderr_tail(self):
+        client = FakeClient()
+        client.set_stderr_tail([
+            "\x1b[33mWARN\x1b[0m codex_core_plugins::manifest: ignoring interface.defaultPrompt[0]: prompt must be at most 128 characters",
+            "WARN sqlx::query: slow statement: execution time exceeded alert threshold db.statement=\"INSERT INTO logs VALUES (?, ?)\"",
+            "rows_affected=0 rows_returned=0 elapsed_secs=6.7",
+        ])
+
+        def boom(method, params):
+            if method == "thread/start":
+                raise TimeoutError("codex method 'thread/start' timed out after 15s")
+            return {}
+
+        client._request_handler = boom
+        s = make_session(client)
+        r = s.run_turn("hi", turn_timeout=2.0)
+        assert r.error is not None
+        assert "prompt must be at most 128 characters" in r.error
+        assert "sqlx::query" not in r.error
+        assert "db.statement" not in r.error
+        assert "rows_affected" not in r.error
+        assert "noisy Codex stderr line(s) omitted" in r.error
 
     def test_interrupt_during_turn_issues_turn_interrupt(self):
         client = FakeClient()

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -7,6 +7,7 @@ deadline timeouts. These tests pin all of that without spawning real codex.
 
 from __future__ import annotations
 
+import logging
 import time
 from unittest.mock import patch
 from typing import Any, Optional
@@ -419,6 +420,33 @@ class TestRunTurn:
         assert "db.statement" not in r.error
         assert "rows_affected" not in r.error
         assert "noisy Codex stderr line(s) omitted" in r.error
+
+    def test_omitted_stderr_lines_land_in_the_log(self, caplog):
+        # The chat copy says "see agent.log", so the omitted lines must
+        # actually be logged — they are redacted upstream, never raw.
+        client = FakeClient()
+        client.set_stderr_tail([
+            "auth bridge rejected token",
+            "WARN sqlx::query: slow statement db.statement=\"INSERT INTO logs VALUES (?, ?)\"",
+            "rows_affected=0 rows_returned=0 elapsed_secs=6.7",
+        ])
+
+        def boom(method, params):
+            if method == "thread/start":
+                raise TimeoutError("codex method 'thread/start' timed out")
+            return {}
+
+        client._request_handler = boom
+        s = make_session(client)
+        with caplog.at_level(
+            logging.INFO, logger="agent.transports.codex_app_server_session"
+        ):
+            r = s.run_turn("hi", turn_timeout=2.0)
+        assert r.error is not None
+        assert "sqlx::query" not in r.error
+        assert "codex stderr omitted from chat" in caplog.text
+        assert "sqlx::query" in caplog.text
+        assert "rows_affected=0" in caplog.text
 
     def test_interrupt_during_turn_issues_turn_interrupt(self):
         client = FakeClient()


### PR DESCRIPTION
## Summary

- Trim noisy Codex app-server startup diagnostics before they reach agent-visible errors.
- Preserve the useful startup failure tail.
- Log omitted stderr lines so the agent.log pointer remains truthful.
- Keep configuration and provider failures diagnosable.

## Verification

- tests/agent/transports/test_codex_app_server_session.py passed with 68 tests.
- Ruff and git diff check passed.
- Both reviewed commits rebased onto current main without alteration.
