### PR TITLE
fix(cli): add explicit encoding to read_text/write_text in service files

### DIFF
--- a/hermes_cli/container_boot.py
+++ b/hermes_cli/container_boot.py
@@ -194,7 +194,7 @@ def _maybe_migrate_legacy_gateway_run_state(
             "desired_state": "running",
             "timestamp": int(time.time()),
             "migrated_from": "legacy-container-cmd",
-        }) + "\n")
+        }) + "\n", encoding="utf-8")
     return "running"
 
 
@@ -331,7 +331,7 @@ def _read_desired_state(profile_dir: Path) -> str | None:
     if not state_file.exists():
         return None
     try:
-        data = json.loads(state_file.read_text())
+        data = json.loads(state_file.read_text(encoding="utf-8"))
         desired_state = data.get("desired_state")
         if desired_state is not None:
             return desired_state
@@ -387,7 +387,7 @@ def _register_service(scandir: Path, profile: str, *, start: bool) -> None:
     tmp_dir.mkdir(parents=True)
 
     try:
-        (tmp_dir / "type").write_text("longrun\n")
+        (tmp_dir / "type").write_text("longrun\n", encoding="utf-8")
 
         # Reuse the manager's run-script rendering — single source of
         # truth so register_profile_gateway and reconcile_profile_gateways
@@ -395,14 +395,14 @@ def _register_service(scandir: Path, profile: str, *, start: bool) -> None:
         # per-profile env can set it via the profile's config.yaml
         # (which the gateway itself loads).
         run = tmp_dir / "run"
-        run.write_text(S6ServiceManager._render_run_script(profile, extra_env={}))
+        run.write_text(S6ServiceManager._render_run_script(profile, extra_env={}), encoding="utf-8")
         run.chmod(0o755)
 
         # Persistent log rotation (OQ8-C).
         log_subdir = tmp_dir / "log"
         log_subdir.mkdir()
         log_run = log_subdir / "run"
-        log_run.write_text(S6ServiceManager._render_log_run(profile))
+        log_run.write_text(S6ServiceManager._render_log_run(profile), encoding="utf-8")
         log_run.chmod(0o755)
 
         # The presence of a `down` file tells s6-supervise to NOT

--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -376,7 +376,7 @@ def _write_gateway_desired_state(name: str, desired_state: str) -> None:
         if not profile_dir.exists():
             return
         try:
-            data = json.loads(state_file.read_text()) if state_file.exists() else {}
+            data = json.loads(state_file.read_text(encoding="utf-8")) if state_file.exists() else {}
             if not isinstance(data, dict):
                 data = {}
         except (OSError, json.JSONDecodeError):
@@ -384,7 +384,7 @@ def _write_gateway_desired_state(name: str, desired_state: str) -> None:
         data["desired_state"] = desired_state
         data["updated_at"] = int(time.time())
         tmp = state_file.with_suffix(state_file.suffix + ".tmp")
-        tmp.write_text(json.dumps(data, separators=(",", ":")) + "\n")
+        tmp.write_text(json.dumps(data, separators=(",", ":")) + "\n", encoding="utf-8")
         tmp.replace(state_file)
     except OSError:
         return
@@ -949,18 +949,18 @@ class S6ServiceManager:
         tmp_dir.mkdir(parents=True)
 
         try:
-            (tmp_dir / "type").write_text("longrun\n")
+            (tmp_dir / "type").write_text("longrun\n", encoding="utf-8")
 
             run_script = self._render_run_script(profile, extra_env or {})
             run_path = tmp_dir / "run"
-            run_path.write_text(run_script)
+            run_path.write_text(run_script, encoding="utf-8")
             run_path.chmod(0o755)
 
             # Persistent log rotation (OQ8-C).
             log_subdir = tmp_dir / "log"
             log_subdir.mkdir()
             log_run = log_subdir / "run"
-            log_run.write_text(self._render_log_run(profile))
+            log_run.write_text(self._render_log_run(profile), encoding="utf-8")
             log_run.chmod(0o755)
 
             # Pre-create the supervise/ skeleton with hermes ownership

--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -57,7 +57,7 @@ def remove_path_from_shell_configs():
     
     for config_path in configs:
         try:
-            content = config_path.read_text()
+            content = config_path.read_text(encoding="utf-8")
             original_content = content
             
             # Remove lines containing hermes-agent or hermes PATH entries
@@ -87,7 +87,7 @@ def remove_path_from_shell_configs():
                 new_content = new_content.replace('\n\n\n', '\n\n')
             
             if new_content != original_content:
-                config_path.write_text(new_content)
+                config_path.write_text(new_content, encoding="utf-8")
                 removed_from.append(config_path)
                 
         except Exception as e:
@@ -108,7 +108,7 @@ def remove_wrapper_script():
         if wrapper.exists():
             try:
                 # Check if it's our wrapper (contains hermes_cli reference)
-                content = wrapper.read_text()
+                content = wrapper.read_text(encoding="utf-8")
                 if 'hermes_cli' in content or 'hermes-agent' in content:
                     wrapper.unlink()
                     removed.append(wrapper)


### PR DESCRIPTION
## Summary

Add `encoding="utf-8"` to 11 `read_text()`/`write_text()` calls across 3 `hermes_cli/` service files.

`Path.read_text()` defaults to system locale (cp1252 on Windows), causing `UnicodeDecodeError` for UTF-8 content. Ruff rule PLW1514.

### Files fixed
| File | Calls |
|------|-------|
| `service_manager.py` | 4 |
| `container_boot.py` | 4 |
| `uninstall.py` | 3 |

## Test plan
- [x] `python3 -m py_compile` passes for all 3 files
- [x] All 11 calls fixed