### PR TITLE
fix(memory): skip honcho provider when sdk is missing

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -255,10 +255,12 @@ class HonchoMemoryProvider(MemoryProvider):
     def is_available(self) -> bool:
         """Check if Honcho is configured. No network calls."""
         try:
+            from importlib.util import find_spec
             from plugins.memory.honcho.client import HonchoClientConfig
             cfg = HonchoClientConfig.from_global_config()
             # Port #2645: baseUrl-only verification — api_key OR base_url suffices
-            return cfg.enabled and bool(cfg.api_key or cfg.base_url)
+            configured = cfg.enabled and bool(cfg.api_key or cfg.base_url)
+            return configured and find_spec("honcho") is not None
         except Exception:
             return False
 

--- a/tests/test_honcho_startup_fail_open.py
+++ b/tests/test_honcho_startup_fail_open.py
@@ -39,6 +39,19 @@ def _configured_tools_config(*, init_on_session_start: bool = False) -> _FakeHon
     return cfg
 
 
+def test_honcho_is_unavailable_when_sdk_dependency_is_missing(monkeypatch):
+    provider = HonchoMemoryProvider()
+    cfg = _configured_hybrid_config()
+
+    monkeypatch.setattr(
+        "plugins.memory.honcho.client.HonchoClientConfig.from_global_config",
+        lambda: cfg,
+    )
+    monkeypatch.setattr("importlib.util.find_spec", lambda name: None)
+
+    assert provider.is_available() is False
+
+
 def test_honcho_hybrid_initialize_returns_without_waiting_for_session_init(monkeypatch):
     """Slow Honcho session creation must not block agent startup."""
     provider = HonchoMemoryProvider()


### PR DESCRIPTION
## What does this PR do?

Prevents the Honcho memory provider from registering/activating when `memory.provider: honcho` is configured but the optional `honcho-ai` SDK is not installed.

`HonchoMemoryProvider.is_available()` now checks both configuration and SDK availability, matching the `MemoryProvider` contract that availability includes installed dependencies. This keeps agent startup from reporting Honcho as activated when the backend cannot actually initialize.

## Related Issue

Fixes #51099

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/memory/honcho/__init__.py`: make `is_available()` return `False` when the `honcho` SDK module is missing.
- `tests/test_honcho_startup_fail_open.py`: add regression coverage for configured Honcho with missing SDK dependency.

## How to Test

1. Configure `memory.provider: honcho` with an API key or base URL.
2. Ensure the optional `honcho-ai` package is not installed.
3. Start Hermes and verify Honcho is treated as unavailable instead of being registered/activated.

Tested locally with:

```bash
python3 -m pytest tests/test_honcho_startup_fail_open.py tests/test_honcho_client_config.py -q --tb=short
python3 -m ruff check plugins/memory/honcho/__init__.py tests/test_honcho_startup_fail_open.py
git diff --check origin/main...HEAD
```

Results:

```text
18 passed in 0.65s
All checks passed!
```

## Checklist

### Code

- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu/Linux

### Documentation & Housekeeping

- [x] Documentation update N/A
- [x] `cli-config.yaml.example` update N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update N/A
- [x] Cross-platform impact considered: dependency detection is pure Python importlib
- [x] Tool descriptions/schemas update N/A

## For New Skills

N/A

## Screenshots / Logs

```text
18 passed in 0.65s
All checks passed!
```
