### PR TITLE
fix(gateway): stop honoring stale planned-stop markers on Windows + name the stopper

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17187,6 +17187,30 @@ def _run_planned_stop_watcher(
                 if not planned_stop_marker_targets_self():
                     stop_event.wait(poll_interval)
                     continue
+                # Name who asked us to stop *before* firing. The marker records
+                # the stopper's PID and argv at write time, so this survives the
+                # stopper exiting — unlike the shutdown forensics' parent lookup,
+                # which logs '(unknown)' once the stopper is gone. This is the
+                # key line for diagnosing "the gateway keeps dying" on Windows.
+                try:
+                    from gateway.status import describe_planned_stop_marker
+                    _stopper = describe_planned_stop_marker()
+                except Exception:
+                    _stopper = None
+                logger.warning(
+                    "Planned-stop marker targets this gateway (pid=%s); "
+                    "initiating clean shutdown. Stopper: %s",
+                    os.getpid(),
+                    _stopper or "unknown",
+                )
+                try:
+                    import traceback as _tb
+                    logger.debug(
+                        "Planned-stop watcher fire stack:\n%s",
+                        "".join(_tb.format_stack()),
+                    )
+                except Exception:
+                    pass
                 # Drive the same path as a real signal handler.
                 # Pass signal=None — the handler tolerates that and consumes
                 # the marker via consume_planned_stop_marker_for_self,
@@ -17531,11 +17555,18 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         # external kill unless the CLI marks it first. SIGINT comes from an
         # interactive Ctrl+C and is likewise an intentional foreground stop.
         planned_stop = False
+        planned_stop_who = None
         if received_signal == signal.SIGINT:
             planned_stop = True
         elif not planned_takeover:
             try:
-                from gateway.status import consume_planned_stop_marker_for_self
+                from gateway.status import (
+                    consume_planned_stop_marker_for_self,
+                    describe_planned_stop_marker,
+                )
+                # Capture who wrote the marker BEFORE the consume unlinks it,
+                # so the "exiting cleanly" line names the exact stopper command.
+                planned_stop_who = describe_planned_stop_marker()
                 planned_stop = consume_planned_stop_marker_for_self()
             except Exception as e:
                 logger.debug("Planned stop marker check failed: %s", e)
@@ -17564,8 +17595,9 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             )
         elif planned_stop:
             logger.info(
-                "Received %s as a planned gateway stop — exiting cleanly",
+                "Received %s as a planned gateway stop — exiting cleanly%s",
                 _shutdown_ctx["signal"] if _shutdown_ctx else "SIGTERM/SIGINT",
+                f" (stopper: {planned_stop_who})" if planned_stop_who else "",
             )
         else:
             _signal_initiated_shutdown = True

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -965,6 +965,14 @@ _TAKEOVER_MARKER_FILENAME = ".gateway-takeover.json"
 _TAKEOVER_MARKER_TTL_S = 60  # Marker older than this is treated as stale
 _PLANNED_STOP_MARKER_FILENAME = ".gateway-planned-stop.json"
 _PLANNED_STOP_MARKER_TTL_S = 60
+# When a marker's ``target_start_time`` is unavailable on either side we fall
+# back to PID equality (see ``_pid_marker_matches_self``). PID reuse can then
+# let a marker written for a dead predecessor match a freshly booted gateway
+# that inherited the recycled PID. As a second line of defence we reject any
+# marker written *before* this process started — a legitimate stop of a running
+# gateway is always requested after it booted. The slack absorbs clock
+# granularity / same-instant boots so a genuine stop is never dropped.
+_MARKER_BOOT_SLACK_S = 5.0
 
 
 def _get_takeover_marker_path() -> Path:
@@ -986,6 +994,89 @@ def _marker_is_stale(written_at: str, ttl_s: int) -> bool:
         return age > ttl_s
     except (TypeError, ValueError):
         return True
+
+
+def _safe_stopper_argv() -> list:
+    """Best-effort snapshot of THIS process's argv, for stop diagnostics.
+
+    Recorded in the marker so the gateway can name *which command* stopped it
+    even after the stopper has exited — which is the common case. The shutdown
+    forensics' ``parent_cmdline`` reads ``(unknown)`` precisely because the
+    process that wrote the marker is already gone by the time the gateway acts
+    on it. ``sys.argv`` needs no psutil and is always available. Capped so a
+    pathological argv can't bloat the marker.
+    """
+    try:
+        return [str(a) for a in sys.argv[:12]]
+    except Exception:
+        return []
+
+
+def _get_process_create_epoch(pid: int) -> Optional[float]:
+    """Return ``pid``'s creation time as float epoch seconds, or ``None``.
+
+    Unlike :func:`_get_process_start_time` (an opaque, platform-specific
+    fingerprint meant only for equality checks), this is a wall-clock epoch
+    directly comparable to a marker's ISO ``written_at``. psutil is a hard
+    dependency and exposes ``create_time`` on every platform, so this is the
+    reliable cross-platform "when did this process start" used by the
+    boot-time staleness guard.
+    """
+    try:
+        import psutil  # type: ignore
+
+        return float(psutil.Process(pid).create_time())
+    except Exception:
+        return None
+
+
+def _marker_predates_process(written_at: str, pid: int) -> bool:
+    """True when ``written_at`` is safely *before* ``pid`` started.
+
+    A marker written before this process existed can never legitimately name
+    it — it belongs to a predecessor that happened to share the recycled PID.
+    Conservative by design: returns ``False`` whenever the timestamp can't be
+    parsed or the process create-time is unavailable, so a real stop is never
+    misclassified as stale.
+    """
+    try:
+        written_dt = datetime.fromisoformat(written_at)
+    except (TypeError, ValueError):
+        return False
+    create_epoch = _get_process_create_epoch(pid)
+    if create_epoch is None:
+        return False
+    try:
+        return written_dt.timestamp() < (create_epoch - _MARKER_BOOT_SLACK_S)
+    except (OverflowError, OSError, ValueError):
+        return False
+
+
+def _pid_marker_matches_self(
+    target_pid: int,
+    target_start_time: Optional[int],
+    written_at: str,
+) -> bool:
+    """Shared identity check for planned-stop / takeover markers.
+
+    Used by both the authoritative consume and the watcher's non-destructive
+    probe so they can never disagree about whether a marker targets us.
+
+    A marker matches when it names our PID *and* either:
+      * both start-times are known and equal (exact identity), or
+      * a start-time is unavailable on either side (psutil hiccup / older
+        marker) AND the marker was not written before we booted.
+
+    The boot-time clause is what makes PID reuse safe when start-time matching
+    is unavailable — see ``_MARKER_BOOT_SLACK_S``.
+    """
+    our_pid = os.getpid()
+    if target_pid != our_pid:
+        return False
+    our_start_time = _get_process_start_time(our_pid)
+    if target_start_time is not None and our_start_time is not None:
+        return target_start_time == our_start_time
+    return not _marker_predates_process(written_at, our_pid)
 
 
 def _consume_pid_marker_for_self(
@@ -1017,26 +1108,19 @@ def _consume_pid_marker_for_self(
             pass
         return False
 
-    our_pid = os.getpid()
-    our_start_time = _get_process_start_time(our_pid)
-    # Start-time is a PID-reuse guard. It is only meaningful when both
-    # sides actually have it: ``_get_process_start_time`` returns None on
-    # platforms without ``/proc`` (macOS, native Windows — the very
-    # platform the planned-stop watcher exists for). Requiring a non-None
-    # match there would make every consume return False, so a legitimate
-    # ``hermes gateway stop`` on Windows would be misclassified as an
-    # unexpected ``UNKNOWN`` exit (exit 1) and revived by the service
-    # manager. So: when both start_times are known they must match; when
-    # either is unknown, fall back to PID equality alone (bounded by the
-    # marker's short TTL). This mirrors ``planned_stop_marker_targets_self``
-    # so the watcher's non-destructive probe and this authoritative
-    # consume agree on every platform (issue #34597).
-    if target_pid != our_pid:
-        matches = False
-    elif target_start_time is not None and our_start_time is not None:
-        matches = target_start_time == our_start_time
-    else:
-        matches = True
+    # Start-time is a PID-reuse guard. It is only meaningful when both sides
+    # actually have it: ``_get_process_start_time`` returns None when psutil
+    # can't read a process (and historically on platforms without ``/proc``).
+    # Requiring a non-None match there would make every consume return False,
+    # so a legitimate ``hermes gateway stop`` on Windows would be misclassified
+    # as an unexpected ``UNKNOWN`` exit (exit 1) and revived by the service
+    # manager. So: when both start_times are known they must match; when either
+    # is unknown, fall back to PID equality — but reject markers written before
+    # we booted so a recycled PID can't resurrect a predecessor's marker. This
+    # shares ``_pid_marker_matches_self`` with ``planned_stop_marker_targets_self``
+    # so the watcher's non-destructive probe and this authoritative consume
+    # agree on every platform (issues #34597, #33778).
+    matches = _pid_marker_matches_self(target_pid, target_start_time, written_at)
 
     try:
         path.unlink(missing_ok=True)
@@ -1063,6 +1147,7 @@ def write_takeover_marker(target_pid: int) -> bool:
             "target_pid": target_pid,
             "target_start_time": target_start_time,
             "replacer_pid": os.getpid(),
+            "stopper_argv": _safe_stopper_argv(),
             "written_at": _utc_now_iso(),
         }
         _write_json_file(_get_takeover_marker_path(), record)
@@ -1111,6 +1196,7 @@ def write_planned_stop_marker(target_pid: int) -> bool:
             "target_pid": target_pid,
             "target_start_time": target_start_time,
             "stopper_pid": os.getpid(),
+            "stopper_argv": _safe_stopper_argv(),
             "written_at": _utc_now_iso(),
         }
         _write_json_file(_get_planned_stop_marker_path(), record)
@@ -1139,11 +1225,11 @@ def planned_stop_marker_targets_self() -> bool:
     the authoritative consume on its own thread.
 
     It *does* clean up markers that can never apply to this process:
-    malformed markers and markers older than the TTL are unlinked so a
-    stale file left behind by a previous gateway instance cannot wedge
-    the new one. Markers naming a different PID/start_time are left in
-    place (they may still be consumed legitimately by the process they
-    name) but report False here.
+    malformed markers, markers older than the TTL, and markers that name our
+    own PID but were written before we booted (a recycled PID from a dead
+    predecessor) are unlinked so a stale file cannot wedge the new gateway.
+    Markers naming a different live PID are left in place (they may still be
+    consumed legitimately by the process they name) but report False here.
 
     Returns False (without raising) on any read/parse error.
     """
@@ -1173,22 +1259,101 @@ def planned_stop_marker_targets_self() -> bool:
             pass
         return False
 
-    our_pid = os.getpid()
-    if target_pid != our_pid:
-        return False
+    # Shared identity check (see ``_pid_marker_matches_self``): same PID plus
+    # either a start-time match or, when start-time is unavailable, a marker
+    # written after we booted. The probe is non-destructive on a match — the
+    # shutdown handler does the authoritative consume on the loop thread.
+    if _pid_marker_matches_self(target_pid, target_start_time, written_at):
+        return True
 
-    # Start-time is a PID-reuse guard. It is only meaningful when both
-    # sides actually have it: ``_get_process_start_time`` returns None on
-    # platforms without ``/proc`` (macOS, native Windows — the very
-    # platform this watcher exists for). Requiring a non-None match there
-    # would make the watcher never fire and re-break the #33778 Windows
-    # session-resume path. So: when both start_times are known they must
-    # match; when either is unknown, fall back to PID equality alone
-    # (the marker is short-lived under a 60s TTL, bounding reuse risk).
-    our_start_time = _get_process_start_time(our_pid)
-    if target_start_time is not None and our_start_time is not None:
-        return target_start_time == our_start_time
-    return True
+    # Self-heal: a marker that names OUR PID but doesn't match us belongs to a
+    # dead predecessor whose PID we recycled (start-time mismatch, or it
+    # predates our boot). Nobody will ever consume it legitimately, so unlink
+    # it rather than let it linger until the TTL. Foreign-PID markers are left
+    # alone — they may belong to the live process they name.
+    if target_pid == os.getpid():
+        try:
+            path.unlink(missing_ok=True)
+        except OSError:
+            pass
+    return False
+
+
+def _describe_stop_marker_record(record: dict) -> str:
+    """Format a planned-stop marker into a one-line "who stopped us" summary.
+
+    Surfaces the recorded ``stopper_pid`` and ``stopper_argv`` (captured when
+    the marker was written, so they survive the stopper exiting) plus the
+    marker age and a best-effort live lookup of the stopper process. This is
+    the single most useful line for diagnosing "the gateway keeps dying":
+    it names the exact command that asked the gateway to stop.
+    """
+    parts = [f"target_pid={record.get('target_pid')}"]
+    stopper_pid = record.get("stopper_pid")
+    if stopper_pid is not None:
+        parts.append(f"stopper_pid={stopper_pid}")
+    argv = record.get("stopper_argv")
+    if isinstance(argv, list) and argv:
+        try:
+            cmd = shlex.join(str(a) for a in argv)
+        except Exception:
+            cmd = " ".join(str(a) for a in argv)
+        parts.append(f"stopper_cmd={cmd!r}")
+    written_at = record.get("written_at")
+    if written_at:
+        parts.append(f"written_at={written_at}")
+        try:
+            age = (
+                datetime.now(timezone.utc) - datetime.fromisoformat(written_at)
+            ).total_seconds()
+            parts.append(f"age={age:.1f}s")
+        except (TypeError, ValueError):
+            pass
+    live = _resolve_live_process(stopper_pid)
+    parts.append(f"stopper_live={live or 'gone'}")
+    return " ".join(parts)
+
+
+def _resolve_live_process(pid: Any) -> Optional[str]:
+    """Return ``name(cmdline)`` for a live ``pid``, or None if gone/unreadable.
+
+    Best-effort and bounded — the stopper is usually already gone by the time
+    we look (which is exactly why the marker records argv at write time).
+    """
+    try:
+        pid = int(pid)
+    except (TypeError, ValueError):
+        return None
+    try:
+        import psutil  # type: ignore
+
+        proc = psutil.Process(pid)
+        name = proc.name()
+        try:
+            cmd = " ".join(proc.cmdline())
+        except Exception:
+            cmd = ""
+        if cmd:
+            return f"{name}({cmd[:200]})"
+        return name
+    except Exception:
+        return None
+
+
+def describe_planned_stop_marker() -> Optional[str]:
+    """One-line description of who wrote the live planned-stop marker.
+
+    Non-destructive. Used by the watcher and shutdown handler to log *which
+    process* asked the gateway to stop. Returns None when there is no readable
+    marker.
+    """
+    record = _read_json_file(_get_planned_stop_marker_path())
+    if not record:
+        return None
+    try:
+        return _describe_stop_marker_record(record)
+    except Exception:
+        return None
 
 
 def clear_planned_stop_marker() -> None:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8351,13 +8351,14 @@ def _write_update_planned_stop_marker(profile_path: Path, pid: int) -> bool:
     try:
         from datetime import timezone
 
-        from gateway.status import _get_process_start_time
+        from gateway.status import _get_process_start_time, _safe_stopper_argv
         from utils import atomic_json_write
 
         record = {
             "target_pid": pid,
             "target_start_time": _get_process_start_time(pid),
             "stopper_pid": os.getpid(),
+            "stopper_argv": _safe_stopper_argv(),
             "written_at": datetime.now(timezone.utc).isoformat(),
         }
         atomic_json_write(

--- a/tests/gateway/test_planned_stop_watcher.py
+++ b/tests/gateway/test_planned_stop_watcher.py
@@ -391,3 +391,54 @@ def test_planned_stop_marker_targets_self_drops_malformed(tmp_path, monkeypatch)
     monkeypatch.setattr(status_mod, "_get_planned_stop_marker_path", lambda: marker)
 
     assert status_mod.planned_stop_marker_targets_self() is False
+
+
+def test_watcher_does_not_fire_for_pid_reuse_marker_predating_boot(
+    tmp_path, monkeypatch
+):
+    """A marker naming our PID but written before we booted must not fire.
+
+    This is the Windows PID-reuse scenario the task targets: a previous gateway
+    was stopped (marker written for its PID with start_time unavailable), it
+    exited, Windows recycled its PID for THIS gateway, and the marker is still
+    within its 60s TTL. The boot-time guard rejects it because it predates our
+    start, and the probe self-heals by unlinking it.
+    """
+    marker = tmp_path / ".gateway-planned-stop.json"
+    # Same PID, no start_time (the psutil-unavailable fallback), fresh enough
+    # to survive the TTL but written before we "booted".
+    record = {
+        "target_pid": os.getpid(),
+        "target_start_time": None,
+        "stopper_pid": 4242,
+        "stopper_argv": ["hermes", "gateway", "stop"],
+        "written_at": status_mod._utc_now_iso(),
+    }
+    marker.write_text(json.dumps(record), encoding="utf-8")
+
+    monkeypatch.setattr(status_mod, "_get_planned_stop_marker_path", lambda: marker)
+    monkeypatch.setattr(status_mod, "_get_process_start_time", lambda pid: None)
+    # Pretend this process started 100s AFTER the marker was written.
+    now = time.time()
+    monkeypatch.setattr(status_mod, "_get_process_create_epoch", lambda pid: now + 100)
+
+    runner = _FakeRunner(running=True, draining=False)
+    loop = _make_loop_capturing_calls()
+    shutdown_handler = MagicMock(name="shutdown_signal_handler")
+    stop_event = threading.Event()
+
+    watcher = threading.Thread(
+        target=_run_planned_stop_watcher,
+        args=(stop_event, runner, loop, shutdown_handler),
+        kwargs={"poll_interval": 0.05},
+        daemon=True,
+    )
+    watcher.start()
+    time.sleep(0.3)
+    stop_event.set()
+    watcher.join(timeout=2.0)
+
+    assert not watcher.is_alive()
+    assert loop._captured == [], "Watcher fired on a PID-reuse marker predating boot"
+    shutdown_handler.assert_not_called()
+    assert not marker.exists(), "Stale PID-reuse marker should be self-healed"

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -1072,6 +1072,113 @@ class TestPlannedStopMarker:
         assert result is False
 
 
+class TestPlannedStopBootTimeGuard:
+    """Boot-time staleness guard for the PID-only fallback (Windows PID reuse).
+
+    When ``target_start_time`` is unavailable on either side we fall back to
+    PID equality. PID reuse can then let a marker written for a dead predecessor
+    match a freshly booted gateway that inherited the recycled PID. The guard
+    rejects any marker written *before* this process started.
+    """
+
+    def test_write_marker_records_stopper_argv(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 42)
+        monkeypatch.setattr(status.sys, "argv", ["hermes", "gateway", "stop"])
+
+        assert status.write_planned_stop_marker(target_pid=12345) is True
+
+        payload = json.loads((tmp_path / ".gateway-planned-stop.json").read_text())
+        assert payload["stopper_argv"] == ["hermes", "gateway", "stop"]
+
+    def test_consume_rejects_marker_written_before_boot(self, tmp_path, monkeypatch):
+        """PID-reuse defence: a marker predating our boot must not match.
+
+        Both start_times are unavailable (the Windows fallback), the PID
+        matches, and the TTL is fresh — but the marker was written before this
+        process started, so it belongs to a dead predecessor with the same PID.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: None)
+        # We "started" 100s after the marker was written.
+        from datetime import datetime, timezone
+        now = datetime.now(timezone.utc).timestamp()
+        monkeypatch.setattr(status, "_get_process_create_epoch", lambda pid: now + 100)
+
+        assert status.write_planned_stop_marker(target_pid=os.getpid()) is True
+
+        assert status.consume_planned_stop_marker_for_self() is False
+        assert not (tmp_path / ".gateway-planned-stop.json").exists()
+
+    def test_consume_matches_marker_written_after_boot(self, tmp_path, monkeypatch):
+        """The fallback still accepts a legit stop issued after we booted."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: None)
+        from datetime import datetime, timezone
+        now = datetime.now(timezone.utc).timestamp()
+        # We started well before the marker was written.
+        monkeypatch.setattr(status, "_get_process_create_epoch", lambda pid: now - 100)
+
+        assert status.write_planned_stop_marker(target_pid=os.getpid()) is True
+
+        assert status.consume_planned_stop_marker_for_self() is True
+
+    def test_targets_self_unlinks_stale_pid_reuse_marker(self, tmp_path, monkeypatch):
+        """The watcher probe self-heals a same-PID marker for a dead predecessor.
+
+        Both start_times are known but DIFFER (PID reuse), so the marker can't
+        be ours. It names our PID, so nobody else will consume it — the probe
+        unlinks it rather than leaving it to wedge us until the TTL.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        marker_path = tmp_path / ".gateway-planned-stop.json"
+        # Marker captured start_time 111; our live start_time is 222.
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 111)
+        status.write_planned_stop_marker(target_pid=os.getpid())
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 222)
+
+        assert status.planned_stop_marker_targets_self() is False
+        assert not marker_path.exists(), "stale same-PID marker should self-heal"
+
+    def test_targets_self_leaves_foreign_pid_marker(self, tmp_path, monkeypatch):
+        """A marker naming a DIFFERENT live PID is left in place."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        marker_path = tmp_path / ".gateway-planned-stop.json"
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 111)
+        status.write_planned_stop_marker(target_pid=os.getpid() + 9999)
+
+        assert status.planned_stop_marker_targets_self() is False
+        assert marker_path.exists(), "foreign-PID marker must not be unlinked"
+
+    def test_describe_planned_stop_marker_names_stopper(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 42)
+        monkeypatch.setattr(status.sys, "argv", ["hermes", "gateway", "stop"])
+        status.write_planned_stop_marker(target_pid=4321)
+
+        desc = status.describe_planned_stop_marker()
+
+        assert desc is not None
+        assert "target_pid=4321" in desc
+        assert f"stopper_pid={os.getpid()}" in desc
+        assert "gateway" in desc and "stop" in desc
+
+    def test_describe_planned_stop_marker_returns_none_when_absent(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        assert status.describe_planned_stop_marker() is None
+
+    def test_marker_predates_process_is_conservative(self, monkeypatch):
+        # Unparseable timestamp → never treat as stale.
+        assert status._marker_predates_process("not-a-date", os.getpid()) is False
+        # Unknown create time → never treat as stale.
+        monkeypatch.setattr(status, "_get_process_create_epoch", lambda pid: None)
+        from datetime import datetime, timezone
+        old = (datetime(2000, 1, 1, tzinfo=timezone.utc)).isoformat()
+        assert status._marker_predates_process(old, os.getpid()) is False
+
+
 class TestReadProcessCmdlinePsFallback:
     """Tests for _read_process_cmdline falling back to ps on non-Linux."""
 


### PR DESCRIPTION
## Symptom

On native Windows the gateway repeatedly shuts itself down **mid-task**, logging:

```
INFO  gateway.run: Received UNKNOWN as a planned gateway stop — exiting cleanly
WARNING gateway.run: Shutdown context: signal=UNKNOWN under_systemd=no parent_pid=… parent_name=? parent_cmdline='(unknown)'
```

This happened ~10×/day on the affected machine. `gateway-exit-diag.log` shows every one of these is a **clean** exit (`asyncio.run.returned success=true`, `gateway.exit_clean`) — not a crash. `signal=UNKNOWN` means the planned-stop **watcher thread** fired (it passes `signal=None`), i.e. a `.gateway-planned-stop.json` marker naming the gateway's PID was present, so the gateway drained and exited and autoheal restarted it minutes later.

## Root cause

Two distinct problems:

1. **No attribution.** There was no way to tell *who* wrote the marker. Shutdown forensics logs `parent_cmdline=(unknown)` because the writer (a `hermes gateway stop`/`restart` or `hermes update` invocation — typically spawned by the desktop app's auto-update / restart flow) has already exited by the time the gateway acts on the marker. `desktop.log` on the affected box shows a repeating `[updates] restart … launched updater: hermes-setup.exe --update` cycle.

2. **PID-reuse hole.** The marker carries the target's `start_time` as a PID-reuse guard, but `_get_process_start_time()` returns `None` whenever the target is already dead at marker-write time (psutil `NoSuchProcess`) or psutil is unavailable. With start_time unavailable, the identity check fell back to **PID equality alone**, so a marker written for a dead predecessor could match a freshly-booted gateway that recycled the same PID (within the 60s TTL) and shut it down.

## Fix

- **Name the stopper.** Record `stopper_pid` + `stopper_argv` in every planned-stop / takeover / update marker at write time, and log it both when the watcher fires and when the gateway classifies the exit. `gateway.log` now names the exact command that stopped the gateway (survives the stopper exiting, unlike the parent lookup).
- **Boot-time staleness guard** (`_marker_predates_process`): a marker written *before* this process started can never legitimately name it, so it is rejected even when start_time matching is unavailable. Conservative — only fires when the process create-time is known and the marker is older by more than a 5s slack, so a real stop of a running gateway is always honored.
- **One shared identity check** (`_pid_marker_matches_self`) for both the watcher's non-destructive probe and the authoritative consume, so they can never disagree across platforms.
- **Self-heal**: the probe now unlinks a same-PID marker that fails the identity check (dead predecessor) instead of leaving it to wedge the gateway until the TTL. Foreign live-PID markers are still left in place.

Legitimate `hermes gateway stop` / restart / update flows are unaffected: their markers are written *after* the target booted and match PID + start_time.

## Files changed

- `gateway/status.py` — boot-time guard, shared identity check, stopper diagnostics (`stopper_argv`, `describe_planned_stop_marker`), self-heal.
- `gateway/run.py` — log the stopper when the watcher fires and in the "exiting cleanly" line.
- `hermes_cli/main.py` — record `stopper_argv` in the update-flow marker.
- `tests/gateway/test_status.py`, `tests/gateway/test_planned_stop_watcher.py` — boot-guard + diagnostics coverage.

## Tests

- `tests/gateway/test_planned_stop_watcher.py` + `tests/gateway/test_status.py`: **98 passed**.
- `tests/hermes_cli/test_gateway_windows.py`, `tests/gateway/test_shutdown_forensics.py`, `tests/hermes_cli/test_gateway_service.py`, `tests/hermes_cli/test_update_concurrent_quarantine.py`: green.
- Pre-existing unrelated failures in `tests/hermes_cli/test_service_manager.py` (POSIX-only `os.chown`, can't run on Windows; that file is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)