### PR TITLE
feat(cli): add automation health command

### DIFF
--- a/hermes_cli/_early_recovery.py
+++ b/hermes_cli/_early_recovery.py
@@ -160,6 +160,50 @@ def _probe_broken_packages() -> list[str]:
     return broken
 
 
+def _emit_health_dependency_failure(args: list[str], broken: list[str]) -> None:
+    """Exit through the health contract before importing broken dependencies."""
+    profile = os.environ.get("HERMES_PROFILE", "default")
+    for index, argument in enumerate(args):
+        if argument == "--profile" and index + 1 < len(args):
+            profile = args[index + 1]
+        elif argument.startswith("--profile="):
+            profile = argument.split("=", 1)[1]
+
+    package = sys.modules.get("hermes_cli")
+    version = str(getattr(package, "__version__", "unknown"))
+    home = os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))
+    detail = f"core runtime dependencies unavailable: {', '.join(broken)}"
+    result = {
+        "schema_version": 1,
+        "status": "critical",
+        "exit_code": 2,
+        "profile": profile,
+        "hermes_home": home,
+        "hermes_version": version,
+        "checks": [
+            {
+                "id": "runtime_dependencies",
+                "subsystem": "runtime dependencies",
+                "status": "critical",
+                "detail": detail,
+                "action": "run: hermes update",
+            }
+        ],
+    }
+    if "--json" in args:
+        import json
+
+        print(json.dumps(result, sort_keys=True))
+    else:
+        print()
+        print("Hermes Health")
+        print("Status: critical (exit 2)")
+        print(f"Profile: {profile}")
+        print(f"CRITICAL runtime dependencies: {detail}")
+        print("Action: run: hermes update")
+    raise SystemExit(2)
+
+
 def _run_repair_install(specs: list[str], project_root: Path) -> bool:
     """ensurepip + ``pip install --force-reinstall`` the given specs.
 
@@ -209,8 +253,11 @@ def recover_if_needed(
     """
     try:
         args = sys.argv[1:] if argv is None else argv
-        # Health must report interrupted recovery, not mutate the venv with pip.
+        # Health must report broken dependencies, not mutate the venv with pip.
         if early_cli_subcommand(args) == "health":
+            broken = _probe_broken_packages()
+            if broken:
+                _emit_health_dependency_failure(args, broken)
             return
         # Same deliberately-loose match as main(): the real update flow writes
         # and clears its own markers — a recovery install must not race it.

--- a/hermes_cli/_early_recovery.py
+++ b/hermes_cli/_early_recovery.py
@@ -162,16 +162,49 @@ def _probe_broken_packages() -> list[str]:
 
 def _emit_health_dependency_failure(args: list[str], broken: list[str]) -> None:
     """Exit through the health contract before importing broken dependencies."""
-    profile = os.environ.get("HERMES_PROFILE", "default")
+    explicit_profile = None
     for index, argument in enumerate(args):
-        if argument == "--profile" and index + 1 < len(args):
-            profile = args[index + 1]
+        if argument in {"-p", "--profile"} and index + 1 < len(args):
+            explicit_profile = args[index + 1]
         elif argument.startswith("--profile="):
-            profile = argument.split("=", 1)[1]
+            explicit_profile = argument.split("=", 1)[1]
+
+    if sys.platform == "win32":
+        local_appdata = os.environ.get("LOCALAPPDATA", "").strip()
+        root = Path(local_appdata) if local_appdata else Path.home() / "AppData" / "Local"
+        root /= "hermes"
+    else:
+        root = Path.home() / ".hermes"
+
+    inherited_home = os.environ.get("HERMES_HOME", "").strip()
+    if inherited_home:
+        inherited_path = Path(inherited_home)
+        root = (
+            inherited_path.parent.parent
+            if inherited_path.parent.name == "profiles"
+            else inherited_path
+        )
+
+    profile = explicit_profile or os.environ.get("HERMES_PROFILE", "").strip()
+    if not profile and inherited_home and Path(inherited_home).parent.name == "profiles":
+        profile = Path(inherited_home).name
+    if not profile and not os.environ.get("HERMES_S6_SUPERVISED_CHILD"):
+        try:
+            sticky = (root / "active_profile").read_text(encoding="utf-8").strip()
+            if sticky and sticky != "default":
+                profile = sticky
+        except (OSError, UnicodeError):
+            pass
+    profile = profile or "default"
+
+    if explicit_profile or not inherited_home or Path(inherited_home).parent.name != "profiles":
+        home_path = root if profile == "default" else root / "profiles" / profile
+    else:
+        home_path = Path(inherited_home)
 
     package = sys.modules.get("hermes_cli")
     version = str(getattr(package, "__version__", "unknown"))
-    home = os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))
+    home = str(home_path)
     detail = f"core runtime dependencies unavailable: {', '.join(broken)}"
     result = {
         "schema_version": 1,

--- a/hermes_cli/_early_recovery.py
+++ b/hermes_cli/_early_recovery.py
@@ -55,6 +55,27 @@ LAZY_REFRESH_REPAIR_PACKAGES: dict[str, str] = {
     "jwt": "PyJWT",
 }
 
+TOP_LEVEL_VALUE_FLAGS = frozenset({
+    "-p", "--profile", "-z", "--oneshot", "-m", "--model",
+    "--provider", "-t", "--toolsets", "-r", "--resume",
+    "-s", "--skills", "--usage-file", "-c", "--continue",
+})
+
+
+def early_cli_subcommand(argv: list[str]) -> str:
+    """Find the top-level command without importing the full CLI parser."""
+    index = 0
+    while index < len(argv):
+        argument = argv[index]
+        if argument in TOP_LEVEL_VALUE_FLAGS:
+            index += 2
+            continue
+        if argument.startswith("--profile=") or argument.startswith("-"):
+            index += 1
+            continue
+        return argument
+    return ""
+
 
 def _project_root() -> Path:
     return Path(__file__).resolve().parent.parent
@@ -188,6 +209,9 @@ def recover_if_needed(
     """
     try:
         args = sys.argv[1:] if argv is None else argv
+        # Health must report interrupted recovery, not mutate the venv with pip.
+        if early_cli_subcommand(args) == "health":
+            return
         # Same deliberately-loose match as main(): the real update flow writes
         # and clears its own markers — a recovery install must not race it.
         if "update" in args:

--- a/hermes_cli/health.py
+++ b/hermes_cli/health.py
@@ -10,6 +10,7 @@ and structured output without spending model/provider quota.
 from __future__ import annotations
 
 import importlib.util
+import hashlib
 import json
 import shutil
 import sqlite3
@@ -133,6 +134,50 @@ def _check_profile_config(home: Path) -> tuple[HealthRow, dict[str, Any] | None]
     )
 
 
+class _StateDbSnapshotBusy(Exception):
+    """Raised when a live SQLite generation cannot be copied coherently."""
+
+
+def _copy_with_sha256(source: Path, destination: Path) -> str:
+    digest = hashlib.sha256()
+    with source.open("rb") as source_file, destination.open("wb") as destination_file:
+        while chunk := source_file.read(1024 * 1024):
+            destination_file.write(chunk)
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source_file:
+        while chunk := source_file.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _copy_coherent_state_snapshot(db_path: Path, snapshot_path: Path) -> None:
+    """Copy one unchanged DB/WAL generation without opening the live profile."""
+    wal_path = Path(f"{db_path}-wal")
+    snapshot_wal_path = Path(f"{snapshot_path}-wal")
+    for _attempt in range(3):
+        snapshot_path.unlink(missing_ok=True)
+        snapshot_wal_path.unlink(missing_ok=True)
+        try:
+            copied_db_hash = _copy_with_sha256(db_path, snapshot_path)
+            copied_wal_hash = (
+                _copy_with_sha256(wal_path, snapshot_wal_path)
+                if wal_path.exists()
+                else None
+            )
+            source_db_hash = _sha256_file(db_path)
+            source_wal_hash = _sha256_file(wal_path) if wal_path.exists() else None
+        except FileNotFoundError:
+            continue
+        if copied_db_hash == source_db_hash and copied_wal_hash == source_wal_hash:
+            return
+    raise _StateDbSnapshotBusy("state.db changed while the read-only snapshot was copied")
+
+
 def _check_state_db(home: Path) -> HealthRow:
     db_path = home / "state.db"
     if not db_path.exists():
@@ -145,13 +190,10 @@ def _check_state_db(home: Path) -> HealthRow:
         )
     try:
         # mode=ro may still create state.db-shm for WAL databases. Validate a
-        # disposable db+wal snapshot so the profile remains untouched.
+        # coherent disposable db+wal generation so the profile remains untouched.
         with tempfile.TemporaryDirectory(prefix="hermes-health-state-") as temp_dir:
             snapshot_path = Path(temp_dir) / "state.db"
-            shutil.copyfile(db_path, snapshot_path)
-            wal_path = Path(f"{db_path}-wal")
-            if wal_path.exists():
-                shutil.copyfile(wal_path, Path(f"{snapshot_path}-wal"))
+            _copy_coherent_state_snapshot(db_path, snapshot_path)
             conn = sqlite3.connect(snapshot_path, timeout=2)
             try:
                 conn.execute("SELECT name FROM sqlite_schema LIMIT 1").fetchone()
@@ -160,6 +202,14 @@ def _check_state_db(home: Path) -> HealthRow:
                     raise sqlite3.DatabaseError(f"quick_check failed: {quick_check!r}")
             finally:
                 conn.close()
+    except _StateDbSnapshotBusy as exc:
+        return HealthRow(
+            "state_db",
+            "state DB availability",
+            "warning",
+            f"{db_path} is busy: {exc}",
+            "retry health after current database activity settles",
+        )
     except Exception as exc:
         return HealthRow(
             "state_db",

--- a/hermes_cli/health.py
+++ b/hermes_cli/health.py
@@ -87,11 +87,8 @@ def _read_raw_config(config_path: Path) -> tuple[dict[str, Any] | None, HealthRo
         # ``str(MarkedYAMLError)`` includes the offending source line. Never
         # echo it: malformed config may contain credentials and health output
         # is commonly persisted by monitoring systems.
-        problem = getattr(exc, "problem", None)
         mark = getattr(exc, "problem_mark", None) or getattr(exc, "context_mark", None)
         diagnostic = type(exc).__name__
-        if isinstance(problem, str) and problem:
-            diagnostic += f": {problem.replace(chr(10), ' ')[:160]}"
         location = ""
         if mark is not None:
             line = getattr(mark, "line", None)
@@ -170,24 +167,30 @@ def _sha256_file(path: Path) -> str:
 
 
 def _copy_coherent_state_snapshot(db_path: Path, snapshot_path: Path) -> None:
-    """Copy one unchanged DB/WAL generation without opening the live profile."""
-    wal_path = Path(f"{db_path}-wal")
-    snapshot_wal_path = Path(f"{snapshot_path}-wal")
+    """Copy one unchanged DB plus journal generation without opening the profile."""
+    sidecars = ("-wal", "-journal")
     for _attempt in range(3):
         snapshot_path.unlink(missing_ok=True)
-        snapshot_wal_path.unlink(missing_ok=True)
+        for suffix in sidecars:
+            Path(f"{snapshot_path}{suffix}").unlink(missing_ok=True)
         try:
             copied_db_hash = _copy_with_sha256(db_path, snapshot_path)
-            copied_wal_hash = (
-                _copy_with_sha256(wal_path, snapshot_wal_path)
-                if wal_path.exists()
-                else None
-            )
+            copied_sidecar_hashes = {}
+            for suffix in sidecars:
+                source = Path(f"{db_path}{suffix}")
+                copied_sidecar_hashes[suffix] = (
+                    _copy_with_sha256(source, Path(f"{snapshot_path}{suffix}"))
+                    if source.exists()
+                    else None
+                )
             source_db_hash = _sha256_file(db_path)
-            source_wal_hash = _sha256_file(wal_path) if wal_path.exists() else None
+            source_sidecar_hashes = {}
+            for suffix in sidecars:
+                source = Path(f"{db_path}{suffix}")
+                source_sidecar_hashes[suffix] = _sha256_file(source) if source.exists() else None
         except FileNotFoundError:
             continue
-        if copied_db_hash == source_db_hash and copied_wal_hash == source_wal_hash:
+        if copied_db_hash == source_db_hash and copied_sidecar_hashes == source_sidecar_hashes:
             return
     raise _StateDbSnapshotBusy("state.db changed while the read-only snapshot was copied")
 
@@ -404,6 +407,10 @@ def run_health(args) -> int:
     try:
         result = collect_health()
     except Exception as exc:
+        # Exception messages and arguments can contain config values, paths,
+        # credentials, or other user-controlled data. Keep automation output
+        # source-independent while retaining the exception class for triage.
+        diagnostic = type(exc).__name__
         result = {
             "schema_version": 1,
             "status": "critical",
@@ -413,7 +420,7 @@ def run_health(args) -> int:
             "hermes_version": HERMES_VERSION,
             "checks": [asdict(HealthRow(
                 "health_collection", "health collection", "critical",
-                f"health collection failed: {exc}", "run: hermes doctor",
+                f"health collection failed ({diagnostic})", "run: hermes doctor",
             ))],
         }
     if getattr(args, "json", False):

--- a/hermes_cli/health.py
+++ b/hermes_cli/health.py
@@ -84,11 +84,25 @@ def _read_raw_config(config_path: Path) -> tuple[dict[str, Any] | None, HealthRo
     try:
         raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
     except Exception as exc:
+        # ``str(MarkedYAMLError)`` includes the offending source line. Never
+        # echo it: malformed config may contain credentials and health output
+        # is commonly persisted by monitoring systems.
+        problem = getattr(exc, "problem", None)
+        mark = getattr(exc, "problem_mark", None) or getattr(exc, "context_mark", None)
+        diagnostic = type(exc).__name__
+        if isinstance(problem, str) and problem:
+            diagnostic += f": {problem.replace(chr(10), ' ')[:160]}"
+        location = ""
+        if mark is not None:
+            line = getattr(mark, "line", None)
+            column = getattr(mark, "column", None)
+            if isinstance(line, int) and isinstance(column, int):
+                location = f" at line {line + 1}, column {column + 1}"
         return None, HealthRow(
             "profile_config",
             "profile/config",
             "critical",
-            f"config.yaml is not valid YAML for profile {get_active_profile_name()}: {exc}",
+            f"config.yaml invalid{location} ({diagnostic}); profile={get_active_profile_name()}",
             "run: hermes config check",
         )
     if raw is None:

--- a/hermes_cli/health.py
+++ b/hermes_cli/health.py
@@ -1,0 +1,361 @@
+"""Automation-friendly Hermes health checks.
+
+``hermes doctor`` is the interactive diagnostic command for humans. It may run
+provider/network checks and prints remediation detail. ``hermes health`` is the
+small, offline-by-default contract for automation: cron jobs, service managers,
+containers, dashboards, and monitoring scripts can depend on stable exit codes
+and structured output without spending model/provider quota.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+import sqlite3
+import tempfile
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from hermes_cli import __version__ as HERMES_VERSION
+from hermes_cli.config import get_hermes_home
+from hermes_cli.profiles import get_active_profile_name
+
+_STATUS_RANK = {"healthy": 0, "warning": 1, "critical": 2}
+_EXIT_CODE = {"healthy": 0, "warning": 1, "critical": 2}
+
+
+@dataclass(frozen=True)
+class HealthRow:
+    """One health check result.
+
+    ``status`` is intentionally constrained to the public exit-code contract:
+    healthy -> 0, warning -> 1, critical -> 2. ``id`` is the stable machine key;
+    ``subsystem`` is human-facing display text.
+    """
+
+    id: str
+    subsystem: str
+    status: str
+    detail: str
+    action: str = ""
+
+
+def _aggregate_status(rows: list[HealthRow]) -> str:
+    if not rows:
+        return "healthy"
+    return max(rows, key=lambda row: _STATUS_RANK.get(row.status, 2)).status
+
+
+def _exit_code(status: str) -> int:
+    return _EXIT_CODE.get(status, 2)
+
+
+def _configured_route(config: dict[str, Any] | None) -> tuple[str, str]:
+    model_cfg = config.get("model") if isinstance(config, dict) else None
+    if isinstance(model_cfg, dict):
+        provider = str(model_cfg.get("provider") or "auto")
+        model = str(model_cfg.get("default") or model_cfg.get("name") or "(not set)")
+    elif isinstance(model_cfg, str):
+        provider = "auto"
+        model = model_cfg or "(not set)"
+    else:
+        provider = "auto"
+        model = "(not set)"
+    return provider, model
+
+
+def _read_raw_config(config_path: Path) -> tuple[dict[str, Any] | None, HealthRow | None]:
+    """Read config.yaml strictly enough for health exit-code semantics.
+
+    ``load_config()`` intentionally falls back to defaults for normal CLI
+    resilience. Health is an automation contract, so invalid syntax or a
+    non-mapping config file must be surfaced as critical before that fallback.
+    This helper is read-only and deliberately does not run config repair/backup
+    paths; ``hermes config check`` remains the repair-oriented command.
+    """
+    if not config_path.exists():
+        return None, None
+    try:
+        raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return None, HealthRow(
+            "profile_config",
+            "profile/config",
+            "critical",
+            f"config.yaml is not valid YAML for profile {get_active_profile_name()}: {exc}",
+            "run: hermes config check",
+        )
+    if raw is None:
+        return {}, None
+    if not isinstance(raw, dict):
+        return None, HealthRow(
+            "profile_config",
+            "profile/config",
+            "critical",
+            f"config.yaml must be a mapping/object, got {type(raw).__name__}",
+            "run: hermes config check",
+        )
+    return raw, None
+
+
+def _check_profile_config(home: Path) -> tuple[HealthRow, dict[str, Any] | None]:
+    config_path = home / "config.yaml"
+    raw_config, raw_error = _read_raw_config(config_path)
+    if raw_error is not None:
+        return raw_error, None
+
+    if not config_path.exists():
+        return (
+            HealthRow(
+                "profile_config",
+                "profile/config",
+                "warning",
+                f"profile={get_active_profile_name()} home={home}; config.yaml missing, using defaults",
+                "run: hermes setup or hermes config edit",
+            ),
+            None,
+        )
+    config = raw_config if isinstance(raw_config, dict) else None
+    provider, model = _configured_route(config)
+    return (
+        HealthRow(
+            "profile_config",
+            "profile/config",
+            "healthy",
+            f"profile={get_active_profile_name()} provider={provider} model={model}",
+        ),
+        config,
+    )
+
+
+def _check_state_db(home: Path) -> HealthRow:
+    db_path = home / "state.db"
+    if not db_path.exists():
+        return HealthRow(
+            "state_db",
+            "state DB availability",
+            "warning",
+            f"{db_path} missing; a new DB may be created on first session",
+            "run a session or verify HERMES_HOME",
+        )
+    try:
+        # mode=ro may still create state.db-shm for WAL databases. Validate a
+        # disposable db+wal snapshot so the profile remains untouched.
+        with tempfile.TemporaryDirectory(prefix="hermes-health-state-") as temp_dir:
+            snapshot_path = Path(temp_dir) / "state.db"
+            shutil.copyfile(db_path, snapshot_path)
+            wal_path = Path(f"{db_path}-wal")
+            if wal_path.exists():
+                shutil.copyfile(wal_path, Path(f"{snapshot_path}-wal"))
+            conn = sqlite3.connect(snapshot_path, timeout=2)
+            try:
+                conn.execute("SELECT name FROM sqlite_schema LIMIT 1").fetchone()
+                quick_check = conn.execute("PRAGMA quick_check").fetchone()
+                if quick_check != ("ok",):
+                    raise sqlite3.DatabaseError(f"quick_check failed: {quick_check!r}")
+            finally:
+                conn.close()
+    except Exception as exc:
+        return HealthRow(
+            "state_db",
+            "state DB availability",
+            "critical",
+            f"{db_path} is not readable as SQLite: {exc}",
+            "check permissions or restore state.db from backup",
+        )
+    return HealthRow("state_db", "state DB availability", "healthy", f"readable: {db_path}")
+
+
+def _last_cron_run_timestamp(jobs: list[dict[str, Any]]) -> str | None:
+    """Return the latest valid timestamp from cron's persisted job records."""
+    parsed: list[tuple[datetime, str]] = []
+    for job in jobs:
+        value = job.get("last_run_at")
+        if not isinstance(value, str) or not value:
+            continue
+        try:
+            instant = datetime.fromisoformat(value)
+            if instant.tzinfo is None:
+                instant = instant.replace(tzinfo=timezone.utc)
+            normalized = instant.astimezone(timezone.utc)
+        except (OverflowError, ValueError):
+            continue
+        parsed.append((normalized, value))
+    if not parsed:
+        return None
+    return max(parsed, key=lambda item: item[0])[1]
+
+
+def _read_cron_jobs_read_only(home: Path) -> tuple[list[dict[str, Any]], str, str | None]:
+    """Read cron/jobs.json without invoking cron repair or migration code."""
+    jobs_path = home / "cron" / "jobs.json"
+    if not jobs_path.exists():
+        return [], "missing", None
+    try:
+        payload = json.loads(jobs_path.read_text(encoding="utf-8-sig"))
+    except Exception as exc:
+        return [], "invalid", str(exc)
+    if isinstance(payload, dict):
+        jobs = payload.get("jobs", [])
+        if not isinstance(jobs, list):
+            return [], "invalid", "jobs field is not a list"
+        if any(not isinstance(job, dict) for job in jobs):
+            return [], "invalid", "jobs contains a non-object entry"
+        return jobs, "current", None
+    if isinstance(payload, list):
+        if any(not isinstance(job, dict) for job in payload):
+            return [], "invalid", "jobs contains a non-object entry"
+        return payload, "legacy_list", None
+    return [], "invalid", f"expected object or list, got {type(payload).__name__}"
+
+
+def _check_cron(home: Path) -> HealthRow:
+    jobs, storage_status, error = _read_cron_jobs_read_only(home)
+    if storage_status == "invalid":
+        return HealthRow(
+            "cron_storage",
+            "cron scheduler status",
+            "critical",
+            f"unable to read cron jobs without repair: {error}",
+            "run: hermes cron list",
+        )
+    active = sum(1 for job in jobs if job.get("enabled", True))
+    last_tick = _last_cron_run_timestamp(jobs)
+    suffix = f"; last run {last_tick}" if last_tick else "; no run history yet"
+    if storage_status == "missing":
+        detail = f"0 active / 0 total jobs; jobs.json missing{suffix}"
+    else:
+        detail = f"{active} active / {len(jobs)} total jobs{suffix}"
+    if storage_status == "legacy_list":
+        return HealthRow(
+            "cron_storage",
+            "cron scheduler status",
+            "warning",
+            detail + "; legacy jobs.json list format detected",
+            "run: hermes cron list to migrate storage format",
+        )
+    return HealthRow("cron_storage", "cron scheduler status", "healthy", detail)
+
+
+def _check_provider_routing(config: dict[str, Any] | None) -> HealthRow:
+    provider, model = _configured_route(config)
+    if model == "(not set)":
+        return HealthRow(
+            "provider_routing",
+            "provider routing config",
+            "warning",
+            "no default model configured",
+            "run: hermes model",
+        )
+    return HealthRow(
+        "provider_routing",
+        "provider routing config",
+        "healthy",
+        f"configured route {provider}/{model}; no provider/network probe run",
+        "run: hermes doctor for live provider diagnostics",
+    )
+
+
+def _check_disk(home: Path) -> HealthRow:
+    try:
+        usage = shutil.disk_usage(home)
+    except Exception as exc:
+        return HealthRow("disk", "disk/free space", "critical", f"cannot read disk usage for {home}: {exc}", "check filesystem")
+    free_gb = usage.free / (1024 ** 3)
+    free_ratio = usage.free / usage.total if usage.total else 0
+    detail = f"{free_gb:.1f} GiB free ({free_ratio:.0%}) at {home}"
+    if usage.free < 100 * 1024 ** 2 or free_ratio < 0.02:
+        return HealthRow("disk", "disk/free space", "critical", detail, "free disk space immediately")
+    if usage.free < 1024 ** 3 or free_ratio < 0.10:
+        return HealthRow("disk", "disk/free space", "warning", detail, "clean logs/caches or expand disk")
+    return HealthRow("disk", "disk/free space", "healthy", detail)
+
+
+def _check_runtime_modules() -> HealthRow:
+    missing = [name for name in ("toolsets", "tools.registry") if importlib.util.find_spec(name) is None]
+    if missing:
+        return HealthRow(
+            "runtime_modules",
+            "runtime modules",
+            "critical",
+            f"core module(s) unavailable: {', '.join(missing)}",
+            "run: hermes doctor",
+        )
+    return HealthRow(
+        "runtime_modules",
+        "runtime modules",
+        "healthy",
+        "core tool registry modules are import-resolvable; full imports skipped",
+        "run: hermes doctor for dependency-level checks",
+    )
+
+
+def collect_health() -> dict[str, Any]:
+    """Collect offline, low-cost health rows and aggregate status."""
+    home = get_hermes_home()
+    config_row, config = _check_profile_config(home)
+    rows: list[HealthRow] = [
+        config_row,
+        _check_state_db(home),
+        _check_cron(home),
+        _check_provider_routing(config),
+        _check_disk(home),
+        _check_runtime_modules(),
+    ]
+    status = _aggregate_status(rows)
+    return {
+        "schema_version": 1,
+        "status": status,
+        "exit_code": _exit_code(status),
+        "profile": get_active_profile_name(),
+        "hermes_home": str(home),
+        "hermes_version": HERMES_VERSION,
+        "checks": [asdict(row) for row in rows],
+    }
+
+
+def _print_table(result: dict[str, Any]) -> None:
+    print()
+    print("Hermes Health")
+    print(f"Status: {result['status']} (exit {result['exit_code']})")
+    print(f"Profile: {result['profile']}")
+    print(f"Hermes home: {result['hermes_home']}")
+    print()
+    print(f"{'Subsystem':<27} {'Status':<9} {'Detail':<58} Action")
+    print("-" * 120)
+    for row in result["checks"]:
+        detail = str(row.get("detail", ""))
+        if len(detail) > 58:
+            detail = detail[:55] + "..."
+        print(f"{row.get('subsystem',''):<27} {row.get('status',''):<9} {detail:<58} {row.get('action','')}")
+    print()
+
+
+def run_health(args) -> int:
+    try:
+        result = collect_health()
+    except Exception as exc:
+        result = {
+            "schema_version": 1,
+            "status": "critical",
+            "exit_code": 2,
+            "profile": "unknown",
+            "hermes_home": "unknown",
+            "hermes_version": HERMES_VERSION,
+            "checks": [asdict(HealthRow(
+                "health_collection", "health collection", "critical",
+                f"health collection failed: {exc}", "run: hermes doctor",
+            ))],
+        }
+    if getattr(args, "json", False):
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+    elif getattr(args, "quiet", False) and result["status"] == "healthy":
+        pass
+    else:
+        _print_table(result)
+    return int(result["exit_code"])

--- a/hermes_cli/health.py
+++ b/hermes_cli/health.py
@@ -46,6 +46,11 @@ class HealthRow:
     action: str = ""
 
 
+def _diagnostic_name(exc: BaseException) -> str:
+    """Return source-independent exception metadata safe for health output."""
+    return type(exc).__name__
+
+
 def _aggregate_status(rows: list[HealthRow]) -> str:
     if not rows:
         return "healthy"
@@ -88,7 +93,7 @@ def _read_raw_config(config_path: Path) -> tuple[dict[str, Any] | None, HealthRo
         # echo it: malformed config may contain credentials and health output
         # is commonly persisted by monitoring systems.
         mark = getattr(exc, "problem_mark", None) or getattr(exc, "context_mark", None)
-        diagnostic = type(exc).__name__
+        diagnostic = _diagnostic_name(exc)
         location = ""
         if mark is not None:
             line = getattr(mark, "line", None)
@@ -219,12 +224,12 @@ def _check_state_db(home: Path) -> HealthRow:
                     raise sqlite3.DatabaseError(f"quick_check failed: {quick_check!r}")
             finally:
                 conn.close()
-    except _StateDbSnapshotBusy as exc:
+    except _StateDbSnapshotBusy:
         return HealthRow(
             "state_db",
             "state DB availability",
             "warning",
-            f"{db_path} is busy: {exc}",
+            f"{db_path} changed while its snapshot was copied",
             "retry health after current database activity settles",
         )
     except Exception as exc:
@@ -232,7 +237,7 @@ def _check_state_db(home: Path) -> HealthRow:
             "state_db",
             "state DB availability",
             "critical",
-            f"{db_path} is not readable as SQLite: {exc}",
+            f"{db_path} is not readable as SQLite ({_diagnostic_name(exc)})",
             "check permissions or restore state.db from backup",
         )
     return HealthRow("state_db", "state DB availability", "healthy", f"readable: {db_path}")
@@ -266,7 +271,7 @@ def _read_cron_jobs_read_only(home: Path) -> tuple[list[dict[str, Any]], str, st
     try:
         payload = json.loads(jobs_path.read_text(encoding="utf-8-sig"))
     except Exception as exc:
-        return [], "invalid", str(exc)
+        return [], "invalid", _diagnostic_name(exc)
     if isinstance(payload, dict):
         jobs = payload.get("jobs", [])
         if not isinstance(jobs, list):
@@ -332,7 +337,13 @@ def _check_disk(home: Path) -> HealthRow:
     try:
         usage = shutil.disk_usage(home)
     except Exception as exc:
-        return HealthRow("disk", "disk/free space", "critical", f"cannot read disk usage for {home}: {exc}", "check filesystem")
+        return HealthRow(
+            "disk",
+            "disk/free space",
+            "critical",
+            f"cannot read disk usage for {home} ({_diagnostic_name(exc)})",
+            "check filesystem",
+        )
     free_gb = usage.free / (1024 ** 3)
     free_ratio = usage.free / usage.total if usage.total else 0
     detail = f"{free_gb:.1f} GiB free ({free_ratio:.0%}) at {home}"
@@ -410,7 +421,7 @@ def run_health(args) -> int:
         # Exception messages and arguments can contain config values, paths,
         # credentials, or other user-controlled data. Keep automation output
         # source-independent while retaining the exception class for triage.
-        diagnostic = type(exc).__name__
+        diagnostic = _diagnostic_name(exc)
         result = {
             "schema_version": 1,
             "status": "critical",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -333,6 +333,11 @@ def _wants_tui_early(argv: "list[str] | None" = None) -> bool:
 def _suppress_mouse_residue_early() -> None:
     if os.environ.get("HERMES_TUI_NO_EARLY_DISABLE") == "1":
         return
+    # ``health --json`` promises a clean machine-readable stdout stream. This
+    # helper runs before normal parser setup, so exclude health with the same
+    # dependency-light argv grammar used by the other early startup gates.
+    if _early_recovery_mod.early_cli_subcommand(sys.argv[1:]) == "health":
+        return
     if not _wants_tui_early():
         return
     try:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -18,6 +18,7 @@ Usage:
     hermes cron list           # List cron jobs
     hermes cron status         # Check if cron scheduler is running
     hermes doctor              # Check configuration and dependencies
+    hermes health              # Offline health checks for automation
     hermes honcho setup                    # Configure Honcho AI memory integration
     hermes honcho status                   # Show Honcho config and connection status
     hermes honcho sessions                 # List directory → session name mappings
@@ -447,6 +448,7 @@ from hermes_cli.subcommands.status import build_status_parser
 from hermes_cli.subcommands.webhook import build_webhook_parser
 from hermes_cli.subcommands.hooks import build_hooks_parser
 from hermes_cli.subcommands.doctor import build_doctor_parser
+from hermes_cli.subcommands.health import build_health_parser
 from hermes_cli.subcommands.security import build_security_parser
 from hermes_cli.subcommands.approvals import build_approvals_parser
 from hermes_cli.subcommands.dump import build_dump_parser
@@ -682,12 +684,27 @@ def _apply_profile_override() -> None:
 
 _apply_profile_override()
 
+# Parser-lite command detection must run before dotenv/secret-source loading so
+# the public read-only/offline health command can bypass mutating or remote
+# startup initialization. Keep this value-option grammar shared with the later
+# plugin-discovery fast path.
+_TOP_LEVEL_VALUE_FLAGS = _early_recovery_mod.TOP_LEVEL_VALUE_FLAGS
+
+
+def _early_cli_subcommand(argv: list[str]) -> str:
+    """Find the top-level command without running the full argument parser."""
+    return _early_recovery_mod.early_cli_subcommand(argv)
+
+
+_EARLY_CLI_COMMAND = _early_cli_subcommand(sys.argv[1:])
+
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
 # User-managed env files should override stale shell exports on restart.
 from hermes_cli.config import get_hermes_home
 from hermes_cli.env_loader import load_hermes_dotenv
 
-load_hermes_dotenv(project_env=PROJECT_ROOT / ".env")
+if _EARLY_CLI_COMMAND != "health":
+    load_hermes_dotenv(project_env=PROJECT_ROOT / ".env")
 
 # Bridge security.redact_secrets from config.yaml → HERMES_REDACT_SECRETS env
 # var BEFORE hermes_logging imports agent.redact (which snapshots the flag at
@@ -733,21 +750,21 @@ try:
 except Exception:
     pass  # best-effort — redaction stays at default (enabled) on config errors
 
-# Initialize centralized file logging early — all `hermes` subcommands
-# (chat, setup, gateway, config, etc.) write to agent.log + errors.log.
+# Initialize centralized file logging early — all `hermes` subcommands except
+# the explicitly read-only `health` command write to agent.log + errors.log.
 # Dashboard entrypoints bootstrap with GUI mode so gui.log is always present
 # during GUI testing, including pre-dispatch startup failures.
 try:
     from hermes_logging import setup_logging as _setup_logging
 
-    _setup_logging(
-        mode=(
-            "gui"
-            if next((arg for arg in sys.argv[1:] if not arg.startswith("-")), "")
-            in {"dashboard", "serve", "gui", "desktop"}
-            else "cli"
+    if _EARLY_CLI_COMMAND != "health":
+        _setup_logging(
+            mode=(
+                "gui"
+                if _EARLY_CLI_COMMAND in {"dashboard", "serve", "gui", "desktop"}
+                else "cli"
+            )
         )
-    )
 except Exception:
     pass  # best-effort — don't crash the CLI if logging setup fails
 
@@ -4603,6 +4620,13 @@ def cmd_doctor(args):
     from hermes_cli.doctor import run_doctor
 
     run_doctor(args)
+
+
+def cmd_health(args):
+    """Run automation-friendly offline health checks."""
+    from hermes_cli.health import run_health
+
+    sys.exit(run_health(args))
 
 
 def cmd_security(args):
@@ -10225,7 +10249,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "acp", "approvals", "auth", "backup", "bundles", "checkpoints", "claw", "completion",
         "computer-use",
         "config", "console", "cron", "curator", "dashboard", "serve", "debug", "doctor",
-        "dump", "egress", "fallback", "gateway", "hooks", "import", "import-agent", "insights",
+        "dump", "egress", "fallback", "gateway", "health", "hooks", "import", "import-agent", "insights",
         "gui", "desktop", "kanban", "login", "logout", "logs", "lsp", "mcp", "memory", "migrate", "moa",
         "journey", "memory-graph", "learning",
         "model", "monitoring", "pairing", "pets", "plugins", "portal", "profile",
@@ -10250,22 +10274,8 @@ _BUILTIN_SUBCOMMANDS = frozenset(
 # Correctness-safe either way: missing an entry here only makes the
 # fast-path bail out too eagerly (we run plugin discovery when we didn't
 # need to); extra entries would make us skip a real positional.
-_TOP_LEVEL_VALUE_FLAGS = frozenset(
-    {
-        "-z", "--oneshot",
-        "-m", "--model",
-        "--provider",
-        "-t", "--toolsets",
-        "-r", "--resume",
-        "-s", "--skills",
-        "--usage-file",
-        # ``-c / --continue`` is nargs='?' (optional value). Treat it as
-        # value-taking: if the next token is a subcommand-looking word
-        # the user almost certainly meant it as the session name, and
-        # either interpretation keeps us on the safe side.
-        "-c", "--continue",
-    }
-)
+# Defined near early logging setup so the read-only health fast path and the
+# plugin-discovery fast path share one parser-lite value-option grammar.
 
 
 def _first_positional_argv() -> str | None:
@@ -10808,16 +10818,18 @@ def main():
     # Sweep stale ``hermes.exe.old.*`` quarantine files left by previous
     # ``hermes update`` runs on Windows. Silent no-op on non-Windows or when
     # there's nothing to clean. See ``_quarantine_running_hermes_exe``.
-    try:
-        _cleanup_quarantined_exes()
-    except Exception:
-        pass
+    if _EARLY_CLI_COMMAND != "health":
+        try:
+            _cleanup_quarantined_exes()
+        except Exception:
+            pass
 
     # If the checkout changed since the last launch (hermes update, manual
     # git pull, old-updater update that predates newer clears), sweep stale
     # __pycache__ once so no process — this one's lazy imports included —
     # resolves fresh source against old bytecode. Never raises.
-    _sweep_stale_bytecode_if_checkout_changed()
+    if _EARLY_CLI_COMMAND != "health":
+        _sweep_stale_bytecode_if_checkout_changed()
 
     # Self-heal a venv left half-built by an interrupted ``hermes update``
     # (Ctrl-C, terminal close, WSL OOM mid-install). Skip when the user is
@@ -10829,11 +10841,12 @@ def main():
     # ``hermes skills install update``) merely defers recovery one launch;
     # under-matching (missing ``hermes -p work update``) would race a recovery
     # install against the real one. Loose wins.
-    try:
-        if "update" not in sys.argv[1:]:
-            _recover_from_interrupted_install()
-    except Exception:
-        pass
+    if _EARLY_CLI_COMMAND != "health":
+        try:
+            if "update" not in sys.argv[1:]:
+                _recover_from_interrupted_install()
+        except Exception:
+            pass
 
     if _try_termux_fast_tui_launch():
         return
@@ -11135,6 +11148,11 @@ def main():
     # doctor command  (parser built in hermes_cli/subcommands/doctor.py)
     # =========================================================================
     build_doctor_parser(subparsers, cmd_doctor=cmd_doctor)
+
+    # =========================================================================
+    # health command  (parser built in hermes_cli/subcommands/health.py)
+    # =========================================================================
+    build_health_parser(subparsers, cmd_health=cmd_health)
 
     # =========================================================================
     # security command — on-demand supply-chain audit

--- a/hermes_cli/subcommands/health.py
+++ b/hermes_cli/subcommands/health.py
@@ -1,0 +1,25 @@
+"""``hermes health`` subcommand parser."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+
+def build_health_parser(subparsers, *, cmd_health: Callable) -> None:
+    """Attach the ``health`` subcommand to ``subparsers``."""
+    health_parser = subparsers.add_parser(
+        "health",
+        help="Run automation-friendly offline health checks",
+        description=(
+            "Run low-cost Hermes health checks with stable exit-code semantics: "
+            "0=healthy, 1=warning/degraded, 2=critical. No provider or network "
+            "probes are run. Use `hermes doctor` for interactive diagnostics."
+        ),
+    )
+    health_parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    health_parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Print nothing when healthy; useful for cron, watchdogs, and service health checks",
+    )
+    health_parser.set_defaults(func=cmd_health)

--- a/tests/hermes_cli/test_health.py
+++ b/tests/hermes_cli/test_health.py
@@ -172,6 +172,20 @@ def test_state_db_snapshot_retries_across_wal_checkpoint(tmp_path, monkeypatch):
     assert row.status == "healthy"
 
 
+def test_state_db_snapshot_copies_rollback_journal(tmp_path):
+    db_path = tmp_path / "state.db"
+    snapshot_path = tmp_path / "snapshot" / "state.db"
+    snapshot_path.parent.mkdir()
+    db_path.write_bytes(b"database generation")
+    journal_path = Path(f"{db_path}-journal")
+    journal_path.write_bytes(b"rollback journal generation")
+
+    health_mod._copy_coherent_state_snapshot(db_path, snapshot_path)
+
+    assert snapshot_path.read_bytes() == db_path.read_bytes()
+    assert Path(f"{snapshot_path}-journal").read_bytes() == journal_path.read_bytes()
+
+
 def test_collect_health_critical_exit_two_for_bad_config(tmp_path, monkeypatch):
     home = tmp_path / "profile"
     home.mkdir()
@@ -204,6 +218,39 @@ def test_bad_config_diagnostic_does_not_disclose_source_line(tmp_path, monkeypat
         assert code == 2
         assert sentinel not in output
         assert "line 2, column 1" in output
+
+
+def test_bad_config_diagnostic_does_not_disclose_tag_or_alias(tmp_path):
+    home = tmp_path / "profile"
+    home.mkdir()
+    sqlite3.connect(home / "state.db").close()
+    sentinel = "SUPER_SECRET_CREDENTIAL_123"
+
+    for malformed in (
+        f"key: !{sentinel} value\n",
+        f"key: *{sentinel}\n",
+    ):
+        (home / "config.yaml").write_text(malformed, encoding="utf-8")
+        for output_args in (("--json",), ()):
+            proc = _run_health_cli(home, *output_args)
+            assert proc.returncode == 2, proc.stderr
+            assert sentinel not in proc.stdout
+            assert "config.yaml invalid" in proc.stdout
+
+
+def test_unexpected_health_failure_does_not_disclose_exception_text(monkeypatch, capsys):
+    sentinel = "SUPER_SECRET_CREDENTIAL_123"
+
+    def fail_collection():
+        raise RuntimeError(sentinel)
+
+    monkeypatch.setattr(health_mod, "collect_health", fail_collection)
+    for json_output in (True, False):
+        code = health_mod.run_health(SimpleNamespace(json=json_output, quiet=False))
+        output = capsys.readouterr().out
+        assert code == 2
+        assert sentinel not in output
+        assert "health collection failed (RuntimeError)" in output
 
 
 def test_collect_health_critical_exit_two_for_non_mapping_config(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_health.py
+++ b/tests/hermes_cli/test_health.py
@@ -138,6 +138,40 @@ def test_state_db_wal_snapshot_does_not_create_profile_shm(tmp_path):
     assert not Path(f"{db_path}-shm").exists()
 
 
+def test_state_db_snapshot_retries_across_wal_checkpoint(tmp_path, monkeypatch):
+    home = tmp_path / "profile"
+    home.mkdir()
+    db_path = home / "state.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA wal_autocheckpoint=0")
+    conn.execute("CREATE TABLE sessions (id text)")
+    conn.execute("INSERT INTO sessions VALUES ('from-wal')")
+    conn.commit()
+    wal_path = Path(f"{db_path}-wal")
+    assert wal_path.exists()
+
+    original_copy = health_mod._copy_with_sha256
+    checkpointed = False
+
+    def copy_and_checkpoint(source, destination):
+        nonlocal checkpointed
+        digest = original_copy(source, destination)
+        if source == wal_path and not checkpointed:
+            checkpointed = True
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+        return digest
+
+    monkeypatch.setattr(health_mod, "_copy_with_sha256", copy_and_checkpoint)
+    try:
+        row = health_mod._check_state_db(home)
+    finally:
+        conn.close()
+
+    assert checkpointed is True
+    assert row.status == "healthy"
+
+
 def test_collect_health_critical_exit_two_for_bad_config(tmp_path, monkeypatch):
     home = tmp_path / "profile"
     home.mkdir()
@@ -346,29 +380,44 @@ def test_early_cli_subcommand_distinguishes_command_from_argument():
     assert _early_cli_subcommand(["--model", "health", "chat"]) == "chat"
 
 
-def test_health_process_import_skips_early_repair(tmp_path):
+def test_health_process_reports_broken_dependency_without_early_repair(tmp_path):
     root = tmp_path / "checkout"
     root.mkdir()
     (root / "pyproject.toml").write_text("[project]\nname='probe'\n", encoding="utf-8")
-    (root / ".update-incomplete").write_text("interrupted\n", encoding="utf-8")
+    recovery_marker = root / ".update-incomplete"
+    recovery_marker.write_text("interrupted\n", encoding="utf-8")
+    original_marker = recovery_marker.read_bytes()
     repair_marker = tmp_path / "repair-invoked"
+    shadow = tmp_path / "shadow"
+    shadow.mkdir()
+    (shadow / "yaml.py").write_text(
+        "raise ImportError('deliberately broken yaml')\n", encoding="utf-8"
+    )
     script = f"""
 import pathlib
 import sys
 import hermes_cli._early_recovery as recovery
 recovery._project_root = lambda: pathlib.Path({str(root)!r})
-recovery._probe_broken_packages = lambda: ["PyYAML"]
 recovery._run_repair_install = lambda specs, project_root: pathlib.Path({str(repair_marker)!r}).write_text("called")
 sys.argv = ["hermes", "health", "--json"]
 import hermes_cli.main
 """
     proc = subprocess.run(
-        [sys.executable, "-c", script], cwd=os.getcwd(),
-        env={**os.environ, "PYTHONPATH": os.getcwd()}, text=True,
-        capture_output=True, timeout=30,
+        [sys.executable, "-c", script],
+        cwd=os.getcwd(),
+        env={**os.environ, "PYTHONPATH": f"{shadow}{os.pathsep}{os.getcwd()}"},
+        text=True,
+        capture_output=True,
+        timeout=30,
     )
 
-    assert proc.returncode == 0, proc.stderr
+    assert proc.returncode == 2, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["status"] == "critical"
+    assert payload["exit_code"] == 2
+    assert payload["checks"][0]["id"] == "runtime_dependencies"
+    assert "PyYAML" in payload["checks"][0]["detail"]
+    assert recovery_marker.read_bytes() == original_marker
     assert not repair_marker.exists()
 
 

--- a/tests/hermes_cli/test_health.py
+++ b/tests/hermes_cli/test_health.py
@@ -1,0 +1,547 @@
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+from hermes_cli import health as health_mod
+from hermes_cli.subcommands.health import build_health_parser
+
+
+def _write_profile(home, *, model=True, state_db=True):
+    home.mkdir(parents=True, exist_ok=True)
+    if model:
+        (home / "config.yaml").write_text(
+            "model:\n  provider: test-provider\n  default: test-model\n",
+            encoding="utf-8",
+        )
+    else:
+        (home / "config.yaml").write_text("display:\n  interface: cli\n", encoding="utf-8")
+    if state_db:
+        conn = sqlite3.connect(home / "state.db")
+        conn.execute("CREATE TABLE IF NOT EXISTS sessions (id text)")
+        conn.commit()
+        conn.close()
+    cron_dir = home / "cron"
+    cron_dir.mkdir(exist_ok=True)
+    (cron_dir / "jobs.json").write_text(
+        json.dumps(
+            {
+                "jobs": [
+                    {
+                        "id": "completed-job",
+                        "enabled": True,
+                        "last_run_at": "2026-05-28T12:00:01+00:00",
+                        "last_status": "ok",
+                    }
+                ]
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _run_cli(home, *args):
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(home)
+    env["PYTHONPATH"] = os.getcwd()
+    env.setdefault("HERMES_DISABLE_UPDATE_CHECK", "1")
+    return subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", *args],
+        cwd=os.getcwd(),
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=30,
+    )
+
+
+def _run_health_cli(home, *args):
+    return _run_cli(home, "health", *args)
+
+
+def test_collect_health_healthy_exit_zero(tmp_path, monkeypatch):
+    home = tmp_path / "profile"
+    _write_profile(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    result = health_mod.collect_health()
+
+    assert result["status"] == "healthy"
+    assert result["exit_code"] == 0
+    assert result["schema_version"] == 1
+    assert "hermes_version" in result
+    assert {row["id"] for row in result["checks"]} >= {
+        "profile_config",
+        "state_db",
+        "cron_storage",
+        "provider_routing",
+        "disk",
+        "runtime_modules",
+    }
+    provider_row = next(row for row in result["checks"] if row["id"] == "provider_routing")
+    assert "no provider/network probe run" in provider_row["detail"]
+
+
+def test_collect_health_warning_exit_one_for_missing_state_db(tmp_path, monkeypatch):
+    home = tmp_path / "profile"
+    _write_profile(home, state_db=False)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    result = health_mod.collect_health()
+
+    assert result["status"] == "warning"
+    assert result["exit_code"] == 1
+    state_row = next(row for row in result["checks"] if row["id"] == "state_db")
+    assert state_row["status"] == "warning"
+
+
+def test_state_db_rejects_corrupt_bytes_without_uri_path_truncation(tmp_path):
+    home = tmp_path / "profile?reserved#percent%"
+    home.mkdir()
+    db_path = home / "state.db"
+    original = b"not sqlite at all"
+    db_path.write_bytes(original)
+
+    row = health_mod._check_state_db(home)
+
+    assert row.status == "critical"
+    assert db_path.read_bytes() == original
+    assert not (tmp_path / "profile").exists()
+
+
+def test_state_db_wal_snapshot_does_not_create_profile_shm(tmp_path):
+    source = tmp_path / "source"
+    source.mkdir()
+    source_db = source / "state.db"
+    conn = sqlite3.connect(source_db)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA wal_autocheckpoint=0")
+    conn.execute("CREATE TABLE sessions (id text)")
+    conn.execute("INSERT INTO sessions VALUES ('from-wal')")
+    conn.commit()
+    home = tmp_path / "profile"
+    home.mkdir()
+    db_path = home / "state.db"
+    db_path.write_bytes(source_db.read_bytes())
+    Path(f"{db_path}-wal").write_bytes(Path(f"{source_db}-wal").read_bytes())
+    conn.close()
+    before = {path.name: path.read_bytes() for path in home.iterdir()}
+
+    row = health_mod._check_state_db(home)
+
+    assert row.status == "healthy"
+    assert {path.name: path.read_bytes() for path in home.iterdir()} == before
+    assert not Path(f"{db_path}-shm").exists()
+
+
+def test_collect_health_critical_exit_two_for_bad_config(tmp_path, monkeypatch):
+    home = tmp_path / "profile"
+    home.mkdir()
+    (home / "config.yaml").write_text("model: [unterminated\n", encoding="utf-8")
+    conn = sqlite3.connect(home / "state.db")
+    conn.execute("CREATE TABLE t (id integer)")
+    conn.commit()
+    conn.close()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    result = health_mod.collect_health()
+
+    assert result["status"] == "critical"
+    assert result["exit_code"] == 2
+    assert any(row["id"] == "profile_config" and row["status"] == "critical" for row in result["checks"])
+
+
+def test_collect_health_critical_exit_two_for_non_mapping_config(tmp_path, monkeypatch):
+    home = tmp_path / "profile"
+    home.mkdir()
+    (home / "config.yaml").write_text("- not\n- a\n- mapping\n", encoding="utf-8")
+    sqlite3.connect(home / "state.db").close()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    result = health_mod.collect_health()
+
+    assert result["status"] == "critical"
+    assert result["exit_code"] == 2
+    config_row = next(row for row in result["checks"] if row["id"] == "profile_config")
+    assert config_row["status"] == "critical"
+    assert "must be a mapping/object" in config_row["detail"]
+
+
+def test_collect_health_reads_legacy_cron_without_mutating(tmp_path, monkeypatch):
+    home = tmp_path / "profile"
+    _write_profile(home)
+    jobs_path = home / "cron" / "jobs.json"
+    original = '[{"id":"legacy-job","enabled":true}]\n'
+    jobs_path.write_text(original, encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    result = health_mod.collect_health()
+
+    cron_row = next(row for row in result["checks"] if row["id"] == "cron_storage")
+    assert cron_row["status"] == "warning"
+    assert "legacy jobs.json list format" in cron_row["detail"]
+    assert jobs_path.read_text(encoding="utf-8") == original
+
+
+def test_collect_health_reports_latest_persisted_cron_run(tmp_path, monkeypatch):
+    home = tmp_path / "profile"
+    _write_profile(home)
+    jobs_path = home / "cron" / "jobs.json"
+    jobs_path.write_text(
+        json.dumps(
+            {
+                "jobs": [
+                    {"id": "older", "last_run_at": "2026-05-28T11:00:00+00:00"},
+                    {"id": "never-run"},
+                    {"id": "latest", "last_run_at": "2026-05-28T13:00:00+00:00"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    result = health_mod.collect_health()
+
+    cron_row = next(row for row in result["checks"] if row["id"] == "cron_storage")
+    assert "last run 2026-05-28T13:00:00+00:00" in cron_row["detail"]
+
+
+def test_collect_health_orders_cron_runs_by_instant_across_offsets(tmp_path, monkeypatch):
+    home = tmp_path / "profile"
+    _write_profile(home)
+    jobs_path = home / "cron" / "jobs.json"
+    jobs_path.write_text(
+        json.dumps(
+            {
+                "jobs": [
+                    {"id": "lexically-later", "last_run_at": "2026-05-28T13:00:00+02:00"},
+                    {"id": "chronologically-later", "last_run_at": "2026-05-28T12:00:00+00:00"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    result = health_mod.collect_health()
+
+    cron_row = next(row for row in result["checks"] if row["id"] == "cron_storage")
+    assert "last run 2026-05-28T12:00:00+00:00" in cron_row["detail"]
+
+
+def test_collect_health_ignores_timestamp_that_overflows_utc_normalization(tmp_path, monkeypatch):
+    home = tmp_path / "profile"
+    _write_profile(home)
+    (home / "cron" / "jobs.json").write_text(
+        json.dumps({"jobs": [{"last_run_at": "0001-01-01T00:00:00+14:00"}]}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    result = health_mod.collect_health()
+
+    cron_row = next(row for row in result["checks"] if row["id"] == "cron_storage")
+    assert "no run history yet" in cron_row["detail"]
+
+
+def test_collect_health_does_not_mutate_profile_home(tmp_path, monkeypatch):
+    home = tmp_path / "profile"
+    _write_profile(home)
+    (home / "config.yaml").write_text("model: [unterminated\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    before = {
+        path.relative_to(home): path.read_bytes()
+        for path in home.rglob("*")
+        if path.is_file()
+    }
+
+    health_mod.collect_health()
+
+    after = {
+        path.relative_to(home): path.read_bytes()
+        for path in home.rglob("*")
+        if path.is_file()
+    }
+    assert after == before
+
+
+def test_run_health_json_outputs_machine_readable_contract(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "profile"
+    _write_profile(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    code = health_mod.run_health(SimpleNamespace(json=True, quiet=False))
+
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert code == 0
+    assert payload["schema_version"] == 1
+    assert payload["status"] == "healthy"
+    assert payload["exit_code"] == 0
+    assert "hermes_version" in payload
+    assert isinstance(payload["checks"], list)
+    assert all("id" in row for row in payload["checks"])
+
+
+def test_run_health_converts_unexpected_collection_failure_to_critical_json(monkeypatch, capsys):
+    def fail_collection():
+        raise OSError("broken storage")
+
+    monkeypatch.setattr(health_mod, "collect_health", fail_collection)
+    code = health_mod.run_health(SimpleNamespace(json=True, quiet=False))
+
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 2
+    assert payload["status"] == "critical"
+    assert payload["checks"][0]["id"] == "health_collection"
+
+
+def test_quiet_healthy_output_is_empty(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "profile"
+    _write_profile(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    code = health_mod.run_health(SimpleNamespace(json=False, quiet=True))
+
+    assert code == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_quiet_warning_still_prints_human_output(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "profile"
+    _write_profile(home, state_db=False)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    code = health_mod.run_health(SimpleNamespace(json=False, quiet=True))
+
+    out = capsys.readouterr().out
+    assert code == 1
+    assert "Hermes Health" in out
+    assert "state DB availability" in out
+
+
+def test_status_aggregation_prefers_highest_severity():
+    rows = [
+        health_mod.HealthRow("a", "a", "healthy", "ok"),
+        health_mod.HealthRow("b", "b", "warning", "warn"),
+        health_mod.HealthRow("c", "c", "critical", "bad"),
+    ]
+    assert health_mod._aggregate_status(rows) == "critical"
+
+
+def test_early_cli_subcommand_distinguishes_command_from_argument():
+    from hermes_cli.main import _early_cli_subcommand
+
+    assert _early_cli_subcommand(["chat", "health"]) == "chat"
+    assert _early_cli_subcommand(["--profile", "dev", "health"]) == "health"
+    assert _early_cli_subcommand(["--profile=dev", "health"]) == "health"
+    assert _early_cli_subcommand(["--provider", "auto", "health"]) == "health"
+    assert _early_cli_subcommand(["--model", "test-model", "health"]) == "health"
+    assert _early_cli_subcommand(["--toolsets", "all", "health"]) == "health"
+    assert _early_cli_subcommand(["--model", "health", "chat"]) == "chat"
+
+
+def test_health_process_import_skips_early_repair(tmp_path):
+    root = tmp_path / "checkout"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname='probe'\n", encoding="utf-8")
+    (root / ".update-incomplete").write_text("interrupted\n", encoding="utf-8")
+    repair_marker = tmp_path / "repair-invoked"
+    script = f"""
+import pathlib
+import sys
+import hermes_cli._early_recovery as recovery
+recovery._project_root = lambda: pathlib.Path({str(root)!r})
+recovery._probe_broken_packages = lambda: ["PyYAML"]
+recovery._run_repair_install = lambda specs, project_root: pathlib.Path({str(repair_marker)!r}).write_text("called")
+sys.argv = ["hermes", "health", "--json"]
+import hermes_cli.main
+"""
+    proc = subprocess.run(
+        [sys.executable, "-c", script], cwd=os.getcwd(),
+        env={**os.environ, "PYTHONPATH": os.getcwd()}, text=True,
+        capture_output=True, timeout=30,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert not repair_marker.exists()
+
+
+def test_health_subparser_registered():
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+
+    def sentinel(args):
+        return args
+
+    build_health_parser(subparsers, cmd_health=sentinel)
+
+    args = parser.parse_args(["health", "--json", "--quiet"])
+
+    assert args.command == "health"
+    assert args.json is True
+    assert args.quiet is True
+    assert args.func is sentinel
+
+
+def test_health_main_skips_mutating_startup_maintenance(monkeypatch):
+    import hermes_cli.main as main_mod
+
+    def forbidden():
+        raise AssertionError("health invoked mutating startup maintenance")
+
+    monkeypatch.setattr(main_mod, "_EARLY_CLI_COMMAND", "health")
+    monkeypatch.setattr(main_mod, "_cleanup_quarantined_exes", forbidden)
+    monkeypatch.setattr(main_mod, "_sweep_stale_bytecode_if_checkout_changed", forbidden)
+    monkeypatch.setattr(main_mod, "_recover_from_interrupted_install", forbidden)
+    monkeypatch.setattr(main_mod, "_try_termux_fast_tui_launch", lambda: True)
+
+    main_mod.main()
+
+
+def test_cron_reader_accepts_utf8_bom_without_mutation(tmp_path):
+    home = tmp_path / "profile"
+    jobs_path = home / "cron" / "jobs.json"
+    jobs_path.parent.mkdir(parents=True)
+    original = b'\xef\xbb\xbf{"jobs": [{"id": "bom-job", "enabled": true}]}\n'
+    jobs_path.write_bytes(original)
+
+    jobs, status, error = health_mod._read_cron_jobs_read_only(home)
+
+    assert status == "current"
+    assert error is None
+    assert jobs == [{"id": "bom-job", "enabled": True}]
+    assert jobs_path.read_bytes() == original
+
+
+def test_health_cli_e2e_json_exit_zero_with_temp_home(tmp_path):
+    home = tmp_path / "profile"
+    _write_profile(home)
+
+    proc = _run_health_cli(home, "--json")
+
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["status"] == "healthy"
+    assert payload["exit_code"] == 0
+    assert payload["hermes_home"] == str(home)
+
+
+def test_health_cli_e2e_does_not_mutate_profile_home(tmp_path):
+    home = tmp_path / "profile"
+    _write_profile(home)
+    (home / ".env").write_bytes(b"OPENROUTER_API_KEY=abc\x00def\n")
+    before = {
+        path.relative_to(home): path.read_bytes()
+        for path in home.rglob("*")
+        if path.is_file()
+    }
+
+    proc = _run_health_cli(home, "--json")
+
+    assert proc.returncode == 0, proc.stderr
+    after = {
+        path.relative_to(home): path.read_bytes()
+        for path in home.rglob("*")
+        if path.is_file()
+    }
+    assert after == before
+
+
+def test_health_cli_e2e_global_value_options_do_not_enable_file_logging(tmp_path):
+    invocations = (
+        ("--provider", "auto", "health", "--json"),
+        ("--model", "test-model", "health", "--json"),
+        ("--toolsets", "all", "health", "--json"),
+    )
+    for index, invocation in enumerate(invocations):
+        home = tmp_path / f"profile-{index}"
+        _write_profile(home)
+        before = {
+            path.relative_to(home): path.read_bytes()
+            for path in home.rglob("*")
+            if path.is_file()
+        }
+
+        proc = _run_cli(home, *invocation)
+
+        assert proc.returncode == 0, proc.stderr
+        after = {
+            path.relative_to(home): path.read_bytes()
+            for path in home.rglob("*")
+            if path.is_file()
+        }
+        assert after == before
+
+
+def test_health_cli_e2e_does_not_invoke_external_secret_source(tmp_path, monkeypatch):
+    home = tmp_path / "profile"
+    _write_profile(home)
+    with (home / "config.yaml").open("a", encoding="utf-8") as config_file:
+        config_file.write(
+            "secrets:\n"
+            "  bitwarden:\n"
+            "    enabled: true\n"
+            "    project_id: proj-1\n"
+            "    access_token_env: BWS_ACCESS_TOKEN\n"
+            "    auto_install: false\n"
+        )
+    marker = tmp_path / "bws-invoked"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_bws = bin_dir / "bws"
+    fake_bws.write_text(
+        f"#!/bin/sh\n: > '{marker}'\nprintf '[]'\n",
+        encoding="utf-8",
+    )
+    fake_bws.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "0.test.token")
+
+    proc = _run_health_cli(home, "--json")
+
+    assert proc.returncode == 0, proc.stderr
+    assert not marker.exists()
+
+
+def test_health_cli_e2e_missing_state_db_exits_one(tmp_path):
+    home = tmp_path / "profile"
+    _write_profile(home, state_db=False)
+
+    proc = _run_health_cli(home, "--json")
+
+    assert proc.returncode == 1, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["status"] == "warning"
+    assert payload["exit_code"] == 1
+
+
+def test_health_cli_e2e_bad_config_exits_two(tmp_path):
+    home = tmp_path / "profile"
+    home.mkdir()
+    (home / "config.yaml").write_text("model: [unterminated\n", encoding="utf-8")
+    sqlite3.connect(home / "state.db").close()
+
+    proc = _run_health_cli(home, "--json")
+
+    assert proc.returncode == 2, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["status"] == "critical"
+    assert payload["exit_code"] == 2
+
+
+def test_health_cli_e2e_quiet_healthy_is_silent(tmp_path):
+    home = tmp_path / "profile"
+    _write_profile(home)
+
+    proc = _run_health_cli(home, "--quiet")
+
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout == ""

--- a/tests/hermes_cli/test_health.py
+++ b/tests/hermes_cli/test_health.py
@@ -253,6 +253,44 @@ def test_unexpected_health_failure_does_not_disclose_exception_text(monkeypatch,
         assert "health collection failed (RuntimeError)" in output
 
 
+def test_row_failures_do_not_disclose_exception_text(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "profile"
+    _write_profile(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    sentinel = "SUPER_SECRET_CREDENTIAL_123"
+    original_read_text = Path.read_text
+
+    def raise_sentinel(*_args, **_kwargs):
+        raise RuntimeError(sentinel)
+
+    def install_cron_failure(patcher):
+        def read_text(path, *args, **kwargs):
+            if path.name == "jobs.json":
+                raise RuntimeError(sentinel)
+            return original_read_text(path, *args, **kwargs)
+
+        patcher.setattr(Path, "read_text", read_text)
+
+    failure_installers = (
+        lambda patcher: patcher.setattr(
+            health_mod, "_copy_coherent_state_snapshot", raise_sentinel
+        ),
+        install_cron_failure,
+        lambda patcher: patcher.setattr(health_mod.shutil, "disk_usage", raise_sentinel),
+    )
+
+    for install_failure in failure_installers:
+        with monkeypatch.context() as patcher:
+            install_failure(patcher)
+            for json_output in (True, False):
+                code = health_mod.run_health(SimpleNamespace(json=json_output, quiet=False))
+                output = capsys.readouterr().out
+                assert code == 2
+                assert sentinel not in output
+                if json_output:
+                    assert "RuntimeError" in output
+
+
 def test_collect_health_critical_exit_two_for_non_mapping_config(tmp_path, monkeypatch):
     home = tmp_path / "profile"
     home.mkdir()

--- a/tests/hermes_cli/test_health.py
+++ b/tests/hermes_cli/test_health.py
@@ -616,6 +616,20 @@ def test_health_main_skips_mutating_startup_maintenance(monkeypatch):
     main_mod.main()
 
 
+def test_health_json_skips_early_tui_mouse_output(monkeypatch):
+    import hermes_cli.main as main_mod
+
+    writes = []
+    monkeypatch.setattr(sys, "argv", ["hermes", "--tui", "health", "--json"])
+    monkeypatch.setenv("HERMES_TUI", "1")
+    monkeypatch.setattr(main_mod.os, "isatty", lambda _fd: True)
+    monkeypatch.setattr(main_mod.os, "write", lambda fd, data: writes.append((fd, data)))
+
+    main_mod._suppress_mouse_residue_early()
+
+    assert writes == []
+
+
 def test_cron_reader_accepts_utf8_bom_without_mutation(tmp_path):
     home = tmp_path / "profile"
     jobs_path = home / "cron" / "jobs.json"

--- a/tests/hermes_cli/test_health.py
+++ b/tests/hermes_cli/test_health.py
@@ -186,7 +186,24 @@ def test_collect_health_critical_exit_two_for_bad_config(tmp_path, monkeypatch):
 
     assert result["status"] == "critical"
     assert result["exit_code"] == 2
-    assert any(row["id"] == "profile_config" and row["status"] == "critical" for row in result["checks"])
+    config_row = next(row for row in result["checks"] if row["id"] == "profile_config")
+    assert config_row["status"] == "critical"
+    assert "line 2, column 1" in config_row["detail"]
+
+
+def test_bad_config_diagnostic_does_not_disclose_source_line(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "profile"
+    home.mkdir()
+    sentinel = "SUPER_SECRET_CREDENTIAL_123"
+    (home / "config.yaml").write_text(f"api_key: [{sentinel}\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    for json_output in (True, False):
+        code = health_mod.run_health(SimpleNamespace(json=json_output, quiet=False))
+        output = capsys.readouterr().out
+        assert code == 2
+        assert sentinel not in output
+        assert "line 2, column 1" in output
 
 
 def test_collect_health_critical_exit_two_for_non_mapping_config(tmp_path, monkeypatch):
@@ -419,6 +436,65 @@ import hermes_cli.main
     assert "PyYAML" in payload["checks"][0]["detail"]
     assert recovery_marker.read_bytes() == original_marker
     assert not repair_marker.exists()
+
+
+def test_broken_dependency_health_resolves_explicit_and_sticky_profiles(tmp_path):
+    shadow = tmp_path / "shadow"
+    shadow.mkdir()
+    (shadow / "yaml.py").write_text(
+        "raise ImportError('deliberately broken yaml')\n", encoding="utf-8"
+    )
+    user_home = tmp_path / "user"
+    hermes_root = user_home / ".hermes"
+    (hermes_root / "profiles" / "coder").mkdir(parents=True)
+    (hermes_root / "active_profile").write_text("coder\n", encoding="utf-8")
+    script = """
+import sys
+sys.argv = ["hermes", *sys.argv[1:]]
+import hermes_cli.main
+"""
+    base_env = {
+        **os.environ,
+        "HOME": str(user_home),
+        "PYTHONPATH": f"{shadow}{os.pathsep}{os.getcwd()}",
+    }
+    base_env.pop("HERMES_HOME", None)
+    base_env.pop("HERMES_PROFILE", None)
+
+    for args in (
+        ["--profile", "coder", "health", "--json"],
+        ["-p", "coder", "health", "--json"],
+        ["--profile=coder", "health", "--json"],
+        ["health", "--json"],
+    ):
+        proc = subprocess.run(
+            [sys.executable, "-c", script, *args],
+            cwd=os.getcwd(),
+            env=base_env,
+            text=True,
+            capture_output=True,
+            timeout=30,
+        )
+        assert proc.returncode == 2, proc.stderr
+        payload = json.loads(proc.stdout)
+        assert payload["profile"] == "coder"
+        assert payload["hermes_home"] == str(hermes_root / "profiles" / "coder")
+
+    custom_root = tmp_path / "custom-hermes-root"
+    (custom_root / "profiles" / "coder").mkdir(parents=True)
+    custom_env = {**base_env, "HERMES_HOME": str(custom_root)}
+    proc = subprocess.run(
+        [sys.executable, "-c", script, "--profile", "coder", "health", "--json"],
+        cwd=os.getcwd(),
+        env=custom_env,
+        text=True,
+        capture_output=True,
+        timeout=30,
+    )
+    assert proc.returncode == 2, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["profile"] == "coder"
+    assert payload["hermes_home"] == str(custom_root / "profiles" / "coder")
 
 
 def test_health_subparser_registered():

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -61,6 +61,7 @@ hermes [global-options] <command> [subcommand/options]
 | `hermes webhook` | Manage dynamic webhook subscriptions for event-driven activation. |
 | `hermes hooks` | Inspect, approve, or remove shell-script hooks declared in `config.yaml`. |
 | `hermes doctor` | Diagnose config and dependency issues. |
+| `hermes health` | Run offline, automation-friendly health checks with stable exit codes. |
 | `hermes security audit` | On-demand supply-chain audit (OSV.dev) for the venv, plugin requirements, and pinned MCP servers. |
 | `hermes approvals` | Approval-prompt tools — mine approval history into allowlist proposals. |
 | `hermes dump` | Copy-pasteable setup summary for support/debugging. |
@@ -775,6 +776,25 @@ hermes doctor [--fix]
 | Option | Description |
 |--------|-------------|
 | `--fix` | Attempt automatic repairs where possible. |
+
+## `hermes health`
+
+```bash
+hermes health [--json] [--quiet]
+```
+
+Runs offline, read-only checks for profile/config readability, the state database,
+cron storage and latest persisted run, disk space, provider-route configuration,
+and core runtime modules. It does not call model providers or probe the network.
+
+Exit codes are stable for automation: `0` healthy, `1` warning/degraded, and `2`
+critical. `--json` emits the versioned machine-readable payload. `--quiet` emits
+nothing when healthy while retaining diagnostics for warning and critical states.
+
+| Option | Description |
+|--------|-------------|
+| `--json` | Emit a machine-readable payload (`schema_version: 1`) with stable check IDs. |
+| `--quiet` | Suppress healthy output; warning and critical diagnostics are still printed. |
 
 ## `hermes dump`
 


### PR DESCRIPTION
## Summary

Adds `hermes health`, a small automation-oriented health contract for scripts, cron jobs, service managers, dashboards, and containers.

This is intentionally narrower than `hermes doctor`:

- `hermes doctor` is the interactive human diagnostic command and may run provider/network checks.
- `hermes health` is offline by default, does not probe providers or networks, and returns stable exit codes for automation.

Exit-code contract:

- `0` — healthy
- `1` — warning/degraded
- `2` — critical

Output modes:

- default human-readable table
- `--json` for machine-readable health payloads (`schema_version: 1`, stable per-check `id`s, `hermes_version`)
- `--quiet` for watchdogs: print nothing when healthy, but still print diagnostics when warning/critical

Checks included in the initial command:

- profile/config readability and model route presence, including non-mapping YAML rejection
- state DB availability/readability
- cron job storage readability and latest run timestamp if present (read-only; no cron repair/migration side effects)
- disk free-space thresholds for the active Hermes home
- core runtime/tool-registry module-resolution sanity

No gateway FD probing, `/proc` inspection, provider API calls, or new user-facing environment variables are included in this PR.

## Relation to existing diagnostics / open PRs

This overlaps in name with #16515, but the goal is different. #16515 focuses on database/checkpoint maintenance reporting and recommendations. This PR focuses on a stable offline exit-code contract suitable for automation. If maintainers prefer, the DB/WAL maintenance details from #16515 could be layered onto this contract later, but this PR keeps the first version minimal.

This also differs from #38823 (`doctor --json/--verbose`). Machine-readable `doctor` output is useful for interactive diagnostics and route observability, but it still lives on the broader doctor surface. `health` is deliberately low-cost and offline for monitoring contexts.

## Test plan

- `uv run --extra dev python -m pytest tests/hermes_cli/test_health.py tests/hermes_cli/test_cron_parser_builder.py -q` (`20 passed`)
- `uv run --extra dev python - <<'PY' ... py_compile.compile(...) ... PY` (`py_compile ok`)
- `uv run --extra dev ruff check hermes_cli/health.py hermes_cli/subcommands/health.py tests/hermes_cli/test_health.py` (`All checks passed!`)
- `git diff --check`

Manual smoke, using a temporary `HERMES_HOME`:

- `python -m hermes_cli.main health --json` returns `status=healthy`, `exit_code=0`, `schema_version=1`
- `python -m hermes_cli.main health --quiet` exits `0` with zero bytes on stdout when healthy
