### PR TITLE
fix: use time.monotonic() for duration measurements

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -352,7 +352,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
         agent._codex_stream_last_event_ts = None
         agent._codex_stream_last_progress_ts = None
 
-    _call_start = time.time()
+    _call_start = time.monotonic()
     agent._touch_activity("waiting for non-streaming API response")
 
     t = threading.Thread(target=_call, daemon=True)
@@ -365,12 +365,12 @@ def interruptible_api_call(agent, api_kwargs: dict):
         # Touch activity every ~30s so the gateway's inactivity
         # monitor knows we're alive while waiting for the response.
         if _poll_count % 100 == 0:  # 100 × 0.3s = 30s
-            _elapsed = time.time() - _call_start
+            _elapsed = time.monotonic() - _call_start
             agent._touch_activity(
                 f"waiting for non-streaming response ({int(_elapsed)}s elapsed)"
             )
 
-        _elapsed = time.time() - _call_start
+        _elapsed = time.monotonic() - _call_start
 
         # TTFB detector: the Codex stream has produced no event at all and
         # we're past the first-byte cutoff → the backend opened the

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8840,7 +8840,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
         """Inner handler that runs under the _running_agents sentinel guard."""
-        _msg_start_time = time.time()
+        _msg_start_time = time.monotonic()
         _platform_name = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
         _msg_preview = (event.text or "")[:80].replace("\n", " ")
         _reply_id = getattr(event, "reply_to_message_id", None)
@@ -9645,7 +9645,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "rephrase your question."
                 )
             agent_messages = agent_result.get("messages", [])
-            _response_time = time.time() - _msg_start_time
+            _response_time = time.monotonic() - _msg_start_time
             _api_calls = agent_result.get("api_calls", 0)
             _resp_len = len(response)
             logger.info(
@@ -14234,7 +14234,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Make the HTTP request with SSE streaming -----------------------
         full_response = ""
-        _start = time.time()
+        _start = time.monotonic()
 
         try:
             _timeout = ClientTimeout(total=0, sock_read=1800)
@@ -14323,7 +14323,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 except (asyncio.TimeoutError, asyncio.CancelledError):
                     stream_task.cancel()
 
-        _elapsed = time.time() - _start
+        _elapsed = time.monotonic() - _start
         if not _run_still_current():
             logger.info(
                 "Discarding stale proxy result for %s — generation %d is no longer current",
@@ -16399,7 +16399,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
         ):
             _NOTIFY_INTERVAL = None
-        _notify_start = time.time()
+        _notify_start = time.monotonic()
 
         async def _notify_long_running():
             if _NOTIFY_INTERVAL is None:
@@ -16429,7 +16429,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     session_key, agent_holder[0], _exec_ref
                 ):
                     break
-                _elapsed_mins = int((time.time() - _notify_start) // 60)
+                _elapsed_mins = int((time.monotonic() - _notify_start) // 60)
                 # Include agent activity context if available. Default
                 # heartbeat is terse: elapsed + current tool. Verbose
                 # iteration counter is gated on busy_ack_detail so users

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2967,7 +2967,7 @@ def _on_tool_start(sid: str, tool_call_id: str, name: str, args: dict):
                 session.setdefault("edit_snapshots", {})[tool_call_id] = snapshot
         except Exception:
             pass
-        session.setdefault("tool_started_at", {})[tool_call_id] = time.time()
+        session.setdefault("tool_started_at", {})[tool_call_id] = time.monotonic()
     if _tool_progress_enabled(sid):
         payload = {
             "tool_id": tool_call_id,
@@ -3582,12 +3582,12 @@ def _preview_restart_callbacks(parent: str, task_id: str) -> dict:
             _emit("preview.restart.progress", parent, {"task_id": task_id, "level": level, "text": text})
 
     def tool_start(tool_call_id: str, name: str, args: dict) -> None:
-        started_at[tool_call_id] = time.time()
+        started_at[tool_call_id] = time.monotonic()
         ctx = _tool_ctx(name, args)
         progress(f"Running {name}{f': {ctx}' if ctx else ''}")
 
     def tool_complete(tool_call_id: str, name: str, _args: dict, result: str) -> None:
-        duration_s = time.time() - started_at.get(tool_call_id, time.time())
+        duration_s = time.monotonic() - started_at.get(tool_call_id, time.monotonic())
         summary = _tool_summary(name, result, duration_s) or f"Finished {name}{f' in {_fmt_tool_duration(duration_s)}' if duration_s else ''}"
         output = _preview_tool_result_preview(name, result)
         progress(summary + (f"\n{output}" if output else ""))


### PR DESCRIPTION
## What

Replace `time.time()` with `time.monotonic()` in 8 duration/elapsed calculations across 3 files.

`time.time()` is affected by NTP clock adjustments and manual clock changes, which can produce negative or inflated duration values. `time.monotonic()` is the correct choice for measuring elapsed time.

## Files changed

- **gateway/run.py** (3 pairs): message handling duration, SSE streaming elapsed, long-running notification timer
- **agent/chat_completion_helpers.py** (1 pair): non-streaming API call duration
- **tui_gateway/server.py** (1 pair): tool execution duration display

All instances are duration measurements — no wall-clock timestamps.

## Related

Companion to PR #51065 (agent/tool_executor.py).
