### PR TITLE
fix: replace bool(config.get()) with is_truthy_value across codebase

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -50,7 +50,7 @@ from agent.tool_guardrails import (
 from hermes_cli.config import cfg_get
 from hermes_cli.timeouts import get_provider_request_timeout
 from hermes_constants import get_hermes_home
-from utils import base_url_host_matches, is_truthy_value
+from utils import is_truthy_value,  base_url_host_matches, is_truthy_value
 
 # Use the same logger name as run_agent so tests patching ``run_agent.logger``
 # capture our warnings.  (run_agent.py also does
@@ -1065,7 +1065,7 @@ def init_agent(
     try:
         from hermes_cli.config import load_config as _load_sess_cfg
         _sess_cfg = (_load_sess_cfg().get("sessions") or {})
-        agent._session_json_enabled = bool(_sess_cfg.get("write_json_snapshots", False))
+        agent._session_json_enabled = is_truthy_value(_sess_cfg.get("write_json_snapshots"), default=False)
     except Exception:
         pass
     # logs_dir is retained unconditionally for request_dump_*.json (debug

--- a/agent/azure_identity_adapter.py
+++ b/agent/azure_identity_adapter.py
@@ -35,6 +35,7 @@ import functools
 import logging
 import os
 import threading
+from utils import is_truthy_value
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional
 
@@ -164,7 +165,7 @@ class EntraIdentityConfig:
                   *, default_scope: Optional[str] = None) -> "EntraIdentityConfig":
         data = data or {}
         scope = str(data.get("scope") or "").strip() or default_scope or SCOPE_AI_AZURE_DEFAULT
-        exclude_browser = bool(data.get("exclude_interactive_browser", True))
+        exclude_browser = is_truthy_value(data.get("exclude_interactive_browser"), default=True)
         return cls(
             scope=scope,
             exclude_interactive_browser=exclude_browser,

--- a/agent/billing_view.py
+++ b/agent/billing_view.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from utils import is_truthy_value
 from dataclasses import dataclass, field
 from decimal import Decimal, InvalidOperation
 from typing import Any, Optional
@@ -152,7 +153,7 @@ def _parse_auto_reload(raw: Any) -> Optional[AutoReload]:
     if not isinstance(raw, dict):
         return None
     return AutoReload(
-        enabled=bool(raw.get("enabled")),
+        enabled=is_truthy_value(raw.get("enabled")),
         threshold_usd=parse_money(raw.get("thresholdUsd")),
         reload_to_usd=parse_money(raw.get("reloadToUsd")),
     )

--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -44,6 +44,7 @@ import logging
 import re
 import shutil
 import tarfile
+from utils import is_truthy_value
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
@@ -158,7 +159,7 @@ def _load_config() -> Dict[str, Any]:
 
 def is_enabled() -> bool:
     """Default ON — the whole point of the backup is safety by default."""
-    return bool(_load_config().get("enabled", True))
+    return is_truthy_value(_load_config().get("enabled"), default=True)
 
 
 def get_keep() -> int:

--- a/agent/plugin_llm.py
+++ b/agent/plugin_llm.py
@@ -63,6 +63,7 @@ import base64
 import json
 import logging
 import re
+from utils import is_truthy_value
 from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence, Union
 
@@ -235,14 +236,14 @@ def _resolve_trust_policy(plugin_id: str) -> _TrustPolicy:
 
     return _TrustPolicy(
         plugin_id=plugin_id,
-        allow_provider_override=bool(llm_cfg.get("allow_provider_override", False)),
+        allow_provider_override=is_truthy_value(llm_cfg.get("allow_provider_override"), default=False),
         allowed_providers=allowed_providers,
         allow_any_provider=allow_any_provider,
-        allow_model_override=bool(llm_cfg.get("allow_model_override", False)),
+        allow_model_override=is_truthy_value(llm_cfg.get("allow_model_override"), default=False),
         allowed_models=allowed_models,
         allow_any_model=allow_any_model,
-        allow_agent_id_override=bool(llm_cfg.get("allow_agent_id_override", False)),
-        allow_profile_override=bool(llm_cfg.get("allow_profile_override", False)),
+        allow_agent_id_override=is_truthy_value(llm_cfg.get("allow_agent_id_override"), default=False),
+        allow_profile_override=is_truthy_value(llm_cfg.get("allow_profile_override"), default=False),
     )
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -736,7 +736,7 @@ def _message_timestamps_enabled(user_config: Optional[dict]) -> bool:
         return False
     mt = gw.get("message_timestamps")
     if isinstance(mt, dict):
-        return bool(mt.get("enabled", False))
+        return is_truthy_value(mt.get("enabled"), default=False)
     # Allow a bare ``message_timestamps: true`` shorthand.
     return bool(mt)
 
@@ -1284,7 +1284,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # Resolve Hermes home directory (respects HERMES_HOME override)
 from hermes_constants import get_hermes_home
-from utils import atomic_json_write, atomic_yaml_write, base_url_host_matches, is_truthy_value
+from utils import is_truthy_value,  atomic_json_write, atomic_yaml_write, base_url_host_matches, is_truthy_value
 _hermes_home = get_hermes_home()
 
 # Load environment variables from ~/.hermes/.env first.

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -26,6 +26,7 @@ piecemeal, the footer is sent as a separate trailing message via
 from __future__ import annotations
 
 import os
+from utils import is_truthy_value
 from typing import Any, Iterable, Optional
 
 _DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "cwd")
@@ -70,7 +71,7 @@ def resolve_footer_config(
     global_cfg = cfg.get("runtime_footer")
     if isinstance(global_cfg, dict):
         if "enabled" in global_cfg:
-            resolved["enabled"] = bool(global_cfg.get("enabled"))
+            resolved["enabled"] = is_truthy_value(global_cfg.get("enabled"))
         if isinstance(global_cfg.get("fields"), list) and global_cfg["fields"]:
             resolved["fields"] = [str(f) for f in global_cfg["fields"]]
 
@@ -81,7 +82,7 @@ def resolve_footer_config(
             plat_footer = plat_cfg.get("runtime_footer")
             if isinstance(plat_footer, dict):
                 if "enabled" in plat_footer:
-                    resolved["enabled"] = bool(plat_footer.get("enabled"))
+                    resolved["enabled"] = is_truthy_value(plat_footer.get("enabled"))
                 if isinstance(plat_footer.get("fields"), list) and plat_footer["fields"]:
                     resolved["fields"] = [str(f) for f in plat_footer["fields"]]
 

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -20,6 +20,7 @@ import sys
 import threading
 import time
 import uuid
+from utils import is_truthy_value
 from datetime import datetime
 from urllib.parse import urlparse
 
@@ -2176,7 +2177,7 @@ class CLICommandsMixin:
 
         cfg = load_config() or {}
         footer_cfg = ((cfg.get("display") or {}).get("runtime_footer") or {})
-        current = bool(footer_cfg.get("enabled", False))
+        current = is_truthy_value(footer_cfg.get("enabled"), default=False)
         fields = footer_cfg.get("fields") or ["model", "context_pct", "cwd"]
 
         if arg in {"status", "?"}:

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 
 from dotenv import load_dotenv
-from utils import atomic_replace
+from utils import is_truthy_value,  atomic_replace
 
 
 # Env var name suffixes that indicate credential values.  These are the
@@ -320,9 +320,9 @@ def _apply_external_secret_sources(home_path: Path) -> None:
         enabled=True,
         access_token_env=bw_cfg.get("access_token_env", "BWS_ACCESS_TOKEN"),
         project_id=bw_cfg.get("project_id", ""),
-        override_existing=bool(bw_cfg.get("override_existing", False)),
+        override_existing=is_truthy_value(bw_cfg.get("override_existing"), default=False),
         cache_ttl_seconds=float(bw_cfg.get("cache_ttl_seconds", 300)),
-        auto_install=bool(bw_cfg.get("auto_install", True)),
+        auto_install=is_truthy_value(bw_cfg.get("auto_install"), default=True),
         server_url=str(bw_cfg.get("server_url", "") or "").strip(),
         home_path=home_path,
     )

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -21,6 +21,7 @@ import os
 import shlex
 import sys
 import time
+from utils import is_truthy_value
 from pathlib import Path
 from typing import Any, Optional
 
@@ -160,7 +161,7 @@ def _check_dispatcher_presence() -> tuple[bool, str]:
     try:
         from hermes_cli.config import load_config
         cfg = load_config()
-        dispatch_on = bool(cfg.get("kanban", {}).get("dispatch_in_gateway", True))
+        dispatch_on = is_truthy_value(cfg.get("kanban", {}).get("dispatch_in_gateway"), default=True)
     except Exception:
         dispatch_on = True  # can't tell — assume default
 

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -40,6 +40,7 @@ import json
 import logging
 import os
 import re
+from utils import is_truthy_value
 from dataclasses import dataclass
 from typing import Optional
 
@@ -294,7 +295,7 @@ def decompose_task(
     orchestrator = _resolve_orchestrator_profile(cfg)
     default_assignee = _resolve_default_assignee(cfg)
     kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
-    auto_promote = bool(kanban_cfg.get("auto_promote_children", True))
+    auto_promote = is_truthy_value(kanban_cfg.get("auto_promote_children"), default=True)
     roster, valid_names = _build_roster()
 
     try:

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -33,6 +33,7 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Iterable, Optional
 import json
 import time
+from utils import is_truthy_value
 
 
 # Severity rungs, ordered least → most urgent. The UI colors them
@@ -304,7 +305,7 @@ def triage_aux_status(config: Optional[dict]) -> Optional[dict]:
     # ``auto_decompose`` defaults to True per kanban DEFAULT_CONFIG.
     auto_decompose = True
     if isinstance(kanban_cfg, dict) and "auto_decompose" in kanban_cfg:
-        auto_decompose = bool(kanban_cfg.get("auto_decompose"))
+        auto_decompose = is_truthy_value(kanban_cfg.get("auto_decompose"))
 
     return {
         "auto_decompose": auto_decompose,
@@ -393,10 +394,10 @@ def _rule_triage_aux_unavailable(task, events, runs, now, cfg) -> list[Diagnosti
     if status is None:
         return []
 
-    auto_decompose = bool(status.get("auto_decompose"))
-    decomposer_explicit = bool(status.get("decomposer_explicit"))
-    specifier_explicit = bool(status.get("specifier_explicit"))
-    main_visible = bool(status.get("main_model_visible"))
+    auto_decompose = is_truthy_value(status.get("auto_decompose"))
+    decomposer_explicit = is_truthy_value(status.get("decomposer_explicit"))
+    specifier_explicit = is_truthy_value(status.get("specifier_explicit"))
+    main_visible = is_truthy_value(status.get("main_model_visible"))
 
     # Determine the primary slot and whether it is usable.
     if auto_decompose:

--- a/hermes_cli/model_catalog.py
+++ b/hermes_cli/model_catalog.py
@@ -53,7 +53,7 @@ from pathlib import Path
 from typing import Any
 
 from hermes_cli import __version__ as _HERMES_VERSION
-from utils import atomic_replace
+from utils import is_truthy_value,  atomic_replace
 
 logger = logging.getLogger(__name__)
 
@@ -104,7 +104,7 @@ def _load_catalog_config() -> dict[str, Any]:
         raw = {}
 
     return {
-        "enabled": bool(raw.get("enabled", True)),
+        "enabled": is_truthy_value(raw.get("enabled"), default=True),
         "url": str(raw.get("url") or DEFAULT_CATALOG_URL),
         "ttl_hours": float(raw.get("ttl_hours") or DEFAULT_TTL_HOURS),
         "providers": raw.get("providers") if isinstance(raw.get("providers"), dict) else {},

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -384,7 +384,7 @@ def resolve_persist_behavior(is_global: bool, is_session: bool) -> bool:
 
         model_cfg = load_config().get("model")
         if isinstance(model_cfg, dict):
-            return bool(model_cfg.get("persist_switch_by_default", True))
+            return is_truthy_value(model_cfg.get("persist_switch_by_default"), default=True)
     except Exception:
         pass
     return True
@@ -1189,6 +1189,7 @@ def switch_model(
 # process — mirrors run_agent's _openrouter_prewarm_done. Without a guard a
 # long-lived process (or repeated triggers) would leak one OS thread per call.
 import threading as _threading  # noqa: E402
+from utils import is_truthy_value
 
 _picker_prewarm_done = _threading.Event()
 

--- a/hermes_cli/secrets_cli.py
+++ b/hermes_cli/secrets_cli.py
@@ -15,6 +15,7 @@ import json
 import os
 import subprocess
 import sys
+from utils import is_truthy_value
 from pathlib import Path
 from typing import List, Optional
 
@@ -293,7 +294,7 @@ def cmd_status(args: argparse.Namespace) -> int:
     cfg = load_config()
     bw_cfg = (cfg.get("secrets") or {}).get("bitwarden") or {}
 
-    enabled = bool(bw_cfg.get("enabled"))
+    enabled = is_truthy_value(bw_cfg.get("enabled"))
     token_env = bw_cfg.get("access_token_env", "BWS_ACCESS_TOKEN")
     project_id = bw_cfg.get("project_id", "")
     server_url = str(bw_cfg.get("server_url", "") or "").strip()
@@ -310,9 +311,9 @@ def cmd_status(args: argparse.Namespace) -> int:
         "Server URL",
         server_url or "[dim]default (US Cloud, https://vault.bitwarden.com)[/dim]",
     )
-    table.add_row("Override existing", _yn(bool(bw_cfg.get("override_existing", False))))
+    table.add_row("Override existing", _yn(is_truthy_value(bw_cfg.get("override_existing"), default=False)))
     table.add_row("Cache TTL (s)",   str(bw_cfg.get("cache_ttl_seconds", 300)))
-    table.add_row("Auto-install",    _yn(bool(bw_cfg.get("auto_install", True))))
+    table.add_row("Auto-install",    _yn(is_truthy_value(bw_cfg.get("auto_install"), default=True)))
 
     binary = bw.find_bws(install_if_missing=False)
     if binary:

--- a/hermes_cli/voice.py
+++ b/hermes_cli/voice.py
@@ -25,6 +25,7 @@ import logging
 import os
 import sys
 import threading
+from utils import is_truthy_value
 from typing import Any, Callable, Optional
 
 # Modifier aliases mirrored from the TUI parser (``ui-tui/src/lib/platform.ts``)
@@ -251,7 +252,7 @@ def _beeps_enabled() -> bool:
 
         voice_cfg = load_config().get("voice", {})
         if isinstance(voice_cfg, dict):
-            return bool(voice_cfg.get("beep_enabled", True))
+            return is_truthy_value(voice_cfg.get("beep_enabled"), default=True)
     except Exception:
         pass
     return True

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -77,7 +77,7 @@ from gateway.status import (
     parse_active_agents,
     read_runtime_status,
 )
-from utils import env_var_enabled
+from utils import is_truthy_value,  env_var_enabled
 
 try:
     from fastapi import (
@@ -4952,7 +4952,7 @@ def _messaging_platform_payload(
             plat_cfg = platforms_cfg.get(platform_id)
             if not isinstance(plat_cfg, dict):
                 plat_cfg = {}
-            enabled = bool(plat_cfg.get("enabled"))
+            enabled = is_truthy_value(plat_cfg.get("enabled"))
             hc = plat_cfg.get("home_channel")
             home_channel = hc if isinstance(hc, dict) else None
         except Exception:

--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Dict
 
 from hermes_constants import display_hermes_home
-from utils import atomic_replace
+from utils import is_truthy_value,  atomic_replace
 from hermes_cli.config import cfg_get
 
 
@@ -91,7 +91,7 @@ def _get_webhook_config() -> dict:
 
 
 def _is_webhook_enabled() -> bool:
-    return bool(_get_webhook_config().get("enabled"))
+    return is_truthy_value(_get_webhook_config().get("enabled"))
 
 
 def _get_webhook_base_url() -> str:

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -40,6 +40,7 @@ import json
 import logging
 import sqlite3
 import time
+from utils import is_truthy_value
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any, Optional
@@ -1705,9 +1706,9 @@ def get_config():
     k_cfg = dash_cfg.get("kanban") or {}
     return {
         "default_tenant": k_cfg.get("default_tenant") or "",
-        "lane_by_profile": bool(k_cfg.get("lane_by_profile", True)),
-        "include_archived_by_default": bool(k_cfg.get("include_archived_by_default", False)),
-        "render_markdown": bool(k_cfg.get("render_markdown", True)),
+        "lane_by_profile": is_truthy_value(k_cfg.get("lane_by_profile"), default=True),
+        "include_archived_by_default": is_truthy_value(k_cfg.get("include_archived_by_default"), default=False),
+        "render_markdown": is_truthy_value(k_cfg.get("render_markdown"), default=True),
     }
 
 
@@ -2274,8 +2275,8 @@ def get_orchestration_settings():
     kanban_cfg = (cfg.get("kanban") or {}) if isinstance(cfg, dict) else {}
     explicit_orch = (kanban_cfg.get("orchestrator_profile") or "").strip()
     explicit_default = (kanban_cfg.get("default_assignee") or "").strip()
-    auto_decompose = bool(kanban_cfg.get("auto_decompose", True))
-    auto_promote_children = bool(kanban_cfg.get("auto_promote_children", True))
+    auto_decompose = is_truthy_value(kanban_cfg.get("auto_decompose"), default=True)
+    auto_promote_children = is_truthy_value(kanban_cfg.get("auto_promote_children"), default=True)
 
     # Resolve fallbacks the same way the decomposer does.
     resolved_orch = explicit_orch

--- a/plugins/platforms/ntfy/adapter.py
+++ b/plugins/platforms/ntfy/adapter.py
@@ -50,6 +50,7 @@ import logging
 import os
 import time
 import uuid
+from utils import is_truthy_value
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
@@ -528,7 +529,7 @@ async def _standalone_send(
 
     token = extra.get("token") or os.getenv("NTFY_TOKEN", "")
     markdown_env = os.getenv("NTFY_MARKDOWN", "").strip().lower()
-    markdown_enabled = bool(extra.get("markdown")) or markdown_env in ("1", "true", "yes")
+    markdown_enabled = is_truthy_value(extra.get("markdown")) or markdown_env in ("1", "true", "yes")
 
     headers = {"Content-Type": "text/plain; charset=utf-8", "X-Tags": _ECHO_TAG, **_build_auth_header(token)}
     if markdown_enabled:


### PR DESCRIPTION
## Summary

Replace `bool(config.get())` with `is_truthy_value()` for config boolean values.

`bool("false")` returns `True` because non-empty strings are truthy. Users who quote YAML values get wrong behavior.

### Files fixed

| Directory | Files | Calls |
|-----------|-------|-------|
| hermes_cli/ | 10 files | 18 |
| gateway/ | 2 files | 3 |
| agent/ | 5 files | 8 |
| plugins/ | 2 files | 6 |

## Test plan
- [x] `python3 -m py_compile` passes for all files
- [x] `is_truthy_value` import added where needed