### PR TITLE
fix: honor per-server connect_timeout in MCP login/probe (was hardcoded 40s)

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -214,7 +214,7 @@ def _resolve_mcp_server_config(config: dict) -> dict:
 
 
 def _probe_single_server(
-    name: str, config: dict, connect_timeout: float = 30
+    name: str, config: dict, connect_timeout: Optional[float] = None
 ) -> List[Tuple[str, str]]:
     """Temporarily connect to one MCP server, list its tools, disconnect.
 
@@ -233,6 +233,17 @@ def _probe_single_server(
     )
 
     config = _resolve_mcp_server_config(config)
+
+    # Honor the per-server ``connect_timeout`` config key (documented in the
+    # MCP config reference) when the caller does not override it. Without this,
+    # OAuth ``login`` and discovery probes were pinned to the 30s default
+    # (+10s = 40s wall clock) regardless of config — too short for remote MCP
+    # servers with slow cold-start OAuth (e.g. relay-fronted endpoints).
+    if connect_timeout is None:
+        try:
+            connect_timeout = float(config.get("connect_timeout") or 30)
+        except (TypeError, ValueError):
+            connect_timeout = 30
 
     _ensure_mcp_loop()
 


### PR DESCRIPTION
## Problem

`hermes mcp login <server>` (and `hermes mcp test` / startup discovery) always
times out after **40s** during the OAuth flow, regardless of the per-server
`connect_timeout` config key documented in the [MCP Config Reference](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/reference/mcp-config-reference.md).

**Root cause:** `_probe_single_server()` in `hermes_cli/mcp_config.py` takes
`connect_timeout: float = 30` as a parameter with a hardcoded default, and every
caller (`cmd_mcp_login`, `cmd_mcp_test`, discovery) invokes it **without passing
the value** — so the configured `connect_timeout` is silently ignored. The probe
wall-clock budget is `connect_timeout + 10 = 40s`.

40s is too short for remote MCP servers whose OAuth handshake has cold-start
latency — e.g. an HTTP server fronted by a serverless/relay layer that must wake
a container before completing authorization + the initial `tools/list`. The auth
then fails with:

```
✗ Authentication failed: MCP call timed out after 40.0s (configured timeout: 40.0s)
```

and there is no way to extend it: the documented `connect_timeout` key has no
effect on this path.

## Fix

Derive `connect_timeout` from the resolved server config when the caller does not
pass it explicitly (default arg becomes `None`, then `config.get("connect_timeout")`
with the existing 30s fallback). This makes the documented config key actually
work for `login`, `test`, and discovery while preserving behaviour for entries
that don't set it:

```yaml
mcp_servers:
  slow_oauth_server:
    url: "https://mcp.example.com/mcp"
    auth: oauth
    connect_timeout: 300   # now honored by `hermes mcp login`
```

## Notes

- Backward-compatible: explicit callers and entries without `connect_timeout`
  keep the 30s default, so wall-clock behaviour is unchanged unless a server opts
  into a longer timeout.
- `connect_timeout` is already documented in `reference/mcp-config-reference.md`;
  this aligns the `login`/probe path with the documented contract.
- Happy to add a unit test if you can point me at the preferred fixture style for
  `_probe_single_server`.
