### PR TITLE
fix: fall through to standalone on cron live-adapter timeout (#51184)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -967,23 +967,26 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                         try:
                             send_result = future.result(timeout=60)
                         except TimeoutError:
-                            # #38922: a slow confirmation does NOT necessarily
-                            # mean the send failed — but we must distinguish two
-                            # cases via future.cancel()'s return value:
-                            #
-                            #   cancel() == False -> the coroutine was already
-                            #     running on the gateway loop when the timeout
-                            #     fired; the request is in flight on the wire and
-                            #     cannot be un-sent.  Re-sending via standalone
-                            #     would be a guaranteed DUPLICATE, so treat it as
-                            #     delivered (assume-delivered).
+                            # #38922 / #51184: a slow confirmation does NOT
+                            # necessarily mean the send failed — but we can no
+                            # longer distinguish "in flight on the wire" from
+                            # "stuck at an await before the HTTP call" based on
+                            # future.cancel()'s return value alone:
                             #
                             #   cancel() == True -> the scheduled callback never
                             #     started executing (loop wedged/backlogged for
-                            #     the full 60s), so nothing was sent.  We MUST
-                            #     fall through to the standalone path or the
-                            #     message is silently dropped (worse than a
-                            #     duplicate).
+                            #     the full 60s), so nothing was sent.  Fall
+                            #     through to standalone.
+                            #
+                            #   cancel() == False -> the coroutine was scheduled
+                            #     on the event loop, but cancel() returning
+                            #     False does NOT confirm the HTTP request was
+                            #     sent.  When the event loop is congested, the
+                            #     coroutine can be stuck at an await before the
+                            #     aiohttp call — nothing hit the wire (#51184).
+                            #     Always fall through to standalone: a possible
+                            #     duplicate is strictly better than silent
+                            #     non-delivery for cron jobs.
                             cancelled = future.cancel()
                             if cancelled:
                                 msg = (
@@ -998,15 +1001,30 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                                 adapter_ok = False  # fall through to standalone path
                                 timeout_handled = True
                             else:
-                                timed_out = True
-                                timeout_handled = True
-                                logger.warning(
-                                    "Job '%s': live adapter send to %s:%s timed out "
-                                    "after 60s; already dispatched (in flight), "
-                                    "assuming delivered (skipping standalone fallback "
-                                    "to avoid duplicate)",
-                                    job["id"], platform_name, chat_id,
+                                # #51184: cancel() == False only means the
+                                # coroutine was *scheduled* on the event loop,
+                                # NOT that the HTTP request was actually sent.
+                                # When the gateway event loop is congested, the
+                                # coroutine can be stuck at an await before the
+                                # aiohttp call — nothing hit the wire.  The old
+                                # "assume delivered" path caused false-positive
+                                # delivery reports for LINE and other adapters.
+                                # Always fall through to standalone: a possible
+                                # duplicate is strictly better than silent
+                                # non-delivery for cron jobs.
+                                msg = (
+                                    f"live adapter send to {platform_name}:{chat_id} "
+                                    "timed out after 60s; coroutine was dispatched "
+                                    "but unconfirmed — falling back to standalone "
+                                    "(possible duplicate)"
                                 )
+                                logger.warning(
+                                    "Job '%s': %s",
+                                    job["id"], msg,
+                                )
+                                target_errors.append(msg)
+                                adapter_ok = False  # fall through to standalone path
+                                timeout_handled = True
                         except Exception as ex:
                             # A real send error (not a slow confirmation) — fall
                             # through to the standalone path so the message is

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2795,19 +2795,25 @@ class TestParallelTick:
 
 class TestDeliverResultTimeoutCancelsFuture:
     """When future.result(timeout=60) raises TimeoutError in the live adapter
-    delivery path, the outcome depends on whether the coroutine was already
-    running.  future.cancel() returning False means it is in flight on the wire
-    (cannot be un-sent) → treat as DELIVERED and skip the standalone fallback to
-    avoid a duplicate (#38922).  future.cancel() returning True means it never
-    started (wedged loop) → nothing was sent, so fall through to standalone or
-    the message is silently dropped.  Regression for #38922.
+    delivery path, both outcomes (cancel True or False) now fall through to
+    standalone delivery.  cancel() == True means the coroutine never started
+    (wedged loop) — nothing was sent.  cancel() == False means the coroutine
+    was scheduled on the event loop but we cannot confirm the HTTP request
+    was actually sent — the coroutine may be stuck at an await before the
+    aiohttp call when the event loop is congested (#51184).  A possible
+    duplicate from standalone fallback is strictly better than silent
+    non-delivery for cron jobs.
     """
 
-    def test_live_adapter_timeout_assumes_delivered_no_duplicate(self):
-        """End-to-end: live adapter confirmation times out past the 60s budget.
-        The fix (#38922) treats the send as already-dispatched/delivered and
-        does NOT run the standalone fallback — otherwise the message is sent
-        twice."""
+    def test_live_adapter_timeout_cancel_false_falls_back_to_standalone(self):
+        """End-to-end: live adapter confirmation times out past the 60s budget
+        and future.cancel() returns False (coroutine was picked up by the
+        event loop).  cancel() == False does NOT mean the HTTP request was
+        actually sent — the coroutine may be stuck at an await before the
+        aiohttp call when the event loop is congested (#51184).  Treating
+        this as assume-delivered caused false-positive delivery reports.
+        Fix: always fall through to standalone on timeout, accepting
+        possible duplicate delivery as the lesser evil vs silent loss."""
         from gateway.config import Platform
         from concurrent.futures import Future
 
@@ -2863,11 +2869,12 @@ class TestDeliverResultTimeoutCancelsFuture:
 
         # 1. cancel() was attempted (returned False = in flight).
         assert cancel_calls == [True], "future.cancel() should be attempted on TimeoutError"
-        # 2. Delivery is reported successful (no error string returned).
+        # 2. The standalone fallback MUST run — we cannot distinguish
+        #    "in-flight on the wire" from "stuck at an await before the
+        #    HTTP call" when cancel() returns False (#51184).
+        standalone_send.assert_awaited_once()
+        # 3. Delivery is reported successful (standalone delivered it).
         assert result is None, f"expected successful delivery, got error: {result!r}"
-        # 3. The standalone fallback must NOT run — that is the #38922 fix:
-        #    an in-flight confirmation timeout is assume-delivered, not a resend.
-        standalone_send.assert_not_awaited()
 
     def test_live_adapter_timeout_before_dispatch_falls_back_to_standalone(self):
         """When the coroutine never started (loop wedged) — future.cancel()


### PR DESCRIPTION
## Summary

When `future.cancel()` returns `False` after the 60s timeout in the cron live-adapter delivery path, the old code assumed the HTTP request was "in-flight on the wire" and skipped the standalone fallback to avoid duplicates. But `cancel() == False` only confirms the coroutine was **scheduled** on the event loop — it does not confirm `aiohttp.ClientSession.post()` was actually invoked. On a congested event loop the coroutine can be stuck at an `await` before the HTTP call, causing false-positive delivery reports.

## Why

Both timeout branches now fall through to standalone delivery. A possible duplicate is strictly better than silent non-delivery for cron jobs.

## Relation to #41007

This PR takes the **opposite** approach to #41007 (which is still open). #41007 proposes the same `TimeoutError` catch but sets `delivered = True` to skip standalone — assuming the message was already sent to avoid duplicates.

Both fixes address the same code path but prioritize differently:

| | Assumes delivered (#41007) | Falls through to standalone (this PR) |
|---|---|---|
| **Prevents** | Duplicates | Silent non-delivery |
| **Risk** | False-positive reports on congested loops | Possible duplicate message |

I believe silent loss is the worse outcome for cron jobs — users set up scheduled tasks expecting delivery, and a false-positive success log with no message is harder to debug than a duplicate. But this is a deliberate trade-off choice and I'm happy to go the other direction if maintainers prefer #41007's semantics.

## Changes

- **`cron/scheduler.py`** — `cancel() == False` branch now sets `adapter_ok = False` and logs a clear warning instead of assuming delivery
- **`tests/cron/test_scheduler.py`** — Updated existing test to assert standalone fallback runs; updated class docstring

## Test Plan

- [x] `TestDeliverResultTimeoutCancelsFuture` — all 6 tests pass
- [x] All 72 delivery-related tests pass
- [x] Pre-existing failures confirmed unrelated (Python compat, file permission tests)

## Risk

Low. The only behavioral change is: a timeout with `cancel() == False` now falls through to standalone instead of assuming delivery. Worst case = duplicate message. Better than silent non-delivery.

Closes #51184
