### PR TITLE
Log Codex service-tier request/response diagnostics

### DIFF
--- a/agent/codex_service_tier_log.py
+++ b/agent/codex_service_tier_log.py
@@ -1,0 +1,120 @@
+"""Safe Codex service-tier diagnostics.
+
+This module writes a tiny JSONL audit trail for the ChatGPT Codex OAuth
+Responses path so users can verify whether Hermes requested Priority
+Processing and what tier the backend reported in the response.
+
+Privacy boundary: never persist prompts, message bodies, authorization headers,
+raw session ids, raw request/response ids, account ids, cookies, or tokens.
+Correlators are short SHA-256 hashes only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+LOG_FILENAME = "codex-service-tier.jsonl"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _hash_identifier(value: Any) -> str | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    digest = hashlib.sha256(text.encode("utf-8", errors="replace")).hexdigest()
+    return f"sha256:{digest[:16]}"
+
+
+def _clean_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _log_path() -> Path:
+    return get_hermes_home() / "logs" / LOG_FILENAME
+
+
+def _append_record(record: dict[str, Any]) -> None:
+    """Best-effort append; diagnostics must never break model calls."""
+    try:
+        path = _log_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        sanitized = {k: v for k, v in record.items() if v is not None}
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(sanitized, ensure_ascii=False, sort_keys=True) + "\n")
+    except Exception:
+        return
+
+
+def record_codex_service_tier_request(
+    *,
+    model: Any = None,
+    issuer_kind: Any = None,
+    requested_service_tier: Any = None,
+    session_id: Any = None,
+    request_id: Any = None,
+    source: str = "transport.build_kwargs",
+) -> None:
+    """Record the safe shape of a Codex service-tier request."""
+    requested = _clean_str(requested_service_tier)
+    if not requested:
+        return
+    _append_record(
+        {
+            "ts": _now_iso(),
+            "event": "request",
+            "source": source,
+            "provider": "openai-codex",
+            "api_mode": "codex_responses",
+            "model": _clean_str(model),
+            "issuer_kind": _clean_str(issuer_kind),
+            "requested_service_tier": requested,
+            "session_hash": _hash_identifier(session_id),
+            "request_hash": _hash_identifier(request_id),
+        }
+    )
+
+
+def record_codex_service_tier_response(
+    *,
+    model: Any = None,
+    issuer_kind: Any = None,
+    requested_service_tier: Any = None,
+    effective_service_tier: Any = None,
+    session_id: Any = None,
+    response_id: Any = None,
+    status: Any = None,
+    source: str = "transport.normalize_response",
+) -> None:
+    """Record the backend-reported service tier for a Codex response."""
+    requested = _clean_str(requested_service_tier)
+    effective = _clean_str(effective_service_tier)
+    if not requested and not effective:
+        return
+    _append_record(
+        {
+            "ts": _now_iso(),
+            "event": "response",
+            "source": source,
+            "provider": "openai-codex",
+            "api_mode": "codex_responses",
+            "model": _clean_str(model),
+            "issuer_kind": _clean_str(issuer_kind),
+            "requested_service_tier": requested,
+            "effective_service_tier": effective,
+            "status": _clean_str(status),
+            "session_hash": _hash_identifier(session_id),
+            "response_hash": _hash_identifier(response_id),
+        }
+    )

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -23,6 +23,7 @@ class ResponsesApiTransport(ProviderTransport):
     # response are stamped with the endpoint that minted them. Plain class
     # attribute default; mutated on the instance, not the class.
     _last_issuer_kind: Optional[str] = None
+    _last_service_tier_diagnostic: Optional[Dict[str, Any]] = None
 
     @property
     def api_mode(self) -> str:
@@ -113,6 +114,7 @@ class ResponsesApiTransport(ProviderTransport):
         # dropped before the API rejects them.
         issuer_kind = self._resolve_issuer_kind(params)
         self._last_issuer_kind = issuer_kind
+        self._last_service_tier_diagnostic = None
 
         # Resolve reasoning effort
         reasoning_effort = "medium"
@@ -329,6 +331,33 @@ class ResponsesApiTransport(ProviderTransport):
             merged_extra_body.setdefault("prompt_cache_key", session_id)
             kwargs["extra_body"] = merged_extra_body
 
+        if is_codex_backend:
+            extra_headers = kwargs.get("extra_headers")
+            request_id = None
+            if isinstance(extra_headers, dict):
+                request_id = extra_headers.get("x-client-request-id") or extra_headers.get("session_id")
+            requested_service_tier = kwargs.get("service_tier")
+            self._last_service_tier_diagnostic = {
+                "model": model,
+                "issuer_kind": issuer_kind,
+                "requested_service_tier": requested_service_tier,
+                "session_id": session_id,
+                "request_id": request_id,
+            }
+            if requested_service_tier:
+                try:
+                    from agent.codex_service_tier_log import record_codex_service_tier_request
+
+                    record_codex_service_tier_request(
+                        model=model,
+                        issuer_kind=issuer_kind,
+                        requested_service_tier=requested_service_tier,
+                        session_id=session_id,
+                        request_id=request_id,
+                    )
+                except Exception:
+                    pass
+
         return kwargs
 
     def normalize_response(self, response: Any, **kwargs) -> NormalizedResponse:
@@ -344,6 +373,28 @@ class ResponsesApiTransport(ProviderTransport):
         issuer_kind = kwargs.get("issuer_kind") or self._last_issuer_kind
         # _normalize_codex_response returns (SimpleNamespace, finish_reason_str)
         msg, finish_reason = _normalize_codex_response(response, issuer_kind=issuer_kind)
+
+        diag = self._last_service_tier_diagnostic
+        if diag:
+            try:
+                from agent.codex_service_tier_log import record_codex_service_tier_response
+
+                def _response_field(name: str) -> Any:
+                    if isinstance(response, dict):
+                        return response.get(name)
+                    return getattr(response, name, None)
+
+                record_codex_service_tier_response(
+                    model=diag.get("model") or _response_field("model"),
+                    issuer_kind=diag.get("issuer_kind") or issuer_kind,
+                    requested_service_tier=diag.get("requested_service_tier"),
+                    effective_service_tier=_response_field("service_tier"),
+                    session_id=diag.get("session_id"),
+                    response_id=_response_field("id"),
+                    status=_response_field("status"),
+                )
+            except Exception:
+                pass
 
         tool_calls = None
         if msg and msg.tool_calls:

--- a/hermes_cli/logs.py
+++ b/hermes_cli/logs.py
@@ -12,6 +12,7 @@ Usage examples::
     hermes logs gateway -n 100    # last 100 lines of gateway.log
     hermes logs gui -f            # follow gui.log (dashboard/pty/ws)
     hermes logs desktop -f        # follow desktop.log (Electron app boot/backend)
+    hermes logs codex-tier -n 20  # requested/effective Codex service_tier JSONL
     hermes logs --level WARNING    # only WARNING+ lines
     hermes logs --session abc123   # filter by session ID substring
     hermes logs --component tools  # only tool-related lines
@@ -35,6 +36,7 @@ LOG_FILES = {
     "gateway": "gateway.log",
     "gui": "gui.log",
     "desktop": "desktop.log",
+    "codex-tier": "codex-service-tier.jsonl",
 }
 
 # Log line timestamp regex — matches "2026-04-05 22:35:00,123" or
@@ -154,7 +156,8 @@ def tail_log(
     Parameters
     ----------
     log_name
-        Which log to read: ``"agent"``, ``"errors"``, ``"gateway"``, ``"gui"``.
+        Which log to read: ``"agent"``, ``"errors"``, ``"gateway"``, ``"gui"``,
+        ``"desktop"``, or ``"codex-tier"``.
     num_lines
         Number of recent lines to show (before follow starts).
     follow
@@ -369,7 +372,7 @@ def list_logs() -> None:
     print(f"Log files in {display_hermes_home()}/logs/:\n")
     found = False
     for entry in sorted(log_dir.iterdir()):
-        if entry.is_file() and entry.suffix == ".log":
+        if entry.is_file() and entry.name in set(LOG_FILES.values()):
             size = entry.stat().st_size
             mtime = datetime.fromtimestamp(entry.stat().st_mtime)
             if size < 1024:

--- a/hermes_cli/subcommands/logs.py
+++ b/hermes_cli/subcommands/logs.py
@@ -18,7 +18,7 @@ def build_logs_parser(subparsers, *, cmd_logs: Callable) -> None:
     logs_parser = subparsers.add_parser(
         "logs",
         help="View and filter Hermes log files",
-        description="View, tail, and filter agent.log / errors.log / gateway.log / gui.log / desktop.log",
+        description="View, tail, and filter agent.log / errors.log / gateway.log / gui.log / desktop.log / codex-service-tier.jsonl",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""\
 Examples:
@@ -28,6 +28,7 @@ Examples:
     hermes logs gateway -n 100     Show last 100 lines of gateway.log
     hermes logs gui -f             Follow gui.log in real time
     hermes logs desktop -f         Follow desktop.log (Electron app boot/backend)
+    hermes logs codex-tier -n 20   Show requested/effective Codex service_tier records
     hermes logs --level WARNING    Only show WARNING and above
     hermes logs --session abc123   Filter by session ID
     hermes logs --component tools  Only show tool-related lines
@@ -40,7 +41,7 @@ Examples:
         "log_name",
         nargs="?",
         default="agent",
-        help="Log to view: agent (default), errors, gateway, gui, or 'list' to show available files",
+        help="Log to view: agent (default), errors, gateway, gui, desktop, codex-tier, or 'list' to show available files",
     )
     logs_parser.add_argument(
         "-n",

--- a/tests/agent/test_codex_service_tier_log.py
+++ b/tests/agent/test_codex_service_tier_log.py
@@ -1,0 +1,108 @@
+import json
+from types import SimpleNamespace
+
+
+def test_codex_service_tier_log_records_safe_request_and_response(tmp_path, monkeypatch):
+    from agent import codex_service_tier_log as tier_log
+
+    monkeypatch.setattr(tier_log, "get_hermes_home", lambda: tmp_path)
+
+    tier_log.record_codex_service_tier_request(
+        model="gpt-5.5",
+        issuer_kind="chatgpt_codex",
+        requested_service_tier="priority",
+        session_id="raw-session-id-should-not-appear",
+        request_id="raw-request-id-should-not-appear",
+        source="transport.build_kwargs",
+    )
+    tier_log.record_codex_service_tier_response(
+        model="gpt-5.5",
+        issuer_kind="chatgpt_codex",
+        requested_service_tier="priority",
+        effective_service_tier="default",
+        session_id="raw-session-id-should-not-appear",
+        response_id="resp-secret-should-not-appear",
+        status="completed",
+        source="transport.normalize_response",
+    )
+
+    log_path = tmp_path / "logs" / "codex-service-tier.jsonl"
+    assert log_path.exists()
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+
+    request = json.loads(lines[0])
+    response = json.loads(lines[1])
+
+    assert request["event"] == "request"
+    assert request["model"] == "gpt-5.5"
+    assert request["requested_service_tier"] == "priority"
+    assert request["session_hash"].startswith("sha256:")
+    assert "session_id" not in request
+    assert "request_id" not in request
+
+    assert response["event"] == "response"
+    assert response["requested_service_tier"] == "priority"
+    assert response["effective_service_tier"] == "default"
+    assert response["response_hash"].startswith("sha256:")
+    assert "response_id" not in response
+
+    raw_log = log_path.read_text(encoding="utf-8")
+    assert "raw-session-id-should-not-appear" not in raw_log
+    assert "raw-request-id-should-not-appear" not in raw_log
+    assert "resp-secret-should-not-appear" not in raw_log
+
+
+def test_codex_transport_logs_requested_and_effective_tiers(tmp_path, monkeypatch):
+    from agent import codex_service_tier_log as tier_log
+    from agent.transports.codex import ResponsesApiTransport
+
+    monkeypatch.setattr(tier_log, "get_hermes_home", lambda: tmp_path)
+
+    transport = ResponsesApiTransport()
+    kwargs = transport.build_kwargs(
+        model="gpt-5.5",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=None,
+        session_id="secret-session",
+        request_overrides={"service_tier": "priority"},
+        is_codex_backend=True,
+    )
+    assert kwargs["service_tier"] == "priority"
+
+    response = SimpleNamespace(
+        id="resp-secret",
+        model="gpt-5.5",
+        status="completed",
+        service_tier="default",
+        output=[],
+        output_text="OK",
+    )
+    transport.normalize_response(response)
+
+    log_path = tmp_path / "logs" / "codex-service-tier.jsonl"
+    records = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+    assert [record["event"] for record in records] == ["request", "response"]
+    assert records[0]["requested_service_tier"] == "priority"
+    assert records[1]["requested_service_tier"] == "priority"
+    assert records[1]["effective_service_tier"] == "default"
+    assert "secret-session" not in log_path.read_text(encoding="utf-8")
+    assert "resp-secret" not in log_path.read_text(encoding="utf-8")
+
+
+def test_logs_command_can_tail_codex_tier_jsonl(tmp_path, monkeypatch, capsys):
+    import hermes_cli.logs as logs_mod
+
+    monkeypatch.setattr(logs_mod, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(logs_mod, "display_hermes_home", lambda: "~/.hermes")
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir(parents=True)
+    log_file = log_dir / "codex-service-tier.jsonl"
+    log_file.write_text('{"event":"response","effective_service_tier":"default"}\n', encoding="utf-8")
+
+    logs_mod.tail_log("codex-tier", num_lines=5)
+
+    out = capsys.readouterr().out
+    assert "codex-service-tier.jsonl" in out
+    assert "effective_service_tier" in out
+    assert "default" in out


### PR DESCRIPTION
## Summary
- add a safe JSONL diagnostic trail for the ChatGPT Codex OAuth Responses path
- record only model/provider/api-mode, requested `service_tier`, backend-reported/effective `service_tier`, status, and short SHA-256 hashes for correlation
- expose the diagnostic via `hermes logs codex-tier -n 20`

## Context
When `agent.service_tier=fast` maps to `service_tier="priority"`, Hermes can verify that the request asked for Priority Processing. The backend may still report a final/effective `service_tier` such as `default`; this PR makes that easy to inspect without logging prompts or credentials.

## Privacy boundary
The diagnostic intentionally does **not** write prompts, message bodies, Authorization headers, OAuth tokens, cookies, account ids, raw session ids, raw request ids, or raw response ids. Correlation fields are short SHA-256 hashes only.

## How to check
```bash
hermes logs codex-tier -n 20
```

Example fields:
- `requested_service_tier`: what Hermes sent, e.g. `priority`
- `effective_service_tier`: what the Codex backend reported, e.g. `default` or `priority`

## Tests
- `/Users/leo/.hermes/hermes-agent/venv/bin/python -m pytest tests/agent/test_codex_service_tier_log.py -q -o addopts=`
- `/Users/leo/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_logs.py tests/agent/test_codex_service_tier_log.py -q -o addopts=`
- `/Users/leo/.hermes/hermes-agent/venv/bin/python -m pytest tests/run_agent/test_provider_parity.py -q -o addopts=`
- `/Users/leo/.hermes/hermes-agent/venv/bin/python -m ruff check agent/codex_service_tier_log.py agent/transports/codex.py hermes_cli/logs.py hermes_cli/subcommands/logs.py tests/agent/test_codex_service_tier_log.py`
- `/Users/leo/.hermes/hermes-agent/venv/bin/python -m py_compile agent/codex_service_tier_log.py agent/transports/codex.py hermes_cli/logs.py hermes_cli/subcommands/logs.py tests/agent/test_codex_service_tier_log.py`
