### PR TITLE
fix(gateway): detect config token credential collisions

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7103,6 +7103,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 token = val.strip()
                 break
         if not token:
+            config = getattr(adapter, "config", None)
+            val = getattr(config, "token", None)
+            if isinstance(val, str) and val.strip():
+                token = val.strip()
+        if not token:
             return None
         import hashlib
         return hashlib.sha256(("hermes-mux:" + token).encode("utf-8")).hexdigest()[:16]

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -5,8 +5,9 @@ from gateway.run import GatewayRunner
 
 
 class _FakeAdapter:
-    def __init__(self, token=None):
+    def __init__(self, token=None, config=None):
         self.token = token
+        self.config = config
 
 
 class TestCredentialFingerprint:
@@ -31,6 +32,17 @@ class TestCredentialFingerprint:
             def __init__(self):
                 self.bot_token = "alt-token"
         assert GatewayRunner._adapter_credential_fingerprint(_AltAdapter()) is not None
+
+    def test_reads_platform_config_token(self):
+        class _Config:
+            token = "config-token"
+
+        fp = GatewayRunner._adapter_credential_fingerprint(
+            _FakeAdapter(token=None, config=_Config())
+        )
+
+        assert fp is not None
+        assert "config-token" not in fp
 
 
 class TestProfileMessageHandler:
@@ -127,10 +139,57 @@ class TestPortBindingHardError:
         connected = await runner._start_one_profile_adapters("reviewer", "/tmp/x", {})
         assert connected == 0  # nothing connected, but no MultiplexConfigError
 
+    @pytest.mark.asyncio
+    async def test_secondary_same_config_token_is_refused(self, monkeypatch):
+        """Adapters that keep their token on config still trip the mux guard."""
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+        class _ConfigTokenAdapter:
+            def __init__(self, token):
+                self.config = PlatformConfig(enabled=True, token=token)
+                self.disconnected = False
+
+            async def connect(self):
+                raise AssertionError("duplicate adapter must not connect")
+
+            async def disconnect(self):
+                self.disconnected = True
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._profile_adapters = {}
+
+        reviewer_cfg = GatewayConfig(multiplex_profiles=True)
+        reviewer_cfg.platforms = {
+            Platform.TELEGRAM: PlatformConfig(enabled=True, token="same-token"),
+        }
+        duplicate = _ConfigTokenAdapter("same-token")
+        claimed = {
+            (
+                Platform.TELEGRAM,
+                GatewayRunner._adapter_credential_fingerprint(
+                    _ConfigTokenAdapter("same-token")
+                ),
+            ): "default"
+        }
+
+        monkeypatch.setattr(
+            "gateway.config.load_gateway_config", lambda: reviewer_cfg
+        )
+        monkeypatch.setattr(runner, "_create_adapter", lambda p, c: duplicate)
+        monkeypatch.setattr(runner, "_adapter_disconnect_timeout_secs", lambda: 0)
+
+        connected = await runner._start_one_profile_adapters(
+            "reviewer", "/tmp/x", claimed
+        )
+
+        assert connected == 0
+        assert duplicate.disconnected is True
+        assert runner._profile_adapters["reviewer"] == {}
+
     def test_port_binding_set_covers_known_listeners(self):
         from gateway.run import _PORT_BINDING_PLATFORM_VALUES
         # Every adapter that binds a TCP port must be in the guard set.
         for p in ("webhook", "api_server", "msgraph_webhook", "feishu",
                   "wecom_callback", "bluebubbles", "sms"):
             assert p in _PORT_BINDING_PLATFORM_VALUES
-


### PR DESCRIPTION
## What does this PR do?

Fixes the multiplex same-token guard so platform adapters that keep their resolved credential on `adapter.config.token` are fingerprinted the same way as adapters that expose a direct `token`/`bot_token` attribute.

Telegram follows the `PlatformConfig.token` path, so the previous helper returned `None` for Telegram adapters and the duplicate-profile collision branch never ran. With this change, duplicate Telegram bot tokens across multiplexed profiles are detected before the secondary adapter connects, while the fingerprint remains a short salted hash and never logs the raw token.

## Related Issue

Fixes #51030

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: fall back from direct adapter token attributes to `adapter.config.token` in `_adapter_credential_fingerprint()`.
- `tests/gateway/test_multiplex_adapter_registry.py`: cover the `config.token` fingerprint path and the actual secondary-profile duplicate-refusal path.

## How to Test

1. Reproduce the bug on the new regression before the code fix:
   `uv run scripts/run_tests.sh tests/gateway/test_multiplex_adapter_registry.py -- -k test_reads_platform_config_token --tb=long`
   - Pre-fix result: failed with `assert None is not None`.
2. Run the focused multiplex adapter registry tests:
   `uv run scripts/run_tests.sh tests/gateway/test_multiplex_adapter_registry.py -- --tb=long`
3. Run adjacent credential-isolation coverage:
   `uv run scripts/run_tests.sh tests/gateway/test_multiplex_credential_isolation.py tests/gateway/test_multiplex_adapter_registry.py -- --tb=long`
4. Lint and diff checks:
   `git diff --check`
   `uv run ruff check gateway/run.py tests/gateway/test_multiplex_adapter_registry.py`
   `uv run python scripts/check-windows-footguns.py --all`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, no user-facing docs changed
- [x] I've updated `cli-config.yaml.example` — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A, no architecture/workflow change
- [x] I've considered cross-platform impact — pure attribute lookup and hashing, no OS-specific behavior
- [x] I've updated tool descriptions/schemas — N/A, no tool schema changed

## Screenshots / Logs

Focused validation passed:

```text
uv run scripts/run_tests.sh tests/gateway/test_multiplex_adapter_registry.py -- --tb=long
# 11 passed

uv run scripts/run_tests.sh tests/gateway/test_multiplex_credential_isolation.py tests/gateway/test_multiplex_adapter_registry.py -- --tb=long
# 18 passed

uv run ruff check gateway/run.py tests/gateway/test_multiplex_adapter_registry.py
# All checks passed

uv run python scripts/check-windows-footguns.py --all
# No Windows footguns found
```

`uv run ty check` was also attempted, but the current project-wide typecheck is not a useful signal locally: it panics in unrelated `tools/checkpoint_manager.py` and reports existing diagnostics across `gateway/run.py`/ACP/TUI surfaces.