### PR TITLE
fix(tui): use is_truthy_value for enabled config boolean

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5547,7 +5547,7 @@ def _(rid, params: dict) -> dict:
     from hermes_cli.nous_billing import BillingError, patch_auto_top_up
 
     try:
-        enabled = bool(params.get("enabled"))
+        enabled = is_truthy_value(params.get("enabled"))
         threshold = params.get("threshold")
         top_up_amount = params.get("top_up_amount")
         if threshold is None or top_up_amount is None:


### PR DESCRIPTION
## Summary

Replace `bool(params.get("enabled"))` with `is_truthy_value()` in `tui_gateway/server.py`.

`bool("false")` returns `True` because non-empty strings are truthy.

## Test plan
- [x] `python3 -m py_compile tui_gateway/server.py` passes