### PR TITLE
fix(mcp): wire Authorization header for http catalog MCPs using api_key auth

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -472,6 +472,18 @@ def _build_server_config(
         cfg["url"] = t.url
         if entry.auth.type == "oauth":
             cfg["auth"] = "oauth"
+        elif entry.auth.type == "api_key":
+            # Mirror the manual ``hermes mcp add`` path (mcp_config.py): the
+            # api_key is prompted for and saved to .env, but an http server only
+            # authenticates if that key is interpolated into an Authorization
+            # header. Prefer an explicit auth.env_var; else fall back to the
+            # first declared env name. Guarded so an api_key entry with no
+            # declared env var writes no unresolvable ``Bearer ${}`` placeholder.
+            env_name = entry.auth.env_var or (
+                entry.auth.env[0].name if entry.auth.env else None
+            )
+            if env_name:
+                cfg["headers"] = {"Authorization": f"Bearer ${{{env_name}}}"}
     return cfg
 
 

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -307,6 +307,36 @@ class TestInstall:
         assert server["url"] == "https://mcp.example.com/sse"
         assert server["auth"] == "oauth"
 
+    def test_install_http_api_key_writes_authorization_header(
+        self, catalog_dir, monkeypatch
+    ):
+        body = _basic_manifest(
+            transport={"type": "http", "url": "https://mcp.example.com/mcp"},
+            auth={
+                "type": "api_key",
+                "env": [{"name": "DEMO_API_KEY", "prompt": "key", "secret": True}],
+            },
+        )
+        _write_manifest(catalog_dir, "demo", body)
+
+        from hermes_cli import mcp_catalog
+
+        monkeypatch.setattr(mcp_catalog, "_prompt_input", lambda *a, **kw: "secret-val")
+
+        from hermes_cli.mcp_catalog import install_entry
+        from hermes_cli.config import get_config_path, get_env_value
+
+        install_entry(_entry("demo"), enable=True)
+
+        # Read the raw config file so we assert the persisted placeholder
+        # rather than load_config()'s ${VAR}-expanded value.
+        with open(get_config_path()) as f:
+            raw = yaml.safe_load(f)
+        server = raw["mcp_servers"]["demo"]
+        assert get_env_value("DEMO_API_KEY") == "secret-val"
+        assert server["url"] == "https://mcp.example.com/mcp"
+        assert server["headers"]["Authorization"] == "Bearer ${DEMO_API_KEY}"
+
     def test_install_required_env_missing_raises(self, catalog_dir, monkeypatch):
         body = _basic_manifest(
             auth={


### PR DESCRIPTION
## What does this PR do?

Installing an `http`-transport catalog MCP that authenticates with an API key (`hermes mcp install <name>`, or the interactive picker) prompts for and saves the key to `~/.hermes/.env`, but the generated `mcp_servers.<name>` block contained only a `url` — no `Authorization` header. The saved key was never referenced, so the server was contacted unauthenticated and every tool call failed (401 / hang) with no obvious cause.

The manual path (`hermes mcp add`) already does this correctly (`hermes_cli/mcp_config.py`), writing `headers: {"Authorization": "Bearer ${VAR}"}`. Only the catalog install path (`_build_server_config` in `hermes_cli/mcp_catalog.py`) was missing it — it handled the `oauth` auth shape for http but silently dropped `api_key`. `http`+`api_key` is a valid, documented manifest combination (the docs describe http auth as an `Authorization: Bearer ${VAR}` header), so this was a latent correctness gap that triggered the moment such a manifest was installed.

## Related Issue

No filed issue — code-originated correctness fix (path-to-path asymmetry between the catalog install path and the manual `hermes mcp add` path).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/mcp_catalog.py`: in the `http` branch of `_build_server_config`, wire the `Authorization` header for `api_key` auth, mirroring the manual-add format. The env-var name comes from `auth.env_var` when set, else the first declared `auth.env` entry (which also gives the parsed-but-unused `AuthSpec.env_var` field a consumer). Guarded so an api_key entry with no declared env var writes no unresolvable `Bearer ${}` placeholder.
- `tests/hermes_cli/test_mcp_catalog.py`: add `test_install_http_api_key_writes_authorization_header`.

## How to Test

1. Add a catalog manifest with `transport.type: http` and `auth.type: api_key` declaring an env var (e.g. `DEMO_API_KEY`).
2. Run `hermes mcp install <name>` and enter the key when prompted.
3. Inspect `~/.hermes/config.yaml`: `mcp_servers.<name>` now contains `headers.Authorization: "Bearer ${DEMO_API_KEY}"` (previously absent). The key in `.env` is now actually used at connect time.

The regression test `test_install_http_api_key_writes_authorization_header` builds an http+api_key manifest, installs it, and asserts the persisted server config carries `headers.Authorization == "Bearer ${DEMO_API_KEY}"`. It fails before the fix (no `headers` key) and passes after. It reads the raw config file rather than `load_config()` so it asserts the persisted `${VAR}` placeholder, not the env-expanded value.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_mcp_catalog.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (no doc change; the http+api_key header shape is already documented)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure string/dict config wiring, no platform-specific paths)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A