### PR TITLE
feat(memory): Graphnosis local memory provider + MCP catalog entry

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -38,6 +38,10 @@ _MCP_PRESETS: Dict[str, Dict[str, Any]] = {
         "command": "codex",
         "args": ["mcp-server"],
     },
+    "graphnosis": {
+        "command": "npx",
+        "args": ["-y", "@graphnosis/mcp-relay", "${HOME}/.graphnosis/mcp.sock"],
+    },
 }
 
 

--- a/optional-mcps/graphnosis/manifest.yaml
+++ b/optional-mcps/graphnosis/manifest.yaml
@@ -1,0 +1,35 @@
+manifest_version: 1
+
+name: graphnosis
+description: Local encrypted memory — recall, remember, edit, engrams, skills. Requires Graphnosis app.
+source: https://graphnosis.com/getting-started/connect-ai
+
+transport:
+  type: stdio
+  command: npx
+  args: ["-y", "@graphnosis/mcp-relay", "${HOME}/.graphnosis/mcp.sock"]
+
+auth:
+  type: none
+
+tools:
+  default_enabled:
+    - recall
+    - remind
+    - remember
+    - edit
+    - forget
+    - stats
+    - cross_search
+    - confirm_data_access
+
+post_install: |
+  Install Graphnosis from https://graphnosis.com/download and unlock your cortex.
+
+  Recommended: also enable the memory provider for auto-prefetch:
+    hermes memory setup    # select graphnosis
+
+  Optional skill (recall hygiene + consent):
+    hermes skills install https://graphnosis.com/skills/graphnosis/SKILL.md
+
+  Start a new Hermes chat session to load MCP tools.

--- a/plugins/memory/graphnosis/README.md
+++ b/plugins/memory/graphnosis/README.md
@@ -1,0 +1,65 @@
+# Graphnosis Memory Provider for Hermes Agent
+
+Local encrypted memory via the Graphnosis desktop app. No API key required.
+
+## Prerequisites
+
+1. Install [Graphnosis](https://graphnosis.com/download)
+2. Unlock your cortex (Graphnosis must be running)
+3. MCP socket at `~/.graphnosis/mcp.sock`
+
+## Quick setup
+
+```bash
+hermes memory setup          # select "graphnosis"
+hermes mcp install graphnosis  # recommended — full MCP tool surface
+hermes graphnosis status
+```
+
+Or set manually in `~/.hermes/config.yaml`:
+
+```yaml
+memory:
+  provider: graphnosis
+
+mcp_servers:
+  graphnosis:
+    command: npx
+    args: ["-y", "@graphnosis/mcp-relay", "${HOME}/.graphnosis/mcp.sock"]
+    enabled: true
+```
+
+Config file: `$HERMES_HOME/graphnosis.json`
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `socket_path` | `~/.graphnosis/mcp.sock` | MCP socket path |
+| `default_engram` | `""` | Default engram for remember |
+| `prefetch_max_tokens` | `1500` | Prefetch token budget |
+
+## Tools (memory provider)
+
+| Tool | Purpose |
+|------|---------|
+| `graphnosis_recall` | Semantic memory search |
+| `graphnosis_remember` | Save durable notes |
+| `graphnosis_stats` | Engram / capacity overview |
+
+## MCP catalog (recommended)
+
+Install for full tools: `edit`, `forget`, `cross_search`, skills, consent.
+
+```bash
+hermes mcp install graphnosis
+```
+
+Tools appear as `mcp_graphnosis_*` in Hermes sessions.
+
+## CLI
+
+```bash
+hermes graphnosis status
+hermes graphnosis test-recall "project priorities"
+```
+
+Only available when `memory.provider: graphnosis`.

--- a/plugins/memory/graphnosis/__init__.py
+++ b/plugins/memory/graphnosis/__init__.py
@@ -1,0 +1,286 @@
+"""Graphnosis memory provider — local encrypted memory via MCP socket."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import threading
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from agent.memory_provider import MemoryProvider
+from tools.registry import tool_error
+
+from .client import GraphnosisMcpClient, GraphnosisMcpError, DEFAULT_SOCKET
+
+logger = logging.getLogger(__name__)
+
+RECALL_SCHEMA = {
+    "name": "graphnosis_recall",
+    "description": (
+        "Search the user's Graphnosis encrypted memory graph. "
+        "Use before answering questions about past notes, preferences, projects, or personal context. "
+        "Strip conversational framing from the query; pass content words in the user's language."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Dense search query (3-8 content words)."},
+            "max_tokens": {
+                "type": "integer",
+                "description": "Token budget for attached context (default 1500).",
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+REMEMBER_SCHEMA = {
+    "name": "graphnosis_remember",
+    "description": (
+        "Save a durable fact, decision, or note to Graphnosis memory. "
+        "Use when the user shares something they would want remembered across sessions. "
+        "To update existing memory, use mcp_graphnosis_edit (MCP catalog) — not a second remember."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "text": {"type": "string", "description": "Content to remember (user's language)."},
+            "target_engram": {
+                "type": "string",
+                "description": "Optional engram name (e.g. 'Work decisions').",
+            },
+            "label": {"type": "string", "description": "Short label for the Sources list."},
+        },
+        "required": ["text"],
+    },
+}
+
+STATS_SCHEMA = {
+    "name": "graphnosis_stats",
+    "description": "List Graphnosis engrams and memory capacity overview.",
+    "parameters": {"type": "object", "properties": {}, "required": []},
+}
+
+
+def _load_config() -> dict:
+    from hermes_constants import get_hermes_home
+
+    config = {
+        "socket_path": DEFAULT_SOCKET,
+        "default_engram": "",
+        "prefetch_max_tokens": 1500,
+    }
+    config_path = get_hermes_home() / "graphnosis.json"
+    if config_path.exists():
+        try:
+            file_cfg = json.loads(config_path.read_text(encoding="utf-8"))
+            config.update({k: v for k, v in file_cfg.items() if v is not None and v != ""})
+        except Exception:
+            pass
+    return config
+
+
+class GraphnosisMemoryProvider(MemoryProvider):
+    """Graphnosis local memory — prefetch + recall/remember tools over MCP socket."""
+
+    def __init__(self, config: Optional[dict] = None):
+        self._config = config or _load_config()
+        self._client: Optional[GraphnosisMcpClient] = None
+        self._prefetch_result = ""
+        self._prefetch_lock = threading.Lock()
+        self._prefetch_thread: Optional[threading.Thread] = None
+
+    @property
+    def name(self) -> str:
+        return "graphnosis"
+
+    def is_available(self) -> bool:
+        path = self._config.get("socket_path", DEFAULT_SOCKET)
+        return Path(str(path)).expanduser().exists()
+
+    def get_config_schema(self):
+        return [
+            {
+                "key": "socket_path",
+                "description": "Graphnosis MCP socket path",
+                "default": DEFAULT_SOCKET,
+            },
+            {
+                "key": "default_engram",
+                "description": "Default engram for remember (optional)",
+                "default": "",
+            },
+            {
+                "key": "prefetch_max_tokens",
+                "description": "Max tokens injected via prefetch per turn",
+                "default": "1500",
+            },
+        ]
+
+    def save_config(self, values: dict, hermes_home: str) -> None:
+        config_path = Path(hermes_home) / "graphnosis.json"
+        existing = {}
+        if config_path.exists():
+            try:
+                existing = json.loads(config_path.read_text(encoding="utf-8"))
+            except Exception:
+                pass
+        existing.update(values)
+        config_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        self._config = self._config or _load_config()
+        socket_path = self._config.get("socket_path", DEFAULT_SOCKET)
+        self._client = GraphnosisMcpClient(socket_path)
+        self._session_id = session_id
+
+    def _get_client(self) -> GraphnosisMcpClient:
+        if self._client is None:
+            self.initialize(session_id="")
+        assert self._client is not None
+        return self._client
+
+    def system_prompt_block(self) -> str:
+        return (
+            "# Graphnosis Memory\n"
+            "Active — local encrypted memory on this machine. "
+            "Relevant context is prefetched each turn; use graphnosis_recall for deeper search. "
+            "For edits, forget, cross-engram search, and skills, use mcp_graphnosis_* tools "
+            "when the Graphnosis MCP catalog is installed (`hermes mcp install graphnosis`)."
+        )
+
+    @staticmethod
+    def _strip_query_framing(query: str) -> str:
+        q = query.strip()
+        q = re.sub(
+            r"^(remind me( about| of)?|what did i (say|tell you) about|do you know( if| about)?)\s+",
+            "",
+            q,
+            flags=re.IGNORECASE,
+        )
+        return q.strip() or query.strip()
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if self._prefetch_thread and self._prefetch_thread.is_alive():
+            self._prefetch_thread.join(timeout=3.0)
+        with self._prefetch_lock:
+            result = self._prefetch_result
+            self._prefetch_result = ""
+        if not result:
+            return ""
+        return f"## Graphnosis Memory\n{result}"
+
+    def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+        if not query:
+            return
+
+        def _run() -> None:
+            try:
+                client = self._get_client()
+                max_tokens = int(self._config.get("prefetch_max_tokens", 1500))
+                text = client.call_tool(
+                    "recall",
+                    {
+                        "query": self._strip_query_framing(query),
+                        "maxTokens": max_tokens,
+                        "maxNodes": 15,
+                    },
+                )
+                if text:
+                    with self._prefetch_lock:
+                        self._prefetch_result = text
+            except GraphnosisMcpError as exc:
+                logger.debug("Graphnosis prefetch failed: %s", exc)
+            except Exception as exc:
+                logger.debug("Graphnosis prefetch error: %s", exc)
+
+        self._prefetch_thread = threading.Thread(target=_run, daemon=True, name="graphnosis-prefetch")
+        self._prefetch_thread.start()
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        # Conservative v1: no automatic extraction every turn.
+        pass
+
+    def on_memory_write(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        if action != "add" or not content:
+            return
+
+        def _mirror() -> None:
+            try:
+                client = self._get_client()
+                note = f"[Hermes {target}] {content}"
+                args: Dict[str, Any] = {"text": note[:4000], "kind": "clip"}
+                default_engram = self._config.get("default_engram")
+                if default_engram:
+                    args["target_engram"] = default_engram
+                client.call_tool("remember", args)
+            except Exception as exc:
+                logger.debug("Graphnosis memory_write mirror failed: %s", exc)
+
+        threading.Thread(target=_mirror, daemon=True, name="graphnosis-mirror").start()
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return [RECALL_SCHEMA, REMEMBER_SCHEMA, STATS_SCHEMA]
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
+        try:
+            client = self._get_client()
+        except GraphnosisMcpError as exc:
+            return tool_error(str(exc))
+
+        try:
+            if tool_name == "graphnosis_recall":
+                query = args.get("query", "")
+                if not query:
+                    return tool_error("Missing required parameter: query")
+                max_tokens = int(args.get("max_tokens", self._config.get("prefetch_max_tokens", 1500)))
+                text = client.call_tool(
+                    "recall",
+                    {
+                        "query": self._strip_query_framing(query),
+                        "maxTokens": max_tokens,
+                        "maxNodes": 20,
+                    },
+                )
+                return json.dumps({"result": text or "No relevant memories found."})
+
+            if tool_name == "graphnosis_remember":
+                text = args.get("text", "")
+                if not text:
+                    return tool_error("Missing required parameter: text")
+                payload: Dict[str, Any] = {"text": text, "kind": "clip"}
+                if args.get("target_engram"):
+                    payload["target_engram"] = args["target_engram"]
+                elif self._config.get("default_engram"):
+                    payload["target_engram"] = self._config["default_engram"]
+                if args.get("label"):
+                    payload["label"] = args["label"]
+                result = client.call_tool("remember", payload)
+                return json.dumps({"result": result or "Saved to Graphnosis."})
+
+            if tool_name == "graphnosis_stats":
+                result = client.call_tool("stats", {})
+                return json.dumps({"result": result or "No stats returned."})
+
+            return tool_error(f"Unknown tool: {tool_name}")
+        except GraphnosisMcpError as exc:
+            return tool_error(str(exc))
+        except Exception as exc:
+            return tool_error(str(exc))
+
+    def shutdown(self) -> None:
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+
+def register(ctx) -> None:
+    ctx.register_memory_provider(GraphnosisMemoryProvider())

--- a/plugins/memory/graphnosis/cli.py
+++ b/plugins/memory/graphnosis/cli.py
@@ -1,0 +1,59 @@
+"""CLI helpers for the Graphnosis memory provider."""
+
+from __future__ import annotations
+
+
+def graphnosis_command(args):
+    sub = getattr(args, "graphnosis_command", None)
+    if sub == "status":
+        _cmd_status()
+    elif sub == "test-recall":
+        _cmd_test_recall(getattr(args, "query", "") or "preferences")
+    else:
+        print("Usage: hermes graphnosis <status|test-recall> [query]")
+
+
+def _cmd_status() -> None:
+    from pathlib import Path
+
+    from plugins.memory.graphnosis.client import DEFAULT_SOCKET, GraphnosisMcpClient, GraphnosisMcpError
+
+    path = Path(DEFAULT_SOCKET).expanduser()
+    print(f"Socket path: {path}")
+    if not path.exists():
+        print("Status: unavailable — socket not found.")
+        print("Install Graphnosis from https://graphnosis.com/download and unlock your cortex.")
+        return
+    try:
+        client = GraphnosisMcpClient(str(path))
+        client.connect()
+        stats = client.call_tool("stats", {})
+        client.close()
+        print("Status: connected")
+        preview = (stats or "").strip().splitlines()
+        for line in preview[:8]:
+            print(f"  {line}")
+        if len(preview) > 8:
+            print("  …")
+    except GraphnosisMcpError as exc:
+        print(f"Status: socket present but not accepting connections — {exc}")
+
+
+def _cmd_test_recall(query: str) -> None:
+    from plugins.memory.graphnosis.client import GraphnosisMcpClient, GraphnosisMcpError
+
+    try:
+        client = GraphnosisMcpClient()
+        text = client.call_tool("recall", {"query": query, "maxTokens": 800, "maxNodes": 8})
+        client.close()
+        print(text or "(no results)")
+    except GraphnosisMcpError as exc:
+        print(f"Recall failed: {exc}")
+
+
+def register_cli(subparser) -> None:
+    subs = subparser.add_subparsers(dest="graphnosis_command")
+    subs.add_parser("status", help="Check Graphnosis socket and cortex connectivity")
+    test = subs.add_parser("test-recall", help="Run a test recall query")
+    test.add_argument("query", nargs="?", default="preferences", help="Recall query")
+    subparser.set_defaults(func=graphnosis_command)

--- a/plugins/memory/graphnosis/client.py
+++ b/plugins/memory/graphnosis/client.py
@@ -1,0 +1,158 @@
+"""Minimal MCP client over Graphnosis's Unix-domain socket.
+
+Wire format matches the sidecar socket transport: newline-delimited JSON-RPC.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import socket
+import threading
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SOCKET = "~/.graphnosis/mcp.sock"
+MCP_PROTOCOL_VERSION = "2024-11-05"
+
+
+class GraphnosisMcpError(Exception):
+    """Raised when the Graphnosis MCP socket is unreachable or returns an error."""
+
+
+class GraphnosisMcpClient:
+    """Thread-safe MCP client for recall / remember / stats tool calls."""
+
+    def __init__(self, socket_path: str = DEFAULT_SOCKET):
+        self._socket_path = str(Path(socket_path).expanduser())
+        self._sock: Optional[socket.socket] = None
+        self._buf = ""
+        self._lock = threading.Lock()
+        self._req_id = 0
+        self._ready = False
+
+    @property
+    def socket_path(self) -> str:
+        return self._socket_path
+
+    @staticmethod
+    def default_socket_exists() -> bool:
+        return Path(DEFAULT_SOCKET).expanduser().exists()
+
+    def connect(self) -> None:
+        with self._lock:
+            if self._ready:
+                return
+            try:
+                sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                sock.settimeout(30.0)
+                sock.connect(self._socket_path)
+            except OSError as exc:
+                raise GraphnosisMcpError(
+                    "Graphnosis is not running or your cortex is locked. "
+                    "Open the Graphnosis app and unlock your cortex, then retry."
+                ) from exc
+            self._sock = sock
+            self._buf = ""
+            self._initialize_locked()
+            self._ready = True
+
+    def close(self) -> None:
+        with self._lock:
+            if self._sock is not None:
+                try:
+                    self._sock.close()
+                except OSError:
+                    pass
+            self._sock = None
+            self._ready = False
+            self._buf = ""
+
+    def call_tool(self, name: str, arguments: Optional[Dict[str, Any]] = None) -> str:
+        """Invoke an MCP tool and return the text content payload."""
+        with self._lock:
+            if not self._ready:
+                self.connect()
+            assert self._sock is not None
+            req_id = self._next_id_locked()
+            self._send_locked(
+                {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "method": "tools/call",
+                    "params": {"name": name, "arguments": arguments or {}},
+                }
+            )
+            result = self._read_until_id_locked(req_id)
+        return _extract_tool_text(result)
+
+    def _initialize_locked(self) -> None:
+        assert self._sock is not None
+        req_id = self._next_id_locked()
+        self._send_locked(
+            {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": MCP_PROTOCOL_VERSION,
+                    "capabilities": {},
+                    "clientInfo": {"name": "hermes-graphnosis", "version": "1.0.0"},
+                },
+            }
+        )
+        self._read_until_id_locked(req_id)
+        self._send_locked({"jsonrpc": "2.0", "method": "notifications/initialized"})
+
+    def _next_id_locked(self) -> int:
+        self._req_id += 1
+        return self._req_id
+
+    def _send_locked(self, msg: Dict[str, Any]) -> None:
+        assert self._sock is not None
+        payload = (json.dumps(msg, separators=(",", ":")) + "\n").encode("utf-8")
+        self._sock.sendall(payload)
+
+    def _read_until_id_locked(self, req_id: int) -> Dict[str, Any]:
+        assert self._sock is not None
+        while True:
+            while "\n" in self._buf:
+                line, self._buf = self._buf.split("\n", 1)
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    msg = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if msg.get("id") == req_id:
+                    if "error" in msg:
+                        err = msg["error"]
+                        message = err.get("message", str(err))
+                        raise GraphnosisMcpError(message)
+                    return msg.get("result") or {}
+            try:
+                chunk = self._sock.recv(65536)
+            except socket.timeout as exc:
+                raise GraphnosisMcpError("Graphnosis MCP request timed out") from exc
+            if not chunk:
+                raise GraphnosisMcpError("Graphnosis MCP connection closed unexpectedly")
+            self._buf += chunk.decode("utf-8", errors="replace")
+
+
+def _extract_tool_text(result: Dict[str, Any]) -> str:
+    """Normalize MCP tools/call result to plain text."""
+    if not result:
+        return ""
+    content = result.get("content")
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                parts.append(str(block.get("text", "")))
+        return "\n".join(p for p in parts if p)
+    if isinstance(result.get("text"), str):
+        return result["text"]
+    return json.dumps(result)

--- a/plugins/memory/graphnosis/plugin.yaml
+++ b/plugins/memory/graphnosis/plugin.yaml
@@ -1,0 +1,6 @@
+name: graphnosis
+version: 1.0.0
+description: "Local encrypted engram graph — recall, remember, and auto-prefetch via Graphnosis."
+hooks:
+  - prefetch
+  - on_memory_write

--- a/tests/agent/test_graphnosis_memory_provider.py
+++ b/tests/agent/test_graphnosis_memory_provider.py
@@ -1,0 +1,75 @@
+"""Tests for the Graphnosis memory provider."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+class FakeGraphnosisClient:
+    def __init__(self, *args, **kwargs):
+        self.calls = []
+
+    def connect(self):
+        return None
+
+    def close(self):
+        return None
+
+    def call_tool(self, name, arguments=None):
+        self.calls.append((name, arguments or {}))
+        if name == "recall":
+            return "Remembered: user prefers TypeScript."
+        if name == "remember":
+            return "Saved."
+        if name == "stats":
+            return "engrams: 3"
+        return ""
+
+
+@pytest.fixture
+def provider_module():
+    from plugins.memory.graphnosis import GraphnosisMemoryProvider
+
+    return GraphnosisMemoryProvider
+
+
+def test_is_available_when_socket_exists(provider_module, tmp_path):
+    sock = tmp_path / "mcp.sock"
+    sock.touch()
+    provider = provider_module({"socket_path": str(sock), "prefetch_max_tokens": 500})
+    assert provider.is_available() is True
+
+
+def test_is_available_when_socket_missing(provider_module):
+    provider = provider_module({"socket_path": "/nonexistent/mcp.sock"})
+    assert provider.is_available() is False
+
+
+def test_handle_recall_tool(provider_module):
+    provider = provider_module({"socket_path": "/tmp/mcp.sock", "prefetch_max_tokens": 500})
+    fake = FakeGraphnosisClient()
+    provider._client = fake
+    result = json.loads(provider.handle_tool_call("graphnosis_recall", {"query": "typescript preference"}))
+    assert "TypeScript" in result["result"]
+    assert fake.calls[0][0] == "recall"
+
+
+def test_handle_remember_tool(provider_module):
+    provider = provider_module({"socket_path": "/tmp/mcp.sock", "prefetch_max_tokens": 500})
+    fake = FakeGraphnosisClient()
+    provider._client = fake
+    result = json.loads(provider.handle_tool_call("graphnosis_remember", {"text": "User prefers zsh"}))
+    assert "Saved" in result["result"]
+    assert fake.calls[0][0] == "remember"
+
+
+def test_prefetch_queue(provider_module):
+    provider = provider_module({"socket_path": "/tmp/mcp.sock", "prefetch_max_tokens": 500})
+    fake = FakeGraphnosisClient()
+    provider._client = fake
+    provider.queue_prefetch("what are my preferences?")
+    if provider._prefetch_thread:
+        provider._prefetch_thread.join(timeout=2.0)
+    block = provider.prefetch("what are my preferences?")
+    assert "Graphnosis Memory" in block or block == ""

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 4
 title: "Memory Providers"
-description: "External memory provider plugins — Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory"
+description: "External memory provider plugins — Graphnosis, Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory"
 ---
 
 # Memory Providers
 
-Hermes Agent ships with 8 external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
+Hermes Agent ships with 9 external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
 
 ## Quick Start
 
@@ -22,7 +22,7 @@ Or set manually in `~/.hermes/config.yaml`:
 
 ```yaml
 memory:
-  provider: openviking   # or honcho, mem0, hindsight, holographic, retaindb, byterover, supermemory
+  provider: openviking   # or graphnosis, honcho, mem0, hindsight, holographic, retaindb, byterover, supermemory
 ```
 
 ## How It Works
@@ -587,12 +587,42 @@ hermes config set memory.provider memori
 hermes memory setup
 ```
 
+### Graphnosis
+
+Local encrypted engram graph — recall, remember, auto-prefetch. Requires the [Graphnosis](https://graphnosis.com/download) desktop app running with cortex unlocked. No API key.
+
+| | |
+|---|---|
+| **Best for** | Personal encrypted memory, cross-session recall, engram routing |
+| **Requires** | [Graphnosis](https://graphnosis.com/download) app + Node 18+ for `npx @graphnosis/mcp-relay` (MCP catalog path) |
+| **Data storage** | Local encrypted cortex on your machine |
+| **Cost** | Free (Graphnosis app) |
+
+**Tools (3):** `graphnosis_recall`, `graphnosis_remember`, `graphnosis_stats`
+
+Also install the MCP catalog for the full tool surface (`edit`, `forget`, `cross_search`, skills, consent):
+
+```bash
+hermes mcp install graphnosis
+```
+
+**Setup:**
+```bash
+hermes memory setup    # select "graphnosis"
+hermes graphnosis status
+```
+
+**Config:** `$HERMES_HOME/graphnosis.json` (`socket_path`, `default_engram`, `prefetch_max_tokens`).
+
+See [Graphnosis + Hermes integration](/user-guide/integrations/graphnosis).
+
 ---
 
 ## Provider Comparison
 
 | Provider | Storage | Cost | Tools | Dependencies | Unique Feature |
 |----------|---------|------|-------|-------------|----------------|
+| **Graphnosis** | Local | Free | 3 | Graphnosis app + `@graphnosis/mcp-relay` | Local encrypted engrams + auto-prefetch |
 | **Honcho** | Cloud | Paid | 5 | `honcho-ai` | Dialectic user modeling + session-scoped context |
 | **OpenViking** | Self-hosted | Free | 5 | `openviking` + server | Filesystem hierarchy + tiered loading |
 | **Mem0** | Cloud/Self-hosted | Free/Paid | 5 | `mem0ai` | Server-side LLM extraction + OSS mode |
@@ -608,7 +638,7 @@ hermes memory setup
 Each provider's data is isolated per [profile](/user-guide/profiles):
 
 - **Local storage providers** (Holographic, ByteRover) use `$HERMES_HOME/` paths which differ per profile
-- **Config file providers** (Honcho, Mem0, Hindsight, Supermemory) store config in `$HERMES_HOME/` so each profile has its own credentials
+- **Config file providers** (Graphnosis, Honcho, Mem0, Hindsight, Supermemory) store config in `$HERMES_HOME/` so each profile has its own credentials
 - **Cloud providers** (RetainDB) auto-derive profile-scoped project names
 - **Env var providers** (OpenViking) are configured via each profile's `.env` file
 

--- a/website/docs/user-guide/integrations/graphnosis.md
+++ b/website/docs/user-guide/integrations/graphnosis.md
@@ -1,0 +1,44 @@
+---
+title: Graphnosis
+description: Connect Hermes Agent to Graphnosis local encrypted memory
+---
+
+# Graphnosis + Hermes Agent
+
+Graphnosis gives Hermes persistent, encrypted memory on your machine — engrams, semantic recall, and optional skills.
+
+## Prerequisites
+
+- [Graphnosis](https://graphnosis.com/download) installed
+- Cortex unlocked (app running)
+
+## Recommended setup (both paths)
+
+```bash
+hermes memory setup          # select graphnosis — auto-prefetch + memory tools
+hermes mcp install graphnosis  # full MCP tools (edit, cross_search, skills)
+hermes skills install https://graphnosis.com/skills/graphnosis/SKILL.md
+```
+
+Start a new Hermes chat session after setup.
+
+## Memory provider
+
+Sets `memory.provider: graphnosis` and enables:
+
+- Automatic prefetch before each turn
+- `graphnosis_recall`, `graphnosis_remember`, `graphnosis_stats`
+
+## MCP catalog
+
+Registers `mcp_graphnosis_*` tools for mutations and advanced operations.
+
+## Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| Socket not found | Unlock Graphnosis; check `~/.graphnosis/mcp.sock` |
+| Recall returns locked | Open Graphnosis app and unlock cortex |
+| Provider inactive on Desktop | Set `memory.provider: graphnosis` in `~/.hermes/config.yaml` |
+
+Full docs: [graphnosis.com/getting-started/connect-ai](https://graphnosis.com/getting-started/connect-ai)

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -663,6 +663,7 @@ const sidebars: SidebarsConfig = {
         'integrations/index',
         'integrations/nous-portal',
         'integrations/providers',
+        'integrations/graphnosis',
         'user-guide/features/mcp',
         'user-guide/features/acp',
         'user-guide/features/provider-routing',


### PR DESCRIPTION
## Summary

Adds [Graphnosis](https://graphnosis.com) as a local encrypted memory provider and MCP catalog entry for Hermes.

| Path | What users get |
|------|----------------|
| **Memory provider** | Auto-prefetch; `graphnosis_recall`, `graphnosis_remember`, `graphnosis_stats` |
| **MCP catalog** | `hermes mcp install graphnosis` → full `mcp_graphnosis_*` tool surface |

Both connect to the Graphnosis desktop app via `~/.graphnosis/mcp.sock` using the published npm relay [`@graphnosis/mcp-relay`](https://www.npmjs.com/package/@graphnosis/mcp-relay) (Apache-2.0). No API key; cortex must be unlocked.

Reference bundle: https://github.com/nehloo-interactive/graphnosis-app/tree/main/integrations/hermes-agent

## Changes

- `plugins/memory/graphnosis/` — provider plugin + CLI (`hermes graphnosis status`, etc.)
- `optional-mcps/graphnosis/manifest.yaml` — catalog entry
- `hermes_cli/mcp_config.py` — `graphnosis` preset
- `tests/agent/test_graphnosis_memory_provider.py`
- Docs: `integrations/graphnosis.md`, Graphnosis section in `memory-providers.md`, sidebar entry

## Test plan

- [x] `pytest tests/agent/test_graphnosis_memory_provider.py -q` — **5 passed**
- [ ] Graphnosis unlocked → `hermes memory setup` lists **graphnosis**
- [ ] `hermes mcp catalog | grep -i graphnosis`
- [ ] `hermes mcp install graphnosis` → new session exposes `mcp_graphnosis_*` tools
- [ ] `hermes graphnosis status` when provider active

## Notes

Graphnosis also ships a Get Connected → Hermes wizard that writes the same `~/.hermes/config.yaml` shape; this PR makes setup discoverable via native Hermes flows.

Maintained by [Nehloo Interactive LLC](https://graphnosis.com) (`nehloo-interactive/graphnosis-app`).