### PR TITLE
fix(logging): rotate active log with copy-truncate

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -30,6 +30,7 @@ Session context:
 import io
 import logging
 import os
+import shutil
 import sys
 import threading
 from pathlib import Path
@@ -389,28 +390,53 @@ def setup_verbose_logging() -> None:
 # ---------------------------------------------------------------------------
 
 class _ManagedRotatingFileHandler(RotatingFileHandler):
-    """RotatingFileHandler that ensures group-writable perms in managed mode
-    AND survives external rotation.
+    """RotatingFileHandler that ensures group-writable perms in managed mode,
+    survives external rotation, AND rotates safely on Windows under
+    multi-process file locks.
 
-    Two responsibilities:
+    Three responsibilities:
 
-    1.  In managed mode (NixOS), the stateDir uses setgid (2770) so new files
-        inherit the hermes group. However, both ``_open()`` (initial creation)
-        and ``doRollover()`` create files via ``open()``, which uses the
-        process umask — typically 0022, producing 0644. This subclass applies
-        ``chmod 0660`` after both operations so the gateway and interactive
-        users can share log files.
+    1.  **Managed-mode perms (NixOS)** — the stateDir uses setgid (2770) so
+        new files inherit the hermes group. However, both ``_open()`` (initial
+        creation) and ``doRollover()`` create files via ``open()``, which uses
+        the process umask — typically 0022, producing 0644. This subclass
+        applies ``chmod 0660`` after both operations so the gateway and
+        interactive users can share log files.
 
-    2.  ``RotatingFileHandler`` keeps an open file descriptor.  If anything
-        rotates the file *externally* (``logrotate``, manual ``mv``,
-        another process rotating under us, a transient unlink), our fd
-        keeps pointing at the renamed/unlinked inode and every subsequent
-        write goes to ``gateway.log.1`` instead of ``gateway.log`` — silent
-        log loss for the file every operator expects to read.  Before each
-        emit we ``stat`` ``baseFilename`` and compare it against the open
-        stream's inode; on mismatch we reopen.  This is the same pattern
-        as stdlib ``WatchedFileHandler.reopenIfNeeded()``, adapted for
-        rotating handlers.
+    2.  **External rotation detection** — ``RotatingFileHandler`` keeps an
+        open file descriptor.  If anything rotates the file *externally*
+        (``logrotate``, manual ``mv``, another process rotating under us, a
+        transient unlink), our fd keeps pointing at the renamed/unlinked
+        inode and every subsequent write goes to ``gateway.log.1`` instead
+        of ``gateway.log`` — silent log loss for the file every operator
+        expects to read.  Before each emit we ``stat`` ``baseFilename`` and
+        compare it against the open stream's inode; on mismatch we reopen.
+        Same pattern as stdlib ``WatchedFileHandler.reopenIfNeeded()``,
+        adapted for rotating handlers.
+
+    3.  **Windows-safe rotation** — stdlib ``RotatingFileHandler.doRollover``
+        rotates by calling ``os.rename(baseFilename, dfn)``.  On Windows that
+        ``rename`` fails with ``OSError`` whenever ANY other process holds
+        the file open (Python's default ``open()`` doesn't pass
+        ``FILE_SHARE_DELETE``).  Hermes runs the gateway as one persistent
+        process and spawns CLI subprocesses that all open ``agent.log`` in
+        append mode — so the moment the file crossed ``maxBytes``, the next
+        rotate attempt deterministically failed.  Worse, the stdlib closes
+        its stream BEFORE attempting the rename, so a failed rename leaves
+        the handler with ``self.stream = None``; the next ``emit()`` reopens,
+        but the very next message re-triggers ``shouldRollover`` →
+        ``doRollover`` → fails again, every line is dropped, and the file
+        stays stuck at the rotation boundary forever.
+
+        ``doRollover`` below uses **copy-truncate** semantics (the same
+        strategy ``logrotate --copytruncate`` uses): copy the file, then
+        truncate the original in place.  ``shutil.copy2`` and
+        ``open(..., "r+b") + truncate(0)`` both succeed regardless of how
+        many other processes have the file open in append mode, because
+        neither operation requires the exclusive rename-style lock.  No
+        rename of the active file is needed.  Active inode is preserved,
+        so the external-rotation detector above does NOT misfire after our
+        own rotation.
     """
 
     def __init__(self, *args, **kwargs):
@@ -500,11 +526,89 @@ class _ManagedRotatingFileHandler(RotatingFileHandler):
         return stream
 
     def doRollover(self):
-        super().doRollover()
+        """Copy-truncate rotation (see class docstring, responsibility 3).
+
+        Mirrors the stdlib ``RotatingFileHandler.doRollover`` behaviour
+        (numbered backups up to ``self.backupCount``, oldest deleted first)
+        but never renames the active file — so it succeeds even when other
+        processes hold it open in append mode (Windows file locks).
+        """
+        # Flush + close our own stream so the copy reads a consistent file
+        # and the truncate that follows is observed by every other writer.
+        if self.stream is not None:
+            try:
+                self.stream.close()
+            except Exception:
+                pass
+            self.stream = None  # type: ignore[assignment]
+
+        # Shift existing backups: .N-1 → .N, …, .1 → .2.  Backups aren't
+        # held open by anything, so ordinary rename works here.  We tolerate
+        # rename failures on individual backups — the active rotation below
+        # is what really matters.
+        if self.backupCount > 0:
+            for i in range(self.backupCount - 1, 0, -1):
+                sfn = self.rotation_filename(f"{self.baseFilename}.{i}")
+                dfn = self.rotation_filename(f"{self.baseFilename}.{i + 1}")
+                if os.path.exists(sfn):
+                    if os.path.exists(dfn):
+                        try:
+                            os.remove(dfn)
+                        except OSError:
+                            continue
+                    try:
+                        os.rename(sfn, dfn)
+                    except OSError:
+                        pass
+
+            dfn = self.rotation_filename(f"{self.baseFilename}.1")
+            if os.path.exists(dfn):
+                try:
+                    os.remove(dfn)
+                except OSError:
+                    pass
+
+            # Copy-truncate the active file.
+            try:
+                shutil.copy2(self.baseFilename, dfn)
+            except OSError as exc:
+                _emit_rollover_stderr("backup copy failed", exc)
+
+            try:
+                with open(self.baseFilename, "r+b") as fh:
+                    fh.truncate(0)
+            except OSError as exc:
+                # Truncation failure leaves the file at its current size; the
+                # handler will still recover (stream reopens below) but the
+                # file may exceed ``maxBytes`` until next rotation succeeds.
+                _emit_rollover_stderr("truncate failed", exc)
+
+        # Reopen the stream so subsequent emit()s have a valid file handle.
+        if not self.delay:
+            self.stream = self._open()
         self._chmod_if_managed()
-        # Our own rollover writes a new baseFilename; refresh the snapshot
-        # so the next emit doesn't mistake it for external rotation.
+        # Our own rollover preserves the active inode (truncate-in-place);
+        # refresh the snapshot so the external-rotation detector at
+        # ``_reopen_if_externally_rotated`` doesn't see a phantom change on
+        # the next emit (mtime/size changed but dev/ino did not).
         self._record_stream_stat()
+
+
+def _emit_rollover_stderr(label: str, exc: BaseException) -> None:
+    """Surface a copy-truncate rotation failure to stderr.
+
+    Routing the message back through ``logging`` would land in the very
+    handler we're trying to recover — so we write directly to stderr.
+    Best-effort; if stderr is closed (daemonized gateway with no console)
+    the message is dropped and the handler still recovers on the next emit.
+    """
+    try:
+        sys.stderr.write(
+            f"[hermes_logging] log rollover: {label}: "
+            f"{type(exc).__name__}: {exc}\n"
+        )
+    except Exception:
+        pass
 
 
 def _add_rotating_handler(

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -764,6 +764,7 @@ class TestAddRotatingHandler:
                 logger.removeHandler(h)
                 h.close()
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX mode bits are not enforced on Windows")
     def test_managed_mode_initial_open_sets_group_writable(self, tmp_path):
         log_path = tmp_path / "managed-open.log"
         logger = logging.getLogger("_test_rotating_managed_open")
@@ -788,6 +789,7 @@ class TestAddRotatingHandler:
                 logger.removeHandler(h)
                 h.close()
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX mode bits are not enforced on Windows")
     def test_managed_mode_rollover_sets_group_writable(self, tmp_path):
         log_path = tmp_path / "managed-rollover.log"
         logger = logging.getLogger("_test_rotating_managed_rollover")
@@ -974,16 +976,53 @@ class TestExternalRotationRecovery:
         finally:
             handler.close()
 
+    def test_rollover_does_not_rename_active_log_file(self, tmp_path, monkeypatch):
+        """Handler-driven rollover uses copy-truncate for the active log file.
+
+        On Windows, renaming an open active log can fail when another Hermes
+        process also has the file open. Simulate that lock by making active-file
+        rename fail. The handler should still rotate successfully because it
+        only renames numbered backups, then copies and truncates the active log.
+        """
+        log_path = tmp_path / "gateway.log"
+        rotated = tmp_path / "gateway.log.1"
+        active_rename_attempts = []
+        real_rename = os.rename
+
+        def guarded_rename(src, dst):
+            if Path(src) == log_path:
+                active_rename_attempts.append((src, dst))
+                raise OSError("active log is locked")
+            return real_rename(src, dst)
+
+        monkeypatch.setattr(hermes_logging.os, "rename", guarded_rename)
+        handler = hermes_logging._ManagedRotatingFileHandler(
+            str(log_path), maxBytes=1, backupCount=2, encoding="utf-8",
+        )
+        handler.setLevel(logging.INFO)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        try:
+            self._emit(handler, "first record")
+            self._emit(handler, "second record")
+
+            assert not active_rename_attempts
+            assert log_path.exists()
+            assert rotated.exists()
+            assert "second record" in log_path.read_text()
+            assert "first record" in rotated.read_text()
+        finally:
+            handler.close()
+
     def test_gateway_log_attached_after_external_rotation_then_re_setup(
         self, hermes_home,
     ):
-        """End-to-end Allen-reproduction: gateway.log gets externally rotated,
+        """End-to-end reproduction: gateway.log gets externally rotated,
         ``setup_logging(mode='gateway')`` is re-called, the handler keeps
         working.
 
-        Reproduces Allen's symptom (gateway.log frozen mid-write, all gateway
-        records leaking to agent.log) when something external rotates the
-        file between setup_logging() calls.
+        Reproduces the symptom where a handler's stale file descriptor keeps
+        writing to the rotated backup instead of recreating the expected live
+        log file.
         """
         hermes_logging.setup_logging(hermes_home=hermes_home, mode="gateway")
         gw_path = hermes_home / "logs" / "gateway.log"
@@ -1010,8 +1049,7 @@ class TestExternalRotationRecovery:
             except Exception: pass
 
         # The new record must reach the live gateway.log, not the rotated
-        # backup.  Allen's logs had everything past the rotation point
-        # going into agent.log only, never gateway.log.
+        # backup.
         assert gw_path.exists(), "gateway.log was never recreated"
         assert "AFTER rotation" in gw_path.read_text()
         assert "AFTER rotation" not in rotated.read_text()


### PR DESCRIPTION
## Summary
- Changes Hermes' managed rotating file handler to rotate the active log with copy-truncate semantics instead of renaming the active file.
- Keeps numbered backup rotation behavior for older backups.
- Adds a regression test that fails if handler-driven rollover attempts to rename the active log file.
- Skips POSIX-mode-bit assertions on Windows, where NTFS does not enforce POSIX modes the same way.

## Why
On Windows, `RotatingFileHandler` can fail when renaming an active log file that another Hermes process has open. If rollover fails after the stream is closed, future log records can repeatedly hit the same rollover failure and get dropped. Copy-truncate avoids the active-file rename while preserving the expected backup files.

## Test Plan
- [x] `pytest tests/test_hermes_logging.py::TestExternalRotationRecovery::test_normal_rollover_still_works tests/test_hermes_logging.py::TestExternalRotationRecovery::test_rollover_does_not_rename_active_log_file tests/test_hermes_logging.py::TestExternalRotationRecovery::test_gateway_log_attached_after_external_rotation_then_re_setup -q --tb=short -n 0 -o addopts=''`
- [x] `pytest tests/test_hermes_logging.py -q --tb=short -n 0 -o addopts=''`
- [x] `git diff --check origin/main...HEAD`
- [x] Added-line static/privacy scan for obvious secrets/shell/eval/pickle/SQL patterns and local/private references
