### PR TITLE
feat(skills): add opt-in external_dirs_readonly guard

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2365,6 +2365,12 @@ DEFAULT_CONFIG = {
     # always goes to ~/.hermes/skills/.
     "skills": {
         "external_dirs": [],   # e.g. ["~/.agents/skills", "/shared/team-skills"]
+        # When true, skill_manage rejects mutations (edit/patch/delete/
+        # write_file/remove_file) on skills located in external_dirs. Skills in
+        # external directories are typically managed by an external package
+        # manager (npx skills, git, etc.) — modifications by the agent would be
+        # silently lost on the next update. Set to true to enable protection.
+        "external_dirs_readonly": False,
         # Substitute ${HERMES_SKILL_DIR} and ${HERMES_SESSION_ID} in SKILL.md
         # content with the absolute skill directory and the active session id
         # before the agent sees it.  Lets skill authors reference bundled

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -1,6 +1,7 @@
 """Tests for tools/skill_manager_tool.py — skill creation, editing, and deletion."""
 
 import json
+import os
 from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
@@ -976,6 +977,130 @@ class TestExternalSkillMutations:
         result = json.loads(raw)
         assert result["success"] is True
 
+
+class TestExternalDirsReadonlyGuard:
+    """skill_manage mutations on external-dir skills are blocked when
+    skills.external_dirs_readonly is enabled."""
+
+    @contextmanager
+    def _external_skill_env(self, tmp_path):
+        """Set up a local + external dir with a skill in the external dir,
+        and patch both SKILLS_DIR and get_all_skills_dirs so _find_skill
+        discovers it. Yields the skill_dir."""
+        ext_dir = tmp_path / "external-skills"
+        ext_dir.mkdir()
+        skill_dir = ext_dir / "ext-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(VALID_SKILL_CONTENT)
+
+        local_dir = tmp_path / "local-skills"
+        local_dir.mkdir()
+
+        with patch("tools.skill_manager_tool.SKILLS_DIR", local_dir), \
+             patch("agent.skill_utils.get_all_skills_dirs",
+                   return_value=[local_dir, ext_dir]), \
+             patch("agent.skill_utils.get_external_skills_dirs",
+                   return_value=[ext_dir]):
+            yield skill_dir
+
+    def test_edit_blocked_with_real_config_path(self, tmp_path):
+        """The real HERMES_HOME config controls the external-dir guard."""
+        ext_dir = tmp_path / "external-skills"
+        skill_dir = ext_dir / "ext-skill"
+        skill_dir.mkdir(parents=True)
+        skill_md = skill_dir / "SKILL.md"
+        skill_md.write_text(VALID_SKILL_CONTENT)
+        (tmp_path / "skills").mkdir()
+        (tmp_path / "config.yaml").write_text(
+            "skills:\n"
+            "  external_dirs:\n"
+            f"    - {ext_dir}\n"
+            "  external_dirs_readonly: true\n",
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            from agent.skill_utils import _external_dirs_cache_clear
+
+            _external_dirs_cache_clear()
+            result = _edit_skill("ext-skill", VALID_SKILL_CONTENT_2)
+
+        assert result["success"] is False
+        assert "external_dirs_readonly" in result["error"]
+        assert skill_md.read_text() == VALID_SKILL_CONTENT
+
+    def test_edit_blocked_on_external_skill(self, tmp_path):
+        with self._external_skill_env(tmp_path), \
+             patch("tools.skill_manager_tool._external_dirs_readonly_enabled",
+                   return_value=True):
+            result = _edit_skill("ext-skill", VALID_SKILL_CONTENT_2)
+        assert result["success"] is False
+        assert "external_dirs_readonly" in result["error"]
+
+    def test_patch_blocked_on_external_skill(self, tmp_path):
+        with self._external_skill_env(tmp_path), \
+             patch("tools.skill_manager_tool._external_dirs_readonly_enabled",
+                   return_value=True):
+            result = _patch_skill("ext-skill", "Do the thing.", "Do the new thing.")
+        assert result["success"] is False
+        assert "external_dirs_readonly" in result["error"]
+
+    def test_delete_blocked_on_external_skill(self, tmp_path):
+        with self._external_skill_env(tmp_path), \
+             patch("tools.skill_manager_tool._external_dirs_readonly_enabled",
+                   return_value=True):
+            result = _delete_skill("ext-skill")
+        assert result["success"] is False
+        assert "external_dirs_readonly" in result["error"]
+
+    def test_write_file_blocked_on_external_skill(self, tmp_path):
+        with self._external_skill_env(tmp_path), \
+             patch("tools.skill_manager_tool._external_dirs_readonly_enabled",
+                   return_value=True):
+            result = _write_file("ext-skill", "references/api.md", "# API")
+        assert result["success"] is False
+        assert "external_dirs_readonly" in result["error"]
+
+    def test_remove_file_blocked_on_external_skill(self, tmp_path):
+        with self._external_skill_env(tmp_path), \
+             patch("tools.skill_manager_tool._external_dirs_readonly_enabled",
+                   return_value=True):
+            result = _remove_file("ext-skill", "references/api.md")
+        assert result["success"] is False
+        assert "external_dirs_readonly" in result["error"]
+
+    def test_create_not_blocked_on_external_skill(self, tmp_path):
+        """create always writes to local ~/.hermes/skills/, never to external."""
+        with self._external_skill_env(tmp_path), \
+             patch("tools.skill_manager_tool._external_dirs_readonly_enabled",
+                   return_value=True):
+            result = _create_skill("new-local-skill", VALID_SKILL_CONTENT)
+        assert result["success"] is True
+
+    def test_mutations_allowed_when_flag_off(self, tmp_path):
+        with self._external_skill_env(tmp_path), \
+             patch("tools.skill_manager_tool._external_dirs_readonly_enabled",
+                   return_value=False):
+            result = _edit_skill("ext-skill", VALID_SKILL_CONTENT_2)
+        assert result["success"] is True
+
+    def test_flag_reads_config_default_false(self):
+        """_external_dirs_readonly_enabled preserves the foreground contract by default."""
+        from tools.skill_manager_tool import _external_dirs_readonly_enabled
+        with patch("hermes_cli.config.load_config", return_value={"skills": {}}):
+            assert _external_dirs_readonly_enabled() is False
+
+    def test_flag_reads_config_when_set_false(self):
+        from tools.skill_manager_tool import _external_dirs_readonly_enabled
+        with patch("hermes_cli.config.load_config",
+                   return_value={"skills": {"external_dirs_readonly": False}}):
+            assert _external_dirs_readonly_enabled() is False
+
+    def test_flag_handles_config_error(self):
+        """If load_config raises, preserve the foreground-edit contract."""
+        from tools.skill_manager_tool import _external_dirs_readonly_enabled
+        with patch("hermes_cli.config.load_config", side_effect=RuntimeError("boom")):
+            assert _external_dirs_readonly_enabled() is False
 
 
 # ---------------------------------------------------------------------------

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -118,6 +118,47 @@ def _guard_agent_created_enabled() -> bool:
         return False
 
 
+def _external_dirs_readonly_enabled() -> bool:
+    """Read skills.external_dirs_readonly from config (default False).
+
+    When enabled, skill_manage rejects mutations on skills located in
+    external_dirs. Users can opt in by setting
+    ``skills.external_dirs_readonly: true`` in config.yaml.
+    """
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        return is_truthy_value(
+            cfg_get(cfg, "skills", "external_dirs_readonly"),
+            default=False,
+        )
+    except Exception:
+        return False  # preserve the foreground-edit contract
+
+
+def _check_external_dirs_readonly(name: str, skill_dir: Path) -> Optional[str]:
+    """Return an error string if the skill is in an external dir and readonly is on.
+
+    Returns None when the mutation is allowed (either the skill is local, or
+    readonly is disabled).
+    """
+    if not _external_dirs_readonly_enabled():
+        return None
+
+    from agent.skill_utils import is_external_skill_path
+
+    if is_external_skill_path(skill_dir):
+        return (
+            f"Skill '{name}' is in an external directory ({skill_dir}) and "
+            f"skills.external_dirs_readonly is enabled. Skills managed by an "
+            f"external package manager should not be modified directly — changes "
+            f"will be lost on the next update. Set "
+            f"`skills.external_dirs_readonly: false` in config.yaml to allow "
+            f"modifications, or copy the skill to ~/.hermes/skills/ first."
+        )
+    return None
+
+
 def _security_scan_skill(skill_dir: Path) -> Optional[str]:
     """Scan a skill directory after write. Returns error string if blocked, else None.
 
@@ -875,6 +916,11 @@ def _edit_skill(name: str, content: str) -> Dict[str, Any]:
     if guard:
         return guard
 
+    # External dirs readonly guard
+    guard_err = _check_external_dirs_readonly(name, existing["path"])
+    if guard_err:
+        return {"success": False, "error": guard_err}
+
     skill_md = existing["path"] / "SKILL.md"
     read_guard = _background_review_read_before_write_guard(
         name, skill_md, "edit", "SKILL.md"
@@ -931,6 +977,11 @@ def _patch_skill(
     existing = _find_skill(name)
     if not existing:
         return {"success": False, "error": _skill_not_found_error(name)}
+
+    # External dirs readonly guard
+    guard_err = _check_external_dirs_readonly(name, existing["path"])
+    if guard_err:
+        return {"success": False, "error": guard_err}
 
     skill_dir = existing["path"]
     guard = _background_review_write_guard(name, skill_dir, "patch")
@@ -1050,6 +1101,11 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
     if fail_closed:
         return fail_closed
 
+    # External dirs readonly guard
+    guard_err = _check_external_dirs_readonly(name, existing["path"])
+    if guard_err:
+        return {"success": False, "error": guard_err}
+
     pinned_err = _pinned_guard(name)
     if pinned_err:
         return {"success": False, "error": pinned_err}
@@ -1160,6 +1216,11 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
     if guard:
         return guard
 
+    # External dirs readonly guard
+    guard_err = _check_external_dirs_readonly(name, existing["path"])
+    if guard_err:
+        return {"success": False, "error": guard_err}
+
     target, err = _resolve_skill_target(existing["path"], file_path)
     if err:
         return {"success": False, "error": err}
@@ -1200,6 +1261,11 @@ def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
     existing = _find_skill(name)
     if not existing:
         return {"success": False, "error": _skill_not_found_error(name)}
+
+    # External dirs readonly guard
+    guard_err = _check_external_dirs_readonly(name, existing["path"])
+    if guard_err:
+        return {"success": False, "error": guard_err}
 
     skill_dir = existing["path"]
     guard = _background_review_write_guard(name, skill_dir, "remove_file")

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -330,8 +330,8 @@ Paths support `~` expansion and `${VAR}` environment variable substitution.
 
 ### How it works
 
-- **Create locally, update in place**: New agent-created skills are written to `~/.hermes/skills/`. Existing skills are modified where they are found, including skills under `external_dirs`, when the agent uses `skill_manage` actions such as `patch`, `edit`, `write_file`, `remove_file`, or `delete`.
-- **External dirs are not a write-protection boundary**: If an external skill directory is writable by the Hermes process, agent-managed skill updates can change files in that directory. Use filesystem permissions or a separate profile/toolset setup if shared external skills must stay read-only.
+- **Create locally, update in place by default**: New agent-created skills are written to `~/.hermes/skills/`. Existing skills are normally modified where they are found, including skills under `external_dirs`, when the agent uses `skill_manage` actions such as `patch`, `edit`, `write_file`, `remove_file`, or `delete`. Set `skills.external_dirs_readonly: true` to reject those mutations for external skills.
+- **External-dir protection is opt-in**: External skills are often managed by an external package manager such as `npx skills` or Git. Enable `skills.external_dirs_readonly` when direct agent mutations must not be lost on the next update. If the flag is disabled and the directory is writable, agent-managed skill updates can change files there. Filesystem permissions remain an independent boundary.
 - **Local precedence**: If the same skill name exists in both the local dir and an external dir, the local version wins.
 - **Full integration**: External skills appear in the system prompt index, `skills_list`, `skill_view`, and as `/skill-name` slash commands — no different from local skills.
 - **Non-existent paths are silently skipped**: If a configured directory doesn't exist, Hermes ignores it without errors. Useful for optional shared directories that may not be present on every machine.


### PR DESCRIPTION
## What

Adds `skills.external_dirs_readonly` as an opt-in guard for skills in external directories.

Skills in `external_dirs` are typically managed by an external package manager (npx skills, git, etc.). When enabled, the guard prevents `skill_manage` from modifying them, avoiding changes that may be silently overwritten on the next update.

The default remains `false` to preserve the existing foreground-edit contract. Users can enable protection with:

```yaml
skills:
  external_dirs_readonly: true
```

The guard reuses the canonical `is_external_skill_path` helper. New skills are still created locally.

## How to test

1. Add an external directory to `config.yaml`:

   ```yaml
   skills:
     external_dirs:
       - ~/test-external-skills
   ```

2. Create a skill there and run Hermes.

3. Set `skills.external_dirs_readonly: true` and try to patch it via `skill_manage`. The operation should fail with an error mentioning `external_dirs_readonly`.

4. Remove the flag or set it to `false`. The foreground patch should be allowed again.

5. Run:

   ```bash
   python -m pytest tests/tools/test_skill_manager_tool.py -v
   ```

   Expected: 118 passed, including real temporary-`HERMES_HOME` config-path coverage.

## Platforms tested

- Linux (WSL2)

## Related

- Relates to #32497 (Hermes unexpectedly modifies its own skills during normal task execution)
- Relates to #25083 (immutable skills feature request)
