### PR TITLE
fix(slack): upload send_message media attachments

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3921,6 +3921,66 @@ async def _standalone_send(
                 exc_info=True,
             )
 
+    media_files = list(media_files or [])
+    if media_files:
+        try:
+            from slack_sdk.web.async_client import AsyncWebClient as _AsyncWebClient
+        except ImportError:
+            return {"error": "Slack file upload failed: slack-sdk not installed. Run: pip install slack-sdk"}
+
+        try:
+            from gateway.platforms.base import resolve_proxy_url
+
+            _proxy = resolve_proxy_url()
+            if _proxy:
+                client = _AsyncWebClient(token=token, proxy=str(_proxy))
+            else:
+                client = _AsyncWebClient(token=token)
+
+            uploadable_files = []
+            for media_path, _is_voice in media_files:
+                media_path = str(media_path)
+                if not os.path.exists(media_path):
+                    return {"error": f"Slack file upload failed: file not found: {media_path}"}
+                uploadable_files.append(
+                    {"file": media_path, "filename": os.path.basename(media_path)}
+                )
+
+            if not uploadable_files:
+                if not formatted.strip():
+                    return {"error": "Slack file upload failed: no media files to upload"}
+            else:
+                last_result = None
+                chunk_size = 10  # Slack files_upload_v2 server-side batch cap.
+                for idx in range(0, len(uploadable_files), chunk_size):
+                    upload_chunk = uploadable_files[idx : idx + chunk_size]
+                    result = await client.files_upload_v2(
+                        channel=chat_id,
+                        file_uploads=upload_chunk,
+                        initial_comment=formatted if idx == 0 else "",
+                        thread_ts=thread_id,
+                    )
+                    if not result.get("ok", True):
+                        return {"error": f"Slack file upload failed: {result.get('error', 'unknown')}"}
+                    last_result = result
+
+                first_file_id = None
+                if last_result is not None:
+                    files = last_result.get("files") or []
+                    if files and isinstance(files[0], dict):
+                        first_file_id = files[0].get("id")
+                    file_info = last_result.get("file")
+                    if not first_file_id and isinstance(file_info, dict):
+                        first_file_id = file_info.get("id")
+                return {
+                    "success": True,
+                    "platform": "slack",
+                    "chat_id": chat_id,
+                    "message_id": first_file_id,
+                }
+        except Exception as e:
+            return {"error": f"Slack file upload failed: {e}"}
+
     try:
         import aiohttp
     except ImportError:

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1026,6 +1026,50 @@ class TestSendDocument:
         assert adapter._app.client.files_upload_v2.await_count == 2
         sleep_mock.assert_awaited_once()
 
+    @pytest.mark.asyncio
+    async def test_standalone_send_uploads_media_files(self, monkeypatch, tmp_path):
+        """Cron/send_message Slack delivery should upload MEDIA files natively."""
+        test_file = tmp_path / "report.pdf"
+        test_file.write_bytes(b"%PDF-1.4 fake content")
+        upload_calls = []
+        created_clients = []
+
+        class FakeAsyncWebClient:
+            def __init__(self, **kwargs):
+                created_clients.append(kwargs)
+
+            async def files_upload_v2(self, **kwargs):
+                upload_calls.append(kwargs)
+                return {"ok": True, "files": [{"id": "F123"}]}
+
+        monkeypatch.setattr(
+            "slack_sdk.web.async_client.AsyncWebClient",
+            FakeAsyncWebClient,
+        )
+        monkeypatch.setattr("gateway.platforms.base.resolve_proxy_url", lambda: None)
+
+        result = await _slack_mod._standalone_send(
+            MagicMock(token="xoxb-test"),
+            "C123",
+            "**report** ready",
+            thread_id="171.000001",
+            media_files=[(str(test_file), False)],
+        )
+
+        assert result["success"] is True
+        assert result["message_id"] == "F123"
+        assert created_clients == [{"token": "xoxb-test"}]
+        assert upload_calls == [
+            {
+                "channel": "C123",
+                "file_uploads": [
+                    {"file": str(test_file), "filename": "report.pdf"},
+                ],
+                "initial_comment": "*report* ready",
+                "thread_ts": "171.000001",
+            }
+        ]
+
 
 class TestSendPrivateNotice:
     @pytest.mark.asyncio

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -783,6 +783,66 @@ class TestSendToPlatformChunking:
         sent_text = send.await_args.args[2]
         assert "<https://en.wikipedia.org/wiki/Foo_(bar)|Foo>" in sent_text
 
+    def test_slack_media_attaches_to_last_chunk(self, monkeypatch, tmp_path):
+        """Slack send_message MEDIA attachments must reach the Slack sender.
+
+        Regression: Slack was migrated to the plugin standalone sender, but
+        the generic send_message router still treated it as a non-media
+        platform, so MEDIA files were silently omitted from Slack deliveries.
+        """
+        _ensure_slack_mock(monkeypatch)
+        import plugins.platforms.slack.adapter as slack_mod
+        monkeypatch.setattr(slack_mod, "SLACK_AVAILABLE", True)
+
+        doc_path = tmp_path / "report.pdf"
+        doc_path.write_bytes(b"%PDF-1.4 fake")
+        media = [(str(doc_path), False)]
+        sent_calls = []
+
+        async def fake_slack_sender(
+            pconfig,
+            chat_id,
+            message,
+            *,
+            thread_id=None,
+            media_files=None,
+            force_document=False,
+        ):
+            sent_calls.append(
+                {
+                    "message": message,
+                    "thread_id": thread_id,
+                    "media_files": media_files or [],
+                    "force_document": force_document,
+                }
+            )
+            return {"success": True, "platform": "slack", "message_id": str(len(sent_calls))}
+
+        entry = _slack_entry()
+        assert entry is not None
+        original = entry.standalone_sender_fn
+        entry.standalone_sender_fn = fake_slack_sender
+        try:
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.SLACK,
+                    SimpleNamespace(enabled=True, token="***", extra={}),
+                    "C123",
+                    "word " * 9000,
+                    media_files=media,
+                    thread_id="171.000001",
+                )
+            )
+        finally:
+            entry.standalone_sender_fn = original
+
+        assert result["success"] is True
+        assert len(sent_calls) >= 2
+        assert all(call["media_files"] == [] for call in sent_calls[:-1])
+        assert sent_calls[-1]["media_files"] == media
+        assert sent_calls[-1]["thread_id"] == "171.000001"
+        assert sent_calls[-1]["force_document"] is False
+
     def test_telegram_media_attaches_to_last_chunk(self):
 
         sent_calls = []

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -896,11 +896,34 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
+    # --- Slack: native media attachment support via the registry's
+    # standalone_sender_fn (plugins/platforms/slack/adapter.py::_standalone_send).
+    if platform == Platform.SLACK:
+        from gateway.platform_registry import platform_registry
+        _slack_entry = platform_registry.get("slack")
+        if _slack_entry is None or _slack_entry.standalone_sender_fn is None:
+            return {"error": "Slack plugin not registered or missing standalone_sender_fn"}
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _slack_entry.standalone_sender_fn(
+                pconfig,
+                chat_id,
+                chunk,
+                thread_id=thread_id,
+                media_files=media_files if is_last else [],
+                force_document=force_document,
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
     # --- Non-media platforms ---
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu; "
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, slack, matrix, weixin, signal, yuanbao and feishu; "
                 f"target {platform.value} had only media attachments"
             )
         }
@@ -908,24 +931,12 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu"
+            "native send_message media delivery is currently only supported for telegram, discord, slack, matrix, weixin, signal, yuanbao and feishu"
         )
 
     last_result = None
     for chunk in chunks:
-        if platform == Platform.SLACK:
-            # Slack migrated to a bundled plugin (#41112); delivery flows
-            # through the registry's standalone_sender_fn, which applies
-            # mrkdwn formatting and posts via the Slack Web API.
-            from gateway.platform_registry import platform_registry
-            _slack_entry = platform_registry.get("slack")
-            if _slack_entry is None or _slack_entry.standalone_sender_fn is None:
-                result = {"error": "Slack plugin not registered or missing standalone_sender_fn"}
-            else:
-                result = await _slack_entry.standalone_sender_fn(
-                    pconfig, chat_id, chunk, thread_id=thread_id
-                )
-        elif platform == Platform.WHATSAPP:
+        if platform == Platform.WHATSAPP:
             result = await _registry_standalone_send("whatsapp", pconfig, chat_id, chunk, thread_id)
         elif platform == Platform.SIGNAL:
             result = await _send_signal(pconfig.extra, chat_id, chunk)


### PR DESCRIPTION
## Summary

- routes Slack `send_message`/cron `MEDIA:<path>` attachments through the Slack plugin standalone sender instead of dropping them as unsupported media
- adds native Slack `files_upload_v2` handling for standalone Slack sends, including thread preservation, captions/initial comments, and 10-file upload chunking
- adds regression coverage for both the generic send-message router and Slack standalone upload path

Closes #51198

## Test Plan

- `uv run pytest tests/tools/test_send_message_tool.py::TestSendToPlatformChunking::test_slack_media_attaches_to_last_chunk tests/gateway/test_slack.py::TestSendDocument::test_standalone_send_uploads_media_files -q`
- `uv run pytest tests/tools/test_send_message_tool.py tests/gateway/test_slack.py -q`
- `uv run ruff check tools/send_message_tool.py plugins/platforms/slack/adapter.py tests/tools/test_send_message_tool.py tests/gateway/test_slack.py`
- `uv run ruff check . --extend-exclude build`
