### PR TITLE
fix: replace remaining 10 assert statements with explicit guards

### DIFF
--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -396,7 +396,8 @@ class CodexAppServerSession:
             # turn re-spawns cleanly.
             result.should_retire = True
             return result
-        assert self._client is not None and self._thread_id is not None
+        if self._client is None or self._thread_id is None:
+            raise RuntimeError("_client and _thread_id must be initialized")
         result.thread_id = self._thread_id
 
         self._interrupt_event.clear()

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4381,7 +4381,8 @@ class APIServerAdapter(BasePlatformAdapter):
         try:
             mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
             self._app = web.Application(middlewares=mws, client_max_size=MAX_REQUEST_BYTES)
-            assert self._app is not None
+            if self._app is None:
+                raise RuntimeError("_app not initialized")
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/health/detailed", self._handle_health_detailed)
             self._app.router.add_get("/v1/health", self._handle_health)

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -217,13 +217,15 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         return text
 
     async def _api_get(self, path: str) -> Dict[str, Any]:
-        assert self.client is not None
+        if self.client is None:
+            raise RuntimeError("client not initialized")
         res = await self.client.get(self._api_url(path))
         res.raise_for_status()
         return res.json()
 
     async def _api_post(self, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
-        assert self.client is not None
+        if self.client is None:
+            raise RuntimeError("client not initialized for _listen")
         res = await self.client.post(self._api_url(path), json=payload)
         res.raise_for_status()
         return res.json()

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -326,7 +326,8 @@ class WebSocketRelayTransport:
         await self._ws.send(json.dumps(frame) + "\n")
 
     async def _read_loop(self) -> None:
-        assert self._ws is not None
+        if self._ws is None:
+            raise RuntimeError("websocket not initialized")
         buf = ""
         try:
             async for chunk in self._ws:

--- a/plugins/google_meet/realtime/openai_client.py
+++ b/plugins/google_meet/realtime/openai_client.py
@@ -221,12 +221,14 @@ class RealtimeSession:
             return False
 
     def _send_json(self, payload: dict) -> None:
-        assert self._ws is not None
+        if self._ws is None:
+            raise RuntimeError("websocket not initialized")
         with self._send_lock:
             self._ws.send(json.dumps(payload))
 
     def _recv(self, timeout: Optional[float] = None):
-        assert self._ws is not None
+        if self._ws is None:
+            raise RuntimeError("websocket not initialized")
         try:
             if timeout is None:
                 return self._ws.recv()

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -107,7 +107,8 @@ async def _cdp_call(
     works for ``Target.*``, ``Browser.*``, ``Storage.*`` and a few other
     globally-scoped domains.
     """
-    assert websockets is not None  # guarded by _WS_AVAILABLE at call-site
+    if websockets is None:
+        raise RuntimeError("websockets not available — install websockets package")
 
     async with websockets.connect(
         ws_url,

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -810,7 +810,8 @@ class CDPSupervisor:
 
     async def _read_loop(self) -> None:
         """Continuously dispatch incoming CDP frames."""
-        assert self._ws is not None
+        if self._ws is None:
+            raise RuntimeError("websocket not initialized")
         try:
             async for raw in self._ws:
                 if self._stop_requested:

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -944,7 +944,8 @@ class DockerEnvironment(BaseEnvironment):
                   timeout: int = 120,
                   stdin_data: str | None = None) -> subprocess.Popen:
         """Spawn a bash process inside the Docker container."""
-        assert self._container_id, "Container not started"
+        if not self._container_id:
+            raise RuntimeError("Container not started")
         cmd = [self._docker_exe, "exec"]
         if stdin_data is not None:
             cmd.append("-i")


### PR DESCRIPTION
## Summary

Replace 10 bare `assert` statements with `if`/`raise` across 8 files.

`assert` is stripped when Python runs with `-O` flag, silently removing these checks.

### Files fixed

| File | Asserts | Variable |
|------|---------|----------|
| `tools/browser_cdp_tool.py` | 1 | `websockets` |
| `tools/environments/docker.py` | 1 | `_container_id` |
| `tools/browser_supervisor.py` | 1 | `_ws` |
| `agent/transports/codex_app_server_session.py` | 1 | `_client`, `_thread_id` |
| `gateway/platforms/api_server.py` | 1 | `_app` |
| `gateway/platforms/bluebubbles.py` | 2 | `client` |
| `gateway/relay/ws_transport.py` | 1 | `_ws` |
| `plugins/google_meet/realtime/openai_client.py` | 2 | `_ws` |

## Test plan
- [x] `python3 -m py_compile` passes for all 8 files
- [x] All 10 asserts replaced with equivalent guard clauses