### PR TITLE
fix(auxiliary): skip vision fallback to text-only main model (#51220)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3129,6 +3129,19 @@ def _try_main_agent_model_fallback(
         _log_skip_unhealthy(main_provider, task)
         return None, None, ""
 
+    # For vision tasks: skip if the main model is not confirmed to support
+    # vision.  Sending an image_url payload to text-only models like DeepSeek
+    # produces a cryptic 400 error ("unknown variant `image_url`, expected
+    # `text`").  Let the original quota/payment error propagate instead so
+    # callers can surface a clear message to the user.  (#51220)
+    if task == "vision" and not _main_model_supports_vision(main_provider, main_model):
+        logger.info(
+            "Auxiliary vision: main model %s (%s) does not support vision "
+            "— skipping main-agent fallback so the original error propagates",
+            main_provider, main_model,
+        )
+        return None, None, ""
+
     try:
         client, resolved_model = resolve_provider_client(
             provider=main_provider, model=main_model,

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1936,6 +1936,41 @@ class TestTryMainAgentModelFallback:
             client, model, label = _try_main_agent_model_fallback("glm", task="vision")
         assert client is None
 
+    def test_skips_vision_fallback_when_main_model_lacks_vision(self):
+        """Vision tasks must NOT fall back to a text-only main model. (#51220)"""
+        from agent.auxiliary_client import _try_main_agent_model_fallback
+        with patch("agent.auxiliary_client._read_main_provider", return_value="deepseek"), \
+             patch("agent.auxiliary_client._read_main_model", return_value="deepseek-chat"), \
+             patch("agent.auxiliary_client._is_provider_unhealthy", return_value=False), \
+             patch("agent.auxiliary_client._main_model_supports_vision", return_value=False):
+            client, model, label = _try_main_agent_model_fallback("gemini", task="vision")
+        assert client is None and model is None and label == ""
+
+    def test_allows_vision_fallback_when_main_model_supports_vision(self):
+        """Vision tasks CAN fall back to a main model that supports vision."""
+        from agent.auxiliary_client import _try_main_agent_model_fallback
+        fake_client = MagicMock()
+        with patch("agent.auxiliary_client._read_main_provider", return_value="openai"), \
+             patch("agent.auxiliary_client._read_main_model", return_value="gpt-4o"), \
+             patch("agent.auxiliary_client._is_provider_unhealthy", return_value=False), \
+             patch("agent.auxiliary_client._main_model_supports_vision", return_value=True), \
+             patch("agent.auxiliary_client.resolve_provider_client",
+                   return_value=(fake_client, "gpt-4o")):
+            client, model, label = _try_main_agent_model_fallback("gemini", task="vision")
+        assert client is fake_client
+
+    def test_skips_vision_fallback_does_not_affect_non_vision_tasks(self):
+        """Non-vision tasks should still fall back regardless of vision capability."""
+        from agent.auxiliary_client import _try_main_agent_model_fallback
+        fake_client = MagicMock()
+        with patch("agent.auxiliary_client._read_main_provider", return_value="deepseek"), \
+             patch("agent.auxiliary_client._read_main_model", return_value="deepseek-chat"), \
+             patch("agent.auxiliary_client._is_provider_unhealthy", return_value=False), \
+             patch("agent.auxiliary_client.resolve_provider_client",
+                   return_value=(fake_client, "deepseek-chat")):
+            client, model, label = _try_main_agent_model_fallback("openrouter", task=None)
+        assert client is fake_client
+
 
 # ---------------------------------------------------------------------------
 # Gate: _resolve_api_key_provider must skip anthropic when not configured


### PR DESCRIPTION
## What does this PR do?

Prevents Hermes from falling back to a text-only main agent model when a vision provider (e.g. Gemini) fails with a quota/payment error. Previously, the fallback sent an `image_url` payload to models like DeepSeek, producing a confusing `400: unknown variant 'image_url', expected 'text'` instead of surfacing the original quota error.

## Related Issue

Fixes #51220

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py`: Added a vision-capability guard in `_try_main_agent_model_fallback()` that skips the main-agent fallback when `task == "vision"` and the main model does not support vision (uses existing `_main_model_supports_vision()` helper)
- `tests/agent/test_auxiliary_client.py`: Added 3 tests covering the new guard — text-only main model blocked, vision-capable main model allowed, non-vision tasks unaffected

## How to Test

1. Run `python -m pytest tests/agent/test_auxiliary_client.py -x -q -k 'TestTryMainAgentModelFallback'`
2. Observed result: `7 passed in 1.33s` — including the 3 new tests: `test_skips_vision_fallback_when_main_model_lacks_vision`, `test_allows_vision_fallback_when_main_model_supports_vision`, `test_skips_vision_fallback_does_not_affect_non_vision_tasks`

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.5
