### PR TITLE
feat(photon): opt-in webhook inbound transport (bypass dying catchUpEvents stream)

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -6,13 +6,22 @@ Both directions of traffic flow through a small supervised Node sidecar
 TypeScript-only and there is no public HTTP message API, so a sidecar is
 unavoidable.
 
-Inbound:
+Inbound (default — ``PHOTON_INBOUND_MODE=stream``):
     The SDK's ``app.messages`` is a long-lived **gRPC** stream. The sidecar
     serializes each message to a normalized JSON event and streams it to this
     adapter over a loopback ``GET /inbound`` (NDJSON). A background task here
     consumes that stream, dedupes on ``messageId``, and dispatches a
     ``MessageEvent`` to the gateway via ``BasePlatformAdapter.handle_message``.
-    No webhook, no public URL, no signing secret.
+
+Inbound (opt-in — ``PHOTON_INBOUND_MODE=webhook``):
+    Spectrum pushes signed HTTPS POSTs to a URL you register in the Photon
+    dashboard (see ``webhook.py``). This avoids the long-lived
+    ``catchUpEvents`` stream entirely — no 16-stream concurrency limit, no
+    zombie/"Live stream ended" reconnect spirals. Requires a public HTTPS
+    ingress to ``PHOTON_WEBHOOK_PORT`` (e.g. a tunnel) and
+    ``PHOTON_WEBHOOK_SECRET``. Set ``PHOTON_SIDECAR_DISABLE_INBOUND=1`` so the
+    sidecar stops its (now unused) inbound subscription; outbound still uses
+    the sidecar below.
 
 Outbound:
     ``send`` / ``send_typing`` are loopback POSTs to the sidecar's control
@@ -72,6 +81,9 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_SIDECAR_PORT = 8789
 _DEFAULT_SIDECAR_BIND = "127.0.0.1"
+_DEFAULT_WEBHOOK_PORT = 8788
+_DEFAULT_WEBHOOK_PATH = "/photon/webhook"
+_DEFAULT_SIDECAR_SEND_TIMEOUT = 120.0
 
 # Photon iMessage messages from the SDK side have no documented hard
 # limit, but the underlying iMessage protocol limits practical message
@@ -227,6 +239,27 @@ class PhotonAdapter(BasePlatformAdapter):
         ).lower() not in ("0", "false", "no")
         self._node_bin = os.getenv("PHOTON_NODE_BIN") or shutil.which("node") or "node"
 
+        # Inbound transport: "stream" (default — sidecar gRPC/WS) or "webhook"
+        # (Photon pushes signed HTTPS POSTs; no long-lived catchUpEvents stream,
+        # so no 16-stream limit / zombie-stream death spirals). Outbound always
+        # stays on the sidecar — Photon has no public HTTP send endpoint.
+        self._inbound_mode = (
+            str(extra.get("inbound_mode") or os.getenv("PHOTON_INBOUND_MODE") or "stream")
+            .strip().lower()
+        )
+        self._webhook_port = _coerce_port(
+            extra.get("webhook_port") or os.getenv("PHOTON_WEBHOOK_PORT"),
+            _DEFAULT_WEBHOOK_PORT,
+        )
+        self._webhook_bind = _DEFAULT_SIDECAR_BIND  # loopback; Funnel fronts it
+        self._webhook_path = (
+            str(extra.get("webhook_path") or os.getenv("PHOTON_WEBHOOK_PATH") or _DEFAULT_WEBHOOK_PATH)
+        )
+        self._webhook_secret = (
+            os.getenv("PHOTON_WEBHOOK_SECRET") or extra.get("webhook_secret") or ""
+        )
+        self._webhook_server = None
+
         # With markdown on, format_message preserves fences and the sidecar's
         # markdown() builder renders them (or degrades them readably).
         self.supports_code_blocks = _markdown_enabled()
@@ -365,6 +398,37 @@ class PhotonAdapter(BasePlatformAdapter):
                 "[photon] sidecar autostart disabled — inbound + outbound will fail"
             )
 
+        # Inbound: webhook (push) or the sidecar gRPC/WS stream (pull).
+        if self._inbound_mode == "webhook":
+            if not self._webhook_secret:
+                self._set_fatal_error(
+                    "MISSING_WEBHOOK_SECRET",
+                    "PHOTON_INBOUND_MODE=webhook requires PHOTON_WEBHOOK_SECRET "
+                    "(the per-webhook signing secret from app.photon.codes).",
+                    retryable=False,
+                )
+                await client.aclose()
+                self._http_client = None
+                return False
+            from .webhook import PhotonWebhookServer
+
+            self._webhook_server = PhotonWebhookServer(
+                self,
+                host=self._webhook_bind,
+                port=self._webhook_port,
+                path=self._webhook_path,
+                secret=self._webhook_secret,
+            )
+            await self._webhook_server.start()
+            self._mark_connected()
+            logger.info(
+                "[photon] connected — sidecar on %s:%d (outbound), inbound via "
+                "webhook on %s:%d%s",
+                self._sidecar_bind, self._sidecar_port,
+                self._webhook_bind, self._webhook_port, self._webhook_path,
+            )
+            return True
+
         # Start consuming the inbound gRPC stream from the sidecar.
         self._inbound_running = True
         self._inbound_task = asyncio.get_event_loop().create_task(
@@ -389,6 +453,12 @@ class PhotonAdapter(BasePlatformAdapter):
             except Exception:
                 pass
             self._inbound_task = None
+        if self._webhook_server is not None:
+            try:
+                await self._webhook_server.stop()
+            except Exception:
+                pass
+            self._webhook_server = None
         await self._stop_sidecar()
         if self._http_client is not None:
             try:

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -347,6 +347,15 @@ async function normalizeEvent(space, message) {
 // iterator itself throws or ends, this consumer would stop forever. Wrap it in
 // a re-subscribe loop with capped exponential backoff + jitter so inbound
 // always recovers (the adapter dedupes any catch-up replay).
+const DISABLE_INBOUND = ["1", "true", "yes"].includes(
+  String(process.env.PHOTON_SIDECAR_DISABLE_INBOUND || "").toLowerCase()
+);
+if (DISABLE_INBOUND) {
+  console.error(
+    "photon-sidecar: inbound stream DISABLED (PHOTON_SIDECAR_DISABLE_INBOUND) — " +
+      "webhook mode, outbound /send only"
+  );
+} else
 (async () => {
   let backoff = 1000;
   for (;;) {

--- a/plugins/platforms/photon/webhook.py
+++ b/plugins/platforms/photon/webhook.py
@@ -1,0 +1,177 @@
+"""Photon iMessage inbound via webhook (push) instead of the gRPC/WS stream.
+
+Photon Spectrum can deliver inbound iMessage events as signed HTTPS POSTs
+(see https://photon.codes/docs/webhooks/events). Receiving inbound this way
+avoids the long-lived ``catchUpEvents`` stream entirely — no 16-stream
+concurrency limit, no zombie/"Live stream ended" death spirals, no shared-line
+inbound starvation. Outbound still goes through the sidecar's ``spectrum-ts``
+SDK, because Photon exposes no public HTTP send endpoint.
+
+This server:
+  * verifies the ``X-Spectrum-Signature`` HMAC-SHA256 over ``v0:{ts}:{body}``,
+  * rejects stale deliveries (clock skew guard) and unsigned/forged ones,
+  * maps the webhook body to the SAME normalized event shape the sidecar's
+    NDJSON stream emits, then hands it to ``PhotonAdapter._dispatch_inbound``
+    so dedup and all downstream handling stay shared with the stream path.
+
+Funnel/ingress (public HTTPS → 127.0.0.1:port) is configured outside Hermes
+(e.g. Tailscale Funnel); this server only binds loopback.
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import time
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+from aiohttp import web
+
+if TYPE_CHECKING:
+    from .adapter import PhotonAdapter
+
+logger = logging.getLogger(__name__)
+
+# Reject deliveries whose signed timestamp is older/newer than this (seconds).
+# Photon signs with the delivery time; their docs reject >5 min on their side.
+_MAX_TIMESTAMP_SKEW_SECONDS = 300
+# Defence-in-depth: cap the request body so a peer can't OOM us.
+_MAX_BODY_BYTES = 5 * 1024 * 1024
+
+
+class PhotonWebhookServer:
+    """Loopback aiohttp server that turns Photon webhooks into MessageEvents."""
+
+    def __init__(
+        self,
+        adapter: "PhotonAdapter",
+        *,
+        host: str,
+        port: int,
+        path: str,
+        secret: str,
+    ) -> None:
+        self._adapter = adapter
+        self._host = host
+        self._port = port
+        self._path = path if path.startswith("/") else f"/{path}"
+        self._secret = secret or ""
+        self._runner: Optional[web.AppRunner] = None
+
+    async def start(self) -> None:
+        app = web.Application(client_max_size=_MAX_BODY_BYTES)
+        app.router.add_post(self._path, self._handle)
+        app.router.add_get(self._path, self._handle_health)
+        runner = web.AppRunner(app)
+        await runner.setup()
+        site = web.TCPSite(runner, self._host, self._port)
+        await site.start()
+        self._runner = runner
+        logger.info(
+            "[photon] webhook inbound listening on http://%s:%d%s",
+            self._host, self._port, self._path,
+        )
+
+    async def stop(self) -> None:
+        if self._runner is not None:
+            try:
+                await self._runner.cleanup()
+            finally:
+                self._runner = None
+
+    # -- handlers ---------------------------------------------------------
+
+    async def _handle_health(self, request: web.Request) -> web.Response:
+        # A bare GET lets you (and Funnel) sanity-check reachability without
+        # a valid signature. Never reveals payloads.
+        return web.json_response({"ok": True, "service": "photon-webhook"})
+
+    async def _handle(self, request: web.Request) -> web.Response:
+        raw = await request.read()
+
+        if not self._verify(request, raw):
+            # 401 (not 5xx) so Photon does NOT retry a forged/misconfigured
+            # delivery forever.
+            return web.json_response({"ok": False, "error": "bad signature"}, status=401)
+
+        try:
+            body = json.loads(raw)
+        except (ValueError, UnicodeDecodeError):
+            return web.json_response({"ok": False, "error": "bad json"}, status=400)
+
+        # Acknowledge anything we recognize as a valid signed delivery with 2xx
+        # so Photon stops retrying; only signature/parse failures get non-2xx.
+        try:
+            await self._process(body)
+        except Exception:
+            logger.exception("[photon] webhook processing failed (acked to avoid retry storm)")
+        return web.json_response({"ok": True})
+
+    # -- verification -----------------------------------------------------
+
+    def _verify(self, request: web.Request, raw: bytes) -> bool:
+        if not self._secret:
+            logger.error("[photon] webhook secret not configured — rejecting delivery")
+            return False
+        ts = request.headers.get("X-Spectrum-Timestamp", "")
+        sig = request.headers.get("X-Spectrum-Signature", "")
+        if not ts or not sig:
+            logger.warning("[photon] webhook missing signature/timestamp headers")
+            return False
+
+        # Clock-skew / replay guard.
+        try:
+            skew = abs(time.time() - int(ts))
+        except ValueError:
+            logger.warning("[photon] webhook timestamp not an integer: %r", ts)
+            return False
+        if skew > _MAX_TIMESTAMP_SKEW_SECONDS:
+            logger.warning("[photon] webhook timestamp too skewed (%.0fs) — rejecting", skew)
+            return False
+
+        # HMAC-SHA256 of "v0:{timestamp}:{rawBody}" keyed by the signing secret.
+        base = b"v0:" + ts.encode("utf-8") + b":" + raw
+        expected = "v0=" + hmac.new(
+            self._secret.encode("utf-8"), base, hashlib.sha256
+        ).hexdigest()
+        if not hmac.compare_digest(expected, sig):
+            logger.warning("[photon] webhook signature mismatch")
+            return False
+        return True
+
+    # -- payload mapping --------------------------------------------------
+
+    async def _process(self, body: Dict[str, Any]) -> None:
+        if body.get("event") != "messages":
+            logger.debug("[photon] webhook ignoring event=%r", body.get("event"))
+            return
+        message = body.get("message") or {}
+        if message.get("direction") and message.get("direction") != "inbound":
+            return  # our own outbound echo
+
+        msg_id = message.get("id")
+        if msg_id and self._adapter._is_duplicate(msg_id):
+            return  # at-least-once delivery replay
+
+        space = message.get("space") or body.get("space") or {}
+        sender = message.get("sender") or {}
+
+        # Normalize into the exact shape PhotonAdapter._dispatch_inbound expects
+        # (matching sidecar/index.mjs), so all downstream handling is shared.
+        event = {
+            "messageId": msg_id,
+            "platform": message.get("platform") or "iMessage",
+            "space": {
+                "id": space.get("id"),
+                "type": space.get("type"),
+                "phone": space.get("phone"),
+            },
+            "sender": {"id": sender.get("id")},
+            "content": message.get("content") or {},
+            "timestamp": message.get("timestamp") or "",
+        }
+        if not event["space"]["id"]:
+            logger.warning("[photon] webhook delivery missing space.id — dropping")
+            return
+        await self._adapter._dispatch_inbound(event)

--- a/tests/plugins/platforms/photon/test_webhook.py
+++ b/tests/plugins/platforms/photon/test_webhook.py
@@ -1,0 +1,138 @@
+"""Photon webhook inbound tests: signature verification + payload mapping.
+
+These exercise ``PhotonWebhookServer`` without binding a socket — ``_verify``
+is called with a fake request and ``_process`` is driven directly, so the
+HMAC scheme, the staleness/replay guards, the webhook→sidecar event mapping,
+and the dedup/echo gating are all covered offline.
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from typing import Any, Dict, List
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.photon.adapter import PhotonAdapter
+from plugins.platforms.photon.webhook import PhotonWebhookServer
+
+_SECRET = "test_signing_secret"
+
+
+def _make_server(monkeypatch: pytest.MonkeyPatch) -> tuple[PhotonWebhookServer, List[Dict[str, Any]]]:
+    monkeypatch.setenv("PHOTON_PROJECT_ID", "test-project-id")
+    monkeypatch.setenv("PHOTON_PROJECT_SECRET", "test-project-secret")
+    adapter = PhotonAdapter(PlatformConfig(enabled=True, token="", extra={}))
+
+    dispatched: List[Dict[str, Any]] = []
+
+    async def fake_dispatch(event: Dict[str, Any]) -> None:
+        dispatched.append(event)
+
+    monkeypatch.setattr(adapter, "_dispatch_inbound", fake_dispatch)
+    server = PhotonWebhookServer(
+        adapter, host="127.0.0.1", port=0, path="/photon/webhook", secret=_SECRET
+    )
+    return server, dispatched
+
+
+class _FakeReq:
+    def __init__(self, headers: Dict[str, str]) -> None:
+        self.headers = headers
+
+
+def _sign(ts: str, raw: bytes) -> str:
+    base = b"v0:" + ts.encode() + b":" + raw
+    return "v0=" + hmac.new(_SECRET.encode(), base, hashlib.sha256).hexdigest()
+
+
+def _text_body(msg_id: str = "spc-msg-1", direction: str = "inbound") -> bytes:
+    return json.dumps(
+        {
+            "event": "messages",
+            "message": {
+                "id": msg_id,
+                "direction": direction,
+                "timestamp": "2026-06-23T10:00:00.000Z",
+                "sender": {"id": "+15550100"},
+                "space": {"id": "any;-;+15550100", "type": "dm", "phone": "+15551234567"},
+                "content": {"type": "text", "text": "hello via webhook"},
+            },
+        }
+    ).encode()
+
+
+def test_verify_accepts_valid_signature(monkeypatch: pytest.MonkeyPatch) -> None:
+    server, _ = _make_server(monkeypatch)
+    raw = _text_body()
+    ts = str(int(time.time()))
+    req = _FakeReq({"X-Spectrum-Timestamp": ts, "X-Spectrum-Signature": _sign(ts, raw)})
+    assert server._verify(req, raw) is True
+
+
+def test_verify_rejects_tampered_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    server, _ = _make_server(monkeypatch)
+    raw = _text_body()
+    ts = str(int(time.time()))
+    req = _FakeReq({"X-Spectrum-Timestamp": ts, "X-Spectrum-Signature": _sign(ts, raw)})
+    assert server._verify(req, raw + b"x") is False
+
+
+def test_verify_rejects_stale_timestamp(monkeypatch: pytest.MonkeyPatch) -> None:
+    server, _ = _make_server(monkeypatch)
+    raw = _text_body()
+    old = str(int(time.time()) - 9999)
+    req = _FakeReq({"X-Spectrum-Timestamp": old, "X-Spectrum-Signature": _sign(old, raw)})
+    assert server._verify(req, raw) is False
+
+
+def test_verify_rejects_missing_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+    server, _ = _make_server(monkeypatch)
+    assert server._verify(_FakeReq({}), _text_body()) is False
+
+
+def test_verify_rejects_when_secret_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    server, _ = _make_server(monkeypatch)
+    server._secret = ""
+    raw = _text_body()
+    ts = str(int(time.time()))
+    req = _FakeReq({"X-Spectrum-Timestamp": ts, "X-Spectrum-Signature": _sign(ts, raw)})
+    assert server._verify(req, raw) is False
+
+
+@pytest.mark.asyncio
+async def test_process_maps_to_sidecar_event_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    server, dispatched = _make_server(monkeypatch)
+    await server._process(json.loads(_text_body()))
+    assert len(dispatched) == 1
+    ev = dispatched[0]
+    assert ev["messageId"] == "spc-msg-1"
+    assert ev["space"] == {"id": "any;-;+15550100", "type": "dm", "phone": "+15551234567"}
+    assert ev["sender"] == {"id": "+15550100"}
+    assert ev["content"] == {"type": "text", "text": "hello via webhook"}
+
+
+@pytest.mark.asyncio
+async def test_process_dedups_replay(monkeypatch: pytest.MonkeyPatch) -> None:
+    server, dispatched = _make_server(monkeypatch)
+    body = json.loads(_text_body())
+    await server._process(body)
+    await server._process(body)  # at-least-once replay
+    assert len(dispatched) == 1
+
+
+@pytest.mark.asyncio
+async def test_process_ignores_outbound_echo(monkeypatch: pytest.MonkeyPatch) -> None:
+    server, dispatched = _make_server(monkeypatch)
+    await server._process(json.loads(_text_body(msg_id="spc-msg-2", direction="outbound")))
+    assert dispatched == []
+
+
+@pytest.mark.asyncio
+async def test_process_ignores_non_message_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    server, dispatched = _make_server(monkeypatch)
+    await server._process({"event": "something-else", "message": {}})
+    assert dispatched == []


### PR DESCRIPTION
## Problem

Photon inbound rides the `spectrum-ts` `app.messages` gRPC/WS stream
(`catchUpEvents`). On shared/free lines that stream degrades periodically —
the 16-stream server-side concurrency limit (`RESOURCE_EXHAUSTED`), zombie
half-open streams, and `RetryableStreamError: Live stream ended` reconnect
spirals — and silently stops delivering inbound. The only recovery today is a
gateway restart or a new line/number. Related: #49858, #50918, #50971.

## Approach

Add an **opt-in, push-based inbound transport** so inbound no longer depends
on a long-lived stream. This mirrors Photon's own recommended integration
shape — their [`n8n-nodes-spectrum`](https://github.com/photon-hq/n8n-nodes-spectrum)
and [`vercel-chat-adapter-imessage`](https://github.com/photon-hq/vercel-chat-adapter-imessage)
both use **webhook-in + SDK-out**. Outbound stays on the sidecar because
Spectrum has no public HTTP send endpoint.

```
PHOTON_INBOUND_MODE=webhook   iMessage → Photon → HTTPS POST → webhook.py → handle_message()
outbound (unchanged)          handle_message reply → sidecar /send (spectrum-ts)
```

## Changes

- **`plugins/platforms/photon/webhook.py`** (new): aiohttp receiver. Verifies
  `X-Spectrum-Signature` (HMAC-SHA256 of `v0:{ts}:{body}`, 5-min skew guard,
  constant-time compare), maps the webhook body to the existing sidecar event
  shape, and reuses `_dispatch_inbound` / `_is_duplicate` so all downstream
  handling (dedup, mention gating, reactions, media) is shared with the stream
  path.
- **`adapter.py`**: `PHOTON_INBOUND_MODE=webhook` starts the webhook server
  instead of the inbound stream loop; `disconnect()` tears it down. New
  `webhook_port` / `webhook_path` / `webhook_secret` config; fails fast if the
  secret is missing.
- **`sidecar/index.mjs`**: `PHOTON_SIDECAR_DISABLE_INBOUND=1` skips the inbound
  subscription (outbound `/send` only) so the now-unused stream stops
  thrashing/logging.

## Backward compatibility

Default is unchanged — `PHOTON_INBOUND_MODE` defaults to `stream`. Webhook mode
is opt-in and needs a public HTTPS ingress to `PHOTON_WEBHOOK_PORT` (e.g. a
tunnel), plus `PHOTON_WEBHOOK_SECRET` (the per-webhook signing secret shown
once when you register the URL at `app.photon.codes` → Spectrum → Webhooks).

## Testing

- `tests/plugins/platforms/photon/test_webhook.py` (new, 9 tests): signature
  accept / tamper-reject / stale-reject / missing-headers / unset-secret;
  payload→event mapping; at-least-once dedup; outbound-echo and non-`messages`
  event gating. All green.
- Verified end-to-end on a live free/shared line: inbound iMessage delivered
  via webhook → agent → sidecar outbound reply, on the same number, with the
  `catchUpEvents` stream disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLorFGZsfrhkmHyz8WrqqW
