### PR TITLE
fix(cli): fall back to agent.clarify_timeout when clarify.timeout is unset

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -509,6 +509,10 @@ def load_cli_config() -> Dict[str, Any]:
     # overwrite env vars that were already set by .env -- only a user's config
     # file should be authoritative.
     _file_has_terminal_config = False
+    # The default clarify timeout is always populated below.  Keep whether it
+    # was explicitly configured separately so the callback can distinguish a
+    # real override from 120.
+    _clarify_timeout_explicitly_configured = False
 
     # Load from file if exists
     if config_path.exists():
@@ -519,6 +523,10 @@ def load_cli_config() -> Dict[str, Any]:
                 file_config = _normalize_root_model_keys(fast_safe_load(f) or {})
             
             _file_has_terminal_config = "terminal" in file_config
+            _clarify_timeout_explicitly_configured = (
+                isinstance(file_config.get("clarify"), dict)
+                and "timeout" in file_config["clarify"]
+            )
 
             # Handle model config - can be string (new format) or dict (old format)
             if "model" in file_config:
@@ -581,7 +589,14 @@ def load_cli_config() -> Dict[str, Any]:
     # normalization, leaf-merge) and is fail-open.
     from hermes_cli import managed_scope
 
+    # A managed value is authoritative even when it happens to equal the
+    # hardcoded default.  Check the key's provenance before applying the
+    # overlay; comparing values would miss a managed ``timeout: 120``.
+    _managed_clarify_timeout = managed_scope.is_key_managed("clarify.timeout")
     defaults = managed_scope.apply_managed_overlay(defaults)
+    defaults["clarify"]["_clarify_timeout_explicitly_configured"] = (
+        _clarify_timeout_explicitly_configured or _managed_clarify_timeout
+    )
 
     # Apply terminal config to environment variables (so terminal_tool picks them up)
     terminal_config = defaults.get("terminal", {})
@@ -11667,7 +11682,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         """
         import time as _time
 
-        timeout = CLI_CONFIG.get("clarify", {}).get("timeout", 120)
+        clarify_config = CLI_CONFIG.get("clarify", {})
+        timeout = clarify_config.get("timeout")
+        if not clarify_config.get("_clarify_timeout_explicitly_configured"):
+            fallback = CLI_CONFIG.get("agent", {}).get("clarify_timeout")
+            if fallback is not None:
+                timeout = fallback
+        if timeout is None:
+            timeout = 120
         response_queue = queue.Queue()
         is_open_ended = not choices
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1115,7 +1115,7 @@ DEFAULT_CONFIG = {
         # a clarify-tool response from the user.  Hit this and the agent
         # unblocks with "[user did not respond within Xm]" so it can adapt
         # rather than pinning the running-agent guard forever.  CLI clarify
-        # blocks indefinitely (input() is synchronous) and ignores this.
+        # reads ``clarify.timeout`` first, then falls back to this value.
         # Default 3600 (1h): real users step away (meetings, AFK) and the
         # old 600s default evicted the entry mid-think, so a later button
         # tap landed on a dead entry (#32762).  Tradeoff: a higher value

--- a/tests/cli/test_clarify_timeout_fallback.py
+++ b/tests/cli/test_clarify_timeout_fallback.py
@@ -1,0 +1,78 @@
+"""Regression coverage for the CLI clarify timeout fallback."""
+
+import os
+import re
+import time
+from pathlib import Path
+from tempfile import gettempdir
+
+# The hermetic runner clears Windows home variables.  cli.py resolves its
+# platform default at import time, before pytest's HERMES_HOME fixture runs.
+os.environ.setdefault("LOCALAPPDATA", str(Path(gettempdir()) / "hermes-test-localappdata"))
+
+import cli as cli_module
+from hermes_cli import managed_scope
+
+
+def _timeout_used_by_callback(monkeypatch, config: dict) -> int:
+    """Run the callback through its timeout path and return its displayed limit."""
+    messages: list[str] = []
+    monkeypatch.setattr(cli_module, "CLI_CONFIG", config)
+    monkeypatch.setattr(cli_module, "_cprint", messages.append)
+
+    cli = cli_module.HermesCLI.__new__(cli_module.HermesCLI)
+    cli._app = None
+
+    calls = 0
+
+    def monotonic() -> float:
+        nonlocal calls
+        calls += 1
+        return 0.0 if calls <= 3 else 1e9
+
+    monkeypatch.setattr(time, "monotonic", monotonic)
+    cli._clarify_callback("Continue?", ["yes", "no"])
+
+    for message in messages:
+        match = re.search(r"timed out after (\d+)s", message)
+        if match:
+            return int(match.group(1))
+    raise AssertionError("clarify callback did not report a timeout")
+
+
+def test_cli_uses_agent_clarify_timeout_without_clarify_override(monkeypatch):
+    """A user-set gateway timeout is the CLI fallback when clarify is unset."""
+    timeout = _timeout_used_by_callback(
+        monkeypatch,
+        {
+            "clarify": {"timeout": 120, "_clarify_timeout_explicitly_configured": False},
+            "agent": {"clarify_timeout": 600},
+            "display": {"persist_prompts": False},
+        },
+    )
+
+    assert timeout == 600
+
+
+def test_managed_clarify_timeout_at_default_value_beats_agent_fallback(
+    monkeypatch, tmp_path
+):
+    """An administrator pin of 120 remains authoritative over a user fallback."""
+    user_home = tmp_path / "user"
+    user_home.mkdir()
+    (user_home / "config.yaml").write_text("agent:\n  clarify_timeout: 600\n")
+
+    managed_home = tmp_path / "managed"
+    managed_home.mkdir()
+    (managed_home / "config.yaml").write_text("clarify:\n  timeout: 120\n")
+
+    monkeypatch.setattr(cli_module, "_hermes_home", user_home)
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed_home))
+    managed_scope.invalidate_managed_cache()
+    try:
+        config = cli_module.load_cli_config()
+
+        assert config["clarify"]["_clarify_timeout_explicitly_configured"] is True
+        assert _timeout_used_by_callback(monkeypatch, config) == 120
+    finally:
+        managed_scope.invalidate_managed_cache()


### PR DESCRIPTION
## Problem

The CLI clarify callback (`_clarify_callback`) reads only `clarify.timeout` with a default of 120s.
The documented config key for gateway clarify timeout is `agent.clarify_timeout` with a default of 600s.
Users who set `agent.clarify_timeout` (via `hermes config set agent.clarify_timeout 600` or the desktop settings UI) expect it to apply everywhere, but the CLI ignores it entirely.

Additionally, the comment in `hermes_cli/config.py` describing `agent.clarify_timeout` says "CLI clarify blocks indefinitely (input() is synchronous) and ignores this" — this is stale. The CLI prompt_toolkit implementation has a timeout.

## Root Cause

`cli.py:10705` reads only `CLI_CONFIG.get("clarify", {}).get("timeout", 120)`.
`hermes_cli/config.py:974-978` has an inaccurate comment about CLI behavior.

## Fix

**cli.py** — Three-step resolution for CLI clarify timeout:
1. `clarify.timeout` — explicit CLI override (unchanged priority)
2. `agent.clarify_timeout` — fallback (NEW)
3. 120s — hardcoded default (unchanged)

**hermes_cli/config.py** — Update comment from "CLI clarify blocks indefinitely" to "The CLI reads `clarify.timeout` first, then falls back to this value."

## Verification

- Backwards compatible: users who explicitly set `clarify.timeout` see no change
- Users who only set `agent.clarify_timeout` now get the expected timeout in the CLI
- No new config keys, no migration needed
- All defaults preserved (120s when nothing is set)