### PR TITLE
feat(desktop): add pink human prompt border

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread.tsx
@@ -970,7 +970,7 @@ const UserMessage: FC<{
   const bubbleClassName = cn(
     USER_BUBBLE_BASE_CLASS,
     'cursor-pointer pr-9 text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground/95 transition-colors',
-    'border-(--ui-stroke-tertiary) hover:border-(--ui-stroke-secondary)'
+    'border-[color-mix(in_srgb,var(--dt-human-prompt-border)_72%,var(--dt-user-bubble-border))] hover:border-[color-mix(in_srgb,var(--dt-human-prompt-border)_92%,transparent)]'
   )
 
   const bubbleContent = hasBody && (
@@ -1718,7 +1718,7 @@ const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sessionId }
           <div
             className={cn(
               USER_BUBBLE_BASE_CLASS,
-              'ui-prompt-input__container relative border-(--ui-stroke-secondary) data-[expanded=true]:min-h-20',
+              'ui-prompt-input__container relative border-[color-mix(in_srgb,var(--dt-human-prompt-border)_72%,var(--dt-user-bubble-border))] data-[expanded=true]:min-h-20',
               COMPOSER_DROP_FADE_CLASS,
               dragActive && COMPOSER_DROP_ACTIVE_CLASS
             )}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -287,6 +287,8 @@
     --dt-ring: var(--ui-stroke-primary);
     --dt-midground: var(--theme-midground);
     --dt-composer-ring: var(--ui-base);
+    /* Kevin's human prompt accent: makes Kevin's own sent prompts/input box easy to find after long replies. */
+    --dt-human-prompt-border: #ff2d73;
     --dt-destructive: #cf2d56;
     --dt-destructive-foreground: #ffffff;
     --dt-sidebar-bg: var(--ui-bg-sidebar);
@@ -1063,13 +1065,13 @@ canvas {
 }
 
 [data-slot='composer-surface'] {
-  border-color: var(--ui-stroke-secondary) !important;
+  border-color: color-mix(in srgb, var(--dt-human-prompt-border) 35%, var(--dt-input)) !important;
 }
 
 /* On focus we don't change the fill — just shift the border ~15% toward the
    foreground, which darkens it in light mode and lightens it in dark mode. */
 [data-slot='composer-surface']:focus-within {
-  border-color: color-mix(in srgb, var(--ui-stroke-secondary) 85%, var(--dt-foreground)) !important;
+  border-color: color-mix(in srgb, var(--dt-human-prompt-border) 75%, transparent) !important;
 }
 
 [data-slot='composer-fade'] {

--- a/docs/hermes-desktop-pink-human-prompt-border.md
+++ b/docs/hermes-desktop-pink-human-prompt-border.md
@@ -1,0 +1,61 @@
+# Hermes Desktop pink human prompt border
+
+Kevin's corrected requirement: make **Kevin's own prompt/message box** in Hermes Desktop visibly identifiable with a persistent hot-pink border. This helps Kevin find the prompt he typed after a long assistant response moves the scroll position downward.
+
+This is not an assistant-answer accent.
+
+## Critical surface distinction
+
+Do not repeat the previous remote-gateway mistake:
+
+- Remote-attached Hermes Desktop GUI still uses the native Desktop renderer/client assets: `apps/desktop/**` in the checkout used by the running Desktop app.
+- Browser dashboard `/chat` uses dashboard/TUI assets: `web/**`, `ui-tui/**`, and `hermes_cli/web_dist/**`.
+
+If Kevin says he is using remote gateway, first verify whether the visible surface is Desktop or browser dashboard. Do not assume server/dashboard files are the target.
+
+## Implementation
+
+Add a Desktop token in `apps/desktop/src/styles.css`:
+
+```css
+--dt-human-prompt-border: #ff2d73;
+```
+
+Apply it to the sent user message bubble and prompt/input container in `apps/desktop/src/components/assistant-ui/thread.tsx`:
+
+```tsx
+'border-[color-mix(in_srgb,var(--dt-human-prompt-border)_72%,var(--dt-user-bubble-border))] hover:border-[color-mix(in_srgb,var(--dt-human-prompt-border)_92%,transparent)]'
+```
+
+```tsx
+'ui-prompt-input__container relative border-[color-mix(in_srgb,var(--dt-human-prompt-border)_72%,var(--dt-user-bubble-border))] data-[expanded=true]:min-h-20'
+```
+
+Patch any unlayered composer override in `apps/desktop/src/styles.css` so it does not mask the pink border:
+
+```css
+[data-slot='composer-surface'] {
+  border-color: color-mix(in srgb, var(--dt-human-prompt-border) 35%, var(--dt-input)) !important;
+}
+
+[data-slot='composer-surface']:focus-within {
+  border-color: color-mix(in srgb, var(--dt-human-prompt-border) 75%, transparent) !important;
+}
+```
+
+## Verification
+
+From `apps/desktop`:
+
+```bash
+npm run typecheck
+npm run build
+```
+
+Then verify the built CSS contains:
+
+```text
+--dt-human-prompt-border:#ff2d73
+```
+
+If the running Windows unpacked app is already open, close/repack or copy the rebuilt `dist/` into the running unpacked app and fully restart Desktop.


### PR DESCRIPTION
Adds a persistent hot-pink border token for the human/user prompt box in Hermes Desktop so Kevin can quickly find his own prompt after long assistant replies.\n\nVerification:\n- npm run typecheck\n- npm run build\n- built CSS contains --dt-human-prompt-border:#ff2d73\n\nNotes:\n- This targets native Desktop apps/desktop, including remote-attached Desktop GUI.\n- This is not a server/dashboard /chat change.