### PR TITLE
fix(dashboard): remove env-seeded auth on API key delete

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -733,6 +733,106 @@ class EnvVarReveal(BaseModel):
     profile: Optional[str] = None
 
 
+def _auth_provider_ids_for_env_key(key: str) -> List[str]:
+    """Return provider ids that may seed credentials from an env var."""
+    env_key = str(key or "").strip()
+    if not env_key:
+        return []
+
+    provider_ids: List[str] = []
+    seen: set[str] = set()
+
+    def _add(provider_id: str) -> None:
+        normalized = str(provider_id or "").strip()
+        if normalized and normalized not in seen:
+            seen.add(normalized)
+            provider_ids.append(normalized)
+
+    # OpenRouter is still special-cased in the credential pool seeding path.
+    if env_key == "OPENROUTER_API_KEY":
+        _add("openrouter")
+
+    # Anthropic accepts several env-token forms before consulting the registry.
+    if env_key in {"ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY"}:
+        _add("anthropic")
+
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY
+    except Exception:
+        return provider_ids
+
+    for provider_id, config in PROVIDER_REGISTRY.items():
+        env_vars = getattr(config, "api_key_env_vars", ()) or ()
+        if env_key in env_vars:
+            _add(provider_id)
+    return provider_ids
+
+
+def _set_env_source_suppression(
+    key: str,
+    *,
+    suppressed: bool,
+    extra_provider_ids: Optional[List[str]] = None,
+) -> None:
+    """Toggle suppression for credentials seeded from a Desktop-managed env var."""
+    provider_ids = _auth_provider_ids_for_env_key(key)
+    for provider_id in extra_provider_ids or []:
+        if provider_id not in provider_ids:
+            provider_ids.append(provider_id)
+    if not provider_ids:
+        return
+
+    source = f"env:{key}"
+    try:
+        from hermes_cli.auth import suppress_credential_source, unsuppress_credential_source
+    except Exception:
+        return
+
+    for provider_id in provider_ids:
+        if suppressed:
+            suppress_credential_source(provider_id, source)
+        else:
+            unsuppress_credential_source(provider_id, source)
+
+
+def _prune_env_seeded_credentials(key: str) -> List[str]:
+    """Remove credential-pool entries that were seeded from a deleted env var."""
+    source = f"env:{key}"
+    try:
+        from hermes_cli.auth import _auth_store_lock, _load_auth_store, _save_auth_store
+    except Exception:
+        return []
+
+    pruned_providers: List[str] = []
+    with _auth_store_lock():
+        auth_store = _load_auth_store()
+        pool = auth_store.get("credential_pool")
+        if not isinstance(pool, dict):
+            return []
+
+        changed = False
+        for provider_id, entries in list(pool.items()):
+            if not isinstance(entries, list):
+                continue
+            retained = [
+                entry for entry in entries
+                if not (isinstance(entry, dict) and entry.get("source") == source)
+            ]
+            if len(retained) == len(entries):
+                continue
+            if retained:
+                pool[provider_id] = retained
+            else:
+                pool.pop(provider_id, None)
+            pruned_providers.append(str(provider_id))
+            changed = True
+
+        if changed:
+            _save_auth_store(auth_store)
+
+    return sorted(pruned_providers)
+
+
 class MemoryProviderConfigUpdate(BaseModel):
     values: Dict[str, str] = {}
 
@@ -4207,6 +4307,7 @@ async def set_env_var(body: EnvVarUpdate, profile: Optional[str] = None):
     try:
         with _profile_scope(body.profile or profile):
             save_env_value(body.key, body.value)
+            _set_env_source_suppression(body.key, suppressed=False)
         return {"ok": True, "key": body.key}
     except ValueError as exc:
         # save_env_value raises ValueError for invalid names and for keys
@@ -4326,9 +4427,19 @@ async def remove_env_var(body: EnvVarDelete, profile: Optional[str] = None):
     try:
         with _profile_scope(body.profile or profile):
             removed = remove_env_value(body.key)
-        if not removed:
-            raise HTTPException(status_code=404, detail=f"{body.key} not found in .env")
-        return {"ok": True, "key": body.key}
+            if not removed:
+                raise HTTPException(status_code=404, detail=f"{body.key} not found in .env")
+            pruned_providers = _prune_env_seeded_credentials(body.key)
+            _set_env_source_suppression(
+                body.key,
+                suppressed=True,
+                extra_provider_ids=pruned_providers,
+            )
+        return {
+            "ok": True,
+            "key": body.key,
+            "auth_providers_removed": pruned_providers,
+        }
     except HTTPException:
         raise
     except ValueError as exc:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1376,6 +1376,73 @@ class TestWebServerEndpoints:
         assert data["AWS_REGION"]["category"] == "provider"
         assert data["AWS_PROFILE"]["provider"] == "bedrock"
 
+    def test_delete_env_var_prunes_matching_env_seeded_auth_entry(self, monkeypatch):
+        """Deleting a Desktop-managed provider key also clears its env-seeded pool entry."""
+        from hermes_constants import get_hermes_home
+        from agent.credential_pool import load_pool
+
+        hermes_home = get_hermes_home()
+        env_path = hermes_home / ".env"
+        auth_path = hermes_home / "auth.json"
+        env_path.write_text("ZAI_API_KEY=sk-zai-old\nOTHER_KEY=keep-me\n")
+        monkeypatch.setenv("ZAI_API_KEY", "sk-zai-old")
+
+        auth_path.write_text(json.dumps({
+            "version": 1,
+            "credential_pool": {
+                "zai": [
+                    {
+                        "id": "env-zai",
+                        "label": "ZAI_API_KEY",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "env:ZAI_API_KEY",
+                        "access_token": "sk-zai-old",
+                    },
+                    {
+                        "id": "manual-zai",
+                        "label": "manual",
+                        "auth_type": "api_key",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "sk-zai-manual",
+                    },
+                ],
+                "minimax-cn": [
+                    {
+                        "id": "env-minimax",
+                        "label": "MINIMAX_CN_API_KEY",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "env:MINIMAX_CN_API_KEY",
+                        "access_token": "sk-minimax",
+                    }
+                ],
+            },
+        }))
+
+        resp = self.client.request("DELETE", "/api/env", json={"key": "ZAI_API_KEY"})
+
+        assert resp.status_code == 200
+        assert resp.json()["auth_providers_removed"] == ["zai"]
+        assert "ZAI_API_KEY" not in env_path.read_text()
+        assert "OTHER_KEY=keep-me" in env_path.read_text()
+        assert os.environ.get("ZAI_API_KEY") is None
+
+        auth_store = json.loads(auth_path.read_text())
+        assert [entry["source"] for entry in auth_store["credential_pool"]["zai"]] == ["manual"]
+        assert auth_store["credential_pool"]["minimax-cn"][0]["source"] == "env:MINIMAX_CN_API_KEY"
+        assert auth_store["suppressed_sources"]["zai"] == ["env:ZAI_API_KEY"]
+
+        set_resp = self.client.put("/api/env", json={"key": "ZAI_API_KEY", "value": "sk-zai-new"})
+
+        assert set_resp.status_code == 200
+        auth_store = json.loads(auth_path.read_text())
+        assert "zai" not in auth_store.get("suppressed_sources", {})
+        pool = load_pool("zai")
+        assert any(entry.source == "env:ZAI_API_KEY" and entry.access_token == "sk-zai-new" for entry in pool.entries())
+        assert any(entry.source == "manual" and entry.access_token == "sk-zai-manual" for entry in pool.entries())
+
     def test_platform_scoped_messaging_env_vars_are_channel_managed(self):
         from hermes_cli.web_server import (
             _MESSAGING_KEYS_PAGE_KEYS,


### PR DESCRIPTION
## What does this PR do?

Fixes the Desktop Settings "Delete API Key" path so removing a provider key no longer leaves a stale env-seeded credential in `auth.json`.

Root cause: `DELETE /api/env` only removed the key from `~/.hermes/.env` and `os.environ`. The credential pool can also contain entries seeded from that env var (`source: env:<KEY>`), so providers such as Z.AI or MiniMax could continue appearing in the model selector after the user deleted their key.

This change:

- maps deleted env keys back to provider ids using the existing provider registry plus the OpenRouter/Anthropic special cases used by credential seeding
- removes only credential-pool entries whose `source` exactly matches the deleted env var
- preserves manual credentials and unrelated provider entries
- suppresses the deleted env source so an exported shell env var does not immediately re-seed the deleted credential
- clears that suppression when the Desktop Settings page saves the same key again

## Related Issue

Fixes #51071

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/web_server.py`: prune matching env-seeded credential-pool entries after a successful `DELETE /api/env`, and toggle the existing credential-source suppression when deleting/re-saving a Desktop-managed key.
- `tests/hermes_cli/test_web_server.py`: cover the delete/re-add flow for `ZAI_API_KEY`, including manual credential preservation and unrelated provider preservation.

## How to Test

Duplicate check performed: no open or closed PRs found for `delete api key auth.json stale provider credential_pool env`; issue search only found #51071.

Validation run locally on macOS:

1. `uv sync --frozen --extra dev`
2. `uv run scripts/run_tests.sh tests/hermes_cli/test_web_server.py -- -k test_delete_env_var_prunes_matching_env_seeded_auth_entry --tb=long`
3. `uv run scripts/run_tests.sh tests/hermes_cli/test_web_server.py -- --tb=long`
4. `uv run ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_server.py`
5. `uv run python scripts/check-windows-footguns.py --all`
6. `git diff --check origin/main...HEAD`
7. `uv run ty check hermes_cli/web_server.py tests/hermes_cli/test_web_server.py` reports the existing broad file baseline (88 diagnostics, e.g. Starlette middleware typing, existing `None` defaults, and existing theme-test nullability); no diagnostics point at the new helper or regression test.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] Documentation updates N/A: this is backend behavior for an existing Settings action
- [x] `cli-config.yaml.example` N/A: no config keys added or changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` N/A: no architecture or workflow change
- [x] Cross-platform impact considered: uses existing auth-store helpers and no shell/path/process changes
- [x] Tool descriptions/schemas N/A: no model tool behavior changed
