### PR TITLE
fix(desktop): prevent deleted sessions from reappearing

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -75,6 +75,7 @@ import {
   enterProject,
   exitProjectScope,
   fetchProjectSessions,
+  filterTombstonedSessions,
   openProjectCreate,
   refreshProjects,
   refreshProjectTree,
@@ -381,8 +382,22 @@ export function ChatSidebar({
   // profile in, grouped by profile below. Single-profile users land here with
   // scope === their only profile, so nothing is filtered out.
   const visibleSessions = useMemo(
-    () => (showAllProfiles ? sessions : sessions.filter(s => normalizeProfileKey(s.profile) === profileScope)),
-    [sessions, showAllProfiles, profileScope]
+    () =>
+      filterTombstonedSessions(
+        showAllProfiles ? sessions : sessions.filter(s => normalizeProfileKey(s.profile) === profileScope),
+        removedSessionIds
+      ),
+    [sessions, showAllProfiles, profileScope, removedSessionIds]
+  )
+
+  const visibleCronSessions = useMemo(
+    () => filterTombstonedSessions(cronSessions, removedSessionIds),
+    [cronSessions, removedSessionIds]
+  )
+
+  const visibleMessagingSessions = useMemo(
+    () => filterTombstonedSessions(messagingSessions, removedSessionIds),
+    [messagingSessions, removedSessionIds]
   )
 
   // Agent session order is pinned to creation time (started_at), NOT activity —
@@ -403,7 +418,7 @@ export function ChatSidebar({
     // Cron sessions are listed separately but can still be pinned, so index
     // them too — otherwise a pinned cron job can't resolve into the Pinned
     // section. Recents take precedence on id collisions (set last).
-    for (const s of [...cronSessions, ...visibleSessions]) {
+    for (const s of [...visibleCronSessions, ...visibleSessions]) {
       map.set(s.id, s)
 
       if (s._lineage_root_id && !map.has(s._lineage_root_id)) {
@@ -412,7 +427,7 @@ export function ChatSidebar({
     }
 
     return map
-  }, [visibleSessions, cronSessions])
+  }, [visibleSessions, visibleCronSessions])
 
   const pinnedSessions = useMemo(() => {
     const seen = new Set<string>()
@@ -490,8 +505,8 @@ export function ChatSidebar({
       out.set(match.session_id, loaded ?? searchResultToSession(match))
     }
 
-    return [...out.values()]
-  }, [trimmedQuery, sortedSessions, serverMatches, sessionByAnyId])
+    return filterTombstonedSessions([...out.values()], removedSessionIds)
+  }, [trimmedQuery, sortedSessions, serverMatches, sessionByAnyId, removedSessionIds])
 
   const unpinnedAgentSessions = useMemo(
     () => sortedSessions.filter(s => !pinnedRealIdSet.has(s.id)),
@@ -863,13 +878,13 @@ export function ChatSidebar({
   // within a platform by recency. Per-platform totals (when a "load more" has
   // resolved them) drive the count + whether more remain on disk.
   const messagingGroups = useMemo<MessagingSection[]>(() => {
-    if (!messagingSessions.length) {
+    if (!visibleMessagingSessions.length) {
       return []
     }
 
     const bySource = new Map<string, SessionInfo[]>()
 
-    for (const session of messagingSessions) {
+    for (const session of visibleMessagingSessions) {
       const sourceId = normalizeSessionSource(session.source)
 
       if (!sourceId) {
@@ -899,7 +914,7 @@ export function ChatSidebar({
         }
       })
       .sort((a, b) => sessionTime(b.sessions[0]) - sessionTime(a.sessions[0]))
-  }, [messagingSessions, messagingPlatformTotals, messagingTruncated])
+  }, [visibleMessagingSessions, messagingPlatformTotals, messagingTruncated])
 
   // ALL-profiles view: one collapsible group per profile, color on the header
   // (not on every row). Default profile floats to the top, the rest alpha.

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -398,6 +398,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     navigate,
     onFreshDraftRouteIntent: clearRoutedSessionIntent,
     requestGateway,
+    refreshSessionsAfterRemoval: refreshSessions,
     resetViewSync,
     runtimeIdByStoredSessionIdRef,
     selectedStoredSessionId,

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -3,10 +3,10 @@ import type { MutableRefObject } from 'react'
 import { useEffect } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { getSessionMessages, type SessionInfo } from '@/hermes'
+import { deleteSession, getSessionMessages, type SessionInfo, setSessionArchived } from '@/hermes'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { $activeGatewayProfile, $newChatProfile, ensureGatewayProfile } from '@/store/profile'
-import { $projectScope, $projectTree, ALL_PROJECTS } from '@/store/projects'
+import { $projectScope, $projectTree, $removedSessionIds, ALL_PROJECTS } from '@/store/projects'
 import {
   $activeSessionId,
   $activeSessionStoredIdRotation,
@@ -16,9 +16,12 @@ import {
   $currentProvider,
   $currentReasoningEffort,
   $messages,
+  $messagingPlatformTotals,
+  $messagingSessions,
   $newChatWorkspaceTarget,
   $resumeFailedSessionId,
   $selectedStoredSessionId,
+  $sessionsTotal,
   setActiveSessionId,
   setActiveSessionStoredIdRotation,
   setCurrentCwd,
@@ -27,10 +30,13 @@ import {
   setCurrentProvider,
   setCurrentReasoningEffort,
   setMessages,
+  setMessagingPlatformTotals,
+  setMessagingSessions,
   setNewChatWorkspaceTarget,
   setResumeFailedSessionId,
   setSelectedStoredSessionId,
-  setSessions
+  setSessions,
+  setSessionsTotal
 } from '@/store/session'
 
 import { sessionRoute } from '../../routes'
@@ -55,18 +61,20 @@ vi.mock('@/store/profile', async importOriginal => ({
 const RUNTIME_SESSION_ID = 'rt-new-001'
 
 function deferred<T>() {
+  let reject!: (reason?: unknown) => void
   let resolve!: (value: T | PromiseLike<T>) => void
 
-  const promise = new Promise<T>(done => {
+  const promise = new Promise<T>((done, fail) => {
+    reject = fail
     resolve = done
   })
 
-  return { promise, resolve }
+  return { promise, reject, resolve }
 }
 
 type HarnessHandle = Pick<
   ReturnType<typeof useSessionActions>,
-  'createBackendSessionForSend' | 'startFreshSessionDraft'
+  'archiveSession' | 'createBackendSessionForSend' | 'removeSession' | 'startFreshSessionDraft'
 >
 
 function storedSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
@@ -90,10 +98,12 @@ function storedSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
 
 function Harness({
   onReady,
-  requestGateway
+  requestGateway,
+  refreshSessionsAfterRemoval
 }: {
   onReady: (handle: HarnessHandle) => void
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+  refreshSessionsAfterRemoval?: () => Promise<void>
 }) {
   const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value })
 
@@ -107,6 +117,7 @@ function Harness({
     getRoutedStoredSessionId: () => null,
     navigate: vi.fn() as never,
     requestGateway,
+    refreshSessionsAfterRemoval,
     resetViewSync: vi.fn(),
     runtimeIdByStoredSessionIdRef: ref(new Map<string, string>()),
     selectedStoredSessionId: null,
@@ -122,6 +133,116 @@ function Harness({
 
   return null
 }
+
+describe('session removal refresh', () => {
+  afterEach(() => {
+    cleanup()
+    setMessagingPlatformTotals({})
+    setMessagingSessions([])
+    setSessions([])
+    setSessionsTotal(0)
+    $removedSessionIds.set(new Set())
+    vi.restoreAllMocks()
+  })
+
+  it('starts delete confirmation only after the backend mutation succeeds', async () => {
+    const mutation = deferred<{ ok: boolean }>()
+    const refreshSessionsAfterRemoval = vi.fn(async () => undefined)
+    vi.mocked(deleteSession).mockReturnValue(mutation.promise)
+    setSessions([storedSession({ id: 'deleted' })])
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={actions => (handle = actions)}
+        refreshSessionsAfterRemoval={refreshSessionsAfterRemoval}
+        requestGateway={async () => ({}) as never}
+      />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    const pending = handle!.removeSession('deleted')
+
+    expect(refreshSessionsAfterRemoval).not.toHaveBeenCalled()
+    mutation.resolve({ ok: true })
+    await pending
+
+    expect(refreshSessionsAfterRemoval).toHaveBeenCalledTimes(1)
+  })
+
+  it('starts archive confirmation only after the backend mutation succeeds', async () => {
+    const mutation = deferred<{ ok: boolean }>()
+    const refreshSessionsAfterRemoval = vi.fn(async () => undefined)
+    vi.mocked(setSessionArchived).mockReturnValue(mutation.promise)
+    setSessions([storedSession({ id: 'archived' })])
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={actions => (handle = actions)}
+        refreshSessionsAfterRemoval={refreshSessionsAfterRemoval}
+        requestGateway={async () => ({}) as never}
+      />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    const pending = handle!.archiveSession('archived')
+
+    expect(refreshSessionsAfterRemoval).not.toHaveBeenCalled()
+    mutation.resolve({ ok: true })
+    await pending
+
+    expect(refreshSessionsAfterRemoval).toHaveBeenCalledTimes(1)
+  })
+
+  it('restores a messaging row removed by a racing refresh when delete fails', async () => {
+    const mutation = deferred<{ ok: boolean }>()
+    const refreshSessionsAfterRemoval = vi.fn(async () => undefined)
+    const deleted = storedSession({ id: 'deleted', source: 'telegram' })
+    vi.mocked(deleteSession).mockReturnValue(mutation.promise)
+    setMessagingPlatformTotals({ telegram: 5 })
+    setMessagingSessions([deleted])
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={actions => (handle = actions)}
+        refreshSessionsAfterRemoval={refreshSessionsAfterRemoval}
+        requestGateway={async () => ({}) as never}
+      />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    const pending = handle!.removeSession('deleted')
+    expect($messagingPlatformTotals.get()).toEqual({ telegram: 4 })
+    setMessagingSessions([])
+    mutation.reject(new Error('delete failed'))
+    await pending
+
+    expect($messagingSessions.get()).toEqual([deleted])
+    expect($messagingPlatformTotals.get()).toEqual({ telegram: 5 })
+    expect($removedSessionIds.get().has('deleted')).toBe(false)
+    expect(refreshSessionsAfterRemoval).toHaveBeenCalledTimes(1)
+  })
+
+  it('restores the pre-mutation total instead of incrementing a stale refresh total', async () => {
+    const mutation = deferred<{ ok: boolean }>()
+    vi.mocked(deleteSession).mockReturnValue(mutation.promise)
+    setSessions([storedSession({ id: 'deleted' })])
+    setSessionsTotal(10)
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={actions => (handle = actions)} requestGateway={async () => ({}) as never} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    const pending = handle!.removeSession('deleted')
+    setSessionsTotal(10)
+    mutation.reject(new Error('delete failed'))
+    await pending
+
+    expect($sessionsTotal.get()).toBe(10)
+  })
+})
 
 function StoredIdRotationHarness({
   activeSessionIdRef,

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -7,6 +7,7 @@ import { deleteSession, getSessionMessages, setSessionArchived } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { type ChatMessage, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
 import { isMissingRpcMethod } from '@/lib/gateway-rpc'
+import { normalizeSessionSource } from '@/lib/session-source'
 import { setSessionYolo } from '@/lib/yolo-session'
 import { clearQueuedPrompts } from '@/store/composer-queue'
 import { $pinnedSessionIds } from '@/store/layout'
@@ -15,14 +16,18 @@ import { $activeGatewayProfile, $newChatProfile, ensureGatewayProfile, normalize
 import { resolveNewSessionCwd, tombstoneSessions, untombstoneSessions } from '@/store/projects'
 import {
   $activeSessionStoredIdRotation,
+  $cronSessions,
   $currentCwd,
   $currentFastMode,
   $currentModel,
   $currentProvider,
   $currentReasoningEffort,
   $messages,
+  $messagingPlatformTotals,
+  $messagingSessions,
   $newChatWorkspaceTarget,
   $sessions,
+  $sessionsTotal,
   $yoloActive,
   type NewChatWorkspaceTarget,
   sessionPinId,
@@ -30,6 +35,7 @@ import {
   setActiveSessionStoredIdRotation,
   setAwaitingResponse,
   setBusy,
+  setCronSessions,
   setCurrentBranch,
   setCurrentCwd,
   setCurrentCwdTransient,
@@ -38,6 +44,8 @@ import {
   setFreshDraftReady,
   setIntroSeed,
   setMessages,
+  setMessagingPlatformTotals,
+  setMessagingSessions,
   setNewChatWorkspaceTarget,
   setResumeExhaustedSessionId,
   setResumeFailedSessionId,
@@ -58,7 +66,7 @@ import {
 } from '@/store/session-states'
 import { broadcastSessionsChanged } from '@/store/session-sync'
 import { isWatchWindow } from '@/store/windows'
-import type { SessionCreateResponse, SessionResumeResponse, UsageStats } from '@/types/hermes'
+import type { SessionCreateResponse, SessionInfo, SessionResumeResponse, UsageStats } from '@/types/hermes'
 
 import { NEW_CHAT_ROUTE, sessionRoute, SETTINGS_ROUTE } from '../../../routes'
 import type { ClientSessionState, SidebarNavItem } from '../../../types'
@@ -91,6 +99,7 @@ interface SessionActionsOptions {
   navigate: NavigateFunction
   onFreshDraftRouteIntent?: () => void
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+  refreshSessionsAfterRemoval?: () => Promise<void>
   resetViewSync: () => void
   runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
   selectedStoredSessionId: string | null
@@ -112,6 +121,16 @@ interface SessionActionsOptions {
 // bounded retry rebinds it when the backend returns. Boot-into-a-stale-last-id
 // (NOT in this set) still legitimately drops to a draft.
 const createdThisRun = new Set<string>()
+
+function findListedSession(storedSessionId: string): SessionInfo | undefined {
+  return [...$sessions.get(), ...$cronSessions.get(), ...$messagingSessions.get()].find(session =>
+    sessionMatchesStoredId(session, storedSessionId)
+  )
+}
+
+function sessionRemovalIds(storedSessionId: string, session?: SessionInfo): string[] {
+  return [...new Set([storedSessionId, session?.id, session?._lineage_root_id].filter(Boolean) as string[])]
+}
 
 // Reflect a stored row's persisted token counts into the live usage atom
 // (total is derived, so callers can't drift it out of sync with input/output).
@@ -194,6 +213,7 @@ export function useSessionActions({
   navigate,
   onFreshDraftRouteIntent,
   requestGateway,
+  refreshSessionsAfterRemoval,
   resetViewSync,
   runtimeIdByStoredSessionIdRef,
   selectedStoredSessionId,
@@ -1139,7 +1159,18 @@ export function useSessionActions({
     async (storedSessionId: string) => {
       clearNotifications()
 
-      const removed = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
+      const removedFromRecents = $sessions.get().some(session => sessionMatchesStoredId(session, storedSessionId))
+      const removedFromCron = $cronSessions.get().some(session => sessionMatchesStoredId(session, storedSessionId))
+
+      const removedFromMessaging = $messagingSessions
+        .get()
+        .some(session => sessionMatchesStoredId(session, storedSessionId))
+
+      const removed = findListedSession(storedSessionId)
+      const removalIds = sessionRemovalIds(storedSessionId, removed)
+      const messagingSource = normalizeSessionSource(removed?.source)
+      const previousMessagingPlatformTotals = $messagingPlatformTotals.get()
+      const previousSessionsTotal = $sessionsTotal.get()
       const wasSelected = selectedStoredSessionId === storedSessionId
       const closingRuntimeId = wasSelected ? activeSessionId : null
       const previousMessages = $messages.get()
@@ -1149,13 +1180,25 @@ export function useSessionActions({
       const removedPinId = removed ? sessionPinId(removed) : storedSessionId
 
       setSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
+
       // Evict from the project tree's optimistic layer too (the backend snapshot
       // still lists it until its next refresh), so grouped + flat views drop the
       // row in lockstep.
-      tombstoneSessions([storedSessionId, removed?.id, removed?._lineage_root_id])
+      tombstoneSessions(removalIds)
+
       // Keep $sessionsTotal in sync so the sidebar's "Load N more" footer
       // doesn't keep claiming the removed row is still on the server.
-      setSessionsTotal(prev => Math.max(0, prev - 1))
+      if (removedFromRecents) {
+        setSessionsTotal(prev => Math.max(0, prev - 1))
+      }
+
+      if (removedFromMessaging && messagingSource && previousMessagingPlatformTotals[messagingSource] !== undefined) {
+        setMessagingPlatformTotals({
+          ...previousMessagingPlatformTotals,
+          [messagingSource]: Math.max(0, previousMessagingPlatformTotals[messagingSource] - 1)
+        })
+      }
+
       $pinnedSessionIds.set(previousPinned.filter(id => id !== storedSessionId && id !== removedPinId))
 
       // Tear down before awaiting so the route effect can't resume the
@@ -1170,6 +1213,16 @@ export function useSessionActions({
         }
 
         await deleteSession(storedSessionId, removed?.profile)
+        await refreshSessionsAfterRemoval?.().catch(() => undefined)
+
+        if (removedFromMessaging && messagingSource && previousMessagingPlatformTotals[messagingSource] !== undefined) {
+          setMessagingPlatformTotals(prev => ({
+            ...prev,
+            [messagingSource]: Math.max(0, previousMessagingPlatformTotals[messagingSource] - 1)
+          }))
+        }
+
+        broadcastSessionsChanged()
         clearQueuedPrompts(storedSessionId)
 
         if (closingRuntimeId) {
@@ -1188,12 +1241,35 @@ export function useSessionActions({
           dropSessionState(tiledRuntimeId)
         }
       } catch (err) {
-        if (removed) {
-          setSessions(prev => [removed, ...prev])
-          setSessionsTotal(prev => prev + 1)
+        if (removed && removedFromRecents) {
+          setSessions(prev =>
+            prev.some(session => sessionMatchesStoredId(session, storedSessionId)) ? prev : [removed, ...prev]
+          )
         }
 
-        untombstoneSessions([storedSessionId, removed?.id, removed?._lineage_root_id])
+        if (removed && removedFromCron) {
+          setCronSessions(prev =>
+            prev.some(session => sessionMatchesStoredId(session, storedSessionId)) ? prev : [removed, ...prev]
+          )
+        }
+
+        if (removed && removedFromMessaging) {
+          setMessagingSessions(prev =>
+            prev.some(session => sessionMatchesStoredId(session, storedSessionId)) ? prev : [removed, ...prev]
+          )
+        }
+
+        setSessionsTotal(previousSessionsTotal)
+
+        if (removedFromMessaging && messagingSource && previousMessagingPlatformTotals[messagingSource] !== undefined) {
+          setMessagingPlatformTotals(prev => ({
+            ...prev,
+            [messagingSource]: previousMessagingPlatformTotals[messagingSource]
+          }))
+        }
+
+        untombstoneSessions(removalIds)
+        await refreshSessionsAfterRemoval?.().catch(() => undefined)
         $pinnedSessionIds.set(previousPinned)
 
         if (wasSelected) {
@@ -1224,6 +1300,7 @@ export function useSessionActions({
       copy,
       navigate,
       requestGateway,
+      refreshSessionsAfterRemoval,
       runtimeIdByStoredSessionIdRef,
       selectedStoredSessionId,
       selectedStoredSessionIdRef,
@@ -1236,7 +1313,18 @@ export function useSessionActions({
     async (storedSessionId: string) => {
       clearNotifications()
 
-      const archived = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
+      const archivedFromRecents = $sessions.get().some(session => sessionMatchesStoredId(session, storedSessionId))
+      const archivedFromCron = $cronSessions.get().some(session => sessionMatchesStoredId(session, storedSessionId))
+
+      const archivedFromMessaging = $messagingSessions
+        .get()
+        .some(session => sessionMatchesStoredId(session, storedSessionId))
+
+      const archived = findListedSession(storedSessionId)
+      const removalIds = sessionRemovalIds(storedSessionId, archived)
+      const messagingSource = normalizeSessionSource(archived?.source)
+      const previousMessagingPlatformTotals = $messagingPlatformTotals.get()
+      const previousSessionsTotal = $sessionsTotal.get()
       const wasSelected = selectedStoredSessionId === storedSessionId
       const previousPinned = $pinnedSessionIds.get()
       // Pins are keyed on the durable lineage-root id; the stored id may be the
@@ -1245,11 +1333,22 @@ export function useSessionActions({
 
       // Soft-hide: drop from the sidebar immediately, keep the data.
       setSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
-      tombstoneSessions([storedSessionId, archived?.id, archived?._lineage_root_id])
+      tombstoneSessions(removalIds)
+
       // Archived sessions are hidden by the listSessions(min_messages=1) query
       // on the next refresh, so they count as "removed" for the load-more
       // footer math.
-      setSessionsTotal(prev => Math.max(0, prev - 1))
+      if (archivedFromRecents) {
+        setSessionsTotal(prev => Math.max(0, prev - 1))
+      }
+
+      if (archivedFromMessaging && messagingSource && previousMessagingPlatformTotals[messagingSource] !== undefined) {
+        setMessagingPlatformTotals({
+          ...previousMessagingPlatformTotals,
+          [messagingSource]: Math.max(0, previousMessagingPlatformTotals[messagingSource] - 1)
+        })
+      }
+
       $pinnedSessionIds.set(previousPinned.filter(id => id !== storedSessionId && id !== archivedPinId))
 
       if (wasSelected) {
@@ -1258,6 +1357,20 @@ export function useSessionActions({
 
       try {
         await setSessionArchived(storedSessionId, true, archived?.profile)
+        await refreshSessionsAfterRemoval?.().catch(() => undefined)
+
+        if (
+          archivedFromMessaging &&
+          messagingSource &&
+          previousMessagingPlatformTotals[messagingSource] !== undefined
+        ) {
+          setMessagingPlatformTotals(prev => ({
+            ...prev,
+            [messagingSource]: Math.max(0, previousMessagingPlatformTotals[messagingSource] - 1)
+          }))
+        }
+
+        broadcastSessionsChanged()
         // A sidebar refresh can race the optimistic removal while the PATCH is
         // in flight and briefly reinsert the still-unarchived backend row. Win
         // that race after the mutation succeeds so right-click → Archive does
@@ -1276,17 +1389,51 @@ export function useSessionActions({
 
         notify({ durationMs: 2_000, kind: 'success', message: copy.archived })
       } catch (err) {
-        if (archived) {
-          setSessions(prev => [archived, ...prev.filter(session => !sessionMatchesStoredId(session, storedSessionId))])
-          setSessionsTotal(prev => prev + 1)
+        if (archived && archivedFromRecents) {
+          setSessions(prev =>
+            prev.some(session => sessionMatchesStoredId(session, storedSessionId)) ? prev : [archived, ...prev]
+          )
         }
 
-        untombstoneSessions([storedSessionId, archived?.id, archived?._lineage_root_id])
+        if (archived && archivedFromCron) {
+          setCronSessions(prev =>
+            prev.some(session => sessionMatchesStoredId(session, storedSessionId)) ? prev : [archived, ...prev]
+          )
+        }
+
+        if (archived && archivedFromMessaging) {
+          setMessagingSessions(prev =>
+            prev.some(session => sessionMatchesStoredId(session, storedSessionId)) ? prev : [archived, ...prev]
+          )
+        }
+
+        setSessionsTotal(previousSessionsTotal)
+
+        if (
+          archivedFromMessaging &&
+          messagingSource &&
+          previousMessagingPlatformTotals[messagingSource] !== undefined
+        ) {
+          setMessagingPlatformTotals(prev => ({
+            ...prev,
+            [messagingSource]: previousMessagingPlatformTotals[messagingSource]
+          }))
+        }
+
+        untombstoneSessions(removalIds)
+        await refreshSessionsAfterRemoval?.().catch(() => undefined)
         $pinnedSessionIds.set(previousPinned)
         notifyError(err, copy.archiveFailed)
       }
     },
-    [copy, runtimeIdByStoredSessionIdRef, selectedStoredSessionId, sessionStateByRuntimeIdRef, startFreshSessionDraft]
+    [
+      copy,
+      refreshSessionsAfterRemoval,
+      runtimeIdByStoredSessionIdRef,
+      selectedStoredSessionId,
+      sessionStateByRuntimeIdRef,
+      startFreshSessionDraft
+    ]
   )
 
   return {

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
@@ -2,12 +2,15 @@ import { act, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { SessionInfo, SidebarSessionsResponse } from '@/hermes'
+import { $removedSessionIds, tombstoneSessions } from '@/store/projects'
 import {
   $cronSessions,
+  $messagingPlatformTotals,
   $messagingSessions,
   $sessions,
   $sessionsLoading,
   setCronSessions,
+  setMessagingPlatformTotals,
   setMessagingSessions,
   setSessions,
   setSessionsLoading
@@ -55,6 +58,16 @@ const sidebar = (
 const listSidebarSessions = vi.fn()
 const listAllProfileSessions = vi.fn()
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+
+  const promise = new Promise<T>(done => {
+    resolve = done
+  })
+
+  return { promise, resolve }
+}
+
 vi.mock('@/hermes', async importOriginal => ({
   ...(await importOriginal<Record<string, unknown>>()),
   getCronJobs: vi.fn(async () => []),
@@ -67,15 +80,20 @@ beforeEach(() => {
   listAllProfileSessions.mockReset()
   setSessions([])
   setCronSessions([])
+  setMessagingPlatformTotals({})
   setMessagingSessions([])
   setSessionsLoading(false)
+  $removedSessionIds.set(new Set())
 })
 
 afterEach(() => {
   setSessions([])
   setCronSessions([])
+  setMessagingPlatformTotals({})
   setMessagingSessions([])
   setSessionsLoading(false)
+  $removedSessionIds.set(new Set())
+  vi.useRealTimers()
 })
 
 describe('refreshSessions identity + loading hygiene', () => {
@@ -186,6 +204,79 @@ describe('refreshSessions batches slices into one request', () => {
     expect($sessions.get().map(s => s.id)).toEqual(['a', 'b'])
     expect($cronSessions.get().map(s => s.id)).toEqual(['c1'])
     expect($messagingSessions.get().map(s => s.id)).toEqual(['m1'])
+  })
+
+  it('filters optimistic removals from recents, cron, and messaging', async () => {
+    tombstoneSessions(['recent-gone', 'cron-gone', 'message-gone'])
+    listSidebarSessions.mockResolvedValue(
+      sidebar(
+        { sessions: [row('recent-gone'), row('recent-kept')], total: 2, profile_totals: { default: 2 } },
+        [row('cron-gone', { source: 'cron' }), row('cron-kept', { source: 'cron' })],
+        [row('message-gone', { source: 'telegram' }), row('message-kept', { source: 'telegram' })]
+      )
+    )
+
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'default' }))
+
+    await act(async () => {
+      await result.current.refreshSessions()
+    })
+
+    expect($sessions.get().map(s => s.id)).toEqual(['recent-kept'])
+    expect($cronSessions.get().map(s => s.id)).toEqual(['cron-kept'])
+    expect($messagingSessions.get().map(s => s.id)).toEqual(['message-kept'])
+  })
+
+  it('retains the hide marker across a delayed response and post-mutation refresh', async () => {
+    vi.useFakeTimers()
+    const stale = deferred<{ sessions: SessionInfo[]; total: number }>()
+    listAllProfileSessions.mockReturnValueOnce(stale.promise)
+    listSidebarSessions.mockResolvedValue(sidebar({ sessions: [], total: 0, profile_totals: {} }))
+
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'default' }))
+    const staleRefresh = result.current.loadMoreMessagingForPlatform('telegram')
+
+    tombstoneSessions(['message-gone'])
+
+    await act(async () => {
+      await result.current.refreshSessions()
+    })
+
+    await vi.advanceTimersByTimeAsync(2_100)
+    expect($removedSessionIds.get().has('message-gone')).toBe(true)
+
+    stale.resolve({ sessions: [row('message-gone', { source: 'telegram' })], total: 5 })
+
+    await act(async () => {
+      await staleRefresh
+    })
+
+    expect($messagingSessions.get()).toEqual([])
+    expect($messagingPlatformTotals.get()).toEqual({})
+    expect($removedSessionIds.get().has('message-gone')).toBe(true)
+  })
+
+  it('filters optimistic removals from per-platform and per-profile paging', async () => {
+    tombstoneSessions(['message-gone', 'profile-gone'])
+    listAllProfileSessions
+      .mockResolvedValueOnce({
+        sessions: [row('message-gone', { source: 'telegram' }), row('message-kept', { source: 'telegram' })],
+        total: 2
+      })
+      .mockResolvedValueOnce({
+        sessions: [row('profile-gone', { profile: 'work' }), row('profile-kept', { profile: 'work' })],
+        total: 2
+      })
+
+    const { result } = renderHook(() => useSessionListActions({ profileScope: '__all__' }))
+
+    await act(async () => {
+      await result.current.loadMoreMessagingForPlatform('telegram')
+      await result.current.loadMoreSessionsForProfile('work')
+    })
+
+    expect($messagingSessions.get().map(s => s.id)).toEqual(['message-kept'])
+    expect($sessions.get().map(s => s.id)).toEqual(['profile-kept'])
   })
 
   it('forwards the active profile scope + section limits to the batched call', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -11,6 +11,7 @@ import {
 import { setCronJobs } from '@/store/cron'
 import { $pinnedSessionIds, $sessionsLimit, bumpSessionsLimit, SIDEBAR_SESSIONS_PAGE_SIZE } from '@/store/layout'
 import { ALL_PROFILES, normalizeProfileKey } from '@/store/profile'
+import { filterTombstonedSessions } from '@/store/projects'
 import {
   $messagingSessions,
   $selectedStoredSessionId,
@@ -73,6 +74,7 @@ interface UseSessionListActionsArgs {
  *  and the per-platform messaging slices. Returns the callbacks the controller
  *  wires into the sidebar and refresh effects. */
 export function useSessionListActions({ profileScope }: UseSessionListActionsArgs) {
+  const refreshMessagingRequestRef = useRef(0)
   const refreshSessionsRequestRef = useRef(0)
 
   // Messaging-platform sessions as their own slice, fetched separately from
@@ -80,14 +82,20 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
   // competes with local chats for the recents page budget. One combined fetch
   // seeds every platform; the sidebar splits the rows per source.
   const refreshMessagingSessions = useCallback(async () => {
+    const requestId = ++refreshMessagingRequestRef.current
+
     try {
       const result = await listAllProfileSessions(MESSAGING_SECTION_LIMIT, 1, 'exclude', 'recent', 'all', {
         excludeSources: MESSAGING_EXCLUDED_SOURCES
       })
 
+      if (refreshMessagingRequestRef.current !== requestId) {
+        return
+      }
+
       // Drop any non-messaging source the broad exclude didn't catch (custom
       // sources) — those stay in local recents, not a platform section.
-      const rows = result.sessions.filter(s => isMessagingSource(s.source))
+      const rows = filterTombstonedSessions(result.sessions).filter(s => isMessagingSource(s.source))
 
       setMessagingSessions(prev => (sameCronSignature(prev, rows) ? prev : rows))
       // Hit the cap → at least one platform may have more on disk than loaded,
@@ -102,6 +110,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
   // pager): fetch that source's next window and merge it back in place, leaving
   // every other platform's rows untouched. Resolves the platform's exact total.
   const loadMoreMessagingForPlatform = useCallback(async (platform: string) => {
+    const requestId = ++refreshMessagingRequestRef.current
     const inPlatform = (s: SessionInfo) => normalizeSessionSource(s.source) === platform
     const loaded = $messagingSessions.get().filter(inPlatform).length
 
@@ -109,7 +118,13 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
       source: platform
     })
 
-    const incoming = result.sessions.filter(s => normalizeSessionSource(s.source) === platform)
+    if (refreshMessagingRequestRef.current !== requestId) {
+      return
+    }
+
+    const incoming = filterTombstonedSessions(result.sessions).filter(
+      s => normalizeSessionSource(s.source) === platform
+    )
 
     setMessagingSessions(prev => [
       ...prev.filter(s => !inPlatform(s)),
@@ -140,6 +155,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
   const refreshSessions = useCallback(async () => {
     const requestId = refreshSessionsRequestRef.current + 1
     refreshSessionsRequestRef.current = requestId
+    const messagingRequestId = ++refreshMessagingRequestRef.current
     // The loading flag exists to drive the initial skeletons (they only render
     // while the list is empty). Turn-complete / reconnect refreshes over a
     // populated list used to flip it true→false anyway, churning every
@@ -179,13 +195,14 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
 
       if (refreshSessionsRequestRef.current === requestId) {
         const recents = result.recents
+        const visibleRecents = filterTombstonedSessions(recents.sessions)
 
         // Signature-gate the swap (same pattern as cron/messaging): a refresh
         // that returns content-identical rows must keep the previous array
         // identity, or every sidebar memo keyed on $sessions recomputes and the
         // whole list re-renders once per turn/broadcast for nothing.
         setSessions(prev => {
-          const next = mergeSessionPage(prev, recents.sessions, sessionsToKeep())
+          const next = mergeSessionPage(prev, visibleRecents, sessionsToKeep())
 
           return sameCronSignature(prev, next) ? prev : next
         })
@@ -201,16 +218,22 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
 
         // Cron section: latest N cron sessions (kept so a pinned cron run still
         // resolves via sessionByAnyId), signature-gated like above.
-        setCronSessions(prev => (sameCronSignature(prev, result.cron.sessions) ? prev : result.cron.sessions))
+        const visibleCron = filterTombstonedSessions(result.cron.sessions)
+
+        setCronSessions(prev => (sameCronSignature(prev, visibleCron) ? prev : visibleCron))
 
         // Messaging sections: drop any non-messaging source the broad exclude
         // didn't catch (custom sources stay in local recents), then split per
         // platform in the UI.
-        const messagingRows = result.messaging.sessions.filter(s => isMessagingSource(s.source))
+        const messagingRows = filterTombstonedSessions(result.messaging.sessions).filter(s =>
+          isMessagingSource(s.source)
+        )
 
-        setMessagingSessions(prev => (sameCronSignature(prev, messagingRows) ? prev : messagingRows))
-        // Hit the cap → at least one platform may have more on disk than loaded.
-        setMessagingTruncated(result.messaging.sessions.length >= MESSAGING_SECTION_LIMIT)
+        if (refreshMessagingRequestRef.current === messagingRequestId) {
+          setMessagingSessions(prev => (sameCronSignature(prev, messagingRows) ? prev : messagingRows))
+          // Hit the cap → at least one platform may have more on disk than loaded.
+          setMessagingTruncated(result.messaging.sessions.length >= MESSAGING_SECTION_LIMIT)
+        }
       }
     } finally {
       if (showLoading && refreshSessionsRequestRef.current === requestId) {
@@ -230,6 +253,8 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
   // ALL-profiles view pages one profile at a time: fetch that profile's next
   // page and merge it in place, leaving every other profile's rows untouched.
   const loadMoreSessionsForProfile = useCallback(async (profile: string) => {
+    const requestId = refreshSessionsRequestRef.current + 1
+    refreshSessionsRequestRef.current = requestId
     const key = normalizeProfileKey(profile)
     const inKey = (s: SessionInfo) => normalizeProfileKey(s.profile) === key
     const loaded = $sessions.get().filter(inKey).length
@@ -238,12 +263,14 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
       excludeSources: SIDEBAR_EXCLUDED_SOURCES
     })
 
-    const keep = sessionsToKeep(key)
+    if (refreshSessionsRequestRef.current !== requestId) {
+      return
+    }
 
-    setSessions(prev => [
-      ...prev.filter(s => !inKey(s)),
-      ...mergeSessionPage(prev.filter(inKey), result.sessions, keep)
-    ])
+    const keep = sessionsToKeep(key)
+    const incoming = filterTombstonedSessions(result.sessions)
+
+    setSessions(prev => [...prev.filter(s => !inKey(s)), ...mergeSessionPage(prev.filter(inKey), incoming, keep)])
 
     const total = result.profile_totals?.[key] ?? result.total ?? result.sessions.length
     setSessionProfileTotals(prev => ({ ...prev, [key]: Math.max(total, result.sessions.length) }))

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -12,7 +12,7 @@ import { setSidebarAgentsGrouped } from '@/store/layout'
 import { notify } from '@/store/notifications'
 import { requestFreshSession } from '@/store/profile'
 import { $selectedStoredSessionId, $sessions, sessionMatchesStoredId, workspaceCwdForNewSession } from '@/store/session'
-import type { ProjectInfo, ProjectsPayload } from '@/types/hermes'
+import type { ProjectInfo, ProjectsPayload, SessionInfo } from '@/types/hermes'
 
 // First-class, per-profile Projects (named, multi-folder workspaces). State is
 // served by the live gateway's `projects.*` JSON-RPC methods, which wrap the
@@ -47,12 +47,30 @@ function projectsStaleBackendError(): Error {
   return new Error(translateNow('sidebar.projects.staleBackend'))
 }
 
-// Client-side cache eviction (Apollo-style optimistic layer): ids the user just
-// deleted/archived. The backend tree is a snapshot that still lists them until
-// its next refresh, so the render-time overlay strips these so the tree matches
-// the live `$sessions` cache exactly — same as the flat Recents list. Pruned on
-// refresh once the server snapshot has caught up.
+// Client-side cache eviction (Apollo-style optimistic layer): ids deleted or
+// archived during this renderer run. Every session-list surface filters these;
+// failed mutations and explicit archive restores remove their markers.
 export const $removedSessionIds = atom<Set<string>>(new Set())
+
+export function sessionIsTombstoned(
+  session: Pick<SessionInfo, '_lineage_root_id' | 'id'>,
+  ids: ReadonlySet<string> = $removedSessionIds.get()
+): boolean {
+  return ids.has(session.id) || Boolean(session._lineage_root_id && ids.has(session._lineage_root_id))
+}
+
+export function filterTombstonedSessions<T extends Pick<SessionInfo, '_lineage_root_id' | 'id'>>(
+  sessions: T[],
+  tombstones: ReadonlySet<string> = $removedSessionIds.get()
+): T[] {
+  if (!tombstones.size) {
+    return sessions
+  }
+
+  const visible = sessions.filter(session => !sessionIsTombstoned(session, tombstones))
+
+  return visible.length === sessions.length ? sessions : visible
+}
 
 export function tombstoneSessions(ids: Array<null | string | undefined>): void {
   const next = new Set($removedSessionIds.get())
@@ -285,36 +303,19 @@ export async function refreshProjects(): Promise<void> {
 interface ProjectTreePayload {
   projects: SidebarProjectTree[]
   active_id: null | string
-  scoped_session_ids: string[]
 }
 
 // Pull the authoritative project tree (overview structure + counts + preview
-// sessions + the scoped-session-id set). Best-effort: a failure leaves the
-// cached tree intact so the sidebar doesn't flicker.
+// sessions). Best-effort: a failure leaves the cached tree intact so the
+// sidebar doesn't flicker.
 export async function refreshProjectTree(): Promise<void> {
   $projectTreeLoading.set(true)
 
   try {
     const res = await gatewayRequest<ProjectTreePayload>('projects.tree', { preview_limit: 3 })
-    // The flat Sessions list shows everything; scoped ids are only used here to
-    // reconcile the optimistic eviction layer against what the server still lists.
-    const scoped = new Set(res.scoped_session_ids ?? [])
 
     $projectTree.set(res.projects ?? [])
     $activeProjectId.set(res.active_id ?? null)
-
-    // Reconcile the optimistic eviction layer against the fresh snapshot: keep
-    // evicting ids the server still lists (delete in flight) and drop the rest
-    // (server caught up), so the set can't grow unbounded across a long session.
-    const tombstones = $removedSessionIds.get()
-
-    if (tombstones.size) {
-      const pending = new Set([...tombstones].filter(id => scoped.has(id)))
-
-      if (pending.size !== tombstones.size) {
-        $removedSessionIds.set(pending)
-      }
-    }
 
     markProjectsRpcSuccess()
   } catch (err) {


### PR DESCRIPTION
## Summary

Desktop session deletes are optimistic, but a sidebar refresh or Load more request can land while the backend mutation is still committing. If that stale response still contains the removed row, the old merge path accepted it and the session showed up again.

This keeps a small local hide set for sessions the user has removed, then filters those rows out of sidebar refresh results before merging. Delete keeps the row hidden for the renderer lifetime; archive uses a short hide window so stale in-flight refreshes cannot reinsert the row, then clears normally. If the mutation fails, the hide marker is cleared and the row is restored.

Also covers the sidebar slices that do not go through the normal recents merge path: cron sessions and messaging sessions.

Fixes #50928

## Changes

- Add local hidden-session tracking in `apps/desktop/src/store/session.ts`
- Filter locally hidden rows inside `mergeSessionPage`
- Mark sessions hidden before `deleteSession(...)`, and clear the marker on delete failure
- Mark archived sessions hidden across the refresh race, and clear the marker on archive failure or unarchive
- Apply the same filtering to cron and messaging sidebar refreshes
- Add regression coverage for stale refresh races and failure rollback

## Test plan

- [x] `npm --workspace apps/desktop run test:ui -- src/store/session.test.ts src/app/session/hooks/use-session-actions.test.tsx`
- [x] `npm --workspace apps/desktop run typecheck`
- [x] `npm --workspace apps/desktop exec eslint -- src/store/session.ts src/store/session.test.ts src/app/session/hooks/use-session-actions.ts src/app/session/hooks/use-session-actions.test.tsx src/app/desktop-controller.tsx src/app/settings/sessions-settings.tsx`
- [x] `npm --workspace apps/desktop exec prettier -- --check src/store/session.ts src/store/session.test.ts src/app/session/hooks/use-session-actions.ts src/app/session/hooks/use-session-actions.test.tsx src/app/desktop-controller.tsx src/app/settings/sessions-settings.tsx`
- [x] `git diff --check`

The regression tests hold the backend delete/archive promises open, inject stale refresh results containing the removed session, and verify the row stays hidden. They also verify failed mutations restore the session.
