### PR TITLE
fix(acp): preserve SSE transport when registering client-provided MCP servers

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -811,6 +811,13 @@ class HermesACPAgent(acp.Agent):
                         "url": server.url,
                         "headers": {item.name: item.value for item in server.headers},
                     }
+                    # McpServerHttp and McpServerSse share the url/headers shape,
+                    # but the downstream registrar (tools/mcp_tool.py) selects the
+                    # SSE client only when config["transport"] == "sse"; without
+                    # this marker an SSE server is contacted as streamable-HTTP
+                    # and the handshake fails.
+                    if isinstance(server, McpServerSse):
+                        config["transport"] = "sse"
                 config_map[name] = config
 
             await asyncio.to_thread(register_mcp_servers, config_map)

--- a/tests/acp/test_mcp_e2e.py
+++ b/tests/acp/test_mcp_e2e.py
@@ -16,6 +16,7 @@ from acp.schema import (
     EnvVariable,
     HttpHeader,
     McpServerHttp,
+    McpServerSse,
     McpServerStdio,
     NewSessionResponse,
     PromptResponse,
@@ -107,6 +108,43 @@ class TestMcpRegistrationE2E:
         assert state.agent.valid_tool_names == {
             "mcp_test_fs_read", "mcp_test_fs_write", "mcp_test_api_search", "terminal"
         }
+
+    @pytest.mark.asyncio
+    async def test_sse_server_preserves_transport_marker(self, acp_agent, mock_manager):
+        """An SSE MCP server must register with transport=sse, not as plain HTTP.
+
+        McpServerHttp and McpServerSse share the url/headers shape, so without an
+        explicit ``transport`` marker the downstream registrar
+        (``tools/mcp_tool.py``, which gates on ``config["transport"] == "sse"``)
+        would contact an SSE endpoint as streamable-HTTP and the handshake fails.
+        """
+        servers = [
+            McpServerSse(
+                name="test-sse",
+                url="https://sse.example.com/sse",
+                headers=[HttpHeader(name="Authorization", value="Bearer sse-tok")],
+            ),
+        ]
+
+        registered_configs = {}
+
+        def mock_register(config_map):
+            registered_configs.update(config_map)
+            return ["mcp_test_sse_query"]
+
+        fake_tools = [{"function": {"name": "mcp_test_sse_query"}}]
+
+        with patch("tools.mcp_tool.register_mcp_servers", side_effect=mock_register), \
+             patch("model_tools.get_tool_definitions", return_value=fake_tools):
+            resp = await acp_agent.new_session(cwd="/tmp", mcp_servers=servers)
+
+        assert isinstance(resp, NewSessionResponse)
+
+        assert "test-sse" in registered_configs
+        sse_cfg = registered_configs["test-sse"]
+        assert sse_cfg["transport"] == "sse"
+        assert sse_cfg["url"] == "https://sse.example.com/sse"
+        assert sse_cfg["headers"] == {"Authorization": "Bearer sse-tok"}
 
     @pytest.mark.asyncio
     async def test_prompt_with_tool_calls_emits_acp_events(self, acp_agent, mock_manager):

--- a/tests/acp/test_mcp_e2e.py
+++ b/tests/acp/test_mcp_e2e.py
@@ -110,7 +110,7 @@ class TestMcpRegistrationE2E:
         }
 
     @pytest.mark.asyncio
-    async def test_sse_server_preserves_transport_marker(self, acp_agent, mock_manager):
+    async def test_sse_server_preserves_transport_marker(self, acp_agent):
         """An SSE MCP server must register with transport=sse, not as plain HTTP.
 
         McpServerHttp and McpServerSse share the url/headers shape, so without an


### PR DESCRIPTION
## What does this PR do?

When an ACP client (Zed / VS Code / JetBrains) registers an SSE-transport MCP server in its session config (`session/new`, `session/load`, `session/resume`, `session/fork`), `_register_session_mcp_servers` builds a config of just `{url, headers}` with no `transport` marker. `McpServerHttp` and `McpServerSse` share the same url/headers shape, and the non-stdio branch handles them identically.

The downstream registrar (`tools/mcp_tool.py`) selects the SSE client only when `config["transport"] == "sse"`, otherwise falling through to `streamablehttp_client`. So an SSE MCP server provided over ACP is registered as streamable-HTTP instead — Hermes speaks the wrong wire protocol to the SSE-only endpoint, the connection mis-handshakes, and the server's tools never appear in the agent.

`config.yaml`-configured SSE servers are unaffected (they carry `transport: sse` already) — only the ACP-provided path dropped the discriminator, which is why this can go unnoticed.

## Related Issue

No filed issue — code-originated correctness fix (dropped transport discriminator in the ACP MCP-registration path).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `acp_adapter/server.py`: set `config["transport"] = "sse"` for `McpServerSse` instances in the http/sse branch of `_register_session_mcp_servers`, so the SSE discriminator the downstream registrar reads is preserved.
- `tests/acp/test_mcp_e2e.py`: add `test_sse_server_preserves_transport_marker` (the existing e2e test covered only `McpServerHttp` + `McpServerStdio`).

## How to Test

1. From an ACP client, create a session declaring an SSE-transport MCP server (`McpServerSse` with a `url` ending in `/sse`).
2. Before this fix, the server is registered without `transport: sse` and is contacted as streamable-HTTP — the handshake fails and its tools never load.
3. After this fix, the registered config carries `transport: "sse"` and the SSE client is selected.

The regression test `test_sse_server_preserves_transport_marker` registers an `McpServerSse` over a new ACP session and asserts the resulting config carries `transport == "sse"` (with url/headers intact). It fails before the fix (`KeyError: 'transport'`) and passes after.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/acp/test_mcp_e2e.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Python 3.11, agent-client-protocol 0.9.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure config-dict wiring, no platform-specific paths)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A