### PR TITLE
fix(gateway): read multiplex_profiles from nested gateway section

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -849,15 +849,18 @@ def load_gateway_config() -> GatewayConfig:
                 gw_data["thread_sessions_per_user"] = yaml_cfg["thread_sessions_per_user"]
 
             # Multiplexing flag: accept both the top-level key and the nested
-            # gateway.multiplex_profiles form (from_dict resolves the nested
-            # fallback, but surface the top-level key here for parity with the
-            # other session-scope flags above).
+            # gateway.multiplex_profiles form (written by
+            # ``hermes config set gateway.multiplex_profiles true``).
             if "multiplex_profiles" in yaml_cfg:
                 gw_data["multiplex_profiles"] = yaml_cfg["multiplex_profiles"]
 
             gateway_section = yaml_cfg.get("gateway")
-            if isinstance(gateway_section, dict) and "max_concurrent_sessions" in gateway_section:
-                gw_data["max_concurrent_sessions"] = gateway_section["max_concurrent_sessions"]
+            if isinstance(gateway_section, dict):
+                if "multiplex_profiles" in gateway_section and "multiplex_profiles" not in gw_data:
+                    # gateway.multiplex_profiles written by `hermes config set gateway.multiplex_profiles true`
+                    gw_data["multiplex_profiles"] = gateway_section["multiplex_profiles"]
+                if "max_concurrent_sessions" in gateway_section:
+                    gw_data["max_concurrent_sessions"] = gateway_section["max_concurrent_sessions"]
 
             if "max_concurrent_sessions" in yaml_cfg:
                 gw_data["max_concurrent_sessions"] = yaml_cfg["max_concurrent_sessions"]

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -330,6 +330,32 @@ class TestLoadGatewayConfig:
 
         assert config.quick_commands == {"limits": {"type": "exec", "command": "echo ok"}}
 
+    def test_multiplex_profiles_from_nested_gateway_section(self, tmp_path, monkeypatch):
+        """``gateway.multiplex_profiles: true`` (the nested form written by
+        ``hermes config set gateway.multiplex_profiles true``) must enable
+        multiplexing when loaded via load_gateway_config().
+
+        Regression: load_gateway_config() only surfaced the *top-level*
+        ``multiplex_profiles`` key into gw_data, so a config.yaml that pinned
+        the flag under the nested ``gateway:`` section silently loaded with
+        multiplex_profiles=False. (from_dict honors the nested fallback, but
+        load_gateway_config builds gw_data from the top-level keys before
+        calling from_dict, so the nested value never reached it.)
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "gateway:\n  multiplex_profiles: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.multiplex_profiles is True
+
     def test_relay_platform_enabled_from_env_url(self, tmp_path, monkeypatch):
         """GATEWAY_RELAY_URL must enable Platform.RELAY in config.platforms so
         start_gateway()'s connect loop actually dials the connector. Registering


### PR DESCRIPTION
## What does this PR do?

Fixes a config-loading bug where `gateway.multiplex_profiles: true` written under the **nested** `gateway:` section of `config.yaml` was silently ignored, so the gateway loaded with `multiplex_profiles=False`.

This is the form written by `hermes config set gateway.multiplex_profiles true`, so the documented CLI path to enable profile multiplexing did not actually take effect when set that way.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Root cause

`gateway/config.py` — `load_gateway_config()` (around the `multiplex_profiles` block, ~line 851):

`load_gateway_config()` builds `gw_data` from the **top-level** keys of `config.yaml` and then calls `GatewayConfig.from_dict(gw_data)`. `from_dict()` *does* honor the nested `gateway.multiplex_profiles` fallback — but only against the dict it is handed. Since `load_gateway_config()` only copied the **top-level** `multiplex_profiles` key into `gw_data`, the nested value never reached `from_dict()`, and the flag defaulted to `False`.

The sibling `max_concurrent_sessions` already had a nested-`gateway:` fallback in this same block; `multiplex_profiles` was missing the equivalent.

## Changes Made

- `gateway/config.py`: in `load_gateway_config()`, read `gateway.multiplex_profiles` into `gw_data` when the top-level key is absent, mirroring the existing nested fallback for `max_concurrent_sessions`.
- `tests/gateway/test_config.py`: add `TestLoadGatewayConfig::test_multiplex_profiles_from_nested_gateway_section` — writes a `config.yaml` with `gateway.multiplex_profiles: true`, calls `load_gateway_config()`, and asserts `cfg.multiplex_profiles is True`.

## How to Test

1. Check out this branch, then run:
   `pytest tests/gateway/test_config.py::TestLoadGatewayConfig::test_multiplex_profiles_from_nested_gateway_section -v`
2. **Without** the `config.py` change the test FAILS (`assert False is True` — `multiplex_profiles=False`); **with** it the test PASSES.
3. Full file is green: `pytest tests/gateway/test_config.py -q` → 70 passed.

Existing coverage gap: `tests/gateway/test_multiplex_phase0.py` only exercises `GatewayConfig.from_dict`, never `load_gateway_config()` with a YAML file — which is exactly where this bug lived.

## Checklist

### Code

- [x] My commit messages follow Conventional Commits (`fix(gateway):`)
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes
- [x] Tested on Ubuntu (Linux), Python 3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)