### PR TITLE
feat: update Git-backed skills safely

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -602,6 +602,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
 
     extra_metadata = dict(getattr(meta, "extra", {}) or {})
     extra_metadata.update(getattr(bundle, "metadata", {}) or {})
+    bundle.metadata = extra_metadata
 
     # Quarantine the bundle
     try:
@@ -1359,6 +1360,34 @@ def do_repair_official(name: str, restore: bool = False,
             pass
 
 
+def do_check_git(apply: bool = False, console: Optional[Console] = None) -> None:
+    """Check or update Git-backed skill repositories."""
+    from tools.skills_hub import check_git_skill_repo_updates
+
+    c = console or _console
+    results = check_git_skill_repo_updates(apply=apply)
+    if not results:
+        c.print("[dim]No Git-backed skill repositories found.[/]\n")
+        return
+
+    table = Table(title="Git-backed Skill Repositories")
+    table.add_column("Path", style="bold cyan")
+    table.add_column("Branch", style="dim")
+    table.add_column("Status", style="dim")
+    table.add_column("Remote", style="dim", overflow="fold")
+    for entry in results:
+        table.add_row(
+            entry.get("path", ""),
+            entry.get("branch", ""),
+            entry.get("status", ""),
+            entry.get("remote", ""),
+        )
+    c.print(table)
+    changed = sum(1 for entry in results if entry.get("status") in {"update_available", "updated"})
+    mode = "updated" if apply else "available"
+    c.print(f"[dim]{changed} Git update(s) {mode} across {len(results)} repo(s)[/]\n")
+
+
 def do_tap(action: str, repo: str = "", console: Optional[Console] = None) -> None:
     """Manage taps (custom GitHub repo sources)."""
     from tools.skills_hub import TapsManager
@@ -1683,6 +1712,8 @@ def skills_command(args) -> None:
         do_check(name=getattr(args, "name", None))
     elif action == "update":
         do_update(name=getattr(args, "name", None))
+    elif action == "git-check":
+        do_check_git(apply=getattr(args, "apply", False))
     elif action == "audit":
         do_audit(name=getattr(args, "name", None),
                  deep=getattr(args, "deep", False))
@@ -1869,6 +1900,9 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
         name = args[0] if args else None
         do_update(name=name, console=c)
 
+    elif action == "git-check":
+        do_check_git(apply="--apply" in args, console=c)
+
     elif action == "audit":
         name = args[0] if args and not args[0].startswith("--") else None
         deep = "--deep" in args
@@ -1961,6 +1995,7 @@ def _print_skills_help(console: Console) -> None:
         "       List installed skills; --enabled-only filters to the active profile's live set\n"
         "  [cyan]check[/] [name]                Check hub skills for upstream updates\n"
         "  [cyan]update[/] [name]               Update hub skills with upstream changes\n"
+        "  [cyan]git-check[/] [--apply]         Check/update Git-backed skill repositories\n"
         "  [cyan]audit[/] [name]                Re-scan hub skills for security\n"
         "  [cyan]uninstall[/] <name>            Remove a hub-installed skill\n"
         "  [cyan]list-modified[/]               List bundled skills you've edited (kept by update)\n"

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -123,6 +123,15 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
         help="Specific skill to update (default: all outdated skills)",
     )
 
+    skills_git_check = skills_subparsers.add_parser(
+        "git-check", help="Check Git-backed skill repositories for fast-forward updates"
+    )
+    skills_git_check.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply available fast-forward updates after checking",
+    )
+
     skills_audit = skills_subparsers.add_parser(
         "audit", help="Re-scan installed hub skills"
     )

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -29,6 +29,7 @@ from tools.skills_hub import (
     append_audit_log,
     _skill_meta_to_dict,
     quarantine_bundle,
+    install_from_quarantine,
 )
 
 
@@ -1168,6 +1169,84 @@ class TestCheckForSkillUpdates:
 
         assert bundle_content_hash(bundle) == content_hash(skill_dir)
 
+    def test_upstream_provenance_block_does_not_change_update_hash(self, tmp_path):
+        from tools.skills_guard import content_hash
+
+        bundle = SkillBundle(
+            name="demo-skill",
+            files={"SKILL.md": "# Demo\n"},
+            source="github",
+            identifier="owner/repo/demo-skill",
+            trust_level="community",
+        )
+        skill_dir = tmp_path / "demo-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "# Demo\n\n"
+            "<!-- hermes-upstream\n"
+            "managed_by: hermes skills\n"
+            "source: github\n"
+            "identifier: owner/repo/demo-skill\n"
+            "installed_version: sha256:abc123\n"
+            "installed_at: 2026-01-01T00:00:00+00:00\n"
+            "-->\n"
+        )
+
+        assert content_hash(skill_dir) == bundle_content_hash(bundle)
+
+    def test_install_writes_upstream_provenance_without_forcing_updates(self, tmp_path, monkeypatch):
+        import tools.skills_hub as hub
+        from tools.skills_guard import ScanResult, content_hash
+
+        skills_dir = tmp_path / "skills"
+        quarantine_dir = tmp_path / "hub" / "quarantine"
+        quarantine_path = quarantine_dir / "demo-skill"
+        quarantine_path.mkdir(parents=True)
+        (quarantine_path / "SKILL.md").write_text("# Demo\n")
+
+        monkeypatch.setattr(hub, "SKILLS_DIR", skills_dir)
+        monkeypatch.setattr(hub, "QUARANTINE_DIR", quarantine_dir)
+        monkeypatch.setattr(hub, "LOCK_FILE", tmp_path / "hub" / "lock.json")
+        monkeypatch.setattr(hub, "AUDIT_LOG", tmp_path / "hub" / "audit.log")
+        lock_records = []
+        monkeypatch.setattr(
+            hub,
+            "HubLockFile",
+            lambda: type(
+                "Lock",
+                (),
+                {"record_install": lambda self, **kwargs: lock_records.append(kwargs)},
+            )(),
+        )
+
+        bundle = SkillBundle(
+            name="demo-skill",
+            files={"SKILL.md": "# Demo\n"},
+            source="github",
+            identifier="owner/repo/demo-skill",
+            trust_level="community",
+            metadata={"repo_url": "https://github.com/owner/repo"},
+        )
+        scan_result = ScanResult(
+            skill_name="demo-skill",
+            source="github",
+            trust_level="community",
+            verdict="safe",
+        )
+
+        install_dir = install_from_quarantine(
+            quarantine_path,
+            "demo-skill",
+            "",
+            bundle,
+            scan_result,
+        )
+
+        skill_md = (install_dir / "SKILL.md").read_text()
+        assert "<!-- hermes-upstream" in skill_md
+        assert "source_url: https://github.com/owner/repo" in skill_md
+        assert content_hash(install_dir) == bundle_content_hash(bundle)
+
     def test_bundle_content_hash_accepts_binary_files(self):
         bundle = SkillBundle(
             name="demo-binary-skill",
@@ -1230,6 +1309,64 @@ class TestCheckForSkillUpdates:
         (skill_dir / "references" / "checklist.md").write_text("- [ ] security\n")
 
         assert bundle_content_hash(bundle) == content_hash(skill_dir)
+
+    def test_git_skill_repo_update_fast_forwards(self, tmp_path):
+        import subprocess
+        from tools.skills_hub import check_git_skill_repo_updates
+
+        def git(cwd, *args):
+            return subprocess.run(
+                ["git", "-C", str(cwd), *args],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                check=True,
+            ).stdout.strip()
+
+        remote = tmp_path / "remote.git"
+        subprocess.run(["git", "init", "--bare", str(remote)], check=True, stdout=subprocess.PIPE)
+        seed = tmp_path / "seed"
+        git(tmp_path, "clone", str(remote), str(seed))
+        git(seed, "config", "user.email", "test@example.com")
+        git(seed, "config", "user.name", "Test")
+        (seed / "SKILL.md").write_text("# v1\n")
+        git(seed, "add", "SKILL.md")
+        git(seed, "commit", "-m", "v1")
+        git(seed, "push", "-u", "origin", "master")
+
+        skills_dir = tmp_path / "skills"
+        repo = skills_dir / "demo-skill"
+        repo.parent.mkdir()
+        git(tmp_path, "clone", str(remote), str(repo))
+
+        (seed / "SKILL.md").write_text("# v2\n")
+        git(seed, "commit", "-am", "v2")
+        git(seed, "push")
+
+        check = check_git_skill_repo_updates(apply=False, skills_dir=skills_dir)
+        assert check[0]["status"] == "update_available"
+
+        updated = check_git_skill_repo_updates(apply=True, skills_dir=skills_dir)
+        assert updated[0]["status"] == "updated"
+        assert (repo / "SKILL.md").read_text() == "# v2\n"
+
+    def test_git_skill_repo_update_blocks_dirty_worktrees(self, tmp_path):
+        import subprocess
+        from tools.skills_hub import check_git_skill_repo_updates
+
+        repo = tmp_path / "skills" / "dirty-skill"
+        repo.mkdir(parents=True)
+        subprocess.run(["git", "init", str(repo)], check=True, stdout=subprocess.PIPE)
+        subprocess.run(["git", "-C", str(repo), "config", "user.email", "test@example.com"], check=True)
+        subprocess.run(["git", "-C", str(repo), "config", "user.name", "Test"], check=True)
+        (repo / "SKILL.md").write_text("# Demo\n")
+        subprocess.run(["git", "-C", str(repo), "add", "SKILL.md"], check=True)
+        subprocess.run(["git", "-C", str(repo), "commit", "-m", "init"], check=True, stdout=subprocess.PIPE)
+        (repo / "SKILL.md").write_text("# Dirty\n")
+
+        results = check_git_skill_repo_updates(apply=True, skills_dir=tmp_path / "skills")
+
+        assert results[0]["status"] == "blocked_dirty"
 
     def test_reports_update_when_remote_hash_differs(self):
         lock = MagicMock()

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -763,15 +763,27 @@ def format_scan_report(result: ScanResult) -> str:
     return "\n".join(lines)
 
 
+_HERMES_UPSTREAM_BLOCK_RE = re.compile(
+    rb"\n?<!-- hermes-upstream\n.*?\n-->\n?",
+    re.DOTALL,
+)
+
+
+def strip_hermes_upstream_block(content: bytes) -> bytes:
+    """Remove Hermes-managed upstream provenance metadata from hash input."""
+    return _HERMES_UPSTREAM_BLOCK_RE.sub(b"", content)
+
+
 def content_hash(skill_path: Path) -> str:
     """Compute a SHA-256 hash of all files in a skill directory for integrity tracking.
 
     File paths (relative to ``skill_path``) are mixed into the hash alongside
     file contents so that swapping the contents of two files in a skill
-    changes the hash. This must stay symmetric with
-    ``tools.skills_hub.bundle_content_hash`` — both functions need to
-    produce the same digest for the same skill (one operates on disk,
-    one on an in-memory bundle), so any change to the hash shape MUST
+    changes the hash. Hermes-managed upstream provenance comments are ignored
+    so local install metadata does not look like an upstream edit. This must
+    stay symmetric with ``tools.skills_hub.bundle_content_hash`` — both
+    functions need to produce the same digest for the same skill (one operates
+    on disk, one on an in-memory bundle), so any change to the hash shape MUST
     land in both places at once.
     """
     h = hashlib.sha256()
@@ -782,11 +794,17 @@ def content_hash(skill_path: Path) -> str:
                     rel = f.relative_to(skill_path).as_posix()
                     h.update(rel.encode("utf-8"))
                     h.update(b"\x00")
-                    h.update(f.read_bytes())
+                    data = f.read_bytes()
+                    if rel == "SKILL.md":
+                        data = strip_hermes_upstream_block(data)
+                    h.update(data)
                 except OSError:
                     continue
     elif skill_path.is_file():
-        h.update(skill_path.read_bytes())
+        data = skill_path.read_bytes()
+        if skill_path.name == "SKILL.md":
+            data = strip_hermes_upstream_block(data)
+        h.update(data)
     return f"sha256:{h.hexdigest()[:16]}"
 
 

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -34,7 +34,7 @@ import httpx
 import yaml
 
 from tools.skills_guard import (
-    ScanResult, content_hash, TRUSTED_REPOS,
+    ScanResult, content_hash, strip_hermes_upstream_block, TRUSTED_REPOS,
 )
 from tools.url_safety import is_safe_url
 from tools.website_policy import check_website_access
@@ -3297,6 +3297,49 @@ def ensure_hub_dirs() -> None:
         TAPS_FILE.write_text('{"taps": []}\n')
 
 
+def _upstream_source_url(bundle: SkillBundle) -> str:
+    metadata = getattr(bundle, "metadata", {}) or {}
+    for key in ("repo_url", "detail_url", "index_url", "endpoint", "url"):
+        value = metadata.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return bundle.identifier
+
+
+def _build_upstream_provenance_block(bundle: SkillBundle, installed_version: str) -> str:
+    """Build a small provenance block for the installed SKILL.md."""
+    payload = {
+        "managed_by": "hermes skills",
+        "source": bundle.source,
+        "identifier": bundle.identifier,
+        "source_url": _upstream_source_url(bundle),
+        "installed_version": installed_version,
+        "installed_at": datetime.now(timezone.utc).isoformat(),
+    }
+    lines = ["<!-- hermes-upstream"]
+    for key, value in payload.items():
+        if value:
+            lines.append(f"{key}: {value}")
+    lines.append("-->")
+    return "\n".join(lines) + "\n"
+
+
+def _write_upstream_provenance(skill_md: Path, bundle: SkillBundle) -> None:
+    """Append/update Hermes-managed upstream metadata in an installed SKILL.md."""
+    try:
+        original = skill_md.read_bytes()
+    except OSError:
+        return
+
+    clean = strip_hermes_upstream_block(original).rstrip() + b"\n"
+    installed_version = f"sha256:{hashlib.sha256(clean).hexdigest()[:16]}"
+    block = _build_upstream_provenance_block(bundle, installed_version).encode("utf-8")
+    try:
+        skill_md.write_bytes(clean + b"\n" + block)
+    except OSError:
+        return
+
+
 def quarantine_bundle(bundle: SkillBundle) -> Path:
     """Write a skill bundle to the quarantine directory for scanning."""
     ensure_hub_dirs()
@@ -3384,6 +3427,8 @@ def install_from_quarantine(
     install_dir.parent.mkdir(parents=True, exist_ok=True)
     shutil.move(str(quarantine_path), str(install_dir))
 
+    _write_upstream_provenance(install_dir / "SKILL.md", bundle)
+
     # Record in lock file
     lock = HubLockFile()
     lock.record_install(
@@ -3447,9 +3492,12 @@ def bundle_content_hash(bundle: SkillBundle) -> str:
         h.update(b"\x00")
         content = bundle.files[rel_path]
         if isinstance(content, bytes):
-            h.update(content)
+            data = content
         else:
-            h.update(content.encode("utf-8"))
+            data = content.encode("utf-8")
+        if rel_path == "SKILL.md":
+            data = strip_hermes_upstream_block(data)
+        h.update(data)
     return f"sha256:{h.hexdigest()[:16]}"
 
 
@@ -3512,6 +3560,127 @@ def check_for_skill_updates(
             "current_hash": current_hash,
             "latest_hash": latest_hash,
             "bundle": bundle,
+        })
+
+    return results
+
+
+def _run_git(repo: Path, *args: str) -> Tuple[int, str]:
+    proc = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=60,
+    )
+    return proc.returncode, proc.stdout.strip()
+
+
+def discover_git_skill_repos(skills_dir: Path = SKILLS_DIR) -> List[Path]:
+    """Find Git repositories under the skills directory that contain skills."""
+    if not skills_dir.exists():
+        return []
+
+    repos: List[Path] = []
+    for dotgit in skills_dir.rglob(".git"):
+        repo = dotgit.parent
+        try:
+            rel = repo.relative_to(skills_dir)
+        except ValueError:
+            continue
+        if rel.parts and rel.parts[0] == ".hub":
+            continue
+        try:
+            if any(p.name == "SKILL.md" for p in repo.rglob("SKILL.md")):
+                repos.append(repo)
+        except OSError:
+            continue
+    return sorted(set(repos))
+
+
+def check_git_skill_repo_updates(*, apply: bool = False, skills_dir: Path = SKILLS_DIR) -> List[dict]:
+    """Check or fast-forward Git-backed skill repositories below skills/."""
+    results: List[dict] = []
+    for repo in discover_git_skill_repos(skills_dir):
+        rel = repo.relative_to(skills_dir).as_posix()
+        _, remote = _run_git(repo, "remote", "get-url", "origin")
+        _, branch = _run_git(repo, "branch", "--show-current")
+        _, before = _run_git(repo, "rev-parse", "HEAD")
+
+        rc, dirty = _run_git(repo, "status", "--porcelain")
+        if rc != 0:
+            results.append({"path": rel, "status": "error", "detail": dirty})
+            continue
+        if dirty:
+            results.append({
+                "path": rel,
+                "remote": remote,
+                "branch": branch,
+                "installed_version": before,
+                "status": "blocked_dirty",
+                "detail": dirty.splitlines()[0],
+            })
+            continue
+
+        rc, fetch_out = _run_git(repo, "fetch", "origin", "--prune")
+        if rc != 0:
+            results.append({"path": rel, "remote": remote, "branch": branch, "status": "fetch_failed", "detail": fetch_out})
+            continue
+
+        rc, upstream = _run_git(repo, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}")
+        if rc != 0 or not upstream:
+            upstream = f"origin/{branch}" if branch else "origin/main"
+
+        rc, remote_sha = _run_git(repo, "rev-parse", upstream)
+        if rc != 0:
+            results.append({"path": rel, "remote": remote, "branch": branch, "status": "upstream_missing", "detail": upstream})
+            continue
+
+        if before == remote_sha:
+            results.append({
+                "path": rel,
+                "remote": remote,
+                "branch": branch,
+                "installed_version": before,
+                "remote_version": remote_sha,
+                "status": "up_to_date",
+            })
+            continue
+
+        rc, _ = _run_git(repo, "merge-base", "--is-ancestor", before, remote_sha)
+        if rc != 0:
+            results.append({
+                "path": rel,
+                "remote": remote,
+                "branch": branch,
+                "installed_version": before,
+                "remote_version": remote_sha,
+                "status": "blocked_non_fast_forward",
+            })
+            continue
+
+        if not apply:
+            results.append({
+                "path": rel,
+                "remote": remote,
+                "branch": branch,
+                "installed_version": before,
+                "remote_version": remote_sha,
+                "status": "update_available",
+            })
+            continue
+
+        rc, merge_out = _run_git(repo, "merge", "--ff-only", upstream)
+        _, after = _run_git(repo, "rev-parse", "HEAD")
+        results.append({
+            "path": rel,
+            "remote": remote,
+            "branch": branch,
+            "installed_version": before,
+            "remote_version": remote_sha,
+            "updated_version": after,
+            "status": "updated" if rc == 0 else "update_failed",
+            "detail": merge_out if rc != 0 else "",
         })
 
     return results

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1037,6 +1037,8 @@ hermes skills install https://sharethis.chat/SKILL.md                     # Dire
 hermes skills install https://example.com/SKILL.md --name my-skill        # Override name when frontmatter has none
 hermes skills check
 hermes skills update
+hermes skills git-check              # Check full Git skill repos under skills/
+hermes skills git-check --apply      # Fast-forward clean Git skill repos only
 hermes skills config
 hermes skills reset google-workspace
 hermes skills reset google-workspace --restore --yes
@@ -1052,6 +1054,7 @@ Notes:
 - `--source well-known` lets you point Hermes at a site exposing `/.well-known/skills/index.json`.
 - `--source browse-sh` searches [browse.sh](https://browse.sh)'s catalog of 200+ site-specific browser-automation skills. Identifiers look like `browse-sh/airbnb.com/search-listings-ddgioa`.
 - Passing an `http(s)://…/*.md` URL installs a single-file SKILL.md directly. When frontmatter has no `name:` and the URL slug isn't a valid identifier, an interactive terminal prompts for a name; non-interactive surfaces (`/skills install` inside the TUI, gateway platforms) require `--name <x>` instead.
+- `hermes skills update` refreshes hub-installed skills; `hermes skills git-check --apply` refreshes full Git repositories placed under the active `skills/` directory and only performs clean fast-forward updates.
 
 ## `hermes bundles`
 

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -466,6 +466,8 @@ hermes skills install https://example.com/SKILL.md --name my-skill # Override na
 hermes skills list --source hub                   # List hub-installed skills
 hermes skills check                               # Check installed hub skills for upstream updates
 hermes skills update                              # Reinstall hub skills with upstream changes when needed
+hermes skills git-check                           # Check full Git skill repos for fast-forward updates
+hermes skills git-check --apply                   # Apply safe fast-forward updates to Git skill repos
 hermes skills audit                               # Re-scan all hub skills for security
 hermes skills uninstall k8s                       # Remove a hub skill
 hermes skills reset google-workspace              # Un-stick a bundled skill from "user-modified" (see below)
@@ -684,6 +686,45 @@ hermes skills update react   # Update one specific installed hub skill
 ```
 
 This uses the stored source identifier plus the current upstream bundle content hash to detect drift.
+
+#### Git-backed skill repositories
+
+`hermes skills check` and `hermes skills update` manage **hub-installed skills**: single skills installed through the Skills Hub, direct `SKILL.md` URLs, well-known endpoints, or GitHub path identifiers.
+
+Some users also keep a whole Git repository inside their skills directory. That pattern is useful for multi-skill packs, private team skill repos, or upstreams that evolve as a complete repo:
+
+```bash
+cd ~/.hermes/skills
+git clone https://github.com/heygen-com/hyperframes.git hyperframes-skills
+
+# Or inside a profile:
+cd ~/.hermes/profiles/mirage/skills
+git clone https://github.com/heygen-com/hyperframes.git hyperframes-skills
+```
+
+For these full Git repositories, use:
+
+```bash
+hermes skills git-check          # Fetch remotes and report Git skill repo updates
+hermes skills git-check --apply  # Apply only clean fast-forward updates
+```
+
+Hermes discovers Git-backed skills by scanning for `.git` directories under the active `skills/` directory that contain at least one `SKILL.md`.
+
+Safety behavior:
+
+- clean and already current → `up_to_date`
+- clean and behind upstream → `update_available`, or `updated` with `--apply`
+- local edits present → `blocked_dirty`
+- no upstream branch → `upstream_missing`
+- fetch failure → `fetch_failed`
+- local branch diverged from upstream → `blocked_non_fast_forward`
+
+`--apply` only runs a `git merge --ff-only` after a successful fetch. It does not reset, rebase, overwrite local changes, resolve conflicts, or delete files.
+
+This makes GitHub-sourced skill packs easy to keep fresh without teaching users to `cd` into every skill repo and run `git pull` manually.
+
+Use `hermes skills update` for hub-installed skills and `hermes skills git-check --apply` for full Git repositories placed directly in your skills directory.
 
 :::tip GitHub rate limits
 Skills hub operations use the GitHub API, which has a rate limit of 60 requests/hour for unauthenticated users. If you see rate-limit errors during install or search, set `GITHUB_TOKEN` in your `.env` file to increase the limit to 5,000 requests/hour. The error message includes an actionable hint when this happens.


### PR DESCRIPTION
## Summary
- add `hermes skills git-check` for Git-backed skill repositories under the skills directory
- support `--apply` to fast-forward clean Git skill repos from their upstream branch
- block unsafe cases instead of mutating them: dirty worktrees, missing upstreams, failed fetches, and non-fast-forward divergence
- document when to use `hermes skills update` vs `hermes skills git-check --apply`, including setup examples and user value
- keep the provenance/hash fix so Hermes-managed upstream metadata in installed `SKILL.md` files does not create false `update_available` results

## Why
Some users install full skill repositories directly from GitHub, not only hub skills. Those repos need a safe native update path: detect Git-backed skills, fetch upstream, report source/current/remote versions, and apply only clean fast-forward updates.

This gives users a standard way to keep GitHub-sourced skill packs current without manually running `git pull` in each repo, while protecting local edits and divergent branches.

## Docs
- `website/docs/user-guide/features/skills.md` explains the feature, setup, safety states, and user value.
- `website/docs/reference/cli-commands.md` lists the new commands and clarifies when to use them.

## Tests
- `python -m py_compile tools/skills_hub.py tools/skills_guard.py hermes_cli/skills_hub.py hermes_cli/subcommands/skills.py`
- `python -m pytest tests/tools/test_skills_hub.py tests/hermes_cli/test_skills_hub.py -o 'addopts=' -q`
- `git diff --check`
