### PR TITLE
fix(photon): harden iMessage outbound recovery

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -96,6 +96,7 @@ _PHOTON_RETRYABLE_PATTERNS = (
     "reset reason: overflow",
     "upstream_overflow",
     "upstream_unavailable",
+    "authentication failed",
 )
 
 # Minimum seconds between typing-indicator calls for the same chat.
@@ -1303,8 +1304,8 @@ class PhotonAdapter(BasePlatformAdapter):
         content: str,
         reply_to: Optional[str] = None,
         metadata: Any = None,
-        max_retries: int = 1,
-        base_delay: float = 2.0,
+        max_retries: int = 3,
+        base_delay: float = 5.0,
     ) -> SendResult:
         """Retry sends without the generic Markdown banner.
 
@@ -1584,6 +1585,35 @@ async def _standalone_send(
         }
     base = f"http://{_DEFAULT_SIDECAR_BIND}:{port}"
     headers = {"X-Hermes-Sidecar-Token": token}
+    def _standalone_retryable_error(text: str) -> bool:
+        lowered = (text or "").lower()
+        return any(pat in lowered for pat in _PHOTON_RETRYABLE_PATTERNS)
+
+    async def _post_with_retry(client: httpx.AsyncClient, path: str, body: Dict[str, Any]) -> Dict[str, Any]:
+        last_error = ""
+        for attempt in range(1, 4):
+            try:
+                resp = await client.post(f"{base}{path}", json=body, headers=headers)
+                if resp.status_code != 200:
+                    last_error = f"sidecar returned {resp.status_code}: {resp.text[:200]}"
+                else:
+                    data = resp.json() or {}
+                    if data.get("ok"):
+                        return data
+                    last_error = data.get("error") or "sidecar reported failure"
+            except Exception as exc:
+                last_error = f"Photon standalone send failed: {exc}"
+            if attempt >= 3 or not _standalone_retryable_error(last_error):
+                break
+            logger.warning(
+                "[photon] standalone send failed (attempt %d/3, retrying in %ds): %s",
+                attempt,
+                5 * attempt,
+                last_error,
+            )
+            await asyncio.sleep(5 * attempt)
+        return {"error": last_error or "sidecar reported failure"}
+
     last_message_id: Optional[str] = None
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
@@ -1595,14 +1625,9 @@ async def _standalone_send(
                 }
                 if _markdown_enabled():
                     send_body["format"] = "markdown"
-                resp = await client.post(
-                    f"{base}/send", json=send_body, headers=headers,
-                )
-                if resp.status_code != 200:
-                    return {"error": f"sidecar returned {resp.status_code}: {resp.text[:200]}"}
-                data = resp.json() or {}
-                if not data.get("ok"):
-                    return {"error": data.get("error") or "sidecar reported failure"}
+                data = await _post_with_retry(client, "/send", send_body)
+                if data.get("error"):
+                    return data
                 last_message_id = data.get("messageId")
 
             # 2. Each attachment as a separate /send-attachment call.
@@ -1623,14 +1648,9 @@ async def _standalone_send(
                 }
                 if guessed:
                     att_body["mimeType"] = guessed
-                resp = await client.post(
-                    f"{base}/send-attachment", json=att_body, headers=headers,
-                )
-                if resp.status_code != 200:
-                    return {"error": f"sidecar returned {resp.status_code}: {resp.text[:200]}"}
-                data = resp.json() or {}
-                if not data.get("ok"):
-                    return {"error": data.get("error") or "sidecar reported failure"}
+                data = await _post_with_retry(client, "/send-attachment", att_body)
+                if data.get("error"):
+                    return data
                 last_message_id = data.get("messageId") or last_message_id
 
         return {"success": True, "message_id": last_message_id}

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -96,8 +96,23 @@ _PHOTON_RETRYABLE_PATTERNS = (
     "reset reason: overflow",
     "upstream_overflow",
     "upstream_unavailable",
-    "authentication failed",
 )
+
+
+class PhotonSidecarError(RuntimeError):
+    """Sanitized sidecar failure with retry semantics from the sidecar."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: Optional[str] = None,
+        retryable: bool = False,
+    ):
+        super().__init__(message)
+        self.code = code
+        self.retryable = retryable
+
 
 # Minimum seconds between typing-indicator calls for the same chat.
 # iMessage is a personal channel — suppressing rapid repeats reduces
@@ -1382,6 +1397,19 @@ class PhotonAdapter(BasePlatformAdapter):
             body["format"] = "markdown"
         try:
             data = await self._sidecar_call("/send", body)
+        except PhotonSidecarError as e:
+            return SendResult(
+                success=False,
+                error=str(e),
+                retryable=e.retryable,
+                error_kind=(
+                    "transient"
+                    if e.retryable
+                    else "forbidden"
+                    if e.code == "target_not_allowed"
+                    else "unknown"
+                ),
+            )
         except Exception as e:
             return SendResult(success=False, error=str(e))
         self._record_sent_message(data.get("messageId"))
@@ -1431,6 +1459,19 @@ class PhotonAdapter(BasePlatformAdapter):
             body["caption"] = caption
         try:
             data = await self._sidecar_call("/send-attachment", body)
+        except PhotonSidecarError as e:
+            return SendResult(
+                success=False,
+                error=str(e),
+                retryable=e.retryable,
+                error_kind=(
+                    "transient"
+                    if e.retryable
+                    else "forbidden"
+                    if e.code == "target_not_allowed"
+                    else "unknown"
+                ),
+            )
         except Exception as e:
             return SendResult(success=False, error=str(e))
         self._record_sent_message(data.get("messageId"))
@@ -1450,13 +1491,27 @@ class PhotonAdapter(BasePlatformAdapter):
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.post(url, json=body, headers=headers)
         if resp.status_code != 200:
-            raise RuntimeError(
-                f"Photon sidecar {path} returned {resp.status_code}: {resp.text[:200]}"
+            error_text = resp.text[:200]
+            code = None
+            retryable = False
+            try:
+                payload = resp.json() or {}
+                error_text = payload.get("error") or error_text
+                code = payload.get("code")
+                retryable = bool(payload.get("retryable"))
+            except Exception:
+                pass
+            raise PhotonSidecarError(
+                f"Photon sidecar {path} returned {resp.status_code}: {error_text}",
+                code=code,
+                retryable=retryable,
             )
         data = resp.json() or {}
         if not data.get("ok"):
-            raise RuntimeError(
-                f"Photon sidecar {path} reported error: {data.get('error')}"
+            raise PhotonSidecarError(
+                f"Photon sidecar {path} reported error: {data.get('error')}",
+                code=data.get("code"),
+                retryable=bool(data.get("retryable")),
             )
         return data
 
@@ -1592,18 +1647,27 @@ async def _standalone_send(
     async def _post_with_retry(client: httpx.AsyncClient, path: str, body: Dict[str, Any]) -> Dict[str, Any]:
         last_error = ""
         for attempt in range(1, 4):
+            retryable = False
             try:
                 resp = await client.post(f"{base}{path}", json=body, headers=headers)
                 if resp.status_code != 200:
-                    last_error = f"sidecar returned {resp.status_code}: {resp.text[:200]}"
+                    try:
+                        data = resp.json() or {}
+                        last_error = data.get("error") or f"sidecar returned {resp.status_code}: {resp.text[:200]}"
+                        retryable = bool(data.get("retryable")) or _standalone_retryable_error(last_error)
+                    except Exception:
+                        last_error = f"sidecar returned {resp.status_code}: {resp.text[:200]}"
+                        retryable = _standalone_retryable_error(last_error)
                 else:
                     data = resp.json() or {}
                     if data.get("ok"):
                         return data
                     last_error = data.get("error") or "sidecar reported failure"
+                    retryable = bool(data.get("retryable")) or _standalone_retryable_error(last_error)
             except Exception as exc:
                 last_error = f"Photon standalone send failed: {exc}"
-            if attempt >= 3 or not _standalone_retryable_error(last_error):
+                retryable = _standalone_retryable_error(last_error)
+            if attempt >= 3 or not retryable:
                 break
             logger.warning(
                 "[photon] standalone send failed (attempt %d/3, retrying in %ds): %s",

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -34,6 +34,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import tempfile
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -1552,6 +1553,53 @@ _AUDIO_EXT_BY_MIME = {
     "audio/mp4": ".m4a",
     "audio/aac": ".m4a",
 }
+_APPLE_IMAGE_MIME_TYPES = {"image/heic", "image/heif"}
+_APPLE_IMAGE_SUFFIXES = {".heic", ".heif"}
+
+
+def _convert_apple_image_to_jpeg(raw: bytes, name: str, mime: str) -> Optional[bytes]:
+    """Convert iPhone HEIC/HEIF attachment bytes to JPEG when possible.
+
+    OpenAI/Anthropic-style vision endpoints generally reject HEIC, even though
+    iMessage sends iPhone screenshots/photos that way.  On macOS, `sips` is
+    available by default and can transcode these bytes before the gateway hands
+    the media path to the model.  If conversion is unavailable or fails, return
+    None so callers can fall back to document caching instead of losing data.
+    """
+
+    suffix = Path(name).suffix.lower() if name else ""
+    if (
+        (mime or "").lower() not in _APPLE_IMAGE_MIME_TYPES
+        and suffix not in _APPLE_IMAGE_SUFFIXES
+    ):
+        return None
+    sips = shutil.which("sips")
+    if not sips:
+        return None
+    in_suffix = suffix if suffix in _APPLE_IMAGE_SUFFIXES else ".heic"
+    try:
+        with tempfile.TemporaryDirectory(prefix="hermes-photon-img-") as tmp:
+            src = Path(tmp) / f"source{in_suffix}"
+            dst = Path(tmp) / "converted.jpg"
+            src.write_bytes(raw)
+            proc = subprocess.run(  # noqa: S603 - executable resolved with shutil.which
+                [sips, "-s", "format", "jpeg", str(src), "--out", str(dst)],
+                capture_output=True,
+                text=True,
+                timeout=15.0,
+                check=False,
+            )
+            if proc.returncode != 0 or not dst.exists():
+                logger.warning(
+                    "[photon] failed to convert inbound Apple image %s with sips: %s",
+                    name,
+                    (proc.stderr or proc.stdout or "unknown error").strip(),
+                )
+                return None
+            return dst.read_bytes()
+    except Exception as exc:
+        logger.warning("[photon] failed to convert inbound Apple image %s: %s", name, exc)
+        return None
 
 
 def _cache_inbound_attachment(
@@ -1590,12 +1638,16 @@ def _cache_inbound_attachment(
     suffix = Path(name).suffix if name else ""
     try:
         if mime.startswith("image/"):
-            ext = suffix or _IMAGE_EXT_BY_MIME.get(mime, ".jpg")
+            converted = _convert_apple_image_to_jpeg(raw, name, mime)
+            if converted:
+                return cache_image_from_bytes(converted, ".jpg")
+            ext = _IMAGE_EXT_BY_MIME.get(mime) or suffix or ".jpg"
             try:
                 return cache_image_from_bytes(raw, ext)
             except ValueError:
-                # Bytes don't look like a supported image (e.g. HEIC magic) —
-                # still deliver them as a document rather than dropping them.
+                # Bytes don't look like a supported model image (e.g. HEIC
+                # magic without a local converter) — still deliver them as a
+                # document rather than dropping them.
                 return cache_document_from_bytes(raw, name)
         if force_audio or mime.startswith("audio/"):
             ext = suffix or _AUDIO_EXT_BY_MIME.get(

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -620,12 +620,24 @@ async function resolveSpace(spaceId) {
   const phoneTarget = phoneTargetFromSpaceId(spaceId);
   let space = null;
 
-  // A bare E.164 phone number addresses a DM, so callers can pass just
-  // "+1..." (e.g. PHOTON_HOME_CHANNEL for cron delivery) instead of an opaque
-  // inbound space id. Photon also represents DM chat ids as `any;-;+1...`;
-  // normalize those through the same path. `space.create` accepts the raw
-  // phone string directly.
-  if (phoneTarget) {
+  // Photon represents DM chat ids as `any;-;+1...`.  Those ids are already
+  // opaque Spectrum space ids, so after a sidecar restart prefer `space.get(id)`
+  // before falling back to `space.create(phone)`.  Creating from the phone first
+  // can be rejected by Spectrum as "Target not allowed for this project" even
+  // though replying to the existing inbound DM space is allowed.  Bare E.164
+  // phone numbers (PHOTON_HOME_CHANNEL / cron delivery) still use create().
+  if (DM_CHAT_GUID_RE.test(spaceId)) {
+    try {
+      space = await im.space.get(spaceId);
+    } catch (e) {
+      console.error(
+        "photon-sidecar: DM space.get failed: " +
+          (e && e.stack ? e.stack : String(e))
+      );
+    }
+  }
+
+  if (!space && phoneTarget) {
     try {
       space = await im.space.create(phoneTarget);
     } catch (e) {
@@ -635,9 +647,10 @@ async function resolveSpace(spaceId) {
       );
     }
   }
-  // Anything else — typically an opaque group GUID — is rehydrated from the
-  // persisted id via `space.get`, so group spaces stay reachable after a
-  // sidecar restart even before any fresh inbound message in that group.
+
+  // Non-DM-ish ids (group spaces, provider-native ids) resolve via `space.get`,
+  // so they stay reachable after a sidecar restart even before any fresh inbound
+  // message in that group.
   if (!space) {
     try {
       space = await im.space.get(spaceId);
@@ -648,6 +661,7 @@ async function resolveSpace(spaceId) {
       );
     }
   }
+
   if (!space) throw new Error(`unable to resolve space id ${spaceId}`);
 
   rememberKnownSpace(spaceId, space);

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -564,13 +564,63 @@ function badRequest(res, msg) {
   res.end(JSON.stringify({ ok: false, error: msg }));
 }
 
-function serverError(res) {
+function classifySidecarError(error) {
+  const raw = error && error.stack ? error.stack : String(error || "");
+  const lower = raw.toLowerCase();
+  if (lower.includes("target not allowed for this project")) {
+    return {
+      code: "target_not_allowed",
+      retryable: false,
+      error: "target not allowed for this Photon project",
+    };
+  }
+  if (
+    lower.includes("invalid credentials") ||
+    lower.includes("status code 401") ||
+    lower.includes(" 401") ||
+    lower.includes("unauthenticated") ||
+    lower.includes("tokenexpired") ||
+    lower.includes("token expired")
+  ) {
+    return {
+      code: "invalid_credentials",
+      retryable: false,
+      error: "Photon credentials are invalid; run `hermes photon setup` and restart the gateway",
+    };
+  }
+  if (
+    lower.includes("connection dropped") ||
+    lower.includes("catchupevents") ||
+    lower.includes("service unavailable") ||
+    lower.includes("unavailable") ||
+    lower.includes("deadline exceeded") ||
+    lower.includes("upstream connect error") ||
+    lower.includes("reset reason") ||
+    lower.includes("overflow")
+  ) {
+    return {
+      code: "upstream_transient",
+      retryable: true,
+      error: "Photon upstream connection dropped; retrying may succeed",
+    };
+  }
+  if (lower.includes("authentication failed")) {
+    return {
+      code: "authentication_failed",
+      retryable: false,
+      error: "Photon upstream authentication failed; refresh credentials with `hermes photon setup`",
+    };
+  }
+  return { code: "internal", retryable: false, error: "internal sidecar error" };
+}
+
+function serverError(res, error) {
   res.statusCode = 500;
   res.setHeader("Content-Type", "application/json");
-  // Don't leak stack traces or raw exception text to the caller — even
-  // though we listen on loopback, the supervisor logs the real error
-  // and the client only needs a generic failure signal.
-  res.end(JSON.stringify({ ok: false, error: "internal sidecar error" }));
+  // Do not leak stack traces or raw exception text over the loopback API. Return
+  // a bounded, machine-readable classification so Python can distinguish
+  // transient reconnect windows from permanent auth/config failures.
+  res.end(JSON.stringify({ ok: false, ...classifySidecarError(error) }));
 }
 
 function ok(res, data) {
@@ -829,7 +879,7 @@ const server = http.createServer(async (req, res) => {
     );
     // serverError() intentionally returns a generic message — see its
     // body for the rationale.
-    return serverError(res);
+    return serverError(res, e);
   }
 });
 

--- a/plugins/platforms/photon/sidecar/package-lock.json
+++ b/plugins/platforms/photon/sidecar/package-lock.json
@@ -9,16 +9,16 @@
       "version": "0.3.0",
       "hasInstallScript": true,
       "dependencies": {
-        "spectrum-ts": "3.1.0"
+        "spectrum-ts": "5.2.0"
       },
       "engines": {
         "node": ">=18.17"
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
-      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
+      "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@grpc/grpc-js": {
@@ -62,15 +62,6 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
-    "node_modules/@msgpack/msgpack": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.3.tgz",
-      "integrity": "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
@@ -81,9 +72,9 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.216.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.216.0.tgz",
-      "integrity": "sha512-KmGTgvxTJ0J01d4mOeX1wMV5NUTNf9HebIuOOGDfIn0a/IrnXIQbOnlylDyl9tkDv4h0DUpdI/GqCdLzfTkUXg==",
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
+      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
@@ -93,9 +84,9 @@
       }
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.7.1.tgz",
-      "integrity": "sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.8.0.tgz",
+      "integrity": "sha512-/3FIraneMcng67SUJCxvyInk/oxzwsxyadufk0wwfOBLf5wqtAGX4MoQASwSbndBPeARzBryUM9Azr5kHIdWLw==",
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -123,6 +114,7 @@
       "version": "0.218.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.218.0.tgz",
       "integrity": "sha512-Qx+4rpVHzgg89dawcWRHyt+XRXeLnhFz/qBtvggmjkcgPUdr+NAB0/u/eIPA8yAeJV0J80Vz43JZCh/XFvZFGw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api-logs": "0.218.0",
         "@opentelemetry/core": "2.7.1",
@@ -137,38 +129,11 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/api-logs": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
-      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz",
-      "integrity": "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.218.0",
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/resources": "2.7.1",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
       "version": "0.218.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.218.0.tgz",
       "integrity": "sha512-8dqezsmPhtKitIK/eTipZhYl9EX2/gNQ5zUMhaz3uxEURwfkNf8IPvo6yNfrzbxdtpAOybS/+h7wmIWYqFSpiw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "2.7.1",
         "@opentelemetry/otlp-exporter-base": "0.218.0",
@@ -183,69 +148,7 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.218.0.tgz",
-      "integrity": "sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA==",
-      "dependencies": {
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/otlp-transformer": "0.218.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.218.0.tgz",
-      "integrity": "sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.218.0",
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/resources": "2.7.1",
-        "@opentelemetry/sdk-logs": "0.218.0",
-        "@opentelemetry/sdk-metrics": "2.7.1",
-        "@opentelemetry/sdk-trace-base": "2.7.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/api-logs": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
-      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz",
-      "integrity": "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.218.0",
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/resources": "2.7.1",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/resources": {
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/resources": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
       "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
@@ -261,40 +164,7 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.216.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.216.0.tgz",
-      "integrity": "sha512-KB3rcwQuitq0JbbsCcNdqMhRJX3kArAYz/ovb0jGRaBQAIrt2roik3xQXuhYxS37zx0jSkUZcJu1z3Y2UCxbDA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.216.0",
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/resources": "2.7.1",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz",
-      "integrity": "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==",
-      "dependencies": {
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/resources": "2.7.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.9.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-base": {
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
       "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
@@ -309,6 +179,204 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.218.0.tgz",
+      "integrity": "sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-transformer": "0.218.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.218.0.tgz",
+      "integrity": "sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-logs": "0.218.0",
+        "@opentelemetry/sdk-metrics": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
+      "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
+      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz",
+      "integrity": "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz",
+      "integrity": "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+      "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
@@ -369,18 +437,18 @@
       }
     },
     "node_modules/@photon-ai/otel": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@photon-ai/otel/-/otel-0.1.1.tgz",
-      "integrity": "sha512-t/NVepO5+fHOLWDI+Eht+RC8PTik0wi7HQsKhU4yPqBjY5JncXmoBZLnWFvG+/qJ/pn6w+tveabKG9pykfkqKg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@photon-ai/otel/-/otel-1.0.0.tgz",
+      "integrity": "sha512-5fACVHN7BtGS+phglVAxun5QLckNUSS4p750oCxR//m9JNVzFQMoLFWfC6DnWBP/W0/+B2yP75+3NMVLodEJEg==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
-        "@opentelemetry/api-logs": "^0.216.0",
+        "@opentelemetry/api-logs": "^0.218.0",
         "@opentelemetry/context-async-hooks": "^2.7.1",
-        "@opentelemetry/exporter-logs-otlp-http": "^0.216.0",
-        "@opentelemetry/exporter-trace-otlp-http": "^0.216.0",
+        "@opentelemetry/exporter-logs-otlp-http": "^0.218.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
         "@opentelemetry/resources": "^2.7.1",
-        "@opentelemetry/sdk-logs": "^0.216.0",
+        "@opentelemetry/sdk-logs": "^0.218.0",
         "@opentelemetry/sdk-trace-base": "^2.7.1"
       },
       "engines": {
@@ -442,10 +510,122 @@
       }
     },
     "node_modules/@repeaterjs/repeater": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.6.tgz",
-      "integrity": "sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.1.0.tgz",
+      "integrity": "sha512-TaoVksZRSx2KWYYpyLQtMQXXeS98VsgZImzW65xmiVgbYhXLk+aEsmzPLirqVuE4/XuUapH2iMtxUzaBNDzdSQ==",
       "license": "MIT"
+    },
+    "node_modules/@spectrum-ts/core": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-aQSWZ75B9eEiJ00Wa72T/GEEPX9RVIlOPXnsdp0lWWgT5K9+twnL25Kob7L1pgQPbzrgoLH/rjQf3iVktriEwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@photon-ai/otel": "^1.0.0",
+        "@photon-ai/proto": "^0.2.4",
+        "@repeaterjs/repeater": "^3.0.6",
+        "marked": "^18.0.5",
+        "mime-types": "^3.0.1",
+        "open-graph-scraper": "^6.11.0",
+        "vcf": "^2.1.2",
+        "zod": "^4.2.1"
+      },
+      "peerDependencies": {
+        "elysia": "^1",
+        "express": "^4 || ^5",
+        "ffmpeg-static": "^5",
+        "hono": "^4",
+        "typescript": "^5 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "elysia": {
+          "optional": true
+        },
+        "express": {
+          "optional": true
+        },
+        "ffmpeg-static": {
+          "optional": true
+        },
+        "hono": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@spectrum-ts/imessage": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/imessage/-/imessage-5.2.0.tgz",
+      "integrity": "sha512-AZztks7jex8J3dnK7xUdjcN87xsXcZK+LCDlhC/gwZ4defH4mxPVcxFKUVND/CO7W3tN4pBD0LDfKUO7jx9uaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@photon-ai/advanced-imessage": "^0.11.0",
+        "@photon-ai/imessage-kit": "^3.0.0",
+        "@photon-ai/otel": "^1.0.0",
+        "lru-cache": "^11.0.0",
+        "marked": "^18.0.5",
+        "zod": "^4.2.1"
+      },
+      "peerDependencies": {
+        "@spectrum-ts/core": "^5.0.0",
+        "typescript": "^5 || ^6.0.0"
+      }
+    },
+    "node_modules/@spectrum-ts/slack": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/slack/-/slack-5.2.0.tgz",
+      "integrity": "sha512-ql6pHuEOxq7xAd9iIfVV9xXqpdmy5T8kUK+87HE8R87YFJm5L6z7df0wE0g0vpgQ6J7FkmTII0XNw/X7//odiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@photon-ai/slack": "^0.2.0",
+        "zod": "^4.2.1"
+      },
+      "peerDependencies": {
+        "@spectrum-ts/core": "^5.0.0",
+        "typescript": "^5 || ^6.0.0"
+      }
+    },
+    "node_modules/@spectrum-ts/telegram": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/telegram/-/telegram-5.2.0.tgz",
+      "integrity": "sha512-ofG2OKK/63Sxkv3a7MEJWkjtCy3Rs8HLEB2pxHSSlofQmAP7SDkXlBEzfgEr1SeM/mIFvE3gXNpIhb97Nz1Dog==",
+      "license": "MIT",
+      "dependencies": {
+        "@photon-ai/telegram-ts": "10.0.0",
+        "marked": "^18.0.5",
+        "zod": "^4.2.1"
+      },
+      "peerDependencies": {
+        "@spectrum-ts/core": "^5.0.0",
+        "typescript": "^5 || ^6.0.0"
+      }
+    },
+    "node_modules/@spectrum-ts/terminal": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/terminal/-/terminal-5.2.0.tgz",
+      "integrity": "sha512-OHSg4HKOgLXhv3mzm0M9eIPiwxdKel9yZglfUWGfUyafibnpCnF2XI069zc9hkDgdvCHynLfxM+TsPXPzdiMbw==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.1"
+      },
+      "peerDependencies": {
+        "@spectrum-ts/core": "^5.0.0",
+        "typescript": "^5 || ^6.0.0"
+      }
+    },
+    "node_modules/@spectrum-ts/whatsapp-business": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/whatsapp-business/-/whatsapp-business-5.2.0.tgz",
+      "integrity": "sha512-JZJwzug6UviSe7FqWb8y9f1Frq3RJ9IOQ/TgCYhijm5uchXtym/HdC+FAmCG06njcFx+ea7boUhwFs8579V4Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@photon-ai/whatsapp-business": "^0.1.1",
+        "mime-types": "^3.0.1",
+        "zod": "^4.2.1"
+      },
+      "peerDependencies": {
+        "@spectrum-ts/core": "^5.0.0",
+        "typescript": "^5 || ^6.0.0"
+      }
     },
     "node_modules/abort-controller-x": {
       "version": "0.5.0",
@@ -477,15 +657,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/async-mutex": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
-      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -507,29 +678,10 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/better-grpc": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/better-grpc/-/better-grpc-0.3.2.tgz",
-      "integrity": "sha512-e+u6C4zHwjE5g7vOvDpFeMe7Nas7FU+xa6FktiheRTcOpEdD5nag+uoIw7L5bPXdxxg995feBAXLwIay/npEqw==",
-      "license": "MIT",
-      "dependencies": {
-        "@msgpack/msgpack": "^3.1.2",
-        "async-mutex": "^0.5.0",
-        "it-pushable": "^3.2.3",
-        "nice-grpc": "^2.1.13",
-        "zod": "^4.1.12"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5"
-      }
-    },
     "node_modules/better-sqlite3": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
-      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -604,9 +756,9 @@
       }
     },
     "node_modules/chardet": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
-      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
       "license": "MIT"
     },
     "node_modules/cheerio": {
@@ -1008,15 +1160,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/it-pushable": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.2.4.tgz",
-      "integrity": "sha512-WSD7Ss4oCRfDZJT4ldLWr0Bom/muY90xxoJ5PQnU3uSKf0kxCOeehqZtiJX1ARqn+ymXGh1bxpDW9bDNHp2ivQ==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "p-defer": "^4.0.0"
-      }
-    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -1182,18 +1325,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/p-defer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.1.tgz",
-      "integrity": "sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -1275,6 +1406,7 @@
       "version": "8.6.1",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.1.tgz",
       "integrity": "sha512-s4qQPr4pU0W95iYnUInh95skjIg+3aM2sakYsw60QYanU+qWRDY2zQxOAQV6zU7ROJpSNDG9B+VSmk4dqdWWSA==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "long": "^5.3.2"
       },
@@ -1361,9 +1493,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -1421,38 +1553,17 @@
       }
     },
     "node_modules/spectrum-ts": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/spectrum-ts/-/spectrum-ts-3.1.0.tgz",
-      "integrity": "sha512-Dv5rsXATxGUXFnKf3VPK0VpkMPyVkf4HHUYkti0V2AKhz2m+ut3I1UPNMsvZOsiqmF+5hW8Xvrw+u/I82+XcDA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/spectrum-ts/-/spectrum-ts-5.2.0.tgz",
+      "integrity": "sha512-CfHz7ZhKP9Cmunb3i7m4r5stXOGl1HNKOkBp/Fkl1DwDmhnGl+PRDy97FC5JBY+XYxAKxKnMRSbVTl8ldczTNg==",
       "license": "MIT",
       "dependencies": {
-        "@photon-ai/advanced-imessage": "^0.11.0",
-        "@photon-ai/imessage-kit": "^3.0.0",
-        "@photon-ai/otel": "^0.1.1",
-        "@photon-ai/proto": "^0.2.4",
-        "@photon-ai/slack": "^0.2.0",
-        "@photon-ai/telegram-ts": "10.0.0",
-        "@photon-ai/whatsapp-business": "^0.1.1",
-        "@repeaterjs/repeater": "^3.0.6",
-        "better-grpc": "^0.3.2",
-        "lru-cache": "^11.0.0",
-        "marked": "^18.0.5",
-        "mime-types": "^3.0.1",
-        "nice-grpc": "^2.1.16",
-        "nice-grpc-common": "^2.0.2",
-        "open-graph-scraper": "^6.11.0",
-        "type-fest": "^5.4.1",
-        "vcf": "^2.1.2",
-        "zod": "^4.2.1"
-      },
-      "peerDependencies": {
-        "ffmpeg-static": "^5",
-        "typescript": "^5 || ^6.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ffmpeg-static": {
-          "optional": true
-        }
+        "@spectrum-ts/core": "5.2.0",
+        "@spectrum-ts/imessage": "5.2.0",
+        "@spectrum-ts/slack": "5.2.0",
+        "@spectrum-ts/telegram": "5.2.0",
+        "@spectrum-ts/terminal": "5.2.0",
+        "@spectrum-ts/whatsapp-business": "5.2.0"
       }
     },
     "node_modules/string_decoder": {
@@ -1501,18 +1612,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/tagged-tag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
-      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -1549,12 +1648,6 @@
       "integrity": "sha512-tLJxacIQUM82IR7JO1UUkKlYuUTmoY9HBJAmNWFzheSlDS5SPMcNIepejHJa4BpPQLAcbRhRf3GDJzyj6rbKvA==",
       "license": "MIT"
     },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -1568,25 +1661,10 @@
         "node": "*"
       }
     },
-    "node_modules/type-fest": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
-      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
-      "license": "(MIT OR CC0-1.0)",
-      "dependencies": {
-        "tagged-tag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -1598,9 +1676,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.26.0.tgz",
-      "integrity": "sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -1691,9 +1769,9 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",

--- a/plugins/platforms/photon/sidecar/package.json
+++ b/plugins/platforms/photon/sidecar/package.json
@@ -13,7 +13,7 @@
     "node": ">=18.17"
   },
   "dependencies": {
-    "spectrum-ts": "3.1.0"
+    "spectrum-ts": "5.2.0"
   },
   "overrides": {
     "protobufjs": "8.6.1",

--- a/plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs
+++ b/plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs
@@ -101,6 +101,22 @@ function patchInbound(source) {
 }
 
 export function patchSpectrumTs(root = scriptDir()) {
+  const pkgPath = path.join(root, "node_modules", "spectrum-ts", "package.json");
+  if (fs.existsSync(pkgPath)) {
+    try {
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+      const major = Number(String(pkg.version || "0").split(".")[0]);
+      if (major >= 5) {
+        return {
+          patched: false,
+          file: pkgPath,
+          reason: `spectrum-ts ${pkg.version} has the newer inbound mapper`,
+        };
+      }
+    } catch {
+      // Fall through to the structural patch attempt below.
+    }
+  }
   const dist = path.join(root, "node_modules", "spectrum-ts", "dist");
   if (!fs.existsSync(dist)) {
     throw new Error(`spectrum-ts dist not found: ${dist}`);

--- a/tests/gateway/test_photon_plugin.py
+++ b/tests/gateway/test_photon_plugin.py
@@ -43,11 +43,7 @@ class _FakeAsyncClient:
 
 @pytest.mark.asyncio
 async def test_photon_standalone_send_retries_transient_sidecar_500(monkeypatch):
-    """Transient Photon/Spectrum send failures should be retried, not dropped.
-
-    This protects iMessage outbound deliveries from short-lived Spectrum
-    `Connection dropped` / `Authentication failed` windows after sidecar reconnect.
-    """
+    """Transient Photon/Spectrum connection failures should be retried."""
 
     monkeypatch.setattr(photon, "HTTPX_AVAILABLE", True)
     monkeypatch.setattr(photon, "httpx", types.SimpleNamespace(AsyncClient=_FakeAsyncClient))
@@ -71,6 +67,32 @@ async def test_photon_standalone_send_retries_transient_sidecar_500(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_photon_standalone_send_uses_sidecar_retryable_flag(monkeypatch):
+    monkeypatch.setattr(photon, "HTTPX_AVAILABLE", True)
+    monkeypatch.setattr(photon, "httpx", types.SimpleNamespace(AsyncClient=_FakeAsyncClient))
+    monkeypatch.setenv("PHOTON_SIDECAR_TOKEN", "token")
+    monkeypatch.setattr(photon.asyncio, "sleep", lambda _delay: _noop_sleep())
+    _FakeAsyncClient.calls = []
+    _FakeAsyncClient.responses = [
+        _FakeResponse(
+            500,
+            {"ok": False, "error": "Photon upstream connection dropped", "retryable": True},
+            '{"ok":false,"error":"Photon upstream connection dropped","retryable":true}',
+        ),
+        _FakeResponse(200, {"ok": True, "messageId": "msg-ok"}),
+    ]
+
+    result = await photon._standalone_send(
+        PlatformConfig(extra={}),
+        "any;-;+15551234567",
+        "hello",
+    )
+
+    assert result == {"success": True, "message_id": "msg-ok"}
+    assert len(_FakeAsyncClient.calls) == 2
+
+
+@pytest.mark.asyncio
 async def test_photon_standalone_send_does_not_retry_non_retryable(monkeypatch):
     monkeypatch.setattr(photon, "HTTPX_AVAILABLE", True)
     monkeypatch.setattr(photon, "httpx", types.SimpleNamespace(AsyncClient=_FakeAsyncClient))
@@ -78,7 +100,11 @@ async def test_photon_standalone_send_does_not_retry_non_retryable(monkeypatch):
     monkeypatch.setattr(photon.asyncio, "sleep", lambda _delay: _noop_sleep())
     _FakeAsyncClient.calls = []
     _FakeAsyncClient.responses = [
-        _FakeResponse(500, {"ok": False}, '{"ok":false,"error":"Target not allowed for this project"}'),
+        _FakeResponse(
+            500,
+            {"ok": False, "error": "target not allowed for this Photon project", "retryable": False},
+            '{"ok":false,"error":"target not allowed for this Photon project","retryable":false}',
+        ),
         _FakeResponse(200, {"ok": True, "messageId": "should-not-send"}),
     ]
 
@@ -88,8 +114,34 @@ async def test_photon_standalone_send_does_not_retry_non_retryable(monkeypatch):
         "hello",
     )
 
-    assert "Target not allowed" in result["error"]
+    assert "target not allowed" in result["error"]
     assert len(_FakeAsyncClient.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_sidecar_call_preserves_retryable_error_classification(monkeypatch):
+    monkeypatch.setattr(photon, "httpx", types.SimpleNamespace(AsyncClient=_FakeAsyncClient))
+    _FakeAsyncClient.calls = []
+    _FakeAsyncClient.responses = [
+        _FakeResponse(
+            500,
+            {
+                "ok": False,
+                "code": "upstream_transient",
+                "error": "Photon upstream connection dropped; retrying may succeed",
+                "retryable": True,
+            },
+        )
+    ]
+    adapter = photon.PhotonAdapter(PlatformConfig(extra={}))
+    adapter._http_client = object()  # type: ignore[assignment]
+
+    with pytest.raises(photon.PhotonSidecarError) as exc_info:
+        await adapter._sidecar_call("/send", {"spaceId": "any;-;+15551234567", "text": "hello"})
+
+    assert exc_info.value.retryable is True
+    assert exc_info.value.code == "upstream_transient"
+    assert "connection dropped" in str(exc_info.value)
 
 
 def test_photon_sidecar_resolves_dm_space_before_phone_create():
@@ -103,6 +155,16 @@ def test_photon_sidecar_resolves_dm_space_before_phone_create():
     dm_get = source.index("photon-sidecar: DM space.get failed")
     phone_create = source.index("photon-sidecar: phone->DM space.create failed")
     assert dm_get < phone_create
+
+
+def test_photon_sidecar_returns_sanitized_error_classifications():
+    source = Path("plugins/platforms/photon/sidecar/index.mjs").read_text()
+    assert "function classifySidecarError" in source
+    assert 'code: "target_not_allowed"' in source
+    assert 'code: "invalid_credentials"' in source
+    assert 'code: "upstream_transient"' in source
+    assert "e && e.stack ? e.stack" in source  # logs keep detail server-side
+    assert "...classifySidecarError(error)" in source  # API returns only classification
 
 
 async def _noop_sleep():

--- a/tests/gateway/test_photon_plugin.py
+++ b/tests/gateway/test_photon_plugin.py
@@ -1,0 +1,109 @@
+"""Regression tests for the Photon platform plugin."""
+
+from __future__ import annotations
+
+import types
+from pathlib import Path
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.photon import adapter as photon
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: dict | None = None, text: str = ""):
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+class _FakeAsyncClient:
+    calls: list[tuple[str, dict]] = []
+    responses: list[_FakeResponse] = []
+
+    def __init__(self, timeout=None):
+        self.timeout = timeout
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def post(self, url, json=None, headers=None):  # noqa: A002 - mirrors httpx API
+        self.calls.append((url, json or {}))
+        if not self.responses:
+            raise AssertionError("no fake response queued")
+        return self.responses.pop(0)
+
+
+@pytest.mark.asyncio
+async def test_photon_standalone_send_retries_transient_sidecar_500(monkeypatch):
+    """Transient Photon/Spectrum send failures should be retried, not dropped.
+
+    This protects iMessage outbound deliveries from short-lived Spectrum
+    `Connection dropped` / `Authentication failed` windows after sidecar reconnect.
+    """
+
+    monkeypatch.setattr(photon, "HTTPX_AVAILABLE", True)
+    monkeypatch.setattr(photon, "httpx", types.SimpleNamespace(AsyncClient=_FakeAsyncClient))
+    monkeypatch.setenv("PHOTON_SIDECAR_TOKEN", "token")
+    monkeypatch.setattr(photon.asyncio, "sleep", lambda _delay: _noop_sleep())
+    _FakeAsyncClient.calls = []
+    _FakeAsyncClient.responses = [
+        _FakeResponse(500, {"ok": False}, '{"ok":false,"error":"Connection dropped"}'),
+        _FakeResponse(200, {"ok": True, "messageId": "msg-ok"}),
+    ]
+
+    result = await photon._standalone_send(
+        PlatformConfig(extra={}),
+        "any;-;+15551234567",
+        "hello",
+    )
+
+    assert result == {"success": True, "message_id": "msg-ok"}
+    assert len(_FakeAsyncClient.calls) == 2
+    assert _FakeAsyncClient.calls[0][1]["spaceId"] == "any;-;+15551234567"
+
+
+@pytest.mark.asyncio
+async def test_photon_standalone_send_does_not_retry_non_retryable(monkeypatch):
+    monkeypatch.setattr(photon, "HTTPX_AVAILABLE", True)
+    monkeypatch.setattr(photon, "httpx", types.SimpleNamespace(AsyncClient=_FakeAsyncClient))
+    monkeypatch.setenv("PHOTON_SIDECAR_TOKEN", "token")
+    monkeypatch.setattr(photon.asyncio, "sleep", lambda _delay: _noop_sleep())
+    _FakeAsyncClient.calls = []
+    _FakeAsyncClient.responses = [
+        _FakeResponse(500, {"ok": False}, '{"ok":false,"error":"Target not allowed for this project"}'),
+        _FakeResponse(200, {"ok": True, "messageId": "should-not-send"}),
+    ]
+
+    result = await photon._standalone_send(
+        PlatformConfig(extra={}),
+        "+15551234567",
+        "hello",
+    )
+
+    assert "Target not allowed" in result["error"]
+    assert len(_FakeAsyncClient.calls) == 1
+
+
+def test_photon_sidecar_resolves_dm_space_before_phone_create():
+    """DM space ids must resolve by `space.get(id)` before phone create().
+
+    Spectrum can reject phone-based DM creation as not allowed even when replying
+    to the already-established `any;-;+E164` DM space is valid.
+    """
+
+    source = Path("plugins/platforms/photon/sidecar/index.mjs").read_text()
+    dm_get = source.index("photon-sidecar: DM space.get failed")
+    phone_create = source.index("photon-sidecar: phone->DM space.create failed")
+    assert dm_get < phone_create
+
+
+async def _noop_sleep():
+    return None

--- a/tests/gateway/test_photon_plugin.py
+++ b/tests/gateway/test_photon_plugin.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import base64
 import types
 from pathlib import Path
 
 import pytest
 
 from gateway.config import PlatformConfig
+from gateway.platforms import base as platform_base
 from plugins.platforms.photon import adapter as photon
 
 
@@ -165,6 +167,28 @@ def test_photon_sidecar_returns_sanitized_error_classifications():
     assert 'code: "upstream_transient"' in source
     assert "e && e.stack ? e.stack" in source  # logs keep detail server-side
     assert "...classifySidecarError(error)" in source  # API returns only classification
+
+
+def test_photon_heic_attachment_converts_to_model_supported_jpeg(monkeypatch, tmp_path):
+    """iPhone HEIC screenshots should not be forwarded to vision as HEIC."""
+
+    monkeypatch.setattr(
+        photon,
+        "_convert_apple_image_to_jpeg",
+        lambda *_args: b"\xff\xd8\xffjpeg",
+    )
+    monkeypatch.setattr(platform_base, "IMAGE_CACHE_DIR", tmp_path)
+    cached = photon._cache_inbound_attachment(
+        {"data": base64.b64encode(b"heic-bytes").decode("ascii")},
+        "IMG_9886.heic",
+        "image/heic",
+    )
+
+    assert cached is not None
+    path = Path(cached)
+    assert path.suffix == ".jpg"
+    assert path.read_bytes().startswith(b"\xff\xd8\xff")
+    assert path.parent == tmp_path
 
 
 async def _noop_sleep():


### PR DESCRIPTION
## Summary
- resolves Photon DM space ids with `space.get()` before falling back to phone-based create, so established `any;-;+E164` iMessage DMs stay sendable after sidecar restart
- upgrades the Photon sidecar to `spectrum-ts@5.2.0` and makes the mixed-attachment patch script explicitly skip the newer inbound mapper instead of failing startup/install
- returns sanitized machine-readable sidecar errors (`code`, `retryable`, `error`) so Hermes retries only classified transient Spectrum reconnect failures and does not spin on permanent auth/project-policy failures
- propagates sidecar retry classification through normal gateway sends, attachment sends, and standalone `hermes send`
- transcodes inbound iPhone HEIC/HEIF images to JPEG before handing them to model vision APIs, avoiding non-retryable `invalid image` provider failures
- expands Photon regression coverage for retryability, non-retryable project-policy failures, sidecar classification, DM resolution ordering, and HEIC image handling

## Tests
- `python -m pytest tests/gateway/test_photon_plugin.py -q -o 'addopts='` → 7 passed
- `python -m py_compile plugins/platforms/photon/adapter.py tests/gateway/test_photon_plugin.py`
- `cd plugins/platforms/photon/sidecar && node --check index.mjs && node --check patch-spectrum-mixed-attachments.mjs && node patch-spectrum-mixed-attachments.mjs`
- `git diff --check origin/main...HEAD`

## Live dogfood verification
- refreshed Photon credentials and reloaded the gateway under launchd
- verified Photon state returned to `connected`
- verified outbound delivery: `hermes send --to photon --json ...` returned real Spectrum message ids
- verified inbound delivery by sending an iMessage to the assigned Photon number; gateway logged `inbound message: platform=photon ... msg='Hermes inbound verification probe 19:55:48'`
- reproduced the later failure as a provider-side invalid-image rejection for an inbound `.heic` screenshot, then verified that the same HEIC bytes now cache as JPEG locally
- verified the gateway/provider path after reload with an inbound Photon text probe; Hermes replied `provider ok`

## Risk
Medium: Photon/iMessage sidecar dependency, outbound error semantics, and macOS-only HEIC conversion via `sips`. Retry behavior remains bounded; permanent auth/project-policy failures are now surfaced as non-retryable instead of being retried as generic sidecar 500s. If HEIC conversion is unavailable, the attachment falls back to document caching rather than being dropped.