### PR TITLE
[codex] preview Kanban dependency impact

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -82,6 +82,16 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
     }
 
 
+def _dependency_impact_child_line(child: kb.DependencyImpactChild) -> str:
+    if child.would_unblock:
+        suffix = "will promote to ready"
+    elif child.blocking_parent_ids:
+        suffix = "still blocked by " + ", ".join(child.blocking_parent_ids)
+    else:
+        suffix = child.reason.replace("_", " ")
+    return f"    {child.id}  {child.status:8s}  {suffix}  {child.title}"
+
+
 def _run_state_kwargs(args: argparse.Namespace) -> Optional[dict[str, str]]:
     st = getattr(args, "state_type", None)
     sn = getattr(args, "state_name", None)
@@ -1445,6 +1455,7 @@ def _cmd_show(args: argparse.Namespace) -> int:
         events = kb.list_events(conn, args.task_id)
         parents = kb.parent_ids(conn, args.task_id)
         children = kb.child_ids(conn, args.task_id)
+        dependency_impact = kb.dependency_impact_preview(conn, args.task_id)
         runs = kb.list_runs(conn, args.task_id, **rsk)
         # Workers hand off via ``task_runs.summary``; ``tasks.result`` is left NULL unless the caller explicitly passed
         # ``result=``. Surfacing the latest summary here keeps ``show`` from
@@ -1457,6 +1468,7 @@ def _cmd_show(args: argparse.Namespace) -> int:
             "latest_summary": latest_summary,
             "parents": parents,
             "children": children,
+            "dependency_impact": dependency_impact.as_dict(),
             "comments": [
                 {"author": c.author, "body": c.body, "created_at": c.created_at}
                 for c in comments
@@ -1554,6 +1566,15 @@ def _cmd_show(args: argparse.Namespace) -> int:
         print(f"  parents:   {', '.join(parents)}")
     if children:
         print(f"  children:  {', '.join(children)}")
+    if dependency_impact.total_children:
+        print(
+            "  impact:    "
+            f"{dependency_impact.will_unblock_count} will unblock, "
+            f"{dependency_impact.still_blocked_count} still blocked, "
+            f"{dependency_impact.unchanged_count} unchanged"
+        )
+        for child in dependency_impact.children:
+            print(_dependency_impact_child_line(child))
     if task.body:
         print()
         print("Body:")

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -915,6 +915,52 @@ class Task:
 
 
 @dataclass
+class DependencyImpactChild:
+    """Preview row for one direct child of a task."""
+
+    id: str
+    title: str
+    status: str
+    assignee: Optional[str]
+    blocking_parent_ids: list[str]
+    would_unblock: bool
+    reason: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "status": self.status,
+            "assignee": self.assignee,
+            "blocking_parent_ids": list(self.blocking_parent_ids),
+            "would_unblock": self.would_unblock,
+            "reason": self.reason,
+        }
+
+
+@dataclass
+class DependencyImpactPreview:
+    """Single-task preview of what completion would unblock downstream."""
+
+    task_id: str
+    total_children: int
+    will_unblock_count: int
+    still_blocked_count: int
+    unchanged_count: int
+    children: list[DependencyImpactChild] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "total_children": self.total_children,
+            "will_unblock_count": self.will_unblock_count,
+            "still_blocked_count": self.still_blocked_count,
+            "unchanged_count": self.unchanged_count,
+            "children": [c.as_dict() for c in self.children],
+        }
+
+
+@dataclass
 class Run:
     """In-memory view of a ``task_runs`` row.
 
@@ -2687,6 +2733,117 @@ def child_ids(conn: sqlite3.Connection, task_id: str) -> list[str]:
         (task_id,),
     ).fetchall()
     return [r["child_id"] for r in rows]
+
+
+def dependency_impact_preview(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    failure_limit: int = None,
+) -> DependencyImpactPreview:
+    """Return the direct children that completing ``task_id`` would unblock.
+
+    The preview intentionally mirrors :func:`recompute_ready`: ``todo`` children
+    promote once all parents are done/archived, while ``blocked`` children only
+    auto-promote when they are dependency-blocked rather than sticky
+    human/worker blocks or circuit-breaker failures.
+    """
+    if failure_limit is None:
+        failure_limit = DEFAULT_FAILURE_LIMIT
+    if get_task(conn, task_id) is None:
+        raise ValueError(f"unknown task {task_id}")
+
+    child_rows = conn.execute(
+        """
+        SELECT c.*
+        FROM tasks c
+        JOIN task_links l ON l.child_id = c.id
+        WHERE l.parent_id = ?
+        ORDER BY c.priority DESC, c.created_at ASC, c.id ASC
+        """,
+        (task_id,),
+    ).fetchall()
+
+    children: list[DependencyImpactChild] = []
+    will_unblock = 0
+    still_blocked = 0
+    unchanged = 0
+    for row in child_rows:
+        child = Task.from_row(row)
+        blockers = [
+            r["id"]
+            for r in conn.execute(
+                """
+                SELECT p.id
+                FROM tasks p
+                JOIN task_links l ON l.parent_id = p.id
+                WHERE l.child_id = ?
+                  AND p.id != ?
+                  AND p.status NOT IN ('done', 'archived')
+                ORDER BY p.id
+                """,
+                (child.id, task_id),
+            ).fetchall()
+        ]
+
+        would_unblock = False
+        reason = "unchanged"
+        if blockers:
+            reason = "blocked_by_other_parents"
+            still_blocked += 1
+        elif child.status == "todo":
+            reason = "will_promote_to_ready"
+            would_unblock = True
+            will_unblock += 1
+        elif child.status == "blocked":
+            failures = int(child.consecutive_failures or 0)
+            task_limit = child.max_retries
+            effective_limit = (
+                int(task_limit) if task_limit is not None else int(failure_limit)
+            )
+            if _has_sticky_block(conn, child.id):
+                reason = "sticky_block"
+                unchanged += 1
+            elif failures >= effective_limit:
+                reason = "failure_limit"
+                unchanged += 1
+            else:
+                reason = "will_promote_to_ready"
+                would_unblock = True
+                will_unblock += 1
+        elif child.status == "ready":
+            reason = "already_ready"
+            unchanged += 1
+        elif child.status == "running":
+            reason = "already_running"
+            unchanged += 1
+        elif child.status in ("done", "archived"):
+            reason = f"already_{child.status}"
+            unchanged += 1
+        else:
+            reason = f"status_{child.status}"
+            unchanged += 1
+
+        children.append(
+            DependencyImpactChild(
+                id=child.id,
+                title=child.title,
+                status=child.status,
+                assignee=child.assignee,
+                blocking_parent_ids=blockers,
+                would_unblock=would_unblock,
+                reason=reason,
+            )
+        )
+
+    return DependencyImpactPreview(
+        task_id=task_id,
+        total_children=len(children),
+        will_unblock_count=will_unblock,
+        still_blocked_count=still_blocked,
+        unchanged_count=unchanged,
+        children=children,
+    )
 
 
 def parent_results(conn: sqlite3.Connection, task_id: str) -> list[tuple[str, Optional[str]]]:

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -3225,6 +3225,7 @@
     const events = props.data.events || [];
     const attachments = props.data.attachments || [];
     const links = props.data.links || { parents: [], children: [] };
+    const dependencyImpact = props.data.dependency_impact || null;
 
     return h("div", { className: "hermes-kanban-drawer-body" },
       h("div", { className: "hermes-kanban-drawer-title" },
@@ -3294,6 +3295,7 @@
         onRemoveParent: props.onRemoveParent,
         onAddChild: props.onAddChild,
         onRemoveChild: props.onRemoveChild,
+        dependencyImpact: dependencyImpact,
       }),
       t.result ? h("div", { className: "hermes-kanban-section" },
         h("div", { className: "hermes-kanban-section-head" }, tx(i18n, "result", "Result")),
@@ -3642,6 +3644,43 @@
     );
   }
 
+  function DependencyImpactPreview(props) {
+    const { t } = useI18n();
+    const impact = props.impact;
+    if (!impact || !impact.total_children) return null;
+    const rows = impact.children || [];
+    const labelFor = function (child) {
+      if (child.would_unblock) return tx(t, "willPromoteReady", "will promote to Ready");
+      if (child.blocking_parent_ids && child.blocking_parent_ids.length > 0) {
+        return `${tx(t, "stillBlockedBy", "still blocked by")} ${child.blocking_parent_ids.join(", ")}`;
+      }
+      return String(child.reason || "unchanged").replace(/_/g, " ");
+    };
+    return h("div", { className: "hermes-kanban-impact" },
+      h("div", { className: "hermes-kanban-impact-summary" },
+        h("span", null, `${impact.will_unblock_count} ${tx(t, "willUnblock", "will unblock")}`),
+        h("span", null, `${impact.still_blocked_count} ${tx(t, "stillBlocked", "still blocked")}`),
+        h("span", null, `${impact.unchanged_count} ${tx(t, "unchanged", "unchanged")}`),
+      ),
+      rows.map(function (child) {
+        return h("div", {
+          key: child.id,
+          className: cn(
+            "hermes-kanban-impact-row",
+            child.would_unblock ? "hermes-kanban-impact-row--yes" : "",
+            child.blocking_parent_ids && child.blocking_parent_ids.length
+              ? "hermes-kanban-impact-row--blocked"
+              : "",
+          ),
+        },
+          h("code", { className: "hermes-kanban-impact-id" }, child.id),
+          h("span", { className: "hermes-kanban-impact-state" }, labelFor(child)),
+          h("span", { className: "hermes-kanban-impact-title" }, child.title || ""),
+        );
+      }),
+    );
+  }
+
   function DependencyEditor(props) {
     const { t } = useI18n();
     const { task, links, allTasks } = props;
@@ -3734,6 +3773,7 @@
           size: "sm",
         }, "+ child"),
       ),
+      h(DependencyImpactPreview, { impact: props.dependencyImpact }),
     );
   }
 

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -696,6 +696,58 @@
 }
 .hermes-kanban-dep-chip-x:hover { color: var(--color-destructive, #d14a4a); }
 
+.hermes-kanban-impact {
+  margin-top: 0.55rem;
+  border-top: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
+  padding-top: 0.55rem;
+}
+.hermes-kanban-impact-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-bottom: 0.4rem;
+  font-size: 0.68rem;
+  color: var(--color-muted-foreground);
+}
+.hermes-kanban-impact-summary span {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm, 0.25rem);
+  padding: 0.08rem 0.35rem;
+  background: color-mix(in srgb, var(--color-foreground) 4%, transparent);
+}
+.hermes-kanban-impact-row {
+  display: grid;
+  grid-template-columns: minmax(6.5rem, 8rem) minmax(0, 1fr);
+  grid-template-areas:
+    "id state"
+    "title title";
+  gap: 0.12rem 0.45rem;
+  padding: 0.35rem 0;
+  border-top: 1px solid color-mix(in srgb, var(--color-border) 45%, transparent);
+  font-size: 0.72rem;
+}
+.hermes-kanban-impact-id {
+  grid-area: id;
+  color: var(--color-foreground);
+}
+.hermes-kanban-impact-state {
+  grid-area: state;
+  color: var(--color-muted-foreground);
+  overflow-wrap: anywhere;
+}
+.hermes-kanban-impact-row--yes .hermes-kanban-impact-state {
+  color: #3fb97d;
+  font-weight: 600;
+}
+.hermes-kanban-impact-row--blocked .hermes-kanban-impact-state {
+  color: #d4b348;
+}
+.hermes-kanban-impact-title {
+  grid-area: title;
+  color: var(--color-foreground);
+  overflow-wrap: anywhere;
+}
+
 /* ---- Inline edit affordances --------------------------------------- */
 
 .hermes-kanban-editable {

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -559,6 +559,9 @@ def get_task(
             "events": [_event_dict(e) for e in kanban_db.list_events(conn, task_id)],
             "attachments": [_attachment_dict(a) for a in kanban_db.list_attachments(conn, task_id)],
             "links": _links_for(conn, task_id),
+            "dependency_impact": kanban_db.dependency_impact_preview(
+                conn, task_id,
+            ).as_dict(),
             "runs": [
                 _run_dict(r)
                 for r in kanban_db.list_runs(

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -130,6 +130,21 @@ def test_run_slash_create_with_parent_and_cascade(kanban_home):
     assert "child" in ready_list
 
 
+def test_run_slash_show_includes_dependency_impact_preview(kanban_home):
+    out1 = kc.run_slash("create 'parent' --assignee alice")
+    import re
+    parent = re.search(r"(t_[a-f0-9]+)", out1).group(1)
+    out2 = kc.run_slash(f"create 'child' --assignee bob --parent {parent}")
+    child = re.search(r"(t_[a-f0-9]+)", out2).group(1)
+
+    show = kc.run_slash(f"show {parent}")
+
+    assert "impact:" in show
+    assert "1 will unblock" in show
+    assert child in show
+    assert "will promote to ready" in show
+
+
 def test_run_slash_show_includes_comments(kanban_home):
     out = kc.run_slash("create 'x'")
     import re

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1422,6 +1422,79 @@ def test_create_with_parents_stays_todo_until_parents_done(kanban_home):
         assert kb.get_task(conn, child).status == "ready"
 
 
+def test_dependency_impact_preview_no_children(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="root", assignee="a")
+
+        impact = kb.dependency_impact_preview(conn, task_id)
+
+    assert impact.task_id == task_id
+    assert impact.total_children == 0
+    assert impact.will_unblock_count == 0
+    assert impact.still_blocked_count == 0
+    assert impact.unchanged_count == 0
+    assert impact.children == []
+
+
+def test_dependency_impact_preview_child_unblocked_by_this_parent(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="a")
+        child = kb.create_task(conn, title="child", assignee="b", parents=[parent])
+
+        impact = kb.dependency_impact_preview(conn, parent)
+
+    assert impact.total_children == 1
+    assert impact.will_unblock_count == 1
+    assert impact.still_blocked_count == 0
+    assert impact.unchanged_count == 0
+    assert impact.children[0].id == child
+    assert impact.children[0].would_unblock is True
+    assert impact.children[0].blocking_parent_ids == []
+    assert impact.children[0].reason == "will_promote_to_ready"
+
+
+def test_dependency_impact_preview_child_still_blocked_by_other_parent(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="a")
+        other = kb.create_task(conn, title="other parent", assignee="a")
+        child = kb.create_task(
+            conn,
+            title="child",
+            assignee="b",
+            parents=[parent, other],
+        )
+
+        impact = kb.dependency_impact_preview(conn, parent)
+
+    assert impact.total_children == 1
+    assert impact.will_unblock_count == 0
+    assert impact.still_blocked_count == 1
+    assert impact.unchanged_count == 0
+    assert impact.children[0].id == child
+    assert impact.children[0].would_unblock is False
+    assert impact.children[0].blocking_parent_ids == [other]
+    assert impact.children[0].reason == "blocked_by_other_parents"
+
+
+def test_dependency_impact_preview_sticky_block_does_not_overpromise(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="a")
+        child = kb.create_task(conn, title="child", assignee="b", parents=[parent])
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (child,))
+        conn.commit()
+        assert kb.block_task(conn, child, reason="needs a human decision")
+
+        impact = kb.dependency_impact_preview(conn, parent)
+
+    assert impact.total_children == 1
+    assert impact.will_unblock_count == 0
+    assert impact.still_blocked_count == 0
+    assert impact.unchanged_count == 1
+    assert impact.children[0].id == child
+    assert impact.children[0].would_unblock is False
+    assert impact.children[0].reason == "sticky_block"
+
+
 def test_unblock_with_pending_parents_goes_to_todo(kanban_home):
     """unblock_task must re-gate on parent completion (Fix 3).
 

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -284,7 +284,13 @@ def test_task_detail_includes_links_and_events(client):
 
     # Detail for the parent shows the child.
     r = client.get(f"/api/plugins/kanban/tasks/{parent['id']}")
-    assert child["id"] in r.json()["links"]["children"]
+    parent_detail = r.json()
+    assert child["id"] in parent_detail["links"]["children"]
+    impact = parent_detail["dependency_impact"]
+    assert impact["total_children"] == 1
+    assert impact["will_unblock_count"] == 1
+    assert impact["children"][0]["id"] == child["id"]
+    assert impact["children"][0]["would_unblock"] is True
 
     # Events exist from creation.
     assert len(data["events"]) >= 1

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -630,6 +630,8 @@ hermes kanban list [--mine] [--assignee P] [--status S] [--tenant T] [--archived
         [--sort created|created-desc|priority|priority-desc|status|assignee|title|updated]
         [--json]
 hermes kanban show <id> [--json]
+# show includes a dependency-impact preview: direct children that would become
+# ready if this task completed, plus children still blocked by other parents.
 hermes kanban assign <id> <profile>                    # or 'none' to unassign
 hermes kanban reassign <id>... <profile>               # bulk re-assign tasks to a profile
 hermes kanban edit <id> [--title ...] [--body ...]     # edit task title / body / priority in place

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -78,6 +78,34 @@ const config: Config = {
             from: '/guides/automation-templates',
             to: '/guides/automation-blueprints',
           },
+          {
+            from: '/reference/commands',
+            to: '/reference/cli-commands',
+          },
+          {
+            from: '/reference/configuration',
+            to: '/user-guide/configuration',
+          },
+          {
+            from: '/reference/tools',
+            to: '/reference/tools-reference',
+          },
+          {
+            from: '/developer-guide',
+            to: '/developer-guide/architecture',
+          },
+          {
+            from: '/features/skills',
+            to: '/user-guide/features/skills',
+          },
+          {
+            from: '/quickstart',
+            to: '/getting-started/quickstart',
+          },
+          {
+            from: '/messaging-platforms/telegram',
+            to: '/user-guide/messaging/telegram',
+          },
         ],
       },
     ],


### PR DESCRIPTION
## Summary

- add a reusable Kanban dependency impact preview helper for direct child tasks
- surface the preview in `hermes kanban show --json`, plain `show`, and the dashboard task drawer API/UI
- document the `show` preview and cover no-child, would-unblock, still-blocked, and sticky-block cases

Fixes #51042

## Tests

- `scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_cli.py tests/plugins/test_kanban_dashboard_plugin.py -- -q`