### PR TITLE
fix(docker): preload Firecrawl in immutable image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -156,9 +156,12 @@ RUN npm install --prefer-offline --no-audit && \
 # git), `[yc-bench]` (another git dep), and `[termux-all]` (Android
 # redundancy), none of which belong in the published container.
 #
-# Provider packages (anthropic, bedrock, azure-identity) are included
+# Provider packages (anthropic, bedrock, azure-identity, firecrawl) are included
 # so Docker users can use these providers without requiring runtime
 # lazy-install access to PyPI (often blocked in containerized envs).
+# Firecrawl is also the default web backend, so the published image must ship
+# its SDK while `HERMES_DISABLE_LAZY_INSTALLS=1` keeps /opt/hermes immutable
+# (#51136).
 #
 # The hindsight memory provider's client (hindsight-client) is baked in
 # for the same reason: it lazy-installs into /opt/hermes/.venv at first
@@ -177,7 +180,7 @@ RUN npm install --prefer-offline --no-audit && \
 # The editable link is created after the source copy below.
 COPY pyproject.toml uv.lock ./
 RUN touch ./README.md
-RUN uv sync --frozen --no-install-project --extra all --extra messaging --extra anthropic --extra bedrock --extra azure-identity --extra hindsight --extra matrix
+RUN uv sync --frozen --no-install-project --extra all --extra messaging --extra anthropic --extra bedrock --extra azure-identity --extra firecrawl --extra hindsight --extra matrix
 
 # ---------- Frontend build (cached independently from Python source) ----------
 # Copy only the frontend source trees first so that Python-only changes don't

--- a/tests/tools/test_dockerfile_pid1_reaping.py
+++ b/tests/tools/test_dockerfile_pid1_reaping.py
@@ -187,6 +187,20 @@ def test_dockerfile_preinstalls_matrix_dependencies(dockerfile_text):
     )
 
 
+def test_dockerfile_preinstalls_firecrawl_web_dependency(dockerfile_text):
+    sync_steps = [
+        step for step in _run_steps(dockerfile_text)
+        if "uv sync" in step and "--no-install-project" in step
+    ]
+
+    assert sync_steps, "Dockerfile must install Python dependencies with uv sync"
+    assert any("--extra firecrawl" in step for step in sync_steps), (
+        "Published Docker images must preload the [firecrawl] extra because "
+        "Firecrawl remains a default web backend but container images disable "
+        "runtime lazy installs into /opt/hermes (#51136)."
+    )
+
+
 def test_dockerfile_installs_matrix_native_build_dependencies(dockerfile_text):
     instructions = _instruction_text(dockerfile_text)
 


### PR DESCRIPTION
## What does this PR do?

Fixes the Docker packaging gap where Firecrawl is the default web backend but `firecrawl-py` is not baked into the published image. The image disables runtime lazy installs and keeps `/opt/hermes` immutable, so Docker users can hit a lazy-install failure on first `web_search` / `web_extract` use.

This keeps the normal install policy intact by adding the `[firecrawl]` extra only to the Docker image `uv sync` command, not to `[all]`.

## Related Issue

Fixes #51136

Related but not duplicate: #49445 / #49527 cover the Exa backend under the same immutable-Docker lazy-install constraint. This PR keeps scope to the Firecrawl backend reported in #51136.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `Dockerfile`: include `--extra firecrawl` in the layer-cached Docker `uv sync` step and document why Docker needs this eager preload.
- `tests/tools/test_dockerfile_pid1_reaping.py`: add a Dockerfile contract test that keeps `[firecrawl]` preloaded while lazy installs are disabled in the image.

## How to Test

1. `uv run --with pytest-timeout pytest tests/tools/test_dockerfile_pid1_reaping.py -q`
2. `uv run --with pytest-timeout pytest tests/test_project_metadata.py tests/tools/test_dockerfile_immutable_install.py tests/tools/test_stage2_hook_immutable_install.py tests/docker/test_immutable_install_permissions.py -q`
3. `uv run ruff check tests/tools/test_dockerfile_pid1_reaping.py`
4. `python3 -m py_compile tests/tools/test_dockerfile_pid1_reaping.py`
5. `git diff --check`
6. `python3 scripts/check-windows-footguns.py --diff origin/main`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS local checkout, Dockerfile contract tests

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; Dockerfile inline comment updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Docker image packaging path only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A. This is a Docker packaging contract change covered by tests.
