### PR TITLE
fix(error_classifier): add LM Studio pattern for multimodal tool content recovery (#51283)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -202,6 +202,9 @@ _MULTIMODAL_TOOL_CONTENT_PATTERNS = [
     "expected string, got array",
     # Alibaba/DashScope variant
     "tool_call.content must be string",
+    # LM Studio / llama.cpp: schema validation rejects list-type tool content
+    # {"error": "Invalid 'messages' in payload. Please check the structure ..."}
+    "invalid 'messages' in payload",
 ]
 
 # Context overflow patterns

--- a/tests/run_agent/test_multimodal_tool_content_recovery.py
+++ b/tests/run_agent/test_multimodal_tool_content_recovery.py
@@ -263,3 +263,21 @@ class TestRecoveryEndToEndClassification:
         )
         result = classify_api_error(err, provider="alibaba", model="qwen3.5-plus")
         assert result.reason == FailoverReason.multimodal_tool_content_unsupported
+        assert result.retryable is True
+
+    def test_lm_studio_variant_classifies(self):
+        """LM Studio / llama.cpp rejects list-type tool content with a
+        generic schema-validation error that must still match the multimodal
+        tool content recovery path."""
+        err = _FakeApiError(
+            status_code=400,
+            message=(
+                "Error code: 400 - {'error': \"Invalid 'messages' in payload. "
+                "Please check the structure of your 'messages' and try again.\"}"
+            ),
+        )
+        result = classify_api_error(
+            err, provider="custom", model="qwen3.6-27b-mtp"
+        )
+        assert result.reason == FailoverReason.multimodal_tool_content_unsupported
+        assert result.retryable is True


### PR DESCRIPTION
## What does this PR do?

Add LM Studio / llama.cpp's `"Invalid 'messages' in payload"` error to `_MULTIMODAL_TOOL_CONTENT_PATTERNS` so that 400 errors from local vision-capable models trigger the existing reactive multimodal recovery path (strip image parts from tool messages, retry with text-only) instead of falling through to a non-retryable `format_error` that cascades across all providers.

## Related Issue

Fixes #51283

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/error_classifier.py`: Added `"invalid 'messages' in payload"` to `_MULTIMODAL_TOOL_CONTENT_PATTERNS` so LM Studio schema-validation rejections are classified as `multimodal_tool_content_unsupported` (retryable) instead of `format_error` (non-retryable).
- `tests/run_agent/test_multimodal_tool_content_recovery.py`: Added `test_lm_studio_variant_classifies` to lock in the classification for the LM Studio error message, and added `assert result.retryable is True` to the existing `test_alibaba_variant_classifies` for consistency.

## How to Test

1. Run `python -m pytest tests/run_agent/test_multimodal_tool_content_recovery.py -x -q`
2. Observed result: `16 passed in 3.82s` — including the new `test_lm_studio_variant_classifies` which verifies the LM Studio error message `"Invalid 'messages' in payload"` classifies to `FailoverReason.multimodal_tool_content_unsupported` with `retryable=True`.
3. Run `python -m pytest tests/agent/test_error_classifier.py -x -q`
4. Observed result: `161 passed in 2.59s` — full error classifier suite still green.

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.5
