### PR TITLE
feat(cron): make skip_memory configurable via config.yaml

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2074,7 +2074,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             # Without a workdir, keep cwd context discovery disabled.
             skip_context_files=not bool(_job_workdir),
             load_soul_identity=True,
-            skip_memory=True,  # Cron system prompts would corrupt user representations
+            skip_memory=bool(_cfg.get("cron", {}).get("skip_memory", True)),
             platform="cron",
             session_id=_cron_session_id,
             session_db=_session_db,


### PR DESCRIPTION
## Summary

Currently `skip_memory` is hardcoded to `True` for all cron jobs in `cron/scheduler.py:2077`:

```python
skip_memory=True,  # Cron system prompts would corrupt user representations
```

This prevents users who want scheduled tasks to benefit from conversation memory (e.g., context-aware daily briefings, memory-informed status reports) from opting in.

## Change

Replace the hardcoded value with a config.yaml lookup:

```python
skip_memory=bool(_cfg.get("cron", {}).get("skip_memory", True)),
```

Default remains `True` — zero breaking change for existing setups. Users who want memory context in their cron jobs can set:

```yaml
cron:
  skip_memory: false
```

## Motivation

Some scheduled tasks (e.g., daily self-review, weekly retrospectives) benefit from knowing the user's accumulated preferences and context. The hardcoded `True` forces all cron sessions into a memory-agnostic mode regardless of user intent.

## Test Plan

- [ ] Verified locally: cron jobs run with `skip_memory=true` (default) and `skip_memory=false` without errors
- [ ] Existing cron behavior unchanged when config key is absent