### PR TITLE
fix(gateway): respect tool_preview_length: 0 as unlimited

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17629,12 +17629,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _code_block_full = f"{_block_header}```\n{_cmd_full}\n```"
                 # Single-line, capped preview for non-verbose modes.
                 _pl = get_tool_preview_max_len()
-                _cap = _pl if _pl > 0 else 40
                 _lines = _cmd_full.splitlines()
                 _cmd_short = _lines[0] if _lines else _cmd_full
                 _multiline = len(_lines) > 1
-                if len(_cmd_short) > _cap:
-                    _cmd_short = _cmd_short[:_cap - 3] + "..."
+                # _pl == 0 means no limit (user wants full visibility);
+                # only truncate when a positive cap is configured.
+                if _pl > 0 and len(_cmd_short) > _pl:
+                    _cmd_short = _cmd_short[:_pl - 3] + "..."
                 elif _multiline:
                     _cmd_short = _cmd_short + " ..."
                 _code_block_short = f"{_block_header}```\n{_cmd_short}\n```"
@@ -17679,9 +17680,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     verb_drops_preview,
                 )
                 _pl = get_tool_preview_max_len()
-                _cap = _pl if _pl > 0 else 40
-                if len(preview) > _cap:
-                    preview = preview[:_cap - 3] + "..."
+                # _pl == 0 means no limit (user wants full visibility);
+                # only truncate when a positive cap is configured.
+                if _pl > 0 and len(preview) > _pl:
+                    preview = preview[:_pl - 3] + "..."
                 # Friendly labels: render a human-phrased line for built-in
                 # tools ("🔍 Searching the web for ...") by prefixing the verb
                 # onto the preview the callback already computed (so the

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -567,17 +567,27 @@ def _run_long_preview_helper(monkeypatch, tmp_path, preview_length=0):
     return adapter, result
 
 
-def test_all_mode_default_truncation_40_chars(monkeypatch, tmp_path):
-    """When tool_preview_length is 0 (default), all/new mode truncates to 40 chars."""
+def test_all_mode_zero_means_unlimited(monkeypatch, tmp_path):
+    """tool_preview_length: 0 means NO limit (documented contract, #51067).
+
+    Regression guard: previously the gateway applied a zero-to-40 fallback
+    (``_cap = _pl if _pl > 0 else 40``), so an explicit 0 wrongly truncated to
+    40 chars. Zero must now preserve the full preview. This exercises the real
+    gateway progress-delivery path via _run_long_preview_helper, so it fails if
+    gateway/run.py reintroduces the falsy-check fallback.
+    """
     adapter, result = _run_long_preview_helper(monkeypatch, tmp_path, preview_length=0)
     assert result["final_response"] == "done"
     assert adapter.sent
     content = adapter.sent[0]["content"]
-    # The long command should be truncated — the preview portion <= 40 chars.
-    assert "..." in content
     preview_text = _extract_progress_preview(content)
     assert preview_text is not None, f"No preview found in: {content}"
-    assert len(preview_text) <= 40, f"Preview too long ({len(preview_text)}): {preview_text}"
+    # The full command (165 chars) must survive untruncated when preview=0.
+    assert len(preview_text) == len(LongPreviewAgent.LONG_CMD), (
+        f"Preview was truncated at zero ({len(preview_text)} chars): {preview_text}"
+    )
+    assert preview_text == LongPreviewAgent.LONG_CMD
+    assert "..." not in content, f"Zero must not truncate, but got ellipsis: {content}"
 
 
 def test_all_mode_respects_custom_preview_length(monkeypatch, tmp_path):
@@ -1411,13 +1421,21 @@ class TerminalCommandAgent:
         "npm install -g hyperframes@latest"
     )
 
-    def __init__(self, **kwargs):
+    # A single long line (no newlines): used to verify explicit
+    # tool_preview_length: 0 does NOT truncate the fenced terminal preview.
+    LONG_LINE = (
+        "find /usr/local/share -type f -name '*.py' "
+        "-exec grep -l 'import asyncio' {} + | sort -u | head -n 50"
+    )
+
+    def __init__(self, command=None, **kwargs):
         self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self._command = command if command is not None else self.CMD
         self.tools = []
 
     def run_conversation(self, message, conversation_history=None, task_id=None):
         self.tool_progress_callback(
-            "tool.started", "terminal", self.CMD, {"command": self.CMD}
+            "tool.started", "terminal", self._command, {"command": self._command}
         )
         # Let the async progress task drain the queue and send before returning.
         time.sleep(0.35)
@@ -1477,6 +1495,72 @@ async def test_terminal_progress_renders_fenced_code_block(monkeypatch, tmp_path
     assert "node --version" not in all_content
     # No truncated quoted preview for the terminal command.
     assert 'terminal: "' not in all_content
+
+
+@pytest.mark.asyncio
+async def test_terminal_progress_long_single_line_not_truncated_at_zero(monkeypatch, tmp_path):
+    """With explicit tool_preview_length: 0, a long single-line terminal command
+    is rendered in full inside the fenced code block — no truncation, no ellipsis.
+
+    Regression guard for #51067 on the terminal (code-block) delivery path:
+    previously the zero-to-40 fallback capped the single-line preview at 40
+    chars. This exercises the real gateway progress path, so it fails if
+    gateway/run.py reintroduces the falsy-check fallback for _cmd_short.
+    """
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    # Emit the long SINGLE-LINE command (no newlines → no multiline suffix).
+    class _LongLineTerminalAgent(TerminalCommandAgent):
+        def __init__(self, **kw):
+            kw.pop("command", None)
+            super().__init__(command=TerminalCommandAgent.LONG_LINE, **kw)
+
+    fake_run_agent.AIAgent = _LongLineTerminalAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    import tools.terminal_tool  # noqa: F401 - register terminal emoji
+
+    # Explicit zero = unlimited.
+    import yaml
+    (tmp_path / "config.yaml").write_text(
+        yaml.dump({"display": {"tool_preview_length": 0}}), encoding="utf-8"
+    )
+
+    adapter = CodeBlockProgressAdapter(platform=Platform.TELEGRAM)
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-terminal-longline-zero",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "done"
+    all_content = " ".join(call["content"] for call in adapter.sent)
+    all_content += " ".join(call["content"] for call in adapter.edits)
+    assert "```" in all_content
+    # The full single-line command must appear untruncated — no ellipsis.
+    assert TerminalCommandAgent.LONG_LINE in all_content, (
+        f"Long single line was truncated at zero: {all_content}"
+    )
+    assert "..." not in all_content, f"Zero must not truncate terminal preview: {all_content}"
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_tool_preview_length_zero.py
+++ b/tests/gateway/test_tool_preview_length_zero.py
@@ -1,95 +1,45 @@
 """Tests for tool_preview_length: 0 (no limit) handling in gateway progress.
 
-Regression test for #51067: setting tool_preview_length to 0 should disable
-truncation entirely, not fall back to a 40-char default.
+Regression test for #51067: setting tool_preview_length to 0 (the documented
+"no limit" value) must disable truncation entirely, not fall back to a 40-char
+default via a falsy check (``_cap = _pl if _pl > 0 else 40``).
+
+The behavioural regression guards live in tests/gateway/test_run_progress_topics.py,
+where they exercise the REAL gateway progress-delivery path via
+``_run_long_preview_helper`` and ``TerminalCommandAgent`` so they fail if
+``gateway/run.py`` reintroduces the falsy-check fallback:
+
+    - test_all_mode_zero_means_unlimited
+        Quoted-preview path: explicit 0 preserves the full preview.
+    - test_all_mode_respects_custom_preview_length
+        Positive cap still truncates.
+    - test_terminal_progress_long_single_line_not_truncated_at_zero
+        Fenced code-block terminal path: explicit 0 preserves the full
+        single-line command (no ellipsis).
+
+This module keeps only lightweight unit coverage for the ``get/set`` accessor
+sentinel — it does NOT re-implement the gateway truncation branch, so it cannot
+mask a regression in gateway/run.py.
 """
 
-import pytest
-from unittest.mock import patch
-
-from agent.display import set_tool_preview_max_len, get_tool_preview_max_len
+from agent.display import get_tool_preview_max_len, set_tool_preview_max_len
 
 
-@pytest.fixture(autouse=True)
-def reset_preview_len():
-    """Reset tool_preview_max_len before/after each test."""
-    set_tool_preview_max_len(0)
-    yield
-    set_tool_preview_max_len(0)
+class TestToolPreviewLengthAccessor:
+    """The 0 sentinel round-trips through the display accessor unchanged."""
 
+    def test_zero_round_trips_as_unlimited_sentinel(self):
+        """Zero is stored and returned as-is (sentinel for 'no limit')."""
+        try:
+            set_tool_preview_max_len(0)
+            assert get_tool_preview_max_len() == 0
+        finally:
+            set_tool_preview_max_len(0)
 
-class TestToolPreviewLengthZeroMeansUnlimited:
-    """tool_preview_length: 0 should mean no truncation."""
-
-    def test_get_returns_zero_for_unlimited(self):
-        """Zero is returned as-is (sentinel for unlimited)."""
-        set_tool_preview_max_len(0)
-        assert get_tool_preview_max_len() == 0
-
-    def test_positive_value_is_stored(self):
-        """Positive values are stored as-is."""
-        set_tool_preview_max_len(80)
-        assert get_tool_preview_max_len() == 80
-
-    def test_zero_does_not_truncate_long_string(self):
-        """When _pl == 0, no truncation occurs regardless of string length."""
-        set_tool_preview_max_len(0)
-        _pl = get_tool_preview_max_len()
-        long_preview = "x" * 200
-        # Simulate the fixed gateway logic:
-        # Only truncate when _pl > 0 and len > _pl
-        if _pl > 0 and len(long_preview) > _pl:
-            long_preview = long_preview[:_pl - 3] + "..."
-        # With _pl == 0, the preview should remain untouched
-        assert len(long_preview) == 200
-        assert "..." not in long_preview
-
-    def test_positive_value_truncates(self):
-        """When _pl > 0 and string exceeds it, truncation occurs."""
-        set_tool_preview_max_len(40)
-        _pl = get_tool_preview_max_len()
-        long_preview = "x" * 200
-        if _pl > 0 and len(long_preview) > _pl:
-            long_preview = long_preview[:_pl - 3] + "..."
-        assert len(long_preview) == 40
-        assert long_preview.endswith("...")
-
-    def test_positive_value_no_truncate_when_short(self):
-        """When _pl > 0 but string is shorter, no truncation."""
-        set_tool_preview_max_len(40)
-        _pl = get_tool_preview_max_len()
-        short_preview = "ls -la"
-        if _pl > 0 and len(short_preview) > _pl:
-            short_preview = short_preview[:_pl - 3] + "..."
-        assert short_preview == "ls -la"
-
-    def test_terminal_multiline_still_gets_ellipsis(self):
-        """Multiline commands still get ' ...' suffix (indicating more lines)."""
-        set_tool_preview_max_len(0)
-        _pl = get_tool_preview_max_len()
-        _cmd_full = "echo hello\necho world"
-        _lines = _cmd_full.splitlines()
-        _cmd_short = _lines[0] if _lines else _cmd_full
-        _multiline = len(_lines) > 1
-        # Fixed logic from gateway/run.py
-        if _pl > 0 and len(_cmd_short) > _pl:
-            _cmd_short = _cmd_short[:_pl - 3] + "..."
-        elif _multiline:
-            _cmd_short = _cmd_short + " ..."
-        assert _cmd_short == "echo hello ..."
-
-    def test_terminal_long_single_line_not_truncated_at_zero(self):
-        """A single long command line is NOT truncated when _pl == 0."""
-        set_tool_preview_max_len(0)
-        _pl = get_tool_preview_max_len()
-        _cmd_full = "find /usr/local/share -name '*.py' -exec grep -l 'import asyncio' {} +"
-        _lines = _cmd_full.splitlines()
-        _cmd_short = _lines[0] if _lines else _cmd_full
-        _multiline = len(_lines) > 1
-        if _pl > 0 and len(_cmd_short) > _pl:
-            _cmd_short = _cmd_short[:_pl - 3] + "..."
-        elif _multiline:
-            _cmd_short = _cmd_short + " ..."
-        # Should be unchanged — no truncation with _pl == 0
-        assert _cmd_short == _cmd_full
-        assert "..." not in _cmd_short
+    def test_positive_value_round_trips(self):
+        """Positive caps are stored and returned unchanged."""
+        try:
+            set_tool_preview_max_len(80)
+            assert get_tool_preview_max_len() == 80
+        finally:
+            set_tool_preview_max_len(0)

--- a/tests/gateway/test_tool_preview_length_zero.py
+++ b/tests/gateway/test_tool_preview_length_zero.py
@@ -1,0 +1,95 @@
+"""Tests for tool_preview_length: 0 (no limit) handling in gateway progress.
+
+Regression test for #51067: setting tool_preview_length to 0 should disable
+truncation entirely, not fall back to a 40-char default.
+"""
+
+import pytest
+from unittest.mock import patch
+
+from agent.display import set_tool_preview_max_len, get_tool_preview_max_len
+
+
+@pytest.fixture(autouse=True)
+def reset_preview_len():
+    """Reset tool_preview_max_len before/after each test."""
+    set_tool_preview_max_len(0)
+    yield
+    set_tool_preview_max_len(0)
+
+
+class TestToolPreviewLengthZeroMeansUnlimited:
+    """tool_preview_length: 0 should mean no truncation."""
+
+    def test_get_returns_zero_for_unlimited(self):
+        """Zero is returned as-is (sentinel for unlimited)."""
+        set_tool_preview_max_len(0)
+        assert get_tool_preview_max_len() == 0
+
+    def test_positive_value_is_stored(self):
+        """Positive values are stored as-is."""
+        set_tool_preview_max_len(80)
+        assert get_tool_preview_max_len() == 80
+
+    def test_zero_does_not_truncate_long_string(self):
+        """When _pl == 0, no truncation occurs regardless of string length."""
+        set_tool_preview_max_len(0)
+        _pl = get_tool_preview_max_len()
+        long_preview = "x" * 200
+        # Simulate the fixed gateway logic:
+        # Only truncate when _pl > 0 and len > _pl
+        if _pl > 0 and len(long_preview) > _pl:
+            long_preview = long_preview[:_pl - 3] + "..."
+        # With _pl == 0, the preview should remain untouched
+        assert len(long_preview) == 200
+        assert "..." not in long_preview
+
+    def test_positive_value_truncates(self):
+        """When _pl > 0 and string exceeds it, truncation occurs."""
+        set_tool_preview_max_len(40)
+        _pl = get_tool_preview_max_len()
+        long_preview = "x" * 200
+        if _pl > 0 and len(long_preview) > _pl:
+            long_preview = long_preview[:_pl - 3] + "..."
+        assert len(long_preview) == 40
+        assert long_preview.endswith("...")
+
+    def test_positive_value_no_truncate_when_short(self):
+        """When _pl > 0 but string is shorter, no truncation."""
+        set_tool_preview_max_len(40)
+        _pl = get_tool_preview_max_len()
+        short_preview = "ls -la"
+        if _pl > 0 and len(short_preview) > _pl:
+            short_preview = short_preview[:_pl - 3] + "..."
+        assert short_preview == "ls -la"
+
+    def test_terminal_multiline_still_gets_ellipsis(self):
+        """Multiline commands still get ' ...' suffix (indicating more lines)."""
+        set_tool_preview_max_len(0)
+        _pl = get_tool_preview_max_len()
+        _cmd_full = "echo hello\necho world"
+        _lines = _cmd_full.splitlines()
+        _cmd_short = _lines[0] if _lines else _cmd_full
+        _multiline = len(_lines) > 1
+        # Fixed logic from gateway/run.py
+        if _pl > 0 and len(_cmd_short) > _pl:
+            _cmd_short = _cmd_short[:_pl - 3] + "..."
+        elif _multiline:
+            _cmd_short = _cmd_short + " ..."
+        assert _cmd_short == "echo hello ..."
+
+    def test_terminal_long_single_line_not_truncated_at_zero(self):
+        """A single long command line is NOT truncated when _pl == 0."""
+        set_tool_preview_max_len(0)
+        _pl = get_tool_preview_max_len()
+        _cmd_full = "find /usr/local/share -name '*.py' -exec grep -l 'import asyncio' {} +"
+        _lines = _cmd_full.splitlines()
+        _cmd_short = _lines[0] if _lines else _cmd_full
+        _multiline = len(_lines) > 1
+        if _pl > 0 and len(_cmd_short) > _pl:
+            _cmd_short = _cmd_short[:_pl - 3] + "..."
+        elif _multiline:
+            _cmd_short = _cmd_short + " ..."
+        # Should be unchanged — no truncation with _pl == 0
+        assert _cmd_short == _cmd_full
+        assert "..." not in _cmd_short


### PR DESCRIPTION
## What

`tool_preview_length: 0` is documented as "no limit" but was truncated to 40 characters in gateway progress messages.

## Why

Two places in `gateway/run.py` used:
```python
_cap = _pl if _pl > 0 else 40
```
When `_pl == 0`, this evaluates to `40` (falsy fallback), defeating the user's intent.

Fixes #51067

## How

Replace the falsy-check pattern with an explicit positive-value guard:
- Only truncate when `_pl > 0` and the string exceeds `_pl`
- When `_pl == 0`, skip truncation entirely (no limit)
- Multiline terminal commands still get a trailing ` ...` suffix to indicate additional lines, regardless of the cap setting

## Testing

```bash
python3 -m pytest tests/gateway/test_tool_preview_length_zero.py -v
```

7 tests covering:
- Zero returns unlimited (no truncation on any length string)
- Positive values still truncate correctly
- Terminal multiline commands preserve the ` ...` indicator
- Single long commands are not truncated when cap is 0

## Breaking changes

None. Positive values behave identically. Only `0` changes from "truncate at 40" to "no limit" (matching documented behavior).