### PR TITLE
fix(whatsapp): resolve LID↔phone aliases in Python DM allowlist

### DIFF
--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -35,6 +35,7 @@ import json
 import logging
 import os
 import re
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 
@@ -148,13 +149,72 @@ class WhatsAppBehaviorMixin:
 
     # ------------------------------------------------------------------ gating
     def _is_dm_allowed(self, sender_id: str) -> bool:
-        """Check whether a DM from the given sender should be processed."""
+        """Check whether a DM from the given sender should be processed.
+
+        Baileys 7.x sends ``senderId`` in LID format (e.g. ``<numeric>@lid``)
+        while user allowlists are typically phone numbers (``+<numeric>``).
+        Without LID↔phone resolution the allowlist never matches known users.
+        See ``scripts/whatsapp-bridge/allowlist.js`` for the JS-side mirror.
+        """
         if self._dm_policy == "disabled":
             return False
         if self._dm_policy == "allowlist":
-            return sender_id in self._allow_from
+            return self._sender_in_allowlist(sender_id)
         # "open" — all DMs allowed
         return True
+
+    def _lid_aliases(self, sender_id: str) -> set:
+        """Resolve a WhatsApp identifier to all known aliases (LID ↔ phone).
+
+        Reads ``lid-mapping-<id>.json`` and ``lid-mapping-<id>_reverse.json``
+        from the session directory (same files the JS bridge writes) and
+        walks both directions so either form resolves to the other.
+        """
+        if not sender_id:
+            return set()
+        normalized = self._normalize_whatsapp_id(sender_id).split("@", 1)[0].lstrip("+")
+        aliases = {normalized}
+        session_dir = getattr(self, "_session_path", None)
+        if session_dir is None:
+            return aliases
+        try:
+            queue = [normalized]
+            seen = set()
+            while queue:
+                current = queue.pop(0)
+                if not current or current in seen:
+                    continue
+                seen.add(current)
+                for suffix in ("", "_reverse"):
+                    mapping_file = Path(session_dir) / f"lid-mapping-{current}{suffix}.json"
+                    if not mapping_file.exists():
+                        continue
+                    try:
+                        import json as _json
+                        mapped = _json.loads(mapping_file.read_text(encoding="utf-8")).strip().lstrip("+")
+                        if mapped and mapped not in aliases:
+                            aliases.add(mapped)
+                            if mapped not in seen:
+                                queue.append(mapped)
+                    except Exception:
+                        continue
+        except Exception:
+            pass
+        return aliases
+
+    def _sender_in_allowlist(self, sender_id: str) -> bool:
+        """Check whether sender_id (any format) is in the DM allowlist."""
+        aliases = self._lid_aliases(sender_id)
+        # ``_allow_from`` is provided by the host adapter per the mixin contract
+        # (see module docstring). Pyright can't see across the mixin boundary.
+        allow_from = self._allow_from  # type: ignore[attr-defined]
+        for alias in aliases:
+            if alias in allow_from:
+                return True
+            # Also try with + prefix (allowlist entries may include +)
+            if f"+{alias}" in allow_from:
+                return True
+        return False
 
     def _is_group_allowed(self, chat_id: str) -> bool:
         """Check whether a group chat should be processed."""


### PR DESCRIPTION
## Bug

Baileys 7.x delivers 1:1 message sender IDs in LID format (e.g. `<numeric>@lid`) while user allowlists typically use phone numbers with `+` prefix (e.g. `+<numeric>`).

The JS bridge already handles this — `scripts/whatsapp-bridge/allowlist.js` strips the `+` prefix and walks `lid-mapping-<id>{,_reverse}.json` files Baileys writes to the session directory, so either form resolves to the other. The Python adapter does not:

```python
# Old _is_dm_allowed
return sender_id in self._allow_from  # always False for LID senders
```

This silently drops every WhatsApp DM after the JS bridge queues it — no error in gateway.log, no notification, just a `[]` response to repeated `/messages` polls. Outbound keeps working (different code path), so the symptom is "WhatsApp stopped replying" rather than "WhatsApp is broken."

## Repro

1. Configure `gateway.platforms.whatsapp.extra.allow_from` with phone numbers.
2. Set `dm_policy: allowlist`.
3. Connect to WhatsApp via Baileys 7.x — sender IDs arrive in LID format.
4. Send a DM from your phone.
5. Observe: JS bridge logs `allowlist_pass` + `queued` with bodyPreview; `messageQueue` non-empty; `/messages` returns the event to Python; Python `_is_dm_allowed("<LID>@lid")` returns False → `_build_message_event` returns None → no `inbound message: platform=whatsapp` in `gateway.log`.

## Fix

Mirror the JS allowlist walk in `WhatsAppBehaviorMixin` via two new helpers:

- `_lid_aliases(sender_id)` — resolves a sender ID to all known aliases (phone ↔ LID) by walking the same `lid-mapping-{id}{,_reverse}.json` files the JS bridge reads.
- `_sender_in_allowlist(sender_id)` — checks the DM allowlist against every alias.

`_is_dm_allowed` now calls `_sender_in_allowlist` when policy is `allowlist`. New `Path` import required for the file-system walk. Mixin-bound `_allow_from` carries a `# type: ignore[attr-defined]` comment with a pointer to the documented mixin contract at the top of the file (Pyright can't see across mixin boundaries).

## Test plan

- Existing behavior preserved: phone-format senders still match when their `+<phone>` is in `_allow_from`.
- New behavior: LID-format senders resolve via mapping files to phone, then match.
- No mapping files: `_lid_aliases` returns `{normalized}` only — sender is rejected unless `normalized` is in `_allow_from` directly (regression-safe).
- Open policy (`dm_policy: "open"`): unchanged, returns True.
- Disabled policy: unchanged, returns False.

## Risk

Low. ~62 lines, two new methods on the existing mixin, no changes to public surface area. The only behavioral change is: previously-rejected DMs from LID-formatted senders now succeed (when the underlying phone resolves to an allowed user via `lid-mapping-*.json`). This matches the JS-side behavior that's already in production.
