### PR TITLE
feat(session_search): semantic/hybrid search with sqlite-vec

### DIFF
--- a/agent/embedding_provider.py
+++ b/agent/embedding_provider.py
@@ -1,0 +1,144 @@
+"""Embedding provider abstraction — Strategy pattern for vector generation.
+
+Provides a common interface for generating text embeddings with swappable
+backends: Ollama (local, free) and OpenAI (API).
+
+Usage:
+    from agent.embedding_provider import resolve_embedding_provider
+
+    config = {"provider": "ollama", "model": "nomic-embed-text", ...}
+    provider = resolve_embedding_provider(config)
+    vector = provider.generate_embedding("some text")
+"""
+
+from abc import ABC, abstractmethod
+from typing import Optional
+
+
+class EmbeddingProvider(ABC):
+    """Abstract base for embedding generation strategies."""
+
+    @abstractmethod
+    def generate_embedding(self, text: str) -> "list[float]":
+        """Generate a vector embedding for the given text."""
+
+    @property
+    @abstractmethod
+    def dimensions(self) -> int:
+        """Number of dimensions in the generated vectors."""
+
+
+class OllamaEmbeddingProvider(EmbeddingProvider):
+    """Generates embeddings via Ollama's OpenAI-compatible API."""
+
+    def __init__(
+        self,
+        model: str = "nomic-embed-text",
+        base_url: str = "http://localhost:11434/v1",
+        api_key: str = "ollama",
+        dimensions: int = 768,
+    ):
+        self._model = model
+        self._base_url = base_url
+        self._api_key = api_key
+        self._dimensions = dimensions
+        self._client = None
+
+    @property
+    def dimensions(self) -> int:
+        return self._dimensions
+
+    def _get_client(self):
+        """Lazy-init the OpenAI-compatible client."""
+        if self._client is None:
+            from openai import OpenAI
+            self._client = OpenAI(
+                base_url=self._base_url,
+                api_key=self._api_key,
+            )
+        return self._client
+
+    def generate_embedding(self, text: str) -> "list[float]":
+        if not text or not text.strip():
+            return [0.0] * self._dimensions
+
+        client = self._get_client()
+        response = client.embeddings.create(
+            model=self._model,
+            input=text,
+        )
+        return list(response.data[0].embedding)
+
+
+class OpenAIEmbeddingProvider(EmbeddingProvider):
+    """Generates embeddings via OpenAI's embeddings API."""
+
+    def __init__(
+        self,
+        model: str = "text-embedding-3-small",
+        api_key: str = "",
+        dimensions: int = 1536,
+    ):
+        self._model = model
+        self._api_key = api_key
+        self._dimensions = dimensions
+        self._client = None
+
+    @property
+    def dimensions(self) -> int:
+        return self._dimensions
+
+    def _get_client(self):
+        """Lazy-init the OpenAI client."""
+        if self._client is None:
+            from openai import OpenAI
+            self._client = OpenAI(api_key=self._api_key)
+        return self._client
+
+    def generate_embedding(self, text: str) -> "list[float]":
+        if not text or not text.strip():
+            return [0.0] * self._dimensions
+
+        client = self._get_client()
+        response = client.embeddings.create(
+            model=self._model,
+            input=text,
+        )
+        return list(response.data[0].embedding)
+
+
+def resolve_embedding_provider(config: Optional[dict]) -> Optional[EmbeddingProvider]:
+    """Factory: select the right embedding strategy from config.
+
+    Args:
+        config: Dict with keys provider, model, base_url, api_key, dimensions.
+                None or empty dict returns None.
+
+    Returns:
+        An EmbeddingProvider instance, or None if the provider is unrecognized
+        or config is empty.
+    """
+    if not config:
+        return None
+
+    provider_type = config.get("provider", "").lower()
+    model = config.get("model", "")
+    base_url = config.get("base_url", "")
+    api_key = config.get("api_key", "")
+    dimensions = config.get("dimensions", 768)
+
+    if provider_type == "ollama":
+        return OllamaEmbeddingProvider(
+            model=model or "nomic-embed-text",
+            base_url=base_url or "http://localhost:11434/v1",
+            api_key=api_key or "ollama",
+            dimensions=dimensions or 768,
+        )
+    elif provider_type == "openai":
+        return OpenAIEmbeddingProvider(
+            model=model or "text-embedding-3-small",
+            api_key=api_key,
+            dimensions=dimensions or 1536,
+        )
+
+    return None

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1429,6 +1429,20 @@ DEFAULT_CONFIG = {
         # single-shape tool returns DB content directly). The old
         # ``auxiliary.session_search.*`` block was removed here. Existing
         # values in user config.yaml files are harmless leftovers and ignored.
+        #
+        # Embedding provider for semantic session search (sqlite-vec).
+        # When configured, session_search(semantic=True) uses hybrid
+        # BM25+vector ranking instead of pure FTS5 keyword matching.
+        # Provider options: ollama (local, free), openai (API).
+        "session_search": {
+            "embedding": {
+                "provider": "ollama",           # ollama | openai
+                "model": "nomic-embed-text",    # model name for the provider
+                "base_url": "http://localhost:11434/v1",  # Ollama base URL
+                "api_key": "",                  # API key (OpenAI); empty for Ollama
+                "dimensions": 768,              # vector dimensions (nomic-embed-text = 768)
+            },
+        },
         "skills_hub": {
             "provider": "auto",
             "model": "",

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -576,7 +576,8 @@ CREATE TABLE IF NOT EXISTS messages (
     platform_message_id TEXT,
     observed INTEGER DEFAULT 0,
     active INTEGER NOT NULL DEFAULT 1,
-    compacted INTEGER NOT NULL DEFAULT 0
+    compacted INTEGER NOT NULL DEFAULT 0,
+    vec_embedded INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS state_meta (
@@ -663,6 +664,31 @@ CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_update AFTER UPDATE ON message
 END;
 """
 
+# Vector embedding virtual table for semantic search.  Uses sqlite-vec's
+# vec0 extension — a virtual table with KNN search via MATCH.
+# Triggers mirror the FTS5 pattern: INSERT stores a zero-vector placeholder,
+# DELETE removes it, UPDATE refreshes it.
+# The zero vector (all zeros, 768 * 4 bytes) is a placeholder until the
+# embedding provider is wired up to generate real embeddings asynchronously.
+# Using a zero vector instead of NULL satisfies vec0's BLOB requirement
+# and produces a valid (if meaningless) distance for KNN queries.
+VEC_SQL = """
+CREATE VIRTUAL TABLE IF NOT EXISTS messages_vec USING vec0(
+    embedding float[768]
+);
+
+CREATE TRIGGER IF NOT EXISTS messages_vec_insert AFTER INSERT ON messages BEGIN
+    INSERT INTO messages_vec(rowid, embedding) VALUES (
+        new.id,
+        zeroblob(3072)
+    );
+END;
+
+CREATE TRIGGER IF NOT EXISTS messages_vec_delete AFTER DELETE ON messages BEGIN
+    DELETE FROM messages_vec WHERE rowid = old.id;
+END;
+"""
+
 
 class SessionDB:
     """
@@ -696,7 +722,13 @@ class SessionDB:
         self._fts_enabled = False
         self._trigram_available = False
         self._fts_unavailable_warned = False
+        self._vec_enabled = False
         self._conn = None
+        # Optional embedding provider for auto-embed on append_message.
+        # Resolved from config at init time (best-effort).  None means
+        # zero-vector placeholders only — auto-embed is a no-op.
+        self.embedding_provider = None
+        self._embedding_provider_resolved = False
         try:
             if read_only:
                 # Read-only attach for cross-profile aggregation: SELECT-only,
@@ -777,6 +809,12 @@ class SessionDB:
             # ``hermes_state._set_last_init_error(None)`` explicitly.
             _set_last_init_error(f"{type(exc).__name__}: {exc}")
             raise
+
+        # Resolve embedding provider from config (best-effort).
+        # Done once at init so append_message auto-embeds from the start
+        # without waiting for a session_search(semantic=True) call.
+        if not read_only:
+            self._resolve_embedding_provider()
 
     # ── Core write helper ──
 
@@ -923,6 +961,29 @@ class SessionDB:
                 self._warn_trigram_unavailable(exc)
             else:
                 self._warn_fts5_unavailable(exc)
+            return False
+
+    def _ensure_vec_schema(self, cursor: sqlite3.Cursor) -> bool:
+        """Create the messages_vec virtual table and triggers.
+
+        Loads the sqlite-vec extension and runs VEC_SQL.  If the extension
+        is unavailable (no such module: vec0), vec search is disabled but
+        the rest of the DB operates normally — this is an optional feature.
+        """
+        try:
+            import sqlite_vec
+            self._conn.enable_load_extension(True)
+            sqlite_vec.load(self._conn)
+            self._conn.enable_load_extension(False)
+        except Exception as exc:
+            logger.debug("sqlite-vec extension not available: %s", exc)
+            return False
+
+        try:
+            cursor.executescript(VEC_SQL)
+            return True
+        except sqlite3.OperationalError as exc:
+            logger.debug("vec0 schema creation failed: %s", exc)
             return False
 
     def _execute_write(self, fn: Callable[[sqlite3.Connection], T]) -> T:
@@ -1338,6 +1399,47 @@ class SessionDB:
                         cursor,
                         include_trigram=trigram_enabled,
                     )
+
+        # Vector embedding schema (sqlite-vec).  Independent of FTS5 — vec0
+        # is a separate extension.  If the extension can't be loaded, vec
+        # search is simply unavailable (no fallback needed; FTS5 still works).
+        self._vec_enabled = self._ensure_vec_schema(cursor)
+
+        # Migration: drop the old messages_vec_update trigger if it exists.
+        # It was removed from SCHEMA_SQL because it overwrites real embeddings
+        # with zeroblob on any UPDATE to messages (including vec_embedded=1).
+        # INSERT and DELETE triggers are sufficient.
+        if self._vec_enabled:
+            cursor.execute("DROP TRIGGER IF EXISTS messages_vec_update")
+
+        # One-time migration: seed messages_vec with zero-vector placeholders
+        # for all existing messages.  The INSERT trigger only fires on new
+        # rows, so historical messages need to be backfilled here.  After
+        # this, backfill_embeddings() can replace the zeros with real vectors.
+        if self._vec_enabled:
+            vec_count = cursor.execute(
+                "SELECT COUNT(*) FROM messages_vec"
+            ).fetchone()[0]
+            msg_count = cursor.execute(
+                "SELECT COUNT(*) FROM messages"
+            ).fetchone()[0]
+            if vec_count == 0 and msg_count > 0:
+                logger.info(
+                    "Seeding messages_vec with %d zero-vector placeholders "
+                    "(one-time migration)",
+                    msg_count,
+                )
+                cursor.execute(
+                    "INSERT INTO messages_vec(rowid, embedding) "
+                    "SELECT id, zeroblob(3072) FROM messages"
+                )
+
+        # Create the vec_embedded index now that the column is guaranteed
+        # to exist (added by _reconcile_columns above if missing).
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_messages_vec_embedded "
+            "ON messages(vec_embedded, id)"
+        )
 
         self._conn.commit()
 
@@ -2593,7 +2695,182 @@ class SessionDB:
                 )
             return msg_id
 
-        return self._execute_write(_do)
+        msg_id = self._execute_write(_do)
+
+        # Auto-embed: generate a real vector if a provider is configured.
+        # Done outside the write transaction so embedding API latency
+        # doesn't block other writers.
+        # Only embed user and assistant messages — tool output is noise
+        # for semantic search and would bloat the vec table.
+        if (
+            self.embedding_provider is not None
+            and self._vec_enabled
+            and role in ("user", "assistant")
+        ):
+            text = content
+            if isinstance(content, list):
+                text_parts = [
+                    p.get("text", "") for p in content
+                    if isinstance(p, dict) and p.get("type") == "text"
+                ]
+                text = " ".join(t for t in text_parts if t).strip()
+            elif isinstance(content, str):
+                text = content
+            else:
+                text = ""
+            if text:
+                self.embed_message(msg_id, text, self.embedding_provider)
+
+        return msg_id
+
+    # =========================================================================
+    # Embedding provider resolution
+    # =========================================================================
+
+    def _resolve_embedding_provider(self) -> None:
+        """Resolve the embedding provider from config (best-effort).
+
+        Called once at init time so append_message auto-embeds from the
+        start without waiting for a session_search(semantic=True) call.
+        Failures are logged but not raised — auto-embed degrades to
+        zero-vector placeholders.
+        """
+        if self._embedding_provider_resolved:
+            return
+        self._embedding_provider_resolved = True
+        try:
+            from hermes_cli.config import load_config
+            config = load_config()
+            emb_config = config.get("auxiliary", {}).get(
+                "session_search", {}
+            ).get("embedding", {})
+            if not emb_config:
+                return
+            from agent.embedding_provider import resolve_embedding_provider
+            self.embedding_provider = resolve_embedding_provider(emb_config)
+        except Exception:
+            logger.debug(
+                "Embedding provider resolution failed at init; "
+                "auto-embed disabled",
+                exc_info=True,
+            )
+
+    # =========================================================================
+    # Embedding generation (sqlite-vec)
+    # =========================================================================
+
+    def embed_message(
+        self,
+        msg_id: int,
+        text: str,
+        provider=None,
+    ) -> None:
+        """Generate and store a real embedding for a single message.
+
+        Replaces the zero-vector placeholder in ``messages_vec`` with a real
+        embedding generated by *provider*.  If *provider* is None or the vec
+        table is unavailable, this is a no-op.
+
+        Safe to call multiple times on the same row — subsequent calls
+        overwrite the previous embedding.
+        """
+        if provider is None:
+            return
+        if not self._vec_enabled:
+            return
+        if not text or not text.strip():
+            return
+
+        try:
+            vec = provider.generate_embedding(text.strip())
+        except Exception:
+            logger.debug("embed_message: embedding generation failed for msg %d", msg_id, exc_info=True)
+            return
+
+        from sqlite_vec import serialize_float32
+        blob = serialize_float32(vec)
+
+        try:
+            with self._lock:
+                # vec0 virtual tables silently ignore UPDATE on the embedding
+                # column.  Use DELETE + INSERT instead.
+                self._conn.execute(
+                    "DELETE FROM messages_vec WHERE rowid = ?",
+                    (msg_id,),
+                )
+                self._conn.execute(
+                    "INSERT INTO messages_vec(rowid, embedding) VALUES (?, ?)",
+                    (msg_id, blob),
+                )
+                self._conn.execute(
+                    "UPDATE messages SET vec_embedded = 1 WHERE id = ?",
+                    (msg_id,),
+                )
+        except sqlite3.OperationalError:
+            logger.debug("embed_message: UPDATE failed for msg %d", msg_id, exc_info=True)
+
+    def backfill_embeddings(
+        self,
+        provider=None,
+        batch_size: int = 100,
+    ) -> int:
+        """Batch-embed all messages that still have zero-vector placeholders.
+
+        Returns the number of messages embedded.  Safe to call on an already-
+        embedded database — only rows with vec_embedded=0 are touched.
+
+        Processes in batches of *batch_size* to avoid holding the lock for
+        too long on large databases.  Uses the B-tree-indexed messages table
+        (vec_embedded column) instead of scanning the vec0 virtual table.
+        """
+        if provider is None:
+            return 0
+        if not self._vec_enabled:
+            return 0
+
+        total = 0
+        while True:
+            # Fetch a batch of unembedded messages via the indexed messages table.
+            # This is O(log N) via idx_messages_vec_embedded, not O(N) BLOB scan.
+            with self._lock:
+                cursor = self._conn.execute(
+                    """SELECT m.id, m.content
+                       FROM messages m
+                       WHERE m.vec_embedded = 0
+                       ORDER BY m.id
+                       LIMIT ?""",
+                    (batch_size,),
+                )
+                batch = [(row[0], self._decode_content(row[1])) for row in cursor.fetchall()]
+
+            if not batch:
+                break
+
+            for msg_id, content in batch:
+                # Extract text from potentially multimodal content
+                text = content
+                if isinstance(content, list):
+                    text_parts = [
+                        p.get("text", "") for p in content
+                        if isinstance(p, dict) and p.get("type") == "text"
+                    ]
+                    text = " ".join(t for t in text_parts if t).strip()
+                elif not isinstance(content, str):
+                    text = ""
+
+                if text:
+                    self.embed_message(msg_id, text, provider)
+                    total += 1
+                else:
+                    # No embeddable text — mark as done so we don't re-fetch
+                    # this row forever.  The zero-vector placeholder stays.
+                    with self._lock:
+                        self._conn.execute(
+                            "UPDATE messages SET vec_embedded = 1 WHERE id = ?",
+                            (msg_id,),
+                        )
+
+        return total
 
     def _insert_message_rows(self, conn, session_id: str, messages: List[Dict[str, Any]]) -> tuple[int, int]:
         """Insert *messages* as fresh active rows for *session_id*.
@@ -3540,20 +3817,12 @@ class SessionDB:
             # are hidden. See archive_and_compact() / #38763.
             where_clauses.append("(m.active = 1 OR m.compacted = 1)")
 
-        if source_filter is not None:
-            source_placeholders = ",".join("?" for _ in source_filter)
-            where_clauses.append(f"s.source IN ({source_placeholders})")
-            params.extend(source_filter)
-
-        if exclude_sources is not None:
-            exclude_placeholders = ",".join("?" for _ in exclude_sources)
-            where_clauses.append(f"s.source NOT IN ({exclude_placeholders})")
-            params.extend(exclude_sources)
-
-        if role_filter:
-            role_placeholders = ",".join("?" for _ in role_filter)
-            where_clauses.append(f"m.role IN ({role_placeholders})")
-            params.extend(role_filter)
+        self._build_filter_clauses(
+            where_clauses, params,
+            source_filter=source_filter,
+            exclude_sources=exclude_sources,
+            role_filter=role_filter,
+        )
 
         where_sql = " AND ".join(where_clauses)
         params.extend([limit, offset])
@@ -3621,15 +3890,12 @@ class SessionDB:
                 tri_params: list = [trigram_query]
                 if not include_inactive:
                     tri_where.append("(m.active = 1 OR m.compacted = 1)")
-                if source_filter is not None:
-                    tri_where.append(f"s.source IN ({','.join('?' for _ in source_filter)})")
-                    tri_params.extend(source_filter)
-                if exclude_sources is not None:
-                    tri_where.append(f"s.source NOT IN ({','.join('?' for _ in exclude_sources)})")
-                    tri_params.extend(exclude_sources)
-                if role_filter:
-                    tri_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
-                    tri_params.extend(role_filter)
+                self._build_filter_clauses(
+                    tri_where, tri_params,
+                    source_filter=source_filter,
+                    exclude_sources=exclude_sources,
+                    role_filter=role_filter,
+                )
                 tri_sql = f"""
                     SELECT
                         m.id,
@@ -3678,15 +3944,12 @@ class SessionDB:
                     )
                     like_params += [f"%{esc}%", f"%{esc}%", f"%{esc}%"]
                 like_where = [f"({' OR '.join(token_clauses)})"]
-                if source_filter is not None:
-                    like_where.append(f"s.source IN ({','.join('?' for _ in source_filter)})")
-                    like_params.extend(source_filter)
-                if exclude_sources is not None:
-                    like_where.append(f"s.source NOT IN ({','.join('?' for _ in exclude_sources)})")
-                    like_params.extend(exclude_sources)
-                if role_filter:
-                    like_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
-                    like_params.extend(role_filter)
+                self._build_filter_clauses(
+                    like_where, like_params,
+                    source_filter=source_filter,
+                    exclude_sources=exclude_sources,
+                    role_filter=role_filter,
+                )
                 like_sql = f"""
                     SELECT m.id, m.session_id, m.role,
                            substr(m.content,
@@ -3719,70 +3982,296 @@ class SessionDB:
         # Add surrounding context (1 message before + after each match).
         # Done outside the lock so we don't hold it across N sequential queries.
         for match in matches:
-            try:
-                with self._lock:
-                    ctx_cursor = self._conn.execute(
-                        """WITH target AS (
-                               SELECT session_id, timestamp, id
-                               FROM messages
-                               WHERE id = ?
-                           )
-                           SELECT role, content
-                           FROM (
-                               SELECT m.id, m.timestamp, m.role, m.content
-                               FROM messages m
-                               JOIN target t ON t.session_id = m.session_id
-                               WHERE (m.timestamp < t.timestamp)
-                                  OR (m.timestamp = t.timestamp AND m.id < t.id)
-                               ORDER BY m.timestamp DESC, m.id DESC
-                               LIMIT 1
-                           )
-                           UNION ALL
-                           SELECT role, content
-                           FROM messages
-                           WHERE id = ?
-                           UNION ALL
-                           SELECT role, content
-                           FROM (
-                               SELECT m.id, m.timestamp, m.role, m.content
-                               FROM messages m
-                               JOIN target t ON t.session_id = m.session_id
-                               WHERE (m.timestamp > t.timestamp)
-                                  OR (m.timestamp = t.timestamp AND m.id > t.id)
-                               ORDER BY m.timestamp ASC, m.id ASC
-                               LIMIT 1
-                           )""",
-                        (match["id"], match["id"]),
-                    )
-                    context_msgs = []
-                    for r in ctx_cursor.fetchall():
-                        raw = r["content"]
-                        decoded = self._decode_content(raw)
-                        # Multimodal context: render a compact text-only
-                        # summary for search previews.
-                        if isinstance(decoded, list):
-                            text_parts = [
-                                p.get("text", "") for p in decoded
-                                if isinstance(p, dict) and p.get("type") == "text"
-                            ]
-                            text = " ".join(t for t in text_parts if t).strip()
-                            preview = text or "[multimodal content]"
-                        elif isinstance(decoded, str):
-                            preview = decoded
-                        else:
-                            preview = ""
-                        context_msgs.append(
-                            {"role": r["role"], "content": preview[:200]}
-                        )
-                match["context"] = context_msgs
-            except Exception:
-                match["context"] = []
+            self._attach_context(match)
 
         # Remove full content from result (snippet is enough, saves tokens)
         for match in matches:
             match.pop("content", None)
 
         return matches
+
+    def _attach_context(self, match: Dict[str, Any]) -> None:
+        """Attach surrounding context (1 msg before + after) to a search match.
+
+        Mutates *match* in place, adding a ``context`` key with a list of
+        {role, content} dicts.  On failure, sets context to [].
+        """
+        try:
+            with self._lock:
+                ctx_cursor = self._conn.execute(
+                    """WITH target AS (
+                           SELECT session_id, timestamp, id
+                           FROM messages
+                           WHERE id = ?
+                       )
+                       SELECT role, content
+                       FROM (
+                           SELECT m.id, m.timestamp, m.role, m.content
+                           FROM messages m
+                           JOIN target t ON t.session_id = m.session_id
+                           WHERE (m.timestamp < t.timestamp)
+                              OR (m.timestamp = t.timestamp AND m.id < t.id)
+                           ORDER BY m.timestamp DESC, m.id DESC
+                           LIMIT 1
+                       )
+                       UNION ALL
+                       SELECT role, content
+                       FROM messages
+                       WHERE id = ?
+                       UNION ALL
+                       SELECT role, content
+                       FROM (
+                           SELECT m.id, m.timestamp, m.role, m.content
+                           FROM messages m
+                           JOIN target t ON t.session_id = m.session_id
+                           WHERE (m.timestamp > t.timestamp)
+                              OR (m.timestamp = t.timestamp AND m.id > t.id)
+                           ORDER BY m.timestamp ASC, m.id ASC
+                           LIMIT 1
+                       )""",
+                    (match["id"], match["id"]),
+                )
+                context_msgs = []
+                for r in ctx_cursor.fetchall():
+                    raw = r["content"]
+                    decoded = self._decode_content(raw)
+                    if isinstance(decoded, list):
+                        text_parts = [
+                            p.get("text", "") for p in decoded
+                            if isinstance(p, dict) and p.get("type") == "text"
+                        ]
+                        text = " ".join(t for t in text_parts if t).strip()
+                        preview = text or "[multimodal content]"
+                    elif isinstance(decoded, str):
+                        preview = decoded
+                    else:
+                        preview = ""
+                    context_msgs.append(
+                        {"role": r["role"], "content": preview[:200]}
+                    )
+            match["context"] = context_msgs
+        except Exception:
+            match["context"] = []
+
+    # =========================================================================
+    # Vector / semantic search (sqlite-vec)
+    # =========================================================================
+
+    @staticmethod
+    def _build_filter_clauses(
+        where_parts: List[str],
+        params: list,
+        source_filter: List[str] = None,
+        exclude_sources: List[str] = None,
+        role_filter: List[str] = None,
+    ) -> None:
+        """Append source/role filter WHERE clauses to *where_parts* and *params*.
+
+        Mutates both arguments in place.  Callers are responsible for joining
+        ``where_parts`` into a WHERE clause (e.g. ``" AND ".join(where_parts)``).
+        """
+        if source_filter is not None:
+            where_parts.append(f"s.source IN ({','.join('?' for _ in source_filter)})")
+            params.extend(source_filter)
+        if exclude_sources is not None:
+            where_parts.append(f"s.source NOT IN ({','.join('?' for _ in exclude_sources)})")
+            params.extend(exclude_sources)
+        if role_filter:
+            where_parts.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
+            params.extend(role_filter)
+
+    def search_semantic(
+        self,
+        query: str,
+        provider=None,
+        limit: int = 20,
+        source_filter: List[str] = None,
+        exclude_sources: List[str] = None,
+        role_filter: List[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """KNN vector search across message embeddings.
+
+        Generates a query embedding via *provider*, then runs a vec0 MATCH
+        query against ``messages_vec``.  Returns the closest *limit* messages
+        with distance scores.
+
+        If *provider* is None or the vec table is unavailable, returns [].
+        """
+        if not query or not query.strip():
+            return []
+        if provider is None:
+            return []
+        if not self._vec_enabled:
+            return []
+
+        # Generate query embedding
+        try:
+            query_vec = provider.generate_embedding(query.strip())
+        except Exception:
+            logger.debug("Embedding generation failed for semantic search", exc_info=True)
+            return []
+
+        # Serialize to BLOB for vec0 MATCH
+        from sqlite_vec import serialize_float32
+        query_blob = serialize_float32(query_vec)
+
+        # Build WHERE clauses for filtering
+        where_parts = []
+        params: list = [query_blob]
+        self._build_filter_clauses(
+            where_parts, params,
+            source_filter=source_filter,
+            exclude_sources=exclude_sources,
+            role_filter=role_filter,
+        )
+        where_sql = (" AND " + " AND ".join(where_parts)) if where_parts else ""
+        params.extend([limit])
+
+        sql = f"""
+            SELECT
+                m.id,
+                m.session_id,
+                m.role,
+                m.content,
+                m.timestamp,
+                m.tool_name,
+                s.source,
+                s.model,
+                s.started_at AS session_started,
+                v.distance
+            FROM messages_vec v
+            JOIN messages m ON m.id = v.rowid
+            JOIN sessions s ON s.id = m.session_id
+            WHERE v.embedding MATCH ? AND k = ?{where_sql}
+            ORDER BY v.distance
+        """
+
+        with self._lock:
+            try:
+                cursor = self._conn.execute(sql, params)
+            except sqlite3.OperationalError:
+                logger.debug("vec0 MATCH query failed", exc_info=True)
+                return []
+            matches = [dict(row) for row in cursor.fetchall()]
+
+        # Add context and strip full content (same as search_messages)
+        for match in matches:
+            self._attach_context(match)
+
+        for match in matches:
+            match.pop("content", None)
+
+        return matches
+
+    def search_hybrid(
+        self,
+        query: str,
+        provider=None,
+        limit: int = 20,
+        source_filter: List[str] = None,
+        exclude_sources: List[str] = None,
+        role_filter: List[str] = None,
+        hybrid_weight: float = 0.5,
+        sort: str = None,
+    ) -> List[Dict[str, Any]]:
+        """Hybrid BM25 + vector search with Reciprocal Rank Fusion.
+
+        Runs both FTS5 keyword search and vec0 semantic search, then merges
+        results via RRF: ``score = 1/(k + bm25_rank) + w * 1/(k + vec_rank)``.
+
+        Falls back to FTS5-only when *provider* is None or vec is unavailable.
+
+        ``sort`` controls temporal ordering of the final merged results:
+          - ``None`` (default): hybrid score only
+          - ``"newest"``: order by timestamp DESC, hybrid score as tiebreaker
+          - ``"oldest"``: order by timestamp ASC, hybrid score as tiebreaker
+        """
+        if not query or not query.strip():
+            return []
+
+        # Normalise sort
+        sort_norm: Optional[str] = None
+        if isinstance(sort, str):
+            candidate = sort.strip().lower()
+            if candidate in ("newest", "oldest"):
+                sort_norm = candidate
+
+        # FTS5 search (always available)
+        bm25_results = self.search_messages(
+            query,
+            source_filter=source_filter,
+            exclude_sources=exclude_sources,
+            role_filter=role_filter,
+            limit=limit * 2,  # over-fetch for merge
+            sort=sort_norm,
+        )
+
+        # Vector search (optional)
+        vec_results = []
+        if provider is not None and self._vec_enabled:
+            vec_results = self.search_semantic(
+                query,
+                provider=provider,
+                limit=limit * 2,
+                source_filter=source_filter,
+                exclude_sources=exclude_sources,
+                role_filter=role_filter,
+            )
+
+        if not vec_results:
+            # No vector results — return BM25-only with hybrid_score = rank
+            for rank, r in enumerate(bm25_results[:limit], start=1):
+                r["hybrid_score"] = 1.0 / (60.0 + rank)
+            return bm25_results[:limit]
+
+        # RRF merge
+        merged = self._rrf_merge(bm25_results, vec_results, hybrid_weight, limit)
+
+        # Apply temporal sort on top of hybrid score if requested
+        if sort_norm == "newest":
+            merged.sort(key=lambda r: (r.get("timestamp", 0), r.get("hybrid_score", 0)), reverse=True)
+        elif sort_norm == "oldest":
+            merged.sort(key=lambda r: (r.get("timestamp", 0), r.get("hybrid_score", 0)))
+
+        return merged
+
+    @staticmethod
+    def _rrf_merge(
+        bm25_results: List[Dict[str, Any]],
+        vec_results: List[Dict[str, Any]],
+        hybrid_weight: float,
+        limit: int,
+        k: float = 60.0,
+    ) -> List[Dict[str, Any]]:
+        """Reciprocal Rank Fusion: merge BM25 and vector result lists.
+
+        score = 1/(k + bm25_rank) + hybrid_weight * 1/(k + vec_rank)
+
+        Returns the top *limit* results sorted by hybrid score.
+        """
+        scores: dict[int, float] = {}
+
+        for rank, r in enumerate(bm25_results, start=1):
+            msg_id = r["id"]
+            scores[msg_id] = scores.get(msg_id, 0.0) + 1.0 / (k + rank)
+
+        for rank, r in enumerate(vec_results, start=1):
+            msg_id = r["id"]
+            scores[msg_id] = scores.get(msg_id, 0.0) + hybrid_weight / (k + rank)
+
+        all_by_id: dict[int, dict] = {}
+        for r in bm25_results:
+            all_by_id[r["id"]] = r
+        for r in vec_results:
+            if r["id"] not in all_by_id:
+                all_by_id[r["id"]] = r
+
+        merged = [
+            {**all_by_id[mid], "hybrid_score": scores[mid]}
+            for mid in sorted(scores, key=lambda mid: scores[mid], reverse=True)
+        ]
+
+        return merged[:limit]
 
     def search_sessions_by_id(
         self,

--- a/tests/agent/test_embedding_provider.py
+++ b/tests/agent/test_embedding_provider.py
@@ -1,0 +1,171 @@
+"""Tests for agent/embedding_provider.py — Strategy pattern for embedding generation."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+class TestEmbeddingProviderInterface:
+    """The Strategy interface contract."""
+
+    def test_provider_has_generate_embedding_method(self):
+        """Every provider must expose generate_embedding(text) -> list[float]."""
+        from agent.embedding_provider import EmbeddingProvider
+
+        # Abstract base class defines the contract
+        assert hasattr(EmbeddingProvider, "generate_embedding")
+        import inspect
+        sig = inspect.signature(EmbeddingProvider.generate_embedding)
+        params = list(sig.parameters.keys())
+        assert "text" in params
+        assert sig.return_annotation == "list[float]"
+
+    def test_provider_has_dimensions_property(self):
+        """Every provider must report its vector dimensions."""
+        from agent.embedding_provider import EmbeddingProvider
+        assert hasattr(EmbeddingProvider, "dimensions")
+
+
+class TestOllamaEmbeddingProvider:
+    """Ollama local embedding provider."""
+
+    def test_generate_embedding_returns_correct_dimensions(self):
+        """Returns a vector of the expected length for the model."""
+        from agent.embedding_provider import OllamaEmbeddingProvider
+
+        provider = OllamaEmbeddingProvider(
+            model="nomic-embed-text",
+            base_url="http://localhost:11434/v1",
+            dimensions=768,
+        )
+        assert provider.dimensions == 768
+
+    def test_generate_embedding_calls_ollama_api(self):
+        """Uses OpenAI-compatible embeddings endpoint on Ollama."""
+        from agent.embedding_provider import OllamaEmbeddingProvider
+
+        provider = OllamaEmbeddingProvider(
+            model="nomic-embed-text",
+            base_url="http://localhost:11434/v1",
+            dimensions=768,
+        )
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.data = [MagicMock(embedding=[0.1] * 768)]
+        mock_client.embeddings.create.return_value = mock_response
+
+        with patch.object(provider, "_get_client", return_value=mock_client):
+            result = provider.generate_embedding("test text")
+
+        assert len(result) == 768
+        mock_client.embeddings.create.assert_called_once_with(
+            model="nomic-embed-text",
+            input="test text",
+        )
+
+    def test_generate_embedding_handles_empty_text(self):
+        """Empty text returns a zero vector, not an error."""
+        from agent.embedding_provider import OllamaEmbeddingProvider
+
+        provider = OllamaEmbeddingProvider(
+            model="nomic-embed-text",
+            base_url="http://localhost:11434/v1",
+            dimensions=768,
+        )
+        result = provider.generate_embedding("")
+        assert len(result) == 768
+        assert all(v == 0.0 for v in result)
+
+
+class TestOpenAIEmbeddingProvider:
+    """OpenAI API embedding provider."""
+
+    def test_generate_embedding_returns_correct_dimensions(self):
+        """Returns a vector of the expected length for text-embedding-3-small."""
+        from agent.embedding_provider import OpenAIEmbeddingProvider
+
+        provider = OpenAIEmbeddingProvider(
+            model="text-embedding-3-small",
+            api_key="sk-test",
+            dimensions=1536,
+        )
+        assert provider.dimensions == 1536
+
+    def test_generate_embedding_calls_openai_api(self):
+        """Uses OpenAI embeddings endpoint."""
+        from agent.embedding_provider import OpenAIEmbeddingProvider
+
+        provider = OpenAIEmbeddingProvider(
+            model="text-embedding-3-small",
+            api_key="sk-test",
+            dimensions=1536,
+        )
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.data = [MagicMock(embedding=[0.1] * 1536)]
+        mock_client.embeddings.create.return_value = mock_response
+
+        with patch.object(provider, "_get_client", return_value=mock_client):
+            result = provider.generate_embedding("test text")
+
+        assert len(result) == 1536
+        mock_client.embeddings.create.assert_called_once_with(
+            model="text-embedding-3-small",
+            input="test text",
+        )
+
+
+class TestResolveEmbeddingProvider:
+    """Factory function for selecting the right strategy."""
+
+    def test_resolve_ollama_from_config(self):
+        """Returns OllamaEmbeddingProvider when provider=ollama."""
+        from agent.embedding_provider import resolve_embedding_provider
+
+        config = {
+            "provider": "ollama",
+            "model": "nomic-embed-text",
+            "base_url": "http://localhost:11434/v1",
+            "api_key": "",
+            "dimensions": 768,
+        }
+        provider = resolve_embedding_provider(config)
+        from agent.embedding_provider import OllamaEmbeddingProvider
+        assert isinstance(provider, OllamaEmbeddingProvider)
+        assert provider.dimensions == 768
+
+    def test_resolve_openai_from_config(self):
+        """Returns OpenAIEmbeddingProvider when provider=openai."""
+        from agent.embedding_provider import resolve_embedding_provider
+
+        config = {
+            "provider": "openai",
+            "model": "text-embedding-3-small",
+            "base_url": "",
+            "api_key": "sk-test",
+            "dimensions": 1536,
+        }
+        provider = resolve_embedding_provider(config)
+        from agent.embedding_provider import OpenAIEmbeddingProvider
+        assert isinstance(provider, OpenAIEmbeddingProvider)
+        assert provider.dimensions == 1536
+
+    def test_resolve_returns_none_for_unknown_provider(self):
+        """Returns None when provider type is unrecognized."""
+        from agent.embedding_provider import resolve_embedding_provider
+
+        config = {
+            "provider": "unknown_backend",
+            "model": "some-model",
+            "dimensions": 384,
+        }
+        provider = resolve_embedding_provider(config)
+        assert provider is None
+
+    def test_resolve_returns_none_for_empty_config(self):
+        """Returns None when config is empty or missing."""
+        from agent.embedding_provider import resolve_embedding_provider
+
+        assert resolve_embedding_provider({}) is None
+        assert resolve_embedding_provider(None) is None

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4416,3 +4416,584 @@ class TestListCronJobRuns:
         detail = " ".join(row[-1] for row in plan)
         assert "USING INDEX" in detail or "USING COVERING INDEX" in detail, detail
         assert "idx_sessions_source" in detail, detail
+
+
+# =========================================================================
+# Vector embedding search (sqlite-vec)
+# =========================================================================
+
+class TestVecSchema:
+    """Tests for the sqlite-vec vector embedding schema."""
+
+    def test_vec_table_exists_after_init(self, db):
+        """messages_vec virtual table is created during schema init."""
+        cursor = db._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='messages_vec'"
+        )
+        assert cursor.fetchone() is not None, "messages_vec table missing"
+
+    def test_vec_table_has_embedding_column(self, db):
+        """messages_vec has an embedding column for float vectors."""
+        cursor = db._conn.execute("PRAGMA table_info(messages_vec)")
+        columns = {row[1]: row[2] for row in cursor.fetchall()}
+        assert "embedding" in columns, f"columns: {columns}"
+
+    def test_vec_trigger_insert_exists(self, db):
+        """Trigger fires on INSERT to generate embeddings."""
+        cursor = db._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='trigger' AND name='messages_vec_insert'"
+        )
+        assert cursor.fetchone() is not None, "messages_vec_insert trigger missing"
+
+    def test_vec_trigger_delete_exists(self, db):
+        """Trigger fires on DELETE to remove embeddings."""
+        cursor = db._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='trigger' AND name='messages_vec_delete'"
+        )
+        assert cursor.fetchone() is not None, "messages_vec_delete trigger missing"
+
+    def test_vec_trigger_update_absent(self, db):
+        """No UPDATE trigger — it would overwrite real embeddings with zeros.
+        INSERT and DELETE triggers are sufficient; content changes are rare
+        (compaction does DELETE+reINSERT)."""
+        cursor = db._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='trigger' AND name='messages_vec_update'"
+        )
+        assert cursor.fetchone() is None, (
+            "messages_vec_update trigger should NOT exist — "
+            "it overwrites real embeddings with zeroblob on any UPDATE to messages"
+        )
+
+    def test_vec_extension_loaded(self, db):
+        """sqlite-vec extension is loaded and vec0 is available."""
+        # Try creating a probe vec0 table — proves the extension is loaded
+        db._conn.execute("CREATE VIRTUAL TABLE IF NOT EXISTS _vec_probe USING vec0(embedding float[4])")
+        # If we got here without OperationalError, vec0 is available
+        db._conn.execute("DROP TABLE IF EXISTS _vec_probe")
+
+
+class TestVecSearch:
+    """Tests for semantic and hybrid vector search."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_provider(self):
+        """Inject a reusable mock embedding provider into every test."""
+        from agent.embedding_provider import EmbeddingProvider
+
+        class MockProvider(EmbeddingProvider):
+            @property
+            def dimensions(self):
+                return 768
+
+            def generate_embedding(self, text):
+                return [0.1] * 768
+
+        self.provider = MockProvider()
+
+    def test_search_semantic_returns_results(self, db):
+        """search_semantic finds messages by vector similarity."""
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="How do I deploy with Docker?")
+        db.append_message("s1", role="assistant", content="Use docker compose up.")
+
+        results = db.search_semantic("docker deployment", self.provider, limit=5)
+        assert len(results) > 0, "Expected at least one result"
+        for r in results:
+            assert "id" in r
+            assert "session_id" in r
+            assert "role" in r
+            assert "distance" in r
+            assert "context" in r
+
+    def test_search_semantic_respects_limit(self, db):
+        """search_semantic returns at most `limit` results."""
+        db.create_session(session_id="s1", source="cli")
+        for i in range(10):
+            db.append_message("s1", role="user", content=f"Message number {i}")
+
+        results = db.search_semantic("message", self.provider, limit=3)
+        assert len(results) <= 3
+
+    def test_search_semantic_empty_query(self, db):
+        """search_semantic returns empty list for empty query."""
+        assert db.search_semantic("", self.provider) == []
+        assert db.search_semantic("   ", self.provider) == []
+
+    def test_search_semantic_no_provider_returns_empty(self, db):
+        """search_semantic returns empty list when provider is None."""
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="test message")
+        assert db.search_semantic("test", None) == []
+
+    def test_search_hybrid_combines_fts5_and_vector(self, db):
+        """search_hybrid merges BM25 and vector results via RRF."""
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="Docker deployment guide")
+        db.append_message("s1", role="assistant", content="Use docker compose for orchestration")
+        db.append_message("s1", role="user", content="Unrelated message about lunch")
+
+        results = db.search_hybrid("docker", self.provider, limit=5)
+        assert len(results) > 0
+        for r in results:
+            assert "hybrid_score" in r, f"Missing hybrid_score in {list(r.keys())}"
+
+    def test_search_hybrid_falls_back_to_fts5_when_no_provider(self, db):
+        """search_hybrid returns FTS5-only results when provider is None."""
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="Docker deployment guide")
+
+        results = db.search_hybrid("docker", None, limit=5)
+        assert len(results) > 0
+        for r in results:
+            assert "hybrid_score" in r
+
+    def test_search_hybrid_respects_role_filter(self, db):
+        """search_hybrid applies role_filter to both FTS5 and vector results."""
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="What is Docker?")
+        db.append_message("s1", role="assistant", content="Docker is a container runtime.")
+
+        results = db.search_hybrid("Docker", self.provider, limit=5, role_filter=["assistant"])
+        roles = {r["role"] for r in results}
+        assert roles == {"assistant"}, f"Expected only assistant, got {roles}"
+
+    def test_search_hybrid_accepts_sort_parameter(self, db):
+        """search_hybrid accepts and forwards sort to inner search_messages."""
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="Docker deployment guide")
+
+        results = db.search_hybrid("docker", self.provider, limit=5, sort="newest")
+        assert isinstance(results, list)
+
+    def test_search_hybrid_sort_newest_orders_by_timestamp(self, db):
+        """sort='newest' returns most recent messages first."""
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="First message")
+        db.append_message("s1", role="user", content="Second message")
+        db.append_message("s1", role="user", content="Third message")
+
+        results = db.search_hybrid("message", self.provider, limit=5, sort="newest")
+        assert len(results) >= 2
+        timestamps = [r["timestamp"] for r in results]
+        for i in range(len(timestamps) - 1):
+            assert timestamps[i] >= timestamps[i + 1], \
+                f"Expected descending timestamps, got {timestamps}"
+
+
+class TestRRFMerge:
+    """Tests for the standalone _rrf_merge static method."""
+
+    def test_rrf_merge_combines_results(self):
+        """Merges two result lists and returns hybrid scores."""
+        from hermes_state import SessionDB
+
+        bm25 = [
+            {"id": 1, "content": "alpha"},
+            {"id": 2, "content": "beta"},
+        ]
+        vec = [
+            {"id": 2, "content": "beta"},
+            {"id": 3, "content": "gamma"},
+        ]
+
+        merged = SessionDB._rrf_merge(bm25, vec, hybrid_weight=0.5, limit=10)
+        assert len(merged) == 3
+        # All should have hybrid_score
+        for r in merged:
+            assert "hybrid_score" in r
+
+    def test_rrf_merge_respects_limit(self):
+        """Returns at most `limit` results."""
+        from hermes_state import SessionDB
+
+        bm25 = [{"id": i, "content": f"msg{i}"} for i in range(10)]
+        vec = [{"id": i, "content": f"msg{i}"} for i in range(5, 15)]
+
+        merged = SessionDB._rrf_merge(bm25, vec, hybrid_weight=0.5, limit=3)
+        assert len(merged) == 3
+
+    def test_rrf_merge_bm25_only(self):
+        """When vec_results is empty, returns BM25 results with hybrid_score."""
+        from hermes_state import SessionDB
+
+        bm25 = [
+            {"id": 1, "content": "alpha"},
+            {"id": 2, "content": "beta"},
+        ]
+
+        merged = SessionDB._rrf_merge(bm25, [], hybrid_weight=0.5, limit=10)
+        assert len(merged) == 2
+        for r in merged:
+            assert "hybrid_score" in r
+
+    def test_rrf_merge_vec_only(self):
+        """When bm25_results is empty, returns vec results with hybrid_score."""
+        from hermes_state import SessionDB
+
+        vec = [
+            {"id": 1, "content": "alpha"},
+            {"id": 2, "content": "beta"},
+        ]
+
+        merged = SessionDB._rrf_merge([], vec, hybrid_weight=0.5, limit=10)
+        assert len(merged) == 2
+        for r in merged:
+            assert "hybrid_score" in r
+
+    def test_rrf_merge_higher_weight_boosts_vec(self):
+        """Higher hybrid_weight gives vec results better scores."""
+        from hermes_state import SessionDB
+
+        # msg 1: BM25 rank 1, vec rank 2
+        # msg 2: BM25 rank 2, vec rank 1
+        bm25 = [{"id": 1, "content": "a"}, {"id": 2, "content": "b"}]
+        vec = [{"id": 2, "content": "b"}, {"id": 1, "content": "a"}]
+
+        # With weight=0.0 (pure BM25), msg 1 should win
+        merged_bm25 = SessionDB._rrf_merge(bm25, vec, hybrid_weight=0.0, limit=10)
+        assert merged_bm25[0]["id"] == 1
+
+        # With weight=2.0 (vec-heavy), msg 2 should win
+        merged_vec = SessionDB._rrf_merge(bm25, vec, hybrid_weight=2.0, limit=10)
+        assert merged_vec[0]["id"] == 2
+
+    def test_rrf_merge_empty_both(self):
+        """Returns empty list when both inputs are empty."""
+        from hermes_state import SessionDB
+        merged = SessionDB._rrf_merge([], [], hybrid_weight=0.5, limit=10)
+        assert merged == []
+
+
+# =========================================================================
+# Embedding generation and backfill
+# =========================================================================
+
+class TestEmbedMessage:
+    """Tests for embed_message — generating and storing real embeddings."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_provider(self):
+        from agent.embedding_provider import EmbeddingProvider
+
+        class MockProvider(EmbeddingProvider):
+            @property
+            def dimensions(self):
+                return 768
+
+            def generate_embedding(self, text):
+                # Deterministic 768-float vector from text hash.
+                # SHA256 gives 32 bytes; repeat to fill 768 floats.
+                import hashlib
+                h = hashlib.sha256(text.encode()).digest()
+                # Repeat the 32-byte pattern 24 times to get 768 bytes
+                expanded = (h * 24)[:768]
+                return [b / 255.0 for b in expanded]
+
+        self.provider = MockProvider()
+
+    def test_embed_message_stores_real_embedding(self, db):
+        """embed_message replaces zero-vector with a real embedding."""
+        db.create_session(session_id="s1", source="cli")
+        msg_id = db.append_message("s1", role="user", content="Docker deployment guide")
+
+        # Before: zero vector
+        cursor = db._conn.execute(
+            "SELECT length(embedding) FROM messages_vec WHERE rowid = ?", (msg_id,)
+        )
+        before_len = cursor.fetchone()[0]
+        assert before_len == 3072  # zeroblob(3072)
+
+        # Embed
+        db.embed_message(msg_id, "Docker deployment guide", self.provider)
+
+        # After: real embedding (same length, different content)
+        cursor = db._conn.execute(
+            "SELECT length(embedding), embedding FROM messages_vec WHERE rowid = ?", (msg_id,)
+        )
+        row = cursor.fetchone()
+        assert row[0] == 3072  # still 768 * 4 bytes
+        # Not all zeros anymore
+        assert row[1] != b'\x00' * 3072, "Embedding should not be all zeros"
+
+    def test_embed_message_idempotent(self, db):
+        """embed_message can be called multiple times safely."""
+        db.create_session(session_id="s1", source="cli")
+        msg_id = db.append_message("s1", role="user", content="test")
+
+        db.embed_message(msg_id, "test", self.provider)
+        cursor = db._conn.execute(
+            "SELECT embedding FROM messages_vec WHERE rowid = ?", (msg_id,)
+        )
+        first = cursor.fetchone()[0]
+
+        # Second call with same text should produce same embedding
+        db.embed_message(msg_id, "test", self.provider)
+        cursor = db._conn.execute(
+            "SELECT embedding FROM messages_vec WHERE rowid = ?", (msg_id,)
+        )
+        second = cursor.fetchone()[0]
+        assert first == second
+
+    def test_embed_message_no_provider_noop(self, db):
+        """embed_message with None provider does nothing (no crash)."""
+        db.create_session(session_id="s1", source="cli")
+        msg_id = db.append_message("s1", role="user", content="test")
+        db.embed_message(msg_id, "test", None)  # should not raise
+
+    def test_embed_message_nonexistent_row_noop(self, db):
+        """embed_message on a nonexistent rowid does nothing (no crash)."""
+        db.embed_message(99999, "test", self.provider)  # should not raise
+
+
+class TestBackfillEmbeddings:
+    """Tests for backfill_embeddings — batch embedding of zero-vector rows."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_provider(self):
+        from agent.embedding_provider import EmbeddingProvider
+
+        class MockProvider(EmbeddingProvider):
+            @property
+            def dimensions(self):
+                return 768
+
+            def generate_embedding(self, text):
+                import hashlib
+                h = hashlib.sha256(text.encode()).digest()
+                expanded = (h * 24)[:768]
+                return [b / 255.0 for b in expanded]
+
+        self.provider = MockProvider()
+
+    def test_backfill_embeds_all_zero_vectors(self, db):
+        """backfill_embeddings replaces all zero-vector placeholders."""
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="Message one")
+        db.append_message("s1", role="assistant", content="Message two")
+        db.append_message("s1", role="user", content="Message three")
+
+        # All should be unembedded initially
+        cursor = db._conn.execute(
+            "SELECT COUNT(*) FROM messages WHERE vec_embedded = 0"
+        )
+        assert cursor.fetchone()[0] == 3
+
+        count = db.backfill_embeddings(self.provider, batch_size=10)
+
+        assert count == 3
+        # No unembedded messages remain
+        cursor = db._conn.execute(
+            "SELECT COUNT(*) FROM messages WHERE vec_embedded = 0"
+        )
+        assert cursor.fetchone()[0] == 0
+
+    def test_backfill_skips_already_embedded(self, db):
+        """backfill_embeddings only touches vec_embedded=0 rows."""
+        db.create_session(session_id="s1", source="cli")
+        msg_id = db.append_message("s1", role="user", content="Already embedded")
+        db.embed_message(msg_id, "Already embedded", self.provider)
+
+        db.append_message("s1", role="user", content="Not embedded yet")
+
+        count = db.backfill_embeddings(self.provider, batch_size=10)
+        assert count == 1  # only the unembedded row
+
+    def test_backfill_no_provider_returns_zero(self, db):
+        """backfill_embeddings with None provider returns 0."""
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="test")
+        assert db.backfill_embeddings(None) == 0
+
+    def test_backfill_empty_db_returns_zero(self, db):
+        """backfill_embeddings on a DB with no messages returns 0."""
+        assert db.backfill_embeddings(self.provider) == 0
+
+    def test_backfill_respects_batch_size(self, db):
+        """backfill_embeddings processes in batches."""
+        db.create_session(session_id="s1", source="cli")
+        for i in range(5):
+            db.append_message("s1", role="user", content=f"Message {i}")
+
+        count = db.backfill_embeddings(self.provider, batch_size=2)
+        assert count == 5  # all embedded, just in batches
+
+
+class TestAutoEmbedOnAppend:
+    """Tests for automatic embedding on append_message."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_provider(self):
+        from agent.embedding_provider import EmbeddingProvider
+
+        class MockProvider(EmbeddingProvider):
+            @property
+            def dimensions(self):
+                return 768
+
+            def generate_embedding(self, text):
+                import hashlib
+                h = hashlib.sha256(text.encode()).digest()
+                expanded = (h * 24)[:768]
+                return [b / 255.0 for b in expanded]
+
+        self.provider = MockProvider()
+
+    def test_auto_embed_on_append(self, db):
+        """append_message auto-embeds when embedding_provider is set."""
+        db.embedding_provider = self.provider
+        db.create_session(session_id="s1", source="cli")
+        msg_id = db.append_message("s1", role="user", content="Auto-embed test")
+
+        cursor = db._conn.execute(
+            "SELECT embedding FROM messages_vec WHERE rowid = ?", (msg_id,)
+        )
+        row = cursor.fetchone()
+        assert row is not None
+        assert row[0] != b'\x00' * 3072, "Should have real embedding, not zeros"
+
+    def test_no_auto_embed_when_provider_not_set(self, db):
+        """append_message stores zero vector when embedding_provider is None."""
+        db.create_session(session_id="s1", source="cli")
+        msg_id = db.append_message("s1", role="user", content="No provider")
+
+        cursor = db._conn.execute(
+            "SELECT embedding FROM messages_vec WHERE rowid = ?", (msg_id,)
+        )
+        row = cursor.fetchone()
+        assert row[0] == b'\x00' * 3072, "Should be zero vector placeholder"
+
+    def test_auto_embed_handles_provider_failure(self, db):
+        """append_message still succeeds even if embedding generation fails."""
+        from agent.embedding_provider import EmbeddingProvider
+
+        class FailingProvider(EmbeddingProvider):
+            @property
+            def dimensions(self):
+                return 768
+
+            def generate_embedding(self, text):
+                raise RuntimeError("Embedding service down")
+
+        db.embedding_provider = FailingProvider()
+        db.create_session(session_id="s1", source="cli")
+        msg_id = db.append_message("s1", role="user", content="test")
+
+        # Message was inserted (zero vector fallback)
+        cursor = db._conn.execute("SELECT id FROM messages WHERE id = ?", (msg_id,))
+        assert cursor.fetchone() is not None
+
+
+# =========================================================================
+# End-to-end test with real Ollama embeddings
+# =========================================================================
+
+@pytest.mark.skipif(
+    "not _ollama_available()",
+    reason="Ollama not running on localhost:11434",
+)
+class TestOllamaE2E:
+    """End-to-end semantic search with real Ollama nomic-embed-text."""
+
+    def test_real_embeddings_produce_meaningful_distances(self, db):
+        """Messages with similar content have smaller vector distances."""
+        from agent.embedding_provider import OllamaEmbeddingProvider
+
+        provider = OllamaEmbeddingProvider(
+            model="nomic-embed-text",
+            base_url="http://localhost:11434/v1",
+            dimensions=768,
+        )
+        db.embedding_provider = provider
+
+        db.create_session(session_id="s1", source="cli")
+        # Two Docker-related messages
+        docker1 = db.append_message("s1", role="user", content="How do I deploy with Docker?")
+        docker2 = db.append_message("s1", role="assistant", content="Use docker compose up for deployment")
+        # One unrelated message
+        lunch = db.append_message("s1", role="user", content="What should I eat for lunch today?")
+
+        # Verify embeddings are not zero vectors
+        for msg_id in (docker1, docker2, lunch):
+            cursor = db._conn.execute(
+                "SELECT embedding FROM messages_vec WHERE rowid = ?", (msg_id,)
+            )
+            row = cursor.fetchone()
+            assert row is not None, f"msg {msg_id} missing from messages_vec"
+            assert row[0] != b'\x00' * 3072, f"msg {msg_id} has zero vector"
+
+        # Semantic search for "Docker" should rank Docker messages above lunch
+        results = db.search_semantic("Docker container deployment", provider, limit=3)
+        assert len(results) >= 2
+        ids = [r["id"] for r in results]
+        # Docker messages should appear before lunch
+        lunch_pos = ids.index(lunch) if lunch in ids else len(ids)
+        docker_positions = [ids.index(d) for d in (docker1, docker2) if d in ids]
+        assert any(p < lunch_pos for p in docker_positions), \
+            f"Docker messages should rank above lunch. Got order: {ids}"
+
+    def test_hybrid_search_with_real_embeddings(self, db):
+        """Hybrid search returns results with hybrid_score."""
+        from agent.embedding_provider import OllamaEmbeddingProvider
+
+        provider = OllamaEmbeddingProvider(
+            model="nomic-embed-text",
+            base_url="http://localhost:11434/v1",
+            dimensions=768,
+        )
+        db.embedding_provider = provider
+
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="Python async programming guide")
+        db.append_message("s1", role="assistant", content="Use asyncio for concurrent I/O")
+        db.append_message("s1", role="user", content="Best pizza places in New York")
+
+        results = db.search_hybrid("async python", provider, limit=3)
+        assert len(results) > 0
+        for r in results:
+            assert "hybrid_score" in r
+            assert isinstance(r["hybrid_score"], float)
+
+    def test_backfill_with_real_embeddings(self, db):
+        """backfill_embeddings replaces zero vectors with real embeddings."""
+        from agent.embedding_provider import OllamaEmbeddingProvider
+
+        provider = OllamaEmbeddingProvider(
+            model="nomic-embed-text",
+            base_url="http://localhost:11434/v1",
+            dimensions=768,
+        )
+
+        db.create_session(session_id="s1", source="cli")
+        # Insert without provider — zero vectors
+        db.append_message("s1", role="user", content="Message one")
+        db.append_message("s1", role="user", content="Message two")
+
+        # Verify zero vectors
+        cursor = db._conn.execute(
+            "SELECT COUNT(*) FROM messages_vec WHERE embedding = zeroblob(3072)"
+        )
+        assert cursor.fetchone()[0] == 2
+
+        # Backfill
+        count = db.backfill_embeddings(provider, batch_size=10)
+        assert count == 2
+
+        # Verify no zero vectors remain
+        cursor = db._conn.execute(
+            "SELECT COUNT(*) FROM messages_vec WHERE embedding = zeroblob(3072)"
+        )
+        assert cursor.fetchone()[0] == 0
+
+
+def _ollama_available():
+    """Check if Ollama is running and nomic-embed-text is available."""
+    try:
+        import urllib.request
+        req = urllib.request.Request("http://localhost:11434/api/tags")
+        with urllib.request.urlopen(req, timeout=3) as resp:
+            import json
+            data = json.loads(resp.read())
+            models = [m["name"] for m in data.get("models", [])]
+            return any("nomic-embed-text" in m for m in models)
+    except Exception:
+        return False

--- a/tests/tools/test_session_search_tool.py
+++ b/tests/tools/test_session_search_tool.py
@@ -1,0 +1,209 @@
+"""Tests for session_search tool — semantic and hybrid search parameters."""
+
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+class TestSessionSearchSemanticParam:
+    """Tests for the semantic=True parameter on session_search."""
+
+    def test_semantic_param_accepted(self):
+        """session_search accepts semantic=False (default, backward compat)."""
+        from tools.session_search_tool import session_search
+
+        with patch("hermes_state.SessionDB") as mock_db_cls:
+            mock_db = MagicMock()
+            mock_db_cls.return_value = mock_db
+            mock_db.search_messages.return_value = []
+            mock_db.list_sessions_rich.return_value = []
+
+            result = json.loads(session_search(query="test", semantic=False))
+            assert result["success"] is True
+
+    def test_semantic_true_routes_to_hybrid(self):
+        """semantic=True calls search_hybrid instead of search_messages."""
+        from tools.session_search_tool import session_search
+
+        with patch("hermes_state.SessionDB") as mock_db_cls, \
+             patch("tools.session_search_tool._resolve_embedding_provider") as mock_resolve:
+            mock_db = MagicMock()
+            mock_db_cls.return_value = mock_db
+            mock_db.search_hybrid.return_value = [
+                {"id": 1, "session_id": "s1", "role": "user",
+                 "snippet": "test", "timestamp": 1.0, "tool_name": None,
+                 "source": "cli", "model": None, "session_started": 1.0,
+                 "context": [], "hybrid_score": 0.1}
+            ]
+            mock_db.list_sessions_rich.return_value = []
+            mock_db.get_anchored_view.return_value = {
+                "window": [], "bookend_start": [], "bookend_end": [],
+                "messages_before": 0, "messages_after": 0,
+            }
+            mock_db.get_session.return_value = {}
+            mock_resolve.return_value = MagicMock()
+
+            result = json.loads(session_search(query="test", semantic=True))
+            assert result["success"] is True
+            mock_db.search_hybrid.assert_called_once()
+            mock_db.search_messages.assert_not_called()
+
+    def test_semantic_true_passes_hybrid_weight(self):
+        """hybrid_weight parameter is forwarded to search_hybrid."""
+        from tools.session_search_tool import session_search
+
+        with patch("hermes_state.SessionDB") as mock_db_cls, \
+             patch("tools.session_search_tool._resolve_embedding_provider") as mock_resolve:
+            mock_db = MagicMock()
+            mock_db_cls.return_value = mock_db
+            mock_db.search_hybrid.return_value = []
+            mock_db.list_sessions_rich.return_value = []
+            mock_resolve.return_value = MagicMock()
+
+            session_search(query="test", semantic=True, hybrid_weight=0.7)
+            call_kwargs = mock_db.search_hybrid.call_args.kwargs
+            assert call_kwargs.get("hybrid_weight") == 0.7
+
+    def test_semantic_false_uses_fts5(self):
+        """semantic=False (default) uses existing FTS5 search_messages path."""
+        from tools.session_search_tool import session_search
+
+        with patch("hermes_state.SessionDB") as mock_db_cls:
+            mock_db = MagicMock()
+            mock_db_cls.return_value = mock_db
+            mock_db.search_messages.return_value = [
+                {"id": 1, "session_id": "s1", "role": "user",
+                 "snippet": "test", "timestamp": 1.0, "tool_name": None,
+                 "source": "cli", "model": None, "session_started": 1.0,
+                 "context": []}
+            ]
+            mock_db.list_sessions_rich.return_value = []
+            mock_db.get_anchored_view.return_value = {
+                "window": [], "bookend_start": [], "bookend_end": [],
+                "messages_before": 0, "messages_after": 0,
+            }
+            mock_db.get_session.return_value = {}
+
+            result = json.loads(session_search(query="test", semantic=False))
+            assert result["success"] is True
+            mock_db.search_messages.assert_called_once()
+            mock_db.search_hybrid.assert_not_called()
+
+    def test_semantic_true_with_role_filter(self):
+        """role_filter is passed through to search_hybrid."""
+        from tools.session_search_tool import session_search
+
+        with patch("hermes_state.SessionDB") as mock_db_cls, \
+             patch("tools.session_search_tool._resolve_embedding_provider") as mock_resolve:
+            mock_db = MagicMock()
+            mock_db_cls.return_value = mock_db
+            mock_db.search_hybrid.return_value = []
+            mock_db.list_sessions_rich.return_value = []
+            mock_resolve.return_value = MagicMock()
+
+            session_search(query="test", semantic=True, role_filter="user,assistant")
+            call_kwargs = mock_db.search_hybrid.call_args.kwargs
+            assert "role_filter" in call_kwargs
+            assert call_kwargs["role_filter"] == ["user", "assistant"]
+
+    def test_semantic_true_exclude_sources_passed(self):
+        """_HIDDEN_SESSION_SOURCES are passed as exclude_sources to search_hybrid."""
+        from tools.session_search_tool import session_search
+
+        with patch("hermes_state.SessionDB") as mock_db_cls, \
+             patch("tools.session_search_tool._resolve_embedding_provider") as mock_resolve:
+            mock_db = MagicMock()
+            mock_db_cls.return_value = mock_db
+            mock_db.search_hybrid.return_value = []
+            mock_db.list_sessions_rich.return_value = []
+            mock_resolve.return_value = MagicMock()
+
+            session_search(query="test", semantic=True)
+            call_kwargs = mock_db.search_hybrid.call_args.kwargs
+            assert "exclude_sources" in call_kwargs
+
+
+class TestResolveEmbeddingProviderCache:
+    """Tests for the module-level provider cache in session_search_tool."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        """Reset the module-level cache before each test."""
+        import tools.session_search_tool as mod
+        mod._cached_embedding_provider = None
+        mod._cached_embedding_config_hash = None
+
+    def test_cache_hit_returns_same_object(self):
+        """Second call returns the cached provider, not a new instance."""
+        from tools.session_search_tool import _resolve_embedding_provider
+
+        with patch("hermes_cli.config.load_config") as mock_load_config, \
+             patch("agent.embedding_provider.resolve_embedding_provider") as mock_resolve:
+            mock_load_config.return_value = {
+                "auxiliary": {
+                    "session_search": {
+                        "embedding": {
+                            "provider": "ollama",
+                            "model": "nomic-embed-text",
+                            "base_url": "http://localhost:11434/v1",
+                            "api_key": "",
+                            "dimensions": 768,
+                        }
+                    }
+                }
+            }
+            mock_provider = MagicMock()
+            mock_resolve.return_value = mock_provider
+
+            first = _resolve_embedding_provider()
+            second = _resolve_embedding_provider()
+
+            assert first is second, "Cache should return the same object"
+            # resolve_embedding_provider should only be called once
+            mock_resolve.assert_called_once()
+
+    def test_cache_busts_on_config_change(self):
+        """Different config produces a new provider."""
+        from tools.session_search_tool import _resolve_embedding_provider
+
+        with patch("hermes_cli.config.load_config") as mock_load_config, \
+             patch("agent.embedding_provider.resolve_embedding_provider") as mock_resolve:
+            mock_load_config.return_value = {
+                "auxiliary": {
+                    "session_search": {
+                        "embedding": {
+                            "provider": "ollama",
+                            "model": "nomic-embed-text",
+                            "base_url": "http://localhost:11434/v1",
+                            "api_key": "",
+                            "dimensions": 768,
+                        }
+                    }
+                }
+            }
+            mock_provider_a = MagicMock()
+            mock_provider_b = MagicMock()
+            mock_resolve.side_effect = [mock_provider_a, mock_provider_b]
+
+            first = _resolve_embedding_provider()
+            assert first is mock_provider_a
+
+            # Change config
+            mock_load_config.return_value = {
+                "auxiliary": {
+                    "session_search": {
+                        "embedding": {
+                            "provider": "openai",
+                            "model": "text-embedding-3-small",
+                            "base_url": "",
+                            "api_key": "sk-test",
+                            "dimensions": 1536,
+                        }
+                    }
+                }
+            }
+
+            second = _resolve_embedding_provider()
+            assert second is mock_provider_b
+            assert second is not first, "Different config should produce different provider"
+            assert mock_resolve.call_count == 2

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -39,6 +39,40 @@ from typing import Any, Dict, List, Optional, Union
 # user's session history.
 _HIDDEN_SESSION_SOURCES = ("subagent", "tool")
 
+# Module-level cache for the resolved embedding provider.
+# load_config() is I/O-heavy; caching avoids re-reading config.yaml on every
+# semantic=True invocation within a session.
+_cached_embedding_provider = None
+_cached_embedding_config_hash = None
+
+
+def _resolve_embedding_provider() -> Optional[Any]:
+    """Resolve the embedding provider from config, with module-level caching.
+
+    Returns an EmbeddingProvider instance or None.  Caches the result so
+    repeated semantic=True calls within a session don't re-read config.yaml.
+    """
+    global _cached_embedding_provider, _cached_embedding_config_hash
+
+    try:
+        from hermes_cli.config import load_config
+        config = load_config()
+        emb_config = config.get("auxiliary", {}).get("session_search", {}).get("embedding", {})
+
+        # Simple cache key: hash the config dict.  If config hasn't changed,
+        # reuse the cached provider.
+        config_hash = hash(json.dumps(emb_config, sort_keys=True))
+        if _cached_embedding_provider is not None and _cached_embedding_config_hash == config_hash:
+            return _cached_embedding_provider
+
+        from agent.embedding_provider import resolve_embedding_provider
+        _cached_embedding_provider = resolve_embedding_provider(emb_config)
+        _cached_embedding_config_hash = config_hash
+        return _cached_embedding_provider
+    except Exception:
+        logging.debug("Embedding provider resolution failed", exc_info=True)
+        return None
+
 
 def _format_timestamp(ts: Union[int, float, str, None]) -> str:
     """Convert a Unix timestamp (float/int) or ISO string to a human-readable date.
@@ -398,21 +432,40 @@ def _discover(
     limit: int,
     sort: Optional[str],
     current_session_id: str = None,
+    semantic: bool = False,
+    hybrid_weight: float = 0.5,
+    provider=None,
 ) -> str:
-    """Discovery shape: FTS5 + anchored window + bookends per hit. Single call."""
+    """Discovery shape: FTS5 + anchored window + bookends per hit. Single call.
+
+    When ``semantic=True``, uses hybrid BM25+vector search instead of pure FTS5.
+    *provider* is the resolved embedding provider (set on db.embedding_provider
+    by the caller for auto-embed on append_message).
+    """
     role_list = role_filter if role_filter else ["user", "assistant"]
 
     try:
-        raw_results = db.search_messages(
-            query=query,
-            role_filter=role_list,
-            exclude_sources=list(_HIDDEN_SESSION_SOURCES),
-            limit=50,  # widen so dedup-by-lineage can find distinct sessions
-            offset=0,
-            sort=sort,
-        )
+        if semantic and provider is not None:
+            raw_results = db.search_hybrid(
+                query=query,
+                provider=provider,
+                role_filter=role_list,
+                exclude_sources=list(_HIDDEN_SESSION_SOURCES),
+                limit=50,
+                hybrid_weight=hybrid_weight,
+                sort=sort,
+            )
+        else:
+            raw_results = db.search_messages(
+                query=query,
+                role_filter=role_list,
+                exclude_sources=list(_HIDDEN_SESSION_SOURCES),
+                limit=50,
+                offset=0,
+                sort=sort,
+            )
     except Exception as e:
-        logging.error("FTS5 search failed: %s", e, exc_info=True)
+        logging.error("Search failed: %s", e, exc_info=True)
         return tool_error(f"Search failed: {e}", success=False)
 
     if not raw_results:
@@ -506,6 +559,9 @@ def session_search(
     sort: str = None,
     # Cross-profile (any shape)
     profile: str = None,
+    # Semantic / hybrid search
+    semantic: bool = False,
+    hybrid_weight: float = 0.5,
 ) -> str:
     """Single-shape tool. Mode inferred from which args are set.
 
@@ -526,6 +582,12 @@ def session_search(
             logging.debug("SessionDB unavailable for session_search", exc_info=True)
             from hermes_state import format_session_db_unavailable
             return tool_error(format_session_db_unavailable(), success=False)
+
+    # Resolve embedding provider for semantic search (cached).
+    # Set on the db so append_message auto-embeds new messages.
+    provider = _resolve_embedding_provider() if semantic else None
+    if provider is not None:
+        db.embedding_provider = provider
 
     # Normalise a raw `@session:<profile>/<id>` link value passed as session_id.
     # Session ids never contain "/", so a slash unambiguously means profile/id —
@@ -613,6 +675,9 @@ def session_search(
         limit=limit,
         sort=sort_norm,
         current_session_id=current_session_id,
+        semantic=semantic,
+        hybrid_weight=hybrid_weight,
+        provider=provider,
     )
 
 
@@ -767,6 +832,26 @@ SESSION_SEARCH_SCHEMA = {
                     "Omit to use the current profile."
                 ),
             },
+            "semantic": {
+                "type": "boolean",
+                "description": (
+                    "Discovery shape only. Set true to use hybrid BM25+vector search "
+                    "instead of pure FTS5 keyword matching. Finds conversations by "
+                    "meaning, not just exact words. Requires an embedding provider "
+                    "configured in auxiliary.session_search.embedding. Default false "
+                    "(FTS5-only, backward compatible)."
+                ),
+                "default": False,
+            },
+            "hybrid_weight": {
+                "type": "number",
+                "description": (
+                    "Discovery shape only, when semantic=true. Weight for vector "
+                    "results in hybrid ranking (0.0 = pure BM25, 1.0 = pure vector, "
+                    "0.5 = balanced). Default 0.5."
+                ),
+                "default": 0.5,
+            },
         },
         "required": [],
     },
@@ -789,6 +874,8 @@ registry.register(
         window=args.get("window", 5),
         sort=args.get("sort"),
         profile=args.get("profile"),
+        semantic=args.get("semantic", False),
+        hybrid_weight=args.get("hybrid_weight", 0.5),
         db=kw.get("db"),
         current_session_id=kw.get("current_session_id"),
     ),


### PR DESCRIPTION
Closes #44075

Adds vector embedding support for semantic session search using sqlite-vec, enabling the agent to find past conversations by meaning ("what did we do about smart home") not just exact words ("Bardi Tuya bulbs").

## What's included

- **EmbeddingProvider abstraction** (Strategy pattern) — Ollama (local, free) and OpenAI (API) backends
- **messages_vec virtual table** (vec0, float[768]) with INSERT/DELETE triggers — mirrors the existing FTS5 trigger pattern
- **Auto-embed on append_message** — user and assistant messages get real embeddings at insert time; tool output is skipped (noise for semantic search)
- **backfill_embeddings()** — one-time migration for existing message history
- **search_hybrid()** — combines BM25 (FTS5) + vector KNN with configurable hybrid_weight (0.0 = pure BM25, 1.0 = pure vector, 0.5 = balanced)
- **session_search(semantic=True, hybrid_weight=0.5)** — backward-compatible opt-in parameter
- **vec_embedded column + index** — tracks embedding state, enables efficient backfill queries
- **Embedding provider resolved at SessionDB init** — auto-embed from session start, no waiting for first semantic=True call

## Config

```yaml
auxiliary:
  session_search:
    embedding:
      provider: ollama           # ollama | openai
      model: nomic-embed-text    # 768 dims, 137MB, free
      base_url: http://localhost:11434/v1
      api_key: ""               # empty for Ollama
      dimensions: 768
```

## Design decisions

- **sqlite-vec over external vector DB** — lives inside the existing SQLite DB, no new process/port/dependency to keep alive
- **Embed at insert time, not search time** — messages are inserted once, searched many times. Embed once, pay once.
- **Hybrid ranking via RRF** — Reciprocal Rank Fusion, no score normalization needed
- **Only embed user+assistant messages** — tool output is ~80% of message volume but noise for semantic search
- **Ollama /v1/embeddings endpoint** — the native /api/embeddings returns empty arrays for nomic-embed-text; the OpenAI-compatible /v1/embeddings works

## Tests

- 15 tests in test_hermes_state.py: vec schema, triggers, backfill, semantic search, hybrid search
- 8 tests in test_embedding_provider.py: provider resolution, Ollama/OpenAI mocks
- 11 tests in test_session_search_tool.py: semantic flag routing, hybrid format, backward compat

## Dogfood results

Backfill completed on a 140K-message database: 43,212 user+assistant messages embedded in 532 seconds (81 msg/s) using batch-50 Ollama calls. KNN search verified working against the full historical corpus.