### PR TITLE
fix: resolve Windows path corruption and test collection crash

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -169,16 +169,27 @@ def _path_from_file_uri(uri: str) -> Path | None:
     else:
         path_text = unquote(raw)
 
-    # file:///C:/Users/... or C:\Users\...
-    if len(path_text) >= 3 and path_text[0] == "/" and path_text[2] == ":" and path_text[1].isalpha():
-        drive = path_text[1].lower()
-        rest = path_text[3:].lstrip("/\\").replace("\\", "/")
-        return Path("/mnt") / drive / rest
-    if len(path_text) >= 2 and path_text[1] == ":" and path_text[0].isalpha():
-        drive = path_text[0].lower()
-        rest = path_text[2:].lstrip("/\\").replace("\\", "/")
-        return Path("/mnt") / drive / rest
+    # Only rewrite Windows drive paths to /mnt/<drive>/... when Hermes itself is
+    # running inside WSL. On native Windows the original drive path is valid and
+    # must be preserved (mirrors acp_adapter/session.py:_translate_acp_cwd).
+    from hermes_constants import is_wsl
 
+    if is_wsl():
+        # file:///C:/Users/... or C:\Users\...
+        if len(path_text) >= 3 and path_text[0] == "/" and path_text[2] == ":" and path_text[1].isalpha():
+            drive = path_text[1].lower()
+            rest = path_text[3:].lstrip("/\\").replace("\\", "/")
+            return Path("/mnt") / drive / rest
+        if len(path_text) >= 2 and path_text[1] == ":" and path_text[0].isalpha():
+            drive = path_text[0].lower()
+            rest = path_text[2:].lstrip("/\\").replace("\\", "/")
+            return Path("/mnt") / drive / rest
+        return Path(path_text)
+
+    # Native Windows / Linux / macOS: strip a leading slash from /C:/... forms
+    # but otherwise keep the path as-is.
+    if len(path_text) >= 3 and path_text[0] == "/" and path_text[2] == ":" and path_text[1].isalpha():
+        path_text = path_text[1:]
     return Path(path_text)
 
 

--- a/tests/acp_adapter/test_acp_images.py
+++ b/tests/acp_adapter/test_acp_images.py
@@ -38,7 +38,9 @@ def test_text_only_acp_blocks_stay_string_for_legacy_prompt_path():
 
 def test_acp_resource_link_file_is_inlined_as_text(tmp_path):
     attached = tmp_path / "notes.md"
-    attached.write_text("# Notes\n\nAttached file body", encoding="utf-8")
+    # newline="" prevents Windows text-mode \n -> \r\n translation so the
+    # on-disk bytes match the asserted \n content cross-platform.
+    attached.write_text("# Notes\n\nAttached file body", encoding="utf-8", newline="")
 
     content = _content_blocks_to_openai_user_content([
         TextContentBlock(type="text", text="Please read this file"),

--- a/tests/test_run_tests_parallel.py
+++ b/tests/test_run_tests_parallel.py
@@ -32,10 +32,15 @@ import pytest
 
 
 # Both tests share the same handoff file: the leaker writes here, the
-# verifier reads here. We park it in $TMPDIR with a unique-per-run name
-# so concurrent invocations of the suite don't clobber each other.
-_HANDOFF_DIR = Path(os.environ.get("TMPDIR", "/tmp")) / "hermes-isolation-probe"
-_HANDOFF_DIR.mkdir(exist_ok=True)
+# verifier reads here. We park it under the platform temp dir with a
+# unique-per-run name so concurrent invocations don't clobber each other.
+# Use tempfile.gettempdir() rather than a hardcoded "/tmp" fallback so the
+# module imports cleanly on native Windows (where "/tmp" does not exist and
+# the mkdir would otherwise abort collection before the win32 skip applies).
+import tempfile
+
+_HANDOFF_DIR = Path(os.environ.get("TMPDIR") or tempfile.gettempdir()) / "hermes-isolation-probe"
+_HANDOFF_DIR.mkdir(parents=True, exist_ok=True)
 
 
 def _handoff_path_for(nonce: str) -> Path:


### PR DESCRIPTION
{
  "title": "fix: resolve Windows path corruption and test collection crash",
  "head": "eksays:fix/startup-hang-windows-path",
  "base": "main",
  "body": "## Summary\n\nBug fixes discovered during a comprehensive audit of the codebase on native Windows.\n\n### Changes\n\n1. **ACP adapter corrupts Windows drive paths** (`acp_adapter/server.py`)\n   - `_path_from_file_uri` unconditionally rewrites `C:\\...` paths to `/mnt/c/...`, which only makes sense inside WSL. Added the same `is_wsl()` guard used by the sibling function in `session.py`.\n   - Three tests (`test_acp_resource_link_file_is_inlined_as_text`, `test_acp_resource_link_image_file_is_inlined_as_image_url`, `test_acp_resource_link_image_mime_inferred_from_suffix`) failed with `FileNotFoundError` — all now pass.\n\n2. **Test collection crash on Windows** (`tests/test_run_tests_parallel.py`)\n   - Module-level `mkdir(\"/tmp\")` fails on Windows where `/tmp` does not exist, aborting collection before `@pytest.mark.skipif(\"win32\")` can apply. Replaced with `tempfile.gettempdir()`.\n\n3. **CRLF mismatch in ACP test** (`tests/acp_adapter/test_acp_images.py`)\n   - `write_text` translates `\\n` to `\\r\\n` on Windows, causing a test assertion to fail. Pinned with `newline=\"\"`.\n\n### Testing\n- ACP adapter tests: 19/19 passed (was 3 failures)\n- Collection: test_run_tests_parallel collects cleanly\n- All existing suites: no regressions\n\nCo-Authored-By: Claude <noreply@anthropic.com>"
}
