### PR TITLE
fix: replace assert statements with proper error handling in production code

### DIFF
--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -396,7 +396,8 @@ class CodexAppServerSession:
             # turn re-spawns cleanly.
             result.should_retire = True
             return result
-        assert self._client is not None and self._thread_id is not None
+        if self._client is None or self._thread_id is None:
+        raise RuntimeError("CodexACPTransport.send called before connect()")
         result.thread_id = self._thread_id
 
         self._interrupt_event.clear()

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4637,7 +4637,8 @@ def _run_with_idle_timeout(
 
     def _reader() -> None:
         nonlocal last_output_ts
-        assert proc.stdout is not None
+        if proc.stdout is None:
+            return
         for line in proc.stdout:
             try:
                 print(f"{indent}{line.rstrip()}", flush=True)

--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -374,7 +374,8 @@ def _run_bootstrap(cwd: Path, commands: List[str]) -> None:
 def _do_git_install(entry: CatalogEntry) -> Path:
     """Clone the entry's repo into ``~/.hermes/mcp-installs/<name>`` and run
     bootstrap commands. Returns the install directory."""
-    assert entry.install is not None and entry.install.type == "git"
+    if entry.install is None or entry.install.type != "git":
+    raise CatalogError(f"Entry '{entry.name}' does not have a git install config")
     install = entry.install
     dest = _install_root() / entry.name
 

--- a/hermes_cli/mcp_picker.py
+++ b/hermes_cli/mcp_picker.py
@@ -219,7 +219,8 @@ def _handle_row(row: _Row) -> None:
                 print(color(f"  '{row.name}' was not installed", Colors.DIM))
     elif choice == 3:
         try:
-            assert row.entry is not None
+            if row.entry is None:
+                raise CatalogError("No catalog entry available for reinstall")
             install_entry(row.entry, enable=True)
         except CatalogError as exc:
             print(color(f"  ✗ reinstall failed: {exc}", Colors.RED))

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -810,7 +810,8 @@ class CDPSupervisor:
 
     async def _read_loop(self) -> None:
         """Continuously dispatch incoming CDP frames."""
-        assert self._ws is not None
+        if self._ws is None:
+            raise RuntimeError("BrowserWebSocket._read_loop called before connect")
         try:
             async for raw in self._ws:
                 if self._stop_requested:

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -944,7 +944,8 @@ class DockerEnvironment(BaseEnvironment):
                   timeout: int = 120,
                   stdin_data: str | None = None) -> subprocess.Popen:
         """Spawn a bash process inside the Docker container."""
-        assert self._container_id, "Container not started"
+        if not self._container_id:
+        raise RuntimeError("Container not started")
         cmd = [self._docker_exe, "exec"]
         if stdin_data is not None:
             cmd.append("-i")


### PR DESCRIPTION
## Problem

`assert` statements are stripped when Python runs with `-O` (optimize) flag. This silently removes these guards, potentially causing NoneType errors or data corruption downstream instead of clear error messages.

## Fix

Replace each `assert` with an explicit `if` check that raises `RuntimeError` or returns early:

```python
# Before (stripped by python -O)
assert self._ws is not None

# After (always runs)
if self._ws is None:
    raise RuntimeError("BrowserWebSocket._read_loop called before connect")
```

## Files changed

- `agent/transports/codex_app_server_session.py`: pre-connect guard
- `tools/environments/docker.py`: container-not-started guard
- `tools/browser_supervisor.py`: websocket-not-connected guard
- `hermes_cli/mcp_catalog.py`: install-config validation
- `hermes_cli/mcp_picker.py`: entry-exists guard
- `hermes_cli/main.py`: stdout-attached guard