### PR TITLE
fix(desktop): include user local bin in backend PATH

### DIFF
--- a/apps/desktop/electron/backend-env.cjs
+++ b/apps/desktop/electron/backend-env.cjs
@@ -2,7 +2,8 @@ const path = require('node:path')
 
 // Match the POSIX fallback surface used by the Python terminal environment.
 // macOS apps launched from Finder/Dock often inherit only /usr/bin:/bin:/usr/sbin:/sbin,
-// which misses Apple Silicon Homebrew and user-installed CLI tools such as codex.
+// which misses Apple Silicon Homebrew, ~/.local/bin tools such as cua-driver,
+// and user-installed CLI tools such as codex.
 const POSIX_SANE_PATH_ENTRIES = Object.freeze([
   '/opt/homebrew/bin',
   '/opt/homebrew/sbin',
@@ -49,8 +50,20 @@ function appendUniquePathEntries(entries, { delimiter = path.delimiter } = {}) {
   return ordered.join(delimiter)
 }
 
+function userLocalBinFromHome({
+  homeDir,
+  hermesHome,
+  platform = process.platform,
+  pathModule = pathModuleForPlatform(platform)
+} = {}) {
+  if (platform === 'win32') return null
+  const baseHome = homeDir || (hermesHome ? pathModule.dirname(hermesHome) : null)
+  return baseHome ? pathModule.join(baseHome, '.local', 'bin') : null
+}
+
 function buildDesktopBackendPath({
   hermesHome,
+  homeDir,
   venvRoot,
   currentPath = '',
   platform = process.platform,
@@ -59,10 +72,11 @@ function buildDesktopBackendPath({
   const delimiter = delimiterForPlatform(platform)
   const hermesNodeBin = hermesHome ? pathModule.join(hermesHome, 'node', 'bin') : null
   const venvBin = venvRoot ? pathModule.join(venvRoot, platform === 'win32' ? 'Scripts' : 'bin') : null
+  const userLocalBin = userLocalBinFromHome({ homeDir, hermesHome, platform, pathModule })
   const saneEntries = platform === 'win32' ? [] : POSIX_SANE_PATH_ENTRIES
 
   return appendUniquePathEntries(
-    [hermesNodeBin, venvBin, currentPath, saneEntries],
+    [hermesNodeBin, venvBin, userLocalBin, currentPath, saneEntries],
     { delimiter }
   )
 }
@@ -93,6 +107,7 @@ function buildDesktopBackendEnv({
     PYTHONPATH: appendUniquePathEntries([...pythonPathEntries, currentPythonPath], { delimiter }),
     [key]: buildDesktopBackendPath({
       hermesHome,
+      homeDir: currentEnv?.HOME,
       venvRoot,
       currentPath: currentPathValue(currentEnv, platform),
       platform,
@@ -108,5 +123,6 @@ module.exports = {
   buildDesktopBackendPath,
   delimiterForPlatform,
   normalizeHermesHomeRoot,
-  pathEnvKey
+  pathEnvKey,
+  userLocalBinFromHome
 }

--- a/apps/desktop/electron/backend-env.test.cjs
+++ b/apps/desktop/electron/backend-env.test.cjs
@@ -8,7 +8,8 @@ const {
   buildDesktopBackendEnv,
   buildDesktopBackendPath,
   normalizeHermesHomeRoot,
-  pathEnvKey
+  pathEnvKey,
+  userLocalBinFromHome
 } = require('./backend-env.cjs')
 
 test('desktop backend PATH adds Hermes-managed bins and missing POSIX sane entries', () => {
@@ -23,6 +24,8 @@ test('desktop backend PATH adds Hermes-managed bins and missing POSIX sane entri
   const entries = result.split(':')
   assert.equal(entries[0], '/Users/test/.hermes/node/bin')
   assert.equal(entries[1], '/Users/test/.hermes/hermes-agent/venv/bin')
+  assert.equal(entries[2], '/Users/test/.local/bin')
+  assert.ok(entries.indexOf('/Users/test/.local/bin') < entries.indexOf('/usr/bin'))
   assert.ok(entries.includes('/opt/homebrew/bin'), 'Apple Silicon Homebrew bin is added')
   assert.ok(entries.includes('/opt/homebrew/sbin'), 'Apple Silicon Homebrew sbin is added')
   assert.ok(entries.includes('/usr/local/sbin'), 'missing standard sbin is added')
@@ -49,12 +52,25 @@ test('desktop backend PATH preserves first occurrence and avoids duplicates', ()
   )
 })
 
+test('desktop backend PATH derives user local bin from HOME before profile-scoped Hermes homes', () => {
+  assert.equal(
+    userLocalBinFromHome({
+      homeDir: '/Users/test',
+      hermesHome: '/Users/test/.hermes/profiles/work',
+      platform: 'darwin',
+      pathModule: path.posix
+    }),
+    '/Users/test/.local/bin'
+  )
+})
+
 test('buildDesktopBackendEnv extends PYTHONPATH and backend PATH together', () => {
   const env = buildDesktopBackendEnv({
     hermesHome: '/Users/test/.hermes',
     pythonPathEntries: ['/repo/hermes-agent'],
     venvRoot: '/Users/test/.hermes/hermes-agent/venv',
     currentEnv: {
+      HOME: '/Users/test',
       PATH: '/usr/bin:/bin',
       PYTHONPATH: '/existing/pythonpath'
     },
@@ -63,7 +79,7 @@ test('buildDesktopBackendEnv extends PYTHONPATH and backend PATH together', () =
   })
 
   assert.equal(env.PYTHONPATH, '/repo/hermes-agent:/existing/pythonpath')
-  assert.ok(env.PATH.startsWith('/Users/test/.hermes/node/bin:/Users/test/.hermes/hermes-agent/venv/bin:'))
+  assert.ok(env.PATH.startsWith('/Users/test/.hermes/node/bin:/Users/test/.hermes/hermes-agent/venv/bin:/Users/test/.local/bin:'))
   assert.ok(env.PATH.includes('/opt/homebrew/bin'))
 })
 


### PR DESCRIPTION
## What does this PR do?

Fixes Hermes Desktop backend PATH assembly so POSIX Desktop launches include the user's `~/.local/bin` directory. This covers helper binaries installed by user-level tools that are available in login shells but missing from Finder/Dock-launched backend processes.

Concrete symptom: `computer_use` can be enabled and `cua-driver` can be ready in a shell, while a fresh Desktop chat still lacks the `computer_use` schema because the backend cannot resolve `~/.local/bin/cua-driver` during the availability check.

## Related Issue

Fixes #51249

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/backend-env.cjs`
  - Adds a `userLocalBinFromHome()` helper for POSIX backend launches.
  - Inserts `~/.local/bin` after Hermes-managed node/venv bins and before the inherited PATH.
  - Threads `currentEnv.HOME` through `buildDesktopBackendEnv()` so profile-scoped Hermes homes still resolve the real user-local bin.
- `apps/desktop/electron/backend-env.test.cjs`
  - Verifies `~/.local/bin` is present and precedes inherited system PATH entries.
  - Verifies profile-scoped Hermes homes use `HOME` for the user-local bin.
  - Keeps the Windows PATH behavior unchanged.

## How to Test

1. Launch Hermes Desktop from a minimal GUI PATH such as `/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin`.
2. Ensure a helper binary exists in `~/.local/bin`, for example `cua-driver`.
3. Start a fresh Desktop chat and verify tool availability checks can resolve that binary.

Local verification run:

```bash
cd apps/desktop
node --test electron/backend-env.test.cjs
```

Result:

```text
# tests 7
# pass 7
# fail 0
```

I also sanity-checked the generated PATH for a minimal macOS GUI-style PATH and confirmed it includes `/Users/test/.local/bin`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted test output is included above.
