### PR TITLE
fix(cron): isolate per-job schedule errors so one bad job can't stall…

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1255,138 +1255,219 @@ def get_due_jobs() -> List[Dict[str, Any]]:
         return _get_due_jobs_locked()
 
 
+def _record_due_scan_error(raw_jobs: List[Dict[str, Any]], job: Dict[str, Any], error: Exception) -> bool:
+    """Quarantine one job with bad schedule metadata so it can't poison the scan.
+
+    Marks the job ``state="error"`` and records the message, returning True when
+    that changed something and ``jobs.json`` should be re-saved. Idempotent: a
+    job already quarantined with the SAME error is left untouched and returns
+    False, so a permanently-corrupt record does not re-log or rewrite jobs.json
+    on every 60s tick. The job stays ``enabled`` and is still re-evaluated each
+    scan, so fixing the schedule lets it fire again — at which point
+    ``mark_job_run`` resets the state back to ``scheduled``.
+    """
+    job_id = str(job.get("id") or "?")
+    msg = f"Invalid cron schedule metadata: {error}"
+    for raw in raw_jobs:
+        if raw.get("id") == job.get("id"):
+            if raw.get("state") == "error" and raw.get("last_error") == msg:
+                return False
+            logger.error("Job '%s': %s", job_id, msg, exc_info=error)
+            raw["state"] = "error"
+            raw["last_status"] = "error"
+            raw["last_error"] = msg
+            return True
+    # No matching raw record (shouldn't happen) — log once, nothing to persist.
+    logger.error("Job '%s': %s", job_id, msg, exc_info=error)
+    return False
+
+
+def _evaluate_due_job(
+    job: Dict[str, Any],
+    now: datetime,
+    raw_jobs: List[Dict[str, Any]],
+    due: List[Dict[str, Any]],
+) -> bool:
+    """Evaluate ONE job; append it to ``due`` if it should fire now.
+
+    Returns True when ``raw_jobs`` was mutated and ``jobs.json`` needs saving.
+    May raise on corrupt schedule metadata (bad cron expr, unparseable
+    timestamp, missing field). The caller isolates each job so one bad record
+    cannot abort the scan — see ``_get_due_jobs_locked``.
+    """
+    needs_save = False
+    next_run = job.get("next_run_at")
+    if not next_run:
+        schedule = job.get("schedule", {})
+        kind = schedule.get("kind")
+
+        # One-shot jobs use a small grace window via the dedicated helper.
+        recovered_next = _recoverable_oneshot_run_at(
+            schedule,
+            now,
+            last_run_at=job.get("last_run_at"),
+        )
+        recovery_kind = "one-shot" if recovered_next else None
+
+        # Recurring jobs reach here only when something — typically a
+        # direct jobs.json edit that bypassed add_job() — left
+        # next_run_at unset.  Without this branch, such jobs are
+        # silently skipped forever; recompute next_run_at from the
+        # schedule so they pick up at their next scheduled tick.
+        if not recovered_next and kind in {"cron", "interval"}:
+            recovered_next = compute_next_run(schedule, now.isoformat())
+            if recovered_next:
+                recovery_kind = kind
+
+        if not recovered_next:
+            return needs_save
+
+        job["next_run_at"] = recovered_next
+        next_run = recovered_next
+        logger.info(
+            "Job '%s' had no next_run_at; recovering %s run at %s",
+            job.get("name", job["id"]),
+            recovery_kind,
+            recovered_next,
+        )
+        for rj in raw_jobs:
+            if rj["id"] == job["id"]:
+                rj["next_run_at"] = recovered_next
+                needs_save = True
+                break
+
+    schedule = job.get("schedule", {})
+    kind = schedule.get("kind")
+
+    # A non-empty but malformed next_run_at (a truncated/migrated value, or
+    # junk hand-edited into jobs.json like "soon") raises here. A recurring
+    # job can self-heal by recomputing its next fire from the schedule, so try
+    # that first. If recovery isn't possible — a one-shot whose run_at can't be
+    # recovered, or a schedule too corrupt to compute (compute_next_run then
+    # raises) — fall through to the scan-level guard, which quarantines the job.
+    try:
+        raw_next_run_dt = datetime.fromisoformat(next_run)
+    except (ValueError, TypeError):
+        recovered_next = compute_next_run(schedule, now.isoformat())
+        if not recovered_next:
+            raise
+        logger.warning(
+            "Job '%s' had unparseable next_run_at=%r; recomputing from "
+            "schedule -> %s",
+            job.get("name", job["id"]),
+            next_run,
+            recovered_next,
+        )
+        for rj in raw_jobs:
+            if rj["id"] == job["id"]:
+                rj["next_run_at"] = recovered_next
+                needs_save = True
+                break
+        return needs_save
+
+    next_run_dt = _ensure_aware(raw_next_run_dt)
+    # Migration repair: a cron job persists next_run_at as an absolute
+    # instant, but the cron expr describes local wall-clock intent. If the
+    # configured/system timezone changed after persistence, the stored
+    # instant's offset no longer matches now's, and its converted time can
+    # look due hours early (21:00+10 -> 13:00+02). When the stored *wall
+    # clock* is still in the future, recompute from the schedule so we fire
+    # at the intended local time instead of early-then-again.
+    #
+    # TRADE-OFF: this cannot distinguish a config/host TZ migration from a
+    # legitimate DST offset change. A DST boundary that satisfies all four
+    # conditions will recompute (and thus SKIP the pending occurrence, no
+    # catch-up) rather than fire it. Accepted: in the pure-migration case
+    # the recompute lands on the same wall-clock time later the same period,
+    # and DST-boundary collisions with a still-future stored wall clock are
+    # rare relative to the double-fire bug this prevents (#28934).
+    if (
+        kind == "cron"
+        and next_run_dt <= now
+        and _timezone_offset_mismatch(raw_next_run_dt, now)
+        and _stored_wall_clock_is_future(raw_next_run_dt, now)
+    ):
+        new_next = compute_next_run(schedule, now.isoformat())
+        if new_next:
+            logger.info(
+                "Job '%s' next_run_at offset changed (%s -> %s). "
+                "Recomputing cron run to preserve local wall-clock intent: %s",
+                job.get("name", job["id"]),
+                raw_next_run_dt.utcoffset(),
+                now.utcoffset(),
+                new_next,
+            )
+            for rj in raw_jobs:
+                if rj["id"] == job["id"]:
+                    rj["next_run_at"] = new_next
+                    needs_save = True
+                    break
+            return needs_save
+
+    if next_run_dt <= now:
+
+        # For recurring jobs, check if the scheduled time is stale
+        # (gateway was down and missed the window). Fast-forward to
+        # the next future occurrence instead of firing a stale run.
+        grace = _compute_grace_seconds(schedule)
+        if kind in {"cron", "interval"} and (now - next_run_dt).total_seconds() > grace:
+            # Job is past its catch-up grace window — skip accumulated
+            # missed runs but still execute once now to avoid deferring
+            # indefinitely (e.g. a long-running job just finished).
+            new_next = compute_next_run(schedule, now.isoformat())
+            if new_next:
+                logger.info(
+                    "Job '%s' missed its scheduled time (%s, grace=%ds). "
+                    "Running now; next run provisionally set to: %s "
+                    "(re-anchored on completion)",
+                    job.get("name", job["id"]),
+                    next_run,
+                    grace,
+                    new_next,
+                )
+                # Persist the fast-forward to storage now (skip accumulated
+                # slots). In the built-in ticker path this is shortly
+                # overwritten by advance_next_run + mark_job_run, but it is
+                # NOT redundant: it (a) protects the crash window between
+                # here and mark_job_run, and (b) covers the external
+                # fire_due provider path, which does not call
+                # advance_next_run. mark_job_run re-anchors next_run_at off
+                # the actual completion time, so this value is provisional.
+                for rj in raw_jobs:
+                    if rj["id"] == job["id"]:
+                        rj["next_run_at"] = new_next
+                        needs_save = True
+                        break
+                # Fall through to due.append(job) — execute once now
+
+        due.append(job)
+
+    return needs_save
+
+
 def _get_due_jobs_locked() -> List[Dict[str, Any]]:
     """Inner implementation of get_due_jobs(); must be called with _jobs_lock held."""
     now = _hermes_now()
     raw_jobs = load_jobs()
     jobs = [_apply_skill_fields(j) for j in copy.deepcopy(raw_jobs)]
-    due = []
+    due: List[Dict[str, Any]] = []
     needs_save = False
 
     for job in jobs:
         if not job.get("enabled", True):
             continue
 
-        next_run = job.get("next_run_at")
-        if not next_run:
-            schedule = job.get("schedule", {})
-            kind = schedule.get("kind")
-
-            # One-shot jobs use a small grace window via the dedicated helper.
-            recovered_next = _recoverable_oneshot_run_at(
-                schedule,
-                now,
-                last_run_at=job.get("last_run_at"),
-            )
-            recovery_kind = "one-shot" if recovered_next else None
-
-            # Recurring jobs reach here only when something — typically a
-            # direct jobs.json edit that bypassed add_job() — left
-            # next_run_at unset.  Without this branch, such jobs are
-            # silently skipped forever; recompute next_run_at from the
-            # schedule so they pick up at their next scheduled tick.
-            if not recovered_next and kind in {"cron", "interval"}:
-                recovered_next = compute_next_run(schedule, now.isoformat())
-                if recovered_next:
-                    recovery_kind = kind
-
-            if not recovered_next:
-                continue
-
-            job["next_run_at"] = recovered_next
-            next_run = recovered_next
-            logger.info(
-                "Job '%s' had no next_run_at; recovering %s run at %s",
-                job.get("name", job["id"]),
-                recovery_kind,
-                recovered_next,
-            )
-            for rj in raw_jobs:
-                if rj["id"] == job["id"]:
-                    rj["next_run_at"] = recovered_next
-                    needs_save = True
-                    break
-
-        raw_next_run_dt = datetime.fromisoformat(next_run)
-        schedule = job.get("schedule", {})
-        kind = schedule.get("kind")
-
-        next_run_dt = _ensure_aware(raw_next_run_dt)
-        # Migration repair: a cron job persists next_run_at as an absolute
-        # instant, but the cron expr describes local wall-clock intent. If the
-        # configured/system timezone changed after persistence, the stored
-        # instant's offset no longer matches now's, and its converted time can
-        # look due hours early (21:00+10 -> 13:00+02). When the stored *wall
-        # clock* is still in the future, recompute from the schedule so we fire
-        # at the intended local time instead of early-then-again.
-        #
-        # TRADE-OFF: this cannot distinguish a config/host TZ migration from a
-        # legitimate DST offset change. A DST boundary that satisfies all four
-        # conditions will recompute (and thus SKIP the pending occurrence, no
-        # catch-up) rather than fire it. Accepted: in the pure-migration case
-        # the recompute lands on the same wall-clock time later the same period,
-        # and DST-boundary collisions with a still-future stored wall clock are
-        # rare relative to the double-fire bug this prevents (#28934).
-        if (
-            kind == "cron"
-            and next_run_dt <= now
-            and _timezone_offset_mismatch(raw_next_run_dt, now)
-            and _stored_wall_clock_is_future(raw_next_run_dt, now)
-        ):
-            new_next = compute_next_run(schedule, now.isoformat())
-            if new_next:
-                logger.info(
-                    "Job '%s' next_run_at offset changed (%s -> %s). "
-                    "Recomputing cron run to preserve local wall-clock intent: %s",
-                    job.get("name", job["id"]),
-                    raw_next_run_dt.utcoffset(),
-                    now.utcoffset(),
-                    new_next,
-                )
-                for rj in raw_jobs:
-                    if rj["id"] == job["id"]:
-                        rj["next_run_at"] = new_next
-                        needs_save = True
-                        break
-                continue
-
-        if next_run_dt <= now:
-
-            # For recurring jobs, check if the scheduled time is stale
-            # (gateway was down and missed the window). Fast-forward to
-            # the next future occurrence instead of firing a stale run.
-            grace = _compute_grace_seconds(schedule)
-            if kind in {"cron", "interval"} and (now - next_run_dt).total_seconds() > grace:
-                # Job is past its catch-up grace window — skip accumulated
-                # missed runs but still execute once now to avoid deferring
-                # indefinitely (e.g. a long-running job just finished).
-                new_next = compute_next_run(schedule, now.isoformat())
-                if new_next:
-                    logger.info(
-                        "Job '%s' missed its scheduled time (%s, grace=%ds). "
-                        "Running now; next run provisionally set to: %s "
-                        "(re-anchored on completion)",
-                        job.get("name", job["id"]),
-                        next_run,
-                        grace,
-                        new_next,
-                    )
-                    # Persist the fast-forward to storage now (skip accumulated
-                    # slots). In the built-in ticker path this is shortly
-                    # overwritten by advance_next_run + mark_job_run, but it is
-                    # NOT redundant: it (a) protects the crash window between
-                    # here and mark_job_run, and (b) covers the external
-                    # fire_due provider path, which does not call
-                    # advance_next_run. mark_job_run re-anchors next_run_at off
-                    # the actual completion time, so this value is provisional.
-                    for rj in raw_jobs:
-                        if rj["id"] == job["id"]:
-                            rj["next_run_at"] = new_next
-                            needs_save = True
-                            break
-                    # Fall through to due.append(job) — execute once now
-
-            due.append(job)
+        # Isolate each job: corrupt schedule metadata on ONE record (bad cron
+        # expr, unparseable timestamp, a field missing from a hand-edited
+        # jobs.json) must never raise out of the scan and starve every OTHER
+        # job — the "ticker alive, nothing ever fires, no error logged"
+        # failure in #51021. Quarantine the bad job and keep going.
+        try:
+            if _evaluate_due_job(job, now, raw_jobs, due):
+                needs_save = True
+        except Exception as e:
+            if _record_due_scan_error(raw_jobs, job, e):
+                needs_save = True
 
     if needs_save:
         save_jobs(raw_jobs)

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -187,6 +187,17 @@ def cron_status():
             ))
             print(f"  PID: {', '.join(map(str, pids))}")
             print("  Cron jobs may NOT be firing. Restart: hermes gateway restart")
+        elif hb_age is not None and ok_age is None:
+            # Loop is alive, but no clean tick has ever been recorded in this
+            # store. The normal startup window is tiny because the ticker ticks
+            # before its first sleep, so this should not be reported healthy.
+            print(color(
+                "⚠ Gateway and cron ticker are running, but no tick has "
+                "succeeded yet — ticks may be failing.",
+                Colors.YELLOW,
+            ))
+            print(f"  PID: {', '.join(map(str, pids))}")
+            print("  Check the gateway log for 'Cron tick error'.")
         elif hb_age is not None and ok_age is not None and ok_age > STALE_AFTER:
             # Loop is alive (fresh heartbeat) but no tick has SUCCEEDED in a
             # long time → ticks are failing every iteration.

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -898,6 +898,232 @@ class TestGetDueJobs:
             recovered_dt = recovered_dt.replace(tzinfo=timezone.utc)
         assert recovered_dt > now
 
+    def test_malformed_active_job_does_not_block_other_due_jobs(self, tmp_cron_dir, monkeypatch):
+        """A single corrupted job record must not prevent unrelated due jobs from firing."""
+        now = datetime(2026, 3, 18, 10, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        save_jobs([
+            {
+                "id": "bad-next-run",
+                "name": "Corrupted job",
+                "prompt": "...",
+                "schedule": {"kind": "once", "run_at": "not-a-date"},
+                "schedule_display": "broken",
+                "repeat": {"times": 1, "completed": 0},
+                "enabled": True,
+                "state": "scheduled",
+                "paused_at": None,
+                "paused_reason": None,
+                "created_at": "2026-03-18T09:00:00+00:00",
+                "next_run_at": "not-a-date",
+                "last_run_at": None,
+                "last_status": None,
+                "last_error": None,
+                "deliver": "local",
+                "origin": None,
+            },
+            {
+                "id": "valid-due",
+                "name": "Valid due job",
+                "prompt": "...",
+                "schedule": {
+                    "kind": "once",
+                    "run_at": "2026-03-18T09:59:00+00:00",
+                    "display": "once at 2026-03-18 09:59",
+                },
+                "schedule_display": "once at 2026-03-18 09:59",
+                "repeat": {"times": 1, "completed": 0},
+                "enabled": True,
+                "state": "scheduled",
+                "paused_at": None,
+                "paused_reason": None,
+                "created_at": "2026-03-18T09:00:00+00:00",
+                "next_run_at": "2026-03-18T09:59:00+00:00",
+                "last_run_at": None,
+                "last_status": None,
+                "last_error": None,
+                "deliver": "local",
+                "origin": None,
+            },
+        ])
+
+        assert [job["id"] for job in get_due_jobs()] == ["valid-due"]
+
+    def test_malformed_recurring_schedule_does_not_block_other_due_jobs(self, tmp_cron_dir, monkeypatch):
+        """A recurring job with a corrupt cron expr must not abort the whole scan.
+
+        Regression for the stale-recurring recompute path: ``compute_next_run``
+        there ran outside the per-job guard, so a bad cron expr raised straight
+        out of ``get_due_jobs`` and starved every other job — the real shape of
+        #51021's "ticker alive, nothing ever fires, no error logged" symptom.
+        The corrupt job is quarantined (state=error) and the valid job fires.
+        """
+        now = datetime(2026, 3, 18, 10, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        save_jobs([
+            {
+                "id": "bad-cron-expr",
+                "name": "Corrupt recurring",
+                "prompt": "...",
+                # next_run_at parses fine but is stale (> grace); the cron expr
+                # is garbage, so the stale-recompute raises CroniterBadCronError.
+                "schedule": {"kind": "cron", "expr": "not a cron expr"},
+                "schedule_display": "broken",
+                "repeat": {"times": 0, "completed": 0},
+                "enabled": True,
+                "state": "scheduled",
+                "paused_at": None,
+                "paused_reason": None,
+                "created_at": "2026-03-18T08:00:00+00:00",
+                "next_run_at": "2026-03-18T08:00:00+00:00",
+                "last_run_at": None,
+                "last_status": None,
+                "last_error": None,
+                "deliver": "local",
+                "origin": None,
+            },
+            {
+                "id": "valid-due",
+                "name": "Valid due job",
+                "prompt": "...",
+                "schedule": {
+                    "kind": "once",
+                    "run_at": "2026-03-18T09:59:00+00:00",
+                    "display": "once at 2026-03-18 09:59",
+                },
+                "schedule_display": "once at 2026-03-18 09:59",
+                "repeat": {"times": 1, "completed": 0},
+                "enabled": True,
+                "state": "scheduled",
+                "paused_at": None,
+                "paused_reason": None,
+                "created_at": "2026-03-18T09:00:00+00:00",
+                "next_run_at": "2026-03-18T09:59:00+00:00",
+                "last_run_at": None,
+                "last_status": None,
+                "last_error": None,
+                "deliver": "local",
+                "origin": None,
+            },
+        ])
+
+        assert [job["id"] for job in get_due_jobs()] == ["valid-due"]
+
+        bad = next(j for j in load_jobs() if j["id"] == "bad-cron-expr")
+        assert bad["state"] == "error"
+        assert bad["last_error"]
+
+    def test_corrupt_job_quarantine_is_idempotent(self, tmp_cron_dir, monkeypatch):
+        """A permanently-corrupt job must not rewrite jobs.json on every tick."""
+        import cron.jobs as jobs_mod
+
+        now = datetime(2026, 3, 18, 10, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        save_jobs([
+            {
+                "id": "bad-cron-expr",
+                "name": "Corrupt recurring",
+                "prompt": "...",
+                "schedule": {"kind": "cron", "expr": "not a cron expr"},
+                "schedule_display": "broken",
+                "repeat": {"times": 0, "completed": 0},
+                "enabled": True,
+                "state": "scheduled",
+                "paused_at": None,
+                "paused_reason": None,
+                "created_at": "2026-03-18T08:00:00+00:00",
+                "next_run_at": "2026-03-18T08:00:00+00:00",
+                "last_run_at": None,
+                "last_status": None,
+                "last_error": None,
+                "deliver": "local",
+                "origin": None,
+            },
+        ])
+
+        # First scan quarantines the job and persists that once.
+        get_due_jobs()
+
+        saves = []
+        real_save = jobs_mod.save_jobs
+        monkeypatch.setattr(
+            jobs_mod, "save_jobs",
+            lambda data, *a, **k: (saves.append(1), real_save(data, *a, **k))[1],
+        )
+
+        # Already quarantined with the same error → no further writes.
+        get_due_jobs()
+        assert saves == []
+
+    def test_malformed_next_run_at_recurring_job_self_heals(self, tmp_cron_dir, monkeypatch):
+        """A recurring job with a corrupt (non-empty) next_run_at recovers by
+        recomputing from its schedule rather than being quarantined — preserves
+        the self-heal behavior of #50377 while the broader guard covers the rest.
+        """
+        now = datetime(2026, 3, 18, 10, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        save_jobs([{
+            "id": "recurring-bad-ts",
+            "name": "Recurring corrupt ts",
+            "prompt": "...",
+            "schedule": {"kind": "interval", "minutes": 60, "display": "every 60m"},
+            "schedule_display": "every 1h",
+            "repeat": {"times": None, "completed": 0},
+            "enabled": True,
+            "state": "scheduled",
+            "paused_at": None,
+            "paused_reason": None,
+            "created_at": "2026-03-18T09:00:00+00:00",
+            "next_run_at": "soon",  # non-empty, unparseable
+            "last_run_at": None,
+            "last_status": None,
+            "last_error": None,
+            "deliver": "local",
+            "origin": None,
+        }])
+
+        assert get_due_jobs() == []  # must not raise; recovered run is in the future
+
+        job = get_job("recurring-bad-ts")
+        assert job["state"] != "error"          # recovered, not quarantined
+        assert job["next_run_at"] not in (None, "soon")
+        from cron.jobs import _ensure_aware
+        assert _ensure_aware(datetime.fromisoformat(job["next_run_at"])) > now
+
+    def test_malformed_next_run_at_with_corrupt_schedule_is_quarantined(self, tmp_cron_dir, monkeypatch):
+        """Corrupt next_run_at AND a corrupt cron expr: recovery itself raises,
+        so the scan-level guard quarantines the job instead of letting the
+        exception escape the tick (the case #50377's unguarded recovery misses).
+        """
+        now = datetime(2026, 3, 18, 10, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        save_jobs([{
+            "id": "double-bad",
+            "name": "Corrupt ts + expr",
+            "prompt": "...",
+            "schedule": {"kind": "cron", "expr": "not a cron expr"},
+            "schedule_display": "broken",
+            "repeat": {"times": 0, "completed": 0},
+            "enabled": True,
+            "state": "scheduled",
+            "paused_at": None,
+            "paused_reason": None,
+            "created_at": "2026-03-18T09:00:00+00:00",
+            "next_run_at": "soon",
+            "last_run_at": None,
+            "last_status": None,
+            "last_error": None,
+            "deliver": "local",
+            "origin": None,
+        }])
+
+        assert get_due_jobs() == []  # must not raise
+        assert get_job("double-bad")["state"] == "error"
 
     def test_cron_next_run_offset_migration_is_rescheduled_not_fired(self, tmp_cron_dir, monkeypatch):
         current_tz = timezone(timedelta(hours=2))

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -494,6 +494,22 @@ def test_cron_status_reports_alive_but_failing(tmp_path, monkeypatch, capsys):
     assert "will fire automatically" not in out
 
 
+def test_cron_status_reports_missing_success_marker(tmp_path, monkeypatch, capsys):
+    """Fresh heartbeat with no successful-tick marker yet is not healthy."""
+    import cron.jobs as jobs
+    from hermes_cli import cron as cron_cli
+
+    monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [4321])
+    monkeypatch.setattr(jobs, "get_ticker_heartbeat_age", lambda: 5.0)
+    monkeypatch.setattr(jobs, "get_ticker_success_age", lambda: None)
+    monkeypatch.setattr("cron.jobs.list_jobs", lambda **k: [])
+
+    cron_cli.cron_status()
+    out = capsys.readouterr().out
+    assert "no tick has succeeded" in out
+    assert "will fire automatically" not in out
+
+
 def test_cron_status_healthy_when_both_fresh(tmp_path, monkeypatch, capsys):
     import cron.jobs as jobs
     from hermes_cli import cron as cron_cli


### PR DESCRIPTION
## What does this PR do?

`get_due_jobs()` scans every cron job on each tick. A single job with corrupt
schedule metadata — a bad cron expression, an unparseable `next_run_at`, or a
field missing from a hand-edited `jobs.json` — raised an exception that escaped
the scan (the tick's only `try/finally` just releases the file lock) and
aborted it **for every job**. The ticker keeps writing its liveness heartbeat
regardless, so `hermes cron status` reports healthy while **no job ever fires** —
the "ticker alive, nothing fires" symptom in #51021. The poisoned record reloads
every tick, so it permanently wedges *all* cron jobs until the file is repaired.

Each job is now evaluated inside a single `try/except`, so any malformed field
degrades that one job instead of the whole tick. A recoverable timestamp
self-heals; an unrecoverable one is quarantined and surfaced.

> **Relationship to #50377.** This extends the open PR #50377, which guards only
> the single `datetime.fromisoformat(next_run)` parse and explicitly scopes
> itself to that site. This PR keeps that behavior — a recurring job with a
> malformed `next_run_at` still self-heals by recomputing from its schedule —
> and additionally:
> - guards the two `compute_next_run()` calls in the stale-recurring and
>   TZ-migration paths (a stale recurring job with a corrupt cron expr still
>   wedges the whole tick under #50377; verified);
> - covers the case where recovery *itself* raises (corrupt timestamp **and**
>   corrupt schedule), which #50377's unguarded recovery call would let escape;
> - makes the quarantine idempotent (no per-tick log spam / `jobs.json` rewrite);
> - adds an honest `cron status`.
>
> Happy to have this supersede #50377 or to rebase it as a delta — maintainer's
> call.

## Related Issue

Fixes #51021

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/jobs.py`: extracted per-job evaluation into `_evaluate_due_job()` and
  wrapped the entire per-job body in one `try/except` in
  `_get_due_jobs_locked()`, covering every throw site — including the
  `compute_next_run()` calls in the stale-recurring and TZ-migration paths. A
  failing job is quarantined (`state="error"`, `last_error` recorded) and the
  scan continues so other due jobs still fire.
- `cron/jobs.py`: a malformed-but-recoverable `next_run_at` self-heals — a
  recurring job recomputes its next fire from the schedule instead of being
  quarantined (preserves #50377); it only quarantines when recovery is
  impossible or the schedule itself is corrupt.
- `cron/jobs.py`: `_record_due_scan_error()` is idempotent — it logs (with
  `exc_info`) and rewrites `jobs.json` only on the *transition* into the error
  state, so a permanently-corrupt record no longer re-logs or rewrites storage
  on every 60s tick. The job stays `enabled` and self-heals once repaired
  (`mark_job_run` resets `state` to `scheduled` on the next success).
- `hermes_cli/cron.py`: `cron status` now warns when the ticker is heartbeating
  but has never recorded a successful tick, instead of falsely reporting healthy.
- `tests/cron/test_jobs.py`, `tests/cron/test_scheduler_provider.py`: regression
  tests for the above.

## How to Test

1. `scripts/run_tests.sh tests/cron/` — 526 pass, including the new regression
   tests:
   - `test_malformed_recurring_schedule_does_not_block_other_due_jobs`
   - `test_malformed_active_job_does_not_block_other_due_jobs`
   - `test_malformed_next_run_at_recurring_job_self_heals`
   - `test_malformed_next_run_at_with_corrupt_schedule_is_quarantined`
   - `test_corrupt_job_quarantine_is_idempotent`
   - `test_cron_status_reports_missing_success_marker`
2. Manual:
   ```
   export HERMES_HOME=$(mktemp -d)
   # hand-edit $HERMES_HOME/cron/jobs.json to add a job with
   #   "schedule": {"kind": "cron", "expr": "not a cron expr"}
   # alongside a valid due job, then:
   hermes cron list      # corrupt job shows state=error; valid job intact
   ```
   The due-scan returns only the valid job (no crash); the corrupt job is
   quarantined.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(cron):`)
- [x] I searched for existing PRs — this is **not a duplicate**: it deliberately
      extends #50377 (see note above; also related #18825, #51061)
- [x] My PR contains only changes related to this fix (4 cron files)
- [x] I've run the tests — cron surface fully green (526 pass via
      `scripts/run_tests.sh`). The full suite's only failures are
      pre-existing/environmental (systemd/WSL/macOS `/tmp`-symlink), verified
      identical on `upstream/main`; none are in cron.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.3.1

### Documentation & Housekeeping

- [x] Documentation — N/A (no user-facing docs; inline docstrings updated)
- [x] `cli-config.yaml.example` — N/A (no config keys added/changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact — considered; pure Python control-flow in the
      due-scan, no OS-specific code, file I/O, or process handling added
- [x] Tool descriptions/schemas — N/A (no tool behavior change)

## Screenshots / Logs

Same store in both runs: one corrupt stale recurring job (`{"kind":"cron","expr":"not a cron expr"}`) and one valid due one-shot.

**Before — `upstream/main` (no fix):** one bad record aborts the whole scan, so the healthy job never fires (#51021).

```
get_due_jobs() RAISED: CroniterBadCronError: Exactly 5, 6 or 7 columns has to be specified for iterator expression.
RESULT: whole scan aborted — valid-due NEVER fires. ❌  (#51021)
```

**After — this PR:** the bad job is quarantined and the healthy job fires.

```
get_due_jobs() -> ['valid-due']
corrupt-cron state -> error
RESULT: valid-due FIRES; corrupt job isolated. ✅
```

(`hermes cron list` then shows `corrupt-cron [active] … error: Invalid cron schedule metadata: …` while `valid-due` stays intact.)
