### PR TITLE
Friday identity self-improvement loop: ledger, gate, earned preferences

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1741,6 +1741,43 @@ def load_soul_md(context_length: Optional[int] = None) -> Optional[str]:
         return None
 
 
+def load_preferences_md(context_length: Optional[int] = None) -> Optional[str]:
+    """Load PREFERENCES.md from HERMES_HOME and return its content, or None.
+
+    The *earned preferences* layer: short, evidence-cited lines that the
+    monthly identity-reflection loop proposes and a human approves, derived
+    from ``~/.hermes/identity/LEDGER.md``.  Injected into the **stable** tier
+    of the system prompt immediately after ``SOUL.md`` (see
+    ``agent/system_prompt.py``) so it is prefix-cache-stable like the soul.
+
+    Mirrors :func:`load_soul_md`: same security scan and head/tail truncation
+    rails.  Returns ``None`` when the file is absent or empty so the caller
+    can cleanly skip the section.
+    """
+    try:
+        from hermes_cli.config import ensure_hermes_home
+        ensure_hermes_home()
+    except Exception as e:
+        logger.debug("Could not ensure HERMES_HOME before loading PREFERENCES.md: %s", e)
+
+    pref_path = get_hermes_home() / "PREFERENCES.md"
+    if not pref_path.exists():
+        return None
+    try:
+        content = pref_path.read_text(encoding="utf-8").strip()
+        if not content:
+            return None
+        content = _scan_context_content(content, "PREFERENCES.md")
+        content = _truncate_content(
+            content, "PREFERENCES.md", context_length=context_length,
+            read_path=str(pref_path),
+        )
+        return content
+    except Exception as e:
+        logger.debug("Could not read PREFERENCES.md from %s: %s", pref_path, e)
+        return None
+
+
 def _load_hermes_md(cwd_path: Path, context_length: Optional[int] = None) -> str:
     """.hermes.md / HERMES.md — walk to git root."""
     hermes_md_path = _find_hermes_md(cwd_path)

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -161,6 +161,20 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         # Fallback to hardcoded identity
         stable_parts.append(DEFAULT_AGENT_IDENTITY)
 
+    # Earned preferences (PREFERENCES.md) — evidence-cited lines proposed by the
+    # monthly identity-reflection loop and human-approved.  Injected into the
+    # stable tier immediately after SOUL.md so it is prefix-cache-stable.  Gated
+    # by the same condition as SOUL so delegation/subagent prompts that skip
+    # context files also skip preferences.  Headered so it is never mistaken for
+    # the constitution (SOUL.md).
+    if agent.load_soul_identity or not agent.skip_context_files:
+        _pref_content = _r.load_preferences_md(_ctx_len)
+        if _pref_content:
+            stable_parts.append(
+                "# Earned preferences (evidence-backed — see "
+                "~/.hermes/identity/LEDGER.md)\n\n" + _pref_content
+            )
+
     # Pointer to the hermes-agent skill + docs for user questions about Hermes itself.
     stable_parts.append(HERMES_AGENT_HELP_GUIDANCE)
 

--- a/assets/identity/LEDGER.seed.md
+++ b/assets/identity/LEDGER.seed.md
@@ -1,0 +1,6 @@
+# LEDGER.md — Friday's evidence record
+
+Append-only. Mechanical. Each entry is a receipt of verifiable work — never a
+self-narration. Entries are written by `identity_ledger.py` (the daily rollup of
+kanban completions, and gated manual `append` of direct work). Do not edit by
+hand.

--- a/assets/identity/PREFERENCES.seed.md
+++ b/assets/identity/PREFERENCES.seed.md
@@ -1,0 +1,3 @@
+# Earned preferences
+
+_(none yet — the reflection loop fills this in over time)_

--- a/assets/identity/friday-identity-reflection.md
+++ b/assets/identity/friday-identity-reflection.md
@@ -1,0 +1,62 @@
+# Friday — Monthly Identity Reflection
+
+You are running as a scheduled, autonomous reflection over your own evidence
+record. This is the engine that turns receipts into *earned* preferences. You do
+not edit any identity file directly — you **propose**, and a human approves.
+
+## Inputs
+
+1. Read `~/.hermes/identity/LEDGER.md` — the append-only, mechanical record of
+   what you verifiably did (kanban completions + gated manual entries). Focus on
+   entries added since the last reflection (the most recent entries at the end).
+2. Read `~/.hermes/PREFERENCES.md` — the preferences already earned, so you do
+   not re-propose something that exists.
+
+## Task
+
+From the ledger evidence — **not** from your self-image or SOUL.md — identify
+patterns that genuinely recur:
+
+- **Compounding** patterns: an approach that *kept paying off* across multiple
+  ledger entries (it shipped, tests passed, the artifact was used again).
+- **Attention-wasting** patterns: something that *kept costing* — repeated rework,
+  abandoned attempts, the same correction more than once.
+
+A pattern earns a preference only if **multiple distinct ledger entries** support
+it. One occurrence is an anecdote, not a preference.
+
+Draft **at most 1–3** earned preferences. Each must be a single, concrete,
+behavioral line (what you will do or avoid), and each must cite the specific
+ledger entries (by date + task id) that earned it.
+
+## Output protocol
+
+- If nothing is genuinely earned this cycle, output exactly `[SILENT]` and stop.
+  Silence is the correct, common outcome. Do not invent preferences to fill space.
+- Otherwise, for each earned preference:
+  1. Write the *full proposed new* `PREFERENCES.md` content (existing entries plus
+     the new line) to a temp draft file, e.g. `/tmp/preferences_draft_<n>.md`.
+  2. Stage it through the gate — never write `PREFERENCES.md` or `SOUL.md`
+     directly:
+
+     ```
+     python3 ~/.hermes/scripts/improvement_queue.py create \
+       --target ~/.hermes/PREFERENCES.md \
+       --proposed-file /tmp/preferences_draft_<n>.md \
+       --source identity-reflection \
+       --risk low \
+       --summary "<the one-line preference>" \
+       --body "<cited ledger receipts: dates + task ids that earned it>"
+     ```
+
+- Report a one-line summary of what you proposed (or that you stayed silent). The
+  human reviews pending proposals via `improvement_queue.py list --status
+  pending_review` and applies them with `approve` — only then does anything reach
+  your prompt.
+
+## Rules
+
+- Proof or don't say it. No preference without cited receipts.
+- Propose only. You have no authority to write identity files directly.
+- Prefer silence over a weak proposal. The gate is cheap; a bad earned preference
+  is expensive because it persists in every future prompt.

--- a/run_agent.py
+++ b/run_agent.py
@@ -163,6 +163,7 @@ from agent.prompt_builder import (  # noqa: F401  # re-exported via _ra() / mock
     build_environment_hints,
     build_nous_subscription_prompt,
     load_soul_md,
+    load_preferences_md,
 )
 from agent.process_bootstrap import _get_proxy_from_env  # noqa: F401
 from agent.message_sanitization import (  # noqa: F401

--- a/scripts/identity_improvement_queue_digest.sh
+++ b/scripts/identity_improvement_queue_digest.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 "${HERMES_HOME:-$HOME/.hermes}/scripts/improvement_queue.py" digest

--- a/scripts/identity_ledger.py
+++ b/scripts/identity_ledger.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""identity_ledger.py — mechanical evidence ledger for Friday's identity loop.
+
+The *court record* half of self-awareness: a dated, append-only log of what the
+agent verifiably did, derived mechanically from kanban completion receipts. No
+model, no prose generation — it cannot flatter, only transcribe receipts.
+
+Subcommands
+-----------
+rollup
+    Read newly-``completed`` kanban work (``task_events`` joined to its closing
+    ``task_runs`` row) since a stored watermark and append one dated entry per
+    completion to ``~/.hermes/identity/LEDGER.md``. Idempotent: a re-run with no
+    new completions is a no-op, and entries are never duplicated.
+
+append
+    Gated manual entry for direct (un-carded) conversational work. Requires a
+    receipt — at least one of ``--file`` (must exist on disk), ``--command``
+    (executed; exit code + captured output stored), or ``--diff``. A prose-only
+    entry exits non-zero and writes nothing. Same evidence bar the intake
+    quality gate enforces, applied to direct work.
+
+Deployed to ``~/.hermes/scripts/`` and run by a daily ``no_agent`` cron job.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+def _candidate_import_roots(script_path: Path, hermes_home: Path) -> list[Path]:
+    """Source roots to try before importing Hermes modules.
+
+    In a checkout, this script lives under ``repo/scripts``. After
+    ``setup_identity_loop.py`` deploys it, it lives under
+    ``~/.hermes/scripts`` while the source checkout commonly remains at
+    ``~/.hermes/hermes-agent``. Add both shapes so direct host smoke commands
+    and no-agent cron can import ``hermes_cli`` consistently.
+    """
+    roots = [
+        script_path.resolve().parent.parent,
+        hermes_home / "hermes-agent",
+    ]
+    env_root = (os.environ.get("HERMES_AGENT_ROOT") or "").strip()
+    if env_root:
+        roots.insert(0, Path(env_root).expanduser())
+    return roots
+
+
+def _add_import_roots() -> None:
+    raw_home = (os.environ.get("HERMES_HOME") or "").strip()
+    hermes_home = Path(raw_home).expanduser() if raw_home else Path.home() / ".hermes"
+    for root in reversed(_candidate_import_roots(Path(__file__), hermes_home)):
+        root_s = str(root)
+        if root_s not in sys.path:
+            sys.path.insert(0, root_s)
+
+
+_add_import_roots()
+
+try:
+    from hermes_constants import get_hermes_home
+except ImportError:  # pragma: no cover - fallback for detached deployments
+    def get_hermes_home() -> Path:  # type: ignore[misc]
+        val = (os.environ.get("HERMES_HOME") or "").strip()
+        return Path(val) if val else Path.home() / ".hermes"
+
+
+def _identity_dir() -> Path:
+    d = get_hermes_home() / "identity"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _ledger_path() -> Path:
+    return _identity_dir() / "LEDGER.md"
+
+
+def _watermark_path() -> Path:
+    return _identity_dir() / ".ledger_watermark"
+
+
+def _read_watermark() -> int:
+    p = _watermark_path()
+    try:
+        return int(p.read_text(encoding="utf-8").strip())
+    except (FileNotFoundError, ValueError):
+        return 0
+
+
+def _write_watermark(value: int) -> None:
+    _watermark_path().write_text(str(int(value)), encoding="utf-8")
+
+
+def _utc_date(epoch: Optional[int]) -> str:
+    ts = epoch if epoch is not None else time.time()
+    return time.strftime("%Y-%m-%d", time.gmtime(ts))
+
+
+def _ensure_ledger_header() -> None:
+    p = _ledger_path()
+    if not p.exists() or not p.read_text(encoding="utf-8").strip():
+        p.write_text(
+            "# LEDGER.md — Friday's evidence record\n\n"
+            "Append-only. Mechanical. Each entry is a receipt of verifiable "
+            "work — never a self-narration.\n",
+            encoding="utf-8",
+        )
+
+
+def _append_entry(text: str) -> None:
+    _ensure_ledger_header()
+    with _ledger_path().open("a", encoding="utf-8") as fh:
+        fh.write("\n" + text.rstrip() + "\n")
+
+
+def _fmt_receipt_list(label: str, value) -> Optional[str]:
+    if not value:
+        return None
+    if isinstance(value, (list, tuple)):
+        items = ", ".join(str(v) for v in value if str(v).strip())
+        if not items:
+            return None
+        return f"- {label}: {items}"
+    return f"- {label}: {value}"
+
+
+# ---------------------------------------------------------------------------
+# rollup
+# ---------------------------------------------------------------------------
+
+def cmd_rollup(_args: argparse.Namespace) -> int:
+    try:
+        from hermes_cli import kanban_db as kb
+    except ImportError as e:  # pragma: no cover - installed deployments have it
+        print(f"identity_ledger: cannot import kanban_db ({e})", file=sys.stderr)
+        return 1
+
+    conn = kb.connect()
+    try:
+        watermark = _read_watermark()
+        rows = conn.execute(
+            "SELECT id, task_id, run_id, created_at FROM task_events "
+            "WHERE kind = 'completed' AND id > ? ORDER BY id ASC",
+            (watermark,),
+        ).fetchall()
+
+        if not rows:
+            return 0
+
+        max_id = watermark
+        appended = 0
+        for row in rows:
+            ev_id = int(row["id"])
+            task_id = row["task_id"]
+            run_id = row["run_id"]
+            created_at = row["created_at"]
+            max_id = max(max_id, ev_id)
+
+            run = kb.get_run(conn, int(run_id)) if run_id is not None else None
+
+            header = f"## {_utc_date(created_at)} — task {task_id}"
+            if run is not None:
+                header += f" (run {run.id})"
+
+            lines = [header]
+            if run is not None:
+                if run.profile:
+                    lines.append(f"- profile: {run.profile}")
+                if run.outcome:
+                    lines.append(f"- outcome: {run.outcome}")
+                if run.summary:
+                    lines.append(f"- summary: {run.summary.strip()}")
+                meta = run.metadata or {}
+                for label, key in (
+                    ("changed_files", "changed_files"),
+                    ("tests_run", "tests_run"),
+                    ("artifacts", "artifacts"),
+                ):
+                    line = _fmt_receipt_list(label, meta.get(key))
+                    if line:
+                        lines.append(line)
+            else:
+                lines.append("- (no closing run recorded)")
+
+            _append_entry("\n".join(lines))
+            appended += 1
+
+        _write_watermark(max_id)
+        print(f"identity_ledger: appended {appended} entr"
+              f"{'y' if appended == 1 else 'ies'} (watermark -> {max_id})")
+        return 0
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# append (gated)
+# ---------------------------------------------------------------------------
+
+def cmd_append(args: argparse.Namespace) -> int:
+    receipts: list[str] = []
+
+    # --file: each must exist on disk.
+    for f in args.file or []:
+        path = Path(f).expanduser()
+        if not path.exists():
+            print(
+                f"identity_ledger: refusing append — file does not exist: {f}",
+                file=sys.stderr,
+            )
+            return 2
+        receipts.append(f"- file: {path}")
+
+    # --command: execute, capture exit code + output.
+    for cmd in args.command or []:
+        try:
+            proc = subprocess.run(
+                cmd, shell=True, capture_output=True, text=True, timeout=120,
+            )
+        except Exception as e:
+            print(f"identity_ledger: command failed to run: {cmd} ({e})",
+                  file=sys.stderr)
+            return 2
+        out = (proc.stdout or "").strip()
+        err = (proc.stderr or "").strip()
+        captured = out or err or "(no output)"
+        # Keep the ledger readable: cap captured output.
+        if len(captured) > 800:
+            captured = captured[:800] + " …[truncated]"
+        receipts.append(
+            f"- command: `{cmd}` (exit {proc.returncode})\n"
+            f"  output: {captured}"
+        )
+
+    # --diff: literal text, or @path to read from a file.
+    if args.diff:
+        diff_val = args.diff
+        if diff_val.startswith("@"):
+            dp = Path(diff_val[1:]).expanduser()
+            if not dp.exists():
+                print(f"identity_ledger: diff file does not exist: {dp}",
+                      file=sys.stderr)
+                return 2
+            diff_val = dp.read_text(encoding="utf-8")
+        if diff_val.strip():
+            receipts.append("- diff:\n```\n" + diff_val.rstrip() + "\n```")
+
+    if not receipts:
+        print(
+            "identity_ledger: refusing prose-only append — a receipt is "
+            "required (--file / --command / --diff). Nothing written.",
+            file=sys.stderr,
+        )
+        return 2
+
+    header = f"## {_utc_date(None)} — direct work (manual)"
+    if args.task:
+        header += f" — task {args.task}"
+    lines = [header, f"- summary: {args.summary.strip()}", *receipts]
+    _append_entry("\n".join(lines))
+    print("identity_ledger: appended manual entry.")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__)
+    # Default action is rollup, so a bare invocation (how the cron scheduler
+    # runs the script — `python identity_ledger.py` with no args) does a rollup.
+    p.set_defaults(func=cmd_rollup)
+    sub = p.add_subparsers(dest="command_name")
+
+    sp_rollup = sub.add_parser(
+        "rollup", help="Append ledger entries for newly-completed kanban work.")
+    sp_rollup.set_defaults(func=cmd_rollup)
+
+    sp_append = sub.add_parser(
+        "append", help="Gated manual entry for direct work (requires a receipt).")
+    sp_append.add_argument("--summary", required=True, help="One-line description.")
+    sp_append.add_argument("--task", help="Optional related task id.")
+    sp_append.add_argument(
+        "--file", action="append",
+        help="Receipt: a file that must exist on disk (repeatable).")
+    sp_append.add_argument(
+        "--command", action="append",
+        help="Receipt: a command to execute; its exit code + output are stored "
+             "(repeatable).")
+    sp_append.add_argument(
+        "--diff", help="Receipt: a unified diff (literal text, or @path).")
+    sp_append.set_defaults(func=cmd_append)
+
+    return p
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/improvement_queue.py
+++ b/scripts/improvement_queue.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""improvement_queue.py — the human-approval gate for Friday's self-authorship.
+
+A receipt layer, not an auto-mutator. The identity-reflection loop (and the very
+first SOUL.md self-description amendment) *propose* file changes here; nothing
+touches a target file until a human runs ``approve``. On approve, the current
+target is snapshotted into ``identity/audit-backups/`` before the proposed
+content is written, so every applied change is reversible and auditable.
+
+Proposals live under ``~/.hermes/identity/queue/<id>/``:
+    meta.json   — id, target, source, risk, summary, body, status, timestamps
+    proposed    — the full proposed file content
+    diff        — unified diff vs the target at creation time
+
+Subcommands: create, list, show, digest, approve, reject.
+Deployed to ``~/.hermes/scripts/``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import hashlib
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+try:
+    from hermes_constants import get_hermes_home
+except ImportError:  # pragma: no cover - fallback for detached deployments
+    def get_hermes_home() -> Path:  # type: ignore[misc]
+        val = (os.environ.get("HERMES_HOME") or "").strip()
+        return Path(val) if val else Path.home() / ".hermes"
+
+
+def _identity_dir() -> Path:
+    d = get_hermes_home() / "identity"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _queue_dir() -> Path:
+    d = _identity_dir() / "queue"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _backups_dir() -> Path:
+    d = _identity_dir() / "audit-backups"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _proposal_dir(pid: str) -> Path:
+    return _queue_dir() / pid
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _read_text_or_empty(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return ""
+
+
+def _next_id() -> str:
+    existing = [
+        int(p.name) for p in _queue_dir().iterdir()
+        if p.is_dir() and p.name.isdigit()
+    ]
+    return f"{(max(existing) + 1) if existing else 1:04d}"
+
+
+def _load_meta(pid: str) -> Optional[dict]:
+    mp = _proposal_dir(pid) / "meta.json"
+    if not mp.exists():
+        return None
+    try:
+        return json.loads(mp.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _save_meta(pid: str, meta: dict) -> None:
+    (_proposal_dir(pid) / "meta.json").write_text(
+        json.dumps(meta, indent=2, ensure_ascii=False), encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# create
+# ---------------------------------------------------------------------------
+
+def cmd_create(args: argparse.Namespace) -> int:
+    target = Path(args.target).expanduser()
+    proposed_path = Path(args.proposed_file).expanduser()
+    if not proposed_path.exists():
+        print(f"improvement_queue: proposed file not found: {proposed_path}",
+              file=sys.stderr)
+        return 2
+
+    proposed = proposed_path.read_text(encoding="utf-8")
+    current = _read_text_or_empty(target)
+
+    diff = "".join(difflib.unified_diff(
+        current.splitlines(keepends=True),
+        proposed.splitlines(keepends=True),
+        fromfile=f"a/{target.name}",
+        tofile=f"b/{target.name}",
+    ))
+    if not diff.strip():
+        print("improvement_queue: proposed content is identical to the target; "
+              "nothing to propose.", file=sys.stderr)
+        return 2
+
+    pid = _next_id()
+    pdir = _proposal_dir(pid)
+    pdir.mkdir(parents=True, exist_ok=True)
+    (pdir / "proposed").write_text(proposed, encoding="utf-8")
+    (pdir / "diff").write_text(diff, encoding="utf-8")
+
+    meta = {
+        "id": pid,
+        "target": str(target),
+        "source": args.source or "unknown",
+        "risk": args.risk or "low",
+        "summary": args.summary or "",
+        "body": args.body or "",
+        "status": "pending_review",
+        "created_at": int(time.time()),
+        "target_sha256_at_create": _sha256(current),
+    }
+    _save_meta(pid, meta)
+    print(f"improvement_queue: created proposal {pid} "
+          f"(target {target}, status pending_review)")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# list / show
+# ---------------------------------------------------------------------------
+
+def _iter_proposals():
+    for p in sorted(_queue_dir().iterdir(), key=lambda x: x.name):
+        if p.is_dir() and p.name.isdigit():
+            meta = _load_meta(p.name)
+            if meta:
+                yield meta
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    found = False
+    for meta in _iter_proposals():
+        if args.status and meta.get("status") != args.status:
+            continue
+        found = True
+        print(f"{meta['id']}  [{meta.get('status')}]  "
+              f"{meta.get('source')}  ->  {meta.get('target')}")
+        if meta.get("summary"):
+            print(f"      {meta['summary']}")
+    if not found:
+        print("(no proposals)" if not args.status
+              else f"(no proposals with status {args.status})")
+    return 0
+
+
+def cmd_show(args: argparse.Namespace) -> int:
+    meta = _load_meta(args.id)
+    if meta is None:
+        print(f"improvement_queue: no such proposal: {args.id}", file=sys.stderr)
+        return 2
+    print(json.dumps(meta, indent=2, ensure_ascii=False))
+    diff = _read_text_or_empty(_proposal_dir(args.id) / "diff")
+    if diff.strip():
+        print("\n--- diff ---")
+        print(diff)
+    return 0
+
+
+def cmd_digest(args: argparse.Namespace) -> int:
+    pending = [
+        meta for meta in _iter_proposals()
+        if meta.get("status") == "pending_review"
+    ]
+    if not pending and not args.force:
+        return 0
+    if not pending:
+        print("Verdict — Identity improvement queue is clear.")
+        print("Action: none.")
+        return 0
+
+    print(f"Verdict — {len(pending)} identity proposal(s) need review.")
+    print("Evidence: ~/.hermes/identity/queue")
+    for meta in pending[:args.limit]:
+        pid = meta["id"]
+        summary = meta.get("summary") or "(no summary)"
+        print(
+            f"- {pid}: {summary} | risk={meta.get('risk', 'unknown')} | "
+            f"source={meta.get('source', 'unknown')} | target={meta.get('target')}"
+        )
+        print(f"  show: python3 ~/.hermes/scripts/improvement_queue.py show {pid}")
+        print(f"  approve: python3 ~/.hermes/scripts/improvement_queue.py approve {pid}")
+        print(f"  reject: python3 ~/.hermes/scripts/improvement_queue.py reject {pid}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# approve / reject
+# ---------------------------------------------------------------------------
+
+def cmd_approve(args: argparse.Namespace) -> int:
+    meta = _load_meta(args.id)
+    if meta is None:
+        print(f"improvement_queue: no such proposal: {args.id}", file=sys.stderr)
+        return 2
+    if meta.get("status") != "pending_review":
+        print(f"improvement_queue: proposal {args.id} is not pending "
+              f"(status: {meta.get('status')}).", file=sys.stderr)
+        return 2
+
+    target = Path(meta["target"]).expanduser()
+    proposed = _read_text_or_empty(_proposal_dir(args.id) / "proposed")
+    current = _read_text_or_empty(target)
+
+    # Drift detection: warn (but proceed) if the target changed since the
+    # proposal was created. The human is approving with eyes open.
+    if _sha256(current) != meta.get("target_sha256_at_create"):
+        print(f"improvement_queue: WARNING — {target} changed since this "
+              f"proposal was created; the diff may not apply as previewed.",
+              file=sys.stderr)
+
+    # Snapshot the current target before overwriting (audit-backup convention).
+    ts = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+    backup = _backups_dir() / f"{ts}-{target.name}-{args.id}.bak"
+    backup.write_text(current, encoding="utf-8")
+    with (_backups_dir() / "MANIFEST.log").open("a", encoding="utf-8") as fh:
+        fh.write(f"{ts}\tproposal={args.id}\ttarget={target}\t"
+                 f"backup={backup.name}\tsource={meta.get('source')}\n")
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(proposed, encoding="utf-8")
+
+    meta["status"] = "approved"
+    meta["approved_at"] = int(time.time())
+    meta["backup"] = backup.name
+    _save_meta(args.id, meta)
+    print(f"improvement_queue: approved {args.id} — wrote {target} "
+          f"(backup: {backup.name})")
+    return 0
+
+
+def cmd_reject(args: argparse.Namespace) -> int:
+    meta = _load_meta(args.id)
+    if meta is None:
+        print(f"improvement_queue: no such proposal: {args.id}", file=sys.stderr)
+        return 2
+    if meta.get("status") != "pending_review":
+        print(f"improvement_queue: proposal {args.id} is not pending "
+              f"(status: {meta.get('status')}).", file=sys.stderr)
+        return 2
+    meta["status"] = "rejected"
+    meta["rejected_at"] = int(time.time())
+    if args.reason:
+        meta["reject_reason"] = args.reason
+    _save_meta(args.id, meta)
+    print(f"improvement_queue: rejected {args.id} (target left untouched)")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__)
+    sub = p.add_subparsers(dest="command_name", required=True)
+
+    c = sub.add_parser("create", help="Stage a proposed change to a target file.")
+    c.add_argument("--target", required=True, help="Path of the file to change.")
+    c.add_argument("--proposed-file", required=True,
+                   help="Path to the file holding the full proposed content.")
+    c.add_argument("--source", help="Who proposed this (e.g. identity-reflection).")
+    c.add_argument("--risk", help="Risk label (default: low).")
+    c.add_argument("--summary", help="One-line summary.")
+    c.add_argument("--body", help="Longer rationale / cited receipts.")
+    c.set_defaults(func=cmd_create)
+
+    li = sub.add_parser("list", help="List proposals.")
+    li.add_argument("--status", help="Filter by status (e.g. pending_review).")
+    li.set_defaults(func=cmd_list)
+
+    sh = sub.add_parser("show", help="Show a proposal's metadata and diff.")
+    sh.add_argument("id")
+    sh.set_defaults(func=cmd_show)
+
+    dg = sub.add_parser("digest", help="Print pending proposals for review delivery.")
+    dg.add_argument("--force", action="store_true",
+                    help="Print a clear message even when no proposals are pending.")
+    dg.add_argument("--limit", type=int, default=8)
+    dg.set_defaults(func=cmd_digest)
+
+    ap = sub.add_parser("approve", help="Apply a proposal (with audit backup).")
+    ap.add_argument("id")
+    ap.set_defaults(func=cmd_approve)
+
+    rj = sub.add_parser("reject", help="Reject a proposal (target untouched).")
+    rj.add_argument("id")
+    rj.add_argument("--reason")
+    rj.set_defaults(func=cmd_reject)
+
+    return p
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/setup_identity_loop.py
+++ b/scripts/setup_identity_loop.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""setup_identity_loop.py — deploy Friday's identity self-improvement loop.
+
+Idempotent one-shot installer that wires the loop into a live ``~/.hermes/``
+runtime. Run it once on the host where Friday actually lives:
+
+    python3 scripts/setup_identity_loop.py
+
+What it does (each step is skip-if-already-present):
+  1. Copy ``identity_ledger.py`` + ``improvement_queue.py`` and the digest
+     wrapper -> ``~/.hermes/scripts/``.
+  2. Copy ``friday-identity-reflection.md`` -> ``~/.hermes/cron/prompts/``.
+  3. Seed ``~/.hermes/PREFERENCES.md`` and ``~/.hermes/identity/LEDGER.md`` from
+     the committed seed templates (only if they don't exist yet).
+  4. Stage the first SOUL.md self-description clause through the queue.
+  5. Register three cron jobs (by name, skipped if they already exist):
+       - daily   : a no_agent job running ``identity_ledger.py`` (rollup).
+       - monthly : an LLM job running the identity-reflection prompt.
+       - daily   : a no_agent digest for pending identity proposals.
+
+The PREFERENCES.md injection hook itself is core source (already in the agent);
+this script only deploys the runtime half.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import json
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from hermes_constants import get_hermes_home  # noqa: E402
+
+_ASSETS = _PROJECT_ROOT / "assets" / "identity"
+_SCRIPTS = _PROJECT_ROOT / "scripts"
+
+# Cron job names — used as the idempotency key (skip if a job with this name
+# already exists).
+_ROLLUP_JOB_NAME = "friday-identity-ledger-rollup"
+_REFLECTION_JOB_NAME = "friday-identity-reflection"
+_DIGEST_JOB_NAME = "friday-identity-review-digest"
+_REVIEW_QUEUE_ORIGIN = {
+    "platform": "discord",
+    "chat_id": "1512110425389400136",
+    "chat_name": "Review Queue",
+    "chat_topic": "Review Queue",
+    "thread_id": "1512260751514009742",
+}
+
+_SELF_DESCRIPTION_MARKER = "Do not recite SOUL.md as a self-description"
+_SELF_DESCRIPTION_CLAUSE = f"""
+## Self-description discipline
+
+{_SELF_DESCRIPTION_MARKER}. Treat SOUL.md as operating guidance, not
+autobiographical evidence. Do not make unbacked identity claims unless the
+claim is grounded in ledger receipts, approved PREFERENCES.md entries, or the
+current task context. Prefer describing observed behavior and evidence over
+identity labels.
+""".strip()
+
+
+def _copy(src: Path, dst: Path, *, executable: bool = False) -> None:
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(src, dst)
+    if executable:
+        dst.chmod(0o755)
+    print(f"  copied {src.name} -> {dst}")
+
+
+def _seed(src: Path, dst: Path) -> None:
+    if dst.exists():
+        print(f"  seed exists, leaving as-is: {dst}")
+        return
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(src, dst)
+    print(f"  seeded {dst}")
+
+
+def _pending_self_description_proposal(home: Path, soul_path: Path) -> bool:
+    qdir = home / "identity" / "queue"
+    if not qdir.exists():
+        return False
+    for meta_path in qdir.glob("*/meta.json"):
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if (
+            meta.get("status") == "pending_review"
+            and meta.get("target") == str(soul_path)
+            and "self-description clause" in (meta.get("summary") or "")
+        ):
+            return True
+    return False
+
+
+def _stage_self_description_clause(home: Path) -> bool:
+    soul_path = home / "SOUL.md"
+    if not soul_path.exists():
+        print(f"  SOUL.md not found, skipping first identity proposal: {soul_path}")
+        return False
+
+    current = soul_path.read_text(encoding="utf-8")
+    if _SELF_DESCRIPTION_MARKER in current:
+        print("  SOUL.md self-description clause already present")
+        return False
+    if _pending_self_description_proposal(home, soul_path):
+        print("  SOUL.md self-description clause proposal already pending")
+        return False
+
+    drafts = home / "identity" / "drafts"
+    drafts.mkdir(parents=True, exist_ok=True)
+    draft = drafts / "SOUL.self-description-clause.md"
+    proposed = current.rstrip() + "\n\n" + _SELF_DESCRIPTION_CLAUSE + "\n"
+    draft.write_text(proposed, encoding="utf-8")
+
+    from scripts import improvement_queue
+
+    rc = improvement_queue.main([
+        "create",
+        "--target", str(soul_path),
+        "--proposed-file", str(draft),
+        "--source", "setup-identity-loop",
+        "--risk", "low",
+        "--summary", "self-description clause: no SOUL.md recitation or unbacked identity claims",
+        "--body",
+        "First dogfood proposal for the identity gate: the agent must not "
+        "recite SOUL.md as self-description or make unbacked identity claims.",
+    ])
+    if rc != 0:
+        raise RuntimeError(f"failed to stage SOUL.md self-description clause (rc={rc})")
+    print("  staged SOUL.md self-description clause for review")
+    return True
+
+
+def _register_cron_jobs(home: Path, *, create_job, existing_names: set[str]) -> None:
+    if _ROLLUP_JOB_NAME in existing_names:
+        print(f"  cron job already exists: {_ROLLUP_JOB_NAME}")
+    else:
+        create_job(
+            prompt=None,
+            schedule="0 3 * * *",  # daily at 03:00
+            name=_ROLLUP_JOB_NAME,
+            script="identity_ledger.py",
+            no_agent=True,
+            deliver="local",
+        )
+        print(f"  created daily cron job: {_ROLLUP_JOB_NAME}")
+
+    if _REFLECTION_JOB_NAME in existing_names:
+        print(f"  cron job already exists: {_REFLECTION_JOB_NAME}")
+    else:
+        prompt_path = home / "cron" / "prompts" / "friday-identity-reflection.md"
+        create_job(
+            prompt=prompt_path.read_text(encoding="utf-8"),
+            schedule="0 4 1 * *",  # monthly, 1st at 04:00
+            name=_REFLECTION_JOB_NAME,
+            deliver="local",
+        )
+        print(f"  created monthly cron job: {_REFLECTION_JOB_NAME}")
+
+    if _DIGEST_JOB_NAME in existing_names:
+        print(f"  cron job already exists: {_DIGEST_JOB_NAME}")
+    else:
+        create_job(
+            prompt=(
+                "Script-only identity improvement queue digest. It prints only "
+                "when pending identity proposals need human approval; empty "
+                "stdout means silent."
+            ),
+            schedule="12 8 * * *",
+            name=_DIGEST_JOB_NAME,
+            script="identity_improvement_queue_digest.sh",
+            no_agent=True,
+            deliver="origin",
+            origin=dict(_REVIEW_QUEUE_ORIGIN),
+        )
+        print(f"  created daily review digest cron job: {_DIGEST_JOB_NAME}")
+
+
+def main() -> int:
+    home = get_hermes_home()
+    print(f"Deploying identity loop into {home}")
+
+    # 1. scripts
+    _copy(_SCRIPTS / "identity_ledger.py", home / "scripts" / "identity_ledger.py",
+          executable=True)
+    _copy(_SCRIPTS / "improvement_queue.py", home / "scripts" / "improvement_queue.py",
+          executable=True)
+    _copy(_SCRIPTS / "identity_improvement_queue_digest.sh",
+          home / "scripts" / "identity_improvement_queue_digest.sh",
+          executable=True)
+
+    # 2. cron prompt
+    _copy(_ASSETS / "friday-identity-reflection.md",
+          home / "cron" / "prompts" / "friday-identity-reflection.md")
+
+    # 3. seeds (only if absent)
+    _seed(_ASSETS / "PREFERENCES.seed.md", home / "PREFERENCES.md")
+    _seed(_ASSETS / "LEDGER.seed.md", home / "identity" / "LEDGER.md")
+
+    # 4. first gated proposal
+    _stage_self_description_clause(home)
+
+    # 5. cron jobs
+    try:
+        from cron.jobs import create_job, list_jobs
+    except Exception as e:
+        print(f"  WARNING: could not import cron.jobs ({e}); skipping job "
+              f"registration. Create the jobs manually with `hermes cron`.")
+        return 0
+
+    existing = {j.get("name") for j in list_jobs(include_disabled=True)}
+    _register_cron_jobs(home, create_job=create_job, existing_names=existing)
+
+    print(
+        "\nDone. Next steps:\n"
+        "  • Review the staged SOUL.md self-description clause:\n"
+        "      python3 ~/.hermes/scripts/improvement_queue.py list --status pending_review\n"
+        "      python3 ~/.hermes/scripts/improvement_queue.py approve <id>\n"
+        "  • Confirm the rollup sees completed work:\n"
+        "      python3 ~/.hermes/scripts/identity_ledger.py rollup\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -57,14 +57,35 @@ class TestContextFileCwd:
         assert _captured_context_cwd(_make_agent()) == tmp_path
 
 
-def _stable_prompt(agent):
+def _stable_prompt(agent, *, preferences=""):
     with (
         patch("run_agent.load_soul_md", return_value=""),
+        patch("run_agent.load_preferences_md", return_value=preferences),
         patch("run_agent.build_nous_subscription_prompt", return_value=""),
         patch("run_agent.build_environment_hints", return_value=""),
         patch("run_agent.build_context_files_prompt", return_value=""),
     ):
         return build_system_prompt_parts(agent)["stable"]
+
+
+class TestPreferencesInjection:
+    def test_injected_into_stable_tier(self):
+        agent = _make_agent(load_soul_identity=True, skip_context_files=True)
+        stable = _stable_prompt(agent, preferences="PREFER_MARKER terse replies")
+        assert "PREFER_MARKER terse replies" in stable
+        assert "Earned preferences" in stable
+
+    def test_absent_when_empty_is_clean_noop(self):
+        agent = _make_agent(load_soul_identity=True, skip_context_files=True)
+        stable = _stable_prompt(agent, preferences="")
+        assert "Earned preferences" not in stable
+
+    def test_skipped_when_context_files_skipped(self):
+        # Delegation/subagent shape: no soul identity and context files skipped
+        # (load_soul_identity=False and skip_context_files=True gates it out).
+        agent = _make_agent(load_soul_identity=False, skip_context_files=True)
+        stable = _stable_prompt(agent, preferences="SHOULD_NOT_APPEAR")
+        assert "SHOULD_NOT_APPEAR" not in stable
 
 
 class TestCodingContextBlock:

--- a/tests/scripts/test_identity_ledger.py
+++ b/tests/scripts/test_identity_ledger.py
@@ -1,0 +1,169 @@
+"""Unit tests for scripts/identity_ledger.py.
+
+Covers the mechanical rollup (kanban completion receipts -> LEDGER.md, with an
+advancing, dedup-safe watermark) and the gated manual append (a receipt is
+mandatory; prose-only entries are refused).
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import scripts.identity_ledger as ledger
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    return home
+
+
+def _complete_a_task(*, summary, metadata):
+    conn = kb.connect()
+    try:
+        # Default initial_status ("running") + no parents resolves to "ready",
+        # which claim_task can then transition to "running" (creating a run).
+        tid = kb.create_task(conn, title="seed task", assignee="builder")
+        kb.claim_task(conn, tid, claimer="builder")
+        kb.complete_task(conn, tid, summary=summary, metadata=metadata)
+        return tid
+    finally:
+        conn.close()
+
+
+def test_rollup_appends_entry_with_receipts_and_advances_watermark(hermes_home):
+    tid = _complete_a_task(
+        summary="implemented the widget",
+        metadata={"changed_files": ["a.py", "b.py"], "tests_run": ["pytest tests/x"]},
+    )
+
+    rc = ledger.main(["rollup"])
+    assert rc == 0
+
+    ledger_text = (hermes_home / "identity" / "LEDGER.md").read_text(encoding="utf-8")
+    assert tid in ledger_text
+    assert "implemented the widget" in ledger_text
+    assert "changed_files: a.py, b.py" in ledger_text
+    assert "tests_run: pytest tests/x" in ledger_text
+
+    watermark = int((hermes_home / "identity" / ".ledger_watermark").read_text())
+    assert watermark > 0
+
+
+def test_bare_invocation_defaults_to_rollup(hermes_home):
+    # The cron scheduler runs `python identity_ledger.py` with no args.
+    tid = _complete_a_task(summary="bare run", metadata={"changed_files": ["z.py"]})
+    assert ledger.main([]) == 0
+    text = (hermes_home / "identity" / "LEDGER.md").read_text(encoding="utf-8")
+    assert tid in text
+
+
+def test_deployed_script_finds_repo_root_from_hermes_home(tmp_path):
+    home = tmp_path / ".hermes"
+    scripts_dir = home / "scripts"
+    agent_root = home / "hermes-agent"
+    scripts_dir.mkdir(parents=True)
+    (agent_root / "hermes_cli").mkdir(parents=True)
+
+    shutil.copyfile(Path(ledger.__file__), scripts_dir / "identity_ledger.py")
+    (agent_root / "hermes_constants.py").write_text(
+        "import os\nfrom pathlib import Path\n"
+        "def get_hermes_home():\n"
+        "    return Path(os.environ['HERMES_HOME'])\n",
+        encoding="utf-8",
+    )
+    (agent_root / "hermes_cli" / "__init__.py").write_text("", encoding="utf-8")
+    (agent_root / "hermes_cli" / "kanban_db.py").write_text(
+        "class _Rows:\n"
+        "    def fetchall(self):\n"
+        "        return []\n"
+        "class _Conn:\n"
+        "    def execute(self, *args, **kwargs):\n"
+        "        return _Rows()\n"
+        "    def close(self):\n"
+        "        pass\n"
+        "def connect():\n"
+        "    return _Conn()\n"
+        "def get_run(conn, run_id):\n"
+        "    return None\n",
+        encoding="utf-8",
+    )
+
+    env = {
+        **os.environ,
+        "HOME": str(tmp_path),
+        "HERMES_HOME": str(home),
+        "PYTHONPATH": "",
+    }
+    proc = subprocess.run(
+        [sys.executable, str(scripts_dir / "identity_ledger.py"), "rollup"],
+        text=True,
+        capture_output=True,
+        cwd=str(tmp_path),
+        env=env,
+        timeout=10,
+    )
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_import_roots_include_deployed_agent_root(tmp_path):
+    home = tmp_path / ".hermes"
+    script = home / "scripts" / "identity_ledger.py"
+    assert home / "hermes-agent" in ledger._candidate_import_roots(script, home)
+
+
+def test_rollup_is_idempotent(hermes_home):
+    _complete_a_task(summary="one", metadata={"changed_files": ["x.py"]})
+    assert ledger.main(["rollup"]) == 0
+    first = (hermes_home / "identity" / "LEDGER.md").read_text(encoding="utf-8")
+
+    # No new completions -> no-op, no duplicate entries.
+    assert ledger.main(["rollup"]) == 0
+    second = (hermes_home / "identity" / "LEDGER.md").read_text(encoding="utf-8")
+    assert first == second
+
+
+def test_append_without_receipt_is_refused(hermes_home):
+    rc = ledger.main(["append", "--summary", "I helped with stuff"])
+    assert rc == 2
+    assert not (hermes_home / "identity" / "LEDGER.md").exists()
+
+
+def test_append_with_file_receipt_is_recorded(hermes_home, tmp_path):
+    receipt = tmp_path / "proof.txt"
+    receipt.write_text("evidence", encoding="utf-8")
+
+    rc = ledger.main([
+        "append", "--summary", "wrote a proof file", "--file", str(receipt),
+    ])
+    assert rc == 0
+    text = (hermes_home / "identity" / "LEDGER.md").read_text(encoding="utf-8")
+    assert "wrote a proof file" in text
+    assert str(receipt) in text
+
+
+def test_append_with_missing_file_receipt_is_refused(hermes_home, tmp_path):
+    rc = ledger.main([
+        "append", "--summary", "claimed a file", "--file", str(tmp_path / "nope.txt"),
+    ])
+    assert rc == 2
+    assert not (hermes_home / "identity" / "LEDGER.md").exists()
+
+
+def test_append_with_command_receipt_records_exit_code(hermes_home):
+    rc = ledger.main([
+        "append", "--summary", "ran a check", "--command", "echo hello-ledger",
+    ])
+    assert rc == 0
+    text = (hermes_home / "identity" / "LEDGER.md").read_text(encoding="utf-8")
+    assert "ran a check" in text
+    assert "exit 0" in text
+    assert "hello-ledger" in text

--- a/tests/scripts/test_improvement_queue.py
+++ b/tests/scripts/test_improvement_queue.py
@@ -1,0 +1,113 @@
+"""Unit tests for scripts/improvement_queue.py — the approval gate.
+
+Covers the full proposal lifecycle: create -> pending_review, list/show,
+approve (writes target + an audit backup), and reject (target untouched).
+"""
+
+from pathlib import Path
+
+import pytest
+
+import scripts.improvement_queue as queue
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    return home
+
+
+def _make_proposal(tmp_path, *, target_text, proposed_text):
+    target = tmp_path / "PREFERENCES.md"
+    target.write_text(target_text, encoding="utf-8")
+    proposed = tmp_path / "draft.md"
+    proposed.write_text(proposed_text, encoding="utf-8")
+    rc = queue.main([
+        "create", "--target", str(target), "--proposed-file", str(proposed),
+        "--source", "identity-reflection", "--summary", "prefer terse replies",
+    ])
+    return rc, target
+
+
+def test_create_lands_pending_review(hermes_home, tmp_path, capsys):
+    rc, _ = _make_proposal(tmp_path, target_text="old\n", proposed_text="old\nnew line\n")
+    assert rc == 0
+
+    capsys.readouterr()
+    assert queue.main(["list", "--status", "pending_review"]) == 0
+    out = capsys.readouterr().out
+    assert "0001" in out
+    assert "identity-reflection" in out
+
+
+def test_digest_is_silent_when_no_pending_proposals(hermes_home, capsys):
+    assert queue.main(["digest"]) == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_digest_surfaces_pending_identity_proposals(hermes_home, tmp_path, capsys):
+    rc, _ = _make_proposal(
+        tmp_path, target_text="old\n", proposed_text="old\nearned: terse\n")
+    assert rc == 0
+
+    capsys.readouterr()
+    assert queue.main(["digest"]) == 0
+    out = capsys.readouterr().out
+    assert "Verdict — 1 identity proposal(s) need review." in out
+    assert "0001" in out
+    assert "prefer terse replies" in out
+    assert "approve 0001" in out
+
+
+def test_create_identical_content_is_refused(hermes_home, tmp_path):
+    rc, _ = _make_proposal(tmp_path, target_text="same\n", proposed_text="same\n")
+    assert rc == 2
+
+
+def test_approve_writes_target_and_audit_backup(hermes_home, tmp_path):
+    rc, target = _make_proposal(
+        tmp_path, target_text="old\n", proposed_text="old\nearned: terse\n")
+    assert rc == 0
+
+    assert queue.main(["approve", "0001"]) == 0
+    assert "earned: terse" in target.read_text(encoding="utf-8")
+
+    backups = list((hermes_home / "identity" / "audit-backups").glob("*.bak"))
+    assert len(backups) == 1
+    assert backups[0].read_text(encoding="utf-8") == "old\n"
+    manifest = (hermes_home / "identity" / "audit-backups" / "MANIFEST.log").read_text()
+    assert "proposal=0001" in manifest
+
+
+def test_approve_twice_is_refused(hermes_home, tmp_path):
+    _make_proposal(tmp_path, target_text="old\n", proposed_text="old\nx\n")
+    assert queue.main(["approve", "0001"]) == 0
+    assert queue.main(["approve", "0001"]) == 2  # no longer pending
+
+
+def test_reject_leaves_target_untouched(hermes_home, tmp_path):
+    rc, target = _make_proposal(
+        tmp_path, target_text="original\n", proposed_text="original\nrejected\n")
+    assert rc == 0
+
+    assert queue.main(["reject", "0001", "--reason", "not earned"]) == 0
+    assert target.read_text(encoding="utf-8") == "original\n"
+    # No audit backup should exist for a rejection.
+    assert not list((hermes_home / "identity" / "audit-backups").glob("*.bak"))
+
+
+def test_ids_increment(hermes_home, tmp_path):
+    _make_proposal(tmp_path, target_text="a\n", proposed_text="a\nb\n")
+    # Second proposal against a different target gets the next id.
+    t2 = tmp_path / "SOUL.md"
+    t2.write_text("soul\n", encoding="utf-8")
+    d2 = tmp_path / "draft2.md"
+    d2.write_text("soul\nclause\n", encoding="utf-8")
+    assert queue.main([
+        "create", "--target", str(t2), "--proposed-file", str(d2),
+    ]) == 0
+    ids = sorted(p.name for p in (hermes_home / "identity" / "queue").iterdir())
+    assert ids == ["0001", "0002"]

--- a/tests/scripts/test_setup_identity_loop.py
+++ b/tests/scripts/test_setup_identity_loop.py
@@ -1,0 +1,81 @@
+"""Unit tests for scripts/setup_identity_loop.py."""
+
+import json
+from pathlib import Path
+
+import scripts.setup_identity_loop as setup
+from agent.prompt_builder import _scan_context_content
+
+
+def test_preferences_seed_is_context_file_safe():
+    content = (setup._ASSETS / "PREFERENCES.seed.md").read_text(encoding="utf-8")
+    assert _scan_context_content(content, "PREFERENCES.md") == content
+
+
+def test_stage_self_description_clause_creates_pending_soul_proposal(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    soul = home / "SOUL.md"
+    soul.write_text("# SOUL\n\nExisting constitution.\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    assert setup._stage_self_description_clause(home) is True
+
+    proposal = home / "identity" / "queue" / "0001"
+    meta = json.loads((proposal / "meta.json").read_text(encoding="utf-8"))
+    proposed = (proposal / "proposed").read_text(encoding="utf-8")
+    assert meta["status"] == "pending_review"
+    assert meta["target"] == str(soul)
+    assert meta["source"] == "setup-identity-loop"
+    assert "self-description clause" in meta["summary"]
+    assert "Existing constitution." in proposed
+    assert "Do not recite SOUL.md as a self-description" in proposed
+    assert "unbacked identity claims" in proposed
+
+
+def test_stage_self_description_clause_is_idempotent_with_pending_proposal(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "SOUL.md").write_text("# SOUL\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    assert setup._stage_self_description_clause(home) is True
+    assert setup._stage_self_description_clause(home) is False
+
+    proposals = list((home / "identity" / "queue").iterdir())
+    assert [p.name for p in proposals] == ["0001"]
+
+
+def test_register_cron_jobs_includes_identity_review_digest(tmp_path):
+    calls = []
+    home = tmp_path / ".hermes"
+    prompt_dir = home / "cron" / "prompts"
+    prompt_dir.mkdir(parents=True, exist_ok=True)
+    (prompt_dir / "friday-identity-reflection.md").write_text("reflect\n", encoding="utf-8")
+
+    def fake_create_job(**kwargs):
+        calls.append(kwargs)
+        return kwargs
+
+    setup._register_cron_jobs(
+        home,
+        create_job=fake_create_job,
+        existing_names=set(),
+    )
+
+    digest_jobs = [
+        c for c in calls
+        if c["name"] == "friday-identity-review-digest"
+    ]
+    assert len(digest_jobs) == 1
+    assert digest_jobs[0]["script"] == "identity_improvement_queue_digest.sh"
+    assert digest_jobs[0]["no_agent"] is True
+    assert digest_jobs[0]["schedule"] == "12 8 * * *"
+    assert digest_jobs[0]["deliver"] == "origin"
+    assert digest_jobs[0]["origin"] == {
+        "platform": "discord",
+        "chat_id": "1512110425389400136",
+        "chat_name": "Review Queue",
+        "chat_topic": "Review Queue",
+        "thread_id": "1512260751514009742",
+    }


### PR DESCRIPTION
## Summary

Adds the Friday identity self-improvement loop as one authored commit from the remote session, with review feedback and live deployment feedback folded into the same PR.

The only core runtime-immutable change is the `PREFERENCES.md` injection hook:
- `agent/prompt_builder.py`: `load_preferences_md`, mirroring `load_soul_md` with safety scanning and truncation.
- `agent/system_prompt.py`: stable-tier `PREFERENCES.md` injection immediately after `SOUL.md`, gated by the same context-files condition.
- `run_agent.py`: re-exports `load_preferences_md` for patchability, matching the existing `load_soul_md` convention.

The runtime half lives under `scripts/` and `assets/identity/` and is deployed into `~/.hermes/` by `scripts/setup_identity_loop.py`. It adds an append-only identity ledger, an approval-gated improvement queue, seed identity files, and the reflection prompt/cron setup.

Review feedback addressed:
- `improvement_queue.py digest` now surfaces pending identity proposals, and `identity_improvement_queue_digest.sh` gives cron a no-argv wrapper for visible review delivery.
- `setup_identity_loop.py` now installs the digest wrapper and registers a daily no-agent `friday-identity-review-digest` cron job.
- `friday-identity-review-digest` now routes through `deliver=origin` to the Discord Review Queue lane: channel `1512110425389400136`, thread `1512260751514009742`.
- `setup_identity_loop.py` now stages the initial SOUL.md self-description clause as the first pending proposal, without applying it. Approval still requires the human gate and creates the normal audit backup.

Live deployment feedback addressed:
- `identity_ledger.py` now finds the source checkout from copied deployments under `~/.hermes/scripts` by adding `~/.hermes/hermes-agent` (or `HERMES_AGENT_ROOT`) to import roots before importing `hermes_cli`.
- Added a regression test for the deployed import-root shape.
- `PREFERENCES.seed.md` no longer uses an HTML comment wrapper, because the context-file safety scanner correctly blocks HTML comments before prompt injection. A regression test now scans the committed seed with the same scanner.

## Validation

- `uv sync --extra dev`
- `.venv/bin/python -m pytest tests/scripts/test_identity_ledger.py tests/scripts/test_improvement_queue.py tests/scripts/test_setup_identity_loop.py tests/agent/test_system_prompt.py -q` -> `29 passed in 0.85s`
- Live setup run on the default profile copied scripts/seeds, staged proposal `0001`, and registered `friday-identity-ledger-rollup`, `friday-identity-reflection`, and `friday-identity-review-digest`.
- Live `friday-identity-review-digest` job was patched to `deliver=origin` with Discord Review Queue channel/thread metadata.
- Live `PREFERENCES.md` was updated to remove the scanner-blocked HTML comment wrapper; a prompt smoke check confirms the earned-preferences block now loads and is not replaced by `[BLOCKED: ...]`.
- Live rollup smoke after the deployment import fix: `python3 /home/fnoor1/.hermes/scripts/identity_ledger.py rollup` -> appended 152 entries, watermark `2645`.
- Live review digest smoke: `bash /home/fnoor1/.hermes/scripts/identity_improvement_queue_digest.sh` surfaces proposal `0001` when pending.

Note: running `python -m pytest ...` without the synced venv used the system Python and failed on missing `python-dotenv`; the venv interpreter from `uv sync` passed the requested targets.
