### PR TITLE
fix(api_server): drop duplicate model kwarg so fallback_providers doesn't crash

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1098,6 +1098,13 @@ class APIServerAdapter(BasePlatformAdapter):
         runtime_kwargs = _resolve_runtime_agent_kwargs()
         reasoning_config = GatewayRunner._load_reasoning_config()
         model = _resolve_gateway_model()
+        # Fallback providers return an explicit model inside runtime_kwargs;
+        # honour it and drop the duplicate so AIAgent isn't passed ``model``
+        # twice (mirrors gateway/run.py:2744). Without this, an activated
+        # fallback crashes with: got multiple values for keyword argument 'model'.
+        _fb_model = runtime_kwargs.pop("model", None)
+        if _fb_model:
+            model = _fb_model
 
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))


### PR DESCRIPTION
## What
Fixes a crash in the **api_server** platform when a `fallback_providers` chain activates: the agent that should serve the fallback is never built, and the request 500s instead of failing over.

## Why it happens
`gateway/run.py::_try_resolve_fallback_provider()` returns a runtime dict that **includes a `model` key** (the fallback entry's model). The native gateway path accounts for this and pops it before building the agent (`gateway/run.py:2744`):

```python
runtime_model = runtime_kwargs.pop("model", None)
if runtime_model:
    model = runtime_model
```

But `gateway/platforms/api_server.py::_create_agent` (added in #4954) splats the dict alongside an explicit `model=`:

```python
runtime_kwargs = _resolve_runtime_agent_kwargs()   # carries "model" on the fallback path
model = _resolve_gateway_model()
...
agent = AIAgent(model=model, **runtime_kwargs, ...)  # model passed twice -> TypeError
```

On the primary path `_resolve_runtime_agent_kwargs()` returns no `model`, so it only fires when a fallback actually activates.

## The fix
Mirror the native gateway's handling — pop the runtime model and honour it:

```python
_fb_model = runtime_kwargs.pop("model", None)
if _fb_model:
    model = _fb_model
```

No-op on the primary path (no `model` key present); fixes the fallback path.

## Traceback (before)
```
ERROR gateway.platforms.api_server: Error running agent for chat completions:
run_agent.AIAgent() got multiple values for keyword argument 'model'
  File "gateway/platforms/api_server.py", line ~1111, in _create_agent
    agent = AIAgent(
TypeError: run_agent.AIAgent() got multiple values for keyword argument 'model'
```

## Reproduction
1. Configure a primary provider plus a `fallback_providers` entry.
2. Force the primary to fail at resolution (e.g. an `openai-codex` provider with no stored credentials, or a rate-limited/expired token).
3. `POST /v1/chat/completions` → 500. The log reaches `Fallback provider resolved: ...` first (the resolver works), then crashes on agent construction.

## Verification
With the patch, a forced primary failure falls over to the configured fallback provider cleanly: `Fallback provider resolved: custom model=<fallback>` → a real response, no `TypeError`. Tested on v0.16.0; the affected code is unchanged on current `main`.
