### PR TITLE
fix(cron): read dashboard jobs from root store

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7637,30 +7637,97 @@ def _annotate_cron_job(job: Dict[str, Any], profile: str, home: Path) -> Dict[st
     return annotated
 
 
-def _call_cron_for_profile(profile: Optional[str], func_name: str, *args, **kwargs):
-    """Run cron.jobs helpers against the selected profile's cron directory.
+def _cron_root_home() -> Path:
+    from hermes_constants import get_default_hermes_root
+
+    return get_default_hermes_root().resolve()
+
+
+def _cron_profile_name_for_job(job: Dict[str, Any]) -> str:
+    raw = job.get("profile")
+    return (str(raw).strip() if isinstance(raw, str) and raw.strip() else "default")
+
+
+def _annotate_cron_jobs(jobs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    annotated: List[Dict[str, Any]] = []
+    for job in jobs:
+        profile_name = _cron_profile_name_for_job(job)
+        try:
+            _selected, home = _cron_profile_home(profile_name)
+        except HTTPException:
+            home = _cron_root_home() if profile_name == "default" else _cron_root_home() / "profiles" / profile_name
+        annotated.append(_annotate_cron_job(job, profile_name, home))
+    return annotated
+
+
+def _call_cron_root(func_name: str, *args, **kwargs):
+    """Run cron.jobs helpers against the shared root cron store.
 
     cron.jobs keeps CRON_DIR/JOBS_FILE/OUTPUT_DIR as module globals resolved
-    from the process HERMES_HOME at import time. The dashboard is a single
-    process that can inspect many profiles, so temporarily retarget those
-    globals while holding a lock and restore them immediately after the call.
+    at import time. The dashboard may be imported before tests or a managed
+    process finish setting the effective Hermes home, so retarget the module to
+    the root cron store for each API operation and restore it afterward.
     """
-    profile_name, home = _cron_profile_home(profile)
     with _CRON_PROFILE_LOCK:
         from cron import jobs as cron_jobs
 
+        root = _cron_root_home()
         old_cron_dir = cron_jobs.CRON_DIR
         old_jobs_file = cron_jobs.JOBS_FILE
         old_output_dir = cron_jobs.OUTPUT_DIR
-        cron_jobs.CRON_DIR = home / "cron"
+        cron_jobs.CRON_DIR = root / "cron"
         cron_jobs.JOBS_FILE = cron_jobs.CRON_DIR / "jobs.json"
         cron_jobs.OUTPUT_DIR = cron_jobs.CRON_DIR / "output"
         try:
-            result = getattr(cron_jobs, func_name)(*args, **kwargs)
+            return getattr(cron_jobs, func_name)(*args, **kwargs)
         finally:
             cron_jobs.CRON_DIR = old_cron_dir
             cron_jobs.JOBS_FILE = old_jobs_file
             cron_jobs.OUTPUT_DIR = old_output_dir
+
+
+def _resolve_cron_job_for_profile(profile_name: str, job_ref: str) -> Optional[Dict[str, Any]]:
+    jobs = _call_cron_root("list_jobs", True)
+    profile_jobs = [j for j in jobs if _cron_profile_name_for_job(j) == profile_name]
+    for job in profile_jobs:
+        if job.get("id") == job_ref:
+            return job
+    ref_lower = job_ref.lower()
+    matches = [job for job in profile_jobs if (job.get("name") or "").lower() == ref_lower]
+    if len(matches) > 1:
+        from cron.jobs import AmbiguousJobReference
+
+        raise AmbiguousJobReference(job_ref, matches)
+    return matches[0] if matches else None
+
+
+def _call_cron_for_profile(profile: Optional[str], func_name: str, *args, **kwargs):
+    """Run cron.jobs helpers against the shared root store for a profile.
+
+    Since #32091, every profile's cron jobs live in the root jobs.json and the
+    per-job ``profile`` field scopes execution. The dashboard keeps a profile
+    query parameter for filtering and mutations, but it must not read legacy
+    ``profiles/<name>/cron/jobs.json`` files as active jobs.
+    """
+    profile_name, home = _cron_profile_home(profile)
+
+    if func_name == "create_job":
+        kwargs.setdefault("profile", profile_name)
+        result = _call_cron_root(func_name, *args, **kwargs)
+    elif func_name == "list_jobs":
+        result = [
+            job for job in _call_cron_root(func_name, *args, **kwargs)
+            if _cron_profile_name_for_job(job) == profile_name
+        ]
+    elif args and isinstance(args[0], str):
+        job = _resolve_cron_job_for_profile(profile_name, args[0])
+        if not job:
+            if func_name == "remove_job":
+                return False
+            return None
+        result = _call_cron_root(func_name, job["id"], *args[1:], **kwargs)
+    else:
+        result = _call_cron_root(func_name, *args, **kwargs)
 
     if isinstance(result, list):
         return [_annotate_cron_job(j, profile_name, home) for j in result]
@@ -7670,13 +7737,14 @@ def _call_cron_for_profile(profile: Optional[str], func_name: str, *args, **kwar
 
 
 def _find_cron_job_profile(job_id: str) -> Optional[str]:
-    for profile in _cron_profile_dicts():
-        name = str(profile.get("name") or "")
-        if not name:
-            continue
-        jobs = _call_cron_for_profile(name, "list_jobs", True)
-        if any(j.get("id") == job_id or j.get("name") == job_id for j in jobs):
-            return name
+    jobs = _call_cron_root("list_jobs", True)
+    for job in jobs:
+        if job.get("id") == job_id:
+            return _cron_profile_name_for_job(job)
+    ref_lower = job_id.lower()
+    for job in jobs:
+        if (job.get("name") or "").lower() == ref_lower:
+            return _cron_profile_name_for_job(job)
     return None
 
 
@@ -7686,16 +7754,7 @@ async def list_cron_jobs(profile: str = "all"):
     if requested.lower() != "all":
         return _call_cron_for_profile(requested, "list_jobs", True)
 
-    jobs: List[Dict[str, Any]] = []
-    for item in _cron_profile_dicts():
-        name = str(item.get("name") or "")
-        if not name:
-            continue
-        try:
-            jobs.extend(_call_cron_for_profile(name, "list_jobs", True))
-        except Exception:
-            _log.exception("Failed to list cron jobs for profile %s", name)
-    return jobs
+    return _annotate_cron_jobs(_call_cron_root("list_jobs", True))
 
 
 @app.get("/api/cron/jobs/{job_id}")
@@ -7865,27 +7924,31 @@ def _fire_cron_job_for_profile(profile: str, job_id: str) -> bool:
     """Run ONE due cron job end-to-end for ``profile`` via the resolved
     scheduler provider's ``fire_due`` (store CAS claim + ``run_one_job``).
 
-    Retargets the ``cron.jobs`` module globals to the profile's cron dir under
-    the shared lock — same mechanism as ``_call_cron_for_profile`` — so the
-    claim and the run operate on the right profile's ``jobs.json``. Runs with
-    no live adapters; delivery falls back to the per-platform send path (the
+    The claim operates on the shared root ``jobs.json``. The job record's own
+    ``profile`` field then scopes execution to the owning profile. Runs with no
+    live adapters; delivery falls back to the per-platform send path (the
     dashboard process has no gateway adapter handles, exactly like the desktop
     cron path above).
     """
-    _profile_name, home = _cron_profile_home(profile)
+    profile_name, _home = _cron_profile_home(profile)
+    job = _resolve_cron_job_for_profile(profile_name, job_id)
+    if not job:
+        return False
+
     with _CRON_PROFILE_LOCK:
         from cron import jobs as cron_jobs
         from cron.scheduler_provider import resolve_cron_scheduler
 
+        root = _cron_root_home()
         old_cron_dir = cron_jobs.CRON_DIR
         old_jobs_file = cron_jobs.JOBS_FILE
         old_output_dir = cron_jobs.OUTPUT_DIR
-        cron_jobs.CRON_DIR = home / "cron"
+        cron_jobs.CRON_DIR = root / "cron"
         cron_jobs.JOBS_FILE = cron_jobs.CRON_DIR / "jobs.json"
         cron_jobs.OUTPUT_DIR = cron_jobs.CRON_DIR / "output"
         try:
             provider = resolve_cron_scheduler()
-            return bool(provider.fire_due(job_id, adapters=None, loop=None))
+            return bool(provider.fire_due(job["id"], adapters=None, loop=None))
         finally:
             cron_jobs.CRON_DIR = old_cron_dir
             cron_jobs.JOBS_FILE = old_jobs_file

--- a/tests/hermes_cli/test_web_server_cron_profiles.py
+++ b/tests/hermes_cli/test_web_server_cron_profiles.py
@@ -1,5 +1,7 @@
 """Regression tests for dashboard cron job profile routing."""
 
+import json
+
 import pytest
 from fastapi import HTTPException
 
@@ -7,6 +9,7 @@ from fastapi import HTTPException
 @pytest.fixture()
 def isolated_profiles(tmp_path, monkeypatch):
     """Give profile discovery an isolated default home with one named profile."""
+    import hermes_constants
     from hermes_cli import profiles
 
     default_home = tmp_path / ".hermes"
@@ -19,10 +22,12 @@ def isolated_profiles(tmp_path, monkeypatch):
 
     monkeypatch.setattr(profiles, "_get_default_hermes_home", lambda: default_home)
     monkeypatch.setattr(profiles, "_get_profiles_root", lambda: profiles_root)
+    monkeypatch.setattr(hermes_constants, "_get_platform_default_hermes_home", lambda: default_home)
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
     return {"default": default_home, "worker_alpha": worker_home}
 
 
-def test_call_cron_for_profile_routes_storage_and_restores_globals(isolated_profiles):
+def test_call_cron_for_profile_routes_storage_to_root_and_restores_globals(isolated_profiles):
     from cron import jobs as cron_jobs
     from hermes_cli import web_server
 
@@ -42,8 +47,8 @@ def test_call_cron_for_profile_routes_storage_and_restores_globals(isolated_prof
     assert job["profile_name"] == "worker_alpha"
     assert job["hermes_home"] == str(isolated_profiles["worker_alpha"])
     assert job["is_default_profile"] is False
-    assert (isolated_profiles["worker_alpha"] / "cron" / "jobs.json").exists()
-    assert not (isolated_profiles["default"] / "cron" / "jobs.json").exists()
+    assert (isolated_profiles["default"] / "cron" / "jobs.json").exists()
+    assert not (isolated_profiles["worker_alpha"] / "cron" / "jobs.json").exists()
 
     assert cron_jobs.CRON_DIR == old_cron_dir
     assert cron_jobs.JOBS_FILE == old_jobs_file
@@ -104,6 +109,34 @@ async def test_list_cron_jobs_specific_profile_filters_results(isolated_profiles
 
     assert [job["id"] for job in jobs] == [worker_job["id"]]
     assert jobs[0]["profile"] == "worker_alpha"
+    assert jobs[0]["hermes_home"] == str(isolated_profiles["worker_alpha"])
+
+
+@pytest.mark.asyncio
+async def test_dashboard_ignores_legacy_profile_local_cron_store(isolated_profiles):
+    from hermes_cli import web_server
+
+    legacy_store = isolated_profiles["worker_alpha"] / "cron" / "jobs.json"
+    legacy_store.parent.mkdir(parents=True, exist_ok=True)
+    legacy_store.write_text(
+        json.dumps({
+            "jobs": [
+                {
+                    "id": "legacy-worker-job",
+                    "name": "stale legacy job",
+                    "prompt": "do not show this",
+                    "enabled": True,
+                    "profile": "worker_alpha",
+                    "schedule": {"kind": "interval", "minutes": 60},
+                }
+            ]
+        }),
+        encoding="utf-8",
+    )
+
+    assert not (isolated_profiles["default"] / "cron" / "jobs.json").exists()
+    assert await web_server.list_cron_jobs(profile="all") == []
+    assert await web_server.list_cron_jobs(profile="worker_alpha") == []
 
 
 @pytest.mark.asyncio
@@ -169,15 +202,15 @@ async def test_cron_delete_with_profile_deletes_only_target_profile(isolated_pro
         schedule="every 1h",
         name="shared-name",
     )
-    worker_job = web_server._call_cron_for_profile(
+    web_server._call_cron_for_profile(
         "worker_alpha",
         "create_job",
         prompt="same-ish worker",
         schedule="every 1h",
-        name="shared-name-worker",
+        name="shared-name",
     )
 
-    deleted = await web_server.delete_cron_job(worker_job["id"], profile="worker_alpha")
+    deleted = await web_server.delete_cron_job("shared-name", profile="worker_alpha")
     assert deleted == {"ok": True}
 
     remaining_default = await web_server.list_cron_jobs(profile="default")


### PR DESCRIPTION

## What does this PR do?

Routes Desktop cron job reads and mutations through the shared root cron store introduced by #32091. The dashboard still accepts a profile filter, but it now filters by each job profile field instead of retargeting `cron.jobs` to `profiles/<name>/cron`.

This prevents stale legacy profile-local `jobs.json` files from appearing as active jobs when the CLI and scheduler no longer read them.

## Related Issue

Fixes #51032

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/web_server.py`: added a root cron-store wrapper for dashboard cron APIs, then filters and annotates jobs by their stored profile.
- `hermes_cli/web_server.py`: resolves profile-scoped job names to canonical job IDs before mutations so same-name jobs in different profiles do not collide in the root store.
- `hermes_cli/web_server.py`: runs dashboard manual fire requests against the root store while keeping execution scoped to the owning job profile.
- `tests/hermes_cli/test_web_server_cron_profiles.py`: covers root-store creation, all-profile listing, specific-profile filtering, ignoring legacy profile-local stores, and same-name cross-profile deletion.

## How to Test

1. `uv sync --extra dev`
2. `uv run scripts/run_tests.sh tests/hermes_cli/test_web_server_cron_profiles.py -- --tb=long`
3. `uv run scripts/run_tests.sh tests/cron/test_cron_profile_storage.py tests/hermes_cli/test_web_server_cron_profiles.py tests/hermes_cli/test_cron_fire_dashboard.py -- --tb=long`
4. `git diff --check`
5. `uv run ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_server_cron_profiles.py`
6. `uv run python scripts/check-windows-footguns.py --all`
7. `uv run ty check tests/hermes_cli/test_web_server_cron_profiles.py`

Also tried `uv run ty check hermes_cli/web_server.py tests/hermes_cli/test_web_server_cron_profiles.py`; the changed test file passes, while `hermes_cli/web_server.py` still reports existing baseline diagnostics outside this patch, such as the current Starlette middleware type and existing `None` defaults.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I have run `pytest tests/ -q` and all tests pass
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: macOS 27.0

### Documentation & Housekeeping

- [x] I have updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I have updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I have considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I have updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

The regression test writes a legacy profile-local `profiles/worker_alpha/cron/jobs.json` while leaving the root `cron/jobs.json` absent, then verifies the Desktop cron list returns no jobs for both `all` and `worker_alpha`. This matches the reported stale UI path in #51032.
