### PR TITLE
fix(desktop): avoid false 'needs setup' on transient runtime-check timeouts

### DIFF
--- a/apps/desktop/src/store/onboarding.test.ts
+++ b/apps/desktop/src/store/onboarding.test.ts
@@ -63,6 +63,16 @@ function onboardingContext(requestGateway: OnboardingContext['requestGateway']):
   return { requestGateway }
 }
 
+function fallbackTimeoutGateway(): OnboardingContext['requestGateway'] {
+  return async method => {
+    if (method === 'setup.status' || method === 'setup.runtime_check') {
+      throw new Error(`request timed out: ${method}`)
+    }
+
+    throw new Error(`unexpected gateway method: ${method}`)
+  }
+}
+
 describe('refreshOnboarding', () => {
   beforeEach(() => {
     window.localStorage.clear()
@@ -114,6 +124,54 @@ describe('refreshOnboarding', () => {
     expect(ready).toBe(false)
     expect(api).not.toHaveBeenCalled()
     expect($desktopOnboarding.get().providers?.map(p => p.id)).toEqual(['cached'])
+  })
+
+  it('does not downgrade configured=true on fallback-only readiness failures', async () => {
+    const api = vi.fn(async ({ path }: { path: string }) => {
+      if (path === '/api/providers/oauth') {
+        return { providers: [provider('fresh')] }
+      }
+
+      throw new Error(`unexpected api path: ${path}`)
+    })
+
+    installApiMock(api)
+    $desktopOnboarding.set(
+      baseState({
+        configured: true,
+        providers: [provider('cached')],
+        reason: null,
+        requested: false
+      })
+    )
+
+    const ready = await refreshOnboarding(onboardingContext(fallbackTimeoutGateway()))
+
+    expect(ready).toBe(false)
+    expect(api).not.toHaveBeenCalled()
+    expect($desktopOnboarding.get().configured).toBe(true)
+    expect($desktopOnboarding.get().reason).toBeNull()
+    expect(window.localStorage.getItem('hermes-desktop-onboarded-v1')).toBeNull()
+  })
+
+  it('still surfaces onboarding when fallback failure happens before configured state', async () => {
+    const api = vi.fn(async ({ path }: { path: string }) => {
+      if (path === '/api/providers/oauth') {
+        return { providers: [provider('fresh')] }
+      }
+
+      throw new Error(`unexpected api path: ${path}`)
+    })
+
+    installApiMock(api)
+    $desktopOnboarding.set(baseState({ configured: false, providers: null, requested: true }))
+
+    const ready = await refreshOnboarding(onboardingContext(fallbackTimeoutGateway()))
+
+    expect(ready).toBe(false)
+    expect(api).toHaveBeenCalledTimes(1)
+    expect($desktopOnboarding.get().configured).toBe(false)
+    expect($desktopOnboarding.get().reason).toContain('request timed out')
   })
 
   it('deduplicates concurrent provider refresh calls', async () => {

--- a/apps/desktop/src/store/onboarding.ts
+++ b/apps/desktop/src/store/onboarding.ts
@@ -188,6 +188,16 @@ async function checkRuntime(ctx: OnboardingContext): Promise<RuntimeReadinessRes
   })
 }
 
+function shouldPreserveConfiguredOnFallback(
+  runtime: RuntimeReadinessResult,
+  state: DesktopOnboardingState
+): boolean {
+  // A fallback result means both runtime probes were non-authoritative
+  // (transport timeout/disconnect). Keep a previously verified configured
+  // state instead of forcing the blocking onboarding overlay.
+  return runtime.source === 'fallback' && state.configured === true && !state.requested && !state.manual
+}
+
 function notifyReady(provider: string) {
   notify({ kind: 'success', title: 'Hermes is ready', message: `${provider} connected.` })
 }
@@ -515,6 +525,10 @@ export async function refreshOnboarding(ctx: OnboardingContext) {
   }
 
   const state = $desktopOnboarding.get()
+  if (shouldPreserveConfiguredOnFallback(runtime, state)) {
+    return false
+  }
+
   const reason = runtime.reason || state.reason || DEFAULT_ONBOARDING_REASON
 
   writeCachedConfigured(false)


### PR DESCRIPTION
## Summary
Desktop onboarding could incorrectly downgrade a previously-configured install to "needs setup" when runtime readiness probes returned only fallback errors (for example transient `request timed out: setup.runtime_check` / reconnect windows).

This showed up as random status flapping (connected -> needs setup -> offline) and could block composer usage even though credentials were already valid.

## Root Cause
`refreshOnboarding()` treated non-ready fallback results as authoritative and immediately set `configured=false`.

Fallback results are intentionally non-authoritative (transport timeout/disconnect), so using them to downgrade state causes false negatives.

## Fix
- Preserve `configured=true` when readiness result is fallback-only and onboarding was not explicitly requested/manual.
- Keep existing strict behavior for first-run/manual/requested onboarding flows.

## Tests
Added regression coverage:
1. Previously configured desktop install is not downgraded on fallback timeout.
2. Unconfigured/requested onboarding still surfaces correctly on fallback failure.

## Commits
1. fix(desktop): keep configured onboarding state on fallback runtime probes
2. test(desktop): cover fallback timeout onboarding downgrade regression