### PR TITLE
feat: add resetlead gateway command

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4192,9 +4192,7 @@ def run_conversation(
         try:
             _failed = getattr(agent, "_turn_failed_file_mutations", None) or {}
             if _failed and agent._file_mutation_verifier_enabled():
-                footer = agent._format_file_mutation_failure_footer(_failed)
-                if footer:
-                    final_response = final_response.rstrip() + "\n\n" + footer
+                final_response = agent._apply_file_mutation_failure_advisory(final_response, _failed)
         except Exception as _ver_err:
             logger.debug("file-mutation verifier footer failed: %s", _ver_err)
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -860,7 +860,7 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["group_allow_admin_from"] = platform_cfg["group_allow_admin_from"]
                 if "group_user_allowed_commands" in platform_cfg:
                     bridged["group_user_allowed_commands"] = platform_cfg["group_user_allowed_commands"]
-                if plat in {Platform.DISCORD, Platform.SLACK} and "channel_skill_bindings" in platform_cfg:
+                if plat in {Platform.DISCORD, Platform.SLACK, Platform.WHATSAPP} and "channel_skill_bindings" in platform_cfg:
                     bridged["channel_skill_bindings"] = platform_cfg["channel_skill_bindings"]
                 if "channel_prompts" in platform_cfg:
                     channel_prompts = platform_cfg["channel_prompts"]

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -21,6 +21,7 @@ import logging
 import os
 import platform
 import re
+import shlex
 import shutil
 import signal
 import subprocess
@@ -188,6 +189,8 @@ from gateway.platforms.base import (
     SUPPORTED_DOCUMENT_TYPES,
     cache_image_from_url,
     cache_audio_from_url,
+    resolve_channel_prompt,
+    resolve_channel_skills,
 )
 
 
@@ -270,6 +273,17 @@ class WhatsAppAdapter(BasePlatformAdapter):
         self._bridge_log: Optional[Path] = None
         self._poll_task: Optional[asyncio.Task] = None
         self._http_session: Optional["aiohttp.ClientSession"] = None
+        self._lead_state_hook_script: Optional[str] = self._coerce_optional_str(
+            config.extra.get("lead_state_hook_script")
+        )
+        self._lead_state_hook_chat_ids: set[str] = self._coerce_allow_list(
+            config.extra.get("lead_state_hook_chat_ids")
+            or config.extra.get("leadStateHookChatIds")
+        )
+        self._lead_state_hook_enabled: bool = self._coerce_bool(
+            config.extra.get("lead_state_hook_enabled"),
+            default=bool(self._lead_state_hook_script and self._lead_state_hook_chat_ids),
+        )
         # Set to True by disconnect() before we SIGTERM our child bridge so
         # _check_managed_bridge_exit() can distinguish an intentional
         # shutdown-time exit (returncode -15 / -2 / 0) from a real crash.
@@ -314,6 +328,26 @@ class WhatsAppAdapter(BasePlatformAdapter):
         return {part.strip() for part in str(raw).split(",") if part.strip()}
 
     @staticmethod
+    def _coerce_bool(raw, default: bool = False) -> bool:
+        if raw is None:
+            return default
+        if isinstance(raw, str):
+            lowered = raw.strip().lower()
+            if lowered in {"true", "1", "yes", "on"}:
+                return True
+            if lowered in {"false", "0", "no", "off"}:
+                return False
+            return default
+        return bool(raw)
+
+    @staticmethod
+    def _coerce_optional_str(raw) -> Optional[str]:
+        if raw is None:
+            return None
+        value = str(raw).strip()
+        return value or None
+
+    @staticmethod
     def _coerce_allow_list(raw) -> set[str]:
         """Parse allow_from / group_allow_from from config or env var."""
         if raw is None:
@@ -321,6 +355,101 @@ class WhatsAppAdapter(BasePlatformAdapter):
         if isinstance(raw, list):
             return {str(part).strip() for part in raw if str(part).strip()}
         return {part.strip() for part in str(raw).split(",") if part.strip()}
+
+    def _should_run_lead_state_hook(self, event: MessageEvent) -> bool:
+        if not self._lead_state_hook_enabled:
+            return False
+        if not self._lead_state_hook_script:
+            return False
+        if not self._lead_state_hook_chat_ids:
+            return False
+        if event.is_command():
+            return False
+        source = event.source
+        if source is None:
+            return False
+        if source.chat_type != "group":
+            return False
+        return str(source.chat_id or "") in self._lead_state_hook_chat_ids
+
+    def _lead_state_message_text(self, event: MessageEvent) -> str:
+        text = (event.text or "").strip()
+        if text:
+            return text
+        msg_type = getattr(event.message_type, "value", str(event.message_type or "message"))
+        return f"[{msg_type}]"
+
+    async def _run_lead_state_inbound_hook(self, event: MessageEvent) -> None:
+        if not self._should_run_lead_state_hook(event):
+            return
+
+        source = event.source
+        raw = event.raw_message if isinstance(event.raw_message, dict) else {}
+        whatsapp_id = self._normalize_whatsapp_id(
+            source.user_id if source is not None else None
+        ) or self._normalize_whatsapp_id(
+            raw.get("senderId") or raw.get("from") or raw.get("author") or raw.get("participant")
+        )
+        display_name = (
+            (source.user_name if source is not None else None)
+            or raw.get("senderName")
+            or raw.get("pushName")
+            or raw.get("notifyName")
+            or raw.get("name")
+        )
+
+        cmd = [
+            "python3",
+            self._lead_state_hook_script,
+            "record-inbound",
+            "--source",
+            "whatsapp",
+            "--preferred-channel",
+            "whatsapp",
+            "--message",
+            self._lead_state_message_text(event),
+        ]
+        if display_name:
+            cmd.extend(["--display-name", str(display_name)])
+        if whatsapp_id:
+            cmd.extend(["--whatsapp-id", whatsapp_id])
+
+        logger.info(
+            "[%s] Running lead-state inbound hook for chat=%s user=%s script=%s",
+            self.name,
+            source.chat_id if source is not None else "",
+            whatsapp_id or (source.user_id if source is not None else ""),
+            self._lead_state_hook_script,
+        )
+
+        def _run() -> subprocess.CompletedProcess:
+            return subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+
+        result = await asyncio.to_thread(_run)
+        if result.returncode != 0:
+            stdout = (result.stdout or "").strip()
+            stderr = (result.stderr or "").strip()
+            logger.warning(
+                "[%s] Lead-state inbound hook failed rc=%s cmd=%s stdout=%s stderr=%s",
+                self.name,
+                result.returncode,
+                shlex.join(cmd),
+                stdout[:500],
+                stderr[:500],
+            )
+            return
+
+        output = (result.stdout or "").strip()
+        if output:
+            logger.info("[%s] Lead-state inbound hook output: %s", self.name, output[:500])
+
+    async def on_processing_start(self, event: MessageEvent) -> None:
+        await self._run_lead_state_inbound_hook(event)
 
     @staticmethod
     def _is_broadcast_chat(chat_id: str) -> bool:
@@ -1183,6 +1312,9 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 user_id=data.get("senderId"),
                 user_name=data.get("senderName"),
             )
+            channel_id = str(data.get("chatId", "") or "")
+            _channel_prompt = resolve_channel_prompt(self.config.extra, channel_id, None)
+            _auto_skill = resolve_channel_skills(self.config.extra, channel_id, None)
             
             # Download media URLs to the local cache so agent tools
             # can access them reliably regardless of URL expiration.
@@ -1276,6 +1408,8 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 message_id=data.get("messageId"),
                 media_urls=cached_urls,
                 media_types=media_types,
+                channel_prompt=_channel_prompt,
+                auto_skill=_auto_skill,
             )
         except Exception as e:
             print(f"[{self.name}] Error building event: {e}")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7118,23 +7118,25 @@ class GatewayRunner:
                 logger.info("STOP for session %s — agent interrupted, session lock released", _quick_key)
                 return EphemeralReply(t("gateway.stop.stopped"))
 
-            # /reset and /new must bypass the running-agent guard so they
-            # actually dispatch as commands instead of being queued as user
-            # text (which would be fed back to the agent with the same
-            # broken history — #2170).  Interrupt the agent first, then
-            # clear the adapter's pending queue so the stale "/reset" text
-            # doesn't get re-processed as a user message after the
-            # interrupt completes.
-            if _cmd_def_inner and _cmd_def_inner.name == "new":
+            # /reset, /new, and session-boundary variants like /resetlead must
+            # bypass the running-agent guard so they actually dispatch as
+            # commands instead of being queued as user text (which would be fed
+            # back to the agent with the same broken history — #2170).
+            # Interrupt the agent first, then clear the adapter's pending queue
+            # so the stale slash text doesn't get re-processed as a user
+            # message after the interrupt completes.
+            if _cmd_def_inner and _cmd_def_inner.name in {"new", "resetlead"}:
                 # Clear any pending messages so the old text doesn't replay
                 await self._interrupt_and_clear_session(
                     _quick_key,
                     source,
                     interrupt_reason=_INTERRUPT_REASON_RESET,
-                    invalidation_reason="new_command",
+                    invalidation_reason=f"{_cmd_def_inner.name}_command",
                 )
                 # Clean up the running agent entry so the reset handler
                 # doesn't think an agent is still active.
+                if _cmd_def_inner.name == "resetlead":
+                    return await self._handle_resetlead_command(event)
                 return await self._handle_reset_command(event)
 
             # /queue <prompt> — queue without interrupting.
@@ -7510,6 +7512,20 @@ class GatewayRunner:
                     _cmd_def = _resolve_cmd(command) if command else None
                     canonical = _cmd_def.name if _cmd_def else command
                     break
+
+        if canonical == "resetlead":
+            async def _do_resetlead():
+                return await self._handle_resetlead_command(event)
+            return await self._maybe_confirm_destructive_slash(
+                event=event,
+                command="resetlead",
+                title="/resetlead",
+                detail=(
+                    "This resets the current lead state and starts a fresh "
+                    "conversation session."
+                ),
+                execute=_do_resetlead,
+            )
 
         if canonical == "new":
             if self._is_telegram_topic_root_lobby(source):
@@ -8348,16 +8364,20 @@ class GatewayRunner:
             session_entry.auto_reset_reason = None
 
         # Auto-load skill(s) for topic/channel bindings (Telegram DM Topics,
-        # Discord channel_skill_bindings).  Supports a single name or ordered list.
-        # Only inject on NEW sessions — ongoing conversations already have the
-        # skill content in their conversation history from the first message.
+        # Discord/Slack/WhatsApp channel_skill_bindings). Supports a single
+        # name or ordered list. For new sessions, inject into the transcript so
+        # the conversation starts with the bound context. For all turns, also
+        # add the bound skill content to the ephemeral channel prompt so long-
+        # lived sessions keep the lane behaviour without requiring a fresh
+        # session after every refinement.
         _auto = getattr(event, "auto_skill", None)
-        if _is_new_session and _auto:
+        if _auto:
             _skill_names = [_auto] if isinstance(_auto, str) else list(_auto)
             try:
                 from agent.skill_commands import _load_skill_payload, _build_skill_message
                 _combined_parts: list[str] = []
                 _loaded_names: list[str] = []
+                _ephemeral_parts: list[str] = []
                 for _sname in _skill_names:
                     _loaded = _load_skill_payload(_sname, task_id=_quick_key)
                     if _loaded:
@@ -8368,10 +8388,21 @@ class GatewayRunner:
                         )
                         _part = _build_skill_message(_loaded_skill, _skill_dir, _note)
                         if _part:
-                            _combined_parts.append(_part)
+                            _ephemeral_parts.append(_part)
+                            if _is_new_session:
+                                _combined_parts.append(_part)
                             _loaded_names.append(_sname)
                     else:
                         logger.warning("[Gateway] Auto-skill '%s' not found", _sname)
+                if _ephemeral_parts:
+                    _ephemeral_block = "\n\n".join(_ephemeral_parts)
+                    if event.channel_prompt:
+                        event.channel_prompt = (
+                            f"{event.channel_prompt.rstrip()}\n\n"
+                            f"[Auto-loaded lane skill context]\n{_ephemeral_block}"
+                        )
+                    else:
+                        event.channel_prompt = f"[Auto-loaded lane skill context]\n{_ephemeral_block}"
                 if _combined_parts:
                     # Append the user's original text after all skill payloads
                     _combined_parts.append(event.text)
@@ -9347,6 +9378,126 @@ class GatewayRunner:
             lines.append(f"◆ Endpoint: {base_url}")
 
         return "\n".join(lines)
+
+    def _skyops_leads_script_path(self, event: MessageEvent | None = None) -> Path:
+        if event is not None:
+            source = getattr(event, "source", None)
+            platform = getattr(source, "platform", None)
+            adapter = self.adapters.get(platform) if platform else None
+            if adapter is not None:
+                hook_script = getattr(adapter, "_lead_state_hook_script", None)
+                hook_chat_ids = getattr(adapter, "_lead_state_hook_chat_ids", None) or set()
+                chat_id = str(getattr(source, "chat_id", "") or "")
+                if hook_script and chat_id and chat_id in hook_chat_ids:
+                    return Path(str(hook_script))
+        return get_hermes_home() / "scripts" / "skyops_leads.py"
+
+    def _build_resetlead_lookup_args(self, event: MessageEvent) -> list[str]:
+        source = event.source
+        manual_lead_id = event.get_command_args().strip()
+        if manual_lead_id:
+            return ["--lead-id", manual_lead_id]
+
+        args: list[str] = []
+        platform_value = source.platform.value if source.platform else ""
+        user_id = (source.user_id or "").strip()
+        chat_id = (source.chat_id or "").strip()
+        user_name = (source.user_name or "").strip()
+
+        if platform_value == "whatsapp":
+            if user_id:
+                args.extend(["--whatsapp-id", user_id])
+            elif chat_id:
+                args.extend(["--whatsapp-id", chat_id])
+        elif platform_value == "email":
+            email_candidate = ""
+            for candidate in (user_id, chat_id):
+                if candidate and "@" in candidate:
+                    email_candidate = candidate
+                    break
+            if email_candidate:
+                args.extend(["--email", email_candidate])
+            elif user_id:
+                args.extend(["--lead-id", user_id])
+            elif chat_id:
+                args.extend(["--lead-id", chat_id])
+        else:
+            fallback = user_id or chat_id
+            if fallback:
+                args.extend(["--lead-id", fallback])
+
+        if user_name:
+            args.extend(["--display-name", user_name])
+        return args
+
+    async def _handle_resetlead_command(self, event: MessageEvent) -> Union[str, EphemeralReply]:
+        script_path = self._skyops_leads_script_path(event)
+        if not script_path.exists():
+            return "This profile does not have lead state support configured."
+
+        lookup_args = self._build_resetlead_lookup_args(event)
+        if not lookup_args:
+            return "I couldn't infer which lead to reset here. Use /resetlead <lead-id>."
+
+        command = [
+            sys.executable,
+            str(script_path),
+            "reset",
+            "--allow-missing",
+            *lookup_args,
+        ]
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *command,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=20)
+        except asyncio.TimeoutError:
+            return "Lead reset timed out before the session could be restarted."
+        except Exception as exc:
+            logger.warning("/resetlead failed to launch helper: %s", exc)
+            return f"Lead reset helper failed to start: {exc}"
+
+        stdout_text = stdout.decode("utf-8", errors="replace").strip()
+        stderr_text = stderr.decode("utf-8", errors="replace").strip()
+        payload = None
+        if stdout_text:
+            try:
+                payload = json.loads(stdout_text)
+            except Exception:
+                payload = None
+
+        if proc.returncode != 0:
+            if isinstance(payload, dict) and payload.get("error"):
+                return f"Lead reset failed: {payload['error']}"
+            detail = stderr_text or stdout_text or f"exit {proc.returncode}"
+            return f"Lead reset failed: {detail}"
+
+        lead_id = ""
+        lead_note = "Lead state reset."
+        if isinstance(payload, dict):
+            lead_id = str(payload.get("lead_id", "")).strip()
+            if payload.get("reset"):
+                previous_state = str(payload.get("previous_state", "")).strip()
+                if lead_id and previous_state:
+                    lead_note = f"Lead {lead_id} reset (previous state: {previous_state})."
+                elif lead_id:
+                    lead_note = f"Lead {lead_id} reset."
+            else:
+                lead_note = (
+                    f"No stored lead state was found for {lead_id}; starting a fresh session anyway."
+                    if lead_id
+                    else "No stored lead state was found; starting a fresh session anyway."
+                )
+
+        reset_reply = await self._handle_reset_command(event)
+        reset_text = str(reset_reply)
+        combined = f"{lead_note}\n\n{reset_text}" if reset_text else lead_note
+        if isinstance(reset_reply, EphemeralReply):
+            return EphemeralReply(combined, ttl_seconds=reset_reply.ttl_seconds)
+        return combined
 
     async def _handle_reset_command(self, event: MessageEvent) -> Union[str, EphemeralReply]:
         """Handle /new or /reset command."""

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -113,6 +113,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("profile", "Show active profile name and home directory", "Info"),
     CommandDef("sethome", "Set this chat as the home channel", "Session",
                gateway_only=True, aliases=("set-home",)),
+    CommandDef("resetlead", "SkyOps: reset the current lead state and start a fresh session", "Session",
+               gateway_only=True, aliases=("reset-lead",), args_hint="[lead-id]"),
     CommandDef("resume", "Resume a previously-named session", "Session",
                args_hint="[name]"),
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -2012,6 +2012,30 @@ class AIAgent:
             lines.append(f"  • … and {remaining} more")
         return "\n".join(lines)
 
+    @classmethod
+    def _apply_file_mutation_failure_advisory(
+        cls,
+        response: str,
+        failed: Dict[str, Dict[str, Any]],
+    ) -> str:
+        """Prepend a prominent warning and append the footer for failed edits.
+
+        The footer alone catches false success claims after the fact, but it can
+        still appear below a cheery "done" summary. This helper hardens the
+        user-facing surface by making the partial-failure state visible before
+        any model-authored prose.
+        """
+        if not response:
+            return response
+        footer = cls._format_file_mutation_failure_footer(failed)
+        if not footer:
+            return response
+        advisory = (
+            "⚠️ Partial edit result: one or more file mutations failed and were NOT "
+            "applied. Treat any contrary wording below as incorrect."
+        )
+        return advisory + "\n\n" + response.rstrip() + "\n\n" + footer
+
     def _apply_pending_steer_to_tool_results(self, messages: list, num_tool_msgs: int) -> None:
         """Forwarder — see ``agent.agent_runtime_helpers.apply_pending_steer_to_tool_results``."""
         from agent.agent_runtime_helpers import apply_pending_steer_to_tool_results

--- a/tests/gateway/test_resetlead_command.py
+++ b/tests/gateway/test_resetlead_command.py
@@ -1,0 +1,166 @@
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import EphemeralReply, MessageEvent
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+class _FakeProc:
+    def __init__(self, returncode=0, stdout=b"", stderr=b""):
+        self.returncode = returncode
+        self._stdout = stdout
+        self._stderr = stderr
+
+    async def communicate(self):
+        return self._stdout, self._stderr
+
+
+def _make_source(platform: Platform = Platform.WHATSAPP) -> SessionSource:
+    return SessionSource(
+        platform=platform,
+        user_id="34600111222",
+        chat_id="120363409910080294@g.us",
+        user_name="Lead Tester",
+        chat_type="group",
+    )
+
+
+def _make_event(text: str, platform: Platform = Platform.WHATSAPP) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(platform=platform), message_id="m1")
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.WHATSAPP: PlatformConfig(enabled=True, token="***")}
+    )
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    runner.adapters = {Platform.WHATSAPP: adapter}
+    runner.hooks = SimpleNamespace(
+        emit=AsyncMock(),
+        emit_collect=AsyncMock(return_value=[]),
+        loaded_hooks=False,
+    )
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.WHATSAPP,
+        chat_type="group",
+    )
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._voice_mode = {}
+    runner._session_db = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._show_reasoning = False
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+    runner._active_session_locks = {}
+    runner._destructive_slash_confirm_sessions = {}
+    from gateway.run import GatewayRunner as _GR
+
+    runner._session_key_for_source = _GR._session_key_for_source.__get__(runner, _GR)
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_routes_resetlead(monkeypatch):
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    sentinel = "resetlead handler reached"
+    runner._maybe_confirm_destructive_slash = AsyncMock(return_value=sentinel)  # type: ignore[attr-defined]
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(_make_event("/resetlead"))
+    assert result == sentinel
+    runner._maybe_confirm_destructive_slash.assert_awaited_once()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_running_agent_bypasses_guard_for_resetlead(monkeypatch):
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    session_key = runner._session_key_for_source(_make_source())
+    runner._running_agents[session_key] = object()
+    runner._interrupt_and_clear_session = AsyncMock()  # type: ignore[attr-defined]
+    runner._handle_resetlead_command = AsyncMock(return_value="ok")  # type: ignore[attr-defined]
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(_make_event("/resetlead"))
+    assert result == "ok"
+    runner._interrupt_and_clear_session.assert_awaited_once()  # type: ignore[attr-defined]
+    _, kwargs = runner._interrupt_and_clear_session.await_args  # type: ignore[attr-defined]
+    assert kwargs["invalidation_reason"] == "resetlead_command"
+
+
+@pytest.mark.asyncio
+async def test_resetlead_handler_resets_persistent_lead_and_session(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    script_path = tmp_path / "skyops_leads.py"
+    script_path.write_text("# helper stub\n", encoding="utf-8")
+    runner._handle_reset_command = AsyncMock(  # type: ignore[attr-defined]
+        return_value=EphemeralReply("Started a new conversation.", ttl_seconds=45)
+    )
+
+    calls = []
+
+    async def _fake_create_subprocess_exec(*args, **kwargs):
+        calls.append((args, kwargs))
+        payload = (
+            '{"ok": true, "lead_id": "lead-123", "reset": true, '
+            '"previous_state": "qualified"}'
+        ).encode("utf-8")
+        return _FakeProc(returncode=0, stdout=payload, stderr=b"")
+
+    monkeypatch.setattr(gateway_run.asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+    monkeypatch.setattr(runner, "_skyops_leads_script_path", lambda: Path(script_path))
+
+    reply = await runner._handle_resetlead_command(_make_event("/resetlead"))
+
+    assert isinstance(reply, EphemeralReply)
+    assert reply.ttl_seconds == 45
+    assert "Lead lead-123 reset (previous state: qualified)." in str(reply)
+    assert "Started a new conversation." in str(reply)
+    runner._handle_reset_command.assert_awaited_once()  # type: ignore[attr-defined]
+
+    args, kwargs = calls[0]
+    assert args[0].endswith("python") or "python" in Path(args[0]).name.lower()
+    assert args[1] == str(script_path)
+    assert args[2:4] == ("reset", "--allow-missing")
+    assert "--whatsapp-id" in args
+    assert "34600111222" in args
+    assert "--display-name" in args
+    assert "Lead Tester" in args
+    assert kwargs["stdout"] is gateway_run.asyncio.subprocess.PIPE
+    assert kwargs["stderr"] is gateway_run.asyncio.subprocess.PIPE

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -106,6 +106,7 @@ class TestResolveCommand:
         assert resolve_command("exit").name == "quit"
         assert resolve_command("gateway").name == "platforms"
         assert resolve_command("set-home").name == "sethome"
+        assert resolve_command("reset-lead").name == "resetlead"
         assert resolve_command("reload_mcp").name == "reload-mcp"
         assert resolve_command("codex_runtime").name == "codex-runtime"
         assert resolve_command("tasks").name == "agents"

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -301,6 +301,21 @@ class TestFormatFooter:
         assert len(bullet_lines) == 11  # 10 shown + 1 summary
 
 
+class TestApplyFailureAdvisory:
+    def test_no_failures_returns_original_response(self):
+        response = "Todo aplicado."
+        assert AIAgent._apply_file_mutation_failure_advisory(response, {}) == response
+
+    def test_warning_is_prepended_and_footer_appended(self):
+        failed = {"/tmp/a.md": {"tool": "patch", "error_preview": "Could not find old_string"}}
+        out = AIAgent._apply_file_mutation_failure_advisory("Hecho.", failed)
+        assert out.startswith("⚠️ Partial edit result:")
+        assert "Hecho." in out
+        assert "/tmp/a.md" in out
+        assert "Could not find old_string" in out
+        assert out.index("Hecho.") < out.index("/tmp/a.md")
+
+
 # ---------------------------------------------------------------------------
 # _file_mutation_verifier_enabled — env + config precedence
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add the SkyOps `resetlead` gateway command and routing.
- Wire the command through the WhatsApp gateway path and related agent/session handling.
- Add/adjust CLI and gateway tests for command resolution and dispatch.

## Notes
- Pushed from fork branch `feat/resetlead-gateway-command`.
