### PR TITLE
fix(memory): apply /memory approve against a fresh on-disk store when no live agent

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2343,7 +2343,7 @@ class GatewaySlashCommandsMixin:
         from gateway.run import _hermes_home
         from hermes_cli.write_approval_commands import handle_pending_subcommand
         from tools import write_approval as wa
-        from tools.memory_tool import MemoryStore
+        from tools.memory_tool import load_on_disk_store
 
         raw_args = event.get_command_args().strip()
         args = raw_args.split() if raw_args else []
@@ -2363,8 +2363,8 @@ class GatewaySlashCommandsMixin:
 
         # Apply approved writes against a fresh on-disk store (the gateway has
         # no long-lived agent; the store persists to the same MEMORY/USER.md).
-        store = MemoryStore()
-        store.load_from_disk()
+        # load_on_disk_store() honors the user's configured char limits.
+        store = load_on_disk_store()
 
         out = handle_pending_subcommand(
             wa.MEMORY, args, memory_store=store, set_mode_fn=_set_approval,

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1361,6 +1361,16 @@ class CLICommandsMixin:
         parts = cmd.strip().split()
         args = parts[1:] if len(parts) > 1 else []
         store = getattr(self.agent, "_memory_store", None) if getattr(self, "agent", None) else None
+        if store is None:
+            # No live agent store (e.g. /memory approve invoked from the Desktop
+            # GUI, or any context without an active agent). Apply against a freshly
+            # loaded on-disk store, mirroring the gateway path
+            # (gateway/slash_commands.py): it persists to the same MEMORY/USER.md
+            # and creates MEMORY.md on the first approved write. Without this the
+            # shared handler returns "memory store unavailable". See #46783.
+            from tools.memory_tool import MemoryStore
+            store = MemoryStore()
+            store.load_from_disk()
         out = handle_pending_subcommand(
             wa.MEMORY, args,
             memory_store=store,

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1368,9 +1368,10 @@ class CLICommandsMixin:
             # (gateway/slash_commands.py): it persists to the same MEMORY/USER.md
             # and creates MEMORY.md on the first approved write. Without this the
             # shared handler returns "memory store unavailable". See #46783.
-            from tools.memory_tool import MemoryStore
-            store = MemoryStore()
-            store.load_from_disk()
+            # load_on_disk_store() honors the user's configured char limits, so
+            # an approval here enforces the same caps as the live agent would.
+            from tools.memory_tool import load_on_disk_store
+            store = load_on_disk_store()
         out = handle_pending_subcommand(
             wa.MEMORY, args,
             memory_store=store,

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -137,6 +137,33 @@ def test_cli_memory_approve_without_live_agent_uses_fresh_store(hermes_home, cap
     assert any("remember the launch date" in e for e in reloaded.memory_entries)
 
 
+def test_load_on_disk_store_honors_configured_char_limits(hermes_home, monkeypatch):
+    """load_on_disk_store() must read memory.memory_char_limit /
+    user_char_limit from config so approvals applied without a live agent
+    enforce the SAME caps as the live agent (agent_init.py). Falls back to
+    defaults when config can't be loaded.
+    """
+    from tools.memory_tool import load_on_disk_store
+
+    # Config override path: helper picks up the configured limits.
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"memory": {"memory_char_limit": 999, "user_char_limit": 444}},
+    )
+    store = load_on_disk_store()
+    assert store.memory_char_limit == 999
+    assert store.user_char_limit == 444
+
+    # Failure path: config raises → defaults, never blows up.
+    def _boom():
+        raise RuntimeError("no config")
+
+    monkeypatch.setattr("hermes_cli.config.load_config", _boom)
+    fallback = load_on_disk_store()
+    assert fallback.memory_char_limit == 2200
+    assert fallback.user_char_limit == 1375
+
+
 # ---------------------------------------------------------------------------
 # Skill gate
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -107,6 +107,36 @@ def test_memory_gate_on_then_apply(hermes_home):
     assert "approved entry" in store.user_entries[0]
 
 
+def test_cli_memory_approve_without_live_agent_uses_fresh_store(hermes_home, capsys):
+    """#46783: ``/memory approve`` from a context with no live agent (e.g. the
+    Desktop GUI) passed ``memory_store=None`` into the shared handler, which
+    returned "memory store unavailable" and applied nothing. The CLI handler must
+    fall back to a freshly loaded on-disk store, like the gateway path does."""
+    import json
+    from tools.memory_tool import memory_tool, MemoryStore
+    from tools import write_approval as wa
+    from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+    _set_approval("memory", True)
+    staging = MemoryStore(); staging.load_from_disk()
+    r = json.loads(memory_tool("add", "memory", "remember the launch date", store=staging))
+    assert r.get("pending_id"), r
+    assert wa.pending_count("memory") == 1
+
+    # Bare CLI handler with no live agent → store resolves to None pre-fix.
+    handler = CLICommandsMixin.__new__(CLICommandsMixin)
+    handler.agent = None
+    handler._handle_memory_command("/memory approve all")
+
+    out = capsys.readouterr().out
+    assert "memory store unavailable" not in out, out
+    assert "Approved 1" in out, out
+    assert wa.pending_count("memory") == 0
+    # The approved write landed in a freshly loaded on-disk store (MEMORY.md).
+    reloaded = MemoryStore(); reloaded.load_from_disk()
+    assert any("remember the launch date" in e for e in reloaded.memory_entries)
+
+
 # ---------------------------------------------------------------------------
 # Skill gate
 # ---------------------------------------------------------------------------

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -731,6 +731,38 @@ class MemoryStore:
             raise RuntimeError(f"Failed to write memory file {path}: {e}")
 
 
+def load_on_disk_store() -> "MemoryStore":
+    """Build a fresh on-disk :class:`MemoryStore`, honoring configured char limits.
+
+    Use this from any context that has no live agent (the messaging gateway, the
+    Desktop GUI, the bare CLI ``/memory`` handler) but still needs to read or
+    apply approved memory writes. Mirrors how the live agent constructs its store
+    in ``agent/agent_init.py`` — including the user's ``memory.memory_char_limit``
+    / ``memory.user_char_limit`` overrides — so an approval applied without a live
+    agent enforces the SAME caps as one applied with one.
+
+    Falls back to the built-in defaults if config can't be loaded, so this can
+    never raise on a missing/unreadable config.
+    """
+    memory_char_limit = 2200
+    user_char_limit = 1375
+    try:
+        from hermes_cli.config import load_config
+
+        mem_cfg = (load_config() or {}).get("memory", {}) or {}
+        memory_char_limit = int(mem_cfg.get("memory_char_limit", memory_char_limit))
+        user_char_limit = int(mem_cfg.get("user_char_limit", user_char_limit))
+    except Exception:
+        pass  # config optional — fall back to defaults rather than break /memory
+
+    store = MemoryStore(
+        memory_char_limit=memory_char_limit,
+        user_char_limit=user_char_limit,
+    )
+    store.load_from_disk()
+    return store
+
+
 def _apply_write_gate(action: str, target: str, content: Optional[str],
                       old_text: Optional[str]) -> Optional[str]:
     """Evaluate the memory write gate. Returns a JSON tool-result string when


### PR DESCRIPTION
## Summary
`/memory approve` and `/memory approve all` now work from contexts with no live agent — the Hermes Desktop GUI, the TUI, and any CLI path — instead of failing with `memory store unavailable` and applying nothing. The shared on-disk fallback now also honors the user's configured memory char limits on every surface.

Root cause: `_handle_memory_command` resolved the store as `self.agent._memory_store`, which is `None` when there is no live agent, and passed it to the shared `handle_pending_subcommand`, which bails out (`if memory_store is None: return False, "memory store unavailable"`). The messaging-gateway handler already sidesteps this by applying against a freshly loaded on-disk store; the CLI/Desktop path did not.

## Changes
**Commit 1 (@maxmilian, #46926 salvage):** when the agent store is `None`, fall back to a fresh on-disk store before running the shared approval handler — mirroring the gateway. Persists to the same `MEMORY.md`/`USER.md`; creates `MEMORY.md` on the first approved write. Adds a red→green regression test.

**Commit 2 (follow-up):** both the CLI fallback and the gateway handler built a bare `MemoryStore()` with the hardcoded default char limits (2200/1375), ignoring the user's configured `memory.memory_char_limit` / `user_char_limit` (a live agent honors them — `agent/agent_init.py`). Extracted a shared `tools.memory_tool.load_on_disk_store()` factory that reads the configured limits (falling back to defaults if config can't load) and wired **both** the CLI and gateway handlers to it — closing the gap on both surfaces and de-duplicating the construction block.

## Validation
| | Before | After |
|---|---|---|
| `/memory approve all` (no live agent) | `memory store unavailable`, nothing applied | `Approved 1`, write persists to `MEMORY.md` |
| no-agent approval char caps | hardcoded 2200/1375, ignored user config | honors `memory.*_char_limit` (CLI + gateway) |

- `scripts/run_tests.sh tests/tools/test_write_approval.py` → 27/27 passing (+2 new).
- `tests/gateway/test_slash_access_dispatch.py` → 18/18.
- E2E with real imports: no-agent `/memory approve all` applies and persists; `load_on_disk_store()` picks up configured limits (900/300 from a real config.yaml).

## Credit
Salvage of #46926 by @maxmilian (cherry-picked, authorship preserved). Root-cause analysis by @Kombuchameister in #46783. Duplicate PR #47488 (@manus-use) fixed the same root cause and is credited. The config-aware char-limit gap was surfaced by review (3 subagents + Codex).

Closes #46783
Closes #47363
