### PR TITLE
fix: preserve CLI image and Kimi fallback fixes

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1196,6 +1196,15 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         ):
             fb_api_mode = "bedrock_converse"
 
+        # Mirror runtime_provider: Kimi Code (api.kimi.com/coding) and other
+        # /anthropic gateways need anthropic_messages, not chat_completions.
+        if fb_api_mode == "chat_completions":
+            from hermes_cli.runtime_provider import _detect_api_mode_for_url
+
+            _url_detected = _detect_api_mode_for_url(fb_base_url)
+            if _url_detected:
+                fb_api_mode = _url_detected
+
         old_model = agent.model
 
         # Clear the per-config context_length override so the fallback

--- a/cli.py
+++ b/cli.py
@@ -3046,7 +3046,24 @@ def _estimate_tui_input_height(
     return min(max(visual_lines, 1), max(1, int(max_height or 1)))
 
 
-def _collect_query_images(query: str | None, image_arg: str | None = None) -> tuple[str, list[Path]]:
+def _normalize_image_args(image_arg) -> list[str]:
+    """Return image CLI arguments as a flat list.
+
+    Python Fire and argparse can pass a scalar string, a list/tuple from repeated
+    --image flags, or occasionally nested tuple/list values. Keep single-image
+    behavior while preserving every repeated flag for Mission Control.
+    """
+    if image_arg is None or image_arg == "":
+        return []
+    if isinstance(image_arg, (list, tuple)):
+        values: list[str] = []
+        for item in image_arg:
+            values.extend(_normalize_image_args(item))
+        return values
+    return [str(image_arg)]
+
+
+def _collect_query_images(query: str | None, image_arg=None) -> tuple[str, list[Path]]:
     """Collect local image attachments for single-query CLI flows."""
     message = query or ""
     images: list[Path] = []
@@ -3057,10 +3074,10 @@ def _collect_query_images(query: str | None, image_arg: str | None = None) -> tu
             images.append(dropped["path"])
             message = dropped["remainder"] or f"[User attached image: {dropped['path'].name}]"
 
-    if image_arg:
-        explicit_path = _resolve_attachment_path(image_arg)
+    for raw_image_arg in _normalize_image_args(image_arg):
+        explicit_path = _resolve_attachment_path(raw_image_arg)
         if explicit_path is None:
-            raise ValueError(f"Image file not found: {image_arg}")
+            raise ValueError(f"Image file not found: {raw_image_arg}")
         if explicit_path.suffix.lower() not in _IMAGE_EXTENSIONS:
             raise ValueError(f"Not a supported image file: {explicit_path}")
         images.append(explicit_path)
@@ -14696,7 +14713,7 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
 def main(
     query: str = None,
     q: str = None,
-    image: str = None,
+    image: str | list[str] | tuple[str, ...] | None = None,
     toolsets: str = None,
     skills: str | list[str] | tuple[str, ...] = None,
     model: str = None,

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -257,7 +257,10 @@ def build_top_level_parser():
         "-q", "--query", help="Single query (non-interactive mode)"
     )
     chat_parser.add_argument(
-        "--image", help="Optional local image path to attach to a single query"
+        "--image",
+        action="append",
+        default=argparse.SUPPRESS,
+        help="Optional local image path to attach to a single query (repeat for multiple images)",
     )
     _inherited_flag(
         chat_parser,

--- a/tests/cli/test_cli_image_command.py
+++ b/tests/cli/test_cli_image_command.py
@@ -5,6 +5,7 @@ from cli import (
     HermesCLI,
     _collect_query_images,
     _format_image_attachment_badges,
+    _normalize_image_args,
     _termux_example_image_path,
 )
 
@@ -61,6 +62,25 @@ class TestCollectQueryImages:
 
         assert message == "describe this"
         assert images == [img]
+
+    def test_collect_query_images_accepts_repeated_image_args(self, tmp_path):
+        img1 = _make_image(tmp_path / "diagram-one.png")
+        img2 = _make_image(tmp_path / "diagram-two.png")
+
+        message, images = _collect_query_images("compare these", [str(img1), str(img2)])
+
+        assert message == "compare these"
+        assert images == [img1, img2]
+
+    def test_collect_query_images_flattens_fire_tuple_values(self, tmp_path):
+        img1 = _make_image(tmp_path / "fire-one.png")
+        img2 = _make_image(tmp_path / "fire-two.png")
+
+        assert _normalize_image_args((str(img1), [str(img2)])) == [str(img1), str(img2)]
+        message, images = _collect_query_images("compare these", (str(img1), [str(img2)]))
+
+        assert message == "compare these"
+        assert images == [img1, img2]
 
     def test_collect_query_images_extracts_leading_path(self, tmp_path):
         img = _make_image(tmp_path / "camera.png")

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5693,6 +5693,33 @@ class TestFallbackAnthropicProvider:
         assert agent.api_mode == "chat_completions"
         assert agent.client is mock_client
 
+    def test_fallback_to_kimi_coding_uses_anthropic_messages(self, agent):
+        """Kimi Code /coding endpoint speaks Anthropic Messages, not chat.completions."""
+        agent._fallback_activated = False
+        agent._fallback_model = {
+            "provider": "kimi-coding",
+            "model": "kimi-for-coding",
+        }
+        agent._fallback_chain = [agent._fallback_model]
+        agent._fallback_index = 0
+
+        mock_client = MagicMock()
+        mock_client.base_url = "https://api.kimi.com/coding/v1"
+        mock_client.api_key = "sk-kimi-test"
+
+        with (
+            patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)),
+            patch("agent.anthropic_adapter.build_anthropic_client") as mock_build,
+            patch("agent.anthropic_adapter.resolve_anthropic_token", return_value=None),
+        ):
+            mock_build.return_value = MagicMock()
+            result = agent._try_activate_fallback()
+
+        assert result is True
+        assert agent.api_mode == "anthropic_messages"
+        assert agent._anthropic_client is not None
+        assert agent.client is None
+
 
 def test_aiagent_uses_copilot_acp_client():
     with (


### PR DESCRIPTION
## Summary
- preserve local CLI --image repeat handling and nested Fire tuple flattening
- preserve Kimi Code fallback API mode detection for /anthropic gateways
- add regression coverage for both paths

## Tests
- python -m pytest tests/cli/test_cli_image_command.py tests/run_agent/test_run_agent.py -o 'addopts=' -q