### PR TITLE
fix: allow hiding Codex gpt-5.5 auto-raise notice

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -82,7 +82,22 @@ def _build_codex_gpt55_autoraise_notice(autoraise: Dict[str, float]) -> str:
         f"ℹ Codex gpt-5.5 caps context at 272K, so auto-compaction was raised "
         f"to {to_pct}% (from {from_pct}%) to use more of the window before "
         f"summarizing.\n"
-        f"  Opt back out: hermes config set compression.codex_gpt55_autoraise false"
+        f"  Hide this notice: hermes config set "
+        f"compression.codex_gpt55_autoraise_notice false\n"
+        f"  Opt back down to the global threshold: hermes config set "
+        f"compression.codex_gpt55_autoraise false"
+    )
+
+
+def should_show_codex_gpt55_autoraise_notice(compression_cfg: Dict[str, Any]) -> bool:
+    """Return whether to show the Codex gpt-5.5 auto-raise notice.
+
+    ``compression.codex_gpt55_autoraise`` controls the behavior. This separate
+    flag only controls the user-facing startup/gateway notice so users can keep
+    the safer threshold behavior without seeing the same explanation in chat.
+    """
+    return is_truthy_value(
+        compression_cfg.get("codex_gpt55_autoraise_notice"), default=True
     )
 
 
@@ -1724,7 +1739,11 @@ def init_agent(
         # gateway users get the same text replayed via _compression_warning on
         # turn 1 (set below, after the warning slot is initialized).
         _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
-        if _autoraise and compression_enabled:
+        if (
+            _autoraise
+            and compression_enabled
+            and should_show_codex_gpt55_autoraise_notice(_compression_cfg)
+        ):
             print(_build_codex_gpt55_autoraise_notice(_autoraise))
 
     # Check immediately so CLI users see the warning at startup.
@@ -1735,7 +1754,11 @@ def init_agent(
     # above only reaches the CLI, so stash the same text here to be replayed
     # through status_callback on the first turn (Telegram/Discord/Slack/etc.).
     _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
-    if _autoraise and compression_enabled:
+    if (
+        _autoraise
+        and compression_enabled
+        and should_show_codex_gpt55_autoraise_notice(_compression_cfg)
+    ):
         agent._compression_warning = _build_codex_gpt55_autoraise_notice(_autoraise)
     # Lazy feasibility check: deferred to the first turn that approaches the
     # compression threshold. Running it eagerly here costs ~400ms cold (network

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1293,6 +1293,11 @@ DEFAULT_CONFIG = {
                                       # exact route is affected — gpt-5.5 on OpenAI's
                                       # direct API, OpenRouter, and Copilot keep the
                                       # global threshold regardless.
+        "codex_gpt55_autoraise_notice": True,  # When True, show a one-time CLI/gateway
+                                      # notice when the Codex gpt-5.5 auto-raise above
+                                      # changes the effective compaction threshold. Set
+                                      # False to keep the safer auto-raise behavior while
+                                      # suppressing the explanatory chat/status message.
         "in_place": False,            # When True, compaction rewrites the message
                                       # list and rebuilds the system prompt WITHOUT
                                       # rotating the session id — the conversation

--- a/tests/agent/test_codex_gpt55_autoraise_notice.py
+++ b/tests/agent/test_codex_gpt55_autoraise_notice.py
@@ -1,0 +1,108 @@
+"""Tests for the Codex gpt-5.5 auto-raise notice toggle."""
+
+from __future__ import annotations
+
+import importlib
+import textwrap
+
+from agent.agent_init import should_show_codex_gpt55_autoraise_notice
+from hermes_cli.config import DEFAULT_CONFIG
+
+
+def _write_config(home, *, show_notice: bool) -> None:
+    (home / "config.yaml").write_text(
+        textwrap.dedent(
+            f"""
+            compression:
+              enabled: true
+              threshold: 0.68
+              codex_gpt55_autoraise: true
+              codex_gpt55_autoraise_notice: {str(show_notice).lower()}
+            model:
+              provider: openai-codex
+              default: gpt-5.5
+              context_length: 400000
+            """
+        ),
+        encoding="utf-8",
+    )
+
+
+def _build_codex_gpt55_agent(monkeypatch, tmp_path, *, show_notice: bool):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    _write_config(tmp_path, show_notice=show_notice)
+
+    from hermes_cli import config as config_mod
+    import run_agent as run_agent_mod
+
+    importlib.reload(config_mod)
+    importlib.reload(run_agent_mod)
+
+    return run_agent_mod.AIAgent(
+        api_key="test-key",
+        base_url="https://chatgpt.com/backend-api/codex",
+        model="gpt-5.5",
+        provider="openai-codex",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        platform="telegram",
+    )
+
+
+def test_codex_gpt55_autoraise_notice_defaults_to_enabled() -> None:
+    compression = DEFAULT_CONFIG["compression"]
+
+    assert compression["codex_gpt55_autoraise"] is True
+    assert compression["codex_gpt55_autoraise_notice"] is True
+    assert should_show_codex_gpt55_autoraise_notice(compression) is True
+
+
+def test_codex_gpt55_autoraise_notice_can_be_hidden_without_disabling_autoraise() -> None:
+    compression = {
+        "codex_gpt55_autoraise": True,
+        "codex_gpt55_autoraise_notice": False,
+    }
+
+    assert should_show_codex_gpt55_autoraise_notice(compression) is False
+    assert compression["codex_gpt55_autoraise"] is True
+
+
+def test_codex_gpt55_autoraise_notice_accepts_common_false_values() -> None:
+    for value in (False, "false", "0", "no", "off"):
+        assert should_show_codex_gpt55_autoraise_notice(
+            {"codex_gpt55_autoraise_notice": value}
+        ) is False
+
+
+def test_codex_gpt55_autoraise_notice_accepts_common_true_values() -> None:
+    for value in (True, "true", "1", "yes", "on"):
+        assert should_show_codex_gpt55_autoraise_notice(
+            {"codex_gpt55_autoraise_notice": value}
+        ) is True
+
+
+def test_notice_toggle_hides_gateway_warning_but_keeps_autoraise(
+    monkeypatch, tmp_path
+) -> None:
+    agent = _build_codex_gpt55_agent(monkeypatch, tmp_path, show_notice=False)
+
+    assert getattr(agent, "_compression_threshold_autoraised") == {
+        "from": 0.68,
+        "to": 0.85,
+    }
+    assert getattr(agent, "_compression_warning") is None
+
+
+def test_notice_enabled_stores_gateway_warning_by_default(monkeypatch, tmp_path) -> None:
+    agent = _build_codex_gpt55_agent(monkeypatch, tmp_path, show_notice=True)
+
+    warning = getattr(agent, "_compression_warning")
+    assert getattr(agent, "_compression_threshold_autoraised") == {
+        "from": 0.68,
+        "to": 0.85,
+    }
+    assert "Codex gpt-5.5 caps context" in warning
+    assert "compression.codex_gpt55_autoraise_notice false" in warning
+    assert "compression.codex_gpt55_autoraise false" in warning

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -85,6 +85,7 @@ compression:
   target_ratio: 0.20         # How much of threshold to keep as tail (default: 0.20)
   protect_last_n: 20         # Minimum protected tail messages (default: 20)
   codex_gpt55_autoraise: true  # gpt-5.5 on Codex OAuth: raise trigger to 85% (default: true)
+  codex_gpt55_autoraise_notice: true  # Show one-time notice when the trigger is raised
 
 # Summarization model/provider configured under auxiliary:
 auxiliary:
@@ -103,6 +104,7 @@ auxiliary:
 | `protect_last_n` | `20` | ≥1 | Minimum number of recent messages always preserved |
 | `protect_first_n` | `3` | (hardcoded) | System prompt + first exchange always preserved |
 | `codex_gpt55_autoraise` | `true` | bool | Raise the trigger to 85% for gpt-5.5 on the ChatGPT Codex OAuth route (see below). Set `false` to keep the global `threshold` |
+| `codex_gpt55_autoraise_notice` | `true` | bool | Show the one-time CLI/gateway notice when `codex_gpt55_autoraise` changes the effective threshold. Set `false` to hide only the notice while keeping the 85% trigger |
 
 ### Codex gpt-5.5 threshold autoraise
 
@@ -117,6 +119,13 @@ your global `threshold`. To opt back down to the global value:
 
 ```bash
 hermes config set compression.codex_gpt55_autoraise false
+```
+
+If you want to keep the 85% trigger but hide only the one-time informational
+notice in CLI/gateway chats, disable the notice separately:
+
+```bash
+hermes config set compression.codex_gpt55_autoraise_notice false
 ```
 
 ### Computed Values (for a 200K context model at defaults)


### PR DESCRIPTION
## Why

Codex gpt-5.5 auto-raise is useful: on the ChatGPT Codex OAuth route the effective window is capped at 272K, so raising compaction to 85% avoids wasting a large part of the available context.

The current notice only suggests `compression.codex_gpt55_autoraise false`, which turns off the behavior entirely. Gateway users may want a quieter chat without losing the safer threshold behavior.

## What changed

- Add `compression.codex_gpt55_autoraise_notice`, defaulting to `true`.
- Gate the CLI startup notice and gateway `_compression_warning` replay on that notice flag.
- Keep `compression.codex_gpt55_autoraise` as the only switch for the actual 85% threshold behavior.
- Update the notice text to show both options:
  - hide only the notice
  - opt back down to the global threshold
- Document the new setting in the context compression guide.

## Tests

- `python -m pytest tests/agent/test_codex_gpt55_autoraise_notice.py -q -o 'addopts='`
- `python -m pytest tests/agent/test_codex_gpt55_autoraise_notice.py tests/agent/test_arcee_trinity_overrides.py tests/run_agent/test_compression_feasibility.py tests/agent/test_turn_context.py -q -o 'addopts='`
- `python -m pytest tests/hermes_cli/test_setup_agent_settings.py tests/hermes_cli/test_ignore_user_config_flags.py -q -o 'addopts='`
