### PR TITLE
test: guard split web backend routing

### DIFF
--- a/changeLog.md
+++ b/changeLog.md
@@ -1,0 +1,19 @@
+# Hermes ChangeLog
+
+## 2026-06-22 — Local SearXNG / Firecrawl routing guard
+
+- Added regression coverage for the production web backend split:
+  - `web.search_backend = searxng` routes `web_search` to local SearXNG when `SEARXNG_URL` is configured.
+  - `web.extract_backend = firecrawl` keeps `web_extract` on Firecrawl because SearXNG is search-only.
+  - Missing `SEARXNG_URL` falls back to the shared `web.backend` path instead of silently selecting an unavailable SearXNG backend.
+- Updated the desktop app entry in `package-lock.json` from `0.15.1` to `0.17.0` so it matches `apps/desktop/package.json`.
+
+Validation:
+
+```text
+python -m pytest tests/tools/test_web_providers_searxng.py -q -o 'addopts='
+29 passed in 1.12s
+
+git diff --check
+# no whitespace errors
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
     },
     "apps/desktop": {
       "name": "hermes",
-      "version": "0.15.1",
+      "version": "0.17.0",
       "dependencies": {
         "@assistant-ui/react": "^0.12.28",
         "@assistant-ui/react-streamdown": "^0.1.11",

--- a/tests/tools/test_web_providers_searxng.py
+++ b/tests/tools/test_web_providers_searxng.py
@@ -329,6 +329,48 @@ class TestCheckWebApiKey:
 
 
 # ---------------------------------------------------------------------------
+# Split routing: search_backend=searxng + extract_backend=firecrawl
+# (the production config shipped 2026-06-20 — local SearxNG for search,
+# Firecrawl kept for extract since SearxNG is search-only. Pins the contract
+# so a future config refactor can't silently re-route search back to the
+# paid backend or break the search/extract split.)
+# ---------------------------------------------------------------------------
+
+
+class TestSplitSearxngSearchFirecrawlExtract:
+    """Production config: SearXNG for search, Firecrawl for extract."""
+
+    _PROD_CONFIG = {"search_backend": "searxng", "extract_backend": "firecrawl"}
+
+    def test_search_backend_searxng_resolves_to_searxng(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: dict(self._PROD_CONFIG))
+        monkeypatch.setenv("SEARXNG_URL", "http://127.0.0.1:8888")
+        assert web_tools._get_search_backend() == "searxng"
+
+    def test_extract_backend_stays_firecrawl(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: dict(self._PROD_CONFIG))
+        monkeypatch.setenv("SEARXNG_URL", "http://127.0.0.1:8888")
+        # _is_backend_available("firecrawl") delegates to check_firecrawl_api_key
+        monkeypatch.setattr(web_tools, "check_firecrawl_api_key", lambda: True)
+        assert web_tools._get_extract_backend() == "firecrawl"
+
+    def test_search_backend_searxng_without_url_falls_back_to_shared(self, monkeypatch):
+        """If SEARXNG_URL is unset the search_backend override is not 'available',
+        so selection falls through to the shared _get_backend() (web.backend)."""
+        from tools import web_tools
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {"search_backend": "searxng", "backend": "firecrawl"},
+        )
+        monkeypatch.delenv("SEARXNG_URL", raising=False)
+        monkeypatch.setattr(web_tools, "check_firecrawl_api_key", lambda: True)
+        assert web_tools._get_search_backend() == "firecrawl"
+
+
+# ---------------------------------------------------------------------------
 # searxng-only: web_extract returns a clear error
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add regression coverage for split web backend routing: SearXNG search + Firecrawl extract.
- Document the local Hermes change in changeLog.md.
- Align apps/desktop package-lock entry with desktop package version 0.17.0.

## Validation
- python -m pytest tests/tools/test_web_providers_searxng.py -q -o 'addopts=' — 29 passed
- git diff --check — no whitespace errors
