### PR TITLE
docs: add legacy documentation redirects

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -84,6 +84,34 @@ const config: Config = {
             from: '/guides/build-a-hermes-plugin',
             to: '/developer-guide/plugins',
           },
+          {
+            from: '/reference/commands',
+            to: '/reference/cli-commands',
+          },
+          {
+            from: '/reference/configuration',
+            to: '/user-guide/configuration',
+          },
+          {
+            from: '/reference/tools',
+            to: '/reference/tools-reference',
+          },
+          {
+            from: '/developer-guide',
+            to: '/developer-guide/architecture',
+          },
+          {
+            from: '/features/skills',
+            to: '/user-guide/features/skills',
+          },
+          {
+            from: '/quickstart',
+            to: '/getting-started/quickstart',
+          },
+          {
+            from: '/messaging-platforms/telegram',
+            to: '/user-guide/messaging/telegram',
+          },
         ],
       },
     ],


### PR DESCRIPTION
## Summary

- Add Docusaurus client redirects for legacy docs URLs reported in #50866.
- Point old sidebar/link targets like `/reference/commands`, `/reference/tools`, `/quickstart`, and `/messaging-platforms/telegram` at their current docs pages.

## Validation

- `npm ci`
- `npm run build`
- Verified generated redirect pages exist for each added legacy route.

Note: the docs build still reports pre-existing broken-link warnings, mostly under zh-Hans/generated skill docs, but exits successfully.

Fixes #50866
