### PR TITLE
fix(copilot): attach Copilot CLI identity + 1M beta on the Claude /v1/messages client

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -446,6 +446,23 @@ def _is_kimi_coding_endpoint(base_url: str | None) -> bool:
     return normalized.rstrip("/").lower().startswith("https://api.kimi.com/coding")
 
 
+def _is_copilot_base_url(base_url: str | None) -> bool:
+    """Return True for GitHub Copilot's Anthropic deployment (api.githubcopilot.com).
+
+    Copilot serves Claude on POST /v1/messages at the real 1M-token input
+    window; this is the host we must attach the Copilot CLI identity headers and
+    the anthropic-beta context window betas to.
+    """
+    if not base_url:
+        return False
+    try:
+        from urllib.parse import urlparse
+        host = (urlparse(base_url).hostname or "").lower()
+    except Exception:
+        return False
+    return host == "api.githubcopilot.com"
+
+
 # Model-name prefixes that identify the Kimi / Moonshot family.  Covers
 # - official slugs: ``kimi-k2.5``, ``kimi_thinking``, ``moonshot-v1-8k``
 # - common release lines: ``k1.5-...``, ``k2-thinking``, ``k25-...``, ``k2.5-...``
@@ -551,7 +568,7 @@ def _base_url_needs_context_1m_beta(base_url: str | None) -> bool:
     normalized = _normalize_base_url_text(base_url).lower()
     if not normalized:
         return False
-    return "azure.com" in normalized
+    return "azure.com" in normalized or "githubcopilot.com" in normalized
 
 
 def _is_minimax_anthropic_endpoint(base_url: str | None) -> bool:
@@ -782,6 +799,37 @@ def build_anthropic_client(
             "User-Agent": "claude-code/0.1.0",
             **( {"anthropic-beta": ",".join(common_betas)} if common_betas else {} )
         }
+    elif _is_copilot_base_url(normalized_base_url):
+        # GitHub Copilot's Anthropic deployment (POST /v1/messages) is the only
+        # Copilot endpoint that serves Claude at the real 1,000,000-token input
+        # window; /chat/completions clamps it and returns a misleading "exceeds
+        # the limit of 168000" error. It requires:
+        #   1. Authorization: Bearer <gh-token>  (NOT Anthropic x-api-key).
+        #   2. The Copilot CLI identity header set (User-Agent,
+        #      Copilot-Integration-Id, etc.) so the request is recognised as the
+        #      Copilot CLI and the account's full entitlement applies.
+        #   3. anthropic-beta context window betas (already computed in
+        #      common_betas for this base_url) to unlock the 1M window.
+        # Checked BEFORE _requires_bearer_auth and the x-api-key fallthrough so
+        # the Copilot token is sent as Bearer, not as an Anthropic API key.
+        kwargs["auth_token"] = api_key
+        _copilot_headers: dict[str, str] = {}
+        try:
+            from hermes_cli.copilot_auth import copilot_request_headers
+            # The single Copilot CLI identity, the same builder used on the
+            # inference path, so /v1/messages and /chat/completions present one
+            # consistent identity.
+            _copilot_headers = copilot_request_headers(is_agent_turn=True)
+        except Exception:
+            # Never block client construction on header enrichment; the bearer
+            # token alone still authenticates.
+            _copilot_headers = {}
+        # The anthropic-beta set (computed in common_betas) is authoritative;
+        # apply it last so it always wins over any value the identity header set
+        # may carry.
+        if common_betas:
+            _copilot_headers["anthropic-beta"] = ",".join(common_betas)
+        kwargs["default_headers"] = _copilot_headers
     elif _requires_bearer_auth(normalized_base_url):
         # Some Anthropic-compatible providers (e.g. MiniMax) expect the API key in
         # Authorization: Bearer *** for regular API keys. Route those endpoints

--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -23,6 +23,7 @@ import logging
 import os
 import shutil
 import subprocess
+import sys
 import time
 from pathlib import Path
 from typing import Optional
@@ -41,6 +42,107 @@ COPILOT_ENV_VARS = ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
 # Polling constants
 _DEVICE_CODE_POLL_INTERVAL = 5  # seconds
 _DEVICE_CODE_POLL_SAFETY_MARGIN = 3  # seconds
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Single Copilot CLI identity.
+#
+# Every Copilot-facing request (inference, token exchange, device-OAuth flow)
+# presents ONE identity: the `copilot-developer-cli` integration with the real
+# `@github/copilot` CLI User-Agent. Previously several call sites each sent a
+# different ad-hoc identity (`GitHubCopilotChat/*`, `HermesAgent/1.0`,
+# `vscode-chat` + `Editor-*` VS Code Chat headers), which is inconsistent and
+# does not match what a CLI agent actually is.
+#
+# Copilot-Integration-Id is the lever the GitHub backend keys the visible model
+# catalog and per-model limits off of (not the User-Agent). A read-only
+# `GET /models` sweep across candidate integration ids found that
+# `copilot-developer-cli` returns a strict superset of the catalog (it is the
+# only id that exposes the newest models with the full reasoning-effort range),
+# so it is used uniformly. Override via HERMES_COPILOT_INTEGRATION_ID for an
+# account that needs a different integrator.
+#
+# The integration-id only unlocks the catalog when the request carries a valid
+# GitHub Bearer token (resolved by resolve_copilot_token()); without it the
+# premium models are not served regardless of the integration-id.
+_COPILOT_INTEGRATION_ID_DEFAULT = "copilot-developer-cli"
+
+# Latest @github/copilot CLI version, used for the User-Agent we present. The
+# real CLI reports `copilot/<ver> (<platform> <node>) term/<TERM_PROGRAM>`; we
+# reproduce that shape from real host values so it is authentic rather than
+# fabricated, degrading to the short `copilot/<ver>` form when node is absent.
+# Env-overridable for pinning. Fallback is the value shipped at time of writing.
+_COPILOT_CLI_VERSION_FALLBACK = "1.0.63"
+
+_copilot_node_version_memo: Optional[str] = None
+
+
+def _copilot_integration_id() -> str:
+    """Return the Copilot-Integration-Id to send (env-overridable)."""
+    override = os.getenv("HERMES_COPILOT_INTEGRATION_ID", "").strip()
+    return override or _COPILOT_INTEGRATION_ID_DEFAULT
+
+
+def _copilot_cli_version() -> str:
+    """Return the @github/copilot CLI version string for the User-Agent."""
+    return os.getenv("HERMES_COPILOT_CLI_VERSION", "").strip() or _COPILOT_CLI_VERSION_FALLBACK
+
+
+def _copilot_node_version() -> str:
+    """Return a ``v``-prefixed Node version for the CLI User-Agent.
+
+    The real ``@github/copilot`` CLI runs on Node and reports
+    ``process.version`` in the parenthetical UA segment. We resolve a real node
+    version from the host (``node --version``) so the value is authentic; if no
+    node is on PATH we return an empty string and the caller falls back to the
+    short UA form. Resolution order: ``HERMES_COPILOT_NODE_VERSION`` env
+    override, then ``node --version`` (cached in-process), then empty.
+    """
+    override = os.getenv("HERMES_COPILOT_NODE_VERSION", "").strip()
+    if override:
+        return override if override.startswith("v") else f"v{override}"
+
+    global _copilot_node_version_memo
+    if _copilot_node_version_memo is not None:
+        return _copilot_node_version_memo
+
+    ver = ""
+    node_path = shutil.which("node")
+    if node_path:
+        try:
+            out = subprocess.run(
+                [node_path, "--version"],
+                capture_output=True, text=True, timeout=2,
+            )
+            cand = (out.stdout or "").strip()
+            if cand.startswith("v"):
+                ver = cand
+        except Exception as exc:  # pragma: no cover - host-dependent
+            logger.debug("node --version probe failed: %s", exc)
+
+    _copilot_node_version_memo = ver
+    return ver
+
+
+def _copilot_user_agent() -> str:
+    """Build the @github/copilot CLI User-Agent presented on every request.
+
+    Reproduces the real CLI builder ``copilot/<ver> (<platform> <node>)
+    term/<TERM_PROGRAM>``. ``TERM_PROGRAM`` is read from the environment, else a
+    valid ``vscode`` default (never the literal ``unknown`` the raw CLI emits
+    when it cannot resolve a terminal). When no node runtime is available the
+    value degrades to the short ``copilot/<ver>`` form.
+    """
+    version = _copilot_cli_version()
+    node = _copilot_node_version()
+    if not node:
+        return f"copilot/{version}"
+    platform = "linux"
+    if sys.platform == "darwin":
+        platform = "darwin"
+    elif sys.platform.startswith("win"):
+        platform = "win32"
+    term = os.getenv("HERMES_COPILOT_TERM_PROGRAM", "").strip() or os.getenv("TERM_PROGRAM", "").strip() or "vscode"
+    return f"copilot/{version} ({platform} {node}) term/{term}"
 
 
 def validate_copilot_token(token: str) -> tuple[bool, str]:
@@ -183,7 +285,7 @@ def copilot_device_code_login(
         headers={
             "Accept": "application/json",
             "Content-Type": "application/x-www-form-urlencoded",
-            "User-Agent": "HermesAgent/1.0",
+            "User-Agent": _copilot_user_agent(),
         },
     )
 
@@ -229,7 +331,7 @@ def copilot_device_code_login(
             headers={
                 "Accept": "application/json",
                 "Content-Type": "application/x-www-form-urlencoded",
-                "User-Agent": "HermesAgent/1.0",
+                "User-Agent": _copilot_user_agent(),
             },
         )
 
@@ -282,10 +384,11 @@ def copilot_device_code_login(
 _jwt_cache: dict[str, tuple[str, float]] = {}
 _JWT_REFRESH_MARGIN_SECONDS = 120  # refresh 2 min before expiry
 
-# Token exchange endpoint and headers (matching VS Code / Copilot CLI)
-_TOKEN_EXCHANGE_URL = "https://api.github.com/copilot_internal/v2/token"
-_EDITOR_VERSION = "vscode/1.104.1"
-_EXCHANGE_USER_AGENT = "GitHubCopilotChat/0.26.7"
+# Token exchange endpoint. We present our single Copilot CLI identity (the
+# `copilot-developer-cli` integration + `_copilot_user_agent()`), the same one
+# used on the inference path, so there is exactly one identity across every
+# Copilot-facing request.
+_TOKEN_EXCHANGE_URL="https:...oken"
 
 
 def _token_fingerprint(raw_token: str) -> str:
@@ -322,9 +425,9 @@ def exchange_copilot_token(raw_token: str, *, timeout: float = 10.0) -> tuple[st
         method="GET",
         headers={
             "Authorization": f"token {raw_token}",
-            "User-Agent": _EXCHANGE_USER_AGENT,
+            "User-Agent": _copilot_user_agent(),
             "Accept": "application/json",
-            "Editor-Version": _EDITOR_VERSION,
+            "Copilot-Integration-Id": _copilot_integration_id(),
         },
     )
 
@@ -380,9 +483,8 @@ def copilot_request_headers(
     Replicates the header set used by opencode and the Copilot CLI.
     """
     headers: dict[str, str] = {
-        "Editor-Version": "vscode/1.104.1",
-        "User-Agent": "HermesAgent/1.0",
-        "Copilot-Integration-Id": "vscode-chat",
+        "User-Agent": _copilot_user_agent(),
+        "Copilot-Integration-Id": _copilot_integration_id(),
         "Openai-Intent": "conversation-edits",
         "x-initiator": "agent" if is_agent_turn else "user",
     }

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -25,7 +25,12 @@ _HERMES_USER_AGENT = f"hermes-cli/{_HERMES_VERSION}"
 
 COPILOT_BASE_URL = "https://api.githubcopilot.com"
 COPILOT_MODELS_URL = f"{COPILOT_BASE_URL}/models"
-COPILOT_EDITOR_VERSION = "vscode/1.104.1"
+# Single Copilot CLI identity (the `copilot-developer-cli` integration that
+# unlocks the full premium model catalog). copilot_auth.py is the authoritative
+# source; these mirror its fallback values for the degraded ImportError path in
+# copilot_default_headers() below, so the identity is identical everywhere.
+_COPILOT_INTEGRATION_ID = "copilot-developer-cli"
+_COPILOT_CLI_VERSION = "1.0.63"
 COPILOT_REASONING_EFFORTS_GPT5 = ["minimal", "low", "medium", "high"]
 COPILOT_REASONING_EFFORTS_O_SERIES = ["low", "medium", "high"]
 
@@ -2732,9 +2737,13 @@ def copilot_default_headers() -> dict[str, str]:
         from hermes_cli.copilot_auth import copilot_request_headers
         return copilot_request_headers(is_agent_turn=True)
     except ImportError:
+        # copilot_auth is the single source of truth; this fallback only fires if
+        # it cannot be imported. Mirror its Copilot CLI identity shape (no
+        # Editor-* VS Code headers, CLI User-Agent) so the identity stays
+        # consistent even on the degraded path.
         return {
-            "Editor-Version": COPILOT_EDITOR_VERSION,
-            "User-Agent": "HermesAgent/1.0",
+            "User-Agent": f"copilot/{_COPILOT_CLI_VERSION}",
+            "Copilot-Integration-Id": _COPILOT_INTEGRATION_ID,
             "Openai-Intent": "conversation-edits",
             "x-initiator": "agent",
         }

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -93,16 +93,67 @@ class TestBuildAnthropicClient:
 
     def test_api_key_uses_api_key(self):
         with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
-            build_anthropic_client("sk-ant-api03-something")
+            build_anthropic_client("sk-ant...hing")
             kwargs = mock_sdk.Anthropic.call_args[1]
-            assert kwargs["api_key"] == "sk-ant-api03-something"
+            assert kwargs["api_key"] == "sk-ant...hing"
             assert "auth_token" not in kwargs
             # API key auth should still get common betas
             betas = kwargs["default_headers"]["anthropic-beta"]
             assert "interleaved-thinking-2025-05-14" in betas
             assert "context-1m-2025-08-07" not in betas
             assert "oauth-2025-04-20" not in betas  # OAuth-only beta NOT present
-            assert "claude-code-20250219" not in betas  # OAuth-only beta NOT present
+
+    def test_copilot_v1messages_uses_bearer_and_cli_identity(self):
+        """Claude on Copilot (/v1/messages) is sent with Bearer auth, the single
+        Copilot CLI identity headers, and the context-1m beta that unlocks the
+        1M input window. The Copilot token must NOT be sent as an Anthropic
+        x-api-key."""
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client(
+                "gho_copaccesstoken",
+                base_url="https://api.githubcopilot.com",
+            )
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            # Bearer, not x-api-key.
+            assert kwargs["auth_token"] == "gho_copaccesstoken"
+            assert "api_key" not in kwargs
+            headers = kwargs["default_headers"]
+            # The single Copilot CLI identity from copilot_request_headers.
+            assert headers["Copilot-Integration-Id"] == "copilot-developer-cli"
+            assert headers["User-Agent"].startswith("copilot/")
+            assert "Editor-Version" not in headers
+            # The 1M-window beta must be present on this path.
+            assert "context-1m-2025-08-07" in headers["anthropic-beta"]
+            assert "interleaved-thinking-2025-05-14" in headers["anthropic-beta"]
+
+    def test_copilot_base_url_detection(self):
+        from agent.anthropic_adapter import _is_copilot_base_url
+        assert _is_copilot_base_url("https://api.githubcopilot.com") is True
+        assert _is_copilot_base_url("https://api.githubcopilot.com/v1") is True
+        assert _is_copilot_base_url("https://api.anthropic.com") is False
+        assert _is_copilot_base_url("") is False
+        assert _is_copilot_base_url(None) is False
+
+    def test_copilot_needs_context_1m_beta(self):
+        from agent.anthropic_adapter import _base_url_needs_context_1m_beta
+        assert _base_url_needs_context_1m_beta("https://api.githubcopilot.com") is True
+        # Native Anthropic must NOT get context-1m by default.
+        assert _base_url_needs_context_1m_beta("https://api.anthropic.com") is False
+
+    def test_copilot_header_enrichment_failure_is_non_fatal(self):
+        """If copilot_request_headers raises, client construction still proceeds
+        with the bearer token and the beta header alone."""
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk, \
+             patch("hermes_cli.copilot_auth.copilot_request_headers",
+                   side_effect=RuntimeError("boom")):
+            build_anthropic_client(
+                "***",
+                base_url="https://api.githubcopilot.com",
+            )
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert kwargs["auth_token"] == "***"
+            # Beta still applied even when identity enrichment failed.
+            assert "context-1m-2025-08-07" in kwargs["default_headers"]["anthropic-beta"]
 
     def test_custom_base_url(self):
         with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -114,8 +114,16 @@ class TestRequestHeaders:
         from hermes_cli.copilot_auth import copilot_request_headers
         headers = copilot_request_headers()
         assert headers["Openai-Intent"] == "conversation-edits"
-        assert headers["User-Agent"] == "HermesAgent/1.0"
-        assert "Editor-Version" in headers
+
+    def test_default_headers_present_single_cli_identity(self):
+        """The unified Copilot CLI identity: developer-cli integration, CLI
+        User-Agent, and no VS Code Editor-* headers."""
+        from hermes_cli.copilot_auth import copilot_request_headers
+        headers = copilot_request_headers()
+        assert headers["Copilot-Integration-Id"] == "copilot-developer-cli"
+        assert headers["User-Agent"].startswith("copilot/")
+        assert "Editor-Version" not in headers
+        assert "Editor-Plugin-Version" not in headers
 
     def test_agent_turn_sets_initiator(self):
         from hermes_cli.copilot_auth import copilot_request_headers
@@ -136,6 +144,57 @@ class TestRequestHeaders:
         from hermes_cli.copilot_auth import copilot_request_headers
         headers = copilot_request_headers()
         assert "Copilot-Vision-Request" not in headers
+
+
+class TestCopilotCliIdentity:
+    """The single Copilot CLI identity builders."""
+
+    def test_integration_id_default(self, monkeypatch):
+        monkeypatch.delenv("HERMES_COPILOT_INTEGRATION_ID", raising=False)
+        from hermes_cli.copilot_auth import _copilot_integration_id
+        assert _copilot_integration_id() == "copilot-developer-cli"
+
+    def test_integration_id_env_override(self, monkeypatch):
+        monkeypatch.setenv("HERMES_COPILOT_INTEGRATION_ID", "vscode-chat")
+        from hermes_cli.copilot_auth import _copilot_integration_id
+        assert _copilot_integration_id() == "vscode-chat"
+
+    def test_cli_version_env_override(self, monkeypatch):
+        monkeypatch.setenv("HERMES_COPILOT_CLI_VERSION", "9.9.9")
+        from hermes_cli.copilot_auth import _copilot_cli_version
+        assert _copilot_cli_version() == "9.9.9"
+
+    def test_user_agent_full_form_with_node(self, monkeypatch):
+        monkeypatch.setenv("HERMES_COPILOT_NODE_VERSION", "v20.0.0")
+        monkeypatch.setenv("HERMES_COPILOT_CLI_VERSION", "1.2.3")
+        monkeypatch.setenv("HERMES_COPILOT_TERM_PROGRAM", "iTerm.app")
+        import hermes_cli.copilot_auth as ca
+        ca._copilot_node_version_memo = None
+        ua = ca._copilot_user_agent()
+        assert ua.startswith("copilot/1.2.3 (")
+        assert "v20.0.0" in ua
+        assert ua.endswith("term/iTerm.app")
+
+    def test_user_agent_short_form_without_node(self, monkeypatch):
+        monkeypatch.setenv("HERMES_COPILOT_NODE_VERSION", "")
+        monkeypatch.setenv("HERMES_COPILOT_CLI_VERSION", "1.2.3")
+        import hermes_cli.copilot_auth as ca
+        ca._copilot_node_version_memo = None
+        monkeypatch.setattr(ca.shutil, "which", lambda _: None)
+        assert ca._copilot_user_agent() == "copilot/1.2.3"
+
+    def test_node_version_override_gets_v_prefix(self, monkeypatch):
+        monkeypatch.setenv("HERMES_COPILOT_NODE_VERSION", "18.1.0")
+        import hermes_cli.copilot_auth as ca
+        ca._copilot_node_version_memo = None
+        assert ca._copilot_node_version() == "v18.1.0"
+
+    def test_models_fallback_mirrors_cli_identity(self):
+        """The degraded ImportError fallback in models.copilot_default_headers
+        presents the same CLI identity, never the old Editor-* / HermesAgent."""
+        from hermes_cli import models
+        assert models._COPILOT_INTEGRATION_ID == "copilot-developer-cli"
+        assert models._COPILOT_CLI_VERSION
 
 
 class TestCopilotDefaultHeaders:

--- a/tests/hermes_cli/test_copilot_token_exchange.py
+++ b/tests/hermes_cli/test_copilot_token_exchange.py
@@ -46,7 +46,8 @@ class TestExchangeCopilotToken:
         call_args = mock_urlopen.call_args
         req = call_args[0][0]
         assert req.get_header("Authorization") == "token gho_test123"
-        assert "GitHubCopilotChat" in req.get_header("User-agent")
+        assert req.get_header("User-agent").startswith("copilot/")
+        assert req.get_header("Copilot-integration-id") == "copilot-developer-cli"
 
     @patch("urllib.request.urlopen")
     def test_caches_result(self, mock_urlopen):


### PR DESCRIPTION
## Problem

`#49184` routes Claude-on-Copilot to `/v1/messages` (the only Copilot endpoint that serves Claude at the real 1M-token input window), and `#51411` unifies the Copilot CLI identity across the inference, token-exchange, and device-OAuth paths. But there was no code attaching that identity, or the 1M-unlock beta, on the `/v1/messages` path itself.

`build_anthropic_client` had branches for Kimi, bearer-auth providers, third-party Anthropic proxies, and OAuth tokens, but **no branch for `api.githubcopilot.com`**. A Claude-on-Copilot request therefore fell through to the generic OAuth/x-api-key handling and went out:

- without the Copilot CLI identity headers (`User-Agent`, `Copilot-Integration-Id`, etc.), and
- without the `context-1m-2025-08-07` beta that unlocks the 1,000,000-token window.

Routing Claude to the right endpoint only helps if the request also presents the right identity and beta on that endpoint. This is the missing keystone of that change.

## Fix

- Add `_is_copilot_base_url()` and a dedicated branch in `build_anthropic_client`, checked **before** `_requires_bearer_auth` so the Copilot token is sent as `Authorization: Bearer` (`auth_token`), never misclassified as an Anthropic x-api-key. The branch attaches the single Copilot CLI identity header set via `copilot_request_headers()` (the same builder used on the inference path, so `/v1/messages` and `/chat/completions` present one consistent identity) and applies the authoritative `anthropic-beta` set last. Header enrichment is fail-open: if it raises, the bearer token alone still authenticates and the beta is still applied.
- Extend `_base_url_needs_context_1m_beta()` to include `githubcopilot.com`, so the `context-1m-2025-08-07` beta is present on this path. It remains withheld from native Anthropic (which rejects it).

## Scope

The Copilot `/v1/messages` client construction only. No change to routing (that is `#49184`), to the identity builders (that is `#51411`), or to the limit numbers (`#49449`).

## Relation to the rest of the Copilot-Claude work

This branch builds on **`#51411`** (it calls `copilot_request_headers`). Until `#51411` merges, this PR's diff will also show `#51411`'s commit; review this PR's own commit (`fix(copilot): attach Copilot CLI identity + 1M beta on the Claude /v1/messages client`) for the net change. The family:

- `#49184` routes Claude-on-Copilot to `/v1/messages`.
- `#51411` gives every Copilot request one CLI identity.
- **this PR** attaches that identity + the 1M beta on the `/v1/messages` client.
- `#49449` corrects the per-model limit numbers (only meaningful once requests are on `/v1/messages`).

## Tests

Extends `tests/agent/test_anthropic_adapter.py`: the base-url detector, the Bearer + CLI-identity + context-1m branch, the context-1m gate (present for Copilot, absent for native Anthropic), and the fail-open enrichment path. 170 anthropic-adapter tests pass; `ruff check` and the Windows-footgun check pass.
