### PR TITLE
test(send_message): lock per-platform import isolation (no eager Slack import takes down all delivery)

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -3097,3 +3097,128 @@ class TestSendTelegramThreadNotFoundRetry:
         finally:
             if media_path and os.path.exists(media_path):
                 os.unlink(media_path)
+
+
+# ── Per-platform import isolation (regression for the #41112 stale eager
+#    Slack import that took down delivery for ALL targets) ────────────────
+
+
+class TestSlackAdapterImportIsolation:
+    """A missing/broken single platform adapter must degrade only that
+    platform, never the whole ``send_message`` dispatch.
+
+    Regression for the crash where ``_send_to_platform`` eagerly ran
+    ``from gateway.platforms.slack import SlackAdapter`` at function entry
+    for *every* target.  After the Slack adapter moved to a bundled plugin
+    in #41112 (``gateway/platforms/slack.py`` deleted), that unconditional
+    import raised ``ModuleNotFoundError: No module named
+    'gateway.platforms.slack'`` and aborted delivery for Discord, local,
+    and everything else — none of which have anything to do with Slack.
+
+    These assert the *behavior contract* (routing a non-Slack send must not
+    touch the Slack adapter), not a snapshot, so they keep catching a
+    reintroduced eager/top-level import regardless of which adapters happen
+    to live on disk.
+    """
+
+    @staticmethod
+    def _register_fake_discord(send_fn):
+        """Override the ``discord`` registry entry with a stub sender and
+        return a restore callable that puts the original back."""
+        from gateway.platform_registry import platform_registry, PlatformEntry
+
+        original = platform_registry.get("discord")
+        platform_registry.register(
+            PlatformEntry(
+                name="discord",
+                label="Discord",
+                adapter_factory=lambda cfg: None,
+                check_fn=lambda: True,
+                standalone_sender_fn=send_fn,
+            )
+        )
+
+        def _restore():
+            if original is not None:
+                platform_registry.register(original)
+            else:
+                platform_registry.unregister("discord")
+
+        return _restore
+
+    @pytest.mark.asyncio
+    async def test_discord_send_survives_absent_slack_module(self, monkeypatch):
+        """A Discord send completes even when ``gateway.platforms.slack`` is
+        un-importable — the original symptom was that it didn't."""
+        from tools.send_message_tool import _send_to_platform
+
+        # Make the Slack adapter module un-importable (as it is post-#41112):
+        # ``import gateway.platforms.slack`` now raises, exactly like the
+        # production crash that motivated this test.
+        monkeypatch.setitem(sys.modules, "gateway.platforms.slack", None)
+
+        sent = {}
+
+        async def discord_send(pconfig, chat_id, message, *, thread_id=None,
+                               media_files=None):
+            sent["chat_id"] = chat_id
+            sent["message"] = message
+            return {"success": True, "message_id": "disc-1"}
+
+        restore = self._register_fake_discord(discord_send)
+        try:
+            result = await _send_to_platform(
+                Platform.DISCORD,
+                SimpleNamespace(extra={}, token="discord-token"),
+                "123456789",
+                "hello discord",
+            )
+        finally:
+            restore()
+
+        assert result == {"success": True, "message_id": "disc-1"}
+        assert sent["message"] == "hello discord"
+
+    @pytest.mark.asyncio
+    async def test_no_eager_slack_import_when_routing_non_slack_target(self, monkeypatch):
+        """Routing a Discord send must not even *attempt* to import the Slack
+        adapter.  This is the tight invariant: it fails the instant an
+        unconditional/top-level ``gateway.platforms.slack`` import is
+        reintroduced, before it can crash delivery in production."""
+        import importlib.abc
+        from tools.send_message_tool import _send_to_platform
+
+        attempts = []
+
+        class _SlackImportTrap(importlib.abc.MetaPathFinder):
+            def find_spec(self, fullname, path, target=None):
+                if fullname == "gateway.platforms.slack":
+                    attempts.append(fullname)
+                return None  # never actually claims the module
+
+        trap = _SlackImportTrap()
+        sys.meta_path.insert(0, trap)
+
+        async def discord_send(pconfig, chat_id, message, *, thread_id=None,
+                               media_files=None):
+            return {"success": True, "message_id": "disc-2"}
+
+        restore = self._register_fake_discord(discord_send)
+        try:
+            result = await _send_to_platform(
+                Platform.DISCORD,
+                SimpleNamespace(extra={}, token="discord-token"),
+                "123456789",
+                "no slack import please",
+            )
+        finally:
+            restore()
+            sys.meta_path.remove(trap)
+
+        assert result == {"success": True, "message_id": "disc-2"}
+        assert attempts == [], (
+            "routing a Discord send tried to import gateway.platforms.slack "
+            f"({attempts}) — an eager Slack import has been reintroduced and "
+            "will crash delivery for every target on a build where the Slack "
+            "adapter has moved to a plugin"
+        )


### PR DESCRIPTION
## Symptom

The `send_message` agent tool failed for **every** target with:

```
Send failed: No module named 'gateway.platforms.slack'
```

Verified against a Discord thread target — which has nothing to do with
Slack — so `send_message` was dead for all media + text delivery through
the tool on the affected build.

## Root cause

Pre-migration `_send_to_platform` (in `tools/send_message_tool.py`) ran an
**unconditional, eager** import at function entry, executed for *every*
target regardless of platform:

```python
from gateway.platforms.base import BasePlatformAdapter, utf16_len
from gateway.platforms.slack import SlackAdapter   # <-- eager, every send
```

When the Slack adapter moved to a bundled plugin in #41112
(`gateway/platforms/slack.py` deleted, logic now in
`plugins/platforms/slack/adapter.py`), that import line started raising
`ModuleNotFoundError: No module named 'gateway.platforms.slack'` — aborting
the whole dispatch for Discord, local, and every other platform.

A long-running gateway process that had loaded the **pre-migration** module
into memory kept executing the dead import after the on-disk tree moved
past the migration, which is how this surfaced in production (a process
restart clears the in-memory copy).

## Status on `main`

`main` already removed the eager import — `_send_to_platform` no longer
imports the Slack adapter, and Slack formatting/delivery flows through the
plugin's registry `standalone_sender_fn`. A fresh-process Discord send on
`main` returns a clean Discord-specific result and never touches the Slack
module.

**This PR adds the missing regression test** so the invariant can't silently
regress (e.g. if another eager/top-level adapter import is reintroduced
during a future refactor).

## Acceptance (from the report)

- ✅ `send_message` to a Discord target succeeds with `gateway.platforms.slack`
  absent/broken.
- ✅ A missing single platform adapter degrades only that platform, never the
  whole dispatch.

## Tests

Two **behavior-contract** tests (assert invariants, not snapshots) in
`tests/tools/test_send_message_tool.py::TestSlackAdapterImportIsolation`:

1. `test_discord_send_survives_absent_slack_module` — forces
   `gateway.platforms.slack` un-importable via `sys.modules[...] = None`
   and asserts a Discord send still completes.
2. `test_no_eager_slack_import_when_routing_non_slack_target` — installs a
   `sys.meta_path` finder that records any attempt to resolve
   `gateway.platforms.slack`, routes a Discord send, and asserts **zero**
   attempts. This fails the instant an eager/top-level Slack import is
   reintroduced — before it can crash delivery.

**Verified non-vacuous:** temporarily re-adding
`from gateway.platforms.slack import SlackAdapter` to `_send_to_platform`
makes both tests fail with the exact production error
(`ModuleNotFoundError: No module named 'gateway.platforms.slack'`) at the
import line; reverting makes them pass. Full module suite stays green.

Test-only change; no runtime/core surface touched.
