### PR TITLE
feat(desktop): add font family and font size settings in Appearance

### DIFF
--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@nanostores/react'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 
 import { LanguageSwitcher } from '@/components/language-switcher'
 import { SegmentedControl } from '@/components/ui/segmented-control'
@@ -10,7 +10,7 @@ import { cn } from '@/lib/utils'
 import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/profile'
 import { $toolViewMode, setToolViewMode } from '@/store/tool-view'
 import { $translucency, setTranslucency } from '@/store/translucency'
-import { useTheme } from '@/themes/context'
+import { $userFontSans, $userFontMono, $userFontSize, useTheme } from '@/themes/context'
 import { installVscodeThemeFromMarketplace } from '@/themes/install'
 import { isUserTheme, removeUserTheme, resolveTheme } from '@/themes/user-themes'
 
@@ -132,6 +132,101 @@ function VscodeThemeInstaller() {
   )
 }
 
+function FontSettings() {
+  const { t } = useI18n()
+  const a = t.settings.appearance
+  const currentSans = useStore($userFontSans)
+  const currentMono = useStore($userFontMono)
+  const currentSize = useStore($userFontSize)
+
+  const updateSans = (value: string) => {
+    $userFontSans.set(value)
+    if (value) {
+      localStorage.setItem('hermes-font-sans', value)
+    } else {
+      localStorage.removeItem('hermes-font-sans')
+    }
+  }
+
+  const updateMono = (value: string) => {
+    $userFontMono.set(value)
+    if (value) {
+      localStorage.setItem('hermes-font-mono', value)
+    } else {
+      localStorage.removeItem('hermes-font-mono')
+    }
+  }
+
+  const updateSize = (value: string) => {
+    $userFontSize.set(value)
+    if (value) {
+      localStorage.setItem('hermes-font-size', value)
+    } else {
+      localStorage.removeItem('hermes-font-size')
+    }
+  }
+
+  const inputClass =
+    'min-w-0 flex-1 rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-bg-quinary) px-3 py-1.5 font-mono text-[length:var(--conversation-caption-font-size)] outline-none placeholder:text-(--ui-text-tertiary) focus:border-(--ui-stroke-secondary)'
+
+  return (
+    <div className="mt-3 space-y-3">
+      <div className="flex items-center gap-2">
+        <input
+          className={inputClass}
+          onChange={e => updateSans(e.target.value)}
+          placeholder='"LXGW WenKai", sans-serif'
+          spellCheck={false}
+          value={currentSans}
+        />
+        <button
+          className="shrink-0 rounded-lg border border-(--ui-stroke-secondary) bg-(--ui-bg-tertiary) px-3 py-1.5 text-[length:var(--conversation-caption-font-size)] font-medium transition hover:bg-(--chrome-action-hover) disabled:opacity-50"
+          disabled={!currentSans}
+          onClick={() => updateSans('')}
+          type="button"
+        >
+          {a.fontReset}
+        </button>
+      </div>
+      <div className="flex items-center gap-2">
+        <input
+          className={inputClass}
+          onChange={e => updateMono(e.target.value)}
+          placeholder='"LXGW WenKai Mono", monospace'
+          spellCheck={false}
+          value={currentMono}
+        />
+        <button
+          className="shrink-0 rounded-lg border border-(--ui-stroke-secondary) bg-(--ui-bg-tertiary) px-3 py-1.5 text-[length:var(--conversation-caption-font-size)] font-medium transition hover:bg-(--chrome-action-hover) disabled:opacity-50"
+          disabled={!currentMono}
+          onClick={() => updateMono('')}
+          type="button"
+        >
+          {a.fontReset}
+        </button>
+      </div>
+      <div className="flex items-center gap-2">
+        <span className="shrink-0 text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary) w-16">{a.fontSize}</span>
+        <input
+          className={inputClass}
+          onChange={e => updateSize(e.target.value)}
+          placeholder="13px"
+          spellCheck={false}
+          value={currentSize}
+        />
+        <button
+          className="shrink-0 rounded-lg border border-(--ui-stroke-secondary) bg-(--ui-bg-tertiary) px-3 py-1.5 text-[length:var(--conversation-caption-font-size)] font-medium transition hover:bg-(--chrome-action-hover) disabled:opacity-50"
+          disabled={!currentSize}
+          onClick={() => updateSize('')}
+          type="button"
+        >
+          {a.fontReset}
+        </button>
+      </div>
+    </div>
+  )
+}
+
 export function AppearanceSettings() {
   const { t, isSavingLocale } = useI18n()
   const { themeName, mode, availableThemes, setTheme, setMode } = useTheme()
@@ -209,6 +304,13 @@ export function AppearanceSettings() {
             }
             description={a.translucencyDesc}
             title={a.translucencyTitle}
+          />
+
+          <ListRow
+            below={<FontSettings />}
+            description={a.fontDesc}
+            title={a.fontTitle}
+            wide
           />
 
           <ListRow

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -372,7 +372,16 @@ export const en: Translations = {
       installError: 'Could not install that theme.',
       installed: name => `Installed “${name}”.`,
       removeTheme: 'Remove theme',
-      importedBadge: 'Imported'
+      importedBadge: 'Imported',
+      fontTitle: 'Font',
+      fontDesc: 'Override theme fonts. These persist across theme switches.',
+      fontSans: 'UI Font',
+      fontSansDesc: 'Sans-serif font for the interface. Leave empty for theme default.',
+      fontMono: 'Code Font',
+      fontMonoDesc: 'Monospace font for code blocks and terminal. Leave empty for theme default.',
+      fontSize: 'Font Size',
+      fontSizeDesc: 'Base font size in pixels or rem. e.g. 14px or 0.875rem. Leave empty for default (13px).',
+      fontReset: 'Reset'
     },
     fieldLabels: FIELD_LABELS,
     fieldDescriptions: FIELD_DESCRIPTIONS,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -287,7 +287,16 @@ export const ja = defineLocale({
       installError: 'そのテーマをインストールできませんでした。',
       installed: name => `「${name}」をインストールしました。`,
       removeTheme: 'テーマを削除',
-      importedBadge: 'インポート済み'
+      importedBadge: 'インポート済み',
+      fontTitle: 'フォント',
+      fontDesc: 'テーマのフォントを上書き。テーマ切替後も保持されます。',
+      fontSans: 'UIフォント',
+      fontSansDesc: 'インターフェース用サンセリフフォント。空欄ならテーマ既定値。',
+      fontMono: 'コードフォント',
+      fontMonoDesc: 'コードブロックとターミナル用モノスペースフォント。空欄ならテーマ既定値。',
+      fontSize: 'フォントサイズ',
+      fontSizeDesc: '基本フォントサイズ（px または rem）。例: 14px や 0.875rem。空欄なら既定値（13px）。',
+      fontReset: 'リセット'
     },
     fieldLabels: defineFieldCopy({
       model: 'デフォルトモデル',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -270,6 +270,15 @@ export interface Translations {
       installed: (name: string) => string
       removeTheme: string
       importedBadge: string
+      fontTitle: string
+      fontDesc: string
+      fontSans: string
+      fontSansDesc: string
+      fontMono: string
+      fontMonoDesc: string
+      fontSize: string
+      fontSizeDesc: string
+      fontReset: string
     }
     fieldLabels: Record<string, string>
     fieldDescriptions: Record<string, string>

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -276,7 +276,16 @@ export const zhHant = defineLocale({
       installError: '無法安裝該主題。',
       installed: name => `已安裝「${name}」。`,
       removeTheme: '移除主題',
-      importedBadge: '已匯入'
+      importedBadge: '已匯入',
+      fontTitle: '字型',
+      fontDesc: '覆蓋主題字型，切換主題後仍保持不變。',
+      fontSans: '介面字型',
+      fontSansDesc: '介面用無襯線字型，留空則用主題預設。',
+      fontMono: '程式碼字型',
+      fontMonoDesc: '程式碼區塊和終端機用等寬字型，留空則用主題預設。',
+      fontSize: '字型大小',
+      fontSizeDesc: '基礎字型大小，支援 px 或 rem，如 14px 或 0.875rem。留空用預設值（13px）。',
+      fontReset: '重置'
     },
     fieldLabels: defineFieldCopy({
       model: '預設模型',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -364,7 +364,16 @@ export const zh: Translations = {
       installError: '无法安装该主题。',
       installed: name => `已安装「${name}」。`,
       removeTheme: '移除主题',
-      importedBadge: '已导入'
+      importedBadge: '已导入',
+      fontTitle: '字体',
+      fontDesc: '覆盖主题字体，切换主题后仍保持不变。',
+      fontSans: '界面字体',
+      fontSansDesc: '界面用无衬线字体，留空则用主题默认。',
+      fontMono: '代码字体',
+      fontMonoDesc: '代码块和终端用等宽字体，留空则用主题默认。',
+      fontSize: '字号',
+      fontSizeDesc: '基础字号，支持 px 或 rem，如 14px 或 0.875rem。留空用默认值（13px）。',
+      fontReset: '重置'
     },
     fieldLabels: defineFieldCopy({
       model: '默认模型',

--- a/apps/desktop/src/themes/context.tsx
+++ b/apps/desktop/src/themes/context.tsx
@@ -9,6 +9,7 @@
  * The two are persisted independently. Shift+X toggles light/dark.
  */
 
+import { atom } from 'nanostores'
 import { useStore } from '@nanostores/react'
 import { createContext, type ReactNode, useCallback, useContext, useEffect, useMemo, useState } from 'react'
 
@@ -38,6 +39,12 @@ const RETIRED_SKINS = new Set(['nous-light', 'default', 'gold'])
 export type ThemeMode = 'light' | 'dark' | 'system'
 
 const INJECTED_FONT_URLS = new Set<string>()
+
+// User font preferences — override theme typography when set.
+// Persisted in localStorage; read by applyTheme, written by FontSettings.
+export const $userFontSans = atom<string>(typeof localStorage !== 'undefined' ? localStorage.getItem('hermes-font-sans') ?? '' : '')
+export const $userFontMono = atom<string>(typeof localStorage !== 'undefined' ? localStorage.getItem('hermes-font-mono') ?? '' : '')
+export const $userFontSize = atom<string>(typeof localStorage !== 'undefined' ? localStorage.getItem('hermes-font-size') ?? '' : '')
 
 const resolveMode = (mode: ThemeMode, systemDark = matchesQuery('(prefers-color-scheme: dark)')): 'light' | 'dark' =>
   mode === 'system' ? (systemDark ? 'dark' : 'light') : mode
@@ -172,7 +179,15 @@ function applyTheme(theme: DesktopTheme, mode: 'light' | 'dark') {
 
   const root = document.documentElement
   const c = theme.colors
-  const typo = { ...DEFAULT_TYPOGRAPHY, ...nousTheme.typography, ...theme.typography }
+  // User font preferences override theme typography, so switching themes never
+  // changes the user's font. Read from nanostores (synced with localStorage).
+  const themeTypo = { ...DEFAULT_TYPOGRAPHY, ...nousTheme.typography, ...theme.typography }
+  const typo = {
+    fontSans: $userFontSans.get() || themeTypo.fontSans,
+    fontMono: $userFontMono.get() || themeTypo.fontMono,
+    fontUrl: themeTypo.fontUrl
+  }
+  const userFontSize = $userFontSize.get()
   const rendered = renderedModeFor(c, mode)
   const isDark = rendered === 'dark'
   const midground = c.midground ?? c.ring
@@ -215,6 +230,8 @@ function applyTheme(theme: DesktopTheme, mode: 'light' | 'dark') {
     '--dt-user-bubble-border': c.userBubbleBorder ?? c.border,
     '--dt-font-sans': typo.fontSans,
     '--dt-font-mono': typo.fontMono,
+    '--dt-base-size': userFontSize || '0.8125rem',
+    '--conversation-text-font-size': userFontSize || '0.8125rem',
     '--noise-opacity-mul': isDark ? 'calc(0.04 / 0.21)' : 'calc(0.34 / 0.21)'
   }
 
@@ -343,7 +360,11 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   // What actually gets painted (matches the `.dark` class applyTheme toggles).
   const renderedMode = useMemo(() => renderedModeFor(activeTheme.colors, resolvedMode), [activeTheme, resolvedMode])
 
-  useEffect(() => applyTheme(activeTheme, resolvedMode), [activeTheme, resolvedMode])
+  // Re-apply when theme, mode, or user font preferences change.
+  const userFontSans = useStore($userFontSans)
+  const userFontMono = useStore($userFontMono)
+  const userFontSize = useStore($userFontSize)
+  useEffect(() => applyTheme(activeTheme, resolvedMode), [activeTheme, resolvedMode, userFontSans, userFontMono, userFontSize])
 
   // Keep the native window appearance pinned to the app theme (vibrancy
   // material, titlebar, new-window pre-paint background).


### PR DESCRIPTION
## Summary

Add user-configurable font settings to **Settings → Appearance → Font** — UI font, code font, and base font size.

### Motivation

Users with non-Latin scripts (CJK, etc.) or accessibility needs want to override the default Inter/JetBrains Mono fonts without editing CSS or reapplying patches after every `hermes update`. Currently, switching themes also resets any manual font changes.

### What's new

| Setting | Default | CSS variable |
|---------|---------|-------------|
| UI font (sans-serif) | `--dt-font-sans` theme value | `--dt-font-sans` |
| Code font (monospace) | `--dt-font-mono` theme value | `--dt-font-mono` |
| Base font size | `0.8125rem` (13px) | `--dt-base-size`, `--conversation-text-font-size` |

### Architecture

- **nanostores** (`$userFontSans`, `$userFontMono`, `$userFontSize`) store user preferences
- `applyTheme()` reads from stores → sets CSS variables with **user > theme > default** priority
- `FontSettings` component in `appearance-settings.tsx` binds to stores
- localStorage persists values across sessions
- Font changes are **immediate** (no restart needed) and **survive theme switches**

### Files changed

- `apps/desktop/src/themes/context.tsx` — nanostores + applyTheme integration
- `apps/desktop/src/app/settings/appearance-settings.tsx` — FontSettings component
- `apps/desktop/src/i18n/{types,en,zh,zh-hant,ja}.ts` — i18n strings

### Testing

1. Open Settings → Appearance → Font
2. Enter a font family (e.g. `"LXGW WenKai", sans-serif`) → text updates immediately
3. Change font size (e.g. `15px`) → all UI text scales
4. Switch theme → font settings persist
5. Restart app → settings restored from localStorage
