### PR TITLE
fix(yuanbao): handle JPEG fill bytes and full SOF marker set in image-size parser

### DIFF
--- a/gateway/platforms/yuanbao_media.py
+++ b/gateway/platforms/yuanbao_media.py
@@ -141,6 +141,14 @@ def _parse_png_size(buf: bytes) -> Optional[dict[str, int]]:
     return {"width": w, "height": h}
 
 
+# SOF（Start Of Frame）标记，宽高位于 +5/+7。
+# 故意排除 0xC4(DHT)、0xC8(JPG)、0xCC(DAC)——它们落在 0xC0–0xCF 区间
+# 但不是帧头，仍需按带长度前缀的普通段处理。
+_JPEG_SOF_MARKERS = frozenset(
+    {0xC0, 0xC1, 0xC2, 0xC3, 0xC5, 0xC6, 0xC7, 0xC9, 0xCA, 0xCB, 0xCD, 0xCE, 0xCF}
+)
+
+
 def _parse_jpeg_size(buf: bytes) -> Optional[dict[str, int]]:
     if len(buf) < 4 or buf[0] != 0xFF or buf[1] != 0xD8:
         return None
@@ -150,7 +158,12 @@ def _parse_jpeg_size(buf: bytes) -> Optional[dict[str, int]]:
             i += 1
             continue
         marker = buf[i + 1]
-        if marker in {0xC0, 0xC2}:
+        # 跳过填充字节：标记前可能有额外的 0xFF 填充（ITU-T T.81 §B.1.1.2），
+        # 逐字节前移直到真正的标记码，避免把填充误读为段长度前缀导致扫描错位。
+        if marker == 0xFF:
+            i += 1
+            continue
+        if marker in _JPEG_SOF_MARKERS:
             h = struct.unpack(">H", buf[i + 5: i + 7])[0]
             w = struct.unpack(">H", buf[i + 7: i + 9])[0]
             return {"width": w, "height": h}

--- a/tests/test_yuanbao_media.py
+++ b/tests/test_yuanbao_media.py
@@ -1,0 +1,62 @@
+"""
+test_yuanbao_media.py - yuanbao_media 单元测试
+
+测试覆盖：
+  1. JPEG 尺寸解析：基线 SOF0（公共路径回归保护）
+  2. JPEG 尺寸解析：标记前含 0xFF 填充字节（ITU-T T.81 §B.1.1.2）
+  3. JPEG 尺寸解析：SOF1（0xC1，基线扩展）
+"""
+
+import sys
+import os
+
+# 确保 hermes-agent 根目录在 sys.path 中
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+import struct
+
+import pytest
+
+from gateway.platforms.yuanbao_media import parse_image_size
+
+
+def _make_jpeg(width: int, height: int, sof_marker: int = 0xC0, fill_bytes: int = 0) -> bytes:
+    """
+    构建一个最小的合法 JPEG 字节串，仅含 SOI + SOF 段 + EOI。
+
+    SOF 段结构（足以让解析器读取宽高）：
+      FF <marker> <2 字节段长> <1 字节精度> <2 字节高> <2 字节宽> <分量数据...>
+    可在 SOF 标记前插入若干 0xFF 填充字节（合法）。
+    """
+    soi = b"\xff\xd8"
+    # SOF 段载荷：精度(1) + 高(2) + 宽(2) + 1 个分量(3) = 8 字节
+    precision = b"\x08"
+    h = struct.pack(">H", height)
+    w = struct.pack(">H", width)
+    component = b"\x01\x11\x00"  # 单分量：id=1, 采样=0x11, 量化表=0
+    payload = precision + h + w + component
+    seg_len = struct.pack(">H", len(payload) + 2)  # 段长含自身 2 字节
+    fill = b"\xff" * fill_bytes
+    sof = fill + bytes([0xFF, sof_marker]) + seg_len + payload
+    eoi = b"\xff\xd9"
+    return soi + sof + eoi
+
+
+def test_parse_jpeg_size_baseline_sof0():
+    """基线 SOF0：公共路径回归保护（main 上即通过）。"""
+    data = _make_jpeg(100, 200, sof_marker=0xC0)
+    assert parse_image_size(data) == {"width": 100, "height": 200}
+
+
+def test_parse_jpeg_size_skips_fill_bytes():
+    """SOF 标记前的 0xFF 填充字节应被跳过（main 上返回 None，本次修复后通过）。"""
+    data = _make_jpeg(100, 200, sof_marker=0xC0, fill_bytes=1)
+    assert parse_image_size(data) == {"width": 100, "height": 200}
+
+
+def test_parse_jpeg_size_sof1():
+    """SOF1（0xC1，基线扩展）应被识别（main 上返回 None，本次修复后通过）。"""
+    data = _make_jpeg(64, 48, sof_marker=0xC1)
+    assert parse_image_size(data) == {"width": 64, "height": 48}

--- a/tests/test_yuanbao_media.py
+++ b/tests/test_yuanbao_media.py
@@ -17,8 +17,6 @@ if _REPO_ROOT not in sys.path:
 
 import struct
 
-import pytest
-
 from gateway.platforms.yuanbao_media import parse_image_size
 
 


### PR DESCRIPTION
## What does this PR do?

`_parse_jpeg_size` in `gateway/platforms/yuanbao_media.py` (used by `parse_image_size` during Yuanbao image upload) returned `None` — silently dropping width/height — for two classes of perfectly valid JPEG:

1. **Fill bytes** — JPEG permits any number of `0xFF` padding bytes immediately before a marker code (ITU-T T.81 §B.1.1.2). When the byte after `0xFF` was itself `0xFF` (a fill byte), the code fell into the segment-skip branch and read the next two bytes as a segment length. That length is garbage, so the marker scan desynced and the function returned `None`.
2. **Incomplete SOF set** — only `SOF0 (0xC0)` and `SOF2 (0xC2)` were recognized. Baseline-extended / progressive / lossless frames (`SOF1 0xC1`, `SOF3 0xC3`, `0xC5–0xC7`, `0xC9–0xCB`, `0xCD–0xCF`) carry width/height at the same `+5/+7` offsets but were missed.

**Why it matters:** affected Yuanbao image sends produce a `TIMImageElem` with `width:0,height:0`, which some IM clients render as a zero-size / mis-laid-out thumbnail. The send still succeeds (graceful degradation), but it is a real user-facing correctness defect on those images.

## Related Issue

No filed issue — author-found correctness bug in `gateway/platforms/yuanbao_media.py`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/yuanbao_media.py`:
  - Skip `0xFF` fill bytes before reading the marker code, so padding can no longer be misread as a segment-length prefix.
  - Match the full set of dimension-carrying SOF markers via a new `_JPEG_SOF_MARKERS` frozenset, **deliberately excluding** the non-frame `0xC4` (DHT), `0xC8` (JPG), `0xCC` (DAC) codes that share the `0xC0–0xCF` range — those remain length-prefixed segments that must keep flowing through the skip branch.
- `tests/test_yuanbao_media.py` (new): regression tests that build minimal valid JPEGs in-process (no binary fixtures).

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/test_yuanbao_media.py -v`
2. Fail-before / pass-after proof (reverting only the production hunk to `main`):
   - `test_parse_jpeg_size_skips_fill_bytes` — SOF0 100x200 with a `0xFF` fill byte before the SOF marker: returns `None` on `main`, `{"width":100,"height":200}` with this change.
   - `test_parse_jpeg_size_sof1` — SOF1 (`0xC1`) 64x48: returns `None` on `main`, `{"width":64,"height":48}` with this change.
   - `test_parse_jpeg_size_baseline_sof0` — plain SOF0 control, guards the common path (passes both before and after).
3. Full touched-area suite stays green: `pytest tests/test_yuanbao_media.py tests/test_yuanbao_proto.py tests/test_yuanbao_integration.py tests/test_yuanbao_pipeline.py tests/test_yuanbao_markdown.py tests/test_yuanbao_shutdown.py` (172 passed).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python byte parsing, platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A