### PR TITLE
fix(browser): skip Chromium install for cloud setup

### DIFF
--- a/hermes_cli/subcommands/tools.py
+++ b/hermes_cli/subcommands/tools.py
@@ -83,13 +83,14 @@ def build_tools_parser(subparsers, *, cmd_tools: Callable) -> None:
             "needs extra dependencies (browser Chromium, Camofox, cua-driver,\n"
             "KittenTTS/Piper, ddgs, Spotify, Langfuse, xAI). Stable,\n"
             "non-interactive target the dashboard spawns to drive backend\n"
-            "setup. Keys: agent_browser, camofox, cua_driver, kittentts,\n"
-            "piper, ddgs, spotify, langfuse, xai_grok."
+            "setup. Keys: agent_browser, agent_browser_cli, camofox,\n"
+            "cua_driver, kittentts, piper, ddgs, spotify, langfuse,\n"
+            "xai_grok."
         ),
     )
     tools_postsetup_p.add_argument(
         "post_setup_key",
         metavar="KEY",
-        help="Post-setup hook key (e.g. agent_browser, camofox, kittentts)",
+        help="Post-setup hook key (e.g. agent_browser, agent_browser_cli, kittentts)",
     )
     tools_parser.set_defaults(func=cmd_tools)

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -474,7 +474,7 @@ TOOL_CATEGORIES = {
                 "requires_nous_auth": True,
                 "managed_nous_feature": "browser",
                 "override_env_vars": ["BROWSER_USE_API_KEY"],
-                "post_setup": "agent_browser",
+                "post_setup": "agent_browser_cli",
             },
             {
                 "name": "Camofox",
@@ -898,7 +898,9 @@ def _run_cua_driver_installer(label: str = "Installing", verbose: bool = True) -
 def _run_post_setup(post_setup_key: str):
     """Run post-setup hooks for tools that need extra installation steps."""
     import shutil
-    if post_setup_key in {"agent_browser", "browserbase"}:
+    # agent_browser_cli is for cloud browser providers: install the shared
+    # npm package/CLI, but skip the local Chromium payload below.
+    if post_setup_key in {"agent_browser", "agent_browser_cli", "browserbase"}:
         node_modules = PROJECT_ROOT / "node_modules" / "agent-browser"
         npm_bin = shutil.which("npm")
         npx_bin = shutil.which("npx")

--- a/plugins/browser/browser_use/provider.py
+++ b/plugins/browser/browser_use/provider.py
@@ -313,5 +313,5 @@ class BrowserUseBrowserProvider(BrowserProvider):
                     "url": "https://browser-use.com",
                 },
             ],
-            "post_setup": "agent_browser",
+            "post_setup": "agent_browser_cli",
         }

--- a/plugins/browser/browserbase/provider.py
+++ b/plugins/browser/browserbase/provider.py
@@ -293,5 +293,5 @@ class BrowserbaseBrowserProvider(BrowserProvider):
                     "prompt": "Browserbase project ID",
                 },
             ],
-            "post_setup": "agent_browser",
+            "post_setup": "agent_browser_cli",
         }

--- a/plugins/browser/firecrawl/provider.py
+++ b/plugins/browser/firecrawl/provider.py
@@ -167,5 +167,5 @@ class FirecrawlBrowserProvider(BrowserProvider):
                     "url": "https://firecrawl.dev",
                 },
             ],
-            "post_setup": "agent_browser",
+            "post_setup": "agent_browser_cli",
         }

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -708,6 +708,67 @@ def test_local_browser_provider_is_saved_explicitly(monkeypatch):
     assert config["browser"]["cloud_provider"] == "local"
 
 
+def test_browser_post_setup_hooks_separate_local_and_cloud_rows():
+    providers = TOOL_CATEGORIES["browser"]["providers"]
+    local_provider = next(
+        provider for provider in providers if provider.get("browser_provider") == "local"
+    )
+    managed_cloud_provider = next(
+        provider
+        for provider in providers
+        if provider.get("browser_provider") == "browser-use"
+    )
+
+    assert local_provider["post_setup"] == "agent_browser"
+    assert managed_cloud_provider["post_setup"] == "agent_browser_cli"
+
+
+def test_configure_cloud_browser_provider_skips_local_chromium_install(
+    monkeypatch, tmp_path
+):
+    calls = []
+
+    def fake_run(cmd, *args, **kwargs):
+        calls.append(list(cmd))
+        if cmd[0] == "/fake/bin/npm":
+            node_modules = tmp_path / "node_modules" / "agent-browser"
+            node_modules.mkdir(parents=True)
+            local_bin = tmp_path / "node_modules" / ".bin"
+            local_bin.mkdir(parents=True)
+            (local_bin / "agent-browser").write_text("#!/bin/sh\n", encoding="utf-8")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("hermes_cli.tools_config.PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(
+        "shutil.which",
+        lambda name: f"/fake/bin/{name}" if name in {"npm", "npx"} else None,
+    )
+    monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "hermes_cli.tools_config.get_env_value",
+        lambda key: "fake-key" if key == "FIRECRAWL_API_KEY" else None,
+    )
+    monkeypatch.setattr("hermes_cli.tools_config._print_success", lambda msg: None)
+    monkeypatch.setattr("hermes_cli.tools_config._print_info", lambda msg: None)
+    monkeypatch.setattr("hermes_cli.tools_config._print_warning", lambda msg: None)
+    monkeypatch.setattr("tools.browser_tool._chromium_installed", lambda: False)
+    monkeypatch.setattr("tools.browser_tool._running_in_docker", lambda: False)
+
+    provider = {
+        "name": "Firecrawl",
+        "browser_provider": "firecrawl",
+        "env_vars": [{"key": "FIRECRAWL_API_KEY", "prompt": "Firecrawl API key"}],
+        "post_setup": "agent_browser_cli",
+    }
+
+    _configure_provider(provider, {}, force_fresh=True)
+
+    assert [cmd for cmd in calls if cmd[:2] == ["/fake/bin/npm", "install"]] == [
+        ["/fake/bin/npm", "install", "--silent", "--workspaces=false"]
+    ]
+    assert [cmd for cmd in calls if "install" in cmd and "--with-deps" in cmd] == []
+
+
 def test_fresh_install_browser_default_is_free_local_not_paid_nous():
     """On a fresh install the browser picker must default to the free local
     backend, never the paid Nous Subscription gateway.
@@ -1540,5 +1601,3 @@ def test_real_configurable_changes_still_reported_in_diff():
     # User adds 'vision' (configurable) — must still report as added.
     new_enabled2 = (current - {"kanban"}) | {"vision"}
     assert ((new_enabled2 - current) & universe) == {"vision"}
-
-

--- a/tests/plugins/browser/test_browser_provider_plugins.py
+++ b/tests/plugins/browser/test_browser_provider_plugins.py
@@ -115,9 +115,9 @@ class TestBundledPluginsRegister:
         assert isinstance(schema, dict)
         assert "name" in schema
         assert "env_vars" in schema
-        # Every cloud-browser plugin needs the agent-browser post-setup hook
-        # so the picker auto-installs the CLI on selection.
-        assert schema.get("post_setup") == "agent_browser"
+        # Cloud-browser plugins need the agent-browser CLI package, but not
+        # the local Chromium install that the local browser provider uses.
+        assert schema.get("post_setup") == "agent_browser_cli"
 
     @pytest.mark.parametrize(
         "plugin_name",
@@ -359,13 +359,12 @@ class TestPickerIntegration:
         assert names == ["browser-use", "browserbase", "firecrawl"]
 
     def test_picker_rows_carry_post_setup_hook(self) -> None:
-        """Every browser plugin row has post_setup='agent_browser' so
-        selecting it triggers the agent-browser CLI install."""
+        """Every browser plugin row carries the cloud-safe agent-browser hook."""
         _ensure_plugins_loaded()
         from hermes_cli.tools_config import _plugin_browser_providers
 
         for row in _plugin_browser_providers():
-            assert row.get("post_setup") == "agent_browser", (
+            assert row.get("post_setup") == "agent_browser_cli", (
                 f"plugin row {row['browser_provider']!r} missing post_setup hook"
             )
 


### PR DESCRIPTION
## Summary
- split browser post-setup so cloud providers install only the shared agent-browser CLI package
- keep local browser on the existing Chromium install path
- move Browser Use, Browserbase, Firecrawl, and managed Nous Browser Use to the cloud-safe hook

Fixes #51237

## Testing
- `uv run pytest tests/hermes_cli/test_tools_config.py -q`
- `uv run pytest tests/plugins/browser/test_browser_provider_plugins.py -q`
- `uv run pytest tests/hermes_cli/test_dashboard_admin_endpoints.py::TestToolsConfigEndpoints::test_post_setup_spawns_action tests/hermes_cli/test_web_server_profile_unification.py::TestProfileScopedPostSetup::test_post_setup_spawns_with_profile_flag tests/hermes_cli/test_web_server_profile_unification.py::TestProfileScopedPostSetup::test_post_setup_without_profile_keeps_legacy_argv -q`
- `git diff --check`