### PR TITLE
fix(skills): protect operator-locked policy regions from self-patch

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1672,6 +1672,7 @@ AUTHOR_MAP = {
     "qs2816661685@gmail.com": "qingshan89",  # PR #46895 co-author (desktop remote artifact download)
     "yspdev@gmail.com": "AJ",  # PR #44510 co-author (desktop named-profile boot loop)
     "steveonjava@gmail.com": "steveonjava",  # PR #29669 (redact secrets in kanban tool payloads)
+    "tyler@koblasa.com": "gtyler",  # operator-locked skill-region self-patch guard
 }
 
 

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -1028,3 +1028,516 @@ class TestDeleteSkillRmtreeGuard:
         assert result["success"] is False
         assert "skills root" in result["error"].lower()
         assert outside.exists()
+
+
+# ---------------------------------------------------------------------------
+# Operator-locked policy regions
+#
+# The self-patcher must never rewrite, drop, reorder, or forge operator-authored
+# policy wrapped in <!-- operator-locked -->...<!-- /operator-locked -->. It may
+# still edit freely OUTSIDE the markers. Modeled on a real incident: a live
+# self-patch silently reversed the positions-optimize --wait-seconds rule.
+# ---------------------------------------------------------------------------
+
+from tools.skill_manager_tool import (  # noqa: E402
+    _locked_region_violation,
+    _extract_locked_regions,
+    _count_lock_markers,
+    _skill_dir_locked_files,
+    _has_lock_marker,
+    apply_skill_pending,
+    OPERATOR_LOCK_OPEN,
+    OPERATOR_LOCK_CLOSE,
+)
+
+
+# A SKILL.md whose execution policy is operator-locked (the real wait-seconds
+# rule) with a free-to-edit calibration section below it.
+LOCKED_SKILL_CONTENT = """\
+---
+name: positions-optimize
+description: Optimize open positions safely.
+---
+
+# Positions Optimize
+
+## Execution policy
+
+<!-- operator-locked -->
+- Keep the executor's `--wait-seconds` at 30.
+- Treat `--wait-seconds 120` as cron-unsafe.
+<!-- /operator-locked -->
+
+## Calibration notes
+
+(none yet)
+"""
+
+# The exact reversal a live agent performed in the incident this guards against.
+REVERSED_LOCK = (
+    "- `--wait-seconds 120` has been observed to work fine.\n"
+    "- Only use `--wait-seconds 30` if you hit actual terminal timeouts."
+)
+
+
+def _make_locked_skill(skills_root: Path, content: str = LOCKED_SKILL_CONTENT) -> Path:
+    """Author the positions-optimize skill with locked content straight to disk
+    (operator out-of-band). create() now refuses to MINT lock markers, so the
+    self-patch tool itself can't set this up.
+    """
+    return _author_locked_file(skills_root / "positions-optimize", "SKILL.md", content)
+
+
+def _author_locked_file(skill_dir: Path, rel_path: str, body: str) -> Path:
+    """Write a locked supporting file straight to disk, simulating an operator
+    authoring it out-of-band (git / dashboard). The self-patch tool itself
+    refuses to MINT lock markers, so tests can't use _write_file to set this up.
+    """
+    target = skill_dir / rel_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body, encoding="utf-8")
+    return target
+
+
+class TestLockedRegionViolation:
+    """Unit tests for the _locked_region_violation invariant checker."""
+
+    def test_no_locks_anywhere_allowed(self):
+        assert _locked_region_violation("plain body", "plain body edited") is None
+
+    def test_edit_outside_lock_allowed(self):
+        updated = LOCKED_SKILL_CONTENT.replace("(none yet)", "- Run 489: 120s took 95s.")
+        assert _locked_region_violation(LOCKED_SKILL_CONTENT, updated) is None
+
+    def test_modifying_locked_text_refused(self):
+        updated = LOCKED_SKILL_CONTENT.replace(
+            "- Treat `--wait-seconds 120` as cron-unsafe.", REVERSED_LOCK
+        )
+        err = _locked_region_violation(LOCKED_SKILL_CONTENT, updated)
+        assert err is not None
+        assert "operator-locked" in err
+        assert "operator-locked" in err
+
+    def test_dropping_locked_region_refused(self):
+        # Remove the whole locked block (markers + content).
+        region = _extract_locked_regions(LOCKED_SKILL_CONTENT)[0]
+        updated = LOCKED_SKILL_CONTENT.replace(region, "- 120 is fine now.")
+        assert _locked_region_violation(LOCKED_SKILL_CONTENT, updated) is not None
+
+    def test_stripping_open_marker_refused(self):
+        updated = LOCKED_SKILL_CONTENT.replace(OPERATOR_LOCK_OPEN + "\n", "")
+        assert _locked_region_violation(LOCKED_SKILL_CONTENT, updated) is not None
+
+    def test_stripping_close_marker_refused(self):
+        updated = LOCKED_SKILL_CONTENT.replace("\n" + OPERATOR_LOCK_CLOSE, "")
+        assert _locked_region_violation(LOCKED_SKILL_CONTENT, updated) is not None
+
+    def test_whitespace_change_inside_lock_refused(self):
+        # Even a trivial reflow inside the region is refused — policy is byte-exact.
+        updated = LOCKED_SKILL_CONTENT.replace(
+            "- Keep the executor's `--wait-seconds` at 30.",
+            "-  Keep the executor's `--wait-seconds` at 30.",
+        )
+        assert _locked_region_violation(LOCKED_SKILL_CONTENT, updated) is not None
+
+    def test_forging_new_lock_on_unlocked_original_refused(self):
+        original = "---\nname: x\ndescription: y\n---\n\nBody.\n"
+        updated = original + f"\n{OPERATOR_LOCK_OPEN}\n- my own rule\n{OPERATOR_LOCK_CLOSE}\n"
+        err = _locked_region_violation(original, updated)
+        assert err is not None
+        assert "may only be" in err
+
+    def test_adding_second_lock_while_preserving_first_refused(self):
+        updated = LOCKED_SKILL_CONTENT + (
+            f"\n{OPERATOR_LOCK_OPEN}\n- forged extra rule\n{OPERATOR_LOCK_CLOSE}\n"
+        )
+        assert _locked_region_violation(LOCKED_SKILL_CONTENT, updated) is not None
+
+    def test_reordering_two_locks_refused(self):
+        two = (
+            f"{OPERATOR_LOCK_OPEN}\nA\n{OPERATOR_LOCK_CLOSE}\n"
+            f"{OPERATOR_LOCK_OPEN}\nB\n{OPERATOR_LOCK_CLOSE}\n"
+        )
+        swapped = (
+            f"{OPERATOR_LOCK_OPEN}\nB\n{OPERATOR_LOCK_CLOSE}\n"
+            f"{OPERATOR_LOCK_OPEN}\nA\n{OPERATOR_LOCK_CLOSE}\n"
+        )
+        assert _locked_region_violation(two, swapped) is not None
+
+    def test_label_is_included_in_error(self):
+        updated = LOCKED_SKILL_CONTENT.replace("at 30.", "at 120.")
+        err = _locked_region_violation(LOCKED_SKILL_CONTENT, updated, label="references/policy.md")
+        assert "references/policy.md" in err
+
+    def test_labeled_marker_variant_is_protected(self):
+        # Operators may annotate the open marker with a reason/ticket.
+        labeled = (
+            "<!-- operator-locked: keep wait-seconds 30 -->\n"
+            "- Keep --wait-seconds at 30.\n"
+            "<!-- /operator-locked -->\n"
+        )
+        assert _extract_locked_regions(labeled), "labeled marker should be recognized"
+        reversed_ = labeled.replace("- Keep --wait-seconds at 30.", "- 120 is fine.")
+        assert _locked_region_violation(labeled, reversed_) is not None
+
+    def test_count_lock_markers(self):
+        assert _count_lock_markers(LOCKED_SKILL_CONTENT) == (1, 1)
+        assert _count_lock_markers("no markers") == (0, 0)
+
+
+class TestOperatorLockEdit:
+    """_edit_skill refuses full rewrites that touch a locked region."""
+
+    def test_edit_reversing_locked_rule_refused(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _make_locked_skill(tmp_path)
+            reversed_content = LOCKED_SKILL_CONTENT.replace(
+                "- Treat `--wait-seconds 120` as cron-unsafe.", REVERSED_LOCK
+            )
+            result = _edit_skill("positions-optimize", reversed_content)
+            on_disk = (tmp_path / "positions-optimize" / "SKILL.md").read_text()
+        assert result["success"] is False
+        assert "operator-locked" in result["error"]
+        # File must be untouched — the original rule still stands, reversal absent.
+        assert "Treat `--wait-seconds 120` as cron-unsafe." in on_disk
+        assert "has been observed to work fine" not in on_disk
+
+    def test_edit_outside_lock_allowed(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _make_locked_skill(tmp_path)
+            updated = LOCKED_SKILL_CONTENT.replace(
+                "(none yet)", "- Run 491: 120s completed, but cron killed it once."
+            )
+            result = _edit_skill("positions-optimize", updated)
+            on_disk = (tmp_path / "positions-optimize" / "SKILL.md").read_text()
+        assert result["success"] is True, result
+        assert "Run 491" in on_disk
+        assert "cron-unsafe" in on_disk  # lock intact
+
+    def test_edit_forging_lock_on_unlocked_skill_refused(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            forged = VALID_SKILL_CONTENT + (
+                f"\n{OPERATOR_LOCK_OPEN}\n- my own rule\n{OPERATOR_LOCK_CLOSE}\n"
+            )
+            result = _edit_skill("my-skill", forged)
+        assert result["success"] is False
+        assert "may only be" in result["error"]
+
+
+class TestOperatorLockPatch:
+    """_patch_skill refuses find/replace whose result touches a locked region."""
+
+    def test_patch_reversing_locked_rule_refused(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _make_locked_skill(tmp_path)
+            result = _patch_skill(
+                "positions-optimize",
+                "- Treat `--wait-seconds 120` as cron-unsafe.",
+                "- `--wait-seconds 120` works fine; only use 30 on terminal timeouts.",
+            )
+            on_disk = (tmp_path / "positions-optimize" / "SKILL.md").read_text()
+        assert result["success"] is False
+        assert "operator-locked" in result["error"]
+        assert "cron-unsafe" in on_disk  # unchanged
+
+    def test_patch_appending_calibration_note_allowed(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _make_locked_skill(tmp_path)
+            result = _patch_skill(
+                "positions-optimize", "(none yet)", "- Run 495: 120s ok in manual run."
+            )
+            on_disk = (tmp_path / "positions-optimize" / "SKILL.md").read_text()
+        assert result["success"] is True, result
+        assert "Run 495" in on_disk
+        assert "cron-unsafe" in on_disk  # lock intact
+
+    def test_patch_replace_all_touching_lock_refused(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _make_locked_skill(tmp_path)
+            # `--wait-seconds` occurs inside the locked region; replace_all would
+            # rewrite locked text.
+            result = _patch_skill(
+                "positions-optimize", "`--wait-seconds`", "`--delay`", replace_all=True
+            )
+            on_disk = (tmp_path / "positions-optimize" / "SKILL.md").read_text()
+        assert result["success"] is False
+        assert "operator-locked" in result["error"]
+        assert "`--delay`" not in on_disk
+
+    def test_patch_supporting_file_lock_refused(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            _author_locked_file(
+                tmp_path / "my-skill",
+                "references/policy.md",
+                f"# Policy\n\n{OPERATOR_LOCK_OPEN}\n- never trim more than 5%\n{OPERATOR_LOCK_CLOSE}\n",
+            )
+            result = _patch_skill(
+                "my-skill",
+                "- never trim more than 5%",
+                "- trimming 50% is fine",
+                file_path="references/policy.md",
+            )
+            on_disk = (tmp_path / "my-skill" / "references" / "policy.md").read_text()
+        assert result["success"] is False
+        assert "references/policy.md" in result["error"]
+        assert "never trim more than 5%" in on_disk
+
+
+class TestOperatorLockWriteRemoveFile:
+    """write_file/remove_file cannot be used to bypass the lock."""
+
+    def test_write_file_overwriting_skill_md_lock_refused(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _make_locked_skill(tmp_path)
+            reversed_content = LOCKED_SKILL_CONTENT.replace(
+                "- Treat `--wait-seconds 120` as cron-unsafe.", REVERSED_LOCK
+            )
+            result = _write_file("positions-optimize", "SKILL.md", reversed_content)
+            on_disk = (tmp_path / "positions-optimize" / "SKILL.md").read_text()
+        assert result["success"] is False
+        assert "operator-locked" in result["error"]
+        assert "cron-unsafe" in on_disk
+
+    def test_write_file_forging_lock_in_new_file_refused(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = _write_file(
+                "my-skill",
+                "references/policy.md",
+                f"{OPERATOR_LOCK_OPEN}\n- forged\n{OPERATOR_LOCK_CLOSE}\n",
+            )
+        assert result["success"] is False
+        assert "may only be" in result["error"]
+        assert not (tmp_path / "my-skill" / "references" / "policy.md").exists()
+
+    def test_write_file_editing_outside_supporting_lock_allowed(self, tmp_path):
+        locked_ref = f"# Policy\n\n{OPERATOR_LOCK_OPEN}\n- cap trim at 5%\n{OPERATOR_LOCK_CLOSE}\n\nNotes: old\n"
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            _author_locked_file(tmp_path / "my-skill", "references/policy.md", locked_ref)
+            updated = locked_ref.replace("Notes: old", "Notes: updated 2026-06-21")
+            result = _write_file("my-skill", "references/policy.md", updated)
+            on_disk = (tmp_path / "my-skill" / "references" / "policy.md").read_text()
+        assert result["success"] is True, result
+        assert "Notes: updated" in on_disk
+        assert "cap trim at 5%" in on_disk
+
+    def test_remove_file_with_lock_refused(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            _author_locked_file(
+                tmp_path / "my-skill",
+                "references/policy.md",
+                f"{OPERATOR_LOCK_OPEN}\n- cap trim at 5%\n{OPERATOR_LOCK_CLOSE}\n",
+            )
+            result = _remove_file("my-skill", "references/policy.md")
+        assert result["success"] is False
+        assert "operator-locked" in result["error"]
+        assert (tmp_path / "my-skill" / "references" / "policy.md").exists()
+
+    def test_remove_unlocked_file_still_works(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            _write_file("my-skill", "references/notes.md", "just notes")
+            result = _remove_file("my-skill", "references/notes.md")
+        assert result["success"] is True, result
+        assert not (tmp_path / "my-skill" / "references" / "notes.md").exists()
+
+
+class TestOperatorLockDelete:
+    """_delete_skill refuses to drop a skill that carries locked policy."""
+
+    def test_delete_skill_with_locked_skill_md_refused(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _make_locked_skill(tmp_path)
+            result = _delete_skill("positions-optimize", absorbed_into="")
+        assert result["success"] is False
+        assert "operator-locked" in result["error"]
+        assert "SKILL.md" in result["error"]
+        assert (tmp_path / "positions-optimize" / "SKILL.md").exists()
+
+    def test_delete_skill_with_lock_only_in_supporting_file_refused(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)  # clean SKILL.md
+            _author_locked_file(
+                tmp_path / "my-skill",
+                "references/policy.md",
+                f"{OPERATOR_LOCK_OPEN}\n- cap trim at 5%\n{OPERATOR_LOCK_CLOSE}\n",
+            )
+            result = _delete_skill("my-skill", absorbed_into="")
+        assert result["success"] is False
+        assert "references/policy.md" in result["error"]
+        assert (tmp_path / "my-skill").exists()
+
+    def test_delete_unlocked_skill_still_works(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = _delete_skill("my-skill", absorbed_into="")
+        assert result["success"] is True, result
+        assert not (tmp_path / "my-skill").exists()
+
+    def test_skill_dir_locked_files_lists_all_locked(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _make_locked_skill(tmp_path)
+            _author_locked_file(
+                tmp_path / "positions-optimize",
+                "references/policy.md",
+                f"{OPERATOR_LOCK_OPEN}\n- x\n{OPERATOR_LOCK_CLOSE}\n",
+            )
+            skill_dir = tmp_path / "positions-optimize"
+            locked = _skill_dir_locked_files(skill_dir)
+        assert "SKILL.md" in locked
+        assert "references/policy.md" in locked
+
+
+class TestOperatorLockDispatcher:
+    """End-to-end through skill_manage() — the agent-facing entry point."""
+
+    def test_patch_reversal_blocked_via_dispatcher(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _make_locked_skill(tmp_path)
+            raw = skill_manage(
+                action="patch",
+                name="positions-optimize",
+                old_string="- Treat `--wait-seconds 120` as cron-unsafe.",
+                new_string="- 120 is fine.",
+            )
+            on_disk = (tmp_path / "positions-optimize" / "SKILL.md").read_text()
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "operator-locked" in result["error"]
+        assert "cron-unsafe" in on_disk
+
+    def test_calibration_append_allowed_via_dispatcher(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _make_locked_skill(tmp_path)
+            raw = skill_manage(
+                action="patch",
+                name="positions-optimize",
+                old_string="(none yet)",
+                new_string="- Run 489 logged.",
+            )
+        result = json.loads(raw)
+        assert result["success"] is True, result
+
+
+# ---------------------------------------------------------------------------
+# Hardening from a self-review of the guard: count-check coverage, lone markers,
+# create() forging, replace_all discrimination, audit log, approval replay.
+# ---------------------------------------------------------------------------
+
+
+class TestLockedRegionViolationHardening:
+    def test_lone_open_marker_smuggle_refused(self):
+        # A lone trailing open marker forms NO balanced region, so the region
+        # list is unchanged — only the marker-count invariant catches it. Pins
+        # _count_lock_markers as load-bearing (not subsumed by region equality).
+        updated = LOCKED_SKILL_CONTENT + f"\n{OPERATOR_LOCK_OPEN}\n- smuggled active rule\n"
+        assert _extract_locked_regions(updated) == _extract_locked_regions(LOCKED_SKILL_CONTENT)
+        assert _count_lock_markers(updated) != _count_lock_markers(LOCKED_SKILL_CONTENT)
+        assert _locked_region_violation(LOCKED_SKILL_CONTENT, updated) is not None
+
+    def test_lone_close_marker_appended_refused(self):
+        updated = LOCKED_SKILL_CONTENT + f"\n{OPERATOR_LOCK_CLOSE}\n"
+        assert _locked_region_violation(LOCKED_SKILL_CONTENT, updated) is not None
+
+    def test_has_lock_marker(self):
+        assert _has_lock_marker(LOCKED_SKILL_CONTENT) is True
+        assert _has_lock_marker(f"only a close {OPERATOR_LOCK_CLOSE}") is True
+        assert _has_lock_marker(f"only an open {OPERATOR_LOCK_OPEN}") is True
+        assert _has_lock_marker("no markers at all") is False
+
+
+class TestOperatorLockCreate:
+    """create() must not be a forging hole — no action may mint operator locks."""
+
+    def test_create_forging_lock_refused(self, tmp_path):
+        forged = VALID_SKILL_CONTENT + (
+            f"\n{OPERATOR_LOCK_OPEN}\n- auto-liquidation approved\n{OPERATOR_LOCK_CLOSE}\n"
+        )
+        with _skill_dir(tmp_path):
+            result = _create_skill("executor-rules", forged)
+        assert result["success"] is False
+        assert "may only be" in result["error"]
+        assert not (tmp_path / "executor-rules").exists()
+
+    def test_create_unlocked_skill_still_works(self, tmp_path):
+        with _skill_dir(tmp_path):
+            result = _create_skill("plain", VALID_SKILL_CONTENT)
+        assert result["success"] is True, result
+
+
+class TestOperatorLockReplaceAllDiscriminates:
+    """replace_all must block when ANY occurrence falls inside a locked region,
+    even when other occurrences are legitimately outside it."""
+
+    SKILL = (
+        "---\nname: s\ndescription: d\n---\n\n# S\n\n"
+        f"{OPERATOR_LOCK_OPEN}\n- cap is FIVE percent\n{OPERATOR_LOCK_CLOSE}\n\n"
+        "Notes: FIVE here is just prose.\n"
+    )
+
+    def test_replace_all_hitting_inside_and_outside_refused(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _author_locked_file(tmp_path / "s", "SKILL.md", self.SKILL)
+            result = _patch_skill("s", "FIVE", "FIFTY", replace_all=True)
+            on_disk = (tmp_path / "s" / "SKILL.md").read_text()
+        assert result["success"] is False
+        assert "operator-locked" in result["error"]
+        assert "FIFTY" not in on_disk  # nothing written
+
+    def test_targeted_replace_of_outside_occurrence_allowed(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _author_locked_file(tmp_path / "s", "SKILL.md", self.SKILL)
+            result = _patch_skill("s", "Notes: FIVE here", "Notes: FIFTY here")
+            on_disk = (tmp_path / "s" / "SKILL.md").read_text()
+        assert result["success"] is True, result
+        assert "cap is FIVE percent" in on_disk  # lock intact
+        assert "Notes: FIFTY here" in on_disk
+
+
+class TestOperatorLockLoneCloseRemoval:
+    def test_remove_file_with_lone_close_marker_refused(self, tmp_path):
+        # A file carrying even a malformed/half lock (lone close) must not be
+        # dropped silently — remove_file gates on _has_lock_marker, not balance.
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            _author_locked_file(
+                tmp_path / "my-skill", "references/policy.md",
+                f"some operator note\n{OPERATOR_LOCK_CLOSE}\n",
+            )
+            result = _remove_file("my-skill", "references/policy.md")
+        assert result["success"] is False
+        assert "operator-locked" in result["error"]
+        assert (tmp_path / "my-skill" / "references" / "policy.md").exists()
+
+
+class TestOperatorLockAuditAndReplay:
+    def test_allowed_touch_of_locked_file_is_logged(self, tmp_path, caplog):
+        import logging
+        with _skill_dir(tmp_path):
+            _make_locked_skill(tmp_path)
+            with caplog.at_level(logging.INFO, logger="tools.skill_manager_tool"):
+                result = _patch_skill("positions-optimize", "(none yet)", "- Run 489 logged.")
+        assert result["success"] is True, result
+        msgs = [r.getMessage() for r in caplog.records]
+        assert any("operator-locked" in m and "positions-optimize" in m for m in msgs), msgs
+
+    def test_approval_replay_still_enforces_lock(self, tmp_path):
+        # apply_skill_pending replays an approved staged write with the approval
+        # gate bypassed — the per-action lock guard must STILL fire.
+        with _skill_dir(tmp_path):
+            _make_locked_skill(tmp_path)
+            raw = apply_skill_pending({
+                "action": "patch",
+                "name": "positions-optimize",
+                "old_string": "- Treat `--wait-seconds 120` as cron-unsafe.",
+                "new_string": "- 120 is fine.",
+            })
+            on_disk = (tmp_path / "positions-optimize" / "SKILL.md").read_text()
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "operator-locked" in result["error"]
+        assert "cron-unsafe" in on_disk

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -553,6 +553,171 @@ def _atomic_write_text(file_path: Path, content: str, encoding: str = "utf-8") -
 
 
 # =============================================================================
+# Operator-locked policy regions
+# =============================================================================
+#
+# Operators mark policy they author by hand — safety rules the live agent must
+# not rewrite for itself: execution gates, kill-switch handling, trim caps,
+# fast-fail rules, the positions-optimize `--wait-seconds 30` rule, etc. — by
+# wrapping them in sentinel HTML comments:
+#
+#     <!-- operator-locked -->
+#     - Keep the executor's --wait-seconds at 30; treat 120s as cron-unsafe.
+#     <!-- /operator-locked -->
+#
+# HTML comments are invisible in rendered Markdown and ignored by the model when
+# it reads the skill, so they cost nothing at read time. What they buy is a hard
+# guarantee: the self-patch tool (edit / patch / write_file / remove_file /
+# delete) must never rewrite, reorder, drop, or forge these regions. The agent
+# may still freely edit everything OUTSIDE the markers — append calibration
+# notes, refine non-policy guidance — so self-improvement keeps working.
+#
+# Background: on 2026-06-18 a live self-patch silently REVERSED the
+# --wait-seconds policy in positions-optimize/SKILL.md (deleted the "120s is
+# cron-unsafe" rule, asserted the opposite, citing its own runs). Nobody was
+# alerted; it was caught only by chance during an unrelated deploy.
+# Operators author and lift these locks out-of-band (git or the dashboard
+# editor), never through this tool.
+#
+# Limitation (by design): this protects the locked *bytes*, not their *meaning*.
+# The agent can still add or relocate text OUTSIDE the markers that
+# recontextualizes a locked rule (e.g. an "obsolete — ignore" note after the
+# close marker, or moving the block under a "superseded" heading). The locked
+# bytes survive verbatim for any human or the deploy reconciler to diff against
+# origin/main, and every allowed self-patch of a file that contains locked policy
+# is audit-logged (see ``_audit_locked_file_touch``) so the touch is never silent
+# — but detecting semantic contradiction is out of scope for a byte-level guard.
+# Pair with a whole-file policy diff at deploy time for defense
+# in depth.
+
+OPERATOR_LOCK_OPEN = "<!-- operator-locked -->"
+OPERATOR_LOCK_CLOSE = "<!-- /operator-locked -->"
+
+# Tolerant of whitespace inside the comment and of an optional trailing label or
+# reason, e.g. `<!-- operator-locked: keep wait-seconds 30 -->`. The open
+# and close markers each have one source pattern so the region regex can't drift
+# from them; they are matched separately so a stray '/' in the close marker can
+# never be read as an opener.
+_LOCK_OPEN_PAT = r"<!--\s*operator-locked\b[^>]*-->"
+_LOCK_CLOSE_PAT = r"<!--\s*/\s*operator-locked\s*-->"
+_LOCK_OPEN_RE = re.compile(_LOCK_OPEN_PAT, re.IGNORECASE)
+_LOCK_CLOSE_RE = re.compile(_LOCK_CLOSE_PAT, re.IGNORECASE)
+_LOCK_REGION_RE = re.compile(
+    _LOCK_OPEN_PAT + r".*?" + _LOCK_CLOSE_PAT, re.IGNORECASE | re.DOTALL
+)
+
+
+def _extract_locked_regions(content: str) -> List[str]:
+    """Return every balanced operator-locked region (markers included), in order."""
+    return _LOCK_REGION_RE.findall(content)
+
+
+def _count_lock_markers(content: str) -> Tuple[int, int]:
+    """Return ``(open_marker_count, close_marker_count)`` found in *content*."""
+    return len(_LOCK_OPEN_RE.findall(content)), len(_LOCK_CLOSE_RE.findall(content))
+
+
+def _has_lock_marker(text: str) -> bool:
+    """True if *text* carries any operator-lock marker, open or close.
+
+    remove_file/delete gate on this rather than on balanced regions: a file
+    holding even half an operator region (a lone or malformed marker) still
+    holds operator intent and must not be dropped silently.
+    """
+    return bool(_LOCK_OPEN_RE.search(text) or _LOCK_CLOSE_RE.search(text))
+
+
+def _audit_locked_file_touch(action: str, name: str, label: str, original: str) -> None:
+    """Breadcrumb an ALLOWED self-patch of a file that contains locked policy.
+
+    The change passed ``_locked_region_violation`` (it is outside the locked
+    bytes), but byte-locking can't tell whether the surrounding edit contradicts
+    the locked rule — so we log the touch for operator review rather than let it
+    pass unseen. Killing the *silence* is the core of this guard.
+    """
+    if _extract_locked_regions(original):
+        logger.info(
+            "skill_manage(%s) on '%s' modified %s outside its operator-locked "
+            "region(s) — review the non-locked change for contradiction.",
+            action, name, label,
+        )
+
+
+def _locked_region_violation(
+    original: str, updated: str, *, label: str = "SKILL.md"
+) -> Optional[str]:
+    """Refuse self-patches that would tamper with operator-locked policy.
+
+    Returns an error string when *updated* must be rejected, else ``None``.
+
+    Two invariants, both required so the markers can't be gamed:
+
+      1. Every operator-locked region in *original* must reappear in *updated*
+         byte-for-byte and in the same order. Catches edits inside a region,
+         dropping a region, and reordering.
+      2. The open- and close-marker counts must be preserved. Catches stripping
+         a single marker (to "unlock" a region) or adding an unbalanced one (to
+         smuggle an edit past invariant 1).
+
+    When *original* carries no locks at all, the only thing refused is the agent
+    FORGING new operator-lock markers around its own text — minting operator
+    authority it does not have. Everything outside the markers is unrestricted.
+    """
+    original_regions = _extract_locked_regions(original)
+    orig_open, orig_close = _count_lock_markers(original)
+    upd_open, upd_close = _count_lock_markers(updated)
+
+    if not original_regions and not orig_open and not orig_close:
+        if upd_open or upd_close:
+            return (
+                f"Refusing to write {label}: operator-lock markers "
+                f"({OPERATOR_LOCK_OPEN} … {OPERATOR_LOCK_CLOSE}) may only be "
+                f"authored by an operator (via git or the dashboard editor), "
+                f"not minted by the self-patch tool. Remove the lock markers "
+                f"and retry."
+            )
+        return None
+
+    if (
+        _extract_locked_regions(updated) != original_regions
+        or upd_open != orig_open
+        or upd_close != orig_close
+    ):
+        return (
+            f"Refusing to write {label}: this change would modify an "
+            f"operator-locked policy region. Text between "
+            f"{OPERATOR_LOCK_OPEN} and {OPERATOR_LOCK_CLOSE} is operator-"
+            f"authored safety policy and must stay exactly as written. "
+            f"Edit only OUTSIDE the locked markers — append "
+            f"calibration notes after them, refine non-policy guidance. If the "
+            f"policy itself genuinely needs to change, that is an operator "
+            f"decision: surface it for review instead of patching it here."
+        )
+    return None
+
+
+def _skill_dir_locked_files(skill_dir: Path) -> List[str]:
+    """Relative paths of files under *skill_dir* that carry an operator-lock
+    marker. Best-effort: symlinks and unreadable files are skipped so a broken
+    tree can never crash a delete.
+    """
+    locked: List[str] = []
+    try:
+        for f in sorted(skill_dir.rglob("*")):
+            try:
+                if f.is_symlink() or not f.is_file():
+                    continue
+                text = f.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            if _has_lock_marker(text):
+                locked.append(str(f.relative_to(skill_dir)))
+    except OSError:
+        pass
+    return locked
+
+
+# =============================================================================
 # Core actions
 # =============================================================================
 
@@ -575,6 +740,13 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
     err = _validate_content_size(content)
     if err:
         return {"success": False, "error": err}
+
+    # No skill_manage action — create included — may MINT operator-lock markers.
+    # Locks are operator authority, authored out-of-band (git / dashboard).
+    lock_err = _locked_region_violation("", content, label="SKILL.md")
+    if lock_err:
+        logger.warning("skill_manage(create) refused for '%s': forges operator-lock markers", name)
+        return {"success": False, "error": lock_err}
 
     # Check for name collisions across all directories
     existing = _find_skill(name)
@@ -641,6 +813,14 @@ def _edit_skill(name: str, content: str) -> Dict[str, Any]:
     skill_md = existing["path"] / "SKILL.md"
     # Back up original content for rollback
     original_content = skill_md.read_text(encoding="utf-8") if skill_md.exists() else None
+
+    # Refuse rewrites that would touch an operator-locked policy region.
+    lock_err = _locked_region_violation(original_content or "", content, label="SKILL.md")
+    if lock_err:
+        logger.warning("skill_manage(edit) refused on '%s': operator-locked region change", name)
+        return {"success": False, "error": lock_err}
+
+    _audit_locked_file_touch("edit", name, "SKILL.md", original_content or "")
     _atomic_write_text(skill_md, content)
 
     # Security scan — roll back on block
@@ -747,6 +927,16 @@ def _patch_skill(
                 "error": f"Patch would break SKILL.md structure: {err}",
             }
 
+    # Refuse patches whose result would touch an operator-locked policy region.
+    lock_err = _locked_region_violation(content, new_content, label=target_label)
+    if lock_err:
+        logger.warning(
+            "skill_manage(patch) refused on '%s' (%s): operator-locked region change",
+            name, target_label,
+        )
+        return {"success": False, "error": lock_err}
+
+    _audit_locked_file_touch("patch", name, target_label, content)
     original_content = content  # for rollback
     _atomic_write_text(target, new_content)
 
@@ -787,6 +977,26 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
     pinned_err = _pinned_guard(name)
     if pinned_err:
         return {"success": False, "error": pinned_err}
+
+    # Refuse to delete a skill that carries operator-locked policy — deleting it
+    # would drop the policy just as silently as rewriting it in place.
+    locked_files = _skill_dir_locked_files(existing["path"])
+    if locked_files:
+        logger.warning(
+            "skill_manage(delete) refused on '%s': %d operator-locked file(s)",
+            name, len(locked_files),
+        )
+        return {
+            "success": False,
+            "error": (
+                f"Refusing to delete skill '{name}': it carries operator-locked "
+                f"policy in {', '.join(locked_files)} "
+                f"({OPERATOR_LOCK_OPEN} … {OPERATOR_LOCK_CLOSE}). Deleting the "
+                f"skill would drop operator-authored safety policy. Lifting the "
+                f"lock is an operator action (git or the dashboard editor); only "
+                f"then can the skill be removed."
+            ),
+        }
 
     # Validate absorbed_into target when declared non-empty
     if absorbed_into is not None and isinstance(absorbed_into, str) and absorbed_into.strip():
@@ -862,9 +1072,22 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
     target, err = _resolve_skill_target(existing["path"], file_path)
     if err:
         return {"success": False, "error": err}
-    target.parent.mkdir(parents=True, exist_ok=True)
-    # Back up for rollback
+    # Read current content (if any) BEFORE creating directories, so a refused
+    # write leaves nothing behind on disk.
     original_content = target.read_text(encoding="utf-8") if target.exists() else None
+
+    # write_file can overwrite SKILL.md or any supporting file — guard it the
+    # same way as edit/patch so it can't be used to bypass the lock.
+    lock_err = _locked_region_violation(original_content or "", file_content, label=file_path)
+    if lock_err:
+        logger.warning(
+            "skill_manage(write_file) refused on '%s' (%s): operator-locked region change",
+            name, file_path,
+        )
+        return {"success": False, "error": lock_err}
+
+    _audit_locked_file_touch("write_file", name, file_path, original_content or "")
+    target.parent.mkdir(parents=True, exist_ok=True)
     _atomic_write_text(target, file_content)
 
     # Security scan — roll back on block
@@ -911,6 +1134,27 @@ def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
             "success": False,
             "error": f"File '{file_path}' not found in skill '{name}'.",
             "available_files": available if available else None,
+        }
+
+    # Refuse to remove a file that carries operator-locked policy.
+    try:
+        _existing = target.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        _existing = ""
+    if _has_lock_marker(_existing):
+        logger.warning(
+            "skill_manage(remove_file) refused on '%s' (%s): operator-locked content",
+            name, file_path,
+        )
+        return {
+            "success": False,
+            "error": (
+                f"Refusing to remove '{file_path}' from skill '{name}': it "
+                f"contains operator-locked policy ({OPERATOR_LOCK_OPEN} … "
+                f"{OPERATOR_LOCK_CLOSE}). Removing the file would drop operator-"
+                f"authored safety policy. Lifting the lock is an operator action "
+                f"(git or the dashboard editor)."
+            ),
         }
 
     target.unlink()
@@ -1126,7 +1370,16 @@ SKILL_MANAGE_SCHEMA = {
         "Pinned skills are protected from deletion only — skill_manage(action='delete') "
         "will refuse with a message pointing the user to `hermes curator unpin <name>`. "
         "Patches and edits go through on pinned skills so you can still improve them as "
-        "pitfalls come up; pin only guards against irrecoverable loss."
+        "pitfalls come up; pin only guards against irrecoverable loss.\n\n"
+        "Operator-locked regions — text between `<!-- operator-locked -->` and "
+        "`<!-- /operator-locked -->` — are operator-authored safety policy. "
+        "patch/edit/write_file/remove_file/delete REFUSE any change that rewrites, drops, "
+        "or reorders a locked region; create/edit/write_file REFUSE content that mints new "
+        "lock markers. Edit only OUTSIDE the markers (append calibration notes after them). "
+        "Do NOT try to route around a lock — relocating a locked block or adding a "
+        "contradicting note nearby to neutralize it defeats operator policy and is logged "
+        "for review. Changing locked policy is an operator action (git or the dashboard "
+        "editor)."
     ),
     "parameters": {
         "type": "object",


### PR DESCRIPTION
## What

Adds an **opt-in** guard that stops the skill self-patch tool (`skill_manage`) from rewriting, dropping, reordering, or forging operator-authored safety policy in a `SKILL.md`. Operators wrap the policy they want frozen in sentinel HTML comments:

```markdown
<!-- operator-locked -->
- Keep the executor's `--wait-seconds` at 30.
<!-- /operator-locked -->
```

`skill_manage` then refuses any `edit` / `patch` / `write_file` / `remove_file` / `delete` that would change the bytes between those markers, while still allowing edits **outside** them. A `SKILL.md` with no markers is completely unaffected.

## Why

The self-patcher lets the agent improve its own skills — but that same power lets it silently rewrite policy a human deliberately set. In one incident a live self-patch deleted a safety rule and asserted the opposite; nobody was alerted — it was found only by chance during an unrelated deploy. There was no in-band way to mark a rule as "human-owned, do not touch."

This gives operators a lightweight way to freeze a region while keeping the rest of the skill self-editable.

## How

A new `_locked_region_violation(original, updated)` helper in `tools/skill_manager_tool.py`, wired into every mutating `skill_manage` action:

- **Byte-exact preservation + marker balance** — every locked region in the original must reappear verbatim in the result, and the open/close marker counts must match, so a lone marker can't be stripped to "unlock" a region.
- **No minting** — `create` / `edit` / `write_file` refuse content that introduces *new* lock markers, so the agent can't author its own fake operator locks.
- **All paths guarded** — `write_file`, `remove_file`, and `delete` are guarded too, so they can't be used to bypass `edit`/`patch`. `remove_file`/`delete` gate on the presence of *any* marker (open or close) so a half or malformed lock is never dropped silently.
- **Audit trail** — refusals are logged, and an *allowed* edit of a file that contains locked policy (a change outside the markers) is logged too, so a divergence attempt is never silent.
- The `skill_manage` schema description documents the contract for the agent.

### Design properties

- **Opt-in & generic** — no markers ⇒ no behavior change; nothing app-specific.
- **Frozen bytes, editable surroundings** — only the marked region is locked; the rest of the file stays self-editable.
- **Documented limitation** — this protects the locked *bytes*, not their *meaning*: the agent can still add text outside the markers that recontextualizes a rule. That can no longer happen *silently* (it is logged); pair with a whole-file policy diff at deploy time for defense in depth.

Operators author and lift locks out-of-band (git or a dashboard editor), never through this tool.

## Tests

`tests/tools/test_skill_manager_tool.py` gains an operator-lock suite: tamper-inside, strip-marker, forge/mint, lone & malformed markers, `replace_all` discrimination (inside vs outside a region), create-forging, approval-replay, the audit-log breadcrumb, and the allowed outside-edit path.

```
tests/tools/test_skill_manager_tool.py  135 passed
```

---

The second commit adds `tyler@koblasa.com → gtyler` to `scripts/release.py` `AUTHOR_MAP` so the contributor-attribution check resolves the author and the contributor is credited in release notes — drop it if you'd rather manage `AUTHOR_MAP` yourselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
