### PR TITLE
fix(memory): respect HINDSIGHT_BANK_ID when config exists

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1284,7 +1284,11 @@ class HindsightMemoryProvider(MemoryProvider):
         self._llm_base_url = self._config.get("llm_base_url", "")
 
         banks = cfg_get(self._config, "banks", "hermes", default={})
-        static_bank_id = self._config.get("bank_id") or banks.get("bankId", "hermes")
+        static_bank_id = (
+            os.environ.get("HINDSIGHT_BANK_ID")
+            or self._config.get("bank_id")
+            or banks.get("bankId", "hermes")
+        )
         self._bank_id_template = self._config.get("bank_id_template", "") or ""
         self._bank_id = _resolve_bank_id_template(
             self._bank_id_template,

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -398,6 +398,31 @@ class TestConfig:
         assert cfg["banks"]["hermes"]["bankId"] == "env-bank"
         assert cfg["banks"]["hermes"]["budget"] == "high"
 
+    def test_env_bank_id_overrides_persisted_config_bank_id(self, tmp_path, monkeypatch):
+        """Profile .env bank override wins over setup's persisted default."""
+        config = {
+            "mode": "cloud",
+            "apiKey": "test-key",
+            "api_url": "http://localhost:9999",
+            "budget": "mid",
+            "memory_mode": "hybrid",
+            "bank_id": "hermes",
+        }
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config))
+
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home",
+            lambda: tmp_path,
+        )
+        monkeypatch.setenv("HINDSIGHT_BANK_ID", "env-bank")
+
+        p = HindsightMemoryProvider()
+        p.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
+
+        assert p._bank_id == "env-bank"
+
     def test_embedded_profile_env_includes_idle_timeout_from_config(self):
         env = _build_embedded_profile_env({
             "llm_provider": "openai",


### PR DESCRIPTION
## Summary
- Fix Hindsight bank resolution so `HINDSIGHT_BANK_ID` is used when `config.json` exists but omits `bank_id`.
- Add a regression test for profile env bank selection with an existing Hindsight config file.

## Root cause
`_load_config()` returns `config.json` directly when present, and provider initialization fell back from missing top-level `bank_id` straight to `banks.hermes.bankId`/`hermes`. That skipped the profile env value reported in #51166.

## Validation
- `uv run --with pytest-timeout pytest tests/plugins/memory/test_hindsight_provider.py -q`
- `uv run ruff check plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py`
- `python3 -m py_compile plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py`
- `git diff --check`
- `python3 scripts/check-windows-footguns.py --diff origin/main`

Fixes #51166