### PR TITLE
fix: avoid OAuth auth lock on streamable MCP connections

### DIFF
--- a/tests/tools/test_mcp_oauth_manager.py
+++ b/tests/tools/test_mcp_oauth_manager.py
@@ -164,3 +164,105 @@ def test_manager_fails_fast_noninteractive_without_cached_tokens(tmp_path, monke
         mgr.get_or_build_provider("linear", "https://mcp.linear.app/mcp", None)
 
     assert mgr._entries["linear"].provider is None
+
+
+
+@pytest.mark.asyncio
+async def test_bearer_header_materializes_cached_valid_token(tmp_path, monkeypatch):
+    """OAuth Streamable-HTTP data-plane can use a plain bearer header.
+
+    The long-lived GET/SSE stream must not be routed through the SDK
+    OAuthClientProvider auth flow, because that provider holds an auth lock
+    until the response completes and can block the following tools/list POST.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch, is_tty=False)
+
+    from mcp.shared.auth import OAuthToken
+
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    await HermesTokenStorage("srv").set_tokens(
+        OAuthToken(
+            access_token="ACCESS",
+            token_type="Bearer",
+            expires_in=3600,
+            refresh_token="REFRESH",
+        )
+    )
+
+    mgr = MCPOAuthManager()
+    header = await mgr.get_bearer_authorization_header(
+        "srv", "https://example.com/mcp", None,
+    )
+
+    assert header == "Bearer ACCESS"
+
+
+@pytest.mark.asyncio
+async def test_bearer_header_refreshes_expired_token(tmp_path, monkeypatch):
+    """Expired cached tokens refresh before a data-plane bearer is returned."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch, is_tty=False)
+
+    from mcp.shared.auth import OAuthClientInformationFull, OAuthMetadata, OAuthToken
+
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    storage = HermesTokenStorage("srv")
+    await storage.set_tokens(
+        OAuthToken(
+            access_token="OLD",
+            token_type="Bearer",
+            expires_in=0,
+            refresh_token="REFRESH",
+        )
+    )
+    await storage.set_client_info(
+        OAuthClientInformationFull(
+            client_id="client-id",
+            client_secret="client-secret",
+            redirect_uris=["http://127.0.0.1/callback"],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method="client_secret_post",
+        )
+    )
+    storage.save_oauth_metadata(
+        OAuthMetadata(
+            issuer="https://auth.example.com",
+            authorization_endpoint="https://auth.example.com/authorize",
+            token_endpoint="https://auth.example.com/token",
+        )
+    )
+
+    class _Resp:
+        status_code = 200
+
+        async def aread(self):
+            return b'{"access_token":"NEW","token_type":"Bearer","expires_in":3600,"refresh_token":"REFRESH2"}'
+
+    class _Client:
+        def __init__(self, *args, **kwargs):
+            self.request = None
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def send(self, request):
+            self.request = request
+            return _Resp()
+
+    monkeypatch.setattr("httpx.AsyncClient", _Client)
+
+    mgr = MCPOAuthManager()
+    header = await mgr.get_bearer_authorization_header(
+        "srv", "https://example.com/mcp", None,
+    )
+
+    assert header == "Bearer NEW"

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1026,6 +1026,74 @@ class TestMCPServerTask:
         asyncio.run(_test())
 
 
+
+
+    def test_streamable_http_oauth_uses_bearer_header_not_auth_provider(self):
+        """OAuth Streamable HTTP must not pass OAuthClientProvider as auth=.
+
+        The SDK provider serializes auth flows with a lock. A long-lived GET/SSE
+        stream can hold that lock forever, preventing tools/list POST from
+        attaching auth. Hermes should materialize OAuth to an Authorization
+        header before opening the data-plane stream.
+        """
+        from tools.mcp_tool import MCPServerTask
+
+        captured = {}
+
+        class _FakeStreamable:
+            async def __aenter__(self):
+                return (MagicMock(), MagicMock(), lambda: "sid")
+
+            async def __aexit__(self, *args):
+                return False
+
+        def fake_streamable_http_client(url, *, http_client=None, **kwargs):
+            captured["url"] = url
+            captured["http_client"] = http_client
+            captured["kwargs"] = kwargs
+            return _FakeStreamable()
+
+        class _FakeSessionCM:
+            def __init__(self, *args, **kwargs):
+                self.session = MagicMock()
+                self.session.initialize = AsyncMock()
+
+            async def __aenter__(self):
+                return self.session
+
+            async def __aexit__(self, *args):
+                return False
+
+        fake_manager = MagicMock()
+        fake_auth_provider = MagicMock(name="oauth-provider")
+        fake_manager.get_or_build_provider.return_value = fake_auth_provider
+        fake_manager.get_bearer_authorization_header = AsyncMock(
+            return_value="Bearer ACCESS"
+        )
+
+        async def _test():
+            server = MCPServerTask("eden")
+            server._auth_type = "oauth"
+            server._sampling = None
+            with patch("tools.mcp_tool._MCP_NEW_HTTP", True), \
+                 patch("tools.mcp_tool.streamable_http_client", new=fake_streamable_http_client), \
+                 patch("tools.mcp_tool.ClientSession", new=_FakeSessionCM), \
+                 patch("tools.mcp_oauth_manager.get_manager", return_value=fake_manager), \
+                 patch.object(MCPServerTask, "_discover_tools", new=AsyncMock()), \
+                 patch.object(MCPServerTask, "_wait_for_lifecycle_event", new=AsyncMock(return_value="shutdown")):
+                await server._run_http({
+                    "url": "https://mcp.example.com/mcp",
+                    "auth": "oauth",
+                })
+
+        asyncio.run(_test())
+
+        http_client = captured["http_client"]
+        assert http_client.headers["Authorization"] == "Bearer ACCESS"
+        assert "auth" not in captured["kwargs"]
+        assert fake_manager.get_bearer_authorization_header.await_count == 1
+
+
 # ---------------------------------------------------------------------------
 # discover_mcp_tools toolset injection
 # ---------------------------------------------------------------------------

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -38,7 +38,7 @@ import asyncio
 import logging
 import threading
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any, Awaitable, Callable, Optional, cast
 
 logger = logging.getLogger(__name__)
 
@@ -384,6 +384,95 @@ class MCPOAuthManager:
                 entry.provider = self._build_provider(server_name, entry)
 
             return entry.provider
+
+    async def get_bearer_authorization_header(
+        self,
+        server_name: str,
+        server_url: str,
+        oauth_config: Optional[dict],
+    ) -> Optional[str]:
+        """Return an Authorization header value for an OAuth MCP server.
+
+        The MCP SDK's OAuthClientProvider is an httpx.Auth implementation whose
+        async auth flow holds its internal lock until the HTTP response
+        completes. Streamable HTTP starts a long-lived GET/SSE stream after the
+        initialized notification; if that GET goes through the provider, it can
+        hold the auth lock forever and the next JSON-RPC POST (usually
+        tools/list) hangs before it can attach auth.
+
+        Hermes still uses the SDK provider for OAuth setup/storage/refresh, but
+        the long-lived MCP data-plane connection should carry a plain bearer
+        header. This materializes and refreshes the token up front so mcp_tool
+        can pass a normal header instead of passing the provider as auth=.
+        """
+        provider = self.get_or_build_provider(server_name, server_url, oauth_config)
+        if provider is None:
+            return None
+
+        try:
+            await self.invalidate_if_disk_changed(server_name)
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.debug(
+                "MCP OAuth '%s': bearer materialization disk-watch failed: %s",
+                server_name, exc,
+            )
+
+        entry = self._entries.get(server_name)
+        if entry is None:
+            return None
+
+        async with entry.lock:
+            ctx = getattr(provider, "context", None)
+            if ctx is None:
+                return None
+
+            if not getattr(provider, "_initialized", False):
+                init = getattr(provider, "_initialize", None)
+                if callable(init):
+                    await cast(Callable[[], Awaitable[None]], init)()
+                if hasattr(provider, "_initialized"):
+                    provider._initialized = True  # noqa: SLF001
+
+            tokens = getattr(ctx, "current_tokens", None)
+            if tokens is not None:
+                update_expiry = getattr(ctx, "update_token_expiry", None)
+                if callable(update_expiry):
+                    update_expiry(tokens)
+
+            is_valid = getattr(ctx, "is_token_valid", None)
+            if not (callable(is_valid) and is_valid()):
+                can_refresh = getattr(ctx, "can_refresh_token", None)
+                if callable(can_refresh) and can_refresh():
+                    refresh = getattr(provider, "_refresh_token", None)
+                    handle_refresh = getattr(provider, "_handle_refresh_response", None)
+                    if not (callable(refresh) and callable(handle_refresh)):
+                        return None
+                    import httpx
+
+                    refresh_request = await cast(Callable[[], Awaitable[Any]], refresh)()
+                    async with httpx.AsyncClient(follow_redirects=True) as client:
+                        refresh_response = await client.send(refresh_request)
+                    handled = await cast(
+                        Callable[[Any], Awaitable[bool]], handle_refresh,
+                    )(refresh_response)
+                    if not handled:
+                        return None
+                else:
+                    return None
+
+            tokens = getattr(ctx, "current_tokens", None)
+            access_token = getattr(tokens, "access_token", None)
+            if not access_token:
+                return None
+
+            try:
+                from tools.mcp_oauth import _get_token_dir, _safe_filename
+
+                tokens_path = _get_token_dir() / f"{_safe_filename(server_name)}.json"
+                entry.last_mtime_ns = tokens_path.stat().st_mtime_ns
+            except Exception:
+                pass
+            return f"Bearer {access_token}"
 
     def _build_provider(
         self,

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1982,9 +1982,23 @@ class MCPServerTask:
         if self._auth_type == "oauth":
             try:
                 from tools.mcp_oauth_manager import get_manager
-                _oauth_auth = get_manager().get_or_build_provider(
+                _oauth_manager = get_manager()
+                _oauth_auth = _oauth_manager.get_or_build_provider(
                     self.name, url, config.get("oauth"),
                 )
+                _bearer_header = await _oauth_manager.get_bearer_authorization_header(
+                    self.name, url, config.get("oauth"),
+                )
+                if _bearer_header:
+                    # Do not pass the SDK OAuth provider into Streamable HTTP's
+                    # long-lived data-plane connection. OAuthClientProvider
+                    # holds its auth-flow lock until the HTTP response
+                    # completes; the GET/SSE stream never completes, so the
+                    # following tools/list POST can hang forever waiting to
+                    # attach auth. Materialize OAuth to a plain bearer header
+                    # up front instead.
+                    headers["Authorization"] = _bearer_header
+                    _oauth_auth = None
             except Exception as exc:
                 logger.warning("MCP OAuth setup failed for '%s': %s", self.name, exc)
                 raise


### PR DESCRIPTION
## Summary
- Materialize OAuth access tokens into bearer headers before opening Streamable HTTP MCP data-plane clients
- Avoid passing the SDK OAuth auth provider into long-lived SSE/Streamable HTTP connections where its auth-flow lock can be held by the GET stream
- Add regression tests for bearer-header materialization, refresh handling, and Streamable HTTP client wiring

## Why
Eden's Streamable HTTP MCP transport opens a long-lived GET/SSE stream after initialize. The Python MCP SDK OAuth provider can hold its auth-flow lock while that response remains open, which blocks subsequent POST requests such as tools/list. Hermes then hangs during tool discovery despite having valid OAuth credentials.

## Test Plan
- uv run --extra dev python -m pytest tests/tools/test_mcp_oauth_manager.py tests/tools/test_mcp_tool.py -q -o 'addopts='
- uv run --extra dev ruff check tools/mcp_oauth_manager.py tools/mcp_tool.py tests/tools/test_mcp_oauth_manager.py tests/tools/test_mcp_tool.py
- HERMES_HOME=/Users/haren/.hermes/profiles/content uv run --extra dev hermes mcp test eden
