### PR TITLE
fix: allow remote non-gateway Hermes service restarts

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -21,11 +21,16 @@ from hermes_cli.colors import Colors, color
 # Deliberately specific — a bare "gateway ... restart" catch-all would block
 # legitimate prompts that merely mention an unrelated gateway (e.g. "summarize
 # the API gateway logs and report restart events").
+#
+# Keep the service-manager patterns scoped to the Hermes gateway service names.
+# Agents often administer remote/non-gateway services over SSH, and blocking any
+# ``systemctl ... *hermes*`` command would reject safe remote operations such as
+# ``ssh host 'systemctl restart hermes-worker.service'`` before SSH can run.
 _GATEWAY_LIFECYCLE_PATTERNS = re.compile(
     r"(?i)"
     r"(hermes\s+gateway\s+(restart|stop|start))"
-    r"|(launchctl\s+(kickstart|unload|load|stop|restart)\s+.*hermes)"
-    r"|(systemctl\s+(-\S+\s+)*(restart|stop|start)\s+.*hermes)"
+    r"|(launchctl\s+(kickstart|unload|load|stop|restart)\s+.*(?:ai\.)?hermes[\w.-]*gateway)"
+    r"|(systemctl\s+(-\S+\s+)*(restart|stop|start)\s+.*(?:ai\.)?hermes[\w.-]*gateway(?:\.service)?\b)"
     r"|(p?kill\s+.*hermes.*gateway)"
 )
 

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -62,6 +62,10 @@ class TestGatewayLifecyclePattern:
         "echo 'just a normal cron job'",
         "run the backup script",
         "gateway is running fine",
+        "systemctl restart hermes-worker.service",
+        "systemctl stop hermes-hl-copy2-fanout.service",
+        "ssh root@example.com 'systemctl restart hermes-hl-copy2-fanout.service'",
+        "ssh root@example.com 'systemctl stop hermes-hl-copy2-position-sync.service'",
         # Regression (#30728 follow-up): legit prompts that merely mention an
         # unrelated gateway + a restart must NOT be blocked.
         "Summarize the API gateway logs and report any restart events from last night",
@@ -317,7 +321,7 @@ class TestTerminalToolGatewayLifecycleGuard:
         assert "Blocked" in result["error"]
 
     def test_safe_systemctl_commands_pass_through(self, monkeypatch):
-        """Non-hermes systemctl commands must not be blocked by this guard."""
+        """Non-gateway systemctl commands must not be blocked by this guard."""
         import tools.terminal_tool as tt
 
         calls = []
@@ -335,6 +339,27 @@ class TestTerminalToolGatewayLifecycleGuard:
 
         assert result["exit_code"] == 0
         assert calls == ["systemctl status nginx"]
+
+    def test_remote_non_gateway_hermes_service_passes_through_inside_gateway(self, monkeypatch):
+        """SSH-administered Hermes services on remote hosts are not this gateway."""
+        import tools.terminal_tool as tt
+
+        calls = []
+
+        class _FakeEnv:
+            env = {}
+            def execute(self, command, **kwargs):
+                calls.append(command)
+                return {"output": "restarted", "returncode": 0}
+
+        command = "ssh root@example.com 'systemctl restart hermes-hl-copy2-fanout.service'"
+        self._patch_env(monkeypatch, _FakeEnv(), inside_gateway=True)
+        monkeypatch.setattr(tt, "_check_all_guards", lambda cmd, env: {"approved": True})
+
+        result = json.loads(tt.terminal_tool(command=command, force=True))
+
+        assert result["exit_code"] == 0
+        assert calls == [command]
 
     def test_guard_inactive_outside_gateway(self, monkeypatch):
         """Without _HERMES_GATEWAY=1 the lifecycle guard must not fire."""


### PR DESCRIPTION
## Summary
- scope the gateway lifecycle guard's service-manager regexes to Hermes gateway service names only
- allow terminal commands that SSH into a remote host and restart non-gateway Hermes services
- add regression coverage for remote `systemctl restart hermes-hl-copy2-fanout.service` commands inside gateway sessions

## Why
The terminal tool hard-blocks gateway lifecycle commands when running inside the gateway so Hermes cannot kill its own process. The shared matcher was too broad: any command containing `systemctl ... restart ... hermes` matched, including safe remote commands such as:

```bash
ssh root@host 'systemctl restart hermes-hl-copy2-fanout.service'
```

That command does not target the local Hermes gateway, but it was blocked before SSH could run.

## Tests
- `python3 -m pytest -q -o addopts='' tests/hermes_cli/test_gateway_restart_loop.py`
- `python3 -m py_compile hermes_cli/cron.py tools/terminal_tool.py tests/hermes_cli/test_gateway_restart_loop.py`
- `git diff --check`
