### PR TITLE
fix(image/video gen): make schema delivery instruction platform-neutral

### DIFF
--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -1184,11 +1184,13 @@ IMAGE_GENERATE_SCHEMA = {
         "`reference_image_urls` for style/composition references; omit both "
         "for text-to-image. The underlying backend (FAL, OpenAI, xAI, etc.) "
         "and model are user-configured and not selectable by the agent. "
-        "Returns either a URL or an absolute file path in the `image` field; "
-        "display it with markdown ![description](url-or-path) and the gateway "
-        "will deliver it. When the active terminal backend has a different "
-        "filesystem, successful local-file results may also include "
-        "`agent_visible_image` for follow-up terminal/file operations."
+        "Returns the result in the `image` field — either a URL or an absolute "
+        "file path. To show it to the user, reference that path/URL in your "
+        "response using the file-delivery convention for the current platform "
+        "(your platform guidance describes how files are delivered here). When "
+        "the active terminal backend has a different filesystem, successful "
+        "local-file results may also include `agent_visible_image` for "
+        "follow-up terminal/file operations."
     ),
     "parameters": {
         "type": "object",

--- a/tools/video_generation_tool.py
+++ b/tools/video_generation_tool.py
@@ -419,9 +419,11 @@ _GENERIC_DESCRIPTION = (
     "endpoint. The backend and model family are user-configured via "
     "`hermes tools` → Video Generation; the agent does not pick them. "
     "Long-running generations may take 30 seconds to several minutes — "
-    "the call blocks until the video is ready. Returns either an HTTP "
-    "URL or an absolute file path in the `video` field; display it with "
-    "markdown ![description](url-or-path) and the gateway will deliver it."
+    "the call blocks until the video is ready. Returns the result in the "
+    "`video` field — either an HTTP URL or an absolute file path. To show "
+    "it to the user, reference that path/URL in your response using the "
+    "file-delivery convention for the current platform (your platform "
+    "guidance describes how files are delivered here)."
 )
 
 


### PR DESCRIPTION
## Summary
The image/video gen tool schemas no longer ship a gateway-only delivery instruction that contradicts the CLI (and is wrong about the mechanism on messaging platforms).

Root cause: `image_generate` and `video_generate` schema descriptions hardcoded *"display it with markdown `![description](url-or-path)` and the gateway will deliver it."* That schema is sent on **every** platform, so:
- On **CLI** it directly contradicts the CLI platform hint (`prompt_builder.py`): "Do NOT emit MEDIA:/path tags ... state its absolute path in plain text."
- On **messaging** platforms it's also wrong about the mechanism — local file paths are delivered via `MEDIA:` tags, not markdown image syntax. Markdown `![]()` only works for **URLs**.

The per-platform file-delivery convention is already owned correctly by the platform hints in `agent/prompt_builder.py` (Telegram/Discord/Slack → `MEDIA:` tags; CLI → plain path; etc.). The schema now just states the result shape and defers "how to deliver" to the active platform's guidance.

## Changes
- `tools/image_generation_tool.py`: schema `description` delivery clause → platform-neutral (describe `image` return shape, defer delivery to platform guidance).
- `tools/video_generation_tool.py`: same change for `_GENERIC_DESCRIPTION` (`video` field).

Provider/model injection was already working via `_build_dynamic_image_schema()` (the `Active backend: <provider> · model: <model>` line) — no change needed there; it's preserved.

## Validation
| | Before | After |
|---|---|---|
| CLI schema vs CLI hint | contradictory (markdown+gateway vs plain path) | consistent — schema defers to platform hint |
| Messaging mechanism | wrong (markdown for local paths) | correct — platform hint owns `MEDIA:` convention |
| Provider/model in description | injected | still injected (unchanged) |

E2E: rebuilt the real dynamic schema against a temp `HERMES_HOME` — `Active backend: FAL.ai · model: ...` line still present, markdown-delivery claim gone from both static and dynamic descriptions. Tests: `test_image_generation*`, `test_video_generation_dynamic_schema`, `test_video_generation_tool_surface_matrix`, `test_media_extraction`, `test_prompt_builder` all green (94 + 155 passing).

## Infographic

![platform-neutral-file-delivery](https://v3b.fal.media/files/b/0a9f5c4f/qehGXbLXoFR0T91Ro7vw5_K84EypqJ.png)
