### PR TITLE
fix(skills): prune uninstalled skill from disabled config

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1091,6 +1091,31 @@ def do_uninstall(name: str, console: Optional[Console] = None,
     success, msg = uninstall_skill(name)
     if success:
         c.print(f"[bold green]{msg}[/]\n")
+        # Prune any lingering disable entry so a future re-install of the same
+        # skill isn't silently disabled. The config.yaml disable state
+        # (skills.disabled / skills.platform_disabled) is separate from the hub
+        # lock file, which uninstall_skill already reconciles on its own.
+        try:
+            from hermes_cli.config import load_config, save_config
+            cfg = load_config()
+            skills_cfg = cfg.get("skills")
+            if isinstance(skills_cfg, dict):
+                changed = False
+                global_disabled = skills_cfg.get("disabled")
+                if isinstance(global_disabled, list) and name in global_disabled:
+                    skills_cfg["disabled"] = [s for s in global_disabled if s != name]
+                    changed = True
+                platform_disabled = skills_cfg.get("platform_disabled")
+                if isinstance(platform_disabled, dict):
+                    for platform, names in list(platform_disabled.items()):
+                        if isinstance(names, list) and name in names:
+                            platform_disabled[platform] = [s for s in names if s != name]
+                            changed = True
+                if changed:
+                    save_config(cfg)
+        except Exception:
+            # Best-effort: a config prune must never abort a successful uninstall.
+            pass
         if invalidate_cache:
             try:
                 from agent.prompt_builder import clear_skills_system_prompt_cache

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1096,8 +1096,12 @@ def do_uninstall(name: str, console: Optional[Console] = None,
         # (skills.disabled / skills.platform_disabled) is separate from the hub
         # lock file, which uninstall_skill already reconciles on its own.
         try:
-            from hermes_cli.config import load_config, save_config
-            cfg = load_config()
+            # Use read_raw_config() (not load_config()) so we touch ONLY the
+            # user's on-disk keys. load_config() deep-merges DEFAULT_CONFIG and
+            # expands env refs, so save_config() of that result would rewrite
+            # config.yaml with large unrelated churn from this narrow cleanup.
+            from hermes_cli.config import read_raw_config, save_config
+            cfg = read_raw_config()
             skills_cfg = cfg.get("skills")
             if isinstance(skills_cfg, dict):
                 changed = False
@@ -1113,9 +1117,14 @@ def do_uninstall(name: str, console: Optional[Console] = None,
                             changed = True
                 if changed:
                     save_config(cfg)
-        except Exception:
-            # Best-effort: a config prune must never abort a successful uninstall.
-            pass
+        except Exception as e:
+            # Best-effort: a config prune must never abort a successful uninstall,
+            # but surface a hint so the "silently disabled on reinstall" symptom
+            # isn't reintroduced without any trace when the prune fails.
+            c.print(
+                f"[yellow]Warning:[/] could not prune '{name}' from disabled "
+                f"skills config: {e}"
+            )
         if invalidate_cache:
             try:
                 from agent.prompt_builder import clear_skills_system_prompt_cache

--- a/tests/hermes_cli/test_skills_skip_confirm.py
+++ b/tests/hermes_cli/test_skills_skip_confirm.py
@@ -12,6 +12,7 @@ Updated for PR #3586 (cache-aware install/uninstall).
 
 from unittest.mock import patch
 
+import yaml
 
 
 class TestHandleSkillsSlashInstallFlags:
@@ -171,3 +172,65 @@ class TestDoUninstallSkipConfirm:
              patch("builtins.input", return_value="n"):
             do_uninstall("test-skill", skip_confirm=False)
             mock_uninstall.assert_not_called()
+
+
+class TestDoUninstallPrunesDisableConfig:
+    """A successful uninstall must also clear the skill's lingering disable
+    state in config.yaml (skills.disabled / skills.platform_disabled), which is
+    stored separately from the hub lock file. Otherwise a later re-install of
+    the same name comes back silently disabled and the enabled/disabled count
+    is wrong.
+    """
+
+    def test_uninstall_prunes_global_and_platform_disabled(self, tmp_path, monkeypatch):
+        from hermes_cli.skills_hub import do_uninstall
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "skills:\n"
+            "  disabled:\n"
+            "    - my-skill\n"
+            "    - keep-skill\n"
+            "  platform_disabled:\n"
+            "    telegram:\n"
+            "      - my-skill\n"
+            "      - keep-skill\n"
+            "    cli:\n"
+            "      - keep-skill\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("HERMES_MANAGED", raising=False)
+
+        with patch("hermes_cli.skills_hub._console"), \
+             patch("tools.skills_hub.uninstall_skill", return_value=(True, "Removed")):
+            do_uninstall("my-skill", skip_confirm=True, invalidate_cache=False)
+
+        saved = yaml.safe_load(config_path.read_text())
+        skills_cfg = saved["skills"]
+        # The uninstalled skill is gone from both global and per-platform lists...
+        assert "my-skill" not in skills_cfg.get("disabled", [])
+        assert "my-skill" not in skills_cfg.get("platform_disabled", {}).get("telegram", [])
+        # ...while unrelated disable entries are left untouched.
+        assert "keep-skill" in skills_cfg.get("disabled", [])
+        assert "keep-skill" in skills_cfg.get("platform_disabled", {}).get("telegram", [])
+        assert "keep-skill" in skills_cfg.get("platform_disabled", {}).get("cli", [])
+
+    def test_uninstall_without_disable_entry_is_noop(self, tmp_path, monkeypatch):
+        """A skill that was never disabled must not perturb config on uninstall."""
+        from hermes_cli.skills_hub import do_uninstall
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "skills:\n"
+            "  disabled:\n"
+            "    - other-skill\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("HERMES_MANAGED", raising=False)
+
+        with patch("hermes_cli.skills_hub._console"), \
+             patch("tools.skills_hub.uninstall_skill", return_value=(True, "Removed")):
+            do_uninstall("my-skill", skip_confirm=True, invalidate_cache=False)
+
+        saved = yaml.safe_load(config_path.read_text())
+        assert saved["skills"]["disabled"] == ["other-skill"]


### PR DESCRIPTION
## What does this PR do?

`hermes skills uninstall <name>` removed the skill from the hub lock file but left the skill's entry in `skills.disabled` / `skills.platform_disabled` in `config.yaml`. That config disable-state is stored and reconciled **separately** from the hub lock file — `uninstall_skill()` only pops the lock entry (`tools/skills_hub.py`), and nothing pruned the config side.

The orphaned entry has two user-visible consequences:

1. A later re-install of the same skill name comes back **silently disabled** — the agent never loads it and there is no hint why.
2. The `hermes skills` enabled/disabled summary count is wrong, because it still counts the uninstalled name as a disabled skill.

This prunes the uninstalled name from the global disabled list and from every `platform_disabled[*]` entry in `do_uninstall`, right after a successful uninstall. The prune is best-effort: an unreadable/locked config must never abort an otherwise-successful uninstall.

The fix lives in the CLI layer (`hermes_cli/skills_hub.py:do_uninstall`), which already owns config and already depends on `tools` — `do_uninstall` is the only production caller of `uninstall_skill`. The hub lock-file layer (`tools/`) is left untouched and gains no new dependency on `hermes_cli`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/skills_hub.py` — in `do_uninstall`, after a successful `uninstall_skill`, prune the uninstalled name from `skills.disabled` and every `skills.platform_disabled[*]` list in `config.yaml`, then `save_config` only if something changed. Wrapped best-effort so a config failure cannot break the uninstall.
- `tests/hermes_cli/test_skills_skip_confirm.py` — regression tests covering (a) prune of both global and per-platform disabled entries while leaving unrelated entries intact, and (b) no-op when the uninstalled skill was never disabled.

## How to Test

1. Disable a skill globally and on a platform: it lands in `skills.disabled` and `skills.platform_disabled[<platform>]` in `~/.hermes/config.yaml`.
2. Uninstall that skill: `hermes skills uninstall <name>`.
3. Inspect `config.yaml` — the name is gone from both `skills.disabled` and `platform_disabled`; unrelated disabled skills are untouched.
4. Re-install the same skill — it is enabled, not silently disabled.

Regression test (fails before the fix, passes after):

```
pytest tests/hermes_cli/test_skills_skip_confirm.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A (pure config-list manipulation, no path/OS-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A