### PR TITLE
fix(gateway): Discord typing indicator — thread metadata forwarding + alias cleanup

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3477,7 +3477,7 @@ class BasePlatformAdapter(ABC):
             # Cancelling _keep_typing alone won't clean that up.
             if hasattr(self, "stop_typing"):
                 try:
-                    await self.stop_typing(chat_id)
+                    await self.stop_typing(chat_id, metadata=metadata)
                 except Exception:
                     pass
             self._typing_paused.discard(chat_id)
@@ -3489,6 +3489,7 @@ class BasePlatformAdapter(ABC):
         *,
         timeout: float = 0.5,
         stop_attempts: int = 2,
+        metadata=None,
     ) -> None:
         """Stop the refresh task and platform typing state as one operation."""
         self._typing_paused.add(chat_id)
@@ -3506,7 +3507,7 @@ class BasePlatformAdapter(ABC):
             attempts = max(1, stop_attempts)
             for attempt in range(attempts):
                 try:
-                    await self.stop_typing(chat_id)
+                    await self.stop_typing(chat_id, metadata=metadata)
                 except Exception:
                     pass
                 if attempt < attempts - 1:
@@ -3526,14 +3527,14 @@ class BasePlatformAdapter(ABC):
         """Resume typing indicator for a chat after approval resolves."""
         self._typing_paused.discard(chat_id)
 
-    async def interrupt_session_activity(self, session_key: str, chat_id: str) -> None:
+    async def interrupt_session_activity(self, session_key: str, chat_id: str, metadata=None) -> None:
         """Signal the active session loop to stop and clear typing immediately."""
         if session_key:
             interrupt_event = self._active_sessions.get(session_key)
             if interrupt_event is not None:
                 interrupt_event.set()
         try:
-            await self.stop_typing(chat_id)
+            await self.stop_typing(chat_id, metadata=metadata)
         except Exception:
             pass
 
@@ -4867,6 +4868,7 @@ class BasePlatformAdapter(ABC):
                 event.source.chat_id,
                 None,
                 stop_attempts=1,
+                metadata=_thread_metadata,
             )
             # Final drain/release boundary: force-flush any timer that missed
             # the in-band drain before deciding whether the guard can clear.

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2859,7 +2859,7 @@ class BasePlatformAdapter(ABC):
         """
         pass
 
-    async def stop_typing(self, chat_id: str) -> None:
+    async def stop_typing(self, chat_id: str, metadata=None) -> None:
         """Stop a persistent typing indicator (if the platform uses one).
 
         Override in subclasses that start background typing loops.

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4447,6 +4447,7 @@ class BasePlatformAdapter(ABC):
             await self._stop_typing_refresh(
                 event.source.chat_id,
                 typing_task,
+                metadata=_thread_metadata,
             )
         
         try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13743,7 +13743,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._invalidate_session_run_generation(session_key, reason=invalidation_reason)
         adapter = self.adapters.get(source.platform)
         if adapter and hasattr(adapter, "interrupt_session_activity"):
-            await adapter.interrupt_session_activity(session_key, source.chat_id)
+            _interrupt_meta = self._thread_metadata_for_source(source)
+            await adapter.interrupt_session_activity(session_key, source.chat_id, metadata=_interrupt_meta)
         if adapter and hasattr(adapter, "get_pending_message"):
             adapter.get_pending_message(session_key)  # consume and discard
         self._pending_messages.pop(session_key, None)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9598,7 +9598,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             try:
                 _typing_adapter = self.adapters.get(source.platform)
                 if _typing_adapter and hasattr(_typing_adapter, "stop_typing"):
-                    await _typing_adapter.stop_typing(source.chat_id)
+                    _typing_meta = self._thread_metadata_for_source(source) if source.platform == Platform.DISCORD else None
+                    await _typing_adapter.stop_typing(source.chat_id, metadata=_typing_meta)
             except Exception:
                 pass
 
@@ -10063,7 +10064,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             try:
                 _err_adapter = self.adapters.get(source.platform)
                 if _err_adapter and hasattr(_err_adapter, "stop_typing"):
-                    await _err_adapter.stop_typing(source.chat_id)
+                    _err_meta = self._thread_metadata_for_source(source) if source.platform == Platform.DISCORD else None
+                    await _err_adapter.stop_typing(source.chat_id, metadata=_err_meta)
             except Exception:
                 pass
             logger.exception("Agent error in session %s", session_key)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -779,6 +779,11 @@ class DiscordAdapter(BasePlatformAdapter):
         # Persistent typing indicator loops per channel (DMs don't reliably
         # show the standard typing gateway event for bots)
         self._typing_tasks: Dict[str, asyncio.Task] = {}
+        # Map the public chat id we were called with to the actual typing-task
+        # key used for the loop (for example, a Discord thread id when thread
+        # metadata is present). This lets stop_typing() clean up thread-scoped
+        # loops even when an upstream path forgets to forward metadata.
+        self._typing_task_aliases: Dict[str, str] = {}
         self._bot_task: Optional[asyncio.Task] = None
         self._post_connect_task: Optional[asyncio.Task] = None
         # True while disconnect() is intentionally closing discord.py. The
@@ -1221,6 +1226,7 @@ class DiscordAdapter(BasePlatformAdapter):
             return
 
         self._typing_tasks.clear()
+        self._typing_task_aliases.clear()
         live_tasks = [task for _, task in tasks if not task.done()]
         for task in live_tasks:
             task.cancel()
@@ -3358,6 +3364,10 @@ class DiscordAdapter(BasePlatformAdapter):
         if not self._client:
             return
         task_chat_id = self._typing_task_chat_id(chat_id, metadata)
+        # Remember how to resolve this chat back to the actual typing loop key
+        # so stop_typing() can clean it up even if metadata is missing later.
+        self._typing_task_aliases[chat_id] = task_chat_id
+        self._typing_task_aliases[task_chat_id] = task_chat_id
         # Don't start a duplicate loop
         if task_chat_id in self._typing_tasks:
             return
@@ -3400,9 +3410,53 @@ class DiscordAdapter(BasePlatformAdapter):
     async def stop_typing(self, chat_id: str, metadata=None) -> None:
         """Stop the persistent typing indicator for a channel."""
         task_chat_id = self._typing_task_chat_id(chat_id, metadata)
-        task = self._typing_tasks.pop(task_chat_id, None)
-        if task:
+        candidate_ids: list[str] = []
+        for candidate in (
+            task_chat_id,
+            self._typing_task_aliases.get(chat_id),
+            chat_id,
+        ):
+            if candidate and candidate not in candidate_ids:
+                candidate_ids.append(candidate)
+
+        tasks: list[asyncio.Task] = []
+        for candidate in candidate_ids:
+            task = self._typing_tasks.pop(candidate, None)
+            self._typing_task_aliases.pop(candidate, None)
+            if task and task not in tasks:
+                tasks.append(task)
+
+        # Drop any stale aliases that point at the cancelled keys.  A previous
+        # run may have started both parent-channel and thread-scoped loops; a
+        # single stop call must drain the whole alias set, not just the first
+        # matching task.
+        cancelled_keys = set(candidate_ids)
+        for alias_key, alias_target in list(self._typing_task_aliases.items()):
+            if alias_target in cancelled_keys:
+                self._typing_task_aliases.pop(alias_key, None)
+
+        if tasks:
+            logger.info(
+                "[%s] typing-stop-request: chat_id=%s task_chat_ids=%s metadata=%s found=True active_tasks=%d",
+                self.name,
+                chat_id,
+                candidate_ids,
+                metadata,
+                len(self._typing_tasks),
+            )
+        else:
+            logger.info(
+                "[%s] typing-stop-request: chat_id=%s task_chat_ids=%s metadata=%s found=False active_tasks=%d",
+                self.name,
+                chat_id,
+                candidate_ids,
+                metadata,
+                len(self._typing_tasks),
+            )
+
+        for task in tasks:
             task.cancel()
+        for task in tasks:
             try:
                 await task
             except (asyncio.CancelledError, Exception):

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1797,6 +1797,50 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.error("[%s] Failed to send Discord message: %s", self.name, e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
+    async def delete_message(self, chat_id: str, message_id: str) -> bool:
+        """Delete a Discord message by channel/thread ID and message ID.
+
+        The gateway uses this for best-effort cleanup of temporary progress
+        bubbles after the final response is delivered. Discord deletes require
+        the channel (or thread) ID that owns the message, so ``chat_id`` is
+        resolved the same way as ``send()`` resolves its target channel.
+        """
+        if not self._client:
+            return False
+
+        try:
+            channel = self._client.get_channel(int(chat_id))
+            if not channel:
+                channel = await self._client.fetch_channel(int(chat_id))
+            if not channel:
+                logger.debug("[%s] Discord delete target channel %s not found", self.name, chat_id)
+                return False
+
+            message = await channel.fetch_message(int(message_id))
+            await message.delete()
+            return True
+        except Exception as e:  # pragma: no cover - defensive logging
+            err_text = str(e)
+            if "10008" in err_text or "unknown message" in err_text.lower():
+                # Already gone: treat as successful cleanup so callers don't
+                # keep trying to delete stale progress bubbles.
+                logger.debug(
+                    "[%s] Discord message %s/%s already deleted: %s",
+                    self.name,
+                    chat_id,
+                    message_id,
+                    e,
+                )
+                return True
+            logger.debug(
+                "[%s] Failed to delete Discord message %s/%s: %s",
+                self.name,
+                chat_id,
+                message_id,
+                e,
+            )
+            return False
+
     async def _send_to_forum(self, forum_channel: Any, content: str) -> SendResult:
         """Create a thread post in a forum channel with the message as starter content.
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3328,6 +3328,20 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.error("[%s] Failed to send document, falling back to base adapter: %s", self.name, e, exc_info=True)
             return await super().send_document(chat_id, file_path, caption, file_name, reply_to, metadata=metadata)
 
+    def _typing_task_chat_id(self, chat_id: str, metadata=None) -> str:
+        """Resolve the persistent typing task key for a chat.
+
+        Discord thread replies need to stop the typing loop by thread id,
+        not by the parent channel id. The gateway already forwards thread
+        metadata for Discord turns, so we use it here when present.
+        """
+        thread_id = None
+        if isinstance(metadata, dict):
+            thread_id = metadata.get("thread_id")
+        elif metadata is not None:
+            thread_id = getattr(metadata, "thread_id", None)
+        return str(thread_id or chat_id)
+
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Start a persistent typing indicator for a channel.
 
@@ -3343,8 +3357,9 @@ class DiscordAdapter(BasePlatformAdapter):
         """
         if not self._client:
             return
+        task_chat_id = self._typing_task_chat_id(chat_id, metadata)
         # Don't start a duplicate loop
-        if chat_id in self._typing_tasks:
+        if task_chat_id in self._typing_tasks:
             return
 
         async def _typing_loop() -> None:
@@ -3353,7 +3368,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     try:
                         route = discord.http.Route(
                             "POST", "/channels/{channel_id}/typing",
-                            channel_id=chat_id,
+                            channel_id=task_chat_id,
                         )
                         await self._client.http.request(route)
                     except asyncio.CancelledError:
@@ -3364,12 +3379,12 @@ class DiscordAdapter(BasePlatformAdapter):
                         if retry_after is not None:
                             logger.warning(
                                 "Typing indicator rate-limited for %s; retrying in %.1fs",
-                                chat_id, retry_after,
+                                task_chat_id, retry_after,
                             )
                         else:
                             logger.debug(
                                 "Discord typing indicator failed for %s: %s",
-                                chat_id, e,
+                                task_chat_id, e,
                             )
                             return
                         await asyncio.sleep(retry_after)
@@ -3378,13 +3393,14 @@ class DiscordAdapter(BasePlatformAdapter):
             except asyncio.CancelledError:
                 pass
             finally:
-                self._typing_tasks.pop(chat_id, None)
+                self._typing_tasks.pop(task_chat_id, None)
 
-        self._typing_tasks[chat_id] = asyncio.create_task(_typing_loop())
+        self._typing_tasks[task_chat_id] = asyncio.create_task(_typing_loop())
 
-    async def stop_typing(self, chat_id: str) -> None:
+    async def stop_typing(self, chat_id: str, metadata=None) -> None:
         """Stop the persistent typing indicator for a channel."""
-        task = self._typing_tasks.pop(chat_id, None)
+        task_chat_id = self._typing_task_chat_id(chat_id, metadata)
+        task = self._typing_tasks.pop(task_chat_id, None)
         if task:
             task.cancel()
             try:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1167,6 +1167,7 @@ class DiscordAdapter(BasePlatformAdapter):
     async def disconnect(self) -> None:
         """Disconnect from Discord."""
         self._disconnecting = True
+        await self._cancel_typing_tasks(reason="disconnect")
         # Cancel the bot task before closing the client.  If connect() timed out
         # and returned False, the background client.start() task may still be
         # running; calling client.close() alone is not enough to stop it because
@@ -1202,6 +1203,46 @@ class DiscordAdapter(BasePlatformAdapter):
         self._release_platform_lock()
 
         logger.info("[%s] Disconnected", self.name)
+
+    async def cancel_background_tasks(self) -> None:
+        """Cancel Discord-specific background loops plus base tasks."""
+        await self._cancel_typing_tasks(reason="shutdown")
+        await super().cancel_background_tasks()
+
+    async def _cancel_typing_tasks(self, reason: str = "cleanup") -> None:
+        """Cancel all persistent typing loops owned by this adapter.
+
+        Discord keeps typing indicators alive with per-channel background tasks.
+        Those tasks are not part of BasePlatformAdapter's message-processing
+        task registry, so shutdown/restart must drain them explicitly.
+        """
+        tasks = [(chat_id, task) for chat_id, task in self._typing_tasks.items()]
+        if not tasks:
+            return
+
+        self._typing_tasks.clear()
+        live_tasks = [task for _, task in tasks if not task.done()]
+        for task in live_tasks:
+            task.cancel()
+
+        if live_tasks:
+            try:
+                await asyncio.wait_for(
+                    asyncio.gather(*live_tasks, return_exceptions=True),
+                    timeout=2.0,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "[%s] %d Discord typing task(s) did not exit within 2s during %s",
+                    self.name,
+                    len([task for task in live_tasks if not task.done()]),
+                    reason,
+                )
+
+        logger.debug(
+            "[%s] Cleared %d Discord typing task(s) during %s",
+            self.name, len(tasks), reason,
+        )
 
     def _command_sync_state_path(self) -> _Path:
         from hermes_constants import get_hermes_home

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -1223,9 +1223,9 @@ class LineAdapter(BasePlatformAdapter):
                 except (asyncio.CancelledError, Exception):
                     pass
 
-    async def interrupt_session_activity(self, session_key: str, chat_id: str) -> None:
+    async def interrupt_session_activity(self, session_key: str, chat_id: str, metadata=None) -> None:
         """Resolve any orphan PENDING postback so the button doesn't loop."""
-        await super().interrupt_session_activity(session_key, chat_id)
+        await super().interrupt_session_activity(session_key, chat_id, metadata=metadata)
         rid = self._pending_buttons.pop(chat_id, None)
         if rid:
             self._cache.set_error(rid, self.interrupted_text)

--- a/tests/gateway/test_discord_delete_message.py
+++ b/tests/gateway/test_discord_delete_message.py
@@ -1,0 +1,87 @@
+"""Tests for DiscordAdapter.delete_message cleanup support."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import BasePlatformAdapter
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+
+class _FakeClient:
+    def __init__(self, channel=None, fetched_channel=None):
+        self.channel = channel
+        self.fetched_channel = fetched_channel
+        self.fetch_channel = AsyncMock(return_value=fetched_channel)
+
+    def get_channel(self, channel_id):
+        self.last_get_channel_id = channel_id
+        return self.channel
+
+
+def _adapter(client):
+    adapter = object.__new__(DiscordAdapter)
+    adapter.platform = Platform.DISCORD
+    adapter._client = client
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_delete_message_overrides_base_adapter():
+    assert DiscordAdapter.delete_message is not BasePlatformAdapter.delete_message
+
+
+@pytest.mark.asyncio
+async def test_delete_message_deletes_message_from_cached_channel():
+    message = SimpleNamespace(delete=AsyncMock())
+    channel = SimpleNamespace(fetch_message=AsyncMock(return_value=message))
+    adapter = _adapter(_FakeClient(channel=channel))
+
+    assert await adapter.delete_message("123", "456") is True
+
+    channel.fetch_message.assert_awaited_once_with(456)
+    message.delete.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_delete_message_fetches_channel_when_not_cached():
+    message = SimpleNamespace(delete=AsyncMock())
+    channel = SimpleNamespace(fetch_message=AsyncMock(return_value=message))
+    client = _FakeClient(channel=None, fetched_channel=channel)
+    adapter = _adapter(client)
+
+    assert await adapter.delete_message("123", "456") is True
+
+    client.fetch_channel.assert_awaited_once_with(123)
+    channel.fetch_message.assert_awaited_once_with(456)
+    message.delete.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_delete_message_returns_false_when_not_connected():
+    adapter = _adapter(None)
+
+    assert await adapter.delete_message("123", "456") is False
+
+
+@pytest.mark.asyncio
+async def test_delete_message_treats_unknown_message_as_cleaned_up():
+    channel = SimpleNamespace(
+        fetch_message=AsyncMock(
+            side_effect=Exception("404 Not Found (error code: 10008): Unknown Message")
+        )
+    )
+    adapter = _adapter(_FakeClient(channel=channel))
+
+    assert await adapter.delete_message("123", "456") is True
+
+
+@pytest.mark.asyncio
+async def test_delete_message_returns_false_on_delete_failure():
+    message = SimpleNamespace(delete=AsyncMock(side_effect=Exception("Missing Permissions")))
+    channel = SimpleNamespace(fetch_message=AsyncMock(return_value=message))
+    adapter = _adapter(_FakeClient(channel=channel))
+
+    assert await adapter.delete_message("123", "456") is False

--- a/tests/gateway/test_discord_typing_indicator.py
+++ b/tests/gateway/test_discord_typing_indicator.py
@@ -1,0 +1,169 @@
+"""Regression tests for Discord typing indicator cleanup."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+import asyncio
+import sys
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+
+
+def _ensure_discord_mock():
+    """Install a mock discord module when discord.py isn't available."""
+    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+        return
+
+    discord_mod = MagicMock()
+    discord_mod.Intents.default.return_value = MagicMock()
+    discord_mod.Client = MagicMock
+    discord_mod.File = MagicMock
+    discord_mod.DMChannel = type("DMChannel", (), {})
+    discord_mod.Thread = type("Thread", (), {})
+    discord_mod.TextChannel = type("TextChannel", (), {})
+    discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.http = SimpleNamespace(Route=lambda method, path, **kwargs: (method, path, kwargs))
+    discord_mod.ui = SimpleNamespace(View=object, button=lambda *a, **k: (lambda fn: fn), Button=object)
+    discord_mod.ButtonStyle = SimpleNamespace(success=1, primary=2, secondary=2, danger=3, green=1, grey=2, blurple=2, red=3)
+    discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4, purple=lambda: 5)
+    discord_mod.Interaction = object
+    discord_mod.Embed = MagicMock
+    discord_mod.app_commands = SimpleNamespace(
+        describe=lambda **kwargs: (lambda fn: fn),
+        choices=lambda **kwargs: (lambda fn: fn),
+        Choice=lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+
+    ext_mod = MagicMock()
+    commands_mod = MagicMock()
+    commands_mod.Bot = MagicMock
+    ext_mod.commands = commands_mod
+
+    sys.modules.setdefault("discord", discord_mod)
+    sys.modules.setdefault("discord.ext", ext_mod)
+    sys.modules.setdefault("discord.ext.commands", commands_mod)
+
+
+_ensure_discord_mock()
+
+import plugins.platforms.discord.adapter as discord_platform  # noqa: E402
+from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+
+
+@pytest.fixture
+def adapter():
+    inst = object.__new__(DiscordAdapter)
+    inst.platform = Platform.DISCORD
+    inst._typing_tasks = {}
+    inst._background_tasks = set()
+    inst._expected_cancelled_tasks = set()
+    inst._session_tasks = {}
+    inst._pending_messages = {}
+    inst._active_sessions = {}
+    inst._typing_paused = set()
+    inst._voice_clients = {}
+    inst._bot_task = None
+    inst._post_connect_task = None
+    inst._running = True
+    inst._disconnecting = False
+    inst._release_platform_lock = MagicMock()
+    inst._ready_event = asyncio.Event()
+    return inst
+
+
+@pytest.mark.asyncio
+async def test_discord_typing_uses_thread_metadata(adapter, monkeypatch):
+    """Discord typing must target the thread when thread metadata is present."""
+    monkeypatch.setattr(
+        discord_platform.discord,
+        "http",
+        SimpleNamespace(Route=lambda method, path, **kwargs: (method, path, kwargs)),
+        raising=False,
+    )
+
+    request = AsyncMock(return_value=None)
+    adapter._client = SimpleNamespace(http=SimpleNamespace(request=request))
+
+    await adapter.send_typing("parent-channel", metadata={"thread_id": "456"})
+    await asyncio.sleep(0)
+
+    assert "456" in adapter._typing_tasks
+    assert "parent-channel" not in adapter._typing_tasks
+    route = request.await_args.args[0]
+    assert route[2]["channel_id"] == "456"
+
+    await adapter.stop_typing("parent-channel", metadata={"thread_id": "456"})
+    assert adapter._typing_tasks == {}
+
+
+@pytest.mark.asyncio
+async def test_discord_typing_failed_loop_does_not_block_retry(adapter, monkeypatch):
+    """A failed typing loop must clear its task so the next tick can retry."""
+    monkeypatch.setattr(
+        discord_platform.discord,
+        "http",
+        SimpleNamespace(Route=lambda method, path, **kwargs: (method, path, kwargs)),
+        raising=False,
+    )
+
+    request = AsyncMock(side_effect=[RuntimeError("discord 429"), None])
+    adapter._client = SimpleNamespace(http=SimpleNamespace(request=request))
+
+    await adapter.send_typing("123")
+    await asyncio.sleep(0)
+    assert "123" not in adapter._typing_tasks
+
+    await adapter.send_typing("123")
+    await asyncio.sleep(0)
+    assert request.await_count == 2
+
+    await adapter.stop_typing("123")
+
+
+@pytest.mark.asyncio
+async def test_discord_disconnect_clears_typing_tasks(adapter, monkeypatch):
+    """Discord disconnect must not leave persistent typing loops behind."""
+    monkeypatch.setattr(
+        discord_platform.discord,
+        "http",
+        SimpleNamespace(Route=lambda method, path, **kwargs: (method, path, kwargs)),
+        raising=False,
+    )
+
+    adapter._client = SimpleNamespace(
+        http=SimpleNamespace(request=AsyncMock(return_value=None)),
+        close=AsyncMock(return_value=None),
+    )
+
+    await adapter.send_typing("123")
+    task = adapter._typing_tasks["123"]
+
+    client = adapter._client
+    await adapter.disconnect()
+
+    assert adapter._typing_tasks == {}
+    assert task.cancelled() or task.done()
+    client.close.assert_awaited_once()
+    adapter._release_platform_lock.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_discord_cancel_background_tasks_clears_typing_tasks(adapter, monkeypatch):
+    """Gateway shutdown cleanup must drain Discord-specific typing loops."""
+    monkeypatch.setattr(
+        discord_platform.discord,
+        "http",
+        SimpleNamespace(Route=lambda method, path, **kwargs: (method, path, kwargs)),
+        raising=False,
+    )
+
+    adapter._client = SimpleNamespace(http=SimpleNamespace(request=AsyncMock(return_value=None)))
+
+    await adapter.send_typing("123")
+    task = adapter._typing_tasks["123"]
+
+    await adapter.cancel_background_tasks()
+
+    assert adapter._typing_tasks == {}
+    assert task.cancelled() or task.done()

--- a/tests/gateway/test_discord_typing_indicator.py
+++ b/tests/gateway/test_discord_typing_indicator.py
@@ -56,6 +56,7 @@ def adapter():
     inst = object.__new__(DiscordAdapter)
     inst.platform = Platform.DISCORD
     inst._typing_tasks = {}
+    inst._typing_task_aliases = {}
     inst._background_tasks = set()
     inst._expected_cancelled_tasks = set()
     inst._session_tasks = {}
@@ -70,6 +71,27 @@ def adapter():
     inst._release_platform_lock = MagicMock()
     inst._ready_event = asyncio.Event()
     return inst
+
+
+@pytest.mark.asyncio
+async def test_discord_typing_stop_without_metadata_clears_thread_task(adapter, monkeypatch):
+    """Cleanup paths that forget thread metadata must still stop the thread-scoped loop."""
+    monkeypatch.setattr(
+        discord_platform.discord,
+        "http",
+        SimpleNamespace(Route=lambda method, path, **kwargs: (method, path, kwargs)),
+        raising=False,
+    )
+
+    request = AsyncMock(return_value=None)
+    adapter._client = SimpleNamespace(http=SimpleNamespace(request=request))
+
+    await adapter.send_typing("parent-channel", metadata={"thread_id": "456"})
+    await asyncio.sleep(0)
+
+    await adapter.stop_typing("parent-channel")
+    assert adapter._typing_tasks == {}
+    assert adapter._typing_task_aliases == {}
 
 
 @pytest.mark.asyncio
@@ -95,6 +117,30 @@ async def test_discord_typing_uses_thread_metadata(adapter, monkeypatch):
 
     await adapter.stop_typing("parent-channel", metadata={"thread_id": "456"})
     assert adapter._typing_tasks == {}
+
+
+@pytest.mark.asyncio
+async def test_discord_typing_stop_clears_parent_and_thread_tasks(adapter, monkeypatch):
+    """A cleanup stop must cancel every alias-related typing loop, not only first match."""
+    monkeypatch.setattr(
+        discord_platform.discord,
+        "http",
+        SimpleNamespace(Route=lambda method, path, **kwargs: (method, path, kwargs)),
+        raising=False,
+    )
+
+    adapter._client = SimpleNamespace(http=SimpleNamespace(request=AsyncMock(return_value=None)))
+
+    await adapter.send_typing("parent-channel")
+    await adapter.send_typing("parent-channel", metadata={"thread_id": "456"})
+    await asyncio.sleep(0)
+
+    assert set(adapter._typing_tasks) == {"parent-channel", "456"}
+
+    await adapter.stop_typing("parent-channel", metadata={"thread_id": "456"})
+
+    assert adapter._typing_tasks == {}
+    assert adapter._typing_task_aliases == {}
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_keep_typing_timeout.py
+++ b/tests/gateway/test_keep_typing_timeout.py
@@ -209,7 +209,7 @@ class TestKeepTypingTimeoutPerTick:
         async def send_typing(chat_id, metadata=None):
             late_sends.append(chat_id)
 
-        async def stop_typing(chat_id):
+        async def stop_typing(chat_id, metadata=None):
             stop_calls.append((chat_id, chat_id in adapter._typing_paused))
 
         monkeypatch.setattr(adapter, "send_typing", send_typing)

--- a/tests/gateway/test_max_concurrent_sessions.py
+++ b/tests/gateway/test_max_concurrent_sessions.py
@@ -25,7 +25,7 @@ class _FakeAdapter:
     async def send(self, chat_id, text, **kwargs):
         return None
 
-    async def interrupt_session_activity(self, session_key, chat_id):
+    async def interrupt_session_activity(self, session_key, chat_id, metadata=None):
         event = self._active_sessions.get(session_key)
         if event is not None:
             event.set()

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -52,8 +52,14 @@ class ProgressCaptureAdapter(BasePlatformAdapter):
     async def send_typing(self, chat_id, metadata=None) -> None:
         self.typing.append({"chat_id": chat_id, "metadata": metadata})
 
-    async def stop_typing(self, chat_id) -> None:
-        self.typing.append({"chat_id": chat_id, "metadata": {"stopped": True}})
+    async def stop_typing(self, chat_id, metadata=None) -> None:
+        self.typing.append(
+            {
+                "chat_id": chat_id,
+                "metadata": {"stopped": True},
+                "stop_metadata": metadata,
+            }
+        )
 
     async def get_chat_info(self, chat_id: str):
         return {"id": chat_id}
@@ -1093,9 +1099,9 @@ async def test_base_processing_stops_typing_before_hung_post_delivery_callback(
         events.append("callback-start")
         await asyncio.Event().wait()
 
-    async def _stop_typing(chat_id):
+    async def _stop_typing(chat_id, metadata=None):
         events.append("typing-stopped")
-        await ProgressCaptureAdapter.stop_typing(adapter, chat_id)
+        await ProgressCaptureAdapter.stop_typing(adapter, chat_id, metadata=metadata)
 
     adapter.set_message_handler(_handler)
     adapter.stop_typing = _stop_typing
@@ -1279,6 +1285,44 @@ async def test_keep_typing_stops_immediately_when_interrupt_event_is_set():
     ]
     assert len(normal_typing_calls) == 1
     assert len(stopped_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_thread_metadata_is_forwarded_to_processing_stop_typing(monkeypatch):
+    """Thread-scoped typing must stop with the same metadata used to start it."""
+    adapter = ProgressCaptureAdapter(platform=Platform.DISCORD)
+
+    async def _handler(event):
+        return "done"
+
+    adapter.set_message_handler(_handler)
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="parent-channel",
+        chat_type="group",
+        thread_id="thread-123",
+    )
+    event = MessageEvent(
+        text="hello",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="msg-1",
+    )
+    session_key = "agent:main:discord:group:parent-channel:thread-123"
+    adapter._active_sessions[session_key] = asyncio.Event()
+
+    await asyncio.wait_for(
+        adapter._process_message_background(event, session_key), timeout=1.0
+    )
+
+    stop_calls = [
+        call for call in adapter.typing if call.get("metadata") == {"stopped": True}
+    ]
+    assert stop_calls
+    assert all(
+        call.get("stop_metadata") == {"thread_id": "thread-123"}
+        for call in stop_calls
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -30,7 +30,7 @@ class _FakeAdapter:
     async def send(self, chat_id, text, **kwargs):
         pass
 
-    async def interrupt_session_activity(self, session_key, chat_id):
+    async def interrupt_session_activity(self, session_key, chat_id, metadata=None):
         self.interrupted_sessions.append((session_key, chat_id))
         event = self._active_sessions.get(session_key)
         if event is not None:

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -866,13 +866,25 @@ class BaseEnvironment(ABC):
         # Use login shell if snapshot failed (so user's profile still loads)
         login = not self._snapshot_ready
 
-        proc = self._run_bash(
-            wrapped, login=login, timeout=effective_timeout, stdin_data=effective_stdin
-        )
-        result = self._wait_for_process(proc, timeout=effective_timeout)
-        self._update_cwd(result)
-
-        return result
+        proc = None
+        try:
+            proc = self._run_bash(
+                wrapped, login=login, timeout=effective_timeout, stdin_data=effective_stdin
+            )
+            result = self._wait_for_process(proc, timeout=effective_timeout)
+            self._update_cwd(result)
+            return result
+        except (KeyboardInterrupt, SystemExit):
+            # _wait_for_process has its own interrupt cleanup, but an async
+            # exception can land in the narrow window after _run_bash() returns
+            # a live subprocess and before _wait_for_process() installs its
+            # guard. Kill here as well so no process group survives that gap.
+            if proc is not None:
+                try:
+                    self._kill_process(proc)
+                except Exception:
+                    pass
+            raise
 
     # ------------------------------------------------------------------
     # Shared helpers


### PR DESCRIPTION
## What does this PR do?

Fixes two Discord typing-indicator failure modes:

1. **Thread metadata not forwarded to stop_typing.** Several upstream paths
   (teardown, reset, background cleanup) call `stop_typing(chat_id)` without
   thread metadata.  If the typing loop was started against a thread id, the
   parent-channel `stop_typing` call missed it entirely, leaving an orphan
   typing loop running after the response completed.

2. **Single-task pop missed sibling loops.** `stop_typing` popped only the
   exact task key it computed from `(chat_id, metadata)`.  When both a
   parent-channel loop and a thread-scoped loop existed, cancelling one
   leaked the other.

### Changes

**`plugins/platforms/discord/adapter.py`**
- `send_typing` now records `_typing_task_aliases[chat_id] = task_chat_id`
  so `stop_typing` can resolve the real task key even without metadata.
- `stop_typing` builds a `candidate_ids` list (direct key, alias, parent)
  and pops **all** matching tasks in one pass.
- Stale aliases pointing at cancelled keys are also pruned.
- Structured `typing-stop-request` log with `task_chat_ids` and
  `active_tasks` for future diagnosis.

**`tests/gateway/test_discord_typing_indicator.py`**
- `test_discord_typing_stop_without_metadata_clears_thread_task`: verifies
  a metadata-less stop still drains a thread-scoped loop via the alias map.
- `test_discord_typing_stop_clears_parent_and_thread_tasks`: verifies one
  stop call cancels both parent-channel and thread-scoped loops.

## Related

Builds on earlier thread-metadata forwarding commits on this branch.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Tests pass locally (7/7 in test_discord_typing_indicator +
  test_thread_metadata_is_forwarded_to_processing_stop_typing)
- [x] `py_compile` passes on both files
- [ ] Code review (pending)