### PR TITLE
fix(feishu): convert markdown pipe tables to fenced text blocks befor…

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -155,11 +155,13 @@ _MARKDOWN_HINT_RE = re.compile(
     re.MULTILINE,
 )
 # Detect markdown tables: a line starting with | followed by a separator line.
-# Feishu post-type 'md' elements do not render tables, so we force text mode.
+# Feishu post-type 'md' elements do not render tables; convert pipe tables to
+# fenced plain-text blocks before building the outbound payload.
 _MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
 _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
+_MARKDOWN_TABLE_SEPARATOR_CELL_RE = re.compile(r"^:?-{3,}:?$")
 _MENTION_RE = re.compile(r"@_user_\d+")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
 _POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incorrect", re.IGNORECASE)
@@ -527,6 +529,88 @@ def _strip_markdown_to_plain_text(text: str) -> str:
     plain = re.sub(r"<u>([\s\S]*?)</u>", r"\1", plain)
     plain = strip_markdown(plain)
     return plain
+
+
+def _is_markdown_table_row(line: str) -> bool:
+    stripped = line.strip()
+    return stripped.startswith("|") and stripped.endswith("|") and stripped.count("|") >= 2
+
+
+def _is_markdown_table_separator(line: str) -> bool:
+    if not _is_markdown_table_row(line):
+        return False
+    cells = [cell.strip().replace(" ", "") for cell in line.strip().strip("|").split("|")]
+    return bool(cells) and all(_MARKDOWN_TABLE_SEPARATOR_CELL_RE.match(cell or "") for cell in cells)
+
+
+def _split_markdown_table_row(line: str) -> List[str]:
+    return [cell.strip() for cell in line.strip().strip("|").split("|")]
+
+
+def _render_markdown_table_as_codeblock(table_lines: List[str]) -> str:
+    rows = [_split_markdown_table_row(line) for index, line in enumerate(table_lines) if index != 1]
+    column_count = max((len(row) for row in rows), default=0)
+    if column_count == 0:
+        return "\n".join(table_lines)
+
+    normalized_rows = [row + [""] * (column_count - len(row)) for row in rows]
+    widths = [
+        max(len(row[column]) for row in normalized_rows)
+        for column in range(column_count)
+    ]
+    rendered_lines = [
+        "  ".join(row[column].ljust(widths[column]) for column in range(column_count)).rstrip()
+        for row in normalized_rows
+    ]
+    return "```text\n" + "\n".join(rendered_lines) + "\n```"
+
+
+def _convert_markdown_tables_to_codeblocks(content: str) -> str:
+    """Convert markdown pipe tables to fenced text blocks for Feishu rendering.
+
+    The transform is intentionally local and deterministic: no model rewrite, no
+    prose changes, and no conversion inside existing fenced code blocks.
+    """
+    if not content or not _MARKDOWN_TABLE_RE.search(content):
+        return content
+
+    lines = content.replace("\r\n", "\n").split("\n")
+    output: List[str] = []
+    index = 0
+    in_code_block = False
+
+    while index < len(lines):
+        line = lines[index]
+        if in_code_block:
+            output.append(line)
+            if _MARKDOWN_FENCE_CLOSE_RE.match(line):
+                in_code_block = False
+            index += 1
+            continue
+
+        if _MARKDOWN_FENCE_OPEN_RE.match(line):
+            in_code_block = True
+            output.append(line)
+            index += 1
+            continue
+
+        if (
+            index + 1 < len(lines)
+            and _is_markdown_table_row(line)
+            and _is_markdown_table_separator(lines[index + 1])
+        ):
+            table_lines = [line, lines[index + 1]]
+            index += 2
+            while index < len(lines) and _is_markdown_table_row(lines[index]):
+                table_lines.append(lines[index])
+                index += 1
+            output.append(_render_markdown_table_as_codeblock(table_lines))
+            continue
+
+        output.append(line)
+        index += 1
+
+    return "\n".join(output)
 
 
 def _coerce_int(value: Any, default: Optional[int] = None, min_value: int = 0) -> Optional[int]:
@@ -4375,12 +4459,10 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
-        if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
+        # Feishu post-type 'md' elements do not render markdown tables. Convert
+        # pipe tables to fenced plain-text blocks so the message can still be
+        # sent as a rich post without asking the model to rewrite anything.
+        content = _convert_markdown_tables_to_codeblocks(content)
         if _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2580,6 +2580,82 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(elements, [{"tag": "md", "text": "可以用 **粗体** 和 *斜体*。"}])
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_send_converts_markdown_table_to_code_block_post(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_table"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        content = (
+            "**Q1财务真相**\n"
+            "| 指标 | 新洁能 | 士兰微 |\n"
+            "|------|--------|--------|\n"
+            "| 营收 | 5.17亿 | 35.19亿 |\n"
+            "| 净利率 | 18.4% | 4.2% |\n"
+            "结论：轻资产弹性更高。"
+        )
+
+        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content=content,
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["request"].request_body.msg_type, "post")
+        payload = json.loads(captured["request"].request_body.content)
+        rendered = "\n".join(row[0]["text"] for row in payload["zh_cn"]["content"])
+        self.assertIn("```text", rendered)
+        self.assertIn("指标", rendered)
+        self.assertIn("营收", rendered)
+        self.assertIn("结论：轻资产弹性更高。", rendered)
+        self.assertNotIn("|------|", rendered)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_markdown_table_conversion_skips_existing_code_blocks(self):
+        from plugins.platforms.feishu.adapter import _convert_markdown_tables_to_codeblocks
+
+        content = "```text\n| 指标 | A |\n|------|---|\n| 营收 | 1 |\n```"
+
+        self.assertEqual(_convert_markdown_tables_to_codeblocks(content), content)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_plain_markdown_table_payload_becomes_post_not_raw_text(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        msg_type, payload = adapter._build_outbound_payload(
+            "| 指标 | A |\n|------|---|\n| 营收 | 1 |"
+        )
+
+        self.assertEqual(msg_type, "post")
+        self.assertIn("```text", payload)
+        self.assertNotIn("|------|", payload)
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_send_splits_fenced_code_blocks_into_separate_post_rows(self):
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter


### PR DESCRIPTION
…e send

Feishu post-type md elements do not render markdown tables reliably. Previously, pipe-table content was force-sent as plain text, leaving the raw |---| markup visible to users.

This change converts markdown pipe tables to fenced ```text blocks deterministically in the outbound payload builder — no model rewrite, no retry, no format scoring.

- Skips tables already inside existing fenced code blocks.
- Col-aligns cells and strips the separator row.
- Preserves rich post delivery for mixed markdown + table content.
- Adds three targeted tests (send path, skip-existing, payload shape).

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

