### PR TITLE
fix: add encoding='utf-8' to os.fdopen() and open() calls

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1576,6 +1576,20 @@ def export_profile(name: str, output_path: str) -> Path:
         return Path(result)
 
 
+_WIN_INVALID_CHARS = re.compile(r'[<>:"|?*]')
+
+
+def _sanitize_path_part(part: str) -> str:
+    """Replace characters that are invalid in Windows file/directory names.
+
+    Archives created on Linux may contain filenames with characters like ``:``
+    (e.g. NuGet cache paths) that are reserved on Windows.  Replacing them
+    with ``_`` keeps the path structure intact while allowing extraction on
+    any platform.
+    """
+    return _WIN_INVALID_CHARS.sub("_", part)
+
+
 def _normalize_profile_archive_parts(member_name: str) -> List[str]:
     """Return safe path parts for a profile archive member."""
     normalized_name = member_name.replace("\\", "/")
@@ -1590,7 +1604,7 @@ def _normalize_profile_archive_parts(member_name: str) -> List[str]:
     ):
         raise ValueError(f"Unsafe archive member path: {member_name}")
 
-    parts = [part for part in posix_path.parts if part not in {"", "."}]
+    parts = [_sanitize_path_part(part) for part in posix_path.parts if part not in {"", "."}]
     if not parts or any(part == ".." for part in parts):
         raise ValueError(f"Unsafe archive member path: {member_name}")
     return parts


### PR DESCRIPTION
## Problem

Several `os.fdopen()` and `open()` calls in text mode are missing an explicit `encoding` parameter. On platforms where the default locale is not UTF-8 (e.g. Windows with cp1252), these calls can raise `UnicodeEncodeError` when writing non-ASCII data or silently produce corrupted output.

This is the same class of bug that was previously fixed in commit `07016afa2` (read_text/write_text) and `bae135e61` (os.fdopen in agent/), but a few instances were missed.

## Changes

| File | Line | Change |
|------|------|--------|
| `agent/nous_rate_guard.py` | 120 | `os.fdopen(fd, "w")` → add `encoding="utf-8"` |
| `agent/shell_hooks.py` | 630 | `os.fdopen(fd, "w")` → add `encoding="utf-8"` |
| `gateway/slash_commands.py` | 3994 | `open(exit_code_path, "w")` → add `encoding="utf-8"` |

## Impact

- `nous_rate_guard.py` writes JSON state with `json.dump()` — keys/values could contain non-ASCII
- `shell_hooks.py` writes JSON data with `json.dumps()` — same issue
- `slash_commands.py` writes a subprocess exit code (integer) — low risk but consistency

All three use atomic write patterns (tempfile + rename), so the fix is minimal and safe.