### PR TITLE
feat: add /resume-last slash command

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7926,6 +7926,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             self.new_session(title=title)
         elif canonical == "resume":
             self._handle_resume_command(cmd_original)
+        elif canonical == "resume-last":
+            self._handle_resume_last_command(cmd_original)
         elif canonical == "sessions":
             self._handle_sessions_command(cmd_original)
         elif canonical == "model":

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8233,6 +8233,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if canonical == "resume":
             return await self._handle_resume_command(event)
 
+        if canonical == "resume-last":
+            return await self._handle_resume_last_command(event)
+
         if canonical == "sessions":
             return await self._handle_sessions_command(event)
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3157,6 +3157,42 @@ class GatewaySlashCommandsMixin:
             return t("gateway.resume.resumed_one", title=title, count=msg_count)
         return t("gateway.resume.resumed_many", title=title, count=msg_count)
 
+    async def _handle_resume_last_command(self, event: MessageEvent) -> str:
+        """Handle /resume-last — resume the most recent session in one keystroke.
+
+        Finds the most recent session for this user/platform (excluding the
+        current one) and delegates to ``_handle_resume_command`` so all
+        existing resume logic (compression-chain resolution, matrix room
+        scoping, session switching, agent eviction) is reused unchanged.
+        """
+        if not self._session_db:
+            from hermes_state import format_session_db_unavailable
+            return format_session_db_unavailable(prefix=t("gateway.shared.session_db_unavailable_prefix"))
+
+        source = event.source
+        user_source = source.platform.value if source.platform else None
+
+        # Identify the current session so we can skip it.
+        current_entry = self.session_store.get_or_create_session(source)
+        current_session_id = current_entry.session_id
+
+        try:
+            sessions = self._session_db.list_sessions_rich(source=user_source, limit=10)
+        except Exception as e:
+            logger.debug("Failed to list sessions for /resume-last: %s", e)
+            return t("gateway.resume.list_failed", error=e)
+
+        recent = [s for s in sessions if s.get("id") != current_session_id]
+        if not recent:
+            return t("gateway.resume_last.no_sessions")
+
+        target_id = recent[0].get("id")
+        if not target_id:
+            return t("gateway.resume_last.no_sessions")
+
+        resume_event = dataclasses.replace(event, text=f"/resume {target_id}")
+        return await self._handle_resume_command(resume_event)
+
     async def _handle_sessions_command(self, event: MessageEvent) -> str:
         """Handle /sessions — list previous sessions for gateway chats."""
         if not self._session_db:

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -811,6 +811,25 @@ class CLICommandsMixin:
         # /sessions <id_or_title> behaves the same as /resume <id_or_title>.
         self._handle_resume_command(f"/resume {arg}")
 
+    def _handle_resume_last_command(self, cmd_original: str) -> None:
+        """Handle /resume-last — resume the most recent session in one keystroke.
+
+        Looks up the most recent session (excluding the current one) and
+        delegates to ``_handle_resume_command`` with its ID, so all existing
+        resume logic (compression-chain resolution, session switching, history
+        recap, memory-provider notification) is reused unchanged.
+        """
+        from cli import _cprint
+
+        sessions = self._list_recent_sessions(limit=1)
+        if not sessions:
+            _cprint("  (._.) No previous sessions to resume.")
+            _cprint("  Tip:   Use /history or `hermes sessions list` to find sessions.")
+            return
+
+        target_id = sessions[0]["id"]
+        self._handle_resume_command(f"/resume {target_id}")
+
     def _handle_branch_command(self, cmd_original: str) -> None:
         """Handle /branch [name] — fork the current session into a new independent copy.
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -118,6 +118,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                gateway_only=True, aliases=("set-home",)),
     CommandDef("resume", "Resume a previously-named session", "Session",
                args_hint="[name]"),
+    CommandDef("resume-last", "Resume the most recent session", "Session",
+               aliases=("rl",)),
 
     # Configuration
     CommandDef("sessions", "Browse and resume previous sessions", "Session"),

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -255,6 +255,9 @@ gateway:
     resumed_many:          "↻ Resumed session **{title}** ({count} messages). Conversation restored."
     resumed_no_count:      "↻ Resumed session **{title}**. Conversation restored."
 
+  resume_last:
+    no_sessions:           "(._.) No previous sessions to resume."
+
   retry:
     no_previous:           "No previous message to retry."
 

--- a/tests/cli/test_cli_resume_command.py
+++ b/tests/cli/test_cli_resume_command.py
@@ -287,3 +287,56 @@ class TestRestoreSessionCwdMarkup:
             assert "Working directory" in printed or "working" in printed.lower()
         finally:
             os.chdir(original_cwd)
+
+
+class TestCliResumeLastCommand:
+    """Tests for /resume-last — resume the most recent session in one step."""
+
+    def test_resume_last_delegates_to_resume_with_most_recent_id(self):
+        """Finds the most recent session and delegates to _handle_resume_command."""
+        cli_obj = _make_cli()
+        cli_obj._list_recent_sessions = MagicMock(return_value=[
+            {"id": "sess_most_recent", "title": "Latest"},
+        ])
+        cli_obj._session_db.get_session.return_value = {"id": "sess_most_recent", "title": "Latest"}
+        cli_obj._session_db.get_messages_as_conversation.return_value = [
+            {"role": "user", "content": "hello"},
+        ]
+        cli_obj._session_db.resolve_resume_session_id.return_value = "sess_most_recent"
+
+        with (
+            patch("hermes_cli.main._resolve_session_by_name_or_id", return_value=None),
+            patch("cli._cprint") as mock_cprint,
+        ):
+            cli_obj._handle_resume_last_command("/resume-last")
+
+        # Should have switched to the most recent session.
+        assert cli_obj.session_id == "sess_most_recent"
+        printed = " ".join(str(call) for call in mock_cprint.call_args_list)
+        assert "Resumed session sess_most_recent" in printed
+
+    def test_resume_last_no_sessions_shows_message(self):
+        """When there are no previous sessions, shows a helpful message."""
+        cli_obj = _make_cli()
+        cli_obj._list_recent_sessions = MagicMock(return_value=[])
+
+        with patch("cli._cprint") as mock_cprint:
+            cli_obj._handle_resume_last_command("/resume-last")
+
+        printed = " ".join(str(call) for call in mock_cprint.call_args_list)
+        assert "No previous sessions to resume" in printed
+        # Session should not have changed.
+        assert cli_obj.session_id == "current_session"
+
+    def test_resume_last_uses_limit_one(self):
+        """Only fetches a single session (the most recent) for efficiency."""
+        cli_obj = _make_cli()
+        cli_obj._list_recent_sessions = MagicMock(return_value=[])
+        cli_obj._handle_resume_command = MagicMock()
+
+        with patch("cli._cprint"):
+            cli_obj._handle_resume_last_command("/resume-last")
+
+        # _list_recent_sessions must be called with limit=1.
+        cli_obj._list_recent_sessions.assert_called_once_with(limit=1)
+


### PR DESCRIPTION
## Summary

Resolves #51040

Adds `/resume-last` (alias `/rl`) — a one-keystroke shortcut that finds the most recent session and delegates to the existing `/resume` logic.

## What it does

- `/resume-last` or `/rl` — resumes the most recent session (excluding the current one)
- Works in both CLI and gateway (Telegram, Discord, Slack, etc.)
- Delegates to `_handle_resume_command` so all existing resume logic is reused unchanged (compression-chain resolution, session switching, history recap, memory-provider notification)
- No new infrastructure — thin wrapper around existing `/resume`

## Changes

| File | Change |
|------|--------|
| `cli.py` | Dispatch `resume-last` canonical command |
| `gateway/run.py` | Dispatch `resume-last` in gateway command handler |
| `gateway/slash_commands.py` | `_handle_resume_last_command()` — finds most recent session, delegates to `/resume` |
| `hermes_cli/cli_commands_mixin.py` | `_handle_resume_last_command()` — CLI version, uses `_list_recent_sessions(limit=1)` |
| `hermes_cli/commands.py` | Command registry entry with `rl` alias |
| `locales/en.yaml` | `gateway.resume_last.no_sessions` locale key |
| `tests/cli/test_cli_resume_command.py` | 3 tests: delegation, empty-state, limit=1 |

## Testing

```
python -m pytest tests/cli/test_cli_resume_command.py -x -q
# 18 passed

python -m pytest tests/gateway/test_resume_command.py -x -q
# 17 passed

python -m ruff check cli.py gateway/run.py gateway/slash_commands.py \
  hermes_cli/cli_commands_mixin.py hermes_cli/commands.py \
  tests/cli/test_cli_resume_command.py
# All checks passed
```