### PR TITLE
fix(google-meet): replace assert with proper check in OpenAI realtime client

### DIFF
--- a/plugins/google_meet/realtime/openai_client.py
+++ b/plugins/google_meet/realtime/openai_client.py
@@ -221,12 +221,14 @@ class RealtimeSession:
             return False
 
     def _send_json(self, payload: dict) -> None:
-        assert self._ws is not None
+        if self._ws is None:
+            raise RuntimeError("WebSocket not connected")
         with self._send_lock:
             self._ws.send(json.dumps(payload))
 
     def _recv(self, timeout: Optional[float] = None):
-        assert self._ws is not None
+        if self._ws is None:
+            raise RuntimeError("WebSocket not connected")
         try:
             if timeout is None:
                 return self._ws.recv()


### PR DESCRIPTION
## Summary

`assert` statements are stripped when Python runs with `-O` flag. Replace `assert self._ws is not None` with `if self._ws is None: raise RuntimeError(...)` in `plugins/google_meet/realtime/openai_client.py`.

## Files changed

- `plugins/google_meet/realtime/openai_client.py` — 2 asserts in `_send_json()` and `_recv()`

## Test plan

- [x] `python3 -m py_compile plugins/google_meet/realtime/openai_client.py` — syntax OK
- [x] Both `assert self._ws is not None` replaced with proper `if/raise` checks