### PR TITLE
fix: clamp codex prompt_cache_key to 64 chars

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -5,10 +5,28 @@ This transport owns format conversion and normalization — NOT client lifecycle
 streaming, or the _run_codex_stream() call path.
 """
 
+import hashlib
 from typing import Any, Dict, List, Optional
 
 from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall
+
+# OpenAI / xAI reject a prompt_cache_key longer than 64 chars with HTTP 400.
+_PROMPT_CACHE_KEY_MAX = 64
+
+
+def _clamp_prompt_cache_key(session_id: str) -> str:
+    """Return a cache key <= 64 chars, stable for a given session id.
+
+    Long Hermes session ids (e.g. ``cron_<name>-<uuid>_<timestamp>``)
+    overflow the provider's 64-char limit, so collapse anything over the
+    limit to its sha256 hex digest (exactly 64 chars). The digest is
+    deterministic, so cross-turn cache hits for the same session are
+    preserved.
+    """
+    if len(session_id) <= _PROMPT_CACHE_KEY_MAX:
+        return session_id
+    return hashlib.sha256(session_id.encode("utf-8")).hexdigest()
 
 
 class ResponsesApiTransport(ProviderTransport):
@@ -215,7 +233,7 @@ class ResponsesApiTransport(ProviderTransport):
         # xAI Responses takes prompt_cache_key in extra_body (set further
         # down); GitHub Models opts out of cache-key routing entirely.
         if not is_github_responses and not is_xai_responses and session_id:
-            kwargs["prompt_cache_key"] = session_id
+            kwargs["prompt_cache_key"] = _clamp_prompt_cache_key(str(session_id))
 
         if reasoning_enabled and is_xai_responses:
             from agent.model_metadata import grok_supports_reasoning_effort
@@ -326,7 +344,9 @@ class ResponsesApiTransport(ProviderTransport):
             merged_extra_body: Dict[str, Any] = {}
             if isinstance(existing_extra_body, dict):
                 merged_extra_body.update(existing_extra_body)
-            merged_extra_body.setdefault("prompt_cache_key", session_id)
+            merged_extra_body.setdefault(
+                "prompt_cache_key", _clamp_prompt_cache_key(str(session_id))
+            )
             kwargs["extra_body"] = merged_extra_body
 
         return kwargs

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -91,6 +91,42 @@ class TestCodexBuildKwargs:
         )
         assert kw.get("prompt_cache_key") == "test-session-123"
 
+    def test_long_session_id_cache_key_clamped_to_64(self, transport):
+        """OpenAI rejects prompt_cache_key longer than 64 chars (HTTP 400).
+        Hermes cron session ids like
+        ``cron_<name>-<uuid>_<timestamp>`` overflow that limit, so the
+        transport must collapse anything over 64 to a stable <=64 key."""
+        long_id = "cron_openclaw-53df86b4-cfe9-4043-a394-f655d1c4f361_20260622_120024"
+        assert len(long_id) > 64
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.4", messages=messages, tools=[],
+            session_id=long_id,
+        )
+        key = kw.get("prompt_cache_key")
+        assert key is not None
+        assert len(key) <= 64
+        # Deterministic: same input -> same key (cross-turn cache hits).
+        kw2 = transport.build_kwargs(
+            model="gpt-5.4", messages=messages, tools=[],
+            session_id=long_id,
+        )
+        assert kw2.get("prompt_cache_key") == key
+
+    def test_long_session_id_xai_extra_body_clamped(self, transport):
+        """The xAI extra_body cache key path must clamp too."""
+        long_id = "cron_openclaw-53df86b4-cfe9-4043-a394-f655d1c4f361_20260622_120024"
+        assert len(long_id) > 64
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="grok-4.3", messages=messages, tools=[],
+            session_id=long_id,
+            is_xai_responses=True,
+        )
+        key = kw.get("extra_body", {}).get("prompt_cache_key")
+        assert key is not None
+        assert len(key) <= 64
+
     def test_github_responses_no_cache_key(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(


### PR DESCRIPTION
## Problem

OpenAI/xAI reject `prompt_cache_key` longer than 64 chars with HTTP 400. Hermes cron session ids have the form `cron_<name>-<uuid>_<timestamp>` (e.g. `cron_openclaw-53df86b4-cfe9-4043-a394-f655d1c4f361_20260622_120024` = **66 chars**), so every cron agent call against `openai-codex` failed:

```
BadRequestError ... HTTP 400: Invalid 'prompt_cache_key': string too long.
Expected a string with maximum length 64, but got a string with length 66 instead.
```

## Fix

Add `_clamp_prompt_cache_key()` in `agent/transports/codex.py`:
- ids `<= 64` chars pass through unchanged (no behavior change for normal sessions)
- longer ids collapse to a stable `sha256` hex digest (exactly 64 chars, deterministic — so cross-turn prompt-cache hits for the same session are preserved)

Applied to **both** cache-key call sites: the OpenAI `prompt_cache_key` kwarg and the xAI `extra_body` path.

## Test plan

- [x] New tests cover the over-64 OpenAI and xAI paths + determinism (TDD: written failing first)
- [x] `pytest tests/agent/transports/test_codex_transport.py` — 61 passed
- [x] `pytest tests/run_agent/test_run_agent_codex_responses.py` — 77 passed
- [x] No regressions; short ids unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)