### PR TITLE
fix(gateway): add TTL to process-wide model cache to prevent fallback stickiness (#51188)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2579,6 +2579,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # silent until the user manually re-sends. See #35314. ``"*"`` holds a
         # process-wide last-known-good for sessions seen for the first time.
         self._last_resolved_model: Dict[str, str] = {}
+        self._last_resolved_model_ts: Dict[str, float] = {}
         # Overflow buffer for explicit /queue commands.  The adapter-level
         # _pending_messages dict is a single slot per session (designed for
         # "next-turn" follow-ups where repeated sends collapse into one
@@ -3396,9 +3397,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # session goes silent until the user manually re-sends. ``getattr``
         # guards against bare test runners built via ``object.__new__``.
         _last_good = getattr(self, "_last_resolved_model", None)
+        _last_good_ts = getattr(self, "_last_resolved_model_ts", None)
         if _last_good is not None:
             if not model:
-                _recovered = _last_good.get(resolved_session_key or "") or _last_good.get("*")
+                _recovered = _last_good.get(resolved_session_key or "")
+                # Per-session entry has no TTL — it's session-scoped and
+                # safe.  Only fall through to the process-wide "*" slot if
+                # the per-session lookup came back empty.
+                if not _recovered:
+                    _global = _last_good.get("*")
+                    if _global:
+                        _ts = (_last_good_ts or {}).get("*", 0)
+                        if time.time() - _ts > 300:
+                            # Stale process-wide cache (>5 min).  Clear it
+                            # so the next successful resolution repopulates
+                            # with the current config rather than carrying a
+                            # fallback model indefinitely (#51188).
+                            _last_good.pop("*", None)
+                            if _last_good_ts:
+                                _last_good_ts.pop("*", None)
+                        else:
+                            _recovered = _global
                 if _recovered:
                     logger.warning(
                         "Empty model resolved for session=%s — recovering "
@@ -3412,6 +3431,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if resolved_session_key:
                     _last_good[resolved_session_key] = model
                 _last_good["*"] = model
+                if _last_good_ts is not None:
+                    _last_good_ts["*"] = time.time()
 
         return model, runtime_kwargs
 

--- a/tests/gateway/test_empty_model_recovery.py
+++ b/tests/gateway/test_empty_model_recovery.py
@@ -22,6 +22,7 @@ def _make_runner():
     runner = object.__new__(gateway_run.GatewayRunner)
     runner._session_model_overrides = {}
     runner._last_resolved_model = {}
+    runner._last_resolved_model_ts = {}
     runner._service_tier = None
     runner._agent_cache = {}
     runner._agent_cache_lock = threading.Lock()
@@ -54,6 +55,8 @@ def test_normal_turn_caches_last_resolved_model(monkeypatch):
     # Cached per-session AND process-wide for first-seen-session recovery.
     assert runner._last_resolved_model[sk] == "deepseek/deepseek-v4-flash"
     assert runner._last_resolved_model["*"] == "deepseek/deepseek-v4-flash"
+    # Timestamp recorded for the process-wide slot.
+    assert runner._last_resolved_model_ts["*"] > 0
 
 
 def test_empty_model_recovers_session_last_good(monkeypatch):
@@ -81,6 +84,47 @@ def test_empty_model_new_session_recovers_global_last_good(monkeypatch):
     # A brand-new session that hits an empty config read still recovers via "*".
     _patch_resolution(monkeypatch, model_from_config="", provider="")
     model, _ = runner._resolve_session_agent_runtime(session_key="agent:main:discord:dm:999", user_config={})
+
+    assert model == "deepseek/deepseek-v4-flash"
+
+
+def test_stale_global_cache_not_used_for_recovery(monkeypatch):
+    """Process-wide "*" entry older than 5 minutes must NOT be used (#51188).
+
+    When a fallback model succeeds and is cached as "*", it should expire so
+    the next successful config resolution repopulates with the current primary
+    model instead of carrying the fallback indefinitely.
+    """
+    import time
+
+    runner = _make_runner()
+
+    # Simulate a stale "*" entry: model cached 10 minutes ago.
+    runner._last_resolved_model["*"] = "glm-5.2"
+    runner._last_resolved_model_ts["*"] = time.time() - 600
+
+    # Empty config read — should NOT recover the stale "*".
+    _patch_resolution(monkeypatch, model_from_config="", provider="")
+    model, _ = runner._resolve_session_agent_runtime(session_key="agent:main:discord:dm:1", user_config={})
+
+    assert model == "", "stale global cache (>5 min) must not be used for recovery"
+    # Stale entry should have been cleared.
+    assert "*" not in runner._last_resolved_model
+
+
+def test_fresh_global_cache_used_for_recovery(monkeypatch):
+    """Process-wide "*" entry within 5-minute TTL IS used for recovery."""
+    import time
+
+    runner = _make_runner()
+
+    # Simulate a fresh "*" entry: model cached 1 minute ago.
+    runner._last_resolved_model["*"] = "deepseek/deepseek-v4-flash"
+    runner._last_resolved_model_ts["*"] = time.time() - 60
+
+    # Empty config read — should recover via fresh "*".
+    _patch_resolution(monkeypatch, model_from_config="", provider="")
+    model, _ = runner._resolve_session_agent_runtime(session_key="agent:main:discord:dm:1", user_config={})
 
     assert model == "deepseek/deepseek-v4-flash"
 


### PR DESCRIPTION
## What does this PR do?

Adds a 5-minute TTL to the process-wide `_last_resolved_model["*"]` cache in `gateway/run.py` to prevent fallback models from persisting indefinitely across new sessions.

## Related Issue

Fixes #51188

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: Added `_last_resolved_model_ts` dict to track timestamps for the process-wide `"*"` cache entry. When recovering from `"*"`, checks if the entry is older than 5 minutes (300s) and clears it if stale. Per-session entries remain untimed (session-scoped, safe).
- `tests/gateway/test_empty_model_recovery.py`: Added `_last_resolved_model_ts` to `_make_runner()` helper. Added `test_stale_global_cache_not_used_for_recovery` and `test_fresh_global_cache_used_for_recovery` to verify TTL behavior. Updated `test_normal_turn_caches_last_resolved_model` to assert timestamp is recorded.

## How to Test

1. Run `python -m pytest tests/gateway/test_empty_model_recovery.py -x -v`
2. Observed result: `11 passed in 3.86s` — including `test_stale_global_cache_not_used_for_recovery` and `test_fresh_global_cache_used_for_recovery`

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.5
