### PR TITLE
fix: add encoding to os.fdopen() calls in agent/

### DIFF
--- a/agent/nous_rate_guard.py
+++ b/agent/nous_rate_guard.py
@@ -117,7 +117,7 @@ def record_nous_rate_limit(
         # Atomic write: write to temp file + rename
         fd, tmp_path = tempfile.mkstemp(dir=state_dir, suffix=".tmp")
         try:
-            with os.fdopen(fd, "w") as f:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
                 json.dump(state, f)
             atomic_replace(tmp_path, path)
         except Exception:

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -627,7 +627,7 @@ def save_allowlist(data: Dict[str, Any]) -> None:
             prefix=f"{p.name}.", suffix=".tmp", dir=str(p.parent),
         )
         try:
-            with os.fdopen(fd, "w") as fh:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
                 fh.write(json.dumps(data, indent=2, sort_keys=True))
             atomic_replace(tmp_path, p)
         except Exception:


### PR DESCRIPTION
## What

Add `encoding="utf-8"` to 2 `os.fdopen(fd, "w")` calls in agent/.

`os.fdopen()` defaults to system locale encoding (`cp1252` on Windows), which can corrupt non-ASCII characters in JSON data.

## Files changed

- **agent/nous_rate_guard.py**: JSON state persistence via `tempfile.mkstemp` + `os.fdopen`
- **agent/shell_hooks.py**: allowlist JSON atomic write via `tempfile.mkstemp` + `os.fdopen`

## Related

Companion to PR #51289 (read_text/write_text encoding fixes).