### PR TITLE
[codex] Handle GLM reasoning and serialize cron LLM runs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -11,6 +11,7 @@ runs at a time if multiple processes overlap.
 import asyncio
 import atexit
 import concurrent.futures
+import contextlib
 import contextvars
 import json
 import logging
@@ -26,10 +27,10 @@ try:
     import fcntl
 except ImportError:
     fcntl = None
-    try:
-        import msvcrt
-    except ImportError:
-        msvcrt = None
+try:
+    import msvcrt
+except ImportError:
+    msvcrt = None
 from pathlib import Path
 from typing import List, Optional
 
@@ -38,7 +39,7 @@ from typing import List, Optional
 # the module) fail with ModuleNotFoundError for hermes_time et al.
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_default_hermes_root, get_hermes_home
 from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.config import load_config, _expand_env_vars
 from hermes_time import now as _hermes_now
@@ -320,6 +321,53 @@ def _get_lock_paths() -> tuple[Path, Path]:
     hermes_home = _get_hermes_home()
     lock_dir = hermes_home / "cron"
     return lock_dir, lock_dir / ".tick.lock"
+
+
+@contextlib.contextmanager
+def _cron_llm_run_lock(job: dict):
+    """Serialize cron LLM runs across Hermes profiles on this host.
+
+    Each profile gateway has its own process and thread pool, so per-process
+    max_parallel_jobs cannot stop simultaneous GLM calls. The lock is rooted in
+    the default Hermes home intentionally: it is a host-wide provider throttle,
+    not profile-local cron storage coordination. no_agent jobs never enter this
+    path, so script-only watchdogs keep running without model contention.
+    """
+    lock_dir = get_default_hermes_root() / "cron"
+    lock_path = lock_dir / ".llm-run.lock"
+    lock_file = None
+    try:
+        lock_dir.mkdir(parents=True, exist_ok=True)
+        lock_file = open(lock_path, "a+", encoding="utf-8")
+        logger.info(
+            "Job '%s': waiting for host-wide cron LLM lock",
+            job.get("name") or job.get("id") or "cron job",
+        )
+        if fcntl:
+            fcntl.flock(lock_file, fcntl.LOCK_EX)
+        elif msvcrt:
+            msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+        logger.info(
+            "Job '%s': acquired host-wide cron LLM lock",
+            job.get("name") or job.get("id") or "cron job",
+        )
+        yield
+    except Exception:
+        if lock_file is None:
+            logger.warning("Cron LLM lock unavailable; running without host-wide throttle", exc_info=True)
+            yield
+        else:
+            raise
+    finally:
+        if lock_file is not None:
+            try:
+                if fcntl:
+                    fcntl.flock(lock_file, fcntl.LOCK_UN)
+                elif msvcrt:
+                    msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+            except (OSError, IOError):
+                pass
+            lock_file.close()
 
 
 def _resolve_origin(job: dict) -> Optional[dict]:
@@ -2102,42 +2150,43 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             _cron_timeout = 600.0
         _cron_inactivity_limit = _cron_timeout if _cron_timeout > 0 else None
         _POLL_INTERVAL = 5.0
-        _cron_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-        # Preserve scheduler-scoped ContextVar state (for example skill-declared
-        # env passthrough registrations) when the cron run hops into the worker
-        # thread used for inactivity timeout monitoring.
-        _cron_context = contextvars.copy_context()
-        _cron_future = _cron_pool.submit(_cron_context.run, agent.run_conversation, prompt)
-        _inactivity_timeout = False
-        try:
-            if _cron_inactivity_limit is None:
-                # Unlimited — just wait for the result.
-                result = _cron_future.result()
-            else:
-                result = None
-                while True:
-                    done, _ = concurrent.futures.wait(
-                        {_cron_future}, timeout=_POLL_INTERVAL,
-                    )
-                    if done:
-                        result = _cron_future.result()
-                        break
-                    # Agent still running — check inactivity.
-                    _idle_secs = 0.0
-                    if hasattr(agent, "get_activity_summary"):
-                        try:
-                            _act = agent.get_activity_summary()
-                            _idle_secs = _act.get("seconds_since_activity", 0.0)
-                        except Exception:
-                            pass
-                    if _idle_secs >= _cron_inactivity_limit:
-                        _inactivity_timeout = True
-                        break
-        except Exception:
-            _cron_pool.shutdown(wait=False, cancel_futures=True)
-            raise
-        finally:
-            _cron_pool.shutdown(wait=False, cancel_futures=True)
+        with _cron_llm_run_lock(job):
+            _cron_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+            # Preserve scheduler-scoped ContextVar state (for example skill-declared
+            # env passthrough registrations) when the cron run hops into the worker
+            # thread used for inactivity timeout monitoring.
+            _cron_context = contextvars.copy_context()
+            _cron_future = _cron_pool.submit(_cron_context.run, agent.run_conversation, prompt)
+            _inactivity_timeout = False
+            try:
+                if _cron_inactivity_limit is None:
+                    # Unlimited — just wait for the result.
+                    result = _cron_future.result()
+                else:
+                    result = None
+                    while True:
+                        done, _ = concurrent.futures.wait(
+                            {_cron_future}, timeout=_POLL_INTERVAL,
+                        )
+                        if done:
+                            result = _cron_future.result()
+                            break
+                        # Agent still running — check inactivity.
+                        _idle_secs = 0.0
+                        if hasattr(agent, "get_activity_summary"):
+                            try:
+                                _act = agent.get_activity_summary()
+                                _idle_secs = _act.get("seconds_since_activity", 0.0)
+                            except Exception:
+                                pass
+                        if _idle_secs >= _cron_inactivity_limit:
+                            _inactivity_timeout = True
+                            break
+            except Exception:
+                _cron_pool.shutdown(wait=False, cancel_futures=True)
+                raise
+            finally:
+                _cron_pool.shutdown(wait=False, cancel_futures=True)
 
         if _inactivity_timeout:
             # Build diagnostic summary from the agent's activity tracker.

--- a/plugins/model-providers/zai/__init__.py
+++ b/plugins/model-providers/zai/__init__.py
@@ -16,6 +16,7 @@ zai = ProviderProfile(
         "glm-4-9b",
     ),
     base_url="https://api.z.ai/api/paas/v4",
+    default_max_tokens=8192,
     default_aux_model="glm-4.5-flash",
 )
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -4986,9 +4986,10 @@ class AIAgent:
     def _needs_thinking_reasoning_pad(self) -> bool:
         """Return True when the active provider enforces reasoning_content echo-back.
 
-        DeepSeek v4 thinking and Kimi / Moonshot thinking both reject replays
+        DeepSeek v4 thinking, Kimi / Moonshot thinking, Xiaomi MiMo thinking,
+        and native Z.AI / GLM reasoning models reject or destabilize replays
         of assistant tool-call messages that omit ``reasoning_content`` (refs
-        #15250, #17400). Xiaomi MiMo thinking mode has the same requirement.
+        #15250, #17400).
 
         Result cached on the AIAgent instance keyed by (provider, model,
         base_url); invalidated whenever ``switch_model()`` /
@@ -5006,9 +5007,26 @@ class AIAgent:
             self._needs_deepseek_tool_reasoning()
             or self._needs_kimi_tool_reasoning()
             or self._needs_mimo_tool_reasoning()
+            or self._needs_glm_tool_reasoning()
         )
         self._thinking_pad_cache = (key, result)
         return result
+
+    def _needs_glm_tool_reasoning(self) -> bool:
+        """Return True when the current provider is native Z.AI / GLM.
+
+        GLM reasoning/tool-call turns need ``reasoning_content`` echoed on
+        replay, like DeepSeek/Kimi/MiMo. Z.AI may surface missing echo-back as
+        overloaded/rate-limit style errors instead of a clean schema error, so
+        keep this detection provider/host-driven and do not apply it to
+        aggregators that merely expose ``z-ai/glm-*`` model names.
+        """
+        provider = (self.provider or "").lower()
+        return (
+            provider in {"zai", "glm", "z-ai", "z.ai", "zhipu"}
+            or base_url_host_matches(self.base_url, "api.z.ai")
+            or base_url_host_matches(self.base_url, "open.bigmodel.cn")
+        )
 
     def _needs_kimi_tool_reasoning(self) -> bool:
         """Return True when the current provider is Kimi / Moonshot thinking mode.

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2040,6 +2040,44 @@ class TestRunJobModelResolution:
 
 
 class TestRunJobSkillBacked:
+    def test_run_job_wraps_agent_call_with_host_wide_llm_lock(self, tmp_path):
+        job = {
+            "id": "llm-lock-job",
+            "name": "LLM lock job",
+            "prompt": "Summarize this.",
+        }
+
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls, \
+             patch("cron.scheduler._cron_llm_run_lock") as mock_lock:
+            mock_lock.return_value.__enter__.return_value = None
+            mock_lock.return_value.__exit__.return_value = None
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+        mock_lock.assert_called_once_with(job)
+        mock_agent.run_conversation.assert_called_once()
+
     def test_run_job_preserves_skill_env_passthrough_into_worker_thread(self, tmp_path):
         job = {
             "id": "skill-env-job",

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -435,6 +435,12 @@ class TestNousProfile:
         assert "reasoning" not in eb
 
 
+class TestZaiProfile:
+    def test_max_tokens(self):
+        p = get_provider_profile("zai")
+        assert p.default_max_tokens == 8192
+
+
 class TestQwenProfile:
     def test_max_tokens(self):
         p = get_provider_profile("qwen-oauth")

--- a/tests/run_agent/test_deepseek_reasoning_content_echo.py
+++ b/tests/run_agent/test_deepseek_reasoning_content_echo.py
@@ -108,6 +108,38 @@ class TestNeedsDeepSeekToolReasoning:
         assert agent._needs_deepseek_tool_reasoning() is False
 
 
+class TestNeedsGlmToolReasoning:
+    """Native Z.AI / GLM reasoning endpoints require reasoning_content echo."""
+
+    @pytest.mark.parametrize("provider", ["zai", "glm", "z-ai", "z.ai", "zhipu"])
+    def test_native_provider_aliases(self, provider: str) -> None:
+        agent = _make_agent(provider=provider, model="glm-5.2")
+        assert agent._needs_glm_tool_reasoning() is True
+
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "https://api.z.ai/api/coding/paas/v4",
+            "https://open.bigmodel.cn/api/paas/v4",
+        ],
+    )
+    def test_native_hosts(self, base_url: str) -> None:
+        agent = _make_agent(provider="custom", model="glm-5.2", base_url=base_url)
+        assert agent._needs_glm_tool_reasoning() is True
+
+    def test_openrouter_glm_model_does_not_enable_native_echo(self) -> None:
+        agent = _make_agent(
+            provider="openrouter",
+            model="z-ai/glm-5.2",
+            base_url="https://openrouter.ai/api/v1",
+        )
+        assert agent._needs_glm_tool_reasoning() is False
+
+    def test_thinking_pad_includes_glm_native_provider(self) -> None:
+        agent = _make_agent(provider="zai", model="glm-5.2")
+        assert agent._needs_thinking_reasoning_pad() is True
+
+
 class TestCopyReasoningContentForApi:
     """_copy_reasoning_content_for_api pads reasoning_content for DeepSeek tool-calls."""
 


### PR DESCRIPTION
## Summary

This PR upstreams the remaining local reliability fixes from a multi-profile Hermes deployment using native Z.AI / GLM reasoning models.

- Adds native Z.AI / GLM detection to the reasoning_content replay path so GLM tool-call turns preserve the same echo-back behavior as DeepSeek/Kimi/MiMo reasoning models.
- Sets the bundled ZAI provider default max_tokens to 8192.
- Serializes cron-backed LLM runs across Hermes profiles with a host-wide lock, while leaving no_agent cron jobs unaffected.
- Adds regression coverage for GLM reasoning detection, ZAI max_tokens, and the cron LLM lock wrapper.

## Why

On a deployment with one gateway per profile, multiple due cron jobs can reach the same reasoning model provider at the same time. That can produce avoidable provider 429s. Separately, native GLM reasoning/tool-call replay needs reasoning_content echoed back; missing replay metadata can surface as provider-side failures rather than a clean schema error.

## Validation

Ran:

```bash
python -m pytest -q \
  tests/cron/test_scheduler.py::TestRunJobSessionPersistence \
  tests/cron/test_scheduler.py::TestRunJobSkillBacked::test_run_job_wraps_agent_call_with_host_wide_llm_lock \
  tests/cron/test_scheduler_provider.py \
  tests/providers/test_profile_wiring.py \
  tests/providers/test_provider_profiles.py \
  tests/run_agent/test_deepseek_reasoning_content_echo.py
```

Result: `176 passed, 3 warnings`.
