### PR TITLE
test: align Hermes home default on Windows

### DIFF
--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1,6 +1,7 @@
 """Tests for hermes_cli configuration management."""
 
 import os
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -30,8 +31,14 @@ class TestGetHermesHome:
     def test_default_path(self):
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("HERMES_HOME", None)
+            local_appdata = os.environ.get("LOCALAPPDATA", "").strip()
+            expected = (
+                (Path(local_appdata) if local_appdata else Path.home() / "AppData" / "Local") / "hermes"
+                if sys.platform == "win32"
+                else Path.home() / ".hermes"
+            )
             home = get_hermes_home()
-            assert home == Path.home() / ".hermes"
+            assert home == expected
 
     def test_env_override(self):
         with patch.dict(os.environ, {"HERMES_HOME": "/custom/path"}):


### PR DESCRIPTION
## Summary
- Aligns `TestGetHermesHome::test_default_path` with the actual Windows default Hermes home behavior.
- Keeps POSIX behavior unchanged (`~/.hermes`).
- Uses `%LOCALAPPDATA%\hermes` on Windows, falling back to `~/AppData/Local/hermes` when `LOCALAPPDATA` is unavailable.

## Test Plan
- [x] `pytest tests/hermes_cli/test_config.py::TestGetHermesHome::test_default_path -v --tb=short -n 0`
- [x] `pytest tests/hermes_cli/test_config.py -q --tb=short -n 0 -o addopts=''`
- [x] `git diff --check origin/main...HEAD`
- [x] Added-line static scan for obvious secrets/shell/eval/pickle/SQL patterns

## Notes
- This branch intentionally contains only the Windows test expectation fix.
- Ryan-local operational scripts and private workflow additions remain out of this upstream candidate.
