### PR TITLE
fix: isolate cron env and quiet api-only allowlist warning

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1782,9 +1782,12 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 
     agent = None
 
-    # Mark this as a cron session so the approval system can apply cron_mode.
-    # This env var is process-wide and persists for the lifetime of the
-    # scheduler process — every job this process runs is a cron job.
+    # Mark this worker as a cron session so the approval system can apply
+    # cron_mode.  HERMES_CRON_SESSION is still an env var for legacy tool paths,
+    # so restore the prior value in finally below; otherwise a completed cron
+    # run can poison later live gateway/API turns and make execute_code report a
+    # misleading "cron jobs run without a user present" block.
+    _prior_cron_session_env = os.environ.get("HERMES_CRON_SESSION", "_UNSET_")
     os.environ["HERMES_CRON_SESSION"] = "1"
 
     # Use ContextVars for per-job session/delivery state so parallel jobs
@@ -2252,6 +2255,12 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         return False, output, "", error_msg
 
     finally:
+        # Restore cron approval scope so scheduled jobs do not leak a process-
+        # global cron marker into later live gateway/API sessions.
+        if _prior_cron_session_env == "_UNSET_":
+            os.environ.pop("HERMES_CRON_SESSION", None)
+        else:
+            os.environ["HERMES_CRON_SESSION"] = _prior_cron_session_env
         # Restore TERMINAL_CWD to whatever it was before this job ran.  We
         # only ever mutate it when the job has a workdir; see the setup block
         # at the top of run_job for the serialization guarantee.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5477,7 +5477,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             os.getenv(v, "").lower() in {"true", "1", "yes"}
             for v in _builtin_allow_all_vars + _plugin_allow_all_vars
         )
-        if not _any_allowlist and not _allow_all:
+        # API Server / webhooks authenticate by API key or route secret rather
+        # than user allowlists.  In local/API-only deployments, warning about
+        # missing chat allowlists is noisy and misleading: there are no inbound
+        # human chat users to authorize.  Keep the warning for actual messaging
+        # adapters (Telegram, Discord, Slack, etc.) where no allowlist means all
+        # unauthorized users will be denied at message time.
+        _non_user_allowlist_platforms = {
+            Platform.API_SERVER,
+            Platform.WEBHOOK,
+            getattr(Platform, "MSGRAPH_WEBHOOK", None),
+        }
+        _enabled_user_allowlist_platforms = [
+            platform for platform, platform_config in self.config.platforms.items()
+            if platform_config.enabled and platform not in _non_user_allowlist_platforms
+        ]
+        if _enabled_user_allowlist_platforms and not _any_allowlist and not _allow_all:
             logger.warning(
                 "No user allowlists configured. All unauthorized users will be denied. "
                 "Set GATEWAY_ALLOW_ALL_USERS=true in ~/.hermes/.env to allow open access, "

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -536,6 +536,7 @@ class TestRunJobEnvVarCleanup:
             "HERMES_SESSION_PLATFORM",
             "HERMES_SESSION_CHAT_ID",
             "HERMES_SESSION_CHAT_NAME",
+            "HERMES_CRON_SESSION",
         ):
             monkeypatch.delenv(key, raising=False)
 
@@ -565,3 +566,4 @@ class TestRunJobEnvVarCleanup:
         assert os.environ.get("HERMES_SESSION_PLATFORM") is None
         assert os.environ.get("HERMES_SESSION_CHAT_ID") is None
         assert os.environ.get("HERMES_SESSION_CHAT_NAME") is None
+        assert os.environ.get("HERMES_CRON_SESSION") is None

--- a/tests/gateway/test_allowlist_startup_check.py
+++ b/tests/gateway/test_allowlist_startup_check.py
@@ -1,7 +1,12 @@
 """Tests for the startup allowlist warning check in gateway/run.py."""
 
+import asyncio
+import logging
 import os
 from unittest.mock import patch
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.run import GatewayRunner
 
 
 def _would_warn():
@@ -44,3 +49,79 @@ class TestAllowlistStartupCheck:
     def test_gateway_allow_all_users_suppresses_warning(self):
         with patch.dict(os.environ, {"GATEWAY_ALLOW_ALL_USERS": "yes"}, clear=True):
             assert _would_warn() is False
+
+
+def _clear_allowlist_env(monkeypatch):
+    prefixes = (
+        "TELEGRAM",
+        "DISCORD",
+        "WHATSAPP",
+        "WHATSAPP_CLOUD",
+        "SLACK",
+        "SIGNAL",
+        "EMAIL",
+        "SMS",
+        "MATTERMOST",
+        "MATRIX",
+        "DINGTALK",
+        "FEISHU",
+        "WECOM",
+        "WECOM_CALLBACK",
+        "WEIXIN",
+        "BLUEBUBBLES",
+        "QQ",
+        "YUANBAO",
+        "GATEWAY",
+    )
+    suffixes = ("ALLOWED_USERS", "ALLOW_ALL_USERS", "GROUP_ALLOWED_USERS", "GROUP_ALLOWED_CHATS")
+    for prefix in prefixes:
+        for suffix in suffixes:
+            monkeypatch.delenv(f"{prefix}_{suffix}", raising=False)
+
+
+def _quiet_startup_after_allowlist_check(monkeypatch):
+    async def _zero_async(*args, **kwargs):
+        return 0
+
+    async def _none_async(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(GatewayRunner, "_create_adapter", lambda self, platform, config: None)
+    monkeypatch.setattr(GatewayRunner, "_start_secondary_profile_adapters", _zero_async)
+    monkeypatch.setattr(GatewayRunner, "_send_update_notification", lambda self: _none_async())
+    monkeypatch.setattr(GatewayRunner, "_send_restart_notification", lambda self: _none_async())
+    monkeypatch.setattr(GatewayRunner, "_finish_startup_restore", lambda self: _none_async())
+    monkeypatch.setattr(GatewayRunner, "_schedule_resume_pending_sessions", lambda self: None)
+    monkeypatch.setattr(GatewayRunner, "_schedule_update_notification_watch", lambda self: None)
+
+
+def _run_start_and_collect_messages(cfg, caplog, monkeypatch):
+    _quiet_startup_after_allowlist_check(monkeypatch)
+    runner = GatewayRunner(cfg)
+    with caplog.at_level(logging.WARNING, logger="gateway.run"):
+        asyncio.run(runner.start())
+    return [record.getMessage() for record in caplog.records]
+
+
+def test_api_and_webhook_only_do_not_emit_user_allowlist_warning(tmp_path, monkeypatch, caplog):
+    _clear_allowlist_env(monkeypatch)
+    cfg = GatewayConfig(
+        sessions_dir=tmp_path / "sessions",
+        platforms={
+            Platform.API_SERVER: PlatformConfig(enabled=True),
+            Platform.WEBHOOK: PlatformConfig(enabled=True),
+            Platform.MSGRAPH_WEBHOOK: PlatformConfig(enabled=True),
+        },
+    )
+    messages = _run_start_and_collect_messages(cfg, caplog, monkeypatch)
+    assert not any("No user allowlists configured" in msg for msg in messages)
+
+
+def test_messaging_platform_still_emits_user_allowlist_warning(tmp_path, monkeypatch, caplog):
+    _clear_allowlist_env(monkeypatch)
+    cfg = GatewayConfig(
+        sessions_dir=tmp_path / "sessions",
+        platforms={Platform.DISCORD: PlatformConfig(enabled=True)},
+    )
+    messages = _run_start_and_collect_messages(cfg, caplog, monkeypatch)
+    assert any("No user allowlists configured" in msg for msg in messages)


### PR DESCRIPTION
## Summary
- restore previous cron session env state after cron job execution, including failure paths
- suppress allowlist startup warning for API/webhook-only gateway deployments
- add regression coverage for cron env cleanup and API-only allowlist warning behavior

## Validation
- python -m py_compile cron/scheduler.py gateway/run.py tests/cron/test_cron_script.py tests/gateway/test_allowlist_startup_check.py
- git diff --check
- pytest tests/cron/test_cron_script.py::TestRunJobEnvVarCleanup tests/gateway/test_allowlist_startup_check.py

Targeted pytest result from clean env: 7 passed in 1.04s
