### PR TITLE
docs: add recall-sqlite as memory provider (tiered storage, auto forgetting, zero LLM)

### DIFF
--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 4
 title: "Memory Providers"
-description: "External memory provider plugins — Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory"
+description: "External memory provider plugins — recall-sqlite, Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory, Memori"
 ---
 
 # Memory Providers
 
-Hermes Agent ships with 8 external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
+Hermes Agent ships with 9 external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
 
 ## Quick Start
 
@@ -274,6 +274,57 @@ Off-gateway these keys do nothing. `hermes memory setup` only prompts for them w
 
 See the [config reference](https://github.com/NousResearch/hermes-agent/blob/main/plugins/memory/honcho/README.md) and [Honcho integration guide](https://docs.honcho.dev/v3/guides/integrations/hermes).
 
+
+---
+
+### recall-sqlite
+
+Zero-LLM, tiered memory with automatic forgetting. Hybrid retrieval (ANN + keyword JOIN + FTS5) with hot/warm/cold storage tiers. Memories that aren't used naturally fade out — no cron, no config, no LLM at query time.
+
+| | |
+|---|---|
+| **Best for** | Local/edge deployments, offline-first, agents that shouldn't drown in stale context |
+| **Requires** | `pip install recall-sqlite recall-memory-hermes` + LM Studio (for embeddings; keyword+FTS5 fallback works without) |
+| **Data storage** | Local SQLite |
+| **Cost** | Free |
+
+**Tools (4):** `recall` (tiered retrieval), `store_memory` (store with auto-keyword indexing), `memory_stats` (tier distribution), `gc_memory` (evict low-score memories)
+
+**Setup:**
+```bash
+pip install recall-sqlite recall-memory-hermes
+hermes config set memory.provider recall
+```
+
+**Architecture:**
+
+Three-tier automatic storage:
+
+| Tier | Capacity | Retrieval | Compute |
+|:-----|:--------:|:----------|:-------:|
+| **Hot** | ~500 | ANN + keywords + FTS5 (3-path RRF) | ~80ms |
+| **Warm** | ~5K | Keywords + FTS5 (2-path RRF) | 66-99% less ANN work |
+| **Cold** | ∞ | Not indexed, fill-gap fallback | ~Zero |
+
+**Key features:**
+- Automatic promotion/demotion based on access frequency
+- Lazy cold sampling every 20 queries — no cron/UI needed
+- Graceful degradation: keyword+FTS5 fallback when embedding server is offline
+- Schema migration automatic on `pip install --upgrade`
+- MCP server for non-Hermes agents (Claude Code, Codex, Gemini CLI)
+- [Benchmark report](https://github.com/Jnocode/recall-memory/blob/main/BENCHMARK.md) vs all other providers
+
+**Config:**
+
+Set `memory.provider: recall` in `~/.hermes/config.yaml`. No additional config files needed.
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `db_path` | auto-detect | Path to recall SQLite database |
+| `fallback_honcho` | `false` | Enable Honcho fallback when recall returns <3 results |
+
+**GitHub:** [github.com/Jnocode/recall-memory](https://github.com/Jnocode/recall-memory)
+**PyPI:** `recall-sqlite` / `recall-memory-hermes`
 
 ---
 
@@ -593,6 +644,7 @@ hermes memory setup
 
 | Provider | Storage | Cost | Tools | Dependencies | Unique Feature |
 |----------|---------|------|-------|-------------|----------------|
+| **recall-sqlite** | Local | Free | 4 | `recall-sqlite` | Tiered storage + automatic forgetting + zero LLM at query |
 | **Honcho** | Cloud | Paid | 5 | `honcho-ai` | Dialectic user modeling + session-scoped context |
 | **OpenViking** | Self-hosted | Free | 5 | `openviking` + server | Filesystem hierarchy + tiered loading |
 | **Mem0** | Cloud/Self-hosted | Free/Paid | 5 | `mem0ai` | Server-side LLM extraction + OSS mode |

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -312,7 +312,7 @@ Three-tier automatic storage:
 - Graceful degradation: keyword+FTS5 fallback when embedding server is offline
 - Schema migration automatic on `pip install --upgrade`
 - MCP server for non-Hermes agents (Claude Code, Codex, Gemini CLI)
-- [Benchmark report](https://github.com/Jnocode/recall-memory/blob/main/BENCHMARK.md) vs all other providers
+- [Benchmark report](https://github.com/Jnocode/recall-memory/blob/master/BENCHMARK.md) vs all other providers
 
 **Config:**
 

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -284,7 +284,7 @@ Zero-LLM, tiered memory with automatic forgetting. Hybrid retrieval (ANN + keywo
 | | |
 |---|---|
 | **Best for** | Local/edge deployments, offline-first, agents that shouldn't drown in stale context |
-| **Requires** | `pip install recall-sqlite recall-memory-hermes` + LM Studio (for embeddings; keyword+FTS5 fallback works without) |
+| **Requires** | `pip install recall-sqlite` + LM Studio (for embeddings; keyword+FTS5 fallback works without) |
 | **Data storage** | Local SQLite |
 | **Cost** | Free |
 
@@ -292,8 +292,17 @@ Zero-LLM, tiered memory with automatic forgetting. Hybrid retrieval (ANN + keywo
 
 **Setup:**
 ```bash
-pip install recall-sqlite recall-memory-hermes
-hermes config set memory.provider recall
+# 1. Install Python dependencies
+pip install recall-sqlite
+
+# 2. Install the Hermes plugin (clones repo to ~/.hermes/plugins/)
+hermes plugins install Jnocode/recall-memory-hermes --enable
+
+# 3. Activate as the memory provider
+hermes config set memory.provider recall-memory-hermes
+
+# 4. Restart the gateway
+hermes gateway restart
 ```
 
 **Architecture:**
@@ -316,7 +325,7 @@ Three-tier automatic storage:
 
 **Config:**
 
-Set `memory.provider: recall` in `~/.hermes/config.yaml`. No additional config files needed.
+Set `memory.provider: recall-memory-hermes` in `~/.hermes/config.yaml`. No additional config files needed.
 
 | Key | Default | Description |
 |-----|---------|-------------|

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -298,8 +298,8 @@ pip install recall-sqlite
 # 2. Install the Hermes plugin (clones repo to ~/.hermes/plugins/)
 hermes plugins install Jnocode/recall-memory-hermes --enable
 
-# 3. Activate as the memory provider
-hermes config set memory.provider recall-memory-hermes
+# 3. 啟用為記憶提供者
+hermes memory setup recall-memory-hermes
 
 # 4. Restart the gateway
 hermes gateway restart


### PR DESCRIPTION
## Summary

Adds recall-sqlite — a zero-LLM, tiered memory provider with automatic forgetting — to the Hermes memory providers documentation.

## What is recall-sqlite?

A memory system for AI agents that doesn't accumulate forever. Three-tier automatic storage (hot/warm/cold) with promotion/demotion based on usage frequency. No LLM at query time. No vector database. Pure SQLite.

## Key differentiators

- Only provider with automatic forgetting — all others accumulate forever
- Zero LLM calls at query time — embedding model only (150MB, local)
- Graceful degradation — keyword+FTS5 fallback when embedding server is offline
- MCP server — works with non-Hermes agents too
- Single SQLite file — no vector DB, no Docker, no API keys

## Changes

- Added recall-sqlite section to memory-providers.md with setup instructions
- Updated provider comparison table
- Updated frontmatter description

## Benchmark

Initial benchmark report at https://github.com/Jnocode/recall-memory/blob/master/BENCHMARK.md

Note: this is a preliminary comparison — the dataset is still growing and needs more test coverage across different query patterns. The numbers shown are real (1469 memories, 40 queries) but should be treated as directional rather than definitive. Community contributions to the benchmark are very welcome.

Early signals:
- p50 latency: 82ms (hot), 61ms (warm fallback)
- Memory: ~1.5MB fixed for hot tier
- Zero LLM calls per query

## Status

- recall-sqlite v0.2.0 on PyPI
- Hermes plugin v0.2.0 on PyPI
- GitHub: github.com/Jnocode/recall-memory
