### PR TITLE
fix(memory): lazy-install mem0ai for mem0 provider

### DIFF
--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -102,6 +102,33 @@ def _load_config() -> dict:
     return config
 
 
+def _ensure_mem0_dependency() -> bool:
+    """Return True when the mem0ai SDK is importable.
+
+    Mem0 is an optional memory backend, so lean installs may have a configured
+    MEM0_API_KEY but no ``mem0ai`` package in the active venv. Use Hermes'
+    lazy-deps path to repair that state before reporting availability or
+    constructing the backend.
+    """
+    try:
+        from tools.lazy_deps import ensure as _lazy_ensure
+        _lazy_ensure("memory.mem0", prompt=False)
+    except ImportError:
+        # Older/source-tree installs without lazy_deps still get the raw import
+        # check below, which keeps the error mode deterministic.
+        pass
+    except Exception as exc:
+        logger.debug("Mem0 dependency unavailable: %s", exc)
+        return False
+
+    try:
+        import mem0  # noqa: F401
+        return True
+    except Exception as exc:
+        logger.debug("Mem0 SDK import failed: %s", exc)
+        return False
+
+
 # ---------------------------------------------------------------------------
 # Tool schemas
 # ---------------------------------------------------------------------------
@@ -216,8 +243,10 @@ class Mem0MemoryProvider(MemoryProvider):
         cfg = _load_config()
         mode = cfg.get("mode", "platform")
         if mode == "oss":
-            return bool(cfg.get("oss", {}).get("vector_store"))
-        return bool(cfg.get("api_key"))
+            configured = bool(cfg.get("oss", {}).get("vector_store"))
+        else:
+            configured = bool(cfg.get("api_key"))
+        return configured and _ensure_mem0_dependency()
 
     def save_config(self, values, hermes_home):
         """Write config to $HERMES_HOME/mem0.json."""
@@ -251,6 +280,8 @@ class Mem0MemoryProvider(MemoryProvider):
 
     def _create_backend(self):
         try:
+            if not _ensure_mem0_dependency():
+                raise ImportError("mem0ai is not installed")
             if self._mode == "oss":
                 from ._backend import OSSBackend
                 return OSSBackend(self._config.get("oss", {}))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,7 @@ edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 hindsight = ["hindsight-client==0.6.1"]
+mem0 = ["mem0ai>=2.0.7,<3"]
 dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "mcp==1.26.0", "starlette==1.0.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==81.0.0"]  # starlette: CVE-2026-48710; setuptools: latest <82 (torch >=2.11 caps setuptools<82)
 messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.13.4", "brotlicffi==1.2.0.1", "slack-bolt==1.27.0", "slack-sdk==3.40.1", "qrcode==7.4.2"]  # aiohttp: CVE-2026-34513/34518/34519/34520/34525
 cron = []  # croniter is now a core dependency; this extra kept for back-compat

--- a/tests/plugins/memory/test_mem0_v3.py
+++ b/tests/plugins/memory/test_mem0_v3.py
@@ -44,6 +44,7 @@ class TestMem0V3Tools:
 
     def _make_provider(self, monkeypatch, backend):
         provider = Mem0MemoryProvider()
+        provider._create_backend = lambda: None  # type: ignore[method-assign]
         provider.initialize("test-session")
         provider._user_id = "u123"
         provider._agent_id = "hermes"
@@ -138,6 +139,7 @@ class TestMem0UpdateDelete:
 
     def _make_provider(self, monkeypatch, backend):
         provider = Mem0MemoryProvider()
+        provider._create_backend = lambda: None  # type: ignore[method-assign]
         provider.initialize("test-session")
         provider._user_id = "u123"
         provider._agent_id = "hermes"
@@ -187,6 +189,7 @@ class TestMem0ErrorHandling:
 
     def _make_provider(self, monkeypatch, backend):
         provider = Mem0MemoryProvider()
+        provider._create_backend = lambda: None  # type: ignore[method-assign]
         provider.initialize("test-session")
         provider._user_id = "u123"
         provider._agent_id = "hermes"
@@ -254,6 +257,7 @@ class TestMem0V3Internal:
 
     def _make_provider(self, monkeypatch, backend):
         provider = Mem0MemoryProvider()
+        provider._create_backend = lambda: None  # type: ignore[method-assign]
         provider.initialize("test-session")
         provider._user_id = "u123"
         provider._agent_id = "hermes"
@@ -331,6 +335,7 @@ class TestMem0ModeSwitch:
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         monkeypatch.setenv("MEM0_API_KEY", "test-key")
         provider = Mem0MemoryProvider()
+        provider._create_backend = lambda: None  # type: ignore[method-assign]
         provider.initialize("test")
         assert provider._mode == "platform"
 
@@ -341,6 +346,7 @@ class TestMem0ModeSwitch:
         config_path.write_text('{"user_id": "old-user"}')
         monkeypatch.setenv("MEM0_API_KEY", "test-key")
         provider = Mem0MemoryProvider()
+        provider._create_backend = lambda: None  # type: ignore[method-assign]
         provider.initialize("test")
         assert provider._mode == "platform"
         assert provider._user_id == "old-user"
@@ -348,18 +354,49 @@ class TestMem0ModeSwitch:
     def test_is_available_platform_needs_key(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         monkeypatch.delenv("MEM0_API_KEY", raising=False)
+        monkeypatch.setattr(
+            "plugins.memory.mem0._ensure_mem0_dependency",
+            lambda: (_ for _ in ()).throw(AssertionError("SDK check should not run without config")),
+        )
         provider = Mem0MemoryProvider()
         assert provider.is_available() is False
 
+    def test_is_available_platform_needs_sdk(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.setattr("plugins.memory.mem0._ensure_mem0_dependency", lambda: False)
+        provider = Mem0MemoryProvider()
+        assert provider.is_available() is False
+
+    def test_is_available_platform_with_key_and_sdk(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.setattr("plugins.memory.mem0._ensure_mem0_dependency", lambda: True)
+        provider = Mem0MemoryProvider()
+        assert provider.is_available() is True
+
     def test_is_available_oss_needs_vector(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr("plugins.memory.mem0._ensure_mem0_dependency", lambda: True)
         config_path = tmp_path / "mem0.json"
         config_path.write_text('{"mode": "oss", "oss": {"vector_store": {"provider": "qdrant"}}}')
         provider = Mem0MemoryProvider()
         assert provider.is_available() is True
 
+    def test_is_available_oss_needs_sdk(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr("plugins.memory.mem0._ensure_mem0_dependency", lambda: False)
+        config_path = tmp_path / "mem0.json"
+        config_path.write_text('{"mode": "oss", "oss": {"vector_store": {"provider": "qdrant"}}}')
+        provider = Mem0MemoryProvider()
+        assert provider.is_available() is False
+
     def test_is_available_oss_no_vector(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(
+            "plugins.memory.mem0._ensure_mem0_dependency",
+            lambda: (_ for _ in ()).throw(AssertionError("SDK check should not run without config")),
+        )
         config_path = tmp_path / "mem0.json"
         config_path.write_text('{"mode": "oss", "oss": {}}')
         provider = Mem0MemoryProvider()

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -72,7 +72,7 @@ def test_lazy_installable_extras_excluded_from_all():
         "voice",  # faster-whisper / sounddevice / numpy
         "modal", "daytona",
         "messaging", "slack", "matrix", "dingtalk", "feishu",
-        "honcho", "hindsight",
+        "honcho", "hindsight", "mem0",
         "mistral",  # mistralai — Voxtral STT/TTS, lazy-installed (stt.mistral / tts.mistral)
     }
     all_extra_specs = optional_dependencies["all"]

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -100,6 +100,12 @@ class TestAllowlist:
         assert cmd.startswith("uv pip install")
         assert "honcho-ai" in cmd
 
+    def test_mem0_feature_install_command(self):
+        cmd = ld.feature_install_command("memory.mem0")
+        assert cmd is not None
+        assert cmd.startswith("uv pip install")
+        assert "mem0ai" in cmd
+
     def test_feature_install_command_unknown(self):
         assert ld.feature_install_command("not.real") is None
 

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -119,6 +119,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # ─── Memory providers ──────────────────────────────────────────────────
     "memory.honcho": ("honcho-ai==2.0.1",),
     "memory.hindsight": ("hindsight-client==0.6.1",),
+    "memory.mem0": ("mem0ai>=2.0.7,<3",),
 
     # ─── Messaging platforms (lazy-installable on demand) ──────────────────
     "platform.telegram": ("python-telegram-bot[webhooks]==22.6",),


### PR DESCRIPTION
# PR title

fix(memory): lazy-install mem0ai for mem0 provider

# PR body

## Summary

- Add `memory.mem0` to the lazy dependency allowlist with `mem0ai>=2.0.7,<3`.
- Add a `mem0` optional extra for explicit installs while keeping it out of `[all]`.
- Make the Mem0 provider verify/repair the `mem0ai` SDK before reporting availability or constructing the backend.
- Add regression coverage for Mem0 availability when configured but the SDK is missing.

## Motivation

A lean or updated Hermes install can retain `memory.provider: mem0` and `MEM0_API_KEY` while the active venv no longer has the `mem0ai` SDK installed. In that state, Mem0 can appear configured/available, but the provider fails later when `plugins.memory.mem0._backend` imports `mem0`.

This change routes Mem0 through the same lazy dependency mechanism used by other optional backends, so configured Mem0 installs can self-heal via the active Hermes venv instead of silently failing at backend construction time.

## Testing

```bash
/home/jinwoo/hermes-agent/venv/bin/python -m py_compile \
  tools/lazy_deps.py \
  plugins/memory/mem0/__init__.py \
  tests/tools/test_lazy_deps.py \
  tests/plugins/memory/test_mem0_v3.py \
  tests/test_project_metadata.py

/home/jinwoo/hermes-agent/venv/bin/python -m pytest \
  tests/tools/test_lazy_deps.py \
  tests/plugins/memory/test_mem0_v3.py \
  tests/test_project_metadata.py \
  tests/test_packaging_metadata.py \
  -q -o 'addopts='
```

Result:

```text
126 passed in 1.12s
```

Additional checks:

```bash
/home/jinwoo/hermes-agent/venv/bin/python -m pip check
git diff --check
```

Result:

```text
No broken requirements found.
```
