### PR TITLE
fix: allow builder reviewer fanout without authority leak

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1317,6 +1317,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             body=args.body,
             assignee=args.assignee,
             created_by=args.created_by or _profile_author(),
+            creator_profile=_profile_author(),
             workspace_kind=ws_kind,
             workspace_path=ws_path,
             branch_name=branch_name,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1181,6 +1181,82 @@ _INIT_LOCK = threading.RLock()
 _SQLITE_HEADER = b"SQLite format 3\x00"
 DEFAULT_BUSY_TIMEOUT_MS = 120_000
 
+# Local deployments can add a SQLite created_by allowlist trigger as an extra
+# hardening layer. Keep the canonical builder->reviewer exception here so init
+# refreshes stale triggers that predate builder-gpt5 style profile names.
+_CREATED_BY_ALLOWLIST_TRIGGER_SQL = """
+DROP TRIGGER IF EXISTS trg_created_by_allowlist;
+CREATE TRIGGER trg_created_by_allowlist BEFORE INSERT ON tasks
+BEGIN
+    SELECT CASE
+        WHEN NEW.created_by IS NULL THEN NULL
+        WHEN NEW.created_by IN (
+            'user', 'mike', 'mike-via-cos', 'cos-cron', 'devex-cron',
+            'ceo', 'ceo-roadmap-publisher', 'dashboard', 'cos', 'Claude-CoS',
+            'agent-marketing', 'worker-coder', 'worker-general', 'ai-engineer',
+            'agents-orchestrator', 'technical-writer', 'app-store-optimizer',
+            'accessibility-auditor', 'builder-deepseek', 'builder-kimi'
+        ) THEN NULL
+        WHEN NEW.created_by GLOB 'agent-*'
+             AND NEW.created_by NOT GLOB '*[^a-zA-Z0-9_-]*'
+             AND NEW.created_by NOT GLOB '*..*' THEN NULL
+        WHEN NEW.created_by GLOB 'worker-*'
+             AND NEW.created_by NOT GLOB '*[^a-zA-Z0-9_-]*'
+             AND NEW.created_by NOT GLOB '*..*' THEN NULL
+        WHEN NEW.created_by GLOB 'mkt-*'
+             AND NEW.created_by NOT GLOB '*[^a-zA-Z0-9_-]*'
+             AND NEW.created_by NOT GLOB '*..*' THEN NULL
+        WHEN NEW.created_by GLOB 'shadow-*'
+             AND NEW.created_by NOT GLOB '*[^a-zA-Z0-9_-]*'
+             AND NEW.created_by NOT GLOB '*..*' THEN NULL
+        WHEN NEW.created_by GLOB 'product-*'
+             AND NEW.created_by NOT GLOB '*[^a-zA-Z0-9_-]*'
+             AND NEW.created_by NOT GLOB '*..*' THEN NULL
+        WHEN NEW.created_by GLOB 'builder-*'
+             AND NEW.created_by NOT GLOB '*[^a-zA-Z0-9_-]*'
+             AND NEW.created_by NOT GLOB '*..*'
+             AND NEW.assignee GLOB 'reviewer-*' THEN NULL
+        ELSE RAISE(ABORT, 'created_by not in allowlist')
+    END;
+END;
+"""
+
+
+def _is_builder_profile(value: Optional[str]) -> bool:
+    return bool(value and str(value).startswith("builder-"))
+
+
+def _is_reviewer_assignee(value: Optional[str]) -> bool:
+    return bool(value and str(value).startswith("reviewer-"))
+
+
+def _enforce_create_identity_policy(
+    *,
+    creator_profile: Optional[str],
+    created_by: Optional[str],
+    assignee: Optional[str],
+) -> None:
+    """Prevent builder workers from minting elevated task identities.
+
+    Database allowlists can validate the recorded ``created_by`` string, but
+    only the application knows the caller/profile that is making the request.
+    Builder workers are deliberately narrow: they may fan out reviewer cards
+    under their own identity, and nothing else. Human/dashboard/CoS callers keep
+    their existing paths because they do not present a builder caller profile.
+    """
+    if not _is_builder_profile(creator_profile):
+        return
+    if created_by != creator_profile:
+        raise ValueError(
+            "builder task creation must use the caller profile as created_by "
+            f"({creator_profile}); refusing created_by={created_by!r}"
+        )
+    if not _is_reviewer_assignee(assignee):
+        raise ValueError(
+            "builder task creation is limited to reviewer-* fanout tasks"
+        )
+
+
 # Bounded acquire for the cross-process init lock (#36644). The original bare
 # blocking flock had no timeout, so a wedged holder blocked the dispatcher's
 # next-tick connect forever. We retry a non-blocking acquire up to this
@@ -1673,6 +1749,7 @@ def connect(
                     # stale PRAGMA snapshots during gateway startup.
                     conn.executescript(SCHEMA_SQL)
                     _migrate_add_optional_columns(conn)
+                    _ensure_created_by_allowlist_trigger(conn)
                     _INITIALIZED_PATHS.add(resolved)
         except Exception:
             conn.close()
@@ -1743,6 +1820,15 @@ def init_db(
     with contextlib.closing(connect(path)):
         pass
     return path
+
+
+def _ensure_created_by_allowlist_trigger(conn: sqlite3.Connection) -> None:
+    """Refresh the optional created_by trigger used by hardened shared boards."""
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='trigger' AND name='trg_created_by_allowlist'"
+    ).fetchone()
+    if row:
+        conn.executescript(_CREATED_BY_ALLOWLIST_TRIGGER_SQL)
 
 
 def _add_column_if_missing(
@@ -2246,6 +2332,7 @@ def create_task(
     body: Optional[str] = None,
     assignee: Optional[str] = None,
     created_by: Optional[str] = None,
+    creator_profile: Optional[str] = None,
     workspace_kind: str = "scratch",
     workspace_path: Optional[str] = None,
     branch_name: Optional[str] = None,
@@ -2287,6 +2374,11 @@ def create_task(
     translation skill regardless of the profile's default config).
     """
     assignee = _canonical_assignee(assignee)
+    _enforce_create_identity_policy(
+        creator_profile=creator_profile,
+        created_by=created_by,
+        assignee=assignee,
+    )
     if not title or not title.strip():
         raise ValueError("title is required")
     if initial_status not in VALID_INITIAL_STATUSES:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -62,6 +62,77 @@ def test_init_creates_expected_tables(kanban_home):
     assert {"tasks", "task_links", "task_comments", "task_events"} <= names
 
 
+def test_builder_reviewer_fanout_created_by_self_succeeds(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="Review PR #110",
+            assignee="reviewer-deepseek",
+            created_by="builder-gpt5",
+            creator_profile="builder-gpt5",
+            body=(
+                "source_build_card=t_build linked_pr=110 branch=fix/x "
+                "builder_model=gpt-5.5 required_reviewer_model=deepseek-v4-pro"
+            ),
+        )
+        task = kb.get_task(conn, task_id)
+
+    assert task is not None
+    assert task.created_by == "builder-gpt5"
+    assert task.assignee == "reviewer-deepseek"
+
+
+def test_builder_created_by_user_is_denied(kanban_home):
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match="must use the caller profile"):
+            kb.create_task(
+                conn,
+                title="forged authority",
+                assignee="reviewer-deepseek",
+                created_by="user",
+                creator_profile="builder-gpt5",
+            )
+
+
+def test_builder_non_reviewer_fanout_is_denied(kanban_home):
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match="limited to reviewer"):
+            kb.create_task(
+                conn,
+                title="non-reviewer fanout",
+                assignee="builder-deepseek",
+                created_by="builder-gpt5",
+                creator_profile="builder-gpt5",
+            )
+
+
+def test_created_by_trigger_allows_builder_only_for_reviewer_cards(kanban_home):
+    with kb.connect() as conn:
+        conn.executescript("""
+        CREATE TRIGGER trg_created_by_allowlist BEFORE INSERT ON tasks
+        BEGIN
+            SELECT CASE
+                WHEN NEW.created_by = 'user' THEN NULL
+                ELSE RAISE(ABORT, 'created_by not in allowlist')
+            END;
+        END;
+        """)
+        kb._ensure_created_by_allowlist_trigger(conn)
+        kb.create_task(
+            conn,
+            title="trigger positive",
+            assignee="reviewer-qwen",
+            created_by="builder-gpt5",
+        )
+        with pytest.raises(sqlite3.IntegrityError, match="created_by not in allowlist"):
+            kb.create_task(
+                conn,
+                title="trigger negative",
+                assignee="builder-deepseek",
+                created_by="builder-gpt5",
+            )
+
+
 def test_connect_honors_kanban_busy_timeout_env(kanban_home, monkeypatch):
     """All kanban connections should use the explicit busy-timeout knob.
 

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -807,6 +807,7 @@ def _handle_create(args: dict, **kw) -> str:
                     if _self_task is not None and _self_task.workspace_kind:
                         workspace_kind = _self_task.workspace_kind
                         workspace_path = _self_task.workspace_path
+            creator = os.environ.get("HERMES_PROFILE") or "worker"
             new_tid = kb.create_task(
                 conn,
                 title=str(title).strip(),
@@ -829,7 +830,8 @@ def _handle_create(args: dict, **kw) -> str:
                     int(goal_max_turns) if goal_max_turns is not None else None
                 ),
                 initial_status=str(initial_status),
-                created_by=os.environ.get("HERMES_PROFILE") or "worker",
+                created_by=creator,
+                creator_profile=creator,
                 session_id=session_id,
             )
             new_task = kb.get_task(conn, new_tid)


### PR DESCRIPTION
## Summary
- Allows builder-* profiles to create reviewer-* fanout cards under their own created_by identity without broadening builder authority.
- Keeps elevated identity attempts blocked when a builder caller tries created_by=user or other non-self identities.
- Refreshes existing hardened SQLite created_by triggers so builder-gpt5 style profile names can create reviewer cards, but not non-reviewer cards.

## Receipts
- Positive policy test: `python -m pytest tests/hermes_cli/test_kanban_db.py -k 'builder_reviewer_fanout_created_by_self_succeeds or builder_created_by_user_is_denied or builder_non_reviewer_fanout_is_denied or created_by_trigger_allows_builder_only_for_reviewer_cards' -q -o 'addopts='` -> 4 passed.
- DB regression suite: `python -m pytest tests/hermes_cli/test_kanban_db.py -q -o 'addopts='` -> 227 passed.
- Tool regression suite: `python -m pytest tests/tools/test_kanban_tools.py -q -o 'addopts='` -> 90 passed.
- Live board trigger refresh: `builder reviewer exception present: True`.
- Live reviewer-card receipts: PR #110 review card `t_00823902`; PR #97 audit card `t_6e79a9ff`.
- Negative receipt: builder-gpt5 + created_by=user raises `ValueError: builder task creation must use the caller profile as created_by (builder-gpt5); refusing created_by='user'`.
