### PR TITLE
fix(agent): route OAuth tokens to Bearer auth before third-party endpoint check

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -792,18 +792,14 @@ def build_anthropic_client(
         kwargs["auth_token"] = api_key
         if common_betas:
             kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
-    elif _is_third_party_anthropic_endpoint(base_url):
-        # Third-party proxies (Microsoft Foundry, AWS Bedrock, etc.) use their
-        # own API keys with x-api-key auth. Skip OAuth detection — their keys
-        # don't follow Anthropic's sk-ant-* prefix convention and would be
-        # misclassified as OAuth tokens.
-        kwargs["api_key"] = api_key
-        if common_betas:
-            kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
     elif _is_oauth_token(api_key):
         # OAuth access token / setup-token → Bearer auth + Claude Code identity.
         # Anthropic routes OAuth requests based on user-agent and headers;
         # without Claude Code's fingerprint, requests get intermittent 500s.
+        # Check BEFORE _is_third_party_anthropic_endpoint: local proxies
+        # (e.g. headroom-proxy) that forward to Anthropic don't contain
+        # "anthropic.com" in their URL but still need OAuth Bearer auth
+        # when the credential is an OAuth token.
         all_betas = common_betas + _OAUTH_ONLY_BETAS
         kwargs["auth_token"] = api_key
         kwargs["default_headers"] = {
@@ -811,6 +807,14 @@ def build_anthropic_client(
             "user-agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
             "x-app": "cli",
         }
+    elif _is_third_party_anthropic_endpoint(base_url):
+        # Third-party proxies (Microsoft Foundry, AWS Bedrock, etc.) use their
+        # own API keys with x-api-key auth. Their keys don't follow
+        # Anthropic's sk-ant-* prefix convention, so _is_oauth_token above
+        # correctly returns False and we fall through here.
+        kwargs["api_key"] = api_key
+        if common_betas:
+            kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
     else:
         # Regular API key → x-api-key header + common betas
         kwargs["api_key"] = api_key


### PR DESCRIPTION
## What does this PR do?

Fixes OAuth credentials being sent via `x-api-key` header instead of `Authorization: Bearer` when `providers.anthropic.base_url` points to a local proxy that forwards to Anthropic.

This is the root cause behind #23370 (closed as not reproducible — the bug only triggers with a non-default `base_url`).

### Root cause

In `build_anthropic_client()`, the `elif` chain checks `_is_third_party_anthropic_endpoint(base_url)` **before** `_is_oauth_token(api_key)`. `_is_third_party_anthropic_endpoint` returns `True` for any URL that does not contain `anthropic.com` — including local proxies like headroom-proxy that transparently forward to `https://api.anthropic.com`.

When both conditions are true (OAuth token + non-Anthropic URL), the third-party branch wins and sends the OAuth token as `x-api-key`. Anthropic rejects it with 401 because OAuth tokens require `Authorization: Bearer` + the `oauth-2025-04-20` beta header.

### Why it was not reproducible on main

The default `base_url` is empty (direct to `api.anthropic.com`), so `_is_third_party_anthropic_endpoint` returns `False` and the OAuth path works. The bug **only** triggers when `base_url` is overridden to a proxy — a valid and documented configuration for tools like headroom-proxy, LiteLLM, or any local Anthropic-compatible proxy.

## Related Issue

Root cause of #23370 (closed as not reproducible — reopening is not needed since this PR addresses it directly)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/anthropic_adapter.py`: Reordered the `elif` branches in `build_anthropic_client()` (lines ~795-818) so `_is_oauth_token(api_key)` is checked before `_is_third_party_anthropic_endpoint(base_url)`

## How to Test

### Exact reproduction steps

**Prerequisites:**
- A local proxy that forwards to Anthropic (e.g. [headroom-proxy](https://github.com/headroom-ai/headroom), LiteLLM, or any reverse proxy to `https://api.anthropic.com`)
- Claude Code OAuth credentials in the credential pool (`hermes auth list` shows `anthropic` with `claude_code` OAuth entry)

**Config** (`~/.hermes/config.yaml`):
```yaml
model:
  default: claude-sonnet-4-6
  provider: anthropic
providers:
  anthropic:
    base_url: http://localhost:8787   # <-- any non-anthropic.com URL
```

**Reproduce:**
```bash
# 1. Start the proxy (e.g. headroom-proxy)
headroom proxy --port 8787

# 2. Start the gateway
hermes gateway run

# 3. Send a request via the API server
API_KEY=$(grep ^API_SERVER_KEY= ~/.hermes/.env | cut -d= -f2-)
curl -X POST http://localhost:8642/v1/chat/completions \
  -H "Authorization: Bearer $API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hello"}],"max_tokens":10}"'
```

**Before fix:** Proxy logs show Hermes sending `x-api-key` header → Anthropic returns 401:
```
headers={"x-api-key": "[REDACTED]", "user-agent": "Anthropic/Python 0.87.0", ...}
Forwarding upstream streaming error status=401
```

**After fix:** Proxy logs show Hermes sending `authorization` Bearer with OAuth beta → Anthropic returns 200:
```
headers={"authorization": "[REDACTED]", "user-agent": "claude-cli/2.1.87 (external, cli)",
  "anthropic-beta": "oauth-2025-04-20,...", ...}
status=200
```

### Why the reorder is safe

The `_is_oauth_token()` function only matches Anthropic-specific token prefixes:
- `sk-ant-` (excluding `sk-ant-api`) → setup tokens, managed keys
- `eyJ` → JWTs from Anthropic OAuth
- `cc-` → Claude Code OAuth tokens

Third-party provider keys (MiniMax `mxp-*`, GLM `glm.*`, DashScope, etc.) do not match any of these prefixes, so they correctly fall through to the `_is_third_party_anthropic_endpoint` branch.

The `_requires_bearer_auth()` check (MiniMax etc.) still runs first, unchanged.

### Existing tests pass

```bash
pytest tests/run_agent/test_anthropic_third_party_oauth_guard.py -v
# 7 passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've tested on my platform: Ubuntu 24.04 (Proxmox LXC)

### Documentation & Housekeeping

- [x] N/A — no config, schema, or doc changes needed (pure routing fix)

## Screenshots / Logs

**Before fix** — headroom-proxy logs showing `x-api-key` from Hermes (rejected):
```
event=proxy_inbound_request client=192.168.1.14
  headers={"x-api-key": "[REDACTED]", "user-agent": "Anthropic/Python 0.87.0",
    "anthropic-beta": "interleaved-thinking-2025-05-14,..."}
Forwarding upstream streaming error status=401 url=https://api.anthropic.com/v1/messages
```

**After fix** — headroom-proxy logs showing `authorization` Bearer from Hermes (accepted):
```
event=proxy_inbound_request client=192.168.1.14
  headers={"authorization": "[REDACTED]", "user-agent": "claude-cli/2.1.87 (external, cli)",
    "anthropic-beta": "oauth-2025-04-20,interleaved-thinking-2025-05-14,..."}
event=proxy_inbound_response status=200 duration_ms=3884.04
```