### PR TITLE
fix(config): write readable unicode yaml

### DIFF
--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1,5 +1,6 @@
 """Tests for hermes_cli configuration management."""
 
+import copy
 import os
 from pathlib import Path
 from unittest.mock import patch
@@ -82,6 +83,40 @@ class TestLoadConfigDefaults:
             config = load_config()
             assert config["agent"]["max_turns"] == 42
             assert "max_turns" not in config
+
+
+class TestSaveConfigSerialization:
+    def test_save_config_writes_readable_unicode_without_escape_continuations(self, tmp_path):
+        """User-facing config.yaml should not emit fragile \\U escapes.
+
+        Issue #51356 reported config corruption around long personality strings
+        containing emoji/kaomoji.  The file should stay parseable while keeping
+        Unicode readable, avoiding Python-style escape continuations that are
+        easy to corrupt during migrations or manual edits.
+        """
+        config = copy.deepcopy(DEFAULT_CONFIG)
+        config["agent"]["personalities"] = {
+            "hype": "YOOO LET'S GOOOO!!! 🔥🔥🔥 "
+            "We are going to CRUSH IT together! 💪😤🚀",
+            "kawaii": "You are a kawaii assistant! Use (◕‿◕), ★, ♪, and ~! ヽ(>∀<☆)ノ",
+            "surfer": "Duuude, keep things super chill. Cowabunga! 🤙",
+        }
+        config["display"]["cursor"] = " █"
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            save_config(config)
+
+        raw = (tmp_path / "config.yaml").read_text(encoding="utf-8")
+        reparsed = yaml.safe_load(raw)
+
+        assert reparsed["agent"]["personalities"]["hype"].startswith("YOOO")
+        assert "🔥" in raw
+        assert "🤙" in raw
+        assert "█" in raw
+        assert "\\U0001F525" not in raw
+        assert "\\U0001F919" not in raw
+        assert "\\u2588" not in raw
+        assert "\\\n" not in raw
 
 
 class TestLoadConfigParseFailure:

--- a/utils.py
+++ b/utils.py
@@ -217,13 +217,15 @@ def atomic_yaml_write(
             # inside multi-line double-quoted strings wrapped with `\`
             # continuations — a structure that stricter/non-PyYAML parsers and
             # hand-edits routinely break into unclosed quotes, corrupting the whole
-            # config (GitHub #51356).
+            # config (GitHub #51356). width=4096 keeps long values on one line so
+            # PyYAML does not introduce fragile backslash continuations.
             yaml.dump(
                 data,
                 f,
                 default_flow_style=default_flow_style,
                 sort_keys=sort_keys,
                 allow_unicode=True,
+                width=4096,
             )
             if extra_content:
                 f.write(extra_content)


### PR DESCRIPTION
## Summary
- Write config YAML with readable Unicode instead of escaped emoji/box characters
- Increase PyYAML width to avoid fragile backslash line continuations in user-facing config.yaml
- Add regression coverage for personality strings containing emoji/kaomoji and cursor glyphs

## Test Plan
- `uv run --with pytest --with pyyaml --with ruamel.yaml python -m pytest tests/hermes_cli/test_config.py -q -o 'addopts='`

Fixes #51356
