### PR TITLE
feat(telegram): deliver and answer Bot API guest messages

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -63,10 +63,10 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
     ``direct_messages_topic_id`` when the Bot API supports it.
     """
     thread_id = getattr(source, "thread_id", None)
-    if thread_id is None:
-        return None
-    metadata = {"thread_id": thread_id}
-    if _platform_name(getattr(source, "platform", None)) == "telegram" and getattr(source, "chat_type", None) == "dm":
+    metadata = {}
+    if thread_id is not None:
+        metadata["thread_id"] = thread_id
+    if thread_id is not None and _platform_name(getattr(source, "platform", None)) == "telegram" and getattr(source, "chat_type", None) == "dm":
         metadata["telegram_dm_topic_reply_fallback"] = True
         tid = str(thread_id)
         if tid and tid not in {"", "1"}:
@@ -74,7 +74,10 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
         anchor = reply_to_message_id or getattr(source, "message_id", None)
         if anchor is not None:
             metadata["telegram_reply_to_message_id"] = str(anchor)
-    return metadata
+    guest_query_id = getattr(source, "guest_query_id", None)
+    if _platform_name(getattr(source, "platform", None)) == "telegram" and guest_query_id:
+        metadata["telegram_guest_query_id"] = str(guest_query_id)
+    return metadata or None
 
 
 def _mark_notify_metadata(metadata: dict | None) -> dict:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12094,13 +12094,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         reply_to_message_id: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """Build the metadata dict platforms need for thread-aware replies."""
-        return self._thread_metadata_for_target(
+        metadata = self._thread_metadata_for_target(
             getattr(source, "platform", None),
             getattr(source, "chat_id", None),
             getattr(source, "thread_id", None),
             chat_type=getattr(source, "chat_type", None),
             reply_to_message_id=reply_to_message_id or getattr(source, "message_id", None),
         )
+        guest_query_id = getattr(source, "guest_query_id", None)
+        if guest_query_id:
+            if metadata is None:
+                metadata = {}
+            metadata["telegram_guest_query_id"] = str(guest_query_id)
+        return metadata
+
+    @staticmethod
+    def _streaming_allowed_for_source(source, streaming_enabled: bool) -> bool:
+        """Whether token/interim streaming may be used for this reply.
+
+        Telegram Guest Mode (Bot API 10) replies go out via ``answerGuestQuery``,
+        which delivers a single, non-editable message and consumes a single-use
+        ``guest_query_id`` token. Streaming edits or interim messages would burn
+        the token on the first chunk — or fall back to ``sendMessage`` in a chat
+        the guest bot isn't a member of (silently dropped) — so guest replies
+        must always be sent as one consolidated final message.
+        """
+        if getattr(source, "guest_query_id", None):
+            return False
+        return streaming_enabled
 
     def _thread_metadata_for_target(
         self,
@@ -14163,6 +14184,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _plat_streaming is None
             else bool(_plat_streaming)
         )
+        # Guest Mode replies are one-shot (answerGuestQuery): never stream them,
+        # or the single-use guest_query_id token is consumed before the final
+        # answer. See _streaming_allowed_for_source for the full rationale.
+        _streaming_enabled = self._streaming_allowed_for_source(source, _streaming_enabled)
 
         _thread_metadata: Optional[Dict[str, Any]] = self._thread_metadata_for_source(source, event_message_id)
 
@@ -15328,8 +15353,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if _plat_streaming is None
                 else bool(_plat_streaming)
             )
+            # Guest Mode replies are one-shot (answerGuestQuery) and must not be
+            # streamed or sent as interim messages — see
+            # _streaming_allowed_for_source. This fixes private-chat guest
+            # replies, which were streaming-only and so never reached the final
+            # consolidated send that carries the guest_query_id token.
+            _is_guest_reply = bool(getattr(source, "guest_query_id", None))
+            _streaming_enabled = self._streaming_allowed_for_source(source, _streaming_enabled)
             _want_stream_deltas = _streaming_enabled
-            _want_interim_messages = interim_assistant_messages_enabled
+            _want_interim_messages = interim_assistant_messages_enabled and not _is_guest_reply
             _want_interim_consumer = _want_interim_messages
             if _want_stream_deltas or _want_interim_consumer:
                 try:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -119,6 +119,7 @@ class SessionSource:
     # None => the gateway's active/default profile. Drives both session-key
     # namespacing and the per-turn config/credential scope.
     profile: Optional[str] = None
+    guest_query_id: Optional[str] = None  # Telegram Bot API Guest Mode reply token (ephemeral)
     
     @property
     def description(self) -> str:
@@ -161,9 +162,11 @@ class SessionSource:
         if self.parent_chat_id:
             d["parent_chat_id"] = self.parent_chat_id
         if self.message_id:
-            d["message_id"] = self.message_id
+            d["message_id"] = str(self.message_id)
         if self.profile:
             d["profile"] = self.profile
+        if self.guest_query_id:
+            d["guest_query_id"] = self.guest_query_id
         return d
 
     @classmethod
@@ -183,6 +186,7 @@ class SessionSource:
             parent_chat_id=data.get("parent_chat_id"),
             message_id=data.get("message_id"),
             profile=data.get("profile"),
+            guest_query_id=data.get("guest_query_id"),
         )
     
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -32,6 +32,7 @@ try:
         CommandHandler,
         CallbackQueryHandler,
         MessageHandler as TelegramMessageHandler,
+        TypeHandler,
         ContextTypes,
         filters,
     )
@@ -50,6 +51,7 @@ except ImportError:
     CommandHandler = Any
     CallbackQueryHandler = Any
     TelegramMessageHandler = Any
+    TypeHandler = Any
     HTTPXRequest = Any
     filters = None
     ParseMode = None
@@ -121,7 +123,7 @@ def check_telegram_requirements() -> bool:
     """
     global TELEGRAM_AVAILABLE, Update, Bot, Message, InlineKeyboardButton
     global InlineKeyboardMarkup, LinkPreviewOptions, Application
-    global CommandHandler, CallbackQueryHandler, TelegramMessageHandler
+    global CommandHandler, CallbackQueryHandler, TelegramMessageHandler, TypeHandler
     global ContextTypes, filters, ParseMode, ChatType, HTTPXRequest
     if TELEGRAM_AVAILABLE:
         return True
@@ -140,7 +142,7 @@ def check_telegram_requirements() -> bool:
         from telegram.ext import (
             Application as _App, CommandHandler as _CH,
             CallbackQueryHandler as _CQH,
-            MessageHandler as _MH,
+            MessageHandler as _MH, TypeHandler as _TH,
             ContextTypes as _CT, filters as _filters,
         )
         from telegram.constants import ParseMode as _PM, ChatType as _CtT
@@ -157,6 +159,7 @@ def check_telegram_requirements() -> bool:
     CommandHandler = _CH
     CallbackQueryHandler = _CQH
     TelegramMessageHandler = _MH
+    TypeHandler = _TH
     ContextTypes = _CT
     filters = _filters
     ParseMode = _PM
@@ -1235,6 +1238,117 @@ class TelegramAdapter(BasePlatformAdapter):
             payload["skip_entity_detection"] = True
         return payload
 
+    @staticmethod
+    def _telegram_allowed_updates() -> List[str]:
+        """Return polling/webhook update names, including Bot API 10 guest messages.
+
+        PTB 22.x predates ``guest_message`` and therefore omits it from
+        ``Update.ALL_TYPES``. Telegram persists ``allowed_updates`` server-side;
+        if we start polling without this literal string, Guest Bot summons are
+        never delivered even when BotFather says supports_guest_queries=true.
+        """
+        allowed: List[str] = []
+        for update_type in getattr(Update, "ALL_TYPES", []):
+            value = getattr(update_type, "value", update_type)
+            text = str(value)
+            if text and text not in allowed:
+                allowed.append(text)
+        if "guest_message" not in allowed:
+            allowed.append("guest_message")
+        return allowed
+
+    @staticmethod
+    def _guest_query_id_from_message(message: Message) -> Optional[str]:
+        direct = getattr(message, "guest_query_id", None)
+        if direct:
+            return str(direct)
+        api_kwargs = getattr(message, "api_kwargs", None) or {}
+        guest_query_id = api_kwargs.get("guest_query_id") if hasattr(api_kwargs, "get") else None
+        return str(guest_query_id) if guest_query_id else None
+
+    @staticmethod
+    def _guest_caller_from_message(message: Message) -> tuple[Optional[Any], Optional[Any]]:
+        """Return the chat/user that summoned a guest message, if present."""
+        caller_chat = getattr(message, "guest_bot_caller_chat", None)
+        caller_user = getattr(message, "guest_bot_caller_user", None)
+        api_kwargs = getattr(message, "api_kwargs", None) or {}
+
+        if caller_chat is None and hasattr(api_kwargs, "get"):
+            raw_chat = api_kwargs.get("guest_bot_caller_chat")
+            if raw_chat:
+                if isinstance(raw_chat, dict):
+                    from types import SimpleNamespace
+                    caller_chat = SimpleNamespace(**raw_chat)
+                else:
+                    caller_chat = raw_chat
+
+        if caller_user is None and hasattr(api_kwargs, "get"):
+            raw_user = api_kwargs.get("guest_bot_caller_user")
+            if raw_user:
+                if isinstance(raw_user, dict):
+                    from types import SimpleNamespace
+                    caller_user = SimpleNamespace(**raw_user)
+                else:
+                    caller_user = raw_user
+
+        return caller_chat, caller_user
+
+    def _guest_answer_payload(self, content: str) -> Dict[str, Any]:
+        """Build an InlineQueryResult for ``answerGuestQuery``.
+
+        Guest replies use the inline-result shape, not ``sendMessage``. Keep the
+        first implementation conservative: text content only, Markdown enabled,
+        and within Telegram's single message ceiling.
+        """
+        text = content.strip()
+        if utf16_len(text) > self.MAX_MESSAGE_LENGTH:
+            text = self.truncate_message(text, self.MAX_MESSAGE_LENGTH, len_fn=utf16_len)[0]
+        return {
+            "type": "article",
+            "id": "hermes-guest-response",
+            "title": "Hermes response",
+            "input_message_content": {
+                "message_text": text,
+                "parse_mode": "Markdown",
+                "disable_web_page_preview": bool(getattr(self, "_disable_link_previews", False)),
+            },
+        }
+
+    async def _answer_guest_query(self, guest_query_id: str, content: str) -> SendResult:
+        """Reply to a Telegram Bot API 10 Guest Mode query."""
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+        try:
+            payload = {
+                "guest_query_id": guest_query_id,
+                "result": self._guest_answer_payload(content),
+            }
+            result = await self._bot.do_api_request(
+                "answerGuestQuery", api_kwargs=payload
+            )
+            message_id = None
+            if isinstance(result, dict):
+                message_id = result.get("inline_message_id") or (result.get("result") or {}).get("inline_message_id")
+            return SendResult(success=True, message_id=str(message_id) if message_id else None, raw_response=result)
+        except Exception as exc:
+            logger.error("[%s] answerGuestQuery failed: %s", self.name, exc, exc_info=True)
+            return SendResult(success=False, error=str(exc), retryable=True)
+
+    def _guest_message_from_update(self, update: Update) -> Optional[Message]:
+        """Extract PTB-native or api_kwargs guest_message payloads."""
+        native = getattr(update, "guest_message", None)
+        if native is not None:
+            return native
+        api_kwargs = getattr(update, "api_kwargs", None) or {}
+        raw = api_kwargs.get("guest_message") if hasattr(api_kwargs, "get") else None
+        if not raw:
+            return None
+        try:
+            return Message.de_json(raw, None)
+        except Exception as exc:
+            logger.warning("[%s] Failed to parse Telegram guest_message payload: %s", self.name, exc)
+            return None
+
     def _is_rich_capability_error(self, exc: Exception) -> bool:
         """True ⇒ the rich endpoint itself is unavailable (old PTB/server).
 
@@ -1631,7 +1745,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
         try:
             await self._app.updater.start_polling(
-                allowed_updates=Update.ALL_TYPES,
+                allowed_updates=self._telegram_allowed_updates(),
                 drop_pending_updates=False,
                 error_callback=self._polling_error_callback_ref,
             )
@@ -1758,7 +1872,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
             try:
                 await self._app.updater.start_polling(
-                    allowed_updates=Update.ALL_TYPES,
+                    allowed_updates=self._telegram_allowed_updates(),
                     drop_pending_updates=False,
                     error_callback=self._polling_error_callback_ref,
                 )
@@ -2246,7 +2360,10 @@ class TelegramAdapter(BasePlatformAdapter):
             self._app = builder.build()
             self._bot = self._app.bot
             
-            # Register handlers
+            # Register handlers. Guest Bot updates are a Bot API 10 field that
+            # PTB 22.x does not model yet; TypeHandler(Update) lets us inspect
+            # Update.api_kwargs without blocking normal MessageHandlers in group 0.
+            self._app.add_handler(TypeHandler(Update, self._handle_guest_update), group=-1)
             self._app.add_handler(TelegramMessageHandler(
                 filters.TEXT & ~filters.COMMAND,
                 self._handle_text_message
@@ -2327,7 +2444,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     url_path=webhook_path,
                     webhook_url=webhook_url,
                     secret_token=webhook_secret,
-                    allowed_updates=Update.ALL_TYPES,
+                    allowed_updates=self._telegram_allowed_updates(),
                     drop_pending_updates=True,
                 )
                 self._webhook_mode = True
@@ -2360,7 +2477,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 self._polling_error_callback_ref = _polling_error_callback
 
                 await self._app.updater.start_polling(
-                    allowed_updates=Update.ALL_TYPES,
+                    allowed_updates=self._telegram_allowed_updates(),
                     drop_pending_updates=True,
                     error_callback=_polling_error_callback,
                 )
@@ -2551,6 +2668,10 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=True, message_id=None)
         
         try:
+            guest_query_id = (metadata or {}).get("telegram_guest_query_id")
+            if guest_query_id:
+                return await self._answer_guest_query(str(guest_query_id), content)
+
             # Bot API 10.1 rich fast-path: send the raw agent markdown via
             # sendRichMessage so tables/task lists/etc. render natively. Falls
             # through to the legacy MarkdownV2 path on permanent/capability
@@ -5187,6 +5308,8 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
         """Send typing indicator."""
+        if metadata and metadata.get("telegram_guest_query_id"):
+            return
         if self._bot:
             _is_dm_topic: bool = False
             message_thread_id: Optional[int] = None
@@ -6150,6 +6273,48 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         return getattr(update, "effective_message", None) or getattr(update, "message", None)
 
+    async def _handle_guest_update(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handle Bot API 10 Guest Bot summons.
+
+        PTB 22.x preserves unknown ``guest_message`` payloads in
+        ``Update.api_kwargs``. Parse that payload manually and let the normal
+        gateway pipeline run; response metadata routes the final send through
+        ``answerGuestQuery`` instead of ``sendMessage``.
+        """
+        msg = self._guest_message_from_update(update)
+        if not msg:
+            return
+        guest_query_id = self._guest_query_id_from_message(msg)
+        if not guest_query_id:
+            logger.warning("[%s] Telegram guest_message missing guest_query_id", self.name)
+            return
+        if not (getattr(msg, "text", None) or getattr(msg, "caption", None)):
+            return
+        if not self._telegram_guest_mode():
+            return
+        if not self._message_mentions_bot(msg):
+            return
+        if not self._should_process_message(msg):
+            return
+
+        caller_chat, caller_user = self._guest_caller_from_message(msg)
+        event = self._build_message_event(
+            msg,
+            MessageType.TEXT,
+            update_id=update.update_id,
+            chat_override=caller_chat,
+            user_override=caller_user,
+        )
+        event.source.guest_query_id = guest_query_id
+        event.text = self._clean_bot_trigger_text(event.text) or event.text
+        logger.info(
+            "[%s] Telegram guest_message accepted: chat=%s from=%s",
+            self.name,
+            getattr(getattr(msg, "chat", None), "id", "unknown"),
+            getattr(getattr(msg, "from_user", None), "id", "unknown"),
+        )
+        self._enqueue_text_event(event)
+
     async def _handle_text_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming text messages.
 
@@ -6908,6 +7073,9 @@ class TelegramAdapter(BasePlatformAdapter):
         message: Message,
         msg_type: MessageType,
         update_id: Optional[int] = None,
+        *,
+        chat_override: Optional[Any] = None,
+        user_override: Optional[Any] = None,
     ) -> MessageEvent:
         """Build a MessageEvent from a Telegram message.
 
@@ -6916,8 +7084,8 @@ class TelegramAdapter(BasePlatformAdapter):
         process can advance past it (prevents ``/restart`` being re-delivered
         when PTB's graceful-shutdown ACK fails).
         """
-        chat = message.chat
-        user = message.from_user
+        chat = chat_override or message.chat
+        user = user_override or message.from_user
         
         # Determine chat type.  Normalize through ``str`` so tests/mocks and
         # python-telegram-bot enum values both work (``ChatType.CHANNEL`` is
@@ -6983,24 +7151,26 @@ class TelegramAdapter(BasePlatformAdapter):
                     break
 
         # Build source
+        chat_name = getattr(chat, "title", None) or getattr(chat, "full_name", None) or getattr(chat, "first_name", None)
+        user_name = (
+            getattr(user, "full_name", None)
+            or (f"{getattr(user, 'first_name', '')} {getattr(user, 'last_name', '')}".strip() or None)
+            if user
+            else None
+        )
+        if user_name is None and user is None:
+            user_name = getattr(chat, "full_name", None) if chat_type == "dm" else (getattr(chat, "title", None) if chat_type == "channel" else None)
+
         source = self.build_source(
             chat_id=str(chat.id),
-            chat_name=chat.title or (chat.full_name if hasattr(chat, "full_name") else None),
+            chat_name=chat_name,
             chat_type=chat_type,
             user_id=(
                 str(user.id)
                 if user
                 else (str(chat.id) if chat_type in {"dm", "channel"} else None)
             ),
-            user_name=(
-                user.full_name
-                if user
-                else (
-                    chat.full_name
-                    if hasattr(chat, "full_name") and chat_type == "dm"
-                    else (chat.title if chat_type == "channel" else None)
-                )
-            ),
+            user_name=user_name,
             thread_id=thread_id_str,
             chat_topic=chat_topic,
             message_id=str(message.message_id),

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -25,22 +25,36 @@ class TestSessionSourceRoundtrip:
         source = SessionSource(
             platform=Platform.TELEGRAM,
             chat_id="12345",
-            chat_name="My Group",
+            chat_name="Group",
             chat_type="group",
-            user_id="99",
-            user_name="alice",
-            thread_id="t1",
+            user_id="42",
+            user_name="Alice",
+            thread_id="99",
+            chat_topic="Topic A",
+            user_id_alt="alt-user",
+            chat_id_alt="alt-chat",
+            guild_id="guild-1",
+            parent_chat_id="parent-1",
+            message_id="m-123",
+            guest_query_id="guest-query-999",
         )
         d = source.to_dict()
         restored = SessionSource.from_dict(d)
 
         assert restored.platform == Platform.TELEGRAM
         assert restored.chat_id == "12345"
-        assert restored.chat_name == "My Group"
+        assert restored.chat_name == "Group"
         assert restored.chat_type == "group"
-        assert restored.user_id == "99"
-        assert restored.user_name == "alice"
-        assert restored.thread_id == "t1"
+        assert restored.user_id == "42"
+        assert restored.user_name == "Alice"
+        assert restored.thread_id == "99"
+        assert restored.chat_topic == "Topic A"
+        assert restored.user_id_alt == "alt-user"
+        assert restored.chat_id_alt == "alt-chat"
+        assert restored.guild_id == "guild-1"
+        assert restored.parent_chat_id == "parent-1"
+        assert restored.message_id == "m-123"
+        assert restored.guest_query_id == "guest-query-999"
 
     def test_full_roundtrip_with_chat_topic(self):
         """chat_topic should survive to_dict/from_dict roundtrip."""

--- a/tests/gateway/test_telegram_guest_mode.py
+++ b/tests/gateway/test_telegram_guest_mode.py
@@ -1,0 +1,212 @@
+import asyncio
+from types import MappingProxyType, SimpleNamespace
+from unittest.mock import AsyncMock
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import _thread_metadata_for_source
+from plugins.platforms.telegram.adapter import TelegramAdapter
+from gateway.run import GatewayRunner
+import plugins.platforms.telegram.adapter as telegram_mod
+
+
+class _GuestBot:
+    id = 8573596292
+    username = "hermes_iar_bot"
+    do_api_request = AsyncMock(return_value={"inline_message_id": "inline-1"})
+
+
+def _guest_raw_payload():
+    return {
+        "message_id": 1,
+        "date": 1700000000,
+        "chat": {"id": -100123, "type": "supergroup", "title": "External group"},
+        "from": {"id": 42, "is_bot": False, "first_name": "Caller"},
+        "text": "@hermes_iar_bot run a web search",
+        "entities": [{"type": "mention", "offset": 0, "length": 15}],
+        "guest_query_id": "guest-query-123",
+    }
+
+
+def _guest_message():
+    return SimpleNamespace(
+        message_id=1,
+        date=None,
+        chat=SimpleNamespace(id=-100123, type="supergroup", title="External group", is_forum=False),
+        from_user=SimpleNamespace(id=42, full_name="Caller", first_name="Caller", is_bot=False),
+        text="@hermes_iar_bot run a web search",
+        caption=None,
+        entities=[SimpleNamespace(type="mention", offset=0, length=15)],
+        caption_entities=[],
+        api_kwargs=MappingProxyType({"guest_query_id": "guest-query-123"}),
+        message_thread_id=None,
+        is_topic_message=False,
+        reply_to_message=None,
+    )
+
+
+def _guest_update_api_kwargs():
+    return SimpleNamespace(
+        update_id=123,
+        guest_message=None,
+        effective_message=None,
+        message=None,
+        api_kwargs=MappingProxyType({"guest_message": _guest_raw_payload()}),
+    )
+
+
+def test_allowed_updates_include_guest_message_even_when_ptb_all_types_omits_it():
+    assert "guest_message" in TelegramAdapter._telegram_allowed_updates()
+
+
+def test_guest_update_api_kwargs_is_parsed_and_routed_to_answer_guest_query(monkeypatch):
+    async def run():
+        _GuestBot.do_api_request.reset_mock()
+        monkeypatch.setattr(
+            telegram_mod.Message,
+            "de_json",
+            staticmethod(lambda raw, bot: _guest_message()),
+            raising=False,
+        )
+        adapter = TelegramAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="fake-token",
+                extra={"guest_mode": True, "require_mention": True},
+            )
+        )
+        adapter._bot = _GuestBot()
+
+        captured = []
+        adapter._enqueue_text_event = lambda event: captured.append(event)
+
+        update = _guest_update_api_kwargs()
+        assert update.effective_message is None  # PTB 22.x does not model guest_message yet
+
+        await adapter._handle_guest_update(update, None)
+
+        assert len(captured) == 1
+        event = captured[0]
+        assert event.text == "run a web search"
+        assert event.source.chat_id == "-100123"
+        assert event.source.guest_query_id == "guest-query-123"
+
+        metadata = _thread_metadata_for_source(event.source)
+        assert metadata == {"telegram_guest_query_id": "guest-query-123"}
+
+        result = await adapter.send(event.source.chat_id, "guest response", metadata=metadata)
+
+        assert result.success is True
+        _GuestBot.do_api_request.assert_awaited_once()
+        (endpoint,) = _GuestBot.do_api_request.call_args.args
+        payload = _GuestBot.do_api_request.call_args.kwargs["api_kwargs"]
+        assert endpoint == "answerGuestQuery"
+        assert payload["guest_query_id"] == "guest-query-123"
+        assert payload["result"]["type"] == "article"
+        assert payload["result"]["input_message_content"]["message_text"] == "guest response"
+
+    asyncio.run(run())
+
+
+def test_gateway_runner_thread_metadata_preserves_guest_query_id():
+    runner = object.__new__(GatewayRunner)
+    runner._thread_metadata_for_target = lambda *args, **kwargs: {"thread_id": "t-1"}
+    source = SimpleNamespace(
+        platform="telegram",
+        chat_id="-100123",
+        thread_id="t-1",
+        chat_type="supergroup",
+        message_id="777",
+        guest_query_id="guest-query-789",
+    )
+
+    meta = GatewayRunner._thread_metadata_for_source(runner, source)
+
+    assert meta == {"thread_id": "t-1", "telegram_guest_query_id": "guest-query-789"}
+
+
+def test_guest_reply_disables_streaming():
+    """Guest Mode replies are one-shot (answerGuestQuery) and must never stream.
+
+    Private-chat guest replies were delivered purely through the streaming/edit
+    path, whose intermediate sends drop the guest_query_id token and fall back
+    to sendMessage in a chat the guest bot isn't a member of. Streaming must be
+    forced off whenever the source carries a guest_query_id, so the reply goes
+    out as a single consolidated answerGuestQuery.
+    """
+    dm_source = SimpleNamespace(
+        platform="telegram",
+        chat_type="dm",
+        guest_query_id="guest-query-789",
+    )
+    group_source = SimpleNamespace(
+        platform="telegram",
+        chat_type="supergroup",
+        guest_query_id="guest-query-789",
+    )
+    normal_source = SimpleNamespace(
+        platform="telegram",
+        chat_type="dm",
+        guest_query_id=None,
+    )
+
+    # Guest replies (DM or group) must disable streaming even when enabled.
+    assert GatewayRunner._streaming_allowed_for_source(dm_source, True) is False
+    assert GatewayRunner._streaming_allowed_for_source(group_source, True) is False
+    # Non-guest replies follow the incoming streaming config unchanged.
+    assert GatewayRunner._streaming_allowed_for_source(normal_source, True) is True
+    assert GatewayRunner._streaming_allowed_for_source(normal_source, False) is False
+
+
+def test_guest_update_uses_caller_chat_when_present(monkeypatch):
+    async def run():
+        _GuestBot.do_api_request.reset_mock()
+
+        def _caller_message():
+            return SimpleNamespace(
+                message_id=1,
+                date=None,
+                chat=SimpleNamespace(id=-100123, type="supergroup", title="Guest relay", is_forum=False),
+                from_user=SimpleNamespace(id=42, full_name="Caller", first_name="Caller", is_bot=False),
+                text="@hermes_iar_bot ping",
+                caption=None,
+                entities=[SimpleNamespace(type="mention", offset=0, length=15)],
+                caption_entities=[],
+                api_kwargs=MappingProxyType({
+                    "guest_query_id": "guest-query-456",
+                    "guest_bot_caller_chat": {"id": -200999, "type": "private", "first_name": "Target"},
+                    "guest_bot_caller_user": {"id": 99, "is_bot": False, "first_name": "Target", "last_name": "User"},
+                }),
+                message_thread_id=None,
+                is_topic_message=False,
+                reply_to_message=None,
+            )
+
+        monkeypatch.setattr(
+            telegram_mod.Message,
+            "de_json",
+            staticmethod(lambda raw, bot: _caller_message()),
+            raising=False,
+        )
+        adapter = TelegramAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="fake-token",
+                extra={"guest_mode": True, "require_mention": True},
+            )
+        )
+        adapter._bot = _GuestBot()
+
+        captured = []
+        adapter._enqueue_text_event = lambda event: captured.append(event)
+
+        update = _guest_update_api_kwargs()
+        await adapter._handle_guest_update(update, None)
+
+        assert len(captured) == 1
+        event = captured[0]
+        assert event.source.chat_id == "-200999"
+        assert event.source.chat_type == "dm"
+        assert event.source.user_id == "99"
+        assert event.source.guest_query_id == "guest-query-456"
+
+    asyncio.run(run())


### PR DESCRIPTION
## What does this PR do?

Adds support for **Telegram Bot API 10 guest messages** — a bot with `supports_guest_queries=true` (set in BotFather) can be summoned via `@mention` from chats it is **not** a member of, including another user's private chat, and replies through the one-shot `answerGuestQuery` path.

`main` currently has **no** guest-message support (a `grep` for `guest_message` / `answerGuestQuery` / `_telegram_allowed_updates` returns nothing — note the existing `guest_mode` config is a *different* feature: the group `@mention` bypass).

**Root cause that makes this non-trivial:** `python-telegram-bot` 22.x predates `guest_message` and omits it from `Update.ALL_TYPES`. Because Telegram **persists `allowed_updates` server-side**, polling with `ALL_TYPES` silently drops guest summons — they are never delivered, even when BotFather reports `supports_guest_queries=true`. The fix registers the literal `"guest_message"` update explicitly.

## Related Issue

Fixes #46196 — that issue describes the one-shot / no-streaming reply requirement, which is the final piece of this feature (it assumed guest delivery was already present).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/platforms/telegram/adapter.py`
  - `_telegram_allowed_updates()` = `Update.ALL_TYPES` + literal `"guest_message"`, wired into all four poll/webhook registration sites.
  - `_guest_message_from_update()` / `_guest_query_id_from_message()` / `_guest_caller_from_message()` — parse the new `guest_message`, `guest_query_id`, `guest_bot_caller_chat`/`guest_bot_caller_user` fields out of `message.api_kwargs` (PTB does not model them yet).
  - Route the reply through `answerGuestQuery` as a single consolidated send.
- `gateway/run.py`, `gateway/session.py`, `gateway/platforms/base.py` — thread the guest caller context + `guest_query_id` through the runner/session and disable streaming / interim edits for one-shot guest replies.
- `tests/gateway/test_telegram_guest_mode.py` (new), `tests/gateway/test_session.py` — coverage for delivery, caller-context extraction from `api_kwargs`, and the non-streaming reply path.

## How to Test

1. In BotFather, enable `supports_guest_queries=true` for the bot.
2. Run the gateway with the Telegram platform enabled.
3. From a private chat with **another** user (or a group the bot isn't in), `@mention` the bot.
4. **Expected:** logs show `[Telegram] Telegram guest_message accepted: chat=… from=…` and the bot replies with a **single** consolidated message via `answerGuestQuery` (no streaming / edits).
5. Unit: `scripts/run_tests.sh tests/gateway/test_telegram_guest_mode.py -- -q` → all pass.

> Reviewer note: because `allowed_updates` is persisted server-side, running a build *without* the `"guest_message"` registration will overwrite the set and disable delivery until re-registered.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(telegram):`, `test(telegram):`)
- [x] I searched for existing PRs — no duplicate for `guest_message` / `answerGuestQuery`
- [x] My PR contains **only** changes related to this feature
- [x] Touched test area passes under the CI-parity runner (`scripts/run_tests.sh tests/gateway/`); the new tests pass under per-file isolation. One **pre-existing, unrelated** failure remains (`test_agent_cache.py::TestExtractCacheBustingConfig::test_honcho_cache_busting_config_memoized_by_mtime`), in code this PR does not touch.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Debian 13 (Linux 6.12, x86_64), Python 3.11.15

### Documentation & Housekeeping

- [x] Documentation — N/A (no new config key; `guest_mode` already documented)
- [x] `cli-config.yaml.example` — N/A (not touched)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (protocol/plumbing only, no OS-specific calls)