### PR TITLE
fix(gateway): detect launchd via XPC_SERVICE_NAME for Telegram /restart path

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10644,11 +10644,13 @@ class GatewayRunner:
         # Docker/Podman container, use the service restart path: exit with
         # code 75 so the service manager / container restart policy restarts
         # us.  The detached subprocess approach (setsid + bash) doesn't work
-        # under systemd (KillMode=mixed kills the cgroup) or Docker (tini
+        # under systemd (KillMode=mixed kills the cgroup), launchd (the
+        # subprocess is not tracked by the service manager), or Docker (tini
         # exits when the gateway dies, taking the detached helper with it).
         _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
+        _under_launchd = bool(os.environ.get("XPC_SERVICE_NAME"))  # launchd sets this
         _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
-        if _under_service or _in_container:
+        if _under_service or _under_launchd or _in_container:
             self.request_restart(detached=False, via_service=True)
         else:
             self.request_restart(detached=True, via_service=False)


### PR DESCRIPTION
## Problem

The `_handle_restart_command` method only checked for `INVOCATION_ID` (systemd) and container markers to decide whether to use the service restart path (`via_service=True`, exit code 75). On macOS under launchd, neither env var is set — but `XPC_SERVICE_NAME` is always present.

Without this detection, the Telegram `/restart` path falls through to `via_service=False` (detached subprocess), which exits with code 0. launchd's `KeepAlive → SuccessfulExit → false` policy treats exit(0) as 'successful, don't restart', so the gateway stays down after a Telegram `/restart` command.

## Fix

Add `_under_launchd = bool(os.environ.get('XPC_SERVICE_NAME'))` and include it in the service-restart condition, matching the existing systemd convention.

## Testing

Verified on macOS 25.3 (arm64): `XPC_SERVICE_NAME=ai.hermes.gateway-dante` is set when running under launchd. The fix ensures the Telegram `/restart` path uses `via_service=True` and exits with code 75, which launchd's `SuccessfulExit → false` policy correctly treats as a restart trigger.

## References

- Commit 5987b2431 (original launchd fix for SIGUSR1 path)
- Closes #28135 (Telegram `/restart` path was missed)