### PR TITLE
fix(telegram): ignore auto-reply to topic creation message in forum supergroups

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5604,7 +5604,21 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._bot or not getattr(message, "reply_to_message", None):
             return False
         reply_user = getattr(message.reply_to_message, "from_user", None)
-        return bool(reply_user and getattr(reply_user, "id", None) == getattr(self._bot, "id", None))
+        if not (reply_user and getattr(reply_user, "id", None) == getattr(self._bot, "id", None)):
+            return False
+        # In forum supergroups, some Telegram clients auto-reply to the
+        # topic-creation message when sending in a topic.  The topic creation
+        # message_id equals the message_thread_id.  Treat this as NOT a real
+        # reply to the bot — it's just the user typing in the topic.
+        thread_id = getattr(message, "message_thread_id", None)
+        reply_msg_id = getattr(message.reply_to_message, "message_id", None)
+        if thread_id is not None and reply_msg_id is not None:
+            try:
+                if int(reply_msg_id) == int(thread_id):
+                    return False
+            except (TypeError, ValueError):
+                pass
+        return True
 
     @staticmethod
     def _extract_bot_mention_usernames(message: Message) -> set[str]:


### PR DESCRIPTION
## Problem

Telegram forum clients (iOS/Android/Desktop) auto-send `reply_to_message_id` equal to the topic's `thread_id` when typing in a forum topic. When the bot created the topic, `_is_reply_to_bot()` returns `True` because the topic creation message's `from_user` matches the bot — even though the user is **not** replying to any bot message.

This causes the bot to bypass `require_mention: true` and respond to every message in the topic, defeating the mention-only configuration.

## Evidence

```
_is_reply_to_bot=True msg_id=<MSG_ID> reply_to_msg_id=<THREAD_ID>
reply_from_id=<BOT_ID> reply_from_name=<BOT_USERNAME>
bot_id=<BOT_ID> reply_text=
```

- `reply_to_msg_id` = topic thread ID (topic creation message)
- `reply_text=` is empty — topic creation message has no text content
- User typed directly (not replying to any message)

## Fix

In `_is_reply_to_bot()`, check if `reply_to_message_id` equals `message_thread_id` (the topic creation message). If so, return `False` — the user is just typing in the topic, not replying to the bot.

## Testing

- Verified in a Telegram forum supergroup with `require_mention: true`
- Before fix: bot responds to every message in the topic
- After fix: bot only responds when explicitly @mentioned or replying to a real bot message