### PR TITLE
fix(feishu): drop empty non-TEXT messages to prevent blank ContentBlock HTTP 400

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3114,8 +3114,11 @@ class FeishuAdapter(BasePlatformAdapter):
                 inbound_type = MessageType.COMMAND
 
         # Guard runs post-strip so a pure "@Bot" message (stripped to "") is dropped.
-        if inbound_type == MessageType.TEXT and not text and not media_urls:
-            logger.debug("[Feishu] Ignoring empty text message id=%s", message_id)
+        # Also catches non-TEXT types (sticker, unrecognised message, failed image parse,
+        # etc.) that yield neither text nor media — these would produce a blank
+        # ContentBlock and cause HTTP 400 "text field is blank" errors from Bedrock/Anthropic.
+        if not text and not media_urls:
+            logger.debug("[Feishu] Ignoring empty message id=%s (type=%s)", message_id, inbound_type.value)
             return
 
         if inbound_type != MessageType.COMMAND:

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3115,8 +3115,10 @@ class FeishuAdapter(BasePlatformAdapter):
 
         # Guard runs post-strip so a pure "@Bot" message (stripped to "") is dropped.
         # Also catches non-TEXT types (sticker, unrecognised message, failed image parse,
-        # etc.) that yield neither text nor media — these would produce a blank
-        # ContentBlock and cause HTTP 400 "text field is blank" errors from Bedrock/Anthropic.
+        # etc.) that yield neither text nor media. Bedrock substitutes a non-empty
+        # whitespace block for blank content (bedrock_adapter.py:500-541), so the
+        # real risk is an empty unsupported event propagating into dispatch unchecked;
+        # this guard keeps it out entirely.
         if not text and not media_urls:
             logger.debug("[Feishu] Ignoring empty message id=%s (type=%s)", message_id, inbound_type.value)
             return

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -4596,6 +4596,29 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
         )
         adapter._dispatch_inbound_event.assert_not_called()
 
+    def test_empty_non_text_event_is_ignored(self):
+        """A non-TEXT event (e.g. sticker) with no text and no downloadable media
+        must not enter dispatch — regression guard for the widened type guard.
+        """
+        adapter = self._build_adapter()
+        message = SimpleNamespace(
+            content="{}",
+            message_type="sticker",
+            message_id="m6",
+            mentions=[],
+            chat_id="oc_chat",
+            parent_id=None,
+            upper_message_id=None,
+            thread_id=None,
+        )
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message, message=message, sender_id=None,
+                chat_type="group", message_id="m6",
+            )
+        )
+        adapter._dispatch_inbound_event.assert_not_called()
+
 
 class TestFeishuFetchMessageText(unittest.TestCase):
     def _build_adapter(self):


### PR DESCRIPTION
## Problem

When Feishu sends a message with no text and no media (e.g. stickers, unrecognised message types, or images that fail to parse), the existing guard only filters `MessageType.TEXT`:

```python
if inbound_type == MessageType.TEXT and not text and not media_urls:
```

Non-TEXT types slip through and are stored in the session DB with a blank `content` field. When those messages are later serialised into API ContentBlocks (`{"type": "text", "text": ""}`), Bedrock rejects the request with HTTP 400:

> The text field in the ContentBlock object at messages.N.content.0 is blank. Add text to the text field, and try again.

This crashes the session for every subsequent message, effectively making the bot unresponsive until the session history is manually cleared.

## Fix

Remove the `inbound_type == MessageType.TEXT` restriction so the guard applies to **all** message types when there is neither text nor media. Messages with media attachments (images, files) are unaffected because `media_urls` is non-empty for those. Reaction synthetic events are also unaffected because they always carry a non-empty text like `reaction:added:LIKE`.

## Changes

- `plugins/platforms/feishu/adapter.py`: broaden the empty-message guard from `MessageType.TEXT` only to all message types with no text and no media