### PR TITLE
fix: defer Telegram streaming overflow chunks

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2745,9 +2745,24 @@ class TelegramAdapter(BasePlatformAdapter):
             if rich_result is not None:
                 return rich_result
 
-        # Pre-flight: if content already exceeds the limit, split-and-deliver
-        # without round-tripping a doomed edit.
+        # Pre-flight: if an in-progress streaming edit grows past Telegram's
+        # 4,096 UTF-16 unit limit, do NOT split it into continuation messages
+        # yet.  Mid-stream overflow continuations are especially prone to Bot
+        # API flood control; if one lands and a later one fails, the stream
+        # consumer has to recover from a partially-visible answer and can
+        # duplicate chunks.  Instead, freeze the current preview and let the
+        # stream consumer send the missing tail once at finalization time.
+        # Final edits still use the overflow splitter below so non-streaming
+        # / completed answers can be delivered in chunks.
         if utf16_len(content) > self.MAX_MESSAGE_LENGTH:
+            if not finalize:
+                return SendResult(
+                    success=False,
+                    message_id=message_id,
+                    error="stream_overflow_deferred",
+                    retryable=False,
+                    raw_response={"stream_overflow_deferred": True},
+                )
             return await self._edit_overflow_split(
                 chat_id, message_id, content, finalize=finalize, metadata=metadata,
             )

--- a/tests/gateway/test_telegram_overflow_partial.py
+++ b/tests/gateway/test_telegram_overflow_partial.py
@@ -24,8 +24,34 @@ def telegram_adapter() -> TelegramAdapter:
 
 
 @pytest.mark.asyncio
+async def test_streaming_overflow_edit_is_deferred_until_final(telegram_adapter):
+    """Mid-stream Telegram overflow must not emit continuation chunks.
+
+    Streaming previews can grow past Telegram's edit limit before the final
+    answer is available. Splitting at that point can leave a partial answer on
+    screen if Telegram flood-controls continuation sends. The adapter should
+    report a failed/deferred edit so the stream consumer freezes the preview and
+    sends the missing tail once on finalization.
+    """
+    content = "word " * 120
+    telegram_adapter._bot.edit_message_text = AsyncMock(return_value=True)
+    telegram_adapter._bot.send_message = AsyncMock(return_value=_message(202))
+
+    result = await telegram_adapter.edit_message(
+        "12345", "201", content, finalize=False, metadata={"thread_id": "77"}
+    )
+
+    assert result.success is False
+    assert result.message_id == "201"
+    assert result.error == "stream_overflow_deferred"
+    assert result.raw_response == {"stream_overflow_deferred": True}
+    telegram_adapter._bot.edit_message_text.assert_not_awaited()
+    telegram_adapter._bot.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_edit_overflow_split_reports_success_when_all_continuations_land(telegram_adapter):
-    """Complete overflow delivery keeps the existing successful contract."""
+    """Complete final overflow delivery keeps the existing successful contract."""
     content = "word " * 120
     telegram_adapter._bot.edit_message_text = AsyncMock(return_value=True)
     telegram_adapter._bot.send_message = AsyncMock(


### PR DESCRIPTION
## Summary
- Avoid emitting Telegram overflow continuation messages during in-progress streaming edits
- Freeze the current preview once it exceeds Telegram's edit limit and let finalization deliver the missing tail once
- Add regression coverage that mid-stream overflow does not call edit/send continuation APIs

## Tests
- uv run --extra dev python -m pytest tests/gateway/test_telegram_overflow_partial.py -q
- uv run --extra dev python -m pytest tests/gateway/test_stream_consumer.py tests/gateway/test_stream_consumer_fresh_final.py tests/gateway/test_duplicate_reply_suppression.py tests/gateway/test_telegram_overflow_partial.py -q