### PR TITLE
fix(cron): suppress delivery for malformed [SILENT] markers

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -242,6 +242,57 @@ from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_
 # response with this marker to suppress delivery.  Output is still saved
 # locally for audit.
 SILENT_MARKER = "[SILENT]"
+_SILENT_BRACKETS_AND_WS = re.compile(r"[\s\[\]]+")
+
+
+def _is_silent_marker(text: str) -> bool:
+    """True iff ``text`` should be treated as the ``[SILENT]`` marker.
+
+    Suppresses delivery in three cases (any of which is sufficient):
+
+    1. **Strict equal** — the response, after stripping whitespace, brackets,
+       and one trailing sentence terminator (``[SILENT]``, ``[SILENT``,
+       ``[SILENT].``, `` [SILENT] ``, etc.).  Catches malformed markers that
+       the LLM emits with a missing closing bracket or stray punctuation.
+    2. **Trailing marker** — the response contains ``[SILENT]`` anywhere
+       (case-insensitive).  Added by #5023 for the preamble-pollution case
+       where the model wraps the marker with explanation text.
+    3. **Trailing malformed marker** — same as (2) but for the substring
+       ``[SILENT`` (no closing bracket) anywhere in the response.
+
+    See issues #5023 (preamble case) and #51438 (malformed-marker case).
+
+    Returns False for empty / whitespace-only / non-marker text so legitimate
+    reports still go through.
+    """
+    if not text:
+        return False
+    stripped = text.strip()
+    if not stripped:
+        return False
+    upper = stripped.upper()
+
+    # Case 1: whole-response match with malformed tolerance.
+    normalized = _SILENT_BRACKETS_AND_WS.sub("", upper)
+    if normalized.endswith((".", "!", "?", ",", ";", ":")):
+        normalized = normalized[:-1]
+    if normalized == "SILENT":
+        return True
+
+    # Case 2: well-formed [SILENT] marker anywhere in the response (#5023).
+    if "[SILENT]" in upper:
+        return True
+
+    # Case 3: malformed [SILENT (no closing bracket) anywhere (#51438).
+    # Require the malformed marker to be a whole token — followed by
+    # whitespace, sentence punctuation, or end of string.  Otherwise
+    # words like ``[SILENTIA]`` would match by prefix.
+    if re.search(r"\[\s*SILENT\s*[\.\!\?\,\;\:]?\s*$", upper, re.M):
+        return True
+    if re.search(r"\[\s*SILENT\s*[\.\!\?\,\;\:]", upper):
+        return True
+
+    return False
 
 # ---------------------------------------------------------------------------
 # Persistent thread pool for parallel cron jobs.
@@ -2335,7 +2386,10 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         # responses: do not deliver a blank message, and let the
         # empty-response guard below mark the run as a soft failure.
         should_deliver = bool(deliver_content.strip())
-        if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
+        # Normalize before matching so malformed markers (truncated
+        # closing bracket, surrounding whitespace, trailing punctuation)
+        # don't bypass suppression.  See issue #51438.
+        if should_deliver and success and _is_silent_marker(deliver_content):
             logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
             should_deliver = False
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2286,6 +2286,68 @@ class TestSilentDelivery:
             tick(verbose=False)
         deliver_mock.assert_not_called()
 
+    def test_silent_missing_closing_bracket_suppresses_delivery(self):
+        """Regression for issue #51438: agent emitted ``[SILENT`` (no ``]``)
+        and the substring-match from #5023 let it slip through to Telegram."""
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", "[SILENT", None)), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.mark_job_run"):
+            from cron.scheduler import tick
+            tick(verbose=False)
+        deliver_mock.assert_not_called()
+
+    def test_silent_with_surrounding_whitespace_suppresses_delivery(self):
+        """Regression for issue #51438: whitespace around the marker
+        should still trigger suppression."""
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", "  [SILENT]  \n", None)), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.mark_job_run"):
+            from cron.scheduler import tick
+            tick(verbose=False)
+        deliver_mock.assert_not_called()
+
+    def test_silent_with_trailing_punctuation_suppresses_delivery(self):
+        """Regression for issue #51438: trailing sentence punctuation
+        (``[SILENT].``) should still trigger suppression."""
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", "[SILENT].", None)), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.mark_job_run"):
+            from cron.scheduler import tick
+            tick(verbose=False)
+        deliver_mock.assert_not_called()
+
+    def test_silent_malformed_trailing_in_report_suppresses_delivery(self):
+        """Regression for issue #51438: malformed ``[SILENT`` (no ``]``)
+        appended to a real report must still trigger suppression."""
+        response = "All clear, nothing changed.\n[SILENT"
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", response, None)), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.mark_job_run"):
+            from cron.scheduler import tick
+            tick(verbose=False)
+        deliver_mock.assert_not_called()
+
+    def test_silent_partial_word_does_not_suppress(self):
+        """Words that merely contain ``SILENT`` as a prefix (``[SILENTIA]``,
+        ``silenced``) must NOT trigger suppression — only the exact marker
+        should."""
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", "noise [SILENTIA] more", None)), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.mark_job_run"):
+            from cron.scheduler import tick
+            tick(verbose=False)
+        deliver_mock.assert_called_once()
+
     def test_silent_is_case_insensitive(self):
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
              patch("cron.scheduler.run_job", return_value=(True, "# output", "[silent] nothing new", None)), \


### PR DESCRIPTION
## Summary

The cron scheduler's delivery suppression check at `cron/scheduler.py:2338` uses substring matching against the literal `"[SILENT]"`. When the agent emits a malformed marker — e.g. `"[SILENT"` without the closing bracket — the check fails and the literal text is delivered to the user's chat.

This is a sibling bug to #5023 (which fixed preamble-polluted responses). That fix covers well-formed `[SILENT]` markers; it does not catch the malformed case.

## Reproduction

Observed 2026-06-23 at 21:20 IST with the Copernicus Health Check job on `minimax-m3:cloud`:
- Agent final response (literal, from cron output file): `[SILENT` (7 chars, hex `5b 53 49 4c 45 4e 54 0a`)
- Scheduler log: `delivered to telegram:8698503351 via live adapter` (no "skipping delivery" log)
- Result: the malformed marker arrived in the user's Telegram DM

Reproduction is non-deterministic — depends on the LLM emitting the marker with exactly the right kind of corruption to slip through substring matching.

## Fix

Replace the inline substring check with a new `_is_silent_marker()` helper that handles three cases:

1. **Strict equal** — the response normalizes to `"SILENT"` after stripping whitespace, brackets, and one trailing sentence terminator. Catches `[SILENT]`, `[SILENT`, `[SILENT].`, ` [SILENT] `, etc.
2. **Trailing well-formed marker** — `[SILENT]` appears anywhere in the response (#5023 case, preserved).
3. **Trailing malformed marker** — `[SILENT` (no closing bracket) appears as a whole token anywhere in the response.

The whole-token requirement for case 3 prevents false positives on words that merely contain `"SILENT"` as a prefix (e.g. `[SILENTIA]`, `silenced`).

## Tests

Five new regression tests in `tests/cron/test_scheduler.py::TestSilentDelivery`:
- `test_silent_missing_closing_bracket_suppresses_delivery` — the exact bug
- `test_silent_with_surrounding_whitespace_suppresses_delivery`
- `test_silent_with_trailing_punctuation_suppresses_delivery`
- `test_silent_malformed_trailing_in_report_suppresses_delivery`
- `test_silent_partial_word_does_not_suppress` — guards against `[SILENTIA]` false positive

All 525 cron tests pass. The 13 pre-existing SILENT tests continue to pass, so the #5023 fix is preserved.

## Related

- #5023 — original `[SILENT]` preamble fix (different bug class)
- #51438 — issue this PR resolves

I verified this locally with `pytest tests/cron/ -q`: 525 passed, 0 failures.