### PR TITLE
fix(tui): preserve config on model switch — atomic writes + custom-provider guard (#48305)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1057,8 +1057,10 @@ def switch_model(
 
         # --- Step e: detect_provider_for_model() as last resort ---
         _base = current_base_url or ""
-        is_custom = current_provider in {"custom", "local"} or (
-            "localhost" in _base or "127.0.0.1" in _base
+        is_custom = (
+            current_provider in {"custom", "local"}
+            or current_provider.startswith("custom:")
+            or ("localhost" in _base or "127.0.0.1" in _base)
         )
 
         if (

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1882,12 +1882,22 @@ def detect_static_provider_for_model(
         return None
 
     # --- Step 1: check static provider catalogs for a direct match ---
+    # If the current provider is a custom endpoint (custom or custom:*), never
+    # auto-switch away from it based on a static catalog match — the user
+    # explicitly configured their own endpoint and the same model name may be
+    # served there (#48305).
+    _is_custom_current = (
+        current_provider == "custom"
+        or current_provider.startswith("custom:")
+    )
     for pid, models in _PROVIDER_MODELS.items():
         if (
             pid in current_keys
             or pid in _AGGREGATOR_PROVIDERS
             or pid in _BORROWED_MODEL_PROVIDERS
         ):
+            continue
+        if _is_custom_current:
             continue
         if any(name_lower == m.lower() for m in models):
             return (pid, name)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1673,6 +1673,7 @@ AUTHOR_MAP = {
     "info@amik.co": "AMIK-coorporations",  # PR #40578 (Urdu README) co-author
     "info@amikchat.site": "AMIK-coorporations",  # PR #40578 (Urdu README)
     "kyssta69@gmail.com": "kyssta-exe",  # PR #44282 (Windows dashboard re-exec)
+    "30467832+Elshayib@users.noreply.github.com": "Elshayib",  # PR #48351 (custom-provider misattribution guard; #48305)
     "loongfay@foxmail.com": "loongfay",  # PR #43508 (Yuanbao wechat forward msg)
     "maplestoryjuni222@gmail.com": "BROCCOLO1D",  # PR #42733 (lazy-parse docker env config)
     "marvin@photon.codes": "underthestars-zhy",  # PR #46907 co-author (Photon Spectrum project ids)

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -301,6 +301,26 @@ class TestDetectProviderForModel:
         assert result is not None
         assert result[0] not in {"nous",}  # nous has claude models but shouldn't be suggested
 
+    def test_custom_provider_not_overridden_by_static_catalog(self):
+        """When current provider is custom:*, a static-catalog match must NOT
+        override it — otherwise a model served by the user's own endpoint gets
+        misattributed to a native provider, rewriting model.provider (#48305).
+
+        `gpt-5.4` is in the static openai catalog; with current=custom:foo,
+        detection must return None instead of switching to openai.
+        """
+        assert detect_provider_for_model("gpt-5.4", "custom:foo") is None
+
+    def test_bare_custom_provider_not_overridden_by_static_catalog(self):
+        """Same protection for the bare 'custom' provider."""
+        assert detect_provider_for_model("gpt-5.4", "custom") is None
+
+    def test_non_custom_provider_detection_unaffected(self):
+        """The custom-provider guard must NOT change detection for non-custom
+        current providers — a static-catalog model still routes normally."""
+        result = detect_provider_for_model("gpt-5.4", "openrouter")
+        assert result is not None and result[0] == "openai"
+
 
 class TestIsNousFreeTier:
     """Tests for is_nous_free_tier — account tier detection."""

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3266,7 +3266,7 @@ def test_config_set_model_global_persists(monkeypatch):
         warning_message="",
     )
     seen = {}
-    saved = {}
+    saved_values = {}
 
     def _switch_model(**kwargs):
         seen.update(kwargs)
@@ -3276,7 +3276,9 @@ def test_config_set_model_global_persists(monkeypatch):
     monkeypatch.setattr("hermes_cli.model_switch.switch_model", _switch_model)
     monkeypatch.setattr(server, "_restart_slash_worker", lambda sid, session: None)
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
-    monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: saved.update(cfg))
+    # _persist_model_switch uses targeted save_config_value writes (#48305) so it
+    # preserves sibling model.* keys instead of rewriting the whole block.
+    monkeypatch.setattr("cli.save_config_value", lambda key, value: saved_values.__setitem__(key, value) or True)
 
     resp = server.handle_request(
         {
@@ -3292,9 +3294,9 @@ def test_config_set_model_global_persists(monkeypatch):
 
     assert resp["result"]["value"] == "anthropic/claude-sonnet-4.6"
     assert seen["is_global"] is True
-    assert saved["model"]["default"] == "anthropic/claude-sonnet-4.6"
-    assert saved["model"]["provider"] == "anthropic"
-    assert saved["model"]["base_url"] == "https://api.anthropic.com"
+    assert saved_values["model.default"] == "anthropic/claude-sonnet-4.6"
+    assert saved_values["model.provider"] == "anthropic"
+    assert saved_values["model.base_url"] == "https://api.anthropic.com"
 
 
 def test_config_set_model_explicit_provider_skips_broken_default_init(monkeypatch):
@@ -7988,3 +7990,73 @@ def test_get_usage_safe_when_active_count_raises(monkeypatch):
     # Field omitted, but the rest of the payload is intact.
     assert "active_subagents" not in usage
     assert usage["model"] == "x"
+
+
+def test_persist_model_switch_preserves_sibling_model_keys(tmp_path, monkeypatch):
+    """#48305: switching models from the TUI must NOT destroy sibling keys under
+    `model:` (model_slots, model_fallback, etc.). _persist_model_switch now uses
+    targeted save_config_value writes instead of rewriting the whole block."""
+    import types
+    import yaml
+    import cli
+
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(
+        "model:\n"
+        "  default: old-model\n"
+        "  provider: openai\n"
+        "  model_slots:\n"
+        "    fast: gpt-5-mini\n"
+        "  model_fallback:\n"
+        "    - claude-haiku\n"
+        "agent:\n"
+        "  system_prompt: keepme\n"
+    )
+    # save_config_value() resolves the config path from cli._hermes_home, which
+    # is captured at import time — patch it directly (set_hermes_home_override
+    # does NOT affect this snapshot).
+    monkeypatch.setattr(cli, "_hermes_home", tmp_path)
+
+    result = types.SimpleNamespace(
+        new_model="new-model", target_provider="anthropic", base_url=None
+    )
+    server._persist_model_switch(result)
+    saved = yaml.safe_load(cfg_path.read_text())
+
+    # The switched fields updated...
+    assert saved["model"]["default"] == "new-model"
+    assert saved["model"]["provider"] == "anthropic"
+    # ...and the sibling keys SURVIVED (the bug was that they got wiped).
+    assert saved["model"]["model_slots"] == {"fast": "gpt-5-mini"}
+    assert saved["model"]["model_fallback"] == ["claude-haiku"]
+    assert saved["agent"]["system_prompt"] == "keepme"
+
+
+def test_persist_model_switch_clears_stale_base_url(tmp_path, monkeypatch):
+    """#48305: switching from a custom endpoint (which set model.base_url) to a
+    provider with no base_url must CLEAR the stale base_url, not leave it
+    pointing at the old host."""
+    import types
+    import yaml
+    import cli
+
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(
+        "model:\n"
+        "  default: local-model\n"
+        "  provider: custom:mylocal\n"
+        "  base_url: http://localhost:1234/v1\n"
+    )
+    monkeypatch.setattr(cli, "_hermes_home", tmp_path)
+
+    # Switch to a native provider with no base_url.
+    result = types.SimpleNamespace(
+        new_model="claude-haiku", target_provider="anthropic", base_url=None
+    )
+    server._persist_model_switch(result)
+    saved = yaml.safe_load(cfg_path.read_text())
+
+    assert saved["model"]["default"] == "claude-haiku"
+    assert saved["model"]["provider"] == "anthropic"
+    # Stale custom base_url must be cleared (null coalesces to absent on read).
+    assert not saved["model"].get("base_url"), saved["model"].get("base_url")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2301,21 +2301,23 @@ def _restart_slash_worker(sid: str, session: dict):
 
 
 def _persist_model_switch(result) -> None:
-    from hermes_cli.config import save_config
+    # Use targeted, atomic key writes (comment/ordering-preserving) instead of
+    # rewriting the whole `model:` block. A full-block rewrite via save_config()
+    # destroys sibling keys the user set under `model:` — `model_slots`,
+    # `model_fallback`, etc. — when switching models from the TUI (#48305).
+    from cli import save_config_value
 
-    cfg = _load_cfg()
-    model_cfg = cfg.get("model")
-    if not isinstance(model_cfg, dict):
-        model_cfg = {}
-        cfg["model"] = model_cfg
-
-    model_cfg["default"] = result.new_model
-    model_cfg["provider"] = result.target_provider
+    save_config_value("model.default", result.new_model)
+    save_config_value("model.provider", result.target_provider)
     if result.base_url:
-        model_cfg["base_url"] = result.base_url
+        save_config_value("model.base_url", result.base_url)
     else:
-        model_cfg.pop("base_url", None)
-    save_config(cfg)
+        # Clear any stale base_url when switching to a provider that doesn't use
+        # one (e.g. custom endpoint -> native provider). Reads coalesce null to
+        # absent (`model_cfg.get("base_url") or ""`), so a null is equivalent to
+        # removal without needing a key-delete. Leaving the old value would
+        # route the new model at the previous custom host (#48305).
+        save_config_value("model.base_url", None)
 
 
 def _apply_model_switch(


### PR DESCRIPTION
## Problem

Switching models from the TUI model picker had **two** independent config-destruction bugs (#48305):

1. **Whole-block rewrite wipes sibling keys.** `_persist_model_switch` rewrote the entire `model:` config block via `save_config(cfg)`, destroying sibling keys the user set under `model:` (`model_slots`, `model_fallback`, etc.) on every switch.
2. **Custom-provider misattribution.** When the current provider is a custom endpoint (`custom` / `custom:*`), the switch pipeline auto-switched to a native provider or OpenRouter based on a static-catalog match — silently rewriting `model.provider` away from the user's explicitly-configured endpoint that may serve the same model name.

## Fix (two complementary sub-roots)

**Atomicity (from #48391, @kyssta-exe):** `_persist_model_switch` now uses targeted, atomic, comment-preserving `save_config_value("model.default"/"model.provider"/"model.base_url")` writes instead of a whole-block rewrite — only the changed keys are touched.

**Misattribution guard (from #48351, @Elshayib):**
- `detect_static_provider_for_model()` skips the static-catalog scan when the current provider is `custom`/`custom:*`.
- `switch_model()` Step e extends `is_custom` to cover `custom:*`, so the `detect_provider_for_model()` last-resort fallback can't fire and reroute.

## Salvage / credit

Both keystone branches were **massively stale** (#48391 was 3050 commits behind main, #48351 was 611) — cherry-picking either would have reverted huge swaths of since-merged work. So the fixes were **re-applied fresh against current main**, preserving each contributor's authorship (one commit each) + an AUTHOR_MAP chore for @Elshayib. (#48351's `_persist_model_switch` change is superseded by the #48391 targeted-write approach.)

## Tests

- `tests/hermes_cli/test_models.py` — 3 new tests: `custom:*` and bare `custom` are NOT overridden by a static-catalog match (using `gpt-5.4`, a real misattribution case — verified they FAIL without the fix); non-custom detection unaffected.
- `tests/test_tui_gateway_server.py::test_persist_model_switch_preserves_sibling_model_keys` — real config roundtrip proving `model_slots`/`model_fallback`/`agent.system_prompt` survive a switch.
- Full suites: 124 passed.

## Closes
Fixes #48305


---

## Review-driven changes (/hermes-pr-review — no Critical)

- **Folded the one Warning — stale base_url:** `_persist_model_switch` now explicitly clears `model.base_url` (writes null, which reads coalesce to absent) when switching to a provider with no base_url, so a custom→native switch can't leave the new model pointed at the old custom host. Added `test_persist_model_switch_clears_stale_base_url`.
- **Fixed a test-isolation bug found while folding:** the persist tests used `set_hermes_home_override`, which does NOT affect `save_config_value` (it resolves `cli._hermes_home`, captured at import). Re-pointed both tests to `monkeypatch.setattr(cli, "_hermes_home", tmp_path)` — they now genuinely write to the temp config and pass in any order (previously a silent path mismatch).

Reviewer confirmed: atomicity preserves all sibling `model.*` keys + top-level sections; the misattribution guard is correctly scoped (Step-1 catalog loop only — doesn't block alias/Step-0/borrow paths); custom vs custom:* parity holds across both files; 3 test_models tests are load-bearing (verified fail without fix). 13 tests pass.

**⚠️ Merge-order note (vs PR #51027):** both PRs touch the same `model_switch.py` Step e block — this PR rewrites the `is_custom` assignment, #51027 adds `not config_routed` to the adjacent gate. They're semantically orthogonal (compose cleanly) but may textually conflict. After both land the combined gate should read `… and not is_custom and not config_routed and not resolved_alias and not resolved_in_current_catalog`. I'll rebase whichever merges second.

---

## Rebased onto main after #51027 (E) merged

#51027 also touched `model_switch.py` Step e (added `not config_routed`). Rebased this PR onto current main and verified the two changes **compose cleanly**: the merged Step e gate now reads `target_provider == current_provider and not is_custom and not resolved_alias and not resolved_in_current_catalog and not config_routed` — D's `is_custom` extension (covers `custom`/`custom:*`/localhost) AND E's `not config_routed` both present. Both `models.py` guards (D's `_is_custom_current` static-catalog skip + E's soft-accept family gate) coexist. Conflict in `test_tui_gateway_server.py` was an independent test-block adjacency (a sibling `_get_usage` test landed at the same spot) — both kept. 16 targeted tests pass incl. the `test_config_set_model_global_persists` regression.