### PR TITLE
fix: suppress Codex commentary stream deltas

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -438,6 +438,22 @@ def _event_field(event: Any, name: str, default: Any = None) -> Any:
     return value if value is not None else default
 
 
+def _response_item_type(item: Any) -> str:
+    """Return a Responses output item type for attr-style or dict items."""
+    value = getattr(item, "type", None)
+    if value is None and isinstance(item, dict):
+        value = item.get("type")
+    return value if isinstance(value, str) else ""
+
+
+def _response_item_phase(item: Any) -> str:
+    """Return a normalized Responses message phase for attr-style or dict items."""
+    value = getattr(item, "phase", None)
+    if value is None and isinstance(item, dict):
+        value = item.get("phase")
+    return value.strip().lower() if isinstance(value, str) else ""
+
+
 def _raise_stream_error(event: Any) -> None:
     """Raise a ``_StreamErrorEvent`` from a ``type=error`` SSE frame.
 
@@ -487,9 +503,10 @@ def _consume_codex_event_stream(
 
     Callbacks:
 
-    * ``on_text_delta(str)`` — fires per ``response.output_text.delta``, suppressed
-      once a function_call event is seen (so tool-call turns don't bleed text
-      into the chat).
+    * ``on_text_delta(str)`` — fires per final-answer ``response.output_text.delta``.
+      Commentary/analysis phase message items are deliberately suppressed because
+      Codex may emit them immediately before a tool call; surfacing those deltas
+      leaks internal planning into chat gateways.
     * ``on_reasoning_delta(str)`` — fires per ``response.reasoning.*.delta``.
     * ``on_first_delta()`` — one-shot, fires on the first text delta only.
     * ``on_event(event)`` — fires for every event before any other processing.
@@ -500,6 +517,7 @@ def _consume_codex_event_stream(
     collected_text_deltas: List[str] = []
     has_tool_calls = False
     first_delta_fired = False
+    suppress_current_text_item = False
     terminal_status: str = "completed"
     terminal_usage: Any = None
     terminal_response_id: str = None
@@ -533,11 +551,28 @@ def _consume_codex_event_stream(
         if event_type == "error":
             _raise_stream_error(event)
 
+        if event_type == "response.output_item.added":
+            added_item = _event_field(event, "item")
+            item_type = _response_item_type(added_item)
+            if item_type == "function_call":
+                has_tool_calls = True
+                suppress_current_text_item = True
+            elif item_type == "message":
+                # Codex Responses may stream a commentary/analysis message item
+                # immediately before a function_call item.  The text is useful
+                # for the transcript/fallback finalizer but must not be pushed
+                # live to Telegram/Discord as if it were the user-facing answer.
+                suppress_current_text_item = _response_item_phase(added_item) in {
+                    "commentary",
+                    "analysis",
+                }
+            continue
+
         if "output_text.delta" in event_type or event_type == "response.output_text.delta":
             delta_text = _event_field(event, "delta", "")
             if delta_text:
                 collected_text_deltas.append(delta_text)
-                if not has_tool_calls:
+                if not has_tool_calls and not suppress_current_text_item:
                     if not first_delta_fired:
                         first_delta_fired = True
                         if on_first_delta is not None:

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -642,6 +642,76 @@ def test_run_codex_stream_parses_create_stream_events(monkeypatch):
     assert response.status == "completed"
 
 
+def test_codex_stream_suppresses_commentary_phase_text_deltas_before_tool_call():
+    """Commentary output_text deltas are transcript material, not live chat text.
+
+    Codex can emit a commentary-phase message immediately before a function_call
+    in the same Responses stream. If we push those deltas through the gateway
+    stream consumer, Telegram receives the model's private todo/planning note.
+    """
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    streamed = []
+    commentary_item = SimpleNamespace(
+        type="message",
+        phase="commentary",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="Need update todo done.")],
+    )
+    tool_item = SimpleNamespace(
+        type="function_call",
+        id="fc_1",
+        call_id="call_1",
+        name="todo",
+        arguments="{}",
+    )
+
+    response = _consume_codex_event_stream(
+        [
+            SimpleNamespace(type="response.output_item.added", item=commentary_item),
+            SimpleNamespace(type="response.output_text.delta", delta="Need update todo done."),
+            SimpleNamespace(type="response.output_item.done", item=commentary_item),
+            SimpleNamespace(type="response.output_item.added", item=tool_item),
+            SimpleNamespace(type="response.output_item.done", item=tool_item),
+            SimpleNamespace(type="response.completed", response=SimpleNamespace(status="completed")),
+        ],
+        model="gpt-5.5",
+        on_text_delta=streamed.append,
+    )
+
+    assert streamed == []
+    assert response.output == [commentary_item, tool_item]
+    assert response.output_text == "Need update todo done."
+
+
+def test_codex_stream_still_streams_final_answer_phase_text_deltas():
+    """Final-answer message phases keep progressive streaming enabled."""
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    streamed = []
+    final_item = SimpleNamespace(
+        type="message",
+        phase="final_answer",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="Done.")],
+    )
+
+    response = _consume_codex_event_stream(
+        [
+            SimpleNamespace(type="response.output_item.added", item=final_item),
+            SimpleNamespace(type="response.output_text.delta", delta="Done."),
+            SimpleNamespace(type="response.output_item.done", item=final_item),
+            SimpleNamespace(type="response.completed", response=SimpleNamespace(status="completed")),
+        ],
+        model="gpt-5.5",
+        on_text_delta=streamed.append,
+    )
+
+    assert streamed == ["Done."]
+    assert response.output == [final_item]
+    assert response.output_text == "Done."
+
+
 def test_run_codex_stream_ignores_completed_response_with_null_output(monkeypatch):
     """Regression: Codex may send response.completed.response.output=null.
 


### PR DESCRIPTION
## Summary
- suppress live streaming of Codex Responses `commentary` / `analysis` message-item deltas
- keep those deltas in collected `output_text` / transcript state for internal handling
- add regression coverage proving commentary before tool calls is not streamed while `final_answer` still streams

## Why
Codex can emit a commentary-phase message immediately before a function call in the same Responses stream. Hermes was treating the `response.output_text.delta` as user-facing stream content, so gateway platforms like Telegram could receive model planning/todo text before final-send suppression kicked in.