### PR TITLE
fix(chat-completions): strip name from tool-result messages for strict providers

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2900,6 +2900,12 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             # and every Hermes-internal underscore-prefixed scaffolding key.
             for schema_foreign in ("tool_name", "codex_reasoning_items", "codex_message_items", "timestamp"):
                 api_msg.pop(schema_foreign, None)
+            # ``name`` on a tool result is outside the Chat Completions schema
+            # (aki.io: "contains item with unknown key name"), but is valid on
+            # user/assistant messages — so the removal is role-qualified, same
+            # as ChatCompletionsTransport.convert_messages().
+            if api_msg.get("role") == "tool":
+                api_msg.pop("name", None)
             # api_content (the persist-what-you-send sidecar) carries the
             # exact bytes every main-loop call sent for this message —
             # substitute it before dropping the key (Hermes bookkeeping,

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -150,6 +150,13 @@ class ChatCompletionsTransport(ProviderTransport):
           ``Extra inputs are not permitted, field: 'messages[N].tool_name'``.
           Permissive providers (OpenRouter, MiniMax) silently ignore the
           field, which masked the bug for months.
+        - ``name`` on tool-result messages — a leftover from the legacy
+          ``role: function`` dialect, written alongside ``tool_name`` by
+          ``make_tool_result_message()``, but absent from the Chat
+          Completions schema for ``role: tool``. Strict providers (aki.io)
+          reject any payload containing it with
+          ``contains item with unknown key name``. Stripped only on
+          ``role: tool`` — other roles keep ``name`` for the legacy dialect.
         - Hermes-internal scaffolding markers — any top-level message key
           starting with ``_`` (e.g. ``_empty_recovery_synthetic``,
           ``_empty_terminal_sentinel``, ``_thinking_prefill``). These are
@@ -173,6 +180,7 @@ class ChatCompletionsTransport(ProviderTransport):
                 or "codex_message_items" in msg
                 or "tool_name" in msg
                 or "timestamp" in msg  # #47868 — strict providers reject this
+                or (msg.get("role") == "tool" and "name" in msg)
             ):
                 needs_sanitize = True
                 break
@@ -203,6 +211,8 @@ class ChatCompletionsTransport(ProviderTransport):
             msg.pop("codex_message_items", None)
             msg.pop("tool_name", None)
             msg.pop("timestamp", None)  # #47868 — leak into strict providers
+            if msg.get("role") == "tool":
+                msg.pop("name", None)  # legacy function-call dialect — tool role only
             # Drop all Hermes-internal scaffolding markers (``_``-prefixed).
             # OpenAI's message schema has no ``_``-prefixed fields, so this
             # is safe and future-proofs against new markers being added.

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -266,6 +266,13 @@ class ChatCompletionsTransport(ProviderTransport):
           ``Extra inputs are not permitted, field: 'messages[N].tool_name'``.
           Permissive providers (OpenRouter, MiniMax) silently ignore the
           field, which masked the bug for months.
+        - ``name`` on tool-result messages — carried over from the tool call
+          for readability, but the Chat Completions schema has no ``name``
+          field on ``role: tool`` (only on ``role: function``, long removed).
+          Strict providers (aki.io) reject any payload containing it with
+          ``contains item with unknown key name``. Stripped on ``role: tool``
+          only; ``name`` on user/assistant messages stays, it is schema-valid
+          there.
         - Hermes-internal scaffolding markers — any top-level message key
           starting with ``_`` (e.g. ``_empty_recovery_synthetic``,
           ``_empty_terminal_sentinel``, ``_thinking_prefill``). These are
@@ -291,6 +298,7 @@ class ChatCompletionsTransport(ProviderTransport):
                 or "effect_disposition" in msg
                 or "timestamp" in msg  # #47868 — strict providers reject this
                 or "api_content" in msg  # persist-what-you-send sidecar
+                or (msg.get("role") == "tool" and "name" in msg)
             ):
                 needs_sanitize = True
                 break
@@ -370,6 +378,11 @@ class ChatCompletionsTransport(ProviderTransport):
                 out_msg.pop("effect_disposition", None)
                 out_msg.pop("timestamp", None)  # #47868 — leak into strict providers
                 out_msg.pop("api_content", None)  # persist-what-you-send sidecar
+
+            # ``name`` is schema-valid on user/assistant messages, so the
+            # removal is role-qualified: only tool results carry it illegally.
+            if msg.get("role") == "tool" and "name" in msg:
+                mutable_msg().pop("name", None)
 
 
             # Drop all Hermes-internal scaffolding markers (``_``-prefixed).

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -104,6 +104,29 @@ class TestChatCompletionsBasic:
         # Original list untouched (deepcopy-on-demand)
         assert msgs[2]["tool_name"] == "execute_code"
 
+    def test_convert_messages_strips_name_on_tool_role_only(self, transport):
+        """A leftover ``name`` from the legacy ``role: function`` dialect is
+        written alongside ``tool_name`` on tool-result messages but is absent
+        from the Chat Completions schema for ``role: tool``. Strict providers
+        (aki.io) reject it with 'contains item with unknown key name'. It must
+        be stripped on ``role: tool`` only — other roles keep ``name`` for the
+        legacy dialect.
+        """
+        msgs = [
+            {"role": "user", "content": "hi", "name": "alice"},
+            {"role": "tool", "tool_call_id": "call_1", "name": "execute_code",
+             "content": "result"},
+        ]
+        result = transport.convert_messages(msgs)
+        # Stripped on the tool message...
+        assert "name" not in result[1]
+        assert result[1]["content"] == "result"
+        assert result[1]["tool_call_id"] == "call_1"
+        # ...but preserved on non-tool roles.
+        assert result[0]["name"] == "alice"
+        # Original list untouched (deepcopy-on-demand)
+        assert msgs[1]["name"] == "execute_code"
+
     def test_convert_messages_strips_timestamp(self, transport):
         """Internal per-message ``timestamp`` metadata (stamped by
         ``_apply_persist_user_message_override`` to preserve platform event

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -78,6 +78,29 @@ class TestChatCompletionsBasic:
         # Original list untouched (deepcopy-on-demand)
         assert msgs[0]["timestamp"] == 1781976577.0
 
+    def test_convert_messages_strips_name_on_tool_results_only(self, transport):
+        """``name`` is carried over from the tool call onto the tool result
+        for readability, but the Chat Completions schema has no ``name`` on
+        ``role: tool`` (only on the long-removed ``role: function``). Strict
+        providers (aki.io) reject the whole payload with 'contains item with
+        unknown key name', which breaks every tool call in the session.
+        ``name`` on user/assistant messages is schema-valid and must survive,
+        so the removal is role-qualified.
+        """
+        msgs = [
+            {"role": "user", "content": "hi", "name": "sylvain"},
+            {"role": "tool", "tool_call_id": "call_1", "content": "ok",
+             "name": "execute_code"},
+        ]
+        result = transport.convert_messages(msgs)
+        assert "name" not in result[1]
+        assert result[1]["content"] == "ok"
+        assert result[1]["tool_call_id"] == "call_1"
+        # Schema-valid on non-tool roles — untouched.
+        assert result[0]["name"] == "sylvain"
+        # Original list untouched (copy-on-write contract)
+        assert msgs[1]["name"] == "execute_code"
+
     def test_convert_messages_no_copy_without_timestamp(self, transport):
         """A timestamp-free message list needs no sanitize pass and is
         returned by identity (preserves the deepcopy-on-demand contract)."""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2609,13 +2609,19 @@ class TestHandleMaxIterations:
         agent.client.chat.completions.create.return_value = _mock_response(content="Summary")
         agent._cached_system_prompt = "You are helpful."
         messages = [
-            {"role": "user", "content": "do stuff"},
+            {"role": "user", "content": "do stuff", "name": "sylvain"},
             {
                 "role": "assistant",
                 "tool_calls": [{"id": "call_1", "function": {"name": "execute_code", "arguments": "{}"}}],
                 "codex_reasoning_items": [{"id": "rs_1"}],
             },
-            {"role": "tool", "tool_call_id": "call_1", "content": "result", "tool_name": "execute_code"},
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": "result",
+                "tool_name": "execute_code",
+                "name": "execute_code",
+            },
             {"role": "assistant", "content": "Done.", "_empty_recovery_synthetic": True},
         ]
 
@@ -2628,8 +2634,15 @@ class TestHandleMaxIterations:
             assert "codex_reasoning_items" not in m, m
             assert "codex_message_items" not in m, m
             assert not any(isinstance(k, str) and k.startswith("_") for k in m), m
+            # ``name`` is schema-foreign on tool results only (aki.io rejects
+            # it with "contains item with unknown key name"); it stays valid
+            # on user/assistant messages.
+            if m.get("role") == "tool":
+                assert "name" not in m, m
+        assert [m for m in sent_msgs if m.get("role") == "user"][0]["name"] == "sylvain"
         # Internal history is untouched — the path copies each message.
         assert messages[2]["tool_name"] == "execute_code"
+        assert messages[2]["name"] == "execute_code"
         assert messages[1]["codex_reasoning_items"] == [{"id": "rs_1"}]
 
 


### PR DESCRIPTION
## What does this PR do?

`make_tool_result_message()` writes a `name` key on `role: tool` messages — a
leftover from the legacy `role: function` dialect, written right next to the
already-stripped `tool_name`. It is **not** part of the Chat Completions schema
for tool messages (which allows only `role`, `content`, `tool_call_id`).

Strict OpenAI-compatible providers reject the whole request:

```
HTTP 400 — contains item with unknown key `name`
```

Because it fails on the **follow-up completion right after a tool call**, a plain
`hermes chat` smoke-test never sees it — it only surfaces the first time the agent
actually uses a tool, then poisons every subsequent turn in the session.
Permissive providers (OpenAI, OpenRouter) silently ignore the field, which masked
it for a long time.

This is the natural sibling of the already-merged `tool_name` (#28958) and
`timestamp` (#47868) strips: **same choke point, same rationale.** Doing it in
`convert_messages()` keeps `name` available to in-process adapters that still read
it, and avoids threading an `include_name` flag through every call site. `name` is
stripped on `role: tool` **only** — other roles keep it for the legacy
function-call dialect.

## Related Issue

No existing issue — searched open PRs/issues for a duplicate, none found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/transports/chat_completions.py` — in `convert_messages()`, pop `name` on
  `role: tool` messages, with a matching `needs_sanitize` trigger and a docstring
  entry alongside the existing `tool_name` / `timestamp` notes.
- `tests/agent/transports/test_chat_completions.py` — regression test
  `test_convert_messages_strips_name_on_tool_role_only`: asserts the strip on
  `role: tool`, **preservation** of `name` on non-tool roles, and the
  deepcopy-on-demand contract (original list untouched).

## How to Test

1. Point a `provider: custom` config at any endpoint that 400s on unknown message
   keys (observed live against the EU provider aki.io).
2. Trigger one tool call → without the patch the follow-up request fails with
   `contains item with unknown key name`; with it, the round-trip succeeds
   (verified live, 400 → 200).
3. `pytest tests/agent/transports/test_chat_completions.py -q` — the new test
   passes. (Note: one pre-existing, unrelated failure on `main`,
   `test_tags_stripped_when_endpoint_is_native_gemini`, is independent of this
   change.)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected test module and the new test passes
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu (WSL2), Python 3.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (the `convert_messages` docstring) — N/A otherwise
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture change)
- [x] Cross-platform impact — N/A (pure dict-key filtering, no platform primitives)
- [x] Tool descriptions/schemas — N/A
