### PR TITLE
fix(delegate): preserve named custom provider overrides

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1148,6 +1148,40 @@ class TestDelegationCredentialResolution(unittest.TestCase):
 
 
 
+    def test_named_custom_provider_with_base_url_keeps_identity_and_resolved_key(self):
+        """delegation.provider should still resolve named custom providers when
+        delegation.base_url is also present (the reporter's #51303 shape).
+        """
+        import hermes_cli.runtime_provider as rp
+
+        full_config = {
+            "providers": {
+                "lms_studio": {
+                    "name": "LMS Studio",
+                    "type": "custom",
+                    "base_url": "http://100.122.60.59:1234/v1",
+                }
+            },
+            "model": {"default": "kimi-k2.5", "provider": "ollama-cloud"},
+        }
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "provider": "lms_studio",
+            "model": "llama-3.1-8b-instruct",
+            "base_url": "http://100.122.60.59:1234/v1",
+        }
+
+        with patch.object(rp, "load_config", lambda: full_config), patch.object(
+            rp, "_get_model_config", lambda: full_config["model"]
+        ):
+            creds = _resolve_delegation_credentials(cfg, parent)
+
+        self.assertEqual(creds["provider"], "lms_studio")
+        self.assertEqual(creds["model"], "llama-3.1-8b-instruct")
+        self.assertEqual(creds["base_url"], "http://100.122.60.59:1234/v1")
+        self.assertEqual(creds["api_key"], "no-key-required")
+        self.assertEqual(creds["api_mode"], "chat_completions")
+
     def test_direct_endpoint_uses_configured_base_url_and_api_key(self):
         parent = _make_mock_parent(depth=0)
         cfg = {

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3003,6 +3003,46 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     _provider_lower = (configured_provider or "").strip().lower()
     _is_native_sdk_provider = _provider_lower in _NATIVE_SDK_PROVIDERS
 
+    if configured_base_url and configured_provider and not _is_native_sdk_provider:
+        # If the user supplied both delegation.provider and delegation.base_url,
+        # do not immediately collapse to bare ``custom``.  Named custom
+        # providers (providers:/custom_providers:) carry identity, API key
+        # policy (including local no-key-required endpoints), api_mode, and
+        # request overrides.  Resolve that runtime first, passing the explicit
+        # base_url as an override so the reporter's #51303 shape keeps
+        # ``provider: lms_studio`` instead of losing it to bare ``custom``.
+        try:
+            from hermes_cli.runtime_provider import (
+                has_named_custom_provider,
+                resolve_runtime_provider,
+            )
+
+            if has_named_custom_provider(configured_provider):
+                runtime = resolve_runtime_provider(
+                    requested=configured_provider,
+                    explicit_api_key=configured_api_key or None,
+                    explicit_base_url=configured_base_url,
+                    target_model=configured_model,
+                )
+                return {
+                    "model": configured_model or runtime.get("model") or None,
+                    "provider": configured_provider
+                    if runtime.get("provider") == _RUNTIME_PROVIDER_CUSTOM
+                    else runtime.get("provider"),
+                    "base_url": runtime.get("base_url"),
+                    "api_key": runtime.get("api_key"),
+                    "api_mode": runtime.get("api_mode"),
+                    "command": runtime.get("command"),
+                    "args": list(runtime.get("args") or []),
+                }
+        except Exception as exc:
+            logger.debug(
+                "Could not resolve named delegation provider '%s' with explicit base_url '%s': %s",
+                configured_provider,
+                configured_base_url,
+                exc,
+            )
+
     if configured_base_url and not _is_native_sdk_provider:
         # When delegation.api_key is not set, return None so _build_child_agent
         # falls back to the parent agent's API key via the credential inheritance


### PR DESCRIPTION
## Summary
- Preserve named custom provider identity when `delegation.provider` is paired with `delegation.base_url`
- Resolve named providers through the runtime provider resolver before falling back to the bare direct-endpoint path
- Add regression coverage for the `lms_studio` shape reported in the issue

## Test Plan
- `uv run --with pytest --with pyyaml --with ruamel.yaml python -m pytest tests/tools/test_delegate.py -q -o 'addopts='`

Fixes #51303
