### PR TITLE
fix(kanban): include review column in kanban stats text output

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2387,7 +2387,7 @@ def _cmd_stats(args: argparse.Namespace) -> int:
         print(json.dumps(stats, indent=2, ensure_ascii=False))
         return 0
     print("By status:")
-    for k in ("triage", "todo", "scheduled", "ready", "running", "blocked", "done"):
+    for k in ("triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done"):
         print(f"  {k:8s}  {stats['by_status'].get(k, 0)}")
     if stats["by_assignee"]:
         print("\nBy assignee:")

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -852,6 +852,35 @@ def test_cli_stats_json(kanban_home):
     assert "oldest_ready_age_seconds" in data
 
 
+def test_cli_stats_text_includes_review_status(kanban_home):
+    """The plain-text (non --json) stats output must list the `review` status.
+
+    `review` is a first-class non-archived status in VALID_STATUSES and is
+    counted by board_stats, but the text renderer's hardcoded status tuple
+    had drifted and omitted it — so tasks awaiting the review agent were
+    invisible in the default board summary.
+    """
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="awaiting review")
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'review' WHERE id = ?",
+                (tid,),
+            )
+    finally:
+        conn.close()
+    out = run_slash("stats")
+    assert "review" in out
+    # The review task is counted on its row, not silently dropped.
+    review_line = next(
+        (ln for ln in out.splitlines() if ln.strip().startswith("review")),
+        None,
+    )
+    assert review_line is not None
+    assert review_line.split()[-1] == "1"
+
+
 def test_cli_notify_subscribe_and_list(kanban_home):
     tid = run_slash("create 'x' --json")
     tid = json.loads(tid)["id"]


### PR DESCRIPTION
## What does this PR do?

`hermes kanban stats` (plain-text, non-`--json`) never printed the `review` status row, so any task sitting in `review` — a worker opened a PR and is awaiting the review agent — was invisible in the default board summary. The operator HUD silently under-reported in-flight work.

`review` is a first-class non-archived status: it is in `VALID_STATUSES` (`hermes_cli/kanban_db.py`), it is live in transitions (`claim_review_task`, the spawn-ready review loop), and `board_stats` already counts it (`GROUP BY status WHERE status != 'archived'`). So `stats["by_status"]["review"]` exists — the text renderer just never emitted it.

The hardcoded status tuple in the `_cmd_stats` text path had drifted from `VALID_STATUSES` when the `review` status was added. The `--json` path was unaffected because it dumps `board_stats` verbatim.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban.py` — add `"review"` to the `_cmd_stats` text-output status loop, in lifecycle order (after `"blocked"`), so it matches `VALID_STATUSES`.
- `tests/hermes_cli/test_kanban_core_functionality.py` — regression test that moves a task to `review` and asserts the plain-text `stats` output lists the `review` row with its count.

## How to Test

1. Create a task and move it to `review`.
2. Run `hermes kanban stats` (no `--json`).
3. The `review` row appears under "By status" with the correct count (before this fix it was missing entirely).

Regression test (fails before the fix, passes after):

```
pytest tests/hermes_cli/test_kanban_core_functionality.py::test_cli_stats_text_includes_review_status -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A (pure output formatting)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A