### PR TITLE
fix: detect per-million pricing from custom endpoints to avoid 1,000,000x cost inflation

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -691,6 +691,15 @@ def _pricing_entry_from_metadata(
     def _per_token_to_per_million(value: Optional[Decimal]) -> Optional[Decimal]:
         if value is None:
             return None
+        # OpenRouter returns per-token prices (e.g., 0.000003 for
+        # $3/1M).  Some OpenAI-compatible endpoints (e.g., Umans)
+        # return per-million prices directly (e.g., 1.4 for
+        # $1.40/1M).  No production model charges more than
+        # ~$0.0001/token ($100/1M), so any value above 0.001 is
+        # almost certainly already per-million — skip the x1M
+        # conversion to avoid a 1,000,000x cost inflation.
+        if value > Decimal("0.001"):
+            return value
         return value * _ONE_MILLION
 
     return PricingEntry(

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -192,6 +192,36 @@ def test_custom_endpoint_models_api_pricing_is_supported(monkeypatch):
     assert float(entry.output_cost_per_million) == 2.0
 
 
+def test_custom_endpoint_per_million_pricing_not_inflated(monkeypatch):
+    """Regression: some OpenAI-compatible endpoints (e.g., Umans) return
+    per-million prices in their /v1/models response (e.g., 1.4 for
+    $1.40/1M).  Hermes must NOT multiply by 1M, which would inflate
+    costs 1,000,000x.  See: #34256 (same bug class, different provider).
+    """
+    monkeypatch.setattr(
+        "agent.usage_pricing.fetch_endpoint_model_metadata",
+        lambda base_url, api_key=None: {
+            "umans-glm-5.2": {
+                "pricing": {
+                    "prompt": 1.4,
+                    "completion": 4.4,
+                }
+            }
+        },
+    )
+
+    entry = get_pricing_entry(
+        "umans-glm-5.2",
+        provider="custom",
+        base_url="https://api.code.umans.ai/v1",
+        api_key="test-key",
+    )
+
+    assert entry is not None
+    assert float(entry.input_cost_per_million) == 1.4
+    assert float(entry.output_cost_per_million) == 4.4
+
+
 def test_nous_portal_pricing_preserves_vendor_prefixed_model_ids(monkeypatch):
     seen = {}
 


### PR DESCRIPTION
## Problem

`_per_token_to_per_million()` in `agent/usage_pricing.py` unconditionally multiplies extracted pricing values by 1,000,000, assuming all `/v1/models` endpoints return per-token prices like OpenRouter does.

Some OpenAI-compatible endpoints (Umans, Crof, and potentially others) return **per-million** prices directly — e.g., `{"input": 1.4, "output": 4.4}` meaning $1.40/1M input, $4.40/1M output. For these endpoints, the x1M multiplication inflates cost estimates by **1,000,000x**.

In practice, this caused `umans-glm-5.2` sessions to report **$919,277** in estimated costs instead of the correct **~$2.33**. The inflated values propagated to `hermes insights`, cost guard alerts, and external tools like tokscale that read `estimated_cost_usd` from `state.db`.

Reported in #34256 for a different provider (Crof/qwen3.5-9b) — same root cause, same bug class.

## Fix

Skip the x1M conversion when a value exceeds `0.001`. No production model charges more than ~$0.0001/token ($100/1M), so any value above 0.001 is almost certainly already per-million. OpenRouter values (always well below 0.001) are unaffected.

```python
if value > Decimal("0.001"):
    return value
return value * _ONE_MILLION
```

The threshold sits safely between:
- Highest realistic per-token price: ~$0.0001 (Claude Opus at $75/1M)
- Lowest realistic per-million price: ~$0.05 (budget models)

## Test

Added `test_custom_endpoint_per_million_pricing_not_inflated` — verifies that per-million API values (`prompt: 1.4`, `completion: 4.4`) produce `input_cost_per_million=1.4` (not 1,400,000). All 16 tests in the file pass.

## Files changed

- `agent/usage_pricing.py` — 9 lines added (heuristic + comment)
- `tests/agent/test_usage_pricing.py` — 30 lines added (regression test)

Fixes #34256