### PR TITLE
fix(dashboard): env reveal works in gated auth mode

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -504,17 +504,12 @@ export const api = {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ key }),
     }),
-  revealEnvVar: async (key: string) => {
-    const token = await getSessionToken();
-    return fetchJSON<{ key: string; value: string }>("/api/env/reveal", {
+  revealEnvVar: (key: string) =>
+    fetchJSON<{ key: string; value: string }>("/api/env/reveal", {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        [SESSION_HEADER]: token,
-      },
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ key }),
-    });
-  },
+    }),
 
   // Cron jobs
   getCronJobs: (profile = "all") =>


### PR DESCRIPTION
The API Keys page's eye/reveal button failed in gated auth mode (`basic_auth` / OAuth) because `revealEnvVar()` awaited `getSessionToken()`, which throws when `window.__HERMES_SESSION_TOKEN__` is intentionally not injected. The rest of the dashboard already uses cookie auth via `fetchJSON()` in gated mode.

Make `revealEnvVar()` consistent with `setEnvVar()` / `deleteEnvVar()`: use `fetchJSON()` directly so `credentials: 'include'` sends the session cookie and the `X-Hermes-Session-Token` header is only added in loopback mode.

## What does this PR do?

Fixes the env-var reveal (eye) button in the web dashboard when authentication is enabled (basic_auth or OAuth). In gated auth mode the server deliberately does not inject `window.__HERMES_SESSION_TOKEN__`; the old `revealEnvVar()` implementation unconditionally called `getSessionToken()` and threw before the network request was sent, causing a "Failed to reveal" toast. The fix removes that call and lets `fetchJSON()` handle auth the same way the other env endpoints already do.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `web/src/lib/api.ts`
  - `revealEnvVar()` now returns `fetchJSON(...)` directly instead of awaiting `getSessionToken()` first
  - This makes the reveal path use the same auth mechanism as `setEnvVar()` and `deleteEnvVar()`

## How to Test

1. Configure dashboard with `basic_auth` in `~/.hermes/config.yaml`:
   ```yaml
   dashboard:
     basic_auth:
       username: admin
       password_hash: "scrypt$..."
   ```
2. Start dashboard on a non-loopback bind:
   ```bash
   hermes dashboard --host 0.0.0.0 --no-open
   ```
3. Log in and go to **API Keys**.
4. Set any env var, then click the eye icon next to it.
5. **Before fix:** toast "Failed to reveal ..." and no network request leaves the browser.
6. **After fix:** the unredacted value appears.

Also verify loopback mode still works (`hermes dashboard` without auth gate) — `fetchJSON()` continues to attach the injected session token when present.

## Testing

- `tests/hermes_cli/test_web_ui_build.py` ✅
- `tests/hermes_cli/test_dashboard_auth_*.py`: 270 passed, 3 pre-existing failures in `test_dashboard_auth_password_login.py` unrelated to this change (backend `/auth/password-login` route returns 400 instead of expected 200/404 in current test setup)
- Manually verified in a Docker deployment with dashboard `basic_auth`: the eye/reveal button now displays env var values

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran targeted dashboard-related subset instead (see Testing section)
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — frontend-only change; covered by manual verification and existing web UI build tests
- [x] I've tested on my platform: Linux (Docker deployment with dashboard `basic_auth`)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure TypeScript frontend change, no platform-specific code
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

N/A

## Screenshots / Logs

Before fix (browser console):
```
Error: Session token not available — page must be served by the Hermes dashboard server
```

After fix: clicking the eye icon successfully reveals the env var value.