### PR TITLE
test(skills): guard auxiliary vision config docs

### DIFF
--- a/tests/skills/test_auxiliary_vision_config_docs.py
+++ b/tests/skills/test_auxiliary_vision_config_docs.py
@@ -1,0 +1,28 @@
+"""Regression guards for skill/docs references to auxiliary vision config."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SEARCH_ROOTS = (
+    REPO_ROOT / "skills",
+    REPO_ROOT / "optional-skills",
+    REPO_ROOT / "website" / "docs",
+    REPO_ROOT / "docs",
+)
+
+
+def test_skills_and_docs_do_not_reference_removed_computer_vision_config_key():
+    """Issue #51150: docs/skills must point at auxiliary.vision, not a dead key."""
+    stale = []
+    for root in SEARCH_ROOTS:
+        if not root.exists():
+            continue
+        for path in root.rglob("*"):
+            if not path.is_file() or path.suffix.lower() not in {".md", ".mdx"}:
+                continue
+            text = path.read_text(encoding="utf-8", errors="ignore")
+            if "auxiliary.computer_vision" in text or "computer_vision" in text:
+                stale.append(str(path.relative_to(REPO_ROOT)))
+
+    assert stale == []

--- a/tests/skills/test_auxiliary_vision_config_docs.py
+++ b/tests/skills/test_auxiliary_vision_config_docs.py
@@ -22,7 +22,7 @@ def test_skills_and_docs_do_not_reference_removed_computer_vision_config_key():
             if not path.is_file() or path.suffix.lower() not in {".md", ".mdx"}:
                 continue
             text = path.read_text(encoding="utf-8", errors="ignore")
-            if "auxiliary.computer_vision" in text or "computer_vision" in text:
+            if "auxiliary.computer_vision" in text:
                 stale.append(str(path.relative_to(REPO_ROOT)))
 
     assert stale == []


### PR DESCRIPTION
## Summary
- Add a regression guard to keep skills/docs from reintroducing stale `computer_vision` config references
- Covers `skills/`, `optional-skills/`, `website/docs/`, and `docs/`

## Notes
- Current `main` no longer appears to contain `auxiliary.computer_vision` references, so this is a focused guard rather than a production docs rewrite.

## Test Plan
- `uv run --with pytest --with pyyaml --with ruamel.yaml python -m pytest tests/skills/test_auxiliary_vision_config_docs.py -q -o 'addopts='`

Refs #51150
