### PR TITLE
fix(kanban): hold external/interactive claims so the dispatcher stops re-dispatching live operator sessions

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -506,7 +506,16 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     )
     p_claim.add_argument("task_id")
     p_claim.add_argument("--ttl", type=int, default=kb.DEFAULT_CLAIM_TTL_SECONDS,
-                         help="Claim TTL in seconds (default: 900)")
+                         help="Claim TTL in seconds (default: 900). Ignored "
+                              "with --external (external holds never expire).")
+    p_claim.add_argument(
+        "--external", action="store_true",
+        help="Mark this as a live interactive-operator hold: held "
+             "indefinitely and NEVER auto-reclaimed by the dispatcher. Use "
+             "this when an interactive session (e.g. Claude Code in tmux "
+             "ccz/ccp) works a task directly, so the dispatcher won't spawn "
+             "a parallel worker on it. Release it with complete / block / "
+             "reclaim (it will NOT free itself on a TTL).")
 
     # --- comment / complete / block / unblock / archive ---
     p_comment = sub.add_parser("comment", help="Append a comment")
@@ -1798,8 +1807,14 @@ def _cmd_unlink(args: argparse.Namespace) -> int:
 
 
 def _cmd_claim(args: argparse.Namespace) -> int:
+    external = bool(getattr(args, "external", False))
     with kb.connect_closing() as conn:
-        task = kb.claim_task(conn, args.task_id, ttl_seconds=args.ttl)
+        task = kb.claim_task(
+            conn, args.task_id,
+            # TTL is meaningless for an external (never-expiring) hold.
+            ttl_seconds=None if external else args.ttl,
+            external=external,
+        )
         if task is None:
             # Report why
             existing = kb.get_task(conn, args.task_id)
@@ -1814,7 +1829,12 @@ def _cmd_claim(args: argparse.Namespace) -> int:
             return 1
         workspace = kb.resolve_workspace(task)
         kb.set_workspace_path(conn, task.id, str(workspace))
-    print(f"Claimed {task.id}")
+    if external:
+        print(f"Claimed {task.id} (external hold — never auto-reclaimed)")
+        print("Release with: hermes kanban complete/block/reclaim "
+              f"{task.id}")
+    else:
+        print(f"Claimed {task.id}")
     print(f"Workspace: {workspace}")
     return 0
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -157,6 +157,30 @@ DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS = 60 * 60
 # signal lands, and the following tick reclaims cleanly.
 RECLAIM_DEFER_GRACE_SECONDS = 120
 
+# ``tasks.claim_kind`` discriminates *who* holds a claim:
+#   * ``worker``   — a dispatcher-spawned worker subprocess. These are
+#     subject to the full reclaim machinery (TTL expiry, PID-liveness,
+#     heartbeat-staleness, max-runtime) so a dead/wedged worker frees its
+#     task for the next dispatcher tick.
+#   * ``external`` — a live interactive operator session (e.g. a Claude
+#     Code session in tmux ``ccz``/``ccp`` that ran ``hermes kanban claim
+#     --external``). These sessions do NOT emit kanban heartbeats or
+#     Hermes API traffic, so their TTL/heartbeat would protrude exactly
+#     like a wedged worker. To stop the dispatcher from re-dispatching a
+#     task a human is actively working on (the #t_0781f106 parallel-work
+#     incident), an external claim is held *indefinitely* (``claim_expires
+#     = NULL``, ``worker_pid = NULL``) and is therefore invisible to all
+#     three reclaimers (``release_stale_claims`` filters
+#     ``claim_expires IS NOT NULL``; ``enforce_max_runtime`` and
+#     ``detect_crashed_workers`` filter ``worker_pid IS NOT NULL``).
+#     ``release_stale_claims`` additionally guards on this column as
+#     defense-in-depth. An external hold is released only by an explicit
+#     ``complete`` / ``block`` / ``reclaim``.
+# A NULL ``claim_kind`` (legacy rows, pre-migration boards) is treated as
+# ``worker`` everywhere so the historical behaviour is preserved.
+CLAIM_KIND_WORKER = "worker"
+CLAIM_KIND_EXTERNAL = "external"
+
 
 def _resolve_claim_ttl_seconds(ttl_seconds: Optional[int] = None) -> int:
     """Return the effective claim TTL, honoring the kanban env override.
@@ -785,6 +809,9 @@ class Task:
     claim_expires: Optional[int]
     tenant: Optional[str]
     branch_name: Optional[str] = None
+    # 'worker' | 'external' | None. None == legacy/worker. An 'external'
+    # claim is a live interactive operator hold and is never auto-reclaimed.
+    claim_kind: Optional[str] = None
     result: Optional[str] = None
     idempotency_key: Optional[str] = None
     # Unified non-success counter. Incremented on any of:
@@ -911,6 +938,9 @@ class Task:
             session_id=(
                 row["session_id"] if "session_id" in keys else None
             ),
+            claim_kind=(
+                row["claim_kind"] if "claim_kind" in keys else None
+            ),
         )
 
 
@@ -1022,6 +1052,10 @@ CREATE TABLE IF NOT EXISTS tasks (
     branch_name          TEXT,
     claim_lock           TEXT,
     claim_expires        INTEGER,
+    -- Who holds the claim: 'worker' (dispatcher-spawned, fully reclaimable)
+    -- or 'external' (live interactive operator session, held indefinitely
+    -- and never auto-reclaimed). NULL = legacy/worker. See CLAIM_KIND_*.
+    claim_kind           TEXT,
     tenant               TEXT,
     result               TEXT,
     idempotency_key      TEXT,
@@ -1882,6 +1916,14 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         _add_column_if_missing(
             conn, "tasks", "session_id", "session_id TEXT"
         )
+
+    if "claim_kind" not in cols:
+        # Discriminates worker claims (fully reclaimable) from external
+        # interactive-operator claims (held indefinitely, never
+        # auto-reclaimed). NULL on legacy rows is treated as 'worker'
+        # everywhere, so existing boards keep their current reclaim
+        # behaviour. See CLAIM_KIND_WORKER / CLAIM_KIND_EXTERNAL.
+        _add_column_if_missing(conn, "tasks", "claim_kind", "claim_kind TEXT")
 
     # Indexes over additive ``tasks`` columns must be created after the
     # columns exist. Keeping them in SCHEMA_SQL breaks legacy boards: SQLite
@@ -3164,15 +3206,30 @@ def claim_task(
     *,
     ttl_seconds: Optional[int] = None,
     claimer: Optional[str] = None,
+    external: bool = False,
 ) -> Optional[Task]:
     """Atomically transition ``ready -> running``.
 
     Returns the claimed ``Task`` on success, ``None`` if the task was
     already claimed (or is not in ``ready`` status).
+
+    ``external=True`` marks the claim as a live interactive-operator hold
+    (``claim_kind = 'external'``). Such a claim is held *indefinitely*
+    (``claim_expires = NULL``) and is therefore never auto-reclaimed by the
+    dispatcher's stale/crash/runtime sweeps — only an explicit
+    ``complete`` / ``block`` / ``reclaim`` releases it. ``ttl_seconds`` is
+    ignored for external claims. This is what stops the dispatcher from
+    spawning a parallel worker on a task a human session is actively
+    working on. See CLAIM_KIND_EXTERNAL.
     """
     now = int(time.time())
     lock = claimer or _claimer_id()
-    expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
+    # External (interactive) holds never expire — they're released only by
+    # an explicit terminal/recovery transition. A NULL ``claim_expires``
+    # also makes the row invisible to ``release_stale_claims`` (which
+    # filters ``claim_expires IS NOT NULL``).
+    expires = None if external else now + _resolve_claim_ttl_seconds(ttl_seconds)
+    kind = CLAIM_KIND_EXTERNAL if external else CLAIM_KIND_WORKER
     with write_txn(conn):
         # Structural invariant: never transition ready -> running while any
         # parent is not yet 'done'. This is the single enforcement point
@@ -3225,12 +3282,13 @@ def claim_task(
                SET status        = 'running',
                    claim_lock    = ?,
                    claim_expires = ?,
+                   claim_kind    = ?,
                    started_at    = COALESCE(started_at, ?)
              WHERE id = ?
                AND status = 'ready'
                AND claim_lock IS NULL
             """,
-            (lock, expires, now, task_id),
+            (lock, expires, kind, now, task_id),
         )
         if cur.rowcount != 1:
             return None
@@ -3266,7 +3324,7 @@ def claim_task(
         )
         _append_event(
             conn, task_id, "claimed",
-            {"lock": lock, "expires": expires, "run_id": run_id},
+            {"lock": lock, "expires": expires, "run_id": run_id, "kind": kind},
             run_id=run_id,
         )
         claimed = get_task(conn, task_id)
@@ -3419,14 +3477,28 @@ def release_stale_claims(
     now = int(time.time())
     reclaimed = 0
     host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
+    # External (interactive-operator) holds are never auto-reclaimed: a
+    # live human session doesn't emit kanban heartbeats, so its claim
+    # would protrude exactly like a wedged worker. ``claim_task(external)``
+    # already sets ``claim_expires = NULL`` (so these rows can't match the
+    # ``claim_expires IS NOT NULL`` filter below), but we also guard on
+    # ``claim_kind`` explicitly as defense-in-depth in case a future code
+    # path stamps an expiry on an external claim. See CLAIM_KIND_EXTERNAL.
     stale = conn.execute(
-        "SELECT id, claim_lock, worker_pid, claim_expires, last_heartbeat_at "
+        "SELECT id, claim_lock, claim_kind, worker_pid, claim_expires, "
+        "       last_heartbeat_at "
         "FROM tasks "
         "WHERE status = 'running' AND claim_expires IS NOT NULL "
-        "  AND claim_expires < ?",
-        (now,),
+        "  AND claim_expires < ? "
+        "  AND (claim_kind IS NULL OR claim_kind != ?)",
+        (now, CLAIM_KIND_EXTERNAL),
     ).fetchall()
     for row in stale:
+        # Belt-and-suspenders: skip external holds even if the query above
+        # somehow surfaced one (it can't under the current schema — the
+        # SELECT already excludes them).
+        if row["claim_kind"] == CLAIM_KIND_EXTERNAL:
+            continue
         lock = row["claim_lock"] or ""
         host_local = lock.startswith(host_prefix)
         hb = row["last_heartbeat_at"]
@@ -3564,9 +3636,13 @@ def reclaim_task(
         row["worker_pid"], prev_lock, signal_fn=signal_fn,
     )
     with write_txn(conn):
+        # Clear claim_kind too: an operator reclaim is the explicit recovery
+        # path for an external hold whose interactive session died without
+        # complete/block. Resetting it to NULL returns the task to a clean
+        # worker-claimable 'ready' state.
         cur = conn.execute(
             "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
-            "claim_expires = NULL, worker_pid = NULL "
+            "claim_expires = NULL, claim_kind = NULL, worker_pid = NULL "
             "WHERE id = ? AND status IN ('running', 'ready', 'blocked') "
             "AND claim_lock IS ?",
             (task_id, prev_lock),
@@ -3841,6 +3917,7 @@ def complete_task(
                        completed_at = ?,
                        claim_lock   = NULL,
                        claim_expires= NULL,
+                       claim_kind   = NULL,
                        worker_pid   = NULL
                  WHERE id = ?
                    AND status IN ('running', 'ready', 'blocked')
@@ -3856,6 +3933,7 @@ def complete_task(
                        completed_at = ?,
                        claim_lock   = NULL,
                        claim_expires= NULL,
+                       claim_kind   = NULL,
                        worker_pid   = NULL
                  WHERE id = ?
                    AND status IN ('running', 'ready', 'blocked')
@@ -4339,6 +4417,7 @@ def block_task(
                    SET status       = 'blocked',
                        claim_lock   = NULL,
                        claim_expires= NULL,
+                       claim_kind   = NULL,
                        worker_pid   = NULL
                  WHERE id = ?
                    AND status IN ('running', 'ready')
@@ -4352,6 +4431,7 @@ def block_task(
                    SET status       = 'blocked',
                        claim_lock   = NULL,
                        claim_expires= NULL,
+                       claim_kind   = NULL,
                        worker_pid   = NULL
                  WHERE id = ?
                    AND status IN ('running', 'ready')

--- a/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
+++ b/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
@@ -148,3 +148,63 @@ def test_kanban_swarm_uses_existing_humanizer_skill():
         f"humanizer skill missing at {humanizer_path}; the kanban_swarm fix "
         "for #29415 requires this bundled skill to exist"
     )
+
+
+def test_cli_claim_external_flag_sets_external_kind(isolated_kanban_home):
+    """``hermes kanban claim <id> --external`` must mark the claim as an
+    external (interactive-operator) hold so the dispatcher never spawns a
+    parallel worker on a task a live ccz/ccp session is working."""
+    from hermes_cli import kanban as kb_cli
+    from hermes_cli import kanban_db
+
+    kanban_db.init_db()
+    with kanban_db.connect() as conn:
+        tid = kanban_db.create_task(conn, title="live work", assignee="a")
+
+    args = SimpleNamespace(
+        task_id=tid, ttl=kanban_db.DEFAULT_CLAIM_TTL_SECONDS, external=True,
+    )
+    rc = kb_cli._cmd_claim(args)
+    assert rc == 0
+
+    with kanban_db.connect() as conn:
+        task = kanban_db.get_task(conn, tid)
+    assert task.status == "running"
+    assert task.claim_kind == kanban_db.CLAIM_KIND_EXTERNAL
+    assert task.claim_expires is None
+
+
+def test_cli_claim_without_external_is_worker(isolated_kanban_home):
+    """The default CLI claim path is unchanged: a worker claim with a TTL."""
+    from hermes_cli import kanban as kb_cli
+    from hermes_cli import kanban_db
+
+    kanban_db.init_db()
+    with kanban_db.connect() as conn:
+        tid = kanban_db.create_task(conn, title="work", assignee="a")
+
+    args = SimpleNamespace(
+        task_id=tid, ttl=kanban_db.DEFAULT_CLAIM_TTL_SECONDS, external=False,
+    )
+    rc = kb_cli._cmd_claim(args)
+    assert rc == 0
+
+    with kanban_db.connect() as conn:
+        task = kanban_db.get_task(conn, tid)
+    assert task.claim_kind == kanban_db.CLAIM_KIND_WORKER
+    assert task.claim_expires is not None
+
+
+def test_cli_claim_parser_accepts_external_flag(isolated_kanban_home):
+    """The argparse surface must expose ``--external`` on the claim
+    subcommand (CLI contract)."""
+    import argparse
+    from hermes_cli import kanban as kb_cli
+
+    top = argparse.ArgumentParser()
+    top_sub = top.add_subparsers(dest="top_cmd")
+    kb_cli.build_parser(top_sub)
+    ns = top.parse_args(["kanban", "claim", "t_abc", "--external"])
+    assert ns.external is True
+    ns2 = top.parse_args(["kanban", "claim", "t_abc"])
+    assert ns2.external is False

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -4766,3 +4766,185 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+# ---------------------------------------------------------------------------
+# External / interactive claim hold (stop dispatcher re-dispatching a task a
+# live ccz/ccp session is actively working — the t_0781f106 parallel-work
+# incident). See CLAIM_KIND_EXTERNAL.
+# ---------------------------------------------------------------------------
+
+def test_claim_external_sets_kind_and_null_expiry(kanban_home):
+    """``claim_task(external=True)`` marks the row external and holds it
+    indefinitely (no expiry), so the stale-claim sweep can never see it."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="live session task", assignee="a")
+        task = kb.claim_task(conn, t, external=True)
+        assert task is not None
+        assert task.status == "running"
+        assert task.claim_kind == kb.CLAIM_KIND_EXTERNAL
+        # Indefinite hold: never-expiring claims are invisible to
+        # release_stale_claims (which filters claim_expires IS NOT NULL).
+        assert task.claim_expires is None
+        # The claimed event records the kind for the audit trail.
+        payload = [
+            r for r in conn.execute(
+                "SELECT kind, payload FROM task_events WHERE task_id = ?", (t,),
+            ).fetchall()
+        ]
+        claimed = [p for p in payload if p["kind"] == "claimed"][0]
+        import json
+        assert json.loads(claimed["payload"])["kind"] == kb.CLAIM_KIND_EXTERNAL
+
+
+def test_claim_default_is_worker_kind(kanban_home):
+    """A plain claim (the dispatcher / worker path) stays a worker claim
+    with a finite TTL — unchanged behaviour."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="worker task", assignee="a")
+        task = kb.claim_task(conn, t)
+        assert task is not None
+        assert task.claim_kind == kb.CLAIM_KIND_WORKER
+        assert task.claim_expires is not None
+
+
+def test_external_claim_not_reclaimed_indefinite(kanban_home, monkeypatch):
+    """An external hold (claim_expires NULL) is never reclaimed by the
+    stale-claim sweep, even with no heartbeat and no live worker PID — the
+    core fix for the live-session-vs-dispatcher race."""
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="live session task", assignee="a")
+        host = _kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, t, claimer=f"{host}:ccz", external=True)
+        # No worker_pid, no heartbeat — exactly how a live interactive
+        # session looks. A worker claim in this state would be reclaimed.
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+        reclaimed = kb.release_stale_claims(conn, signal_fn=lambda _p, _s: None)
+        assert reclaimed == 0
+        task = kb.get_task(conn, t)
+        assert task.status == "running"
+        assert task.claim_kind == kb.CLAIM_KIND_EXTERNAL
+        kinds = [
+            r["kind"] for r in conn.execute(
+                "SELECT kind FROM task_events WHERE task_id = ?", (t,),
+            ).fetchall()
+        ]
+        assert "reclaimed" not in kinds
+
+
+def test_external_claim_guard_holds_even_if_expiry_stamped(
+    kanban_home, monkeypatch,
+):
+    """Defense-in-depth: even if some future code path stamps a (stale)
+    expiry on an external claim, the claim_kind guard in
+    release_stale_claims still refuses to reclaim it."""
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="live session task", assignee="a")
+        host = _kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, t, claimer=f"{host}:ccz", external=True)
+        # Simulate a bug that stamps a stale finite expiry on the external
+        # claim. The kind guard must still protect it.
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ? WHERE id = ?",
+            (int(time.time()) - 3600, t),
+        )
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+        reclaimed = kb.release_stale_claims(conn, signal_fn=lambda _p, _s: None)
+        assert reclaimed == 0
+        task = kb.get_task(conn, t)
+        assert task.status == "running"
+        assert task.claim_kind == kb.CLAIM_KIND_EXTERNAL
+
+
+def test_worker_claim_still_reclaimed_when_stale(kanban_home, monkeypatch):
+    """Regression guard: the external hold must NOT change worker-claim
+    reclaim. A stale worker claim with a dead PID is still reclaimed."""
+    import signal
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="worker task", assignee="a")
+        host = _kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, t, claimer=f"{host}:worker")  # default = worker
+        kb._set_worker_pid(conn, t, 12345)
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ? WHERE id = ?",
+            (int(time.time()) - 3600, t),
+        )
+        killed: list[int] = []
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+        reclaimed = kb.release_stale_claims(
+            conn, signal_fn=lambda _p, sig: killed.append(sig),
+        )
+        assert reclaimed == 1
+        assert kb.get_task(conn, t).status == "ready"
+        assert killed == [signal.SIGTERM]
+
+
+def test_reclaim_clears_external_hold(kanban_home):
+    """Explicit operator ``reclaim`` is the recovery path for a dead
+    external session: it releases the hold and resets claim_kind so the
+    task is cleanly worker-claimable again."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="live session task", assignee="a")
+        kb.claim_task(conn, t, external=True)
+        assert kb.reclaim_task(conn, t, reason="session died") is True
+        task = kb.get_task(conn, t)
+        assert task.status == "ready"
+        assert task.claim_kind is None
+        assert task.claim_lock is None
+        assert task.claim_expires is None
+
+
+def test_complete_clears_external_hold(kanban_home):
+    """Completing an external-held task clears the hold marker."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="live session task", assignee="a")
+        kb.claim_task(conn, t, external=True)
+        assert kb.complete_task(conn, t, result="done by hand") is True
+        task = kb.get_task(conn, t)
+        assert task.status == "done"
+        assert task.claim_kind is None
+
+
+def test_block_clears_external_hold(kanban_home):
+    """Blocking an external-held task clears the hold marker."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="live session task", assignee="a")
+        kb.claim_task(conn, t, external=True)
+        assert kb.block_task(conn, t, reason="needs input") is True
+        task = kb.get_task(conn, t)
+        assert task.status == "blocked"
+        assert task.claim_kind is None
+
+
+def test_claim_kind_column_added_to_legacy_db(tmp_path):
+    """``_migrate_add_optional_columns`` must add ``claim_kind`` to a DB
+    created before the column existed (additive, default NULL = worker)."""
+    db_path = tmp_path / "legacy.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    # Legacy ``tasks`` shape without claim_kind.
+    conn.execute(
+        "CREATE TABLE tasks (id TEXT PRIMARY KEY, title TEXT NOT NULL, "
+        "status TEXT NOT NULL, claim_lock TEXT, claim_expires INTEGER)"
+    )
+    # ``_migrate_add_optional_columns`` also touches task_events for the
+    # run_id back-fill, so the table must exist (mirrors the legacy-index
+    # migration test above).
+    conn.execute(
+        "CREATE TABLE task_events (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "task_id TEXT NOT NULL, kind TEXT NOT NULL, payload TEXT, "
+        "created_at INTEGER NOT NULL)"
+    )
+    conn.commit()
+    cols_before = {r["name"] for r in conn.execute("PRAGMA table_info(tasks)")}
+    assert "claim_kind" not in cols_before
+    kb._migrate_add_optional_columns(conn)
+    cols_after = {r["name"] for r in conn.execute("PRAGMA table_info(tasks)")}
+    assert "claim_kind" in cols_after
+    conn.close()


### PR DESCRIPTION
## Problem

A live interactive operator session (e.g. a Claude Code session in tmux) that runs `hermes kanban claim <id>` does **not** emit kanban heartbeats or other Hermes API traffic. Its `claim_expires` / `last_heartbeat_at` therefore go stale exactly like a wedged worker, and `release_stale_claims()` cannot tell the two apart. It reclaims the task, and the next dispatcher tick spawns a **parallel worker on a task a human is actively working on** — double work, merge conflicts, and `wt/*` worktree sprawl.

This is distinct from the cgroup-throttle duplication that `RECLAIM_DEFER_GRACE_SECONDS` addresses: here the claim holder is a healthy *interactive* process that legitimately never heartbeats.

## Fix — explicit external/interactive claim hold

- New nullable `tasks.claim_kind` column (`'worker'` | `'external'`; `NULL` = legacy/worker). Additive migration via `_migrate_add_optional_columns`; existing boards keep current behaviour.
- `claim_task(external=True)` marks the claim `'external'` and holds it **indefinitely** (`claim_expires = NULL`). Such a row is invisible to all three reclaimers: `release_stale_claims` (filters `claim_expires IS NOT NULL`), `enforce_max_runtime` and `detect_crashed_workers` (filter `worker_pid IS NOT NULL` — an external hold has none). A `claim_kind` guard in `release_stale_claims` adds defense-in-depth.
- CLI: `hermes kanban claim <id> --external` (opt-in; the default claim path is unchanged — still a worker claim with a TTL). An external hold is released only by an explicit `complete` / `block` / `reclaim`.
- `complete` / `block` / `reclaim` clear `claim_kind`, so a reclaimed external task is cleanly worker-claimable again (operator recovery path for a dead interactive session).

Reclaim of genuinely dead/wedged **worker** claims is unchanged (regression-guarded).

## Tests

Adds coverage in `test_kanban_db.py` and `test_kanban_cli_dispatch_passthrough.py`: external claim survives the stale sweep (indefinite + forced-expiry guard), worker claim still reclaimed, `--external` CLI contract, `complete`/`block`/`reclaim` clear the hold, and the additive migration. Full affected-file suites pass (239 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)