### PR TITLE
fix(feishu): add timeout to outbound send calls to prevent chat lock starvation

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -191,6 +191,7 @@ _FEISHU_DOC_UPLOAD_TYPES = {
 _MAX_TEXT_INJECT_BYTES = 100 * 1024
 _FEISHU_CONNECT_ATTEMPTS = 3
 _FEISHU_SEND_ATTEMPTS = 3
+_FEISHU_SEND_TIMEOUT_SECONDS = float(os.getenv("FEISHU_SEND_TIMEOUT_SECONDS", "30"))
 _FEISHU_APP_LOCK_SCOPE = "feishu-app-id"
 _DEFAULT_TEXT_BATCH_DELAY_SECONDS = 0.6
 _DEFAULT_TEXT_BATCH_MAX_MESSAGES = 8
@@ -4420,7 +4421,10 @@ class FeishuAdapter(BasePlatformAdapter):
                 uuid_value=str(uuid.uuid4()),
             )
             request = self._build_reply_message_request(effective_reply_to, body)
-            return await asyncio.to_thread(self._client.im.v1.message.reply, request)
+            return await asyncio.wait_for(
+                asyncio.to_thread(self._client.im.v1.message.reply, request),
+                timeout=_FEISHU_SEND_TIMEOUT_SECONDS,
+            )
 
         # For topic/thread messages that fell back from reply→create, use
         # thread_id as receive_id so the message lands in the topic instead of
@@ -4450,7 +4454,10 @@ class FeishuAdapter(BasePlatformAdapter):
                 uuid_value=str(uuid.uuid4()),
             )
             request = self._build_create_message_request(receive_id_type, body)
-        return await asyncio.to_thread(self._client.im.v1.message.create, request)
+        return await asyncio.wait_for(
+            asyncio.to_thread(self._client.im.v1.message.create, request),
+            timeout=_FEISHU_SEND_TIMEOUT_SECONDS,
+        )
 
     @staticmethod
     def _response_succeeded(response: Any) -> bool:


### PR DESCRIPTION
## Bug Description

In production use, the Feishu/Lark gateway adapter would occasionally stop responding to a user for several minutes (observed 4–12 minutes) before either recovering on its own or requiring a gateway restart.

The bot appeared alive in the Feishu client but every new message from the user just queued up with no reply.

## Root Cause

`FeishuAdapter._send_raw_message` wraps the synchronous lark SDK calls in `asyncio.to_thread` with **no timeout**:

```python
return await asyncio.to_thread(self._client.im.v1.message.create, request)
```

If the lark SDK or its underlying HTTP client hangs (server-side stall on Feishu's side, dropped TCP connection that the SDK doesn't notice, DNS hang on reconnect, etc.), this `await` never returns.

Inbound messages are serialized per-chat via `async with self._chat_locks[chat_id]` (see `FeishuAdapter._get_chat_lock` / line 2888). A hung outbound send therefore **holds the per-chat lock for the entire hang duration**, so every subsequent inbound message on the same chat queues behind the stuck turn. From the user's perspective the bot is completely frozen.

## Fix

Wrap both send paths in `asyncio.wait_for(..., timeout=...)` with a configurable timeout (default 30s, env var `FEISHU_SEND_TIMEOUT_SECONDS`).

```python
return await asyncio.wait_for(
    asyncio.to_thread(self._client.im.v1.message.create, request),
    timeout=_FEISHU_SEND_TIMEOUT_SECONDS,
)
```

When the timeout fires:
1. `asyncio.wait_for` raises `TimeoutError`.
2. The existing retry logic in `_feishu_send_with_retry` catches it (3 attempts × 1/2/4s back-off) and retries — the SDK may simply have been transiently slow.
3. If all 3 attempts time out, the exception propagates up through `send()`, which returns `SendResult(success=False, error=...)`. The `async with chat_lock` block exits, the lock is released, and the next queued inbound message can be processed normally.

### Why 30 seconds?

Keeps the per-attempt timeout just above the existing retry budget so a single slow-but-successful request is not penalized, while bounding the worst case at ~90s (3 attempts × 30s + 1+2+4s back-off) instead of unbounded.

## How to Verify

1. Apply the patch to a Feishu-enabled Hermes install.
2. From Feishu, send the bot a message that triggers a long-ish reply (e.g. one that causes an image upload + send — 22:50 series in my gateway log showed the lock surviving for 12 minutes during a multi-image exchange).
3. Manually block outbound HTTP from the gateway to `open.feishu.cn` (e.g. `sudo pfctl` rule, or a temporary firewall block).
4. Send another message to the bot.

**Before the patch**: the chat will appear frozen for as long as the network block stays in place (minutes to indefinitely).

**After the patch**: within ~30s the first send attempt times out, retries fire, and within ~90s the lock is released and the next inbound message is processed normally. Logs will show `[Feishu] Send attempt N/3 failed for chat …; retrying in Ns: …` instead of silent silence.

## Test Plan

- [x] Manual reproduction: confirmed two distinct 4-minute and 12-minute hangs in production logs (chat `oc_3657446d5c8a31fd949f4befb0b696cd`, sender `ou_cef50af949e6f5db0e5bde53e253461d`) on June 23, 2026.
- [ ] Existing `tests/gateway/test_feishu.py` should continue to pass — the change is purely additive (a timeout around an existing await).
- [ ] Ideally add a regression test that monkey-patches `_send_raw_message` to sleep past the timeout and asserts that the chat lock is released after the configured budget. Happy to add this in a follow-up commit if maintainers prefer it landed separately.

## Risk Assessment

**Low.**

- Change is purely additive: it bounds an existing unbounded wait, it does not change the success path or retry semantics.
- Default 30s is comfortably above the SDK's normal response time (typically <1s) so no false-positive timeouts in the happy path.
- The new env var `FEISHU_SEND_TIMEOUT_SECONDS` defaults to the new behaviour, so existing installs are unaffected unless they opt in — wait, that's backwards; the new behaviour is the default and the env var lets users *extend* the timeout. If maintainers prefer the timeout to be opt-in, happy to flip the default to `0` (disabled) and document it that way.
- Blast radius: only the Feishu adapter's outbound send path. No effect on other platforms, no effect on inbound handling, no schema/migration changes.