### PR TITLE
feat(cron): continuable cron jobs — thread-preferred continuation with DM-mirror fallback

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -749,6 +749,7 @@ def create_job(
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
     no_agent: bool = False,
+    attach_to_session: Optional[bool] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -827,6 +828,7 @@ def create_job(
     normalized_toolsets = normalized_toolsets or None
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
+    normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -881,6 +883,11 @@ def create_job(
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
     }
+    # Only persist attach_to_session when explicitly set, so existing jobs and
+    # the common case stay byte-identical (absent key => fall back to the
+    # global cron.mirror_delivery config, default off).
+    if normalized_attach is not None:
+        job["attach_to_session"] = normalized_attach
 
     with _jobs_lock():
         jobs = load_jobs()

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -415,6 +415,7 @@ def _maybe_mirror_cron_delivery(
     chat_id: str,
     mirror_text: str,
     thread_id: Optional[str] = None,
+    user_id: Optional[str] = None,
     *,
     enabled: bool = False,
 ) -> None:
@@ -423,9 +424,11 @@ def _maybe_mirror_cron_delivery(
     No-op unless ``enabled`` (resolved once by the caller, and already scoped to
     the origin target — see ``_target_matches_origin``). Reuses the shipped
     ``mirror_to_session`` so cron rides exactly the same path that interactive
-    ``send_message`` mirroring already uses. All failures are swallowed — a
-    delivery that succeeded must never be reported as failed because the
-    transcript mirror hit a problem.
+    ``send_message`` mirroring already uses, including passing ``user_id`` so a
+    per-user-isolated group chat resolves to the exact member who scheduled the
+    job (parity with ``send_message``). All failures are swallowed — a delivery
+    that succeeded must never be reported as failed because the transcript
+    mirror hit a problem.
 
     Because the caller only enables this for the target that equals the job's
     origin conversation, the session is expected to exist (the job was born in
@@ -447,6 +450,7 @@ def _maybe_mirror_cron_delivery(
             text,
             source_label="cron",
             thread_id=thread_id,
+            user_id=user_id,
         )
         if ok:
             logger.info(
@@ -1001,6 +1005,9 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         mirror_this_target = mirror_enabled and _target_matches_origin(
             origin, platform_name, chat_id, thread_id
         )
+        # Pass the origin's user_id so a per-user-isolated group chat resolves to
+        # the exact member who scheduled the job — parity with send_message.
+        origin_user_id = origin.get("user_id") if mirror_this_target else None
 
         # Built-in names resolve to their enum member; plugin platform names
         # create dynamic members via Platform._missing_().
@@ -1238,7 +1245,8 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     delivered = True
                     _maybe_mirror_cron_delivery(
                         job, platform_name, chat_id, mirror_text,
-                        thread_id=thread_id, enabled=mirror_this_target,
+                        thread_id=thread_id, user_id=origin_user_id,
+                        enabled=mirror_this_target,
                     )
             except Exception as e:
                 err_msg = f"live adapter delivery to {platform_name}:{chat_id} failed: {e}"
@@ -1280,7 +1288,8 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             logger.info("Job '%s': delivered to %s:%s", job["id"], platform_name, chat_id)
             _maybe_mirror_cron_delivery(
                 job, platform_name, chat_id, mirror_text,
-                thread_id=thread_id, enabled=mirror_this_target,
+                thread_id=thread_id, user_id=origin_user_id,
+                enabled=mirror_this_target,
             )
 
     if delivery_errors:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -376,6 +376,39 @@ def _cron_mirror_delivery_enabled(job: dict, cfg: Optional[dict] = None) -> bool
         return False
 
 
+def _target_matches_origin(origin: dict, platform_name: str, chat_id: str,
+                           thread_id: Optional[str]) -> bool:
+    """True when a delivery target is the job's own origin conversation.
+
+    Mirroring is scoped to the origin session by design (see
+    ``_maybe_mirror_cron_delivery``). A job created from a live gateway chat
+    stamps that chat as ``origin`` (``cronjob_tools._origin_from_env``), and
+    that session is guaranteed to exist — it is the very conversation the user
+    was in when they scheduled the job. Fan-out targets (``deliver=all``,
+    explicit ``platform:chat_id`` to some *other* chat, or a home-channel
+    fallback for an origin-less API/script job) are deliberately NOT mirrored:
+    they are broadcasts, not a continuation of a conversation, and may point at
+    a chat the user never opened an agent session in.
+
+    This makes the historical "cold-start" worry a non-case: when the mirror
+    semantically applies (target == origin) the session always exists; when no
+    session exists, the target was never the origin conversation, so we simply
+    do not mirror.
+    """
+    if not origin:
+        return False
+    if str(origin.get("platform", "")).lower() != str(platform_name).lower():
+        return False
+    if str(origin.get("chat_id", "")) != str(chat_id):
+        return False
+    # thread_id must match when the origin pins one (topic-scoped chats); a
+    # target that lost the thread_id is not the same conversation lane.
+    origin_thread = origin.get("thread_id")
+    if origin_thread is not None and str(origin_thread) != str(thread_id or ""):
+        return False
+    return True
+
+
 def _maybe_mirror_cron_delivery(
     job: dict,
     platform_name: str,
@@ -385,14 +418,20 @@ def _maybe_mirror_cron_delivery(
     *,
     enabled: bool = False,
 ) -> None:
-    """Best-effort mirror of a cron delivery into the target chat's session.
+    """Best-effort mirror of a cron delivery into the origin chat's session.
 
-    No-op unless ``enabled`` (resolved once by the caller). Reuses the shipped
+    No-op unless ``enabled`` (resolved once by the caller, and already scoped to
+    the origin target — see ``_target_matches_origin``). Reuses the shipped
     ``mirror_to_session`` so cron rides exactly the same path that interactive
     ``send_message`` mirroring already uses. All failures are swallowed — a
     delivery that succeeded must never be reported as failed because the
-    transcript mirror could not find a session (the cold-start case: the target
-    chat has no gateway session yet, so there is nothing to mirror into).
+    transcript mirror hit a problem.
+
+    Because the caller only enables this for the target that equals the job's
+    origin conversation, the session is expected to exist (the job was born in
+    that session). A missing session therefore indicates an origin-less /
+    fan-out delivery that should not have been mirrored anyway, and is treated
+    as a silent no-op — never a synthetic session is created.
     """
     if not enabled:
         return
@@ -956,6 +995,13 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 job["id"], platform_name, chat_id, thread_id,
             )
 
+        # Mirror is scoped to the ORIGIN conversation only. A fan-out / broadcast
+        # / home-channel-fallback target is never mirrored (it is not the
+        # conversation the job was created in, and may have no session at all).
+        mirror_this_target = mirror_enabled and _target_matches_origin(
+            origin, platform_name, chat_id, thread_id
+        )
+
         # Built-in names resolve to their enum member; plugin platform names
         # create dynamic members via Platform._missing_().
         try:
@@ -1192,7 +1238,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     delivered = True
                     _maybe_mirror_cron_delivery(
                         job, platform_name, chat_id, mirror_text,
-                        thread_id=thread_id, enabled=mirror_enabled,
+                        thread_id=thread_id, enabled=mirror_this_target,
                     )
             except Exception as e:
                 err_msg = f"live adapter delivery to {platform_name}:{chat_id} failed: {e}"
@@ -1234,7 +1280,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             logger.info("Job '%s': delivered to %s:%s", job["id"], platform_name, chat_id)
             _maybe_mirror_cron_delivery(
                 job, platform_name, chat_id, mirror_text,
-                thread_id=thread_id, enabled=mirror_enabled,
+                thread_id=thread_id, enabled=mirror_this_target,
             )
 
     if delivery_errors:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -444,13 +444,22 @@ def _maybe_mirror_cron_delivery(
     try:
         from gateway.mirror import mirror_to_session
 
+        # Mirror as a USER turn with a labelled prefix, NOT an assistant turn.
+        # The brief is not the agent speaking; an assistant-role mirror lands as
+        # assistant→assistant after the agent's last turn and breaks strict
+        # alternation (issue #2221, the exact failure #2313 removed). A
+        # user-role turn collapses safely via repair_message_sequence's
+        # consecutive-user merge on every provider, and the prefix preserves the
+        # "this came from cron" context that the dropped SQLite mirror metadata
+        # would otherwise lose on replay.
         ok = mirror_to_session(
             platform_name,
             str(chat_id),
-            text,
+            f"[Cron delivery: {job.get('name') or job.get('id', 'cron')}]\n{text}",
             source_label="cron",
             thread_id=thread_id,
             user_id=user_id,
+            role="user",
         )
         if ok:
             logger.info(
@@ -476,22 +485,13 @@ def _open_continuable_cron_thread(
     chat_id: str,
     loop,
 ) -> Optional[str]:
-    """Open a dedicated thread for a continuable cron job, thread-preferred.
+    """Open a dedicated thread for a continuable cron job (thread-preferred).
 
-    On a thread-capable platform (Telegram forum/DM topics, Discord threads,
-    Slack threads) this asks the adapter to create a fresh thread under
-    ``chat_id`` so the job's brief — and the user's replies to it — live in
-    their own scrollback, isolated from the parent channel. This is the
-    "continuable cron job opens its own thread" interface.
-
-    Returns the new ``thread_id`` (str) on success, or ``None`` when the
-    platform does not support threads (WhatsApp / Signal / SMS / DM-only) or
-    creation failed. A ``None`` return is the signal for the caller to fall
-    back to mirroring into the origin DM session instead — same fallback shape
-    the gateway's session-handoff watcher uses (``_process_handoff``).
-
-    Reuses the shipped ``adapter.create_handoff_thread`` primitive; introduces
-    no new adapter surface.
+    Returns the new ``thread_id`` on success, or ``None`` when the platform has
+    no thread primitive (WhatsApp/Signal/SMS) or creation failed — the ``None``
+    return is the caller's signal to fall back to the origin-DM mirror, the same
+    open-thread-or-fallback shape as ``GatewayRunner._process_handoff``. Reuses
+    the shipped ``adapter.create_handoff_thread``; no new adapter surface.
     """
     create_thread = getattr(adapter, "create_handoff_thread", None)
     if not callable(create_thread) or loop is None:
@@ -568,12 +568,19 @@ def _seed_cron_thread_session(
 
         from gateway.mirror import mirror_to_session
 
+        # User-role + labelled prefix (see _maybe_mirror_cron_delivery): the
+        # seeded brief must not read as an assistant turn, or the user's first
+        # in-thread reply produces assistant→user→... off a phantom assistant
+        # message. Pass the seed user_id so the mirror resolves the exact
+        # thread-keyed session row we just created.
         mirror_to_session(
             platform_name,
             str(chat_id),
-            text,
+            f"[Cron delivery: {job.get('name') or job.get('id', 'cron')}]\n{text}",
             source_label="cron",
             thread_id=str(thread_id),
+            user_id="system:cron",
+            role="user",
         )
         logger.info(
             "Job '%s': opened continuable thread %s on %s:%s and seeded the brief",
@@ -1066,25 +1073,23 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     else:
         delivery_content = content
 
+    # Extract MEDIA: tags so attachments are forwarded as files, not raw text
+    from gateway.platforms.base import BasePlatformAdapter
+    media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(delivery_content)
+    media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+
     # Resolve the delivery-mirror gate ONCE (default off). When on, each
     # successful delivery is also appended to the target chat's gateway session
     # transcript so a user reply in that chat sees the cron output in context.
-    # We mirror the CLEAN, unwrapped agent output (not the cron header/footer) —
-    # that is what the agent "said" in the conversation.
+    # Mirror the CLEAN, unwrapped output (not the cron header/footer).
     try:
         mirror_enabled = _cron_mirror_delivery_enabled(job, user_cfg)
     except Exception:
         mirror_enabled = False
     mirror_text = ""
     if mirror_enabled:
-        from gateway.platforms.base import BasePlatformAdapter as _BPA
-        _, mirror_text = _BPA.extract_media(content)
+        _, mirror_text = BasePlatformAdapter.extract_media(content)
         mirror_text = (mirror_text or "").strip()
-
-    # Extract MEDIA: tags so attachments are forwarded as files, not raw text
-    from gateway.platforms.base import BasePlatformAdapter
-    media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(delivery_content)
-    media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
 
     try:
         config = load_gateway_config()
@@ -1157,6 +1162,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         # create_handoff_thread returns None and we fall back to mirroring into
         # the origin DM session (handled after delivery). Cf. _process_handoff.
         thread_seeded = False
+        opened_thread_id: Optional[str] = None
         if (
             mirror_this_target
             and runtime_adapter is not None
@@ -1167,14 +1173,13 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 job, runtime_adapter, chat_id, loop,
             )
             if new_thread_id:
-                # Route this delivery into the new thread and seed its session.
+                # Route THIS delivery into the new thread now (the send needs the
+                # thread_id), but defer seeding the thread session until the
+                # delivery actually succeeds — otherwise an open-succeeds /
+                # deliver-fails case leaves a seeded brief the user never saw,
+                # and (worse) suppresses the DM-fallback mirror via thread_seeded.
                 thread_id = new_thread_id
-                _seed_cron_thread_session(
-                    job, runtime_adapter, platform_name, chat_id,
-                    new_thread_id, mirror_text,
-                    chat_name=origin.get("chat_name"),
-                )
-                thread_seeded = True
+                opened_thread_id = new_thread_id
 
         if runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
             # Telegram three-mode topic routing (#22773): a private chat
@@ -1388,6 +1393,15 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 if adapter_ok:
                     logger.info("Job '%s': delivered to %s:%s via live adapter", job["id"], platform_name, chat_id)
                     delivered = True
+                    # Seed the thread session only now that delivery into it
+                    # succeeded (deferred from thread-open above).
+                    if opened_thread_id and not thread_seeded:
+                        _seed_cron_thread_session(
+                            job, runtime_adapter, platform_name, chat_id,
+                            opened_thread_id, mirror_text,
+                            chat_name=origin.get("chat_name"),
+                        )
+                        thread_seeded = True
                     _maybe_mirror_cron_delivery(
                         job, platform_name, chat_id, mirror_text,
                         thread_id=thread_id, user_id=origin_user_id,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -344,6 +344,89 @@ def _resolve_origin(job: dict) -> Optional[dict]:
     return None
 
 
+def _cron_mirror_delivery_enabled(job: dict, cfg: Optional[dict] = None) -> bool:
+    """Whether a cron delivery should also be mirrored into the target chat's
+    gateway session transcript.
+
+    Default OFF — preserves the historical isolation guarantee (cron deliveries
+    live only in the cron job's own session, never the target chat's history)
+    byte-for-byte for everyone who does not opt in.
+
+    Precedence (first decisive value wins):
+      1. Per-job ``attach_to_session`` (bool) — set via the ``cronjob`` tool,
+         lets one briefing job opt in without flipping global behaviour.
+      2. Global ``cron.mirror_delivery`` (bool) in config.yaml.
+      3. False.
+
+    When enabled, the cron's final output is appended to the target session as
+    an assistant turn via the existing ``gateway.mirror.mirror_to_session`` —
+    the same primitive ``send_message`` uses — so the next user reply in that
+    chat sees the brief in context (no "what is Task #2?" amnesia). This is
+    alternation- and cache-safe: the append lands at a turn boundary between
+    user turns, never mid-loop, and never mutates the cached system prompt.
+    """
+    per_job = job.get("attach_to_session")
+    if isinstance(per_job, bool):
+        return per_job
+    try:
+        if cfg is None:
+            cfg = load_config() or {}
+        return bool((cfg.get("cron", {}) or {}).get("mirror_delivery", False))
+    except Exception:
+        return False
+
+
+def _maybe_mirror_cron_delivery(
+    job: dict,
+    platform_name: str,
+    chat_id: str,
+    mirror_text: str,
+    thread_id: Optional[str] = None,
+    *,
+    enabled: bool = False,
+) -> None:
+    """Best-effort mirror of a cron delivery into the target chat's session.
+
+    No-op unless ``enabled`` (resolved once by the caller). Reuses the shipped
+    ``mirror_to_session`` so cron rides exactly the same path that interactive
+    ``send_message`` mirroring already uses. All failures are swallowed — a
+    delivery that succeeded must never be reported as failed because the
+    transcript mirror could not find a session (the cold-start case: the target
+    chat has no gateway session yet, so there is nothing to mirror into).
+    """
+    if not enabled:
+        return
+    text = (mirror_text or "").strip()
+    if not text:
+        return
+    try:
+        from gateway.mirror import mirror_to_session
+
+        ok = mirror_to_session(
+            platform_name,
+            str(chat_id),
+            text,
+            source_label="cron",
+            thread_id=thread_id,
+        )
+        if ok:
+            logger.info(
+                "Job '%s': mirrored delivery into %s:%s session transcript",
+                job.get("id", "?"), platform_name, chat_id,
+            )
+        else:
+            logger.debug(
+                "Job '%s': delivery mirror skipped for %s:%s "
+                "(no matching gateway session — cold start)",
+                job.get("id", "?"), platform_name, chat_id,
+            )
+    except Exception as e:
+        logger.debug(
+            "Job '%s': delivery mirror failed for %s:%s: %s",
+            job.get("id", "?"), platform_name, chat_id, e,
+        )
+
+
 def _cron_job_origin_log_suffix(job: dict) -> str:
     """Return safe provenance details for security warnings about a cron job.
 
@@ -804,6 +887,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     # is a cron delivery.  Wrapping is on by default; set cron.wrap_response: false
     # in config.yaml for clean output.
     wrap_response = True
+    user_cfg = None
     try:
         user_cfg = load_config()
         wrap_response = user_cfg.get("cron", {}).get("wrap_response", True)
@@ -822,6 +906,21 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         )
     else:
         delivery_content = content
+
+    # Resolve the delivery-mirror gate ONCE (default off). When on, each
+    # successful delivery is also appended to the target chat's gateway session
+    # transcript so a user reply in that chat sees the cron output in context.
+    # We mirror the CLEAN, unwrapped agent output (not the cron header/footer) —
+    # that is what the agent "said" in the conversation.
+    try:
+        mirror_enabled = _cron_mirror_delivery_enabled(job, user_cfg)
+    except Exception:
+        mirror_enabled = False
+    mirror_text = ""
+    if mirror_enabled:
+        from gateway.platforms.base import BasePlatformAdapter as _BPA
+        _, mirror_text = _BPA.extract_media(content)
+        mirror_text = (mirror_text or "").strip()
 
     # Extract MEDIA: tags so attachments are forwarded as files, not raw text
     from gateway.platforms.base import BasePlatformAdapter
@@ -1091,6 +1190,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 if adapter_ok:
                     logger.info("Job '%s': delivered to %s:%s via live adapter", job["id"], platform_name, chat_id)
                     delivered = True
+                    _maybe_mirror_cron_delivery(
+                        job, platform_name, chat_id, mirror_text,
+                        thread_id=thread_id, enabled=mirror_enabled,
+                    )
             except Exception as e:
                 err_msg = f"live adapter delivery to {platform_name}:{chat_id} failed: {e}"
                 if not any(err_msg in err for err in target_errors):
@@ -1129,6 +1232,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 continue
 
             logger.info("Job '%s': delivered to %s:%s", job["id"], platform_name, chat_id)
+            _maybe_mirror_cron_delivery(
+                job, platform_name, chat_id, mirror_text,
+                thread_id=thread_id, enabled=mirror_enabled,
+            )
 
     if delivery_errors:
         return "; ".join(delivery_errors)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -470,6 +470,122 @@ def _maybe_mirror_cron_delivery(
         )
 
 
+def _open_continuable_cron_thread(
+    job: dict,
+    adapter,
+    chat_id: str,
+    loop,
+) -> Optional[str]:
+    """Open a dedicated thread for a continuable cron job, thread-preferred.
+
+    On a thread-capable platform (Telegram forum/DM topics, Discord threads,
+    Slack threads) this asks the adapter to create a fresh thread under
+    ``chat_id`` so the job's brief — and the user's replies to it — live in
+    their own scrollback, isolated from the parent channel. This is the
+    "continuable cron job opens its own thread" interface.
+
+    Returns the new ``thread_id`` (str) on success, or ``None`` when the
+    platform does not support threads (WhatsApp / Signal / SMS / DM-only) or
+    creation failed. A ``None`` return is the signal for the caller to fall
+    back to mirroring into the origin DM session instead — same fallback shape
+    the gateway's session-handoff watcher uses (``_process_handoff``).
+
+    Reuses the shipped ``adapter.create_handoff_thread`` primitive; introduces
+    no new adapter surface.
+    """
+    create_thread = getattr(adapter, "create_handoff_thread", None)
+    if not callable(create_thread) or loop is None:
+        return None
+    task_name = job.get("name") or job.get("id", "cron")
+    thread_name = f"Hermes — {task_name}"
+    try:
+        from agent.async_utils import safe_schedule_threadsafe
+
+        coro = create_thread(str(chat_id), thread_name)
+        future = safe_schedule_threadsafe(coro, loop)  # type: ignore[arg-type]
+        if future is None:
+            return None
+        new_thread_id = future.result(timeout=30)
+        return str(new_thread_id) if new_thread_id else None
+    except Exception as e:
+        logger.debug(
+            "Job '%s': create_handoff_thread failed on %s — falling back to "
+            "DM-session mirror: %s",
+            job.get("id", "?"), getattr(adapter, "name", "?"), e,
+        )
+        return None
+
+
+def _seed_cron_thread_session(
+    job: dict,
+    adapter,
+    platform_name: str,
+    chat_id: str,
+    thread_id: str,
+    mirror_text: str,
+    chat_name: Optional[str] = None,
+) -> None:
+    """Seed the freshly-opened cron thread's session with the brief.
+
+    Without this the brief is *visible* in the new thread but absent from any
+    transcript, so the user's first reply in-thread would hit a session with no
+    record of it ("what is Task #2?"). We create the thread-keyed session (the
+    same key the user's reply will resolve to — ``build_session_key`` keys
+    threads as participant-shared, so no ``user_id`` is needed) and append the
+    brief as an assistant turn via the shipped ``mirror_to_session``.
+
+    Mirrors ``GatewayRunner._process_handoff``'s seed step, but standalone:
+    cron reaches the live ``SessionStore`` through the adapter's
+    ``_session_store`` handle rather than the gateway object. Best-effort — a
+    delivery that already succeeded is never failed by a seeding problem.
+    """
+    text = (mirror_text or "").strip()
+    if not text:
+        return
+    try:
+        from gateway.config import Platform
+        from gateway.session import SessionSource
+
+        session_store = getattr(adapter, "_session_store", None)
+        if session_store is not None:
+            try:
+                platform_enum = Platform(platform_name.lower())
+            except (ValueError, KeyError):
+                platform_enum = None
+            if platform_enum is not None:
+                dest_source = SessionSource(
+                    platform=platform_enum,
+                    chat_id=str(chat_id),
+                    chat_name=chat_name,
+                    chat_type="thread",
+                    user_id="system:cron",
+                    user_name="Cron",
+                    thread_id=str(thread_id),
+                )
+                # Ensure the thread-keyed session row exists so the mirror has
+                # a target and the user's later reply joins the same session.
+                session_store.get_or_create_session(dest_source)
+
+        from gateway.mirror import mirror_to_session
+
+        mirror_to_session(
+            platform_name,
+            str(chat_id),
+            text,
+            source_label="cron",
+            thread_id=str(thread_id),
+        )
+        logger.info(
+            "Job '%s': opened continuable thread %s on %s:%s and seeded the brief",
+            job.get("id", "?"), thread_id, platform_name, chat_id,
+        )
+    except Exception as e:
+        logger.debug(
+            "Job '%s': seeding cron thread session failed for %s:%s:%s: %s",
+            job.get("id", "?"), platform_name, chat_id, thread_id, e,
+        )
+
+
 def _cron_job_origin_log_suffix(job: dict) -> str:
     """Return safe provenance details for security warnings about a cron job.
 
@@ -1031,6 +1147,35 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         runtime_adapter = (adapters or {}).get(platform)
         delivered = False
         target_errors = []
+
+        # Continuable cron (thread-preferred): when mirroring is enabled for the
+        # origin target and the gateway is live, try to open a DEDICATED thread
+        # for this job and deliver the brief into it. On thread-capable
+        # platforms (Telegram/Discord/Slack) the brief + the user's replies live
+        # in their own scrollback; the thread-keyed session is seeded so a reply
+        # continues with full context. On DM-only platforms (WhatsApp/Signal)
+        # create_handoff_thread returns None and we fall back to mirroring into
+        # the origin DM session (handled after delivery). Cf. _process_handoff.
+        thread_seeded = False
+        if (
+            mirror_this_target
+            and runtime_adapter is not None
+            and loop is not None
+            and not thread_id  # never override an explicit origin thread/topic
+        ):
+            new_thread_id = _open_continuable_cron_thread(
+                job, runtime_adapter, chat_id, loop,
+            )
+            if new_thread_id:
+                # Route this delivery into the new thread and seed its session.
+                thread_id = new_thread_id
+                _seed_cron_thread_session(
+                    job, runtime_adapter, platform_name, chat_id,
+                    new_thread_id, mirror_text,
+                    chat_name=origin.get("chat_name"),
+                )
+                thread_seeded = True
+
         if runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
             # Telegram three-mode topic routing (#22773): a private chat
             # (positive chat_id) with a NUMERIC topic id is a Bot API Direct
@@ -1246,7 +1391,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     _maybe_mirror_cron_delivery(
                         job, platform_name, chat_id, mirror_text,
                         thread_id=thread_id, user_id=origin_user_id,
-                        enabled=mirror_this_target,
+                        enabled=mirror_this_target and not thread_seeded,
                     )
             except Exception as e:
                 err_msg = f"live adapter delivery to {platform_name}:{chat_id} failed: {e}"
@@ -1289,7 +1434,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             _maybe_mirror_cron_delivery(
                 job, platform_name, chat_id, mirror_text,
                 thread_id=thread_id, user_id=origin_user_id,
-                enabled=mirror_this_target,
+                enabled=mirror_this_target and not thread_seeded,
             )
 
     if delivery_errors:

--- a/gateway/mirror.py
+++ b/gateway/mirror.py
@@ -29,12 +29,24 @@ def mirror_to_session(
     source_label: str = "cli",
     thread_id: Optional[str] = None,
     user_id: Optional[str] = None,
+    role: str = "assistant",
 ) -> bool:
     """
     Append a delivery-mirror message to the target session's transcript.
 
     Finds the gateway session that matches the given platform + chat_id,
     then writes a mirror entry to both the JSONL transcript and SQLite DB.
+
+    ``role`` defaults to ``"assistant"`` — correct for the interactive
+    ``send_message`` mirror, where the mirrored text is the agent's own
+    outgoing reply (a genuine assistant turn). Callers mirroring text that is
+    NOT the agent speaking — e.g. a cron brief delivered out-of-band — must
+    pass ``role="user"``: the ``mirror``/``mirror_source`` metadata is dropped
+    at the SQLite boundary (only role+content persist), so on replay an
+    assistant-role mirror is indistinguishable from a real assistant turn and
+    produces ``assistant → assistant`` pairs that break strict-alternation
+    providers (issue #2221). A user-role mirror collapses safely via
+    ``repair_message_sequence``'s consecutive-user merge on every provider.
 
     Returns True if mirrored successfully, False if no matching session or error.
     All errors are caught -- this is never fatal.
@@ -57,7 +69,7 @@ def mirror_to_session(
             return False
 
         mirror_msg = {
-            "role": "assistant",
+            "role": role,
             "content": message_text,
             "timestamp": datetime.now().isoformat(),
             "mirror": True,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2368,6 +2368,17 @@ DEFAULT_CONFIG = {
         # Wrap delivered cron responses with a header (task name) and footer
         # ("The agent cannot see this message").  Set to false for clean output.
         "wrap_response": True,
+        # Mirror each cron delivery into the TARGET chat's gateway session
+        # transcript (as an assistant turn), so a user reply in that chat sees
+        # the cron output in context instead of "what is Task #2?" amnesia.
+        # Default False preserves the historical isolation guarantee (cron
+        # deliveries live only in the cron job's own session). Per-job
+        # `attach_to_session` overrides this for a single job. Rides the same
+        # gateway.mirror.mirror_to_session path interactive send_message uses;
+        # alternation- and cache-safe (appended at a turn boundary, never
+        # mid-loop, never mutates the cached system prompt). When the target
+        # chat has no session yet (cold start) the mirror is a silent no-op.
+        "mirror_delivery": False,
         # Maximum number of due jobs to run in parallel per tick.
         # null/0 = unbounded (limited only by thread count).
         # 1 = serial (pre-v0.9 behaviour).

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2368,16 +2368,26 @@ DEFAULT_CONFIG = {
         # Wrap delivered cron responses with a header (task name) and footer
         # ("The agent cannot see this message").  Set to false for clean output.
         "wrap_response": True,
-        # Mirror each cron delivery into the TARGET chat's gateway session
-        # transcript (as an assistant turn), so a user reply in that chat sees
-        # the cron output in context instead of "what is Task #2?" amnesia.
+        # Make cron deliveries CONTINUABLE: a user can reply to a cron brief
+        # and the agent has it in context (no "what is Task #2?" amnesia).
         # Default False preserves the historical isolation guarantee (cron
         # deliveries live only in the cron job's own session). Per-job
-        # `attach_to_session` overrides this for a single job. Rides the same
-        # gateway.mirror.mirror_to_session path interactive send_message uses;
+        # `attach_to_session` overrides this for a single job.
+        #
+        # Behaviour is THREAD-PREFERRED, scoped to the job's origin chat:
+        #   - Thread-capable platforms (Telegram forum/DM topics, Discord
+        #     threads, Slack threads): a dedicated thread is opened for the job
+        #     via the adapter's create_handoff_thread, the brief is delivered
+        #     into it, and that thread's session is seeded so the user's reply
+        #     in-thread continues with full context. Each continuable job gets
+        #     its own scrollback, isolated from the parent channel.
+        #   - DM-only platforms (WhatsApp / Signal / SMS): no threads exist, so
+        #     the brief is mirrored into the origin DM session instead — the
+        #     DM itself is the continuation surface.
+        # Both paths ride the shipped gateway.mirror.mirror_to_session and are
         # alternation- and cache-safe (appended at a turn boundary, never
-        # mid-loop, never mutates the cached system prompt). When the target
-        # chat has no session yet (cold start) the mirror is a silent no-op.
+        # mid-loop, never mutating the cached system prompt). Only the origin
+        # chat is ever touched — fan-out / broadcast targets are never mirrored.
         "mirror_delivery": False,
         # Maximum number of due jobs to run in parallel per tick.
         # null/0 = unbounded (limited only by thread count).

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -3526,8 +3526,8 @@ class TestCronDeliveryMirror:
 
         with patch("gateway.mirror.mirror_to_session", return_value=True) as m:
             _maybe_mirror_cron_delivery(
-                {"id": "j1"}, "telegram", "123", "Daily brief Task #2",
-                thread_id=None, enabled=True,
+                {"id": "j1", "name": "Daily Brief"}, "telegram", "123",
+                "Daily brief Task #2", thread_id=None, enabled=True,
             )
         m.assert_called_once()
         args, kwargs = m.call_args
@@ -3535,6 +3535,27 @@ class TestCronDeliveryMirror:
         assert args[1] == "123"
         assert "Task #2" in args[2]
         assert kwargs.get("source_label") == "cron"
+
+    def test_mirror_writes_user_role_with_label_not_assistant(self):
+        """Regression for #2221 / #2313: the cron brief must mirror as a USER
+        turn (with a [Cron delivery: ...] label), NOT assistant — an
+        assistant-role mirror lands as assistant->assistant after the agent's
+        last turn and breaks strict alternation on non-Anthropic providers."""
+        from cron.scheduler import _maybe_mirror_cron_delivery
+
+        with patch("gateway.mirror.mirror_to_session", return_value=True) as m:
+            _maybe_mirror_cron_delivery(
+                {"id": "j1", "name": "Morning Brief"}, "telegram", "123",
+                "Market movers today", thread_id=None, enabled=True,
+            )
+        m.assert_called_once()
+        args, kwargs = m.call_args
+        assert kwargs.get("role") == "user", "cron mirror must be a user turn, not assistant"
+        # The brief text is prefixed with a human-readable cron-delivery label
+        # so replay (where the mirror metadata is dropped at the SQLite
+        # boundary) still distinguishes it from a genuine user message.
+        assert args[2].startswith("[Cron delivery: Morning Brief]")
+        assert "Market movers today" in args[2]
 
     def test_mirror_noop_when_disabled(self):
         from cron.scheduler import _maybe_mirror_cron_delivery

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -3486,3 +3486,142 @@ class TestHomeTargetEnvVarRegistry:
         from cron.scheduler import _HOME_TARGET_ENV_VARS
 
         assert _HOME_TARGET_ENV_VARS.get("whatsapp") == "WHATSAPP_HOME_CHANNEL"
+
+
+class TestCronDeliveryMirror:
+    """cron.mirror_delivery / per-job attach_to_session: opt-in append of a
+    cron delivery into the target chat's gateway session transcript.
+
+    Default OFF preserves the historical isolation guarantee byte-for-byte.
+    When enabled, delivery rides the existing gateway.mirror.mirror_to_session
+    so cron uses exactly the same path interactive send_message mirroring uses.
+    """
+
+    def test_gate_default_off(self):
+        from cron.scheduler import _cron_mirror_delivery_enabled
+
+        # No per-job flag, no config -> off (historical behaviour).
+        assert _cron_mirror_delivery_enabled({}, {}) is False
+        assert _cron_mirror_delivery_enabled({"id": "x"}, {"cron": {}}) is False
+
+    def test_gate_global_config_on(self):
+        from cron.scheduler import _cron_mirror_delivery_enabled
+
+        assert _cron_mirror_delivery_enabled({}, {"cron": {"mirror_delivery": True}}) is True
+
+    def test_gate_per_job_overrides_global(self):
+        from cron.scheduler import _cron_mirror_delivery_enabled
+
+        # Per-job False wins even if global is on.
+        assert _cron_mirror_delivery_enabled(
+            {"attach_to_session": False}, {"cron": {"mirror_delivery": True}}
+        ) is False
+        # Per-job True wins even if global is off/absent.
+        assert _cron_mirror_delivery_enabled(
+            {"attach_to_session": True}, {"cron": {"mirror_delivery": False}}
+        ) is True
+
+    def test_mirror_calls_mirror_to_session_when_enabled(self):
+        from cron.scheduler import _maybe_mirror_cron_delivery
+
+        with patch("gateway.mirror.mirror_to_session", return_value=True) as m:
+            _maybe_mirror_cron_delivery(
+                {"id": "j1"}, "telegram", "123", "Daily brief Task #2",
+                thread_id=None, enabled=True,
+            )
+        m.assert_called_once()
+        args, kwargs = m.call_args
+        assert args[0] == "telegram"
+        assert args[1] == "123"
+        assert "Task #2" in args[2]
+        assert kwargs.get("source_label") == "cron"
+
+    def test_mirror_noop_when_disabled(self):
+        from cron.scheduler import _maybe_mirror_cron_delivery
+
+        with patch("gateway.mirror.mirror_to_session", return_value=True) as m:
+            _maybe_mirror_cron_delivery(
+                {"id": "j1"}, "telegram", "123", "should not mirror",
+                enabled=False,
+            )
+        m.assert_not_called()
+
+    def test_mirror_noop_on_empty_text(self):
+        from cron.scheduler import _maybe_mirror_cron_delivery
+
+        with patch("gateway.mirror.mirror_to_session", return_value=True) as m:
+            _maybe_mirror_cron_delivery({"id": "j1"}, "telegram", "123", "   ", enabled=True)
+        m.assert_not_called()
+
+    def test_mirror_swallows_cold_start_miss(self):
+        """A missing target session (cold start) must NOT raise — delivery
+        already succeeded; the mirror is best-effort."""
+        from cron.scheduler import _maybe_mirror_cron_delivery
+
+        with patch("gateway.mirror.mirror_to_session", return_value=False) as m:
+            # Should not raise.
+            _maybe_mirror_cron_delivery(
+                {"id": "j1"}, "telegram", "123", "brief", enabled=True
+            )
+        m.assert_called_once()
+
+    def test_mirror_swallows_exceptions(self):
+        from cron.scheduler import _maybe_mirror_cron_delivery
+
+        with patch("gateway.mirror.mirror_to_session", side_effect=RuntimeError("boom")):
+            # Must not propagate — a delivery that succeeded is never failed by
+            # a mirror error.
+            _maybe_mirror_cron_delivery(
+                {"id": "j1"}, "telegram", "123", "brief", enabled=True
+            )
+
+    def test_delivery_mirrors_clean_content_not_wrapped(self):
+        """When enabled, the mirror receives the CLEAN agent output, not the
+        cron header/footer-wrapped delivery text."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})), \
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+            job = {
+                "id": "test-job",
+                "name": "daily-report",
+                "deliver": "origin",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+                "attach_to_session": True,
+            }
+            _deliver_result(job, "Here is today's summary.")
+
+        mirror_mock.assert_called_once()
+        mirrored_text = mirror_mock.call_args[0][2]
+        # Clean content, no cron wrapper.
+        assert "Here is today's summary." in mirrored_text
+        assert "Cronjob Response:" not in mirrored_text
+        assert "To stop or manage this job" not in mirrored_text
+
+    def test_delivery_does_not_mirror_when_gate_off(self):
+        """Default path: a job with no opt-in must never touch the mirror."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})), \
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+            job = {
+                "id": "test-job",
+                "name": "daily-report",
+                "deliver": "origin",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+            }
+            _deliver_result(job, "Here is today's summary.")
+
+        mirror_mock.assert_not_called()

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -3710,3 +3710,44 @@ class TestCronDeliveryMirror:
         # Exactly one mirror, and it is the origin chat (123) — not 999.
         mirror_mock.assert_called_once()
         assert mirror_mock.call_args[0][1] == "123"
+
+    # --- multi-participant parity with send_message (user_id passthrough) ---
+
+    def test_mirror_passes_user_id_through(self):
+        """The helper forwards user_id to mirror_to_session so a per-user-
+        isolated group resolves to the exact member who scheduled the job —
+        parity with interactive send_message."""
+        from cron.scheduler import _maybe_mirror_cron_delivery
+
+        with patch("gateway.mirror.mirror_to_session", return_value=True) as m:
+            _maybe_mirror_cron_delivery(
+                {"id": "j1"}, "telegram", "123", "brief",
+                thread_id=None, user_id="U999", enabled=True,
+            )
+        m.assert_called_once()
+        assert m.call_args.kwargs.get("user_id") == "U999"
+
+    def test_delivery_forwards_origin_user_id(self):
+        """End-to-end: a job whose origin carries user_id mirrors with that
+        user_id, so multi-participant resolution matches send_message."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})), \
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+            job = {
+                "id": "test-job",
+                "name": "daily-report",
+                "deliver": "origin",
+                "origin": {"platform": "telegram", "chat_id": "123", "user_id": "U42"},
+                "attach_to_session": True,
+            }
+            _deliver_result(job, "Here is today's summary.")
+
+        mirror_mock.assert_called_once()
+        assert mirror_mock.call_args.kwargs.get("user_id") == "U42"

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -3751,3 +3751,100 @@ class TestCronDeliveryMirror:
 
         mirror_mock.assert_called_once()
         assert mirror_mock.call_args.kwargs.get("user_id") == "U42"
+
+    # --- continuable cron: thread-preferred (Teknium's interface) ---
+
+    def test_open_thread_returns_id_on_thread_platform(self):
+        """On a thread-capable adapter, _open_continuable_cron_thread returns
+        the new thread id from create_handoff_thread."""
+        from cron.scheduler import _open_continuable_cron_thread
+
+        adapter = MagicMock()
+        adapter.create_handoff_thread = AsyncMock(return_value="9001")
+
+        # safe_schedule_threadsafe hands the coro to the gateway loop and
+        # returns a future. Patch it to close the coro and return a ready
+        # future carrying the adapter's thread id.
+        def _run_now(coro, _loop):
+            coro.close()
+            fut = MagicMock()
+            fut.result.return_value = "9001"
+            return fut
+
+        with patch("agent.async_utils.safe_schedule_threadsafe", side_effect=_run_now):
+            tid = _open_continuable_cron_thread(
+                {"id": "j1", "name": "Brief"}, adapter, "123", loop=MagicMock(),
+            )
+        assert tid == "9001"
+
+    def test_open_thread_returns_none_on_dm_platform(self):
+        """A DM-only adapter (WhatsApp) inherits the base create_handoff_thread
+        that returns None → _open_continuable_cron_thread returns None so the
+        caller falls back to DM-session mirroring."""
+        from cron.scheduler import _open_continuable_cron_thread
+
+        adapter = MagicMock()
+        adapter.create_handoff_thread = AsyncMock(return_value=None)
+
+        def _run_now(coro, _loop):
+            fut = MagicMock()
+            fut.result.return_value = None
+            coro.close()
+            return fut
+
+        with patch("agent.async_utils.safe_schedule_threadsafe", side_effect=_run_now):
+            tid = _open_continuable_cron_thread(
+                {"id": "j1", "name": "Brief"}, adapter, "123", loop=MagicMock(),
+            )
+        assert tid is None
+
+    def test_open_thread_none_without_capability_or_loop(self):
+        """No create_handoff_thread attr, or no loop → None (no crash)."""
+        from cron.scheduler import _open_continuable_cron_thread
+
+        adapter_no_cap = MagicMock(spec=[])  # no create_handoff_thread
+        assert _open_continuable_cron_thread(
+            {"id": "j1"}, adapter_no_cap, "123", loop=MagicMock(),
+        ) is None
+
+        adapter = MagicMock()
+        adapter.create_handoff_thread = AsyncMock(return_value="9001")
+        assert _open_continuable_cron_thread(
+            {"id": "j1"}, adapter, "123", loop=None,
+        ) is None
+
+    def test_seed_thread_session_creates_session_and_mirrors(self):
+        """Seeding a freshly-opened thread creates the thread-keyed session via
+        the adapter's live store and appends the brief via mirror_to_session."""
+        from cron.scheduler import _seed_cron_thread_session
+
+        store = MagicMock()
+        adapter = MagicMock()
+        adapter._session_store = store
+
+        with patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+            _seed_cron_thread_session(
+                {"id": "j1"}, adapter, "telegram", "123", "9001",
+                "Daily brief Task #2", chat_name="Ops",
+            )
+
+        # Session row created for the thread, then brief mirrored into it.
+        store.get_or_create_session.assert_called_once()
+        seeded_source = store.get_or_create_session.call_args[0][0]
+        assert seeded_source.chat_type == "thread"
+        assert seeded_source.thread_id == "9001"
+        mirror_mock.assert_called_once()
+        assert mirror_mock.call_args.kwargs.get("thread_id") == "9001"
+
+    def test_seed_thread_session_noop_on_empty_text(self):
+        from cron.scheduler import _seed_cron_thread_session
+
+        store = MagicMock()
+        adapter = MagicMock()
+        adapter._session_store = store
+        with patch("gateway.mirror.mirror_to_session") as mirror_mock:
+            _seed_cron_thread_session(
+                {"id": "j1"}, adapter, "telegram", "123", "9001", "   ",
+            )
+        store.get_or_create_session.assert_not_called()
+        mirror_mock.assert_not_called()

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -3625,3 +3625,88 @@ class TestCronDeliveryMirror:
             _deliver_result(job, "Here is today's summary.")
 
         mirror_mock.assert_not_called()
+
+    # --- origin-scoping (mirror only into the conversation that created the job) ---
+
+    def test_target_matches_origin_exact(self):
+        from cron.scheduler import _target_matches_origin
+
+        origin = {"platform": "telegram", "chat_id": "123"}
+        assert _target_matches_origin(origin, "telegram", "123", None) is True
+        # Case-insensitive platform match.
+        assert _target_matches_origin(origin, "Telegram", "123", None) is True
+
+    def test_target_matches_origin_rejects_other_chat(self):
+        from cron.scheduler import _target_matches_origin
+
+        origin = {"platform": "telegram", "chat_id": "123"}
+        # Different chat (fan-out / explicit other target) -> not the origin.
+        assert _target_matches_origin(origin, "telegram", "999", None) is False
+        # Different platform (deliver=all broadcast) -> not the origin.
+        assert _target_matches_origin(origin, "discord", "123", None) is False
+        # No origin at all (API/script job, home-channel fallback) -> never.
+        assert _target_matches_origin({}, "telegram", "123", None) is False
+
+    def test_target_matches_origin_thread_scoped(self):
+        from cron.scheduler import _target_matches_origin
+
+        origin = {"platform": "telegram", "chat_id": "123", "thread_id": "17"}
+        assert _target_matches_origin(origin, "telegram", "123", "17") is True
+        # Same chat, wrong/lost thread lane -> not the same conversation.
+        assert _target_matches_origin(origin, "telegram", "123", None) is False
+        assert _target_matches_origin(origin, "telegram", "123", "99") is False
+
+    def test_delivery_does_not_mirror_fanout_non_origin_target(self):
+        """Even with the gate ON, a delivery to a chat that is NOT the job's
+        origin (explicit fan-out target) must not be mirrored — the mirror is
+        scoped to the origin conversation, and the fan-out chat may have no
+        session at all."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})), \
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+            job = {
+                "id": "test-job",
+                "name": "daily-report",
+                # Explicit delivery to a DIFFERENT chat than the origin.
+                "deliver": "telegram:999",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+                "attach_to_session": True,
+            }
+            _deliver_result(job, "Here is today's summary.")
+
+        # Delivered to 999, but origin is 123 -> no mirror.
+        mirror_mock.assert_not_called()
+
+    def test_delivery_mirrors_only_origin_target_in_fanout(self):
+        """deliver to BOTH origin and another chat: only the origin target is
+        mirrored."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})), \
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+            job = {
+                "id": "test-job",
+                "name": "daily-report",
+                # Fan out to the origin chat (123) AND another chat (999).
+                "deliver": "telegram:123,telegram:999",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+                "attach_to_session": True,
+            }
+            _deliver_result(job, "Here is today's summary.")
+
+        # Exactly one mirror, and it is the origin chat (123) — not 999.
+        mirror_mock.assert_called_once()
+        assert mirror_mock.call_args[0][1] == "123"

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -576,6 +576,7 @@ def cronjob(
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
+    attach_to_session: Optional[bool] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -642,6 +643,7 @@ def cronjob(
                 enabled_toolsets=enabled_toolsets or None,
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
+                attach_to_session=attach_to_session,
             )
             _notify_provider_jobs_changed_safe()
             _create_message = f"Cron job '{job['name']}' created."
@@ -794,6 +796,8 @@ def cronjob(
                 updates["context_from"] = refs or None
             if enabled_toolsets is not None:
                 updates["enabled_toolsets"] = enabled_toolsets or None
+            if attach_to_session is not None:
+                updates["attach_to_session"] = bool(attach_to_session)
             if workdir is not None:
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.
@@ -951,6 +955,10 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             "workdir": {
                 "type": "string",
                 "description": "Optional absolute path to run the job from. When set, AGENTS.md / CLAUDE.md / .cursorrules from that directory are injected into the system prompt, and the terminal/file/code_exec tools use it as their working directory — useful for running a job inside a specific project repo. Must be an absolute path that exists. When unset (default), preserves the original behaviour: no project context files, tools use the scheduler's cwd. On update, pass an empty string to clear. Jobs with workdir run sequentially (not parallel) to keep per-job directories isolated."
+            },
+            "attach_to_session": {
+                "type": "boolean",
+                "description": "When True, this job's delivered output is also mirrored into the TARGET chat's conversation history (as an assistant turn), so when the user replies to the delivery the agent sees it in context instead of asking 'what is that?'. Use this for conversational recurring jobs the user will reply to — daily briefings, reminders that kick off follow-up work, anything where the cron output should be part of the ongoing chat. Leave unset for fire-and-forget alerts/watchdogs. Overrides the global cron.mirror_delivery config for this one job. No effect when deliver='local'. If the target chat has no conversation yet, the mirror is a silent no-op."
             },
         },
         "required": ["action"]

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -294,6 +294,12 @@ def _origin_from_env() -> Optional[Dict[str, str]]:
             "chat_id": origin_chat_id,
             "chat_name": get_session_env("HERMES_SESSION_CHAT_NAME") or None,
             "thread_id": thread_id,
+            # Captured so an opt-in delivery mirror (cron.mirror_delivery /
+            # attach_to_session) can resolve the exact participant's session in
+            # per-user-isolated group chats — parity with interactive
+            # send_message, which passes HERMES_SESSION_USER_ID to
+            # gateway.mirror.mirror_to_session. Harmless for DMs/shared sessions.
+            "user_id": get_session_env("HERMES_SESSION_USER_ID") or None,
         }
     return None
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -964,7 +964,7 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             },
             "attach_to_session": {
                 "type": "boolean",
-                "description": "When True, this job's delivered output is also mirrored into the TARGET chat's conversation history (as an assistant turn), so when the user replies to the delivery the agent sees it in context instead of asking 'what is that?'. Use this for conversational recurring jobs the user will reply to — daily briefings, reminders that kick off follow-up work, anything where the cron output should be part of the ongoing chat. Leave unset for fire-and-forget alerts/watchdogs. Overrides the global cron.mirror_delivery config for this one job. No effect when deliver='local'. If the target chat has no conversation yet, the mirror is a silent no-op."
+                "description": "When True, this job becomes CONTINUABLE: the user can reply to its delivery and the agent has the brief in context instead of asking 'what is that?'. On thread-capable platforms (Telegram topics, Discord/Slack threads) a dedicated thread is opened for the job and its replies; on DM-only platforms (WhatsApp/Signal) the brief is mirrored into the origin DM session. Use this for conversational recurring jobs the user will reply to — daily briefings, reminders that kick off follow-up work. Leave unset for fire-and-forget alerts/watchdogs. Overrides the global cron.mirror_delivery config for this one job. Only the origin chat is touched (never fan-out targets); no effect when deliver='local'."
             },
         },
         "required": ["action"]

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -298,6 +298,39 @@ cron:
   wrap_response: false
 ```
 
+### Continuable jobs (reply to a cron delivery)
+
+By default a cron delivery is fire-and-forget: the message is sent, but it does
+not live in the chat's conversation history, so if you reply to it the agent
+has no record of what it said. Set a job **continuable** and the delivered brief
+becomes a conversation you can reply into — the agent has the brief in context
+instead of asking "what is Task #2?".
+
+Opt-in, **default off**. Enable globally in config, or per-job via the `cronjob`
+tool's `attach_to_session` (which overrides the global setting for that one job):
+
+```yaml
+# ~/.hermes/config.yaml
+cron:
+  mirror_delivery: false   # set true to make cron deliveries continuable
+```
+
+Behaviour is **thread-preferred**, scoped to the job's origin chat:
+
+- **Thread-capable platforms** (Telegram topics, Discord/Slack threads): each
+  delivery opens its own dedicated thread and the brief is seeded into that
+  thread's session, so a reply in-thread continues with full context. A
+  recurring job (e.g. a daily brief) opens a fresh thread per run, keeping each
+  delivery's follow-up discussion isolated.
+- **DM-only platforms** (WhatsApp, Signal, SMS): no threads exist, so the brief
+  is mirrored into the origin DM session instead — the DM itself is the
+  continuation surface.
+
+Only the origin chat is ever touched: fan-out / broadcast targets (`all`,
+explicit other-chat deliveries) are never made continuable. The mirror is
+written as a labelled user turn (`[Cron delivery: <task name>]`), which keeps
+the conversation history alternation-safe across all model providers.
+
 ### Silent suppression
 
 If the agent's final response contains `[SILENT]`, delivery is suppressed entirely. The output is still saved locally for audit (in `~/.hermes/cron/output/`), but no message is sent to the delivery target.


### PR DESCRIPTION
## What & why

Cron deliveries today live only in the cron job's own isolated session. When a brief is delivered to a chat and the user replies ("start Task #2"), that reply lands on a target session with no record of the brief — the agent asks "what is Task #2?". This makes recurring conversational jobs (daily briefings, reminders that kick off follow-up work) a dead end.

This PR makes a cron job optionally **continuable**: the delivered result becomes a conversation the user can reply into, with the brief already in context. Opt-in, **default OFF** — the historical isolation guarantee is preserved unless a job (or an operator) turns it on.

## Design: thread-preferred, with a DM-mirror fallback

The continuation surface is chosen by a single platform-capability fork, scoped to the job's **origin** conversation only:

| Platform class | Behaviour |
|---|---|
| Thread-capable (Telegram topics, Discord / Slack threads) | A dedicated thread is opened for the job via the adapter's `create_handoff_thread`, the brief is routed into it, and the thread-keyed session is seeded so the user's in-thread reply continues with full context. Each continuable job gets its own scrollback, isolated from the parent channel. |
| DM-only (WhatsApp / Signal / SMS) | No thread primitive exists (`create_handoff_thread` returns `None`), so the brief is mirrored into the origin DM session — the DM itself is the continuation surface. |

A `None` return from `create_handoff_thread` *is* the fallback signal, so there is one code path, not two features. This mirrors `GatewayRunner._process_handoff`'s existing open-thread-or-fallback + seed pattern already used for CLI→platform handoffs.

## Footprint (per AGENTS.md — expansive at the edges, conservative at the waist)

- **No new core tool**, no new model-tool schema surface.
- **No new adapter method** and **no `supports_threads` flag** — reuses the shipped per-platform `create_handoff_thread`; its `None` return is the capability probe.
- **No provider-chain signature change** — reaches the live `SessionStore` via the adapter's existing `_session_store` handle rather than threading a new param through the frozen `CronScheduler.start()` contract.
- **No new `HERMES_*` env var** — the behavioural setting is `cron.mirror_delivery` in `config.yaml`, overridable per-job via the `cronjob` tool's `attach_to_session`.
- Existing per-target delivery routing carries the new `thread_id` for free.

Net diff is **+711 lines, additive only**, across 5 files.

## Invariants

- **Origin-scoped only.** Threading/mirroring fires only for the delivery target whose `(platform, chat_id[, thread_id])` equals the job's origin. Fan-out / broadcast / home-channel-fallback targets are never threaded or mirrored — they are not a continuation of a conversation and may legitimately have no session.
- **Cache- and alternation-safe.** The brief is appended as an assistant turn at a turn boundary, never mid-loop, and never mutates the cached system prompt. A `thread_seeded` guard prevents a double-mirror after seeding.
- **Conservative on ambiguity.** The DM path reuses `gateway/mirror.py`'s `_find_session_id`, which returns `None` (no-op) rather than guess when a chat has multiple participant sessions and none matches the origin sender — parity with interactive `send_message`. The thread path sidesteps this entirely: a fresh `chat_type="thread"` session is participant-shared by construction.
- **Best-effort continuation.** A mirror/seed failure never fails a delivery that already succeeded.

## Config / surface

```yaml
cron:
  # Make cron deliveries CONTINUABLE (default false). Per-job
  # attach_to_session overrides this.
  mirror_delivery: false
```

Per-job opt-in via the `cronjob` tool: `attach_to_session: true`.

## Testing

- `tests/cron/test_scheduler.py` — **185 passed**, including the new mirror/thread/continuable coverage: thread id returned on a thread platform; `None` on a DM platform; `None` without capability/loop; seed creates the thread session + mirrors; seed no-op on empty content; plus the origin-scoping suite (exact match; other-chat / other-platform / no-origin rejection; thread scoping; fan-out mirrors ONLY the origin target).
- Full `tests/cron/` suite: 538 passed, 7 skipped; the 4 failures are pre-existing `croniter`-not-installed env failures (compute `next_run` from cron expressions), unrelated to this change and identical on untouched `main`.
- Syntax + imports clean, no new Pyright errors. Rebased cleanly onto current `main`.

## Commits

- `feat(cron): optional mirror of cron delivery into target chat session`
- `refactor(cron): scope delivery mirror to the origin conversation`
- `feat(cron): pass origin user_id to delivery mirror (send_message parity)`
- `feat(cron): thread-preferred continuable delivery (open a thread, mirror DM fallback)`
