### PR TITLE
docs(computer-use): document Windows UIPI elevated-window limitation

### DIFF
--- a/website/docs/user-guide/features/computer-use.md
+++ b/website/docs/user-guide/features/computer-use.md
@@ -255,6 +255,19 @@ of screenshot context, not ~600K.
   drawing (Logic, Final Cut, some games) have sparse or empty AX trees.
   Fall back to pixel coordinates if the tree is empty — or skip the
   task entirely.
+- **Windows: elevated (admin) windows can't be driven from a normal
+  agent.** Windows UIPI (User Interface Privilege Isolation) enforces
+  integrity-level boundaries: a Medium-integrity process (the default
+  Hermes agent) cannot enumerate the UIA tree of, or inject mouse input
+  into, a window owned by a High-integrity (Administrator) process.
+  Symptom: `capture(mode='som')` returns 0 elements and `click(...)`
+  reports success while doing nothing, even though the screenshot
+  renders fine (GDI capture sits below the integrity check). Keyboard
+  events partially bypass UIPI, so Tab / Enter can still navigate an
+  elevated dialog. This is an OS constraint, not a cua-driver bug — it
+  affects every Windows automation stack. To drive elevated windows,
+  run the Hermes agent itself at High integrity (launch from an
+  elevated terminal); otherwise target non-elevated windows.
 - **Platform-specific deployment gotchas:**
   - **macOS** uses private SkyLight SPIs. Apple can change them in any
     OS update. Hermes warns when the installed cua-driver is older than


### PR DESCRIPTION
## Summary

Documents the Windows UIPI limitation reported in #49067: a Medium-integrity Hermes agent cannot drive High-integrity (admin) windows — UIPI blocks UIA enumeration and mouse injection. This is an OS constraint affecting every Windows automation stack, not a cua-driver bug, so it gets a docs note rather than a code fix.

## Changes

- `website/docs/user-guide/features/computer-use.md` — new Limitations bullet covering the integrity boundary, the symptom (SOM returns 0 elements, clicks silently no-op, screenshots still work, keyboard partially bypasses), why it's an OS rule, and the workaround (run the agent at High integrity).

## Context

Reported by @Icather in #49067, who explicitly framed it as documentation/knowledge rather than a fix request ("This issue does not request changes to the backend"). Verified the analysis matches the OS behavior; closing #49067 as a documented limitation.

## Infographic

![windows-uipi-limit](https://v3b.fal.media/files/b/0a9f62ec/v04bk0K5q-Imhwz7zMG6E_zmnbIJaF.png)
