### PR TITLE
fix(email): support STARTTLS for IMAP connections (#51263)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1138,6 +1138,29 @@ def load_gateway_config() -> GatewayConfig:
 
     config = GatewayConfig.from_dict(gw_data)
 
+    # Bridge structured email IMAP/SMTP config to extra dict so the adapter
+    # can read imap_encryption, imap_port, etc.  The YAML block
+    # ``platforms.email.imap.encryption: start-tls`` ends up in
+    # gw_data["platforms"]["email"]["imap"] but PlatformConfig.from_dict()
+    # only reads data["extra"], so we bridge the nested keys here.
+    try:
+        _email_plat = gw_data.get("platforms", {}).get("email", {})
+        if isinstance(_email_plat, dict):
+            _imap_block = _email_plat.get("imap", {})
+            if isinstance(_imap_block, dict) and Platform.EMAIL in config.platforms:
+                _email_extra = config.platforms[Platform.EMAIL].extra
+                if "encryption" in _imap_block and "imap_encryption" not in _email_extra:
+                    _email_extra["imap_encryption"] = _imap_block["encryption"]
+                if "port" in _imap_block and "imap_port" not in _email_extra:
+                    _email_extra["imap_port"] = _imap_block["port"]
+            _smtp_block = _email_plat.get("smtp", {})
+            if isinstance(_smtp_block, dict) and Platform.EMAIL in config.platforms:
+                _email_extra = config.platforms[Platform.EMAIL].extra
+                if "encryption" in _smtp_block and "smtp_encryption" not in _email_extra:
+                    _email_extra["smtp_encryption"] = _smtp_block["encryption"]
+    except Exception as e:
+        logger.debug("Email IMAP/SMTP config bridge skipped: %s", e)
+
     # Override with environment variables
     _apply_env_overrides(config)
     

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -326,6 +326,22 @@ class EmailAdapter(BasePlatformAdapter):
         self._smtp_port = env_int("EMAIL_SMTP_PORT", 587)
         self._poll_interval = env_int("EMAIL_POLL_INTERVAL", 15)
 
+        # IMAP encryption mode: "tls" (implicit TLS via IMAP4_SSL, default for
+        # port 993) or "starttls" (STARTTLS via IMAP4 + starttls(), default for
+        # port 143).  Read from env var, then extra dict, then auto-detect by
+        # port number.
+        raw_enc = (
+            os.getenv("EMAIL_IMAP_ENCRYPTION", "").strip().lower()
+            or extra.get("imap_encryption", "").strip().lower()
+        )
+        if raw_enc in ("starttls", "start-tls", "start_tls"):
+            self._imap_encryption = "starttls"
+        elif raw_enc in ("tls", "ssl", "implicit"):
+            self._imap_encryption = "tls"
+        else:
+            # Auto-detect: port 143 → STARTTLS, everything else → implicit TLS
+            self._imap_encryption = "starttls" if self._imap_port == 143 else "tls"
+
         # Skip attachments — configured via config.yaml:
         #   platforms:
         #     email:
@@ -361,6 +377,25 @@ class EmailAdapter(BasePlatformAdapter):
         except (ValueError, TypeError):
             # Fallback: just clear old entries if sort fails
             self._seen_uids = set(list(self._seen_uids)[-self._seen_uids_max // 2:])
+
+    def _connect_imap(self) -> imaplib.IMAP4:
+        """Create an IMAP connection using the configured encryption mode.
+
+        When *starttls* is configured (or auto-detected for port 143), connects
+        via plain ``IMAP4`` and upgrades with ``starttls()``.  Otherwise uses
+        ``IMAP4_SSL`` for implicit TLS (port 993 default).
+
+        This mirrors ``_connect_smtp()`` which selects ``SMTP_SSL`` vs
+        ``SMTP`` + ``starttls()`` based on port.
+        """
+        ctx = ssl.create_default_context()
+        if self._imap_encryption == "starttls":
+            imap = imaplib.IMAP4(self._imap_host, self._imap_port, timeout=30)
+            imap.starttls(ssl_context=ctx)
+            return imap
+        return imaplib.IMAP4_SSL(
+            self._imap_host, self._imap_port, timeout=30, ssl_context=ctx,
+        )
 
     def _connect_smtp(self) -> smtplib.SMTP:
         """Create an SMTP connection, selecting the correct protocol for the port.
@@ -438,7 +473,7 @@ class EmailAdapter(BasePlatformAdapter):
 
         try:
             # Test IMAP connection
-            imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
+            imap = self._connect_imap()
             imap.login(self._address, self._password)
             _send_imap_id(imap)
             # Mark all existing messages as seen so we only process new ones
@@ -507,7 +542,7 @@ class EmailAdapter(BasePlatformAdapter):
         """Fetch new (unseen) messages from IMAP. Runs in executor thread."""
         results = []
         try:
-            imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
+            imap = self._connect_imap()
             try:
                 imap.login(self._address, self._password)
                 _send_imap_id(imap)

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -91,6 +91,22 @@ def _esecret_bool(name: str, default: bool = False) -> bool:
     return is_truthy_value(_get_esecret(name, ""), default=default)
 
 
+def _coerce_valid_port(value: Any, default: int) -> int:
+    """Coerce a port from env/YAML config into a valid TCP port number.
+
+    Accepts the ``EMAIL_IMAP_PORT``/``EMAIL_SMTP_PORT`` env value or the
+    ``platforms.email.imap.port`` YAML value (seeded into extra). Invalid or
+    out-of-range values (0, 65536, non-numeric) fall back to *default* rather
+    than reaching ``imaplib``/``smtplib`` and raising a confusing
+    ``gaierror``/``OverflowError`` deep in the connect path.
+    """
+    try:
+        port = int(str(value).strip())
+    except (TypeError, ValueError):
+        return default
+    return port if 1 <= port <= 65535 else default
+
+
 # Automated sender patterns — emails from these are silently ignored
 _NOREPLY_PATTERNS = (
     "noreply", "no-reply", "no_reply", "donotreply", "do-not-reply",
@@ -553,10 +569,31 @@ class EmailAdapter(BasePlatformAdapter):
         self._address = (_get_secret("EMAIL_ADDRESS", "") or extra.get("address", "")).strip()
         self._password = _get_secret("EMAIL_PASSWORD", "")
         self._imap_host = (_get_secret("EMAIL_IMAP_HOST", "") or extra.get("imap_host", "")).strip()
-        self._imap_port = _esecret_int("EMAIL_IMAP_PORT", 993)
+        self._imap_port = _coerce_valid_port(
+            _get_secret("EMAIL_IMAP_PORT", "").strip() or extra.get("imap_port"), 993,
+        )
         self._smtp_host = (_get_secret("EMAIL_SMTP_HOST", "") or extra.get("smtp_host", "")).strip()
-        self._smtp_port = _esecret_int("EMAIL_SMTP_PORT", 587)
+        self._smtp_port = _coerce_valid_port(
+            _get_secret("EMAIL_SMTP_PORT", "").strip() or extra.get("smtp_port"), 587,
+        )
         self._poll_interval = _esecret_int("EMAIL_POLL_INTERVAL", 15)
+
+        # IMAP encryption mode: "tls" (implicit TLS via IMAP4_SSL, default for
+        # port 993) or "starttls" (STARTTLS via IMAP4 + starttls(), default for
+        # port 143).  Read from env var, then extra dict (seeded by the
+        # email plugin's apply_yaml_config_fn from ``platforms.email.imap``),
+        # then auto-detect by port number.
+        raw_enc = (
+            _get_secret("EMAIL_IMAP_ENCRYPTION", "").strip().lower()
+            or str(extra.get("imap_encryption", "")).strip().lower()
+        )
+        if raw_enc in ("starttls", "start-tls", "start_tls"):
+            self._imap_encryption = "starttls"
+        elif raw_enc in ("tls", "ssl", "implicit"):
+            self._imap_encryption = "tls"
+        else:
+            # Auto-detect: port 143 → STARTTLS, everything else → implicit TLS
+            self._imap_encryption = "starttls" if self._imap_port == 143 else "tls"
 
         # Skip attachments — configured via config.yaml:
         #   platforms:
@@ -626,6 +663,25 @@ class EmailAdapter(BasePlatformAdapter):
         except (ValueError, TypeError):
             # Fallback: just clear old entries if sort fails
             self._seen_uids = set(list(self._seen_uids)[-self._seen_uids_max // 2:])
+
+    def _connect_imap(self) -> imaplib.IMAP4:
+        """Create an IMAP connection using the configured encryption mode.
+
+        When *starttls* is configured (or auto-detected for port 143), connects
+        via plain ``IMAP4`` and upgrades with ``starttls()``.  Otherwise uses
+        ``IMAP4_SSL`` for implicit TLS (port 993 default).
+
+        This mirrors ``_connect_smtp()`` which selects ``SMTP_SSL`` vs
+        ``SMTP`` + ``starttls()`` based on port.
+        """
+        ctx = ssl.create_default_context()
+        if self._imap_encryption == "starttls":
+            imap = imaplib.IMAP4(self._imap_host, self._imap_port, timeout=30)
+            imap.starttls(ssl_context=ctx)
+            return imap
+        return imaplib.IMAP4_SSL(
+            self._imap_host, self._imap_port, timeout=30, ssl_context=ctx,
+        )
 
     def _connect_smtp(self) -> smtplib.SMTP:
         """Create an SMTP connection, selecting the correct protocol for the port.
@@ -711,7 +767,7 @@ class EmailAdapter(BasePlatformAdapter):
             # (#79889).
             imap = None
             try:
-                imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
+                imap = self._connect_imap()
                 imap.login(self._address, self._password)
                 _send_imap_id(imap)
                 imap.select("INBOX")
@@ -855,7 +911,7 @@ class EmailAdapter(BasePlatformAdapter):
         results = []
         imap: Optional[imaplib.IMAP4] = None
         try:
-            imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
+            imap = self._connect_imap()
             try:
                 imap.login(self._address, self._password)
                 _send_imap_id(imap)
@@ -1491,6 +1547,36 @@ def _build_adapter(config):
     return EmailAdapter(config)
 
 
+def _apply_yaml_config(yaml_cfg: dict, email_cfg: dict) -> "dict | None":
+    """Translate config.yaml ``platforms.email.imap``/``smtp`` blocks into
+    PlatformConfig.extra entries.
+
+    Implements the apply_yaml_config_fn contract (#24849). The adapter
+    resolves ``imap_host``/``imap_port``/``imap_encryption`` (and the SMTP
+    twins) from env first, then from extra — seeding extra here makes the
+    nested YAML config effective for YAML-only setups (#51263) while env
+    vars keep precedence. SMTP ``encryption`` is deliberately not bridged:
+    ``_connect_smtp()`` selects implicit TLS vs STARTTLS by port, so no
+    adapter consumer exists for it.
+    """
+    extras: dict = {}
+    imap_block = email_cfg.get("imap")
+    if isinstance(imap_block, dict):
+        if "host" in imap_block:
+            extras.setdefault("imap_host", imap_block["host"])
+        if "port" in imap_block:
+            extras.setdefault("imap_port", imap_block["port"])
+        if "encryption" in imap_block:
+            extras.setdefault("imap_encryption", imap_block["encryption"])
+    smtp_block = email_cfg.get("smtp")
+    if isinstance(smtp_block, dict):
+        if "host" in smtp_block:
+            extras.setdefault("smtp_host", smtp_block["host"])
+        if "port" in smtp_block:
+            extras.setdefault("smtp_port", smtp_block["port"])
+    return extras or None
+
+
 def register(ctx) -> None:
     """Plugin entry point — called by the Hermes plugin system."""
     ctx.register_platform(
@@ -1501,6 +1587,7 @@ def register(ctx) -> None:
         is_connected=_is_connected,
         required_env=["EMAIL_ADDRESS", "EMAIL_PASSWORD", "EMAIL_SMTP_HOST"],
         install_hint="Email uses the Python stdlib (smtplib/imaplib) — no extra deps",
+        apply_yaml_config_fn=_apply_yaml_config,
         allowed_users_env="EMAIL_ALLOWED_USERS",
         allow_all_env="EMAIL_ALLOW_ALL_USERS",
         cron_deliver_env_var="EMAIL_HOME_ADDRESS",

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -1482,5 +1482,81 @@ class TestConnectionConfigResolution(unittest.TestCase):
             self.assertTrue(check_email_requirements())
 
 
+class TestIMAPEncryptionMode(unittest.TestCase):
+    """Test IMAP connection mode selection based on encryption config (#51263)."""
+
+    def _make_adapter(self, **env_overrides):
+        """Create an EmailAdapter with mocked env vars."""
+        from gateway.config import PlatformConfig
+        base_env = {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        }
+        base_env.update(env_overrides)
+        with patch.dict(os.environ, base_env):
+            from plugins.platforms.email.adapter import EmailAdapter
+            adapter = EmailAdapter(PlatformConfig(enabled=True))
+        return adapter
+
+    def test_default_port_993_uses_tls(self):
+        """Default port 993 should use implicit TLS (IMAP4_SSL)."""
+        adapter = self._make_adapter()
+        self.assertEqual(adapter._imap_encryption, "tls")
+
+    def test_port_143_auto_detects_starttls(self):
+        """Port 143 without explicit encryption should auto-detect STARTTLS."""
+        adapter = self._make_adapter(EMAIL_IMAP_PORT="143")
+        self.assertEqual(adapter._imap_encryption, "starttls")
+
+    def test_explicit_starttls_env_var(self):
+        """EMAIL_IMAP_ENCRYPTION=starttls should force STARTTLS mode."""
+        adapter = self._make_adapter(EMAIL_IMAP_ENCRYPTION="starttls")
+        self.assertEqual(adapter._imap_encryption, "starttls")
+
+    def test_explicit_tls_env_var(self):
+        """EMAIL_IMAP_ENCRYPTION=tls should force implicit TLS mode."""
+        adapter = self._make_adapter(EMAIL_IMAP_PORT="143", EMAIL_IMAP_ENCRYPTION="tls")
+        self.assertEqual(adapter._imap_encryption, "tls")
+
+    def test_starttls_from_extra_dict(self):
+        """imap_encryption in extra dict should be respected."""
+        from gateway.config import PlatformConfig
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        }):
+            config = PlatformConfig(enabled=True, extra={"imap_encryption": "start-tls"})
+            from plugins.platforms.email.adapter import EmailAdapter
+            adapter = EmailAdapter(config)
+        self.assertEqual(adapter._imap_encryption, "starttls")
+
+    def test_connect_imap_starttls(self):
+        """_connect_imap should use IMAP4 + starttls for STARTTLS mode."""
+        adapter = self._make_adapter(EMAIL_IMAP_PORT="143")
+        with patch("plugins.platforms.email.adapter.imaplib.IMAP4") as mock_imap4,              patch("plugins.platforms.email.adapter.ssl.create_default_context") as mock_ctx:
+            mock_ctx.return_value = "fake_ctx"
+            mock_instance = mock_imap4.return_value
+            result = adapter._connect_imap()
+            mock_imap4.assert_called_once_with("imap.test.com", 143, timeout=30)
+            mock_instance.starttls.assert_called_once_with(ssl_context="fake_ctx")
+            self.assertIs(result, mock_instance)
+
+    def test_connect_imap_implicit_tls(self):
+        """_connect_imap should use IMAP4_SSL for implicit TLS mode."""
+        adapter = self._make_adapter()
+        with patch("plugins.platforms.email.adapter.imaplib.IMAP4_SSL") as mock_imap4ssl,              patch("plugins.platforms.email.adapter.ssl.create_default_context") as mock_ctx:
+            mock_ctx.return_value = "fake_ctx"
+            mock_instance = mock_imap4ssl.return_value
+            result = adapter._connect_imap()
+            mock_imap4ssl.assert_called_once_with(
+                "imap.test.com", 993, timeout=30, ssl_context="fake_ctx",
+            )
+            self.assertIs(result, mock_instance)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -1122,5 +1122,186 @@ class TestSenderAuthentication(unittest.TestCase):
         self.assertFalse(ok, reason)
 
 
+class TestIMAPEncryptionMode(unittest.TestCase):
+    """Test IMAP connection mode selection based on encryption config (#51263)."""
+
+    def _make_adapter(self, **env_overrides):
+        """Create an EmailAdapter with mocked env vars."""
+        from gateway.config import PlatformConfig
+        base_env = {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        }
+        base_env.update(env_overrides)
+        with patch.dict(os.environ, base_env):
+            from plugins.platforms.email.adapter import EmailAdapter
+            adapter = EmailAdapter(PlatformConfig(enabled=True))
+        return adapter
+
+    def test_default_port_993_uses_tls(self):
+        """Default port 993 should use implicit TLS (IMAP4_SSL)."""
+        adapter = self._make_adapter()
+        self.assertEqual(adapter._imap_encryption, "tls")
+
+    def test_port_143_auto_detects_starttls(self):
+        """Port 143 without explicit encryption should auto-detect STARTTLS."""
+        adapter = self._make_adapter(EMAIL_IMAP_PORT="143")
+        self.assertEqual(adapter._imap_encryption, "starttls")
+
+    def test_explicit_starttls_env_var(self):
+        """EMAIL_IMAP_ENCRYPTION=starttls should force STARTTLS mode."""
+        adapter = self._make_adapter(EMAIL_IMAP_ENCRYPTION="starttls")
+        self.assertEqual(adapter._imap_encryption, "starttls")
+
+    def test_explicit_tls_env_var(self):
+        """EMAIL_IMAP_ENCRYPTION=tls should force implicit TLS mode."""
+        adapter = self._make_adapter(EMAIL_IMAP_PORT="143", EMAIL_IMAP_ENCRYPTION="tls")
+        self.assertEqual(adapter._imap_encryption, "tls")
+
+    def test_starttls_from_extra_dict(self):
+        """imap_encryption in extra dict should be respected."""
+        from gateway.config import PlatformConfig
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        }):
+            config = PlatformConfig(enabled=True, extra={"imap_encryption": "start-tls"})
+            from plugins.platforms.email.adapter import EmailAdapter
+            adapter = EmailAdapter(config)
+        self.assertEqual(adapter._imap_encryption, "starttls")
+
+    def test_connect_imap_starttls(self):
+        """_connect_imap should use IMAP4 + starttls for STARTTLS mode."""
+        adapter = self._make_adapter(EMAIL_IMAP_PORT="143")
+        with patch("plugins.platforms.email.adapter.imaplib.IMAP4") as mock_imap4, \
+                patch("plugins.platforms.email.adapter.ssl.create_default_context") as mock_ctx:
+            mock_ctx.return_value = "fake_ctx"
+            mock_instance = mock_imap4.return_value
+            result = adapter._connect_imap()
+            mock_imap4.assert_called_once_with("imap.test.com", 143, timeout=30)
+            mock_instance.starttls.assert_called_once_with(ssl_context="fake_ctx")
+            self.assertIs(result, mock_instance)
+
+    def test_connect_imap_implicit_tls(self):
+        """_connect_imap should use IMAP4_SSL for implicit TLS mode."""
+        adapter = self._make_adapter()
+        with patch("plugins.platforms.email.adapter.imaplib.IMAP4_SSL") as mock_imap4ssl, \
+                patch("plugins.platforms.email.adapter.ssl.create_default_context") as mock_ctx:
+            mock_ctx.return_value = "fake_ctx"
+            mock_instance = mock_imap4ssl.return_value
+            result = adapter._connect_imap()
+            mock_imap4ssl.assert_called_once_with(
+                "imap.test.com", 993, timeout=30, ssl_context="fake_ctx",
+            )
+            self.assertIs(result, mock_instance)
+
+
+class TestEmailYamlConfigBridge(unittest.TestCase):
+    """Nested ``platforms.email.imap``/``smtp`` YAML must reach the adapter
+    through the email plugin's apply_yaml_config_fn hook.
+
+    This is the end-to-end path the #51263 review asked to be covered: the
+    adapter used to resolve ports only from ``EMAIL_*`` env vars, so a
+    YAML-only ``imap.port: 143`` setup silently kept implicit TLS on 993."""
+
+    _YAML = """\
+platforms:
+  email:
+    enabled: true
+    imap:
+      host: imap.test.com
+      port: 143
+      encryption: start-tls
+    smtp:
+      host: smtp.test.com
+      port: 465
+"""
+
+    def _load_and_build(self, yaml_text=None, env_overrides=None):
+        """Write config.yaml into a temp HERMES_HOME, run the full
+        load_gateway_config() path, and build the adapter from the resulting
+        PlatformConfig — mirroring how the gateway constructs it."""
+        import tempfile
+        from pathlib import Path
+        from gateway.config import load_gateway_config, Platform
+        from plugins.platforms.email.adapter import EmailAdapter
+
+        # Base env satisfies the adapter's required secrets; port/encryption
+        # vars are blanked so the YAML values are what the adapter resolves.
+        env = {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_PORT": "",
+            "EMAIL_SMTP_PORT": "",
+            "EMAIL_IMAP_ENCRYPTION": "",
+        }
+        env.update(env_overrides or {})
+        with tempfile.TemporaryDirectory() as td:
+            home = Path(td) / ".hermes"
+            home.mkdir()
+            (home / "config.yaml").write_text(
+                yaml_text if yaml_text is not None else self._YAML,
+                encoding="utf-8",
+            )
+            with patch.dict(os.environ, {"HERMES_HOME": str(home), **env}):
+                config = load_gateway_config()
+                adapter = EmailAdapter(config.platforms[Platform.EMAIL])
+        return config.platforms[Platform.EMAIL], adapter
+
+    def test_nested_yaml_seeds_extra(self):
+        from gateway.config import Platform
+        pconfig, _ = self._load_and_build()
+        extra = pconfig.extra or {}
+        self.assertEqual(extra.get("imap_port"), 143)
+        self.assertEqual(extra.get("imap_encryption"), "start-tls")
+        self.assertEqual(extra.get("imap_host"), "imap.test.com")
+        self.assertEqual(extra.get("smtp_port"), 465)
+
+    def test_nested_yaml_reaches_adapter_as_starttls(self):
+        """imap.port 143 + encryption start-tls must produce an adapter that
+        connects via plain IMAP4 upgraded with starttls()."""
+        _, adapter = self._load_and_build()
+        self.assertEqual(adapter._imap_port, 143)
+        self.assertEqual(adapter._imap_encryption, "starttls")
+        self.assertEqual(adapter._smtp_port, 465)
+        with patch("plugins.platforms.email.adapter.imaplib.IMAP4") as mock_imap4, \
+                patch("plugins.platforms.email.adapter.imaplib.IMAP4_SSL") as mock_imap4ssl, \
+                patch("plugins.platforms.email.adapter.ssl.create_default_context") as mock_ctx:
+            mock_ctx.return_value = "fake_ctx"
+            adapter._connect_imap()
+            mock_imap4.assert_called_once_with("imap.test.com", 143, timeout=30)
+            mock_imap4.return_value.starttls.assert_called_once_with(
+                ssl_context="fake_ctx",
+            )
+            mock_imap4ssl.assert_not_called()
+
+    def test_env_port_overrides_yaml(self):
+        """EMAIL_IMAP_PORT keeps env > YAML precedence over the bridge. The
+        explicit YAML ``encryption: start-tls`` still wins over port-based
+        auto-detection — only the port itself is overridden."""
+        _, adapter = self._load_and_build(
+            env_overrides={"EMAIL_IMAP_PORT": "993"},
+        )
+        self.assertEqual(adapter._imap_port, 993)
+        self.assertEqual(adapter._imap_encryption, "starttls")
+
+    def test_invalid_yaml_port_falls_back_to_default(self):
+        _, adapter = self._load_and_build(
+            yaml_text=(
+                "platforms:\n"
+                "  email:\n"
+                "    enabled: true\n"
+                "    imap:\n"
+                "      port: 99999\n"
+            ),
+        )
+        self.assertEqual(adapter._imap_port, 993)
+        self.assertEqual(adapter._imap_encryption, "tls")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What does this PR do?

Fixes the email platform adapter's IMAP connection to support STARTTLS mode. Previously, the adapter always used `IMAP4_SSL` (implicit TLS) regardless of the `encryption` config setting, causing `SSL: WRONG_VERSION_NUMBER` when configured with `encryption: start-tls` on port 143.

## Related Issue

Fixes #51263

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/email/adapter.py`: Added `_connect_imap()` method that selects `IMAP4` + `starttls()` for STARTTLS mode or `IMAP4_SSL` for implicit TLS, mirroring the existing `_connect_smtp()` pattern. Reads encryption mode from `EMAIL_IMAP_ENCRYPTION` env var, `extra["imap_encryption"]`, or auto-detects by port (143 → starttls, 993 → tls).
- `plugins/platforms/email/adapter.py`: Replaced hardcoded `imaplib.IMAP4_SSL()` calls in `connect()` and `_fetch_new_messages()` with `self._connect_imap()`.
- `gateway/config.py`: Added bridge for structured YAML config `platforms.email.imap.encryption` → `extra["imap_encryption"]` so the adapter can read the encryption setting from config.yaml's nested `imap` block.
- `tests/gateway/test_email.py`: Added `TestIMAPEncryptionMode` test class with 7 tests covering auto-detection, explicit config, env var override, and mock verification of both IMAP connection modes.

## How to Test

1. Run `python -m pytest tests/gateway/test_email.py -x -q`
2. Observed result: `80 passed in 3.11s` — including 7 new tests in `TestIMAPEncryptionMode` that verify STARTTLS auto-detection for port 143, explicit `EMAIL_IMAP_ENCRYPTION` env var, `extra["imap_encryption"]` config, and correct `IMAP4`/`IMAP4_SSL` selection in `_connect_imap()`.

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.5
