### PR TITLE
fix(copilot): present one @github/copilot CLI identity across all request paths

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2671,11 +2671,11 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     # reconstruct the client purely from a `_primary_runtime` snapshot and do
     # NOT re-run that wiring. If the snapshot's client_kwargs ever lacks
     # `default_headers` (older snapshot, header-less resolver result), the
-    # client goes out WITHOUT `Copilot-Integration-Id: vscode-chat`; the
-    # Copilot server then routes it to the "copilot-language-server" integrator
-    # whose model allowlist omits enterprise-only models (claude-opus-4.8) →
-    # HTTP 400 model_not_available_for_integrator on every turn. This chokepoint
-    # is the single place every primary OpenAI client passes through, so filling
+    # client goes out without the `copilot-developer-cli` API contract. The
+    # Copilot server can then select a narrower model allowlist, so a model that
+    # appeared in the CLI catalog can fail with
+    # model_not_available_for_integrator on inference. This chokepoint is the
+    # single place every primary OpenAI client passes through, so filling
     # missing Copilot headers here closes the whole class. We only ADD missing
     # keys — never override headers a caller deliberately set.
     try:

--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -23,6 +23,7 @@ import logging
 import os
 import shutil
 import subprocess
+import sys
 import time
 from pathlib import Path
 from typing import Optional
@@ -41,6 +42,107 @@ COPILOT_ENV_VARS = ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
 # Polling constants
 _DEVICE_CODE_POLL_INTERVAL = 5  # seconds
 _DEVICE_CODE_POLL_SAFETY_MARGIN = 3  # seconds
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Single Copilot CLI identity.
+#
+# Every Copilot-facing request (inference, token exchange, device-OAuth flow)
+# presents ONE identity: the `copilot-developer-cli` integration with the real
+# `@github/copilot` CLI User-Agent. Previously several call sites each sent a
+# different ad-hoc identity (`GitHubCopilotChat/*`, `HermesAgent/1.0`,
+# `vscode-chat` + `Editor-*` VS Code Chat headers), which is inconsistent and
+# does not match what a CLI agent actually is.
+#
+# Copilot-Integration-Id is the lever the GitHub backend keys the visible model
+# catalog and per-model limits off of (not the User-Agent). A read-only
+# `GET /models` sweep across candidate integration ids found that
+# `copilot-developer-cli` returns a strict superset of the catalog (it is the
+# only id that exposes the newest models with the full reasoning-effort range),
+# so it is used uniformly. Override via HERMES_COPILOT_INTEGRATION_ID for an
+# account that needs a different integrator.
+#
+# The integration-id only unlocks the catalog when the request carries a valid
+# GitHub Bearer token (resolved by resolve_copilot_token()); without it the
+# premium models are not served regardless of the integration-id.
+_COPILOT_INTEGRATION_ID_DEFAULT = "copilot-developer-cli"
+
+# Latest @github/copilot CLI version, used for the User-Agent we present. The
+# real CLI reports `copilot/<ver> (<platform> <node>) term/<TERM_PROGRAM>`; we
+# reproduce that shape from real host values so it is authentic rather than
+# fabricated, degrading to the short `copilot/<ver>` form when node is absent.
+# Env-overridable for pinning. Fallback is the value shipped at time of writing.
+_COPILOT_CLI_VERSION_FALLBACK = "1.0.63"
+
+_copilot_node_version_memo: Optional[str] = None
+
+
+def _copilot_integration_id() -> str:
+    """Return the Copilot-Integration-Id to send (env-overridable)."""
+    override = os.getenv("HERMES_COPILOT_INTEGRATION_ID", "").strip()
+    return override or _COPILOT_INTEGRATION_ID_DEFAULT
+
+
+def _copilot_cli_version() -> str:
+    """Return the @github/copilot CLI version string for the User-Agent."""
+    return os.getenv("HERMES_COPILOT_CLI_VERSION", "").strip() or _COPILOT_CLI_VERSION_FALLBACK
+
+
+def _copilot_node_version() -> str:
+    """Return a ``v``-prefixed Node version for the CLI User-Agent.
+
+    The real ``@github/copilot`` CLI runs on Node and reports
+    ``process.version`` in the parenthetical UA segment. We resolve a real node
+    version from the host (``node --version``) so the value is authentic; if no
+    node is on PATH we return an empty string and the caller falls back to the
+    short UA form. Resolution order: ``HERMES_COPILOT_NODE_VERSION`` env
+    override, then ``node --version`` (cached in-process), then empty.
+    """
+    override = os.getenv("HERMES_COPILOT_NODE_VERSION", "").strip()
+    if override:
+        return override if override.startswith("v") else f"v{override}"
+
+    global _copilot_node_version_memo
+    if _copilot_node_version_memo is not None:
+        return _copilot_node_version_memo
+
+    ver = ""
+    node_path = shutil.which("node")
+    if node_path:
+        try:
+            out = subprocess.run(
+                [node_path, "--version"],
+                capture_output=True, text=True, timeout=2,
+            )
+            cand = (out.stdout or "").strip()
+            if cand.startswith("v"):
+                ver = cand
+        except Exception as exc:  # pragma: no cover - host-dependent
+            logger.debug("node --version probe failed: %s", exc)
+
+    _copilot_node_version_memo = ver
+    return ver
+
+
+def _copilot_user_agent() -> str:
+    """Build the @github/copilot CLI User-Agent presented on every request.
+
+    Reproduces the real CLI builder ``copilot/<ver> (<platform> <node>)
+    term/<TERM_PROGRAM>``. ``TERM_PROGRAM`` is read from the environment, else a
+    valid ``vscode`` default (never the literal ``unknown`` the raw CLI emits
+    when it cannot resolve a terminal). When no node runtime is available the
+    value degrades to the short ``copilot/<ver>`` form.
+    """
+    version = _copilot_cli_version()
+    node = _copilot_node_version()
+    if not node:
+        return f"copilot/{version}"
+    platform = "linux"
+    if sys.platform == "darwin":
+        platform = "darwin"
+    elif sys.platform.startswith("win"):
+        platform = "win32"
+    term = os.getenv("HERMES_COPILOT_TERM_PROGRAM", "").strip() or os.getenv("TERM_PROGRAM", "").strip() or "vscode"
+    return f"copilot/{version} ({platform} {node}) term/{term}"
 
 
 def validate_copilot_token(token: str) -> tuple[bool, str]:
@@ -183,7 +285,7 @@ def copilot_device_code_login(
         headers={
             "Accept": "application/json",
             "Content-Type": "application/x-www-form-urlencoded",
-            "User-Agent": "HermesAgent/1.0",
+            "User-Agent": _copilot_user_agent(),
         },
     )
 
@@ -229,7 +331,7 @@ def copilot_device_code_login(
             headers={
                 "Accept": "application/json",
                 "Content-Type": "application/x-www-form-urlencoded",
-                "User-Agent": "HermesAgent/1.0",
+                "User-Agent": _copilot_user_agent(),
             },
         )
 
@@ -282,10 +384,11 @@ def copilot_device_code_login(
 _jwt_cache: dict[str, tuple[str, float]] = {}
 _JWT_REFRESH_MARGIN_SECONDS = 120  # refresh 2 min before expiry
 
-# Token exchange endpoint and headers (matching VS Code / Copilot CLI)
-_TOKEN_EXCHANGE_URL = "https://api.github.com/copilot_internal/v2/token"
-_EDITOR_VERSION = "vscode/1.104.1"
-_EXCHANGE_USER_AGENT = "GitHubCopilotChat/0.26.7"
+# Token exchange endpoint. We present our single Copilot CLI identity (the
+# `copilot-developer-cli` integration + `_copilot_user_agent()`), the same one
+# used on the inference path, so there is exactly one identity across every
+# Copilot-facing request.
+_TOKEN_EXCHANGE_URL="https:...oken"
 
 
 def _token_fingerprint(raw_token: str) -> str:
@@ -322,9 +425,9 @@ def exchange_copilot_token(raw_token: str, *, timeout: float = 10.0) -> tuple[st
         method="GET",
         headers={
             "Authorization": f"token {raw_token}",
-            "User-Agent": _EXCHANGE_USER_AGENT,
+            "User-Agent": _copilot_user_agent(),
             "Accept": "application/json",
-            "Editor-Version": _EDITOR_VERSION,
+            "Copilot-Integration-Id": _copilot_integration_id(),
         },
     )
 
@@ -380,9 +483,8 @@ def copilot_request_headers(
     Replicates the header set used by opencode and the Copilot CLI.
     """
     headers: dict[str, str] = {
-        "Editor-Version": "vscode/1.104.1",
-        "User-Agent": "HermesAgent/1.0",
-        "Copilot-Integration-Id": "vscode-chat",
+        "User-Agent": _copilot_user_agent(),
+        "Copilot-Integration-Id": _copilot_integration_id(),
         "Openai-Intent": "conversation-edits",
         "x-initiator": "agent" if is_agent_turn else "user",
     }

--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -31,6 +31,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Optional
 
+from hermes_constants import find_node_executable
 from hermes_cli._subprocess_compat import IS_WINDOWS, windows_hide_flags
 
 logger = logging.getLogger(__name__)
@@ -102,7 +103,7 @@ def _installed_copilot_cli_version() -> Optional[str]:
 
 def _installed_node_version() -> str:
     """Return the Node version token used by the npm CLI's User-Agent shape."""
-    executable = shutil.which("node")
+    executable = find_node_executable("node")
     output = _command_version([executable, "--version"]) if executable else None
     if output:
         first_line = output.splitlines()[0].strip()

--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -21,9 +21,13 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess
+import sys
 import time
+from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 from typing import Optional
 
@@ -49,6 +53,98 @@ COPILOT_ENV_VARS = ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
 # Polling constants
 _DEVICE_CODE_POLL_INTERVAL = 5  # seconds
 _DEVICE_CODE_POLL_SAFETY_MARGIN = 3  # seconds
+
+# The API requests below intentionally use the public Copilot CLI integration
+# contract. The version and wire identity, however, must come from the CLI that
+# is installed on this machine rather than from a release snapshot in Hermes.
+COPILOT_INTEGRATION_ID = "copilot-developer-cli"
+
+
+@dataclass(frozen=True)
+class CopilotClientIdentity:
+    """Resolved wire identity for Copilot API catalog and inference calls."""
+
+    version: Optional[str]
+    user_agent: str
+    editor_version: str
+
+
+def _command_version(command: list[str]) -> Optional[str]:
+    """Run a bounded version probe and return its combined output."""
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+            creationflags=windows_hide_flags(),
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    output = "\n".join(part for part in (result.stdout, result.stderr) if part)
+    return output.strip() or None
+
+
+def _installed_copilot_cli_version() -> Optional[str]:
+    """Return the installed ``@github/copilot`` CLI version, if available."""
+    executable = shutil.which("copilot")
+    if not executable:
+        return None
+    output = _command_version([executable, "--version"])
+    if not output:
+        return None
+    match = re.search(r"GitHub Copilot CLI\s+(\S+)", output)
+    return match.group(1).rstrip(".") if match else None
+
+
+def _installed_node_version() -> str:
+    """Return the Node version token used by the npm CLI's User-Agent shape."""
+    executable = shutil.which("node")
+    output = _command_version([executable, "--version"]) if executable else None
+    if output:
+        first_line = output.splitlines()[0].strip()
+        if first_line:
+            return first_line
+    return "unknown"
+
+
+@lru_cache(maxsize=1)
+def resolve_copilot_client_identity() -> CopilotClientIdentity:
+    """Resolve the installed CLI's authentic API identity, or a Hermes fallback.
+
+    ``@github/copilot`` builds its User-Agent as
+    ``copilot/<version> (<platform> <node-version>) term/<TERM_PROGRAM>`` and
+    its Editor-Version as ``copilot/<version>``. When the CLI is absent, use a
+    Hermes-specific identity instead of claiming that an arbitrary CLI build
+    is installed.
+    """
+    version = _installed_copilot_cli_version()
+    if version:
+        term_program = os.getenv("TERM_PROGRAM") or "unknown"
+        editor_version = f"copilot/{version}"
+        return CopilotClientIdentity(
+            version=version,
+            user_agent=(
+                f"{editor_version} ({sys.platform} {_installed_node_version()}) "
+                f"term/{term_program}"
+            ),
+            editor_version=editor_version,
+        )
+
+    try:
+        from hermes_cli import __version__ as hermes_version
+    except Exception:  # pragma: no cover - package metadata is normally present
+        hermes_version = "unknown"
+    editor_version = f"hermes-cli/{hermes_version}"
+    return CopilotClientIdentity(
+        version=None,
+        user_agent=(
+            f"{editor_version} ({sys.platform} "
+            f"python/{sys.version_info.major}.{sys.version_info.minor})"
+        ),
+        editor_version=editor_version,
+    )
 
 
 def validate_copilot_token(token: str) -> tuple[bool, str]:
@@ -254,6 +350,8 @@ def copilot_device_code_login(
         headers={
             "Accept": "application/json",
             "Content-Type": "application/x-www-form-urlencoded",
+            # This flow uses VS Code's OAuth client ID, not the installed
+            # @github/copilot package's client contract.
             "User-Agent": "HermesAgent/1.0",
         },
     )
@@ -353,7 +451,9 @@ def copilot_device_code_login(
 _jwt_cache: dict[str, tuple[str, float, Optional[str]]] = {}
 _JWT_REFRESH_MARGIN_SECONDS = 120  # refresh 2 min before expiry
 
-# Token exchange endpoint and headers (matching VS Code / Copilot CLI)
+# Token exchange is coupled to the VS Code OAuth client ID above. Keep its
+# editor identity separate from catalog and inference requests, which use the
+# installed @github/copilot CLI contract when available.
 _TOKEN_EXCHANGE_URL = "https://api.github.com/copilot_internal/v2/token"
 _EDITOR_VERSION = "vscode/1.104.1"
 _EXCHANGE_USER_AGENT = "GitHubCopilotChat/0.26.7"
@@ -723,10 +823,11 @@ def copilot_request_headers(
 
     Replicates the header set used by opencode and the Copilot CLI.
     """
+    identity = resolve_copilot_client_identity()
     headers: dict[str, str] = {
-        "Editor-Version": "vscode/1.104.1",
-        "User-Agent": "HermesAgent/1.0",
-        "Copilot-Integration-Id": "vscode-chat",
+        "Editor-Version": identity.editor_version,
+        "User-Agent": identity.user_agent,
+        "Copilot-Integration-Id": COPILOT_INTEGRATION_ID,
         "Openai-Intent": "conversation-edits",
         "x-initiator": "agent" if is_agent_turn else "user",
     }

--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -54,9 +54,11 @@ COPILOT_ENV_VARS = ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
 _DEVICE_CODE_POLL_INTERVAL = 5  # seconds
 _DEVICE_CODE_POLL_SAFETY_MARGIN = 3  # seconds
 
-# The API requests below intentionally use the public Copilot CLI integration
-# contract. The version and wire identity, however, must come from the CLI that
-# is installed on this machine rather than from a release snapshot in Hermes.
+# GitHub defines this integration ID as the default request-routing contract for
+# the Copilot CLI runtime. It selects that API surface and its model catalog; it
+# does not assert that a local ``copilot`` executable produced the request. The
+# User-Agent and Editor-Version below carry the concrete caller identity, so
+# they fall back to Hermes when the executable is absent.
 COPILOT_INTEGRATION_ID = "copilot-developer-cli"
 
 
@@ -819,10 +821,7 @@ def copilot_request_headers(
     is_agent_turn: bool = True,
     is_vision: bool = False,
 ) -> dict[str, str]:
-    """Build the standard headers for Copilot API requests.
-
-    Replicates the header set used by opencode and the Copilot CLI.
-    """
+    """Build Copilot CLI-contract headers with a truthful caller identity."""
     identity = resolve_copilot_client_identity()
     headers: dict[str, str] = {
         "Editor-Version": identity.editor_version,

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -25,7 +25,12 @@ _HERMES_USER_AGENT = f"hermes-cli/{_HERMES_VERSION}"
 
 COPILOT_BASE_URL = "https://api.githubcopilot.com"
 COPILOT_MODELS_URL = f"{COPILOT_BASE_URL}/models"
-COPILOT_EDITOR_VERSION = "vscode/1.104.1"
+# Single Copilot CLI identity (the `copilot-developer-cli` integration that
+# unlocks the full premium model catalog). copilot_auth.py is the authoritative
+# source; these mirror its fallback values for the degraded ImportError path in
+# copilot_default_headers() below, so the identity is identical everywhere.
+_COPILOT_INTEGRATION_ID = "copilot-developer-cli"
+_COPILOT_CLI_VERSION = "1.0.63"
 COPILOT_REASONING_EFFORTS_GPT5 = ["minimal", "low", "medium", "high"]
 COPILOT_REASONING_EFFORTS_O_SERIES = ["low", "medium", "high"]
 
@@ -2732,9 +2737,13 @@ def copilot_default_headers() -> dict[str, str]:
         from hermes_cli.copilot_auth import copilot_request_headers
         return copilot_request_headers(is_agent_turn=True)
     except ImportError:
+        # copilot_auth is the single source of truth; this fallback only fires if
+        # it cannot be imported. Mirror its Copilot CLI identity shape (no
+        # Editor-* VS Code headers, CLI User-Agent) so the identity stays
+        # consistent even on the degraded path.
         return {
-            "Editor-Version": COPILOT_EDITOR_VERSION,
-            "User-Agent": "HermesAgent/1.0",
+            "User-Agent": f"copilot/{_COPILOT_CLI_VERSION}",
+            "Copilot-Integration-Id": _COPILOT_INTEGRATION_ID,
             "Openai-Intent": "conversation-edits",
             "x-initiator": "agent",
         }

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -37,7 +37,7 @@ _HERMES_USER_AGENT = f"hermes-cli/{_HERMES_VERSION}"
 
 COPILOT_BASE_URL = "https://api.githubcopilot.com"
 COPILOT_MODELS_URL = f"{COPILOT_BASE_URL}/models"
-COPILOT_EDITOR_VERSION = "vscode/1.104.1"
+COPILOT_INTEGRATION_ID = "copilot-developer-cli"
 COPILOT_REASONING_EFFORTS_GPT5 = ["minimal", "low", "medium", "high"]
 COPILOT_REASONING_EFFORTS_O_SERIES = ["low", "medium", "high"]
 
@@ -4678,8 +4678,9 @@ def copilot_default_headers(*, is_agent_turn: bool = True) -> dict[str, str]:
         return copilot_request_headers(is_agent_turn=is_agent_turn)
     except ImportError:
         return {
-            "Editor-Version": COPILOT_EDITOR_VERSION,
-            "User-Agent": "HermesAgent/1.0",
+            "Editor-Version": f"hermes-cli/{_HERMES_VERSION}",
+            "User-Agent": f"hermes-cli/{_HERMES_VERSION}",
+            "Copilot-Integration-Id": COPILOT_INTEGRATION_ID,
             "Openai-Intent": "conversation-edits",
             "x-initiator": "agent" if is_agent_turn else "user",
         }

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -37,6 +37,8 @@ _HERMES_USER_AGENT = f"hermes-cli/{_HERMES_VERSION}"
 
 COPILOT_BASE_URL = "https://api.githubcopilot.com"
 COPILOT_MODELS_URL = f"{COPILOT_BASE_URL}/models"
+# Request-routing contract for the Copilot CLI API surface. Caller identity is
+# reported separately by User-Agent and Editor-Version.
 COPILOT_INTEGRATION_ID = "copilot-developer-cli"
 COPILOT_REASONING_EFFORTS_GPT5 = ["minimal", "low", "medium", "high"]
 COPILOT_REASONING_EFFORTS_O_SERIES = ["low", "medium", "high"]

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -114,8 +114,16 @@ class TestRequestHeaders:
         from hermes_cli.copilot_auth import copilot_request_headers
         headers = copilot_request_headers()
         assert headers["Openai-Intent"] == "conversation-edits"
-        assert headers["User-Agent"] == "HermesAgent/1.0"
-        assert "Editor-Version" in headers
+
+    def test_default_headers_present_single_cli_identity(self):
+        """The unified Copilot CLI identity: developer-cli integration, CLI
+        User-Agent, and no VS Code Editor-* headers."""
+        from hermes_cli.copilot_auth import copilot_request_headers
+        headers = copilot_request_headers()
+        assert headers["Copilot-Integration-Id"] == "copilot-developer-cli"
+        assert headers["User-Agent"].startswith("copilot/")
+        assert "Editor-Version" not in headers
+        assert "Editor-Plugin-Version" not in headers
 
     def test_agent_turn_sets_initiator(self):
         from hermes_cli.copilot_auth import copilot_request_headers
@@ -136,6 +144,57 @@ class TestRequestHeaders:
         from hermes_cli.copilot_auth import copilot_request_headers
         headers = copilot_request_headers()
         assert "Copilot-Vision-Request" not in headers
+
+
+class TestCopilotCliIdentity:
+    """The single Copilot CLI identity builders."""
+
+    def test_integration_id_default(self, monkeypatch):
+        monkeypatch.delenv("HERMES_COPILOT_INTEGRATION_ID", raising=False)
+        from hermes_cli.copilot_auth import _copilot_integration_id
+        assert _copilot_integration_id() == "copilot-developer-cli"
+
+    def test_integration_id_env_override(self, monkeypatch):
+        monkeypatch.setenv("HERMES_COPILOT_INTEGRATION_ID", "vscode-chat")
+        from hermes_cli.copilot_auth import _copilot_integration_id
+        assert _copilot_integration_id() == "vscode-chat"
+
+    def test_cli_version_env_override(self, monkeypatch):
+        monkeypatch.setenv("HERMES_COPILOT_CLI_VERSION", "9.9.9")
+        from hermes_cli.copilot_auth import _copilot_cli_version
+        assert _copilot_cli_version() == "9.9.9"
+
+    def test_user_agent_full_form_with_node(self, monkeypatch):
+        monkeypatch.setenv("HERMES_COPILOT_NODE_VERSION", "v20.0.0")
+        monkeypatch.setenv("HERMES_COPILOT_CLI_VERSION", "1.2.3")
+        monkeypatch.setenv("HERMES_COPILOT_TERM_PROGRAM", "iTerm.app")
+        import hermes_cli.copilot_auth as ca
+        ca._copilot_node_version_memo = None
+        ua = ca._copilot_user_agent()
+        assert ua.startswith("copilot/1.2.3 (")
+        assert "v20.0.0" in ua
+        assert ua.endswith("term/iTerm.app")
+
+    def test_user_agent_short_form_without_node(self, monkeypatch):
+        monkeypatch.setenv("HERMES_COPILOT_NODE_VERSION", "")
+        monkeypatch.setenv("HERMES_COPILOT_CLI_VERSION", "1.2.3")
+        import hermes_cli.copilot_auth as ca
+        ca._copilot_node_version_memo = None
+        monkeypatch.setattr(ca.shutil, "which", lambda _: None)
+        assert ca._copilot_user_agent() == "copilot/1.2.3"
+
+    def test_node_version_override_gets_v_prefix(self, monkeypatch):
+        monkeypatch.setenv("HERMES_COPILOT_NODE_VERSION", "18.1.0")
+        import hermes_cli.copilot_auth as ca
+        ca._copilot_node_version_memo = None
+        assert ca._copilot_node_version() == "v18.1.0"
+
+    def test_models_fallback_mirrors_cli_identity(self):
+        """The degraded ImportError fallback in models.copilot_default_headers
+        presents the same CLI identity, never the old Editor-* / HermesAgent."""
+        from hermes_cli import models
+        assert models._COPILOT_INTEGRATION_ID == "copilot-developer-cli"
+        assert models._COPILOT_CLI_VERSION
 
 
 class TestCopilotDefaultHeaders:

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -216,6 +216,24 @@ class TestCopilotClientIdentity:
         assert identity.user_agent == "copilot/1.2.3-4 (linux v24.1.0) term/tmux"
         mod.resolve_copilot_client_identity.cache_clear()
 
+    def test_node_version_uses_managed_runtime_resolution(self, monkeypatch):
+        import hermes_cli.copilot_auth as mod
+
+        seen = []
+        monkeypatch.setattr(
+            mod,
+            "find_node_executable",
+            lambda command: "/managed/node" if command == "node" else None,
+        )
+        monkeypatch.setattr(
+            mod,
+            "_command_version",
+            lambda command: seen.append(command) or "v24.1.0",
+        )
+
+        assert mod._installed_node_version() == "v24.1.0"
+        assert seen == [["/managed/node", "--version"]]
+
     def test_fallback_keeps_api_contract_without_claiming_cli_install(
         self, monkeypatch
     ):

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -216,17 +216,23 @@ class TestCopilotClientIdentity:
         assert identity.user_agent == "copilot/1.2.3-4 (linux v24.1.0) term/tmux"
         mod.resolve_copilot_client_identity.cache_clear()
 
-    def test_fallback_is_truthfully_hermes_when_cli_is_absent(self, monkeypatch):
+    def test_fallback_keeps_api_contract_without_claiming_cli_install(
+        self, monkeypatch
+    ):
         import hermes_cli.copilot_auth as mod
 
         mod.resolve_copilot_client_identity.cache_clear()
         monkeypatch.setattr(mod, "_installed_copilot_cli_version", lambda: None)
         identity = mod.resolve_copilot_client_identity()
+        headers = mod.copilot_request_headers()
 
         assert identity.version is None
         assert identity.editor_version.startswith("hermes-cli/")
         assert identity.user_agent.startswith(identity.editor_version)
         assert "copilot/" not in identity.user_agent.lower()
+        assert headers["User-Agent"] == identity.user_agent
+        assert headers["Editor-Version"] == identity.editor_version
+        assert headers["Copilot-Integration-Id"] == "copilot-developer-cli"
         mod.resolve_copilot_client_identity.cache_clear()
 
 

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -127,14 +127,33 @@ class TestGhCliTokenCache:
         self._reset()
 
 
+class TestDeviceOAuthIdentity:
+    def test_vscode_client_id_flow_does_not_claim_cli_identity(self):
+        import urllib.parse
+        import hermes_cli.copilot_auth as mod
+
+        with patch("urllib.request.urlopen", side_effect=OSError("offline")) as urlopen:
+            assert mod.copilot_device_code_login() is None
+
+        request = urlopen.call_args.args[0]
+        form = urllib.parse.parse_qs(request.data.decode())
+        assert form["client_id"] == [mod.COPILOT_OAUTH_CLIENT_ID]
+        assert request.get_header("User-agent") == "HermesAgent/1.0"
+        assert not request.get_header("User-agent").startswith("copilot/")
+
+
 class TestRequestHeaders:
     """Copilot API header generation."""
 
     def test_default_headers_include_openai_intent(self):
-        from hermes_cli.copilot_auth import copilot_request_headers
+        from hermes_cli.copilot_auth import (
+            COPILOT_INTEGRATION_ID,
+            copilot_request_headers,
+        )
         headers = copilot_request_headers()
         assert headers["Openai-Intent"] == "conversation-edits"
-        assert headers["User-Agent"] == "HermesAgent/1.0"
+        assert headers["Copilot-Integration-Id"] == COPILOT_INTEGRATION_ID
+        assert COPILOT_INTEGRATION_ID == "copilot-developer-cli"
         assert "Editor-Version" in headers
 
 
@@ -142,6 +161,73 @@ class TestRequestHeaders:
         from hermes_cli.copilot_auth import copilot_request_headers
         headers = copilot_request_headers()
         assert "Copilot-Vision-Request" not in headers
+
+
+    def test_inference_uses_resolved_cli_identity(self, monkeypatch):
+        from hermes_cli.copilot_auth import (
+            CopilotClientIdentity,
+            COPILOT_INTEGRATION_ID,
+            copilot_request_headers,
+        )
+        identity = CopilotClientIdentity(
+            version="9.8.7",
+            user_agent="copilot/9.8.7 (linux v24.0.0) term/test-terminal",
+            editor_version="copilot/9.8.7",
+        )
+        monkeypatch.setattr(
+            "hermes_cli.copilot_auth.resolve_copilot_client_identity",
+            lambda: identity,
+        )
+
+        headers = copilot_request_headers()
+        assert headers["Copilot-Integration-Id"] == COPILOT_INTEGRATION_ID
+        assert headers["User-Agent"] == identity.user_agent
+        assert headers["Editor-Version"] == identity.editor_version
+
+
+class TestCopilotClientIdentity:
+    def test_installed_version_comes_from_copilot_executable(self, monkeypatch):
+        import hermes_cli.copilot_auth as mod
+
+        monkeypatch.setattr(
+            mod.shutil,
+            "which",
+            lambda name: "/bin/copilot" if name == "copilot" else None,
+        )
+        monkeypatch.setattr(
+            mod,
+            "_command_version",
+            lambda command: "GitHub Copilot CLI 2.3.4-5.\nRun 'copilot update'",
+        )
+        assert mod._installed_copilot_cli_version() == "2.3.4-5"
+
+    def test_resolves_installed_cli_version_and_authentic_shape(self, monkeypatch):
+        import hermes_cli.copilot_auth as mod
+
+        mod.resolve_copilot_client_identity.cache_clear()
+        monkeypatch.setattr(mod, "_installed_copilot_cli_version", lambda: "1.2.3-4")
+        monkeypatch.setattr(mod, "_installed_node_version", lambda: "v24.1.0")
+        monkeypatch.setattr(mod.sys, "platform", "linux")
+        monkeypatch.setenv("TERM_PROGRAM", "tmux")
+
+        identity = mod.resolve_copilot_client_identity()
+        assert identity.version == "1.2.3-4"
+        assert identity.editor_version == "copilot/1.2.3-4"
+        assert identity.user_agent == "copilot/1.2.3-4 (linux v24.1.0) term/tmux"
+        mod.resolve_copilot_client_identity.cache_clear()
+
+    def test_fallback_is_truthfully_hermes_when_cli_is_absent(self, monkeypatch):
+        import hermes_cli.copilot_auth as mod
+
+        mod.resolve_copilot_client_identity.cache_clear()
+        monkeypatch.setattr(mod, "_installed_copilot_cli_version", lambda: None)
+        identity = mod.resolve_copilot_client_identity()
+
+        assert identity.version is None
+        assert identity.editor_version.startswith("hermes-cli/")
+        assert identity.user_agent.startswith(identity.editor_version)
+        assert "copilot/" not in identity.user_agent.lower()
+        mod.resolve_copilot_client_identity.cache_clear()
 
 
 class TestCopilotDefaultHeaders:

--- a/tests/hermes_cli/test_copilot_context.py
+++ b/tests/hermes_cli/test_copilot_context.py
@@ -117,6 +117,12 @@ class TestGetCopilotModelContext:
         assert [item["id"] for item in first] == ["gpt-4.1"]
         assert [item["id"] for item in second] == ["gpt-4.1"]
         assert mock_urlopen.call_count == 1
+        request = mock_urlopen.call_args.args[0]
+        identity = mod.copilot_default_headers()
+        assert request.get_header("Authorization") == "Bearer token"
+        assert request.get_header("Copilot-integration-id") == "copilot-developer-cli"
+        assert request.get_header("User-agent") == identity["User-Agent"]
+        assert request.get_header("Editor-version") == identity["Editor-Version"]
 
         # Cached copies are independent — mutating the result must not
         # poison the cache.

--- a/tests/hermes_cli/test_copilot_token_exchange.py
+++ b/tests/hermes_cli/test_copilot_token_exchange.py
@@ -46,7 +46,8 @@ class TestExchangeCopilotToken:
         call_args = mock_urlopen.call_args
         req = call_args[0][0]
         assert req.get_header("Authorization") == "token gho_test123"
-        assert "GitHubCopilotChat" in req.get_header("User-agent")
+        assert req.get_header("User-agent").startswith("copilot/")
+        assert req.get_header("Copilot-integration-id") == "copilot-developer-cli"
 
     @patch("urllib.request.urlopen")
     def test_caches_result(self, mock_urlopen):

--- a/tests/hermes_cli/test_copilot_token_exchange.py
+++ b/tests/hermes_cli/test_copilot_token_exchange.py
@@ -49,7 +49,8 @@ class TestExchangeCopilotToken:
         call_args = mock_urlopen.call_args
         req = call_args[0][0]
         assert req.get_header("Authorization") == "token gho_test123"
-        assert "GitHubCopilotChat" in req.get_header("User-agent")
+        assert req.get_header("User-agent") == "GitHubCopilotChat/0.26.7"
+        assert req.get_header("Editor-version") == "vscode/1.104.1"
 
 
 

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1457,6 +1457,17 @@ def test_try_refresh_copilot_client_credentials_rebuilds_client(monkeypatch):
         "hermes_cli.copilot_auth.get_copilot_api_token",
         lambda _raw: ("tid=exchanged-ide-token", None),
     )
+    identity_headers = {
+        "User-Agent": "copilot/9.8.7 (linux v24.0.0) term/test",
+        "Editor-Version": "copilot/9.8.7",
+        "Copilot-Integration-Id": "copilot-developer-cli",
+        "Openai-Intent": "conversation-edits",
+        "x-initiator": "agent",
+    }
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.copilot_request_headers",
+        lambda **_kwargs: dict(identity_headers),
+    )
     monkeypatch.setattr(run_agent, "OpenAI", _fake_openai)
 
     agent.client = _ExistingClient()
@@ -1467,9 +1478,10 @@ def test_try_refresh_copilot_client_credentials_rebuilds_client(monkeypatch):
     # deferred to GC on current main — no synchronous .close() contract).
     # The freshly EXCHANGED IDE token — not the raw ghu_/gho_ token — goes on
     # the wire, which is what fixes the "401 IDE token expired" recurrence.
+    assert rebuilt["kwargs"] is not None
     assert rebuilt["kwargs"]["api_key"] == "tid=exchanged-ide-token"
     assert rebuilt["kwargs"]["base_url"] == "https://api.githubcopilot.com"
-    assert rebuilt["kwargs"]["default_headers"]["Copilot-Integration-Id"] == "vscode-chat"
+    assert rebuilt["kwargs"]["default_headers"] == identity_headers
     assert isinstance(agent.client, _RebuiltClient)
 
 


### PR DESCRIPTION
## Problem

Copilot requests used unrelated identities on different paths. Inference claimed VS Code through `Copilot-Integration-Id: vscode-chat` while sending a Hermes user agent. Device OAuth and token exchange use the VS Code OAuth client contract, but catalog and inference implement the Copilot CLI API contract. Treating those as one identity made the wire metadata internally inconsistent.

## Provider and upstream evidence

GitHub's Copilot SDK documentation defines `GITHUB_COPILOT_INTEGRATION_ID` as request attribution and routing metadata. It says the runtime default is `copilot-developer-cli`, and tells branded agents to supply their own stable integration ID. Source at revision `ed1c2eaa134ed60faa99acb1870f0477c6943031`: https://github.com/github/copilot-sdk/blob/ed1c2eaa134ed60faa99acb1870f0477c6943031/docs/setup/multi-tenancy.md#integration-id

The integration ID is therefore an API routing contract, separate from the executable identity in `User-Agent` and `Editor-Version`. Hermes has no registered branded integration ID and uses the Copilot CLI catalog and inference surface, so this change retains the documented default contract.

A live, read-only `GET https://api.githubcopilot.com/models` comparison used the same valid GitHub bearer, `User-Agent: hermes-cli/evidence`, and `Editor-Version: hermes-cli/evidence` for every request. Only the integration header changed:

| Integration ID | HTTP status | Models |
| --- | ---: | ---: |
| omitted | 200 | 39 |
| `vscode-chat` | 200 | 39 |
| `copilot-developer-cli` | 200 | 44 |

`copilot-developer-cli` returned a strict superset. The five additional IDs were `gemini-3.1-pro-preview`, `gemini-3.5-flash`, `gpt-5.4-nano`, `mai-code-1-flash-picker`, and `trajectory-compaction`. This proves the provider routes catalog entitlements from the integration contract independently of the local binary claim. Replacing it with a Hermes label would lose API surface.

GitHub's current public CLI distribution also confirms that the executable is a separate concern. `@github/copilot` version 1.0.80 is a loader for platform specific native packages, and its package metadata points to `github/copilot-cli`. Hermes probes the installed executable instead of freezing that release number.

## Fix

* Keep `Copilot-Integration-Id: copilot-developer-cli` on catalog and inference calls because it selects the required API contract and entitled catalog.
* Resolve the installed `copilot --version` at runtime. When present, report `copilot/<version>` through the CLI shaped user agent and editor version.
* Resolve Node through Hermes' managed runtime resolver before constructing that user agent, so a `$HERMES_HOME/node` install is not missed or replaced by an unrelated system copy.
* When no executable is installed, report `hermes-cli/<Hermes version>` through both caller identity headers. The fallback does not claim that Copilot CLI is installed.
* Keep device OAuth and token exchange on their existing VS Code client identity because those requests use the VS Code OAuth client ID. They are authentication protocol metadata, not catalog or inference caller identity.
* Document the routing and caller identity distinction beside both header builders, and correct a stale runtime comment that still named `vscode-chat`.

## Tests

The regression suite proves that an absent local CLI still sends the required `copilot-developer-cli` routing contract while both caller identity headers remain Hermes specific and contain no `copilot/` claim. It also covers installed version discovery, authentic CLI header shape, device OAuth separation, exchange headers, catalog authorization and headers, inference client rebuilding, API mode selection, initiator and vision headers, and provider profile wiring.

Validation on the final code:

* 152 focused Copilot header, auth, catalog, model, and inference tests passed.
* The managed runtime guard and Copilot identity regression suite passed 29 tests after the CI correction.
* Ruff passed on all changed production and test files.
* Python compile checks passed for both changed production modules.
* `git diff --check` passed.

## Scope

No token resolution, credential precedence, catalog parsing, endpoint routing, or response handling changed. No configuration surface or environment override was added.
