### PR TITLE
fix(hindsight): stop embedded daemon restarting every session

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -542,6 +542,22 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
     return env_values
 
 
+def _persisted_profile_env_keys(env: dict[str, str]) -> dict[str, str]:
+    """Return only the keys the embedded daemon manager persists to the profile env.
+
+    ``hindsight_embed``'s ``_register_profile`` writes only ``HINDSIGHT_API_*``
+    keys to the on-disk profile env, dropping the ``HINDSIGHT_EMBED_*`` keys that
+    ``_build_embedded_profile_env`` also emits (e.g.
+    ``HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT``). Restart-on-config-change must compare
+    on this subset; comparing the full built env against the stripped on-disk file
+    is always unequal and restarts the daemon every session. The daemon still
+    receives the idle timeout via its ``--idle-timeout`` flag at startup, so the
+    only trade-off is that an idle-timeout-only change is picked up on the daemon's
+    next restart rather than forcing one.
+    """
+    return {k: v for k, v in env.items() if k.startswith("HINDSIGHT_API_")}
+
+
 def _embedded_profile_env_path(config: dict[str, Any]):
     from pathlib import Path
 
@@ -1421,7 +1437,10 @@ class HindsightMemoryProvider(MemoryProvider):
                     profile_env = _embedded_profile_env_path(self._config)
                     expected_env = _build_embedded_profile_env(self._config)
                     saved = _load_simple_env(profile_env)
-                    config_changed = saved != expected_env
+                    config_changed = (
+                        _persisted_profile_env_keys(saved)
+                        != _persisted_profile_env_keys(expected_env)
+                    )
 
                     if config_changed:
                         profile_env = _materialize_embedded_profile_env(self._config)

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -23,6 +23,7 @@ from plugins.memory.hindsight import (
     RETAIN_SCHEMA,
     _load_config,
     _build_embedded_profile_env,
+    _persisted_profile_env_keys,
     _normalize_observation_scopes,
     _normalize_retain_tags,
     _resolve_bank_id_template,
@@ -416,6 +417,49 @@ class TestConfig:
         })
 
         assert env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "42"
+
+    def test_persisted_profile_env_keys_filters_to_api_keys(self):
+        env = {
+            "HINDSIGHT_API_LLM_PROVIDER": "provider-x",
+            "HINDSIGHT_API_LLM_MODEL": "model-x",
+            "HINDSIGHT_API_LOG_LEVEL": "info",
+            "HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT": "0",
+        }
+
+        persisted = _persisted_profile_env_keys(env)
+
+        assert persisted == {
+            "HINDSIGHT_API_LLM_PROVIDER": "provider-x",
+            "HINDSIGHT_API_LLM_MODEL": "model-x",
+            "HINDSIGHT_API_LOG_LEVEL": "info",
+        }
+        assert "HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT" not in persisted
+
+    def test_persisted_keys_equal_when_only_idle_timeout_differs(self):
+        # The hindsight_embed daemon manager (_register_profile) persists only
+        # HINDSIGHT_API_* keys, so the on-disk profile env never contains the
+        # HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT key that _build_embedded_profile_env
+        # emits. A raw comparison is therefore always unequal and restarts the
+        # daemon every session; comparing the persisted subset must be equal.
+        # (provider/model are inert string inputs here; no LLM is invoked.)
+        built = _build_embedded_profile_env({
+            "llm_provider": "provider-x",
+            "llm_model": "model-x",
+            "idle_timeout": 0,
+        })
+        on_disk = {k: v for k, v in built.items() if k.startswith("HINDSIGHT_API_")}
+
+        assert built != on_disk
+        assert _persisted_profile_env_keys(built) == _persisted_profile_env_keys(on_disk)
+
+    def test_persisted_keys_differ_when_model_changes(self):
+        # A real HINDSIGHT_API_* change (the model) must still register so the
+        # daemon is restarted to pick it up.
+        base = {"llm_provider": "provider-x", "llm_model": "model-x", "idle_timeout": 0}
+        built_a = _build_embedded_profile_env(base)
+        built_b = _build_embedded_profile_env({**base, "llm_model": "model-y"})
+
+        assert _persisted_profile_env_keys(built_a) != _persisted_profile_env_keys(built_b)
 
     def test_get_client_passes_idle_timeout_to_hindsight_embedded(self, monkeypatch):
         captured = {}


### PR DESCRIPTION
## What does this PR do?

Fixes the Hindsight `local_embedded` daemon being torn down and restarted on
**every memory session** instead of staying warm.

`HindsightMemoryProvider._start_daemon()` decides whether to restart the daemon
by comparing the on-disk profile env file against the freshly built env:

```python
expected_env = _build_embedded_profile_env(self._config)
saved = _load_simple_env(profile_env)
config_changed = saved != expected_env
```

These can never be equal: `_build_embedded_profile_env()` emits
`HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT` whenever `idle_timeout` is set, but the
`hindsight_embed` daemon manager (`_register_profile`) persists **only**
`HINDSIGHT_API_*` keys to that file, stripping the `HINDSIGHT_EMBED_*` ones. So
`config_changed` is always `True`, and the daemon is restarted on every
`initialize()` — reloading the embedding/reranker models and firing an LLM
`Say 'ok'` connection check each time, plus a cold-start window where the first
retain of a session can be dropped.

The fix compares only the `HINDSIGHT_API_*` keys the manager actually persists,
via a documented `_persisted_profile_env_keys` helper. Real config changes (LLM
provider/model/key/log level) still trigger a restart. `idle_timeout` reaches the
daemon via its `--idle-timeout` startup flag, not this file, so excluding it is
safe — the only trade-off (documented in the helper) is that an
idle-timeout-only change is applied on the daemon's next restart rather than
forcing one.

## Related Issue

Fixes #
<!-- No existing issue tracks this specific churn. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/hindsight/__init__.py`: add module-level
  `_persisted_profile_env_keys()` helper (filters an env dict to the
  `HINDSIGHT_API_*` keys the daemon manager persists) and use it on both sides of
  the `config_changed` comparison in `_start_daemon()`.
- `tests/plugins/memory/test_hindsight_provider.py`: add 3 tests — the helper's
  filtering, the regression case (built env vs. stripped on-disk env compare equal
  under the filter), and a guard that a real `HINDSIGHT_API_*` change still
  registers.

## How to Test

1. Configure the `hindsight` memory provider in `local_embedded` mode with
   `idle_timeout` set (e.g. `0`).
2. Run any sequence of commands/sessions that touch memory.
3. **Before:** the daemon logs a fresh startup + `Verifying connection: …`
   (`Say 'ok'`) per session, and `hindsight-embed.log` records
   `=== Config changed, restarting daemon ===` every time, despite no config
   change.
   **After:** the daemon stays up across sessions; no spurious restarts.
4. Automated: `scripts/run_tests.sh tests/plugins/memory/test_hindsight_provider.py`
   → 119 passed (the 3 new tests cover the fix).

Verified on a real `local_embedded` deployment: before, the daemon restarted
~once per session; after, it stays warm and a retain→consolidate→recall
round-trip succeeds against it with no failed operations.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(hindsight): …`)
- [x] I searched for existing PRs (related: #42279, #47323, #48717 rework the same profile-env code, but none touch this comparison)
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected suite (`tests/plugins/memory/test_hindsight_provider.py` — 119 passed) + `ruff check` clean; CI runs the full suite
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstring on the new helper) — or N/A
- [x] N/A — no config keys added (`cli-config.yaml.example`)
- [x] N/A — no architecture/workflow change (`CONTRIBUTING.md`/`AGENTS.md`)
- [x] I've considered cross-platform impact — pure dict filtering, no platform-specific behavior
- [x] N/A — no tool behavior/schema change

## Screenshots / Logs

N/A
