### PR TITLE
fix(bootstrap-installer): break run_streamed on child exit to prevent Windows pipe hang

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -31,6 +31,7 @@ use anyhow::{anyhow, Result};
 use tauri::{AppHandle, Emitter};
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
+use tokio::time::timeout;
 
 use crate::events::{BootstrapEvent, LogStream, StageInfo, StageState};
 
@@ -672,13 +673,35 @@ async fn run_streamed(
                 Ok(None) => {}
                 Err(e) => { tracing::warn!("stderr read error: {e}"); }
             },
+            // On Windows, grandchild processes (e.g. npm → electron-builder) inherit
+            // the stdout pipe handle and keep it open after the main child exits,
+            // preventing EOF and stalling the loop forever. Break as soon as the
+            // immediate child exits. (#51127)
+            _ = child.wait() => break,
         }
     }
-    while let Ok(Some(l)) = out.next_line().await {
-        emit_log(app, stage_owned.as_deref(), LogStream::Stdout, &l);
+    // Drain any lines buffered since the loop exited. On Windows, grandchildren
+    // may still hold the pipe open so wrap with a short timeout to avoid
+    // re-introducing the hang.
+    #[cfg(target_os = "windows")]
+    {
+        let _ = timeout(Duration::from_millis(300), async {
+            while let Ok(Some(l)) = out.next_line().await {
+                emit_log(app, stage_owned.as_deref(), LogStream::Stdout, &l);
+            }
+            while let Ok(Some(l)) = err.next_line().await {
+                emit_log(app, stage_owned.as_deref(), LogStream::Stderr, &l);
+            }
+        }).await;
     }
-    while let Ok(Some(l)) = err.next_line().await {
-        emit_log(app, stage_owned.as_deref(), LogStream::Stderr, &l);
+    #[cfg(not(target_os = "windows"))]
+    {
+        while let Ok(Some(l)) = out.next_line().await {
+            emit_log(app, stage_owned.as_deref(), LogStream::Stdout, &l);
+        }
+        while let Ok(Some(l)) = err.next_line().await {
+            emit_log(app, stage_owned.as_deref(), LogStream::Stderr, &l);
+        }
     }
 
     let status = child.wait().await.map_err(|e| anyhow!("waiting for child: {e}"))?;


### PR DESCRIPTION
## Problem

Fixes #51127

On Windows, the Desktop update progress bar freezes after npm deprecation warnings and never completes. The user must force-close and relaunch manually even though the update itself succeeded.

**Root cause:** `run_streamed` in `apps/bootstrap-installer/src-tauri/src/update.rs` reads stdout/stderr in a `tokio::select!` loop that only breaks on stdout EOF. On Windows, `npm` and `electron-builder` spawn grandchild processes that inherit the stdout pipe handle via `CREATE_NO_WINDOW`. These grandchildren keep the pipe open after the main child exits — stdout never reaches EOF, the loop stalls forever, and `emit_stage("rebuild", Succeeded)` + `emit(Complete)` are never called.

## Fix

Add a `child.wait()` arm to the `tokio::select!` loop in `run_streamed` so the loop breaks when the immediate child exits, regardless of pipe state:

- On Windows: after breaking, drain remaining buffered output with a 300ms timeout to capture any last lines without re-blocking on grandchild-held handles
- On non-Windows: drain path unchanged (stdout EOF arrives normally, `child.wait()` arm is a no-op safety net)

## Test plan

- [ ] Windows: run update via Desktop GUI — progress bar advances through all stages and auto-relaunches
- [ ] macOS/Linux: `hermes update` continues to work normally
- [ ] Stage log output still streams live during update and rebuild stages