### PR TITLE
fix(openviking): write memories under agent root

### DIFF
--- a/plugins/memory/openviking/README.md
+++ b/plugins/memory/openviking/README.md
@@ -55,9 +55,8 @@ Hermes sends `OPENVIKING_ACCOUNT` and `OPENVIKING_USER` as identity headers.
 
 `viking_remember` writes directly to OpenViking with `POST /api/v1/content/write`
 and `mode=create`. It creates peer-scoped memory files under
-`viking://user/peers/${OPENVIKING_AGENT}/memories/...`; OpenViking may return a
-canonical user-scoped form such as
-`viking://user/default/peers/${OPENVIKING_AGENT}/memories/...` in API-key mode.
+`viking://user/${OPENVIKING_AGENT}/memories/...`; OpenViking may return a
+canonical user-scoped form with the same memory-root layout in API-key mode.
 Explicit remembers do not depend on session commit extraction.
 
 Hermes built-in `memory` tool additions are mirrored to OpenViking after the
@@ -74,8 +73,9 @@ memory URI.
 
 `viking_forget` is intentionally narrow. It only accepts concrete user memory
 file URIs, such as
-`viking://user/peers/hermes/memories/preferences/mem_abc123.md` or the canonical
-`viking://user/default/peers/hermes/memories/preferences/mem_abc123.md`. Files
+`viking://user/hermes/memories/preferences/mem_abc123.md`; legacy
+`viking://user/peers/hermes/memories/...` files are also accepted for cleanup.
+Files
 directly under `memories/`, such as `viking://user/default/memories/profile.md`,
 are also allowed because OpenViking supports them. The tool rejects directories,
 resources, skills, sessions, generated summary files, and URIs with query

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -2873,7 +2873,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
     def _build_memory_uri(self, subdir: str) -> str:
         """Build a viking:// memory URI under the configured peer namespace."""
         slug = uuid.uuid4().hex[:12]
-        return f"viking://user/peers/{self._agent}/memories/{subdir}/mem_{slug}.md"
+        return f"viking://user/{self._agent}/memories/{subdir}/mem_{slug}.md"
 
     def on_memory_write(
         self,

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -2871,7 +2871,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
         )
 
     def _build_memory_uri(self, subdir: str) -> str:
-        """Build a viking:// memory URI under the configured peer namespace."""
+        """Build a viking:// memory URI under the configured agent memory root."""
         slug = uuid.uuid4().hex[:12]
         return f"viking://user/{self._agent}/memories/{subdir}/mem_{slug}.md"
 

--- a/tests/openviking_plugin/test_openviking.py
+++ b/tests/openviking_plugin/test_openviking.py
@@ -822,10 +822,10 @@ class TestOpenVikingBrowse:
 
 
 class TestOpenVikingMemoryUriBuilder:
-    """Regression tests for _build_memory_uri — fixes #36969.
+    """Regression tests for _build_memory_uri.
 
-    OpenViking's current memory layout stores peer-scoped memories under
-    viking://user/peers/{peer_id}/...
+    OpenViking v0.3.23 stores peer-scoped memories under
+    viking://user/{peer_id}/...
     """
 
     def _make_provider(self, user="alice", agent="coder"):
@@ -834,19 +834,20 @@ class TestOpenVikingMemoryUriBuilder:
         p._agent = agent
         return p
 
-    def test_uri_layout_includes_peer_segment(self):
-        """URI must contain /peers/{peer_id}/ between user and memories."""
+    def test_uri_layout_uses_agent_memory_root(self):
+        """URI must use the configured agent root directly under user."""
         p = self._make_provider(user="alice", agent="coder")
         uri = p._build_memory_uri("preferences")
-        assert uri.startswith("viking://user/peers/coder/memories/preferences/mem_")
+        assert uri.startswith("viking://user/coder/memories/preferences/mem_")
         assert uri.endswith(".md")
 
     def test_uri_uses_configured_peer_not_default(self):
         """_agent value is the OpenViking actor peer ID, not hardcoded to 'hermes'."""
         p = self._make_provider(user="alice", agent="research-bot")
         uri = p._build_memory_uri("entities")
-        assert "/peers/research-bot/" in uri
-        assert "/peers/hermes/" not in uri
+        assert "/user/research-bot/" in uri
+        assert "/peers/" not in uri
+        assert "/user/hermes/" not in uri
 
     def test_uri_slug_is_twelve_hex_chars_and_unique(self):
         """Slug must be 12 hex chars and differ between calls."""
@@ -869,3 +870,28 @@ class TestOpenVikingMemoryUriBuilder:
             assert f"/memories/{subdir}/mem_" in uri, (
                 f"subdir '{subdir}' not placed correctly in URI: {uri}"
             )
+
+    def test_viking_remember_writes_to_agent_memory_root(self):
+        """viking_remember must send content/write to the same valid URI layout."""
+        calls = []
+
+        class Client:
+            def post(self, path, payload=None, **kwargs):
+                calls.append((path, payload or {}))
+                return {"result": {"written_bytes": 17}}
+
+        p = self._make_provider(user="alice", agent="coder")
+        p._client = Client()
+
+        result = json.loads(p._tool_remember({
+            "content": "Alice prefers concise answers.",
+            "category": "entity",
+        }))
+
+        assert result["status"] == "stored"
+        assert calls[0][0] == "/api/v1/content/write"
+        payload = calls[0][1]
+        assert payload["mode"] == "create"
+        assert payload["content"] == "Alice prefers concise answers."
+        assert payload["uri"].startswith("viking://user/coder/memories/entities/mem_")
+        assert "/peers/" not in payload["uri"]

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -2764,7 +2764,7 @@ def test_on_memory_write_uses_content_write_independent_of_session_rotation():
     assert captured_payloads[0]["content"] == "remember this"
     assert captured_payloads[0]["mode"] == "create"
     assert captured_payloads[0]["uri"].startswith(
-        "viking://user/peers/hermes/memories/preferences/mem_"
+        "viking://user/hermes/memories/preferences/mem_"
     )
 
 


### PR DESCRIPTION
## Summary

Fixes #50701.

`viking_remember` and the built-in memory mirror both use `_build_memory_uri()` before calling `content/write`. That helper was generating paths under:

```text
viking://user/peers/{agent}/memories/...
```

Current OpenViking memory writes use the agent memory root instead:

```text
viking://user/{agent}/memories/...
```

The issue reports the old `/peers/` path failing with `NOT_FOUND` on OpenViking v0.3.23. A live v0.3.23 smoke test also confirms the old path is not treated as memory: `content/write` classifies `viking://user/peers/{agent}/memories/...` as `context_type="resource"`, while the corrected `viking://user/{agent}/memories/...` path is classified as `context_type="memory"`.

## What changed

- Changed `_build_memory_uri()` to generate `viking://user/{agent}/memories/{subdir}/mem_*.md`.
- Added a direct `viking_remember` regression test that asserts the `content/write` payload uses the corrected URI.
- Updated the built-in memory mirror test to assert the same URI layout.
- Updated the OpenViking README to document the current write path.

`viking_forget` still accepts legacy `/peers/` memory URIs, so users can clean up old paths if they have them.

## Validation

- Reproduced the bug at the unit seam before the fix: the URI-builder/`viking_remember` tests failed because the payload still used `viking://user/peers/coder/...`.
- Live OpenViking v0.3.23 smoke test:
  - `viking://user/peers/hermes/memories/preferences/...` -> `200`, `context_type="resource"`
  - `viking://user/hermes/memories/preferences/...` -> `200`, `context_type="memory"`
- `scripts/run_tests.sh tests/openviking_plugin/test_openviking.py tests/plugins/memory/test_openviking_provider.py -- -o addopts=` -> `158 tests passed, 0 failed`
- `uv run --with ruff ruff check plugins/memory/openviking/__init__.py tests/openviking_plugin/test_openviking.py tests/plugins/memory/test_openviking_provider.py` -> passed
- `uv run python -m py_compile plugins/memory/openviking/__init__.py tests/openviking_plugin/test_openviking.py tests/plugins/memory/test_openviking_provider.py` -> passed
- `git diff --check` -> passed

## Duplicate check

Searched open PRs for `50701`, `viking_remember wrong URI path`, `viking://user/peers`, and `openviking remember`. I found no active direct fix PR. There is a broader OpenViking mirror PR (#49270), but it does not directly fix this issue and still describes the old `/peers/` add path.
