### PR TITLE
fix(desktop): finalize Linux sandbox and install launcher after every pack

### DIFF
--- a/hermes_cli/desktop_linux.py
+++ b/hermes_cli/desktop_linux.py
@@ -1,0 +1,47 @@
+"""Linux-specific Hermes Desktop packaging helpers."""
+
+from __future__ import annotations
+
+import shutil
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+
+def ensure_electron_sandbox_fixup(packaged_executable: Path) -> bool:
+    """Configure Electron's Linux SUID sandbox helper when required."""
+    if sys.platform != "linux":
+        return True
+
+    sandbox = packaged_executable.parent / "chrome-sandbox"
+    if not sandbox.exists():
+        print(f"✗ Hermes Desktop is missing Electron's Linux sandbox helper: {sandbox}")
+        return False
+
+    # Reject symlinks — chown/chmod must not follow an attacker-controlled
+    # link to an arbitrary path.  Use lstat() so we inspect the link itself
+    # rather than the target, and require a regular file.
+    try:
+        sandbox_lstat = sandbox.lstat()
+    except OSError:
+        print(f"✗ Cannot stat Electron's Linux sandbox helper: {sandbox}")
+        return False
+    if not stat.S_ISREG(sandbox_lstat.st_mode):
+        print(f"✗ Electron's Linux sandbox helper is not a regular file: {sandbox}")
+        return False
+
+    if sandbox_lstat.st_uid == 0 and stat.S_IMODE(sandbox_lstat.st_mode) == 0o4755:
+        return True
+
+    sudo = shutil.which("sudo")
+    if not sudo:
+        print("✗ Hermes Desktop requires sudo to configure Electron's Linux sandbox helper.")
+        return False
+
+    print("→ Configuring Electron Linux sandbox helper (sudo required)...")
+    for command in ([sudo, "chown", "root:root", str(sandbox)], [sudo, "chmod", "4755", str(sandbox)]):
+        if subprocess.run(command, check=False).returncode != 0:
+            print(f"✗ Failed to configure Electron's Linux sandbox helper: {sandbox}")
+            return False
+    return True

--- a/hermes_cli/gui_uninstall.py
+++ b/hermes_cli/gui_uninstall.py
@@ -142,12 +142,9 @@ def packaged_gui_app_paths() -> "list[Path]":
         # hint rather than guessing. deb/rpm installs are owned by the system
         # package manager and must be removed via apt/dnf — see the message in
         # ``uninstall_gui``.
-        data = os.environ.get("XDG_DATA_HOME")
-        data_base = Path(data) if data else (home / ".local" / "share")
-        paths += [
-            data_base / "applications" / "hermes.desktop",
-            data_base / "applications" / "Hermes.desktop",
-        ]
+        from hermes_cli.linux_desktop_launcher import linux_desktop_shortcut_paths
+
+        paths += linux_desktop_shortcut_paths()
     return paths
 
 

--- a/hermes_cli/linux_desktop_launcher.py
+++ b/hermes_cli/linux_desktop_launcher.py
@@ -1,0 +1,183 @@
+"""Install and run the Linux Hermes Desktop launcher (.desktop + wrapper script).
+
+Unlike Windows shortcuts that can point directly at the packaged ``Hermes.exe``,
+Linux Electron builds require a one-time ``chrome-sandbox`` setuid setup after
+every unpack/rebuild.  The wrapper ensures that invariant before ``exec``-ing
+the packaged binary — the correct Linux analogue of a Start Menu shortcut.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+from hermes_constants import get_hermes_home
+
+from hermes_cli.desktop_linux import ensure_electron_sandbox_fixup
+
+LAUNCHER_NAME = "hermes-desktop-launch"
+DESKTOP_FILENAME = "hermes-desktop.desktop"
+STARTUP_WM_CLASS = "Hermes"
+
+
+def resolve_packaged_executable(agent_root: Path) -> Path | None:
+    """Return the newest packaged Linux desktop executable under *agent_root*."""
+    release_dir = agent_root / "apps" / "desktop" / "release"
+    candidates = [
+        release_dir / "linux-unpacked" / "Hermes",
+        release_dir / "linux-unpacked" / "hermes",
+        release_dir / "linux-arm64-unpacked" / "Hermes",
+        release_dir / "linux-arm64-unpacked" / "hermes",
+    ]
+    existing = [p for p in candidates if p.is_file()]
+    if not existing:
+        return None
+    return max(existing, key=lambda p: p.stat().st_mtime)
+
+
+def _agent_root_from_env() -> Path:
+    hermes_home = Path(os.environ.get("HERMES_HOME", get_hermes_home())).expanduser()
+    return Path(os.environ.get("HERMES_AGENT", hermes_home / "hermes-agent")).expanduser().resolve()
+
+
+def _local_bin_dir() -> Path:
+    return Path.home() / ".local" / "bin"
+
+
+def _applications_dir() -> Path:
+    xdg_data = os.environ.get("XDG_DATA_HOME")
+    data_base = Path(xdg_data).expanduser() if xdg_data else (Path.home() / ".local" / "share")
+    return data_base / "applications"
+
+
+def _desktop_icon_path(agent_root: Path) -> Path:
+    return agent_root / "apps" / "desktop" / "assets" / "icon.png"
+
+
+def render_launcher_script(agent_root: Path) -> str:
+    agent_root = agent_root.resolve()
+    return f"""#!/usr/bin/env bash
+set -euo pipefail
+export HERMES_HOME="${{HERMES_HOME:-$HOME/.hermes}}"
+export HERMES_AGENT="${{HERMES_AGENT:-$HERMES_HOME/hermes-agent}}"
+export PATH="$HERMES_AGENT/venv/bin:$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin"
+exec "$HERMES_AGENT/venv/bin/python" -m hermes_cli.linux_desktop_launcher launch "$@"
+"""
+
+
+def render_desktop_entry(*, launcher_path: Path, icon_path: Path) -> str:
+    return (
+        "[Desktop Entry]\n"
+        "Type=Application\n"
+        "Name=Hermes\n"
+        "Comment=Hermes Agent desktop app\n"
+        f"Exec={launcher_path}\n"
+        f"Icon={icon_path}\n"
+        "Terminal=false\n"
+        "Categories=Development;\n"
+        f"StartupWMClass={STARTUP_WM_CLASS}\n"
+    )
+
+
+def install_linux_desktop_shortcuts(agent_root: Path) -> list[Path]:
+    """Install the launcher script and .desktop entry. Best-effort; returns paths written."""
+    if sys.platform != "linux":
+        return []
+
+    agent_root = agent_root.resolve()
+    icon_path = _desktop_icon_path(agent_root)
+    if not icon_path.is_file():
+        raise FileNotFoundError(f"Desktop icon not found: {icon_path}")
+
+    launcher_dir = _local_bin_dir()
+    launcher_dir.mkdir(parents=True, exist_ok=True)
+    launcher_path = launcher_dir / LAUNCHER_NAME
+    launcher_path.write_text(render_launcher_script(agent_root), encoding="utf-8")
+    launcher_path.chmod(launcher_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    apps_dir = _applications_dir()
+    apps_dir.mkdir(parents=True, exist_ok=True)
+    desktop_path = apps_dir / DESKTOP_FILENAME
+    desktop_path.write_text(
+        render_desktop_entry(launcher_path=launcher_path.resolve(), icon_path=icon_path.resolve()),
+        encoding="utf-8",
+    )
+    return [launcher_path, desktop_path]
+
+
+def linux_desktop_shortcut_paths() -> list[Path]:
+    """Standard install locations for the Linux desktop launcher artifacts."""
+    return [
+        _local_bin_dir() / LAUNCHER_NAME,
+        _applications_dir() / DESKTOP_FILENAME,
+        _applications_dir() / "hermes.desktop",
+        _applications_dir() / "Hermes.desktop",
+    ]
+
+
+def finalize_packaged_linux_desktop(agent_root: Path, packaged_executable: Path) -> bool:
+    """Post-build invariant: sandbox helper configured and launcher installed."""
+    if sys.platform != "linux":
+        return True
+
+    if not ensure_electron_sandbox_fixup(packaged_executable):
+        return False
+
+    try:
+        written = install_linux_desktop_shortcuts(agent_root)
+    except OSError as exc:
+        print(f"  (warning: could not install Linux desktop launcher: {exc})")
+        return True
+
+    for path in written:
+        print(f"✓ Linux desktop launcher installed: {path}")
+    return True
+
+
+def launch_packaged_desktop(extra_args: list[str]) -> None:
+    """Ensure sandbox is configured, then replace this process with Hermes Desktop."""
+    agent_root = _agent_root_from_env()
+    packaged_executable = resolve_packaged_executable(agent_root)
+    if packaged_executable is None:
+        print(
+            f"✗ No packaged Hermes Desktop executable found under {agent_root / 'apps/desktop/release'}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    if not ensure_electron_sandbox_fixup(packaged_executable):
+        raise SystemExit(1)
+
+    argv = [str(packaged_executable), *extra_args]
+    os.execve(str(packaged_executable), argv, os.environ)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if not args or args[0] == "launch":
+        launch_args = args[1:] if args and args[0] == "launch" else args
+        launch_packaged_desktop(launch_args)
+        return 1
+
+    if args[0] == "finalize-build":
+        if len(args) != 2:
+            print("usage: python -m hermes_cli.linux_desktop_launcher finalize-build <agent-root>", file=sys.stderr)
+            return 2
+        agent_root = Path(args[1]).expanduser().resolve()
+        packaged_executable = resolve_packaged_executable(agent_root)
+        if packaged_executable is None:
+            print(f"✗ No packaged Linux desktop executable found under {agent_root}", file=sys.stderr)
+            return 1
+        return 0 if finalize_packaged_linux_desktop(agent_root, packaged_executable) else 1
+
+    print(
+        "usage: python -m hermes_cli.linux_desktop_launcher [launch [args...] | finalize-build <agent-root>]",
+        file=sys.stderr,
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5404,42 +5404,12 @@ def _desktop_macos_relaunchable_fixup(desktop_dir: Path) -> None:
         print(f"  (warning: macOS relaunch fixup skipped: {exc})")
 
 
-def _desktop_linux_sandbox_fixup(packaged_executable: Path) -> bool:
-    """Configure Electron's Linux SUID sandbox helper when required."""
-    if sys.platform != "linux":
-        return True
+def _finalize_packaged_linux_desktop(packaged_executable: Path) -> None:
+    """Apply Linux post-build invariants after a packaged desktop build."""
+    from hermes_cli.linux_desktop_launcher import finalize_packaged_linux_desktop
 
-    sandbox = packaged_executable.parent / "chrome-sandbox"
-    if not sandbox.exists():
-        print(f"✗ Hermes Desktop is missing Electron's Linux sandbox helper: {sandbox}")
-        return False
-
-    # Reject symlinks — chown/chmod must not follow an attacker-controlled
-    # link to an arbitrary path.  Use lstat() so we inspect the link itself
-    # rather than the target, and require a regular file.
-    try:
-        sandbox_lstat = sandbox.lstat()
-    except OSError:
-        print(f"✗ Cannot stat Electron's Linux sandbox helper: {sandbox}")
-        return False
-    if not stat.S_ISREG(sandbox_lstat.st_mode):
-        print(f"✗ Electron's Linux sandbox helper is not a regular file: {sandbox}")
-        return False
-
-    if sandbox_lstat.st_uid == 0 and stat.S_IMODE(sandbox_lstat.st_mode) == 0o4755:
-        return True
-
-    sudo = shutil.which("sudo")
-    if not sudo:
-        print("✗ Hermes Desktop requires sudo to configure Electron's Linux sandbox helper.")
-        return False
-
-    print("→ Configuring Electron Linux sandbox helper (sudo required)...")
-    for command in ([sudo, "chown", "root:root", str(sandbox)], [sudo, "chmod", "4755", str(sandbox)]):
-        if subprocess.run(command, check=False).returncode != 0:
-            print(f"✗ Failed to configure Electron's Linux sandbox helper: {sandbox}")
-            return False
-    return True
+    if not finalize_packaged_linux_desktop(PROJECT_ROOT, packaged_executable):
+        sys.exit(1)
 
 
 def cmd_gui(args: argparse.Namespace):
@@ -5591,6 +5561,8 @@ def cmd_gui(args: argparse.Namespace):
 
             # Build succeeded — write the stamp so next run can skip
             _write_desktop_build_stamp(PROJECT_ROOT, source_mode=source_mode)
+            if packaged_executable is not None and not source_mode:
+                _finalize_packaged_linux_desktop(packaged_executable)
 
     # --build-only: produce the artifact but do NOT launch. The installer's
     # --update flow drives the rebuild headlessly and then launches the desktop
@@ -5610,6 +5582,7 @@ def cmd_gui(args: argparse.Namespace):
             sys.exit(1)
         else:
             print(f"✓ Desktop packaged app ready: {packaged_executable} (not launching; --build-only)")
+            _finalize_packaged_linux_desktop(packaged_executable)
         return
 
     if source_mode:
@@ -5622,7 +5595,9 @@ def cmd_gui(args: argparse.Namespace):
         print("  Expected an unpacked Electron app for the current OS.")
         sys.exit(1)
 
-    if not _desktop_linux_sandbox_fixup(packaged_executable):
+    from hermes_cli.desktop_linux import ensure_electron_sandbox_fixup
+
+    if not ensure_electron_sandbox_fixup(packaged_executable):
         sys.exit(1)
 
     print(f"→ Launching packaged Hermes Desktop: {packaged_executable}")

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2593,27 +2593,12 @@ install_desktop() {
     fi
     log_success "Desktop app built: $app"
 
-    # Linux: Electron's chrome-sandbox helper needs root:root 4755 or the
-    # sandboxed renderer will abort on startup.  Check the file is a regular
-    # file (not a symlink) before chown/chmod so we don't follow an
-    # attacker-controlled link to an arbitrary path.
+    # Linux: configure Electron's chrome-sandbox helper and install the .desktop
+    # launcher via the shared Python module (same path as `hermes desktop`).
     if [ "$OS" = "linux" ]; then
-        local sandbox="$desktop_dir/release/linux-unpacked/chrome-sandbox"
-        if [ -f "$sandbox" ] && [ ! -L "$sandbox" ]; then
-            if [ "$(id -u)" -eq 0 ]; then
-                chown root:root "$sandbox" && chmod 4755 "$sandbox" || {
-                    log_error "Cannot configure Electron sandbox helper: $sandbox"
-                    return 1
-                }
-            elif command -v sudo >/dev/null 2>&1; then
-                sudo chown root:root "$sandbox" && sudo chmod 4755 "$sandbox" || {
-                    log_error "Cannot configure Electron sandbox helper (sudo failed): $sandbox"
-                    return 1
-                }
-            else
-                log_error "Cannot configure Electron sandbox helper without sudo: $sandbox"
-                return 1
-            fi
+        if ! "$INSTALL_DIR/venv/bin/python" -m hermes_cli.linux_desktop_launcher finalize-build "$INSTALL_DIR"; then
+            log_error "Cannot finalize Linux desktop launcher/sandbox helper"
+            return 1
         fi
     fi
 

--- a/tests/hermes_cli/test_desktop_linux.py
+++ b/tests/hermes_cli/test_desktop_linux.py
@@ -1,0 +1,61 @@
+"""Tests for Linux Electron sandbox fixup."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import desktop_linux
+
+
+def test_ensure_electron_sandbox_fixup_configures_missing_setuid(tmp_path, monkeypatch):
+    monkeypatch.setattr(desktop_linux.sys, "platform", "linux")
+    packaged = tmp_path / "Hermes"
+    packaged.write_text("", encoding="utf-8")
+    sandbox = packaged.parent / "chrome-sandbox"
+    sandbox.write_text("", encoding="utf-8")
+    sandbox.chmod(0o755)
+    ok = subprocess.CompletedProcess([], 0)
+
+    with patch("hermes_cli.desktop_linux.shutil.which", return_value="/usr/bin/sudo"), \
+         patch("hermes_cli.desktop_linux.subprocess.run", return_value=ok) as mock_run:
+        assert desktop_linux.ensure_electron_sandbox_fixup(packaged) is True
+
+    assert mock_run.call_args_list[0].args[0] == ["/usr/bin/sudo", "chown", "root:root", str(sandbox)]
+    assert mock_run.call_args_list[1].args[0] == ["/usr/bin/sudo", "chmod", "4755", str(sandbox)]
+
+
+def test_ensure_electron_sandbox_fixup_rejects_symlink(tmp_path, monkeypatch):
+    monkeypatch.setattr(desktop_linux.sys, "platform", "linux")
+    packaged = tmp_path / "Hermes"
+    packaged.write_text("", encoding="utf-8")
+    target = tmp_path / "target"
+    target.write_text("pwned", encoding="utf-8")
+    sandbox = packaged.parent / "chrome-sandbox"
+    sandbox.symlink_to(target)
+
+    with patch("hermes_cli.desktop_linux.shutil.which", return_value="/usr/bin/sudo"), \
+         patch("hermes_cli.desktop_linux.subprocess.run") as mock_run:
+        assert desktop_linux.ensure_electron_sandbox_fixup(packaged) is False
+
+    mock_run.assert_not_called()
+
+
+def test_ensure_electron_sandbox_fixup_skips_when_already_configured(tmp_path, monkeypatch):
+    monkeypatch.setattr(desktop_linux.sys, "platform", "linux")
+    packaged = tmp_path / "Hermes"
+    packaged.write_text("", encoding="utf-8")
+    sandbox = packaged.parent / "chrome-sandbox"
+    sandbox.write_text("", encoding="utf-8")
+    import stat as stat_mod
+
+    fake_stat = type("s", (), {"st_uid": 0, "st_mode": 0o4755 | stat_mod.S_IFREG})()
+    monkeypatch.setattr(type(sandbox), "lstat", lambda self: fake_stat)
+
+    with patch("hermes_cli.desktop_linux.subprocess.run") as mock_run:
+        assert desktop_linux.ensure_electron_sandbox_fixup(packaged) is True
+
+    mock_run.assert_not_called()

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -162,8 +162,8 @@ def test_gui_linux_configures_sandbox_before_launch(tmp_path, monkeypatch):
     sandbox.chmod(0o755)
     ok = subprocess.CompletedProcess([], 0)
 
-    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/sudo"), \
-         patch("hermes_cli.main.subprocess.run", return_value=ok) as mock_run, \
+    with patch("hermes_cli.desktop_linux.shutil.which", return_value="/usr/bin/sudo"), \
+         patch("hermes_cli.desktop_linux.subprocess.run", return_value=ok) as mock_run, \
          pytest.raises(SystemExit) as exc:
         cli_main.cmd_gui(_ns(skip_build=True))
 
@@ -183,8 +183,8 @@ def test_gui_linux_rejects_symlink_sandbox(tmp_path, monkeypatch):
     sandbox = packaged_exe.parent / "chrome-sandbox"
     sandbox.symlink_to(target)
 
-    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/sudo"), \
-         patch("hermes_cli.main.subprocess.run") as mock_run, \
+    with patch("hermes_cli.desktop_linux.shutil.which", return_value="/usr/bin/sudo"), \
+         patch("hermes_cli.desktop_linux.subprocess.run") as mock_run, \
          pytest.raises(SystemExit) as exc:
         cli_main.cmd_gui(_ns(skip_build=True))
 
@@ -211,7 +211,7 @@ def test_gui_linux_skips_fixup_when_already_configured(tmp_path, monkeypatch):
 
     launch_ok = subprocess.CompletedProcess([str(packaged_exe)], 0)
 
-    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/sudo"), \
+    with patch("hermes_cli.desktop_linux.shutil.which", return_value="/usr/bin/sudo"), \
          patch("hermes_cli.main.subprocess.run", return_value=launch_ok) as mock_run, \
          pytest.raises(SystemExit) as exc:
         cli_main.cmd_gui(_ns(skip_build=True))
@@ -482,7 +482,8 @@ def test_gui_retries_pack_once_after_purging_build_cache(tmp_path, monkeypatch):
     with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
          patch("hermes_cli.main._run_npm_install_deterministic", return_value=install_ok), \
          patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
-         patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=True), \
+         patch("hermes_cli.main._finalize_packaged_linux_desktop"), \
+         patch("hermes_cli.desktop_linux.ensure_electron_sandbox_fixup", return_value=True), \
          patch("hermes_cli.main._write_desktop_build_stamp"), \
          patch("hermes_cli.main._purge_electron_build_cache", return_value=[Path("/c/electron.zip")]) as mock_purge, \
          patch("hermes_cli.main._electron_dist_ok", return_value=False), \
@@ -588,7 +589,8 @@ def test_gui_install_failure_self_heals_electron_and_continues(tmp_path, monkeyp
 
     with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
          patch("hermes_cli.main._run_npm_install_deterministic", return_value=install_fail), \
-         patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=True), \
+         patch("hermes_cli.main._finalize_packaged_linux_desktop"), \
+         patch("hermes_cli.desktop_linux.ensure_electron_sandbox_fixup", return_value=True), \
          patch("hermes_cli.main._write_desktop_build_stamp"), \
          patch("hermes_cli.main._electron_dist_ok", return_value=False), \
          patch("hermes_cli.main._try_redownload_electron_dist", return_value=True) as mock_dl, \

--- a/tests/hermes_cli/test_linux_desktop_launcher.py
+++ b/tests/hermes_cli/test_linux_desktop_launcher.py
@@ -1,0 +1,107 @@
+"""Tests for the Linux Hermes Desktop launcher installer/wrapper."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from unittest.mock import patch
+
+from hermes_cli import main as cli_main
+from hermes_cli.linux_desktop_launcher import (
+    DESKTOP_FILENAME,
+    LAUNCHER_NAME,
+    finalize_packaged_linux_desktop,
+    install_linux_desktop_shortcuts,
+    render_desktop_entry,
+    render_launcher_script,
+    resolve_packaged_executable,
+)
+
+
+def _make_agent_tree(tmp_path: Path) -> Path:
+    root = tmp_path / "hermes-agent"
+    desktop = root / "apps" / "desktop"
+    desktop.mkdir(parents=True)
+    (desktop / "package.json").write_text("{}", encoding="utf-8")
+    (desktop / "assets").mkdir(parents=True)
+    (desktop / "assets" / "icon.png").write_bytes(b"png")
+    exe = desktop / "release" / "linux-unpacked" / "Hermes"
+    exe.parent.mkdir(parents=True)
+    exe.write_text("", encoding="utf-8")
+    return root
+
+
+def test_resolve_packaged_executable_prefers_newest(tmp_path):
+    root = _make_agent_tree(tmp_path)
+    older = root / "apps" / "desktop" / "release" / "linux-unpacked" / "hermes"
+    older.write_text("", encoding="utf-8")
+    resolved = resolve_packaged_executable(root)
+    assert resolved == root / "apps" / "desktop" / "release" / "linux-unpacked" / "Hermes"
+
+
+def test_render_launcher_script_points_at_python_module(tmp_path):
+    root = _make_agent_tree(tmp_path)
+    script = render_launcher_script(root)
+    assert 'python" -m hermes_cli.linux_desktop_launcher launch' in script
+    assert 'export HERMES_AGENT="${HERMES_AGENT:-$HERMES_HOME/hermes-agent}"' in script
+
+
+def test_render_desktop_entry_uses_wrapper_not_raw_binary(tmp_path):
+    launcher = tmp_path / "bin" / LAUNCHER_NAME
+    icon = tmp_path / "icon.png"
+    entry = render_desktop_entry(launcher_path=launcher, icon_path=icon)
+    assert f"Exec={launcher}" in entry
+    assert "StartupWMClass=Hermes" in entry
+    assert "Terminal=false" in entry
+
+
+def test_install_linux_desktop_shortcuts_writes_files(tmp_path, monkeypatch):
+    monkeypatch.setattr("hermes_cli.linux_desktop_launcher.sys.platform", "linux")
+    monkeypatch.setattr("hermes_cli.linux_desktop_launcher.Path.home", lambda: tmp_path)
+    root = _make_agent_tree(tmp_path)
+
+    written = install_linux_desktop_shortcuts(root)
+
+    launcher = tmp_path / ".local" / "bin" / LAUNCHER_NAME
+    desktop = tmp_path / ".local" / "share" / "applications" / DESKTOP_FILENAME
+    assert written == [launcher, desktop]
+    assert launcher.is_file()
+    assert desktop.is_file()
+    assert "hermes_cli.linux_desktop_launcher launch" in launcher.read_text(encoding="utf-8")
+
+
+def test_finalize_packaged_linux_desktop_runs_fixup_and_install(tmp_path, monkeypatch):
+    monkeypatch.setattr("hermes_cli.linux_desktop_launcher.sys.platform", "linux")
+    monkeypatch.setattr("hermes_cli.linux_desktop_launcher.Path.home", lambda: tmp_path)
+    root = _make_agent_tree(tmp_path)
+    exe = resolve_packaged_executable(root)
+    assert exe is not None
+
+    with patch("hermes_cli.linux_desktop_launcher.ensure_electron_sandbox_fixup", return_value=True) as mock_fixup:
+        assert finalize_packaged_linux_desktop(root, exe) is True
+
+    mock_fixup.assert_called_once_with(exe)
+    assert (tmp_path / ".local" / "bin" / LAUNCHER_NAME).is_file()
+
+
+def test_gui_build_only_finalizes_linux_desktop(tmp_path, monkeypatch):
+    root = _make_agent_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    monkeypatch.setattr(cli_main.sys, "platform", "linux")
+    packaged = resolve_packaged_executable(root)
+    assert packaged is not None
+
+    with patch("hermes_cli.main._desktop_packaged_executable", return_value=packaged), \
+         patch("hermes_cli.main._finalize_packaged_linux_desktop") as mock_finalize:
+        cli_main.cmd_gui(argparse.Namespace(
+            skip_build=True,
+            build_only=True,
+            force_build=False,
+            source=False,
+            fake_boot=False,
+            ignore_existing=False,
+            hermes_root=None,
+            cwd=None,
+        ))
+
+    mock_finalize.assert_called_once_with(packaged)


### PR DESCRIPTION
## Summary

- Extract Electron `chrome-sandbox` fixup into `hermes_cli/desktop_linux.py` (single source of truth)
- Add official Linux launcher (`~/.local/bin/hermes-desktop-launch` + `hermes-desktop.desktop`) that runs fixup before `exec` — the correct Linux analogue of Windows Start Menu shortcuts pointing at `Hermes.exe`
- Run shared `finalize_packaged_linux_desktop()` after every successful packaged desktop build, including `hermes desktop --build-only` (in-app update path)
- Replace duplicated shell `chown/chmod` in `install.sh` with the same Python module

Fixes #51327

## Problem

On Linux, clicking a `.desktop` entry that execs the packaged `Hermes` binary directly fails silently after any rebuild that recreates `linux-unpacked/`, because `chrome-sandbox` loses `root:root 4755`. `hermes desktop` from a terminal worked because it ran fixup first; icon launchers bypassed that path.

## Approach

1. **Post-build invariant** — sandbox + launcher installation are part of “package is launch-ready”, not only “CLI decided to launch”.
2. **Official wrapper launcher** — `.desktop` points at `hermes-desktop-launch`, not the raw Electron binary.
3. **No `--no-sandbox` workaround** — security model unchanged.

## Test plan

- [x] `pytest tests/hermes_cli/test_desktop_linux.py tests/hermes_cli/test_linux_desktop_launcher.py tests/hermes_cli/test_gui_command.py tests/hermes_cli/test_gui_uninstall.py`
- [ ] `hermes desktop --build-only` on Linux configures `chrome-sandbox` and installs launcher
- [ ] Click Hermes icon in app grid after rebuild — window opens
- [ ] In-app update rebuild → relaunch works without manual `sudo chmod 4755`