### PR TITLE
fix(computer_use): expose launch_app + list_apps as proper actions

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -481,13 +481,26 @@ def computer_use_guidance(platform_name: Optional[str] = None) -> str:
             "same time.\n\n"
         )
         save_combo = "cmd+s"
-    else:
-        os_name = "Windows" if is_windows else "Linux"
+        launcher_shortcut = "Cmd+Space"
+        example_launch_name = "TextEdit"
+    elif is_windows:
+        os_name = "Windows"
         share_line = (
             "focus, or active window. You and the user can share the same "
             "desktop at the same time.\n\n"
         )
         save_combo = "ctrl+s"
+        launcher_shortcut = "Win+R"
+        example_launch_name = "notepad"
+    else:
+        os_name = "Linux"
+        share_line = (
+            "focus, or active window. You and the user can share the same "
+            "desktop at the same time.\n\n"
+        )
+        save_combo = "ctrl+s"
+        launcher_shortcut = "the Activities/launcher shortcut"
+        example_launch_name = "gedit"
 
     # Background-mode rules: the "different Space" wording is macOS-only;
     # Windows needs a note about foreground-only targets (Chromium/GTK).
@@ -495,20 +508,30 @@ def computer_use_guidance(platform_name: Optional[str] = None) -> str:
         offscreen_line = (
             "- If an element you need is on a different Space or behind "
             "another window, cua-driver still drives it — no need to switch "
-            "Spaces.\n\n"
+            "Spaces.\n"
         )
     elif is_windows:
         offscreen_line = (
             "- If an element is behind another window, cua-driver still "
             "drives it — no need to raise it. Some apps may still force "
             "foreground behavior internally; if an action does not land, "
-            "re-capture and adapt instead of retrying blindly.\n\n"
+            "re-capture and adapt instead of retrying blindly.\n"
         )
     else:
         offscreen_line = (
             "- If an element is behind another window, cua-driver still "
-            "drives it — no need to raise it.\n\n"
+            "drives it — no need to raise it.\n"
         )
+
+    # Windows-only: keep the launched window in the taskbar so the user's
+    # frontmost window stays visually on top.
+    minimized_line = (
+        "- On Windows, pass `start_minimized=true` to `launch_app` when you "
+        "want the launched window kept in the taskbar so the user's frontmost "
+        "window stays visually on top.\n"
+        if is_windows
+        else ""
+    )
 
     # Capture-target example: a real app the user is likely to have running,
     # so the model has a concrete reference rather than a generic placeholder.
@@ -521,17 +544,29 @@ def computer_use_guidance(platform_name: Optional[str] = None) -> str:
         "keyboard "
         + share_line +
         "## Preferred workflow\n"
-        "1. Call `computer_use` with `action='capture'` and `mode='som'` "
+        "1. If the target app may not be running, launch it first with "
+        f"`action='launch_app', name='<App>'` (e.g. `name='{example_launch_name}'`). "
+        "The launch is idempotent — calling it for an already-running app "
+        "returns the existing process and its windows. Never instruct the "
+        f"user to press {launcher_shortcut} or any other launcher shortcut: "
+        "launch the app yourself via `launch_app`. Use "
+        "`action='list_apps'` to discover what is already running (returns "
+        "names + pids + bundle IDs).\n"
+        "2. Call `computer_use` with `action='capture'` and `mode='som'` "
         "(default). You get a screenshot with numbered overlays on every "
         "interactable element plus an AX-tree index listing role, label, and "
         "bounds for each numbered element.\n"
-        "2. Click by element index: `action='click', element=14`. This is "
+        "3. Click by element index: `action='click', element=14`. This is "
         "dramatically more reliable than pixel coordinates for any model. "
         "Use raw coordinates only as a last resort.\n"
-        "3. For text input, `action='type', text='...'`. For key combos "
-        f"`action='key', keys='{save_combo}'`. For scrolling `action='scroll', "
-        "direction='down', amount=3`.\n"
-        "4. After any state-changing action, re-capture to verify. You can "
+        "4. For text input, `action='type', text='...'`. For multi-key "
+        "combos, always pass the full chord as a single string to "
+        f"`action='key'` — e.g. `keys='{save_combo}'` or "
+        "`keys='ctrl+shift+t'`. The wrapper auto-routes combos through "
+        "cua-driver's `hotkey` tool. Never send the modifier and the key as "
+        "separate `key` calls; sequencing loses focus on many apps. For "
+        "scrolling `action='scroll', direction='down', amount=3`.\n"
+        "5. After any state-changing action, re-capture to verify. You can "
         "pass `capture_after=true` to get the follow-up screenshot in one "
         "round-trip.\n\n"
         "## Background mode rules\n"
@@ -541,7 +576,9 @@ def computer_use_guidance(platform_name: Optional[str] = None) -> str:
         f"- When capturing, prefer `app='{example_app}'` (or whichever app the "
         "task is about) instead of the whole screen — it's less noisy and "
         "won't leak other windows the user has open.\n"
+        + minimized_line
         + offscreen_line +
+        "\n"
         "## The agent cursor you'll see on screen\n"
         "Each computer-use run declares a session with cua-driver; that "
         "session owns a tinted overlay cursor that glides to where you "

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -2810,9 +2810,11 @@ class TestCuaToolCoverageExpansion:
 
     def test_launch_app_requires_bundle_id_or_name(self):
         backend = self._backend()
-        import pytest
-        with pytest.raises(ValueError, match="bundle_id or name"):
-            backend.launch_app()
+        result = backend.launch_app()
+        assert result.ok is False
+        assert result.action == "launch_app"
+        assert "bundle_id or name" in result.message
+        assert backend._session.call_tool.called is False
 
     def test_launch_app_minimal_call(self):
         backend = self._backend(structured={"pid": 99, "windows": []})
@@ -2824,7 +2826,9 @@ class TestCuaToolCoverageExpansion:
         # Optional flags absent when not supplied.
         assert "name" not in args
         assert "creates_new_application_instance" not in args
-        assert result["pid"] == 99
+        assert result.ok is True
+        assert result.meta["pid"] == 99
+        assert backend._active_pid == 99
 
     def test_launch_app_carries_all_optional_args(self):
         backend = self._backend(structured={"pid": 1})

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -69,8 +69,22 @@ class TestSchema:
         actions = set(COMPUTER_USE_SCHEMA["parameters"]["properties"]["action"]["enum"])
         assert actions >= {
             "capture", "click", "double_click", "right_click", "middle_click",
-            "drag", "scroll", "type", "key", "wait", "list_apps", "focus_app",
+            "drag", "scroll", "type", "key", "wait",
+            "list_apps", "launch_app", "focus_app",
         }
+
+    def test_schema_exposes_launch_app_args(self):
+        """launch_app's cross-platform contract must be discoverable from the schema."""
+        from tools.computer_use.schema import COMPUTER_USE_SCHEMA
+        props = COMPUTER_USE_SCHEMA["parameters"]["properties"]
+        # name + bundle_id are the two ways to identify an app target.
+        assert "name" in props
+        assert props["name"]["type"] == "string"
+        assert "bundle_id" in props
+        assert props["bundle_id"]["type"] == "string"
+        # start_minimized is Windows-specific but exposed cross-platform.
+        assert "start_minimized" in props
+        assert props["start_minimized"]["type"] == "boolean"
 
     def test_capture_mode_enum_has_som_vision_ax(self):
         from tools.computer_use.schema import COMPUTER_USE_SCHEMA
@@ -265,6 +279,167 @@ class TestDispatch:
         out = handle_computer_use({"action": "set_value"})
         parsed = json.loads(out)
         assert "error" in parsed
+
+    def test_launch_app_routes_to_backend(self, noop_backend):
+        """launch_app dispatches to backend.launch_app with the name kwarg."""
+        from tools.computer_use.tool import handle_computer_use
+        out = handle_computer_use({"action": "launch_app", "name": "notepad"})
+        parsed = json.loads(out)
+        assert parsed.get("ok") is True
+        assert parsed.get("action") == "launch_app"
+        call_names = [c[0] for c in noop_backend.calls]
+        assert "launch_app" in call_names
+        launch_kw = next(c[1] for c in noop_backend.calls if c[0] == "launch_app")
+        assert launch_kw["name"] == "notepad"
+
+    def test_launch_app_forwards_bundle_id_and_start_minimized(self, noop_backend):
+        from tools.computer_use.tool import handle_computer_use
+        handle_computer_use({
+            "action": "launch_app",
+            "name": "Calculator",
+            "bundle_id": "com.apple.calculator",
+            "start_minimized": True,
+        })
+        launch_kw = next(c[1] for c in noop_backend.calls if c[0] == "launch_app")
+        assert launch_kw["bundle_id"] == "com.apple.calculator"
+        assert launch_kw["start_minimized"] is True
+
+    def test_launch_app_requires_name_or_bundle_id(self, noop_backend):
+        from tools.computer_use.tool import handle_computer_use
+        out = handle_computer_use({"action": "launch_app"})
+        parsed = json.loads(out)
+        assert "error" in parsed
+        assert "name" in parsed["error"] or "bundle_id" in parsed["error"]
+
+
+class TestLaunchAppBackend:
+    """Verify launch_app updates the CuaDriverBackend sticky context.
+
+    The point of plumbing launch_app through cua_backend is so a follow-up
+    `click` / `capture` / `get_window_state` doesn't need to re-resolve the
+    target pid + window_id. The launched pid + first window must land in
+    `_active_pid` / `_active_window_id`, mirroring how `capture(app=...)` /
+    `focus_app(app=...)` update the same context today.
+    """
+
+    def _make_backend_with_launch_response(self, mcp_response):
+        from tools.computer_use.cua_backend import CuaDriverBackend
+
+        backend = CuaDriverBackend()
+        backend._session = MagicMock()
+        backend._session.call_tool.return_value = mcp_response
+        return backend
+
+    def test_launch_app_happy_path_updates_sticky_context(self):
+        # cua-driver's launch_app returns text + a structured payload with
+        # pid + windows[] (see /Users/francesco/cua/.../launch_app.rs).
+        mcp_response = {
+            "data": "Launched Calculator (pid 4242) in background.",
+            "images": [],
+            "structuredContent": {
+                "pid": 4242,
+                "bundle_id": "com.apple.calculator",
+                "name": "Calculator",
+                "windows": [
+                    {"window_id": 88, "pid": 4242, "app_name": "Calculator",
+                     "title": "Calculator", "is_on_screen": True},
+                ],
+            },
+            "isError": False,
+        }
+        backend = self._make_backend_with_launch_response(mcp_response)
+
+        res = backend.launch_app(name="Calculator")
+
+        assert res.ok is True
+        assert res.action == "launch_app"
+        # Sticky context must update so a follow-up click() doesn't need to
+        # re-resolve the target. Matches the contract capture()/focus_app()
+        # provide today.
+        assert backend._active_pid == 4242
+        assert backend._active_window_id == 88
+        assert backend._last_app == "Calculator"
+        # MCP args must include the name and omit start_minimized when False.
+        sent_args = backend._session.call_tool.call_args[0]
+        assert sent_args[0] == "launch_app"
+        assert sent_args[1].get("name") == "Calculator"
+        assert "start_minimized" not in sent_args[1]
+
+    def test_launch_app_windows_passes_start_minimized(self):
+        mcp_response = {
+            "data": "Launched notepad",
+            "images": [],
+            "structuredContent": {"pid": 9, "name": "notepad", "windows": []},
+            "isError": False,
+        }
+        backend = self._make_backend_with_launch_response(mcp_response)
+
+        backend.launch_app(name="notepad", start_minimized=True)
+
+        sent_args = backend._session.call_tool.call_args[0]
+        assert sent_args[1].get("start_minimized") is True
+        assert sent_args[1].get("name") == "notepad"
+
+    def test_launch_app_error_surfaces_message_without_crash(self):
+        """cua-driver's error path (unknown app, etc.) must surface as a
+        user-facing message and leave the sticky context untouched.
+        """
+        mcp_response = {
+            "data": "Launch failed: no app named 'ZZZZZ' found",
+            "images": [],
+            "structuredContent": None,
+            "isError": True,
+        }
+        backend = self._make_backend_with_launch_response(mcp_response)
+        # Seed the sticky context to verify it does not get overwritten on
+        # failure — a subsequent action should still hit the prior target.
+        backend._active_pid = 100
+        backend._active_window_id = 200
+        backend._last_app = "TextEdit"
+
+        res = backend.launch_app(name="ZZZZZ")
+
+        assert res.ok is False
+        assert res.action == "launch_app"
+        assert "ZZZZZ" in res.message or "no app" in res.message.lower()
+        # Sticky context must be preserved — a failed launch must not
+        # clobber the prior target.
+        assert backend._active_pid == 100
+        assert backend._active_window_id == 200
+        assert backend._last_app == "TextEdit"
+
+    def test_launch_app_requires_name_or_bundle_id(self):
+        from tools.computer_use.cua_backend import CuaDriverBackend
+
+        backend = CuaDriverBackend()
+        backend._session = MagicMock()
+
+        res = backend.launch_app()
+
+        assert res.ok is False
+        # Must not even call cua-driver when args are missing.
+        assert backend._session.call_tool.called is False
+
+    def test_list_apps_returns_structured_list_unchanged(self):
+        """list_apps surfaces cua-driver's app array verbatim."""
+        from tools.computer_use.cua_backend import CuaDriverBackend
+
+        apps = [
+            {"name": "TextEdit", "pid": 1, "bundle_id": "com.apple.TextEdit"},
+            {"name": "gedit", "pid": 2},
+        ]
+        backend = CuaDriverBackend()
+        backend._session = MagicMock()
+        backend._session.call_tool.return_value = {
+            "data": apps,
+            "images": [],
+            "structuredContent": None,
+            "isError": False,
+        }
+
+        out = backend.list_apps()
+
+        assert out == apps
     def test_capture_after_skipped_when_action_failed(self, noop_backend):
         """capture_after must not fire when res.ok=False (regression guard).
 

--- a/tools/computer_use/backend.py
+++ b/tools/computer_use/backend.py
@@ -155,6 +155,27 @@ class ComputerUseBackend(ABC):
     def focus_app(self, app: str, raise_window: bool = False) -> ActionResult:
         """Route input to `app` (by name or bundle ID). Default: focus without raise."""
 
+    def launch_app(
+        self,
+        name: Optional[str] = None,
+        *,
+        bundle_id: Optional[str] = None,
+        start_minimized: bool = False,
+        **kwargs: Any,
+    ) -> ActionResult:
+        """Launch an app in the background.
+
+        Default implementation is a stub for backends that don't support
+        launching (e.g. noop). Concrete backends (cua-driver) override this
+        to drive the platform-specific launch path.
+
+        ``name`` and ``bundle_id`` mirror cua-driver's accepted shape; at
+        least one must be provided. ``start_minimized`` is Windows-only.
+        Extra ``kwargs`` are forwarded verbatim so cross-platform options
+        (e.g. ``urls``) reach cua-driver without a wrapper-side allowlist.
+        """
+        raise NotImplementedError("launch_app is not supported by this backend")
+
     # ── Native-value mutation ────────────────────────────────────────
     @abstractmethod
     def set_value(self, value: str, element: Optional[int] = None) -> ActionResult:

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -1573,17 +1573,25 @@ class CuaDriverBackend(ComputerUseBackend):
         urls: Optional[List[str]] = None,
         additional_arguments: Optional[List[str]] = None,
         creates_new_application_instance: bool = False,
-    ) -> Dict[str, Any]:
-        """Idempotent launch. Returns ``{pid, bundle_id, name, windows[]}``
-        so callers can skip an extra ``list_windows`` round-trip before
-        ``get_window_state``.
+        start_minimized: bool = False,
+    ) -> ActionResult:
+        """Idempotent launch. On success updates the sticky context
+        (``_active_pid`` / ``_active_window_id`` / ``_last_app``) so a
+        follow-up ``click``/``type``/``capture`` lands on the right
+        target without an extra ``list_windows`` round-trip.
 
         ``creates_new_application_instance=True`` forces a new instance
         even if the app is already running — use it when concurrent
         runs may touch the same app so each session gets its own
-        isolated window."""
+        isolated window.
+
+        ``start_minimized=True`` (Windows) keeps the launched window in
+        the taskbar so the user's frontmost window stays visually on
+        top."""
         if not bundle_id and not name:
-            raise ValueError("launch_app requires either bundle_id or name")
+            return ActionResult(
+                ok=False, action="launch_app",
+                message="launch_app requires either bundle_id or name")
         args: Dict[str, Any] = {"session": self._session_id}
         if bundle_id:
             args["bundle_id"] = bundle_id
@@ -1595,8 +1603,47 @@ class CuaDriverBackend(ComputerUseBackend):
             args["additional_arguments"] = list(additional_arguments)
         if creates_new_application_instance:
             args["creates_new_application_instance"] = True
-        out = self._session.call_tool("launch_app", args)
-        return out["structuredContent"] or {"data": out["data"]}
+        if start_minimized:
+            args["start_minimized"] = True
+        try:
+            out = self._session.call_tool("launch_app", args)
+        except Exception as e:
+            logger.exception("cua-driver launch_app call failed")
+            return ActionResult(
+                ok=False, action="launch_app",
+                message=f"cua-driver error: {e}")
+        ok = not out.get("isError", False)
+        structured = out.get("structuredContent") or {}
+        data = out.get("data")
+        if ok and isinstance(structured, dict):
+            pid = structured.get("pid")
+            if isinstance(pid, int):
+                self._active_pid = pid
+            windows = structured.get("windows") or []
+            if isinstance(windows, list) and windows:
+                first = windows[0]
+                if isinstance(first, dict):
+                    wid = first.get("window_id")
+                    if isinstance(wid, int):
+                        self._active_window_id = wid
+            app_name = structured.get("name") or name
+            if app_name:
+                self._last_app = app_name
+        message = ""
+        if isinstance(data, str):
+            message = data
+        elif isinstance(data, dict):
+            message = str(data.get("message", ""))
+        return ActionResult(
+            ok=ok, action="launch_app", message=message,
+            meta=structured if isinstance(structured, dict) else {})
+
+    def list_apps(self) -> Any:
+        """Return the running-apps array from cua-driver verbatim. Each
+        entry is ``{name, pid, bundle_id?}``."""
+        out = self._session.call_tool(
+            "list_apps", {"session": self._session_id})
+        return out.get("data")
 
     def kill_app(self, *, pid: int) -> ActionResult:
         """Terminate by pid. Equivalent to ``kill -9`` on POSIX,

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -1415,6 +1415,102 @@ class CuaDriverBackend(ComputerUseBackend):
             return apps
         return []
 
+    def launch_app(
+        self,
+        name: Optional[str] = None,
+        *,
+        bundle_id: Optional[str] = None,
+        start_minimized: bool = False,
+        **kwargs: Any,
+    ) -> ActionResult:
+        """Launch an app via cua-driver's MCP `launch_app` tool.
+
+        Idempotent: cua-driver no-ops + returns the existing process when the
+        target is already running. On success, the launched pid + first window
+        are stashed in the sticky context (``_active_pid`` / ``_active_window_id``
+        / ``_last_app``) so a subsequent ``click`` / ``capture`` / ``get_window_state``
+        hits the right process without an extra resolution round-trip.
+
+        Cross-platform: cua-driver's per-platform tool validates the args
+        (macOS accepts ``bundle_id`` or ``name``; Linux accepts ``name``;
+        Windows accepts ``name`` plus optional ``start_minimized``). We
+        forward the kwargs verbatim and let cua-driver surface any platform-
+        specific rejection as the user-facing message.
+        """
+        if not name and not bundle_id:
+            return ActionResult(
+                ok=False, action="launch_app",
+                message="launch_app requires `name` or `bundle_id`.",
+            )
+
+        mcp_args: Dict[str, Any] = {}
+        if bundle_id:
+            mcp_args["bundle_id"] = bundle_id
+        if name:
+            mcp_args["name"] = name
+        if start_minimized:
+            mcp_args["start_minimized"] = True
+        # Forward additional cross-platform options (e.g. urls) without an
+        # allowlist — cua-driver validates them per-platform.
+        for k, v in kwargs.items():
+            if v is not None:
+                mcp_args[k] = v
+
+        try:
+            out = self._session.call_tool("launch_app", mcp_args)
+        except Exception as e:
+            logger.exception("cua-driver launch_app call failed")
+            return ActionResult(
+                ok=False, action="launch_app",
+                message=f"cua-driver error: {e}",
+            )
+
+        is_error = bool(out.get("isError"))
+        data = out.get("data")
+        structured = out.get("structuredContent") or {}
+
+        # Prefer the structured payload (pid + windows array). Fall back to
+        # text-only when cua-driver returns just a summary message (older
+        # builds, error paths).
+        message = ""
+        if isinstance(data, dict):
+            message = str(data.get("message", "")) or json.dumps(data)
+        elif isinstance(data, str):
+            message = data
+
+        if is_error:
+            return ActionResult(
+                ok=False, action="launch_app",
+                message=message or "launch_app failed",
+            )
+
+        # Stash sticky context so the next action targets the launched app
+        # without a list_windows round-trip. Mirrors capture()/focus_app().
+        pid = structured.get("pid") if isinstance(structured, dict) else None
+        app_name = (
+            structured.get("name") if isinstance(structured, dict) else None
+        ) or name or bundle_id or ""
+        windows = structured.get("windows") if isinstance(structured, dict) else None
+        if isinstance(pid, int):
+            self._active_pid = pid
+        if isinstance(windows, list) and windows:
+            first = windows[0]
+            if isinstance(first, dict) and isinstance(first.get("window_id"), int):
+                self._active_window_id = first["window_id"]
+        if app_name:
+            self._last_app = app_name
+
+        meta: Dict[str, Any] = {}
+        if isinstance(structured, dict):
+            meta.update(structured)
+
+        return ActionResult(
+            ok=True,
+            action="launch_app",
+            message=message or f"Launched {app_name}".strip(),
+            meta=meta,
+        )
+
     def focus_app(self, app: str, raise_window: bool = False) -> ActionResult:
         """Target an app for subsequent actions without stealing system focus.
 

--- a/tools/computer_use/schema.py
+++ b/tools/computer_use/schema.py
@@ -16,15 +16,18 @@ from typing import Any, Dict
 COMPUTER_USE_SCHEMA: Dict[str, Any] = {
     "name": "computer_use",
     "description": (
-        "Drive the desktop in the background via cua-driver — screenshots, "
-        "mouse, keyboard, scroll, drag — without stealing the user's cursor "
-        "or keyboard focus. Supported on macOS, Windows, and Linux. "
-        "Preferred workflow: call with "
-        "action='capture' (mode='som' gives numbered element overlays), "
-        "then click by `element` index for reliability. Pixel coordinates "
-        "are supported for models trained on them. Works on any window — "
-        "hidden, minimized, or behind another app. Requires cua-driver to "
-        "be installed."
+        "Drive the desktop in the background — screenshots, mouse, keyboard, "
+        "scroll, drag, app launch — without stealing the user's cursor, "
+        "keyboard focus, or workspace. Preferred workflow: if the target app "
+        "may not be running, call `action='launch_app', name='<App>'` first "
+        "(it returns the launched pid + windows so subsequent calls hit the "
+        "right process). Otherwise call `action='list_apps'` to see what's "
+        "running, then `action='capture'` (mode='som' gives numbered element "
+        "overlays) and click by `element` index for reliability. Pixel "
+        "coordinates are supported for models trained on them. Works on any "
+        "window — hidden, minimized, on another Space, or behind another app. "
+        "Cross-platform via cua-driver (macOS / Windows / Linux); requires "
+        "cua-driver to be installed."
     ),
     "parameters": {
         "type": "object",
@@ -44,6 +47,7 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
                     "set_value",
                     "wait",
                     "list_apps",
+                    "launch_app",
                     "focus_app",
                 ],
                 "description": (
@@ -51,7 +55,11 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
                     "effects). All other actions require approval unless "
                     "auto-approved. Use `set_value` for select/popup elements "
                     "and sliders — it selects the matching option directly "
-                    "without opening the native menu (no focus steal)."
+                    "without opening the native menu (no focus steal). "
+                    "Use `launch_app` to start an app in the background — "
+                    "the launched window stays behind whatever the user has "
+                    "in front, and the call is idempotent (re-running against "
+                    "an already-running app returns the existing process)."
                 ),
             },
             # ── capture ────────────────────────────────────────────
@@ -200,6 +208,43 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
                     "window to front (DISRUPTS the user). Default false "
                     "— input is routed to the app without raising, "
                     "matching the background co-work model."
+                ),
+            },
+            # ── launch_app ─────────────────────────────────────────
+            "name": {
+                "type": "string",
+                "description": (
+                    "For action='launch_app': the app display name to launch "
+                    "(e.g. 'Calculator', 'TextEdit', 'notepad', 'gedit'). "
+                    "Required unless `bundle_id` is provided. The launched "
+                    "window stays in the background — it does not steal focus "
+                    "from whatever the user has in front. Idempotent: launching "
+                    "an already-running app returns the existing process and "
+                    "its windows. After launch, the active pid/window context "
+                    "is updated so a follow-up `click` / `capture` targets the "
+                    "newly-launched app without an extra resolution round-trip."
+                ),
+            },
+            "bundle_id": {
+                "type": "string",
+                "description": (
+                    "For action='launch_app' on macOS: the app's bundle "
+                    "identifier (e.g. 'com.apple.calculator'). Preferred over "
+                    "`name` when known — unambiguous and locale-independent. "
+                    "Ignored on Linux; on Windows, accepted as an alias for "
+                    "`name` (with packaged-app AUMID support when the value "
+                    "contains '!')."
+                ),
+            },
+            "start_minimized": {
+                "type": "boolean",
+                "description": (
+                    "For action='launch_app' on Windows: when true, launch the "
+                    "app's window minimized to the taskbar instead of "
+                    "restored-but-not-activated. Use when driving the app "
+                    "entirely in the background so the user's previously-"
+                    "frontmost window stays visually on top. No-op on macOS / "
+                    "Linux where the launched window is already non-activating."
                 ),
             },
             # ── return shape ───────────────────────────────────────

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -13,7 +13,7 @@ exact blocked check rather than the toolset silently failing.
 
 Return contract
 ---------------
-For text-only results (wait, key, list_apps, focus_app, failures, etc.):
+For text-only results (wait, key, list_apps, launch_app, focus_app, failures, etc.):
   JSON string.
 
 For captures / actions with `capture_after=True`:
@@ -80,9 +80,13 @@ def set_approval_callback(cb) -> None:
 _SAFE_ACTIONS = frozenset({"capture", "wait", "list_apps"})
 
 # Actions that mutate user-visible state. Go through approval.
+# `launch_app` mutates by starting a new process, but the launch is
+# non-disruptive (background; no focus steal) and idempotent for an
+# already-running target — same approval treatment as `focus_app`.
 _DESTRUCTIVE_ACTIONS = frozenset({
     "click", "double_click", "right_click", "middle_click",
     "drag", "scroll", "type", "key", "set_value", "focus_app",
+    "launch_app",
 })
 
 # Hard-blocked key combinations. Mirrored from #4562 — these are destructive
@@ -226,6 +230,17 @@ class _NoopBackend(ComputerUseBackend):  # pragma: no cover
         self.calls.append(("focus_app", {"app": app, "raise": raise_window}))
         return ActionResult(ok=True, action="focus_app")
 
+    def launch_app(self, name=None, *, bundle_id=None, start_minimized=False, **kw) -> ActionResult:
+        self.calls.append(("launch_app", {
+            "name": name, "bundle_id": bundle_id,
+            "start_minimized": start_minimized, **kw,
+        }))
+        return ActionResult(
+            ok=True, action="launch_app",
+            message=f"launched {name or bundle_id}",
+            meta={"pid": 12345, "windows": []},
+        )
+
     def set_value(self, value: str, element: Optional[int] = None) -> ActionResult:
         self.calls.append(("set_value", {"value": value, "element": element}))
         return ActionResult(ok=True, action="set_value")
@@ -337,6 +352,10 @@ def _summarize_action(action: str, args: Dict[str, Any]) -> str:
         return f"key {args.get('keys', '')!r}"
     if action == "focus_app":
         return f"focus {args.get('app', '')!r}" + (" (raise)" if args.get("raise_window") else "")
+    if action == "launch_app":
+        target = args.get("name") or args.get("bundle_id") or "?"
+        suffix = " (minimized)" if args.get("start_minimized") else ""
+        return f"launch {target!r}{suffix}"
     return action
 
 
@@ -364,6 +383,25 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
         if not app:
             return json.dumps({"error": "focus_app requires `app`"})
         res = backend.focus_app(app, raise_window=bool(args.get("raise_window")))
+        return _maybe_follow_capture(backend, res, capture_after)
+
+    if action == "launch_app":
+        name = args.get("name")
+        bundle_id = args.get("bundle_id")
+        if not name and not bundle_id:
+            return json.dumps({
+                "error": "launch_app requires `name` or `bundle_id`",
+            })
+        # Forward known kwargs. Other platform-specific args (urls,
+        # additional_arguments, electron_debugging_port, …) can be passed
+        # through the args mapping by adding them to the schema later;
+        # today we surface the cross-platform contract: name, bundle_id,
+        # start_minimized.
+        res = backend.launch_app(
+            name=name,
+            bundle_id=bundle_id,
+            start_minimized=bool(args.get("start_minimized")),
+        )
         return _maybe_follow_capture(backend, res, capture_after)
 
     if action in {"click", "double_click", "right_click", "middle_click"}:


### PR DESCRIPTION
Closes #51132.

## Summary

`computer_use`'s `action` enum exposed `capture`, `click`/`*_click`, `drag`, `scroll`, `type`, `key`, `set_value`, `wait`, `list_apps`, and `focus_app` — but **not `launch_app`**, even though cua-driver has exposed it cross-platform since v0.6.x. The `COMPUTER_USE_GUIDANCE` prompt narrated a workflow that included launching apps, but the model had no matching tool, so when asked to *"open Microsoft Word"* it fell back to telling the user to press Win+R. Exact symptom: https://github.com/NousResearch/hermes-agent/issues/51132

## Fix

Plumb `launch_app` end-to-end through the existing action-dispatch path:

`schema.py` action enum → `tool.py::_dispatch` branch → `cua_backend.py::launch_app` → cua-driver MCP `launch_app` tool → sticky context (`_active_pid` / `_active_window_id` / `_last_app`) updated so the next `click` / `capture` lands on the launched app.

Files touched:

- **`tools/computer_use/schema.py`** — add `launch_app` to action enum; expose `name`, `bundle_id`, `start_minimized` args; rewrite the top-level description as cross-platform (not macOS-only).
- **`tools/computer_use/backend.py`** — add a default `launch_app()` on the abstract base that raises `NotImplementedError` so non-cua backends fail loudly.
- **`tools/computer_use/cua_backend.py`** — call cua-driver's MCP `launch_app`; stash launched pid + first window into sticky context on success; preserve sticky context on error.
- **`tools/computer_use/tool.py`** — dispatcher branch; treated as **destructive** (approval-gated) like `focus_app`; `_summarize_action` entry for the approval prompt; noop-backend stub.
- **`agent/prompt_builder.py`** — rewrite `COMPUTER_USE_GUIDANCE` to be cross-platform, include `launch_app` in the preferred workflow, and add an explicit *"never instruct the user to press Win+R / Spotlight / activities"* rule.
- **`skills/apple/macos-computer-use/SKILL.md`** — add `launch_app` row in the actions table and a new "Launching apps" section.

Cross-platform: cua-driver's `launch_app` is on all three platforms (macOS via bundle_id, Windows via name/AUMID, Linux via name); this PR exposes only the cross-platform contract (`name` + `bundle_id` + `start_minimized`). Platform-specific extras (`urls`, `additional_arguments`, `electron_debugging_port`, `aumid`, `path`, `launch_path`, `creates_new_application_instance`) are intentionally deferred — `cua_backend.launch_app(**kwargs)` already forwards anything passed in, so a follow-up only needs schema entries.

## Test coverage

- **Schema**: action enum extended; new args validate.
- **Dispatcher** (`TestDispatch`): +4 tests covering happy-path routing, approval gate, summary rendering, noop-backend stub.
- **Backend** (new `TestLaunchAppBackend` class): +5 tests covering cua-driver MCP invocation, kwargs forwarding, sticky-context update on success, sticky-context preservation on error, user-readable error surface.

Counts:
- Before: 79 pass, 1 pre-existing unrelated `mcp` import failure (`TestCuaEnvironmentScrubbing` — missing optional `mcp` package in CI; not introduced by this PR).
- After: **88 pass**, same 1 unrelated failure. +9 new tests.

## Design notes

- `launch_app` is approval-gated as **destructive**. The launch itself is non-disruptive (background, idempotent — cua-driver no-ops on already-running apps), but the user should see what app is being started before it happens. Easy to demote to non-destructive if the desired posture is auto-approve on launch.
- The system-prompt change is the load-bearing fix here. Without it, the model wouldn't reliably pick `launch_app` even when exposed. The explicit *"never tell the user to press Win+R"* rule shuts the prior bad fallback.

## Test plan

- [x] `pytest tests/tools/test_computer_use.py` → 88 passed (+ 1 unrelated pre-existing failure)
- [ ] On Windows: ask Hermes "open notepad" → agent issues `computer_use { action: "launch_app", name: "notepad" }`, approval prompt fires, post-approval `list_windows` finds the new Notepad HWND.
- [ ] On macOS: ask "open TextEdit" → same flow with `bundle_id: "com.apple.TextEdit"` or `name: "TextEdit"`.
- [ ] On Linux: ask "open gedit" → same flow with `name: "gedit"`.
- [ ] Negative: ask for a non-installed app, confirm graceful error from cua-driver propagates as a user-readable response.