### PR TITLE
fix(agent): persist session progress across tool loops and compression

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -338,6 +338,16 @@ def compress_context(
     # Set True once the in-place DB write actually completes (the DB block can
     # raise and skip it). Surfaced to the gateway via agent._last_compaction_in_place.
     compacted_in_place = False
+    compressed_messages_persisted = False
+
+    def _mark_compressed_messages_persisted() -> None:
+        """Align the incremental DB flush cursor with the compacted transcript."""
+        agent._flushed_db_message_ids = {
+            id(msg) for msg in compressed if isinstance(msg, dict)
+        }
+        agent._flushed_db_message_session_id = getattr(agent, "session_id", None)
+        agent._last_flushed_db_idx = len(compressed)
+
     logger.info(
         "context compression started: session=%s messages=%d tokens=~%s model=%s focus=%r",
         agent.session_id or "none", _pre_msg_count,
@@ -544,12 +554,13 @@ def compress_context(
                 # WITHOUT destroying history, unlike a hard replace_messages).
                 # See #38763.
                 agent._session_db.archive_and_compact(agent.session_id, compressed)
-                # Reset the flush identity set so the next turn's appends are
-                # diffed against the COMPACTED transcript: the compacted dicts
-                # are passed as conversation_history next turn and skipped by
-                # identity, so only genuinely new turn messages get appended
-                # (no dup of the summary, no resurrection of dropped turns).
-                agent._flushed_db_message_ids = set()
+                # Mark the compacted dicts as already persisted. Auto-
+                # compression continues the same turn after this call, and
+                # final persistence may run before the next turn reloads
+                # conversation_history from SQLite; the identity cursor keeps
+                # that final flush from appending the summary a second time.
+                _mark_compressed_messages_persisted()
+                compressed_messages_persisted = True
                 # Rotation-independent signal: the conversation was compacted in
                 # place (id unchanged). The gateway reads this (NOT an id-change
                 # diff) to re-baseline transcript handling.
@@ -639,6 +650,20 @@ def compress_context(
                     agent._session_db_created = True
                     raise
                 agent._session_db_created = True
+                try:
+                    # The continuation child must be durable immediately after
+                    # rotation. Waiting for final turn persistence leaves a
+                    # restart window where the child row exists but has no live
+                    # transcript, so resume starts from only the next prompt.
+                    agent._session_db.replace_messages(agent.session_id, compressed)
+                    _mark_compressed_messages_persisted()
+                    compressed_messages_persisted = True
+                except Exception as _msg_err:
+                    logger.warning(
+                        "Compression child transcript write failed for session %s: %s",
+                        agent.session_id or "?",
+                        _msg_err,
+                    )
                 # Carry a persistent /goal onto the continuation session.
                 # Compression mints a fresh child id; load_goal does a flat
                 # per-session lookup with no parent walk, so without this an
@@ -658,10 +683,11 @@ def compress_context(
 
             # Shared post-write steps (both modes target agent.session_id, which
             # in-place keeps and rotation has already reassigned to the new id):
-            # refresh the stored system prompt and reset the flush cursor so the
-            # next turn re-bases its append diff.
+            # refresh the stored system prompt and only reset the flush cursor
+            # when the compacted rows were not durably written above.
             agent._session_db.update_system_prompt(agent.session_id, new_system_prompt)
-            agent._last_flushed_db_idx = 0
+            if not compressed_messages_persisted:
+                agent._last_flushed_db_idx = 0
         except Exception as e:
             # If the rotation rolled back to the parent (orphan-avoidance
             # above), agent.session_id is the still-indexed parent and

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4077,6 +4077,11 @@ def run_conversation(
                         pass
 
                 agent._execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count)
+                agent._checkpoint_session_progress(
+                    messages,
+                    conversation_history,
+                    reason="post_tool_execution",
+                )
 
                 if agent._tool_guardrail_halt_decision is not None:
                     decision = agent._tool_guardrail_halt_decision

--- a/run_agent.py
+++ b/run_agent.py
@@ -1521,6 +1521,62 @@ class AIAgent:
         self._save_session_log(messages)
         self._flush_messages_to_session_db(messages, conversation_history)
 
+    def _checkpoint_session_progress(
+        self,
+        messages: List[Dict],
+        conversation_history: List[Dict] = None,
+        *,
+        reason: str = "tool_iteration",
+    ) -> None:
+        """Best-effort durable checkpoint for long in-flight tool loops.
+
+        ``_persist_session`` runs at turn start and finalization. Long TUI
+        coding turns can execute many assistant(tool_calls) + tool-result
+        iterations before finalization; if the desktop is rebuilt/restarted in
+        that window, resume sees only the first user row. This checkpoint writes
+        the valid prefix after each completed tool batch while preserving the
+        append de-dupe/identity semantics owned by
+        ``_flush_messages_to_session_db``.
+
+        Checkpoint failures must never interrupt the live turn: they are a
+        crash-resilience aid, not part of model/tool execution correctness.
+        """
+        session_id = getattr(self, "session_id", None) or "none"
+        try:
+            self._apply_persist_user_message_override(messages)
+            self._session_messages = messages
+        except Exception as exc:
+            logger.warning(
+                "Session progress checkpoint preparation failed "
+                "(session=%s, reason=%s): %s",
+                session_id,
+                reason,
+                exc,
+            )
+            return
+
+        try:
+            self._save_session_log(messages)
+        except Exception as exc:
+            logger.warning(
+                "Session progress JSON checkpoint failed "
+                "(session=%s, reason=%s): %s",
+                session_id,
+                reason,
+                exc,
+            )
+
+        try:
+            self._flush_messages_to_session_db(messages, conversation_history)
+        except Exception as exc:
+            logger.warning(
+                "Session progress DB checkpoint failed "
+                "(session=%s, reason=%s): %s",
+                session_id,
+                reason,
+                exc,
+            )
+
     def _drop_trailing_empty_response_scaffolding(self, messages: List[Dict]) -> None:
         """Remove private empty-response retry/failure scaffolding from transcript tails.
 
@@ -1579,7 +1635,7 @@ class AIAgent:
         from agent.agent_runtime_helpers import repair_message_sequence
         return repair_message_sequence(self, messages)
 
-    def _flush_messages_to_session_db(self, messages: List[Dict], conversation_history: List[Dict] = None):
+    def _flush_messages_to_session_db(self, messages: List[Dict], conversation_history: Optional[List[Dict]] = None):
         """Persist any un-flushed messages to the SQLite session store.
 
         Uses per-session message identity tracking so repeated calls (from

--- a/tests/agent/test_compression_rotation_state.py
+++ b/tests/agent/test_compression_rotation_state.py
@@ -87,6 +87,25 @@ class TestGoalMigratesOnRotation:
             goals._DB_CACHE.clear()
 
 
+class TestCompressedChildDurability:
+    def test_rotation_writes_child_messages_before_turn_finalization(self, tmp_path: Path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        parent = "PARENT_CHILD_ROWS"
+        db.create_session(parent, source="cli")
+        agent = _build_agent_with_db(db, parent)
+
+        agent._compress_context(_msgs(), "sys", approx_tokens=120_000)
+        child = agent.session_id
+
+        assert child != parent
+        rows = db.get_messages_as_conversation(child)
+        assert [row["content"] for row in rows] == [
+            "[CONTEXT COMPACTION] summary",
+            "tail",
+        ]
+        assert agent._last_flushed_db_idx == len(rows)
+
+
 class TestOrphanRollbackOnCreateFailure:
     def test_rolls_back_to_parent_when_child_create_fails(self, tmp_path: Path):
         db = SessionDB(db_path=tmp_path / "state.db")

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -230,11 +230,10 @@ class TestHTTP413Compression:
     def test_413_clears_conversation_history_on_persist(self, agent):
         """After 413-triggered compression, _persist_session must receive None history.
 
-        Bug: _compress_context() creates a new session and resets _last_flushed_db_idx=0,
-        but if conversation_history still holds the original (pre-compression) list,
-        _flush_messages_to_session_db computes flush_from = max(len(history), 0) which
-        exceeds len(compressed_messages), so messages[flush_from:] is empty and nothing
-        is written to the new session → "Session found but has no messages" on resume.
+        Bug: after _compress_context() creates a compressed session, stale
+        conversation_history can make positional flush logic slice past the
+        compacted message list. Nothing is written to the new session, so
+        resume reports "Session found but has no messages."
         """
         err_413 = _make_413_error()
         ok_resp = _mock_response(content="OK", finish_reason="stop")

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -7,7 +7,7 @@ agent) and JSONL (via the gateway).
 Bug scenario (pre-fix):
   1. Gateway loads 200-message history, passes to agent
   2. Agent's run_conversation() compresses to ~30 messages mid-run
-  3. _compress_context() resets _last_flushed_db_idx = 0
+  3. The old positional flush logic re-baselines at the compressed session
   4. On exit, _flush_messages_to_session_db() calculates:
      flush_from = max(len(conversation_history=200), _last_flushed_db_idx=0) = 200
   5. messages[200:] is empty (only ~30 messages after compression)

--- a/tests/run_agent/test_in_place_compaction.py
+++ b/tests/run_agent/test_in_place_compaction.py
@@ -3,10 +3,11 @@
 When ``compression.in_place`` is True, ``compress_context()`` rewrites the
 message list and rebuilds the system prompt but keeps the SAME ``session_id``:
 no ``end_session``, no ``parent_session_id`` child row, no ``name #N`` title
-renumber, no flush-cursor reset. This eliminates the session-rotation bug
-cluster (#33618 /goal loss, #14238 lost response, #33907 orphans, #45117 search
-gaps, #42228 null cwd). When the flag is False (default), rotation behaves
-exactly as before.
+renumber. The DB flush cursor is aligned to the compacted rows so final
+same-turn persistence does not duplicate them. This eliminates the
+session-rotation bug cluster (#33618 /goal loss, #14238 lost response,
+#33907 orphans, #45117 search gaps, #42228 null cwd). When the flag is False
+(default), rotation behaves exactly as before.
 """
 
 import os
@@ -115,10 +116,12 @@ class TestInPlaceCompaction:
                 (sid,),
             ).fetchone()
             assert hit is not None
-            # Flush identity/cursor reset so next-turn appends diff against the
-            # compacted transcript (rebuilds the identity set on next flush).
-            assert agent._last_flushed_db_idx == 0
-            assert agent._flushed_db_message_ids == set()
+            # Flush identity/cursor now matches the compacted transcript so a
+            # same-turn final persistence does not append the summary again.
+            assert agent._last_flushed_db_idx == len(compressed)
+            assert agent._flushed_db_message_ids == {
+                id(msg) for msg in compressed if isinstance(msg, dict)
+            }
             # Rotation-independent in-place signal set for the gateway.
             assert agent._last_compaction_in_place is True
             # Live transcript actually shrank.
@@ -162,6 +165,33 @@ class TestInPlaceCompaction:
                 approx_tokens=100_000, system_message="sys",
             )
             assert calls["n"] == 0
+
+    def test_in_place_final_flush_does_not_duplicate_compacted_rows(self):
+        """Final turn persistence runs after auto-compaction in the same turn.
+
+        The compacted rows were already inserted by archive_and_compact(), so
+        the identity cursor must skip them on the later flush.
+        """
+        from hermes_state import SessionDB
+        from agent.conversation_compression import compress_context
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            sid = "ip_final_flush"
+            _seed(db, sid, "flush")
+            agent = _make_agent(db, sid, in_place=True)
+            compressed, _ = compress_context(
+                agent, [{"role": "user", "content": "x"}] * 8,
+                approx_tokens=100_000, system_message="sys",
+            )
+
+            agent._flush_messages_to_session_db(compressed, None)
+
+            live_rows = db.get_messages_as_conversation(sid)
+            assert [m["content"] for m in live_rows] == [
+                "[CONTEXT COMPACTION] summary of prior turns",
+                "recent reply",
+            ]
 
     def test_rotation_still_preflushes(self):
         """Rotation MUST pre-flush so current-turn messages survive in the
@@ -211,10 +241,74 @@ class TestRotationStillDefault:
             ).fetchall()
             assert len(child) == 1
             assert child[0]["title"] == "my-research #2"
-            # Flush cursor reset for the new row.
-            assert agent._last_flushed_db_idx == 0
+            # The child row is durable immediately after rotation, before any
+            # later final-turn persistence has a chance to run.
+            child_messages = db.get_messages_as_conversation(agent.session_id)
+            assert [m["content"] for m in child_messages] == [
+                "[CONTEXT COMPACTION] summary of prior turns",
+                "recent reply",
+            ]
+            assert agent._last_flushed_db_idx == len(child_messages)
             # Rotation mode does NOT set the in-place signal.
             assert getattr(agent, "_last_compaction_in_place", False) is False
+
+    def test_rotation_final_flush_does_not_duplicate_compacted_rows(self):
+        """The child transcript is written at rotation, then flushed again on
+        normal turn finalization. The second flush must be a no-op for the
+        compacted rows.
+        """
+        from hermes_state import SessionDB
+        from agent.conversation_compression import compress_context
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            sid = "rot_final_flush"
+            _seed(db, sid, "flush")
+            agent = _make_agent(db, sid, in_place=False)
+            compressed, _ = compress_context(
+                agent, [{"role": "user", "content": "x"}] * 8,
+                approx_tokens=100_000, system_message="sys",
+            )
+
+            agent._flush_messages_to_session_db(compressed, None)
+
+            child_rows = db.get_messages_as_conversation(agent.session_id)
+            assert [m["content"] for m in child_rows] == [
+                "[CONTEXT COMPACTION] summary of prior turns",
+                "recent reply",
+            ]
+
+    def test_rotation_partial_tail_flush_appends_tail_once(self):
+        """Manual partial compression reattaches a verbatim tail after
+        _compress_context() returns. The compacted head is already persisted;
+        the final flush should append only the new tail rows.
+        """
+        from hermes_state import SessionDB
+        from agent.conversation_compression import compress_context
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            sid = "rot_tail_flush"
+            _seed(db, sid, "tail")
+            agent = _make_agent(db, sid, in_place=False)
+            compressed, _ = compress_context(
+                agent, [{"role": "user", "content": "x"}] * 8,
+                approx_tokens=100_000, system_message="sys",
+            )
+            tail = [
+                {"role": "user", "content": "tail question"},
+                {"role": "assistant", "content": "tail answer"},
+            ]
+
+            agent._flush_messages_to_session_db(compressed + tail, None)
+
+            child_rows = db.get_messages_as_conversation(agent.session_id)
+            assert [m["content"] for m in child_rows] == [
+                "[CONTEXT COMPACTION] summary of prior turns",
+                "recent reply",
+                "tail question",
+                "tail answer",
+            ]
 
 
 class TestInPlaceSignalForGateway:
@@ -313,4 +407,3 @@ class TestCompactedTurnsStaySearchable:
                 "ZEBRAWORD", role_filter=["user", "assistant"], include_inactive=True
             )
             assert len(recovered) == 1
-

--- a/tests/run_agent/test_incremental_tool_persistence.py
+++ b/tests/run_agent/test_incremental_tool_persistence.py
@@ -1,0 +1,120 @@
+"""Regression coverage for crash-safe tool-loop persistence.
+
+A long TUI turn can run dozens of API/tool iterations before producing a final
+assistant response. If Hermes is rebuilt/restarted during that window, only the
+early user turn was durable before this regression test existed. The next resume
+then loaded a one-message session even though logs proved substantial tool work
+had happened.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _tool_call_response():
+    tool_call = SimpleNamespace(
+        id="call_read_1",
+        type="function",
+        function=SimpleNamespace(
+            name="read_file",
+            arguments=json.dumps({"path": "README.md"}),
+        ),
+    )
+    message = SimpleNamespace(content=None, reasoning=None, tool_calls=[tool_call])
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason="tool_calls")],
+        usage=None,
+    )
+
+
+def _final_response():
+    message = SimpleNamespace(content="done", reasoning=None, tool_calls=[])
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason="stop")],
+        usage=None,
+    )
+
+
+class _CheckpointAwareCompletions:
+    def __init__(self, session_db):
+        self.session_db = session_db
+        self.calls = 0
+
+    def create(self, **kwargs):
+        self.calls += 1
+        if self.calls == 1:
+            return _tool_call_response()
+
+        # This second request is assembled after the first tool call was
+        # executed but before the final assistant response exists. The durable
+        # store must already contain the assistant tool-call turn and its tool
+        # result, otherwise a rebuild/restart in this window resumes a
+        # one-message session.
+        roles = [call.kwargs.get("role") for call in self.session_db.append_message.call_args_list]
+        assert roles == ["user", "assistant", "tool"]
+        return _final_response()
+
+
+def test_tool_results_checkpoint_before_next_model_call(monkeypatch):
+    session_db = MagicMock()
+    completions = _CheckpointAwareCompletions(session_db)
+    fake_client = SimpleNamespace(chat=SimpleNamespace(completions=completions))
+
+    monkeypatch.setattr("run_agent.OpenAI", lambda **kwargs: fake_client)
+    monkeypatch.setattr(
+        "run_agent.get_tool_definitions",
+        lambda *args, **kwargs: [{"function": {"name": "read_file"}}],
+    )
+    monkeypatch.setattr("run_agent.check_toolset_requirements", lambda *args, **kwargs: {})
+    monkeypatch.setattr(
+        "run_agent.handle_function_call",
+        lambda name, args, task_id=None, **kwargs: json.dumps({"ok": True}),
+    )
+
+    agent = AIAgent(
+        model="test-model",
+        api_key="test-key",
+        base_url="http://localhost:8080/v1",
+        platform="tui",
+        session_id="checkpoint-session",
+        session_db=session_db,
+        max_iterations=3,
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    setattr(agent, "_disable_streaming", True)
+
+    result = agent.run_conversation("read the file")
+
+    assert result["final_response"] == "done"
+    roles = [call.kwargs.get("role") for call in session_db.append_message.call_args_list]
+    assert roles == ["user", "assistant", "tool", "assistant"]
+
+
+def test_checkpoint_continues_to_db_when_json_log_fails():
+    agent = SimpleNamespace(
+        session_id="checkpoint-session",
+        _persist_user_message_idx=None,
+        _persist_user_message_override=None,
+        _persist_user_message_timestamp=None,
+        _session_messages=[],
+        _stash_api_user_message_override=lambda messages: None,
+        _apply_persist_user_message_override=lambda messages: None,
+        _strip_internal_message_fields=lambda messages: [m.copy() for m in messages],
+        _save_session_log=MagicMock(side_effect=OSError("disk full")),
+        _flush_messages_to_session_db=MagicMock(),
+    )
+
+    messages = [
+        {"role": "user", "content": "start"},
+        {"role": "assistant", "content": "", "tool_calls": []},
+    ]
+
+    getattr(AIAgent, "_checkpoint_session_progress")(agent, messages, reason="test")
+
+    agent._save_session_log.assert_called_once()
+    agent._flush_messages_to_session_db.assert_called_once_with(messages, None)

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1015,6 +1015,59 @@ def test_session_resume_follows_compression_tip(monkeypatch, tmp_path):
     assert "post-compression reply" in texts
 
 
+def test_session_resume_reuses_live_owner_after_unsynced_compression(monkeypatch):
+    """A running turn may rotate ``agent.session_id`` before the gateway syncs
+    ``session['session_key']``. Resuming the DB continuation during that window
+    must reattach to the live parent object, not build a second owner.
+    """
+
+    class FakeDB:
+        def get_session(self, target):
+            return {"id": target, "cwd": ""}
+
+        def get_session_by_title(self, _target):
+            return None
+
+        def resolve_resume_session_id(self, target):
+            return "cont_tip" if target == "parent_root" else target
+
+    live_agent = types.SimpleNamespace(
+        session_id="cont_tip",
+        model="test",
+        provider="test",
+    )
+    previous_sessions = dict(server._sessions)
+    server._sessions.clear()
+    server._sessions["live-parent"] = _session(
+        agent=live_agent,
+        session_key="parent_root",
+        running=True,
+    )
+    monkeypatch.setattr(server, "_get_db", lambda: FakeDB())
+    monkeypatch.setattr(
+        server,
+        "_fallback_session_info",
+        lambda _session: {"model": "test", "tools": {}, "skills": {}},
+    )
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.resume",
+                "params": {"session_id": "parent_root"},
+            }
+        )
+    finally:
+        server._sessions.clear()
+        server._sessions.update(previous_sessions)
+
+    assert resp["result"]["session_id"] == "live-parent"
+    assert resp["result"]["session_key"] == "cont_tip"
+    assert resp["result"]["running"] is True
+    assert resp["result"]["status"] == "working"
+
+
 def test_session_resume_passes_stored_runtime_to_agent(monkeypatch):
     captured = {}
 
@@ -5835,6 +5888,48 @@ def test_prompt_submit_preserves_empty_response_without_error(monkeypatch):
     # Text stays empty — we did NOT fabricate an "Error:" string
     text = payload.get("text", "")
     assert text in {"", None}, f"expected empty text, got {text!r}"
+
+
+def test_prompt_submit_rejects_duplicate_live_continuation_owner(monkeypatch):
+    """If compression created a continuation DB row but the gateway session has
+    not synced its session_key yet, a resumed continuation must not accept a
+    second user turn while the original live owner is still running.
+    """
+
+    class _Agent:
+        def run_conversation(self, *args, **kwargs):  # pragma: no cover
+            raise AssertionError("duplicate owner should not run")
+
+    previous_sessions = dict(server._sessions)
+    server._sessions.clear()
+    server._sessions["parent-sid"] = _session(
+        agent=types.SimpleNamespace(session_id="cont-tip"),
+        session_key="parent-root",
+        running=True,
+    )
+    server._sessions["cont-sid"] = _session(
+        agent=_Agent(),
+        session_key="cont-tip",
+        running=False,
+    )
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {"session_id": "cont-sid", "text": "new turn"},
+            }
+        )
+        duplicate_running = server._sessions["cont-sid"]["running"]
+    finally:
+        server._sessions.clear()
+        server._sessions.update(previous_sessions)
+
+    assert resp["error"]["code"] == 4009
+    assert resp["error"]["message"] == "session busy"
+    assert duplicate_running is False
 
 
 # ── active live TUI sessions ─────────────────────────────────────────

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1566,7 +1566,7 @@ def _cwd_for_session_key(session_key: str) -> str:
         return ""
     with _sessions_lock:
         for sess in list(_sessions.values()):
-            if sess.get("session_key") == session_key:
+            if session_key in _session_live_keys(sess):
                 return str(sess.get("cwd") or "")
     return ""
 
@@ -1583,7 +1583,7 @@ def _set_session_context(session_key: str, cwd: str | None = None) -> list:
         source = "tui"
         with _sessions_lock:
             for sess in list(_sessions.values()):
-                if sess.get("session_key") == session_key:
+                if session_key in _session_live_keys(sess):
                     source = _session_source(sess)
                     break
         return set_session_vars(session_key=session_key, source=source, cwd=resolved)
@@ -2816,6 +2816,33 @@ def _current_profile_name() -> str:
 DESKTOP_BACKEND_CONTRACT = 2
 
 
+def _session_agent_id(session: dict | None) -> str:
+    agent = (session or {}).get("agent")
+    if agent is None:
+        return ""
+    return str(getattr(agent, "session_id", None) or "").strip()
+
+
+def _session_stored_key(session: dict | None) -> str:
+    agent_id = _session_agent_id(session)
+    if agent_id:
+        return agent_id
+    return str((session or {}).get("session_key") or "").strip()
+
+
+def _session_live_keys(session: dict | None) -> tuple[str, ...]:
+    keys: list[str] = []
+    for value in (
+        (session or {}).get("session_key"),
+        _session_agent_id(session),
+        (session or {}).get("resume_session_id"),
+    ):
+        key = str(value or "").strip()
+        if key and key not in keys:
+            keys.append(key)
+    return tuple(keys)
+
+
 def _session_info(agent, session: dict | None = None) -> dict:
     if session is None:
         for candidate in _sessions.values():
@@ -2823,9 +2850,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
                 session = candidate
                 break
     cwd = _session_cwd(session)
-    session_key = str(
-        (session or {}).get("session_key") or getattr(agent, "session_id", "") or ""
-    )
+    session_key = _session_stored_key(session or {"agent": agent})
     cfg_personality = ((_load_cfg().get("display") or {}).get("personality") or "")
     personality = (session or {}).get("personality", cfg_personality)
     reasoning_config = getattr(agent, "reasoning_config", None)
@@ -5067,7 +5092,7 @@ def _session_live_title(session: dict, key: str) -> str:
 
 
 def _session_live_item(sid: str, session: dict, current_sid: str = "") -> dict:
-    key = _session_lookup_key(session, fallback=sid)
+    key = _session_stored_key(session) or str(session.get("session_key") or sid)
     agent = session.get("agent")
     history = list(session.get("history") or [])
     status = _session_live_status(sid, session)
@@ -5091,23 +5116,52 @@ def _session_live_item(sid: str, session: dict, current_sid: str = "") -> dict:
     }
 
 
-def _session_lookup_key(session: dict, *, fallback: str = "") -> str:
-    agent = session.get("agent")
-    return str(
-        getattr(agent, "session_id", None)
-        or session.get("session_key")
-        or fallback
-        or ""
-    )
+def _live_session_match_score(session: dict, session_key: str) -> int:
+    score = 0
+    if _session_agent_id(session) == session_key:
+        score += 4
+    if session.get("running"):
+        score += 2
+    if not session.get("lazy"):
+        score += 1
+    return score
 
 
-def _find_live_session_by_key(session_key: str) -> tuple[str, dict] | None:
+def _session_owns_key_authoritatively(session: dict, session_key: str) -> bool:
+    return bool(session.get("running")) or _session_agent_id(session) == session_key
+
+
+def _find_live_session_by_key_locked(
+    session_key: str,
+    *,
+    exclude: dict | None = None,
+) -> tuple[str, dict] | None:
+    target = str(session_key or "").strip()
+    if not target:
+        return None
+    best: tuple[int, str, dict] | None = None
     for sid, session in list(_sessions.items()):
+        if session is exclude:
+            continue
         if session.get("_finalized"):
             continue
-        if _session_lookup_key(session, fallback=sid) == session_key:
-            return sid, session
-    return None
+        if target not in _session_live_keys(session):
+            continue
+        score = _live_session_match_score(session, target)
+        if best is None or score > best[0]:
+            best = (score, sid, session)
+    if best is None:
+        return None
+    return best[1], best[2]
+
+
+def _find_live_session_by_key(
+    session_key: str,
+    *,
+    exclude: dict | None = None,
+) -> tuple[str, dict] | None:
+    with _sessions_lock:
+        return _find_live_session_by_key_locked(session_key, exclude=exclude)
 
 
 def _fallback_session_info(session: dict) -> dict:
@@ -5143,13 +5197,14 @@ def _live_session_payload(
         )
         inflight = _inflight_snapshot(session)
         running = bool(session.get("running"))
+        key = _session_stored_key(session) or str(session.get("session_key") or sid)
     payload = {
         "info": _fallback_session_info(session),
         "message_count": len(history),
         "messages": _history_to_messages(history),
         "running": running,
         "session_id": sid,
-        "session_key": _session_lookup_key(session, fallback=sid),
+        "session_key": key,
         "started_at": float(session.get("created_at") or time.time()),
         "status": _session_live_status(sid, session),
     }
@@ -5249,7 +5304,11 @@ def _(rid, params: dict) -> dict:
             snapshot = list(_sessions.values())
     except Exception as e:
         return _err(rid, 5036, f"could not enumerate active sessions: {e}")
-    active = {s.get("session_key") for s in snapshot if s.get("session_key")}
+    active = {
+        key
+        for s in snapshot
+        for key in _session_live_keys(s)
+    }
     if target in active:
         return _err(rid, 4023, "cannot delete an active session")
     sessions_dir = get_hermes_home() / "sessions"
@@ -7454,36 +7513,48 @@ def _(rid, params: dict) -> dict:
     # or fallback moved the session transport to stdio.
     if (t := current_transport()) is not None:
         session["transport"] = t
-    with session["history_lock"]:
-        if session.get("running"):
-            return _err(rid, 4009, "session busy")
-        # A watch session's run lives in the PARENT turn, so its own running
-        # flag is False — without this, typing mid-run builds a second agent
-        # racing the in-flight child on the same stored session (interleaved
-        # transcript, stale fork). After the run completes, submitting is fine:
-        # the upgrade resumes the child's transcript as a normal conversation.
-        if session.get("lazy") and _child_run_active(str(session.get("session_key") or "")):
-            return _err(rid, 4009, "subagent still running — wait for it to finish")
-        if truncate_user_ordinal is not None:
-            try:
-                ordinal = int(truncate_user_ordinal)
-            except (TypeError, ValueError):
-                return _err(rid, 4004, "truncate_before_user_ordinal must be an integer")
-            history = session.get("history", [])
-            user_indices = [i for i, m in enumerate(history) if m.get("role") == "user"]
-            if ordinal >= len(user_indices):
-                return _err(rid, 4018, "target user message is no longer in session history")
-            truncated = history[: user_indices[ordinal]]
-            session["history"] = truncated
-            session["history_version"] = int(session.get("history_version", 0)) + 1
-            if (db := _get_db()) is not None:
+    with _sessions_lock:
+        live_key = _session_stored_key(session) or str(session.get("session_key") or "")
+        owner = _find_live_session_by_key_locked(live_key, exclude=session)
+        if owner is not None and _session_owns_key_authoritatively(owner[1], live_key):
+            _owner_sid, owner_session = owner
+            if owner_session.get("running"):
+                return _err(rid, 4009, "session busy")
+            return _err(
+                rid,
+                4009,
+                "session already active in another tab — switch to that live session",
+            )
+        with session["history_lock"]:
+            if session.get("running"):
+                return _err(rid, 4009, "session busy")
+            # A watch session's run lives in the PARENT turn, so its own running
+            # flag is False — without this, typing mid-run builds a second agent
+            # racing the in-flight child on the same stored session (interleaved
+            # transcript, stale fork). After the run completes, submitting is fine:
+            # the upgrade resumes the child's transcript as a normal conversation.
+            if session.get("lazy") and _child_run_active(str(session.get("session_key") or "")):
+                return _err(rid, 4009, "subagent still running — wait for it to finish")
+            if truncate_user_ordinal is not None:
                 try:
-                    db.replace_messages(session["session_key"], truncated)
-                except Exception as exc:
-                    print(f"[tui_gateway] prompt.submit: replace_messages failed: {exc}", file=sys.stderr)
-        session["running"] = True
-        session["last_active"] = time.time()
-        _start_inflight_turn(session, text)
+                    ordinal = int(truncate_user_ordinal)
+                except (TypeError, ValueError):
+                    return _err(rid, 4004, "truncate_before_user_ordinal must be an integer")
+                history = session.get("history", [])
+                user_indices = [i for i, m in enumerate(history) if m.get("role") == "user"]
+                if ordinal >= len(user_indices):
+                    return _err(rid, 4018, "target user message is no longer in session history")
+                truncated = history[: user_indices[ordinal]]
+                session["history"] = truncated
+                session["history_version"] = int(session.get("history_version", 0)) + 1
+                if (db := _get_db()) is not None:
+                    try:
+                        db.replace_messages(session["session_key"], truncated)
+                    except Exception as exc:
+                        print(f"[tui_gateway] prompt.submit: replace_messages failed: {exc}", file=sys.stderr)
+            session["running"] = True
+            session["last_active"] = time.time()
+            _start_inflight_turn(session, text)
 
     # Persist the DB row lazily, now that the user has actually sent a message.
     _ensure_session_db_row(session)
@@ -7511,33 +7582,88 @@ def _(rid, params: dict) -> dict:
     return _ok(rid, {"status": "streaming"})
 
 
-def _notification_event_belongs_elsewhere(session: dict, evt: dict) -> bool:
-    """True if ``evt`` is owned by a *different* live session.
+def _notification_event_route(session: dict, evt: dict) -> str:
+    """Classify whether ``session`` may consume a queued runtime event.
 
-    Background-process events carry the ``session_key`` of the session that
-    started the process. Since all desktop sessions share one process-wide
-    completion queue, each poller must skip events it doesn't own so a
-    background job's completion surfaces in the session that launched it — not
-    whichever poller happened to dequeue first. Orphaned events (owner gone)
-    and global/system events (empty ``session_key``) return False so the
-    current poller still handles them rather than losing them.
+    Returns ``"handle"`` for events owned by this session (or truly global
+    events with no owner), ``"defer"`` for events owned by another live
+    session, ``"unowned"`` for runtime events that are missing an owner key,
+    and ``"orphan"`` for events stamped with a non-empty owner that has no live
+    session.  Non-handle routes fail closed: they are never injected into
+    whichever unrelated desktop tab drains the shared process-wide queue first.
     """
     evt_key = str(evt.get("session_key") or "")
+    evt_type = str(evt.get("type") or "completion")
     if not evt_key:
-        return False
-    if evt_key == str(session.get("session_key") or ""):
-        return False
+        if evt_type in _OWNER_REQUIRED_NOTIFICATION_TYPES or evt_type.startswith("watch_overflow_"):
+            return "unowned"
+        return "handle"
+    if evt_key in _session_live_keys(session):
+        with _sessions_lock:
+            other_owner = _find_live_session_by_key_locked(evt_key, exclude=session)
+        if (
+            other_owner is not None
+            and _session_owns_key_authoritatively(other_owner[1], evt_key)
+        ):
+            return "defer"
+        return "handle"
     try:
         with _sessions_lock:
             snapshot = list(_sessions.values())
     except Exception:
-        # If we can't safely enumerate live sessions, fail open so we don't
-        # crash the poller thread or drop the event.
-        return False
+        # If we can't safely enumerate live sessions, do not deliver the event
+        # to the wrong session.  Park it rather than fail-open into user intent.
+        return "orphan"
 
-    return any(
-        s is not session and str(s.get("session_key") or "") == evt_key
+    if any(
+        s is not session and evt_key in _session_live_keys(s)
         for s in snapshot
+    ):
+        return "defer"
+    return "orphan"
+
+
+def _notification_event_belongs_elsewhere(session: dict, evt: dict) -> bool:
+    """Compatibility wrapper used by older tests/callers."""
+    return _notification_event_route(session, evt) != "handle"
+
+
+def _park_orphaned_notification(evt: dict, *, reason: str = "orphaned") -> None:
+    """Keep bounded diagnostics for a completion event with no live owner."""
+    record = {
+        "parked_at": time.time(),
+        "reason": reason,
+        "session_key": str(evt.get("session_key") or ""),
+        "type": evt.get("type", "completion"),
+        "event": dict(evt),
+    }
+    _orphaned_notifications.append(record)
+    del _orphaned_notifications[:-_MAX_ORPHANED_NOTIFICATIONS]
+
+
+def _notification_persist_user_message(evt: dict) -> str:
+    """Short durable transcript marker for runtime-triggered turns.
+
+    The live model prompt still receives the formatted notification, but the DB
+    transcript should not preserve large foreign result blobs as if a human
+    typed them.  Store a compact, typed provenance marker instead.
+    """
+    evt_type = evt.get("type", "completion")
+    if evt_type == "async_delegation":
+        delegation_id = evt.get("delegation_id") or "unknown"
+        return (
+            "Runtime notification for this session: async delegation "
+            f"{delegation_id} completed."
+        )
+    session_id = evt.get("session_id") or "unknown"
+    if evt_type == "watch_match":
+        return (
+            "Runtime notification for this session: background process "
+            f"{session_id} matched watch pattern."
+        )
+    return (
+        "Runtime notification for this session: background process "
+        f"{session_id} completed."
     )
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7585,18 +7585,13 @@ def _(rid, params: dict) -> dict:
 def _notification_event_route(session: dict, evt: dict) -> str:
     """Classify whether ``session`` may consume a queued runtime event.
 
-    Returns ``"handle"`` for events owned by this session (or truly global
-    events with no owner), ``"defer"`` for events owned by another live
-    session, ``"unowned"`` for runtime events that are missing an owner key,
-    and ``"orphan"`` for events stamped with a non-empty owner that has no live
-    session.  Non-handle routes fail closed: they are never injected into
-    whichever unrelated desktop tab drains the shared process-wide queue first.
+    Returns ``"handle"`` for events owned by this session, global events with
+    no owner, and events whose owner is no longer live. Returns ``"defer"``
+    for events owned by another live session so that owner's poller can handle
+    them.
     """
     evt_key = str(evt.get("session_key") or "")
-    evt_type = str(evt.get("type") or "completion")
     if not evt_key:
-        if evt_type in _OWNER_REQUIRED_NOTIFICATION_TYPES or evt_type.startswith("watch_overflow_"):
-            return "unowned"
         return "handle"
     if evt_key in _session_live_keys(session):
         with _sessions_lock:
@@ -7607,64 +7602,16 @@ def _notification_event_route(session: dict, evt: dict) -> str:
         ):
             return "defer"
         return "handle"
-    try:
-        with _sessions_lock:
-            snapshot = list(_sessions.values())
-    except Exception:
-        # If we can't safely enumerate live sessions, do not deliver the event
-        # to the wrong session.  Park it rather than fail-open into user intent.
-        return "orphan"
-
-    if any(
-        s is not session and evt_key in _session_live_keys(s)
-        for s in snapshot
-    ):
+    with _sessions_lock:
+        owner = _find_live_session_by_key_locked(evt_key, exclude=session)
+    if owner is not None:
         return "defer"
-    return "orphan"
+    return "handle"
 
 
 def _notification_event_belongs_elsewhere(session: dict, evt: dict) -> bool:
     """Compatibility wrapper used by older tests/callers."""
     return _notification_event_route(session, evt) != "handle"
-
-
-def _park_orphaned_notification(evt: dict, *, reason: str = "orphaned") -> None:
-    """Keep bounded diagnostics for a completion event with no live owner."""
-    record = {
-        "parked_at": time.time(),
-        "reason": reason,
-        "session_key": str(evt.get("session_key") or ""),
-        "type": evt.get("type", "completion"),
-        "event": dict(evt),
-    }
-    _orphaned_notifications.append(record)
-    del _orphaned_notifications[:-_MAX_ORPHANED_NOTIFICATIONS]
-
-
-def _notification_persist_user_message(evt: dict) -> str:
-    """Short durable transcript marker for runtime-triggered turns.
-
-    The live model prompt still receives the formatted notification, but the DB
-    transcript should not preserve large foreign result blobs as if a human
-    typed them.  Store a compact, typed provenance marker instead.
-    """
-    evt_type = evt.get("type", "completion")
-    if evt_type == "async_delegation":
-        delegation_id = evt.get("delegation_id") or "unknown"
-        return (
-            "Runtime notification for this session: async delegation "
-            f"{delegation_id} completed."
-        )
-    session_id = evt.get("session_id") or "unknown"
-    if evt_type == "watch_match":
-        return (
-            "Runtime notification for this session: background process "
-            f"{session_id} matched watch pattern."
-        )
-    return (
-        "Runtime notification for this session: background process "
-        f"{session_id} completed."
-    )
 
 
 def _notification_event_dedup_key(evt: dict) -> tuple:


### PR DESCRIPTION
## What does this PR do?

Fixes two restart/resume durability gaps in core session persistence:

- checkpoints completed assistant tool-call turns and tool results before the next model call, so long tool loops do not resume as a one-message session if Hermes restarts mid-turn
- persists compressed continuation transcripts immediately when compression rotates to a child session, so resume cannot land on an empty child before final turn persistence runs

This is a general Hermes bugfix, not a fork-specific integration change. It touches only core agent/session persistence and regression tests. It is also distinct from #29293: this PR preserves existing compression semantics and does not add a new handoff feature or config surface.

## Related Issue

Fixes #51089.

Found while investigating sessions that resumed after compression with no continuation context and only the next prompt.

Duplicate search checked open/closed issues and PRs for the session persistence,
compression resume, and tool-loop persistence symptoms; no matching active fix
was found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/conversation_loop.py`: checkpoint session progress after each completed tool-call batch.
- `run_agent.py`: add best-effort `_checkpoint_session_progress()` that writes JSON/SQLite progress without interrupting live tool execution.
- `agent/conversation_compression.py`: write compressed child transcripts at the rotation boundary and align DB flush cursors for rotation and in-place compaction.
- `tests/run_agent/test_incremental_tool_persistence.py`: cover tool-loop checkpointing before the follow-up model call.
- `tests/agent/test_compression_rotation_state.py` and `tests/run_agent/test_in_place_compaction.py`: cover immediate compressed-child durability and duplicate/tail flush behavior.
- Existing compression persistence comments/tests were updated to match the current identity-based flush behavior.

## How to Test

1. `venv/bin/python -m pytest tests/run_agent/test_incremental_tool_persistence.py tests/agent/test_compression_rotation_state.py tests/run_agent/test_in_place_compaction.py tests/run_agent/test_compression_persistence.py -q`
2. `venv/bin/python -m pytest tests/run_agent/test_413_compression.py tests/run_agent/test_860_dedup.py tests/run_agent/test_identity_flush.py tests/run_agent/test_message_sequence_repair.py -q`
3. `venv/bin/python -m pytest tests/gateway/test_compress_command.py tests/gateway/test_session_hygiene.py tests/test_tui_gateway_server.py tests/acp/test_server.py -q`
4. `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat:`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/Linux local checkout

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, internal bugfix covered by regression tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no workflow or architecture guidance changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — persistence-only Python path, no OS-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool schema changes

## For New Skills

N/A.

## Screenshots / Logs

N/A. Regression tests cover the restart/resume persistence windows directly.
