### PR TITLE
fix(api_server): sanitize X-Hermes-Error header to prevent response c…

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2126,7 +2126,15 @@ class APIServerAdapter(BasePlatformAdapter):
             response_headers["X-Hermes-Completed"] = "false"
             response_headers["X-Hermes-Partial"] = "true" if is_partial else "false"
             if err_msg:
-                response_headers["X-Hermes-Error"] = err_msg[:200]
+                # HTTP header values MUST NOT contain newlines/CR/null — aiohttp
+                # raises ValueError("...header injection attack") at serialize
+                # time and crashes the whole response handler if they do. Upstream
+                # provider errors (e.g. a 502 whose body embeds a multi-line
+                # error string) routinely carry newlines, so strip them
+                # via the same sanitizer used for audit-log values before this
+                # ever reaches _write_headers. The full multi-line detail is still
+                # preserved untouched in the JSON body's hermes.error field above.
+                response_headers["X-Hermes-Error"] = self._clean_log_value(err_msg)
 
         return web.json_response(response_data, headers=response_headers)
 


### PR DESCRIPTION
…rash

## Problem

When the API server returns an error, it copies the upstream error message verbatim into the `X-Hermes-Error` response header (truncated to 200 chars):

    response_headers["X-Hermes-Error"] = err_msg[:200]

HTTP header values must not contain CR/LF/NUL. aiohttp validates this at serialize time and raises `ValueError("Newline or carriage return character detected in HTTP status message or header. This is a potential security issue.")`, which crashes the entire response handler — the client gets a broken/aborted response instead of the intended structured error.

Upstream provider errors routinely carry newlines. A multi-line 502 body from a proxy/provider is enough to detonate this path, so a transient upstream blip gets amplified into a hard crash of the gateway's error response.

## Fix

Route the value through the existing `_clean_log_value()` sanitizer (already used for audit-log values), which replaces CR/LF with spaces, strips, and caps length (default `max_len=200` — same truncation as before, no behavior change for the length cap):

    response_headers["X-Hermes-Error"] = self._clean_log_value(err_msg)

The full multi-line error detail is still preserved untouched in the JSON response body's `hermes.error` field — only the header copy is flattened, which is exactly what HTTP requires.

## Why this shape

- Reuses an existing, tested helper rather than adding a new one (narrow footprint).
- Fixes the whole bug class: every multi-line error string, not just the one that surfaced it.
- No new config, no env var, no new dependency.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

