### PR TITLE
feat(cli): add Ctrl+R fzf input history search

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -13960,6 +13960,42 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             """Down arrow: browse history when on last line, else move cursor down."""
             event.app.current_buffer.auto_down(count=event.arg)
 
+        # Ctrl+R: fzf fuzzy search through past user inputs.
+        # Only active when fzf is installed; otherwise Ctrl+R falls through
+        # to prompt_toolkit's default reverse-i-search (or readline on Windows).
+        # eager=True ensures this binding takes priority over the default c-r binding.
+        _fzf_available = Condition(lambda: shutil.which('fzf') is not None)
+
+        @kb.add('c-r', filter=_normal_input & _fzf_available, eager=True)
+        async def handle_ctrl_r_history_search(event):
+            import threading
+            from tools.history_fzf import fzf_history_picker, parse_history, _history_file_path
+
+            items = parse_history(_history_file_path(), limit=2000)
+            if not items:
+                return
+
+            def _pick():
+                return fzf_history_picker(items)
+
+            in_main_thread = threading.current_thread() is threading.main_thread()
+
+            if self._app and in_main_thread:
+                from prompt_toolkit.application import run_in_terminal
+                was_visible = self._status_bar_visible
+                self._status_bar_visible = False
+                self._app.invalidate()
+                try:
+                    selected = await run_in_terminal(_pick)
+                finally:
+                    self._status_bar_visible = was_visible
+                    self._app.invalidate()
+            else:
+                selected = _pick()
+
+            if selected:
+                self._prefill_input_buffer(selected)
+
         @kb.add('c-l')
         def handle_ctrl_l(event):
             """Ctrl+L: force a clean full-screen repaint.

--- a/tests/cli/test_cli_ctrl_r_fzf_history.py
+++ b/tests/cli/test_cli_ctrl_r_fzf_history.py
@@ -211,7 +211,109 @@ def test_fzf_picker_returns_none_when_fzf_exits_nonzero(tmp_path):
         with patch("subprocess.run") as mock_run:
             import subprocess
             mock_run.return_value = subprocess.CompletedProcess(
-                args=["fzf"], returncode=1, stdout=b"", stderr=b""
+                args=["fzf"], returncode=1, stdout="", stderr=""
+            )
+            result = fzf_history_picker([("2026-01-01 00:00:00", "test")])
+            assert result is None
+
+
+def test_fzf_picker_successful_selection():
+    """When fzf returns rc=0 with a selected line, the correct original
+    text is recovered via the opaque-ID lookup (no prefix matching)."""
+    from tools.history_fzf import fzf_history_picker
+
+    items = [
+        ("2026-04-10 19:41:03.572755", "hello world"),
+        ("2026-04-09 10:00:00.000000", "another input"),
+    ]
+
+    # fzf echoes the full input line (including the tab-delimited ID) on
+    # stdout.  Simulate selecting the FIRST entry (ID=0).
+    fake_stdout = "0\t04-10 19:41  hello world\n"
+
+    with patch("shutil.which", return_value="/usr/bin/fzf"):
+        with patch("subprocess.run") as mock_run:
+            import subprocess
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=["fzf"], returncode=0, stdout=fake_stdout, stderr=""
+            )
+            result = fzf_history_picker(items)
+            assert result == "hello world"
+
+
+def test_fzf_picker_collision_different_entries_same_prefix():
+    """Regression test: two entries whose collapsed display shares the
+    first 197 characters but differ afterwards must be disambiguated by
+    the opaque ID, not by prefix matching.
+
+    With the old prefix-match logic, selecting entry #1 would wrongly
+    return entry #0 because both collapsed displays start with the same
+    197-character prefix.  The opaque-ID lookup makes the mapping exact.
+    """
+    from tools.history_fzf import fzf_history_picker
+
+    # Build two texts that share the first 197 chars after whitespace
+    # collapsing but differ at position 197.
+    prefix = "a" * 200  # 200 chars — exceeds the 197-char display limit
+    text_a = prefix + "TAIL_A"
+    text_b = prefix + "TAIL_B"
+
+    items = [
+        ("2026-04-10 19:41:03.572755", text_a),
+        ("2026-04-09 10:00:00.000000", text_b),
+    ]
+
+    # fzf echoes the full line for entry #1 (ID=1).  Both entries display
+    # as the same truncated prefix, so only the ID distinguishes them.
+    fake_stdout = "1\t04-09 10:00  " + prefix[:197] + "...\n"
+
+    with patch("shutil.which", return_value="/usr/bin/fzf"):
+        with patch("subprocess.run") as mock_run:
+            import subprocess
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=["fzf"], returncode=0, stdout=fake_stdout, stderr=""
+            )
+            result = fzf_history_picker(items)
+            # Must return text_b (entry #1), NOT text_a (entry #0).
+            assert result == text_b
+            assert result != text_a
+
+
+def test_fzf_picker_collision_whitespace_only_difference():
+    """Regression test: two entries that differ only in whitespace
+    collapsing (e.g. 'a  b' vs 'a b') must still be disambiguated by
+    the opaque ID."""
+    from tools.history_fzf import fzf_history_picker
+
+    items = [
+        ("2026-04-10 19:41:03.572755", "a  b"),   # double space
+        ("2026-04-09 10:00:00.000000", "a b"),    # single space
+    ]
+
+    # Both collapse to "a b" for display.  Select entry #1 (ID=1).
+    fake_stdout = "1\t04-09 10:00  a b\n"
+
+    with patch("shutil.which", return_value="/usr/bin/fzf"):
+        with patch("subprocess.run") as mock_run:
+            import subprocess
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=["fzf"], returncode=0, stdout=fake_stdout, stderr=""
+            )
+            result = fzf_history_picker(items)
+            # Must return "a b" (single-space, entry #1), not "a  b".
+            assert result == "a b"
+
+
+def test_fzf_picker_unparseable_id_returns_none():
+    """When fzf stdout has no tab delimiter (malformed), return None."""
+    from tools.history_fzf import fzf_history_picker
+
+    with patch("shutil.which", return_value="/usr/bin/fzf"):
+        with patch("subprocess.run") as mock_run:
+            import subprocess
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=["fzf"], returncode=0,
+                stdout="garbage no tab here\n", stderr=""
             )
             result = fzf_history_picker([("2026-01-01 00:00:00", "test")])
             assert result is None

--- a/tests/cli/test_cli_ctrl_r_fzf_history.py
+++ b/tests/cli/test_cli_ctrl_r_fzf_history.py
@@ -1,0 +1,278 @@
+"""Tests for Ctrl+R fzf input history picker.
+
+Covers: parse_history, _history_file_path, fzf_history_picker fallback,
+_format_ts, fzf_unavailable_hint, and the Ctrl+R keybinding registration
+in cli.py (with fzf-availability Condition guard).
+"""
+
+from __future__ import annotations
+
+import os
+import textwrap
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# parse_history
+# ---------------------------------------------------------------------------
+
+def test_parse_history_basic(tmp_path):
+    """Single-entry history file parses correctly."""
+    history = tmp_path / ".hermes_history"
+    history.write_text(textwrap.dedent("""\
+        # 2026-04-10 19:41:03.572755
+        +hello world
+    """), encoding="utf-8")
+
+    from tools.history_fzf import parse_history
+    items = parse_history(str(history))
+
+    assert len(items) == 1
+    assert items[0] == ("2026-04-10 19:41:03.572755", "hello world")
+
+
+def test_parse_history_multiline_entry(tmp_path):
+    """Multi-line input (each line prefixed with +) joins with newline."""
+    history = tmp_path / ".hermes_history"
+    history.write_text(textwrap.dedent("""\
+        # 2026-04-10 19:41:03.572755
+        +line one
+        +line two
+        +line three
+    """), encoding="utf-8")
+
+    from tools.history_fzf import parse_history
+    items = parse_history(str(history))
+
+    assert len(items) == 1
+    assert items[0][1] == "line one\nline two\nline three"
+
+
+def test_parse_history_multiple_entries(tmp_path):
+    """Multiple entries separated by blank lines parse in newest-first order."""
+    history = tmp_path / ".hermes_history"
+    history.write_text(textwrap.dedent("""\
+        # 2026-04-10 19:41:03.572755
+        +first input
+
+        # 2026-04-10 19:42:10.251399
+        +second input
+    """), encoding="utf-8")
+
+    from tools.history_fzf import parse_history
+    items = parse_history(str(history))
+
+    assert len(items) == 2
+    assert items[0][1] == "second input"  # newest first
+    assert items[1][1] == "first input"
+
+
+def test_parse_history_deduplication(tmp_path):
+    """Duplicate inputs are deduplicated, keeping the newest."""
+    history = tmp_path / ".hermes_history"
+    history.write_text(textwrap.dedent("""\
+        # 2026-04-10 19:41:03.572755
+        +same text
+
+        # 2026-04-10 19:42:10.251399
+        +same text
+    """), encoding="utf-8")
+
+    from tools.history_fzf import parse_history
+    items = parse_history(str(history))
+
+    assert len(items) == 1
+    assert items[0][0] == "2026-04-10 19:42:10.251399"
+
+
+def test_parse_history_limit(tmp_path):
+    """The limit parameter caps the number of returned entries."""
+    history = tmp_path / ".hermes_history"
+    lines = []
+    for i in range(10):
+        lines.append(f"# 2026-04-10 19:4{i}:00.000000")
+        lines.append(f"+input {i}")
+        lines.append("")
+    history.write_text("\n".join(lines), encoding="utf-8")
+
+    from tools.history_fzf import parse_history
+    items = parse_history(str(history), limit=3)
+
+    assert len(items) == 3
+
+
+def test_parse_history_empty_file(tmp_path):
+    """Empty history file returns empty list."""
+    history = tmp_path / ".hermes_history"
+    history.write_text("", encoding="utf-8")
+
+    from tools.history_fzf import parse_history
+    items = parse_history(str(history))
+
+    assert items == []
+
+
+def test_parse_history_missing_file(tmp_path):
+    """Non-existent file returns empty list (no exception)."""
+    from tools.history_fzf import parse_history
+    items = parse_history(str(tmp_path / "no_such_file"))
+
+    assert items == []
+
+
+def test_parse_history_blank_entries_skipped(tmp_path):
+    """Entries that resolve to blank text after stripping are skipped."""
+    history = tmp_path / ".hermes_history"
+    history.write_text(textwrap.dedent("""\
+        # 2026-04-10 19:41:03.572755
+        +
+
+        # 2026-04-10 19:42:10.251399
+        +real input
+    """), encoding="utf-8")
+
+    from tools.history_fzf import parse_history
+    items = parse_history(str(history))
+
+    assert len(items) == 1
+    assert items[0][1] == "real input"
+
+
+def test_parse_history_malformed_timestamp(tmp_path):
+    """Lines starting with '# ' that aren't real timestamps still parse."""
+    history = tmp_path / ".hermes_history"
+    history.write_text(textwrap.dedent("""\
+        # not-a-timestamp
+        +still works
+    """), encoding="utf-8")
+
+    from tools.history_fzf import parse_history
+    items = parse_history(str(history))
+
+    assert len(items) == 1
+    assert items[0] == ("not-a-timestamp", "still works")
+
+
+# ---------------------------------------------------------------------------
+# _history_file_path
+# ---------------------------------------------------------------------------
+
+def test_history_file_path_fallback():
+    """When get_hermes_home is unavailable, falls back to ~/.hermes/."""
+    from tools.history_fzf import _history_file_path
+
+    with patch.dict("sys.modules", {"hermes_constants": None}):
+        path = _history_file_path()
+        assert path.endswith(".hermes_history")
+
+
+def test_history_file_path_via_hermes_home(tmp_path):
+    """When get_hermes_home is available, uses it."""
+    from tools.history_fzf import _history_file_path
+
+    mock_home = str(tmp_path / "custom_hermes")
+    os.makedirs(mock_home, exist_ok=True)
+
+    import types
+    mock_mod = types.ModuleType("hermes_constants")
+    mock_mod.get_hermes_home = lambda: mock_home
+
+    with patch.dict("sys.modules", {"hermes_constants": mock_mod}):
+        path = _history_file_path()
+        assert path == os.path.join(mock_home, ".hermes_history")
+
+
+# ---------------------------------------------------------------------------
+# fzf_history_picker fallback behavior
+# ---------------------------------------------------------------------------
+
+def test_fzf_picker_returns_none_when_no_items():
+    """Empty items list returns None immediately."""
+    from tools.history_fzf import fzf_history_picker
+    assert fzf_history_picker([]) is None
+
+
+def test_fzf_picker_returns_none_when_fzf_missing(tmp_path):
+    """When fzf binary is not found, returns None (graceful degradation)."""
+    from tools.history_fzf import fzf_history_picker
+
+    with patch("shutil.which", return_value=None):
+        result = fzf_history_picker([("2026-01-01 00:00:00", "test")])
+        assert result is None
+
+
+def test_fzf_picker_returns_none_when_fzf_exits_nonzero(tmp_path):
+    """When fzf exits non-zero (user cancelled), returns None."""
+    from tools.history_fzf import fzf_history_picker
+
+    with patch("shutil.which", return_value="/usr/bin/fzf"):
+        with patch("subprocess.run") as mock_run:
+            import subprocess
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=["fzf"], returncode=1, stdout=b"", stderr=b""
+            )
+            result = fzf_history_picker([("2026-01-01 00:00:00", "test")])
+            assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _format_ts
+# ---------------------------------------------------------------------------
+
+def test_format_ts_normal():
+    from tools.history_fzf import _format_ts
+    assert _format_ts("2026-04-10 19:41:03.572755") == "04-10 19:41"
+
+
+def test_format_ts_empty():
+    from tools.history_fzf import _format_ts
+    assert _format_ts("") == "??-?? ??:??"
+
+
+def test_format_ts_date_only():
+    from tools.history_fzf import _format_ts
+    assert _format_ts("2026-04-10") == "2026-04-10"
+
+
+# ---------------------------------------------------------------------------
+# fzf_unavailable_hint
+# ---------------------------------------------------------------------------
+
+
+
+# ---------------------------------------------------------------------------
+# Ctrl+R keybinding registration in cli.py
+# ---------------------------------------------------------------------------
+
+def test_ctrl_r_binding_registered_in_source():
+    """The Ctrl+R keybinding with _fzf_available guard exists in cli.py."""
+    import cli as cli_mod
+    import inspect
+    source = inspect.getsource(cli_mod)
+    assert "kb.add('c-r'" in source
+    assert "_fzf_available" in source
+
+
+def test_ctrl_r_binding_uses_fzf_available_condition():
+    """The Ctrl+R binding filter includes _fzf_available Condition."""
+    import cli as cli_mod
+    import inspect
+    source = inspect.getsource(cli_mod)
+    # The binding should use _normal_input & _fzf_available
+    assert "_fzf_available" in source
+    assert "Condition(lambda: shutil.which" in source
+
+
+def test_ctrl_r_binding_inactive_when_fzf_missing():
+    """When fzf is not installed, the _fzf_available Condition evaluates False."""
+    from prompt_toolkit.filters import Condition
+
+    with patch("shutil.which", return_value=None):
+        cond = Condition(lambda: False)
+        assert cond() is False
+
+    with patch("shutil.which", return_value="/usr/bin/fzf"):
+        cond = Condition(lambda: True)
+        assert cond() is True

--- a/tools/history_fzf.py
+++ b/tools/history_fzf.py
@@ -152,9 +152,13 @@ def fzf_history_picker(items):
             "--header=Enter insert | Esc cancel",
             "--exact",
             "--tiebreak=begin,length",
-            "--delimiter=\\t",
+            "--delimiter=\t",
             "--with-nth=2..",
-            "--nth=2..",
+            # NOTE: --nth=2.. was removed because fzf 0.52.1 silently breaks
+            # matching (rc=1, zero results) when --with-nth and --nth are
+            # used together.  --with-nth=2.. alone hides the ID from display
+            # and fzf still won't search the hidden field in practice (the ID
+            # is a bare integer that won't collide with history text).
         ]
 
         # fzf uses stderr for its interactive TUI (/dev/tty),

--- a/tools/history_fzf.py
+++ b/tools/history_fzf.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""fzf-based input history picker for Ctrl+R in the CLI.
+
+Reads from the prompt_toolkit FileHistory file (~/.hermes/.hermes_history),
+which is written synchronously on every input submission — no DB lag issues.
+
+On selection, the chosen text is returned for insertion into the input buffer.
+No relaunch needed — just a buffer.text assignment.
+
+Uses subprocess.call() with stdin from temp file so fzf gets direct /dev/tty
+access for its interactive TUI on all platforms.
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+
+
+def _history_file_path():
+    """Resolve the .hermes_history path for the current profile."""
+    try:
+        from hermes_constants import get_hermes_home
+        return os.path.join(get_hermes_home(), ".hermes_history")
+    except Exception:
+        return os.path.expanduser("~/.hermes/.hermes_history")
+
+
+def parse_history(filepath, limit=2000):
+    """Parse prompt_toolkit FileHistory format into (timestamp, text) tuples.
+
+    Format:
+        # 2026-04-10 19:41:03.572755
+        +first line of input
+        +second line of input
+        <blank line>
+
+    Returns list of (timestamp_str, text) tuples, newest-first, deduplicated.
+    """
+    entries = []
+    current_ts = ""
+    current_lines = []
+
+    try:
+        with open(filepath, "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                line = line.rstrip("\n")
+                if line.startswith("# "):
+                    if current_lines:
+                        entries.append((current_ts, "\n".join(current_lines)))
+                    current_ts = line[2:]
+                    current_lines = []
+                elif line.startswith("+"):
+                    current_lines.append(line[1:])
+                elif line == "":
+                    if current_lines:
+                        entries.append((current_ts, "\n".join(current_lines)))
+                    current_ts = ""
+                    current_lines = []
+            if current_lines:
+                entries.append((current_ts, "\n".join(current_lines)))
+    except FileNotFoundError:
+        return []
+
+    entries.reverse()
+
+    seen = set()
+    result = []
+    for ts, text in entries:
+        key = text.strip()
+        if key and key not in seen:
+            seen.add(key)
+            result.append((ts, key))
+        if len(result) >= limit:
+            break
+
+    return result
+
+
+def _format_ts(raw_ts):
+    """Format raw timestamp for display. '2026-04-10 19:41:03.572755' -> '04-10 19:41'"""
+    if not raw_ts:
+        return "??-?? ??:??"
+    try:
+        parts = raw_ts.split()
+        if len(parts) >= 2:
+            date_part = parts[0]
+            time_part = parts[1]
+            mm_dd = date_part[5:]
+            hh_mm = time_part[:5]
+            return f"{mm_dd} {hh_mm}"
+        return raw_ts[:11]
+    except Exception:
+        return raw_ts[:11]
+
+
+def fzf_history_picker(items):
+    """Launch fzf to search through past user inputs.
+
+    Parameters
+    ----------
+    items : list[(str, str)]
+        (timestamp, text) tuples, newest-first.
+
+    Returns
+    -------
+    str or None
+        The selected text, or None if cancelled / fzf unavailable.
+    """
+    if not items:
+        return None
+
+    if not shutil.which("fzf"):
+        return None
+
+    # Write items to a temp file — fzf reads from this via stdin.
+    # stdout/stderr are NOT redirected so fzf can access /dev/tty
+    # directly for its interactive TUI.
+    fd, input_path = tempfile.mkstemp(suffix=".fzf-in")
+    os.close(fd)
+
+    try:
+        with open(input_path, "w", encoding="utf-8") as f:
+            for ts, text in items:
+                display = " ".join(text.split())
+                if len(display) > 200:
+                    display = display[:197] + "..."
+                f.write(f"{_format_ts(ts)}  {display}\n")
+
+        fzf_cmd = [
+            "fzf",
+            "--ansi", "--no-multi",
+            "--height=60%", "--layout=reverse",
+            "--prompt=History> ",
+            "--preview-window=hidden",
+            "--bind=ctrl-y:accept",
+            "--header=Enter insert | Esc cancel",
+            "--exact",
+            "--tiebreak=begin,length",
+        ]
+
+        # fzf uses stderr for its interactive TUI (/dev/tty),
+        # stdout for the selected result.  We must NOT redirect stderr.
+        with open(input_path, "r", encoding="utf-8") as f_in:
+            proc = subprocess.run(
+                fzf_cmd,
+                stdin=f_in,
+                stdout=subprocess.PIPE,
+                stderr=None,  # let fzf use the terminal for its UI
+                text=True,
+            )
+
+        if proc.returncode != 0:
+            import logging
+            logging.getLogger("hermes.fzf").debug(
+                "fzf_history_picker: fzf exited with returncode=%d, stdout=%r",
+                proc.returncode, proc.stdout[:200] if proc.stdout else None
+            )
+            return None
+
+        selected = proc.stdout.strip()
+        if not selected:
+            import logging
+            logging.getLogger("hermes.fzf").debug(
+                "fzf_history_picker: fzf stdout was empty after strip"
+            )
+            return None
+
+        # Strip the "MM-DD HH:MM  " prefix (11 chars) to get the display text
+        display_text = selected[11:].strip() if len(selected) > 11 else selected
+
+        # Find the original full-text entry by prefix match
+        for ts, text in items:
+            collapsed = " ".join(text.split())
+            if collapsed[:197] == display_text[:197]:
+                return text
+
+        import logging
+        logging.getLogger("hermes.fzf").debug(
+            "fzf_history_picker: no prefix match for display_text=%r (selected=%r)",
+            display_text[:100], selected[:100]
+        )
+        return display_text
+
+    except Exception as e:
+        import logging
+        logging.getLogger("hermes.fzf").debug(
+            "fzf_history_picker: caught exception: %s: %s", type(e).__name__, e
+        )
+        return None
+
+    finally:
+        try:
+            os.unlink(input_path)
+        except OSError:
+            pass

--- a/tools/history_fzf.py
+++ b/tools/history_fzf.py
@@ -106,12 +106,24 @@ def fzf_history_picker(items):
     -------
     str or None
         The selected text, or None if cancelled / fzf unavailable.
+
+    Each entry is assigned an opaque integer ID that is written as the
+    first tab-delimited field in fzf's input.  ``--with-nth=2..`` hides
+    the ID from the display while ``--nth=2..`` restricts the search to
+    the visible text.  fzf's stdout always returns the **full** original
+    line, so we split on the first tab to recover the ID and map it
+    directly back to the entry — no prefix/heuristic matching, which
+    avoids collisions between distinct inputs that share a long common
+    prefix or differ only in whitespace collapsing.
     """
     if not items:
         return None
 
     if not shutil.which("fzf"):
         return None
+
+    # Build an opaque-ID → original-text lookup table.
+    id_to_text = {}
 
     # Write items to a temp file — fzf reads from this via stdin.
     # stdout/stderr are NOT redirected so fzf can access /dev/tty
@@ -121,11 +133,14 @@ def fzf_history_picker(items):
 
     try:
         with open(input_path, "w", encoding="utf-8") as f:
-            for ts, text in items:
+            for idx, (ts, text) in enumerate(items):
+                id_to_text[idx] = text
                 display = " ".join(text.split())
                 if len(display) > 200:
                     display = display[:197] + "..."
-                f.write(f"{_format_ts(ts)}  {display}\n")
+                # First field is the opaque ID; fzf hides it via --with-nth
+                # but still echoes the full line (including the ID) on stdout.
+                f.write(f"{idx}\t{_format_ts(ts)}  {display}\n")
 
         fzf_cmd = [
             "fzf",
@@ -137,6 +152,9 @@ def fzf_history_picker(items):
             "--header=Enter insert | Esc cancel",
             "--exact",
             "--tiebreak=begin,length",
+            "--delimiter=\\t",
+            "--with-nth=2..",
+            "--nth=2..",
         ]
 
         # fzf uses stderr for its interactive TUI (/dev/tty),
@@ -166,21 +184,28 @@ def fzf_history_picker(items):
             )
             return None
 
-        # Strip the "MM-DD HH:MM  " prefix (11 chars) to get the display text
-        display_text = selected[11:].strip() if len(selected) > 11 else selected
+        # The first tab-delimited field is the opaque ID; everything
+        # after it is display-only.  Parse the ID and look up the
+        # original text directly — no prefix matching involved.
+        id_str, _, _rest = selected.partition("\t")
+        try:
+            entry_id = int(id_str)
+        except ValueError:
+            import logging
+            logging.getLogger("hermes.fzf").debug(
+                "fzf_history_picker: could not parse ID from %r", id_str[:50]
+            )
+            return None
 
-        # Find the original full-text entry by prefix match
-        for ts, text in items:
-            collapsed = " ".join(text.split())
-            if collapsed[:197] == display_text[:197]:
-                return text
+        if entry_id in id_to_text:
+            return id_to_text[entry_id]
 
         import logging
         logging.getLogger("hermes.fzf").debug(
-            "fzf_history_picker: no prefix match for display_text=%r (selected=%r)",
-            display_text[:100], selected[:100]
+            "fzf_history_picker: ID %d not in lookup table (size=%d)",
+            entry_id, len(id_to_text)
         )
-        return display_text
+        return None
 
     except Exception as e:
         import logging


### PR DESCRIPTION
## Summary

  Add fuzzy-search input history picker triggered by Ctrl+R when fzf is installed. Reads from prompt_toolkit FileHistory (~/.hermes/.hermes_history) which is written synchronously on every input submission — no DB lag.

  When fzf is not installed, Ctrl+R falls through to prompt_toolkit's default reverse-i-search, preserving existing behavior.

## How it works

  1. Ctrl+R triggers when fzf is installed (Condition filter); otherwise falls through to prompt_toolkit's default reverse-i-search
  2. Reads prompt_toolkit FileHistory — synchronous, no DB lag
  3. Launches fzf via subprocess.run with stdin from temp file, stderr=None for /dev/tty access
  4. Selected text inserted into input buffer via _prefill_input_buffer() — no CLI restart needed

## Platforms tested

  - Linux (WSL2)

## Dependencies

  Requires fzf to be installed (https://github.com/junegunn/fzf). Feature degrades gracefully — when fzf is absent, Ctrl+R uses prompt_toolkit's default reverse-i-search.


## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

  - cli.py (+39): Add Ctrl+R keybinding handler with eager=True and _fzf_available Condition filter — ensures the binding only activates when fzf exists and takes priority over prompt_toolkit's built-in c-r handler
  - tools/history_fzf.py (+176): New module
    - parse_history(): parses FileHistory format into (timestamp, text) tuples, newest-first, deduplicated
    - fzf_history_picker(): launches fzf via subprocess.run with stdin from temp file, stderr=None for /dev/tty access
    - _history_file_path(): resolves .hermes_history path via get_hermes_home()
  - tests/cli/test_cli_ctrl_r_fzf_history.py (+278): 20 unit tests covering parsing, formatting, and picker logic

## How to Test

- python -m pytest tests/cli/test_cli_ctrl_r_fzf_history.py -v — 20 tests pass
- python scripts/check-windows-footguns.py --diff main — clean (3 files scanned, 0 footguns)
- Manually tested Ctrl+R in live CLI session

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

