### PR TITLE
Add agent readiness checks for profile path and credential drift

### DIFF
--- a/hermes_cli/agent_readiness.py
+++ b/hermes_cli/agent_readiness.py
@@ -1,0 +1,436 @@
+"""Agent readiness checks for profile paths and assigned credentials.
+
+The checker is intentionally independent from the dashboard so the same
+contract can be used by profile creation, ``hermes doctor``, cron/doctor jobs,
+and future UI endpoints.  It does not inspect secret values; it only verifies
+that the runtime is pointed at the expected profile and that configured
+credential files are present/readable.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from hermes_constants import get_hermes_home
+
+READY = "ready"
+WARN = "warn"
+REPAIRING = "repairing"
+FIXED = "fixed"
+REPAIR_FAILED = "repair_failed"
+NEEDS_MANUAL_INTERVENTION = "needs_manual_intervention"
+
+_READY_DIR = ".readiness"
+_ISSUES_FILE = "issues.json"
+_LOG_FILE = "repair.log.jsonl"
+
+
+@dataclass
+class ReadinessIssue:
+    """A structured warning surfaced on an agent profile."""
+
+    check: str
+    message: str
+    expected: str
+    actual: str
+    status: str = WARN
+    severity: str = "warn"
+    repairable: bool = False
+    first_detected_at: str = ""
+    last_checked_at: str = ""
+    last_repair_attempt_at: str | None = None
+    repair_error: str | None = None
+
+
+@dataclass
+class ReadinessResult:
+    """Result of a readiness pass for one profile."""
+
+    profile: str
+    profile_dir: str
+    status: str
+    issues: list[ReadinessIssue] = field(default_factory=list)
+    repaired: int = 0
+    log_path: str | None = None
+    issues_path: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.status in {READY, FIXED} and not self.issues
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _read_json(path: Path, default: Any) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, TypeError):
+        return default
+
+
+def _write_json(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def _append_log(profile_dir: Path, event: dict[str, Any]) -> Path:
+    readiness_dir = profile_dir / _READY_DIR
+    readiness_dir.mkdir(parents=True, exist_ok=True)
+    log_path = readiness_dir / _LOG_FILE
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, sort_keys=True) + "\n")
+    return log_path
+
+
+def _profile_name_from_dir(profile_dir: Path) -> str:
+    if profile_dir.parent.name == "profiles":
+        return profile_dir.name
+    return "default"
+
+
+def _safe_relative_or_absolute(path_text: str, profile_dir: Path) -> Path:
+    path = Path(os.path.expanduser(os.path.expandvars(path_text)))
+    if not path.is_absolute():
+        path = profile_dir / path
+    return path
+
+
+def _path_under(path: Path, parent: Path) -> bool:
+    try:
+        path.resolve().relative_to(parent.resolve())
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def _expected_profile_paths(profile_dir: Path) -> dict[str, Path]:
+    return {
+        "profile_home": profile_dir,
+        "config": profile_dir / "config.yaml",
+        "env": profile_dir / ".env",
+        "skills": profile_dir / "skills",
+        "plugins": profile_dir / "plugins",
+        "cron": profile_dir / "cron",
+        "memories": profile_dir / "memories",
+        "sessions": profile_dir / "sessions",
+        "logs": profile_dir / "logs",
+        "workspace": profile_dir / "workspace",
+    }
+
+
+def _configured_credential_files(config: dict[str, Any], profile_dir: Path) -> list[dict[str, Any]]:
+    """Return credential-file checks from config.
+
+    The dashboard/UI can write either::
+
+        agent_readiness:
+          credential_files:
+            - name: google
+              path: google_token.json
+
+    or, for convenience, ``credentials`` with the same shape.  String entries
+    are treated as relative paths under the profile directory.
+    """
+
+    readiness_cfg = config.get("agent_readiness") or config.get("readiness") or {}
+    if not isinstance(readiness_cfg, dict):
+        return []
+    entries = readiness_cfg.get("credential_files") or readiness_cfg.get("credentials") or []
+    if not isinstance(entries, list):
+        return []
+
+    checks: list[dict[str, Any]] = []
+    for entry in entries:
+        if isinstance(entry, str):
+            checks.append({"name": entry, "path": str(_safe_relative_or_absolute(entry, profile_dir))})
+            continue
+        if not isinstance(entry, dict):
+            continue
+        raw_path = entry.get("path") or entry.get("file")
+        if not raw_path:
+            continue
+        name = str(entry.get("name") or raw_path)
+        checks.append(
+            {
+                "name": name,
+                "path": str(_safe_relative_or_absolute(str(raw_path), profile_dir)),
+                "required": bool(entry.get("required", True)),
+            }
+        )
+    return checks
+
+
+def _issue(
+    *,
+    check: str,
+    message: str,
+    expected: Path | str,
+    actual: Path | str,
+    repairable: bool = False,
+    severity: str = "warn",
+    previous: dict[str, Any] | None = None,
+) -> ReadinessIssue:
+    now = _now()
+    return ReadinessIssue(
+        check=check,
+        message=message,
+        expected=str(expected),
+        actual=str(actual),
+        repairable=repairable,
+        severity=severity,
+        first_detected_at=(previous or {}).get("first_detected_at") or now,
+        last_checked_at=now,
+        last_repair_attempt_at=(previous or {}).get("last_repair_attempt_at"),
+        repair_error=(previous or {}).get("repair_error"),
+    )
+
+
+def _merge_previous(issues: Iterable[ReadinessIssue], previous_rows: list[dict[str, Any]]) -> list[ReadinessIssue]:
+    previous_by_check = {
+        str(row.get("check")): row for row in previous_rows if isinstance(row, dict)
+    }
+    merged: list[ReadinessIssue] = []
+    for issue in issues:
+        prev = previous_by_check.get(issue.check)
+        if prev:
+            issue.first_detected_at = prev.get("first_detected_at") or issue.first_detected_at
+            issue.last_repair_attempt_at = prev.get("last_repair_attempt_at")
+            issue.repair_error = prev.get("repair_error")
+        merged.append(issue)
+    return merged
+
+
+def _load_config_for_profile(profile_dir: Path) -> dict[str, Any]:
+    config_path = profile_dir / "config.yaml"
+    if not config_path.exists():
+        return {}
+    try:
+        import yaml
+
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def check_agent_readiness(
+    *,
+    profile_name: str | None = None,
+    profile_dir: Path | str | None = None,
+    runtime_home: Path | str | None = None,
+    config: dict[str, Any] | None = None,
+    repair: bool = False,
+    persist: bool = True,
+) -> ReadinessResult:
+    """Check one agent profile for path/credential readiness drift.
+
+    ``profile_dir`` is the expected profile home. ``runtime_home`` is the
+    home the currently running process resolved; if omitted, the live
+    ``get_hermes_home()`` value is used.  For commissioning-time tests, callers
+    can pass ``runtime_home=profile_dir`` to verify the new profile's intended
+    environment without mutating global process state.
+    """
+
+    expected_home = Path(profile_dir) if profile_dir is not None else get_hermes_home()
+    expected_home = expected_home.expanduser()
+    actual_home = Path(runtime_home) if runtime_home is not None else get_hermes_home()
+    actual_home = actual_home.expanduser()
+    profile = profile_name or _profile_name_from_dir(expected_home)
+    cfg = config if config is not None else _load_config_for_profile(expected_home)
+
+    issues_path = expected_home / _READY_DIR / _ISSUES_FILE
+    previous = _read_json(issues_path, []) if issues_path.exists() else []
+    previous_by_check = {str(row.get("check")): row for row in previous if isinstance(row, dict)}
+
+    issues: list[ReadinessIssue] = []
+
+    if expected_home.resolve() != actual_home.resolve():
+        issues.append(
+            _issue(
+                check="profile_home",
+                message="Runtime HERMES_HOME does not match the assigned agent profile home.",
+                expected=expected_home,
+                actual=actual_home,
+                repairable=False,
+                previous=previous_by_check.get("profile_home"),
+            )
+        )
+
+    for name, path in _expected_profile_paths(expected_home).items():
+        if name in {"config", "env"}:
+            # Freshly-created profiles may not have config.yaml until first
+            # setup/config write.  .env is checked separately as a credential
+            # boundary, so keep this check about directory drift.
+            continue
+        if not _path_under(path, expected_home):
+            issues.append(
+                _issue(
+                    check=f"path:{name}",
+                    message=f"Profile path {name!r} is outside the assigned profile home.",
+                    expected=expected_home,
+                    actual=path,
+                    repairable=False,
+                    previous=previous_by_check.get(f"path:{name}"),
+                )
+            )
+        if not path.exists():
+            issues.append(
+                _issue(
+                    check=f"path_exists:{name}",
+                    message=f"Required profile path {name!r} is missing.",
+                    expected=path,
+                    actual="missing",
+                    repairable=True,
+                    previous=previous_by_check.get(f"path_exists:{name}"),
+                )
+            )
+
+    env_path = expected_home / ".env"
+    if not env_path.exists():
+        issues.append(
+            _issue(
+                check="credential_boundary:.env",
+                message="Profile credential boundary .env is missing.",
+                expected=env_path,
+                actual="missing",
+                repairable=True,
+                previous=previous_by_check.get("credential_boundary:.env"),
+            )
+        )
+    elif not os.access(env_path, os.R_OK):
+        issues.append(
+            _issue(
+                check="credential_boundary:.env.readable",
+                message="Profile credential boundary .env is not readable by this runtime.",
+                expected="readable",
+                actual=env_path,
+                repairable=False,
+                previous=previous_by_check.get("credential_boundary:.env.readable"),
+            )
+        )
+
+    for credential in _configured_credential_files(cfg, expected_home):
+        path = Path(str(credential["path"]))
+        check_id = f"credential:{credential['name']}"
+        if not path.exists():
+            issues.append(
+                _issue(
+                    check=check_id,
+                    message=f"Assigned credential file {credential['name']!r} is missing.",
+                    expected=path,
+                    actual="missing",
+                    repairable=False,
+                    previous=previous_by_check.get(check_id),
+                )
+            )
+        elif not os.access(path, os.R_OK):
+            issues.append(
+                _issue(
+                    check=check_id,
+                    message=f"Assigned credential file {credential['name']!r} is not readable.",
+                    expected="readable",
+                    actual=path,
+                    repairable=False,
+                    previous=previous_by_check.get(check_id),
+                )
+            )
+
+    repaired = 0
+    if repair and issues:
+        for item in issues:
+            if not item.repairable:
+                continue
+            item.status = REPAIRING
+            item.last_repair_attempt_at = _now()
+            log_event = {
+                "timestamp": item.last_repair_attempt_at,
+                "profile": profile,
+                "check": item.check,
+                "status": REPAIRING,
+                "expected": item.expected,
+                "actual": item.actual,
+            }
+            try:
+                if item.check.startswith("path_exists:"):
+                    Path(item.expected).mkdir(parents=True, exist_ok=True)
+                elif item.check == "credential_boundary:.env":
+                    env_path.parent.mkdir(parents=True, exist_ok=True)
+                    env_path.write_text(
+                        "# Per-profile secrets for this Hermes profile.\n",
+                        encoding="utf-8",
+                    )
+                    try:
+                        os.chmod(str(env_path), 0o600)
+                    except OSError:
+                        pass
+                else:
+                    continue
+                item.status = FIXED
+                item.repair_error = None
+                log_event["status"] = FIXED
+                repaired += 1
+            except OSError as exc:
+                item.status = REPAIR_FAILED
+                item.repair_error = str(exc)
+                log_event["status"] = REPAIR_FAILED
+                log_event["error"] = str(exc)
+            if persist:
+                _append_log(expected_home, log_event)
+
+        # Re-check after safe repairs so fixed issues disappear from the active
+        # warning list and only remain in the audit log.
+        if repaired:
+            return check_agent_readiness(
+                profile_name=profile,
+                profile_dir=expected_home,
+                runtime_home=actual_home,
+                config=cfg,
+                repair=False,
+                persist=persist,
+            )
+
+    unresolved = [item for item in issues if item.status not in {FIXED}]
+    status = READY if not unresolved else WARN
+    if persist:
+        if unresolved:
+            _write_json(issues_path, [asdict(item) for item in unresolved])
+        else:
+            _write_json(issues_path, [])
+    return ReadinessResult(
+        profile=profile,
+        profile_dir=str(expected_home),
+        status=status,
+        issues=unresolved,
+        repaired=repaired,
+        log_path=str(expected_home / _READY_DIR / _LOG_FILE),
+        issues_path=str(issues_path),
+    )
+
+
+def check_all_agent_readiness(*, repair: bool = False, persist: bool = True) -> list[ReadinessResult]:
+    """Run the readiness contract for the default profile and all named profiles."""
+
+    from hermes_cli.profiles import iter_profiles_for_gateway
+
+    results: list[ReadinessResult] = []
+    for profile_name, profile_dir in iter_profiles_for_gateway(multiplex=True):
+        runtime_home = profile_dir if profile_name != _profile_name_from_dir(get_hermes_home()) else get_hermes_home()
+        results.append(
+            check_agent_readiness(
+                profile_name=profile_name,
+                profile_dir=profile_dir,
+                runtime_home=runtime_home,
+                repair=repair,
+                persist=persist,
+            )
+        )
+    return results

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -660,6 +660,31 @@ def run_doctor(args):
         except ImportError:
             check_warn(name, "(optional, not installed)")
     
+    _section("Agent Readiness")
+    try:
+        from hermes_cli.agent_readiness import check_agent_readiness
+
+        readiness = check_agent_readiness(repair=should_fix)
+        if readiness.issues:
+            for item in readiness.issues:
+                detail = f"expected={item.expected} actual={item.actual}"
+                check_warn(item.message, detail)
+                if item.repairable and not should_fix:
+                    issues.append("Run `hermes doctor --fix` to repair profile readiness drift")
+                elif not item.repairable:
+                    manual_issues.append(
+                        f"Agent readiness drift ({item.check}): {item.message}"
+                    )
+        else:
+            check_ok("Agent profile paths and credential boundary are ready")
+        if should_fix and readiness.repaired:
+            fixed_count += readiness.repaired
+            check_info(f"Repaired {readiness.repaired} readiness issue(s); log: {readiness.log_path}")
+        elif readiness.issues_path:
+            check_info(f"Readiness state: {readiness.issues_path}")
+    except Exception as e:
+        check_warn(f"Agent readiness check failed: {e}")
+
     _section("Configuration Files")
     # Managed scope (administrator-pinned config/env), when present.
     managed_scope_check()

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1011,6 +1011,24 @@ def create_profile(
     # unit-generation paths handle gateway lifecycle.
     _maybe_register_gateway_service(canon)
 
+    # Commissioning-time readiness contract: a profile is not merely created;
+    # it must also prove its path/credential boundary is internally wired to
+    # the profile it represents.  Persisting the result gives the dashboard and
+    # doctor cron a common issue file to surface/repair if creation drift ever
+    # appears.
+    try:
+        from hermes_cli.agent_readiness import check_agent_readiness
+
+        check_agent_readiness(
+            profile_name=canon,
+            profile_dir=profile_dir,
+            runtime_home=profile_dir,
+            repair=True,
+            persist=True,
+        )
+    except Exception:
+        pass  # readiness diagnostics must not strand an otherwise valid profile
+
     return profile_dir
 
 

--- a/tests/hermes_cli/test_agent_readiness.py
+++ b/tests/hermes_cli/test_agent_readiness.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from hermes_cli.agent_readiness import (
+    FIXED,
+    READY,
+    WARN,
+    check_agent_readiness,
+)
+from hermes_cli.profiles import create_profile
+
+
+def _profile(root: Path) -> Path:
+    profile = root / "profiles" / "jeeves"
+    for name in ["skills", "plugins", "cron", "memories", "sessions", "logs", "workspace"]:
+        (profile / name).mkdir(parents=True, exist_ok=True)
+    (profile / ".env").write_text("# secrets\n", encoding="utf-8")
+    return profile
+
+
+def test_ready_profile_has_no_issues(tmp_path: Path) -> None:
+    profile = _profile(tmp_path)
+
+    result = check_agent_readiness(
+        profile_name="jeeves",
+        profile_dir=profile,
+        runtime_home=profile,
+        persist=True,
+    )
+
+    assert result.status == READY
+    assert result.issues == []
+    assert json.loads((profile / ".readiness" / "issues.json").read_text()) == []
+
+
+def test_profile_home_drift_is_warned_and_persisted(tmp_path: Path) -> None:
+    profile = _profile(tmp_path)
+    wrong_home = tmp_path / "profiles" / "alfred"
+    wrong_home.mkdir(parents=True)
+
+    result = check_agent_readiness(
+        profile_name="jeeves",
+        profile_dir=profile,
+        runtime_home=wrong_home,
+        persist=True,
+    )
+
+    assert result.status == WARN
+    assert [issue.check for issue in result.issues] == ["profile_home"]
+    assert result.issues[0].expected == str(profile)
+    assert result.issues[0].actual == str(wrong_home)
+    persisted = json.loads((profile / ".readiness" / "issues.json").read_text())
+    assert persisted[0]["check"] == "profile_home"
+    assert persisted[0]["status"] == WARN
+
+
+def test_missing_assigned_credential_file_is_warned(tmp_path: Path) -> None:
+    profile = _profile(tmp_path)
+    config = {
+        "agent_readiness": {
+            "credential_files": [
+                {"name": "CodeWalnut Google Workspace", "path": "google_token.json"}
+            ]
+        }
+    }
+
+    result = check_agent_readiness(
+        profile_name="jeeves",
+        profile_dir=profile,
+        runtime_home=profile,
+        config=config,
+        persist=False,
+    )
+
+    assert result.status == WARN
+    assert result.issues[0].check == "credential:CodeWalnut Google Workspace"
+    assert result.issues[0].repairable is False
+
+
+def test_repair_recreates_safe_profile_paths_and_logs(tmp_path: Path) -> None:
+    profile = _profile(tmp_path)
+    missing = profile / "cron"
+    missing.rmdir()
+
+    result = check_agent_readiness(
+        profile_name="jeeves",
+        profile_dir=profile,
+        runtime_home=profile,
+        repair=True,
+        persist=True,
+    )
+
+    assert result.status == READY
+    assert missing.is_dir()
+    assert result.issues == []
+    log_text = (profile / ".readiness" / "repair.log.jsonl").read_text(encoding="utf-8")
+    assert '"check": "path_exists:cron"' in log_text
+    assert f'"status": "{FIXED}"' in log_text
+
+
+def test_profile_create_runs_commissioning_readiness(monkeypatch, tmp_path: Path) -> None:
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    profile = create_profile("field-agent", no_alias=True, no_skills=True)
+
+    assert profile == home / "profiles" / "field-agent"
+    issues_path = profile / ".readiness" / "issues.json"
+    assert issues_path.exists()
+    assert json.loads(issues_path.read_text(encoding="utf-8")) == []
+    assert (profile / ".env").exists()


### PR DESCRIPTION
## What does this PR do?

Adds a fleet-ready agent readiness contract for detecting profile path and assigned credential drift.

This reframes #51338 away from a one-off "wrong credentials" symptom and into a reusable readiness check that doctor/cron, profile commissioning, and future UI surfaces can all consume.

The implementation persists structured warning state under the agent profile and logs safe repair attempts, so the UI can show warning/repair/fixed states without re-inventing the drift detector.

## Related Issue

Fixes #51338

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `hermes_cli/agent_readiness.py`
  - checks runtime home vs assigned profile home
  - checks expected profile-local paths: `skills`, `plugins`, `cron`, `memories`, `sessions`, `logs`, `workspace`
  - checks profile `.env` exists/readable as the credential boundary
  - checks configured assigned credential files via `agent_readiness.credential_files` / `readiness.credentials`
  - writes warning state to `<profile>/.readiness/issues.json`
  - logs repair attempts to `<profile>/.readiness/repair.log.jsonl`
- Updated `hermes_cli/doctor.py`
  - adds an **Agent Readiness** section
  - surfaces drift warnings
  - uses `hermes doctor --fix` for safe repairs
- Updated `hermes_cli/profiles.py`
  - runs a commissioning-time readiness pass when a new profile is created
- Added `tests/hermes_cli/test_agent_readiness.py`
  - ready profile
  - profile home drift
  - missing assigned credential
  - safe repair + repair log
  - profile-create commissioning check

## How to Test

1. Run the focused readiness tests:

   ```bash
   python -m pytest tests/hermes_cli/test_agent_readiness.py -q
   ```

2. Run the readiness tests with a neighbouring doctor test:

   ```bash
   python -m pytest tests/hermes_cli/test_agent_readiness.py tests/hermes_cli/test_doctor_dedicated_provider_skip.py -q
   ```

3. Run lint/compile checks:

   ```bash
   python -m compileall -q hermes_cli/agent_readiness.py hermes_cli/doctor.py hermes_cli/profiles.py
   python -m ruff check hermes_cli/agent_readiness.py hermes_cli/doctor.py hermes_cli/profiles.py tests/hermes_cli/test_agent_readiness.py
   ```

4. Smoke `hermes doctor` against an isolated temporary `HERMES_HOME` and confirm it prints an **Agent Readiness** section.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A: docstrings added for new readiness module; no user docs yet because this is a first backend contract.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A: N/A, optional config keys are consumed when present but no required config surface changed.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A: N/A.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — uses `pathlib`, JSON, and stdlib file checks; no shell-specific runtime logic.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A: N/A.

## For New Skills

N/A — this PR does not add a skill.

## Screenshots / Logs

Verification performed on this branch:

```bash
python -m pytest tests/hermes_cli/test_agent_readiness.py -q
# .....                                                                    [100%]
# 5 passed in 0.35s

python -m pytest tests/hermes_cli/test_agent_readiness.py tests/hermes_cli/test_doctor_dedicated_provider_skip.py -q
# .......                                                                  [100%]
# 7 passed in 0.29s

python -m compileall -q hermes_cli/agent_readiness.py hermes_cli/doctor.py hermes_cli/profiles.py
# exit 0

python -m ruff check hermes_cli/agent_readiness.py hermes_cli/doctor.py hermes_cli/profiles.py tests/hermes_cli/test_agent_readiness.py
# All checks passed!
```

Manual doctor smoke with isolated `HERMES_HOME`:

```text
◆ Agent Readiness
  ✓ Agent profile paths and credential boundary are ready
    → Readiness state: /tmp/.../.readiness/issues.json
```

No runtime UI was changed in this branch; the profile/UI-consumable artefact is `<profile>/.readiness/issues.json` plus `<profile>/.readiness/repair.log.jsonl`.
