### PR TITLE
fix(telegram): honor base_url in standalone send_message tool (#51223)

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -997,6 +997,21 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
             _tg_proxy = resolve_proxy_url("TELEGRAM_PROXY", target_hosts=["api.telegram.org"])
         except Exception:
             _tg_proxy = None
+        # Honour a custom Bot API base_url (self-hosted telegram-bot-api server),
+        # mirroring the gateway adapter's platforms.telegram.extra.base_url. Without
+        # this, the standalone send path always hits api.telegram.org and times out
+        # in regions where it is blocked, even when interactive gateway replies work.
+        # Resolve from config first, then fall back to the env var.
+        _tg_base_url = ""
+        try:
+            from gateway.config import load_gateway_config
+            _cfg = load_gateway_config() or {}
+            _tg_extra = (_cfg.get("platforms", {}) or {}).get("telegram", {}).get("extra", {}) or {}
+            _tg_base_url = str(_tg_extra.get("base_url", "") or "").strip()
+        except Exception:
+            _tg_base_url = ""
+        if not _tg_base_url:
+            _tg_base_url = os.getenv("TELEGRAM_BOT_API_BASE_URL", "").strip()
         if _tg_proxy:
             try:
                 from telegram.request import HTTPXRequest
@@ -1009,6 +1024,9 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
             except Exception as _proxy_err:
                 logger.warning("send_message: failed to attach Telegram proxy (%s), falling back to direct connection", _proxy_err)
                 bot = Bot(token=token)
+        elif _tg_base_url:
+            logger.info("send_message: standalone Telegram send via custom Bot API base_url %s", _tg_base_url)
+            bot = Bot(token=token, base_url=_tg_base_url)
         else:
             bot = Bot(token=token)
         int_chat_id = int(chat_id)


### PR DESCRIPTION
## What

The standalone `send_message` tool (`tools/send_message_tool.py` → `_send_telegram`) now honors a custom Telegram Bot API `base_url`, mirroring the gateway adapter (`gateway/platforms/telegram.py`, which applies `extra.base_url` via `builder.base_url(...)`).

## Why

In deployments where `api.telegram.org` is blocked and a self-hosted `telegram-bot-api` server is used (configured via `platforms.telegram.extra.base_url`), **interactive gateway replies work but proactive/cron sends fail**, because `_send_telegram` constructed `Bot(token=token)` with no base_url and connected straight to `api.telegram.org`:

```
Tool send_message returned error: {"error": "Telegram send failed: Timed out"}
```

The send path already honors `TELEGRAM_PROXY` but not `base_url`, so it was asymmetric with the gateway adapter. Fixes #51223.

## How

Resolve the base URL from `platforms.telegram.extra.base_url` (single source of truth with the gateway), falling back to a `TELEGRAM_BOT_API_BASE_URL` env var, and pass it to `Bot(token=token, base_url=...)`.

- Additive and backward-compatible — when neither is set, behavior is unchanged (`Bot(token=token)`).
- Config lookup is wrapped in try/except so it can never break the send path.
- Proxy path takes precedence (unchanged), then base_url, then default.

## Testing

Running this in production: a fleet of gateway bots behind a self-hosted Bot API server in a network where `api.telegram.org` is blocked. Before: cron/proactive `send_message` calls timed out. After: they route through the configured Bot API server identically to interactive replies.

`python3 -m py_compile tools/send_message_tool.py` passes.
