### PR TITLE
fix: require demonstrated done receipts for kanban completion

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -527,6 +527,8 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_complete.add_argument("--metadata", default=None,
                             help='JSON dict of structured facts (e.g. \'{"changed_files": [...], '
                                  '"tests_run": 12}\'). Stored on the closing run.')
+    p_complete.add_argument("--receipt", default=None,
+                            help="Runnable Demonstrated Done receipt required by cards with Verifiable by:")
 
     p_edit = sub.add_parser(
         "edit",
@@ -1884,6 +1886,7 @@ def _cmd_complete(args: argparse.Namespace) -> int:
                 summary=summary,
                 metadata=metadata,
                 expected_run_id=_worker_run_id_for(tid),
+                demonstrated_done_receipt=getattr(args, "receipt", None),
             ):
                 failed.append(tid)
                 print(f"cannot complete {tid} (unknown id or terminal state)", file=sys.stderr)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2239,6 +2239,64 @@ def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
     return normalize_profile_name(assignee)
 
 
+_VERIFIABLE_BY_RE = re.compile(r"(?im)^\s*Verifiable by:\s*(.+?)\s*$")
+_DATA_LANDING_RE = re.compile(
+    r"\b(db|database|supabase|table|migration|insert|select|queue|row|record|data[- ]landing)\b",
+    re.IGNORECASE,
+)
+_READBACK_ROWS_RE = re.compile(r"\b(?:rows?|count)\s*[=:]\s*(\d+)\b", re.IGNORECASE)
+
+
+def _extract_verifiable_by(body: Optional[str]) -> Optional[str]:
+    if not body:
+        return None
+    match = _VERIFIABLE_BY_RE.search(body)
+    if not match:
+        return None
+    value = match.group(1).strip()
+    return value or None
+
+
+def _requires_verifiable_by_on_create(*, body: Optional[str], created_by: Optional[str], triage: bool) -> bool:
+    if triage:
+        return False
+    return bool(created_by and body and body.strip())
+
+
+def _is_data_landing_task(body: Optional[str], verifiable_by: Optional[str]) -> bool:
+    text = "\n".join(part for part in (body, verifiable_by) if part)
+    return bool(_DATA_LANDING_RE.search(text))
+
+
+class DemonstratedDoneError(ValueError):
+    """Raised by ``complete_task`` when a task lacks a valid runnable receipt."""
+
+    def __init__(self, task_id: str, reason: str, *, receipt: Optional[str] = None):
+        self.task_id = task_id
+        self.reason = reason
+        self.receipt = receipt
+        super().__init__(f"DemonstratedDoneError: {reason}")
+
+
+def _validate_demonstrated_done_receipt(*, body: Optional[str], receipt: Optional[str]) -> tuple[bool, Optional[str], Optional[str]]:
+    verifiable_by = _extract_verifiable_by(body)
+    if not verifiable_by:
+        return True, None, None
+    cleaned = (receipt or "").strip()
+    if not cleaned:
+        return False, "missing receipt: attach a runnable receipt before completing", verifiable_by
+    low = cleaned.lower()
+    if any(token in low for token in ("no such table", "missing table", "missing migration")):
+        return False, "missing table/migration in receipt", verifiable_by
+    if _is_data_landing_task(body, verifiable_by):
+        has_readback = "select" in low or "read-back" in low or "readback" in low
+        row_match = _READBACK_ROWS_RE.search(cleaned)
+        rows = int(row_match.group(1)) if row_match else 0
+        if not has_readback or rows < 1 or "mock" in low:
+            return False, "data-landing tasks require real read-back returning >=1 row of the expected shape", verifiable_by
+    return True, None, verifiable_by
+
+
 def create_task(
     conn: sqlite3.Connection,
     *,
@@ -2289,6 +2347,11 @@ def create_task(
     assignee = _canonical_assignee(assignee)
     if not title or not title.strip():
         raise ValueError("title is required")
+    if _requires_verifiable_by_on_create(body=body, created_by=created_by, triage=triage) and not _extract_verifiable_by(body):
+        raise ValueError(
+            "nontrivial kanban tasks must include a `Verifiable by:` field "
+            "with a runnable receipt command or read-back check"
+        )
     if initial_status not in VALID_INITIAL_STATUSES:
         raise ValueError(
             f"initial_status must be one of {sorted(VALID_INITIAL_STATUSES)}"
@@ -3773,6 +3836,7 @@ def complete_task(
     metadata: Optional[dict] = None,
     created_cards: Optional[Iterable[str]] = None,
     expected_run_id: Optional[int] = None,
+    demonstrated_done_receipt: Optional[str] = None,
 ) -> bool:
     """Transition ``running|ready -> done`` and record ``result``.
 
@@ -3830,6 +3894,30 @@ def complete_task(
             raise HallucinatedCardsError(phantom_cards, task_id)
     else:
         verified_cards = []
+
+    task_row = conn.execute("SELECT body FROM tasks WHERE id = ?", (task_id,)).fetchone()
+    ok, demo_reason, verifiable_by = _validate_demonstrated_done_receipt(
+        body=task_row["body"] if task_row else None,
+        receipt=demonstrated_done_receipt,
+    )
+    if not ok:
+        with write_txn(conn):
+            _append_event(
+                conn, task_id, "completion_blocked_demonstrated_done",
+                {
+                    "reason": demo_reason,
+                    "verifiable_by": verifiable_by,
+                    "receipt": (demonstrated_done_receipt or "")[:1000] or None,
+                    "summary_preview": (
+                        (summary or result or "").strip().splitlines()[0][:200]
+                        if (summary or result) else None
+                    ),
+                },
+            )
+        raise DemonstratedDoneError(
+            task_id, demo_reason or "missing demonstrated-done receipt",
+            receipt=demonstrated_done_receipt,
+        )
 
     with write_txn(conn):
         if expected_run_id is None:
@@ -3894,6 +3982,8 @@ def complete_task(
         }
         if verified_cards:
             completed_payload["verified_cards"] = verified_cards
+        if demonstrated_done_receipt:
+            completed_payload["demonstrated_done_receipt"] = demonstrated_done_receipt
         # Carry artifact paths in the event payload so the gateway
         # notifier can upload them as native attachments alongside the
         # completion message. Workers pass these via

--- a/skills/devops/demonstrated-done/SKILL.md
+++ b/skills/devops/demonstrated-done/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: demonstrated-done
+description: Run and attach verifiable receipts before completing Kanban cards.
+version: 1.0.0
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [kanban, verification, receipts]
+---
+
+# Demonstrated Done
+
+Use this when a Kanban card contains `Verifiable by:` or when the task's real function is data/table/queue landing.
+
+## Worker flow
+
+1. Read the card body and extract the `Verifiable by:` line.
+2. Classify the function:
+   - code/test/build: run the named test, build, grep, diff, or smoke command.
+   - DB/table/queue/data-landing: run a real read-back against the target table/queue. A mocked test is not enough.
+3. Capture the runnable command and its output.
+4. Complete with the receipt attached:
+   - tool: `kanban_complete(summary="...", receipt="<command> -> <output>")`
+   - CLI: `hermes kanban complete <task_id> --summary "..." --receipt "<command> -> <output>"`
+
+## Data landing receipt requirements
+
+For DB/table/queue/data-landing tasks, the receipt must show:
+- the real read-back command or query (`SELECT`, `read-back`, or equivalent),
+- `rows=<N>` or `count=<N>` with N >= 1,
+- the expected shape/columns,
+- no missing table/migration errors.
+
+If the read-back reports `no such table`, `missing table`, or `missing migration`, do not complete. The DemonstratedDoneError gate will block completion and keep the task in flight.

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -175,7 +175,10 @@ def test_run_slash_dispatch_dry_run_counts(kanban_home):
 
 
 def test_run_slash_context_output_format(kanban_home):
-    out = kc.run_slash("create 'tech spec' --assignee alice --body 'write an RFC'")
+    out = kc.run_slash(
+        "create 'tech spec' --assignee alice --body "
+        "'write an RFC\n\nVerifiable by: grep -n RFC docs/spec.md'"
+    )
     import re
     tid = re.search(r"(t_[a-f0-9]+)", out).group(1)
     kc.run_slash(f"comment {tid} 'remember to include performance section'")

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -222,6 +222,28 @@ def test_create_task_no_parents_is_ready(kanban_home):
     assert t.workspace_kind == "scratch"
 
 
+def test_create_nontrivial_task_requires_verifiable_by_field(kanban_home, monkeypatch):
+    monkeypatch.delenv("HERMES_PROFILE_NAME", raising=False)
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+    with kb.connect() as conn, pytest.raises(ValueError, match="Verifiable by"):
+        kb.create_task(
+            conn, title="land decision records",
+            body="Write decision records into Supabase.",
+            assignee="builder", created_by="planner",
+        )
+
+
+def test_create_nontrivial_task_accepts_verifiable_by_field(kanban_home, monkeypatch):
+    monkeypatch.delenv("HERMES_PROFILE_NAME", raising=False)
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+    body = "Write decision records into Supabase.\n\nVerifiable by: python scripts/readback.py --expect decision_record"
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="land decision records", body=body, assignee="builder", created_by="planner")
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.body == body
+
+
 def test_create_task_with_parent_is_todo_until_parent_done(kanban_home):
     with kb.connect() as conn:
         p = kb.create_task(conn, title="parent")
@@ -1168,6 +1190,61 @@ def test_complete_records_result(kanban_home):
     assert task.status == "done"
     assert task.result == "done and dusted"
     assert task.completed_at is not None
+
+
+def test_demonstrated_done_blocks_completion_without_receipt(kanban_home, monkeypatch):
+    monkeypatch.delenv("HERMES_PROFILE_NAME", raising=False)
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+    body = "Build the thing.\n\nVerifiable by: pytest tests/test_thing.py -q"
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="build thing", body=body, created_by="planner")
+        with pytest.raises(kb.DemonstratedDoneError, match="runnable receipt"):
+            kb.complete_task(conn, t, summary="implemented")
+        assert kb.get_task(conn, t).status == "ready"
+        events = kb.list_events(conn, t)
+    assert events[-1].kind == "completion_blocked_demonstrated_done"
+    assert "missing receipt" in events[-1].payload["reason"]
+
+
+def test_demonstrated_done_blocks_t6_absent_table_receipt(kanban_home, monkeypatch):
+    monkeypatch.delenv("HERMES_PROFILE_NAME", raising=False)
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+    body = "Land decision records into Supabase.\n\nVerifiable by: SELECT id, decision_record FROM decision_records LIMIT 1"
+    receipt = "SELECT id, decision_record FROM decision_records LIMIT 1 -> ERROR no such table: decision_records"
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="land decision records", body=body, created_by="planner")
+        with pytest.raises(kb.DemonstratedDoneError, match="missing table"):
+            kb.complete_task(conn, t, summary="landed", demonstrated_done_receipt=receipt)
+        assert kb.get_task(conn, t).status == "ready"
+        events = kb.list_events(conn, t)
+    assert events[-1].kind == "completion_blocked_demonstrated_done"
+    assert "decision_records" in events[-1].payload["receipt"]
+
+
+def test_demonstrated_done_allows_data_landing_readback_receipt(kanban_home, monkeypatch):
+    monkeypatch.delenv("HERMES_PROFILE_NAME", raising=False)
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+    body = "Land decision records into Supabase.\n\nVerifiable by: SELECT id, decision_record FROM decision_records LIMIT 1"
+    receipt = "SELECT id, decision_record FROM decision_records LIMIT 1 -> rows=1 shape={id: uuid, decision_record: jsonb}"
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="land decision records", body=body, created_by="planner")
+        assert kb.complete_task(conn, t, summary="landed", demonstrated_done_receipt=receipt)
+        task = kb.get_task(conn, t)
+        events = kb.list_events(conn, t)
+    assert task.status == "done"
+    completed = [e for e in events if e.kind == "completed"][-1]
+    assert completed.payload["demonstrated_done_receipt"] == receipt
+
+
+def test_demonstrated_done_rejects_mocked_data_landing_receipt(kanban_home, monkeypatch):
+    monkeypatch.delenv("HERMES_PROFILE_NAME", raising=False)
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+    body = "Land queue records for downstream processing.\n\nVerifiable by: SELECT id, payload FROM queue_records LIMIT 1"
+    receipt = "pytest tests/test_queue_records.py::test_insert_mocked_supabase -q PASSED"
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="land queue records", body=body, created_by="planner")
+        with pytest.raises(kb.DemonstratedDoneError, match="read-back"):
+            kb.complete_task(conn, t, summary="landed", demonstrated_done_receipt=receipt)
 
 
 def test_block_then_unblock(kanban_home):

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -61,6 +61,33 @@ def test_kanban_tools_visible_with_env_var(monkeypatch, tmp_path):
     assert kanban == expected, f"expected {expected}, got {kanban}"
 
 
+def test_kanban_complete_schema_exposes_demonstrated_done_receipt(monkeypatch, tmp_path):
+    """Regression: receipt belongs on kanban_complete, never kanban_show."""
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_fake")
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import tools.kanban_tools  # ensure registered
+    from tools.registry import invalidate_check_fn_cache, registry
+    from toolsets import resolve_toolset
+
+    invalidate_check_fn_cache()
+    schema = registry.get_definitions(set(resolve_toolset("hermes-cli")), quiet=True)
+    by_name = {
+        item["function"]["name"]: item["function"]
+        for item in schema
+        if "function" in item and item["function"].get("name", "").startswith("kanban_")
+    }
+    complete_props = by_name["kanban_complete"]["parameters"]["properties"]
+    show_props = by_name["kanban_show"]["parameters"]["properties"]
+
+    assert "receipt" in complete_props
+    assert "demonstrated_done_receipt" in complete_props
+    assert "receipt" not in show_props
+    assert "demonstrated_done_receipt" not in show_props
+
+
 def test_kanban_worker_env_overrides_profile_toolset_filter(monkeypatch, tmp_path):
     """Dispatcher-spawned workers must get lifecycle tools even when the
     assignee profile restricts enabled toolsets and does not list kanban.

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -488,10 +488,15 @@ def _handle_complete(args: dict, **kw) -> str:
     summary = args.get("summary")
     metadata = args.get("metadata")
     result = args.get("result")
+    demonstrated_done_receipt = args.get("receipt") or args.get("demonstrated_done_receipt")
     if summary:
         summary = redact_sensitive_text(str(summary), force=True)
     if result:
         result = redact_sensitive_text(str(result), force=True)
+    if demonstrated_done_receipt:
+        demonstrated_done_receipt = redact_sensitive_text(
+            str(demonstrated_done_receipt), force=True
+        )
     if metadata is not None and isinstance(metadata, dict):
         meta_json = json.dumps(metadata)
         meta_json = redact_sensitive_text(meta_json, force=True)
@@ -572,6 +577,13 @@ def _handle_complete(args: dict, **kw) -> str:
                     result=result, summary=summary, metadata=metadata,
                     created_cards=created_cards,
                     expected_run_id=_worker_run_id(tid),
+                    demonstrated_done_receipt=demonstrated_done_receipt,
+                )
+            except kb.DemonstratedDoneError as demo_err:
+                return tool_error(
+                    f"kanban_complete blocked by DemonstratedDoneError: {demo_err.reason}. "
+                    f"Your task is still in-flight (no state change). Attach a runnable receipt "
+                    f"matching the card's Verifiable by field and retry."
                 )
             except kb.HallucinatedCardsError as hall_err:
                 # Structured rejection — surface the phantom ids so the
@@ -1037,6 +1049,10 @@ KANBAN_SHOW_SCHEMA = {
             "task_id": {
                 "type": "string",
                 "description": _DESC_TASK_ID_DEFAULT,
+            },
+            "receipt": {
+                "type": "string",
+                "description": "Runnable Demonstrated Done receipt. Required when the card body contains `Verifiable by:`; data-landing receipts must include a real SELECT/read-back with rows>=1.",
             },
             "board": _board_schema_prop(),
         },

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1050,10 +1050,6 @@ KANBAN_SHOW_SCHEMA = {
                 "type": "string",
                 "description": _DESC_TASK_ID_DEFAULT,
             },
-            "receipt": {
-                "type": "string",
-                "description": "Runnable Demonstrated Done receipt. Required when the card body contains `Verifiable by:`; data-landing receipts must include a real SELECT/read-back with rows>=1.",
-            },
             "board": _board_schema_prop(),
         },
         "required": [],
@@ -1190,6 +1186,22 @@ KANBAN_COMPLETE_SCHEMA = {
                     "are not the deliverable. The path must exist "
                     "on disk when the notifier runs; missing files "
                     "are silently skipped."
+                ),
+            },
+            "receipt": {
+                "type": "string",
+                "description": (
+                    "Runnable Demonstrated Done receipt. Required when the "
+                    "card body contains `Verifiable by:`; data-landing "
+                    "receipts must include a real SELECT/read-back with "
+                    "rows>=1. Alias: demonstrated_done_receipt."
+                ),
+            },
+            "demonstrated_done_receipt": {
+                "type": "string",
+                "description": (
+                    "Alias for receipt. Use this for explicitness when "
+                    "attaching the runnable Demonstrated Done receipt."
                 ),
             },
             "board": _board_schema_prop(),


### PR DESCRIPTION
## Summary
- Requires nontrivial kanban cards to declare `Verifiable by:` at creation.
- Adds `DemonstratedDoneError` completion gate for cards with `Verifiable by:`.
- Requires runnable receipts on completion; data-landing receipts must be real read-backs with rows >= 1.
- Blocks missing migration/table and mocked/zero-row receipts.
- Adds `/demonstrated-done` worker skill guidance.

## Receipts
- Targeted Demonstrated Done DB fixtures: 6 passed.
- Impacted suites: `tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_cli.py tests/tools/test_kanban_tools.py` => 366 passed in 12.11s.

## Live temp-board demonstration
- Missing `Verifiable by:` at creation => blocked with `ValueError`.
- t6-style missing table receipt => blocked with `DemonstratedDoneError: missing table/migration in receipt`; task stayed non-terminal and emitted `completion_blocked_demonstrated_done`.
- Correct data-landing receipt => completed with receipt attached: `SELECT ... -> rows=1 shape={id: uuid, decision_record: jsonb}`.

## Scope
Demonstrated Done only. No fanout-policy changes and no CoS observability changes.
