### PR TITLE
fix(computer-use): reconnect MCP session on stale empty result (#51164)

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1449,6 +1449,73 @@ class TestCuaDriverSessionReconnect:
         assert bridge.calls[1][0] == ("call", "list_apps", {})
         assert len(bridge.calls) == 2
 
+    def test_call_tool_reconnects_on_stale_empty_result(self):
+        """When the MCP session returns a completely empty result (no data, no
+        images, no structured content, no error), the stdio transport may have
+        silently degraded.  The session should reconnect and retry once."""
+
+        class FakeBridge:
+            def __init__(self):
+                self.calls = []
+                # 1st call -> empty result; retried call -> normal result.
+                self.effects = [
+                    {"data": None, "images": [], "structuredContent": None, "isError": False},
+                    {"data": "ok", "images": [], "structuredContent": None, "isError": False},
+                ]
+
+            def run(self, value, timeout=None):
+                self.calls.append((value, timeout))
+                return self.effects.pop(0)
+
+        bridge = FakeBridge()
+        session = self._make_session(bridge)
+
+        result = session.call_tool("list_windows", {"on_screen_only": True})
+        assert result == {"data": "ok", "images": [], "structuredContent": None, "isError": False}
+        # Reconnect sequence: empty result -> stop -> start -> retried call.
+        assert session._reconnect_log == ["stop", "start"]
+        assert len(bridge.calls) == 2
+
+    def test_call_tool_does_not_reconnect_on_nonempty_result(self):
+        """Results with any content (text, images, structured, or error) must
+        NOT trigger a reconnect — only completely empty results do."""
+
+        class FakeBridge:
+            def __init__(self):
+                self.calls = []
+
+            def run(self, value, timeout=None):
+                self.calls.append((value, timeout))
+                return {"data": "some text", "images": [], "structuredContent": None, "isError": False}
+
+        bridge = FakeBridge()
+        session = self._make_session(bridge)
+
+        result = session.call_tool("list_windows", {})
+        assert result["data"] == "some text"
+        # No reconnect — the result had content.
+        assert session._reconnect_log == []
+        assert len(bridge.calls) == 1
+
+    def test_call_tool_does_not_reconnect_when_is_error(self):
+        """Error responses must NOT trigger a stale-session reconnect."""
+
+        class FakeBridge:
+            def __init__(self):
+                self.calls = []
+
+            def run(self, value, timeout=None):
+                self.calls.append((value, timeout))
+                return {"data": None, "images": [], "structuredContent": None, "isError": True}
+
+        bridge = FakeBridge()
+        session = self._make_session(bridge)
+
+        result = session.call_tool("get_window_state", {"pid": 123})
+        assert result["isError"] is True
+        assert session._reconnect_log == []
+        assert len(bridge.calls) == 1
+
     def test_call_tool_does_not_retry_on_unrelated_error(self):
         """Non-transport errors must propagate without a reconnect attempt."""
         class FakeBridge:

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -803,7 +803,7 @@ class _CuaDriverSession:
     def call_tool(self, name: str, args: Dict[str, Any], timeout: float = 30.0) -> Dict[str, Any]:
         self._require_started()
         try:
-            return self._bridge.run(self._call_tool_async(name, args), timeout=timeout)
+            result = self._bridge.run(self._call_tool_async(name, args), timeout=timeout)
         except Exception as e:
             if not self._is_closed_session_error(e):
                 raise
@@ -814,6 +814,24 @@ class _CuaDriverSession:
             with self._lock:
                 self._restart_session_locked()
             return self._bridge.run(self._call_tool_async(name, args), timeout=timeout)
+
+        # Detect stale session: if the call returned no data at all (no text, no
+        # images, no structured content, no error), the stdio transport may have
+        # silently degraded.  Reconnect and retry once — same budget as the
+        # closed-session path above.
+        if (result.get("data") is None
+                and not result.get("images")
+                and result.get("structuredContent") is None
+                and not result.get("isError")):
+            logger.warning(
+                "cua-driver %s returned empty result (possible stale session); "
+                "reconnecting and retrying", name,
+            )
+            with self._lock:
+                self._restart_session_locked()
+            return self._bridge.run(self._call_tool_async(name, args), timeout=timeout)
+
+        return result
 
 
 def _extract_tool_result(mcp_result: Any) -> Dict[str, Any]:


### PR DESCRIPTION
## What does this PR do?

Adds stale-session detection to `_CuaDriverSession.call_tool`: when the MCP session returns a completely empty result (no text, images, structured content, or error), the session reconnects and retries once — matching the existing closed-session recovery budget.

## Related Issue

Fixes #51164

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/computer_use/cua_backend.py`: After a successful `call_tool` return, check if the result is completely empty (`data=None`, no images, no structuredContent, no error). If so, call `_restart_session_locked()` and retry once. This handles the case where the stdio transport silently degrades between tool calls without raising `ClosedResourceError` or similar exceptions.
- `tests/tools/test_computer_use.py`: Added 3 new tests to `TestCuaDriverSessionReconnect`:
  - `test_call_tool_reconnects_on_stale_empty_result`: verifies empty result triggers reconnect+retry
  - `test_call_tool_does_not_reconnect_on_nonempty_result`: verifies non-empty results pass through
  - `test_call_tool_does_not_reconnect_when_is_error`: verifies error responses are not treated as stale

## How to Test

1. Run `python -m pytest tests/tools/test_computer_use.py::TestCuaDriverSessionReconnect -x -v`
2. Observed result: `5 passed in 0.30s` — including the 3 new stale-session tests
3. Run `python -m pytest tests/tools/test_computer_use.py -x -q` for full regression
4. Observed result: `170 passed, 1 warning in 6.97s`

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.5
