### PR TITLE
fix(weixin): stop line wrapping from breaking markdown links

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -719,6 +719,7 @@ def _wrap_copy_friendly_lines_for_weixin(content: str) -> str:
             or not stripped
             or stripped.startswith("|")
             or _TABLE_RULE_RE.match(stripped)
+            or _MARKDOWN_LINK_RE.search(stripped)
         ):
             wrapped.append(line)
             continue

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -68,6 +68,21 @@ class TestWeixinFormatting:
         assert all(len(line) <= weixin.WEIXIN_COPY_LINE_WIDTH for line in formatted.splitlines())
         assert " ".join(formatted.split()) == " ".join(content.split())
 
+    def test_format_message_does_not_wrap_long_markdown_links(self):
+        adapter = _make_adapter()
+
+        content = (
+            "Read [Designcenter NX中的分析载荷]"
+            "(https://example.com/articles/"
+            + "a" * weixin.WEIXIN_COPY_LINE_WIDTH
+            + ")"
+        )
+
+        formatted = adapter.format_message(content)
+
+        assert formatted == content
+        assert "\n" not in formatted
+
     def test_format_message_does_not_wrap_long_code_block_lines(self):
         adapter = _make_adapter()
 


### PR DESCRIPTION
## What does this PR do?

Fixes a Weixin delivery-formatting regression where the copy-friendly long-line wrapper can split valid Markdown links in the middle of the `[text](url)` syntax. When that happens, WeChat receives broken Markdown and shows what should have been a clickable link as plain text.

This is most visible in cron/report/article-summary messages: the source Markdown is valid, but the Weixin adapter rewrites a long single-line link before delivery.

## Root cause

Follow-up to #21258 / #19161. `_wrap_copy_friendly_lines_for_weixin()` intentionally wraps long non-code, non-table lines at `WEIXIN_COPY_LINE_WIDTH` so WeChat users can copy long prose more reliably.

That is still useful for plain text, but `textwrap.wrap()` does not understand Markdown inline syntax. A valid link such as:

```md
[Designcenter NX中的分析载荷](https://...)
```

can be delivered as:

```md
[Designcenter
NX中的分析载荷](https://...)
```

At that point WeChat no longer sees a valid Markdown link. The content is correct before formatting; it is corrupted during Weixin delivery formatting.

## Related Issue

Follow-up to #21258 and #19161. I did not find an existing duplicate PR/issue for the interaction between Weixin copy-friendly wrapping and long Markdown links.

Related historical context, but not duplicates:
- #8665 / #10338 preserved native Weixin Markdown behavior.
- #21258 added the copy-friendly long-line wrapper for Weixin text.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/platforms/weixin.py`: skip copy-friendly wrapping for lines that contain Markdown links, reusing the existing `_MARKDOWN_LINK_RE`.
- `tests/gateway/test_weixin.py`: add a regression test for long Markdown links that exceed `WEIXIN_COPY_LINE_WIDTH`.

This keeps #21258's wrapping behavior for long plain text, issue-template/log-style prose, and other copy-unfriendly lines, while treating Markdown links as atomic inline content.

## How to Test

1. Format a Weixin message containing a long Markdown link that exceeds `WEIXIN_COPY_LINE_WIDTH`.
2. Before this change, the wrapper can insert a newline inside `[text](url)` and break the link.
3. After this change, the Markdown link remains intact, while long plain text still wraps.

Tests run on Windows:

```text
.\.venv\Scripts\python.exe -m pytest -p no:timeout -o "addopts=" tests/gateway/test_weixin.py::TestWeixinFormatting::test_format_message_wraps_long_plain_lines_for_copying tests/gateway/test_weixin.py::TestWeixinFormatting::test_format_message_does_not_wrap_long_markdown_links tests/gateway/test_weixin.py::TestWeixinFormatting::test_format_message_does_not_wrap_long_code_block_lines -q
# 3 passed

.\.venv\Scripts\python.exe scripts/run_tests_parallel.py tests/gateway/test_weixin.py -- -q -p no:timeout -o "addopts="
# 70 passed

.\.venv\Scripts\python.exe scripts/check-windows-footguns.py gateway/platforms/weixin.py tests/gateway/test_weixin.py
# No Windows footguns found

uv tool run --offline ruff@0.15.10 check gateway/platforms/weixin.py tests/gateway/test_weixin.py
# All checks passed

git diff --check
# passed
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant pytest suite and all targeted tests pass
- [x] I've added tests for my changes
- [x] I've tested on Windows

### Documentation & Housekeeping

- [x] Documentation update N/A — this preserves existing Weixin formatting semantics
- [x] `cli-config.yaml.example` N/A — no config changes
- [x] `CONTRIBUTING.md` / `AGENTS.md` N/A — no workflow or architecture changes
- [x] Cross-platform impact considered — change is pure string formatting logic
- [x] Tool descriptions/schemas N/A — no tool schema changes