### PR TITLE
fix(gemini): filter out raw encrypted thought signatures from reasoning

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -517,7 +517,14 @@ def translate_gemini_response(resp: Dict[str, Any], model: str) -> SimpleNamespa
         if not isinstance(part, dict):
             continue
         if part.get("thought") is True and isinstance(part.get("text"), str):
-            reasoning_pieces.append(part["text"])
+            text_val = part["text"]
+            # Filter out encrypted thought signatures that leak as thinking text
+            if len(text_val.strip()) > 64 and " " not in text_val.strip() and not any(c in text_val for c in ".,!?-*#"):
+                import re
+                if re.match(r"^[A-Za-z0-9+/=]+$", text_val.strip()):
+                    logger.debug("Filtered out encrypted thought signature from non-streaming reasoning")
+                    continue
+            reasoning_pieces.append(text_val)
             continue
         if isinstance(part.get("text"), str):
             text_pieces.append(part["text"])
@@ -656,7 +663,14 @@ def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices:
         if not isinstance(part, dict):
             continue
         if part.get("thought") is True and isinstance(part.get("text"), str):
-            chunks.append(_make_stream_chunk(model=model, reasoning=part["text"]))
+            text_val = part["text"]
+            # Filter out encrypted thought signatures that leak as thinking text
+            if len(text_val.strip()) > 64 and " " not in text_val.strip() and not any(c in text_val for c in ".,!?-*#"):
+                import re
+                if re.match(r"^[A-Za-z0-9+/=]+$", text_val.strip()):
+                    logger.debug("Filtered out encrypted thought signature from streaming reasoning")
+                    continue
+            chunks.append(_make_stream_chunk(model=model, reasoning=text_val))
             continue
         if isinstance(part.get("text"), str) and part["text"]:
             chunks.append(_make_stream_chunk(model=model, content=part["text"]))

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
     },
     "apps/desktop": {
       "name": "hermes",
-      "version": "0.15.1",
+      "version": "0.17.0",
       "dependencies": {
         "@assistant-ui/react": "^0.12.28",
         "@assistant-ui/react-streamdown": "^0.1.11",
@@ -1419,7 +1419,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1436,7 +1435,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1453,7 +1451,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1470,7 +1467,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1487,7 +1483,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1504,7 +1499,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1521,7 +1515,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1538,7 +1531,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1555,7 +1547,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1572,7 +1563,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1589,7 +1579,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1606,7 +1595,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1623,7 +1611,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1640,7 +1627,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1657,7 +1643,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1674,7 +1659,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1691,7 +1675,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1708,7 +1691,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1725,7 +1707,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1742,7 +1723,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1759,7 +1739,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1776,7 +1755,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1793,7 +1771,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1810,7 +1787,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1827,7 +1803,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1844,7 +1819,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }


### PR DESCRIPTION
### Description

When utilizing Gemini 2.5/3 thinking models with reasoning effort set to `Max`, the Google API occasionally streams stateful `thoughtSignature` tokens inside `thought` parts as raw base64 blocks (especially during multi-step tool-calling loops). 

Because these blocks are tagged as `thought: true` by the API, they bypass standard reasoning text filters and render directly onto the terminal UI / gateway consoles as a giant yellow wall of scrambled base64 characters, heavily degrading the user experience.

This PR introduces smart, defensive filtering in `agent/gemini_native_adapter.py` to intercept and filter out these raw encrypted thought signatures from both the streaming (`translate_stream_event`) and non-streaming (`translate_gemini_response`) adapter paths.

---

### Key Changes
- **Smart Base64 Filtering:** Added a check inside `gemini_native_adapter.py` that catches any incoming `thought` part whose text payload is longer than 64 characters, contains absolutely no spaces, has no standard markdown/text punctuation (`.,!?-*#`), and matches standard base64 character sets (`^[A-Za-z0-9+/=]+$`).
- **Pristine Visuals:** Skipped streaming these signatures to the user's terminal/dashboard reasoning box.
- **Robust Tool Replays:** Preserved the original logic for parsing and attaching `thoughtSignature` under `extra_content` for function calls so that multi-step agent tool replays still function perfectly (bypassing HTTP 400 validation errors).

---

### Verification Checklist
- [x] Tested with `gemini-2.5-pro` and `gemini-2.5-flash-thinking` under `REASONING: Max`.
- [x] Verified that standard markdown-formatted natural language thinking is rendered correctly.
- [x] Verified that raw base64 blocks are silently skipped without throwing errors or breaking subsequent tool call requests.
