### PR TITLE
fix(auxiliary): prefer resolved model over main-model prefill in auto mode (#51278)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3689,7 +3689,15 @@ def resolve_provider_client(
                 "Dropping OpenRouter-format model %r for non-OpenRouter "
                 "auxiliary provider (using %r instead)", model, resolved)
             model = None
-        final_model = model or resolved
+        # Prefer the model resolved by _resolve_auto (from fallback chain)
+        # over the model pre-filled at the top of this function.  When
+        # provider is "auto" and the caller passed model=None, the
+        # pre-fill step substitutes the *main* session model (e.g.
+        # "MiniMax-M3"), but _resolve_auto may have landed on a different
+        # provider (e.g. DeepSeek) whose correct model is in ``resolved``.
+        # Using the pre-filled main model on the wrong endpoint causes
+        # HTTP 400 "Model Not Exist" errors (GH #51278).
+        final_model = resolved if resolved else model
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                 else (client, final_model))
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3993,6 +3993,64 @@ class TestAuxUnhealthyCache:
             assert _is_provider_unhealthy("openrouter") is True
 
 
+class TestAutoModelResolution:
+    """Regression: provider='auto' must prefer the model resolved by
+    _resolve_auto over the main-model pre-fill (GH #51278)."""
+
+    def test_auto_prefers_resolved_model_over_main_model_prefill(self):
+        """When provider='auto' and model=None, the model returned by
+        _resolve_auto (from fallback chain) must win over the main
+        session model that gets pre-filled at the top of
+        resolve_provider_client.
+
+        Reproduces GH #51278: title generation sends "MiniMax-M3" to
+        DeepSeek's endpoint instead of "deepseek-v4-flash" because the
+        main model pre-fill takes priority over _resolve_auto's result.
+        """
+        fallback_client = MagicMock()
+        with patch("agent.auxiliary_client._resolve_auto",
+                    return_value=(fallback_client, "deepseek-v4-flash")), \
+             patch("agent.auxiliary_client._get_aux_model_for_provider",
+                    return_value=""), \
+             patch("agent.auxiliary_client._read_main_model",
+                    return_value="MiniMax-M3"):
+            client, model = resolve_provider_client("auto")
+        assert client is fallback_client
+        assert model == "deepseek-v4-flash"
+
+    def test_auto_falls_back_to_prefill_when_resolved_model_empty(self):
+        """When _resolve_auto returns no model, the pre-filled model
+        (from _get_aux_model_for_provider or _read_main_model) should
+        still be used as a fallback."""
+        fallback_client = MagicMock()
+        with patch("agent.auxiliary_client._resolve_auto",
+                    return_value=(fallback_client, None)), \
+             patch("agent.auxiliary_client._get_aux_model_for_provider",
+                    return_value=""), \
+             patch("agent.auxiliary_client._read_main_model",
+                    return_value="gpt-4o-mini"):
+            client, model = resolve_provider_client("auto")
+        assert client is fallback_client
+        assert model == "gpt-4o-mini"
+
+    def test_auto_prefers_resolved_over_explicit_model_openrouter_format(self):
+        """When auto lands on a non-OpenRouter provider, an OpenRouter-
+        format model is dropped and resolved wins (existing behavior
+        preserved by this fix)."""
+        fallback_client = MagicMock()
+        with patch("agent.auxiliary_client._resolve_auto",
+                    return_value=(fallback_client, "deepseek-v4-flash")), \
+             patch("agent.auxiliary_client._get_aux_model_for_provider",
+                    return_value=""), \
+             patch("agent.auxiliary_client._read_main_model",
+                    return_value="MiniMax-M3"):
+            # Explicit OpenRouter-format model should be dropped
+            client, model = resolve_provider_client(
+                "auto", model="google/gemini-3-flash-preview")
+        assert client is fallback_client
+        assert model == "deepseek-v4-flash"
+
+
 # ── auxiliary_max_tokens_param ──────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes title generation (and other auxiliary tasks) sending the main session model name to a fallback provider's endpoint when `provider: auto` resolution lands on a different provider via the fallback chain. The root cause is that the universal model pre-fill at the top of `resolve_provider_client()` substitutes the main model (e.g. "MiniMax-M3") before `_resolve_auto()` runs, and the auto branch then prefers the pre-filled model over the correctly resolved fallback model.

## Related Issue

Fixes #51278

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py`: In the `provider == "auto"` branch of `resolve_provider_client()`, change `final_model = model or resolved` to `final_model = resolved if resolved else model` so the model returned by `_resolve_auto()` (from the fallback chain) takes priority over the main-model pre-fill. Added comment explaining the precedence logic and referencing GH #51278.
- `tests/agent/test_auxiliary_client.py`: Added `TestAutoModelResolution` class with 3 regression tests: (1) resolved model wins over main-model prefill, (2) prefill is used when resolved is empty, (3) OpenRouter-format model is correctly dropped when auto lands on non-OpenRouter provider.

## How to Test

1. Run `python -m pytest tests/agent/test_auxiliary_client.py::TestAutoModelResolution -x -v`
2. Observed result: `3 passed in 0.50s` — all three regression tests pass:
   - `test_auto_prefers_resolved_model_over_main_model_prefill` — verifies "deepseek-v4-flash" wins over "MiniMax-M3"
   - `test_auto_falls_back_to_prefill_when_resolved_model_empty` — verifies prefill fallback still works
   - `test_auto_prefers_resolved_over_explicit_model_openrouter_format` — verifies OpenRouter-format drop preserved
3. Full test suite: `python -m pytest tests/agent/test_auxiliary_client.py -x -q`
4. Observed result: `228 passed, 1 warning in 10.59s` — no regressions

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.5
