### PR TITLE
fix(mattermost): honor documented mention_patterns wake words (parity with #50843)

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -828,14 +828,14 @@ class MattermostAdapter(BasePlatformAdapter):
             free_channels = {ch.strip() for ch in free_channels_raw.split(",") if ch.strip()}
             is_free_channel = channel_id in free_channels
 
-            mention_patterns = [
+            bot_mention_patterns = [
                 f"@{self._bot_username}",
                 f"@{self._bot_user_id}",
             ]
             has_mention = any(
                 pattern.lower() in message_text.lower()
-                for pattern in mention_patterns
-            )
+                for pattern in bot_mention_patterns
+            ) or self._mattermost_message_matches_mention_patterns(message_text)
 
             if require_mention and not is_free_channel and not has_mention:
                 logger.debug(
@@ -846,7 +846,7 @@ class MattermostAdapter(BasePlatformAdapter):
 
             # Strip @mention from the message text so the agent sees clean input.
             if has_mention:
-                for pattern in mention_patterns:
+                for pattern in bot_mention_patterns:
                     message_text = re.sub(
                         re.escape(pattern), "", message_text, flags=re.IGNORECASE
                     ).strip()
@@ -948,7 +948,49 @@ class MattermostAdapter(BasePlatformAdapter):
 
         await self.handle_message(msg_event)
 
+    # -- mention_patterns (wake-word) support --------------------------------
 
+    def _mattermost_mention_patterns(self) -> List[re.Pattern]:
+        cached = getattr(self, "_compiled_mention_patterns", None)
+        if cached is not None:
+            return cached
+
+        patterns = self.config.extra.get("mention_patterns") if self.config.extra else None
+        if patterns is None:
+            raw = os.getenv("MATTERMOST_MENTION_PATTERNS", "").strip()
+            if raw:
+                try:
+                    patterns = json.loads(raw)
+                except Exception:
+                    patterns = [p.strip() for p in raw.replace("\n", ",").split(",") if p.strip()]
+
+        if isinstance(patterns, str):
+            patterns = [patterns]
+
+        compiled: List[re.Pattern] = []
+        if isinstance(patterns, list):
+            for pat in patterns:
+                if not isinstance(pat, str) or not pat.strip():
+                    continue
+                try:
+                    compiled.append(re.compile(pat, re.IGNORECASE))
+                except re.error as exc:
+                    logger.warning("[Mattermost] Invalid mention pattern %r: %s", pat, exc)
+        elif patterns is not None:
+            logger.warning(
+                "[Mattermost] mention_patterns must be a list or string; got %s",
+                type(patterns).__name__,
+            )
+
+        if compiled:
+            logger.info("[Mattermost] Loaded %d mention pattern(s)", len(compiled))
+        self._compiled_mention_patterns = compiled
+        return compiled
+
+    def _mattermost_message_matches_mention_patterns(self, text: str) -> bool:
+        if not text:
+            return False
+        return any(pattern.search(text) for pattern in self._mattermost_mention_patterns())
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -709,6 +709,113 @@ class TestMattermostMentionBehavior:
 
 
 # ---------------------------------------------------------------------------
+# mention_patterns (wake words) — parity with Slack #50843
+# ---------------------------------------------------------------------------
+
+class TestMattermostMentionPatterns:
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.adapter._bot_user_id = "bot_user_id"
+        self.adapter._bot_username = "hermes-bot"
+        self.adapter.handle_message = AsyncMock()
+
+    def _make_event(self, message, channel_type="O", channel_id="chan_456"):
+        post_data = {
+            "id": "post_mp",
+            "user_id": "user_123",
+            "channel_id": channel_id,
+            "message": message,
+        }
+        return {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post_data),
+                "channel_type": channel_type,
+                "sender_name": "@alice",
+            },
+        }
+
+    def test_no_patterns_default(self):
+        """No configured patterns → empty list, no match."""
+        assert self.adapter._mattermost_mention_patterns() == []
+        assert self.adapter._mattermost_message_matches_mention_patterns("hello") is False
+
+    def test_patterns_from_config_extra(self):
+        """Patterns loaded from config.extra match correctly."""
+        self.adapter.config = PlatformConfig(
+            enabled=True, token="t", extra={"url": "https://mm.example.com", "mention_patterns": ["hey hermes", "hermes,"]}
+        )
+        assert self.adapter._mattermost_message_matches_mention_patterns("hey hermes, do it") is True
+        assert self.adapter._mattermost_message_matches_mention_patterns("just chatting") is False
+
+    def test_patterns_case_insensitive(self):
+        self.adapter.config = PlatformConfig(
+            enabled=True, token="t", extra={"url": "https://mm.example.com", "mention_patterns": ["hey hermes"]}
+        )
+        assert self.adapter._mattermost_message_matches_mention_patterns("HEY HERMES!") is True
+
+    def test_single_string_pattern(self):
+        self.adapter.config = PlatformConfig(
+            enabled=True, token="t", extra={"url": "https://mm.example.com", "mention_patterns": "^hermes"}
+        )
+        assert self.adapter._mattermost_message_matches_mention_patterns("hermes do this") is True
+        assert self.adapter._mattermost_message_matches_mention_patterns("ok hermes") is False
+
+    def test_invalid_regex_skipped(self):
+        self.adapter.config = PlatformConfig(
+            enabled=True, token="t", extra={"url": "https://mm.example.com", "mention_patterns": ["(unclosed", "hey hermes"]}
+        )
+        assert self.adapter._mattermost_message_matches_mention_patterns("hey hermes") is True
+
+    def test_env_var_fallback(self, monkeypatch):
+        monkeypatch.setenv("MATTERMOST_MENTION_PATTERNS", '["hey hermes", "hermes,"]')
+        assert self.adapter._mattermost_message_matches_mention_patterns("hey hermes") is True
+
+    def test_env_var_csv_fallback(self, monkeypatch):
+        monkeypatch.setenv("MATTERMOST_MENTION_PATTERNS", "hey hermes,hermes,")
+        patterns = self.adapter._mattermost_mention_patterns()
+        assert [p.pattern for p in patterns] == ["hey hermes", "hermes"]
+        assert self.adapter._mattermost_message_matches_mention_patterns("hey hermes") is True
+
+    @pytest.mark.asyncio
+    async def test_wake_word_triggers_in_channel(self):
+        """A wake word triggers the bot even with require_mention on."""
+        self.adapter.config = PlatformConfig(
+            enabled=True, token="t", extra={"url": "https://mm.example.com", "mention_patterns": ["hey hermes"]}
+        )
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MATTERMOST_REQUIRE_MENTION", None)
+            os.environ.pop("MATTERMOST_FREE_RESPONSE_CHANNELS", None)
+            await self.adapter._handle_ws_event(
+                self._make_event("hey hermes what is the status")
+            )
+            assert self.adapter.handle_message.called
+
+    @pytest.mark.asyncio
+    async def test_no_wake_word_still_skipped(self):
+        """Unrelated chatter is still skipped with require_mention on."""
+        self.adapter.config = PlatformConfig(
+            enabled=True, token="t", extra={"url": "https://mm.example.com", "mention_patterns": ["hey hermes"]}
+        )
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MATTERMOST_REQUIRE_MENTION", None)
+            os.environ.pop("MATTERMOST_FREE_RESPONSE_CHANNELS", None)
+            await self.adapter._handle_ws_event(
+                self._make_event("lunch anyone?")
+            )
+            assert not self.adapter.handle_message.called
+
+    def test_patterns_cached_on_instance(self):
+        """Compiled patterns are cached — second call returns same objects."""
+        self.adapter.config = PlatformConfig(
+            enabled=True, token="t", extra={"url": "https://mm.example.com", "mention_patterns": ["hey hermes"]}
+        )
+        first = self.adapter._mattermost_mention_patterns()
+        second = self.adapter._mattermost_mention_patterns()
+        assert first is second
+
+
+# ---------------------------------------------------------------------------
 # File upload (send_image)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
The Mattermost adapter silently drops user-configured `mention_patterns` wake words — messages matching a custom pattern are ignored in `require_mention` channels, even though the Slack parity fix (#50843) documents Mattermost as a supported platform.

Root cause: `_handle_ws_event` (adapter.py:831-838) hardcodes `mention_patterns` to only the bot's `@username` and `@user_id`. The user-configured `mention_patterns` value — already bridged into `config.extra["mention_patterns"]` by `gateway/config.py:994-995` for all platforms — is never read. The `MATTERMOST_MENTION_PATTERNS` env var is also ignored.

## Changes
- `plugins/platforms/mattermost/adapter.py`: add `_mattermost_mention_patterns()` (compiles configured patterns from `config.extra` or `MATTERMOST_MENTION_PATTERNS` env, caches on instance) and `_mattermost_message_matches_mention_patterns()` (returns True on first match). OR the result into the `has_mention` gate alongside the existing bot-username/bot-user-id checks.
- `tests/gateway/test_mattermost.py`: 10 regression tests covering default no-match, config list, case insensitivity, single string, invalid regex skip, env var JSON fallback, env var CSV fallback, channel wake-word trigger, channel no-match skip, and instance caching.

## Validation
| | Before | After |
|---|---|---|
| `mention_patterns: ["hey hermes"]` in config | ignored — message skipped | triggers bot |
| `MATTERMOST_MENTION_PATTERNS='["hey hermes"]'` env | ignored — message skipped | triggers bot |
| No configured patterns | only @bot mention works | unchanged |
| Invalid regex in list | — | skipped with warning, valid siblings still work |

`tests/gateway/test_mattermost.py` → 68 passed (58 existing + 10 new), 0 failed. `ruff check` clean.

Parity with #50843 (Slack). Mirrors `_slack_mention_patterns()` / `_slack_message_matches_mention_patterns()`.