### PR TITLE
fix(tui): open session model picker from model session flag

### DIFF
--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createSlashHandler } from '../app/createSlashHandler.js'
-import { getOverlayState, resetOverlayState } from '../app/overlayStore.js'
+import { closeModelPicker, getOverlayState, resetOverlayState } from '../app/overlayStore.js'
 import { DASHBOARD_EXIT_DISABLED_MESSAGE, DASHBOARD_UPDATE_DISABLED_MESSAGE } from '../app/slash/commands/core.js'
 import { getUiState, patchUiState, resetUiState } from '../app/uiStore.js'
 import type * as EnvModule from '../config/env.js'
@@ -206,7 +206,23 @@ describe('createSlashHandler', () => {
 
     expect(createSlashHandler(ctx)('/model --refresh')).toBe(true)
     expect(getOverlayState().modelPicker).toEqual({ refresh: true })
+    expect(getOverlayState().modelPickerSessionOnly).toBe(false)
     expect(ctx.gateway.rpc).not.toHaveBeenCalled()
+  })
+
+  it('clears session-only picker state after dismissal before opening a refreshed picker', () => {
+    patchUiState({ sid: 'sid-abc' })
+    const ctx = buildCtx()
+
+    createSlashHandler(ctx)('/model --session')
+    expect(getOverlayState().modelPickerSessionOnly).toBe(true)
+
+    closeModelPicker()
+    expect(getOverlayState().modelPickerSessionOnly).toBe(false)
+
+    createSlashHandler(ctx)('/model --refresh')
+    expect(getOverlayState().modelPicker).toEqual({ refresh: true })
+    expect(getOverlayState().modelPickerSessionOnly).toBe(false)
   })
 
   it('honors TUI picker session scope without adding --global', async () => {
@@ -228,6 +244,16 @@ describe('createSlashHandler', () => {
       session_id: 'sid-abc',
       value: 'anthropic/claude-sonnet-4.6 --provider openrouter --session'
     })
+  })
+
+  it('opens a session-only model picker for /model --session', () => {
+    patchUiState({ sid: 'sid-abc' })
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/model --session')).toBe(true)
+    expect(getOverlayState().modelPicker).toBe(true)
+    expect(getOverlayState().modelPickerSessionOnly).toBe(true)
+    expect(ctx.gateway.rpc).not.toHaveBeenCalled()
   })
 
   it('does not duplicate --global for explicit persistent model switches', () => {

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -293,6 +293,7 @@ export interface OverlayState {
   widget: ActiveWidget | null
   journey: boolean
   modelPicker: boolean | { refresh?: boolean }
+  modelPickerSessionOnly: boolean
   pager: null | PagerState
   petPicker: boolean
   pluginsHub: boolean

--- a/ui-tui/src/app/overlayStore.ts
+++ b/ui-tui/src/app/overlayStore.ts
@@ -13,6 +13,7 @@ const buildOverlayState = (): OverlayState => ({
   widget: null,
   journey: false,
   modelPicker: false,
+  modelPickerSessionOnly: false,
   pager: null,
   petPicker: false,
   pluginsHub: false,
@@ -70,6 +71,9 @@ export const getOverlayState = () => $overlayState.get()
 export const patchOverlayState = (next: Partial<OverlayState> | ((state: OverlayState) => OverlayState)) =>
   $overlayState.set(typeof next === 'function' ? next($overlayState.get()) : { ...$overlayState.get(), ...next })
 
+/** Close the picker and discard scope that only applies to its active selection. */
+export const closeModelPicker = () => patchOverlayState({ modelPicker: false, modelPickerSessionOnly: false })
+
 /** Full reset — used by session/turn teardown and tests. */
 export const resetOverlayState = () => $overlayState.set(buildOverlayState())
 
@@ -90,6 +94,7 @@ export const resetFlowOverlays = () =>
     widget: $overlayState.get().widget,
     journey: $overlayState.get().journey,
     modelPicker: $overlayState.get().modelPicker,
+    modelPickerSessionOnly: $overlayState.get().modelPickerSessionOnly,
     petPicker: $overlayState.get().petPicker,
     pluginsHub: $overlayState.get().pluginsHub,
     sessions: $overlayState.get().sessions,

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -77,6 +77,8 @@ const reasoningConfigPayload = (arg: string, sid: string) => {
   }
 }
 
+const opensSessionModelPicker = (arg: string) => arg.trim() === '--session'
+
 export const sessionCommands: SlashCommand[] = [
   {
     aliases: ['bg', 'btw'],
@@ -108,12 +110,12 @@ export const sessionCommands: SlashCommand[] = [
         return
       }
 
-      if (!arg.trim()) {
-        return patchOverlayState({ modelPicker: true })
+      if (!arg.trim() || opensSessionModelPicker(arg)) {
+        return patchOverlayState({ modelPicker: true, modelPickerSessionOnly: opensSessionModelPicker(arg) })
       }
 
       if (arg.trim() === '--refresh') {
-        return patchOverlayState({ modelPicker: { refresh: true } })
+        return patchOverlayState({ modelPicker: { refresh: true }, modelPickerSessionOnly: false })
       }
 
       const switchModel = (confirmExpensiveModel = false) =>

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -25,7 +25,7 @@ import {
   type InputHandlerResult,
   type OverlayState
 } from './interfaces.js'
-import { $isBlocked, $overlayState, patchOverlayState } from './overlayStore.js'
+import { $isBlocked, $overlayState, closeModelPicker, patchOverlayState } from './overlayStore.js'
 import { turnController } from './turnController.js'
 import { patchTurnState } from './turnStore.js'
 import { getUiState } from './uiStore.js'
@@ -188,7 +188,7 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
     }
 
     if (overlay.modelPicker) {
-      return patchOverlayState({ modelPicker: false })
+      return closeModelPicker()
     }
 
     if (overlay.petPicker) {

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -47,7 +47,7 @@ import { createSlashHandler } from './createSlashHandler.js'
 import { planGatewayRecovery } from './gatewayRecovery.js'
 import { getInputSelection } from './inputSelectionStore.js'
 import { type GatewayRpc, type TranscriptRow } from './interfaces.js'
-import { $overlayState, patchOverlayState } from './overlayStore.js'
+import { $overlayState, closeModelPicker, patchOverlayState } from './overlayStore.js'
 import { $goodVibesTick } from './petFlashStore.js'
 import { scrollWithSelectionBy } from './scroll.js'
 import { turnController } from './turnController.js'
@@ -994,7 +994,7 @@ export function useMainApp(gw: GatewayClient) {
   )
 
   const onModelSelect = useCallback((value: string) => {
-    patchOverlayState({ modelPicker: false })
+    closeModelPicker()
     slashRef.current(`/model ${value}`)
   }, [])
 

--- a/ui-tui/src/components/appOverlays.tsx
+++ b/ui-tui/src/components/appOverlays.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from 'react'
 
 import { useGateway } from '../app/gatewayContext.js'
 import type { AppOverlaysProps } from '../app/interfaces.js'
-import { $overlayState, patchOverlayState } from '../app/overlayStore.js'
+import { $overlayState, closeModelPicker, patchOverlayState } from '../app/overlayStore.js'
 import { $uiSessionId, $uiTheme } from '../app/uiStore.js'
 
 import { ActiveSessionSwitcher } from './activeSessionSwitcher.js'
@@ -248,10 +248,11 @@ export function FloatingOverlays({
       render: width => (
         <FloatBox color={theme.color.border}>
           <ModelPicker
+            allowPersistGlobal={!overlay.modelPickerSessionOnly}
             gw={gw}
             initialRefresh={initialRefresh}
             maxWidth={width}
-            onCancel={() => patchOverlayState({ modelPicker: false })}
+            onCancel={closeModelPicker}
             onSelect={onModelSelect}
             sessionId={sid}
             t={theme}


### PR DESCRIPTION
## What does this PR do?

Makes the TUI `/model --session` command open the model picker in session-only mode instead of treating `--session` as a model name.

The picker continues using main's shared `sessionScopedModelArg()` normalizer, so picker selections translate the internal `--tui-session` marker to the backend `--session` flag.

## Related Issue

Fixes #51279

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Open a session-only picker for `/model --session` and disable global persistence there.
- Reset session-only picker state through every close path, including Ctrl-C, picker cancel, and selection.
- Clear forced session-only state before `/model --refresh` opens its picker.
- Preserve main's `sessionScopedModelArg()` normalization rather than duplicating marker parsing.
- Add regression coverage for session-picker opening and dismissal followed by refresh.

## How to Test

```text
npm --prefix ui-tui test -- createSlashHandler.test.ts useInputHandlers.test.ts modelPicker.test.ts
# 3 files passed, 96 tests passed

npm --prefix ui-tui run typecheck
# passed

npm --prefix ui-tui run build
# passed

git diff --check upstream/main..HEAD
# passed

python3 scripts/check-windows-footguns.py --diff upstream/main
# passed
```

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] My PR contains only changes related to this fix.
- [ ] I've run `pytest tests/ -q` and all tests pass (not applicable to this TUI-only change).
- [x] I've added tests for my changes.
- [x] I've tested on Linux.

### Documentation & Housekeeping

- [x] Documentation/config/schema updates are N/A.
- [x] I've considered cross-platform impact.
