### PR TITLE
fix(cli): add explicit encoding to read_text/write_text in main.py

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -470,7 +470,7 @@ def _apply_profile_override() -> None:
 
             active_path = get_default_hermes_root() / "active_profile"
             if active_path.exists():
-                name = active_path.read_text().strip()
+                name = active_path.read_text(encoding="utf-8").strip()
                 if name and name != "default":
                     profile_name = name
                     consume = 0  # don't strip anything from argv
@@ -846,7 +846,7 @@ def _has_any_provider_configured() -> bool:
         try:
             import json
 
-            auth = json.loads(auth_file.read_text())
+            auth = json.loads(auth_file.read_text(encoding="utf-8"))
             active = auth.get("active_provider")
             if active:
                 status = get_auth_status(active)
@@ -4522,7 +4522,7 @@ def _gateway_prompt(prompt_text: str, default: str = "", timeout: float = 300.0)
         "id": str(_uuid.uuid4()),
     }
     tmp = prompt_path.with_suffix(".tmp")
-    tmp.write_text(_json.dumps(payload))
+    tmp.write_text(_json.dumps(payload), encoding="utf-8")
     tmp.replace(prompt_path)
 
     # Poll for response
@@ -4530,7 +4530,7 @@ def _gateway_prompt(prompt_text: str, default: str = "", timeout: float = 300.0)
     while _time.monotonic() < deadline:
         if response_path.exists():
             try:
-                answer = response_path.read_text().strip()
+                answer = response_path.read_text(encoding="utf-8").strip()
                 response_path.unlink(missing_ok=True)
                 prompt_path.unlink(missing_ok=True)
                 return answer if answer else default
@@ -9631,7 +9631,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         if gateway_mode:
             _exit_code_path = get_hermes_home() / ".update_exit_code"
             try:
-                _exit_code_path.write_text("0")
+                _exit_code_path.write_text("0", encoding="utf-8")
             except OSError:
                 pass
 
@@ -11016,7 +11016,7 @@ def _render_distribution_plan(plan) -> None:
                 env_path = plan.target_dir / ".env"
                 if env_path.is_file():
                     try:
-                        for raw in env_path.read_text().splitlines():
+                        for raw in env_path.read_text(encoding="utf-8").splitlines():
                             line = raw.strip()
                             if not line or line.startswith("#"):
                                 continue


### PR DESCRIPTION
## Summary

Add `encoding="utf-8"` to 6 remaining `read_text()`/`write_text()` calls in `hermes_cli/main.py` (1 already had encoding).

`Path.read_text()` defaults to system locale (cp1252 on Windows), causing `UnicodeDecodeError` for UTF-8 content. Ruff rule PLW1514.

## Test plan
- [x] `python3 -m py_compile hermes_cli/main.py` passes
- [x] All calls fixed