### PR TITLE
fix(tools): invalidate cached terminal environments when runtime backend changes

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -45,6 +45,7 @@ from tools.code_execution_tool import (
     build_execute_code_schema,
     EXECUTE_CODE_SCHEMA,
     _TOOL_DOC_LINES,
+    _get_or_create_env,
     _execute_remote,
 )
 
@@ -141,6 +142,65 @@ class TestHermesToolsGeneration(unittest.TestCase):
 
 
 class TestExecuteCodeRemoteTempDir(unittest.TestCase):
+    def test_get_or_create_env_uses_raw_task_id_fallback(self):
+        """execute_code must reuse raw-key envs created before task collapse."""
+        from tools import terminal_tool as tt
+
+        config = {
+            "env_type": "local",
+            "timeout": 30,
+            "cwd": "/workspace/raw",
+            "host_cwd": None,
+            "modal_mode": "auto",
+            "docker_image": "",
+            "singularity_image": "",
+            "modal_image": "",
+            "daytona_image": "",
+            "docker_mount_cwd_to_workspace": False,
+            "docker_volumes": [],
+            "docker_forward_env": [],
+            "docker_env": {},
+            "docker_run_as_host_user": False,
+            "docker_network": True,
+            "docker_extra_args": [],
+            "docker_persist_across_processes": True,
+            "docker_orphan_reaper": True,
+            "container_cpu": 1,
+            "container_memory": 5120,
+            "container_disk": 51200,
+            "container_persistent": True,
+            "ssh_host": "",
+            "ssh_user": "",
+            "ssh_port": 22,
+            "ssh_key": "",
+            "ssh_persistent": True,
+            "local_persistent": False,
+        }
+        task_id = "raw-session-env"
+        cached_env = MagicMock(name="cached_raw_env")
+        setattr(
+            cached_env,
+            tt._ENV_SIGNATURE_ATTR,
+            tt._terminal_env_signature(config, task_id="default"),
+        )
+        tt._active_environments.clear()
+        tt._last_activity.clear()
+        tt._environment_lease_states.clear()
+        tt._active_environments[task_id] = cached_env
+
+        try:
+            with patch("tools.terminal_tool._get_env_config", return_value=config), \
+                 patch("tools.terminal_tool._create_environment") as create_env:
+                env, env_type = _get_or_create_env(task_id)
+        finally:
+            tt._active_environments.clear()
+            tt._last_activity.clear()
+            tt._environment_lease_states.clear()
+
+        self.assertIs(env, cached_env)
+        self.assertEqual(env_type, "local")
+        create_env.assert_not_called()
+
     def test_execute_remote_uses_backend_temp_dir_for_sandbox(self):
         class FakeEnv:
             def __init__(self):
@@ -161,7 +221,7 @@ class TestExecuteCodeRemoteTempDir(unittest.TestCase):
         fake_thread = MagicMock()
 
         with patch("tools.code_execution_tool._load_config", return_value={"timeout": 30, "max_tool_calls": 5}), \
-             patch("tools.code_execution_tool._get_or_create_env", return_value=(env, "ssh")), \
+             patch("tools.code_execution_tool._get_or_create_env_lease", return_value=(env, "ssh", MagicMock())), \
              patch("tools.code_execution_tool._ship_file_to_remote"), \
              patch("tools.code_execution_tool.threading.Thread", return_value=fake_thread):
             result = json.loads(_execute_remote("print('hello')", "task-1", ["terminal"]))
@@ -202,8 +262,8 @@ class TestExecuteCodeRemoteTempDir(unittest.TestCase):
 
         with patch("tools.code_execution_tool._load_config",
                    return_value={"timeout": 30, "max_tool_calls": 5}), \
-             patch("tools.code_execution_tool._get_or_create_env",
-                   return_value=(env, "ssh")), \
+             patch("tools.code_execution_tool._get_or_create_env_lease",
+                   return_value=(env, "ssh", MagicMock())), \
              patch("tools.code_execution_tool._ship_file_to_remote"), \
              patch("tools.code_execution_tool.threading.Thread",
                    return_value=fake_thread), \
@@ -218,6 +278,29 @@ class TestExecuteCodeRemoteTempDir(unittest.TestCase):
         # shlex.quote wraps values containing special characters in single quotes
         self.assertIn("TZ='US/Eastern; echo PWNED'", run_cmd,
                       "TZ value must be wrapped in single quotes by shlex.quote()")
+
+    def test_remote_execution_releases_lease_when_python_missing(self):
+        """Remote execute_code releases its backend lease on early error returns."""
+        class FakeEnv:
+            def get_temp_dir(self):
+                return "/tmp"
+
+            def execute(self, command, cwd=None, timeout=None):
+                if "command -v python3" in command:
+                    return {"output": "", "returncode": 1}
+                return {"output": "", "returncode": 0}
+
+        lease = MagicMock()
+
+        with patch("tools.code_execution_tool._load_config",
+                   return_value={"timeout": 30, "max_tool_calls": 5}), \
+             patch("tools.code_execution_tool._get_or_create_env_lease",
+                   return_value=(FakeEnv(), "ssh", lease)):
+            result = json.loads(_execute_remote("print('hello')", "task-1", ["terminal"]))
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("Python 3 is not available", result["error"])
+        lease.release.assert_called_once_with()
 
 
 @unittest.skipIf(sys.platform == "win32", "UDS not available on Windows")
@@ -1041,7 +1124,7 @@ for i in range(15000):
         fake_thread = MagicMock()
 
         with patch("tools.code_execution_tool._load_config", return_value={"timeout": 30, "max_tool_calls": 5}), \
-             patch("tools.code_execution_tool._get_or_create_env", return_value=(FakeEnv(), "ssh")), \
+             patch("tools.code_execution_tool._get_or_create_env_lease", return_value=(FakeEnv(), "ssh", MagicMock())), \
              patch("tools.code_execution_tool._ship_file_to_remote"), \
              patch("tools.code_execution_tool.threading.Thread", return_value=fake_thread):
             result = json.loads(_execute_remote("print('large')", "task-1", ["terminal"]))

--- a/tests/tools/test_file_tools_cwd_resolution.py
+++ b/tests/tools/test_file_tools_cwd_resolution.py
@@ -151,20 +151,41 @@ class _DummyDockerEnvironment:
 
 
 def test_container_path_detection_uses_live_docker_environment(monkeypatch):
-    """A live DockerEnvironment-shaped env should beat config fallback."""
+    """A signature-compatible live Docker environment should select container paths."""
+    config = {"env_type": "docker", "cwd": "/workspace"}
+    env = _DummyDockerEnvironment()
+    runtime = terminal_tool.resolve_terminal_runtime_identity(config, raw_task_id="default")
+    setattr(env, terminal_tool._ENV_SIGNATURE_ATTR, runtime["signature"])
     monkeypatch.setattr(
         terminal_tool,
         "_active_environments",
-        {"default": _DummyDockerEnvironment()},
+        {"default": env},
     )
-    monkeypatch.setattr(
-        terminal_tool,
-        "_get_env_config",
-        lambda: (_ for _ in ()).throw(AssertionError("should not read config")),
-    )
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: config)
     monkeypatch.delenv("TERMINAL_ENV", raising=False)
 
     assert ft._uses_container_paths("default") is True
+
+
+def test_container_path_detection_ignores_stale_docker_environment(monkeypatch):
+    """Current runtime config, not a stale cached backend, controls path semantics."""
+    old_config = {"env_type": "docker", "cwd": "/workspace"}
+    current_config = {"env_type": "local", "cwd": "/host/project"}
+    backend = _DummyDockerEnvironment()
+    old_runtime = terminal_tool.resolve_terminal_runtime_identity(
+        old_config,
+        raw_task_id="default",
+    )
+    setattr(backend, terminal_tool._ENV_SIGNATURE_ATTR, old_runtime["signature"])
+    monkeypatch.setattr(
+        terminal_tool,
+        "_active_environments",
+        {"default": backend},
+    )
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: current_config)
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
+    assert ft._uses_container_paths("default") is False
 
 
 def test_resolution_base_always_absolute_no_terminal_cwd(_isolated_cwd, monkeypatch):

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -773,6 +773,40 @@ class TestSpawnEnvSanitization:
         args, kwargs = env.commands[0]
         assert kwargs.get("rewrite_compound_background") is False
 
+    def test_spawn_via_env_kills_remote_process_when_poller_start_fails(self, registry):
+        events = []
+
+        class FakeEnv:
+            def __init__(self):
+                self.commands = []
+
+            def execute(self, command, **kwargs):
+                self.commands.append((command, kwargs))
+                if "nohup bash" in command:
+                    events.append("launch")
+                    return {"output": "4321\n", "returncode": 0}
+                if command == "kill 4321 2>/dev/null":
+                    events.append("kill")
+                    return {"output": "", "returncode": 0}
+                raise AssertionError(f"unexpected command: {command}")
+
+        class FailingThread:
+            def start(self):
+                raise RuntimeError("thread start failed")
+
+        env = FakeEnv()
+        lease = MagicMock()
+        lease.release.side_effect = lambda: events.append("release")
+
+        with patch("tools.process_registry.threading.Thread", return_value=FailingThread()), \
+             patch.object(registry, "_write_checkpoint"):
+            with pytest.raises(RuntimeError, match="thread start failed"):
+                registry.spawn_via_env(env, "echo hello", environment_lease=lease)
+
+        assert events == ["launch", "kill", "release"]
+        assert registry._running == {}
+        lease.release.assert_called_once_with()
+
     def test_env_poller_quotes_temp_paths_with_spaces(self, registry):
         session = _make_session(sid="proc_space")
         session.exited = False

--- a/tests/tools/test_session_cwd_store.py
+++ b/tests/tools/test_session_cwd_store.py
@@ -75,13 +75,13 @@ class TestPostCommandDualWrite:
 
     def _run(self, monkeypatch, task_id, env):
         import json
+        config = {"env_type": "local", "cwd": "/default", "timeout": 60,
+                  "lifetime_seconds": 3600}
+        signature = tt.resolve_terminal_runtime_identity(config, raw_task_id=task_id)["signature"]
+        setattr(env, tt._ENV_SIGNATURE_ATTR, signature)
         monkeypatch.setattr(tt, "_active_environments", {task_id: env})
         monkeypatch.setattr(tt, "_last_activity", {})
-        monkeypatch.setattr(
-            tt, "_get_env_config",
-            lambda: {"env_type": "local", "cwd": "/default", "timeout": 60,
-                     "lifetime_seconds": 3600},
-        )
+        monkeypatch.setattr(tt, "_get_env_config", lambda: config)
         monkeypatch.setattr(
             tt, "_check_all_guards",
             lambda command, env_type, **kwargs: {"approved": True},
@@ -95,7 +95,7 @@ class TestPostCommandDualWrite:
             def execute(self, command, **kwargs):
                 # Simulate the env's own post-command tracking (marker parse).
                 self.cwd = "/new/dir"
-                return {"output": "", "returncode": 0}
+                return {"output": "", "returncode": 0, "cwd": self.cwd}
 
         result = self._run(monkeypatch, "sess-a", FakeEnv())
         assert result["exit_code"] == 0
@@ -130,7 +130,7 @@ class TestFileToolsReadTheRecord:
         monkeypatch.setattr(tt, "_active_environments", {})
 
         # Each session ran commands that recorded its own cwd. No env alive,
-        # no registered overrides — just the records.
+        # no registered overrides - just the records.
         tt.record_session_cwd("sess-a", str(wt_a))
         tt.record_session_cwd("sess-b", str(wt_b))
 
@@ -139,7 +139,7 @@ class TestFileToolsReadTheRecord:
 
     def test_record_beats_foreign_env_cwd_without_ownership_metadata(self, tmp_path, monkeypatch):
         """The leak-A scenario, solved structurally: the shared env's cwd is
-        never consulted for path resolution — only the session's own record."""
+        never consulted for path resolution - only the session's own record."""
         import tools.file_tools as ft
 
         wt_a = tmp_path / "wt_a"
@@ -223,16 +223,16 @@ class TestCommandCwdReadsTheRecord:
                 self.last_cwd_arg = kwargs.get("cwd")
                 if command.startswith("cd "):
                     self.cwd = command[3:]
-                return {"output": "", "returncode": 0}
+                return {"output": "", "returncode": 0, "cwd": self.cwd}
 
         fake = FakeEnv()
+        config = {"env_type": "local", "cwd": "/default", "timeout": 60,
+                  "lifetime_seconds": 3600}
+        signature = tt.resolve_terminal_runtime_identity(config, raw_task_id="sess-a")["signature"]
+        setattr(fake, tt._ENV_SIGNATURE_ATTR, signature)
         monkeypatch.setattr(tt, "_active_environments", {"sess-a": fake})
         monkeypatch.setattr(tt, "_last_activity", {})
-        monkeypatch.setattr(
-            tt, "_get_env_config",
-            lambda: {"env_type": "local", "cwd": "/default", "timeout": 60,
-                     "lifetime_seconds": 3600},
-        )
+        monkeypatch.setattr(tt, "_get_env_config", lambda: config)
         monkeypatch.setattr(
             tt, "_check_all_guards",
             lambda command, env_type, **kwargs: {"approved": True},

--- a/tests/tools/test_terminal_env_signature_cache.py
+++ b/tests/tools/test_terminal_env_signature_cache.py
@@ -1,0 +1,1007 @@
+"""Regression tests for terminal runtime cache invalidation."""
+
+import json
+import threading
+from unittest.mock import MagicMock, patch
+
+
+def _make_env_config(**overrides):
+    config = {
+        "env_type": "local",
+        "timeout": 180,
+        "cwd": "/tmp",
+        "host_cwd": None,
+        "modal_mode": "auto",
+        "docker_image": "",
+        "singularity_image": "",
+        "modal_image": "",
+        "daytona_image": "",
+        "docker_mount_cwd_to_workspace": False,
+        "docker_volumes": [],
+        "docker_forward_env": [],
+        "docker_env": {},
+        "docker_run_as_host_user": False,
+        "docker_network": True,
+        "docker_extra_args": [],
+        "docker_persist_across_processes": True,
+        "docker_orphan_reaper": True,
+        "container_cpu": 1,
+        "container_memory": 5120,
+        "container_disk": 51200,
+        "container_persistent": True,
+        "ssh_host": "",
+        "ssh_user": "",
+        "ssh_port": 22,
+        "ssh_key": "",
+        "ssh_persistent": True,
+        "local_persistent": False,
+    }
+    config.update(overrides)
+    return config
+
+
+def _reset_terminal_cache(tt):
+    tt._active_environments.clear()
+    tt._last_activity.clear()
+    tt._environment_lease_states.clear()
+    tt._creation_locks.clear()
+    tt._task_env_overrides.clear()
+    with tt._session_cwd_lock:
+        tt._session_cwd.clear()
+
+
+def _reset_file_ops_cache(ft):
+    ft._file_ops_cache.clear()
+
+
+def test_terminal_env_cache_invalidates_when_backend_signature_changes(monkeypatch):
+    """A session cached under SSH must not be reused after runtime switches local."""
+    from tools import terminal_tool as tt
+
+    _reset_terminal_cache(tt)
+    monkeypatch.setenv("HERMES_HOME", "/tmp/hermes-default")
+
+    task_id = "session-1"
+    ssh_config = _make_env_config(
+        env_type="ssh",
+        cwd="~",
+        ssh_host="old-ssh.example.test",
+        ssh_user="agent-user",
+    )
+    old_env = MagicMock(name="old_ssh_env")
+    setattr(
+        old_env,
+        tt._ENV_SIGNATURE_ATTR,
+        tt._terminal_env_signature(ssh_config, task_id=task_id),
+    )
+    tt._active_environments[task_id] = old_env
+    tt._last_activity[task_id] = 1
+
+    local_config = _make_env_config(
+        env_type="local",
+        cwd="/workspace/local-project",
+    )
+    new_env = MagicMock(name="new_local_env")
+    new_env.execute.return_value = {"output": "local-host\n", "returncode": 0}
+
+    with patch("tools.terminal_tool._get_env_config", return_value=local_config), \
+         patch("tools.terminal_tool._create_environment", return_value=new_env) as create_env, \
+         patch("tools.terminal_tool._start_cleanup_thread"), \
+         patch("tools.terminal_tool._check_all_guards", return_value={"approved": True}):
+        result = json.loads(tt.terminal_tool("hostname", task_id=task_id))
+
+    assert result["output"] == "local-host"
+    old_env.cleanup.assert_called_once_with()
+    create_env.assert_called_once()
+    assert create_env.call_args.kwargs["env_type"] == "local"
+    assert create_env.call_args.kwargs["cwd"] == "/workspace/local-project"
+    assert tt._active_environments["default"] is new_env
+    assert len(tt._environment_lease_states) == 1
+    assert not next(iter(tt._environment_lease_states.values())).retired
+    assert getattr(new_env, tt._ENV_SIGNATURE_ATTR)["env_type"] == "local"
+    assert getattr(new_env, tt._ENV_SIGNATURE_ATTR)["ssh_host"] == ""
+
+    _reset_terminal_cache(tt)
+
+
+def test_terminal_env_cache_reuses_when_signature_matches(monkeypatch):
+    """Matching runtime signature still preserves the intended per-session cache."""
+    from tools import terminal_tool as tt
+
+    _reset_terminal_cache(tt)
+    monkeypatch.setenv("HERMES_HOME", "/tmp/hermes-default")
+
+    task_id = "session-2"
+    local_config = _make_env_config(env_type="local", cwd="/tmp/project")
+    cached_env = MagicMock(name="cached_local_env")
+    cached_env.execute.return_value = {"output": "ok\n", "returncode": 0}
+    setattr(
+        cached_env,
+        tt._ENV_SIGNATURE_ATTR,
+        tt._terminal_env_signature(local_config, task_id="default"),
+    )
+    tt._active_environments["default"] = cached_env
+    tt._last_activity["default"] = 1
+
+    with patch("tools.terminal_tool._get_env_config", return_value=local_config), \
+         patch("tools.terminal_tool._create_environment") as create_env, \
+         patch("tools.terminal_tool._start_cleanup_thread"), \
+         patch("tools.terminal_tool._check_all_guards", return_value={"approved": True}):
+        result = json.loads(tt.terminal_tool("echo ok", task_id=task_id))
+
+    assert result["output"] == "ok"
+    create_env.assert_not_called()
+    cached_env.cleanup.assert_not_called()
+    assert tt._active_environments["default"] is cached_env
+
+    _reset_terminal_cache(tt)
+
+
+def test_terminal_env_cache_reuses_raw_session_key_when_signature_matches(monkeypatch):
+    """A raw-key cached session remains reusable after cwd-only task collapse."""
+    from tools import terminal_tool as tt
+
+    _reset_terminal_cache(tt)
+    monkeypatch.setenv("HERMES_HOME", "/tmp/hermes-default")
+
+    task_id = "session-raw"
+    local_config = _make_env_config(env_type="local", cwd="/tmp/raw-project")
+    cached_env = MagicMock(name="cached_raw_local")
+    cached_env.execute.return_value = {"output": "raw-ok\n", "returncode": 0}
+    setattr(
+        cached_env,
+        tt._ENV_SIGNATURE_ATTR,
+        tt._terminal_env_signature(local_config, task_id="default"),
+    )
+    tt._active_environments[task_id] = cached_env
+    tt._last_activity[task_id] = 1
+
+    with patch("tools.terminal_tool._get_env_config", return_value=local_config), \
+         patch("tools.terminal_tool._create_environment") as create_env, \
+         patch("tools.terminal_tool._start_cleanup_thread"), \
+         patch("tools.terminal_tool._check_all_guards", return_value={"approved": True}):
+        result = json.loads(tt.terminal_tool("echo raw-ok", task_id=task_id))
+
+    assert result["output"] == "raw-ok"
+    create_env.assert_not_called()
+    cached_env.cleanup.assert_not_called()
+    assert tt._active_environments[task_id] is cached_env
+
+    _reset_terminal_cache(tt)
+
+
+def test_effective_stale_entry_falls_back_to_compatible_raw_session(monkeypatch):
+    """Retiring an incompatible effective entry must still try raw fallback."""
+    from tools import terminal_tool as tt
+
+    _reset_terminal_cache(tt)
+    monkeypatch.setenv("HERMES_HOME", "/tmp/hermes-default")
+
+    task_id = "raw-fallback-session"
+    old_config = _make_env_config(env_type="local", cwd="/tmp/old-default")
+    current_config = _make_env_config(env_type="local", cwd="/tmp/current")
+    stale_default = MagicMock(name="stale_default_env")
+    compatible_raw = MagicMock(name="compatible_raw_env")
+    setattr(
+        stale_default,
+        tt._ENV_SIGNATURE_ATTR,
+        tt._terminal_env_signature(old_config, task_id="default"),
+    )
+    current_signature = tt._terminal_env_signature(current_config, task_id="default")
+    setattr(compatible_raw, tt._ENV_SIGNATURE_ATTR, current_signature)
+    tt._active_environments["default"] = stale_default
+    tt._active_environments[task_id] = compatible_raw
+    tt._last_activity["default"] = 1
+    tt._last_activity[task_id] = 1
+
+    lease = tt._acquire_active_environment_if_compatible(
+        "default",
+        current_signature,
+        raw_task_id=task_id,
+    )
+
+    assert lease is not None
+    assert getattr(lease, "env") is compatible_raw
+    assert "default" not in tt._active_environments
+    assert tt._active_environments[task_id] is compatible_raw
+    stale_default.cleanup.assert_called_once_with()
+    compatible_raw.cleanup.assert_not_called()
+    lease.release()
+    _reset_terminal_cache(tt)
+
+
+def test_file_ops_cache_invalidates_when_backend_signature_changes(monkeypatch):
+    """File tools must not keep ShellFileOperations for a stale backend."""
+    from tools import file_tools as ft
+    from tools import terminal_tool as tt
+
+    _reset_terminal_cache(tt)
+    _reset_file_ops_cache(ft)
+    monkeypatch.setenv("HERMES_HOME", "/tmp/hermes-default")
+
+    ssh_config = _make_env_config(
+        env_type="ssh",
+        cwd="~",
+        ssh_host="old-ssh.example.test",
+        ssh_user="agent-user",
+    )
+    old_backend = MagicMock(name="old_remote")
+    setattr(old_backend, "cwd", "~")
+    setattr(
+        old_backend,
+        tt._ENV_SIGNATURE_ATTR,
+        tt._terminal_env_signature(ssh_config, task_id="default"),
+    )
+    tt._active_environments["default"] = old_backend
+    tt._last_activity["default"] = 1
+    old_file_ops = ft.ShellFileOperations(old_backend)
+    ft._file_ops_cache["default"] = old_file_ops
+
+    local_config = _make_env_config(env_type="local", cwd="/workspace/local-project")
+    new_backend = MagicMock(name="new_local")
+    setattr(new_backend, "cwd", "/workspace/local-project")
+
+    with patch("tools.terminal_tool._get_env_config", return_value=local_config), \
+         patch("tools.terminal_tool._create_environment", return_value=new_backend) as create_env, \
+         patch("tools.terminal_tool._start_cleanup_thread"):
+        file_ops = ft._get_file_ops("session-file")
+
+    old_backend.cleanup.assert_called_once_with()
+    create_env.assert_called_once()
+    assert create_env.call_args.kwargs["env_type"] == "local"
+    assert create_env.call_args.kwargs["cwd"] == "/workspace/local-project"
+    assert getattr(file_ops, "env") is new_backend
+    assert getattr(ft._file_ops_cache["default"], "env") is new_backend
+    assert tt._active_environments["default"] is new_backend
+    assert tt.get_session_cwd("session-file") is None
+    assert len(tt._environment_lease_states) == 1
+    assert not next(iter(tt._environment_lease_states.values())).retired
+    _reset_file_ops_cache(ft)
+    _reset_terminal_cache(tt)
+
+
+def test_file_ops_reresolves_runtime_after_waiting_for_old_creation_lock(monkeypatch):
+    """A stale waiter must not publish an env for the pre-wait effective key."""
+    from tools import file_tools as ft
+    from tools import terminal_tool as tt
+
+    _reset_terminal_cache(tt)
+    _reset_file_ops_cache(ft)
+    monkeypatch.setenv("HERMES_HOME", "/tmp/hermes-default")
+
+    task_id = "isolated-file-task"
+    old_config = _make_env_config(env_type="local", cwd="/tmp/old-generation")
+    current_config = _make_env_config(
+        env_type="docker",
+        cwd="/workspace/current-generation",
+        docker_image="python:3.12",
+    )
+    first_config_read = threading.Event()
+    release_default_lock = threading.Event()
+    config_box = {"value": old_config, "reads": 0}
+
+    def current_config_reader():
+        config_box["reads"] += 1
+        if config_box["reads"] == 1:
+            first_config_read.set()
+        return config_box["value"]
+
+    default_lock = threading.Lock()
+    default_lock.acquire()
+    with tt._creation_locks_lock:
+        tt._creation_locks["default"] = default_lock
+
+    compatible_env = MagicMock(name="compatible_current_env")
+    compatible_env.cwd = "/workspace/current-generation"
+    result_box = {}
+
+    def worker():
+        try:
+            result_box["ops"] = ft._get_file_ops(task_id)
+        finally:
+            release_default_lock.set()
+
+    thread = threading.Thread(target=worker)
+    with patch("tools.terminal_tool._get_env_config", side_effect=current_config_reader), \
+         patch("tools.terminal_tool._create_environment") as create_env, \
+         patch("tools.terminal_tool._start_cleanup_thread"):
+        thread.start()
+        assert first_config_read.wait(5)
+        tt.register_task_env_overrides(task_id, {"docker_image": "python:3.12"})
+        current_runtime = tt.resolve_terminal_runtime_identity(
+            current_config,
+            raw_task_id=task_id,
+        )
+        setattr(compatible_env, tt._ENV_SIGNATURE_ATTR, current_runtime["signature"])
+        tt._store_active_environment(task_id, compatible_env, current_runtime["signature"])
+        config_box["value"] = current_config
+        default_lock.release()
+        thread.join(timeout=5)
+
+    assert release_default_lock.is_set()
+    assert not thread.is_alive()
+    assert getattr(result_box["ops"], "env") is compatible_env
+    assert task_id in ft._file_ops_cache
+    assert "default" not in ft._file_ops_cache
+    create_env.assert_not_called()
+    _reset_file_ops_cache(ft)
+    _reset_terminal_cache(tt)
+
+
+def test_execute_code_reresolves_runtime_after_waiting_for_old_creation_lock(monkeypatch):
+    """execute_code must also switch to the current effective creation lock."""
+    from tools import code_execution_tool as cet
+    from tools import terminal_tool as tt
+
+    _reset_terminal_cache(tt)
+    monkeypatch.setenv("HERMES_HOME", "/tmp/hermes-default")
+
+    task_id = "isolated-code-task"
+    old_config = _make_env_config(env_type="local", cwd="/tmp/old-generation")
+    current_config = _make_env_config(
+        env_type="docker",
+        cwd="/workspace/current-generation",
+        docker_image="python:3.12",
+    )
+    first_config_read = threading.Event()
+    config_box = {"value": old_config, "reads": 0}
+
+    def current_config_reader():
+        config_box["reads"] += 1
+        if config_box["reads"] == 1:
+            first_config_read.set()
+        return config_box["value"]
+
+    default_lock = threading.Lock()
+    default_lock.acquire()
+    with tt._creation_locks_lock:
+        tt._creation_locks["default"] = default_lock
+
+    compatible_env = MagicMock(name="compatible_code_env")
+    result_box = {}
+
+    def worker():
+        env, env_type, lease = cet._get_or_create_env_lease(task_id)
+        try:
+            result_box["env"] = env
+            result_box["env_type"] = env_type
+        finally:
+            lease.release()
+
+    thread = threading.Thread(target=worker)
+    with patch("tools.terminal_tool._get_env_config", side_effect=current_config_reader), \
+         patch("tools.terminal_tool._create_environment") as create_env, \
+         patch("tools.terminal_tool._start_cleanup_thread"):
+        thread.start()
+        assert first_config_read.wait(5)
+        tt.register_task_env_overrides(task_id, {"docker_image": "python:3.12"})
+        current_runtime = tt.resolve_terminal_runtime_identity(
+            current_config,
+            raw_task_id=task_id,
+        )
+        setattr(compatible_env, tt._ENV_SIGNATURE_ATTR, current_runtime["signature"])
+        tt._store_active_environment(task_id, compatible_env, current_runtime["signature"])
+        config_box["value"] = current_config
+        default_lock.release()
+        thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert result_box == {"env": compatible_env, "env_type": "docker"}
+    create_env.assert_not_called()
+    _reset_terminal_cache(tt)
+
+
+def test_terminal_tool_reresolves_runtime_after_waiting_for_old_creation_lock(monkeypatch):
+    """terminal_tool must retry under the current effective creation lock."""
+    from tools import terminal_tool as tt
+
+    _reset_terminal_cache(tt)
+    monkeypatch.setenv("HERMES_HOME", "/tmp/hermes-default")
+
+    task_id = "isolated-terminal-task"
+    old_config = _make_env_config(env_type="local", cwd="/tmp/old-generation")
+    current_config = _make_env_config(
+        env_type="docker",
+        cwd="/workspace/current-generation",
+        docker_image="python:3.12",
+    )
+    first_config_read = threading.Event()
+    config_box = {"value": old_config, "reads": 0}
+
+    def current_config_reader():
+        config_box["reads"] += 1
+        if config_box["reads"] == 1:
+            first_config_read.set()
+        return config_box["value"]
+
+    default_lock = threading.Lock()
+    default_lock.acquire()
+    with tt._creation_locks_lock:
+        tt._creation_locks["default"] = default_lock
+
+    compatible_backend = MagicMock(name="compatible_terminal_backend")
+    compatible_backend.execute.return_value = {
+        "output": "ok\n",
+        "returncode": 0,
+        "cwd": "/workspace/current-generation",
+    }
+    result_box = {}
+
+    def worker():
+        result_box["result"] = json.loads(
+            tt.terminal_tool("printf ok", task_id=task_id)
+        )
+
+    thread = threading.Thread(target=worker)
+    with patch("tools.terminal_tool._get_env_config", side_effect=current_config_reader), \
+         patch("tools.terminal_tool._create_environment") as create_backend, \
+         patch("tools.terminal_tool._start_cleanup_thread"), \
+         patch("tools.terminal_tool._check_all_guards", return_value={"approved": True}):
+        thread.start()
+        assert first_config_read.wait(5)
+        tt.register_task_env_overrides(task_id, {"docker_image": "python:3.12"})
+        current_runtime = tt.resolve_terminal_runtime_identity(
+            current_config,
+            raw_task_id=task_id,
+        )
+        setattr(compatible_backend, tt._ENV_SIGNATURE_ATTR, current_runtime["signature"])
+        tt._store_active_environment(task_id, compatible_backend, current_runtime["signature"])
+        config_box["value"] = current_config
+        default_lock.release()
+        thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert result_box["result"]["output"] == "ok"
+    assert compatible_backend.execute.called
+    create_backend.assert_not_called()
+    _reset_terminal_cache(tt)
+
+
+def test_file_ops_signature_replacement_preserves_existing_raw_session_cwd(monkeypatch):
+    """Old backend cwd must not overwrite the raw session's current cwd."""
+    from tools import file_tools as ft
+    from tools import terminal_tool as tt
+
+    _reset_terminal_cache(tt)
+    _reset_file_ops_cache(ft)
+    monkeypatch.setenv("HERMES_HOME", "/tmp/hermes-default")
+
+    ssh_config = _make_env_config(
+        env_type="ssh",
+        cwd="~",
+        ssh_host="old-ssh.example.test",
+        ssh_user="agent-user",
+    )
+    old_backend = MagicMock(name="old_remote")
+    setattr(old_backend, "cwd", "~")
+    setattr(
+        old_backend,
+        tt._ENV_SIGNATURE_ATTR,
+        tt._terminal_env_signature(ssh_config, task_id="default"),
+    )
+    tt._active_environments["default"] = old_backend
+    tt._last_activity["default"] = 1
+    ft._file_ops_cache["default"] = ft.ShellFileOperations(old_backend)
+    tt.record_session_cwd("session-file", "/workspace/current")
+
+    local_config = _make_env_config(env_type="local", cwd="/workspace/local-project")
+    new_backend = MagicMock(name="new_local")
+    setattr(new_backend, "cwd", "/workspace/current")
+
+    with patch("tools.terminal_tool._get_env_config", return_value=local_config), \
+         patch("tools.terminal_tool._create_environment", return_value=new_backend) as create_env, \
+         patch("tools.terminal_tool._start_cleanup_thread"):
+        ft._get_file_ops("session-file")
+
+    assert tt.get_session_cwd("session-file") == "/workspace/current"
+    assert create_env.call_args.kwargs["cwd"] == "/workspace/current"
+    old_backend.cleanup.assert_called_once_with()
+    _reset_file_ops_cache(ft)
+    _reset_terminal_cache(tt)
+
+
+def test_docker_creation_inputs_affect_runtime_signature(monkeypatch):
+    """Docker creation knobs that change runtime compatibility are signed."""
+    from tools import terminal_tool as tt
+
+    _reset_terminal_cache(tt)
+    monkeypatch.setenv("HERMES_HOME", "/tmp/hermes-default")
+
+    base_config = _make_env_config(
+        env_type="docker",
+        cwd="/workspace",
+        docker_image="python:3.12",
+    )
+    base = tt.resolve_terminal_runtime_identity(base_config)["signature"]
+
+    for key, value in {
+        "docker_extra_args": ["--add-host=host.docker.internal:host-gateway"],
+        "docker_network": False,
+        "docker_persist_across_processes": False,
+        "docker_orphan_reaper": False,
+    }.items():
+        changed_config = _make_env_config(
+            env_type="docker",
+            cwd="/workspace",
+            docker_image="python:3.12",
+            **{key: value},
+        )
+        changed = tt.resolve_terminal_runtime_identity(changed_config)["signature"]
+        assert changed != base
+        assert changed[key] != base[key]
+
+    runtime = tt.resolve_terminal_runtime_identity(
+        _make_env_config(
+            env_type="docker",
+            cwd="/workspace",
+            docker_image="python:3.12",
+            docker_extra_args=["--init"],
+            docker_network=False,
+            docker_persist_across_processes=False,
+            docker_orphan_reaper=False,
+        )
+    )
+    container_config = runtime["container_config"]
+    assert container_config["docker_extra_args"] == ["--init"]
+    assert container_config["docker_network"] is False
+    assert container_config["docker_persist_across_processes"] is False
+    assert container_config["docker_orphan_reaper"] is False
+
+
+def test_shared_cwd_only_overrides_do_not_change_runtime_signature(monkeypatch):
+    """Per-session cwd on the shared env is an operation cwd, not identity."""
+    from tools import terminal_tool as tt
+
+    _reset_terminal_cache(tt)
+    config = _make_env_config(env_type="local", cwd="/workspace/default")
+    tt.register_task_env_overrides("sess-a", {"cwd": "/workspace/a"})
+    tt.register_task_env_overrides("sess-b", {"cwd": "/workspace/b"})
+
+    runtime_a = tt.resolve_terminal_runtime_identity(config, raw_task_id="sess-a")
+    runtime_b = tt.resolve_terminal_runtime_identity(config, raw_task_id="sess-b")
+
+    assert runtime_a["effective_task_id"] == "default"
+    assert runtime_b["effective_task_id"] == "default"
+    assert runtime_a["cwd"] == "/workspace/a"
+    assert runtime_b["cwd"] == "/workspace/b"
+    assert runtime_a["signature"] == runtime_b["signature"]
+    assert runtime_a["signature"]["cwd"] == "/workspace/default"
+
+    _reset_terminal_cache(tt)
+
+
+def test_runtime_creation_cwd_prefers_current_session_record_over_override(monkeypatch):
+    """Backend replacement must seed from the live session cwd after a cd."""
+    from tools import terminal_tool as tt
+
+    _reset_terminal_cache(tt)
+    config = _make_env_config(env_type="local", cwd="/workspace/default")
+    tt.register_task_env_overrides("sess-live", {"cwd": "/workspace/initial"})
+    tt.record_session_cwd("sess-live", "/workspace/current")
+
+    runtime = tt.resolve_terminal_runtime_identity(config, raw_task_id="sess-live")
+
+    assert runtime["effective_task_id"] == "default"
+    assert runtime["cwd"] == "/workspace/current"
+    assert runtime["signature"]["cwd"] == "/workspace/default"
+
+    _reset_terminal_cache(tt)
+
+
+def test_isolated_override_cwd_still_changes_runtime_signature(monkeypatch):
+    """Isolation-keyed task overrides can include cwd in their env identity."""
+    from tools import terminal_tool as tt
+
+    _reset_terminal_cache(tt)
+    config = _make_env_config(
+        env_type="docker",
+        cwd="/workspace/default",
+        docker_image="python:3.12",
+    )
+    tt.register_task_env_overrides(
+        "rollout-a",
+        {"docker_image": "custom:a", "cwd": "/workspace/a"},
+    )
+
+    runtime = tt.resolve_terminal_runtime_identity(config, raw_task_id="rollout-a")
+
+    assert runtime["effective_task_id"] == "rollout-a"
+    assert runtime["signature"]["cwd"] == "/workspace/a"
+    assert runtime["signature"]["image"] == "custom:a"
+
+    _reset_terminal_cache(tt)
+
+
+def test_ssh_key_fingerprint_changes_when_key_material_changes(tmp_path):
+    """Rotating a key at the same path invalidates cached SSH environments."""
+    from tools import terminal_tool as tt
+
+    key_path = tmp_path / "ssh-fixture-key"
+    key_path.write_text("first-key\n", encoding="utf-8")
+    config = _make_env_config(env_type="ssh", ssh_key=str(key_path))
+    first = tt.resolve_terminal_runtime_identity(config)["signature"]
+
+    key_path.write_text("second-key\n", encoding="utf-8")
+    second = tt.resolve_terminal_runtime_identity(config)["signature"]
+
+    assert first["ssh_key_present"] == "true"
+    assert second["ssh_key_present"] == "true"
+    assert first["ssh_key_fingerprint"] != second["ssh_key_fingerprint"]
+    assert second["ssh_key_fingerprint"] not in str(tt._safe_signature_for_log(second))
+    assert str(key_path) not in str(tt._safe_signature_for_log(second))
+
+
+def test_ssh_key_fingerprint_value_is_not_logged_when_signature_changes(tmp_path, caplog):
+    """The SSH key fingerprint invalidates compatibility without entering logs."""
+    from tools import terminal_tool as tt
+
+    _reset_terminal_cache(tt)
+    key_path = tmp_path / "ssh-fixture-key"
+    key_path.write_text("first-key\n", encoding="utf-8")
+    old_config = _make_env_config(env_type="ssh", ssh_key=str(key_path))
+    old_env = MagicMock(name="old_ssh_env")
+    old_signature = tt._terminal_env_signature(old_config, task_id="default")
+    setattr(old_env, tt._ENV_SIGNATURE_ATTR, old_signature)
+    tt._active_environments["default"] = old_env
+
+    key_path.write_text("second-key\n", encoding="utf-8")
+    new_signature = tt._terminal_env_signature(
+        _make_env_config(env_type="ssh", ssh_key=str(key_path)),
+        task_id="default",
+    )
+
+    with caplog.at_level("WARNING", logger="tools.terminal_tool"):
+        assert tt._get_active_environment_if_compatible("default", new_signature) is None
+
+    log_text = caplog.text
+    assert "ssh_key_fingerprint" in log_text
+    assert old_signature["ssh_key_fingerprint"] not in log_text
+    assert new_signature["ssh_key_fingerprint"] not in log_text
+    assert str(key_path) not in log_text
+
+    _reset_terminal_cache(tt)
+
+
+def test_safe_signature_log_redacts_image_docker_args_and_env_secrets():
+    from tools import terminal_tool as tt
+
+    signature = tt._terminal_env_signature(
+        _make_env_config(
+            env_type="docker",
+            docker_image="registry.example.test/user:secret-token@repo/image:latest",
+            docker_extra_args=["--env", "API_TOKEN=supersecret", "--env-file", "/tmp/secret-file"],
+            docker_env={"PASSWORD": "supersecret"},
+            docker_forward_env=["SECRET_TOKEN"],
+        ),
+        task_id="default",
+    )
+
+    safe = tt._safe_signature_for_log(signature)
+    safe_text = str(safe)
+
+    assert "supersecret" not in safe_text
+    assert "secret-token" not in safe_text
+    assert "API_TOKEN" not in safe_text
+    assert "PASSWORD" not in safe_text
+    assert "/tmp/secret-file" not in safe_text
+    assert "image_fingerprint" in safe
+    assert "docker_extra_args_fingerprint" in safe
+    assert "docker_env_fingerprint" in safe
+
+
+def test_terminal_retirement_waits_for_inflight_terminal_operation(monkeypatch):
+    """Signature retirement must not clean a backend while terminal_tool uses it."""
+    from tools import terminal_tool as tt
+
+    _reset_terminal_cache(tt)
+    config = _make_env_config(env_type="local", cwd="/tmp/project-a")
+    new_config = _make_env_config(env_type="local", cwd="/tmp/project-b")
+    started = threading.Event()
+    release = threading.Event()
+    old_env = MagicMock(name="leased_terminal_env")
+
+    def _execute(*_args, **_kwargs):
+        started.set()
+        assert release.wait(5)
+        return {"output": "done\n", "returncode": 0}
+
+    old_env.execute.side_effect = _execute
+    setattr(old_env, tt._ENV_SIGNATURE_ATTR, tt._terminal_env_signature(config, task_id="default"))
+    tt._active_environments["default"] = old_env
+
+    result_box = {}
+
+    def _run():
+        result_box["result"] = json.loads(tt.terminal_tool("echo done", task_id="session-a"))
+
+    worker = threading.Thread(target=_run)
+    with patch("tools.terminal_tool._get_env_config", return_value=config), \
+         patch("tools.terminal_tool._start_cleanup_thread"), \
+         patch("tools.terminal_tool._check_all_guards", return_value={"approved": True}):
+        worker.start()
+        assert started.wait(5)
+
+        new_signature = tt._terminal_env_signature(new_config, task_id="default")
+        assert tt._acquire_active_environment_if_compatible("default", new_signature) is None
+        old_env.cleanup.assert_not_called()
+
+        release.set()
+        worker.join(timeout=5)
+
+    assert not worker.is_alive()
+    assert result_box["result"]["output"] == "done"
+    old_env.cleanup.assert_called_once_with()
+    assert tt._environment_lease_states == {}
+    _reset_terminal_cache(tt)
+
+
+def test_background_process_lease_cleans_after_registry_completion():
+    """Env-backed background processes keep the backend leased until completion."""
+    from tools import terminal_tool as tt
+    from tools.process_registry import ProcessRegistry
+
+    _reset_terminal_cache(tt)
+    config = _make_env_config(env_type="ssh", ssh_host="host", ssh_user="user")
+    old_env = MagicMock(name="background_env")
+    old_env.get_temp_dir.return_value = "/tmp"
+    old_env.execute.return_value = {"output": "1234\n", "returncode": 0}
+    setattr(old_env, tt._ENV_SIGNATURE_ATTR, tt._terminal_env_signature(config, task_id="default"))
+    tt._store_active_environment("default", old_env, tt._terminal_env_signature(config, task_id="default"))
+    lease = tt._acquire_active_environment_if_compatible(
+        "default", tt._terminal_env_signature(config, task_id="default")
+    )
+
+    registry = ProcessRegistry()
+    with patch("tools.process_registry.threading.Thread") as thread_cls, \
+         patch.object(registry, "_write_checkpoint"):
+        thread_cls.return_value = MagicMock()
+        session = registry.spawn_via_env(old_env, "sleep 1", environment_lease=lease)
+
+    tt.cleanup_vm("default")
+    old_env.cleanup.assert_not_called()
+
+    session.exit_code = 0
+    session.exited = True
+    registry._move_to_finished(session)
+
+    old_env.cleanup.assert_called_once_with()
+    assert tt._environment_lease_states == {}
+    _reset_terminal_cache(tt)
+
+
+def test_file_ops_lease_defers_cleanup_until_operation_release():
+    """File-operation acquisition holds the backend lease across use."""
+    from tools import file_tools as ft
+    from tools import terminal_tool as tt
+
+    _reset_terminal_cache(tt)
+    _reset_file_ops_cache(ft)
+    config = _make_env_config(env_type="local", cwd="/tmp/file-a")
+    next_config = _make_env_config(env_type="local", cwd="/tmp/file-b")
+    old_env = MagicMock(name="file_env")
+    setattr(old_env, tt._ENV_SIGNATURE_ATTR, tt._terminal_env_signature(config, task_id="default"))
+    tt._store_active_environment("default", old_env, tt._terminal_env_signature(config, task_id="default"))
+
+    with patch("tools.terminal_tool._get_env_config", return_value=config):
+        with ft._leased_file_ops("default"):
+            assert tt._acquire_active_environment_if_compatible(
+                "default", tt._terminal_env_signature(next_config, task_id="default")
+            ) is None
+            old_env.cleanup.assert_not_called()
+
+    old_env.cleanup.assert_called_once_with()
+    assert tt._environment_lease_states == {}
+    _reset_file_ops_cache(ft)
+    _reset_terminal_cache(tt)
+
+
+def test_file_ops_bind_raw_session_cwd_during_concurrent_shared_env_use(monkeypatch):
+    """Collapsed CWD-only sessions must not inherit the shared backend cwd."""
+    from tools import file_tools as ft
+    from tools import terminal_tool as tt
+
+    _reset_terminal_cache(tt)
+    _reset_file_ops_cache(ft)
+    config = _make_env_config(env_type="local", cwd="/workspace/default")
+    tt.register_task_env_overrides("sess-a", {"cwd": "/workspace/a"})
+    tt.register_task_env_overrides("sess-b", {"cwd": "/workspace/b"})
+
+    a_entered = threading.Event()
+    b_finished = threading.Event()
+    calls = []
+
+    class RecordingBackend:
+        cwd = "/workspace/shared-stale"
+
+        def execute(self, command, **kwargs):
+            calls.append((command, kwargs.get("cwd")))
+            if command == "probe-a":
+                a_entered.set()
+                assert b_finished.wait(5)
+            elif command == "probe-b":
+                assert a_entered.wait(5)
+                self.cwd = "/workspace/b"
+                b_finished.set()
+            return {"output": "ok\n", "returncode": 0}
+
+    backend = RecordingBackend()
+    signature = tt._terminal_env_signature(config, task_id="default")
+    tt._store_active_environment("default", backend, signature)
+    results = {}
+
+    def run_probe(task_id, command):
+        with ft._leased_file_ops(task_id) as ops:
+            results[task_id] = ops._exec(command).stdout
+
+    with patch("tools.terminal_tool._get_env_config", return_value=config):
+        thread_a = threading.Thread(target=run_probe, args=("sess-a", "probe-a"))
+        thread_b = threading.Thread(target=run_probe, args=("sess-b", "probe-b"))
+        thread_a.start()
+        thread_b.start()
+        thread_a.join(timeout=5)
+        thread_b.join(timeout=5)
+
+    assert not thread_a.is_alive()
+    assert not thread_b.is_alive()
+    assert results == {"sess-a": "ok\n", "sess-b": "ok\n"}
+    assert ("probe-a", "/workspace/a") in calls
+    assert ("probe-b", "/workspace/b") in calls
+    assert ("probe-a", "/workspace/shared-stale") not in calls
+    _reset_file_ops_cache(ft)
+    _reset_terminal_cache(tt)
+
+
+def test_execute_code_remote_lease_defers_cleanup_until_script_finishes(monkeypatch):
+    """Remote execute_code keeps the backend leased through script and RPC cleanup."""
+    from tools import code_execution_tool as cet
+    from tools import terminal_tool as tt
+
+    _reset_terminal_cache(tt)
+    config = _make_env_config(env_type="ssh", ssh_host="host", ssh_user="user")
+    signature = tt._terminal_env_signature(config, task_id="default")
+    started = threading.Event()
+    release = threading.Event()
+
+    class FakeEnv:
+        def __init__(self):
+            self.cleanup = MagicMock()
+            self.commands = []
+
+        def get_temp_dir(self):
+            return "/tmp"
+
+        def execute(self, command, **kwargs):
+            self.commands.append((command, kwargs))
+            if "command -v python3" in command:
+                return {"output": "OK\n", "returncode": 0}
+            if "python3 script.py" in command:
+                started.set()
+                assert release.wait(5)
+                return {"output": "remote-ok\n", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+    env = FakeEnv()
+    setattr(env, tt._ENV_SIGNATURE_ATTR, signature)
+    tt._store_active_environment("default", env, signature)
+
+    result_box = {}
+
+    def _run():
+        result_box["result"] = json.loads(cet._execute_remote("print('remote-ok')", "default", []))
+
+    worker = threading.Thread(target=_run)
+    with patch("tools.terminal_tool._get_env_config", return_value=config), \
+         patch("tools.code_execution_tool._load_config", return_value={"timeout": 30, "max_tool_calls": 5}):
+        worker.start()
+        assert started.wait(5)
+        tt.cleanup_vm("default")
+        env.cleanup.assert_not_called()
+        release.set()
+        worker.join(timeout=5)
+
+    assert not worker.is_alive()
+    assert result_box["result"]["status"] == "success"
+    assert result_box["result"]["output"] == "remote-ok\n"
+    env.cleanup.assert_called_once_with()
+    assert tt._environment_lease_states == {}
+    _reset_terminal_cache(tt)
+
+
+def test_repeated_signature_replacements_do_not_accumulate_retired_state():
+    """No-lease replacements clean immediately and leave bounded lifecycle state."""
+    from tools import terminal_tool as tt
+
+    _reset_terminal_cache(tt)
+    for idx in range(25):
+        config = _make_env_config(env_type="local", cwd=f"/tmp/project-{idx}")
+        next_config = _make_env_config(env_type="local", cwd=f"/tmp/project-{idx + 1}")
+        env = MagicMock(name=f"env_{idx}")
+        setattr(env, tt._ENV_SIGNATURE_ATTR, tt._terminal_env_signature(config, task_id="default"))
+        tt._active_environments["default"] = env
+        tt._last_activity["default"] = 1
+
+        assert tt._acquire_active_environment_if_compatible(
+            "default", tt._terminal_env_signature(next_config, task_id="default")
+        ) is None
+
+        env.cleanup.assert_called_once_with()
+        assert tt._active_environments == {}
+        assert tt._environment_lease_states == {}
+
+    _reset_terminal_cache(tt)
+
+
+def test_explicit_retired_cleanup_drains_releaseable_states():
+    """Explicit retired cleanup drains releaseable retired lifecycle state."""
+    from tools import terminal_tool as tt
+
+    _reset_terminal_cache(tt)
+    env = MagicMock(name="retired_env")
+    state = tt._EnvironmentLeaseState("default", env)
+    state.retired = True
+    tt._environment_lease_states[id(env)] = state
+
+    cleaned = tt._cleanup_retired_environments()
+
+    assert cleaned == [env]
+    env.cleanup.assert_called_once_with()
+    assert tt._environment_lease_states == {}
+    _reset_terminal_cache(tt)
+
+
+def test_cleanup_worker_retries_transient_cleanup_failed_retired_state():
+    """Periodic cleanup should retry a failed retired backend and drain it."""
+    from tools import terminal_tool as tt
+
+    _reset_terminal_cache(tt)
+    env = MagicMock(name="retired_retry_env")
+    state = tt._EnvironmentLeaseState("default", env)
+    state.retired = True
+    state.cleanup_failed = True
+    state.cleanup_attempts = 1
+    tt._environment_lease_states[id(env)] = state
+
+    def stop_after_one_sleep(_seconds):
+        tt._cleanup_running = False
+
+    try:
+        tt._cleanup_running = True
+        with patch("tools.terminal_tool._get_env_config", return_value={"lifetime_seconds": 999}), \
+             patch("tools.terminal_tool._cleanup_inactive_envs"), \
+             patch("tools.terminal_tool.time.sleep", side_effect=stop_after_one_sleep):
+            tt._cleanup_thread_worker()
+    finally:
+        tt._cleanup_running = False
+
+    env.cleanup.assert_called_once_with()
+    assert tt._environment_lease_states == {}
+    _reset_terminal_cache(tt)
+
+
+def test_cleanup_worker_does_not_retry_retired_state_past_budget():
+    """Periodic cleanup retries are bounded for persistent cleanup failures."""
+    from tools import terminal_tool as tt
+
+    _reset_terminal_cache(tt)
+    env = MagicMock(name="retired_budget_env")
+    state = tt._EnvironmentLeaseState("default", env)
+    state.retired = True
+    state.cleanup_failed = True
+    state.cleanup_attempts = tt._RETIRED_CLEANUP_WORKER_MAX_ATTEMPTS
+    tt._environment_lease_states[id(env)] = state
+
+    def stop_after_one_sleep(_seconds):
+        tt._cleanup_running = False
+
+    try:
+        tt._cleanup_running = True
+        with patch("tools.terminal_tool._get_env_config", return_value={"lifetime_seconds": 999}), \
+             patch("tools.terminal_tool._cleanup_inactive_envs"), \
+             patch("tools.terminal_tool.time.sleep", side_effect=stop_after_one_sleep):
+            tt._cleanup_thread_worker()
+    finally:
+        tt._cleanup_running = False
+
+    env.cleanup.assert_not_called()
+    assert tt._environment_lease_states[id(env)] is state
+    _reset_terminal_cache(tt)

--- a/tests/tools/test_terminal_foreground_timeout_cap.py
+++ b/tests/tools/test_terminal_foreground_timeout_cap.py
@@ -27,6 +27,14 @@ def _make_env_config(**overrides):
     return config
 
 
+def _mark_compatible(env, config, task_id="default"):
+    from tools import terminal_tool
+
+    runtime = terminal_tool.resolve_terminal_runtime_identity(config, raw_task_id=task_id)
+    setattr(env, terminal_tool._ENV_SIGNATURE_ATTR, runtime["signature"])
+    return env
+
+
 class TestForegroundTimeoutCap:
     """FOREGROUND_MAX_TIMEOUT rejects foreground commands that exceed it."""
 
@@ -84,6 +92,7 @@ class TestForegroundTimeoutCap:
 
             mock_env = MagicMock()
             mock_env.execute.return_value = {"output": "usage", "returncode": 0}
+            _mark_compatible(mock_env, _make_env_config())
 
             with patch("tools.terminal_tool._active_environments", {"default": mock_env}), \
                  patch("tools.terminal_tool._last_activity", {"default": 0}), \
@@ -103,6 +112,7 @@ class TestForegroundTimeoutCap:
 
             mock_env = MagicMock()
             mock_env.execute.return_value = {"output": "done", "returncode": 0}
+            _mark_compatible(mock_env, _make_env_config())
 
             with patch("tools.terminal_tool._active_environments", {"default": mock_env}), \
                  patch("tools.terminal_tool._last_activity", {"default": 0}), \
@@ -131,6 +141,8 @@ class TestForegroundTimeoutCap:
 
             mock_env = MagicMock()
             mock_env.execute.return_value = {"output": "done", "returncode": 0}
+            _mark_compatible(mock_env, _make_env_config())
+            _mark_compatible(mock_env, _make_env_config(timeout=900))
 
             with patch("tools.terminal_tool._active_environments", {"default": mock_env}), \
                  patch("tools.terminal_tool._last_activity", {"default": 0}), \
@@ -151,6 +163,7 @@ class TestForegroundTimeoutCap:
 
             mock_env = MagicMock()
             mock_env.env = {}
+            _mark_compatible(mock_env, _make_env_config())
             mock_proc_session = MagicMock()
             mock_proc_session.id = "test-123"
             mock_proc_session.pid = 1234
@@ -184,6 +197,7 @@ class TestForegroundTimeoutCap:
 
             mock_env = MagicMock()
             mock_env.execute.return_value = {"output": "done", "returncode": 0}
+            _mark_compatible(mock_env, _make_env_config())
 
             with patch("tools.terminal_tool._active_environments", {"default": mock_env}), \
                  patch("tools.terminal_tool._last_activity", {"default": 0}), \
@@ -203,6 +217,7 @@ class TestForegroundTimeoutCap:
 
             mock_env = MagicMock()
             mock_env.execute.return_value = {"output": "done", "returncode": 0}
+            _mark_compatible(mock_env, _make_env_config())
 
             with patch("tools.terminal_tool._active_environments", {"default": mock_env}), \
                  patch("tools.terminal_tool._last_activity", {"default": 0}), \

--- a/tests/tools/test_terminal_task_cwd.py
+++ b/tests/tools/test_terminal_task_cwd.py
@@ -1,6 +1,7 @@
 """Regression tests for task/session cwd propagation in terminal_tool."""
 
 import json
+import threading
 from types import SimpleNamespace
 
 import tools.terminal_tool as terminal_tool
@@ -15,6 +16,12 @@ def _minimal_terminal_config(cwd="/default"):
     }
 
 
+def _mark_compatible(env, config, task_id):
+    runtime = terminal_tool.resolve_terminal_runtime_identity(config, raw_task_id=task_id)
+    setattr(env, terminal_tool._ENV_SIGNATURE_ATTR, runtime["signature"])
+    return env
+
+
 def test_foreground_command_uses_registered_task_cwd_for_existing_environment(monkeypatch):
     """ACP can update task cwd after the local env exists; foreground must honor it."""
     calls = []
@@ -27,10 +34,13 @@ def test_foreground_command_uses_registered_task_cwd_for_existing_environment(mo
             return {"output": "ok", "returncode": 0}
 
     task_id = "acp-session-1"
-    monkeypatch.setattr(terminal_tool, "_active_environments", {task_id: FakeEnv()})
+    env = FakeEnv()
+    monkeypatch.setattr(terminal_tool, "_active_environments", {task_id: env})
     monkeypatch.setattr(terminal_tool, "_last_activity", {})
     monkeypatch.setattr(terminal_tool, "_task_env_overrides", {task_id: {"cwd": "/workspace/acp"}})
-    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: _minimal_terminal_config())
+    config = _minimal_terminal_config()
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: config)
+    _mark_compatible(env, config, task_id)
     monkeypatch.setattr(
         terminal_tool,
         "_check_all_guards",
@@ -54,10 +64,13 @@ def test_explicit_workdir_still_wins_over_registered_task_cwd(monkeypatch):
             return {"output": "ok", "returncode": 0}
 
     task_id = "acp-session-1"
-    monkeypatch.setattr(terminal_tool, "_active_environments", {task_id: FakeEnv()})
+    env = FakeEnv()
+    monkeypatch.setattr(terminal_tool, "_active_environments", {task_id: env})
     monkeypatch.setattr(terminal_tool, "_last_activity", {})
     monkeypatch.setattr(terminal_tool, "_task_env_overrides", {task_id: {"cwd": "/workspace/acp"}})
-    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: _minimal_terminal_config())
+    config = _minimal_terminal_config()
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: config)
+    _mark_compatible(env, config, task_id)
     monkeypatch.setattr(
         terminal_tool,
         "_check_all_guards",
@@ -89,13 +102,16 @@ def test_foreground_command_prefers_recorded_session_cwd_over_init_time_cwd(monk
             return {"output": "ok", "returncode": 0}
 
     task_id = "session-live-cwd"
-    monkeypatch.setattr(terminal_tool, "_active_environments", {task_id: FakeEnv()})
+    env = FakeEnv()
+    monkeypatch.setattr(terminal_tool, "_active_environments", {task_id: env})
     monkeypatch.setattr(terminal_tool, "_last_activity", {})
     monkeypatch.setattr(terminal_tool, "_session_cwd", {})
     monkeypatch.setattr(terminal_tool, "_task_env_overrides", {task_id: {"cwd": "/workspace/init"}})
-    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: _minimal_terminal_config(cwd="/workspace/init"))
+    config = _minimal_terminal_config(cwd="/workspace/init")
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: config)
     monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
     monkeypatch.setattr(terminal_tool, "_resolve_container_task_id", lambda value: value or "default")
+    _mark_compatible(env, config, task_id)
     monkeypatch.setattr(
         terminal_tool,
         "_check_all_guards",
@@ -130,13 +146,16 @@ def test_background_command_prefers_recorded_session_cwd_over_init_time_cwd(monk
 
     registry = FakeRegistry()
     task_id = "session-live-cwd-bg"
-    monkeypatch.setattr(terminal_tool, "_active_environments", {task_id: FakeEnv()})
+    env = FakeEnv()
+    monkeypatch.setattr(terminal_tool, "_active_environments", {task_id: env})
     monkeypatch.setattr(terminal_tool, "_last_activity", {})
     monkeypatch.setattr(terminal_tool, "_session_cwd", {})
     monkeypatch.setattr(terminal_tool, "_task_env_overrides", {task_id: {"cwd": "/workspace/init"}})
-    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: _minimal_terminal_config(cwd="/workspace/init"))
+    config = _minimal_terminal_config(cwd="/workspace/init")
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: config)
     monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
     monkeypatch.setattr(terminal_tool, "_resolve_container_task_id", lambda value: value or "default")
+    _mark_compatible(env, config, task_id)
     monkeypatch.setattr(
         terminal_tool,
         "_check_all_guards",
@@ -250,12 +269,15 @@ def test_stale_env_cwd_from_different_session_is_ignored(monkeypatch):
             return {"output": "ok", "returncode": 0}
 
     task_id = "session-B"
-    monkeypatch.setattr(terminal_tool, "_active_environments", {"default": FakeEnv()})
+    env = FakeEnv()
+    monkeypatch.setattr(terminal_tool, "_active_environments", {"default": env})
     monkeypatch.setattr(terminal_tool, "_last_activity", {})
     monkeypatch.setattr(terminal_tool, "_task_env_overrides", {})
-    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: _minimal_terminal_config(cwd="/home/user/src/hermes-agent"))
+    config = _minimal_terminal_config(cwd="/home/user/src/hermes-agent")
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: config)
     monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
     monkeypatch.setattr(terminal_tool, "_resolve_container_task_id", lambda value: "default")
+    _mark_compatible(env, config, task_id)
     monkeypatch.setattr(
         terminal_tool,
         "_check_all_guards",
@@ -281,7 +303,7 @@ def test_same_session_recorded_cwd_survives_across_commands(monkeypatch):
 
         def execute(self, command, **kwargs):
             calls.append((command, kwargs))
-            return {"output": "ok", "returncode": 0}
+            return {"output": "ok", "returncode": 0, "cwd": self.cwd}
 
     env = FakeEnv()
     task_id = "session-X"
@@ -289,9 +311,11 @@ def test_same_session_recorded_cwd_survives_across_commands(monkeypatch):
     monkeypatch.setattr(terminal_tool, "_last_activity", {})
     monkeypatch.setattr(terminal_tool, "_task_env_overrides", {})
     monkeypatch.setattr(terminal_tool, "_session_cwd", {})
-    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: _minimal_terminal_config(cwd="/workspace/config"))
+    config = _minimal_terminal_config(cwd="/workspace/config")
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: config)
     monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
     monkeypatch.setattr(terminal_tool, "_resolve_container_task_id", lambda value: "default")
+    _mark_compatible(env, config, task_id)
     monkeypatch.setattr(
         terminal_tool,
         "_check_all_guards",
@@ -309,6 +333,91 @@ def test_same_session_recorded_cwd_survives_across_commands(monkeypatch):
     result = json.loads(terminal_tool.terminal_tool(command="pwd", task_id=task_id))
     assert result["exit_code"] == 0
     assert calls[1] == ("pwd", {"timeout": 60, "cwd": "/workspace/deep", "bounded_capture": True})
+
+
+def test_foreground_records_result_cwd_not_shared_cwd_after_concurrent_run(monkeypatch):
+    """A shared backend cwd update after execute must not corrupt this session."""
+    terminal_tool._active_environments.clear()
+    terminal_tool._last_activity.clear()
+    terminal_tool._environment_lease_states.clear()
+    calls = []
+    a_entered = threading.Event()
+    b_finished = threading.Event()
+
+    class FakeEnv:
+        env = {}
+        cwd = "/workspace/shared-stale"
+
+        def execute(self, command, **kwargs):
+            calls.append((command, kwargs))
+            if command == "cmd-a":
+                a_entered.set()
+                assert b_finished.wait(5)
+                self.cwd = "/workspace/b-finished"
+                return {
+                    "output": "a",
+                    "returncode": 0,
+                    "cwd": "/workspace/a-finished",
+                }
+            if command == "cmd-b":
+                assert a_entered.wait(5)
+                self.cwd = "/workspace/b-finished"
+                b_finished.set()
+                return {
+                    "output": "b",
+                    "returncode": 0,
+                    "cwd": "/workspace/b-finished",
+                }
+            raise AssertionError(command)
+
+    config = _minimal_terminal_config(cwd="/workspace/default")
+    env = FakeEnv()
+    signature = terminal_tool._terminal_env_signature(config, task_id="default")
+    terminal_tool._store_active_environment("default", env, signature)
+    monkeypatch.setattr(terminal_tool, "_task_env_overrides", {
+        "sess-a": {"cwd": "/workspace/a-start"},
+        "sess-b": {"cwd": "/workspace/b-start"},
+    })
+    monkeypatch.setattr(terminal_tool, "_session_cwd", {})
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: config)
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_tool,
+        "_check_all_guards",
+        lambda command, env_type, **kwargs: {"approved": True},
+    )
+
+    results = {}
+
+    def run_command(task_id, command):
+        results[task_id] = json.loads(
+            terminal_tool.terminal_tool(command=command, task_id=task_id)
+        )
+
+    thread_a = threading.Thread(target=run_command, args=("sess-a", "cmd-a"))
+    thread_b = threading.Thread(target=run_command, args=("sess-b", "cmd-b"))
+    thread_a.start()
+    thread_b.start()
+    thread_a.join(timeout=5)
+    thread_b.join(timeout=5)
+
+    assert not thread_a.is_alive()
+    assert not thread_b.is_alive()
+    assert results["sess-a"]["output"] == "a"
+    assert results["sess-b"]["output"] == "b"
+    assert calls[0] == (
+        "cmd-a",
+        {"timeout": 60, "cwd": "/workspace/a-start", "bounded_capture": True},
+    )
+    assert calls[1] == (
+        "cmd-b",
+        {"timeout": 60, "cwd": "/workspace/b-start", "bounded_capture": True},
+    )
+    assert terminal_tool.get_session_cwd("sess-a") == "/workspace/a-finished"
+    assert terminal_tool.get_session_cwd("sess-b") == "/workspace/b-finished"
+    terminal_tool._active_environments.clear()
+    terminal_tool._last_activity.clear()
+    terminal_tool._environment_lease_states.clear()
 
 
 def test_safe_getcwd_returns_real_cwd(monkeypatch):

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -704,7 +704,7 @@ def _rpc_server_loop(
 # Remote execution support (file-based RPC via terminal backend)
 # ---------------------------------------------------------------------------
 
-def _get_or_create_env(task_id: str):
+def _get_or_create_env_lease(task_id: str):
     """Get or create the terminal environment for *task_id*.
 
     Reuses the same environment (container/sandbox/SSH session) that the
@@ -712,99 +712,91 @@ def _get_or_create_env(task_id: str):
     Returns ``(env, env_type)`` tuple.
     """
     from tools.terminal_tool import (
-        _active_environments, _env_lock, _create_environment,
-        _get_env_config, _last_activity, _start_cleanup_thread,
-        _creation_locks, _creation_locks_lock, _task_env_overrides,
-        _resolve_container_task_id,
+        _create_environment,
+        _get_env_config,
+        _start_cleanup_thread,
+        _creation_locks,
+        _creation_locks_lock,
+        _acquire_active_environment_if_compatible,
+        _store_active_environment,
+        resolve_terminal_runtime_identity,
     )
 
-    effective_task_id = _resolve_container_task_id(task_id)
+    config = _get_env_config()
+    runtime = resolve_terminal_runtime_identity(
+        config,
+        raw_task_id=task_id,
+    )
+    effective_task_id = runtime["effective_task_id"]
+    env_signature = runtime["signature"]
 
-    # Fast path: environment already exists
-    with _env_lock:
-        if effective_task_id in _active_environments:
-            _last_activity[effective_task_id] = time.time()
-            return _active_environments[effective_task_id], _get_env_config()["env_type"]
+    # Fast path: environment already exists and still matches current runtime.
+    env_lease = _acquire_active_environment_if_compatible(
+        effective_task_id,
+        env_signature,
+        raw_task_id=task_id,
+    )
+    if env_lease is not None:
+        return getattr(env_lease, "env"), runtime["env_type"], env_lease
 
     # Slow path: create environment (same pattern as file_tools._get_file_ops)
-    with _creation_locks_lock:
-        if effective_task_id not in _creation_locks:
-            _creation_locks[effective_task_id] = threading.Lock()
-        task_lock = _creation_locks[effective_task_id]
+    while True:
+        with _creation_locks_lock:
+            if effective_task_id not in _creation_locks:
+                _creation_locks[effective_task_id] = threading.Lock()
+            task_lock = _creation_locks[effective_task_id]
 
-    with task_lock:
-        with _env_lock:
-            if effective_task_id in _active_environments:
-                _last_activity[effective_task_id] = time.time()
-                return _active_environments[effective_task_id], _get_env_config()["env_type"]
+        with task_lock:
+            config = _get_env_config()
+            runtime = resolve_terminal_runtime_identity(
+                config,
+                raw_task_id=task_id,
+            )
+            if runtime["effective_task_id"] != effective_task_id:
+                effective_task_id = runtime["effective_task_id"]
+                env_signature = runtime["signature"]
+                continue
+            env_signature = runtime["signature"]
 
-        config = _get_env_config()
-        env_type = config["env_type"]
-        overrides = _task_env_overrides.get(effective_task_id, {})
+            env_lease = _acquire_active_environment_if_compatible(
+                effective_task_id,
+                env_signature,
+                raw_task_id=task_id,
+            )
+            if env_lease is not None:
+                return getattr(env_lease, "env"), runtime["env_type"], env_lease
 
-        if env_type == "docker":
-            image = overrides.get("docker_image") or config["docker_image"]
-        elif env_type == "singularity":
-            image = overrides.get("singularity_image") or config["singularity_image"]
-        elif env_type == "modal":
-            image = overrides.get("modal_image") or config["modal_image"]
-        elif env_type == "daytona":
-            image = overrides.get("daytona_image") or config["daytona_image"]
-        else:
-            image = ""
+            env_type = runtime["env_type"]
 
-        cwd = overrides.get("cwd") or config["cwd"]
+            logger.info("Creating new %s environment for execute_code task %s...",
+                         env_type, effective_task_id[:8])
+            env = _create_environment(
+                env_type=env_type,
+                image=runtime["image"],
+                cwd=runtime["cwd"],
+                timeout=config["timeout"],
+                ssh_config=runtime["ssh_config"],
+                container_config=runtime["container_config"],
+                local_config=runtime["local_config"],
+                task_id=effective_task_id,
+                host_cwd=config.get("host_cwd"),
+            )
 
-        container_config = None
-        if env_type in {"docker", "singularity", "modal", "daytona"}:
-            container_config = {
-                "container_cpu": config.get("container_cpu", 1),
-                "container_memory": config.get("container_memory", 5120),
-                "container_disk": config.get("container_disk", 51200),
-                "container_persistent": config.get("container_persistent", True),
-                "docker_volumes": config.get("docker_volumes", []),
-                "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
-                "docker_network": config.get("docker_network", True),
-            }
+            env_lease = _store_active_environment(
+                effective_task_id, env, env_signature, lease=True
+            )
+            env = getattr(env_lease, "env") if env_lease is not None else env
 
-        ssh_config = None
-        if env_type == "ssh":
-            ssh_config = {
-                "host": config.get("ssh_host", ""),
-                "user": config.get("ssh_user", ""),
-                "port": config.get("ssh_port", 22),
-                "key": config.get("ssh_key", ""),
-                "persistent": config.get("ssh_persistent", False),
-            }
+            _start_cleanup_thread()
+            logger.info("%s environment ready for execute_code task %s",
+                         env_type, effective_task_id[:8])
+            return env, env_type, env_lease
 
-        local_config = None
-        if env_type == "local":
-            local_config = {
-                "persistent": config.get("local_persistent", False),
-            }
 
-        logger.info("Creating new %s environment for execute_code task %s...",
-                     env_type, effective_task_id[:8])
-        env = _create_environment(
-            env_type=env_type,
-            image=image,
-            cwd=cwd,
-            timeout=config["timeout"],
-            ssh_config=ssh_config,
-            container_config=container_config,
-            local_config=local_config,
-            task_id=effective_task_id,
-            host_cwd=config.get("host_cwd"),
-        )
-
-        with _env_lock:
-            _active_environments[effective_task_id] = env
-            _last_activity[effective_task_id] = time.time()
-
-        _start_cleanup_thread()
-        logger.info("%s environment ready for execute_code task %s",
-                     env_type, effective_task_id[:8])
-        return env, env_type
+def _get_or_create_env(task_id: str):
+    env, env_type, lease = _get_or_create_env_lease(task_id)
+    lease.release()
+    return env, env_type
 
 
 def _ship_file_to_remote(env, remote_path: str, content: str) -> None:
@@ -1015,13 +1007,25 @@ def _execute_remote(
         sandbox_tools = SANDBOX_ALLOWED_TOOLS
 
     effective_task_id = task_id or "default"
-    env, env_type = _get_or_create_env(effective_task_id)
+    env, env_type, env_lease = _get_or_create_env_lease(effective_task_id)
+    lease_released = False
 
-    sandbox_id = uuid.uuid4().hex[:12]
-    temp_dir = _env_temp_dir(env)
-    sandbox_dir = f"{temp_dir}/hermes_exec_{sandbox_id}"
-    quoted_sandbox_dir = shlex.quote(sandbox_dir)
-    quoted_rpc_dir = shlex.quote(f"{sandbox_dir}/rpc")
+    def _release_env_lease_once() -> None:
+        nonlocal lease_released
+        if lease_released:
+            return
+        lease_released = True
+        env_lease.release()
+
+    try:
+        sandbox_id = uuid.uuid4().hex[:12]
+        temp_dir = _env_temp_dir(env)
+        sandbox_dir = f"{temp_dir}/hermes_exec_{sandbox_id}"
+        quoted_sandbox_dir = shlex.quote(sandbox_dir)
+        quoted_rpc_dir = shlex.quote(f"{sandbox_dir}/rpc")
+    except Exception:
+        _release_env_lease_once()
+        raise
 
     tool_call_log: list = []
     tool_call_counter = [0]
@@ -1130,6 +1134,8 @@ def _execute_remote(
             )
         except Exception:
             logger.debug("Failed to clean up remote sandbox %s", sandbox_dir)
+        finally:
+            _release_env_lease_once()
 
     duration = round(time.monotonic() - exec_start, 2)
 
@@ -1178,7 +1184,10 @@ def _execute_remote(
         result["status"] = "error"
         result["error"] = f"Script exited with code {exit_code}"
 
-    return json.dumps(result, ensure_ascii=False)
+    try:
+        return json.dumps(result, ensure_ascii=False)
+    finally:
+        _release_env_lease_once()
 
 
 # ---------------------------------------------------------------------------
@@ -1321,11 +1330,12 @@ def execute_code(
         # Two transports:
         #   POSIX: AF_UNIX stream socket on sock_path, chmod 0600 for
         #   owner-only access.  Filesystem permissions gate the socket.
-        #   Windows: AF_INET stream socket on 127.0.0.1 with an ephemeral
-        #   port.  No filesystem permission story, but loopback-only bind
-        #   means only the current user's processes (not remote) can
-        #   connect.  HERMES_RPC_SOCKET is set to ``tcp://127.0.0.1:<port>``
-        #   which the generated client parses to pick AF_INET.
+        #   Windows, or restricted POSIX sandboxes that reject AF_UNIX bind:
+        #   AF_INET stream socket on 127.0.0.1 with an ephemeral port.  No
+        #   filesystem permission story, but loopback-only bind plus the
+        #   per-run token keeps dispatch fail-closed. HERMES_RPC_SOCKET is set
+        #   to ``tcp://127.0.0.1:<port>`` which the generated client parses to
+        #   pick AF_INET.
         if _use_tcp_rpc:
             server_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             server_sock.bind(("127.0.0.1", 0))  # ephemeral port
@@ -1333,8 +1343,15 @@ def execute_code(
             rpc_endpoint = f"tcp://{_host}:{_port}"
         else:
             server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            server_sock.bind(sock_path)
-            os.chmod(sock_path, 0o600)
+            try:
+                server_sock.bind(sock_path)
+                os.chmod(sock_path, 0o600)
+            except PermissionError:
+                server_sock.close()
+                server_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                server_sock.bind(("127.0.0.1", 0))
+                _host, _port = server_sock.getsockname()[:2]
+                rpc_endpoint = f"tcp://{_host}:{_port}"
         server_sock.listen(1)
 
         # Wrapped so the thread inherits the turn's approval context + callbacks

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -1073,6 +1073,7 @@ class BaseEnvironment(ABC):
         cwd_path = output[first + len(marker) : last].strip()
         if cwd_path:
             self.cwd = cwd_path
+            result["cwd"] = cwd_path
 
         # Strip the marker line AND the \n we injected before it.
         # The wrapper emits: printf '\n__MARKER__%s__MARKER__\n'
@@ -1163,6 +1164,7 @@ class BaseEnvironment(ABC):
             proc, timeout=effective_timeout, bounded_capture=bounded_capture
         )
         self._update_cwd(result)
+        result.setdefault("cwd", effective_cwd)
 
         return result
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1527,17 +1527,22 @@ class LocalEnvironment(BaseEnvironment):
         ``result["output"]`` so output formatting is identical.
         """
         # Snapshot pre-existing cwd, defer to base for parsing + marker
-        # stripping, then validate / normalize whatever it assigned.
+        # stripping, then validate / normalize the cwd parsed for this exact
+        # command result. Do not reread self.cwd after base parsing: another
+        # shared-backend command can update that mutable field concurrently.
         prev_cwd = self.cwd
         super()._extract_cwd_from_output(result)
-        if self.cwd != prev_cwd:
-            normalized = _msys_to_windows_path(self.cwd) if _IS_WINDOWS else self.cwd
+        parsed_cwd = result.get("cwd")
+        if isinstance(parsed_cwd, str) and parsed_cwd and parsed_cwd != prev_cwd:
+            normalized = _msys_to_windows_path(parsed_cwd) if _IS_WINDOWS else parsed_cwd
             if normalized and os.path.isdir(normalized):
                 self.cwd = normalized
+                result["cwd"] = normalized
             else:
                 # Stale / non-existent path — keep previous cwd; _run_bash
                 # will resolve a safe fallback on the next call if needed.
                 self.cwd = prev_cwd
+                result["cwd"] = prev_cwd
 
     def cleanup(self):
         """Clean up temp files."""

--- a/tools/environments/modal_utils.py
+++ b/tools/environments/modal_utils.py
@@ -105,6 +105,7 @@ class BaseModalExecutionEnvironment(BaseEnvironment):
             return self._error_result(f"{self._unexpected_error_prefix}: {exc}")
 
         if start.immediate_result is not None:
+            start.immediate_result.setdefault("cwd", prepared.cwd)
             return start.immediate_result
 
         if start.handle is None:
@@ -128,7 +129,9 @@ class BaseModalExecutionEnvironment(BaseEnvironment):
                     self._cancel_modal_exec(start.handle)
                 except Exception:
                     pass
-                return self._result(self._interrupt_output, 130)
+                result = self._result(self._interrupt_output, 130)
+                result["cwd"] = prepared.cwd
+                return result
 
             try:
                 result = self._poll_modal_exec(start.handle)
@@ -136,6 +139,7 @@ class BaseModalExecutionEnvironment(BaseEnvironment):
                 return self._error_result(f"{self._unexpected_error_prefix}: {exc}")
 
             if result is not None:
+                result.setdefault("cwd", prepared.cwd)
                 return result
 
             if deadline is not None and time.monotonic() >= deadline:
@@ -143,7 +147,9 @@ class BaseModalExecutionEnvironment(BaseEnvironment):
                     self._cancel_modal_exec(start.handle)
                 except Exception:
                     pass
-                return self._timeout_result_for_modal(prepared.timeout)
+                result = self._timeout_result_for_modal(prepared.timeout)
+                result["cwd"] = prepared.cwd
+                return result
 
             # Periodic activity touch so the gateway knows we're alive
             try:

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -798,7 +798,7 @@ class ShellFileOperations(FileOperations):
     This includes local, docker, singularity, ssh, modal, and daytona environments.
     """
     
-    def __init__(self, terminal_env, cwd: str = None):
+    def __init__(self, terminal_env, cwd: str = None, *, bind_cwd: bool = False):
         """
         Initialize file operations with a terminal environment.
 
@@ -806,14 +806,16 @@ class ShellFileOperations(FileOperations):
             terminal_env: Any object with execute(command, cwd) method.
                          Returns {"output": str, "returncode": int}
             cwd: Optional explicit fallback cwd when the terminal env has
-                 no cwd attribute (rare — most backends track cwd live).
+                 no cwd attribute, or the operation cwd when bind_cwd=True.
+            bind_cwd: Prefer cwd over the shared backend's mutable cwd.
 
         Note:
             Every _exec() call prefers the LIVE ``terminal_env.cwd`` over
             ``self.cwd`` so ``cd`` commands run via the terminal tool are
             picked up immediately.  ``self.cwd`` is only used as a fallback
             when the env has no cwd at all — it is NOT the authoritative
-            cwd, despite being settable at init time.
+            cwd, despite being settable at init time. bind_cwd=True is used
+            by callers that already resolved a per-operation session cwd.
 
             Historical bug (fixed): prior versions of this class used the
             init-time cwd for every _exec() call, which caused relative
@@ -829,6 +831,7 @@ class ShellFileOperations(FileOperations):
         # If nothing provides a cwd, use "/" as a safe universal default.
         self.cwd = cwd or getattr(terminal_env, 'cwd', None) or \
                    getattr(getattr(terminal_env, 'config', None), 'cwd', None) or "/"
+        self._bind_cwd = bind_cwd
 
         # Cache for command availability checks
         self._command_cache: Dict[str, bool] = {}
@@ -843,8 +846,9 @@ class ShellFileOperations(FileOperations):
 
         Cwd resolution order (critical — see class docstring):
           1. Explicit ``cwd`` arg (if provided)
-          2. Live ``self.env.cwd`` (tracks ``cd`` commands run via terminal)
-          3. Init-time ``self.cwd`` (fallback when env has no cwd attribute)
+          2. Bound ``self.cwd`` when bind_cwd=True
+          3. Live ``self.env.cwd`` (tracks ``cd`` commands run via terminal)
+          4. Init-time ``self.cwd`` (fallback when env has no cwd attribute)
 
         This ordering ensures relative paths in file operations follow the
         terminal's current directory — not the directory this file_ops was
@@ -856,9 +860,14 @@ class ShellFileOperations(FileOperations):
         if stdin_data is not None:
             kwargs['stdin_data'] = stdin_data
 
-        # Resolve cwd from the live env so `cd` commands are picked up.
-        # Fall through to init-time self.cwd only if the env doesn't track cwd.
-        effective_cwd = cwd or getattr(self.env, 'cwd', None) or self.cwd
+        if cwd:
+            effective_cwd = cwd
+        elif self._bind_cwd:
+            effective_cwd = self.cwd
+        else:
+            # Resolve cwd from the live env so `cd` commands are picked up.
+            # Fall through to init-time self.cwd only if the env doesn't track cwd.
+            effective_cwd = getattr(self.env, 'cwd', None) or self.cwd
         result = self.env.execute(command, cwd=effective_cwd, **kwargs)
         return ExecuteResult(
             stdout=result.get("output", ""),

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -8,6 +8,7 @@ import os
 import posixpath
 import sys
 import threading
+from contextlib import contextmanager
 from pathlib import Path, PurePosixPath
 
 from agent.file_safety import get_read_block_error
@@ -175,7 +176,17 @@ def _terminal_env_type_for_task(task_id: str = "default") -> str:
             _env_lock,
             _get_env_config,
             _resolve_container_task_id,
+            resolve_terminal_runtime_identity,
         )
+
+        cfg = _get_env_config()
+        try:
+            runtime = resolve_terminal_runtime_identity(cfg, raw_task_id=task_id)
+            env_type = str(runtime.get("env_type") or "").lower()
+            if env_type:
+                return env_type
+        except Exception:
+            logger.debug("Could not resolve current terminal runtime identity", exc_info=True)
 
         try:
             container_key = _resolve_container_task_id(task_id)
@@ -197,7 +208,6 @@ def _terminal_env_type_for_task(task_id: str = "default") -> str:
                 return "modal"
             if "daytona" in name:
                 return "daytona"
-        cfg = _get_env_config()
         return str(cfg.get("env_type") or os.getenv("TERMINAL_ENV") or "local").lower()
     except Exception:
         return str(os.getenv("TERMINAL_ENV") or "local").lower()
@@ -925,7 +935,7 @@ def _is_internal_file_tool_content(content: str) -> bool:
     )
 
 
-def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
+def _get_file_ops_with_lease(task_id: str = "default") -> tuple[ShellFileOperations, object]:
     """Get or create ShellFileOperations for a terminal environment.
 
     Respects the TERMINAL_ENV setting -- if the task_id doesn't have an
@@ -941,160 +951,169 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
     a registered env override keep their isolation.
     """
     from tools.terminal_tool import (
-        _active_environments, _env_lock, _create_environment,
-        _get_env_config, _last_activity, _start_cleanup_thread,
+        _create_environment,
+        _ENV_SIGNATURE_ATTR,
+        _acquire_active_environment_if_compatible,
+        _get_env_config,
+        _start_cleanup_thread,
+        _store_active_environment,
         _creation_locks,
         _creation_locks_lock,
-        _resolve_container_task_id,
-        _is_unusable_container_cwd,
-        _CONTAINER_BACKENDS,
+        get_session_cwd,
+        resolve_terminal_runtime_identity,
     )
-    import time
 
     raw_task_id = task_id or "default"
-    task_id = _resolve_container_task_id(raw_task_id)
+    config = _get_env_config()
+    runtime = resolve_terminal_runtime_identity(
+        config,
+        raw_task_id=raw_task_id,
+        cwd_fallback=get_session_cwd(raw_task_id),
+    )
+    task_id = runtime["effective_task_id"]
+    env_signature = runtime["signature"]
 
     # Fast path: check cache -- but also verify the underlying environment
-    # is still alive (it may have been killed by the cleanup thread).
+    # is still alive and still compatible with the current runtime.
     with _file_ops_lock:
         cached = _file_ops_cache.get(task_id)
     if cached is not None:
-        with _env_lock:
-            if task_id in _active_environments:
-                _last_activity[task_id] = time.time()
-                return cached
-            else:
-                # Environment was cleaned up -- preserve the old cwd in the
-                # session record before invalidating the stale cache entry
-                # (fixes #26211: silent file-creation failures in long-running
-                # conversations). Usually a no-op: every completed command
-                # already recorded its cwd.
-                old_cwd = getattr(cached, "cwd", None)
-                if old_cwd:
-                    try:
-                        from tools.terminal_tool import record_session_cwd
-                        record_session_cwd(raw_task_id, old_cwd)
-                    except Exception:
-                        pass
-                with _file_ops_lock:
-                    _file_ops_cache.pop(task_id, None)
+        terminal_lease = _acquire_active_environment_if_compatible(
+            task_id,
+            env_signature,
+            raw_task_id=raw_task_id,
+        )
+        if terminal_lease is not None:
+            if getattr(cached, "env", None) is terminal_lease.env:
+                return cached, terminal_lease
+            terminal_lease.release()
+        # Environment was cleaned up or replaced -- preserve the old cwd before
+        # invalidating the stale cache entry only for idle cleanup where no
+        # raw session record exists (fixes #26211: silent file-creation
+        # failures in long-running conversations). Do not copy cwd out of a
+        # signature-replaced backend; that can restore an old SSH/container cwd
+        # over the current local/session cwd.
+        old_env = getattr(cached, "env", None)
+        old_cwd = getattr(old_env, "cwd", None) or getattr(cached, "cwd", None)
+        old_signature = getattr(old_env, _ENV_SIGNATURE_ATTR, None)
+        signature_replaced = (
+            isinstance(old_signature, dict)
+            and old_signature != env_signature
+        )
+        if old_cwd and not signature_replaced and get_session_cwd(raw_task_id) is None:
+            try:
+                from tools.terminal_tool import record_session_cwd
+                record_session_cwd(raw_task_id, old_cwd)
+            except Exception:
+                pass
+            runtime = resolve_terminal_runtime_identity(
+                config,
+                raw_task_id=raw_task_id,
+                cwd_fallback=old_cwd,
+            )
+            env_signature = runtime["signature"]
+        with _file_ops_lock:
+            _file_ops_cache.pop(task_id, None)
 
     # Need to ensure the environment exists before building file_ops.
     # Acquire per-task lock so only one thread creates the sandbox.
-    with _creation_locks_lock:
-        if task_id not in _creation_locks:
-            _creation_locks[task_id] = threading.Lock()
-        task_lock = _creation_locks[task_id]
+    while True:
+        with _creation_locks_lock:
+            if task_id not in _creation_locks:
+                _creation_locks[task_id] = threading.Lock()
+            task_lock = _creation_locks[task_id]
 
-    with task_lock:
-        # Double-check: another thread may have created it while we waited
-        with _env_lock:
-            if task_id in _active_environments:
-                _last_activity[task_id] = time.time()
-                terminal_env = _active_environments[task_id]
-            else:
-                terminal_env = None
-
-        if terminal_env is None:
-            from tools.terminal_tool import resolve_task_overrides
-
+        with task_lock:
+            # Config/runtime may have changed while this thread waited. If the
+            # effective cache key changed, switch to that key's creation lock
+            # before touching the cache or publishing a backend.
             config = _get_env_config()
-            env_type = config["env_type"]
-            overrides = resolve_task_overrides(raw_task_id)
-
-            if env_type == "docker":
-                image = overrides.get("docker_image") or config["docker_image"]
-            elif env_type == "singularity":
-                image = overrides.get("singularity_image") or config["singularity_image"]
-            elif env_type == "modal":
-                image = overrides.get("modal_image") or config["modal_image"]
-            elif env_type == "daytona":
-                image = overrides.get("daytona_image") or config["daytona_image"]
-            else:
-                image = ""
-
-            try:
-                from tools.terminal_tool import get_session_cwd
-                recorded_cwd = get_session_cwd(raw_task_id)
-            except Exception:
-                recorded_cwd = None
-            cwd = overrides.get("cwd") or recorded_cwd or config["cwd"]
-            # Re-apply the container cwd guard that _get_env_config() already
-            # ran on config["cwd"] (see #50636).  A per-task cwd override
-            # registered by the gateway/TUI/ACP for workspace tracking is a
-            # raw host path (e.g. a Desktop session's /Users/<me>/workspace or
-            # C:\\Users\\<me>). On a container backend that reaches
-            # ``docker run -w <host-path>`` and the container starts in a
-            # directory that doesn't exist inside the sandbox, so search_files
-            # and friends silently return empty results (#54447).  Sanitize it
-            # back to the already-validated config["cwd"] so the override can't
-            # bypass the guard.  Valid in-container override paths (RL/benchmark
-            # sandboxes that set cwd to /workspace, /root, etc.) are absolute
-            # non-host paths and pass through untouched.
-            if env_type in _CONTAINER_BACKENDS and _is_unusable_container_cwd(cwd):
-                if cwd != config["cwd"]:
-                    logger.info(
-                        "Ignoring host/relative cwd override %r for %s backend "
-                        "(won't exist in sandbox). Using %r instead.",
-                        cwd, env_type, config["cwd"],
-                    )
-                cwd = config["cwd"]
-            logger.info("Creating new %s environment for task %s...", env_type, task_id[:8])
-
-            container_config = None
-            if env_type in {"docker", "singularity", "modal", "daytona"}:
-                container_config = {
-                    "container_cpu": config.get("container_cpu", 1),
-                    "container_memory": config.get("container_memory", 5120),
-                    "container_disk": config.get("container_disk", 51200),
-                    "container_persistent": config.get("container_persistent", True),
-                    "docker_volumes": config.get("docker_volumes", []),
-                    "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
-                    "docker_forward_env": config.get("docker_forward_env", []),
-                    "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
-                    "docker_network": config.get("docker_network", True),
-                }
-
-            ssh_config = None
-            if env_type == "ssh":
-                ssh_config = {
-                    "host": config.get("ssh_host", ""),
-                    "user": config.get("ssh_user", ""),
-                    "port": config.get("ssh_port", 22),
-                    "key": config.get("ssh_key", ""),
-                    "persistent": config.get("ssh_persistent", False),
-                }
-
-            local_config = None
-            if env_type == "local":
-                local_config = {
-                    "persistent": config.get("local_persistent", False),
-                }
-
-            terminal_env = _create_environment(
-                env_type=env_type,
-                image=image,
-                cwd=cwd,
-                timeout=config["timeout"],
-                ssh_config=ssh_config,
-                container_config=container_config,
-                local_config=local_config,
-                task_id=task_id,
-                host_cwd=config.get("host_cwd"),
+            runtime = resolve_terminal_runtime_identity(
+                config,
+                raw_task_id=raw_task_id,
+                cwd_fallback=get_session_cwd(raw_task_id),
             )
+            if runtime["effective_task_id"] != task_id:
+                task_id = runtime["effective_task_id"]
+                env_signature = runtime["signature"]
+                continue
+            env_signature = runtime["signature"]
 
-            with _env_lock:
-                _active_environments[task_id] = terminal_env
-                _last_activity[task_id] = time.time()
+            # Double-check: another thread may have created it while we waited
+            terminal_lease = _acquire_active_environment_if_compatible(
+                task_id,
+                env_signature,
+                raw_task_id=raw_task_id,
+            )
+            terminal_env = getattr(terminal_lease, "env") if terminal_lease is not None else None
 
-            _start_cleanup_thread()
-            logger.info("%s environment ready for task %s", env_type, task_id[:8])
+            if terminal_env is None:
+                env_type = runtime["env_type"]
+                logger.info("Creating new %s environment for task %s...", env_type, task_id[:8])
+
+                terminal_env = _create_environment(
+                    env_type=env_type,
+                    image=runtime["image"],
+                    cwd=runtime["cwd"],
+                    timeout=config["timeout"],
+                    ssh_config=runtime["ssh_config"],
+                    container_config=runtime["container_config"],
+                    local_config=runtime["local_config"],
+                    task_id=task_id,
+                    host_cwd=config.get("host_cwd"),
+                )
+
+                terminal_lease = _store_active_environment(
+                    task_id, terminal_env, env_signature, lease=True
+                )
+                terminal_env = getattr(terminal_lease, "env") if terminal_lease is not None else terminal_env
+
+                _start_cleanup_thread()
+                logger.info("%s environment ready for task %s", env_type, task_id[:8])
+            break
 
     # Build file_ops from the (guaranteed live) environment and cache it
     file_ops = ShellFileOperations(terminal_env)
     with _file_ops_lock:
         _file_ops_cache[task_id] = file_ops
+    return file_ops, terminal_lease
+
+
+def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
+    file_ops, lease = _get_file_ops_with_lease(task_id)
+    lease.release()
     return file_ops
+
+
+_REAL_GET_FILE_OPS = _get_file_ops
+
+
+def _bind_file_ops_to_task_cwd(
+    file_ops: ShellFileOperations,
+    task_id: str = "default",
+) -> ShellFileOperations:
+    operation_cwd = _authoritative_workspace_root(task_id)
+    if not operation_cwd or not isinstance(file_ops, ShellFileOperations):
+        return file_ops
+    bound = ShellFileOperations(
+        getattr(file_ops, "env"),
+        cwd=operation_cwd,
+        bind_cwd=True,
+    )
+    bound._command_cache = file_ops._command_cache
+    return bound
+
+
+@contextmanager
+def _leased_file_ops(task_id: str = "default"):
+    if _get_file_ops is not _REAL_GET_FILE_OPS:
+        yield _get_file_ops(task_id)
+        return
+    file_ops, lease = _get_file_ops_with_lease(task_id)
+    try:
+        yield _bind_file_ops_to_task_cwd(file_ops, task_id)
+    finally:
+        lease.release()
 
 
 def clear_file_ops_cache(task_id: str = None):
@@ -1136,13 +1155,14 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
             except ExtractionError:
                 logger.debug("document extraction failed for %s", path, exc_info=True)
             else:
-                file_ops = _get_file_ops(task_id)
                 lines = extracted_text.splitlines()
                 total_lines = len(lines)
                 end_line = offset + limit - 1
                 page_text = "\n".join(lines[offset - 1:end_line])
+                with _leased_file_ops(task_id) as file_ops:
+                    numbered_content = file_ops._add_line_numbers(page_text, offset) if page_text else ""
                 result_dict = {
-                    "content": file_ops._add_line_numbers(page_text, offset) if page_text else "",
+                    "content": numbered_content,
                     "total_lines": total_lines,
                     "file_size": os.path.getsize(_resolved),
                     "truncated": total_lines > end_line,
@@ -1267,8 +1287,8 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 pass  # stat failed — fall through to full read
 
         # ── Perform the read ──────────────────────────────────────────
-        file_ops = _get_file_ops(task_id)
-        result = file_ops.read_file(path, offset, limit)
+        with _leased_file_ops(task_id) as file_ops:
+            result = file_ops.read_file(path, offset, limit)
         result_dict = result.to_dict()
 
         # ── Character-count guard ─────────────────────────────────────
@@ -1604,8 +1624,8 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
 
         if _resolved is None:
             stale_warning = _check_file_staleness(path, task_id)
-            file_ops = _get_file_ops(task_id)
-            result = file_ops.write_file(path, content)
+            with _leased_file_ops(task_id) as file_ops:
+                result = file_ops.write_file(path, content)
             result_dict = result.to_dict()
             if stale_warning:
                 result_dict["_warning"] = stale_warning
@@ -1625,8 +1645,8 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             # Workspace-divergence warning: relative path resolving outside the
             # terminal's cwd (the worktree-cwd bug). Lowest priority of the three.
             cwd_warning = _path_resolution_warning(path, Path(_resolved), task_id)
-            file_ops = _get_file_ops(task_id)
-            result = file_ops.write_file(_resolved, content)
+            with _leased_file_ops(task_id) as file_ops:
+                result = file_ops.write_file(_resolved, content)
             result_dict = result.to_dict()
             effective_warning = cross_warning or stale_warning or cwd_warning
             if effective_warning:
@@ -1758,26 +1778,25 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 if _sw:
                     stale_warnings.append(_sw)
 
-            file_ops = _get_file_ops(task_id)
-
-            if mode == "replace":
-                if not path:
-                    return tool_error("path required")
-                if old_string is None or new_string is None:
-                    return tool_error("old_string and new_string required")
-                # Pass the resolved ABSOLUTE path to the shell layer so it
-                # operates on the exact file the tool layer resolved — the
-                # shell's own cwd may differ (worktree-cwd bug), and a relative
-                # path would let the two layers disagree about which file is
-                # being edited.
-                _replace_target = _path_to_resolved.get(path) or path
-                result = file_ops.patch_replace(_replace_target, old_string, new_string, replace_all)
-            elif mode == "patch":
-                if not patch:
-                    return tool_error("patch content required")
-                result = file_ops.patch_v4a(patch)
-            else:
-                return tool_error(f"Unknown mode: {mode}")
+            with _leased_file_ops(task_id) as file_ops:
+                if mode == "replace":
+                    if not path:
+                        return tool_error("path required")
+                    if old_string is None or new_string is None:
+                        return tool_error("old_string and new_string required")
+                    # Pass the resolved ABSOLUTE path to the shell layer so it
+                    # operates on the exact file the tool layer resolved — the
+                    # shell's own cwd may differ (worktree-cwd bug), and a relative
+                    # path would let the two layers disagree about which file is
+                    # being edited.
+                    _replace_target = _path_to_resolved.get(path) or path
+                    result = file_ops.patch_replace(_replace_target, old_string, new_string, replace_all)
+                elif mode == "patch":
+                    if not patch:
+                        return tool_error("patch content required")
+                    result = file_ops.patch_v4a(patch)
+                else:
+                    return tool_error(f"Unknown mode: {mode}")
 
             result_dict = result.to_dict()
             if stale_warnings:
@@ -1896,11 +1915,11 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
         if block_error:
             return json.dumps({"error": block_error}, ensure_ascii=False)
 
-        file_ops = _get_file_ops(task_id)
-        result = file_ops.search(
-            pattern=pattern, path=path, target=target, file_glob=file_glob,
-            limit=limit, offset=offset, output_mode=output_mode, context=context
-        )
+        with _leased_file_ops(task_id) as file_ops:
+            result = file_ops.search(
+                pattern=pattern, path=path, target=target, file_glob=file_glob,
+                limit=limit, offset=offset, output_mode=output_mode, context=context
+            )
         omitted = _filter_read_blocked_search_results(result, task_id)
         if hasattr(result, 'matches'):
             for m in result.matches:

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -96,7 +96,8 @@ class ProcessSession:
     session_key: str = ""                       # Gateway session key (for reset protection)
     pid: Optional[int] = None                   # OS process ID
     process: Optional[subprocess.Popen] = None  # Popen handle (local only)
-    env_ref: Any = None                         # Reference to the environment object
+    env_ref: Any = None                         # Reference to the backend object
+    environment_lease: Any = None              # Lease held while backend process is running
     cwd: Optional[str] = None                   # Working directory
     started_at: float = 0.0                     # time.time() of spawn (wall clock)
     host_start_time: Optional[int] = None       # kernel start ticks (/proc/<pid>/stat f22) — PID-reuse guard
@@ -842,6 +843,7 @@ class ProcessRegistry:
         task_id: str = "",
         session_key: str = "",
         timeout: int = 10,
+        environment_lease: Any = None,
     ) -> ProcessSession:
         """
         Spawn a background process through a non-local environment backend.
@@ -862,6 +864,7 @@ class ProcessRegistry:
             cwd=cwd,
             started_at=time.time(),
             env_ref=env,
+            environment_lease=environment_lease,
             pid_scope="sandbox",
         )
 
@@ -922,7 +925,28 @@ class ProcessRegistry:
                 name=f"proc-poller-{session.id}",
             )
             session._reader_thread = reader
-            reader.start()
+            try:
+                reader.start()
+            except Exception as exc:
+                # The remote process is already running, but it has not been
+                # published to the registry yet. Roll it back before releasing
+                # the backend lease so replacement/cleanup cannot tear down a
+                # backend with an untracked process still alive inside it.
+                if session.pid is not None:
+                    try:
+                        env.execute(f"kill {session.pid} 2>/dev/null", timeout=5)
+                    except Exception:
+                        logger.debug(
+                            "Could not terminate remote process after poller start failure",
+                            exc_info=True,
+                        )
+                session.exited = True
+                session.exit_code = -1
+                session.completion_reason = "failed_start"
+                session.termination_source = "failed_start"
+                session.output_buffer = f"Failed to start poller: {exc}"
+                self._release_environment_lease(session)
+                raise
 
         with self._lock:
             self._prune_if_needed()
@@ -931,6 +955,8 @@ class ProcessRegistry:
 
         if not session.exited:
             self._write_checkpoint()
+        else:
+            self._release_environment_lease(session)
 
         return session
 
@@ -1139,6 +1165,21 @@ class ProcessRegistry:
             session.completion_reason = "exited"
         self._move_to_finished(session)
 
+    @staticmethod
+    def _release_environment_lease_object(lease: Any) -> None:
+        if lease is None:
+            return
+        try:
+            lease.release()
+        except Exception as exc:
+            logger.debug("Terminal backend lease release failed: %s", exc, exc_info=True)
+
+    def _release_environment_lease(self, session: ProcessSession) -> None:
+        with self._lock:
+            lease = getattr(session, "environment_lease", None)
+            session.environment_lease = None
+        self._release_environment_lease_object(lease)
+
     def _move_to_finished(self, session: ProcessSession):
         """Move a session from running to finished.
 
@@ -1149,7 +1190,11 @@ class ProcessRegistry:
         with self._lock:
             was_running = self._running.pop(session.id, None) is not None
             self._finished[session.id] = session
+            lease = session.environment_lease if was_running else None
+            if was_running:
+                session.environment_lease = None
         session._completion_event.set()
+        self._release_environment_lease_object(lease)
         self._write_checkpoint()
 
         # Only enqueue completion notification on the FIRST move.  Without

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -32,6 +32,7 @@ Usage:
 """
 
 import importlib.util
+import hashlib
 import json
 import logging
 import os
@@ -982,6 +983,55 @@ Do NOT use vim/nano/interactive tools without pty=true — they hang without a p
 _active_environments: Dict[str, Any] = {}
 _last_activity: Dict[str, float] = {}
 _env_lock = threading.Lock()
+_RETIRED_CLEANUP_WORKER_MAX_ATTEMPTS = 3
+
+
+class _EnvironmentLeaseState:
+    """Refcount state for one terminal backend object."""
+
+    def __init__(self, task_id: str, env: Any):
+        self.task_id = task_id
+        self.env = env
+        self.refcount = 0
+        self.retired = False
+        self.cleaned = False
+        self.cleaning = False
+        self.cleanup_failed = False
+        self.cleanup_attempts = 0
+        self.next_cleanup_retry_at = 0.0
+        self.force_remove = False
+
+
+class _EnvironmentLease:
+    """A held reference that keeps a backend object alive until released."""
+
+    def __init__(self, state: _EnvironmentLeaseState):
+        self._state = state
+        self.env = state.env
+        self._released = False
+
+    def release(self) -> None:
+        cleanup_item = None
+        with _env_lock:
+            if self._released:
+                return
+            self._released = True
+            state = self._state
+            if state.refcount > 0:
+                state.refcount -= 1
+            if state.retired and state.refcount == 0 and not state.cleaned:
+                cleanup_item = _mark_environment_state_cleaning_locked(state)
+        if cleanup_item is not None:
+            _cleanup_environment_item(cleanup_item)
+
+    def __enter__(self):
+        return self.env
+
+    def __exit__(self, exc_type, exc, tb):
+        self.release()
+
+
+_environment_lease_states: Dict[int, _EnvironmentLeaseState] = {}
 _creation_locks: Dict[str, threading.Lock] = {}  # Per-task locks for sandbox creation
 _creation_locks_lock = threading.Lock()  # Protects _creation_locks dict itself
 _cleanup_thread = None
@@ -1078,11 +1128,9 @@ _task_env_overrides: Dict[str, Dict[str, Any]] = {}
 # wrong-worktree bug class (env.cwd_owner stamping, _last_known_cwd, and the
 # ownership ladder in file_tools are all patches over that misplacement).
 #
-# Step 1 (this change): dual-write only. Every site that learns a session's
-# live cwd (post-command tracking, cwd-override registration) also records it
-# here. Readers still use the legacy env.cwd ladder. Later steps flip
-# file_tools and _resolve_command_cwd to read this store, then delete the
-# env-side tracking + ownership guards.
+# Every site that learns a session's live cwd records it here. Terminal cwd
+# resolution and file-tool relative operations read this raw session record so
+# a collapsed shared backend cannot leak one session's cwd into another.
 _session_cwd: Dict[str, str] = {}
 _session_cwd_lock = threading.Lock()
 
@@ -1225,6 +1273,530 @@ def resolve_task_overrides(task_id: Optional[str]) -> Dict[str, Any]:
         or _task_env_overrides.get(_resolve_container_task_id(raw))
         or {}
     )
+
+
+# Attribute stored on live execution environments so a config/profile/backend
+# change cannot accidentally reuse a sandbox/SSH shell created for a different
+# runtime. The cache key remains the session/task id; the signature is the
+# compatibility guard for the cached value behind that key.
+_ENV_SIGNATURE_ATTR = "_hermes_terminal_env_signature"
+
+
+def _normalize_signature_value(value: Any) -> str:
+    """Return a stable string for runtime signature values."""
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (list, tuple, dict)):
+        try:
+            return json.dumps(value, sort_keys=True, separators=(",", ":"))
+        except TypeError:
+            return str(value)
+    return str(value)
+
+
+def _fingerprint_for_signature(value: Any) -> str:
+    """Return a stable one-way fingerprint for sensitive signature fields."""
+    normalized = _normalize_signature_value(value)
+    if not normalized:
+        return ""
+    return hashlib.sha256(normalized.encode("utf-8", "surrogateescape")).hexdigest()
+
+
+def _ssh_key_fingerprint(key: Any) -> str:
+    """Fingerprint SSH key configuration without storing the raw path/material.
+
+    When *key* points at a readable file, include both normalized path identity
+    and file content so replacing a key at the same path invalidates the cached
+    SSH connection. If it is not a readable file, hash the configured value
+    itself; that preserves compatibility invalidation without exposing it.
+    """
+    if not isinstance(key, str) or not key.strip():
+        return ""
+    expanded = os.path.expanduser(key)
+    path = Path(expanded)
+    try:
+        resolved = str(path.resolve(strict=False))
+    except OSError:
+        resolved = expanded
+    digest = hashlib.sha256()
+    digest.update(resolved.encode("utf-8", "surrogateescape"))
+    try:
+        st = path.stat()
+        digest.update(f":{st.st_dev}:{st.st_ino}:{st.st_size}:{st.st_mtime_ns}:".encode("ascii"))
+        with path.open("rb") as fh:
+            for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError:
+        digest.update(b":unreadable:")
+        digest.update(key.encode("utf-8", "surrogateescape"))
+    return digest.hexdigest()
+
+
+def _runtime_image_for_config(config: Dict[str, Any], overrides: Optional[Dict[str, Any]] = None) -> str:
+    """Return the selected backend image for the current config/overrides."""
+    overrides = overrides or {}
+    env_type = config.get("env_type") or "local"
+    if env_type == "docker":
+        return overrides.get("docker_image") or config.get("docker_image") or ""
+    if env_type == "singularity":
+        return overrides.get("singularity_image") or config.get("singularity_image") or ""
+    if env_type == "modal":
+        return overrides.get("modal_image") or config.get("modal_image") or ""
+    if env_type == "daytona":
+        return overrides.get("daytona_image") or config.get("daytona_image") or ""
+    return ""
+
+
+def _container_config_for_runtime(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the complete container config passed to environment creation."""
+    return {
+        "container_cpu": config.get("container_cpu", 1),
+        "container_memory": config.get("container_memory", 5120),
+        "container_disk": config.get("container_disk", 51200),
+        "container_persistent": config.get("container_persistent", True),
+        "modal_mode": config.get("modal_mode", "auto"),
+        "docker_volumes": config.get("docker_volumes", []),
+        "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
+        "docker_forward_env": config.get("docker_forward_env", []),
+        "docker_env": config.get("docker_env", {}),
+        "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
+        "docker_extra_args": config.get("docker_extra_args", []),
+        "docker_network": config.get("docker_network", True),
+        "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
+        "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
+    }
+
+
+def _ssh_config_for_runtime(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Return SSH config passed to environment creation."""
+    return {
+        "host": config.get("ssh_host", ""),
+        "user": config.get("ssh_user", ""),
+        "port": config.get("ssh_port", 22),
+        "key": config.get("ssh_key", ""),
+        "persistent": config.get("ssh_persistent", False),
+    }
+
+
+def _local_config_for_runtime(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Return local backend config passed to environment creation."""
+    return {
+        "persistent": config.get("local_persistent", False),
+    }
+
+
+def _terminal_env_signature(
+    config: Dict[str, Any],
+    *,
+    task_id: str = "default",
+    overrides: Optional[Dict[str, Any]] = None,
+    image: Optional[str] = None,
+    cwd: Optional[str] = None,
+) -> Dict[str, str]:
+    """Build the runtime signature for a cached terminal environment."""
+    overrides = overrides or {}
+    env_type = config.get("env_type") or "local"
+    if image is None:
+        image = _runtime_image_for_config(config, overrides)
+    if cwd is None:
+        cwd = overrides.get("cwd") or config.get("cwd") or ""
+    fields = {
+        "task_id": task_id or "default",
+        "hermes_home": os.getenv("HERMES_HOME", ""),
+        "hermes_config_path": os.getenv("HERMES_CONFIG_PATH", ""),
+        "session_profile": os.getenv("HERMES_SESSION_PROFILE", ""),
+        "env_type": env_type,
+        "cwd": cwd,
+        "host_cwd": config.get("host_cwd"),
+        "image": image,
+        "modal_mode": config.get("modal_mode"),
+        "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace"),
+        "docker_volumes": config.get("docker_volumes"),
+        "docker_forward_env": config.get("docker_forward_env"),
+        "docker_env": config.get("docker_env"),
+        "docker_run_as_host_user": config.get("docker_run_as_host_user"),
+        "docker_network": config.get("docker_network"),
+        "docker_extra_args": config.get("docker_extra_args"),
+        "docker_persist_across_processes": config.get("docker_persist_across_processes"),
+        "docker_orphan_reaper": config.get("docker_orphan_reaper"),
+        "container_cpu": config.get("container_cpu"),
+        "container_memory": config.get("container_memory"),
+        "container_disk": config.get("container_disk"),
+        "container_persistent": config.get("container_persistent"),
+        "ssh_host": config.get("ssh_host"),
+        "ssh_user": config.get("ssh_user"),
+        "ssh_port": config.get("ssh_port"),
+        # Do not include raw key path/material in logs or signatures.
+        # Fingerprint distinguishes key-backed SSH identities and key rotation.
+        "ssh_key_present": bool(config.get("ssh_key")),
+        "ssh_key_fingerprint": _ssh_key_fingerprint(config.get("ssh_key")),
+        "ssh_persistent": config.get("ssh_persistent"),
+        "local_persistent": config.get("local_persistent"),
+        "timeout": config.get("timeout"),
+    }
+    return {key: _normalize_signature_value(value) for key, value in fields.items()}
+
+
+def resolve_terminal_runtime_identity(
+    config: Dict[str, Any],
+    *,
+    raw_task_id: Optional[str] = "default",
+    cwd_fallback: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Resolve current runtime identity and creation inputs for terminal envs."""
+    raw_task_id = raw_task_id or "default"
+    effective_task_id = _resolve_container_task_id(raw_task_id)
+    overrides = resolve_task_overrides(raw_task_id)
+    env_type = config["env_type"]
+    image = _runtime_image_for_config(config, overrides)
+    cwd_only_shared_override = (
+        effective_task_id != raw_task_id
+        and set(overrides.keys()) == {"cwd"}
+    )
+    signature_cwd = (
+        config["cwd"]
+        if cwd_only_shared_override
+        else (overrides.get("cwd") or config["cwd"])
+    )
+    session_cwd = get_session_cwd(raw_task_id)
+    cwd = (
+        session_cwd
+        or overrides.get("cwd")
+        or cwd_fallback
+        or config["cwd"]
+    )
+
+    if env_type in _CONTAINER_BACKENDS and _is_unusable_container_cwd(cwd):
+        if cwd != config["cwd"]:
+            logger.info(
+                "Ignoring host/relative cwd override %r for %s backend "
+                "(won't exist in sandbox). Using %r instead.",
+                cwd, env_type, config["cwd"],
+            )
+        cwd = config["cwd"]
+    if env_type in _CONTAINER_BACKENDS and _is_unusable_container_cwd(signature_cwd):
+        signature_cwd = config["cwd"]
+
+    container_config = (
+        _container_config_for_runtime(config)
+        if env_type in _CONTAINER_BACKENDS
+        else None
+    )
+    ssh_config = _ssh_config_for_runtime(config) if env_type == "ssh" else None
+    local_config = _local_config_for_runtime(config) if env_type == "local" else None
+    signature = _terminal_env_signature(
+        config,
+        task_id=effective_task_id,
+        overrides=overrides,
+        image=image,
+        cwd=signature_cwd,
+    )
+
+    return {
+        "raw_task_id": raw_task_id,
+        "effective_task_id": effective_task_id,
+        "overrides": overrides,
+        "env_type": env_type,
+        "image": image,
+        "cwd": cwd,
+        "container_config": container_config,
+        "ssh_config": ssh_config,
+        "local_config": local_config,
+        "signature": signature,
+    }
+
+
+def _safe_signature_for_log(signature: Optional[Dict[str, str]]) -> Dict[str, str]:
+    """Return a compact redacted signature suitable for warning logs."""
+    if not signature:
+        return {}
+    sensitive_fingerprint_keys = {
+        "image",
+        "docker_extra_args",
+        "docker_env",
+        "docker_forward_env",
+    }
+    safe_keys = (
+        "hermes_home",
+        "session_profile",
+        "env_type",
+        "cwd",
+        "host_cwd",
+        "image",
+        "docker_network",
+        "docker_forward_env",
+        "docker_env",
+        "docker_extra_args",
+        "docker_persist_across_processes",
+        "docker_orphan_reaper",
+        "ssh_host",
+        "ssh_user",
+        "ssh_port",
+        "ssh_key_present",
+        "local_persistent",
+        "ssh_persistent",
+    )
+    safe: Dict[str, str] = {}
+    for key in safe_keys:
+        value = signature.get(key, "")
+        if not value:
+            continue
+        if key in sensitive_fingerprint_keys:
+            safe[f"{key}_fingerprint"] = _fingerprint_for_signature(value)[:16]
+        else:
+            safe[key] = value
+    return safe
+
+
+def _signature_changed_fields_for_log(
+    old: Optional[Dict[str, str]],
+    new: Optional[Dict[str, str]],
+) -> list[str]:
+    """Return changed signature field names without logging sensitive values."""
+    old = old or {}
+    new = new or {}
+    return sorted(key for key in set(old) | set(new) if old.get(key) != new.get(key))
+
+
+def _clear_file_ops_cache_for_task(task_id: str) -> None:
+    """Best-effort invalidation for file_tools' wrapper around terminal envs."""
+    try:
+        from tools.file_tools import clear_file_ops_cache
+
+        clear_file_ops_cache(task_id)
+    except Exception:
+        logger.debug("Could not clear file ops cache for task %s", task_id, exc_info=True)
+
+
+def _cleanup_environment_object(task_id: str, env: Any, force_remove: bool = False) -> bool:
+    """Clean one backend object outside the lifecycle lock."""
+    try:
+        if hasattr(env, 'cleanup'):
+            if force_remove:
+                import inspect
+                sig = inspect.signature(env.cleanup)
+                if "force_remove" in sig.parameters:
+                    env.cleanup(force_remove=True)
+                else:
+                    env.cleanup()
+            else:
+                env.cleanup()
+        elif hasattr(env, 'stop'):
+            env.stop()
+        elif hasattr(env, 'terminate'):
+            env.terminate()
+        return True
+    except Exception as exc:
+        error_str = str(exc)
+        if "404" in error_str or "not found" in error_str.lower():
+            logger.info("Terminal backend for task %s already cleaned up", task_id)
+            return True
+        logger.warning("Error cleaning terminal backend for task %s: %s", task_id, exc)
+        return False
+
+
+def _environment_state_key(env: Any) -> int:
+    return id(env)
+
+
+def _environment_state_for_locked(task_id: str, env: Any) -> _EnvironmentLeaseState:
+    key = _environment_state_key(env)
+    state = _environment_lease_states.get(key)
+    if state is None:
+        state = _EnvironmentLeaseState(task_id, env)
+        _environment_lease_states[key] = state
+    else:
+        state.task_id = task_id
+    return state
+
+
+def _mark_environment_state_cleaning_locked(state: _EnvironmentLeaseState) -> tuple[str, Any, bool]:
+    state.cleaning = True
+    state.cleanup_failed = False
+    state.cleanup_attempts += 1
+    return state.task_id, state.env, state.force_remove
+
+
+def _finish_environment_state_cleanup(task_id: str, env: Any, success: bool) -> None:
+    with _env_lock:
+        state = _environment_lease_states.get(_environment_state_key(env))
+        if state is None:
+            return
+        state.cleaning = False
+        if success:
+            state.cleaned = True
+            state.cleanup_failed = False
+            state.next_cleanup_retry_at = 0.0
+            _environment_lease_states.pop(_environment_state_key(env), None)
+            return
+        state.task_id = task_id
+        state.cleanup_failed = True
+        delay = min(300.0, 30.0 * (2 ** max(0, state.cleanup_attempts - 1)))
+        state.next_cleanup_retry_at = time.time() + delay
+
+
+def _cleanup_environment_item(item: tuple[str, Any, bool]) -> bool:
+    task_id, env, force_remove = item
+    success = _cleanup_environment_object(task_id, env, force_remove)
+    _finish_environment_state_cleanup(task_id, env, success)
+    return success
+
+
+def _retire_environment_locked(task_id: str, env: Any, *, force_remove: bool = False) -> tuple[str, Any, bool] | None:
+    state = _environment_state_for_locked(task_id, env)
+    state.retired = True
+    state.force_remove = state.force_remove or force_remove
+    if state.refcount == 0 and not state.cleaned:
+        if state.cleaning:
+            return None
+        return _mark_environment_state_cleaning_locked(state)
+    return None
+
+
+def _retire_replaced_environment(task_id: str, env: Any) -> None:
+    """Retire an active-cache replacement and clean it after current leases."""
+    cleanup_item = None
+    with _env_lock:
+        cleanup_item = _retire_environment_locked(task_id, env)
+    if cleanup_item is not None:
+        _cleanup_environment_item(cleanup_item)
+
+
+def _acquire_environment_lease_locked(task_id: str, env: Any) -> _EnvironmentLease:
+    state = _environment_state_for_locked(task_id, env)
+    if state.retired or state.cleaned:
+        raise RuntimeError("Cannot acquire a retired terminal backend")
+    state.refcount += 1
+    return _EnvironmentLease(state)
+
+
+def _get_active_environment_if_compatible(
+    effective_task_id: str,
+    signature: Dict[str, str],
+    *,
+    raw_task_id: Optional[str] = None,
+) -> Any | None:
+    """Return a compatible active backend without holding a long-lived lease.
+
+    New execution paths should use ``_acquire_active_environment_if_compatible``
+    so the backend cannot be cleaned while in use. This compatibility wrapper is
+    kept for older tests and read-only helpers that only inspect the object.
+    """
+    lease = _acquire_active_environment_if_compatible(
+        effective_task_id,
+        signature,
+        raw_task_id=raw_task_id,
+    )
+    if lease is None:
+        return None
+    env = lease.env
+    lease.release()
+    return env
+
+
+def _acquire_active_environment_if_compatible(
+    effective_task_id: str,
+    signature: Dict[str, str],
+    *,
+    raw_task_id: Optional[str] = None,
+) -> _EnvironmentLease | None:
+    """Lease cached backend only when its runtime signature matches."""
+    lease = None
+    stale_records: list[tuple[str, Optional[Dict[str, str]], tuple[str, Any, bool] | None]] = []
+    with _env_lock:
+        candidate_keys = [effective_task_id]
+        if raw_task_id and raw_task_id != effective_task_id:
+            candidate_keys.append(raw_task_id)
+
+        for existing_key in candidate_keys:
+            env = _active_environments.get(existing_key)
+            if env is None:
+                continue
+
+            existing_signature = getattr(env, _ENV_SIGNATURE_ATTR, None)
+            if existing_signature == signature:
+                _last_activity[existing_key] = time.time()
+                lease = _acquire_environment_lease_locked(existing_key, env)
+                break
+
+            stale = _active_environments.pop(existing_key, None)
+            _last_activity.pop(existing_key, None)
+            stale_cleanup = None
+            if stale is not None:
+                stale_cleanup = _retire_environment_locked(existing_key, stale)
+            stale_records.append((
+                existing_key,
+                existing_signature if isinstance(existing_signature, dict) else None,
+                stale_cleanup,
+            ))
+
+    for stale_key, stale_signature, stale_cleanup in stale_records:
+        for key in {stale_key, effective_task_id, raw_task_id or ""}:
+            if key:
+                _clear_file_ops_cache_for_task(key)
+        logger.warning(
+            "Discarding cached terminal backend for task %s because runtime signature changed: changed_fields=%s old=%s new=%s",
+            stale_key[:8],
+            _signature_changed_fields_for_log(stale_signature, signature),
+            _safe_signature_for_log(stale_signature),
+            _safe_signature_for_log(signature),
+        )
+        if stale_cleanup is not None:
+            _cleanup_environment_item(stale_cleanup)
+    return lease
+
+
+def _store_active_environment(task_id: str, env: Any, signature: Dict[str, str], *, lease: bool = False) -> _EnvironmentLease | None:
+    """Store backend in the active cache with its runtime signature."""
+    try:
+        setattr(env, _ENV_SIGNATURE_ATTR, dict(signature))
+    except Exception:
+        logger.debug("Could not attach terminal backend signature for task %s", task_id, exc_info=True)
+    cleanup_items = []
+    acquired_lease = None
+    with _env_lock:
+        existing = _active_environments.get(task_id)
+        if existing is not None and existing is not env:
+            existing_signature = getattr(existing, _ENV_SIGNATURE_ATTR, None)
+            if existing_signature == signature:
+                _last_activity[task_id] = time.time()
+                cleanup_item = _retire_environment_locked(task_id, env)
+                if cleanup_item is not None:
+                    cleanup_items.append(cleanup_item)
+                if lease:
+                    acquired_lease = _acquire_environment_lease_locked(task_id, existing)
+            else:
+                cleanup_item = _retire_environment_locked(task_id, existing)
+                if cleanup_item is not None:
+                    cleanup_items.append(cleanup_item)
+                _active_environments[task_id] = env
+                _last_activity[task_id] = time.time()
+                state = _environment_state_for_locked(task_id, env)
+                state.retired = False
+                state.cleaned = False
+                state.cleanup_failed = False
+                state.next_cleanup_retry_at = 0.0
+                state.force_remove = False
+                if lease:
+                    state.refcount += 1
+                    acquired_lease = _EnvironmentLease(state)
+        else:
+            _active_environments[task_id] = env
+            _last_activity[task_id] = time.time()
+            state = _environment_state_for_locked(task_id, env)
+            state.retired = False
+            state.cleaned = False
+            state.cleanup_failed = False
+            state.next_cleanup_retry_at = 0.0
+            state.force_remove = False
+            if lease:
+                state.refcount += 1
+                acquired_lease = _EnvironmentLease(state)
+    for item in cleanup_items:
+        _cleanup_environment_item(item)
+    return acquired_lease
 
 
 # Configuration from environment variables
@@ -1634,24 +2206,19 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
 
 
 def _cleanup_inactive_envs(lifetime_seconds: int = 300):
-    """Clean up environments that have been inactive for longer than lifetime_seconds."""
+    """Retire environments that have been inactive longer than lifetime_seconds."""
     current_time = time.time()
 
-    # Check the process registry -- skip cleanup for sandboxes with active
-    # background processes (their _last_activity gets refreshed to keep them alive).
     try:
         from tools.process_registry import process_registry
         for task_id in list(_last_activity.keys()):
             if process_registry.has_active_processes(task_id):
-                _last_activity[task_id] = current_time  # Keep sandbox alive
+                _last_activity[task_id] = current_time
     except ImportError:
         pass
 
-    # Phase 1: collect stale entries and remove them from tracking dicts while
-    # holding the lock.  Do NOT call env.cleanup() inside the lock -- Modal and
-    # Docker teardown can block for 10-15s, which would stall every concurrent
-    # terminal/file tool call waiting on _env_lock.
-    envs_to_stop = []  # list of (task_id, env) pairs
+    cleanup_items = []
+    retired_tasks = []
 
     with _env_lock:
         for task_id, last_time in list(_last_activity.items()):
@@ -1659,40 +2226,26 @@ def _cleanup_inactive_envs(lifetime_seconds: int = 300):
                 env = _active_environments.pop(task_id, None)
                 _last_activity.pop(task_id, None)
                 if env is not None:
-                    envs_to_stop.append((task_id, env))
+                    retired_tasks.append(task_id)
+                    item = _retire_environment_locked(task_id, env)
+                    if item is not None:
+                        cleanup_items.append(item)
 
-        # Also purge per-task creation locks for cleaned-up tasks
         with _creation_locks_lock:
-            for task_id, _ in envs_to_stop:
+            for task_id in retired_tasks:
                 _creation_locks.pop(task_id, None)
 
-    # Phase 2: stop the actual sandboxes OUTSIDE the lock so other tool calls
-    # are not blocked while Modal/Docker sandboxes shut down.
-    for task_id, env in envs_to_stop:
-        # Invalidate stale file_ops cache entry (Bug fix: prevents
-        # ShellFileOperations from referencing a dead sandbox)
+    for task_id in retired_tasks:
         try:
             from tools.file_tools import clear_file_ops_cache
             clear_file_ops_cache(task_id)
         except ImportError:
             pass
 
-        try:
-            if hasattr(env, 'cleanup'):
-                env.cleanup()
-            elif hasattr(env, 'stop'):
-                env.stop()
-            elif hasattr(env, 'terminate'):
-                env.terminate()
-
+    for item in cleanup_items:
+        task_id = item[0]
+        if _cleanup_environment_item(item):
             logger.info("Cleaned up inactive environment for task: %s", task_id)
-
-        except Exception as e:
-            error_str = str(e)
-            if "404" in error_str or "not found" in error_str.lower():
-                logger.info("Environment for task %s already cleaned up", task_id)
-            else:
-                logger.warning("Error cleaning up environment for task %s: %s", task_id, e)
 
 
 def _cleanup_thread_worker():
@@ -1701,6 +2254,9 @@ def _cleanup_thread_worker():
         try:
             config = _get_env_config()
             _cleanup_inactive_envs(config["lifetime_seconds"])
+            _cleanup_retired_environments(
+                max_attempts=_RETIRED_CLEANUP_WORKER_MAX_ATTEMPTS
+            )
         except Exception as e:
             logger.warning("Error in cleanup thread: %s", e, exc_info=True)
 
@@ -1758,7 +2314,7 @@ def is_persistent_env(task_id: str) -> bool:
 
 
 
-def cleanup_all_environments():
+def cleanup_all_environments(*, force_retired: bool = False):
     """Clean up ALL active environments. Use with caution."""
     task_ids = list(_active_environments.keys())
     cleaned = 0
@@ -1769,6 +2325,8 @@ def cleanup_all_environments():
             cleaned += 1
         except Exception as e:
             logger.error("Error cleaning %s: %s", task_id, e, exc_info=True)
+
+    cleaned += len(_cleanup_retired_environments(force=force_retired))
     
     # Also clean any orphaned directories
     scratch_dir = _get_scratch_dir()
@@ -1785,85 +2343,86 @@ def cleanup_all_environments():
     return cleaned
 
 
+def _cleanup_retired_environments(
+    *,
+    force: bool = False,
+    max_attempts: int | None = None,
+) -> list[Any]:
+    """Drain retired backends whose final operation lease has been released."""
+    cleanup_items = []
+    now = time.time()
+    with _env_lock:
+        for state in list(_environment_lease_states.values()):
+            if (
+                state.retired
+                and (force or state.refcount == 0)
+                and not state.cleaned
+                and not state.cleaning
+                and (
+                    force
+                    or max_attempts is None
+                    or state.cleanup_attempts < max_attempts
+                )
+                and (force or state.next_cleanup_retry_at <= now)
+            ):
+                if force:
+                    state.force_remove = True
+                cleanup_items.append(_mark_environment_state_cleaning_locked(state))
+
+    cleaned_envs = []
+    for item in cleanup_items:
+        task_id, env, _force_remove = item
+        if _cleanup_environment_item(item):
+            cleaned_envs.append(env)
+            logger.info("Cleaned up retired environment for task: %s", task_id)
+    return cleaned_envs
+
+
 def cleanup_vm(task_id: str, *, force_remove: bool = False):
-    """Manually clean up a specific environment by task_id.
+    """Retire a specific environment by task_id.
 
-    *force_remove* (default False) is forwarded to backends that accept it
-    — currently only ``DockerEnvironment``. The default of False matches
-    session-lifecycle semantics: this function is called from
-    ``AIAgent.close()`` (TUI session close, gateway session teardown) and the
-    per-turn cleanup branch for non-persistent envs, both of which should
-    honor the user's persist-mode preference. Stopping the container here
-    would defeat the "ONE long-lived container shared across sessions"
-    contract — exactly the bug Ben reported when the container was killed
-    on every TUI session close.
-
-    Pass ``force_remove=True`` for actual user-initiated teardown
-    (e.g. ``/reset``-style flows that haven't been wired yet, or future
-    "destroy my sandbox" commands).
-
-    The idle reaper passes the env through ``env.cleanup()`` directly (not
-    via this function), so persist-mode idle envs are similarly no-op'd —
-    only the orphan reaper at next startup reclaims them.
+    Cleanup runs immediately when no operation holds a lease; otherwise the
+    final lease release performs it.
     """
-    # Remove from tracking dicts while holding the lock, but defer the
-    # actual (potentially slow) env.cleanup() call to outside the lock
-    # so other tool calls aren't blocked.
-    env = None
+    cleanup_item = None
     with _env_lock:
         env = _active_environments.pop(task_id, None)
         _last_activity.pop(task_id, None)
+        if env is not None:
+            cleanup_item = _retire_environment_locked(
+                task_id, env, force_remove=force_remove
+            )
 
-    # Clean up per-task creation lock
     with _creation_locks_lock:
         _creation_locks.pop(task_id, None)
 
-    # Invalidate stale file_ops cache entry
     try:
         from tools.file_tools import clear_file_ops_cache
         clear_file_ops_cache(task_id)
     except ImportError:
         pass
 
-    if env is None:
+    if cleanup_item is None:
         return
 
-    try:
-        if hasattr(env, 'cleanup'):
-            # Pass force_remove only if the env's cleanup() accepts it
-            # (DockerEnvironment after issue #20561; other backends don't).
-            import inspect
-            sig = inspect.signature(env.cleanup)
-            if "force_remove" in sig.parameters:
-                env.cleanup(force_remove=force_remove)
-            else:
-                env.cleanup()
-        elif hasattr(env, 'stop'):
-            env.stop()
-        elif hasattr(env, 'terminate'):
-            env.terminate()
-
+    if _cleanup_environment_item(cleanup_item):
         logger.info("Manually cleaned up environment for task: %s", task_id)
-
-    except Exception as e:
-        error_str = str(e)
-        if "404" in error_str or "not found" in error_str.lower():
-            logger.info("Environment for task %s already cleaned up", task_id)
-        else:
-            logger.warning("Error cleaning up environment for task %s: %s", task_id, e)
 
 
 def _atexit_cleanup():
     """Stop cleanup thread and shut down all remaining sandboxes on exit."""
     _stop_cleanup_thread()
-    if _active_environments:
+    with _env_lock:
         count = len(_active_environments)
+        envs_to_wait = list(_active_environments.values()) + [
+            state.env for state in _environment_lease_states.values()
+        ]
+    if count or envs_to_wait:
         logger.info("Shutting down %d remaining sandbox(es)...", count)
         # Snapshot the env objects BEFORE cleanup_all_environments empties
         # the dict; we need them to wait on docker cleanup threads after the
         # registry has been cleared.
-        envs_to_wait = list(_active_environments.values())
-        cleanup_all_environments()
+        cleanup_all_environments(force_retired=True)
         # Block briefly so docker stop/rm actually completes before the
         # interpreter exits. Issue #20561 — without this join, the daemon
         # cleanup threads were getting torn down mid-`docker stop`, leaving
@@ -2140,6 +2699,7 @@ def terminal_tool(
         # Force run after user confirmation
         # Note: force parameter is internal only, not exposed to model API
     """
+    env_lease = None
     try:
         if not isinstance(command, str):
             logger.warning(
@@ -2157,52 +2717,11 @@ def terminal_tool(
         config = _get_env_config()
         env_type = config["env_type"]
 
-        # Use task_id for environment isolation. By default all subagent
-        # task_ids collapse back to "default" so the top-level agent and
-        # every delegate_task child share one container; only task_ids with
-        # a registered env override (RL benchmarks) get isolated sandboxes.
-        effective_task_id = _resolve_container_task_id(task_id)
-
-        # Check per-task overrides (set by environments like TerminalBench2Env)
-        # before falling back to global env var config. ``resolve_task_overrides``
-        # reads the raw task id first then the collapsed container id, so a
-        # CWD-only override (which collapses ``effective_task_id`` to
-        # ``"default"``) is still found under its originating session id while
-        # isolation-keyed RL/benchmark overrides keep resolving as before.
-        overrides = resolve_task_overrides(task_id)
-        
-        # Select image based on env type, with per-task override support
-        if env_type == "docker":
-            image = overrides.get("docker_image") or config["docker_image"]
-        elif env_type == "singularity":
-            image = overrides.get("singularity_image") or config["singularity_image"]
-        elif env_type == "modal":
-            image = overrides.get("modal_image") or config["modal_image"]
-        elif env_type == "daytona":
-            image = overrides.get("daytona_image") or config["daytona_image"]
-        else:
-            image = ""
-
-        cwd = overrides.get("cwd") or get_session_cwd(task_id) or config["cwd"]
-        # A per-task cwd override (registered by the gateway/TUI for workspace
-        # tracking, or by RL/benchmark envs) wins over config["cwd"] — but
-        # config["cwd"] was already sanitized for container backends in
-        # _get_env_config() while the override is raw. On a container backend a
-        # raw host path (e.g. a Windows desktop session's C:\Users\<user>, or a
-        # POSIX /home/<user>) reaches `docker run -w <host-path>` and the
-        # container fails to start (exit 125). Re-apply the same host/relative
-        # path guard to the *resolved* cwd so the override can't bypass it.
-        # Valid in-container override paths (RL/benchmark sandboxes that set
-        # cwd to /workspace, /root, etc.) are absolute non-host paths and pass
-        # through untouched.
-        if env_type in _CONTAINER_BACKENDS and _is_unusable_container_cwd(cwd):
-            if cwd != config["cwd"]:
-                logger.info(
-                    "Ignoring host/relative cwd override %r for %s backend "
-                    "(won't exist in sandbox). Using %r instead.",
-                    cwd, env_type, config["cwd"],
-                )
-            cwd = config["cwd"]
+        runtime = resolve_terminal_runtime_identity(config, raw_task_id=task_id)
+        effective_task_id = runtime["effective_task_id"]
+        image = runtime["image"]
+        cwd = runtime["cwd"]
+        env_signature = runtime["signature"]
         default_timeout = config["timeout"]
         effective_timeout = timeout or default_timeout
 
@@ -2236,91 +2755,74 @@ def terminal_tool(
         # Use a per-task creation lock so concurrent tool calls for the same
         # task_id wait for the first one to finish creating the sandbox,
         # instead of each creating their own (wasting Modal resources).
-        env = None
-        with _env_lock:
-            # Prefer the collapsed container id, but fall back to an env cached
-            # under the raw task_id. Per-session surfaces (ACP/gateway/dashboard)
-            # with a CWD-only override collapse to "default" for container
-            # sharing, yet an env may already be cached under the originating
-            # task_id; honor it instead of spawning a duplicate.
-            _existing_key = (
-                effective_task_id if effective_task_id in _active_environments
-                else (task_id if task_id and task_id in _active_environments else None)
-            )
-            if _existing_key is not None:
-                _last_activity[_existing_key] = time.time()
-                env = _active_environments[_existing_key]
-                needs_creation = False
-            else:
-                needs_creation = True
+        env_lease = _acquire_active_environment_if_compatible(
+            effective_task_id,
+            env_signature,
+            raw_task_id=task_id,
+        )
+        env = env_lease.env if env_lease is not None else None
+        needs_creation = env_lease is None
 
-        if needs_creation:
-            # Per-task lock: only one thread creates the sandbox, others wait
+        while needs_creation:
+            # Per-task lock: only one thread creates the sandbox for the
+            # effective cache key. Runtime identity can change while we wait,
+            # so switch locks before touching the cache or publishing.
+            lock_task_id = effective_task_id
             with _creation_locks_lock:
-                if effective_task_id not in _creation_locks:
-                    _creation_locks[effective_task_id] = threading.Lock()
-                task_lock = _creation_locks[effective_task_id]
+                if lock_task_id not in _creation_locks:
+                    _creation_locks[lock_task_id] = threading.Lock()
+                task_lock = _creation_locks[lock_task_id]
 
             with task_lock:
-                # Double-check after acquiring the per-task lock
-                with _env_lock:
-                    _existing_key = (
-                        effective_task_id if effective_task_id in _active_environments
-                        else (task_id if task_id and task_id in _active_environments else None)
-                    )
-                    if _existing_key is not None:
-                        _last_activity[_existing_key] = time.time()
-                        env = _active_environments[_existing_key]
-                        needs_creation = False
+                # Config/runtime may have changed while this thread waited.
+                # Recompute before compatibility checks or publishing a new
+                # backend so a stale waiter cannot retire a freshly-created
+                # backend with the current signature.
+                config = _get_env_config()
+                runtime = resolve_terminal_runtime_identity(config, raw_task_id=task_id)
+                effective_task_id = runtime["effective_task_id"]
+                image = runtime["image"]
+                cwd = runtime["cwd"]
+                env_signature = runtime["signature"]
+                env_type = runtime["env_type"]
+                default_timeout = config["timeout"]
+                effective_timeout = timeout or default_timeout
+
+                if effective_task_id != lock_task_id:
+                    continue
+
+                if not background and timeout and timeout > FOREGROUND_MAX_TIMEOUT:
+                    return json.dumps({
+                        "error": (
+                            f"Foreground timeout {timeout}s exceeds the maximum of "
+                            f"{FOREGROUND_MAX_TIMEOUT}s. Use background=true with "
+                            f"notify_on_complete=true for long-running commands."
+                        ),
+                    }, ensure_ascii=False)
+
+                # Double-check after acquiring the per-task lock with the
+                # freshly recomputed signature.
+                env_lease = _acquire_active_environment_if_compatible(
+                    effective_task_id,
+                    env_signature,
+                    raw_task_id=task_id,
+                )
+                env = env_lease.env if env_lease is not None else None
+                needs_creation = env_lease is None
 
                 if needs_creation:
                     if env_type == "singularity":
                         _check_disk_usage_warning()
                     logger.info("Creating new %s environment for task %s...", env_type, effective_task_id[:8])
                     try:
-                        ssh_config = None
-                        if env_type == "ssh":
-                            ssh_config = {
-                                "host": config.get("ssh_host", ""),
-                                "user": config.get("ssh_user", ""),
-                                "port": config.get("ssh_port", 22),
-                                "key": config.get("ssh_key", ""),
-                                "persistent": config.get("ssh_persistent", False),
-                            }
-
-                        container_config = None
-                        if env_type in {"docker", "singularity", "modal", "daytona"}:
-                            container_config = {
-                                "container_cpu": config.get("container_cpu", 1),
-                                "container_memory": config.get("container_memory", 5120),
-                                "container_disk": config.get("container_disk", 51200),
-                                "container_persistent": config.get("container_persistent", True),
-                                "modal_mode": config.get("modal_mode", "auto"),
-                                "docker_volumes": config.get("docker_volumes", []),
-                                "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
-                                "docker_forward_env": config.get("docker_forward_env", []),
-                                "docker_env": config.get("docker_env", {}),
-                                "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
-                                "docker_extra_args": config.get("docker_extra_args", []),
-                                "docker_network": config.get("docker_network", True),
-                                "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
-                                "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
-                            }
-
-                        local_config = None
-                        if env_type == "local":
-                            local_config = {
-                                "persistent": config.get("local_persistent", False),
-                            }
-
                         new_env = _create_environment(
                             env_type=env_type,
                             image=image,
                             cwd=cwd,
                             timeout=effective_timeout,
-                            ssh_config=ssh_config,
-                            container_config=container_config,
-                            local_config=local_config,
+                            ssh_config=runtime["ssh_config"],
+                            container_config=runtime["container_config"],
+                            local_config=runtime["local_config"],
                             task_id=effective_task_id,
                             host_cwd=config.get("host_cwd"),
                         )
@@ -2332,10 +2834,11 @@ def terminal_tool(
                             "status": "disabled"
                         }, ensure_ascii=False)
 
-                    with _env_lock:
-                        _active_environments[effective_task_id] = new_env
-                        _last_activity[effective_task_id] = time.time()
-                        env = new_env
+                    env_lease = _store_active_environment(
+                        effective_task_id, new_env, env_signature, lease=True
+                    )
+                    env = env_lease.env if env_lease is not None else new_env
+                    needs_creation = False
                     logger.info("%s environment ready for task %s", env_type, effective_task_id[:8])
 
         if env is None:
@@ -2481,7 +2984,9 @@ def terminal_tool(
                         cwd=effective_cwd,
                         task_id=effective_task_id,
                         session_key=session_key,
+                        environment_lease=env_lease,
                     )
+                    env_lease = None
 
                 result_data = {
                     "output": "Background process started",
@@ -2764,13 +3269,11 @@ def terminal_tool(
                 # Got a result
                 break
 
-            # Dual-write (cwd rearch step 1): the env's post-command tracking
-            # (marker parse / local sync) has just updated env.cwd with the
-            # directory this command finished in. That cwd belongs to THIS
-            # session — record it under the session key so the durable record
-            # never depends on the shared env surviving or on who drives the
-            # env next.
-            record_session_cwd(session_key, getattr(env, "cwd", None))
+            # The execution result carries the cwd observed by THIS command's
+            # wrapper. Do not read the shared backend cwd here: another session
+            # can drive the same collapsed environment before we persist ours.
+            result_cwd = result.get("cwd") if isinstance(result, dict) else None
+            record_session_cwd(session_key, result_cwd)
 
             # Extract output
             output = result.get("output", "")
@@ -2906,6 +3409,9 @@ def terminal_tool(
             "traceback": tb_str,
             "status": "error"
         }, ensure_ascii=False)
+    finally:
+        if env_lease is not None:
+            env_lease.release()
 
 
 def check_terminal_requirements() -> bool:


### PR DESCRIPTION
## Summary

Fix stale terminal/runtime environment reuse when the configured backend changes under the same task/session id.

Previously, `terminal`, `execute_code`, and file-backed tools reused `_active_environments` by task id without checking whether the current runtime configuration still matched the cached environment. If a session first created an SSH-backed environment and then the runtime switched back to local execution, later tool calls could continue using the stale SSH environment.

This PR attaches a runtime signature to cached terminal environments and validates it before reuse. When the signature differs, the stale environment is removed, cleaned up best-effort, and recreated with the current runtime configuration.

## Details

- Add a terminal environment runtime signature helper.
- Validate cached environments before reuse.
- Share the cache-validation helpers across:
  - `terminal_tool`
  - `code_execution_tool`
  - `file_tools`
- Preserve backwards compatibility for pre-existing cached env objects that do not have a signature yet.
- Add regression coverage for SSH -> local backend switching under the same session/task id.
- Keep existing foreground timeout behavior covered.

## Scope

This intentionally fixes the tool/runtime cache boundary only. It does not change WebUI profile switching behavior or profile gateway status reporting.

## Test Plan

- `python -m py_compile tools/terminal_tool.py tools/code_execution_tool.py tools/file_tools.py tests/tools/test_terminal_env_signature_cache.py`
- `python -m pytest tests/tools/test_terminal_env_signature_cache.py tests/tools/test_terminal_foreground_timeout_cap.py -o addopts= -q`
  - `13 passed`

## Hygiene

- `git diff --cached --check`
- non-ASCII added-line scan: `0`
- private host/path token scan: no matches


## Related PRs

- Related to earlier PR #23321, which implements the same broad stale terminal environment cache-invalidation mechanism for terminal/file tools. This PR is based on current `main` and also applies the shared cache-validation path to `code_execution_tool`.
