### PR TITLE
fix(telegram): prune stale DM topic binding in the media/anchor-retry fallback too (follow-up to #50990)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -934,6 +934,25 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             if reset_media is not None:
                 reset_media()
+            # If the topic itself is gone (Bot API "thread not found"), the
+            # retry below strips routing but the stale
+            # ``telegram_dm_topic_bindings`` row would survive and keep steering
+            # future inbound messages back into the deleted topic (#31501) — the
+            # same prune the streaming-send and control-message fallbacks
+            # already perform. Gated on ``_is_thread_not_found_error`` exactly
+            # like those sites, so a case-1 stale reply anchor (the topic still
+            # exists) and a merely ``topic_closed`` topic are deliberately left
+            # untouched; only the ``direct_messages_topic_id`` topic-deletion
+            # case prunes.
+            if (
+                metadata
+                and metadata.get("direct_messages_topic_id")
+                and self._is_thread_not_found_error(send_err)
+            ):
+                self._prune_stale_dm_topic_binding(
+                    send_kwargs.get("chat_id"),
+                    metadata.get("direct_messages_topic_id"),
+                )
             retry_kwargs = dict(send_kwargs)
             retry_kwargs["reply_to_message_id"] = None
             retry_kwargs.pop("message_thread_id", None)

--- a/tests/gateway/test_telegram_prune_stale_topic_binding_31501.py
+++ b/tests/gateway/test_telegram_prune_stale_topic_binding_31501.py
@@ -26,6 +26,7 @@ The fix has three pieces — these tests pin all three:
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 from types import SimpleNamespace
 
@@ -456,4 +457,128 @@ class TestRecoveryAfterPrune:
             thread_id="1",
         ))
         assert after == "111"
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Media / synthetic send path — #50990 wired the streaming and control-message
+# fallbacks but not _send_with_dm_topic_reply_anchor_retry, so #31501 recurred
+# for photo/voice/document/synthetic sends.  Drive the helper end-to-end.
+# ---------------------------------------------------------------------------
+
+
+class _BadRequest(Exception):
+    """Stand-in for ``telegram.error.BadRequest``.
+
+    ``_is_bad_request_error`` sniffs the class name, so any exception whose
+    name ends in ``badrequest`` is treated as a permanent BadRequest.
+    """
+
+
+class TestAnchorRetryMediaPathPrunesBinding:
+    """The media / synthetic send path must also prune the stale binding when
+    Telegram reports the DM topic is gone — and must NOT prune when only the
+    reply anchor is stale (case-1) or the topic is merely ``topic_closed``.
+    """
+
+    @staticmethod
+    def _drive(adapter, *, error, metadata, reply_to_message_id=None):
+        """Run the anchor-retry helper with a send_fn that fails once with
+        ``error`` then succeeds; return (result, list-of-call-kwargs)."""
+        calls = []
+
+        async def send_fn(**kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                raise error
+            return SimpleNamespace(message_id=999)
+
+        send_kwargs = {
+            "chat_id": "5595856929",
+            "message_thread_id": 15287,
+            "direct_messages_topic_id": 15287,
+            "reply_to_message_id": reply_to_message_id,
+        }
+        result = asyncio.run(
+            adapter._send_with_dm_topic_reply_anchor_retry(
+                send_fn,
+                send_kwargs,
+                metadata,
+                reply_to_message_id,
+                "photo",
+            )
+        )
+        return result, calls
+
+    def test_prunes_when_topic_deleted(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        _seed_binding(db, thread_id="15287")
+        adapter = _bare_adapter(db)
+
+        result, calls = self._drive(
+            adapter,
+            error=_BadRequest("Bad Request: message thread not found"),
+            metadata={
+                "telegram_dm_topic_reply_fallback": True,
+                "direct_messages_topic_id": 15287,
+            },
+        )
+
+        # Retried with routing stripped, and the retry succeeded.
+        assert len(calls) == 2
+        assert calls[1].get("message_thread_id") is None
+        assert calls[1].get("direct_messages_topic_id") is None
+        assert result.message_id == 999
+        # The stale binding is gone, so recovery stops resurrecting the
+        # deleted topic for the next inbound message (#31501).
+        assert db.get_telegram_topic_binding(
+            chat_id="5595856929", thread_id="15287",
+        ) is None
+        db.close()
+
+    def test_does_not_prune_on_stale_reply_anchor(self, tmp_path):
+        # Case-1: the reply *target* was deleted, not the topic. The topic is
+        # still alive, so the binding must survive even though we retry.
+        db = SessionDB(db_path=tmp_path / "state.db")
+        _seed_binding(db, thread_id="15287")
+        adapter = _bare_adapter(db)
+
+        _result, calls = self._drive(
+            adapter,
+            error=_BadRequest(
+                "Bad Request: message to be replied not found",
+            ),
+            metadata={
+                "telegram_dm_topic_reply_fallback": True,
+                "direct_messages_topic_id": 15287,
+            },
+            reply_to_message_id=4242,
+        )
+
+        assert len(calls) == 2  # still retried without the anchor
+        assert db.get_telegram_topic_binding(
+            chat_id="5595856929", thread_id="15287",
+        ) is not None
+        db.close()
+
+    def test_does_not_prune_when_topic_only_closed(self, tmp_path):
+        # ``topic_closed`` triggers the retry (it is a topic marker) but the
+        # topic still exists, so the binding must NOT be pruned.
+        db = SessionDB(db_path=tmp_path / "state.db")
+        _seed_binding(db, thread_id="15287")
+        adapter = _bare_adapter(db)
+
+        _result, calls = self._drive(
+            adapter,
+            error=_BadRequest("Bad Request: TOPIC_CLOSED"),
+            metadata={
+                "telegram_dm_topic_reply_fallback": True,
+                "direct_messages_topic_id": 15287,
+            },
+        )
+
+        assert len(calls) == 2
+        assert db.get_telegram_topic_binding(
+            chat_id="5595856929", thread_id="15287",
+        ) is not None
         db.close()


### PR DESCRIPTION
## Follow-up to #50990 (closes #31501 for the media path)

#50990 added `_prune_stale_dm_topic_binding` and wired it into **2 of the 3**
deleted-topic fallback sites:

- the streaming send loop (`send`, "retrying without message_thread_id"), and
- the control-message helper (`_send_message_with_thread_fallback`).

The **third** site — `_send_with_dm_topic_reply_anchor_retry`, the path every
media / synthetic send goes through (`send_image_file` / voice / audio /
document) — strips the dead-topic routing on retry but never prunes the binding:

```python
retry_kwargs.pop("message_thread_id", None)
retry_kwargs.pop("direct_messages_topic_id", None)
return await send_fn(**retry_kwargs)
```

So `gateway.run._recover_telegram_topic_thread_id` keeps walking the user's
bindings newest-first and steering future inbound messages back into the
deleted topic — the exact #31501 symptom — for the photo / voice / document /
synthetic subset. #50990 only stands recovery down when a **text/control** send
fails first.

## Fix

Prune at this site too, gated on `self._is_thread_not_found_error(send_err)` —
**the same gate the two existing sites use** — so the media path prunes on
exactly the same genuine-deletion condition, not a broader one:

- **case-1** (stale *reply anchor*: `"message to be replied not found"`, the
  topic is still alive) → retried, **not** pruned;
- **`topic_closed`** (topic merely closed, still exists) → retried, **not**
  pruned;
- only the `direct_messages_topic_id` topic-deletion case prunes.

`chat_id` comes from `send_kwargs`; the binding key (`thread_id`) is
`metadata["direct_messages_topic_id"]` (== the bound `thread_id` per
`gateway.run.bind_telegram_topic`). The prune helper is best-effort and already
swallows its own errors, so a failed cleanup can never turn a successful retry
into a failed send.

## Tests

Extends `tests/gateway/test_telegram_prune_stale_topic_binding_31501.py` with a
behavioral class that drives `_send_with_dm_topic_reply_anchor_retry`
end-to-end (real helper + real `SessionDB`) across the three cases: topic
deleted → pruned + retry succeeds; stale reply anchor → retried, binding kept;
`topic_closed` → retried, binding kept.

All file:line references and the prune gate were source-verified against `main`.
