### PR TITLE
fix: send messages to running CLI sessions

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3771,6 +3771,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         self.preloaded_skills: list[str] = []
         self._startup_skills_line_shown = False
         self._active_session_lease = None
+        self._session_ipc_server = None
 
         # Voice mode state (also reinitialized inside run() for interactive TUI).
         self._voice_lock = threading.Lock()
@@ -5459,7 +5460,72 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             except Exception:
                 pass
 
+    def _handle_session_ipc_message(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Accept a user message from ``hermes send`` and route it like TUI input."""
+        content = str(payload.get("content") or "")
+        message_id = uuid.uuid4().hex
+        if not content.strip():
+            return {"sent": False, "message_id": message_id, "error": "Message content is empty"}
+        mode = str(payload.get("mode") or "auto").strip().lower()
+        if mode not in {"auto", "queue", "steer", "interrupt", "reject"}:
+            return {"sent": False, "message_id": message_id, "error": f"Unsupported mode: {mode}"}
+        busy = bool(getattr(self, "_agent_running", False))
+        status = "delivered"
 
+        if busy and mode == "reject":
+            return {
+                "sent": False,
+                "session": self.session_id,
+                "message_id": message_id,
+                "status": "busy",
+                "error": "Session is busy",
+            }
+
+        effective_mode = self.busy_input_mode if busy and mode == "auto" else mode
+        if not busy:
+            effective_mode = "queue"
+        if busy and effective_mode == "reject":
+            return {
+                "sent": False,
+                "session": self.session_id,
+                "message_id": message_id,
+                "status": "busy",
+                "error": "Session is busy",
+            }
+
+        if busy and effective_mode == "steer":
+            accepted = False
+            try:
+                # AIAgent.steer() is internally locked; the IPC handler runs on
+                # a socket worker thread while the turn runs on process_loop.
+                if self.agent is not None and hasattr(self.agent, "steer"):
+                    accepted = bool(self.agent.steer(content))
+            except Exception as exc:
+                logger.debug("IPC steer failed; falling back to queue: %s", exc)
+            if accepted:
+                status = "steered"
+            else:
+                self._pending_input.put(content)
+                status = "queued"
+        elif busy and effective_mode == "interrupt":
+            self._interrupt_queue.put(content)
+            status = "interrupt_queued"
+        else:
+            self._pending_input.put(content)
+            status = "queued" if busy else "delivered"
+
+        app = getattr(self, "_app", None)
+        if app is not None:
+            try:
+                app.invalidate()
+            except Exception:
+                pass
+        return {
+            "sent": True,
+            "session": self.session_id,
+            "message_id": message_id,
+            "status": status,
+        }
 
     def _install_tool_callbacks(self) -> None:
         """Install tool callbacks that need the live prompt UI."""
@@ -12129,6 +12195,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         """Run the interactive CLI loop with persistent input at bottom."""
         if not self._claim_active_session("cli"):
             return
+        if (self.config.get("session_ipc") or {}).get("enabled", True):
+            try:
+                from hermes_cli.session_ipc import SessionIPCServer
+
+                self._session_ipc_server = SessionIPCServer(
+                    self.session_id,
+                    self._handle_session_ipc_message,
+                    surface="cli",
+                )
+                self._session_ipc_server.start()
+            except Exception as exc:
+                logger.warning("Session IPC unavailable for this run: %s", exc)
 
         # Detect light/dark terminal mode now (before pt grabs the tty).
         # Caches the result so subsequent _hex_to_ansi / style calls
@@ -14585,6 +14663,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     )
                 except Exception:
                     pass
+            _ipc_server = getattr(self, '_session_ipc_server', None)
+            if _ipc_server is not None:
+                try:
+                    _ipc_server.stop()
+                except Exception:
+                    logger.debug("Could not stop session IPC server", exc_info=True)
+                self._session_ipc_server = None
             _run_cleanup()
             self._print_exit_summary()
             self._release_active_session()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -889,6 +889,10 @@ DEFAULT_CONFIG = {
     # Global active chat session cap across CLI, TUI/dashboard, and messaging.
     # None/0 = unbounded.
     "max_concurrent_sessions": None,
+    # Local-only IPC receive channel for `hermes send --session/--current`.
+    # The socket is same-user (0600) and non-networked; set enabled false to
+    # opt out of live session injection.
+    "session_ipc": {"enabled": True},
     "agent": {
         "max_turns": 90,
         # Inactivity timeout for gateway agent execution (seconds).

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12372,6 +12372,9 @@ def main():
 
             seen_plugin_commands = set()
             for cmd_info in discover_plugin_cli_commands():
+                if cmd_info["name"] in getattr(subparsers, "choices", {}):
+                    seen_plugin_commands.add(cmd_info["name"])
+                    continue
                 plugin_parser = subparsers.add_parser(
                     cmd_info["name"],
                     help=cmd_info["help"],
@@ -12386,6 +12389,8 @@ def main():
             discover_plugins()
             for cmd_info in get_plugin_manager()._cli_commands.values():
                 if cmd_info["name"] in seen_plugin_commands:
+                    continue
+                if cmd_info["name"] in getattr(subparsers, "choices", {}):
                     continue
                 plugin_parser = subparsers.add_parser(
                     cmd_info["name"],
@@ -12653,6 +12658,12 @@ def main():
         "--limit", type=int, default=20, help="Max sessions to show"
     )
 
+    sessions_subparsers.add_parser(
+        "running",
+        aliases=["live"],
+        help="List live interactive sessions that can receive hermes send messages",
+    )
+
     sessions_export = sessions_subparsers.add_parser(
         "export", help="Export sessions to a JSONL file"
     )
@@ -12796,7 +12807,27 @@ def main():
         _source = getattr(args, "source", None)
         _exclude = None if _source else ["tool"]
 
-        if action == "list":
+        if action in {"running", "live"}:
+            from hermes_cli.session_ipc import list_live_sessions
+
+            sessions = list_live_sessions()
+            if not sessions:
+                print("No running sessions found.")
+                db.close()
+                return
+            print(f"{'Session':<28} {'Surface':<8} {'PID':<8} Socket")
+            print("─" * 90)
+            for entry in sessions:
+                print(
+                    f"{str(entry.get('session_id', '')):<28} "
+                    f"{str(entry.get('surface', '')):<8} "
+                    f"{str(entry.get('pid', '')):<8} "
+                    f"{entry.get('socket_path', '')}"
+                )
+            db.close()
+            return
+
+        elif action == "list":
             sessions = db.list_sessions_rich(
                 source=args.source, exclude_sources=_exclude, limit=args.limit
             )

--- a/hermes_cli/send_cmd.py
+++ b/hermes_cli/send_cmd.py
@@ -311,6 +311,50 @@ def cmd_send(args: argparse.Namespace) -> None:
         exit_code = _list_targets(platform_filter, json_mode=getattr(args, "json", False))
         sys.exit(exit_code)
 
+    live_session = getattr(args, "session", None)
+    use_current = bool(getattr(args, "current", False))
+    if live_session or use_current:
+        if getattr(args, "to", None):
+            print(
+                "hermes send: --to cannot be combined with --session or --current",
+                file=sys.stderr,
+            )
+            sys.exit(_USAGE_EXIT)
+        message = _read_message_body(
+            getattr(args, "message", None),
+            getattr(args, "file", None),
+        )
+        if message is None or not message.strip():
+            print(
+                "hermes send: no message provided. Pass text as a positional "
+                "argument, use --file PATH, or pipe data via stdin.",
+                file=sys.stderr,
+            )
+            sys.exit(_USAGE_EXIT)
+        subject = getattr(args, "subject", None)
+        if subject:
+            message = f"{subject}\n\n{message.lstrip()}"
+        from hermes_cli.session_ipc import send_message_to_session
+
+        result = send_message_to_session(
+            session=live_session,
+            current=use_current,
+            message=message,
+            mode=getattr(args, "mode", "auto"),
+        )
+        if getattr(args, "json", False):
+            print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+        elif not getattr(args, "quiet", False):
+            if result.get("sent"):
+                print("sent: true")
+                print(f"session: {result.get('session')}")
+                print(f"message_id: {result.get('message_id')}")
+                print(f"status: {result.get('status')}")
+            else:
+                print("sent: false")
+                print(f"error: {result.get('error')}", file=sys.stderr)
+        sys.exit(_SUCCESS_EXIT if result.get("sent") else _FAILURE_EXIT)
+
     target = _resolve_target(getattr(args, "to", None))
     if not target:
         print(
@@ -385,6 +429,8 @@ def register_send_subparser(subparsers) -> argparse.ArgumentParser:
         epilog=(
             "Examples:\n"
             "  hermes send --to telegram \"deploy finished\"\n"
+            "  hermes send --current \"continue with the queued review\"\n"
+            "  hermes send --session 20260622_153814_f1c0de --mode queue \"run this next\"\n"
             "  echo \"RAM 92%\" | hermes send --to telegram:-1001234567890\n"
             "  hermes send --to discord:#ops --file /tmp/report.md\n"
             "  hermes send --to slack:#eng --subject \"[CI]\" --file build.log\n"
@@ -407,8 +453,27 @@ def register_send_subparser(subparsers) -> argparse.ArgumentParser:
             "'platform:chat_id', 'platform:chat_id:thread_id', or "
             "'platform:#channel-name'. Examples: telegram, "
             "telegram:-1001234567890:17585, discord:#ops, slack:C0123ABCD, "
-            "signal:+15551234567."
+            "signal:+15551234567. Required unless --session/--current is used."
         ),
+    )
+    live_target = parser.add_mutually_exclusive_group()
+    live_target.add_argument(
+        "--session",
+        metavar="SESSION_ID",
+        default=None,
+        help="Send to a running interactive Hermes session by ID or unique prefix.",
+    )
+    live_target.add_argument(
+        "--current",
+        action="store_true",
+        default=False,
+        help="Send to the most recently started running interactive Hermes session.",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["auto", "queue", "steer", "interrupt", "reject"],
+        default="auto",
+        help="Busy-session behavior for --session/--current (default: auto, follows the running session's configured busy behavior).",
     )
 
     parser.add_argument(

--- a/hermes_cli/session_ipc.py
+++ b/hermes_cli/session_ipc.py
@@ -1,0 +1,414 @@
+"""Local IPC for sending messages to a running Hermes CLI session.
+
+The persisted session store lets a new process resume historical context, but it
+cannot safely inject a message into an already running prompt_toolkit session.
+This module provides a tiny localhost-only/same-user IPC surface for that live
+path.  POSIX uses Unix domain sockets; Python exposes AF_UNIX on modern Windows
+too, but unsupported platforms fail closed with a clear error.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import socket
+import socketserver
+import stat
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+_MAX_PAYLOAD_BYTES = 1024 * 1024
+_DEFAULT_TIMEOUT = 5.0
+
+
+def _runtime_dir() -> Path:
+    return get_hermes_home() / "runtime" / "session_ipc"
+
+
+def _registry_path() -> Path:
+    return _runtime_dir() / "live_sessions.json"
+
+
+def _lock_path() -> Path:
+    return _runtime_dir() / "live_sessions.lock"
+
+
+class AmbiguousSessionError(ValueError):
+    """Raised when a session selector matches more than one live session."""
+
+    def __init__(self, selector: str, matches: list[str]):
+        self.selector = selector
+        self.matches = matches
+        preview = ", ".join(matches[:5])
+        more = f" (+{len(matches) - 5} more)" if len(matches) > 5 else ""
+        super().__init__(
+            f"Multiple running Hermes sessions match {selector!r}: {preview}{more}. "
+            "Use a longer session id prefix."
+        )
+
+
+def socket_path_for_session(session_id: str) -> Path:
+    safe = "".join(ch if ch.isalnum() or ch in {"_", "-", "."} else "_" for ch in str(session_id))
+    # Keep Unix socket paths comfortably below the traditional 108-byte limit.
+    # Pytest/macOS temp homes and deeply nested profile paths can make
+    # ``$HERMES_HOME/runtime/...`` too long, so fall back to /tmp while keeping
+    # the authoritative registry under HERMES_HOME.
+    candidate = _runtime_dir() / f"{safe}.sock"
+    if len(str(candidate).encode("utf-8")) < 100:
+        return candidate
+    import hashlib
+    import tempfile
+
+    home_digest = hashlib.sha256(str(get_hermes_home()).encode("utf-8")).hexdigest()[:12]
+    session_digest = hashlib.sha256(str(session_id).encode("utf-8")).hexdigest()[:16]
+    uid = getattr(os, "getuid", lambda: os.getpid())()
+    base = Path(tempfile.gettempdir()) / f"hermes-ipc-{uid}-{home_digest}"
+    return base / f"{session_digest}.sock"
+
+
+class _FileLock:
+    def __init__(self, path: Path):
+        self.path = path
+        self._fh = None
+
+    def __enter__(self):
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._fh = open(self.path, "a+b")
+        if os.name == "nt":
+            try:
+                import msvcrt
+
+                self._fh.seek(0)
+                msvcrt.locking(self._fh.fileno(), msvcrt.LK_LOCK, 1)
+            except Exception as exc:
+                self._fh.close()
+                self._fh = None
+                raise RuntimeError("session IPC file lock unavailable") from exc
+        else:
+            try:
+                import fcntl
+
+                fcntl.flock(self._fh.fileno(), fcntl.LOCK_EX)
+            except Exception as exc:
+                self._fh.close()
+                self._fh = None
+                raise RuntimeError("session IPC file lock unavailable") from exc
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        if self._fh is None:
+            return
+        if os.name == "nt":
+            try:
+                import msvcrt
+
+                self._fh.seek(0)
+                msvcrt.locking(self._fh.fileno(), msvcrt.LK_UNLCK, 1)
+            except Exception:
+                pass
+        else:
+            try:
+                import fcntl
+
+                fcntl.flock(self._fh.fileno(), fcntl.LOCK_UN)
+            except Exception:
+                pass
+        try:
+            self._fh.close()
+        finally:
+            self._fh = None
+
+
+def _read_registry(path: Path) -> list[dict[str, Any]]:
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except FileNotFoundError:
+        return []
+    except Exception:
+        logger.warning("Ignoring corrupt live session IPC registry at %s", path)
+        return []
+    entries = data.get("entries") if isinstance(data, dict) else data
+    if not isinstance(entries, list):
+        return []
+    return [entry for entry in entries if isinstance(entry, dict)]
+
+
+def _write_registry(path: Path, entries: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump({"entries": entries}, fh, sort_keys=True)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+    os.replace(tmp, path)
+
+
+def _pid_alive(pid: Any) -> bool:
+    try:
+        pid_int = int(pid)
+    except (TypeError, ValueError):
+        return False
+    if pid_int <= 0:
+        return False
+    try:
+        from gateway.status import _pid_exists
+
+        return bool(_pid_exists(pid_int))
+    except Exception:
+        try:
+            os.kill(pid_int, 0)
+            return True
+        except PermissionError:
+            return True
+        except OSError:
+            return False
+
+
+def _socket_usable(path: Any) -> bool:
+    if not path:
+        return False
+    sock_path = Path(str(path))
+    if not sock_path.exists():
+        return False
+    if os.name != "nt":
+        try:
+            return stat.S_ISSOCK(sock_path.stat().st_mode)
+        except OSError:
+            return False
+    return True
+
+
+def _prune_entries(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [entry for entry in entries if _pid_alive(entry.get("pid")) and _socket_usable(entry.get("socket_path"))]
+
+
+def register_live_session(session_id: str, socket_path: Path, *, surface: str = "cli") -> None:
+    now = time.time()
+    entry = {
+        "session_id": str(session_id),
+        "surface": str(surface),
+        "pid": os.getpid(),
+        "socket_path": str(socket_path),
+        "started_at": now,
+        "updated_at": now,
+    }
+    path = _registry_path()
+    with _FileLock(_lock_path()):
+        entries = [e for e in _prune_entries(_read_registry(path)) if str(e.get("session_id")) != str(session_id)]
+        entries.append(entry)
+        _write_registry(path, entries)
+
+
+def unregister_live_session(session_id: str, socket_path: Path | None = None) -> None:
+    path = _registry_path()
+    try:
+        with _FileLock(_lock_path()):
+            entries = _prune_entries(_read_registry(path))
+            kept = []
+            for entry in entries:
+                same_id = str(entry.get("session_id")) == str(session_id)
+                same_socket = socket_path is not None and str(entry.get("socket_path")) == str(socket_path)
+                if same_id and (socket_path is None or same_socket):
+                    continue
+                kept.append(entry)
+            _write_registry(path, kept)
+    except Exception:
+        logger.debug("Failed to unregister live session IPC entry", exc_info=True)
+
+
+def list_live_sessions() -> list[dict[str, Any]]:
+    path = _registry_path()
+    with _FileLock(_lock_path()):
+        entries = _prune_entries(_read_registry(path))
+        _write_registry(path, entries)
+        return entries
+
+
+def resolve_live_session(selector: str | None = None, *, current: bool = False) -> Optional[dict[str, Any]]:
+    entries = list_live_sessions()
+    if not entries:
+        return None
+    if current:
+        return max(entries, key=lambda e: float(e.get("updated_at") or e.get("started_at") or 0.0))
+    wanted = (selector or "").strip()
+    if not wanted:
+        return None
+    exact = [e for e in entries if str(e.get("session_id")) == wanted]
+    if len(exact) == 1:
+        return exact[0]
+    matches = [
+        e for e in entries
+        if str(e.get("session_id", "")).startswith(wanted)
+    ]
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        raise AmbiguousSessionError(wanted, [str(e.get("session_id")) for e in matches])
+    return None
+
+
+def send_message_to_session(
+    *,
+    session: str | None,
+    message: str,
+    mode: str = "auto",
+    current: bool = False,
+    timeout: float = _DEFAULT_TIMEOUT,
+) -> dict[str, Any]:
+    try:
+        target = resolve_live_session(session, current=current)
+    except AmbiguousSessionError as exc:
+        return {"sent": False, "error": str(exc)}
+    if target is None:
+        label = "current" if current else session
+        return {"sent": False, "error": f"No running Hermes session found for {label!r}"}
+    socket_path = target.get("socket_path")
+    if not socket_path:
+        return {"sent": False, "error": "Running session has no IPC socket registered"}
+    payload = {
+        "session_id": target.get("session_id"),
+        "role": "user",
+        "content": message,
+        "source": "cli-send",
+        "mode": mode,
+        "created_at": time.time(),
+    }
+    raw = (json.dumps(payload, ensure_ascii=False) + "\n").encode("utf-8")
+    if len(raw) > _MAX_PAYLOAD_BYTES:
+        return {"sent": False, "error": f"Message too large ({len(raw)} bytes; max {_MAX_PAYLOAD_BYTES})"}
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+            client.settimeout(timeout)
+            client.connect(str(socket_path))
+            client.sendall(raw)
+            client.shutdown(socket.SHUT_WR)
+            chunks: list[bytes] = []
+            while True:
+                chunk = client.recv(65536)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+    except AttributeError:
+        return {"sent": False, "error": "Unix-domain sockets are not supported by this Python build"}
+    except OSError as exc:
+        return {"sent": False, "error": f"Could not reach running session: {exc}"}
+    try:
+        reply = json.loads(b"".join(chunks).decode("utf-8") or "{}")
+    except Exception:
+        reply = {"sent": False, "error": "Running session returned an invalid IPC response"}
+    if isinstance(reply, dict):
+        reply.setdefault("session", target.get("session_id"))
+        return reply
+    return {"sent": False, "error": "Running session returned a non-object IPC response"}
+
+
+@dataclass
+class SessionIPCServer:
+    session_id: str
+    callback: Callable[[dict[str, Any]], dict[str, Any]]
+    surface: str = "cli"
+    socket_path: Path | None = None
+
+    def __post_init__(self) -> None:
+        self.socket_path = self.socket_path or socket_path_for_session(self.session_id)
+        self._server: socketserver.UnixStreamServer | None = None
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        if not hasattr(socketserver, "UnixStreamServer") or not hasattr(socket, "AF_UNIX"):
+            raise RuntimeError("Unix-domain sockets are not supported by this Python build")
+        assert self.socket_path is not None
+        self.socket_path.parent.mkdir(parents=True, exist_ok=True)
+        if os.name != "nt":
+            try:
+                os.chmod(self.socket_path.parent, 0o700)
+            except OSError:
+                pass
+        try:
+            self.socket_path.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError:
+            logger.debug("Could not remove stale session IPC socket %s", self.socket_path, exc_info=True)
+
+        outer = self
+
+        class _Handler(socketserver.BaseRequestHandler):
+            def handle(self) -> None:  # type: ignore[override]
+                try:
+                    self.request.settimeout(10.0)
+                except Exception:
+                    pass
+                data = bytearray()
+                response: dict[str, Any]
+                try:
+                    while len(data) <= _MAX_PAYLOAD_BYTES:
+                        chunk = self.request.recv(65536)
+                        if not chunk:
+                            break
+                        data.extend(chunk)
+                except socket.timeout:
+                    response = {"sent": False, "error": "Timed out while reading IPC payload"}
+                except OSError as exc:
+                    response = {"sent": False, "error": f"Failed to read IPC payload: {exc}"}
+                else:
+                    if len(data) > _MAX_PAYLOAD_BYTES:
+                        response = {"sent": False, "error": f"Payload too large (max {_MAX_PAYLOAD_BYTES} bytes)"}
+                    else:
+                        try:
+                            payload = json.loads(data.decode("utf-8"))
+                            if not isinstance(payload, dict):
+                                raise ValueError("payload must be a JSON object")
+                            response = outer.callback(payload)
+                        except Exception as exc:
+                            logger.debug("Session IPC request failed", exc_info=True)
+                            response = {"sent": False, "error": str(exc)}
+                try:
+                    self.request.sendall(json.dumps(response, ensure_ascii=False).encode("utf-8"))
+                except OSError:
+                    pass
+
+        class _Server(socketserver.ThreadingMixIn, socketserver.UnixStreamServer):
+            daemon_threads = True
+            allow_reuse_address = True
+
+        self._server = _Server(str(self.socket_path), _Handler)
+        if os.name != "nt":
+            os.chmod(self.socket_path, 0o600)
+        register_live_session(self.session_id, self.socket_path, surface=self.surface)
+        self._thread = threading.Thread(target=self._server.serve_forever, name=f"hermes-session-ipc-{self.session_id}", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        server = self._server
+        self._server = None
+        if server is not None:
+            try:
+                server.shutdown()
+                server.server_close()
+            except Exception:
+                logger.debug("Failed to stop session IPC server", exc_info=True)
+        if self.socket_path is not None:
+            unregister_live_session(self.session_id, self.socket_path)
+            try:
+                self.socket_path.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError:
+                logger.debug("Failed to remove session IPC socket", exc_info=True)

--- a/tests/hermes_cli/test_send_cmd.py
+++ b/tests/hermes_cli/test_send_cmd.py
@@ -136,6 +136,36 @@ def test_quiet_suppresses_stdout(fake_tool, capsys):
     assert out.out == ""
 
 
+def test_live_session_quiet_suppresses_stdout(monkeypatch, capsys):
+    import sys as _sys
+    import types as _types
+
+    fake_mod = _types.ModuleType("hermes_cli.session_ipc")
+    setattr(fake_mod, "send_message_to_session", lambda **_kw: {
+        "sent": True,
+        "session": "sid",
+        "message_id": "m1",
+        "status": "queued",
+    })
+    monkeypatch.setitem(_sys.modules, "hermes_cli.session_ipc", fake_mod)
+
+    args = _parse(["--current", "--quiet", "shh"])
+    with pytest.raises(SystemExit) as exc:
+        send_cmd.cmd_send(args)
+    assert exc.value.code == 0
+    out = capsys.readouterr()
+    assert out.out == ""
+
+
+def test_live_session_rejects_platform_target_mix(capsys):
+    args = _parse(["--to", "telegram", "--current", "ambiguous"])
+    with pytest.raises(SystemExit) as exc:
+        send_cmd.cmd_send(args)
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "cannot be combined" in err
+
+
 # ---------------------------------------------------------------------------
 # Error paths
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_session_ipc.py
+++ b/tests/hermes_cli/test_session_ipc.py
@@ -1,0 +1,232 @@
+import os
+import queue
+import stat
+import time
+
+import pytest
+
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(__import__("socket"), "AF_UNIX"),
+    reason="Unix-domain sockets are not available on this Python build",
+)
+
+
+def _cli_stub(*, running=True, busy_mode="queue", agent=None):
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "sid"
+    cli._agent_running = running
+    cli.busy_input_mode = busy_mode
+    cli._pending_input = queue.Queue()
+    cli._interrupt_queue = queue.Queue()
+    cli.agent = agent
+    cli._app = None
+    return HermesCLI, cli
+
+
+def test_session_ipc_server_accepts_and_registers_live_session(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from hermes_cli.session_ipc import (
+        SessionIPCServer,
+        list_live_sessions,
+        send_message_to_session,
+    )
+
+    received = []
+
+    server = SessionIPCServer(
+        "20260622_153814_f1c0de",
+        lambda payload: received.append(payload) or {
+            "sent": True,
+            "session": payload["session_id"],
+            "message_id": "m1",
+            "status": "queued",
+        },
+    )
+    server.start()
+    try:
+        live = list_live_sessions()
+        assert [entry["session_id"] for entry in live] == ["20260622_153814_f1c0de"]
+        if os.name != "nt":
+            socket_mode = stat.S_IMODE(os.stat(live[0]["socket_path"]).st_mode)
+            registry_mode = stat.S_IMODE(os.stat(tmp_path / "runtime" / "session_ipc" / "live_sessions.json").st_mode)
+            assert socket_mode == 0o600
+            assert registry_mode == 0o600
+
+        result = send_message_to_session(
+            session="20260622_153814_f1c0de",
+            message="Run the review",
+        )
+
+        assert result["sent"] is True
+        assert result["status"] == "queued"
+        assert received[0]["content"] == "Run the review"
+        assert received[0]["source"] == "cli-send"
+    finally:
+        server.stop()
+
+    assert list_live_sessions() == []
+
+
+def test_session_ipc_current_targets_most_recent_session(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from hermes_cli.session_ipc import SessionIPCServer, send_message_to_session
+
+    seen = []
+    older = SessionIPCServer("older", lambda payload: {"sent": True, "session": "older", "message_id": "old", "status": "queued"})
+    newer = SessionIPCServer("newer", lambda payload: seen.append(payload) or {"sent": True, "session": "newer", "message_id": "new", "status": "queued"})
+    older.start()
+    try:
+        time.sleep(0.05)
+        newer.start()
+        try:
+            result = send_message_to_session(session=None, current=True, message="hello")
+            assert result["sent"] is True
+            assert result["session"] == "newer"
+            assert seen[0]["content"] == "hello"
+        finally:
+            newer.stop()
+    finally:
+        older.stop()
+
+
+def test_session_ipc_exact_match_wins_over_prefix(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from hermes_cli.session_ipc import SessionIPCServer, resolve_live_session
+
+    first = SessionIPCServer("abc", lambda payload: {"sent": True})
+    second = SessionIPCServer("abcdef", lambda payload: {"sent": True})
+    first.start()
+    try:
+        second.start()
+        try:
+            resolved = resolve_live_session("abc")
+            assert resolved is not None
+            assert resolved["session_id"] == "abc"
+        finally:
+            second.stop()
+    finally:
+        first.stop()
+
+
+def test_session_ipc_ambiguous_prefix_reports_clear_error(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from hermes_cli.session_ipc import SessionIPCServer, send_message_to_session
+
+    first = SessionIPCServer("abc123", lambda payload: {"sent": True})
+    second = SessionIPCServer("abc456", lambda payload: {"sent": True})
+    first.start()
+    try:
+        second.start()
+        try:
+            result = send_message_to_session(session="abc", message="hello")
+            assert result["sent"] is False
+            assert "Multiple running Hermes sessions match" in result["error"]
+        finally:
+            second.stop()
+    finally:
+        first.stop()
+
+
+def test_cli_ipc_message_routes_by_busy_mode(monkeypatch):
+    HermesCLI, cli = _cli_stub(running=True, busy_mode="queue")
+
+    result = HermesCLI._handle_session_ipc_message(
+        cli,
+        {"content": "queued message", "mode": "auto"},
+    )
+
+    assert result["sent"] is True
+    assert result["status"] == "queued"
+    assert cli._pending_input.get_nowait() == "queued message"
+
+
+def test_cli_ipc_auto_reject_mode_reports_busy():
+    HermesCLI, cli = _cli_stub(running=True, busy_mode="reject")
+
+    result = HermesCLI._handle_session_ipc_message(
+        cli,
+        {"content": "do not queue", "mode": "auto"},
+    )
+
+    assert result["sent"] is False
+    assert result["status"] == "busy"
+    assert cli._pending_input.empty()
+
+
+def test_cli_ipc_explicit_reject_mode_reports_busy():
+    HermesCLI, cli = _cli_stub(running=True, busy_mode="queue")
+
+    result = HermesCLI._handle_session_ipc_message(
+        cli,
+        {"content": "do not queue", "mode": "reject"},
+    )
+
+    assert result["sent"] is False
+    assert result["status"] == "busy"
+    assert cli._pending_input.empty()
+
+
+def test_cli_ipc_interrupt_mode_uses_interrupt_queue():
+    HermesCLI, cli = _cli_stub(running=True, busy_mode="queue")
+
+    result = HermesCLI._handle_session_ipc_message(
+        cli,
+        {"content": "interrupt this", "mode": "interrupt"},
+    )
+
+    assert result["sent"] is True
+    assert result["status"] == "interrupt_queued"
+    assert cli._interrupt_queue.get_nowait() == "interrupt this"
+    assert cli._pending_input.empty()
+
+
+def test_cli_ipc_steer_mode_uses_agent_steer():
+    class Agent:
+        def __init__(self):
+            self.seen = []
+
+        def steer(self, text):
+            self.seen.append(text)
+            return True
+
+    agent = Agent()
+    HermesCLI, cli = _cli_stub(running=True, busy_mode="queue", agent=agent)
+
+    result = HermesCLI._handle_session_ipc_message(
+        cli,
+        {"content": "steer this", "mode": "steer"},
+    )
+
+    assert result["sent"] is True
+    assert result["status"] == "steered"
+    assert agent.seen == ["steer this"]
+    assert cli._pending_input.empty()
+
+
+def test_cli_ipc_idle_session_delivers_next_turn():
+    HermesCLI, cli = _cli_stub(running=False, busy_mode="queue")
+
+    result = HermesCLI._handle_session_ipc_message(
+        cli,
+        {"content": "next turn", "mode": "auto"},
+    )
+
+    assert result["sent"] is True
+    assert result["status"] == "delivered"
+    assert cli._pending_input.get_nowait() == "next turn"
+
+
+def test_cli_ipc_preserves_message_whitespace():
+    HermesCLI, cli = _cli_stub(running=False, busy_mode="queue")
+    content = "\n\n  indented/trailing  \n"
+
+    result = HermesCLI._handle_session_ipc_message(
+        cli,
+        {"content": content, "mode": "auto"},
+    )
+
+    assert result["sent"] is True
+    assert cli._pending_input.get_nowait() == content


### PR DESCRIPTION
## Summary

Closes #51079.

Adds a local IPC channel for running interactive Hermes CLI sessions so a separate invocation can inject follow-up input into an already-running session:

- Adds `hermes send --current "message"` and `hermes send --session SESSION_ID "message"`.
- Adds `hermes send --mode auto|queue|steer|interrupt|reject` for busy-session behavior.
- Adds `hermes sessions running` / `hermes sessions live` to list live CLI sessions that can receive messages.
- Starts/stops a same-user Unix-domain socket server with the interactive CLI lifecycle.
- Stores live session metadata in a 0600 registry under `$HERMES_HOME/runtime/session_ipc/` and prunes stale entries.
- Keeps the existing `hermes send --to ...` platform-delivery behavior intact.

## Safety / compatibility

- Local-only Unix-domain sockets, no TCP listener.
- Socket and registry are restricted to same-user access.
- Payloads capped at 1 MiB.
- Platforms without `socket.AF_UNIX` fail gracefully on the client and skip IPC tests.
- No new model tools, no system prompt/tool schema changes, no prompt-cache footprint increase.

## Test plan

- `python -m pytest tests/hermes_cli/test_send_cmd.py tests/hermes_cli/test_session_ipc.py -q -o 'addopts='`
  - `34 passed in 5.08s`
- `python -m compileall hermes_cli/session_ipc.py cli.py hermes_cli/main.py hermes_cli/send_cmd.py hermes_cli/config.py tests/hermes_cli/test_session_ipc.py tests/hermes_cli/test_send_cmd.py`
- `git diff --check origin/main..HEAD`

## Independent reviews

Iterated until all three independent reviewers approved:

- Kimi: APPROVED (`/tmp/hermes-51079-review/round4/kimi.md`)
- GLM 5.2: APPROVED (`/tmp/hermes-51079-review/round4/glm.md`)
- GPT-5.5: APPROVED (`/tmp/hermes-51079-review/round4/gpt55.md`)
