### PR TITLE
fix(nix): support HERMES_PYTHON environment variable

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1253,7 +1253,8 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             )
         argv = [_bash, str(path)]
     else:
-        argv = [sys.executable, str(path)]
+        python_bin = os.environ.get("HERMES_PYTHON", sys.executable)
+        argv = [python_bin, str(path)]
 
     try:
         from tools.environments.local import _sanitize_subprocess_env

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2220,7 +2220,8 @@ def _resolve_hermes_bin() -> Optional[list[str]]:
         import importlib.util
 
         if importlib.util.find_spec("hermes_cli") is not None:
-            return [sys.executable, "-m", "hermes_cli.main"]
+            python_bin = os.environ.get("HERMES_PYTHON", sys.executable)
+            return [python_bin, "-m", "hermes_cli.main"]
     except Exception:
         pass
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7108,7 +7108,8 @@ def _module_hermes_argv() -> list[str]:
     # ``hermes_cli.main`` is the console-script target declared in
     # pyproject.toml, NOT a top-level ``hermes`` package — there is no
     # ``hermes`` package to import.
-    return [sys.executable, "-m", "hermes_cli.main"]
+    python_bin = os.environ.get("HERMES_PYTHON", sys.executable)
+    return [python_bin, "-m", "hermes_cli.main"]
 
 
 def _absolute_hermes_path(path: str) -> str:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9293,7 +9293,8 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
         if (desktop_dir / "package.json").exists() and find_node_executable("npm") and has_desktop_app:
             print("→ Checking if desktop app needs rebuilding...")
-            _desktop_build_cmd = [sys.executable, "-m", "hermes_cli.main", "desktop", "--build-only"]
+            _desktop_python = os.environ.get("HERMES_PYTHON", sys.executable)
+            _desktop_build_cmd = [_desktop_python, "-m", "hermes_cli.main", "desktop", "--build-only"]
             # Stream the build output live (long Electron builds otherwise
             # look hung). On the rare nonzero exit, retry once after waiting
             # again for the venv — this covers a still-settling rebuild window
@@ -11293,8 +11294,9 @@ def cmd_dashboard(args):
             f"Routing to the machine dashboard (profile '{_launch_profile}' "
             f"preselected). Use --isolated for a dedicated per-profile server."
         )
+        _reexec_python = os.environ.get("HERMES_PYTHON", sys.executable)
         reexec_argv = [
-            sys.executable, "-m", "hermes_cli.main",
+            _reexec_python, "-m", "hermes_cli.main",
             "-p", "default",
             "dashboard",
             "--port", str(args.port),
@@ -11335,7 +11337,7 @@ def cmd_dashboard(args):
             proc = subprocess.Popen(reexec_argv, env=env)
             sys.exit(proc.wait())
         else:
-            os.execvpe(sys.executable, reexec_argv, env)
+            os.execvpe(_reexec_python, reexec_argv, env)
 
     # Attach gui.log early so dashboard startup/build failures are captured in
     # the same logs directory as every other Hermes surface.

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1034,8 +1034,9 @@ def seed_profile_skills(profile_dir: Path, quiet: bool = False) -> Optional[dict
         }
     project_root = Path(__file__).parent.parent.resolve()
     try:
+        python_bin = os.environ.get("HERMES_PYTHON", sys.executable)
         result = subprocess.run(
-            [sys.executable, "-c",
+            [python_bin, "-c",
              "import json; from tools.skills_sync import sync_skills; "
              "r = sync_skills(quiet=True); print(json.dumps(r))"],
             env={**os.environ, "HERMES_HOME": str(profile_dir)},

--- a/hermes_cli/relaunch.py
+++ b/hermes_cli/relaunch.py
@@ -141,7 +141,8 @@ def build_relaunch_argv(
     if bin_path:
         argv = [bin_path]
     else:
-        argv = [sys.executable, "-m", "hermes_cli.main"]
+        python_bin = os.environ.get("HERMES_PYTHON", sys.executable)
+        argv = [python_bin, "-m", "hermes_cli.main"]
 
     src = list(original_argv) if original_argv is not None else list(sys.argv[1:])
 

--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -459,7 +459,8 @@ def _uninstall_profile(profile) -> None:
     # 1. Stop and remove this profile's gateway service.
     #    Use `python -m hermes_cli.main` so we don't depend on a `hermes`
     #    wrapper that may be half-removed mid-uninstall.
-    hermes_invocation = [_sys.executable, "-m", "hermes_cli.main", "--profile", name]
+    python_bin = os.environ.get("HERMES_PYTHON", _sys.executable)
+    hermes_invocation = [python_bin, "-m", "hermes_cli.main", "--profile", name]
     for subcmd in ("stop", "uninstall"):
         try:
             subprocess.run(

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2372,7 +2372,8 @@ def _spawn_hermes_action(subcommand: List[str], name: str) -> subprocess.Popen:
         f"\n=== {name} started {time.strftime('%Y-%m-%d %H:%M:%S')} ===\n".encode()
     )
 
-    cmd = [sys.executable, "-m", "hermes_cli.main", *subcommand]
+    python_bin = os.environ.get("HERMES_PYTHON", sys.executable)
+    cmd = [python_bin, "-m", "hermes_cli.main", *subcommand]
 
     popen_kwargs: Dict[str, Any] = {
         "cwd": str(PROJECT_ROOT),

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8815,8 +8815,9 @@ def _(rid, params: dict) -> dict:
     if hint:
         return _ok(rid, {"blocked": True, "hint": hint, "code": -1, "output": ""})
     try:
+        python_bin = os.environ.get("HERMES_PYTHON", sys.executable)
         r = subprocess.run(
-            [sys.executable, "-m", "hermes_cli.main", *argv],
+            [python_bin, "-m", "hermes_cli.main", *argv],
             capture_output=True,
             text=True,
             timeout=min(int(params.get("timeout", 240)), 600),


### PR DESCRIPTION
Allows overriding the Python executable used for subprocesses and re-executions, falling back to `sys.executable` if not set. This is relevant for Nix-based installations, where a wrapper script sets `HERMES_PYTHON` to point to a different Python than the one resolved under `sys.executable`.

## What does this PR do?

When restarting the gateway from the dashboard, the following error appears.

```
=== gateway-restart started 2026-06-23 <redacted> ===
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "<redacted>/lib/python3.13/site-packages/hermes_cli/main.py", line 400, in <module>
    from hermes_cli.config import get_hermes_home
  File "<redacted>/lib/python3.13/site-packages/hermes_cli/config.py", line 290, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'
```

I found that this was due to the system python being used, instead of the environment specified under the wrapper as `HERMES_PYTHON`.

The changes in the PR fix this by changing affected `sys.executable` callsites to use `HERMES_PYTHON`.


## Related Issue

N/A -- this is a small bugfix specific to certain Nix-based configurations.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

See diff.

## How to Test

On NixOS 26.05 with the provided Hermes Agent flake.
1. Configure `services.hermes-agent` per the recommended defaults.
2. Start the dashboard from `inputs.hermes-agent.packages`.
3. Click 'restart gateway' on the dashboard.


## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] ~I've added tests for my changes~
- [x] I've tested on my platform: NixOS 26.05

### Documentation & Housekeeping

- [x] ~I've updated relevant documentation (README, `docs/`, docstrings) — or~ N/A
- [x] ~I've updated `cli-config.yaml.example` if I added/changed config keys — or~ N/A
- [x] ~I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or~ N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) ~— or N/A~
- [x] ~I've updated tool descriptions/schemas if I changed tool behavior — or~ N/A

## Screenshots / Logs

There is no anomalous behavior.

## Discussion

Alternatively, the dashboard could be started in a way that lets `sys.executable` already be the same Python as `HERMES_PYTHON`, which depends on how the user has configured their system.


