### PR TITLE
fix(goals): schedule driver wake-up for time-based wait barriers

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8483,6 +8483,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 except Exception as exc:
                     logging.debug("goal continuation enqueue failed: %s", exc)
 
+        resume_after = decision.get("resume_after_seconds")
+        if resume_after and resume_after > 0:
+            def _goal_deadline_fire():
+                import time as _t
+                _t.sleep(resume_after)
+                try:
+                    self._pending_input.put(
+                        "The wait period has elapsed. Continue working on the goal."
+                    )
+                except Exception:
+                    pass
+            threading.Thread(
+                target=_goal_deadline_fire, daemon=True, name="goal-deadline",
+            ).start()
+
 
 
     def _toggle_verbose(self):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10670,6 +10670,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if msg and source is not None:
             await self._defer_goal_status_notice_after_delivery(source, msg)
 
+        resume_after = decision.get("resume_after_seconds")
+        if resume_after and resume_after > 0 and source is not None:
+            async def _goal_deadline_fire():
+                await asyncio.sleep(resume_after)
+                try:
+                    _adapter = self.adapters.get(source.platform)
+                    _key = self._session_key_for_source(source)
+                    if _adapter and _key:
+                        _evt = MessageEvent(
+                            text="The wait period has elapsed. Continue working on the goal.",
+                            message_type=MessageType.TEXT,
+                            source=source,
+                            message_id=None,
+                            channel_prompt=None,
+                        )
+                        self._enqueue_fifo(_key, _evt, _adapter)
+                except Exception as exc:
+                    logger.debug("goal deadline fire: %s", exc)
+            asyncio.ensure_future(_goal_deadline_fire())
+
         if not decision.get("should_continue"):
             return
 

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -1428,7 +1428,7 @@ class GoalManager:
                 remaining = max(0, int(state.waiting_until - time.time()))
                 tgt = f"{remaining}s remaining"
             reason = state.waiting_reason or tgt
-            return {
+            result = {
                 "status": "active",
                 "should_continue": False,
                 "continuation_prompt": None,
@@ -1436,6 +1436,9 @@ class GoalManager:
                 "reason": reason,
                 "message": f"⏳ Goal parked — waiting on {tgt}: {reason}",
             }
+            if state.waiting_until and state.waiting_on_pid is None and state.waiting_on_session is None:
+                result["resume_after_seconds"] = max(1, int(state.waiting_until - time.time()))
+            return result
 
         # Count the turn that just finished.
         state.turns_used += 1
@@ -1466,6 +1469,7 @@ class GoalManager:
         # exits or the deadline passes (next evaluate_after_turn falls through
         # the is_waiting() short-circuit once the barrier clears).
         if verdict == "wait" and wait_directive:
+            resume_secs = None
             if wait_directive.get("session_id"):
                 self.wait_on_session(str(wait_directive["session_id"]), reason=reason)
                 tgt = f"session {wait_directive['session_id']}"
@@ -1473,9 +1477,11 @@ class GoalManager:
                 self.wait_on(int(wait_directive["pid"]), reason=reason)
                 tgt = f"pid {wait_directive['pid']}"
             else:
-                self.wait_for_seconds(int(wait_directive["seconds"]), reason=reason)
-                tgt = f"{wait_directive['seconds']}s"
-            return {
+                secs = int(wait_directive["seconds"])
+                self.wait_for_seconds(secs, reason=reason)
+                tgt = f"{secs}s"
+                resume_secs = secs
+            result = {
                 "status": "active",
                 "should_continue": False,
                 "continuation_prompt": None,
@@ -1483,6 +1489,9 @@ class GoalManager:
                 "reason": reason,
                 "message": f"⏳ Goal parked (judge) — waiting on {tgt}: {reason}",
             }
+            if resume_secs is not None:
+                result["resume_after_seconds"] = resume_secs
+            return result
 
         if verdict == "done":
             state.status = "done"

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -1079,6 +1079,75 @@ class TestJudgeDrivenWait:
         assert mgr.is_waiting() is False
         assert mgr.state.waiting_until == 0.0
 
+    def test_time_wait_verdict_includes_resume_after_seconds(self, hermes_home):
+        """wait_for_seconds verdict must include resume_after_seconds so
+        drivers can schedule a timer to re-enter the loop."""
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="jw-resume-secs", default_max_turns=10)
+        mgr.set("do work")
+        with patch.object(
+            goals, "judge_goal",
+            return_value=("wait", "rate limited", False, {"seconds": 60}),
+        ):
+            decision = mgr.evaluate_after_turn("Hit a 429.")
+        assert decision["verdict"] == "wait"
+        assert decision["should_continue"] is False
+        assert decision["resume_after_seconds"] == 60
+
+    def test_time_barrier_is_waiting_includes_resume_after_seconds(self, hermes_home):
+        """When a turn fires while a time barrier is active, the decision
+        must carry resume_after_seconds so the driver can (re)schedule."""
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="jw-resume-wait")
+        mgr.set("g")
+        mgr.wait_for_seconds(120, reason="backoff")
+        decision = mgr.evaluate_after_turn("response")
+        assert decision["verdict"] == "waiting"
+        assert decision["should_continue"] is False
+        assert "resume_after_seconds" in decision
+        assert 0 < decision["resume_after_seconds"] <= 120
+
+    def test_pid_wait_verdict_has_no_resume_after_seconds(self, hermes_home):
+        """PID-based waits should NOT include resume_after_seconds — they
+        wake via process-exit events, not timers."""
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="jw-pid-no-resume", default_max_turns=10)
+        mgr.set("watch a process")
+        with patch.object(
+            goals, "judge_goal",
+            return_value=("wait", "compiling", False, {"pid": 99999}),
+        ), patch.object(goals, "_pid_alive", return_value=True):
+            decision = mgr.evaluate_after_turn("started build")
+        assert decision["verdict"] == "wait"
+        assert "resume_after_seconds" not in decision
+
+    def test_time_barrier_deadline_falls_through_to_judge(self, hermes_home):
+        """After the time deadline passes, evaluate_after_turn must fall
+        through to the judge instead of short-circuiting — verifying the
+        full driver path, not just is_waiting() in isolation."""
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="jw-fall-through", default_max_turns=10)
+        mgr.set("do work")
+        mgr.wait_for_seconds(5, reason="backoff")
+        # Force deadline into the past.
+        mgr.state.waiting_until = time.time() - 1
+        with patch.object(
+            goals, "judge_goal",
+            return_value=("continue", "keep going", False, None),
+        ) as mock_judge:
+            decision = mgr.evaluate_after_turn("some response")
+        mock_judge.assert_called_once()
+        assert decision["verdict"] == "continue"
+        assert decision["should_continue"] is True
+        assert mgr.state.waiting_until == 0.0
+
     def test_continue_verdict_still_continues_with_background(self, hermes_home):
         """A running process present but judge says continue → normal loop."""
         from hermes_cli import goals

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6849,6 +6849,38 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                                 cont_prompt = decision.get("continuation_prompt") or ""
                                 if cont_prompt:
                                     goal_followup = cont_prompt
+
+                            resume_secs = decision.get("resume_after_seconds")
+                            if resume_secs and resume_secs > 0:
+                                _dl_sid = sid
+                                _dl_session = session
+                                _dl_rid = rid
+                                def _goal_deadline_fire():
+                                    import time as _t
+                                    _t.sleep(resume_secs)
+                                    with _dl_session["history_lock"]:
+                                        if _dl_session.get("running"):
+                                            return
+                                        _dl_session["running"] = True
+                                    try:
+                                        _emit("message.start", _dl_sid)
+                                        _run_prompt_submit(
+                                            _dl_rid, _dl_sid, _dl_session,
+                                            "The wait period has elapsed. Continue working on the goal.",
+                                        )
+                                    except Exception as _dl_exc:
+                                        print(
+                                            f"[tui_gateway] goal deadline fire failed: "
+                                            f"{type(_dl_exc).__name__}: {_dl_exc}",
+                                            file=sys.stderr,
+                                        )
+                                        with _dl_session["history_lock"]:
+                                            _dl_session["running"] = False
+                                threading.Thread(
+                                    target=_goal_deadline_fire,
+                                    daemon=True,
+                                    name="goal-deadline",
+                                ).start()
                 except Exception as _goal_exc:
                     print(
                         f"[tui_gateway] goal continuation hook failed: "


### PR DESCRIPTION
## Summary

When the judge returns a `wait_for_seconds` verdict (e.g. rate-limit backoff), the goal loop parks with `should_continue=False` but **no timer is armed** to resume it once the deadline passes. PID and session barriers wake via process-exit events, but a time barrier produces no event — the loop stays parked indefinitely until the user manually sends a message or runs `/goal unwait`.

### Root cause

`evaluate_after_turn` returns `should_continue=False` for all wait verdicts. For PID/session barriers, an external completion event re-enters the conversation loop and calls `evaluate_after_turn` again, where `is_waiting()` detects the satisfied barrier and falls through to the judge. For time barriers, no such event exists — the wall-clock deadline passes silently with nothing to poke the loop.

The existing test `test_time_barrier_clears_after_deadline` calls `is_waiting()` directly, which proves the barrier *can* clear but not that it *does* clear in the driver loop.

### Fix

Add a `resume_after_seconds` field to the `evaluate_after_turn` decision dict for time-based barriers. Each driver reads this field and schedules a delayed continuation:

- **CLI** — daemon thread sleeps then enqueues via `_pending_input.put()`
- **Gateway** — `asyncio.ensure_future` with `asyncio.sleep` then `_enqueue_fifo`
- **TUI** — daemon thread sleeps then calls `_run_prompt_submit()` (same guard pattern as `goal_followup`)

When the timer fires, the re-entered turn calls `evaluate_after_turn` → `is_waiting()` finds the expired deadline → barrier clears → judge runs normally.

## Test plan

- [x] `test_time_wait_verdict_includes_resume_after_seconds` — initial verdict carries the field
- [x] `test_time_barrier_is_waiting_includes_resume_after_seconds` — subsequent short-circuit carries it
- [x] `test_pid_wait_verdict_has_no_resume_after_seconds` — PID waits are unaffected
- [x] `test_time_barrier_deadline_falls_through_to_judge` — after deadline, evaluate_after_turn calls the judge (full path, not just `is_waiting()`)
- [x] All 105 existing goal tests pass