### PR TITLE
security: redact sensitive request dump fields

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -33,6 +33,46 @@ from typing import Any, Dict, List, Optional
 
 from hermes_cli.timeouts import get_provider_request_timeout
 from agent.prompt_builder import format_steer_marker
+
+# Keys to redact in request debug dumps (case-insensitive match).
+_REDACTED_DUMP_KEYS: frozenset = frozenset({
+    "authorization",
+    "cookie",
+    "set-cookie",
+    "x-api-key",
+    "api_key",
+    "api-key",
+    "access_token",
+    "refresh_token",
+    "agent_key",
+    "id_token",
+    "bearer",
+    "token",
+    "password",
+    "secret",
+    "private_key",
+})
+
+
+def _redact_sensitive_dump_fields(obj: Any, _path: str = "") -> Any:
+    """Recursively walk *obj* and replace any value whose key name matches a
+    sensitive pattern with ``"[REDACTED]"``.
+
+    Works on nested dicts, lists, and primitive values.  Non-sensitive fields
+    are preserved unchanged.
+    """
+    if isinstance(obj, dict):
+        result: dict = {}
+        for k, v in obj.items():
+            if isinstance(k, str) and k.lower() in _REDACTED_DUMP_KEYS:
+                result[k] = "[REDACTED]"
+            else:
+                result[k] = _redact_sensitive_dump_fields(v, f"{_path}.{k}")
+        return result
+    if isinstance(obj, list):
+        return [_redact_sensitive_dump_fields(item, f"{_path}[{i}]")
+                for i, item in enumerate(obj)]
+    return obj
 from agent.tool_dispatch_helpers import _trajectory_normalize_msg, make_tool_result_message
 from agent.trajectory import convert_scratchpad_to_think
 from agent.credential_pool import STATUS_EXHAUSTED
@@ -1133,6 +1173,11 @@ def dump_api_request_debug(
                     _ra().logger.debug("Could not extract error response details: %s", e)
 
             dump_payload["error"] = error_info
+
+        # Redact sensitive fields before writing — prevents raw tokens from
+        # leaking into on-disk request dump files even when the request body
+        # or error response contains nested sensitive keys.
+        dump_payload = _redact_sensitive_dump_fields(dump_payload)
 
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
         dump_file = agent.logs_dir / f"request_dump_{agent.session_id}_{timestamp}.json"

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1774,6 +1774,106 @@ def test_run_conversation_codex_continues_after_ack_for_directory_listing_prompt
     assert any(msg.get("role") == "tool" and msg.get("tool_call_id") == "call_1" for msg in result["messages"])
 
 
+def test_dump_api_request_debug_redacts_authorization_header(monkeypatch, tmp_path):
+    """Authorization header must be redacted in debug dumps."""
+    import json
+    from agent.agent_runtime_helpers import _redact_sensitive_dump_fields
+
+    agent = _build_agent(monkeypatch)
+    agent.base_url = "http://127.0.0.1:9208/v1"
+    agent.logs_dir = tmp_path
+
+    kwargs_with_token = {
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": "hi"}],
+        "headers": {"Authorization": "Bearer sk-real-key-12345"},
+    }
+
+    dump_file = agent._dump_api_request_debug(kwargs_with_token, reason="preflight")
+    payload = json.loads(dump_file.read_text())
+
+    # The explicit Authorization header inside the body must be redacted
+    assert payload["request"]["body"]["headers"]["Authorization"] == "[REDACTED]"
+    assert "sk-real-key" not in json.dumps(payload)
+
+
+def test_dump_api_request_debug_redacts_nested_access_token(monkeypatch, tmp_path):
+    """Nested access_token fields must be redacted recursively."""
+    import json
+
+    agent = _build_agent(monkeypatch)
+    agent.base_url = "http://127.0.0.1:9208/v1"
+    agent.logs_dir = tmp_path
+
+    kwargs = {
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": "hi"}],
+        "auth": {"access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9", "token_type": "bearer"},
+    }
+
+    dump_file = agent._dump_api_request_debug(kwargs, reason="preflight")
+    payload = json.loads(dump_file.read_text())
+
+    assert payload["request"]["body"]["auth"]["access_token"] == "[REDACTED]"
+    assert payload["request"]["body"]["auth"]["token_type"] == "bearer"  # not a secret key
+    assert "eyJhbGci" not in json.dumps(payload)
+
+
+def test_dump_api_request_debug_preserves_normal_fields(monkeypatch, tmp_path):
+    """Non-sensitive fields like model and messages must be preserved."""
+    import json
+
+    agent = _build_agent(monkeypatch)
+    agent.base_url = "http://127.0.0.1:9208/v1"
+    agent.logs_dir = tmp_path
+
+    kwargs = {
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": "hello world"}],
+        "temperature": 0.7,
+    }
+
+    dump_file = agent._dump_api_request_debug(kwargs, reason="preflight")
+    payload = json.loads(dump_file.read_text())
+
+    assert payload["request"]["body"]["model"] == "gpt-4o"
+    assert payload["request"]["body"]["temperature"] == 0.7
+    assert "hello world" in json.dumps(payload)
+
+
+def test_redact_sensitive_dump_fields_standalone():
+    """Unit test for the standalone redaction helper."""
+    from agent.agent_runtime_helpers import _redact_sensitive_dump_fields
+
+    payload = {
+        "timestamp": "2026-06-22T12:00:00",
+        "request": {
+            "headers": {
+                "Authorization": "Bearer secret123",
+                "Content-Type": "application/json",
+            },
+            "body": {
+                "model": "gpt-4o",
+                "messages": [{"role": "user", "content": "hi"}],
+                "access_token": "leaked-token",
+                "nested": {"api_key": "sk-abc123", "normal": "keep-me"},
+            },
+        },
+    }
+
+    result = _redact_sensitive_dump_fields(payload)
+
+    assert result["request"]["headers"]["Authorization"] == "[REDACTED]"
+    assert result["request"]["headers"]["Content-Type"] == "application/json"
+    assert result["request"]["body"]["access_token"] == "[REDACTED]"
+    assert result["request"]["body"]["nested"]["api_key"] == "[REDACTED]"
+    assert result["request"]["body"]["nested"]["normal"] == "keep-me"
+    assert result["request"]["body"]["model"] == "gpt-4o"
+    assert result["timestamp"] == "2026-06-22T12:00:00"
+    assert "secret123" not in str(result)
+    assert "sk-abc123" not in str(result)
+
+
 def test_dump_api_request_debug_uses_responses_url(monkeypatch, tmp_path):
     """Debug dumps should show /responses URL when in codex_responses mode."""
     import json


### PR DESCRIPTION
## Request dump redaction

### Changes
- Added centralized `_redact_sensitive_dump_fields()` helper in `agent_runtime_helpers.py`
- Redacts 15 sensitive key patterns case-insensitively: Authorization, Bearer, token, api_key, access_token, refresh_token, agent_key, cookie, set-cookie, x-api-key, id_token, password, secret, private_key
- Integrated into `dump_api_request_debug()` before writing to disk
- Preserves non-sensitive metadata: timestamp, model, messages, session_id, reason
- Works on nested dicts, lists, and primitive values recursively

### Tests (4 new)
- Authorization header redacted
- Nested access_token redacted recursively
- Normal fields preserved unchanged
- Standalone unit test for the helper
- All 6 tests pass (4 new + 2 existing URL tests)

### Safety
- No real secrets displayed
- No runtime provider calls added
- No /execute modified
- Only redaction logic changed (no behavioral changes to existing dump format)