### PR TITLE
fix(memory): require Honcho SDK for provider activation

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -255,6 +255,7 @@ class HonchoMemoryProvider(MemoryProvider):
     def is_available(self) -> bool:
         """Check if Honcho is configured. No network calls."""
         try:
+            import honcho  # noqa: F401
             from plugins.memory.honcho.client import HonchoClientConfig
             cfg = HonchoClientConfig.from_global_config()
             # Port #2645: baseUrl-only verification — api_key OR base_url suffices

--- a/tests/honcho_plugin/test_honcho_availability.py
+++ b/tests/honcho_plugin/test_honcho_availability.py
@@ -1,0 +1,25 @@
+"""Availability checks for the Honcho memory provider."""
+
+from __future__ import annotations
+
+import builtins
+from unittest.mock import MagicMock, patch
+
+from plugins.memory.honcho import HonchoMemoryProvider
+
+
+def test_is_available_false_when_honcho_dependency_missing():
+    provider = HonchoMemoryProvider()
+    cfg = MagicMock(enabled=True, api_key="honcho-test-key", base_url="")
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "honcho":
+            raise ImportError("No module named 'honcho'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    with patch(
+        "plugins.memory.honcho.client.HonchoClientConfig.from_global_config",
+        return_value=cfg,
+    ), patch("builtins.__import__", side_effect=fake_import):
+        assert provider.is_available() is False


### PR DESCRIPTION
## Summary
- require the `honcho` SDK import in `HonchoMemoryProvider.is_available()` so configured-but-missing installs stay inactive
- add a focused regression test covering the missing-dependency case

## Testing
- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/honcho_plugin/test_honcho_availability.py tests/honcho_plugin/test_empty_profile_hint.py -q`
- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m ruff check plugins/memory/honcho/__init__.py tests/honcho_plugin/test_honcho_availability.py`
- `git diff --check`

Fixes #51099