### PR TITLE
fix(gateway): honor explicit api_server enabled:false under env key

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1761,7 +1761,19 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if api_server_enabled or api_server_key:
         if Platform.API_SERVER not in config.platforms:
             config.platforms[Platform.API_SERVER] = PlatformConfig()
-        config.platforms[Platform.API_SERVER].enabled = True
+        # Respect an explicit ``enabled: false`` in config.yaml (flagged by
+        # ``_enabled_explicit``). In multiplex mode a secondary profile's
+        # config.yaml pins ``platforms.api_server.enabled: false`` so it shares
+        # the default profile's listener instead of binding its own port. That
+        # profile still inherits the process-level env (including
+        # ``API_SERVER_KEY``); without this guard the env-var presence would
+        # force-enable the listener and trip the MultiplexConfigError check.
+        # Pop (don't read) the marker — the api_server branch is terminal (no
+        # later registry pass re-enables it), so this both consumes the flag and
+        # avoids reading it twice, matching the pop convention used elsewhere.
+        api_server_explicit = config.platforms[Platform.API_SERVER].extra.pop("_enabled_explicit", False)
+        if not api_server_explicit or config.platforms[Platform.API_SERVER].enabled:
+            config.platforms[Platform.API_SERVER].enabled = True
         if api_server_key:
             config.platforms[Platform.API_SERVER].extra["key"] = api_server_key
         if api_server_cors_origins:

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -1467,3 +1467,36 @@ class TestMultiplexProfilesEnvOverride:
         for noise in ("", "   ", "maybe", "2"):
             monkeypatch.setenv("GATEWAY_MULTIPLEX_PROFILES", noise)
             assert _env_multiplex_profiles_override() is None, repr(noise)
+
+
+class TestApiServerEnvOverride:
+    def test_env_key_does_not_reenable_explicitly_disabled_api_server(self):
+        """An explicit ``platforms.api_server.enabled: false`` must survive
+        _apply_env_overrides() even when API_SERVER_KEY is present in the env.
+
+        Regression: _apply_env_overrides() force-set api_server.enabled = True
+        whenever API_SERVER_KEY (or API_SERVER_ENABLED) was set. In multiplex
+        mode a secondary profile pins ``api_server.enabled: false`` so it shares
+        the default profile's listener instead of binding its own port, but it
+        still inherits the process-level API_SERVER_KEY. The unconditional
+        re-enable flipped it back on and tripped the MultiplexConfigError check.
+
+        The fix honors the explicit disable, flagged by ``_enabled_explicit`` in
+        the platform's extra (set when the config.yaml pins enabled).
+        """
+        config = GatewayConfig(
+            platforms={
+                Platform.API_SERVER: PlatformConfig(
+                    enabled=False,
+                    extra={"_enabled_explicit": True},
+                ),
+            },
+        )
+
+        with patch.dict(os.environ, {"API_SERVER_KEY": "secret-key"}, clear=True):
+            _apply_env_overrides(config)
+
+        # Explicit disable wins over the env-var presence.
+        assert config.platforms[Platform.API_SERVER].enabled is False
+        # The key is still wired through for the shared listener.
+        assert config.platforms[Platform.API_SERVER].extra.get("key") == "secret-key"


### PR DESCRIPTION
## What does this PR do?

Honor an explicit `platforms.api_server.enabled: false` under the presence of an API-server env key.

**The contract:** when `config.yaml` explicitly pins `platforms.api_server.enabled: false` (recorded via the `_enabled_explicit` marker in `PlatformConfig.extra`), that explicit disable takes precedence over the mere presence of `API_SERVER_ENABLED` / `API_SERVER_KEY` **in the same scope**. Today `_apply_env_overrides()` unconditionally re-enables `api_server` whenever either env var is present, silently overriding the explicit disable.

This aligns `api_server` with the already-migrated plugin platforms (telegram / matrix / slack), which already consult `_enabled_explicit` (via `_enable_from_env()`) before re-enabling. The `api_server` block re-enables inline and was the one platform that did not honor the marker.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Root cause

`gateway/config.py` — `_apply_env_overrides()`, the `# API Server` block:

```python
if api_server_enabled or api_server_key:
    if Platform.API_SERVER not in config.platforms:
        config.platforms[Platform.API_SERVER] = PlatformConfig()
    config.platforms[Platform.API_SERVER].enabled = True   # <-- unconditional
```

The presence of `API_SERVER_KEY` / `API_SERVER_ENABLED` in the environment force-enables the platform even when the same scope's `config.yaml` explicitly set `enabled: false`. The migrated plugin platforms read `_enabled_explicit` before re-enabling; `api_server` did not.

## Changes Made

- `gateway/config.py`: guard the `api_server.enabled = True` assignment on the explicit-disable marker. Use `extra.pop("_enabled_explicit", False)`: the `api_server` branch is **terminal** (unlike the migrated plugin platforms, no later registry pass re-enables `api_server`), so popping consumes the flag in a single read and avoids a double-read; the per-platform `_enabled_explicit` cleanup at the end of `_apply_env_overrides` remains a no-op for `api_server`. The normal env-enable path (no explicit disable) is unchanged.
- `tests/gateway/test_config.py`: retain the focused regression test `TestApiServerEnvOverride::test_env_key_does_not_reenable_explicitly_disabled_api_server`.

## Scope: same-scope precedence, not cross-profile multiplexing

This PR is about the **same-scope explicit-disable precedence** contract only. It is deliberately **orthogonal** to the cross-profile (multiplex) contract already covered on `main`:

- The profile-scoped gateway env reads were added on `main` in `0f154e780e...`.
- `tests/gateway/test_config.py` on `main` already verifies that a **default-profile** API-server env setting does **not** enable a **secondary** profile.

That orthogonal contract answers "does a default-profile env var leak into another profile's scope?" — this PR answers a different question: "within one scope, does an explicit `enabled: false` in `config.yaml` survive the presence of an env key in that same scope?" It does not, today; this PR makes it so. No cross-profile / multiplexing behavior is added or changed here.

## How to test

```bash
pytest tests/gateway/test_config.py::TestApiServerEnvOverride::test_env_key_does_not_reenable_explicitly_disabled_api_server -v
```

With the fix the test passes; removing the `_enabled_explicit` guard makes it fail (the `enabled` flag flips back to `True` under `API_SERVER_KEY`). Full config regression: `pytest tests/gateway/test_config.py -q` (100 passed) and `pytest tests/gateway/test_multiplex_phase0.py -q` (28 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)