### PR TITLE
fix(auxiliary_client): treat Copilot 400 model_not_supported as a refreshable stale credential

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2614,6 +2614,29 @@ def _is_auth_error(exc: Exception) -> bool:
     return False
 
 
+def _is_stale_copilot_credential_error(exc: Exception) -> bool:
+    """Detect a Copilot ``400 model_not_supported`` that is really a STALE TOKEN.
+
+    A long-lived process (e.g. the Council daemon, or any multi-hour agent) caches
+    a Copilot+Claude client whose bearer token was captured at build time. When
+    GitHub rotates the account's Copilot entitlement, the *cached* token's request
+    starts coming back as ``400 model_not_supported`` even though the model name is
+    valid and the same model succeeds on a freshly-resolved token. This is NOT a
+    real "the model doesn't exist" error: it is a credential-staleness symptom that
+    Copilot surfaces with a 400 instead of a clean 401.
+
+    We classify it narrowly so a genuinely wrong model name (a real 400) does not
+    trigger a pointless refresh loop: the status must be 400 AND the body must carry
+    the ``model_not_supported`` marker. Provider scoping (copilot only) is enforced
+    by the caller, and the downstream retry is single-shot, so there is no loop risk.
+    """
+    status = getattr(exc, "status_code", None)
+    err_lower = str(exc).lower()
+    if status != 400 and "error code: 400" not in err_lower:
+        return False
+    return "model_not_supported" in err_lower or "the requested model is not supported" in err_lower
+
+
 def _is_unsupported_parameter_error(exc: Exception, param: str) -> bool:
     """Detect provider 400s for an unsupported request parameter.
 
@@ -3038,6 +3061,19 @@ def _refresh_provider_credentials(provider: str) -> bool:
 
             creds = resolve_xai_oauth_runtime_credentials(force_refresh=True)
             if not str(creds.get("api_key", "") or "").strip():
+                return False
+            _evict_cached_clients(normalized)
+            return True
+        if normalized == "copilot":
+            # Copilot bearer = the GitHub OAuth/PAT token resolved fresh from the
+            # gh credential store / env / hosts.yml. A long-lived process caches a
+            # client built with a token whose Copilot entitlement later rotated,
+            # so re-resolve the freshest token and evict the cached client; the
+            # next call rebuilds the Copilot+Claude client with the fresh bearer.
+            from hermes_cli.copilot_auth import resolve_copilot_token
+
+            token, _source = resolve_copilot_token()
+            if not str(token or "").strip():
                 return False
             _evict_cached_clients(normalized)
             return True
@@ -5557,7 +5593,19 @@ def call_llm(
                     refreshed_client.chat.completions.create(**kwargs), task)
 
         # ── Auth refresh retry ───────────────────────────────────────
-        if (_is_auth_error(first_err)
+        # Normal auth failures are 401s. Copilot has a quirk: when a long-lived
+        # process holds a cached client whose bearer token's entitlement has
+        # rotated, Copilot returns ``400 model_not_supported`` instead of a clean
+        # 401. Treat that stale-credential 400 as auth-class too, but ONLY for the
+        # copilot provider (so a genuinely wrong model name on another provider is
+        # never mistaken for a refreshable auth error). The retry below is
+        # single-shot, so there is no loop risk.
+        _norm_provider = _normalize_aux_provider(resolved_provider)
+        _is_refreshable_auth = (
+            _is_auth_error(first_err)
+            or (_norm_provider == "copilot" and _is_stale_copilot_credential_error(first_err))
+        )
+        if (_is_refreshable_auth
                 and resolved_provider not in {"auto", "", None}
                 and not client_is_nous):
             if _refresh_provider_credentials(resolved_provider):

--- a/tests/agent/test_stale_copilot_credential.py
+++ b/tests/agent/test_stale_copilot_credential.py
@@ -1,0 +1,78 @@
+"""Regression tests for the stale-Copilot-credential 400 self-heal.
+
+A long-lived process (e.g. the Hermes Council daemon, or any multi-hour agent)
+holds a cached Copilot+Claude client whose bearer token's entitlement later
+rotates. Copilot then returns ``400 model_not_supported`` instead of a clean
+401. Before the fix, ``_is_auth_error`` only matched 401, so the stale-credential
+400 bypassed the refresh+evict+retry path entirely and the cached client looped
+forever. These tests pin the corrected classification.
+"""
+
+from agent.auxiliary_client import (
+    _is_auth_error,
+    _is_stale_copilot_credential_error,
+    _normalize_aux_provider,
+)
+
+
+class _FakeAPIError(Exception):
+    def __init__(self, msg, status_code=None):
+        super().__init__(msg)
+        self.status_code = status_code
+
+
+_COPILOT_400 = (
+    "Error code: 400 - {'error': {'message': 'The requested model is not "
+    "supported.', 'code': 'model_not_supported', 'param': 'model', 'type': "
+    "'invalid_request_error'}}"
+)
+_CODEX_401 = (
+    "Error code: 401 - {'error': {'message': 'Your authentication token has "
+    "been invalidated.', 'code': 'token_invalidated'}}"
+)
+
+
+def test_stale_copilot_400_is_detected():
+    exc = _FakeAPIError(_COPILOT_400, status_code=400)
+    assert _is_stale_copilot_credential_error(exc) is True
+
+
+def test_clean_401_is_not_a_stale_copilot_400():
+    exc = _FakeAPIError(_CODEX_401, status_code=401)
+    assert _is_stale_copilot_credential_error(exc) is False
+
+
+def test_unrelated_400_is_not_stale_credential():
+    exc = _FakeAPIError(
+        "Error code: 400 - {'error': {'message': 'temperature must be <= 2'}}",
+        status_code=400,
+    )
+    assert _is_stale_copilot_credential_error(exc) is False
+
+
+def _refresh_gate(exc, provider):
+    """Mirror the exact gate logic in call_llm's except chain."""
+    norm = _normalize_aux_provider(provider)
+    refreshable = _is_auth_error(exc) or (
+        norm == "copilot" and _is_stale_copilot_credential_error(exc)
+    )
+    return refreshable and provider not in {"auto", "", None}
+
+
+def test_refresh_gate_fires_for_copilot_400():
+    # The bug fix: copilot stale-credential 400 is now refreshable.
+    assert _refresh_gate(_FakeAPIError(_COPILOT_400, status_code=400), "copilot") is True
+
+
+def test_refresh_gate_still_fires_for_401():
+    # No regression: a real 401 still triggers refresh.
+    assert _refresh_gate(_FakeAPIError(_CODEX_401, status_code=401), "copilot") is True
+
+
+def test_refresh_gate_does_not_fire_for_400_on_other_provider():
+    # A genuinely-wrong-model 400 on a non-copilot provider must NOT loop-refresh.
+    assert _refresh_gate(_FakeAPIError(_COPILOT_400, status_code=400), "openrouter") is False
+
+
+def test_refresh_gate_excludes_auto_provider():
+    assert _refresh_gate(_FakeAPIError(_COPILOT_400, status_code=400), "auto") is False


### PR DESCRIPTION
## What this fixes

A long-lived process (for example a daemon that holds a cached client, or any multi-hour agent) builds a Copilot+Claude client with a bearer token captured at startup. When GitHub later rotates that account's Copilot entitlement, the cached token's request starts coming back as `400 model_not_supported` even though the model name is perfectly valid and the same model succeeds on a freshly resolved token.

The existing auth-refresh path is gated on `_is_auth_error`, which only matches `401`. So this stale-credential `400` slipped straight past the refresh+evict+retry logic, and the cached client looped on a doomed request indefinitely.

## The fix

Two narrow additions to `auxiliary_client.py`:

- `_is_stale_copilot_credential_error()` classifies a `400` whose body carries the `model_not_supported` marker as a refreshable stale-credential signal. It's deliberately narrow (status must be 400 **and** the body must carry the marker) so a genuinely wrong model name isn't mistaken for an auth problem.
- `_refresh_provider_credentials()` gains a `copilot` branch that re-resolves the freshest token via `hermes_cli.copilot_auth.resolve_copilot_token` and evicts the cached client. It previously handled codex/nous/anthropic/xai-oauth but not copilot.

The refresh gate in `call_llm` now fires on `_is_auth_error(...)` **or** (`provider == copilot` **and** the stale-credential 400). The copilot scoping means a wrong-model 400 on any other provider can never trigger a refresh loop, and the retry is single-shot, so there's no loop risk.

## Tests

`tests/agent/test_stale_copilot_credential.py` (7 cases): the copilot stale-credential 400 is detected; a clean 401 is not misclassified as one; an unrelated 400 (e.g. a bad temperature) is not; the refresh gate fires for the copilot 400 and still fires for a real 401; a wrong-model 400 on a non-copilot provider does not trigger refresh; the `auto` provider is excluded. The existing `auxiliary_client` suite is unaffected.
