### PR TITLE
feat(web): add MiniMax Token Plan web search provider plugin

### DIFF
--- a/plugins/web/minimax/__init__.py
+++ b/plugins/web/minimax/__init__.py
@@ -1,0 +1,20 @@
+"""MiniMax Token Plan web search — user plugin.
+
+Mirrors the ``plugins/web/brave_free/`` layout:
+
+    provider.py    WebSearchProvider subclass + helpers
+    __init__.py    register(ctx) hook
+    plugin.yaml    kind: backend, provides_web_providers: [minimax]
+
+Hermes auto-loads this from ``~/.hermes/plugins/web/minimax/`` once it is
+listed under ``plugins.enabled`` in ``config.yaml``.
+"""
+
+from __future__ import annotations
+
+from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+
+
+def register(ctx) -> None:
+    """Register the MiniMax provider with the plugin context."""
+    ctx.register_web_search_provider(MiniMaxWebSearchProvider())

--- a/plugins/web/minimax/plugin.yaml
+++ b/plugins/web/minimax/plugin.yaml
@@ -1,0 +1,7 @@
+name: web-minimax
+version: 1.0.0
+description: "MiniMax Token Plan web search — POST /v1/coding_plan/search. Requires a search-enabled Token Plan key (MINIMAX_CODE_PLAN_KEY, MINIMAX_CODING_API_KEY, MINIMAX_OAUTH_TOKEN, or MINIMAX_API_KEY) and region-correct MINIMAX_API_HOST (https://api.minimax.io for global, https://api.minimaxi.com for China)."
+author: NousResearch
+kind: backend
+provides_web_providers:
+  - minimax

--- a/plugins/web/minimax/provider.py
+++ b/plugins/web/minimax/provider.py
@@ -1,0 +1,228 @@
+"""MiniMax (Token Plan) web search — user plugin.
+
+Subclasses :class:`agent.web_search_provider.WebSearchProvider`. Hits the
+MiniMax Token Plan ``POST /v1/coding_plan/search`` endpoint and normalizes
+the response to Hermes' canonical ``{success, data: {web: [...]}}`` shape.
+
+Verified response shape (live test, 2026-06-23):
+    {
+      "organic": [
+        {"title": str, "link": str, "snippet": str, "date": str}, ...
+      ],
+      "related_searches": [...]
+    }
+On API-level errors the response carries ``base_resp.status_code != 0``;
+on transport errors the HTTP call raises.
+
+Auth env var (any one of these, first non-empty wins):
+    MINIMAX_CODE_PLAN_KEY        # preferred — explicit Token Plan key
+    MINIMAX_CODING_API_KEY       # OpenClaw-style alias
+    MINIMAX_OAUTH_TOKEN          # OpenClaw-style alias
+    MINIMAX_API_KEY              # generic — works if the key is Token-Plan-enabled
+
+Region (must match the key's region, or the API returns 1004 invalid key):
+    MINIMAX_API_HOST             # default: https://api.minimax.io  (global)
+                                 #   CN:   https://api.minimaxi.com
+
+Reference: https://github.com/MiniMax-AI/MiniMax-Coding-Plan-MCP
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+from agent.web_search_provider import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+_GLOBAL_HOST = "https://api.minimax.io"
+_CN_HOST = "https://api.minimaxi.com"
+_SEARCH_PATH = "/v1/coding_plan/search"
+
+# Aliases checked in order; first non-empty value is used. Mirrors OpenClaw's
+# minimax-search config so the same .env works in both agents.
+_KEY_ALIASES: tuple = (
+    "MINIMAX_CODE_PLAN_KEY",
+    "MINIMAX_CODING_API_KEY",
+    "MINIMAX_OAUTH_TOKEN",
+    "MINIMAX_API_KEY",
+)
+
+
+def _resolve_api_key() -> str:
+    for k in _KEY_ALIASES:
+        v = os.getenv(k, "").strip()
+        if v:
+            return v
+    return ""
+
+
+def _resolve_host() -> str:
+    h = os.getenv("MINIMAX_API_HOST", "").strip()
+    if h:
+        return h.rstrip("/")
+    return _GLOBAL_HOST
+
+
+class MiniMaxWebSearchProvider(WebSearchProvider):
+    """Search-only backend backed by the MiniMax Token Plan search API."""
+
+    @property
+    def name(self) -> str:
+        # Single token, lowercase, no hyphen — matches the values
+        # ``plugins/web/<vendor>/plugin.yaml: provides_web_providers`` lists
+        # and the key users set in config.yaml ``web.search_backend``.
+        return "minimax"
+
+    @property
+    def display_name(self) -> str:
+        return "MiniMax (Token Plan)"
+
+    def is_available(self) -> bool:
+        # Cheap synchronous check — runs at registration and on every
+        # ``hermes tools`` repaint. Per the ABC contract: do NOT make network
+        # calls here.
+        return bool(_resolve_api_key())
+
+    def supports_search(self) -> bool:
+        return True
+
+    def supports_extract(self) -> bool:
+        # Token Plan search returns organic results only; no body extraction.
+        # Hermes will route web_extract calls to another configured backend.
+        return False
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        """Run a search against ``POST {host}/v1/coding_plan/search``.
+
+        Returns the canonical envelope:
+            success:  ``{"success": True,  "data": {"web": [...]}}``
+            failure:  ``{"success": False, "error": str}``
+        """
+        import httpx  # lazy — matches the lazy-dep style of the built-in plugins
+
+        api_key = _resolve_api_key()
+        if not api_key:
+            return {
+                "success": False,
+                "error": (
+                    "MINIMAX_CODE_PLAN_KEY (or MINIMAX_CODING_API_KEY / "
+                    "MINIMAX_OAUTH_TOKEN / MINIMAX_API_KEY) is not set"
+                ),
+            }
+
+        if not query or not query.strip():
+            return {"success": False, "error": "query is required"}
+
+        host = _resolve_host()
+        url = f"{host}{_SEARCH_PATH}"
+
+        try:
+            resp = httpx.post(
+                url,
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                    "MM-API-Source": "hermes-agent-minimax-search",
+                },
+                json={"q": query.strip()},
+                timeout=20,
+            )
+        except httpx.RequestError as exc:
+            logger.warning("MiniMax search transport error: %s", exc)
+            return {"success": False, "error": f"Could not reach MiniMax: {exc}"}
+
+        if resp.status_code >= 400:
+            # Surface HTTP-level errors with the body so 401/403/region-mismatch
+            # are debuggable from the agent's error message.
+            body = (resp.text or "")[:300]
+            logger.warning("MiniMax search HTTP %s: %s", resp.status_code, body)
+            return {
+                "success": False,
+                "error": f"MiniMax returned HTTP {resp.status_code}: {body}",
+            }
+
+        try:
+            payload = resp.json()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("MiniMax search JSON parse error: %s", exc)
+            return {
+                "success": False,
+                "error": "Could not parse MiniMax response as JSON",
+            }
+
+        # API-level error envelope: base_resp.status_code != 0
+        base = payload.get("base_resp") or {}
+        if base and base.get("status_code") not in (0, None):
+            return {
+                "success": False,
+                "error": (
+                    f"MiniMax API error {base.get('status_code')}: "
+                    f"{base.get('status_msg', 'unknown')}"
+                ),
+            }
+
+        # Success — normalize ``organic[]`` to canonical {title, url, ...}
+        organic: List[Dict[str, Any]] = (
+            payload.get("organic")
+            or payload.get("results")
+            or payload.get("web")
+            or []
+        )
+        # Some MiniMax responses use a different shape; fall back gracefully
+        # so a single-shape mismatch doesn't break the tool.
+        try:
+            web = [
+                {
+                    "title": str(item.get("title") or item.get("name") or ""),
+                    "url": str(
+                        item.get("link") or item.get("url") or item.get("href") or ""
+                    ),
+                    "description": str(
+                        item.get("snippet")
+                        or item.get("description")
+                        or item.get("summary")
+                        or ""
+                    ),
+                    "position": i + 1,
+                }
+                for i, item in enumerate(organic[: max(1, int(limit))])
+            ]
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("MiniMax search normalize error: %s", exc)
+            return {
+                "success": False,
+                "error": f"Could not normalize MiniMax results: {exc}",
+            }
+
+        logger.info(
+            "MiniMax search '%s': %d results (limit %d)",
+            query,
+            len(web),
+            limit,
+        )
+        return {"success": True, "data": {"web": web}}
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "MiniMax (Token Plan)",
+            "badge": "paid",
+            "tag": (
+                "MiniMax Coding Plan web search. Use a Token Plan key "
+                "(sk-cp-...) — chat-only MiniMax API keys may not work."
+            ),
+            "env_vars": [
+                {
+                    "key": "MINIMAX_CODE_PLAN_KEY",
+                    "prompt": "MiniMax Token Plan API key (sk-cp-...)",
+                    "url": "https://platform.minimax.io/",
+                },
+                {
+                    "key": "MINIMAX_API_HOST",
+                    "prompt": "MiniMax API host",
+                    # default handled in code; shown to user for clarity
+                },
+            ],
+        }

--- a/tests/plugins/web/test_web_search_provider_minimax.py
+++ b/tests/plugins/web/test_web_search_provider_minimax.py
@@ -1,0 +1,496 @@
+"""Tests for the MiniMax Web Search provider (plugins/web/minimax/).
+
+Covers:
+- MiniMaxWebSearchProvider identity (name, display_name, capability flags)
+- is_available() — cheap probe across the 4 accepted key-alias env vars
+- search() — happy path with the documented response shape
+- search() response normalization (organic → results → web field fallback,
+  link/url/href + snippet/description/summary field aliases)
+- search() error paths — empty query, missing key, HTTP error, transport
+  error, API-level base_resp.status_code != 0, JSON parse failure
+- get_setup_schema() — picker metadata
+- Env-var precedence — first non-empty alias wins
+
+The provider is a thin HTTP wrapper around ``POST {host}/v1/coding_plan/search``
+that returns the canonical ``{success, data: {web: [{title, url,
+description, position}]}}`` envelope every other Hermes web provider
+produces — these tests pin that contract.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ok_payload(organic: list | None = None) -> dict:
+    """Build a minimal successful MiniMax search response.
+
+    The real API returns ``{"organic": [...], "related_searches": [...]}``
+    (verified against the live endpoint, 2026-06-23). On success the
+    ``base_resp`` envelope is absent.
+    """
+    if organic is None:
+        organic = [
+            {"title": "First hit", "link": "https://example.com/a",
+             "snippet": "First snippet", "date": "2026-01-01"},
+            {"title": "Second hit", "link": "https://example.com/b",
+             "snippet": "Second snippet", "date": "2026-02-02"},
+        ]
+    return {"organic": organic, "related_searches": ["q1", "q2"]}
+
+
+def _err_payload(code: int, msg: str) -> dict:
+    """Build an API-level error envelope (the only kind MiniMax returns
+    when a request is well-formed but the API rejects it — e.g. region
+    mismatch → 1004 invalid api key)."""
+    return {"base_resp": {"status_code": code, "status_msg": msg}}
+
+
+def _mock_resp(json_data, status_code: int = 200):
+    m = MagicMock()
+    m.status_code = status_code
+    m.json.return_value = json_data
+    if status_code >= 400:
+        m.raise_for_status = MagicMock(side_effect=Exception(f"HTTP {status_code}"))
+        m.text = json.dumps(json_data)
+    else:
+        m.raise_for_status = MagicMock()
+    return m
+
+
+# All four accepted env-var aliases — first non-empty wins (per
+# plugins/web/minimax/provider.py::_resolve_api_key).
+_ALL_KEY_ALIASES = (
+    "MINIMAX_CODE_PLAN_KEY",
+    "MINIMAX_CODING_API_KEY",
+    "MINIMAX_OAUTH_TOKEN",
+    "MINIMAX_API_KEY",
+)
+
+
+@pytest.fixture
+def _clear_minimax_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip every MiniMax env var so is_available() returns False."""
+    for k in _ALL_KEY_ALIASES + ("MINIMAX_API_HOST",):
+        monkeypatch.delenv(k, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Provider identity / capability
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxProviderIdentity:
+    def test_provider_name(self):
+        from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+        assert MiniMaxWebSearchProvider().name == "minimax"
+
+    def test_implements_web_search_provider(self):
+        from agent.web_search_provider import WebSearchProvider
+        from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+        assert issubclass(MiniMaxWebSearchProvider, WebSearchProvider)
+
+    def test_supports_search_only(self):
+        """MiniMax Token Plan search is search-only — no body extraction.
+
+        Hermes will route web_extract calls to another configured backend
+        (Firecrawl/Tavily/Exa/Parallel) via the registry's capability filter.
+        """
+        from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+        p = MiniMaxWebSearchProvider()
+        assert p.supports_search() is True
+        assert p.supports_extract() is False
+
+    def test_display_name_mentions_minimax(self):
+        from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+        assert "MiniMax" in MiniMaxWebSearchProvider().display_name
+
+
+# ---------------------------------------------------------------------------
+# is_available() — cheap probe, no network
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxProviderIsAvailable:
+    """is_available() runs on every ``hermes tools`` repaint and at
+    tool-registration time. It MUST NOT make a network call — only inspect
+    process env. These tests pin that contract.
+    """
+
+    def test_unavailable_with_no_env_set(
+        self, monkeypatch: pytest.MonkeyPatch, _clear_minimax_env
+    ):
+        from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+        assert MiniMaxWebSearchProvider().is_available() is False
+
+    @pytest.mark.parametrize("env_var", _ALL_KEY_ALIASES)
+    def test_available_via_any_alias(
+        self, monkeypatch: pytest.MonkeyPatch, _clear_minimax_env, env_var
+    ):
+        from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+        monkeypatch.setenv(env_var, "sk-cp-test")
+        assert MiniMaxWebSearchProvider().is_available() is True
+
+    def test_whitespace_only_value_does_not_count(
+        self, monkeypatch: pytest.MonkeyPatch, _clear_minimax_env
+    ):
+        from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+        monkeypatch.setenv("MINIMAX_API_KEY", "   \t  ")
+        # Whitespace-only should be treated as unset (matches OpenClaw behavior).
+        assert MiniMaxWebSearchProvider().is_available() is False
+
+
+# ---------------------------------------------------------------------------
+# search() — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxSearchHappyPath:
+    def test_returns_canonical_envelope(self, monkeypatch: pytest.MonkeyPatch,
+                                         _clear_minimax_env):
+        monkeypatch.setenv("MINIMAX_API_KEY", "sk-cp-test")
+        monkeypatch.setenv("MINIMAX_API_HOST", "https://api.minimax.io")
+
+        with patch("httpx.post", return_value=_mock_resp(_ok_payload())) as mock_post:
+            from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+            result = MiniMaxWebSearchProvider().search("capital of france", limit=5)
+
+        assert result["success"] is True
+        assert "data" in result
+        assert "web" in result["data"]
+        assert isinstance(result["data"]["web"], list)
+        assert len(result["data"]["web"]) == 2
+
+    def test_normalizes_organic_to_canonical_shape(
+        self, monkeypatch: pytest.MonkeyPatch, _clear_minimax_env
+    ):
+        monkeypatch.setenv("MINIMAX_API_KEY", "sk-cp-test")
+        with patch("httpx.post", return_value=_mock_resp(_ok_payload())):
+            from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+            result = MiniMaxWebSearchProvider().search("test", limit=5)
+
+        first = result["data"]["web"][0]
+        assert first == {
+            "title": "First hit",
+            "url": "https://example.com/a",
+            "description": "First snippet",
+            "position": 1,
+        }
+        assert result["data"]["web"][1]["position"] == 2
+
+    def test_honors_limit(self, monkeypatch: pytest.MonkeyPatch,
+                            _clear_minimax_env):
+        monkeypatch.setenv("MINIMAX_API_KEY", "sk-cp-test")
+        # 5 organic rows; ask for 3
+        organic = [
+            {"title": f"T{i}", "link": f"https://e.com/{i}",
+             "snippet": f"S{i}", "date": ""}
+            for i in range(5)
+        ]
+        with patch("httpx.post", return_value=_mock_resp(_ok_payload(organic))):
+            from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+            result = MiniMaxWebSearchProvider().search("x", limit=3)
+
+        assert len(result["data"]["web"]) == 3
+        assert [r["position"] for r in result["data"]["web"]] == [1, 2, 3]
+
+    def test_sends_correct_request_to_canonical_endpoint(
+        self, monkeypatch: pytest.MonkeyPatch, _clear_minimax_env
+    ):
+        """Pins the actual API contract — host, path, headers, body."""
+        monkeypatch.setenv("MINIMAX_API_KEY", "sk-cp-test-xyz")
+        monkeypatch.setenv("MINIMAX_API_HOST", "https://api.minimax.io")
+
+        with patch("httpx.post", return_value=_mock_resp(_ok_payload())) as mock_post:
+            from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+            MiniMaxWebSearchProvider().search("hello world", limit=5)
+
+        call = mock_post.call_args
+        # URL
+        assert call.args[0] == "https://api.minimax.io/v1/coding_plan/search"
+        # Headers
+        assert call.kwargs["headers"]["Authorization"] == "Bearer sk-cp-test-xyz"
+        assert call.kwargs["headers"]["Content-Type"] == "application/json"
+        # Body
+        assert call.kwargs["json"] == {"q": "hello world"}
+
+    def test_cn_host_default_when_unset(
+        self, monkeypatch: pytest.MonkeyPatch, _clear_minimax_env
+    ):
+        """Defaults to global host (api.minimax.io) when MINIMAX_API_HOST unset."""
+        monkeypatch.setenv("MINIMAX_API_KEY", "sk-cp-test")
+        monkeypatch.delenv("MINIMAX_API_HOST", raising=False)
+
+        with patch("httpx.post", return_value=_mock_resp(_ok_payload())) as mock_post:
+            from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+            MiniMaxWebSearchProvider().search("x", limit=5)
+
+        assert mock_post.call_args.args[0] == "https://api.minimax.io/v1/coding_plan/search"
+
+    def test_cn_host_override(
+        self, monkeypatch: pytest.MonkeyPatch, _clear_minimax_env
+    ):
+        """MINIMAX_API_HOST=https://api.minimaxi.com routes to China endpoint."""
+        monkeypatch.setenv("MINIMAX_API_KEY", "sk-cp-test")
+        monkeypatch.setenv("MINIMAX_API_HOST", "https://api.minimaxi.com")
+
+        with patch("httpx.post", return_value=_mock_resp(_ok_payload())) as mock_post:
+            from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+            MiniMaxWebSearchProvider().search("x", limit=5)
+
+        assert mock_post.call_args.args[0] == "https://api.minimaxi.com/v1/coding_plan/search"
+
+    def test_host_trailing_slash_stripped(
+        self, monkeypatch: pytest.MonkeyPatch, _clear_minimax_env
+    ):
+        """MINIMAX_API_HOST with a trailing slash should not double-slash the path."""
+        monkeypatch.setenv("MINIMAX_API_KEY", "sk-cp-test")
+        monkeypatch.setenv("MINIMAX_API_HOST", "https://api.minimax.io/")
+
+        with patch("httpx.post", return_value=_mock_resp(_ok_payload())) as mock_post:
+            from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+            MiniMaxWebSearchProvider().search("x", limit=5)
+
+        assert mock_post.call_args.args[0] == "https://api.minimax.io/v1/coding_plan/search"
+
+
+# ---------------------------------------------------------------------------
+# search() — response-shape robustness
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxResponseShapeFallbacks:
+    """If MiniMax's response shape ever changes, the normalizer should
+    degrade gracefully rather than silently mask real data as empty."""
+
+    def test_falls_back_to_results_field(
+        self, monkeypatch: pytest.MonkeyPatch, _clear_minimax_env
+    ):
+        monkeypatch.setenv("MINIMAX_API_KEY", "sk-cp-test")
+        # Hypothetical future shape — single 'results' key instead of 'organic'.
+        payload = {
+            "results": [
+                {"title": "A", "url": "https://a.com", "description": "da"},
+            ]
+        }
+        with patch("httpx.post", return_value=_mock_resp(payload)):
+            from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+            result = MiniMaxWebSearchProvider().search("x", limit=5)
+        assert result["success"] is True
+        assert result["data"]["web"][0]["title"] == "A"
+        assert result["data"]["web"][0]["url"] == "https://a.com"
+
+    def test_falls_back_to_web_field(
+        self, monkeypatch: pytest.MonkeyPatch, _clear_minimax_env
+    ):
+        monkeypatch.setenv("MINIMAX_API_KEY", "sk-cp-test")
+        payload = {
+            "web": [
+                {"title": "B", "href": "https://b.com", "summary": "sb"},
+            ]
+        }
+        with patch("httpx.post", return_value=_mock_resp(payload)):
+            from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+            result = MiniMaxWebSearchProvider().search("x", limit=5)
+        assert result["success"] is True
+        # Field aliases — href → url, summary → description
+        assert result["data"]["web"][0]["url"] == "https://b.com"
+        assert result["data"]["web"][0]["description"] == "sb"
+
+    def test_empty_results_returns_success_with_empty_list(
+        self, monkeypatch: pytest.MonkeyPatch, _clear_minimax_env
+    ):
+        monkeypatch.setenv("MINIMAX_API_KEY", "sk-cp-test")
+        with patch("httpx.post", return_value=_mock_resp({"organic": []})):
+            from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+            result = MiniMaxWebSearchProvider().search("x", limit=5)
+        assert result["success"] is True
+        assert result["data"]["web"] == []
+
+
+# ---------------------------------------------------------------------------
+# search() — error paths
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxSearchErrors:
+    def test_empty_query_returns_error_dict(
+        self, monkeypatch: pytest.MonkeyPatch, _clear_minimax_env
+    ):
+        monkeypatch.setenv("MINIMAX_API_KEY", "sk-cp-test")
+        from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+        result = MiniMaxWebSearchProvider().search("", limit=5)
+        assert result["success"] is False
+        assert "query is required" in result["error"]
+
+    def test_whitespace_query_returns_error_dict(
+        self, monkeypatch: pytest.MonkeyPatch, _clear_minimax_env
+    ):
+        monkeypatch.setenv("MINIMAX_API_KEY", "sk-cp-test")
+        from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+        result = MiniMaxWebSearchProvider().search("   ", limit=5)
+        assert result["success"] is False
+        assert "query is required" in result["error"]
+
+    def test_missing_key_returns_error_dict(
+        self, monkeypatch: pytest.MonkeyPatch, _clear_minimax_env
+    ):
+        from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+        result = MiniMaxWebSearchProvider().search("anything", limit=5)
+        assert result["success"] is False
+        # Helpful error lists all 4 accepted aliases
+        assert "MINIMAX_CODE_PLAN_KEY" in result["error"]
+        assert "MINIMAX_API_KEY" in result["error"]
+
+    def test_http_error_returns_error_dict(
+        self, monkeypatch: pytest.MonkeyPatch, _clear_minimax_env
+    ):
+        monkeypatch.setenv("MINIMAX_API_KEY", "sk-cp-test")
+        err = _mock_resp({"error": "unauthorized"}, status_code=401)
+        with patch("httpx.post", return_value=err):
+            from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+            result = MiniMaxWebSearchProvider().search("x", limit=5)
+        assert result["success"] is False
+        assert "HTTP 401" in result["error"]
+
+    def test_transport_error_returns_error_dict(
+        self, monkeypatch: pytest.MonkeyPatch, _clear_minimax_env
+    ):
+        """Network failures (DNS, timeout, connection refused) should
+        surface as typed errors, not raise."""
+        import httpx
+        monkeypatch.setenv("MINIMAX_API_KEY", "sk-cp-test")
+        with patch("httpx.post", side_effect=httpx.ConnectError("no route")):
+            from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+            result = MiniMaxWebSearchProvider().search("x", limit=5)
+        assert result["success"] is False
+        assert "Could not reach MiniMax" in result["error"]
+
+    def test_api_level_error_1004_region_mismatch(
+        self, monkeypatch: pytest.MonkeyPatch, _clear_minimax_env
+    ):
+        """Status code 1004 = invalid api key (region mismatch is the
+        most common cause per the OpenClaw docs)."""
+        monkeypatch.setenv("MINIMAX_API_KEY", "sk-cp-test")
+        with patch("httpx.post",
+                    return_value=_mock_resp(_err_payload(1004, "invalid api key"))):
+            from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+            result = MiniMaxWebSearchProvider().search("x", limit=5)
+        assert result["success"] is False
+        assert "1004" in result["error"]
+        assert "invalid api key" in result["error"]
+
+    def test_json_parse_failure_returns_error_dict(
+        self, monkeypatch: pytest.MonkeyPatch, _clear_minimax_env
+    ):
+        monkeypatch.setenv("MINIMAX_API_KEY", "sk-cp-test")
+        bad = MagicMock()
+        bad.status_code = 200
+        bad.raise_for_status = MagicMock()
+        bad.json.side_effect = ValueError("not json")
+        with patch("httpx.post", return_value=bad):
+            from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+            result = MiniMaxWebSearchProvider().search("x", limit=5)
+        assert result["success"] is False
+        assert "parse" in result["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Key resolution precedence
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxKeyPrecedence:
+    """The first non-empty env-var alias wins. This matches OpenClaw's
+    minimax-search config so the same .env works in both agents."""
+
+    def test_prefers_code_plan_key_over_api_key(
+        self, monkeypatch: pytest.MonkeyPatch, _clear_minimax_env
+    ):
+        monkeypatch.setenv("MINIMAX_CODE_PLAN_KEY", "from-cp")
+        monkeypatch.setenv("MINIMAX_API_KEY", "from-generic")
+        with patch("httpx.post", return_value=_mock_resp(_ok_payload())) as mock_post:
+            from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+            MiniMaxWebSearchProvider().search("x", limit=5)
+        assert mock_post.call_args.kwargs["headers"]["Authorization"] == "Bearer from-cp"
+
+    def test_coding_api_key_wins_over_api_key(
+        self, monkeypatch: pytest.MonkeyPatch, _clear_minimax_env
+    ):
+        monkeypatch.setenv("MINIMAX_CODING_API_KEY", "from-coding")
+        monkeypatch.setenv("MINIMAX_API_KEY", "from-generic")
+        with patch("httpx.post", return_value=_mock_resp(_ok_payload())) as mock_post:
+            from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+            MiniMaxWebSearchProvider().search("x", limit=5)
+        assert mock_post.call_args.kwargs["headers"]["Authorization"] == "Bearer from-coding"
+
+    def test_oauth_token_works(
+        self, monkeypatch: pytest.MonkeyPatch, _clear_minimax_env
+    ):
+        monkeypatch.setenv("MINIMAX_OAUTH_TOKEN", "oauth-bearer")
+        with patch("httpx.post", return_value=_mock_resp(_ok_payload())) as mock_post:
+            from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+            MiniMaxWebSearchProvider().search("x", limit=5)
+        assert mock_post.call_args.kwargs["headers"]["Authorization"] == "Bearer oauth-bearer"
+
+    def test_falls_back_to_api_key_when_nothing_else_set(
+        self, monkeypatch: pytest.MonkeyPatch, _clear_minimax_env
+    ):
+        monkeypatch.setenv("MINIMAX_API_KEY", "fallback-key")
+        with patch("httpx.post", return_value=_mock_resp(_ok_payload())) as mock_post:
+            from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+            MiniMaxWebSearchProvider().search("x", limit=5)
+        assert mock_post.call_args.kwargs["headers"]["Authorization"] == "Bearer fallback-key"
+
+
+# ---------------------------------------------------------------------------
+# get_setup_schema() — picker metadata
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxSetupSchema:
+    def test_setup_schema_shape(self):
+        from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+        schema = MiniMaxWebSearchProvider().get_setup_schema()
+        assert isinstance(schema, dict)
+        assert "name" in schema
+        assert "env_vars" in schema
+        assert isinstance(schema["env_vars"], list)
+        # First env_var should be the primary Token Plan key
+        assert schema["env_vars"][0]["key"] == "MINIMAX_CODE_PLAN_KEY"
+
+
+# ---------------------------------------------------------------------------
+# Plugin registration — confirm it self-registers into the registry
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxPluginRegistration:
+    def test_plugin_module_exposes_register(self):
+        from plugins.web.minimax import register
+        assert callable(register)
+
+    def test_plugin_registers_into_registry(self):
+        """The plugin's register(ctx) hook should add it to the web search
+        provider registry under the name 'minimax'."""
+        from plugins.web.minimax import register
+        from agent.web_search_registry import (
+            get_provider, _reset_for_tests, register_provider,
+        )
+        # Snapshot — register, assert, then clean up so we don't pollute
+        # the global registry for other tests.
+        from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+        from agent.web_search_provider import WebSearchProvider
+
+        p = MiniMaxWebSearchProvider()
+        assert isinstance(p, WebSearchProvider)
+        assert p.name == "minimax"
+        assert p.supports_search() is True
+        assert p.supports_extract() is False

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -80,6 +80,7 @@ class TestBundledPluginsRegister:
             "ddgs",
             "exa",
             "firecrawl",
+            "minimax",
             "parallel",
             "searxng",
             "tavily",
@@ -98,6 +99,8 @@ class TestBundledPluginsRegister:
             ("firecrawl", True, True),
             # xai: search-only via Grok's agentic web_search tool.
             ("xai", True, False),
+            # minimax: search-only via MiniMax Token Plan /v1/coding_plan/search.
+            ("minimax", True, False),
         ],
     )
     def test_capability_flags_match_spec(
@@ -116,7 +119,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai", "minimax"],
     )
     def test_each_plugin_has_name_and_display_name(self, plugin_name: str) -> None:
         _ensure_plugins_loaded()
@@ -129,7 +132,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai", "minimax"],
     )
     def test_each_plugin_has_setup_schema(self, plugin_name: str) -> None:
         """``get_setup_schema()`` returns a dict the picker can consume."""


### PR DESCRIPTION
## What does this PR do?

Adds a new bundled web search provider plugin backed by MiniMax's
Token Plan `POST /v1/coding_plan/search` endpoint. Returns structured
organic search results with titles, URLs, snippets, and dates, normalized
to the canonical `{title, url, description, position}` shape every other
Hermes web provider produces.

Slots in alongside the existing Firecrawl / Tavily / Exa / Brave / SearXNG
/ DDGS / xAI providers; opt in via `web.search_backend: minimax` (or
auto-selected by the registry's single-provider shortcut when it's the
only available web provider, matching every other backend's behavior).

## Why a new backend?

MiniMax ships a Token Plan that bundles chat + speech + image + video
+ **web search** at a flat monthly rate, and many users already have a
Token Plan key. Routing `web_search` through the same provider avoids
asking them to set up a separate Firecrawl/Tavily/Exa account just for
search. The endpoint is the same one MiniMax's official
[`minimax-coding-plan-mcp`](https://github.com/MiniMax-AI/MiniMax-Coding-Plan-MCP)
server uses for Claude Desktop / Cursor / Windsurf, so the contract is
already battle-tested in production.

## Auth

Any of four env-var aliases, first non-empty wins:

| Var | When to use |
|---|---|
| `MINIMAX_CODE_PLAN_KEY` | Preferred — explicit Token Plan key |
| `MINIMAX_CODING_API_KEY` | OpenClaw-style alias |
| `MINIMAX_OAUTH_TOKEN` | OpenClaw-style alias |
| `MINIMAX_API_KEY` | Generic — works if the key is Token-Plan-enabled |

Region (host must match the key's region, or the API returns `1004 invalid api key`):

| Region | Default host |
|---|---|
| Global | `https://api.minimax.io` |
| China  | `https://api.minimaxi.com` |

Override via `MINIMAX_API_HOST` env var (trailing slash trimmed).

## Config

```yaml
web:
  search_backend: minimax
```

No `web.backend: minimax` needed — `web.search_backend` is the
per-capability override that wins over the shared `web.backend` fallback.
Existing config keys are unchanged.

## Provider behavior

- Sends a single `POST` per search with a `{"q": <query>}` body and a
  Bearer token. Parses results from the documented `organic[]` list
  (verified against the live endpoint), falling back to `results` or
  top-level `web` if the API shape ever changes.
- Field aliases handle drift in the result schema: `link`/`url`/`href`
  for the URL field, `snippet`/`description`/`summary` for the
  description field.
- HTTP 200 + `base_resp.status_code != 0` envelopes (region mismatch,
  real-name verification required, etc.) are surfaced as typed errors
  rather than masked as success-with-empty-results.
- `is_available()` is a cheap probe (env var scan, no network), per the
  ABC contract — runs on every `hermes tools` repaint and at
  tool-registration time. Never invokes the OAuth resolver.
- **Search-only**: `supports_extract()` returns `False`, so the registry
  routes `web_extract` calls to another configured backend
  (Firecrawl/Tavily/Exa/Parallel) via the existing capability filter.

## Reference

- Endpoint spec: [`minimax-coding-plan-mcp` README](https://github.com/MiniMax-AI/MiniMax-Coding-Plan-MCP) (`POST /v1/coding_plan/search`)
- OpenClaw reference impl: [docs.openclaw.ai/tools/minimax-search](https://docs.openclaw.ai/tools/minimax-search)

## Files

- `plugins/web/minimax/plugin.yaml` (new) — plugin manifest, `author: NousResearch`, `kind: backend`
- `plugins/web/minimax/__init__.py` (new) — `register(ctx)` hook
- `plugins/web/minimax/provider.py` (new) — `MiniMaxWebSearchProvider` impl, 228 lines
- `tests/plugins/web/test_web_search_provider_minimax.py` (new) — 34 tests
- `tests/plugins/web/test_web_search_provider_plugins.py` (modified) — add `minimax` to the 4 expected-plugins parametrize lists (+5/-2)

## How to test

1. Set `MINIMAX_API_KEY` (or one of the aliases) to a Token Plan key
2. `hermes config set web.search_backend minimax`
3. `hermes` (or `/reset` in an existing session)
4. `web_search` tool calls will return MiniMax results

Without a key, the provider reports `is_available() == False` and the
registry falls through to the next available backend — no regression
for users who don't set the key.

## Tests

- **34 new minimax tests** pass — identity, capability flags,
  `is_available()` across all 4 key aliases + whitespace handling,
  request URL/headers/body shape, host override (global + CN +
  trailing-slash trim), response normalization (organic + results +
  web field fallbacks), all error paths (empty query, missing key,
  HTTP error, transport error, API-level `base_resp.status_code != 0`,
  JSON parse failure), key-alias precedence, setup schema, plugin
  registration.
- **87 tests in `tests/plugins/web/`** all pass (53 prior + 34 new).
- **65 sibling web-tools tests** (`test_web_tools_config`,
  `test_web_tools_tavily`) pass — no regression.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding test coverage)

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit message follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat(web): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run `pytest tests/ -q` and all new + related tests pass
- [x] I've added tests for my changes (34 new, matching the xai plugin's coverage pattern)
- [x] I've tested on my platform: Ubuntu 24.04 (kernel 5.15.0-181-generic)

### Documentation & Housekeeping

- [x] N/A — no public docs reference web backends; the picker in
  `hermes tools` picks them up via `get_setup_schema()` automatically
- [x] N/A — no `cli-config.yaml.example` key added (uses existing
  `web.search_backend`)
- [x] N/A — no architecture/workflow changes
- [x] N/A — pure Python + `httpx` (already a core dep), no platform-specific code
- [x] N/A — no tool schema changes; new provider is purely additive