### PR TITLE
fix(security): deny WhatsApp Baileys session directory in media delivery

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1102,6 +1102,10 @@ def _media_delivery_denied_paths() -> List[Path]:
     # overlap.)
     _ROOT_CREDENTIAL_DIRS = (
         "pairing",
+        # WhatsApp Baileys auth state (noise key, signed identity/pre-keys,
+        # registration).  creds.json + session keys let an attacker hijack
+        # the paired WhatsApp account.
+        os.path.join("whatsapp", "session"),
     )
     for hermes_root in (_HERMES_HOME, _HERMES_ROOT):
         for rel in _ROOT_CREDENTIAL_FILES:

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1027,6 +1027,43 @@ class TestMediaDeliveryDefaultMode:
 
         assert BasePlatformAdapter.validate_media_delivery_path(str(token)) is None
 
+    def test_denylist_blocks_whatsapp_session_creds(self, tmp_path, monkeypatch):
+        """~/.hermes/whatsapp/session/creds.json (Baileys auth state) must
+        not be deliverable — it contains the noise key and signed identity
+        keys that control the paired WhatsApp account.
+        """
+        self._patch_roots(monkeypatch)
+
+        fake_home = tmp_path / "home"
+        hermes_dir = fake_home / ".hermes"
+        session = hermes_dir / "whatsapp" / "session"
+        session.mkdir(parents=True)
+        creds = session / "creds.json"
+        creds.write_text('{"noiseKey": "secret"}')
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", hermes_dir)
+        monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_dir)
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(creds)) is None
+
+    def test_denylist_blocks_whatsapp_session_lid_mapping(self, tmp_path, monkeypatch):
+        """Other session files (lid-mapping-*.json) are also credential
+        material and must not be deliverable.
+        """
+        self._patch_roots(monkeypatch)
+
+        fake_home = tmp_path / "home"
+        hermes_dir = fake_home / ".hermes"
+        session = hermes_dir / "whatsapp" / "session"
+        session.mkdir(parents=True)
+        lid = session / "lid-mapping-12345.json"
+        lid.write_text('{"lid": "data"}')
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", hermes_dir)
+        monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_dir)
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(lid)) is None
+
     def test_hermes_cache_still_delivers_under_denied_home(self, tmp_path, monkeypatch):
         """The targeted credential denylist must not break legitimate cache
         deliveries: a generated artifact under the allowlisted cache root is


### PR DESCRIPTION
## Summary
The media-delivery denylist (`_media_delivery_denied_paths()` in `gateway/platforms/base.py`) was missing the WhatsApp Baileys auth-state directory (`whatsapp/session/`). Files under this path — notably `creds.json` (noise key, signed identity/pre-keys, registration) — could be auto-attached to a chat reply via prompt injection in non-strict (default) mode, leaking a full WhatsApp account credential.

The session directory is created by `hermes_cli/main.py:2570` (`get_hermes_home() / "whatsapp" / "session"`) and read by `gateway/whatsapp_identity.py:136` and `hermes_cli/gateway.py:4569`. It was not covered by any existing denylist entry, nor by the sibling PRs (#37222 for `mcp-tokens/`, #41071 for `state.db`/`kanban.db`).

## Changes
- `gateway/platforms/base.py`: add `whatsapp/session` to `_ROOT_CREDENTIAL_DIRS` alongside the existing `pairing/` entry.
- `tests/gateway/test_platform_base.py`: 2 regression tests — `creds.json` and `lid-mapping-*.json` both blocked.

## Validation
| Path | Before | After |
|---|---|---|
| `~/.hermes/whatsapp/session/creds.json` | delivered | **rejected** |
| `~/.hermes/whatsapp/session/lid-mapping-12345.json` | delivered | **rejected** |
| `~/.hermes/cache/documents/report.pdf` | delivered | delivered (allowlist wins) |

- `tests/gateway/test_platform_base.py` → 162 passed, 0 failed.
- Negative check: both new tests fail on `main` without the fix. ✓
- `ruff check` clean.

Sibling of #51055. Follows the per-file/per-dir enumeration shape accepted by maintainers (#32090, #34425).