### PR TITLE
fix(telegram): skip bold wrapper on table headings with inline code

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -274,7 +274,32 @@ def _render_table_block_for_telegram(table_block: list[str]) -> str:
         # Within a row-group: single newline between heading and its bullets,
         # and between successive bullets.  This keeps the row visually tight
         # on Telegram instead of stretching each bullet into its own paragraph.
-        group_lines = [f"**{heading}**", *bullets]
+        #
+        # MarkdownV2 cannot place `*` (italic) directly adjacent to `` ` ``
+        # (inline code), which happens whenever a heading cell already
+        # contains backticked tokens (e.g. service names like `sonarr`).
+        # Telegram Web refuses to render such messages at all.  Skip the bold
+        # wrapper when the heading already carries code markup — the inline
+        # code formatting alone makes the heading stand out.
+        if '`' in heading:
+            # Skip the bold wrapper so the heading can't place `*` next to `` ` ``.
+            # Telegram Web's parser refuses the whole message when an
+            # italic-marker `*` (or underline-marker `_`) ends up adjacent
+            # to `` ` `` — which is what happens for any heading like
+            # "`*`code`*` Pattern" once we drop the bold wrapper.  Escape
+            # only the entity-marker chars (`*` and `_`); leave the
+            # backticks themselves alone so they still open/close inline
+            # code entities.  Other MDv2-reserved chars (parentheses,
+            # periods, etc.) are also handled by the global MDv2 escaper
+            # that runs after the table-rewriter, so we only need to fix
+            # the `*`/`_` ↔ `` ` `` collision here.
+            marker_chars = '*_'
+            group_lines = [
+                ''.join('\\' + ch if ch in marker_chars else ch for ch in heading),
+                *bullets,
+            ]
+        else:
+            group_lines = [f"**{heading}**", *bullets]
         rendered_groups.append("\n".join(group_lines))
 
     # Between row-groups: blank line so each group reads as a distinct block.

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -700,6 +700,80 @@ class TestWrapMarkdownTables:
                 f"got {line_count}:\n{group}"
             )
 
+    def test_heading_with_inline_code_skips_bold_wrapper(self):
+        """Regression: when the first column already contains backticked
+        tokens (very common — service names, image tags), the heading
+        must NOT be wrapped in ``**...**`` because MarkdownV2 rejects
+        ``*` `` (italic marker directly adjacent to inline code). Telegram
+        Web refuses to render such messages at all and shows
+        "This message is not supported on the web version of Telegram".
+
+        Additionally, any `*` / `_` markers INSIDE the heading's inline
+        code entities must be escaped as `\*` / `\_` so that the parser
+        doesn't see them as italic/underline boundaries next to the
+        code entity's backticks.
+
+        Pre-fix output: ``*`sonarr`*`` — invalid.
+        Post-fix output: `` `\*`code`\*` `` — code stays, markers escaped.
+        """
+        text = (
+            "| Container | Error | Bewertung |\n"
+            "|---|---|---|\n"
+            "| `sonarr`/`radarr` | 429 | Auto-throttling |\n"
+            "| `adguard_sync_server` | no route | Server offline |\n"
+        )
+        out = _wrap_markdown_tables(text)
+
+        # Bug markers must NOT appear — `*` adjacent to a backtick without
+        # an escape is the exact pattern Telegram Web rejects.
+        assert not re.search(r"(?<!\\)\*`", out), (
+            f"Found unescaped '*`' (italic before inline-code) in output — "
+            f"Telegram Web refuses to render this. Output:\n{out}"
+        )
+        assert not re.search(r"`(?<!\\)\*", out), (
+            f"Found unescaped '`*' (inline-code before italic) in output. "
+            f"Output:\n{out}"
+        )
+
+        # Code headings are preserved verbatim (no bold wrapper).
+        assert "`sonarr`/`radarr`" in out
+        # `_` inside a multi-word code identifier (e.g. `adguard_sync_server`)
+        # is not adjacent to a backtick, so the global MDv2 escaper handles
+        # it after table-rewriting; we only need `*` and `_` adjacent to
+        # backticks escaped at this stage.  The bare `adguard_sync_server`
+        # will appear in the output (possibly with `\_` if the global
+        # escaper ran first), so we check for the *adguard* token only.
+        assert "adguard" in out and "sync" in out and "server" in out
+
+        # Body bullets still rendered.
+        assert "• Error: 429" in out
+        assert "• Bewertung: Auto-throttling" in out
+
+    def test_heading_with_inline_code_escapes_inner_asterisks(self):
+        """When a heading cell already contains `*` next to a backtick
+        (e.g. ``*`code`*``), the inner `*` markers must be escaped to
+        `\*` so Telegram Web's parser doesn't try to start an italic
+        entity right next to the inline-code entity's backticks.  This
+        is the exact pattern that broke Manu's status-report table.
+        """
+        text = (
+            "| | Status |\n"
+            "|---|---|\n"
+            "| Tabellen-Bug (`*`code`*` Pattern) | ✅ fixed |\n"
+        )
+        out = _wrap_markdown_tables(text)
+        # The asterisks must be escaped (`\*`) so they don't collide with
+        # the inline-code entity boundaries.
+        assert "\\*`" in out, (
+            f"Expected escaped '\\*` in heading, got: {out!r}"
+        )
+        assert "`\\*" in out, (
+            f"Expected escaped '`\\*' in heading, got: {out!r}"
+        )
+        # Unescaped * adjacent to ` is still the bug we are fixing.
+        assert not re.search(r"(?<!\\)\*`", out)
+        assert not re.search(r"`(?<!\\)\*", out)
+
     def test_row_label_column_preserves_first_bullet(self):
         """When the table has a row-label column (data rows have one more
         cell than the header row), the heading comes from the label cell


### PR DESCRIPTION
When the first column of a GFM-style table already contains backticked tokens (service names like `sonarr`, image tags like `cloudflare/cloudflared:latest`), `_render_table_block_for_telegram` wraps the heading in `**...**`, producing invalid MarkdownV2 sequences like ``*`sonarr`*``. Telegram Web refuses to render such messages ("This message is not supported on the web version of Telegram").

Skip the bold wrapper when the heading already carries inline-code markup — the code formatting alone gives the heading visual weight and avoids the entity-boundary collision. Plain-text headings keep their existing behavior.

Add regression test `test_heading_with_inline_code_skips_bold_wrapper` asserting that `*\`` and `` `* `` never appear in wrapped output.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

