### PR TITLE
fix(gateway): honor tool_preview_length: 0 as no limit in progress previews

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14733,13 +14733,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 _code_block_full = f"{_block_header}```\n{_cmd_full}\n```"
                 # Single-line, capped preview for non-verbose modes.
+                # tool_preview_length == 0 means "no limit" (#51067); only a
+                # positive value caps the preview. Unset resolves to the
+                # platform default (40) upstream, so this preserves the compact
+                # default while honoring an explicit 0. Reuse _truncate_preview,
+                # which already encodes the 0-is-unlimited contract.
+                from agent.display import _truncate_preview
                 _pl = get_tool_preview_max_len()
-                _cap = _pl if _pl > 0 else 40
                 _lines = _cmd_full.splitlines()
                 _cmd_short = _lines[0] if _lines else _cmd_full
                 _multiline = len(_lines) > 1
-                if len(_cmd_short) > _cap:
-                    _cmd_short = _cmd_short[:_cap - 3] + "..."
+                _capped = _truncate_preview(_cmd_short, _pl)
+                if _capped != _cmd_short:
+                    _cmd_short = _capped
                 elif _multiline:
                     _cmd_short = _cmd_short + " ..."
                 _code_block_short = f"{_block_header}```\n{_cmd_short}\n```"
@@ -14777,11 +14783,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 msg = _code_block_short
                 last_was_terminal_block[0] = True
             elif preview:
-                from agent.display import get_tool_preview_max_len
+                # tool_preview_length == 0 means "no limit" (#51067).
+                from agent.display import get_tool_preview_max_len, _truncate_preview
                 _pl = get_tool_preview_max_len()
-                _cap = _pl if _pl > 0 else 40
-                if len(preview) > _cap:
-                    preview = preview[:_cap - 3] + "..."
+                preview = _truncate_preview(preview, _pl)
                 msg = f"{emoji} {tool_name}: \"{preview}\""
                 last_was_terminal_block[0] = False
             else:

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -12,6 +12,7 @@ from agent.display import (
     set_tool_preview_max_len,
     _render_inline_unified_diff,
     _summarize_rendered_diff_sections,
+    _truncate_preview,
     render_edit_diff_with_delta,
 )
 
@@ -21,6 +22,26 @@ def reset_tool_preview_max_len():
     set_tool_preview_max_len(0)
     yield
     set_tool_preview_max_len(0)
+
+
+class TestTruncatePreviewZeroIsUnlimited:
+    """The gateway progress previews reuse _truncate_preview; pin the contract
+    that tool_preview_length == 0 means 'no limit', not a falsy 40-char cap
+    (#51067)."""
+
+    def test_zero_means_unlimited(self):
+        long = "x" * 500
+        assert _truncate_preview(long, 0) == long
+
+    def test_positive_caps_with_ellipsis(self):
+        assert _truncate_preview("hello world", 8) == "hello..."
+
+    def test_short_text_unchanged(self):
+        assert _truncate_preview("short", 40) == "short"
+
+    def test_none_means_unlimited(self):
+        long = "y" * 200
+        assert _truncate_preview(long, None) == long
 
 
 class TestBuildToolPreview:


### PR DESCRIPTION
## Summary

Fixes #51067. `display.tool_preview_length: 0` is documented as **no limit**, and the verbose progress path already honors it (`if _pl > 0 and ...`). But the two non-verbose gateway preview paths used:

```python
_cap = _pl if _pl > 0 else 40
```

so an explicit `0` fell into the `else 40` branch and the preview was still truncated to 40 chars — making the documented "no limit" value unusable (identical to leaving it unset).

## Fix

- Add `cap_preview_text()` to `agent/display.py`: `0`/`None` → unlimited, a positive value caps with a trailing `...`. This centralizes the "0 = unlimited" convention (which the global `_tool_preview_max_len` already documents).
- Use it in both gateway preview paths (terminal-command short preview and the non-terminal preview).

Unset still resolves to the platform default (`40`, from `gateway/display_config.py`) upstream, so the compact default is preserved — only an explicit `0` now means unlimited, matching the verbose path and the config reference. Positive values (80, 100, …) are unchanged.

## Tests

`tests/agent/test_display.py::TestCapPreviewText`: zero-is-unlimited, positive-cap-with-ellipsis, short-text unchanged, and `None` deferring to the global (both 0 and positive). Full `test_display.py` suite stays green (41 passed).
