### PR TITLE
fix(kanban): clear crash diagnostics after blocked runs

### DIFF
--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -672,13 +672,16 @@ def _rule_repeated_crashes(task, events, runs, now, cfg) -> list[Diagnostic]:
             consecutive += 1
             if last_err is None:
                 last_err = _task_field(r, "error")
-        elif outcome in {"completed", "reclaimed"}:
-            # A success (or manual reclaim) breaks the streak.
+        elif outcome in {"completed", "reclaimed", "blocked"}:
+            # A success, manual reclaim, or intentional protocol block breaks
+            # the streak. A blocked run means the worker reached a human gate
+            # or known recovery point; stale pre-gate crashes should not keep
+            # the card red after the latest outcome is a valid block.
             break
         else:
-            # Other outcomes (timed_out, blocked, spawn_failed, gave_up)
-            # aren't crash signals — don't count them, but they also
-            # don't break the crash streak.
+            # Other outcomes (timed_out, spawn_failed, gave_up) aren't crash
+            # signals — don't count them, but they also don't break the crash
+            # streak.
             continue
     if consecutive < threshold:
         return []

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -265,6 +265,16 @@ def test_repeated_crashes_breaks_on_recent_success():
     assert kd.compute_task_diagnostics(task, [], runs) == []
 
 
+def test_repeated_crashes_breaks_on_recent_blocked_gate():
+    task = _task(status="blocked", assignee="pm")
+    runs = [
+        _run(outcome="crashed", run_id=1),
+        _run(outcome="crashed", run_id=2),
+        _run(outcome="blocked", run_id=3),
+    ]
+    assert kd.compute_task_diagnostics(task, [], runs) == []
+
+
 def test_repeated_crashes_escalates_on_many_crashes():
     task = _task(status="ready", assignee="x")
     runs = [_run(outcome="crashed", run_id=i) for i in range(1, 6)]  # 5 in a row


### PR DESCRIPTION
## Summary
- Treat a later `blocked` Kanban run as breaking a repeated-crash diagnostic streak.
- Prevent stale pre-gate crash diagnostics from staying red after a worker reaches an intentional human/recovery block.
- Add regression coverage for blocked runs following crashes.

## Tests
- `uv run --with pytest python -m pytest tests/hermes_cli/test_kanban_diagnostics.py tests/plugins/test_kanban_dashboard_plugin.py -o 'addopts=' -q`\n- 143 passed, 1 warning