### PR TITLE
feat: add skills.only config option to filter skill index

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -384,7 +384,36 @@ def get_disabled_skill_names(platform: str | None = None) -> Set[str]:
             resolved_platform
         )
         if platform_disabled is not None:
-            return global_disabled | _normalize_string_set(platform_disabled)
+            global_disabled |= _normalize_string_set(platform_disabled)
+
+    # ── skills.only — if set, ALL skills NOT in this list are disabled ──
+    only_list = skills_cfg.get("only")
+    if only_list is not None:
+        import json
+        # Parse JSON list strings (from hermes config set)
+        if isinstance(only_list, str):
+            try:
+                only_list = json.loads(only_list)
+            except (json.JSONDecodeError, TypeError):
+                only_list = [only_list]
+        allowed = _normalize_string_set(only_list)
+        if allowed:
+            all_skills = set()
+            for skills_dir in get_all_skills_dirs():
+                if not skills_dir.is_dir():
+                    continue
+                for sf in iter_skill_index_files(skills_dir, "SKILL.md"):
+                    try:
+                        raw = sf.read_text(encoding="utf-8")
+                        fm, _ = parse_frontmatter(raw)
+                        name = fm.get("name") or sf.parent.name
+                        all_skills.add(str(name).strip())
+                    except Exception:
+                        all_skills.add(sf.parent.name)
+            for skill_name in all_skills:
+                if skill_name not in allowed:
+                    global_disabled.add(skill_name)
+
     return global_disabled
 
 


### PR DESCRIPTION
## Summary

Adds a `skills.only` config option that filters the `<available_skills>` index in the system prompt to only show listed skills. All non-listed skills are treated as disabled, saving \~9KB per session.

## Config

```yaml
skills:
  only: [coder, decision-log, kanban-swarm]
```

## Implementation

The filter is applied inside `get_disabled_skill_names()` in `agent/skill_utils.py`. It scans all installed SKILL.md files and adds any skill not in the `only` list to the disabled set. This flows through automatically to the prompt builder, skill bundles, and config var discovery — no other code changes needed.

Supports JSON list strings (from `hermes config set skills.only '[...]'`) and native YAML list format.

## Why

With 91 installed skills, the `<available_skills>` index takes \~8.8KB in every session prompt. Most profiles only use 2-6 skills. This option lets users scope the index to relevant skills, reducing prompt size without modifying Hermes source.