### PR TITLE
fix: add explicit encoding to read_text/write_text in optional-skills and root files

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1354,7 +1354,7 @@ def _setup_worktree(repo_root: str = None, sync_base: bool = True) -> Optional[D
     gitignore = Path(repo_root) / ".gitignore"
     _ignore_entry = ".worktrees/"
     try:
-        existing = gitignore.read_text() if gitignore.exists() else ""
+        existing = gitignore.read_text(encoding="utf-8") if gitignore.exists() else ""
         if _ignore_entry not in existing.splitlines():
             with open(gitignore, "a", encoding="utf-8") as f:
                 if existing and not existing.endswith("\n"):
@@ -1404,7 +1404,7 @@ def _setup_worktree(repo_root: str = None, sync_base: bool = True) -> Optional[D
         try:
             repo_root_resolved = Path(repo_root).resolve()
             wt_path_resolved = wt_path.resolve()
-            for line in include_file.read_text().splitlines():
+            for line in include_file.read_text(encoding="utf-8").splitlines():
                 entry = line.strip()
                 if not entry or entry.startswith("#"):
                     continue

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -82,7 +82,7 @@ def get_hermes_home() -> Path:
         try:
             fallback_home = _get_platform_default_hermes_home()
             active_path = fallback_home / "active_profile"
-            active = active_path.read_text().strip() if active_path.exists() else ""
+            active = active_path.read_text(encoding="utf-8").strip() if active_path.exists() else ""
         except (UnicodeDecodeError, OSError):
             active = ""
         if active and active != "default":

--- a/optional-skills/creative/kanban-video-orchestrator/scripts/bootstrap_pipeline.py
+++ b/optional-skills/creative/kanban-video-orchestrator/scripts/bootstrap_pipeline.py
@@ -68,7 +68,7 @@ ASSETS_DIR = Path(__file__).resolve().parent.parent / "assets"
 
 
 def load_template(name: str) -> str:
-    return (ASSETS_DIR / name).read_text()
+    return (ASSETS_DIR / name).read_text(encoding="utf-8")
 
 
 PROFILE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
@@ -471,7 +471,7 @@ def main():
                     help="Write TEAM.md alongside (default: skipped)")
     args = ap.parse_args()
 
-    plan = json.loads(Path(args.plan_json).read_text())
+    plan = json.loads(Path(args.plan_json).read_text(encoding="utf-8"))
     errors = validate_plan(plan)
     if errors:
         print("Plan validation failed:", file=sys.stderr)
@@ -483,15 +483,15 @@ def main():
     team = render_team_md(plan)
     setup = render_setup_sh(plan, brief, team)
 
-    Path(args.out).write_text(setup)
+    Path(args.out).write_text(setup, encoding="utf-8")
     os.chmod(args.out, 0o755)
     print(f"Wrote {args.out}")
 
     if args.brief_out:
-        Path(args.brief_out).write_text(brief)
+        Path(args.brief_out).write_text(brief, encoding="utf-8")
         print(f"Wrote {args.brief_out}")
     if args.team_out:
-        Path(args.team_out).write_text(team)
+        Path(args.team_out).write_text(team, encoding="utf-8")
         print(f"Wrote {args.team_out}")
 
 

--- a/optional-skills/research/osint-investigation/scripts/build_findings.py
+++ b/optional-skills/research/osint-investigation/scripts/build_findings.py
@@ -141,7 +141,7 @@ def build_findings(
 
     # 3. Timing-based findings.
     if timing_path and Path(timing_path).exists():
-        timing = json.loads(Path(timing_path).read_text())
+        timing = json.loads(Path(timing_path).read_text(encoding="utf-8"))
         for r in timing.get("results", []):
             if not r.get("significant"):
                 continue
@@ -190,7 +190,7 @@ def build_findings(
         },
         "findings": findings,
     }
-    Path(out_path).write_text(json.dumps(payload, indent=2))
+    Path(out_path).write_text(json.dumps(payload, indent=2), encoding="utf-8")
     return payload
 
 

--- a/optional-skills/research/osint-investigation/scripts/timing_analysis.py
+++ b/optional-skills/research/osint-investigation/scripts/timing_analysis.py
@@ -198,7 +198,7 @@ def analyze(
         "results": results,
     }
 
-    Path(out_path).write_text(json.dumps(payload, indent=2))
+    Path(out_path).write_text(json.dumps(payload, indent=2), encoding="utf-8")
     return payload
 
 


### PR DESCRIPTION
## Summary

Add `encoding="utf-8"` to `read_text()`/`write_text()` calls in `optional-skills/` and root files (`cli.py`, `hermes_constants.py`).

Ruff rule PLW1514.

## Test plan
- [x] `python3 -m py_compile` passes for all files