### PR TITLE
fix(cli): throttle spinner repaints under Warp to stop screen flicker

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2950,6 +2950,17 @@ def _disable_prompt_toolkit_cpr_warning(app) -> None:
         pass
 
 
+def _is_warp_terminal() -> bool:
+    """Return True when running under Warp (``TERM_PROGRAM=WarpTerminal``).
+
+    Warp is a block-based renderer: it re-renders the whole active block on
+    each repaint, so the ~10 Hz bottom-chrome invalidation the spinner uses in
+    non-fullscreen mode shows up as whole-screen flicker. Callers throttle the
+    work-time repaint under Warp to keep output stable (#51039).
+    """
+    return (os.environ.get("TERM_PROGRAM") or "").strip().lower() == "warpterminal"
+
+
 def _strip_leaked_terminal_responses_with_meta(text: str) -> tuple[str, bool]:
     """Strip leaked terminal control-response sequences from user input.
 
@@ -14111,14 +14122,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
         app._on_resize = _resize_clear_ghosts
 
+        # Warp re-renders the whole active block on every repaint, so the
+        # default ~10 Hz work-time chrome invalidation flickers the screen.
+        # Throttle to ~2 Hz under Warp — output stays stable; the only cost is
+        # a slower spinner animation for Warp users (#51039). TERM_PROGRAM is
+        # fixed for the process, so resolve the interval once.
+        _work_invalidate_interval = 0.5 if _is_warp_terminal() else 0.1
+
         def spinner_loop():
             while not self._should_exit:
                 if not self._app:
                     time.sleep(0.1)
                     continue
                 if self._command_running:
-                    self._invalidate(min_interval=0.1)
-                    time.sleep(0.1)
+                    self._invalidate(min_interval=_work_invalidate_interval)
+                    time.sleep(_work_invalidate_interval)
                 else:
                     # Do not repaint the idle prompt every second. In non-full-screen
                     # prompt_toolkit mode, background redraws can fight tmux/Ghostty/cmux

--- a/tests/cli/test_warp_terminal_detection.py
+++ b/tests/cli/test_warp_terminal_detection.py
@@ -1,0 +1,36 @@
+"""Tests for Warp terminal detection used to throttle spinner repaints (#51039).
+
+Warp re-renders the whole active block on each repaint, so the interactive
+CLI throttles its work-time chrome invalidation under Warp. The detection
+helper keys off ``TERM_PROGRAM=WarpTerminal``.
+"""
+
+import os
+from unittest.mock import patch
+
+from cli import _is_warp_terminal
+
+
+def test_warp_terminal_detected():
+    with patch.dict(os.environ, {"TERM_PROGRAM": "WarpTerminal"}, clear=False):
+        assert _is_warp_terminal() is True
+
+
+def test_warp_terminal_detected_case_insensitive():
+    with patch.dict(os.environ, {"TERM_PROGRAM": "warpterminal"}, clear=False):
+        assert _is_warp_terminal() is True
+
+
+def test_warp_terminal_detected_with_whitespace():
+    with patch.dict(os.environ, {"TERM_PROGRAM": "  WarpTerminal  "}, clear=False):
+        assert _is_warp_terminal() is True
+
+
+def test_other_terminal_not_warp():
+    with patch.dict(os.environ, {"TERM_PROGRAM": "iTerm.app"}, clear=False):
+        assert _is_warp_terminal() is False
+
+
+def test_unset_term_program_not_warp():
+    with patch.dict(os.environ, {}, clear=True):
+        assert _is_warp_terminal() is False


### PR DESCRIPTION
## Summary

Addresses #51039. Running the interactive CLI under **Warp** (`TERM_PROGRAM=WarpTerminal`) flickers the whole screen while the agent works. Warp is a block-based renderer — it re-renders the entire active block on each repaint — so the spinner's ~10 Hz work-time chrome invalidation (`_invalidate(min_interval=0.1)` while a command runs) forces a full-screen repaint.

The CLI already special-cases Ghostty / tmux / iTerm via `TERM_PROGRAM`, but had no Warp path, so Warp fell through to the untuned generic cadence.

## Fix

- Add `_is_warp_terminal()` (`TERM_PROGRAM=WarpTerminal`, case/whitespace tolerant).
- Under Warp, raise the work-time invalidate interval from `0.1s` to `0.5s` (~10 Hz → ~2 Hz). `TERM_PROGRAM` is fixed per process, so it's resolved once before the spinner loop.

Output stays stable in scrollback; the only trade-off is a slower spinner animation for Warp users — which is the issue's preferred fix (suggestion #1). Other terminals are completely unchanged.

## Tests

`tests/cli/test_warp_terminal_detection.py`: Warp detected (exact / case-insensitive / whitespace-padded), other terminals and unset `TERM_PROGRAM` are not Warp.

Note: I don't have a Warp setup to confirm the flicker is fully gone end-to-end; the reporter offered to test patches. The change is conservative (Warp-only, strictly fewer repaints) so it can only reduce flicker, never worsen behavior elsewhere.
