### PR TITLE
fix(telegram): align processing reactions with lifecycle

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -7108,13 +7108,19 @@ class TelegramAdapter(BasePlatformAdapter):
             return False
 
     async def on_processing_start(self, event: MessageEvent) -> None:
-        """Add an in-progress reaction when message processing begins."""
+        """Add an in-progress reaction when message processing begins.
+
+        The Telegram communication convention uses ⚡ once the gateway has
+        accepted the message and actual processing is starting. Telegram
+        reactions replace the previous bot-set reaction, so the completion
+        hook can later swap this to 👌/👎.
+        """
         if not self._reactions_enabled():
             return
         chat_id = getattr(event.source, "chat_id", None)
         message_id = getattr(event, "message_id", None)
         if chat_id and message_id:
-            await self._set_reaction(chat_id, message_id, "\U0001f440")
+            await self._set_reaction(chat_id, message_id, "⚡")
 
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
         """Swap the in-progress reaction for a final success/failure reaction.
@@ -7123,10 +7129,10 @@ class TelegramAdapter(BasePlatformAdapter):
         replaces all existing reactions in one call — no remove step needed.
 
         On CANCELLED outcomes (e.g. the user runs ``/stop``, or a session is
-        interrupted mid-flight), we explicitly clear the 👀 in-progress
+        interrupted mid-flight), we explicitly clear the in-progress
         reaction so it doesn't linger on the user's message indefinitely.
-        Without this clear, the only way to remove the 👀 was to wait for
-        another agent run to swap it to 👍/👎 — which never happens if the
+        Without this clear, the only way to remove the reaction was to wait for
+        another agent run to swap it to 👌/👎 — which never happens if the
         cancellation was the last activity in the chat.
         """
         if not self._reactions_enabled():
@@ -7141,7 +7147,7 @@ class TelegramAdapter(BasePlatformAdapter):
             await self._set_reaction(
                 chat_id,
                 message_id,
-                "\U0001f44d" if outcome == ProcessingOutcome.SUCCESS else "\U0001f44e",
+                "👌" if outcome == ProcessingOutcome.SUCCESS else "👎",
             )
 
 

--- a/tests/gateway/test_telegram_reactions.py
+++ b/tests/gateway/test_telegram_reactions.py
@@ -126,8 +126,8 @@ async def test_set_reaction_handles_api_error_gracefully(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_on_processing_start_adds_eyes_reaction(monkeypatch):
-    """Processing start should add eyes reaction when enabled."""
+async def test_on_processing_start_adds_lightning_reaction(monkeypatch):
+    """Processing start should add ⚡ reaction when enabled."""
     monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
     adapter = _make_adapter()
     event = _make_event()
@@ -137,7 +137,7 @@ async def test_on_processing_start_adds_eyes_reaction(monkeypatch):
     adapter._bot.set_message_reaction.assert_awaited_once_with(
         chat_id=123,
         message_id=456,
-        reaction="\U0001f440",
+        reaction="⚡",
     )
 
 
@@ -175,7 +175,7 @@ async def test_on_processing_start_handles_missing_ids(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_on_processing_complete_success(monkeypatch):
-    """Successful processing should set thumbs-up reaction."""
+    """Successful processing should set 👌 reaction."""
     monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
     adapter = _make_adapter()
     event = _make_event()
@@ -185,7 +185,7 @@ async def test_on_processing_complete_success(monkeypatch):
     adapter._bot.set_message_reaction.assert_awaited_once_with(
         chat_id=123,
         message_id=456,
-        reaction="\U0001f44d",
+        reaction="👌",
     )
 
 
@@ -221,8 +221,8 @@ async def test_on_processing_complete_skipped_when_disabled(monkeypatch):
 async def test_on_processing_complete_cancelled_clears_reaction(monkeypatch):
     """Cancelled processing should clear the in-progress reaction.
 
-    Without this clear, the 👀 reaction lingers on the user's message
-    indefinitely (until another agent run swaps it for 👍/👎). On a
+    Without this clear, the in-progress reaction lingers on the user's message
+    indefinitely (until another agent run swaps it for 👌/👎). On a
     ``/stop`` that ends a session, that reaction never gets cleaned up.
     """
     monkeypatch.setenv("TELEGRAM_REACTIONS", "true")


### PR DESCRIPTION
## Summary
- Switch Telegram processing-start reaction from 👀 to ⚡.
- Switch successful processing completion from 👍 to 👌.
- Keep failure as 👎 and cancellation clearing behavior unchanged.
- Update reaction tests for the lifecycle convention.

## What I did not port
- The stale local Codex tools change is already superseded on current main by omitting tools entirely when empty.
- The stale local Telegram typing-after-send removal is already superseded on current main by skipping re-trigger only for final notify sends while preserving intermediate typing refreshes.

## Test Plan
- scripts/run_tests.sh tests/gateway/test_telegram_reactions.py tests/gateway/test_telegram_format.py tests/run_agent/test_codex_xai_oauth_recovery.py