### PR TITLE
fix(gateway): honor auto TTS for text replies

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10926,14 +10926,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return False
 
         chat_id = event.source.chat_id
-        voice_mode = self._voice_mode.get(self._voice_key(event.source.platform, chat_id), "off")
+        voice_key = self._voice_key(event.source.platform, chat_id)
+        voice_mode = self._voice_mode.get(voice_key)
         is_voice_input = (event.message_type == MessageType.VOICE)
+
+        adapter = self.adapters.get(event.source.platform)
+        adapter_auto_tts = False
+        if adapter and hasattr(adapter, "_should_auto_tts_for_chat"):
+            try:
+                adapter_auto_tts = bool(adapter._should_auto_tts_for_chat(chat_id))
+            except Exception:
+                adapter_auto_tts = False
 
         should = (
             (voice_mode == "all")
             or (voice_mode == "voice_only" and is_voice_input)
+            # ``voice.auto_tts`` is synced into the adapter on gateway startup.
+            # Treat it as "voice accompanies text replies" unless a chat was
+            # explicitly turned off. The base adapter's own auto-TTS path only
+            # covers voice-input replies, so final text replies need the runner
+            # path here.
+            or (voice_mode != "off" and adapter_auto_tts)
         )
         if not should:
+            logger.debug(
+                "Auto voice reply skipped: mode=%s adapter_auto_tts=%s chat=%s platform=%s",
+                voice_mode, adapter_auto_tts, chat_id, event.source.platform.value,
+            )
             return False
 
         # Dedup: agent already called TTS tool

--- a/tests/gateway/test_auto_voice_reply_format.py
+++ b/tests/gateway/test_auto_voice_reply_format.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from gateway.config import Platform
-from gateway.platforms.base import MessageEvent
+from gateway.platforms.base import MessageEvent, MessageType
 from gateway.run import GatewayRunner
 from gateway.session import SessionSource
 
@@ -70,6 +70,37 @@ class TestAutoVoiceReplyFormat:
         assert requested_paths[0].endswith(".mp3")
         adapter.send_voice.assert_awaited_once()
         assert adapter.send_voice.await_args.kwargs["audio_path"].endswith(".mp3")
+    def test_should_send_voice_reply_uses_global_auto_tts_adapter_default(self):
+        """voice.auto_tts=true should make normal text replies get voice too."""
+        runner = _make_runner()
+        adapter = _make_adapter(Platform.TELEGRAM)
+        adapter._should_auto_tts_for_chat = MagicMock(return_value=True)
+        runner.adapters[Platform.TELEGRAM] = adapter
+        event = _make_event(Platform.TELEGRAM, chat_id="123")
+
+        assert runner._should_send_voice_reply(event, "hello", []) is True
+        adapter._should_auto_tts_for_chat.assert_called_once_with("123")
+
+    def test_should_send_voice_reply_honors_explicit_voice_off_over_global_auto_tts(self):
+        """A chat-level /voice off remains a hard override."""
+        runner = _make_runner()
+        runner._voice_mode["telegram:123"] = "off"
+        adapter = _make_adapter(Platform.TELEGRAM)
+        adapter._should_auto_tts_for_chat = MagicMock(return_value=True)
+        runner.adapters[Platform.TELEGRAM] = adapter
+        event = _make_event(Platform.TELEGRAM, chat_id="123")
+
+        assert runner._should_send_voice_reply(event, "hello", []) is False
+
+    def test_should_send_voice_reply_voice_only_still_requires_voice_input(self):
+        runner = _make_runner()
+        runner._voice_mode["telegram:123"] = "voice_only"
+        event = _make_event(Platform.TELEGRAM, chat_id="123")
+
+        assert runner._should_send_voice_reply(event, "hello", []) is False
+
+        voice_event = _make_event(Platform.TELEGRAM, chat_id="123", message_type=MessageType.VOICE)
+        assert runner._should_send_voice_reply(voice_event, "hello", [], already_sent=True) is True
 
 
 def _make_runner() -> GatewayRunner:
@@ -87,14 +118,15 @@ def _make_adapter(platform: Platform) -> MagicMock:
     return adapter
 
 
-def _make_event(platform: Platform) -> MessageEvent:
+def _make_event(platform: Platform, chat_id: str = "123", message_type: MessageType = MessageType.TEXT) -> MessageEvent:
     return MessageEvent(
         text="trigger",
         source=SessionSource(
             platform=platform,
-            chat_id="123",
+            chat_id=chat_id,
             user_id="u1",
             user_name="User",
         ),
+        message_type=message_type,
         message_id="456",
     )


### PR DESCRIPTION
## Summary
- honor platform adapter auto-TTS defaults when deciding whether final text replies should also receive voice output
- preserve explicit per-chat /voice off as a hard override
- keep voice_only limited to voice input replies

## Validation
- ./venv/bin/python -m pytest tests/gateway/test_auto_voice_reply_format.py -q -o 'addopts='
