### PR TITLE
fix(dashboard): block automatic web installs in non-interactive startup

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -190,6 +190,50 @@ def _suppress_mouse_residue_early() -> None:
 _suppress_mouse_residue_early()
 
 
+# ── Dashboard auto-install policy ───────────────────────────────────────
+# Dashboard startup may trigger dependency installation or a web UI build.
+# In non-interactive contexts this is an explicit maintenance action, so
+# automatic installation is denied by default unless the operator
+# explicitly opts in.
+#
+# Default policy: only auto-install when both stdin and stdout are TTYs
+# (interactive operator) AND the operator has not explicitly disabled it
+# via HERMES_DASHBOARD_AUTO_INSTALL=0. The companion opt-in
+# HERMES_DASHBOARD_AUTO_INSTALL=1 is provided for CI / non-TTY pipelines
+# that *do* want the install to run.
+#
+# This helper is the single source of truth for the dashboard auto-install
+# gate. The gate is enforced at the only dashboard call site
+# (``cmd_dashboard``) by short-circuiting BEFORE invoking the shared
+# ``_build_web_ui`` helper. ``_build_web_ui`` is also called by
+# ``hermes web`` and ``hermes update --desktop``; its signature and
+# behaviour remain unchanged for those callers.
+_DASHBOARD_AUTO_INSTALL_ENV = "HERMES_DASHBOARD_AUTO_INSTALL"
+
+
+def _dashboard_auto_install_allowed() -> bool:
+    """Return True if the dashboard should auto-run ``npm install`` for the web UI.
+
+    The default is "allowed only when both stdin and stdout are TTYs and the
+    operator has not disabled it." The escape hatches are explicit env-var
+    values:
+
+        HERMES_DASHBOARD_AUTO_INSTALL=0  → force deny
+        HERMES_DASHBOARD_AUTO_INSTALL=1  → force allow (e.g. CI)
+
+    An empty/unset value falls through to the TTY test.
+    """
+    val = os.environ.get(_DASHBOARD_AUTO_INSTALL_ENV, "").strip().lower()
+    if val in {"0", "false", "no", "off"}:
+        return False
+    if val in {"1", "true", "yes", "on"}:
+        return True
+    try:
+        return bool(sys.stdin.isatty() and sys.stdout.isatty())
+    except (AttributeError, ValueError, OSError):
+        return False
+
+
 def _is_termux_startup_environment_fast() -> bool:
     """Tiny Termux check for pre-import startup shortcuts."""
     prefix = os.environ.get("PREFIX", "")
@@ -11366,7 +11410,34 @@ def cmd_dashboard(args):
     _sync_bundled_skills_quietly()
 
     if "HERMES_WEB_DIST" not in os.environ and not getattr(args, "skip_build", False):
-        if not _build_web_ui(PROJECT_ROOT / "web", fatal=True):
+        # Dashboard auto-install policy: in non-TTY / systemd / service
+        # contexts the dashboard must NEVER spawn `npm install` on its
+        # own — TUI / web dependencies are an explicit maintenance
+        # action. The policy is enforced by short-circuiting BEFORE
+        # calling ``_build_web_ui`` (a shared helper used by ``hermes
+        # web`` and ``hermes update --desktop``) so the helper's
+        # signature and behaviour stay unchanged for every other
+        # caller. The single side effect is a fail-closed SystemExit(1)
+        # with an actionable recovery hint.
+        web_dir = PROJECT_ROOT / "web"
+        if (
+            not _dashboard_auto_install_allowed()
+            and (web_dir / "package.json").exists()
+            and _web_ui_build_needed(web_dir)
+        ):
+            print(
+                "✗ Web UI TUI dependencies not installed. The dashboard was "
+                "started in a non-interactive context and cannot run `npm install`."
+            )
+            print("  To install TUI dependencies, run this from the Hermes checkout:")
+            print("    cd web && npm install && npm run build")
+            print("  Then re-run `hermes dashboard` (or pass `--skip-build` to "
+                  "bypass the build step entirely if the dist is already built).")
+            print("  Set HERMES_DASHBOARD_AUTO_INSTALL=1 to allow non-interactive "
+                  "dashboard starts to install TUI dependencies (not recommended "
+                  "on memory-constrained hosts).")
+            sys.exit(1)
+        if not _build_web_ui(web_dir, fatal=True):
             sys.exit(1)
     elif getattr(args, "skip_build", False):
         # --build-mode skip trusts the caller to have pre-built the web UI.

--- a/tests/hermes_cli/test_dashboard_auto_install_guard.py
+++ b/tests/hermes_cli/test_dashboard_auto_install_guard.py
@@ -1,0 +1,192 @@
+import argparse
+import sys
+import os
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+import pytest
+
+from hermes_cli.main import (
+    cmd_dashboard,
+    _dashboard_auto_install_allowed,
+)
+
+
+def _ns(**kw):
+    """Build an argparse.Namespace with dashboard defaults plus overrides."""
+    defaults = dict(
+        port=9119, host="127.0.0.1", no_open=False, insecure=False,
+        stop=False, status=False, skip_build=False, isolated=False,
+        open_profile=""
+    )
+    defaults.update(kw)
+    return argparse.Namespace(**defaults)
+
+
+class TestDashboardAutoInstallAllowed:
+
+    @pytest.fixture(autouse=True)
+    def clean_env(self):
+        """Ensure env var is clean before each test."""
+        old_val = os.environ.get("HERMES_DASHBOARD_AUTO_INSTALL")
+        if "HERMES_DASHBOARD_AUTO_INSTALL" in os.environ:
+            del os.environ["HERMES_DASHBOARD_AUTO_INSTALL"]
+        yield
+        if old_val is not None:
+            os.environ["HERMES_DASHBOARD_AUTO_INSTALL"] = old_val
+        elif "HERMES_DASHBOARD_AUTO_INSTALL" in os.environ:
+            del os.environ["HERMES_DASHBOARD_AUTO_INSTALL"]
+
+    @pytest.mark.parametrize("val", ["0", "false", "no", "off", " 0 ", "FALSE"])
+    def test_explicit_opt_out_env(self, val):
+        os.environ["HERMES_DASHBOARD_AUTO_INSTALL"] = val
+        # Should be False regardless of TTY status
+        with patch("sys.stdin.isatty", return_value=True), \
+             patch("sys.stdout.isatty", return_value=True):
+            assert _dashboard_auto_install_allowed() is False
+
+        with patch("sys.stdin.isatty", return_value=False), \
+             patch("sys.stdout.isatty", return_value=False):
+            assert _dashboard_auto_install_allowed() is False
+
+    @pytest.mark.parametrize("val", ["1", "true", "yes", "on", " 1 ", "TRUE"])
+    def test_explicit_opt_in_env(self, val):
+        os.environ["HERMES_DASHBOARD_AUTO_INSTALL"] = val
+        # Should be True regardless of TTY status
+        with patch("sys.stdin.isatty", return_value=False), \
+             patch("sys.stdout.isatty", return_value=False):
+            assert _dashboard_auto_install_allowed() is True
+
+        with patch("sys.stdin.isatty", return_value=True), \
+             patch("sys.stdout.isatty", return_value=True):
+            assert _dashboard_auto_install_allowed() is True
+
+    def test_default_tty_allowed(self):
+        # Unset env, both stdin and stdout are TTY -> Allowed
+        with patch("sys.stdin.isatty", return_value=True), \
+             patch("sys.stdout.isatty", return_value=True):
+            assert _dashboard_auto_install_allowed() is True
+
+    @pytest.mark.parametrize("stdin_tty, stdout_tty", [
+        (True, False),
+        (False, True),
+        (False, False)
+    ])
+    def test_default_non_tty_blocked(self, stdin_tty, stdout_tty):
+        # Unset env, either stdin or stdout is non-TTY -> Blocked
+        with patch("sys.stdin.isatty", return_value=stdin_tty), \
+             patch("sys.stdout.isatty", return_value=stdout_tty):
+            assert _dashboard_auto_install_allowed() is False
+
+
+class TestCmdDashboardAutoInstallGuard:
+
+    @pytest.fixture(autouse=True)
+    def mock_dashboard_deps(self):
+        """Mock out downstream steps in cmd_dashboard to prevent server start."""
+        with patch("hermes_cli.main._sync_bundled_skills_quietly"), \
+             patch("hermes_cli.plugins.discover_plugins"), \
+             patch("hermes_cli.mcp_startup.start_background_mcp_discovery"), \
+             patch("hermes_cli.main._maybe_setup_dashboard_auth_interactively"), \
+             patch("hermes_cli.web_server.start_server"), \
+             patch.dict(sys.modules, {"fastapi": MagicMock(), "uvicorn": MagicMock()}):
+            yield
+
+    @pytest.fixture(autouse=True)
+    def clean_env(self):
+        """Ensure env var is clean before each test."""
+        old_val = os.environ.get("HERMES_DASHBOARD_AUTO_INSTALL")
+        if "HERMES_DASHBOARD_AUTO_INSTALL" in os.environ:
+            del os.environ["HERMES_DASHBOARD_AUTO_INSTALL"]
+        yield
+        if old_val is not None:
+            os.environ["HERMES_DASHBOARD_AUTO_INSTALL"] = old_val
+        elif "HERMES_DASHBOARD_AUTO_INSTALL" in os.environ:
+            del os.environ["HERMES_DASHBOARD_AUTO_INSTALL"]
+
+    @patch("hermes_cli.main._web_ui_build_needed", return_value=True)
+    @patch("hermes_cli.main._build_web_ui")
+    @patch("hermes_cli.main._dashboard_auto_install_allowed", return_value=False)
+    @patch("pathlib.Path.exists", return_value=True)  # Mock package.json check
+    def test_non_tty_build_needed_no_override_blocked(
+        self, mock_exists, mock_allowed, mock_build, mock_build_needed, capsys
+    ):
+        with pytest.raises(SystemExit) as exc:
+            cmd_dashboard(_ns())
+
+        assert exc.value.code == 1
+        mock_build.assert_not_called()
+        out = capsys.readouterr().out
+        assert "Web UI TUI dependencies not installed" in out
+        assert "started in a non-interactive context and cannot run `npm install`" in out
+
+    @patch("hermes_cli.main._web_ui_build_needed", return_value=True)
+    @patch("hermes_cli.main._build_web_ui", return_value=True)
+    @patch("hermes_cli.main._dashboard_auto_install_allowed", return_value=True)
+    @patch("pathlib.Path.exists", return_value=True)
+    def test_tty_build_needed_allowed(
+        self, mock_exists, mock_allowed, mock_build, mock_build_needed
+    ):
+        # Should not raise SystemExit(1)
+        cmd_dashboard(_ns())
+        mock_build.assert_called_once()
+
+    @patch("hermes_cli.main._web_ui_build_needed", return_value=True)
+    @patch("hermes_cli.main._build_web_ui")
+    @patch("pathlib.Path.exists", return_value=True)
+    def test_env_opt_out_blocked(self, mock_exists, mock_build, mock_build_needed):
+        os.environ["HERMES_DASHBOARD_AUTO_INSTALL"] = "0"
+        with pytest.raises(SystemExit) as exc:
+            cmd_dashboard(_ns())
+
+        assert exc.value.code == 1
+        mock_build.assert_not_called()
+
+    @patch("hermes_cli.main._web_ui_build_needed", return_value=True)
+    @patch("hermes_cli.main._build_web_ui", return_value=True)
+    @patch("pathlib.Path.exists", return_value=True)
+    def test_env_opt_in_allowed(self, mock_exists, mock_build, mock_build_needed):
+        os.environ["HERMES_DASHBOARD_AUTO_INSTALL"] = "1"
+        cmd_dashboard(_ns())
+        mock_build.assert_called_once()
+
+    @patch("hermes_cli.main._web_ui_build_needed", return_value=False)
+    @patch("hermes_cli.main._build_web_ui", return_value=True)
+    @patch("hermes_cli.main._dashboard_auto_install_allowed", return_value=False)
+    @patch("pathlib.Path.exists", return_value=True)
+    def test_build_not_needed_unaffected(
+        self, mock_exists, mock_allowed, mock_build, mock_build_needed
+    ):
+        # If dependencies are fresh (build not needed), dashboard startup is
+        # permitted and does not fail closed, regardless of TTY or env flags.
+        cmd_dashboard(_ns())
+        mock_build.assert_called_once()
+
+    @patch("hermes_cli.main._web_ui_build_needed", return_value=True)
+    @patch("hermes_cli.main._build_web_ui")
+    @patch("hermes_cli.main._dashboard_auto_install_allowed", return_value=False)
+    @patch("pathlib.Path.exists", return_value=True)
+    @patch("hermes_cli.main.Path.exists", return_value=True) # Mock index.html existence for skip-build check
+    def test_skip_build_unaffected(
+        self, mock_exists_path, mock_exists, mock_allowed, mock_build, mock_build_needed
+    ):
+        # With skip_build=True, the entire build step is bypassed.
+        cmd_dashboard(_ns(skip_build=True))
+        mock_build.assert_not_called()
+        mock_build_needed.assert_not_called()
+
+    @patch("hermes_cli.main._web_ui_build_needed", return_value=True)
+    @patch("hermes_cli.main._build_web_ui")
+    @patch("hermes_cli.main._dashboard_auto_install_allowed", return_value=False)
+    @patch("pathlib.Path.exists", return_value=True)
+    def test_hermes_web_dist_env_var_set_unaffected(
+        self, mock_exists, mock_allowed, mock_build, mock_build_needed
+    ):
+        # When HERMES_WEB_DIST env var is set, dashboard startup is permitted
+        # and does not fail closed, and _build_web_ui is not called.
+        os.environ["HERMES_WEB_DIST"] = "/some/prebuilt/dist"
+        try:
+            cmd_dashboard(_ns())
+        finally:
+            del os.environ["HERMES_WEB_DIST"]
+        mock_build.assert_not_called()
+        mock_build_needed.assert_not_called()


### PR DESCRIPTION
- Non-interactive/systemd startup now fails closed before dependency installation when a build is needed.
- Explicit `HERMES_DASHBOARD_AUTO_INSTALL=1` opt-in remains available for automated pipelines/CI.
- `HERMES_DASHBOARD_AUTO_INSTALL=0` forces denial regardless of TTY presence.
- Interactive, `--skip-build`, fresh-build, and `HERMES_WEB_DIST` paths remain covered and unaffected.
- 44 tests passed (combining the new guard checks and existing web build checks).
- No production deployment was performed during this local maintenance.