### PR TITLE
fix(agent): parse Gemini retry-in cooldowns

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -293,7 +293,7 @@ def _extract_retry_delay_seconds(message: str) -> Optional[float]:
     if delay_match:
         value = float(delay_match.group(1))
         return value / 1000.0 if delay_match.group(2).lower() == "ms" else value
-    sec_match = re.search(r"retry\s+(?:after\s+)?(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)", message, re.IGNORECASE)
+    sec_match = re.search(r"retry\s+(?:(?:after|in)\s+)?(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)", message, re.IGNORECASE)
     if sec_match:
         return float(sec_match.group(1))
     # "Resets in 4hr 5min" format used by OpenCode Go weekly usage limits

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -24,6 +24,19 @@ def _jwt_with_claims(claims: dict) -> str:
     return f"{_part({'alg': 'none', 'typ': 'JWT'})}.{_part(claims)}.sig"
 
 
+def test_normalize_error_context_parses_gemini_retry_in_message(monkeypatch):
+    from agent import credential_pool
+
+    monkeypatch.setattr(credential_pool.time, "time", lambda: 1000.0)
+
+    normalized = credential_pool._normalize_error_context({
+        "message": "Resource exhausted. Please retry in 6.19s.",
+    })
+
+    assert normalized["message"] == "Resource exhausted. Please retry in 6.19s."
+    assert normalized["reset_at"] == pytest.approx(1006.19)
+
+
 def test_fill_first_selection_skips_recently_exhausted_entry(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     _write_auth_store(


### PR DESCRIPTION
## What does this PR do?

Fixes the credential-pool retry-delay parser so Gemini messages such as `Please retry in 6.19s` set a short `last_error_reset_at` cooldown instead of falling back to the default one-hour exhausted window.

The existing parser handled `retry after X` and `retry X`, but not Gemini's `retry in X` wording. This keeps the existing formats intact and only adds the missing preposition.

## Related Issue

Fixes #51450

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `agent/credential_pool.py`: accept `retry in Xs` in `_extract_retry_delay_seconds`.
- `tests/agent/test_credential_pool.py`: add a regression test through `_normalize_error_context` proving a Gemini-style message produces a near-term reset timestamp.

## How to Test

1. Trigger credential-pool error normalization with `Resource exhausted. Please retry in 6.19s.`
2. Confirm the normalized context includes `reset_at` approximately 6.19 seconds after the current time, not no reset timestamp.
3. Run the focused credential-pool test file.

## Validation

- `scripts/run_tests.sh tests/agent/test_credential_pool.py -- --tb=long` - 80 passed
- `uv run ruff check agent/credential_pool.py tests/agent/test_credential_pool.py`
- `git diff --check origin/main...HEAD`

## Duplicate check

Searched open and closed PRs for `51450` and `credential_pool Gemini retry`; no existing PR matched this Gemini `retry in Xs` issue. Related absolute timestamp issue #46891 has separate open PRs (#46902, #46930), so this PR stays scoped to #51450.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run focused tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 / Python 3.11.15 via `uv`

### Documentation & Housekeeping

- [x] Documentation N/A
- [x] `cli-config.yaml.example` N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` N/A
- [x] Cross-platform impact considered: regex-only parser change, no OS-specific behavior
- [x] Tool descriptions/schemas N/A
