### PR TITLE
feat(mcp): add Krea to the MCP catalog + optional creative skill

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -77,6 +77,12 @@ class TransportSpec:
     args: List[str] = field(default_factory=list)
     url: Optional[str] = None
     version: Optional[str] = None  # informational, pinned
+    # Static headers for http transport, copied verbatim into the
+    # mcp_servers.<name>.headers block. Values may contain ${ENV} placeholders
+    # (resolved at runtime by tools/mcp_tool.py::_interpolate_env_vars), which
+    # is how an api_key auth entry threads a prompted secret into an
+    # Authorization header without ever writing the literal token to config.
+    headers: Dict[str, str] = field(default_factory=dict)
 
 
 @dataclass
@@ -184,17 +190,24 @@ def _parse_manifest(path: Path) -> CatalogEntry:
     args = transport_raw.get("args") or []
     if not isinstance(args, list):
         raise CatalogError(f"{path}: transport.args must be a list")
+    headers_raw = transport_raw.get("headers") or {}
+    if not isinstance(headers_raw, dict):
+        raise CatalogError(f"{path}: transport.headers must be a mapping")
+    headers = {str(k): str(v) for k, v in headers_raw.items()}
     transport = TransportSpec(
         type=t_type,
         command=transport_raw.get("command"),
         args=[str(a) for a in args],
         url=transport_raw.get("url"),
         version=transport_raw.get("version"),
+        headers=headers,
     )
     if t_type == "stdio" and not transport.command:
         raise CatalogError(f"{path}: stdio transport requires 'command'")
     if t_type == "http" and not transport.url:
         raise CatalogError(f"{path}: http transport requires 'url'")
+    if headers and t_type != "http":
+        raise CatalogError(f"{path}: transport.headers is only valid for http transport")
 
     auth_raw = data.get("auth") or {"type": "none"}
     if not isinstance(auth_raw, dict):
@@ -470,6 +483,12 @@ def _build_server_config(
             cfg["args"] = [_expand_install_dir(a, install_dir) for a in t.args]
     elif t.type == "http":
         cfg["url"] = t.url
+        if t.headers:
+            # Copied verbatim — values may carry ${ENV} placeholders that the
+            # runtime resolves per-profile (tools/mcp_tool.py). This is how an
+            # api_key entry sends its prompted secret as an Authorization
+            # header without persisting the literal token in config.yaml.
+            cfg["headers"] = dict(t.headers)
         if entry.auth.type == "oauth":
             cfg["auth"] = "oauth"
     return cfg

--- a/optional-mcps/krea/manifest.yaml
+++ b/optional-mcps/krea/manifest.yaml
@@ -1,0 +1,52 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: krea
+description: Generate images and video through Krea's hosted API — 40+ models (Flux, Imagen, Nano Banana, Veo, Kling, Seedance), plus Topaz upscaling and LoRA styles.
+source: https://docs.krea.ai/developers/mcp
+
+# Krea ships a hosted MCP server over Streamable HTTP. It supports OAuth (billed
+# to a Krea account's compute units) OR a workspace API token (billed to the
+# workspace's separate prepaid API balance). Hermes's MCP client cannot run the
+# interactive OAuth browser flow non-interactively, so this entry uses the API
+# token path: the prompted key is stored in ~/.hermes/.env and threaded into the
+# Authorization header via the ${KREA_API_KEY} placeholder, which the runtime
+# resolves per-profile at connect time. The literal token never lands in
+# config.yaml.
+transport:
+  type: http
+  url: https://api.krea.ai/mcp
+  headers:
+    Authorization: "Bearer ${KREA_API_KEY}"
+
+auth:
+  type: api_key
+  env:
+    - name: KREA_API_KEY
+      prompt: "Krea API token (create at krea.ai/settings/api-tokens — workspace owners/admins only)"
+      required: true
+      secret: true
+
+# Tool selection at install time:
+# Krea's MCP exposes a small, coherent surface — model discovery, schema
+# inspection, generate (image/video), enhance, asset upload, node-app execution,
+# and job polling/cancel. None are destructive to anything but the user's own
+# jobs, so we leave default_enabled unset: the install-time probe lists whatever
+# the server advertises and pre-checks all of it. Users prune from there.
+
+post_install: |
+  Krea's API balance is SEPARATE from any Krea web-app subscription/compute
+  units. Generation calls draw from a prepaid API balance — top up at
+  krea.ai/app/api (workspace owners only). Reads (list_models, get_model_schema,
+  get_job) are free; completed generations are billed per model, and failed or
+  cancelled jobs are not charged.
+
+  Create a token at krea.ai/settings/api-tokens (owners/admins only). If API
+  access isn't enabled on your workspace yet, email support@krea.ai.
+
+  Start a new Hermes session to load the Krea tools. Model IDs match the API
+  docs, e.g. image/krea/krea-2/medium, google/nano-banana-pro, google/veo-3.1.
+
+  Re-run the tool checklist any time with:
+    hermes mcp configure krea

--- a/optional-skills/creative/krea/SKILL.md
+++ b/optional-skills/creative/krea/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: krea
+description: Use when generating or transforming media through Krea's hosted API — text-to-image, image editing, text/image-to-video, upscaling/enhance, and LoRA styles across 40+ models (Flux, Imagen, Nano Banana, Krea 2, Veo, Kling, Seedance, Topaz). Covers both the Krea MCP tools and the krea CLI.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [krea, image-generation, video-generation, upscaling, mcp, media]
+    related_skills: [hermes-media-generation, native-mcp]
+---
+
+# Krea
+
+Generate and transform media through Krea's hosted API: 40+ image/video models
+behind one credential, plus Topaz upscaling and custom LoRA styles. Krea exposes
+two surfaces Hermes can drive — a hosted **MCP server** (first-class tools) and a
+**CLI** (`krea`, headless/agent-friendly). Prefer whichever is already set up.
+
+## When to Use
+
+- Text-to-image, image editing (image-to-image), text/image-to-video
+- Upscaling / enhancement (Topaz standard, bloom, generative — up to 22K)
+- Generating with a specific Krea-hosted model not available via Hermes' own
+  `image_generate` / `video_generate` (e.g. Nano Banana Pro, Veo 3.1, Kling 3.0)
+- Training or using a custom LoRA style; running a Krea node app
+
+Don't use for: a quick one-off image/video where Hermes' built-in
+`image_generate` / `video_generate` already covers it — those need no extra
+credential or balance. Reach for Krea when you specifically want its model
+lineup, upscaling, or styles.
+
+## Surface Check (do this first)
+
+Use whichever is present. Don't fall back to raw HTTP unless neither exists.
+
+**MCP (preferred when available):** look for `mcp_krea_*` tools in your tool list
+(`list_models`, `get_model_schema`, `generate_image`, `generate_video`,
+`enhance_image`, `upload_asset`, `get_job`, `cancel_job`, node-app tools). Install
+from the catalog if absent:
+
+```bash
+hermes mcp install krea     # prompts for the API token, writes the auth header
+# start a new session so the mcp_krea_* tools load
+```
+
+**CLI:** check it's installed and authenticated:
+
+```bash
+command -v krea && krea doctor      # all checks should be ok
+```
+
+Install + auth if needed (the token billing draws the workspace API balance):
+
+```bash
+npm install -g @krea-ai/cli
+krea auth login --api-key "$KREA_API_KEY"   # stored in the OS keyring
+```
+
+## Billing — read before generating
+
+- Krea's **API balance is SEPARATE** from any Krea web-app subscription /
+  compute units. API calls draw a **prepaid USD balance**; an empty balance
+  returns HTTP 402 with a "top up your API balance" message even though auth
+  succeeds. Top up at krea.ai/app/api (workspace owners only).
+- **Reads are free** (`list_models`, `get_model_schema`, `get_job`). Completed
+  generations are billed per model; **failed/cancelled jobs are not charged**.
+- There is **no API endpoint to check balance** — monitor it in-app.
+- A token can only be created by a workspace **owner/admin** at
+  krea.ai/settings/api-tokens.
+
+Confirm with the user before firing paid generations. Rough prices: Flux
+$0.04/img, Nano Banana Pro 4K $0.30/img, Veo 3.1 $0.20/sec, Topaz $0.10/img.
+
+## Generate (MCP)
+
+1. `mcp_krea_list_models` → pick a model `id` (matches API paths, e.g.
+   `google/nano-banana-pro`, `krea/krea-2/medium`, `google/veo-3.1`).
+2. `mcp_krea_get_model_schema` for that id → use ONLY the fields it accepts.
+   Param shapes differ per model (aspect_ratio/resolution vs width/height;
+   creativity sliders for Krea 2; duration/mode for video).
+3. `mcp_krea_generate_image` / `generate_video` / `enhance_image` with the
+   model id + input. Submit **async** (default) — the response carries a
+   `job_id`. The MCP Apps widget auto-polls; only call `mcp_krea_get_job`
+   yourself if there's no widget or the user asks for a text status.
+4. Pull the result URL(s) into chat when complete.
+
+For image/video inputs (editing, i2v, enhance): pass an external URL, a base64
+data URI, or `mcp_krea_upload_asset` a local file (≤75MB) and use the returned
+URL.
+
+## Generate (CLI)
+
+Discover live shapes from the CLI itself — don't trust remembered flags:
+
+```bash
+krea models list --json | jq '.[] | select(.category=="image") | .id'
+krea generate image --help
+krea generate image -p "a cyberpunk cat" -m bfl/flux-1.1-pro --wait -o ./out.png
+krea generate video -m google/veo-3.1 -p "..."     # async; then: krea jobs wait <id>
+```
+
+`--wait` blocks and prints the URL; `-o <path>` implies `--wait` and downloads.
+
+## Common Pitfalls
+
+1. **Empty API balance looks like an auth failure but isn't.** A 402 / "top up"
+   message means auth worked and the balance is $0. Don't re-check the key —
+   top up at krea.ai/app/api. Web-app compute units do NOT cover the API.
+2. **Stale `KREA_API_KEY` env var shadows a good credential.** The CLI reads env
+   before keyring; an exported placeholder/wrong value yields a 401 with
+   `source=env`. `unset KREA_API_KEY` and re-check `krea auth status`.
+3. **Per-model param schemas differ.** Always `get_model_schema` (MCP) or
+   `generate ... --help` (CLI) first. Passing Krea-2 fields to Seedream, or
+   aspect_ratio to a width/height model, fails validation.
+4. **Submit async, don't block.** Default async + widget auto-poll is cheapest
+   and cleanest. Only poll `get_job` manually when there's no widget.
+5. **Generation is OAuth-or-token, billed differently.** MCP OAuth bills compute
+   units; API-token (the catalog install) bills the prepaid API balance. The
+   catalog entry uses the token path.
+
+## Verification Checklist
+
+- [ ] Surface confirmed: `mcp_krea_*` tools present OR `krea doctor` all-ok
+- [ ] Model id taken from a live `list_models`, not memory
+- [ ] Request fields validated against `get_model_schema` / `--help`
+- [ ] User confirmed spend for paid generations; balance is non-zero
+- [ ] Job submitted async; result URL retrieved before reporting done

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -197,6 +197,53 @@ class TestManifestParsing:
         assert get_entry("official/demo") is not None
         assert get_entry("missing") is None
 
+    def test_http_headers_parsed(self, catalog_dir):
+        body = _basic_manifest(
+            transport={
+                "type": "http",
+                "url": "https://mcp.example.com/mcp",
+                "headers": {"Authorization": "Bearer ${DEMO_KEY}"},
+            },
+            auth={
+                "type": "api_key",
+                "env": [{"name": "DEMO_KEY", "prompt": "key", "secret": True}],
+            },
+        )
+        _write_manifest(catalog_dir, "demo", body)
+        from hermes_cli.mcp_catalog import get_entry
+
+        e = get_entry("demo")
+        assert e is not None
+        assert e.transport.headers == {"Authorization": "Bearer ${DEMO_KEY}"}
+
+    def test_http_headers_must_be_mapping(self, catalog_dir):
+        body = _basic_manifest(
+            transport={
+                "type": "http",
+                "url": "https://mcp.example.com/mcp",
+                "headers": ["not", "a", "mapping"],
+            }
+        )
+        _write_manifest(catalog_dir, "demo", body)
+        from hermes_cli.mcp_catalog import list_catalog
+
+        # Invalid manifest is skipped silently by list_catalog().
+        assert list_catalog() == []
+
+    def test_headers_rejected_on_stdio_transport(self, catalog_dir):
+        body = _basic_manifest()
+        body["transport"] = {
+            "type": "stdio",
+            "command": "npx",
+            "args": ["-y", "demo-mcp"],
+            "headers": {"Authorization": "Bearer x"},
+        }
+        _write_manifest(catalog_dir, "demo", body)
+        from hermes_cli.mcp_catalog import list_catalog
+
+        # headers are http-only; stdio + headers is a malformed manifest.
+        assert list_catalog() == []
+
 
 # ---------------------------------------------------------------------------
 # Install flow
@@ -306,6 +353,50 @@ class TestInstall:
         server = load_config()["mcp_servers"]["demo"]
         assert server["url"] == "https://mcp.example.com/sse"
         assert server["auth"] == "oauth"
+
+    def test_install_http_api_key_writes_header_and_saves_secret(
+        self, catalog_dir, monkeypatch
+    ):
+        """End-to-end http + api_key: the prompted secret lands in .env and the
+        manifest's Authorization header is copied into the server config with
+        the ${ENV} placeholder intact (resolved at runtime, never persisted).
+        """
+        body = _basic_manifest(
+            transport={
+                "type": "http",
+                "url": "https://api.example.com/mcp",
+                "headers": {"Authorization": "Bearer ${DEMO_KEY}"},
+            },
+            auth={
+                "type": "api_key",
+                "env": [{"name": "DEMO_KEY", "prompt": "key", "secret": True}],
+            },
+        )
+        _write_manifest(catalog_dir, "demo", body)
+
+        from hermes_cli import mcp_catalog
+
+        monkeypatch.setattr(
+            mcp_catalog, "_prompt_input", lambda *a, **kw: "secret-val"
+        )
+
+        from hermes_cli.mcp_catalog import install_entry
+        from hermes_cli.config import get_env_value, load_config, get_config_path
+
+        install_entry(_entry("demo"), enable=True)
+
+        server = load_config()["mcp_servers"]["demo"]
+        assert server["url"] == "https://api.example.com/mcp"
+        # api_key path must not write an oauth marker.
+        assert "auth" not in server
+        # The secret itself is stored in .env.
+        assert get_env_value("DEMO_KEY") == "secret-val"
+        # On DISK the header keeps the ${ENV} placeholder — the literal token is
+        # never persisted to config.yaml. (load_config() expands ${VAR} in
+        # memory on read, so this check reads the raw file.)
+        raw = get_config_path().read_text()
+        assert "Bearer ${DEMO_KEY}" in raw
+        assert "secret-val" not in raw
 
     def test_install_required_env_missing_raises(self, catalog_dir, monkeypatch):
         body = _basic_manifest(

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -154,6 +154,32 @@ Note this is distinct from `${INSTALL_DIR}` in catalog manifests, which is
 substituted at install-time with the path the catalog cloned the entry's
 repo into.
 
+### HTTP catalog entries with a static API token
+
+A catalog entry whose server authenticates with a static bearer token (rather
+than OAuth) declares `auth: api_key` to prompt for the secret at install time,
+and a `transport.headers` block to send it:
+
+```yaml
+transport:
+  type: http
+  url: https://api.example.com/mcp
+  headers:
+    Authorization: "Bearer ${EXAMPLE_API_KEY}"
+auth:
+  type: api_key
+  env:
+    - name: EXAMPLE_API_KEY
+      prompt: "Example API token"
+      secret: true
+```
+
+At install the prompted token is written to `~/.hermes/.env` and the header is
+copied into `mcp_servers.<name>.headers` **with the `${ENV}` placeholder
+intact** — the literal token is never persisted to `config.yaml`; it's resolved
+per-profile at connect time. `transport.headers` is only valid for `http`
+transport.
+
 ### Updating tool selection later
 
 ```bash


### PR DESCRIPTION
## Summary

Adds **Krea** ([krea.ai](https://krea.ai)) to Hermes as a one-click MCP catalog entry plus an optional creative skill. Users get access to Krea's 40+ image/video models (Flux, Imagen, Nano Banana, Krea 2, Veo, Kling, Seedance), Topaz upscaling, and custom LoRA styles — one credential, MCP-native.

```bash
hermes mcp install krea     # prompts for the API token, wires the auth header
# new session → mcp_krea_* tools (list_models, generate_image/video, enhance_image, get_job, …)
```

## Why a small core change rides along

Krea's hosted MCP server speaks Streamable HTTP and authenticates with **either** OAuth (billed to compute units) **or** a workspace API token (billed to the separate prepaid API balance). A catalog install can't run the interactive OAuth browser flow, so this entry uses the **API-token path** — which surfaced a real gap:

The catalog could prompt for an `api_key` and save it to `.env`, but had **no way to thread it into an `Authorization` header for an http-transport server**. The existing entries never exercised this combination:

| entry | transport | auth |
|-------|-----------|------|
| linear | http | oauth |
| n8n | stdio | api_key (secret flows in via subprocess `env`) |
| unreal-engine | http | none |
| **krea (this PR)** | **http** | **api_key** ← first of its kind |

So `http + api_key` was dead on arrival. Krea is the concrete consumer that motivates the fix (not speculative infra — it ships in this same PR).

## Changes

- **`mcp_catalog.py`** — add `transport.headers` to the manifest schema. Parsed, validated (must be a mapping; http-only), and copied verbatim into `mcp_servers.<name>.headers`. Values keep their `${ENV}` placeholders, which the runtime **already** resolves per-profile (`tools/mcp_tool.py::_interpolate_env_vars`). Net effect: the literal token is written to `~/.hermes/.env`, **never** to `config.yaml`.
- **`optional-mcps/krea/manifest.yaml`** — `http + api_key` entry sending `Authorization: Bearer ${KREA_API_KEY}`.
- **`optional-skills/creative/krea/SKILL.md`** — Hermes-authored skill covering both the MCP tools and the `krea` CLI as alternative surfaces, the API-balance-vs-compute-units gotcha, per-model schema discovery, and async job polling. (The CLI is documented as optional, not bundled as an install step.)
- **tests** — parse/validate the header field, reject headers on stdio transport, and an end-to-end `http + api_key` install asserting the header lands with the `${ENV}` placeholder intact and **no literal token hits `config.yaml` on disk**.
- **docs** — `website/docs/user-guide/features/mcp.md` documents `transport.headers` for `http + api_key` catalog entries.

## Testing

```
tests/hermes_cli/test_mcp_catalog.py ......................................... 39 passed
hermes_cli MCP suite (-k "mcp or catalog") ............................. 286 passed
```

- New: `test_http_headers_parsed`, `test_http_headers_must_be_mapping`, `test_headers_rejected_on_stdio_transport`, `test_install_http_api_key_writes_header_and_saves_secret`.
- The existing `TestShippedCatalog::test_all_shipped_manifests_parse` contract test validates the new Krea manifest automatically.

## Notes

- The skill lives in `optional-skills/` (niche paid-service integration with a heavyweight dependency = API key + prepaid balance), matching the optional-skills policy.
- No new core model tools — capability arrives via the catalog (MCP) + a skill, per the footprint ladder.
- `transport.headers` is a general capability; it's documented and tested independent of Krea, so future http+api_key catalog entries reuse it.
