### PR TITLE
fix(gateway): replace 5 assert statements in weixin adapter

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1335,7 +1335,8 @@ class WeixinAdapter(BasePlatformAdapter):
         logger.info("[%s] Disconnected", self.name)
 
     async def _poll_loop(self) -> None:
-        assert self._poll_session is not None
+        if self._poll_session is None:
+            raise RuntimeError("_poll_loop called before _poll_session is initialized")
         sync_buf = _load_sync_buf(self._hermes_home, self._account_id)
         timeout_ms = LONG_POLL_TIMEOUT_MS
         consecutive_failures = 0
@@ -1401,7 +1402,8 @@ class WeixinAdapter(BasePlatformAdapter):
             logger.error("[%s] unhandled inbound error from=%s: %s", self.name, _safe_id(message.get("from_user_id")), exc, exc_info=True)
 
     async def _process_message(self, message: Dict[str, Any]) -> None:
-        assert self._poll_session is not None
+        if self._poll_session is None:
+            raise RuntimeError("_process_message called before _poll_session is initialized")
         sender_id = str(message.get("from_user_id") or "").strip()
         if not sender_id:
             return
@@ -1813,7 +1815,8 @@ class WeixinAdapter(BasePlatformAdapter):
                 )
                 if wait > 0:
                     await asyncio.sleep(wait)
-        assert last_error is not None
+        if last_error is None:
+                raise RuntimeError("last_error should not be None after retry loop")
         raise last_error
 
     async def send(
@@ -2068,7 +2071,8 @@ class WeixinAdapter(BasePlatformAdapter):
         if not is_safe_url(url):
             raise ValueError(f"Blocked unsafe URL (SSRF protection): {url}")
 
-        assert self._send_session is not None
+        if self._send_session is None:
+            raise RuntimeError("_send_session not initialized")
         # Use asyncio.wait_for() instead of aiohttp ClientTimeout to avoid
         # "Timeout context manager should be used inside a task" errors.
         async def _do_fetch():
@@ -2088,7 +2092,8 @@ class WeixinAdapter(BasePlatformAdapter):
         caption: str,
         force_file_attachment: bool = False,
     ) -> str:
-        assert self._send_session is not None and self._token is not None
+        if self._send_session is None or self._token is None:
+            raise RuntimeError("_send_session and _token must be initialized")
         plaintext = Path(path).read_bytes()
         media_type, item_builder = self._outbound_media_builder(path, force_file_attachment=force_file_attachment)
         filekey = secrets.token_hex(16)


### PR DESCRIPTION
## Summary

Replace 5 bare `assert` statements with `if`/`raise` in `gateway/platforms/weixin.py`.

`assert` is stripped when Python runs with `-O` flag.

### Fixes

| Line | Assert | Replacement |
|------|--------|-------------|
| 1338 | `assert self._poll_session is not None` | `if/raise RuntimeError` |
| 1404 | `assert self._poll_session is not None` | `if/raise RuntimeError` |
| 1816 | `assert last_error is not None` | `if/raise RuntimeError` |
| 2071 | `assert self._send_session is not None` | `if/raise RuntimeError` |
| 2091 | `assert self._send_session is not None and self._token is not None` | `if/raise RuntimeError` |

## Test plan

- [x] `python3 -m py_compile gateway/platforms/weixin.py` passes
- [x] All 5 asserts replaced, 0 bare asserts remaining