### PR TITLE
fix(hooks): resolve live terminal cwd for pre_tool_call payload

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -515,14 +515,49 @@ def _make_callback(spec: ShellHookSpec) -> Callable[..., Optional[Dict[str, Any]
     return _callback
 
 
+def _live_terminal_cwd(kwargs: Dict[str, Any]) -> Optional[str]:
+    """Best-effort resolve the live working directory of the terminal tool.
+
+    The default payload ``cwd`` is the agent/gateway process's own
+    ``Path.cwd()`` (see :func:`_serialize_payload`), which never tracks the
+    shell's ``cd`` state: the terminal tool runs commands in a persistent
+    backend env whose cwd lives in ``tools.terminal_tool`` process memory, not
+    in this process's cwd. For a ``pre_tool_call`` on a ``terminal`` command,
+    the honest "where will this run" answer is that env's tracked cwd, which is
+    updated from ``pwd -P`` after every command. Hooks that resolve git state
+    (e.g. the feature-branch guard) need the live value, or a bare
+    ``git commit`` is judged against a stale directory and can false-block in a
+    worktree-off-main layout.
+
+    Lazy import: terminal_tool is heavy and importing it at module load would
+    risk a cycle. Fail-open: any miss (no env, no task, import error) returns
+    None so the caller falls back to ``Path.cwd()`` and the prior behavior.
+    """
+    if kwargs.get("tool_name") != "terminal":
+        return None
+    task_id = kwargs.get("task_id") or ""
+    try:
+        from tools.terminal_tool import get_active_env
+
+        env = get_active_env(task_id)
+        cwd = getattr(env, "cwd", None) if env is not None else None
+        if isinstance(cwd, str) and cwd.strip():
+            return cwd
+    except Exception:
+        return None
+    return None
+
+
 def _serialize_payload(event: str, kwargs: Dict[str, Any]) -> str:
     """Render the stdin JSON payload.  Unserialisable values are
     stringified via ``default=str`` rather than dropped."""
     extras = {k: v for k, v in kwargs.items() if k not in _TOP_LEVEL_PAYLOAD_KEYS}
-    try:
-        cwd = str(Path.cwd())
-    except OSError:
-        cwd = ""
+    cwd = _live_terminal_cwd(kwargs)
+    if cwd is None:
+        try:
+            cwd = str(Path.cwd())
+        except OSError:
+            cwd = ""
     payload = {
         "hook_event_name": event,
         "tool_name": kwargs.get("tool_name"),

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -529,12 +529,22 @@ def _live_terminal_cwd(kwargs: Dict[str, Any]) -> Optional[str]:
     ``git commit`` is judged against a stale directory and can false-block in a
     worktree-off-main layout.
 
+    An explicit ``args.workdir`` outranks the tracked env cwd:
+    :func:`_resolve_command_cwd` resolves the per-command directory as
+    ``workdir > env.cwd > default``, so the payload mirrors that order or a
+    hook is judged against a directory the command will not run in.
+
     Lazy import: terminal_tool is heavy and importing it at module load would
     risk a cycle. Fail-open: any miss (no env, no task, import error) returns
     None so the caller falls back to ``Path.cwd()`` and the prior behavior.
     """
     if kwargs.get("tool_name") != "terminal":
         return None
+    args = kwargs.get("args")
+    if isinstance(args, dict):
+        workdir = args.get("workdir")
+        if isinstance(workdir, str) and workdir.strip():
+            return workdir
     task_id = kwargs.get("task_id") or ""
     try:
         from tools.terminal_tool import get_active_env

--- a/tests/agent/test_shell_hooks.py
+++ b/tests/agent/test_shell_hooks.py
@@ -173,6 +173,84 @@ class TestSerializePayload:
         assert payload["extra"]["obj"] == "<weird>"
 
 
+# ── _live_terminal_cwd (payload cwd reflects the shell's live cwd) ─────────
+
+
+class TestLiveTerminalCwd:
+    """The pre_tool_call payload cwd must track the terminal tool's live
+    working directory, not the agent process's Path.cwd(). Without this a
+    bare ``git commit`` is judged against a stale directory and the
+    feature-branch guard false-blocks in a worktree-off-main layout.
+    """
+
+    def _patch_active_env(self, monkeypatch, cwd):
+        """Install a fake tools.terminal_tool.get_active_env returning an
+        object whose .cwd is *cwd* (or a module that raises if cwd is the
+        sentinel ``RAISE``)."""
+        import sys
+        import types
+
+        class _Env:
+            def __init__(self, cwd):
+                self.cwd = cwd
+
+        def _get_active_env(task_id):
+            if cwd == "RAISE":
+                raise RuntimeError("boom")
+            if cwd is None:
+                return None
+            return _Env(cwd)
+
+        mod = types.ModuleType("tools.terminal_tool")
+        mod.get_active_env = _get_active_env
+        # Ensure the parent package exists so `from tools.terminal_tool import`
+        # resolves to our stub.
+        pkg = sys.modules.get("tools") or types.ModuleType("tools")
+        monkeypatch.setitem(sys.modules, "tools", pkg)
+        monkeypatch.setitem(sys.modules, "tools.terminal_tool", mod)
+
+    def test_terminal_uses_live_env_cwd(self, monkeypatch):
+        self._patch_active_env(monkeypatch, "/live/worktree")
+        raw = shell_hooks._serialize_payload(
+            "pre_tool_call",
+            {"tool_name": "terminal", "args": {"command": "git commit"}, "task_id": "t-1"},
+        )
+        assert json.loads(raw)["cwd"] == "/live/worktree"
+
+    def test_non_terminal_tool_falls_back_to_process_cwd(self, monkeypatch):
+        # Even if an env exists, a non-terminal tool must not adopt it.
+        self._patch_active_env(monkeypatch, "/live/worktree")
+        raw = shell_hooks._serialize_payload(
+            "pre_tool_call",
+            {"tool_name": "read_file", "args": {"path": "x"}, "task_id": "t-1"},
+        )
+        assert json.loads(raw)["cwd"] == str(Path.cwd())
+
+    def test_no_active_env_falls_back_to_process_cwd(self, monkeypatch):
+        self._patch_active_env(monkeypatch, None)
+        raw = shell_hooks._serialize_payload(
+            "pre_tool_call",
+            {"tool_name": "terminal", "args": {"command": "ls"}, "task_id": "t-1"},
+        )
+        assert json.loads(raw)["cwd"] == str(Path.cwd())
+
+    def test_env_lookup_error_fails_open_to_process_cwd(self, monkeypatch):
+        self._patch_active_env(monkeypatch, "RAISE")
+        raw = shell_hooks._serialize_payload(
+            "pre_tool_call",
+            {"tool_name": "terminal", "args": {"command": "ls"}, "task_id": "t-1"},
+        )
+        assert json.loads(raw)["cwd"] == str(Path.cwd())
+
+    def test_blank_env_cwd_falls_back_to_process_cwd(self, monkeypatch):
+        self._patch_active_env(monkeypatch, "   ")
+        raw = shell_hooks._serialize_payload(
+            "pre_tool_call",
+            {"tool_name": "terminal", "args": {"command": "ls"}, "task_id": "t-1"},
+        )
+        assert json.loads(raw)["cwd"] == str(Path.cwd())
+
+
 # ── Matcher behaviour ─────────────────────────────────────────────────────
 
 

--- a/tests/agent/test_shell_hooks.py
+++ b/tests/agent/test_shell_hooks.py
@@ -250,6 +250,45 @@ class TestLiveTerminalCwd:
         )
         assert json.loads(raw)["cwd"] == str(Path.cwd())
 
+    def test_explicit_workdir_wins_over_live_env_cwd(self, monkeypatch):
+        # terminal_tool resolves the per-command cwd as workdir > env.cwd
+        # (_resolve_command_cwd), so the payload must report the directory
+        # the command will actually run in when both are set and differ.
+        self._patch_active_env(monkeypatch, "/live/worktree")
+        raw = shell_hooks._serialize_payload(
+            "pre_tool_call",
+            {
+                "tool_name": "terminal",
+                "args": {"command": "git commit", "workdir": "/explicit/dir"},
+                "task_id": "t-1",
+            },
+        )
+        assert json.loads(raw)["cwd"] == "/explicit/dir"
+
+    def test_blank_workdir_falls_through_to_live_env_cwd(self, monkeypatch):
+        self._patch_active_env(monkeypatch, "/live/worktree")
+        raw = shell_hooks._serialize_payload(
+            "pre_tool_call",
+            {
+                "tool_name": "terminal",
+                "args": {"command": "ls", "workdir": "   "},
+                "task_id": "t-1",
+            },
+        )
+        assert json.loads(raw)["cwd"] == "/live/worktree"
+
+    def test_workdir_on_non_terminal_tool_is_ignored(self, monkeypatch):
+        self._patch_active_env(monkeypatch, "/live/worktree")
+        raw = shell_hooks._serialize_payload(
+            "pre_tool_call",
+            {
+                "tool_name": "read_file",
+                "args": {"path": "x", "workdir": "/explicit/dir"},
+                "task_id": "t-1",
+            },
+        )
+        assert json.loads(raw)["cwd"] == str(Path.cwd())
+
 
 # ── Matcher behaviour ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

The `pre_tool_call` hook payload `cwd` is the agent/gateway process's own `Path.cwd()` (`agent/shell_hooks.py` `_serialize_payload`), which never tracks the terminal tool's `cd` state. The terminal runs commands in a persistent backend env whose cwd lives in `tools.terminal_tool` process memory and is refreshed from `pwd -P` after every command; the gateway process itself never `chdir`s. So a shell hook that resolves git (or any directory-relative) state from the payload `cwd` sees a stale, session-start directory rather than where the command will actually run.

This surfaces as a false block in the feature-branch guard shell hook: a bare `git commit` (no `cd <path>` prefix for the guard's parser to resolve) is judged against the session-start dir. In a worktree-off-main layout — parent repo checked out on `main`, work happening in a `git worktree` on a feature branch — the guard reads `main` and blocks a commit that is genuinely on a feature branch.

## Root cause (verified empirically)

- Payload `cwd` is set from `Path.cwd()` at `shell_hooks.py` `_serialize_payload`. Live probe: a bare `git commit` executed in a different directory than the one the payload reported, because the gateway process never moved.
- The session row's persisted `cwd` is also frozen at session start, so it is not a live source either.
- The terminal tool's real live cwd lives only in `tools.terminal_tool._active_environments[task_id].cwd` (in-process memory), updated from `pwd -P` after each command (`tools/environments/base.py`).
- The `pre_tool_call` dispatch contract honors only `action/decision: "block"` (allow otherwise) and cannot rewrite the command, so the fix must run in the payload builder, which has `task_id` in scope.

## Fix

In `_serialize_payload`, when `tool_name == "terminal"`, resolve the live working directory via `tools.terminal_tool.get_active_env(task_id).cwd` and use it for the payload `cwd`, falling back to `Path.cwd()` on any miss. The helper is:

- **Lazy-imported** — `terminal_tool` is heavy and a module-load import would risk a cycle.
- **Fail-open** — no env, no task, blank cwd, or import error returns `None`, so the caller falls back to the prior `Path.cwd()` behavior.
- **Scoped to terminal** — non-terminal tools keep `Path.cwd()` exactly as before.

All three configured `pre_tool_call` hooks benefit, and none is weakened: a commit whose live env is genuinely on `main` still blocks.

## Testing

- New unit tests in `tests/agent/test_shell_hooks.py` (`TestLiveTerminalCwd`): terminal uses live env cwd; explicit `workdir` takes precedence over env cwd (blank workdir falls through); non-terminal falls back; no-env / lookup-error / blank-cwd all fail open to `Path.cwd()`.
- Full `tests/agent/test_shell_hooks.py` passes (61 tests); `tests/hermes_cli/test_hooks_cli.py` passes (14).
- Verified end-to-end through the real registered hook chain (`get_pre_tool_call_block_message` with hooks loaded from live config) against an ephemeral parent-on-main + worktree-on-feature repo:
  - bare commit, process on main, live env in feature worktree -> **allowed** (was blocked)
  - bare commit, live env genuinely on main -> **blocked** (guard intact)
  - `cd <worktree> && git commit` parser path -> allowed (unchanged)
  - no active env -> falls back to process cwd (main) -> blocked (conservative fallback intact)

## Risk

Low. Additive helper; the only behavior change is that a terminal `pre_tool_call` payload carries the live working directory instead of the gateway's process cwd. Every non-terminal path and every failure mode preserves the previous `Path.cwd()` value.
