### PR TITLE
fix: handle NULL schema_version in _init_schema

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1163,6 +1163,12 @@ class SessionDB:
             )
         else:
             current_version = row["version"] if isinstance(row, sqlite3.Row) else row[0]
+            if current_version is None:
+                # Schema version row exists but its value is NULL (partial or
+                # corrupted initialization). Treat as version 0 so the migration
+                # chain below can reconcile the database state and bump it to
+                # SCHEMA_VERSION.
+                current_version = 0
             # Data migrations that can't be expressed declaratively (row
             # backfills, index changes tied to a specific version step) stay
             # in a version-gated chain. Column additions are handled by

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2769,6 +2769,37 @@ class TestSchemaInit:
                     f"but missing from live DB. Live columns: {live_cols}"
                 )
 
+    def test_schema_version_null_does_not_crash(self, tmp_path):
+            """Opening a DB where schema_version row has NULL version should not raise.
+
+            Regression: a partially-initialized or corrupted database can have a
+            schema_version row whose version column is NULL.  _init_schema must
+            handle this gracefully instead of raising
+            TypeError: '<' not supported between instances of 'NoneType' and 'int'.
+            """
+            db_path = tmp_path / "null_version.db"
+            conn = sqlite3.connect(str(db_path))
+            conn.executescript(SCHEMA_SQL)
+            # Recreate schema_version WITHOUT NOT NULL to simulate legacy/corrupt DB
+            conn.execute("DROP TABLE schema_version")
+            conn.execute("CREATE TABLE IF NOT EXISTS schema_version (version INTEGER)")
+            conn.execute("INSERT INTO schema_version (version) VALUES (?)", (None,))
+            conn.commit()
+            conn.close()
+
+            db = SessionDB(db_path=db_path)
+            try:
+                # _init_schema should have treated NULL as 0 and bumped to SCHEMA_VERSION.
+                row = db._conn.execute(
+                    "SELECT version FROM schema_version"
+                ).fetchone()
+                assert row[0] == SCHEMA_VERSION
+                # Basic operations should still work.
+                db.create_session(session_id="s1", source="cli")
+                assert db.get_session("s1") is not None
+            finally:
+                db.close()
+
 
 class TestTitleUniqueness:
     """Tests for unique title enforcement and title-based lookups."""


### PR DESCRIPTION
## Problem

When the `schema_version` table exists but its `version` column is `NULL` (e.g. from partial/corrupt initialization, or a legacy DB created before the `NOT NULL` constraint), `_init_schema` raises:

```
TypeError: '<' not supported between instances of 'NoneType' and 'int'
```

This propagates through the Starlette middleware stack and surfaces as a `host_header_middleware` crash during dashboard operations (e.g. `count_empty_sessions_endpoint`).

## Fix

After reading `current_version` from the row, guard against `None` by defaulting to `0`. This allows the migration chain below to reconcile the database state and bump to `SCHEMA_VERSION`.

## Test

New test `test_schema_version_null_does_not_crash` in `TestSchemaInit`:
1. Creates a DB with `schema_version` set to NULL (simulating legacy/corrupt state)
2. Opens `SessionDB` (triggers `_init_schema`)
3. Verifies no crash and version is set to `SCHEMA_VERSION`
4. Verifies basic operations still work

All 279 tests in `test_hermes_state.py` pass.
