### PR TITLE
fix: respect streaming.enabled config in CLI conversation loop

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -58,7 +58,7 @@ from agent.prompt_caching import apply_anthropic_cache_control
 from agent.retry_utils import jittered_backoff
 from agent.trajectory import has_incomplete_scratchpad
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
-from hermes_constants import PARTIAL_STREAM_STUB_ID
+from hermes_constants import PARTIAL_STREAM_STUB_ID, get_hermes_home
 from hermes_logging import set_session_context
 from tools.skill_provenance import set_current_write_origin
 from utils import base_url_host_matches, env_var_enabled
@@ -1112,6 +1112,19 @@ def run_conversation(
                         agent.thinking_callback("")
 
                 _use_streaming = True
+                # Respect streaming.enabled from config.yaml — master switch for
+                # turning off SSE streaming globally.  When false, use non-streaming
+                # API calls which avoids reasoning_content / content splitting issues
+                # on providers that return long chain-of-thought (GLM-5.2, etc.).
+                try:
+                    import yaml as _yaml
+                    _cfg_path = get_hermes_home() / "config.yaml"
+                    if _cfg_path.exists():
+                        _cfg = _yaml.safe_load(_cfg_path.read_text()) or {}
+                        if not _cfg.get("streaming", {}).get("enabled", True):
+                            _use_streaming = False
+                except Exception:
+                    pass
                 # Provider signaled "stream not supported" on a previous
                 # attempt — switch to non-streaming for the rest of this
                 # session instead of re-failing every retry.


### PR DESCRIPTION
# fix: respect `streaming.enabled` config in CLI conversation loop

## Problem

The `streaming.enabled` config setting in `config.yaml` was documented as the master switch for controlling SSE streaming **(see comments at `config.py:1674`)**, but it was never checked in the CLI conversation loop. The code hardcodes `_use_streaming = True` at `conversation_loop.py:1114`, ignoring the user's config entirely.

When users set `streaming.enabled: false`, they expect non-streaming API calls. Instead, the conversation loop always forces `stream: true` regardless.

This is especially problematic for reasoning models (GLM-5.2, DeepSeek, etc.) that return long `reasoning_content` chains in streaming mode. With streaming on, models like `@cf/zai-org/glm-5.2` emit ~79 reasoning tokens for every 1 content token — the streaming display pipeline can't keep up, producing garbled output like `"TheExamine theex://her.-1"` instead of the model's actual response.

Non-streaming returns a single clean JSON response where `content` and `reasoning_content` are properly separated fields — the agent already handles this correctly.

## Fix

Two minimal changes to `agent/conversation_loop.py`:

1. **Import `get_hermes_home`** from `hermes_constants` (used to locate `config.yaml`)
2. **Read `streaming.enabled`** from config before falling through to the existing `_disable_streaming` / Copilot exclusion checks

The config read is wrapped in try/except so a missing or malformed config file never crashes the agent loop.

## Related Work

The **gateway path** had the identical bug and was fixed in:
- **#8635** — `fix(gateway): respect streaming.enabled: false even when display.streaming is true` 
- **#9799** — `fix(gateway): regression causing display.streaming to override root gateway streaming config`

But the CLI conversation loop was never updated, leaving the fix incomplete.

## Related issues
- #8338 — display.streaming enables gateway streaming when streaming.enabled: false  
- #8635 — gateway fix for the above  
- #9799 — regression fix for the gateway  
- #31063 — request for per-provider streaming disable  
- #42008 — reasoning/CoT dropped in gateway streaming mode  
- #16844 — reasoning_content not preserved in chat history  

## Testing

Verified with `streaming.enabled: false` in config.yaml:
- **Cloudflare GLM-5.2**: Returns `"Hello!"` instead of garbled reasoning fragments ✓
- **Default provider (DeepSeek via Nous)**: Still returns `"Hello."` ✓

## How to apply

```bash
# Via patch file
cd /usr/local/lib/hermes-agent
patch -p1 < ~/.hermes/patches/0001-respect-streaming-enabled.patch

# Or manually edit:
#   1. agent/conversation_loop.py line 61: add ", get_hermes_home" to import
#   2. agent/conversation_loop.py after line 1114: add the streaming check block
```