### PR TITLE
Tool Prioritization — Weighted Tool Selection

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,142 @@
+# Tool Prioritization — Weighted Tool Selection
+
+## Problem
+
+When Hermes exposes multiple tools with overlapping functionality, the LLM's tool selection is non-deterministic. The model chooses based on name similarity and training bias, not operational needs like cost, latency, quality, or debugging.
+
+**Example from production:**
+- `mcp_ocr_ocr_image_from_base64` (local OCR MCP server, OpenRouter vision + Tesseract fallback)
+- `mcp_zai_vision_extract_text_from_screenshot` (zai-vision MCP server, GLM-4V)
+
+Both do OCR. The model consistently picks the first one because "ocr_image_from_base64" matches the task name better, even though:
+- zai-vision produces better quality
+- zai-vision is the intended production tool
+- We want deterministic behavior for debugging
+
+This happens anytime tools overlap:
+- Multiple OCR implementations
+- Multiple search tools (web_search vs x_search)
+- Multiple vision tools
+- Local vs cloud variants
+
+## Solution
+
+Add **tool prioritization** via configurable weights per profile. Tools can be assigned weights (0-100) that influence the LLM's selection.
+
+### Three modes of operation
+
+**1. Reorder mode**
+Sort tools by weight descending. LLMs sometimes prefer tools listed earlier in the schema.
+
+**2. Description hints mode** (recommended)
+Inject `[PREFERRED]` or `[FALLBACK]` markers into tool descriptions:
+```
+[PREFERRED] Extract text from screenshots using z.ai GLM-4V...
+[FALLBACK] Read a local image file and extract text using OpenRouter...
+```
+
+**3. System prompt mode**
+Append explicit directives to system prompt:
+```
+When performing OCR, prefer mcp_zai_vision_extract_text_from_screenshot over mcp_ocr_ocr_image_from_base64.
+```
+
+### Configuration
+
+```yaml
+# ~/.hermes/config.yaml
+profiles:
+  documents:
+    model: glm-4.7
+    provider: zai
+    toolsets:
+    - mcp-ocr
+    - mcp-zai-vision
+    tool_weights:
+      mode: description_hints  # reorder | description_hints | system_prompt
+      weights:
+        mcp_zai_vision_extract_text_from_screenshot: 90
+        mcp_ocr_ocr_image_from_base64: 10
+```
+
+### Manual competition groups (v1)
+
+To avoid applying weights globally, tools are grouped into explicit competition sets:
+
+```yaml
+tool_weights:
+  competitions:
+    - name: ocr
+      tools:
+        - mcp_zai_vision_extract_text_from_screenshot
+        - mcp_ocr_ocr_image_from_base64
+      preferred: mcp_zai_vision_extract_text_from_screenshot  # weight 100
+      fallback: mcp_ocr_ocr_image_from_base64                # weight 10
+```
+
+This is explicit and debuggable. Auto-detection (v2) can use TF-IDF/embeddings on tool descriptions.
+
+## Benefits
+
+1. **Cost control**: Prefer free tools over paid ones
+2. **Quality gates**: Ensure high-quality tools are used first
+3. **Latency optimization**: Prefer faster tools
+4. **Determinism**: Same prompt → same tool choice
+5. **Debuggability**: Easier to troubleshoot when you know which tool will be called
+6. **Gradual rollout**: Shift weights from old→new implementation (50/50 → 30/70 → 0/100)
+7. **A/B testing**: Compare tool effectiveness by adjusting weights
+
+## Implementation
+
+### Changes
+
+1. **`model_tools.py`** (~100 lines)
+   - Hook into `get_tool_definitions()` after tool filtering
+   - Read `tool_weights` from profile config
+   - Apply mode logic (reorder/hints/system_prompt)
+
+2. **`cli-config.yaml.example`** (~20 lines)
+   - Add `tool_weights` schema documentation
+
+3. **Tests** (~200 lines)
+   - Test tool reordering
+   - Test description hint injection
+   - Test system prompt mode
+   - Test profile isolation
+   - Test competition groups
+
+### Total scope: ~320 lines
+
+## Future work (v2)
+
+- **Auto-detection**: Use embeddings to detect overlapping tools automatically
+- **Dynamic weights**: Adjust weights based on success/failure telemetry
+- **Tool categories**: Tools register `category: "ocr"` for automatic grouping
+- **Context-aware weights**: Different weights based on task type
+
+## Alternatives considered
+
+1. **Plugin only** — Works, but this is core agent behavior that benefits all users
+2. **Hardcoded tool aliases** — Too rigid, can't adjust weights
+3. **Toolset filtering only** — Can't express "prefer A, use B as fallback"
+
+## Questions for maintainers
+
+1. **Mode preference**: Is `description_hints` the right default, or should we start with `reorder`?
+2. **Competition groups**: Should we support manual groups (v1), or try auto-detection from the start?
+3. **Profile vs global**: Should weights be profile-scoped only, or also support global defaults?
+4. **Testing**: What test coverage is expected? Unit tests only, or integration tests with actual LLMs?
+
+## Checklist
+
+- [ ] Config schema in `cli-config.yaml.example`
+- [ ] Core logic in `model_tools.get_tool_definitions()`
+- [ ] Three modes implemented
+- [ ] Competition groups supported
+- [ ] Profile isolation tested
+- [ ] Documentation updated
+- [ ] Migration guide (if any breaking changes)
+
+---
+
+**Draft PR description — NO CODE CHANGES**

--- a/skills/orchestration/bug-pipeline/SKILL.md
+++ b/skills/orchestration/bug-pipeline/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: bug-pipeline
+description: Six-stage quality-gate pipeline for fixing bugs — research, analysis, implementation, review, test, document. Each stage gates on evidence before the next proceeds. Uses delegate_task with MPM profiles for execution.
+version: 2.0.0
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [orchestration, pipeline, bug-fix, quality]
+    related_skills: [task-router, orchestration-patterns]
+---
+
+# Bug Pipeline — 6-Stage Quality Gate
+
+> One bug, one pipeline, one verified fix. Never skip stages. Never claim done without evidence.
+
+## Trigger
+
+Apply this skill when fixing a **bug** from a GitHub issue, kanban card, user report, or test failure.
+
+Do NOT trigger for:
+- Feature work (use `orchestration-patterns`)
+- Small fixes ≤10 lines, ≤2 files, no security impact, no API changes → do it inline
+- Pure research
+
+## How the pipeline works
+
+The pipeline is something **you** (the main agent) execute sequentially. You do NOT delegate the whole pipeline — you walk each stage yourself, delegating sub-tasks to MPM profiles where specialized work is needed.
+
+For each stage you:
+1. Read the stage procedure
+2. Do the work (delegate, search, read code, run tests as needed)
+3. Record evidence in the KB (`lore-axi kb-add key=<stage>/<evidence> value="..."`)
+4. Move to the next stage
+
+---
+
+## Stage 1 — Research
+
+**You do this yourself.** Use your installed tools (tavily, exa, gh-axi, lore-axi, terminal, file_read).
+
+1. **Duplicate check:** `gh-axi pr search "is:open <issue keywords>"`. If a PR exists → review it instead. If a PR was rejected → read why. Record result.
+2. **Understand the bug:** Read the issue body. Note exact environment, expected vs observed behavior, reproduction steps.
+3. **Find relevant files:** Use `terminal` + grep/find or code search tools to locate the components mentioned.
+4. **Identify constraints:** Platform compat (Windows?), security boundaries, no-regression requirements.
+5. **Record:** `lore-axi kb-add key="research/duplicate-check" value="pass|fail — details"` and `lore-axi kb-add key="research/files-found" value="file1, file2, ..."`
+
+**Gate:** All evidence recorded → move to Analysis.
+
+---
+
+## Stage 2 — Code Analysis
+
+**Delegate this to the `debugger` or `think` profile.** They have the toolset for deep code tracing.
+
+```
+delegate_task(
+  profile="debugger",
+  goal="Trace the root cause of bug <N>: <title>",
+  context="Files to examine: <paths>. Bug reproduction: <steps>"
+)
+```
+
+The subagent should return:
+- Root cause identification (which code path, what condition fails)
+- Fix approach (numbered list of changes)
+- Scope assessment (what files to touch, minimal change)
+
+**Record:**
+- `lore-axi kb-add key="analysis/root-cause" value="..."` 
+- `lore-axi kb-add key="analysis/fix-plan" value="..."`
+
+**Gate:** Root cause + fix plan documented → move to Implementation.
+
+---
+
+## Stage 3 — Implementation
+
+**Delegate this to the `engineer` profile.** They have terminal + file + code_execution toolsets.
+
+```
+delegate_task(
+  profile="engineer",
+  goal="Apply the fix for bug <N>",
+  context="Fix plan: <numbered changes>. Files to modify: <paths>."
+)
+```
+
+After the subagent returns, **verify yourself:**
+- Syntax check: `python3 -c "ast.parse(open('file.py').read())"` (or equivalent for your language)
+- Test the affected module: run the existing test suite
+
+**Record:**
+- `lore-axi kb-add key="implementation/changes" value="<diff summary>"`
+- `lore-axi kb-add key="implementation/tests-pass" value="X tests passed, 0 regressions"`
+- `lore-axi kb-add key="implementation/lint-pass" value="syntax OK"`
+
+**Gate:** Tests pass + lint OK → move to Review.
+
+---
+
+## Stage 4 — Code Review
+
+**You do the review yourself** using the severity-tagged checklist below. Read the actual diff.
+
+| Severity | What to check |
+|----------|---------------|
+| CRITICAL | Secrets hardcoded, SQL injection, code execution, auth bypass, infinite loops |
+| HIGH | No bare except, no mutable defaults, tests pass, error cases handled |
+| MEDIUM | Functions ≤20 lines, docstrings on public methods, no `Any` types |
+| LOW | Naming, imports, no commented-out code |
+
+**Verdict:**
+- **APPROVE** — no CRITICAL/HIGH → proceed
+- **WARN** — no CRITICAL, some HIGH → log findings, proceed
+- **BLOCK** — any CRITICAL → stop, surface to user
+
+If MPM gate is enabled (`hermes mpm gate-status`), you can route the diff through it for an independent reviewer:
+```
+delegate_task(profile="think", goal="Review this diff for bugs...", context="<diff>")
+```
+
+**Record:**
+- `lore-axi kb-add key="review/verdict" value="APPROVE|WARN|BLOCK"`
+- `lore-axi kb-add key="review/findings" value="<finding table>"`
+
+**Gate:** APPROVE or WARN → move to QA.
+
+---
+
+## Stage 5 — QA
+
+**You run tests yourself** via the terminal tool.
+
+1. Run the full test suite for the affected module(s)
+2. Check for regressions (all pre-existing failures should be noted)
+3. Run lint/type check if available
+
+**Record:**
+- `lore-axi kb-add key="qa/test-results" value="X passed, Y failed — 0 regressions"`
+
+**Gate:** Tests pass → move to Documentation.
+
+---
+
+## Stage 6 — Documentation
+
+**You do this yourself.**
+
+1. Update inline comments for any non-obvious design decisions
+2. Write a changelog fragment if the project uses them (changelog.d/ or similar)
+3. Create the pull request via `gh-axi`
+
+```
+gh-axi pr create \
+  --title "fix(<scope>): <short description> (#<N>)" \
+  --body "<summary of the fix>" \
+  --base main
+```
+
+**Record:**
+- `lore-axi kb-add key="documentation/comments-updated" value="<what was documented>"`
+- `lore-axi kb-add key="documentation/pr-link" value="<PR URL>"`
+
+---
+
+## Circuit Breakers
+
+| # | Rule | What to do instead |
+|---|------|-------------------|
+| 1 | NEVER edit files yourself | Delegate to `engineer` profile |
+| 2 | NEVER use bash for modifications | Bash only for: git, ls, running tests |
+| 3 | NEVER claim "done" without evidence | Show subagent output or test output |
+| 4 | NEVER skip stages | Each stage must complete sequentially |
+| 5 | Parallelize independent tasks | Use `tasks=[...]` in delegate_task |
+
+## Fast-Path (skip heavy pipeline)
+
+**ALL must be true:** ≤10 source lines, ≤2 files, no new deps, no API changes, no security impact.
+
+Route: `Research (5-min scan) → Implementation → Docs`. Skip Analysis, Review, full QA. Run `pytest <module>` as sanity check only.
+
+## KB evidence cheatsheet
+
+Use lore-axi to record gates:
+
+```bash
+lore-axi kb-add key="research/duplicate-check" value="no existing PRs — proceeding"
+lore-axi kb-add key="analysis/root-cause" value="<verdict>"
+lore-axi kb-add key="implementation/tests-pass" value="57 passed"
+lore-axi kb-add key="review/verdict" value="APPROVE"
+lore-axi kb-add key="qa/test-results" value="57 passed, 0 regressions"
+lore-axi kb-add key="documentation/pr-link" value="https://github.com/.../pull/N"
+```
+
+To check earlier stages:
+```bash
+lore-axi kb-search "research/" | head
+```

--- a/skills/orchestration/simplicio-orient/SKILL.md
+++ b/skills/orchestration/simplicio-orient/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: simplicio-orient
+description: Terminal-first execution — answer facts with shell commands, never with the LLM. Run builds, tests, and shell operations with compressed output to save context.
+version: 1.0.0
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [terminal, execution, shell, token-economy]
+    related_skills: [simplicio-tasks]
+---
+
+# Simplicio Orient — Terminal-First Execution
+
+> Answer facts with the shell, never with the LLM. Keep raw output out of context.
+
+## Trigger
+
+Any time you need a fact about the filesystem, git history, build output, test results, or system state. Run it in shell first; only bring the derived summary into context.
+
+## Principles
+
+1. **Shell first, LLM never** — Need to know if a file exists? `ls`. What's in the diff? `git diff`. Did tests pass? `pytest`. Never ask the LLM to guess filesystem state.
+2. **Summarize, don't dump** — After running a command, summarize the output in 1-2 lines rather than dumping the full output into context. Only include relevant excerpts.
+3. **Compress on the way out** — Use `tee` to cache results. Use `grep -c` instead of full output. Use `tail -5` instead of `cat`.

--- a/skills/orchestration/simplicio-review/SKILL.md
+++ b/skills/orchestration/simplicio-review/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: simplicio-review
+description: Deep adversarial code review — runs dual-perspective analysis (security/correctness + code quality) in parallel, then deduplicates into a single verdict. Use before merging any non-trivial change.
+version: 1.0.0
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [review, code-quality, security, adversarial]
+    related_skills: [bug-pipeline, simplicio-tasks]
+---
+
+# Simplicio Review — Adversarial Branch Review
+
+> Two parallel review rubrics → deduped into one verdict. Scoped strictly to the diff.
+
+## Trigger
+
+Before merging non-trivial work, when the user says "review this branch/PR hard", or when simplicio-tasks needs the verify gate.
+
+## Procedure
+
+1. Read the full diff: `git diff main...HEAD` or `gh-axi pr diff <N>`
+2. Run TWO parallel reviews (delegate to `think` or `debugger` profile):
+   - **Review A** — Security + correctness (CRITICAL/HIGH findings)
+   - **Review B** — Code quality + patterns (MEDIUM/LOW findings)
+3. Deduplicate findings into one verdict table
+4. Verdict: APPROVE / WARN / BLOCK (same severity rules as bug-pipeline)
+
+Record: `lore-axi kb-add key="simplicio-review/verdict" value="APPROVE|WARN|BLOCK"`

--- a/skills/orchestration/simplicio-tasks/SKILL.md
+++ b/skills/orchestration/simplicio-tasks/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: simplicio-tasks
+description: Autonomous work-item orchestrator — drains a queue of bugs/issues/tasks with auto-looping, evidence-gated completion, and capacity-based parallel execution. Use when clearing a backlog, processing multiple bug reports, or running CI fix waves.
+version: 1.0.0
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [orchestration, automation, task-queue, loop]
+    related_skills: [bug-pipeline, orchestration-patterns, task-router]
+---
+
+# Simplicio Tasks — Autonomous Queue Orchestrator
+
+> Drains a queue of work-items (bugs, issues, CI failures, kanban cards) autonomously. Loops until the queue is empty, then exits with evidence.
+
+## Trigger
+
+Use when asked to clear a queue of work — "process these bugs", "drain the CI failures", "clear the kanban board", "implement milestone X tickets", "fix all failing tests". Also triggers on `/simplicio-tasks` pattern.
+
+Do NOT use for:
+- A single well-defined bug fix (use `bug-pipeline` instead)
+- A single feature implement (use `engineer` profile directly)
+
+## How it works
+
+Simplicio runs as a **loop**. It:
+1. Discovers open work-items from the source (GitHub issues, kanban board, CI failures)
+2. Prioritizes and deduplicates them
+3. Processes them in parallel up to capacity limits
+4. Verifies each item is truly done with evidence
+5. Loops until queue is empty or cap is hit
+
+---
+
+## Step 1: Intake — discover the work
+
+Identify the work source. For each source, run the appropriate discovery:
+
+**GitHub issues:**
+```bash
+gh-axi issue list --repo <owner/repo> --state open --limit 50 --json number,title,labels
+```
+
+**Kanban board:**
+```bash
+kanban-axi tasks --column <column>
+```
+
+**CI failures:**
+```bash
+gh-axi run list --repo <owner/repo> --workflow <name> --branch main --limit 10
+```
+
+Prioritize by: severity (P1 > P2 > P3) → age (oldest first) → dependencies.
+
+Emit: `Intake: <N> items discovered, <M> actionable after dedup`
+
+---
+
+## Step 2: Route & Scale
+
+Decide how many items to process in parallel based on:
+- Available capacity (CPU/memory/API rate limits)
+- Item complexity (P1 needs full pipeline, P3 may be fast-path)
+- Dependencies between items
+
+For independent items, fan them out with `delegate_task(tasks=[...])` using appropriate profiles:
+- Bug fixes → `engineer` with `context="use bug-pipeline skill"`
+- Research → `search` or `web_researcher`
+- Code review → `think` or `debugger`
+
+For dependent items, run them sequentially.
+
+---
+
+## Step 3: Auto-Loop
+
+Simplicio IS a loop. After completing a batch:
+
+1. Verify each completed item:
+   - Bug fix → evidence it's fixed (test output, PR link)
+   - Issue → evidence it's closed (API response, merged PR)
+2. Re-check the source for remaining work
+3. If items remain → process next batch
+4. If queue is empty → emit `SIMPLICIO_DONE` with evidence
+
+**Loop termination** (any of these):
+- Queue is fully drained AND all items verified — emit `SIMPLICIO_DONE` with evidence
+- `/stop` interrupt received
+- Cap reached (max iterations or budget)
+
+---
+
+## Step 4: Verification Gate
+
+Every claimed completion MUST have evidence:
+
+| Claim | Evidence |
+|-------|----------|
+| "Bug is fixed" | PR link + test output showing pass |
+| "Issue is closed" | GitHub API response or PR merged |
+| "Tests pass" | `pytest` output showing 0 failures |
+| "CI is green" | Workflow run URL showing success |
+
+Forbidden: "should be fixed", "looks good", "appears to work".
+
+---
+
+## Companion Skills
+
+| Skill | Purpose | When to load |
+|-------|---------|--------------|
+| `bug-pipeline` | 6-stage quality gate for individual bug fixes | Per bug item in queue |
+| `simplicio-review` | Deep adversarial review of completed diffs | Before merging |
+| `simplicio-orient` | Terminal-first execution & token economy | Heavy shell work |
+| `simplicio-compress` | Compression for long-running sessions | When context fills |
+
+These are NOT required — simplicio-tasks works standalone. Load them when extra rigor is needed.
+
+---
+
+## Pitfalls
+
+| Problem | How to avoid |
+|---------|-------------|
+| Over-parallelization hitting API rate limits | Cap parallel tasks at 3 for external APIs |
+| Context window overflow from long loops | Compress intermediate results; use lore-axi KB to store state |
+| Committing untested changes | Always run tests after engineer returns |
+| Creating competing PRs | Run duplicate check before implementing |
+| Claiming done on partial evidence | Gate every item on verifiable proof |


### PR DESCRIPTION
# Tool Prioritization — Weighted Tool Selection

## Problem

When Hermes exposes multiple tools with overlapping functionality, the LLM's tool selection is non-deterministic. The model chooses based on name similarity and training bias, not operational needs like cost, latency, quality, or debugging.

**Example from production:**
- `mcp_ocr_ocr_image_from_base64` (local OCR MCP server, OpenRouter vision + Tesseract fallback)
- `mcp_zai_vision_extract_text_from_screenshot` (zai-vision MCP server, GLM-4V)

Both do OCR. The model consistently picks the first one because "ocr_image_from_base64" matches the task name better, even though:
- zai-vision produces better quality
- zai-vision is the intended production tool
- We want deterministic behavior for debugging

This happens anytime tools overlap:
- Multiple OCR implementations
- Multiple search tools (web_search vs x_search)
- Multiple vision tools
- Local vs cloud variants

## Solution

Add **tool prioritization** via configurable weights per profile. Tools can be assigned weights (0-100) that influence the LLM's selection.

### Three modes of operation

**1. Reorder mode**
Sort tools by weight descending. LLMs sometimes prefer tools listed earlier in the schema.

**2. Description hints mode** (recommended)
Inject `[PREFERRED]` or `[FALLBACK]` markers into tool descriptions:
```
[PREFERRED] Extract text from screenshots using z.ai GLM-4V...
[FALLBACK] Read a local image file and extract text using OpenRouter...
```

**3. System prompt mode**
Append explicit directives to system prompt:
```
When performing OCR, prefer mcp_zai_vision_extract_text_from_screenshot over mcp_ocr_ocr_image_from_base64.
```

### Configuration

```yaml
# ~/.hermes/config.yaml
profiles:
  documents:
    model: glm-4.7
    provider: zai
    toolsets:
    - mcp-ocr
    - mcp-zai-vision
    tool_weights:
      mode: description_hints  # reorder | description_hints | system_prompt
      weights:
        mcp_zai_vision_extract_text_from_screenshot: 90
        mcp_ocr_ocr_image_from_base64: 10
```

### Manual competition groups (v1)

To avoid applying weights globally, tools are grouped into explicit competition sets:

```yaml
tool_weights:
  competitions:
    - name: ocr
      tools:
        - mcp_zai_vision_extract_text_from_screenshot
        - mcp_ocr_ocr_image_from_base64
      preferred: mcp_zai_vision_extract_text_from_screenshot  # weight 100
      fallback: mcp_ocr_ocr_image_from_base64                # weight 10
```

This is explicit and debuggable. Auto-detection (v2) can use TF-IDF/embeddings on tool descriptions.

## Benefits

1. **Cost control**: Prefer free tools over paid ones
2. **Quality gates**: Ensure high-quality tools are used first
3. **Latency optimization**: Prefer faster tools
4. **Determinism**: Same prompt → same tool choice
5. **Debuggability**: Easier to troubleshoot when you know which tool will be called
6. **Gradual rollout**: Shift weights from old→new implementation (50/50 → 30/70 → 0/100)
7. **A/B testing**: Compare tool effectiveness by adjusting weights

## Implementation

### Changes

1. **`model_tools.py`** (~100 lines)
   - Hook into `get_tool_definitions()` after tool filtering
   - Read `tool_weights` from profile config
   - Apply mode logic (reorder/hints/system_prompt)

2. **`cli-config.yaml.example`** (~20 lines)
   - Add `tool_weights` schema documentation

3. **Tests** (~200 lines)
   - Test tool reordering
   - Test description hint injection
   - Test system prompt mode
   - Test profile isolation
   - Test competition groups

### Total scope: ~320 lines

## Future work (v2)

- **Auto-detection**: Use embeddings to detect overlapping tools automatically
- **Dynamic weights**: Adjust weights based on success/failure telemetry
- **Tool categories**: Tools register `category: "ocr"` for automatic grouping
- **Context-aware weights**: Different weights based on task type

## Alternatives considered

1. **Plugin only** — Works, but this is core agent behavior that benefits all users
2. **Hardcoded tool aliases** — Too rigid, can't adjust weights
3. **Toolset filtering only** — Can't express "prefer A, use B as fallback"

## Questions for maintainers

1. **Mode preference**: Is `description_hints` the right default, or should we start with `reorder`?
2. **Competition groups**: Should we support manual groups (v1), or try auto-detection from the start?
3. **Profile vs global**: Should weights be profile-scoped only, or also support global defaults?
4. **Testing**: What test coverage is expected? Unit tests only, or integration tests with actual LLMs?

## Checklist

- [ ] Config schema in `cli-config.yaml.example`
- [ ] Core logic in `model_tools.get_tool_definitions()`
- [ ] Three modes implemented
- [ ] Competition groups supported
- [ ] Profile isolation tested
- [ ] Documentation updated
- [ ] Migration guide (if any breaking changes)

---

**Draft PR description — NO CODE CHANGES**