### PR TITLE
[codex] fix(docker): avoid mounting host home as workspace

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -101,6 +101,31 @@ def test_auto_mount_host_cwd_adds_volume(monkeypatch, tmp_path):
     assert f"{project_dir}:/workspace" in run_args_str
 
 
+@pytest.mark.parametrize("home_env", ["HOME", "USERPROFILE"])
+def test_auto_mount_skips_host_home_directory(monkeypatch, tmp_path, home_env):
+    """The explicit cwd-mount opt-in must never expose an entire host home."""
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+
+    monkeypatch.delenv("HOME", raising=False)
+    monkeypatch.delenv("USERPROFILE", raising=False)
+    monkeypatch.setenv(home_env, str(home_dir))
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(
+        cwd="/workspace",
+        host_cwd=str(home_dir),
+        auto_mount_cwd=True,
+    )
+
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    run_args_str = " ".join(run_calls[0][0])
+    assert f"{home_dir}:/workspace" not in run_args_str
+    assert "/workspace:rw,exec,size=10g" in run_args_str
+
+
 def test_non_persistent_cleanup_removes_container(monkeypatch):
     """When persist_across_processes=false, cleanup() must docker stop AND
     docker rm so containers don't leak across hermes processes.

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -126,6 +126,28 @@ def test_auto_mount_skips_host_home_directory(monkeypatch, tmp_path, home_env):
     assert "/workspace:rw,exec,size=10g" in run_args_str
 
 
+def test_auto_mount_preserves_posix_host_cwd(monkeypatch):
+    posix_cwd = "/Users/alice/project"
+    real_isdir = docker_env.os.path.isdir
+
+    def _isdir(path):
+        return path == posix_cwd or real_isdir(path)
+
+    monkeypatch.setattr(docker_env.os.path, "isdir", _isdir)
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(
+        cwd="/workspace",
+        host_cwd=posix_cwd,
+        auto_mount_cwd=True,
+    )
+
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    assert f"{posix_cwd}:/workspace" in " ".join(run_calls[0][0])
+
+
 def test_non_persistent_cleanup_removes_container(monkeypatch):
     """When persist_across_processes=false, cleanup() must docker stop AND
     docker rm so containers don't leak across hermes processes.

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -28,6 +28,13 @@ from tools.interrupt import is_interrupted
 
 logger = logging.getLogger(__name__)
 
+def normalize_docker_host_cwd(cwd: str) -> str:
+    expanded = os.path.expanduser(cwd)
+    if expanded.startswith(("/Users/", "/home/")):
+        return expanded
+    return os.path.abspath(expanded)
+
+
 # Opt-in debug tracing for the interrupt/activity/poll machinery.  Set
 # HERMES_DEBUG_INTERRUPT=1 to log loop entry/exit, periodic heartbeats, and
 # every is_interrupted() state change from _wait_for_process.  Off by default

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -22,6 +22,7 @@ from tools.environments.base import (
     BaseEnvironment,
     EnvironmentConnectionError,
     _popen_bash,
+    normalize_docker_host_cwd,
 )
 from tools.environments.local import (
     _HERMES_PROVIDER_ENV_BLOCKLIST,
@@ -987,7 +988,7 @@ class DockerEnvironment(BaseEnvironment):
             else:
                 logger.warning("Docker volume '%s' missing colon, skipping", vol)
 
-        host_cwd_abs = os.path.abspath(os.path.expanduser(host_cwd)) if host_cwd else ""
+        host_cwd_abs = normalize_docker_host_cwd(host_cwd) if host_cwd else ""
         host_cwd_is_home = bool(host_cwd_abs) and _is_user_home_path(host_cwd_abs)
         bind_host_cwd = (
             auto_mount_cwd

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -45,6 +45,27 @@ _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _EGRESS_LABEL_KEY = "hermes-egress"
 
 
+def _is_user_home_path(path: str) -> bool:
+    """Return whether *path* resolves to the invoking user's home directory."""
+    if not path:
+        return False
+
+    def _normalized(candidate: str) -> str:
+        return os.path.normcase(os.path.realpath(os.path.abspath(os.path.expanduser(candidate))))
+
+    normalized_path = _normalized(path)
+    home_candidates = (
+        os.path.expanduser("~"),
+        os.environ.get("HOME", ""),
+        os.environ.get("USERPROFILE", ""),
+    )
+    return any(
+        normalized_path == _normalized(home)
+        for home in home_candidates
+        if home
+    )
+
+
 def _normalize_forward_env_names(forward_env: list[str] | None) -> list[str]:
     """Return a deduplicated list of valid environment variable names."""
     normalized: list[str] = []
@@ -967,14 +988,18 @@ class DockerEnvironment(BaseEnvironment):
                 logger.warning("Docker volume '%s' missing colon, skipping", vol)
 
         host_cwd_abs = os.path.abspath(os.path.expanduser(host_cwd)) if host_cwd else ""
+        host_cwd_is_home = bool(host_cwd_abs) and _is_user_home_path(host_cwd_abs)
         bind_host_cwd = (
             auto_mount_cwd
             and bool(host_cwd_abs)
             and os.path.isdir(host_cwd_abs)
+            and not host_cwd_is_home
             and not workspace_explicitly_mounted
         )
         if auto_mount_cwd and host_cwd and not os.path.isdir(host_cwd_abs):
             logger.debug("Skipping docker cwd mount: host_cwd is not a valid directory: %s", host_cwd)
+        elif auto_mount_cwd and host_cwd_is_home:
+            logger.warning("Skipping docker cwd mount for host home directory: %s", host_cwd_abs)
 
         self._workspace_dir: Optional[str] = None
         self._home_dir: Optional[str] = None

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -45,6 +45,27 @@ _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _EGRESS_LABEL_KEY = "hermes-egress"
 
 
+def _is_user_home_path(path: str) -> bool:
+    """Return whether *path* resolves to the invoking user's home directory."""
+    if not path:
+        return False
+
+    def _normalized(candidate: str) -> str:
+        return os.path.normcase(os.path.realpath(os.path.abspath(os.path.expanduser(candidate))))
+
+    normalized_path = _normalized(path)
+    home_candidates = (
+        os.path.expanduser("~"),
+        os.environ.get("HOME", ""),
+        os.environ.get("USERPROFILE", ""),
+    )
+    return any(
+        normalized_path == _normalized(home)
+        for home in home_candidates
+        if home
+    )
+
+
 def _normalize_forward_env_names(forward_env: list[str] | None) -> list[str]:
     """Return a deduplicated list of valid environment variable names."""
     normalized: list[str] = []
@@ -963,14 +984,18 @@ class DockerEnvironment(BaseEnvironment):
                 logger.warning("Docker volume '%s' missing colon, skipping", vol)
 
         host_cwd_abs = os.path.abspath(os.path.expanduser(host_cwd)) if host_cwd else ""
+        host_cwd_is_home = bool(host_cwd_abs) and _is_user_home_path(host_cwd_abs)
         bind_host_cwd = (
             auto_mount_cwd
             and bool(host_cwd_abs)
             and os.path.isdir(host_cwd_abs)
+            and not host_cwd_is_home
             and not workspace_explicitly_mounted
         )
         if auto_mount_cwd and host_cwd and not os.path.isdir(host_cwd_abs):
             logger.debug("Skipping docker cwd mount: host_cwd is not a valid directory: %s", host_cwd)
+        elif auto_mount_cwd and host_cwd_is_home:
+            logger.warning("Skipping docker cwd mount for host home directory: %s", host_cwd_abs)
 
         self._workspace_dir: Optional[str] = None
         self._home_dir: Optional[str] = None

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1071,7 +1071,7 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
 
 
 # Environment classes now live in tools/environments/
-from tools.environments.base import EnvironmentConnectionError
+from tools.environments.base import EnvironmentConnectionError, normalize_docker_host_cwd
 from tools.environments.local import LocalEnvironment as _LocalEnvironment
 from tools.environments.singularity import SingularityEnvironment as _SingularityEnvironment
 from tools.environments.ssh import SSHEnvironment as _SSHEnvironment
@@ -1652,7 +1652,7 @@ def _get_env_config() -> Dict[str, Any]:
     host_cwd = None
     if env_type == "docker" and mount_docker_cwd:
         docker_cwd_source = os.getenv("TERMINAL_CWD") or _safe_getcwd()
-        candidate = os.path.abspath(os.path.expanduser(docker_cwd_source))
+        candidate = normalize_docker_host_cwd(docker_cwd_source)
         if (
             any(candidate.startswith(p) for p in _HOST_CWD_PREFIXES)
             or (os.path.isabs(candidate) and os.path.isdir(candidate) and not candidate.startswith(("/workspace", "/root")))


### PR DESCRIPTION
## Summary

Fixes the Windows Docker backend path boundary described in #48137.

- Do not pass native Windows host paths such as `C:\Users\alice` to Docker `-w`; use `/workspace` inside the container instead.
- Do not auto bind-mount the host user's home directory to `/workspace` when `docker_mount_cwd_to_workspace` is enabled.
- Preserve `/Users/...` and `/home/...` cwd strings in terminal config instead of rewriting them through the Windows current drive.

## Root cause

The Docker environment accepted host cwd values at the container boundary. On Windows this could either make `docker run -w` receive an invalid native path, or bind-mount the whole user profile into `/workspace` when cwd passthrough was enabled.

## Validation

- `python -m pytest tests/tools/test_docker_environment.py -q`
- `python -m pytest tests/tools/test_docker_environment.py tests/tools/test_modal_sandbox_fixes.py tests/tools/test_terminal_config_env_sync.py tests/tools/test_terminal_task_cwd.py -q`
- `python -m py_compile tools/environments/docker.py tools/terminal_tool.py`
- `git diff --check`
