### PR TITLE
fix(cli): keep quiet single-query stdout clean

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -39,7 +39,7 @@ import uuid
 import textwrap
 from collections import deque
 from urllib.parse import unquote, urlparse
-from contextlib import contextmanager
+from contextlib import contextmanager, redirect_stdout
 from pathlib import Path
 from datetime import datetime
 from typing import List, Dict, Any, Optional
@@ -1134,6 +1134,23 @@ def _finalize_single_query(cli) -> None:
         _run_cleanup(notify_session_finalize=False)
     finally:
         cli._release_active_session()
+
+
+def _run_quiet_single_query_conversation(agent, *, user_message, conversation_history):
+    """Run the quiet one-shot agent loop without letting internal prints hit stdout.
+
+    ``hermes chat -Q -q`` is consumed by automation wrappers that expect stdout
+    to contain only the final assistant answer. Tool renderers, approval hooks,
+    or lower-level status helpers may still write to stdout while the agent loop
+    runs. In quiet one-shot mode those incidental writes are diagnostics, so
+    route them to stderr and print the final response exactly once after this
+    helper returns.
+    """
+    with redirect_stdout(sys.stderr):
+        return agent.run_conversation(
+            user_message=user_message,
+            conversation_history=conversation_history,
+        )
 
 
 def _reset_terminal_input_modes_on_exit() -> None:
@@ -15084,7 +15101,8 @@ def main(
                         cli.agent.stream_delta_callback = None
                         cli.agent.tool_gen_callback = None
                         try:
-                            result = cli.agent.run_conversation(
+                            result = _run_quiet_single_query_conversation(
+                                cli.agent,
                                 user_message=effective_query,
                                 conversation_history=cli.conversation_history,
                             )

--- a/tests/cli/test_quiet_single_query_stdout.py
+++ b/tests/cli/test_quiet_single_query_stdout.py
@@ -1,0 +1,37 @@
+"""Regression tests for clean stdout in `hermes chat -Q -q`.
+
+Dedicated automation wrappers rely on quiet single-query stdout containing only
+one human answer. Tool/rendering noise produced inside the agent loop must not
+share that stream.
+"""
+
+import contextlib
+import io
+
+
+class _NoisyAgent:
+    def run_conversation(self, *, user_message, conversation_history):
+        print("review diff: noisy tool renderer output")
+        print("Timeout - denying command")
+        return {"final_response": "clean final answer", "messages": []}
+
+
+def test_quiet_single_query_redirects_agent_stdout_to_stderr():
+    from cli import _run_quiet_single_query_conversation
+
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        result = _run_quiet_single_query_conversation(
+            _NoisyAgent(),
+            user_message="do work",
+            conversation_history=[],
+        )
+        response = result.get("final_response", "")
+        if response:
+            print(response)
+
+    assert stdout.getvalue() == "clean final answer\n"
+    assert "review diff: noisy tool renderer output" in stderr.getvalue()
+    assert "Timeout - denying command" in stderr.getvalue()


### PR DESCRIPTION
## Summary
- Keeps `hermes chat -Q -q` stdout machine-readable by routing incidental stdout from `run_conversation` to stderr during quiet one-shot execution.
- Preserves stdout for the final assistant answer only.
- Adds a regression that simulates noisy internal prints and verifies only the final answer reaches stdout.

## Validation
- `scripts/run_tests.sh tests/cli/test_quiet_single_query_stdout.py tests/cli/test_resume_quiet_stderr.py tests/hermes_cli/test_argparse_flag_propagation.py -- -q` → 22 tests passed on clean `upstream/main` worktree.
- `python -m py_compile cli.py tests/cli/test_quiet_single_query_stdout.py` → OK.
- `git diff --cached --check` → OK.
- Staged secret scan for token/JWT/bearer patterns → 0 matches.

## Evidence
- `hermes-cli-quiet-stdout-p2-20260622`
