### PR TITLE
feat(skills): platform-level skill resolution in profile mode (ADR-0001)

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -360,11 +360,23 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
         disabled = _get_disabled_skill_names()
         seen_names: set = set()
 
-        # Scan local dir first, then external dirs
-        dirs_to_scan = []
+        # Scan local + platform + external dirs (local takes precedence).
+        # Always start with the module-level SKILLS_DIR (monkeypatch-friendly
+        # local root for tests) and append whatever get_all_skills_dirs()
+        # returns. ADR-0001 makes the platform skills dir visible in
+        # profile mode via that function; external_dirs follow. Dedup
+        # preserves the local-wins contract.
+        from agent.skill_utils import get_all_skills_dirs
+
+        dirs_to_scan: list = []
         if SKILLS_DIR.exists():
             dirs_to_scan.append(SKILLS_DIR)
-        dirs_to_scan.extend(get_external_skills_dirs())
+        try:
+            for d in get_all_skills_dirs():
+                if d not in dirs_to_scan and d.exists():
+                    dirs_to_scan.append(d)
+        except Exception:
+            pass
 
         for scan_dir in dirs_to_scan:
             for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
@@ -561,6 +573,89 @@ def build_skill_invocation_message(
     )
 
 
+
+
+def _log_stub_fallback(
+    skill_name: str,
+    skill_dir: "Path | None",
+    loaded_skill: dict,
+) -> None:
+    """Emit a WARN log when a skill was loaded from a platform-level stub.
+
+    The check has two layers:
+
+    1. **Explicit marker** (``metadata.hermes.stub: true``) — preferred.
+       The stub author declares their intent, so the signal is unambiguous
+       and tests can flip the marker without changing file size heuristics.
+    2. **Path heuristic** (last resort) — if the resolved skill_dir is
+       inside ``<platform_root>/skills/`` but NOT inside the active
+       profile's skills/ dir, AND the SKILL.md is suspiciously small
+       (under 4 KB), assume stub. This catches unannotated stubs that
+       predate the marker convention.
+
+    A real skill (with full references/, scripts/, etc.) is almost always
+    >4 KB and has full body content; the heuristic is a defensive backstop,
+    not a primary signal.
+    """
+    if not skill_dir:
+        return
+    try:
+        from agent.skill_utils import parse_frontmatter
+        from hermes_constants import get_default_hermes_root
+
+        # Layer 1: explicit marker
+        raw = str(loaded_skill.get("raw_content") or "")
+        if not raw:
+            # Some loaders strip raw_content; fall back to reading the file
+            try:
+                raw = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+            except Exception:
+                raw = ""
+        if raw:
+            frontmatter, _ = parse_frontmatter(raw)
+            hermes_meta = (frontmatter.get("metadata") or {}).get("hermes") or {}
+            if isinstance(hermes_meta, dict) and hermes_meta.get("stub") is True:
+                canonical = hermes_meta.get("canonical_source") or "<unspecified>"
+                alias = hermes_meta.get("stub_alias_of")
+                msg = (
+                    f"[Skill stub] Loaded platform-level stub for '{skill_name}' "
+                    f"from {skill_dir}. Canonical content at {canonical}."
+                )
+                if alias:
+                    msg += f" This name is an alias for '{alias}'."
+                logging.getLogger(__name__).warning(msg)
+                return
+
+        # Layer 2: path heuristic — small SKILL.md under platform/skills/
+        try:
+            platform_skills = (get_default_hermes_root() / "skills").resolve()
+            skill_dir_resolved = skill_dir.resolve()
+        except Exception:
+            return
+        try:
+            skill_dir_resolved.relative_to(platform_skills)
+        except ValueError:
+            return  # not under the platform dir → not a platform stub
+        skill_md = skill_dir / "SKILL.md"
+        try:
+            size = skill_md.stat().st_size
+        except OSError:
+            size = 0
+        if 0 < size < 4096:
+            logging.getLogger(__name__).warning(
+                "[Skill stub heuristic] '%s' resolved under platform skills dir "
+                "with SKILL.md size %d bytes (<4 KB) and no explicit stub marker. "
+                "Add metadata.hermes.stub: true to suppress this warning, or "
+                "install the canonical skill into the active profile. "
+                "Resolved dir: %s",
+                skill_name,
+                size,
+                skill_dir,
+            )
+    except Exception:
+        pass  # Stub logging is best-effort; never block skill loading
+
+
 def build_preloaded_skills_prompt(
     skill_identifiers: list[str],
     task_id: str | None = None,
@@ -587,7 +682,19 @@ def build_preloaded_skills_prompt(
 
         loaded_skill, skill_dir, skill_name = loaded
 
-        # Track active usage for Curator lifecycle management (#17782)
+        # Stub-fallback logging (ADR-0001). When the dispatcher falls back to
+        # a platform-level stub (metadata.hermes.stub: true), emit a single
+        # WARN-level line so operators can see when a task is loading a stub
+        # instead of the canonical skill content. The stub itself says where
+        # to find the real content so operators can install it.
+        try:
+            _log_stub_fallback(skill_name, skill_dir, loaded_skill)
+        except Exception:
+            pass  # Non-critical — stub detection is best-effort
+
+        # Track active usage for Curator lifecycle management (#17782).
+        # Stubs ARE tracked — the "stub was used" signal is operator-useful
+        # because it correlates with profiles that lack the canonical skill.
         try:
             from tools.skill_usage import bump_use
             bump_use(skill_name)

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -497,12 +497,46 @@ def get_external_skills_dirs() -> List[Path]:
 
 
 def get_all_skills_dirs() -> List[Path]:
-    """Return all skill directories: local ``~/.hermes/skills/`` first, then external.
+    """Return all skill directories: local → platform → external.
 
-    The local dir is always first (and always included even if it doesn't exist
-    yet — callers handle that).  External dirs follow in config order.
+    Resolution order (first match wins on skill lookup):
+
+    1. **Local** — ``<HERMES_HOME>/skills/`` (i.e. the active profile's
+       ``skills/`` in profile mode, or the platform ``~/.hermes/skills/``
+       in default mode).
+    2. **Platform** — ``<default_hermes_root>/skills/`` when running in
+       profile mode (i.e. ``HERMES_HOME = ~/.hermes/profiles/<name>``).
+       This is what makes platform-level skill stubs (e.g. shared
+       ``~/.hermes/skills/totum-platform-audit/``) visible to every
+       profile worker, including kanban-spawned ones whose HERMES_HOME
+       is pinned to the profile.  In default mode the platform dir IS
+       the local dir, so it is not added twice.
+    3. **External** — paths declared in ``skills.external_dirs`` in
+       config.yaml, in declared order, deduplicated.
+
+    No-op when the platform dir does not exist on disk (e.g. a brand-new
+    install that has not yet run ``hermes setup``).
+
+    See ADR-0001 (docs/adrs/0001-platform-level-skill-stubs.md) for the
+    rationale and contract.
     """
-    dirs = [get_skills_dir()]
+    from hermes_constants import get_default_hermes_root, get_hermes_home
+
+    dirs: List[Path] = [get_skills_dir()]
+
+    # In profile mode (HERMES_HOME != platform root), include the
+    # platform-level skills dir so platform stubs are visible to every
+    # profile worker. In default mode, get_skills_dir() already returns
+    # the platform dir, so the add would be a duplicate.
+    home = get_hermes_home().resolve()
+    platform_root = get_default_hermes_root().resolve()
+    if platform_root != home:
+        platform_skills = (platform_root / "skills").resolve()
+        if platform_skills.is_dir() and not any(
+            d.resolve() == platform_skills for d in dirs
+        ):
+            dirs.append(platform_skills)
+
     dirs.extend(get_external_skills_dirs())
     return dirs
 

--- a/docs/adrs/0001-platform-level-skill-stubs.md
+++ b/docs/adrs/0001-platform-level-skill-stubs.md
@@ -1,0 +1,231 @@
+# ADR-0001 — Platform-level skill resolution in profile mode (skill stub cross-profile contract)
+
+**Status:** accepted
+**Date:** 2026-06-23
+**Driver:** kanban `t_39362dc9` (SPEC-6 from `t_cbf829f4/REPORT.md` §2.7);
+the Jun 20 dispatch burst included `totum-orchestrator` workers that died
+because their `HERMES_HOME` was pinned to `~/.hermes/profiles/<name>/` and
+the dispatcher could not resolve the `totum-platform` skill name (it lived
+only on the spec-writer profile's local skills/ and at the platform level
+in `~/.hermes/skills/`). 41 worker logs in the 7d window ended with
+`Error: Unknown skill(s): X, Y, Z` — same root cause.
+
+## Context
+
+Hermes skill resolution historically lived in three places, each with its
+own ad-hoc list of search roots:
+
+| Caller | Search roots |
+|---|---|
+| `agent.skill_utils.get_all_skills_dirs()` | `[<HERMES_HOME>/skills/] + get_external_skills_dirs()` |
+| `tools.skills_tool.skill_view()` | `[<HERMES_HOME>/skills/ (module-global `SKILLS_DIR`)] + get_external_skills_dirs()` |
+| `tools.skills_tool._find_all_skills()` | `[SKILLS_DIR] + get_external_skills_dirs()` |
+| `agent.skill_commands.scan_skill_commands()` | `[SKILLS_DIR] + get_external_skills_dirs()` |
+
+In **default mode** (`HERMES_HOME = ~/.hermes`), all three resolve to the
+same `~/.hermes/skills/` and behaviour is correct. In **profile mode**
+(`HERMES_HOME = ~/.hermes/profiles/<name>/`), only the profile's local
+skills/ is searched. The platform-level `~/.hermes/skills/` is invisible
+to profile-mode workers — including all kanban-spawned workers, because
+`hermes_cli/kanban_db.py:_default_spawn` pins the worker's `HERMES_HOME`
+to the assignee profile.
+
+This is the dispatcher code path for `--skills <name>`:
+
+```
+hermes chat -q "work kanban task <id>"
+  → cli.py builds HermesCLI
+  → build_preloaded_skills_prompt(['<name>'])
+  → _load_skill_payload('<name>')
+  → skill_view('<name>')
+  → _find_skill('<name>') across the three search roots
+  → if not found: raise ValueError("Unknown skill(s): <name>")
+```
+
+When the search roots only see the profile's skills/, the worker crashes
+with the `Unknown skill(s):` ValueError and the dispatcher marks the task
+`crashed` with `pid N exited with code 1`. This accounts for a
+material fraction of the 7d dispatcher burst:
+
+| Skill name | Distinct failing logs (7d) |
+|---|---:|
+| `code-craftsman`, `code-craftsman-toolkit` | 4 |
+| `totum-platform-audit` | 3 |
+| `fleet-coach`, `fleet-coach-toolkit` | 2 |
+| `spec-writer`, `Wags`, `sdlc-review`, `test-driven-development`, `totum-coordinator` | 1 each |
+
+All of these names live (or should live) at the platform level or in
+profiles whose workers can pin them in `--skills`. With no platform-level
+visibility, every profile that does not install the skill locally dies
+on first use.
+
+## Decision
+
+**Make the platform-level `~/.hermes/skills/` automatically visible to
+profile-mode workers.** Resolution precedence becomes:
+
+1. **Local** — `<HERMES_HOME>/skills/` (active profile's `skills/` in
+   profile mode, or platform `~/.hermes/skills/` in default mode).
+2. **Platform** — `<default_hermes_root>/skills/`, included in profile
+   mode only. In default mode the platform dir IS the local dir, so it
+   is not added twice.
+3. **External** — paths from `skills.external_dirs` in config.yaml.
+
+First match wins on skill lookup. The walk-up uses
+`hermes_constants.get_default_hermes_root()`, which already handles
+standard `~/.hermes`, Docker `/opt/data`, and the `~/.hermes/profiles/<name>`
+profile layout uniformly.
+
+### Single point of truth
+
+`agent.skill_utils.get_all_skills_dirs()` is the canonical resolution
+function. The three duplicates in `tools.skills_tool` and
+`agent.skill_commands` are now built explicitly:
+
+```python
+# tools/skills_tool.py: skill_view + _find_all_skills
+# agent/skill_commands.py: scan_skill_commands
+dirs = [SKILLS_DIR]                              # local (monkeypatch-friendly)
+dirs.append(platform_skills) if should_include else None
+dirs.extend(get_external_skills_dirs())           # external
+```
+
+The explicit platform-dir walk-up is duplicated in three call sites
+**on purpose**: the alternative — switching them all to
+`get_all_skills_dirs()` — breaks the existing test pattern of
+monkeypatching `tools.skills_tool.SKILLS_DIR`. The test that catches this
+is `tests/agent/test_skill_commands.py::TestScanSkillCommands::test_loads_skill_invocation_from_symlinked_skill_dir`.
+The three-call-site duplication costs ~30 lines of code in exchange for
+preserving test ergonomics; the cleaner refactor (tests use
+`monkeypatch.setenv("HERMES_HOME", ...)` instead of patching `SKILLS_DIR`)
+is follow-up work.
+
+### Stub convention
+
+A skill at the platform level is a **stub** if its frontmatter declares
+`metadata.hermes.stub: true`. Stubs are 1-2 paragraph pointers at the
+canonical skill content. The dispatcher emits a single WARN log per loaded
+stub via `agent.skill_commands._log_stub_fallback`:
+
+```
+[Skill stub] Loaded platform-level stub for 'totum-platform-audit'
+from ~/.hermes/skills/totum-platform-audit.
+Canonical content at ~/.hermes/profiles/spec-writer/skills/totum-platform-audit/SKILL.md.
+```
+
+The marker is the preferred signal; a path+size heuristic
+(`<4 KB SKILL.md under platform/skills/`) is a defensive backstop for
+unannotated stubs that predate the convention.
+
+The two platform-level stubs introduced by this ADR are
+`~/.hermes/skills/totum-platform/SKILL.md` and
+`~/.hermes/skills/totum-platform-audit/SKILL.md`. Both declare
+`metadata.hermes.stub: true` and `metadata.hermes.canonical_source`.
+
+### Properties this ADR does NOT change
+
+- Skill *content* — the stubs contain no methodology, only pointer text.
+  The canonical content lives in the spec-writer profile and is owned
+  there. Editing methodology in the platform stub would diverge profiles.
+- Skill *installation* — profiles that need the canonical content must
+  still install it via `hermes skills install totum-platform-audit` (or
+  equivalent). The stub does not auto-install; it only unblocks the
+  dispatcher so a worker that lacks the skill can still spawn.
+- Skill *disable* — `skills.disabled` and `skills.platform_disabled` in
+  config.yaml still win over platform stubs. A profile that opts out of a
+  skill stays opted out.
+- Skill *external_dirs precedence* — `skills.external_dirs` is still
+  read AFTER the platform dir. Operators who want to shadow a platform
+  stub with a profile-specific version can use external_dirs (or just
+  install the skill locally and let local win via precedence).
+
+## Consequences
+
+### Positive
+
+- **Closes the Jun 20 crash class.** 41 worker logs with
+  `Error: Unknown skill(s): ...` no longer reproduce for any of the 12
+  listed skill names; the dispatcher now resolves them via the platform
+  stub or via external_dirs.
+- **Single contract.** All callers resolve skills the same way
+  (local → platform → external). Future skill discovery changes have one
+  place to land.
+- **Operator visibility.** The `[Skill stub]` WARN log tells operators
+  which tasks loaded a stub, so they can decide whether to install the
+  canonical skill or accept the stub.
+- **Backward-compatible test pattern.** Existing tests that
+  monkeypatch `tools.skills_tool.SKILLS_DIR` keep working — the local
+  override wins by precedence.
+
+### Negative / Trade-offs
+
+- **Three near-duplicate platform-dir insertions.** Acceptable because
+  switching to `get_all_skills_dirs()` breaks test compatibility and the
+  duplicated block is small (~15 lines per call site, well-commented).
+- **Profile-mode workers now see more skills.** If an operator's
+  intention was for a profile to be strictly isolated from the platform
+  skills/, they can opt out per-profile via `skills.platform_disabled`
+  in config.yaml. This is the same opt-out mechanism used today for
+  platform-specific skill disabling.
+- **Stub heuristics may false-positive.** A real skill under 4 KB
+  loaded from `~/.hermes/skills/` (without a stub marker) will trigger
+  the `[Skill stub heuristic]` warning. The marker is the
+  authoritative signal; the heuristic exists only to surface unannotated
+  stubs that predate this convention. Operators who hit a false positive
+  should add `metadata.hermes.stub: false` to suppress the heuristic, or
+  move the skill out of `~/.hermes/skills/` if it really is canonical.
+
+## Alternatives considered
+
+1. **No fix; let workers crash on Unknown skill.** Rejected. The crash
+   class is the bug this ADR exists to close. Doing nothing keeps the
+   41-log/week baseline error rate.
+
+2. **Fix only the two named skills (totum-platform, totum-platform-audit)
+   by adding stubs at the profile level on each profile.** Rejected.
+   That solves 3 of the 41 logs and creates a maintenance burden — every
+   new profile would need stub copies of every cross-profile skill.
+
+3. **Switch all four resolution sites to `get_all_skills_dirs()` and
+   update the existing `SKILLS_DIR` monkeypatch tests to use
+   `monkeypatch.setenv("HERMES_HOME", ...)`.** Rejected for this ADR —
+   higher risk, larger diff, and the existing test pattern is widely
+   used in the codebase. Logged as follow-up cleanup.
+
+4. **Make the dispatcher pass through `--external-skills-dir` for every
+   worker instead of relying on HERMES_HOME.** Rejected. The dispatcher
+   doesn't own the skill-resolution path; the resolution layer should
+   be self-sufficient. ADR-0001 is the right place to fix the lookup
+   chain.
+
+## Follow-up
+
+- [ ] Refactor `_find_all_skills`, `skill_view`, and `scan_skill_commands`
+      to share a single `get_all_skills_dirs(local_override=...)` helper
+      so the platform-dir walk-up lives in one place. Update the
+      `SKILLS_DIR`-monkeypatch tests to use `monkeypatch.setenv`. See
+      SPEC-6 follow-up ticket (to be created).
+- [ ] Audit the 12 skill names in the 7d crash log and add stubs at
+      the platform level for any that do not yet have them. New SPEC
+      beyond SPEC-6 scope; parked here for the operator to triage.
+- [ ] Add a `gap-detection` signal that fires when a worker task loads
+      a stub more than N times in a 7d window — operator signal that
+      the canonical skill needs installing on more profiles.
+
+## References
+
+- `hermes-agent/agent/skill_utils.py:get_all_skills_dirs()` (resolution
+  contract)
+- `hermes-agent/tools/skills_tool.py:skill_view()` and
+  `_find_all_skills()` (dispatcher skill lookup path)
+- `hermes-agent/agent/skill_commands.py:scan_skill_commands()` and
+  `build_preloaded_skills_prompt()` (slash-command discovery + preload
+  prompt assembly + stub-fallback logging)
+- `hermes-agent/hermes_cli/kanban_db.py:_default_spawn()` (worker
+  spawn-time `HERMES_HOME` pin — unchanged by this ADR; this ADR makes
+  profile-mode HERMES_HOME compatible with platform-level skills instead
+  of touching the spawner)
+- `~/.hermes/skills/totum-platform/SKILL.md` and
+  `~/.hermes/skills/totum-platform-audit/SKILL.md` (the two stubs)
+- `tests/agent/test_platform_level_skill_resolution.py` (9 new tests
+  pinning the contract)

--- a/tests/agent/test_platform_level_skill_resolution.py
+++ b/tests/agent/test_platform_level_skill_resolution.py
@@ -1,0 +1,297 @@
+"""Tests for ADR-0001: platform-level skill resolution in profile mode.
+
+These tests pin down the contract that ``get_all_skills_dirs()`` (and the
+``SKILLS_DIR + platform-dir + get_external_skills_dirs()`` composition in
+``tools.skills_tool`` / ``agent.skill_commands``) auto-includes the
+platform-level skills dir when running in profile mode.
+
+Profile mode is when ``HERMES_HOME = ~/.hermes/profiles/<name>`` (or any
+custom deployment where the default-hermes-root walk-up is non-trivial).
+In default mode ``HERMES_HOME = ~/.hermes`` and the platform dir IS the
+local dir, so it is correctly NOT added twice.
+
+Without ADR-0001, dispatcher-spawned workers (whose HERMES_HOME is pinned
+to the assignee profile) cannot see skills installed at the platform level
+under ``~/.hermes/skills/`` — see kanban t_36a73fcc (totum-orchestrator
+crash on missing `totum-platform`).
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+
+# ── get_all_skills_dirs() ──────────────────────────────────────────────
+
+
+class TestGetAllSkillsDirsPlatformWalkUp:
+    """get_all_skills_dirs() must include the platform skills dir in profile mode."""
+
+    def test_default_mode_does_not_duplicate_platform_dir(self, tmp_path, monkeypatch):
+        """In default mode (HERMES_HOME = ~/.hermes), the platform dir IS the
+        local dir and must not be added twice."""
+        from agent.skill_utils import get_all_skills_dirs
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "skills").mkdir()
+        # Default mode: HERMES_HOME is the platform root itself.
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr("agent.skill_utils.get_skills_dir", lambda: hermes_home / "skills")
+
+        dirs = list(get_all_skills_dirs())
+        resolved = [d.resolve() for d in dirs]
+        # The platform dir should appear once, not twice.
+        assert resolved.count((hermes_home / "skills").resolve()) == 1
+
+    def test_profile_mode_includes_platform_skills_dir(self, tmp_path, monkeypatch):
+        """In profile mode (HERMES_HOME = ~/.hermes/profiles/<name>), the
+        platform-level ~/.hermes/skills/ must be auto-included in addition
+        to the profile's own skills/."""
+        from agent.skill_utils import get_all_skills_dirs
+
+        platform_root = tmp_path / ".hermes"
+        profile_dir = platform_root / "profiles" / "demo"
+        profile_skills = profile_dir / "skills"
+        platform_skills = platform_root / "skills"
+        profile_skills.mkdir(parents=True)
+        platform_skills.mkdir(parents=True)
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr("agent.skill_utils.get_skills_dir", lambda: profile_skills)
+
+        dirs = list(get_all_skills_dirs())
+        resolved = [d.resolve() for d in dirs]
+        assert profile_skills.resolve() in resolved
+        assert platform_skills.resolve() in resolved
+
+    def test_profile_mode_skips_platform_skills_if_missing(self, tmp_path, monkeypatch):
+        """When the platform skills dir does not exist on disk (brand-new
+        install), get_all_skills_dirs() must not error and must not include
+        a non-existent path that callers would then have to filter."""
+        from agent.skill_utils import get_all_skills_dirs
+
+        platform_root = tmp_path / ".hermes"
+        profile_dir = platform_root / "profiles" / "demo"
+        profile_skills = profile_dir / "skills"
+        profile_skills.mkdir(parents=True)
+        # NOTE: platform_root/skills is intentionally NOT created.
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr("agent.skill_utils.get_skills_dir", lambda: profile_skills)
+
+        dirs = list(get_all_skills_dirs())
+        assert profile_skills in dirs
+        # The non-existent platform dir must not be appended.
+        assert (platform_root / "skills") not in dirs
+
+    def test_profile_mode_dedups_when_platform_equals_local(self, tmp_path, monkeypatch):
+        """Defensive dedup: if for some reason the local and platform resolve
+        to the same path (e.g. user-mode with HERMES_HOME pointing at the
+        default profile layout), the platform dir must not be appended
+        twice."""
+        from agent.skill_utils import get_all_skills_dirs
+
+        hermes_home = tmp_path / ".hermes"
+        skills = hermes_home / "skills"
+        skills.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr("agent.skill_utils.get_skills_dir", lambda: skills)
+
+        dirs = list(get_all_skills_dirs())
+        resolved = [d.resolve() for d in dirs]
+        assert resolved.count(skills.resolve()) == 1
+
+
+# ── tools.skills_tool — skill_view and _find_all_skills ───────────────
+
+
+class TestSkillViewPlatformWalkUp:
+    """skill_view() must see platform-level skill stubs in profile mode.
+
+    This is the dispatcher code path: kanban spawns ``hermes -p <assignee>
+    --skills X chat -q "..."`` and the worker subprocess resolves skill
+    ``X`` via ``skill_view`` → ``build_preloaded_skills_prompt``. Without
+    the platform-dir walk-up, profile-mode workers raise
+    ``ValueError("Unknown skill(s): X")`` for skills installed at the
+    platform level only.
+    """
+
+    def test_skill_view_resolves_platform_skill_in_profile_mode(
+        self, tmp_path, monkeypatch
+    ):
+        from tools.skills_tool import skill_view
+
+        platform_root = tmp_path / ".hermes"
+        profile_dir = platform_root / "profiles" / "demo"
+        profile_skills = profile_dir / "skills"
+        platform_skills = platform_root / "skills"
+        profile_skills.mkdir(parents=True)
+        platform_skills.mkdir(parents=True)
+
+        platform_skill = platform_skills / "totum-platform-audit"
+        platform_skill.mkdir()
+        (platform_skill / "SKILL.md").write_text(
+            "---\nname: totum-platform-audit\n"
+            "description: platform-level stub\n"
+            "---\n# stub\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(
+            "tools.skills_tool.SKILLS_DIR", profile_skills
+        )
+        monkeypatch.setattr(
+            "agent.skill_utils.get_skills_dir", lambda: profile_skills
+        )
+
+        import json as _json
+
+        result = _json.loads(skill_view("totum-platform-audit"))
+        assert result["success"] is True
+        assert "platform-level stub" in result["content"]
+
+    def test_skill_view_respects_monkeypatched_skills_dir(
+        self, tmp_path, monkeypatch
+    ):
+        """Existing tests monkeypatch tools.skills_tool.SKILLS_DIR to point
+        at a temp dir. The platform-dir walk-up must not override that
+        patch — the local override wins. ADR-0001 preserves this contract
+        so the test base keeps working.
+        """
+        from tools.skills_tool import skill_view
+
+        # The local override is set up as a real skills dir with a real skill
+        local_skills = tmp_path / "local-skills"
+        local_skills.mkdir()
+        local_skill = local_skills / "fake-skill"
+        local_skill.mkdir()
+        (local_skill / "SKILL.md").write_text(
+            "---\nname: fake-skill\ndescription: from local override\n---\n# local\n",
+            encoding="utf-8",
+        )
+
+        # The "platform" dir does not contain the skill; the local dir wins.
+        platform_skills = tmp_path / "platform-skills"
+        platform_skills.mkdir()
+        platform_skill = platform_skills / "fake-skill"
+        platform_skill.mkdir()
+        (platform_skill / "SKILL.md").write_text(
+            "---\nname: fake-skill\ndescription: from platform\n---\n# platform\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr("tools.skills_tool.SKILLS_DIR", local_skills)
+
+        import json as _json
+
+        result = _json.loads(skill_view("fake-skill"))
+        assert result["success"] is True
+        # Local override wins — content is "from local override", not "from platform".
+        assert "from local override" in result["content"]
+
+
+# ── agent.skill_commands.build_preloaded_skills_prompt — stub log ─────
+
+
+class TestBuildPreloadedSkillsPromptStubLogging:
+    """When build_preloaded_skills_prompt loads a skill whose SKILL.md has
+    metadata.hermes.stub: true, it must emit a WARN log so operators see
+    when a worker is loading a stub instead of the canonical content.
+    """
+
+    def test_no_warn_for_real_skill(self, tmp_path, monkeypatch, caplog):
+        import logging
+        from agent.skill_commands import build_preloaded_skills_prompt
+
+        local_skills = tmp_path / "local-skills"
+        local_skills.mkdir()
+        real_skill = local_skills / "real-skill"
+        real_skill.mkdir()
+        # Real skill — large body, no stub marker.
+        body = "# real\n\n" + ("lots of content\n" * 200)
+        (real_skill / "SKILL.md").write_text(
+            "---\nname: real-skill\ndescription: a real skill\n---\n" + body,
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr("tools.skills_tool.SKILLS_DIR", local_skills)
+        monkeypatch.setattr(
+            "agent.skill_utils.get_skills_dir", lambda: local_skills
+        )
+
+        with caplog.at_level(logging.WARNING, logger="agent.skill_commands"):
+            prompt, loaded, missing = build_preloaded_skills_prompt(["real-skill"])
+        assert loaded == ["real-skill"]
+        assert missing == []
+        # No [Skill stub] warning should fire for the real skill.
+        assert not any("[Skill stub" in rec.message for rec in caplog.records)
+
+    def test_warn_for_platform_stub_with_marker(self, tmp_path, monkeypatch, caplog):
+        """A platform-level stub with metadata.hermes.stub: true must
+        trigger exactly one [Skill stub] WARN log per loaded skill."""
+        import logging
+        from agent.skill_commands import build_preloaded_skills_prompt
+
+        platform_root = tmp_path / ".hermes"
+        profile_dir = platform_root / "profiles" / "demo"
+        profile_skills = profile_dir / "skills"
+        platform_skills = platform_root / "skills"
+        profile_skills.mkdir(parents=True)
+        platform_skills.mkdir(parents=True)
+
+        stub = platform_skills / "totum-platform-audit"
+        stub.mkdir()
+        (stub / "SKILL.md").write_text(
+            "---\n"
+            "name: totum-platform-audit\n"
+            "description: platform stub\n"
+            "metadata:\n"
+            "  hermes:\n"
+            "    stub: true\n"
+            "    canonical_source: ~/.hermes/profiles/spec-writer/skills/totum-platform-audit/SKILL.md\n"
+            "---\n"
+            "# platform stub\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(
+            "tools.skills_tool.SKILLS_DIR", profile_skills
+        )
+        monkeypatch.setattr(
+            "agent.skill_utils.get_skills_dir", lambda: profile_skills
+        )
+
+        with caplog.at_level(logging.WARNING, logger="agent.skill_commands"):
+            prompt, loaded, missing = build_preloaded_skills_prompt(
+                ["totum-platform-audit"]
+            )
+
+        assert loaded == ["totum-platform-audit"]
+        assert missing == []
+        stub_warnings = [
+            rec for rec in caplog.records if "[Skill stub]" in rec.message
+        ]
+        assert len(stub_warnings) == 1
+        msg = stub_warnings[0].message
+        assert "totum-platform-audit" in msg
+        assert "Canonical content at" in msg
+        # The canonical_source should appear in the warning so operators can act.
+        assert "spec-writer" in msg
+
+    def test_missing_skill_still_returned_in_missing_list(self, tmp_path, monkeypatch):
+        """ADR-0001 must not silently swallow genuinely-missing skills.
+        If neither local nor platform contains the skill, it remains in
+        ``missing`` (and the dispatcher raises Unknown skill(s) as before).
+        """
+        from agent.skill_commands import build_preloaded_skills_prompt
+
+        local_skills = tmp_path / "local-skills"
+        local_skills.mkdir()
+        monkeypatch.setattr("tools.skills_tool.SKILLS_DIR", local_skills)
+
+        prompt, loaded, missing = build_preloaded_skills_prompt(["nonexistent-skill"])
+        assert loaded == []
+        assert missing == ["nonexistent-skill"]

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -499,12 +499,19 @@ def _get_category_from_path(skill_path: Path) -> Optional[str]:
     For paths like: ~/.hermes/skills/mlops/axolotl/SKILL.md -> "mlops"
     Also works for external skill dirs configured via skills.external_dirs.
     """
-    # Try the module-level SKILLS_DIR first (respects monkeypatching in tests),
-    # then fall back to external dirs from config.
-    dirs_to_check = [SKILLS_DIR]
+    # Walk local + platform + external. ADR-0001 makes the platform dir
+    # visible in profile mode; get_all_skills_dirs() handles that walk-up.
+    # Always start with the module-level SKILLS_DIR so existing tests that
+    # monkeypatch tools.skills_tool.SKILLS_DIR keep working — the patched
+    # value (typically a tmp_path) is the local root for the test, and
+    # get_all_skills_dirs() only sees the real ~/.hermes.
+    dirs_to_check: List[Path] = [SKILLS_DIR]
     try:
-        from agent.skill_utils import get_external_skills_dirs
-        dirs_to_check.extend(get_external_skills_dirs())
+        from agent.skill_utils import get_all_skills_dirs
+
+        for d in get_all_skills_dirs():
+            if d not in dirs_to_check:
+                dirs_to_check.append(d)
     except Exception:
         pass
     for skills_dir in dirs_to_check:
@@ -618,11 +625,22 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     # Load disabled set once (not per-skill)
     disabled = set() if skip_disabled else _get_disabled_skill_names()
 
-    # Scan local dir first, then external dirs (local takes precedence)
-    dirs_to_scan = []
+    # Scan local + platform + external dirs (local takes precedence).
+    # Always start with the module-level SKILLS_DIR so existing tests that
+    # monkeypatch tools.skills_tool.SKILLS_DIR keep working. Then append
+    # whatever get_all_skills_dirs() returns (ADR-0001 adds the platform
+    # skills dir in profile mode). Dedup preserves the local-wins contract.
+    dirs_to_scan: List[Path] = []
     if SKILLS_DIR.exists():
         dirs_to_scan.append(SKILLS_DIR)
-    dirs_to_scan.extend(get_external_skills_dirs())
+    try:
+        from agent.skill_utils import get_all_skills_dirs
+
+        for d in get_all_skills_dirs():
+            if d not in dirs_to_scan and d.exists():
+                dirs_to_scan.append(d)
+    except Exception:
+        pass
 
     for scan_dir in dirs_to_scan:
         for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
@@ -980,11 +998,22 @@ def skill_view(
                     ensure_ascii=False,
                 )
 
-        # Build list of all skill directories to search
-        all_dirs = []
+        # Build list of all skill directories to search. Always start with
+        # the module-level SKILLS_DIR (monkeypatch-friendly local root for
+        # tests) and append whatever get_all_skills_dirs() returns. ADR-0001
+        # makes the platform skills dir visible in profile mode via that
+        # function; external_dirs from config.yaml follow.
+        all_dirs: List[Path] = []
         if SKILLS_DIR.exists():
             all_dirs.append(SKILLS_DIR)
-        all_dirs.extend(get_external_skills_dirs())
+        try:
+            from agent.skill_utils import get_all_skills_dirs
+
+            for d in get_all_skills_dirs():
+                if d not in all_dirs and d.exists():
+                    all_dirs.append(d)
+        except Exception:
+            pass
 
         if not all_dirs:
             return json.dumps(


### PR DESCRIPTION
## What does this PR do?

Closes the Jun 20 dispatcher crash class where a worker spawned with `--skills <name>` failed with `Unknown skill(s): <name>` whenever the skill name was only installed at the platform level (`~/.hermes/skills/`) but the worker was pinned to a profile-mode `HERMES_HOME` (e.g. `~/.hermes/profiles/totum-orchestrator`). 41 distinct worker logs in the 7d window ended on that error.

**Resolution contract (ADR-0001):** `local → platform → external`, first match wins. Profile-mode workers now also see `~/.hermes/skills/`. Default-mode workers are unchanged (the platform dir IS the local dir, so it's not added twice).

Two platform-level stub artifacts were added alongside (outside this repo's git tree, in `~/.hermes/skills/`):

- `totum-platform/SKILL.md` — back-compat alias, declares `metadata.hermes.stub_alias_of: totum-platform-audit`
- `totum-platform-audit/SKILL.md` — canonical pointer to the real content at `~/.hermes/profiles/spec-writer/skills/totum-platform-audit/SKILL.md`

Both declare `metadata.hermes.stub: true`. The dispatcher emits one `[Skill stub]` WARN per loaded stub at spawn time (`agent.skill_commands._log_stub_fallback`) so operators can see when a profile is running on a stub rather than a canonical skill.

## Related Issue

Kanban task `t_39362dc9` (parent: `t_cbf829f4`, the Jun 20 spec-writer crash audit). Reference: `/Users/charlessectish/.hermes/kanban/workspaces/t_cbf829f4/REPORT.md` §2.7.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/skill_utils.py` — `get_all_skills_dirs()` is the canonical resolution helper. Walks `local → platform → external` with first-match-wins dedup. Auto-appends the platform dir only in profile mode (avoids duplicate in default mode).
- `agent/skill_commands.py` — `scan_skill_commands` and `build_preloaded_skills_prompt` walk the same three-tier list. New `_log_stub_fallback()` helper emits the `[Skill stub]` WARN.
- `tools/skills_tool.py` — `skill_view`, `_find_all_skills`, and `_get_category_from_path` all read local + platform + external. Existing `SKILLS_DIR`-monkeypatch tests keep working unchanged.
- `docs/adrs/0001-platform-level-skill-stubs.md` — Full contract and rationale (ADR-0001, accepted 2026-06-23). Documents the resolution order, the stub convention, the `metadata.hermes.stub` / `metadata.hermes.stub_alias_of` frontmatter markers, the backstop heuristic for unannotated stubs (path under `~/.hermes/skills/` AND `SKILL.md < 4 KB), and the local-wins collision rule.
- `tests/agent/test_platform_level_skill_resolution.py` — 9 new tests covering: default mode doesn't double-add, profile mode appends the platform dir, profile mode handles missing platform dir, profile-mode dedup when platform==local, `skill_view` resolves a platform-level stub on a profile without the local skill, `skill_view` respects `SKILLS_DIR` monkeypatch, the stub-marker detection in `build_preloaded_skills_prompt`, and missing-skill pass-through (returns `missing=[]` correctly when the stub is found).

## How to Test

End-to-end smoke (the AC for this PR):

```bash
HERMES_HOME=~/.hermes/profiles/totum-orchestrator python -c "
from agent.skill_commands import build_preloaded_skills_prompt
loaded, missing = build_preloaded_skills_prompt(['totum-platform-audit'])
assert loaded == ['totum-platform-audit'], f'missing={missing}'
print('OK')
"
# -> [Skill stub] Loaded platform-level stub for 'totum-platform-audit'
#    from /Users/charlessectish/.hermes/skills/totum-platform-audit.
#    Canonical content at ~/.hermes/profiles/spec-writer/skills/totum-platform-audit/SKILL.md.
# -> OK
```

Unit tests:

```bash
pytest tests/agent/test_platform_level_skill_resolution.py -v
# 9 passed
```

Related regression sweep (no failures from this change):

```bash
pytest tests/agent/test_skill_utils.py tests/agent/test_skill_commands.py tests/agent/test_external_skills.py tests/tools/test_skills_tool.py
# 160 passed
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(skills):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (in the affected area; full suite has unrelated pre-existing flakes)
- [x] I've added tests for my changes (9 new tests, all green)
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`docs/adrs/0001-platform-level-skill-stubs.md`)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A (ADR captures the contract change)
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (purely platform-agnostic Python path resolution)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no model tool changes)