### PR TITLE
fix(config,skills): strip 'export' prefix when parsing .env files

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5975,7 +5975,17 @@ def load_env() -> Dict[str, str]:
         for line in lines:
             line = line.strip()
             if line and not line.startswith('#') and '=' in line:
-                key, _, value = line.partition('=')
+                raw_line = line
+                # Strip 'export ' (bash) and 'set ' (cmd) shell prefixes so
+                # .env files written with ``export KEY=VALUE`` syntax are
+                # parsed correctly. Without this, get_env_value("NOTION_API_KEY")
+                # returns None for ``export NOTION_API_KEY=xxx`` because the
+                # key would be "export NOTION_API_KEY".
+                for _sh_prefix in ('export ', 'set '):
+                    if raw_line.lower().startswith(_sh_prefix):
+                        raw_line = raw_line[len(_sh_prefix):]
+                        break
+                key, _, value = raw_line.partition('=')
                 env_vars[key.strip()] = value.strip().strip('"\'')
 
     if cache_key is not None:
@@ -6192,7 +6202,14 @@ def save_env_value(key: str, value: str):
     # Find and update or append
     found = False
     for i, line in enumerate(lines):
-        if line.strip().startswith(f"{key}="):
+        stripped = line.strip()
+        # Match KEY=VALUE, export KEY=VALUE, set KEY=VALUE
+        check = stripped
+        for _p in ('export ', 'set '):
+            if check.lower().startswith(_p):
+                check = check[len(_p):]
+                break
+        if check.startswith(f"{key}="):
             lines[i] = f"{key}={value}\n"
             found = True
             break
@@ -6271,7 +6288,16 @@ def remove_env_value(key: str) -> bool:
         lines = f.readlines()
     lines = _sanitize_env_lines(lines)
 
-    new_lines = [line for line in lines if not line.strip().startswith(f"{key}=")]
+    new_lines = []
+    for line in lines:
+        stripped = line.strip()
+        check = stripped
+        for _p in ('export ', 'set '):
+            if check.lower().startswith(_p):
+                check = check[len(_p):]
+                break
+        if not check.startswith(f"{key}="):
+            new_lines.append(line)
     found = len(new_lines) < len(lines)
 
     if found:

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -149,7 +149,13 @@ def load_env() -> Dict[str, str]:
         for line in f:
             line = line.strip()
             if line and not line.startswith("#") and "=" in line:
-                key, _, value = line.partition("=")
+                raw_line = line
+                # Strip shell export/set prefixes
+                for _p in ('export ', 'set '):
+                    if raw_line.lower().startswith(_p):
+                        raw_line = raw_line[len(_p):]
+                        break
+                key, _, value = raw_line.partition("=")
                 env_vars[key.strip()] = value.strip().strip("\"'")
     return env_vars
 


### PR DESCRIPTION
## Problem

The `load_env()` functions in `hermes_cli/config.py` and `tools/skills_tool.py` parsed lines with `line.partition('=')` directly. On `.env` files that use bash-compatible `export KEY=VALUE` syntax, this produced keys like `export NOTION_API_KEY` instead of `NOTION_API_KEY`.

On Windows the Hermes desktop app does not source `.env` into `os.environ`, so every lookup fell through to `load_env()`, which never found the real key. This caused the `NOTION_API_KEY` (and any other `export`-prefixed skill env var) setup popup to reappear endlessly — even after the user entered a valid token through the UI.

The same bug existed in the write paths: `save_env_value()` and `remove_env_value()` matched `startswith('KEY=')` which missed `export KEY=...` lines, creating duplicate entries on every UI save.

## Fix

- Strip `export ` (bash) and `set ` (cmd) shell prefixes before parsing the key/value pair in `load_env()` in `config.py` and `skills_tool.py`
- Match shell-prefixed lines in `save_env_value()` and `remove_env_value()` write paths
- Matches the existing behavior in `agent/secret_scope.py` (`load_env_file()`) which already handled the `export` prefix correctly

## Testing

- Confirmed `get_env_value('NOTION_API_KEY')` returns the correct value after the fix (previously returned `None`)
- Verified both with and without `export` prefix work correctly