### PR TITLE
🐛 fix(update): broaden gateway restart glob to catch profile services

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9829,7 +9829,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
             relaunched_profiles = []
 
             # --- Systemd services (Linux) ---
-            # Discover all hermes-gateway* units (default + profiles)
+            # Discover all Hermes gateway units (default + profiles).
+            # Default service is ``hermes-gateway.service``; profile services
+            # follow ``hermes-<profile>-gateway.service`` (e.g.
+            # ``hermes-secondbrain-gateway.service``).  The glob
+            # ``hermes*gateway*`` catches both shapes.
             if supports_systemd_services():
                 try:
                     _ensure_user_systemd_env()
@@ -9845,7 +9849,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                             scope_cmd
                             + [
                                 "list-units",
-                                "hermes-gateway*",
+                                "hermes*gateway*",
                                 "--plain",
                                 "--no-legend",
                                 "--no-pager",

--- a/tests/hermes_cli/test_update_gateway_glob.py
+++ b/tests/hermes_cli/test_update_gateway_glob.py
@@ -1,0 +1,137 @@
+"""Regression test for the systemd unit-glob used by ``hermes update``.
+
+The post-update auto-restart phase discovers all running Hermes gateway
+systemd units via ``systemctl list-units <glob>``.  The glob must match
+both the default service (``hermes-gateway.service``) and profile-named
+services (``hermes-<profile>-gateway.service``, e.g.
+``hermes-secondbrain-gateway.service``).
+
+A previous version used ``hermes-gateway*``, which silently missed
+profile-named gateway services — leaving them running stale code after
+an update.  These tests lock the glob down so that regression cannot
+recur without failing loudly.
+
+Because the discovery logic is inline inside ``_cmd_update_impl`` and
+not factored into a helper, we exercise the *contract*: the glob string
+the source passes to ``systemctl list-units`` must match both unit-name
+shapes.  We extract the glob from the source to avoid hard-coding drift,
+and we also assert against a realistic ``systemctl list-units`` stdout
+fixture (the same format the production code parses line-by-line).
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+
+import pytest
+
+from hermes_cli import main as cli_main
+
+
+# ─── Source extraction ────────────────────────────────────────────────────────
+
+
+def _extract_gateway_glob_from_source() -> str:
+    """Pull the literal glob string passed to ``list-units`` in source.
+
+    The discovery call looks like::
+
+        subprocess.run(scope_cmd + ["list-units", "<glob>", "--plain", ...])
+
+    We regex the source so the test tracks the production value without
+    hard-coding it.  If the call shape changes materially, this helper
+    raises — better a loud test failure than a silent glob regression.
+    """
+    import inspect
+
+    src = inspect.getsource(cli_main._cmd_update_impl)
+    # Find the list-units call and capture the glob argument that follows.
+    m = re.search(r'["\']list-units["\']\s*,\s*\n\s*["\'](hermes[^"\']*gateway[^"\']*)["\']', src)
+    if not m:
+        pytest.fail(
+            "Could not locate the `list-units <glob>` call inside "
+            "_cmd_update_impl — has the discovery code been restructured?"
+        )
+    return m.group(1)
+
+
+# ─── Realistic systemctl list-units stdout fixture ────────────────────────────
+
+
+# Format matches `systemctl list-units --plain --no-legend --no-pager`:
+#   UNIT                               LOAD   ACTIVE SUB     DESCRIPTION
+# Columns are whitespace-separated; production code does line.split()[0].
+LIST_UNITS_STDOUT = (
+    "hermes-gateway.service             loaded active running Hermes Agent Gateway\n"
+    "hermes-secondbrain-gateway.service loaded active running Hermes Second Brain Gateway\n"
+)
+
+
+def _parse_units(stdout: str) -> list[str]:
+    """Mirror the production parse: first whitespace token per line."""
+    units = []
+    for line in stdout.strip().splitlines():
+        parts = line.split()
+        if parts and parts[0].endswith(".service"):
+            units.append(parts[0])
+    return units
+
+
+# ─── Tests ────────────────────────────────────────────────────────────────────
+
+
+class TestUpdateGatewayServiceGlob:
+    """The glob must catch default + profile gateway services alike."""
+
+    def test_glob_matches_default_service(self):
+        glob = _extract_gateway_glob_from_source()
+        # fnmatch is what systemd uses for unit-name globs.
+        import fnmatch
+
+        assert fnmatch.fnmatch("hermes-gateway.service", glob), (
+            f"Glob {glob!r} must match the default 'hermes-gateway.service'"
+        )
+
+    def test_glob_matches_profile_gateway_service(self):
+        glob = _extract_gateway_glob_from_source()
+        import fnmatch
+
+        assert fnmatch.fnmatch("hermes-secondbrain-gateway.service", glob), (
+            f"Glob {glob!r} must match profile-named "
+            "'hermes-secondbrain-gateway.service' — otherwise profile "
+            "gateways are left running stale code after an update"
+        )
+
+    def test_glob_matches_arbitrary_profile_name(self):
+        """A profile with hyphens or numbers in its name must also match."""
+        glob = _extract_gateway_glob_from_source()
+        import fnmatch
+
+        for name in ("hermes-work-gateway.service", "hermes-coder-2-gateway.service"):
+            assert fnmatch.fnmatch(name, glob), (
+                f"Glob {glob!r} must match {name!r}"
+            )
+
+    def test_full_list_units_fixture_both_discovered(self):
+        """End-to-end: parsing realistic systemctl output yields both units."""
+        glob = _extract_gateway_glob_from_source()
+        import fnmatch
+
+        units = _parse_units(LIST_UNITS_STDOUT)
+        matched = [u for u in units if fnmatch.fnmatch(u, glob)]
+        assert matched == [
+            "hermes-gateway.service",
+            "hermes-secondbrain-gateway.service",
+        ], (
+            "Glob must discover both default and profile gateway services; "
+            f"got {matched!r}"
+        )
+
+    def test_glob_is_not_the_old_buggy_value(self):
+        """The old glob ``hermes-gateway*`` missed profile services — guard it."""
+        glob = _extract_gateway_glob_from_source()
+        assert glob != "hermes-gateway*", (
+            "Glob regressed to the old 'hermes-gateway*' value which misses "
+            "profile-named gateway services (e.g. hermes-secondbrain-gateway)"
+        )


### PR DESCRIPTION
## Problem

`hermes update` was not restarting profile-named gateway services after pulling new code. The post-update auto-restart logic discovers systemd gateway units via:

```python
systemctl list-units 'hermes-gateway*'
```

This glob only matches the default `hermes-gateway.service` and silently skips profile-named services that follow the `hermes-<profile>-gateway.service` convention (e.g. `hermes-secondbrain-gateway.service`).

As a result, after an update that changes shared code (e.g. adding `utils.env_float`), profile gateways keep running stale code. The user sees `ImportError: cannot import name 'env_float' from 'utils'` when messaging the profile bot on Telegram, even though the default bot works fine.

The discovery comment already states the intent — "Discover all hermes-gateway* units (default + profiles)" — but the glob was too narrow for the profile shape.

## Fix

Widen the glob from `hermes-gateway*` → `hermes*gateway*` so it catches both:
- `hermes-gateway.service` (default profile)
- `hermes-secondbrain-gateway.service` (`hermes-<profile>-gateway.service`)

## Verification

```
systemctl --user list-units 'hermes-gateway*'   # OLD: only 1 unit discovered
hermes-gateway.service

systemctl --user list-units 'hermes*gateway*'   # NEW: both units discovered
hermes-gateway.service
hermes-secondbrain-gateway.service
```

- Existing `tests/hermes_cli/test_update_concurrent_quarantine.py` + `test_update_yes_flag.py`: 27 passed
- New `tests/hermes_cli/test_update_gateway_glob.py`: 5 passed (regression guard on the glob contract)
- `ruff check` on both changed files: clean

## Checklist

- [x] Bug fix (non-breaking)
- [x] Tests added/updated
- [x] Lint passes
- [x] Commit message uses conventional + Gitmoji format