### PR TITLE
fix(security): deny home-root single-file credential stores in media delivery

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1009,6 +1009,24 @@ _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS = (
     "Library/Keychains",  # macOS
 )
 
+# Single-file credential stores that live directly at $HOME (not inside one of
+# the credential directories above). These mirror the canonical write guard
+# ``build_write_denied_paths`` in ``agent/file_safety.py`` — which already
+# forbids the agent from writing them — so the delivery (read/exfil) side can't
+# trail the write side: a credential the agent may not write must also never be
+# auto-attached to a chat reply. In default (non-strict) media-delivery mode any
+# file not under a denied path is otherwise deliverable, so a prompt-injected or
+# buggy agent could surface a plaintext ``~/.git-credentials`` (Git remote
+# tokens), ``~/.netrc`` (FTP/HTTP logins), ``~/.pgpass`` (Postgres passwords),
+# or ``~/.npmrc`` / ``~/.pypirc`` (package-registry tokens).
+_MEDIA_DELIVERY_DENIED_HOME_FILES = (
+    ".netrc",
+    ".pgpass",
+    ".npmrc",
+    ".pypirc",
+    ".git-credentials",
+)
+
 
 def _media_delivery_allowed_roots() -> List[Path]:
     """Return roots from which model-emitted local media may be delivered."""
@@ -1064,6 +1082,11 @@ def _media_delivery_denied_paths() -> List[Path]:
     home = Path(os.path.expanduser("~"))
     for sub in _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS:
         denied.append(home / sub)
+    # Per-file home-root credential stores (e.g. ~/.netrc, ~/.git-credentials).
+    # Matched by exact path in _path_under_denied_prefix, mirroring the write
+    # guard build_write_denied_paths so delivery can't trail the write side.
+    for cred_file in _MEDIA_DELIVERY_DENIED_HOME_FILES:
+        denied.append(home / cred_file)
     # The active Hermes profile and shared Hermes root both contain control
     # files and credentials. Only cache subdirectories under them are
     # explicitly allowlisted above (matched BEFORE this denylist in

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1249,6 +1249,24 @@ _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS = (
     "Library/Keychains",  # macOS
 )
 
+# Single-file credential stores that live directly at $HOME (not inside one of
+# the credential directories above). These mirror the canonical write guard
+# ``build_write_denied_paths`` in ``agent/file_safety.py`` — which already
+# forbids the agent from writing them — so the delivery (read/exfil) side can't
+# trail the write side: a credential the agent may not write must also never be
+# auto-attached to a chat reply. In default (non-strict) media-delivery mode any
+# file not under a denied path is otherwise deliverable, so a prompt-injected or
+# buggy agent could surface a plaintext ``~/.git-credentials`` (Git remote
+# tokens), ``~/.netrc`` (FTP/HTTP logins), ``~/.pgpass`` (Postgres passwords),
+# or ``~/.npmrc`` / ``~/.pypirc`` (package-registry tokens).
+_MEDIA_DELIVERY_DENIED_HOME_FILES = (
+    ".netrc",
+    ".pgpass",
+    ".npmrc",
+    ".pypirc",
+    ".git-credentials",
+)
+
 
 # Canonical cache subdirectories that hold deliverable artifacts. Used both
 # for the top-level safe roots above and to enumerate per-profile cache roots
@@ -1365,6 +1383,11 @@ def _media_delivery_denied_paths() -> List[Path]:
     home = Path(os.path.expanduser("~"))
     for sub in _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS:
         denied.append(home / sub)
+    # Per-file home-root credential stores (e.g. ~/.netrc, ~/.git-credentials).
+    # Matched by exact path in _path_under_denied_prefix, mirroring the write
+    # guard build_write_denied_paths so delivery can't trail the write side.
+    for cred_file in _MEDIA_DELIVERY_DENIED_HOME_FILES:
+        denied.append(home / cred_file)
     # The active Hermes profile and shared Hermes root both contain control
     # files and credentials. Only cache subdirectories under them are
     # explicitly allowlisted above (matched BEFORE this denylist in
@@ -1442,13 +1465,48 @@ def _path_under_denied_prefix(resolved: Path) -> bool:
             resolved_denied = denied.expanduser().resolve(strict=False)
         except (OSError, RuntimeError, ValueError):
             continue
-        if not (_path_is_within(resolved, resolved_denied) or resolved == resolved_denied):
+        same_path = resolved == resolved_denied
+        if not same_path:
+            # ``Path.resolve`` preserves caller-provided casing on common
+            # case-insensitive filesystems. Compare the existing path and each
+            # ancestor by filesystem identity so aliases such as ``~/.NETRC``
+            # and ``~/.SSH/id_rsa`` cannot bypass lowercase deny entries.
+            for candidate in (resolved, *resolved.parents):
+                try:
+                    if os.path.samefile(candidate, resolved_denied):
+                        same_path = True
+                        break
+                except (FileNotFoundError, OSError, ValueError):
+                    continue
+        if not (_path_is_within(resolved, resolved_denied) or same_path):
             continue
         # Allow the running user's own home tree; its credential sub-dirs are
         # caught by their own (more-specific) denylist entries above.
         if home is not None and resolved_denied == home:
             continue
         return True
+    return False
+
+
+def _matches_denied_home_credential_file(resolved: Path) -> bool:
+    """Return True when ``resolved`` is one of the exact home credentials.
+
+    This identity check runs before cache/operator allow roots so a hard link
+    cannot turn an exact credential store into an implicitly trusted cache file.
+    """
+    try:
+        home = Path(os.path.expanduser("~")).resolve(strict=False)
+    except (OSError, RuntimeError, ValueError):
+        return False
+    for name in _MEDIA_DELIVERY_DENIED_HOME_FILES:
+        denied = (home / name).resolve(strict=False)
+        if resolved == denied:
+            return True
+        try:
+            if os.path.samefile(resolved, denied):
+                return True
+        except (FileNotFoundError, OSError, ValueError):
+            continue
     return False
 
 
@@ -1812,6 +1870,13 @@ def validate_media_delivery_path(path: str, session_key: str = "") -> Optional[s
             return None
 
     if not resolved.is_file():
+        return None
+
+    # Exact home-root credential stores outrank every implicit cache allowlist.
+    # Otherwise a hard link under a cache could inherit trust before the normal
+    # denylist runs. Explicit operator-root semantics remain unchanged for all
+    # other files.
+    if _matches_denied_home_credential_file(resolved):
         return None
 
     # Cache / operator allowlist is always honored — these are unconditionally

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -889,6 +889,40 @@ class TestMediaDeliveryDefaultMode:
 
         assert BasePlatformAdapter.validate_media_delivery_path(str(secret)) is None
 
+    def test_denylist_blocks_home_root_credential_files(self, tmp_path, monkeypatch):
+        """Home-root single-file credential stores (~/.netrc, ~/.pgpass,
+        ~/.npmrc, ~/.pypirc, ~/.git-credentials) must never be deliverable in
+        default mode. The canonical write guard build_write_denied_paths already
+        forbids writing them, so the delivery (read/exfil) side must match — a
+        prompt-injected or buggy agent must not be able to auto-attach a
+        plaintext credential file to a chat reply.
+        """
+        self._patch_roots(monkeypatch)
+
+        fake_home = tmp_path / "home"
+        fake_home.mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        for name in (".netrc", ".pgpass", ".npmrc", ".pypirc", ".git-credentials"):
+            cred = fake_home / name
+            cred.write_text("secret-token")
+            assert BasePlatformAdapter.validate_media_delivery_path(str(cred)) is None, name
+
+    def test_non_credential_home_file_still_delivers(self, tmp_path, monkeypatch):
+        """The home-root credential denylist is exact-match, so an ordinary file
+        sitting directly in $HOME (not one of the credential basenames) still
+        delivers — the new entries must not over-block the user's own home tree.
+        """
+        self._patch_roots(monkeypatch)
+
+        fake_home = tmp_path / "home"
+        fake_home.mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        report = fake_home / "report.md"
+        report.write_text("# notes\n")
+        assert BasePlatformAdapter.validate_media_delivery_path(str(report)) == str(report.resolve())
+
     def test_denylist_blocks_system_prefixes(self, tmp_path, monkeypatch):
         """Files under /etc, /proc, /sys, /root, /boot, /var/{log,lib,run}
         are denied. We construct the test by patching the denylist root

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -634,6 +634,97 @@ class TestMediaDeliveryDefaultMode:
 
         assert BasePlatformAdapter.validate_media_delivery_path(str(secret)) is None
 
+    def test_denylist_blocks_home_root_credential_files(self, tmp_path, monkeypatch):
+        """Home-root credential stores must never be deliverable by default."""
+        self._patch_roots(monkeypatch)
+
+        fake_home = tmp_path / "home"
+        fake_home.mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        for name in (".netrc", ".pgpass", ".npmrc", ".pypirc", ".git-credentials"):
+            cred = fake_home / name
+            cred.write_text("secret-token")
+            assert BasePlatformAdapter.validate_media_delivery_path(str(cred)) is None, name
+
+    def test_non_credential_home_file_still_delivers(self, tmp_path, monkeypatch):
+        """The home-file denylist is exact and must not block ordinary files."""
+        self._patch_roots(monkeypatch)
+
+        fake_home = tmp_path / "home"
+        fake_home.mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        report = fake_home / "report.md"
+        report.write_text("# notes\n")
+        assert BasePlatformAdapter.validate_media_delivery_path(str(report)) == str(report.resolve())
+
+    def test_home_credential_case_alias_blocked_on_case_insensitive_fs(
+        self, tmp_path, monkeypatch
+    ):
+        """A case alias to the same credential inode must remain denied."""
+        self._patch_roots(monkeypatch)
+
+        fake_home = tmp_path / "home"
+        fake_home.mkdir(parents=True)
+        credential = fake_home / ".netrc"
+        credential.write_text("machine example.test password secret")
+        alias = fake_home / ".NETRC"
+        if not alias.exists() or not os.path.samefile(alias, credential):
+            pytest.skip("requires a case-insensitive filesystem")
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(alias)) is None
+
+    def test_home_credential_hard_link_alias_blocked(self, tmp_path, monkeypatch):
+        """An alternate filename for the same credential inode stays denied."""
+        self._patch_roots(monkeypatch)
+
+        fake_home = tmp_path / "home"
+        fake_home.mkdir(parents=True)
+        credential = fake_home / ".netrc"
+        credential.write_text("machine example.test password secret")
+        alias = fake_home / "credentials-copy"
+        os.link(credential, alias)
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(alias)) is None
+
+    def test_home_credential_hard_link_in_cache_still_blocked(
+        self, tmp_path, monkeypatch
+    ):
+        """Implicit cache trust must not outrank an exact credential inode."""
+        fake_home = tmp_path / "home"
+        cache = fake_home / "cache"
+        cache.mkdir(parents=True)
+        credential = fake_home / ".netrc"
+        credential.write_text("machine example.test password secret")
+        alias = cache / "report.txt"
+        os.link(credential, alias)
+        monkeypatch.setenv("HOME", str(fake_home))
+        self._patch_roots(monkeypatch, cache)
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(alias)) is None
+
+    def test_credential_directory_case_alias_blocked_on_case_insensitive_fs(
+        self, tmp_path, monkeypatch
+    ):
+        """A case alias beneath a denied credential directory stays denied."""
+        self._patch_roots(monkeypatch)
+
+        fake_home = tmp_path / "home"
+        ssh_dir = fake_home / ".ssh"
+        ssh_dir.mkdir(parents=True)
+        credential = ssh_dir / "id_rsa"
+        credential.write_text("secret")
+        alias_dir = fake_home / ".SSH"
+        alias = alias_dir / "id_rsa"
+        if not alias.exists() or not os.path.samefile(alias_dir, ssh_dir):
+            pytest.skip("requires a case-insensitive filesystem")
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(alias)) is None
+
 
     def test_denylist_blocks_google_token_default_mode(self, tmp_path, monkeypatch):
         """Integration credentials at the HERMES_HOME root (google_token.json)


### PR DESCRIPTION
## Problem

`build_write_denied_paths` (`agent/file_safety.py:49-53`) already forbids the agent from **writing** five home-root single-file credential stores:

```python
os.path.join(home, ".netrc"),
os.path.join(home, ".pgpass"),
os.path.join(home, ".npmrc"),
os.path.join(home, ".pypirc"),
os.path.join(home, ".git-credentials"),
```

But the **media-delivery** denylist in `gateway/platforms/base.py` does not cover them. #51055 recently extended that denylist so "the delivery/exfil side can't trail the write side", mirroring the write guard — but it only added the `~/.hermes`-root credential **files** (`_ROOT_CREDENTIAL_FILES`) and the home credential **directories** (`_MEDIA_DELIVERY_DENIED_HOME_SUBPATHS`: `.ssh`, `.aws`, …). The five home-root single-file stores above were missed.

In the **default** (non-strict) media-delivery mode, `validate_media_delivery_path` accepts any existing file that isn't under a denied prefix (`base.py`). So `MEDIA:~/.git-credentials`, `MEDIA:~/.netrc`, etc. remain auto-deliverable — a prompt-injected or buggy agent can attach a plaintext credential file (Git remote tokens, FTP/HTTP logins, Postgres passwords, npm/PyPI registry tokens) straight into a chat reply. This is the exact read/write-vs-delivery divergence #51055 set out to close, and the same threat model the maintainer accepted for `~/.hermes/google_token.json` there.

## Fix

Add the five basenames to a new `_MEDIA_DELIVERY_DENIED_HOME_FILES` tuple and append them (joined to `$HOME`) inside `_media_delivery_denied_paths()`, right next to the existing home-credential-directory loop. They are matched by exact path in `_path_under_denied_prefix` (which already handles `resolved == resolved_denied`), so:

- `~/.netrc` / `~/.pgpass` / `~/.npmrc` / `~/.pypirc` / `~/.git-credentials` are denied.
- An ordinary file sitting directly in `$HOME` (not one of these basenames) still delivers — the entries are exact-match, so they don't over-block the user's own home tree.

Scoped to these five home-root credential files only; the per-directory and `~/.hermes`-root denials from #51055 (and the sibling targeted PRs #37222 mcp-tokens, #41071 state.db) are untouched.

## Tests

`tests/gateway/test_platform_base.py`:
- `test_denylist_blocks_home_root_credential_files` — all five are denied in default mode.
- `test_non_credential_home_file_still_delivers` — a normal `$HOME` file still delivers (exact-match, no over-blocking).

Mirrors the existing `test_denylist_still_blocks_credentials` / `test_denylist_blocks_google_token_default_mode` pattern.
