### PR TITLE
DingTalk: silent WebSocket hang fix, clarify emoji-pill, and 8-platform config force-enable fix

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1744,7 +1744,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if dingtalk_client_id and dingtalk_client_secret:
         if Platform.DINGTALK not in config.platforms:
             config.platforms[Platform.DINGTALK] = PlatformConfig()
-        config.platforms[Platform.DINGTALK].enabled = True
+            config.platforms[Platform.DINGTALK].enabled = True
         config.platforms[Platform.DINGTALK].extra.update({
             "client_id": dingtalk_client_id,
             "client_secret": dingtalk_client_secret,
@@ -1764,7 +1764,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if feishu_app_id and feishu_app_secret:
         if Platform.FEISHU not in config.platforms:
             config.platforms[Platform.FEISHU] = PlatformConfig()
-        config.platforms[Platform.FEISHU].enabled = True
+            config.platforms[Platform.FEISHU].enabled = True
         config.platforms[Platform.FEISHU].extra.update({
             "app_id": feishu_app_id,
             "app_secret": feishu_app_secret,
@@ -1792,7 +1792,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if wecom_bot_id and wecom_secret:
         if Platform.WECOM not in config.platforms:
             config.platforms[Platform.WECOM] = PlatformConfig()
-        config.platforms[Platform.WECOM].enabled = True
+            config.platforms[Platform.WECOM].enabled = True
         config.platforms[Platform.WECOM].extra.update({
             "bot_id": wecom_bot_id,
             "secret": wecom_secret,
@@ -1815,7 +1815,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if wecom_callback_corp_id and wecom_callback_corp_secret:
         if Platform.WECOM_CALLBACK not in config.platforms:
             config.platforms[Platform.WECOM_CALLBACK] = PlatformConfig()
-        config.platforms[Platform.WECOM_CALLBACK].enabled = True
+            config.platforms[Platform.WECOM_CALLBACK].enabled = True
         config.platforms[Platform.WECOM_CALLBACK].extra.update({
             "corp_id": wecom_callback_corp_id,
             "corp_secret": wecom_callback_corp_secret,
@@ -1832,7 +1832,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if weixin_token or weixin_account_id:
         if Platform.WEIXIN not in config.platforms:
             config.platforms[Platform.WEIXIN] = PlatformConfig()
-        config.platforms[Platform.WEIXIN].enabled = True
+            config.platforms[Platform.WEIXIN].enabled = True
         if weixin_token:
             config.platforms[Platform.WEIXIN].token = weixin_token
         extra = config.platforms[Platform.WEIXIN].extra
@@ -1874,7 +1874,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if bluebubbles_server_url and bluebubbles_password:
         if Platform.BLUEBUBBLES not in config.platforms:
             config.platforms[Platform.BLUEBUBBLES] = PlatformConfig()
-        config.platforms[Platform.BLUEBUBBLES].enabled = True
+            config.platforms[Platform.BLUEBUBBLES].enabled = True
         config.platforms[Platform.BLUEBUBBLES].extra.update({
             "server_url": bluebubbles_server_url.rstrip("/"),
             "password": bluebubbles_password,
@@ -1914,7 +1914,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if qq_app_id or qq_client_secret:
         if Platform.QQBOT not in config.platforms:
             config.platforms[Platform.QQBOT] = PlatformConfig()
-        config.platforms[Platform.QQBOT].enabled = True
+            config.platforms[Platform.QQBOT].enabled = True
         extra = config.platforms[Platform.QQBOT].extra
         if qq_app_id:
             extra["app_id"] = qq_app_id
@@ -1956,7 +1956,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if yuanbao_app_id and yuanbao_app_secret:
         if Platform.YUANBAO not in config.platforms:
             config.platforms[Platform.YUANBAO] = PlatformConfig()
-        config.platforms[Platform.YUANBAO].enabled = True
+            config.platforms[Platform.YUANBAO].enabled = True
         extra = config.platforms[Platform.YUANBAO].extra
         extra["app_id"] = yuanbao_app_id
         extra["app_secret"] = yuanbao_app_secret

--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -910,7 +910,10 @@ class DingTalkAdapter(BasePlatformAdapter):
                 # the card path.
                 if is_final_reply:
                     self._fire_done_reaction(chat_id)
-                return SendResult(success=True, message_id=uuid.uuid4().hex[:12])
+                # Card SDK not available — return the __no_edit__ sentinel so
+                # stream_consumer doesn't try to call edit_message (which would
+                # crash on self._card_sdk.streaming_update_with_options_async).
+                return SendResult(success=True, message_id="__no_edit__")
             body = resp.text
             logger.warning(
                 "[%s] Send failed HTTP %d: %s", self.name, resp.status_code, body[:200]
@@ -929,6 +932,53 @@ class DingTalkAdapter(BasePlatformAdapter):
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """DingTalk does not support typing indicators."""
         pass
+
+    # -- Clarify (button-style interaction prompts) --------------------------
+
+    async def send_clarify(
+        self,
+        chat_id: str,
+        question: str,
+        choices: Optional[list],
+        clarify_id: str,
+        session_key: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Render clarify prompts with button-style formatting for DingTalk.
+
+        DingTalk doesn't have native inline keyboard buttons like Telegram,
+        so we render choices as emoji-pill buttons in markdown — rich enough
+        to feel interactive while still working through the session webhook.
+
+        Multiple choice: emoji-numbered button pills + reply instruction.
+        Open-ended: plain question text (gateway text-intercept resolves it).
+        """
+        from tools.clarify_gateway import mark_awaiting_text
+
+        if choices:
+            # --- Multiple choice: emoji button pills ---
+            lines = [f"❓ **{question}**", ""]
+            for i, choice in enumerate(choices, start=1):
+                emoji = ["1️⃣", "2️⃣", "3️⃣", "4️⃣"][i - 1]
+                lines.append(f"> {emoji}  **{choice}**")
+                if i < len(choices):
+                    lines.append("")  # spacing between options
+            lines.append("")
+            lines.append("---")
+            lines.append("💬 回复 **数字** 或 **选项文本**，也可输入其他答案")
+            text = "\n".join(lines)
+
+            # Enable text-capture so the gateway picks up the reply
+            mark_awaiting_text(clarify_id)
+        else:
+            # --- Open-ended ---
+            text = f"❓ **{question}**\n\n💬 请在下方回复"
+
+        return await self.send(
+            chat_id=chat_id,
+            content=text,
+            metadata=metadata,
+        )
 
     async def send_image(
         self,
@@ -1151,6 +1201,11 @@ class DingTalkAdapter(BasePlatformAdapter):
         """
         if not message_id:
             return SendResult(success=False, error="message_id required")
+        if not self._card_sdk:
+            return SendResult(
+                success=False,
+                error="AI Card not configured — install alibabacloud_dingtalk and set card_template_id in config.yaml",
+            )
         token = await self._get_access_token()
         if not token:
             return SendResult(success=False, error="No access token")

--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -299,14 +299,35 @@ class DingTalkAdapter(BasePlatformAdapter):
             return False
 
     async def _run_stream(self) -> None:
-        """Run the async stream client with auto-reconnection."""
+        """Run the async stream client with auto-reconnection.
+
+        The dingtalk-stream SDK's ``start()`` loops internally with its own
+        reconnect backoff, but it only handles explicit
+        ``ConnectionClosedError``.  When the underlying TCP connection drops
+        silently (proxy timeout / RST without close-frame), the websockets
+        ``async for`` iterator may hang forever — no exception, no return.
+        We guard against that with a generous timeout so we always recover.
+        """
         backoff_idx = 0
+        STREAM_START_TIMEOUT = 300  # 5 min — a healthy stream gets messages far more often
         while self._running:
             try:
                 logger.debug("[%s] Starting stream client...", self.name)
-                await self._stream_client.start()
+                await asyncio.wait_for(
+                    self._stream_client.start(),
+                    timeout=STREAM_START_TIMEOUT,
+                )
             except asyncio.CancelledError:
                 return
+            except asyncio.TimeoutError:
+                if not self._running:
+                    return
+                logger.warning(
+                    "[%s] Stream client timed out after %ds — WebSocket may have silently "
+                    "disconnected; will reconnect",
+                    self.name,
+                    STREAM_START_TIMEOUT,
+                )
             except Exception as e:
                 if not self._running:
                     return


### PR DESCRIPTION
## Summary

Three independent improvements to the gateway and DingTalk platform,
all motivated by issues observed in our production deployment:

1. **DingTalk silent WebSocket hang fix** — guards the stream client's
   `start()` with a 5-minute `asyncio.wait_for` so the reconnection
   loop always recovers when the underlying TCP connection drops
   without a close-frame.
2. **8-platform config force-enable fix** — auto-detection of platform
   env vars no longer overrides `enabled: false` set in `config.yaml`.
   Affects DingTalk, Feishu, WeCom, WeCom Callback, Weixin,
   BlueBubbles, QQBot, Yuanbao.
3. **DingTalk clarify emoji-pill rendering** —
   `DingTalkAdapter.send_clarify()` renders multiple-choice prompts
   as emoji-numbered pills since DingTalk lacks native inline
   keyboard buttons.

## What changed

### 1. `fix(dingtalk): prevent silent WebSocket hang on TCP disconnect`

The `dingtalk-stream` SDK's `start()` only catches explicit
`ConnectionClosedError`. When the underlying TCP connection drops
silently (proxy timeout / RST without close-frame), the `websockets`
library's `async for` iterator may hang forever — no exception, no
return — and the gateway never reconnects.

Reproed in production: a gateway process showed `connected` in state
but had zero TCP connections to DingTalk servers and zero log
activity for 3+ hours.

Wraps `await self._stream_client.start()` in
`asyncio.wait_for(timeout=300)` and handles `asyncio.TimeoutError`
explicitly so the reconnection loop always recovers within 5 minutes.

### 2. `fix(config): don't force-enable platforms when user explicitly disables them`

The auto-detection code in `_apply_env_overrides()` (`DINGTALK_CLIENT_ID`,
`FEISHU_APP_ID`, etc.) would unconditionally set `enabled=True` even
when `config.yaml` had `enabled: false`. This caused platform
"leakage" when running multiple isolated gateway processes from the
same machine — env vars inherited from a parent process would
silently re-enable platforms the user had explicitly disabled.

`enabled=True` is now only set when the platform entry is newly
created by auto-detection. Platforms already present in `config.yaml`
keep their original `enabled` flag.

### 3. `feat(dingtalk): clarify emoji-pill rendering + AI Card SDK fallback`

`DingTalkAdapter.send_clarify()` overrides the base implementation to
render multiple-choice prompts as emoji-numbered button pills:

```
❓ **Pick a backup target**

> 1️⃣  **Backup A**
>
> 2️⃣  **Backup B**
>
> 3️⃣  **Backup C**

---
💬 回复 **数字** 或 **选项文本**，也可输入其他答案
```

Also adds a guard in `edit_message()` to return a descriptive error
when the AI Card SDK is not configured (previously the missing
`self._card_sdk.streaming_update_with_options_async` would crash),
and returns the `__no_edit__` sentinel from `send()` when the card
path is not available so `stream_consumer` skips `edit_message()`
cleanly.

## Testing

- (1) replayed the silent-disconnect scenario in a test environment by
  killing the TCP connection without a close-frame; confirmed the
  stream recovered within 5 minutes instead of hanging indefinitely.
- (2) verified all 8 platforms: with `enabled: false` in `config.yaml`
  and corresponding env vars set, platforms now stay disabled.
- (3) live-tested on a DingTalk bot: emoji pills render correctly;
  numeric and free-form replies both accepted.

## Diff

```
 gateway/config.py             | 16 ++++-----
 gateway/platforms/dingtalk.py | 82 +++++++++++++++++++++++++++++++++++++++++--
 2 files changed, 87 insertions(+), 11 deletions(-)
```

Commits (newest first):
- `a0f379530` fix(config): don't force-enable platforms when user explicitly disables them
- `88e85c41a` fix(dingtalk): prevent silent WebSocket hang on TCP disconnect
- `3fc15afb0` feat(dingtalk): clarify emoji-pill rendering + AI Card SDK fallback
