### PR TITLE
feat(secrets): add 1Password and Keychain sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ models-dev-upstream/
 .mcp.json
 opencode.json
 config/mcporter.json
+workers.json
 
 hermes_cli/tui_dist/*
 hermes_cli/scripts/

--- a/agent/secret_sources/__init__.py
+++ b/agent/secret_sources/__init__.py
@@ -10,4 +10,11 @@ Currently shipped:
   - ``bitwarden`` — Bitwarden Secrets Manager (`bws` CLI).  See
     ``agent.secret_sources.bitwarden`` for the integration and
     ``hermes_cli.secrets_cli`` for the user-facing setup wizard.
+  - ``onepassword`` — 1Password CLI (`op`) reference resolver.  See
+    ``agent.secret_sources.onepassword``; it resolves ``op://`` links into
+    process-local environment variables without writing secret values to disk.
+  - ``keychain`` — macOS Keychain generic-password resolver.  See
+    ``agent.secret_sources.keychain``; it reads machine-local Keychain items
+    into process-local environment variables without putting values in
+    ``~/.hermes/.env`` or wrapper scripts.
 """

--- a/agent/secret_sources/keychain.py
+++ b/agent/secret_sources/keychain.py
@@ -1,0 +1,205 @@
+"""macOS Keychain secret-source integration.
+
+This backend resolves named environment variables from macOS Keychain at
+process startup.  It is intended for local machine credentials such as a
+Telegram bot token already stored in the login/system keychain, without putting
+that value in ``~/.hermes/.env`` or wrapper scripts.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+
+_DEFAULT_TIMEOUT_SECONDS = 6.0
+_ENV_NAME_RE_CHARS = set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_")
+
+
+@dataclass
+class FetchResult:
+    secrets: dict[str, str] = field(default_factory=dict)
+    applied: list[str] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    error: Optional[str] = None
+    binary_path: Optional[Path] = None
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None
+
+
+def _valid_env_name(name: str) -> bool:
+    return bool(name) and (name[0].isalpha() or name[0] == "_") and all(ch in _ENV_NAME_RE_CHARS for ch in name)
+
+
+def find_security_binary(path: str | os.PathLike | None = None) -> Optional[Path]:
+    if path:
+        candidate = Path(path)
+        return candidate if candidate.exists() and os.access(candidate, os.X_OK) else None
+    for raw in ("/usr/bin/security", shutil.which("security")):
+        if not raw:
+            continue
+        candidate = Path(raw)
+        if candidate.exists() and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+def _normalise_env_map(raw: Any) -> dict[str, dict[str, str]]:
+    """Coerce supported config shapes into env-var keychain specs.
+
+    Preferred YAML shape:
+
+    .. code-block:: yaml
+
+       secrets:
+         keychain:
+           env:
+             TELEGRAM_BOT_TOKEN:
+               service: halvo-shared
+               account: HERMES_MBP_TELEGRAM_BOT_TOKEN
+
+    String shorthand ``service/account`` is also accepted.
+    """
+
+    if not raw:
+        return {}
+    result: dict[str, dict[str, str]] = {}
+    if isinstance(raw, Mapping):
+        for name, spec in raw.items():
+            if not isinstance(name, str):
+                continue
+            if isinstance(spec, Mapping):
+                service = str(spec.get("service") or spec.get("name") or "").strip()
+                account = str(spec.get("account") or spec.get("username") or "").strip()
+                keychain = str(spec.get("keychain") or "").strip()
+            elif isinstance(spec, str) and "/" in spec:
+                service, account = (part.strip() for part in spec.split("/", 1))
+                keychain = ""
+            else:
+                continue
+            if service and account:
+                item = {"service": service, "account": account}
+                if keychain:
+                    item["keychain"] = keychain
+                result[name.strip()] = item
+    elif isinstance(raw, list):
+        for item in raw:
+            if not isinstance(item, Mapping):
+                continue
+            name = str(item.get("name") or item.get("env") or item.get("env_var") or "").strip()
+            service = str(item.get("service") or "").strip()
+            account = str(item.get("account") or item.get("username") or "").strip()
+            keychain = str(item.get("keychain") or "").strip()
+            if name and service and account:
+                spec = {"service": service, "account": account}
+                if keychain:
+                    spec["keychain"] = keychain
+                result[name] = spec
+    return result
+
+
+def read_keychain_secret(
+    *,
+    service: str,
+    account: str,
+    binary: Path,
+    keychain: str = "",
+    timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+) -> str:
+    """Read one Keychain generic-password value using ``security``.
+
+    The secret is returned to the caller but never logged here.  Errors include
+    only service/account metadata, not the secret value.
+    """
+
+    command = [str(binary), "find-generic-password", "-s", service, "-a", account, "-w"]
+    if keychain:
+        command.append(keychain)
+    try:
+        completed = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=max(float(timeout_seconds), 0.1),
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"security timed out after {timeout_seconds:g}s") from exc
+    except OSError as exc:
+        raise RuntimeError(f"failed to execute security: {exc}") from exc
+
+    if completed.returncode != 0:
+        detail = " ".join(
+            line.strip() for line in (completed.stderr or completed.stdout).splitlines() if line.strip()
+        )
+        raise RuntimeError(detail[:240] or f"security exited {completed.returncode}")
+    return completed.stdout.rstrip("\r\n")
+
+
+def apply_keychain_secrets(
+    *,
+    enabled: bool,
+    env: Any = None,
+    mappings: Any = None,
+    references: Any = None,
+    override_existing: bool = False,
+    timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+    security_path: str = "",
+) -> FetchResult:
+    result = FetchResult()
+    if not enabled:
+        return result
+
+    specs: dict[str, dict[str, str]] = {}
+    for raw in (env, mappings, references):
+        specs.update(_normalise_env_map(raw))
+    if not specs:
+        return result
+
+    for name in list(specs):
+        if not _valid_env_name(name):
+            result.warnings.append(f"skipping invalid environment variable name {name!r}")
+            specs.pop(name, None)
+
+    if not specs:
+        return result
+
+    binary = find_security_binary(security_path)
+    result.binary_path = binary
+    if binary is None:
+        result.error = "macOS security CLI not found; cannot read Keychain secrets"
+        return result
+
+    for name, spec in sorted(specs.items()):
+        current = os.environ.get(name, "")
+        if current and not override_existing:
+            result.skipped.append(name)
+            continue
+        try:
+            value = read_keychain_secret(
+                service=spec["service"],
+                account=spec["account"],
+                keychain=spec.get("keychain", ""),
+                binary=binary,
+                timeout_seconds=timeout_seconds,
+            )
+        except RuntimeError as exc:
+            result.warnings.append(f"{name}: {exc}")
+            continue
+        if value == "":
+            result.warnings.append(f"{name}: Keychain item resolved to an empty value")
+            continue
+        os.environ[name] = value
+        result.secrets[name] = value
+        result.applied.append(name)
+
+    if not result.applied and not result.skipped and result.warnings:
+        result.error = "no Keychain secrets were applied"
+    return result

--- a/agent/secret_sources/onepassword.py
+++ b/agent/secret_sources/onepassword.py
@@ -1,0 +1,298 @@
+"""1Password CLI (`op`) secret-reference integration.
+
+Hermes can resolve non-secret 1Password references (``op://Vault/Item/field``)
+into process-local environment variables at startup.  The references live in
+``config.yaml`` or ``.env``; the secret values never get written back to disk,
+logged, cached, or embedded in service wrappers.
+
+This integration is intentionally small and subprocess-driven:
+
+* It uses the installed ``op`` CLI instead of a Python SDK.
+* Every ``op read`` is timeout-bounded so a locked desktop app cannot hang
+  gateway/cron startup indefinitely.
+* Failures are fail-open: Hermes keeps starting with whatever non-1Password
+  credentials were already present.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+
+_CREDENTIAL_SUFFIXES = ("_API_KEY", "_TOKEN", "_SECRET", "_KEY")
+_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_DEFAULT_TIMEOUT_SECONDS = 8.0
+_COMMON_OP_PATHS = (
+    "/opt/homebrew/bin/op",
+    "/usr/local/bin/op",
+    "/usr/bin/op",
+    "~/.local/bin/op",
+)
+
+
+@dataclass
+class FetchResult:
+    """Outcome of applying 1Password references."""
+
+    secrets: dict[str, str] = field(default_factory=dict)
+    applied: list[str] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    error: Optional[str] = None
+    binary_path: Optional[Path] = None
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None
+
+
+def is_onepassword_reference(value: str | None) -> bool:
+    """Return True when ``value`` is an ``op://`` secret reference."""
+
+    return bool(isinstance(value, str) and value.strip().startswith("op://"))
+
+
+def _is_credential_env_var(name: str) -> bool:
+    return any(name.endswith(suffix) for suffix in _CREDENTIAL_SUFFIXES)
+
+
+def _normalise_env_map(raw: Any) -> dict[str, str]:
+    """Coerce supported config shapes into ``ENV_VAR -> op://ref``.
+
+    Preferred shape:
+
+    .. code-block:: yaml
+
+       secrets:
+         onepassword:
+           env:
+             TELEGRAM_BOT_TOKEN: op://Employee/Hermes Telegram/credential
+
+    A list of objects is accepted too for config UIs that prefer arrays:
+    ``[{name: TELEGRAM_BOT_TOKEN, ref: op://...}]``.
+    """
+
+    if not raw:
+        return {}
+
+    result: dict[str, str] = {}
+    if isinstance(raw, Mapping):
+        for name, ref in raw.items():
+            if isinstance(name, str) and isinstance(ref, str):
+                result[name.strip()] = ref.strip()
+        return result
+
+    if isinstance(raw, list):
+        for item in raw:
+            if not isinstance(item, Mapping):
+                continue
+            name = str(
+                item.get("name")
+                or item.get("env")
+                or item.get("env_var")
+                or item.get("key")
+                or ""
+            ).strip()
+            ref = str(
+                item.get("ref")
+                or item.get("reference")
+                or item.get("op_ref")
+                or item.get("value")
+                or ""
+            ).strip()
+            if name and ref:
+                result[name] = ref
+    return result
+
+
+def _collect_configured_refs(
+    *,
+    env: Any = None,
+    mappings: Any = None,
+    references: Any = None,
+) -> dict[str, str]:
+    refs: dict[str, str] = {}
+    for raw in (env, mappings, references):
+        refs.update(_normalise_env_map(raw))
+    return refs
+
+
+def _collect_env_reference_values() -> dict[str, str]:
+    """Find credential-like environment variables whose value is an op ref."""
+
+    refs: dict[str, str] = {}
+    for name, value in os.environ.items():
+        if _is_credential_env_var(name) and is_onepassword_reference(value):
+            refs[name] = value.strip()
+    return refs
+
+
+def find_op(op_path: str | os.PathLike | None = None) -> Optional[Path]:
+    """Return a usable 1Password CLI path, if one is available."""
+
+    if op_path:
+        candidate = Path(op_path).expanduser()
+        if candidate.exists() and os.access(candidate, os.X_OK):
+            return candidate
+        return None
+
+    found = shutil.which("op")
+    if found:
+        return Path(found)
+
+    for raw in _COMMON_OP_PATHS:
+        candidate = Path(raw).expanduser()
+        if candidate.exists() and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+def _op_env() -> dict[str, str]:
+    """Build the environment for ``op`` without injecting secret values."""
+
+    env = os.environ.copy()
+    env.setdefault("NO_COLOR", "1")
+    return env
+
+
+def _summarize_op_failure(reference: str, message: str) -> str:
+    """Return a one-line op error without echoing the configured reference."""
+
+    cleaned = (message or "").replace(reference, "[1Password reference]")
+    cleaned = " ".join(line.strip() for line in cleaned.splitlines() if line.strip())
+    if not cleaned:
+        return "op read failed"
+    return cleaned[:240]
+
+
+def read_onepassword_reference(
+    reference: str,
+    *,
+    binary: Path,
+    timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+    account: str = "",
+) -> str:
+    """Read a single ``op://`` reference via ``op read``.
+
+    Raises ``RuntimeError`` with a redacted message on any failure.
+    """
+
+    if not is_onepassword_reference(reference):
+        raise RuntimeError("not a 1Password op:// reference")
+
+    command = [str(binary), "read", reference]
+    if account:
+        command.extend(["--account", account])
+
+    try:
+        completed = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=max(float(timeout_seconds), 0.1),
+            env=_op_env(),
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"op read timed out after {timeout_seconds:g}s") from exc
+    except OSError as exc:
+        raise RuntimeError(f"failed to execute op: {exc}") from exc
+
+    if completed.returncode != 0:
+        detail = _summarize_op_failure(reference, completed.stderr or completed.stdout)
+        raise RuntimeError(f"op read exited {completed.returncode}: {detail}")
+
+    # op prints a single trailing newline for normal secret values.  Strip only
+    # line terminators it added; preserve any meaningful internal whitespace.
+    return completed.stdout.rstrip("\r\n")
+
+
+def apply_onepassword_secrets(
+    *,
+    enabled: bool,
+    env: Any = None,
+    mappings: Any = None,
+    references: Any = None,
+    override_existing: bool = False,
+    timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+    op_path: str = "",
+    account: str = "",
+    resolve_env_references: bool = True,
+) -> FetchResult:
+    """Resolve configured 1Password references into ``os.environ``.
+
+    ``env``/``mappings``/``references`` are synonyms so config authors can use
+    the most obvious name.  Values must be ``op://`` references.  When
+    ``resolve_env_references`` is true, existing credential-like env vars whose
+    value is already an ``op://`` reference are resolved too; this lets a
+    non-secret link live in ``~/.hermes/.env`` without putting the actual token
+    on disk.
+    """
+
+    result = FetchResult()
+    if not enabled:
+        return result
+
+    refs: dict[str, str] = {}
+    if resolve_env_references:
+        refs.update(_collect_env_reference_values())
+    refs.update(_collect_configured_refs(env=env, mappings=mappings, references=references))
+
+    if not refs:
+        return result
+
+    invalid_names = sorted(name for name in refs if not _ENV_NAME_RE.match(name))
+    for name in invalid_names:
+        result.warnings.append(f"skipping invalid environment variable name {name!r}")
+        refs.pop(name, None)
+
+    invalid_refs = sorted(name for name, ref in refs.items() if not is_onepassword_reference(ref))
+    for name in invalid_refs:
+        result.warnings.append(f"skipping {name}: value is not an op:// reference")
+        refs.pop(name, None)
+
+    if not refs:
+        return result
+
+    binary = find_op(op_path)
+    result.binary_path = binary
+    if binary is None:
+        result.error = "1Password CLI `op` not found; install it or set secrets.onepassword.op_path"
+        return result
+
+    for name, reference in sorted(refs.items()):
+        current = os.environ.get(name, "")
+        current_is_ref = is_onepassword_reference(current)
+        if current and not current_is_ref and not override_existing:
+            result.skipped.append(name)
+            continue
+
+        try:
+            value = read_onepassword_reference(
+                reference,
+                binary=binary,
+                timeout_seconds=timeout_seconds,
+                account=account,
+            )
+        except RuntimeError as exc:
+            result.warnings.append(f"{name}: {exc}")
+            continue
+
+        if value == "":
+            result.warnings.append(f"{name}: 1Password reference resolved to an empty value")
+            continue
+
+        os.environ[name] = value
+        result.secrets[name] = value
+        result.applied.append(name)
+
+    if not result.applied and not result.skipped and result.warnings:
+        result.error = "no 1Password references were applied"
+
+    return result

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -21,7 +21,7 @@ _CREDENTIAL_SUFFIXES = ("_API_KEY", "_TOKEN", "_SECRET", "_KEY")
 # tests) don't spam the same warning multiple times.
 _WARNED_KEYS: set[str] = set()
 
-# Map of env-var name → source label ("bitwarden", etc.) for credentials
+# Map of env-var name → source label ("bitwarden", "1password", etc.) for credentials
 # that were injected by an external secret source during load_hermes_dotenv().
 # Used by setup / `hermes model` flows to label detected credentials so
 # users understand WHERE a key came from when their .env doesn't contain it
@@ -42,9 +42,11 @@ _APPLIED_HOMES: set[str] = set()
 def get_secret_source(env_var: str) -> str | None:
     """Return the label of the secret source that supplied ``env_var``, if any.
 
-    Returns ``"bitwarden"`` for keys pulled from Bitwarden Secrets Manager
-    during the current process's ``load_hermes_dotenv()`` call.  Returns
-    ``None`` for keys that came from ``.env``, the shell environment, or
+    Returns ``"bitwarden"`` for keys pulled from Bitwarden Secrets Manager,
+    ``"1password"`` for keys resolved through 1Password CLI references, or
+    ``"keychain"`` for keys resolved through macOS Keychain during the
+    current process's ``load_hermes_dotenv()`` call.  Returns ``None`` for
+    keys that came from ``.env``, the shell environment, or
     aren't tracked.  The returned label is metadata only: credential-pool
     persistence may store it to explain the origin of a borrowed secret, but
     must never treat it as authorization to persist the raw value.
@@ -63,6 +65,7 @@ def reset_secret_source_cache() -> None:
     that want to refresh after a config change.
     """
     _APPLIED_HOMES.clear()
+    _SECRET_SOURCES.clear()
 
 
 def format_secret_source_suffix(env_var: str) -> str:
@@ -78,6 +81,10 @@ def format_secret_source_suffix(env_var: str) -> str:
         return ""
     if source == "bitwarden":
         return " (from Bitwarden)"
+    if source == "1password":
+        return " (from 1Password)"
+    if source == "keychain":
+        return " (from macOS Keychain)"
     # Generic fallback — future-proofing for additional secret sources
     # (e.g. 1Password, HashiCorp Vault) without having to update every
     # call site.
@@ -281,20 +288,23 @@ def _apply_managed_env() -> None:
 
 
 def _apply_external_secret_sources(home_path: Path) -> None:
-    """Pull secrets from external sources (currently Bitwarden) into env.
+    """Pull secrets from external sources into env.
+
+    Supported sources currently include Bitwarden Secrets Manager, 1Password
+    references, and macOS Keychain generic-password items.
 
     Runs AFTER dotenv loads so .env values are visible (we use them to
     locate the access token) but BEFORE the rest of Hermes reads
-    ``os.environ`` for credentials.  Any failure here is logged and
+    ``os.environ`` for credentials.  Any failure here is reported and
     swallowed — external secret sources must never block startup.
 
     Idempotent within a process: subsequent calls for the same
     ``home_path`` are no-ops.  ``load_hermes_dotenv()`` runs at import
     time from several hot modules (cli.py, hermes_cli/main.py,
     run_agent.py, trajectory_compressor.py, ...), so without this guard
-    the Bitwarden status line would print 3-5x per CLI startup.  Use
+    the secret-source status line would print 3-5x per CLI startup.  Use
     ``reset_secret_source_cache()`` if you need to force a re-pull
-    (tests, future ``hermes secrets bitwarden sync`` from a long-running
+    (tests, future secret-source sync commands from a long-running
     process).
     """
     home_key = str(Path(home_path).resolve())
@@ -307,53 +317,138 @@ def _apply_external_secret_sources(home_path: Path) -> None:
     except Exception:  # noqa: BLE001 — config errors must not block startup
         return
 
-    bw_cfg = (cfg or {}).get("bitwarden") or {}
-    if not bw_cfg.get("enabled"):
-        return
+    cfg = cfg or {}
 
-    try:
-        from agent.secret_sources.bitwarden import apply_bitwarden_secrets
-    except ImportError:
-        return
+    bw_cfg = cfg.get("bitwarden") or {}
+    if bw_cfg.get("enabled"):
+        try:
+            from agent.secret_sources.bitwarden import apply_bitwarden_secrets
+        except ImportError:
+            apply_bitwarden_secrets = None  # type: ignore[assignment]
 
-    result = apply_bitwarden_secrets(
-        enabled=True,
-        access_token_env=bw_cfg.get("access_token_env", "BWS_ACCESS_TOKEN"),
-        project_id=bw_cfg.get("project_id", ""),
-        override_existing=bool(bw_cfg.get("override_existing", False)),
-        cache_ttl_seconds=float(bw_cfg.get("cache_ttl_seconds", 300)),
-        auto_install=bool(bw_cfg.get("auto_install", True)),
-        server_url=str(bw_cfg.get("server_url", "") or "").strip(),
-        home_path=home_path,
-    )
+        if apply_bitwarden_secrets is not None:
+            result = apply_bitwarden_secrets(
+                enabled=True,
+                access_token_env=bw_cfg.get("access_token_env", "BWS_ACCESS_TOKEN"),
+                project_id=bw_cfg.get("project_id", ""),
+                override_existing=bool(bw_cfg.get("override_existing", False)),
+                cache_ttl_seconds=float(bw_cfg.get("cache_ttl_seconds", 300)),
+                auto_install=bool(bw_cfg.get("auto_install", True)),
+                server_url=str(bw_cfg.get("server_url", "") or "").strip(),
+                home_path=home_path,
+            )
 
-    if result.applied:
-        # Re-run the ASCII sanitization pass: BSM values are user-supplied
-        # and might have the same copy-paste corruption as a manually
-        # edited .env (see #6843).
-        _sanitize_loaded_credentials()
-        # Remember where these came from so the setup / `hermes model`
-        # flows can label detected credentials with "(from Bitwarden)" —
-        # otherwise users see "credentials ✓" with no hint that the value
-        # came from BSM rather than .env.
-        for name in result.applied:
-            _SECRET_SOURCES[name] = "bitwarden"
-        print(
-            f"  Bitwarden Secrets Manager: applied {len(result.applied)} "
-            f"secret{'s' if len(result.applied) != 1 else ''} "
-            f"({', '.join(sorted(result.applied))})",
-            file=sys.stderr,
-        )
-    if result.error:
-        print(
-            f"  Bitwarden Secrets Manager: {result.error}",
-            file=sys.stderr,
-        )
-    for warn in result.warnings:
-        print(
-            f"  Bitwarden Secrets Manager: {warn}",
-            file=sys.stderr,
-        )
+            if result.applied:
+                # Re-run the ASCII sanitization pass: BSM values are user-supplied
+                # and might have the same copy-paste corruption as a manually
+                # edited .env (see #6843).
+                _sanitize_loaded_credentials()
+                # Remember where these came from so setup / `hermes model`
+                # flows can label detected credentials with "(from Bitwarden)".
+                for name in result.applied:
+                    _SECRET_SOURCES[name] = "bitwarden"
+                print(
+                    f"  Bitwarden Secrets Manager: applied {len(result.applied)} "
+                    f"secret{'s' if len(result.applied) != 1 else ''} "
+                    f"({', '.join(sorted(result.applied))})",
+                    file=sys.stderr,
+                )
+            if result.error:
+                print(
+                    f"  Bitwarden Secrets Manager: {result.error}",
+                    file=sys.stderr,
+                )
+            for warn in result.warnings:
+                print(
+                    f"  Bitwarden Secrets Manager: {warn}",
+                    file=sys.stderr,
+                )
+
+    op_cfg = cfg.get("onepassword") or cfg.get("1password") or {}
+    if op_cfg.get("enabled"):
+        try:
+            from agent.secret_sources.onepassword import apply_onepassword_secrets
+        except ImportError:
+            apply_onepassword_secrets = None  # type: ignore[assignment]
+
+        if apply_onepassword_secrets is not None:
+            result = apply_onepassword_secrets(
+                enabled=True,
+                env=op_cfg.get("env"),
+                mappings=op_cfg.get("mappings"),
+                references=op_cfg.get("references"),
+                override_existing=bool(op_cfg.get("override_existing", False)),
+                timeout_seconds=float(op_cfg.get("timeout_seconds", 8)),
+                op_path=str(op_cfg.get("op_path", "") or "").strip(),
+                account=str(op_cfg.get("account", "") or "").strip(),
+                resolve_env_references=bool(op_cfg.get("resolve_env_references", True)),
+            )
+
+            if result.applied:
+                # 1Password values are resolved only into this process.  They
+                # may still have copy/paste corruption, so apply the same ASCII
+                # credential cleanup as dotenv/Bitwarden values.
+                _sanitize_loaded_credentials()
+                for name in result.applied:
+                    _SECRET_SOURCES[name] = "1password"
+                print(
+                    f"  1Password CLI: applied {len(result.applied)} "
+                    f"secret{'s' if len(result.applied) != 1 else ''} "
+                    f"({', '.join(sorted(result.applied))})",
+                    file=sys.stderr,
+                )
+            if result.error:
+                print(
+                    f"  1Password CLI: {result.error}",
+                    file=sys.stderr,
+                )
+            for warn in result.warnings:
+                print(
+                    f"  1Password CLI: {warn}",
+                    file=sys.stderr,
+                )
+
+    keychain_cfg = cfg.get("keychain") or {}
+    if keychain_cfg.get("enabled"):
+        try:
+            from agent.secret_sources.keychain import apply_keychain_secrets
+        except ImportError:
+            apply_keychain_secrets = None  # type: ignore[assignment]
+
+        if apply_keychain_secrets is not None:
+            result = apply_keychain_secrets(
+                enabled=True,
+                env=keychain_cfg.get("env"),
+                mappings=keychain_cfg.get("mappings"),
+                references=keychain_cfg.get("references"),
+                override_existing=bool(keychain_cfg.get("override_existing", False)),
+                timeout_seconds=float(keychain_cfg.get("timeout_seconds", 6)),
+                security_path=str(keychain_cfg.get("security_path", "") or "").strip(),
+            )
+
+            if result.applied:
+                # Keychain values are machine-local and process-only.  They may
+                # still have copy/paste corruption, so normalize like other
+                # secret sources.
+                _sanitize_loaded_credentials()
+                for name in result.applied:
+                    _SECRET_SOURCES[name] = "keychain"
+                print(
+                    f"  macOS Keychain: applied {len(result.applied)} "
+                    f"secret{'s' if len(result.applied) != 1 else ''} "
+                    f"({', '.join(sorted(result.applied))})",
+                    file=sys.stderr,
+                )
+            if result.error:
+                print(
+                    f"  macOS Keychain: {result.error}",
+                    file=sys.stderr,
+                )
+            for warn in result.warnings:
+                print(
+                    f"  macOS Keychain: {warn}",
+                    file=sys.stderr,
+                )
 
 
 def _load_secrets_config(home_path: Path) -> dict:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3299,6 +3299,7 @@ _LAUNCHD_JOB_UNLOADED_EXIT_CODES = frozenset({3, 113, 125})
 # supervise the gateway at all, so we degrade to a detached background process
 # (the documented `nohup hermes gateway run` workaround). See #23387.
 _LAUNCHCTL_DOMAIN_UNSUPPORTED_CODES = frozenset({5, 125})
+_LAUNCHD_REFRESH_STARTED_DETACHED_FALLBACK = False
 
 
 def _launchd_error_indicates_unloaded(exc: subprocess.CalledProcessError) -> bool:
@@ -3314,6 +3315,11 @@ def _launchctl_domain_unsupported(returncode: int) -> bool:
     unavailable" and degrade gracefully to a detached process.
     """
     return returncode in _LAUNCHCTL_DOMAIN_UNSUPPORTED_CODES
+
+
+def _launchd_refresh_started_detached_fallback() -> bool:
+    """True when the most recent launchd plist refresh spawned fallback."""
+    return _LAUNCHD_REFRESH_STARTED_DETACHED_FALLBACK
 
 
 def _gateway_run_command() -> list[str]:
@@ -3507,6 +3513,9 @@ def refresh_launchd_plist_if_needed() -> bool:
     ``launchctl kickstart`` cycle — no daemon-reload is needed. We still bootout/
     bootstrap to make launchd re-read the updated plist immediately.
     """
+    global _LAUNCHD_REFRESH_STARTED_DETACHED_FALLBACK
+    _LAUNCHD_REFRESH_STARTED_DETACHED_FALLBACK = False
+
     plist_path = get_launchd_plist_path()
     if not plist_path.exists() or launchd_plist_is_current():
         return False
@@ -3569,15 +3578,32 @@ def refresh_launchd_plist_if_needed() -> bool:
         check=False,
         timeout=90,
     )
-    subprocess.run(
+    bootstrap = subprocess.run(
         ["launchctl", "bootstrap", domain, str(plist_path)],
         check=False,
         timeout=30,
     )
+    if _launchctl_domain_unsupported(bootstrap.returncode):
+        if _launchd_fallback_to_detached(
+            f"launchctl bootstrap exit {bootstrap.returncode}",
+            exit_on_failure=False,
+        ):
+            _LAUNCHD_REFRESH_STARTED_DETACHED_FALLBACK = True
     print(
         "↻ Updated gateway launchd service definition to match the current Hermes install"
     )
     return True
+
+
+def _detached_gateway_running_without_launchd_service() -> bool:
+    """True when launchd fallback has already started a gateway process."""
+    try:
+        from gateway.status import get_running_pid
+
+        return get_running_pid() is not None and not _probe_launchd_service_running()
+    except Exception:
+        logger.debug("detached gateway fallback probe failed", exc_info=True)
+        return False
 
 
 def launchd_install(force: bool = False):
@@ -3670,6 +3696,11 @@ def launchd_start():
         return
 
     refresh_launchd_plist_if_needed()
+    if (
+        _launchd_refresh_started_detached_fallback()
+        or _detached_gateway_running_without_launchd_service()
+    ):
+        return
     try:
         subprocess.run(
             ["launchctl", "kickstart", f"{_launchd_domain()}/{label}"],

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12089,16 +12089,17 @@ def main():
     fallback_parser.set_defaults(func=cmd_fallback)
 
     # =========================================================================
-    # secrets command — external secret managers (currently: Bitwarden)
+    # secrets command — external secret managers
     # =========================================================================
     secrets_parser = subparsers.add_parser(
         "secrets",
-        help="Manage external secret sources (Bitwarden Secrets Manager)",
+        help="Manage external secret sources",
         description=(
             "Pull API keys from an external secret manager at process startup "
-            "instead of storing them in ~/.hermes/.env.  Currently supports "
-            "Bitwarden Secrets Manager.  See: "
-            "https://hermes-agent.nousresearch.com/docs/user-guide/secrets/bitwarden"
+            "instead of storing them in ~/.hermes/.env.  Bitwarden has CLI "
+            "setup commands; 1Password and macOS Keychain are configured "
+            "with non-secret references in config.yaml.  See: "
+            "https://hermes-agent.nousresearch.com/docs/user-guide/secrets/"
         ),
     )
     secrets_subparsers = secrets_parser.add_subparsers(dest="secrets_command")

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -68,6 +68,7 @@ class TestSystemdServiceRefresh:
 
         monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
         monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n")
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
 
         calls = []
 
@@ -91,6 +92,7 @@ class TestSystemdServiceRefresh:
 
         monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
         monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n")
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
 
         calls = []
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
@@ -719,6 +721,109 @@ class TestLaunchdServiceRecovery:
             ["launchctl", "bootstrap", domain, str(plist_path)],
         ]
 
+    def test_refresh_falls_back_to_detached_when_bootstrap_domain_unsupported(
+        self, tmp_path, monkeypatch
+    ):
+        """macOS 26 can return launchctl bootstrap exit 5 after a plist refresh.
+
+        In that case launchd cannot supervise the gateway, so the refresh path
+        must degrade to the same detached fallback used by launchd_start().
+        """
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text("<plist>old content</plist>", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "launchd_plist_is_current", lambda: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "generate_launchd_plist",
+            lambda: (
+                "<plist>--replace\n<key>HERMES_HOME</key>"
+                "<string>/Users/alice/.hermes</string></plist>"
+            ),
+        )
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda *a, **k: None)
+        monkeypatch.setattr(
+            gateway_cli, "_LAUNCHD_REFRESH_STARTED_DETACHED_FALLBACK", False
+        )
+
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            if cmd and cmd[:2] == ["launchctl", "bootstrap"]:
+                return SimpleNamespace(returncode=5, stdout="", stderr="Input/output error")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        fallback_reasons = []
+        monkeypatch.setattr(
+            gateway_cli,
+            "_launchd_fallback_to_detached",
+            lambda reason, exit_on_failure=True: fallback_reasons.append(
+                (reason, exit_on_failure)
+            )
+            or True,
+        )
+
+        result = gateway_cli.refresh_launchd_plist_if_needed()
+
+        assert result is True
+        assert ["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)] in calls
+        assert fallback_reasons == [("launchctl bootstrap exit 5", False)]
+        assert gateway_cli._launchd_refresh_started_detached_fallback() is True
+
+    def test_launchd_start_returns_if_refresh_started_detached_fallback(
+        self, tmp_path, monkeypatch
+    ):
+        """Do not kickstart launchd after refresh has already spawned fallback."""
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "refresh_launchd_plist_if_needed", lambda: True)
+        monkeypatch.setattr(
+            gateway_cli, "_detached_gateway_running_without_launchd_service", lambda: True
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *a, **k: (_ for _ in ()).throw(
+                AssertionError("launchd_start should not kickstart after fallback")
+            ),
+        )
+
+        gateway_cli.launchd_start()
+
+    def test_launchd_start_returns_if_refresh_marker_reports_detached_fallback(
+        self, tmp_path, monkeypatch
+    ):
+        """Avoid kickstart races before the detached gateway has written its PID."""
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+
+        def fake_refresh():
+            gateway_cli._LAUNCHD_REFRESH_STARTED_DETACHED_FALLBACK = True
+            return True
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            gateway_cli, "_LAUNCHD_REFRESH_STARTED_DETACHED_FALLBACK", False
+        )
+        monkeypatch.setattr(gateway_cli, "refresh_launchd_plist_if_needed", fake_refresh)
+        monkeypatch.setattr(
+            gateway_cli, "_detached_gateway_running_without_launchd_service", lambda: False
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *a, **k: (_ for _ in ()).throw(
+                AssertionError("launchd_start should not kickstart after fallback")
+            ),
+        )
+
+        gateway_cli.launchd_start()
+
     def test_launchd_start_reloads_unloaded_job_and_retries(self, tmp_path, monkeypatch):
         plist_path = tmp_path / "ai.hermes.gateway.plist"
         plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
@@ -1249,6 +1354,7 @@ class TestGatewaySystemServiceRouting:
 
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: calls.append(("refresh", system)))
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
         monkeypatch.setattr(
@@ -1294,6 +1400,7 @@ class TestGatewaySystemServiceRouting:
 
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 10.0)
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
@@ -1353,6 +1460,7 @@ class TestGatewaySystemServiceRouting:
 
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
         monkeypatch.setattr(gateway_cli, "_recover_pending_systemd_restart", lambda system=False, previous_pid=None: False)
@@ -1383,6 +1491,7 @@ class TestGatewaySystemServiceRouting:
     def test_systemd_restart_recovers_failed_planned_restart(self, monkeypatch, capsys):
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
         monkeypatch.setattr(
             "gateway.status.read_runtime_status",

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -7,6 +7,7 @@ don't see an unexplained "credentials ✓" line when their .env is empty.
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
@@ -53,6 +54,22 @@ def test_format_secret_source_suffix_bitwarden_uses_proper_name():
     )
 
 
+def test_format_secret_source_suffix_onepassword_uses_proper_name():
+    env_loader._SECRET_SOURCES["OPENAI_API_KEY"] = "1password"
+    assert (
+        env_loader.format_secret_source_suffix("OPENAI_API_KEY")
+        == " (from 1Password)"
+    )
+
+
+def test_format_secret_source_suffix_keychain_uses_proper_name():
+    env_loader._SECRET_SOURCES["TELEGRAM_BOT_TOKEN"] = "keychain"
+    assert (
+        env_loader.format_secret_source_suffix("TELEGRAM_BOT_TOKEN")
+        == " (from macOS Keychain)"
+    )
+
+
 def test_format_secret_source_suffix_generic_label_for_future_sources():
     # Future-proofing: a new secret source (e.g. "vault") should still
     # produce a sensible label without needing to edit every call site.
@@ -61,6 +78,14 @@ def test_format_secret_source_suffix_generic_label_for_future_sources():
         env_loader.format_secret_source_suffix("OPENAI_API_KEY")
         == " (from vault)"
     )
+
+
+def test_reset_secret_source_cache_clears_origin_labels():
+    env_loader._SECRET_SOURCES["OPENAI_API_KEY"] = "1password"
+
+    env_loader.reset_secret_source_cache()
+
+    assert env_loader.format_secret_source_suffix("OPENAI_API_KEY") == ""
 
 
 def test_apply_external_secret_sources_records_bitwarden_origin(tmp_path, monkeypatch):
@@ -102,6 +127,84 @@ def test_apply_external_secret_sources_records_bitwarden_origin(tmp_path, monkey
         env_loader.format_secret_source_suffix("ANTHROPIC_API_KEY")
         == " (from Bitwarden)"
     )
+
+
+def test_apply_external_secret_sources_records_onepassword_and_keychain_origins(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "secrets:\n"
+        "  '1password':\n"
+        "    enabled: true\n"
+        "    timeout_seconds: 3\n"
+        "    override_existing: true\n"
+        "    resolve_env_references: false\n"
+        "    env:\n"
+        "      OP_API_KEY: 'op://Vault/Item/key'\n"
+        "  keychain:\n"
+        "    enabled: true\n"
+        "    timeout_seconds: 4\n"
+        "    env:\n"
+        "      KEYCHAIN_TOKEN:\n"
+        "        service: halvo-shared\n"
+        "        account: HERMES_MBP_TELEGRAM_BOT_TOKEN\n",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("OP_API_KEY", raising=False)
+    monkeypatch.delenv("KEYCHAIN_TOKEN", raising=False)
+
+    from agent.secret_sources.keychain import FetchResult as KeychainFetchResult
+    from agent.secret_sources.onepassword import FetchResult as OnePasswordFetchResult
+
+    calls = []
+
+    def fake_op_apply(**kwargs):
+        calls.append(("op", kwargs))
+        os.environ["OP_API_KEY"] = "from-op"
+        return OnePasswordFetchResult(
+            secrets={"OP_API_KEY": "from-op"},
+            applied=["OP_API_KEY"],
+        )
+
+    def fake_keychain_apply(**kwargs):
+        calls.append(("keychain", kwargs))
+        os.environ["KEYCHAIN_TOKEN"] = "from-keychain"
+        return KeychainFetchResult(
+            secrets={"KEYCHAIN_TOKEN": "from-keychain"},
+            applied=["KEYCHAIN_TOKEN"],
+        )
+
+    monkeypatch.setattr(
+        "agent.secret_sources.onepassword.apply_onepassword_secrets",
+        fake_op_apply,
+    )
+    monkeypatch.setattr(
+        "agent.secret_sources.keychain.apply_keychain_secrets",
+        fake_keychain_apply,
+    )
+
+    env_loader._apply_external_secret_sources(tmp_path)
+
+    assert os.environ["OP_API_KEY"] == "from-op"
+    assert os.environ["KEYCHAIN_TOKEN"] == "from-keychain"
+    assert env_loader.get_secret_source("OP_API_KEY") == "1password"
+    assert env_loader.get_secret_source("KEYCHAIN_TOKEN") == "keychain"
+    assert env_loader.format_secret_source_suffix("OP_API_KEY") == " (from 1Password)"
+    assert env_loader.format_secret_source_suffix("KEYCHAIN_TOKEN") == " (from macOS Keychain)"
+    assert [kind for kind, _kwargs in calls] == ["op", "keychain"]
+    assert calls[0][1]["timeout_seconds"] == 3
+    assert calls[0][1]["override_existing"] is True
+    assert calls[0][1]["resolve_env_references"] is False
+    assert calls[1][1]["timeout_seconds"] == 4
+
+    stderr = capsys.readouterr().err
+    assert "1Password CLI: applied 1 secret (OP_API_KEY)" in stderr
+    assert "macOS Keychain: applied 1 secret (KEYCHAIN_TOKEN)" in stderr
+    assert "from-op" not in stderr
+    assert "from-keychain" not in stderr
 
 
 def test_apply_external_secret_sources_noop_when_disabled(tmp_path, monkeypatch):
@@ -153,6 +256,7 @@ def test_apply_external_secret_sources_dedupes_within_process(tmp_path, monkeypa
         )
 
     import agent.secret_sources.bitwarden as bw_module
+
     monkeypatch.setattr(bw_module, "apply_bitwarden_secrets", _fake_apply)
 
     # Five calls in a row, simulating module-import-time invocations from

--- a/tests/test_keychain_secrets.py
+++ b/tests/test_keychain_secrets.py
@@ -1,0 +1,158 @@
+"""Hermetic tests for the macOS Keychain secret-source integration."""
+
+from __future__ import annotations
+
+import os
+import sys
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from agent.secret_sources import keychain as kc  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for name in ("TELEGRAM_BOT_TOKEN", "OPENROUTER_API_KEY", "EXISTING_API_KEY"):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_normalise_env_map_accepts_mapping_list_and_shorthand():
+    assert kc._normalise_env_map(  # noqa: SLF001 - private parser is the contract under test
+        {
+            "TELEGRAM_BOT_TOKEN": {
+                "service": "halvo-shared",
+                "account": "HERMES_MBP_TELEGRAM_BOT_TOKEN",
+                "keychain": "/Users/alice/Library/Keychains/login.keychain-db",
+            }
+        }
+    ) == {
+        "TELEGRAM_BOT_TOKEN": {
+            "service": "halvo-shared",
+            "account": "HERMES_MBP_TELEGRAM_BOT_TOKEN",
+            "keychain": "/Users/alice/Library/Keychains/login.keychain-db",
+        }
+    }
+
+    assert kc._normalise_env_map(  # noqa: SLF001
+        [{"env": "OPENROUTER_API_KEY", "service": "svc", "username": "acct"}]
+    ) == {"OPENROUTER_API_KEY": {"service": "svc", "account": "acct"}}
+
+    assert kc._normalise_env_map(  # noqa: SLF001
+        {"EXISTING_API_KEY": "svc/acct"}
+    ) == {"EXISTING_API_KEY": {"service": "svc", "account": "acct"}}
+
+
+def test_read_keychain_secret_invokes_security_and_strips_newline(monkeypatch):
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(returncode=0, stdout="secret-value\n", stderr="")
+
+    monkeypatch.setattr(kc.subprocess, "run", fake_run)
+
+    value = kc.read_keychain_secret(
+        service="halvo-shared",
+        account="HERMES_MBP_TELEGRAM_BOT_TOKEN",
+        keychain="/Users/alice/Library/Keychains/login.keychain-db",
+        binary=Path("/usr/bin/security"),
+        timeout_seconds=4,
+    )
+
+    assert value == "secret-value"
+    assert captured["cmd"] == [
+        "/usr/bin/security",
+        "find-generic-password",
+        "-s",
+        "halvo-shared",
+        "-a",
+        "HERMES_MBP_TELEGRAM_BOT_TOKEN",
+        "-w",
+        "/Users/alice/Library/Keychains/login.keychain-db",
+    ]
+    assert captured["kwargs"]["timeout"] == 4
+
+
+def test_read_keychain_secret_timeout_is_reported(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout") or 0)
+
+    monkeypatch.setattr(kc.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="timed out after 2s"):
+        kc.read_keychain_secret(
+            service="svc",
+            account="acct",
+            binary=Path("/usr/bin/security"),
+            timeout_seconds=2,
+        )
+
+
+def test_apply_resolves_keychain_specs_and_skips_existing(monkeypatch):
+    monkeypatch.setenv("EXISTING_API_KEY", "already-real")
+    monkeypatch.setattr(kc, "find_security_binary", lambda path="": Path("/usr/bin/security"))
+
+    calls = []
+
+    def fake_read(**kwargs):
+        calls.append(kwargs)
+        return f"resolved:{kwargs['account']}"
+
+    monkeypatch.setattr(kc, "read_keychain_secret", fake_read)
+
+    result = kc.apply_keychain_secrets(
+        enabled=True,
+        env={
+            "TELEGRAM_BOT_TOKEN": {
+                "service": "halvo-shared",
+                "account": "HERMES_MBP_TELEGRAM_BOT_TOKEN",
+            },
+            "EXISTING_API_KEY": {"service": "svc", "account": "existing"},
+        },
+        override_existing=False,
+    )
+
+    assert result.ok
+    assert result.applied == ["TELEGRAM_BOT_TOKEN"]
+    assert result.skipped == ["EXISTING_API_KEY"]
+    assert os.environ["TELEGRAM_BOT_TOKEN"] == "resolved:HERMES_MBP_TELEGRAM_BOT_TOKEN"
+    assert os.environ["EXISTING_API_KEY"] == "already-real"
+    assert [call["account"] for call in calls] == ["HERMES_MBP_TELEGRAM_BOT_TOKEN"]
+
+
+def test_apply_rejects_invalid_names_before_security_lookup(monkeypatch):
+    monkeypatch.setattr(
+        kc,
+        "find_security_binary",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("security lookup not needed")),
+    )
+
+    result = kc.apply_keychain_secrets(
+        enabled=True,
+        env={"1BAD": {"service": "svc", "account": "acct"}},
+    )
+
+    assert result.ok
+    assert not result.applied
+    assert any("invalid environment variable" in warning for warning in result.warnings)
+
+
+def test_apply_reports_missing_security_binary(monkeypatch):
+    monkeypatch.setattr(kc, "find_security_binary", lambda path="": None)
+
+    result = kc.apply_keychain_secrets(
+        enabled=True,
+        env={"TELEGRAM_BOT_TOKEN": {"service": "svc", "account": "acct"}},
+    )
+
+    assert not result.ok
+    assert "security CLI not found" in (result.error or "")

--- a/tests/test_onepassword_secrets.py
+++ b/tests/test_onepassword_secrets.py
@@ -1,0 +1,175 @@
+"""Hermetic tests for the 1Password CLI secret-source integration."""
+
+from __future__ import annotations
+
+import os
+import sys
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from agent.secret_sources import onepassword as op  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for name in ("TELEGRAM_BOT_TOKEN", "OPENROUTER_API_KEY", "EXISTING_API_KEY"):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_normalise_env_map_accepts_mapping_and_list():
+    assert op._normalise_env_map(  # noqa: SLF001 - private parser is the contract under test
+        {" TELEGRAM_BOT_TOKEN ": " op://Vault/Bot/token "}
+    ) == {"TELEGRAM_BOT_TOKEN": "op://Vault/Bot/token"}
+
+    assert op._normalise_env_map(  # noqa: SLF001
+        [{"env_var": "OPENROUTER_API_KEY", "reference": "op://Vault/OpenRouter/key"}]
+    ) == {"OPENROUTER_API_KEY": "op://Vault/OpenRouter/key"}
+
+
+def test_read_onepassword_reference_uses_op_read_and_strips_newline(monkeypatch):
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(returncode=0, stdout="secret-value\n", stderr="")
+
+    monkeypatch.setattr(op.subprocess, "run", fake_run)
+
+    value = op.read_onepassword_reference(
+        "op://Vault/Item/field",
+        binary=Path("/usr/local/bin/op"),
+        timeout_seconds=2,
+        account="empire",
+    )
+
+    assert value == "secret-value"
+    assert captured["cmd"] == [
+        "/usr/local/bin/op",
+        "read",
+        "op://Vault/Item/field",
+        "--account",
+        "empire",
+    ]
+    assert captured["kwargs"]["timeout"] == 2
+    assert captured["kwargs"]["env"]["NO_COLOR"] == "1"
+
+
+def test_read_onepassword_reference_redacts_reference_on_failure(monkeypatch):
+    reference = "op://Vault/Item/field"
+
+    def fake_run(cmd, **kwargs):
+        return SimpleNamespace(
+            returncode=1,
+            stdout="",
+            stderr=f"could not read {reference}: item not found",
+        )
+
+    monkeypatch.setattr(op.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        op.read_onepassword_reference(reference, binary=Path("/usr/local/bin/op"))
+
+    message = str(exc_info.value)
+    assert reference not in message
+    assert "[1Password reference]" in message
+
+
+def test_read_onepassword_reference_timeout_is_reported(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout") or 0)
+
+    monkeypatch.setattr(op.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="timed out after 3s"):
+        op.read_onepassword_reference(
+            "op://Vault/Item/field",
+            binary=Path("/usr/local/bin/op"),
+            timeout_seconds=3,
+        )
+
+
+def test_apply_resolves_config_refs_and_env_refs(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "op://Vault/Bot/token")
+    monkeypatch.setattr(op, "find_op", lambda op_path="": Path("/usr/local/bin/op"))
+
+    calls = []
+
+    def fake_read(reference, **kwargs):
+        calls.append((reference, kwargs))
+        return f"resolved:{reference.rsplit('/', 1)[-1]}"
+
+    monkeypatch.setattr(op, "read_onepassword_reference", fake_read)
+
+    result = op.apply_onepassword_secrets(
+        enabled=True,
+        env={"OPENROUTER_API_KEY": "op://Vault/OpenRouter/key"},
+        resolve_env_references=True,
+    )
+
+    assert result.ok
+    assert sorted(result.applied) == ["OPENROUTER_API_KEY", "TELEGRAM_BOT_TOKEN"]
+    assert os.environ["TELEGRAM_BOT_TOKEN"] == "resolved:token"
+    assert os.environ["OPENROUTER_API_KEY"] == "resolved:key"
+    assert [call[0] for call in calls] == [
+        "op://Vault/OpenRouter/key",
+        "op://Vault/Bot/token",
+    ]
+
+
+def test_apply_skips_existing_real_value_unless_override(monkeypatch):
+    monkeypatch.setenv("EXISTING_API_KEY", "already-real")
+    monkeypatch.setattr(op, "find_op", lambda op_path="": Path("/usr/local/bin/op"))
+    monkeypatch.setattr(
+        op,
+        "read_onepassword_reference",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not read skipped ref")),
+    )
+
+    result = op.apply_onepassword_secrets(
+        enabled=True,
+        env={"EXISTING_API_KEY": "op://Vault/Existing/key"},
+        override_existing=False,
+    )
+
+    assert result.ok
+    assert result.skipped == ["EXISTING_API_KEY"]
+    assert os.environ["EXISTING_API_KEY"] == "already-real"
+
+
+def test_apply_rejects_invalid_names_and_non_refs_before_find_op(monkeypatch):
+    monkeypatch.setattr(
+        op,
+        "find_op",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("op lookup not needed")),
+    )
+
+    result = op.apply_onepassword_secrets(
+        enabled=True,
+        env={"1BAD": "op://Vault/Bad/key", "OPENROUTER_API_KEY": "not-a-reference"},
+    )
+
+    assert result.ok
+    assert not result.applied
+    assert any("invalid environment variable" in warning for warning in result.warnings)
+    assert any("not an op:// reference" in warning for warning in result.warnings)
+
+
+def test_apply_reports_missing_op(monkeypatch):
+    monkeypatch.setattr(op, "find_op", lambda op_path="": None)
+
+    result = op.apply_onepassword_secrets(
+        enabled=True,
+        env={"OPENROUTER_API_KEY": "op://Vault/OpenRouter/key"},
+    )
+
+    assert not result.ok
+    assert "op` not found" in (result.error or "")

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -49,7 +49,7 @@ hermes [global-options] <command> [subcommand/options]
 | `hermes auth` | Manage credentials — add, list, remove, reset, status, logout. Handles OAuth flows for Codex/Nous/Anthropic. |
 | `hermes login` / `logout` | **Deprecated** — use `hermes auth` instead. |
 | `hermes send` | Send a one-shot message to a configured messaging platform (Telegram, Discord, Slack, Signal, SMS, …). Useful from shell scripts, cron jobs, CI hooks, and monitoring daemons — no agent loop, no LLM. |
-| `hermes secrets` | Manage external secret sources (currently Bitwarden Secrets Manager) for pulling API keys at process startup instead of from `~/.hermes/.env`. |
+| `hermes secrets` | Manage external secret sources for pulling API keys at process startup instead of from `~/.hermes/.env`. Bitwarden has a CLI wizard; 1Password and macOS Keychain are configured via `config.yaml` references. |
 | `hermes migrate` | Diagnose and (optionally) rewrite `config.yaml` to replace references to retired models or deprecated settings (e.g. `migrate xai`). |
 | `hermes status` | Show agent, auth, and platform status. |
 | `hermes cron` | Inspect and tick the cron scheduler. |
@@ -409,7 +409,7 @@ hermes secrets bitwarden <subcommand>
 hermes secrets bw <subcommand>          # short alias
 ```
 
-Pull API keys from an external secret manager at process startup instead of storing them in `~/.hermes/.env`. Currently supports **Bitwarden Secrets Manager**. See the full guide: [Bitwarden integration](../user-guide/secrets/bitwarden.md).
+Pull API keys from an external secret manager at process startup instead of storing them in `~/.hermes/.env`. **Bitwarden Secrets Manager** has CLI subcommands; **1Password CLI** and **macOS Keychain** are configured in `config.yaml` with non-secret references/lookup metadata. See the full guides: [Bitwarden integration](../user-guide/secrets/bitwarden.md), [1Password CLI](../user-guide/secrets/1password.md), and [macOS Keychain](../user-guide/secrets/keychain.md).
 
 `bitwarden` (alias `bw`) subcommands:
 

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -154,12 +154,27 @@ Select **Telegram** when prompted. The wizard asks for your bot token and allowe
 
 ### Option B: Manual Configuration
 
-Add the following to `~/.hermes/.env`:
+Recommended: keep the bot token in 1Password and put only a non-secret
+reference in `~/.hermes/config.yaml`:
+
+```yaml
+secrets:
+  onepassword:
+    enabled: true
+    env:
+      TELEGRAM_BOT_TOKEN: "op://Employee/Hermes Telegram/credential"
+```
+
+Then keep non-secret routing/access settings in `~/.hermes/.env`:
 
 ```bash
-TELEGRAM_BOT_TOKEN=123456789:ABCdefGHIjklMNOpqrSTUvwxYZ
 TELEGRAM_ALLOWED_USERS=123456789    # Comma-separated for multiple users
 ```
+
+If you are not using an external secret manager, you can still set
+`TELEGRAM_BOT_TOKEN` directly in `.env`, but do not put raw tokens in service
+wrappers, launchd plists, shell scripts, or checked-in files. See
+[1Password CLI secrets](../secrets/1password) for the `op://` reference mode.
 
 ### Start the Gateway
 

--- a/website/docs/user-guide/secrets/1password.md
+++ b/website/docs/user-guide/secrets/1password.md
@@ -1,0 +1,79 @@
+# 1Password CLI
+
+Hermes can resolve [1Password CLI](https://developer.1password.com/docs/cli/) references at process startup so API keys and bot tokens stay in 1Password instead of plaintext `~/.hermes/.env`, launchd plists, systemd units, or wrapper scripts.
+
+## How it works
+
+1. You store the real secret in 1Password.
+2. `config.yaml` or `.env` stores only a non-secret reference such as `op://Employee/Hermes Telegram/credential`.
+3. When `hermes`, the gateway, cron, ACP, or the desktop backend starts, Hermes runs `op read <reference>` with a short timeout and sets the resulting value in `os.environ` for that process only.
+4. The value is never written back to disk, logged, cached, or embedded into a service wrapper.
+
+This is best for personal Macs and other machines where the 1Password CLI / desktop app or a service-account-backed `op` environment is already configured. If `op` is locked or unavailable, Hermes starts anyway and prints a one-line warning.
+
+## Configuration
+
+Add this to `~/.hermes/config.yaml`:
+
+```yaml
+secrets:
+  onepassword:
+    enabled: true
+    timeout_seconds: 8
+    override_existing: false
+    env:
+      TELEGRAM_BOT_TOKEN: "op://Employee/Hermes Telegram/credential"
+      OPENROUTER_API_KEY: "op://Employee/OpenRouter/credential"
+```
+
+Supported keys:
+
+| Key | Default | What it does |
+|---|---:|---|
+| `enabled` | `false` | Master switch. When false, 1Password is never contacted. |
+| `env` | `{}` | Mapping of environment-variable names to `op://` references. `mappings` and `references` are accepted aliases. |
+| `timeout_seconds` | `8` | Per-reference timeout for `op read`. Prevents locked desktop auth from hanging startup. |
+| `override_existing` | `false` | When false, a real existing env value wins. Existing `op://` values are still resolved. |
+| `resolve_env_references` | `true` | Also resolve credential-like env vars whose current value is an `op://` reference. |
+| `op_path` | auto | Optional absolute path to the `op` binary. Hermes checks `PATH`, Homebrew paths, and `~/.local/bin/op` first. |
+| `account` | `""` | Optional 1Password account shorthand passed to `op read --account`. |
+
+The alias key `secrets.1password` also works if you prefer that spelling.
+
+## Telegram example
+
+To keep the Telegram bot token out of `.env` and service wrappers:
+
+```yaml
+secrets:
+  onepassword:
+    enabled: true
+    env:
+      TELEGRAM_BOT_TOKEN: "op://Employee/Hermes Telegram/credential"
+```
+
+Keep the non-secret Telegram routing settings wherever you normally keep them:
+
+```bash
+TELEGRAM_ALLOWED_USERS=123456789
+TELEGRAM_HOME_CHANNEL=123456789
+```
+
+Then restart the gateway. On startup, Hermes resolves `TELEGRAM_BOT_TOKEN` in memory before the Telegram adapter reads gateway config.
+
+## `.env` reference mode
+
+If you prefer keeping the reference near other env settings, `.env` may contain a link instead of the secret:
+
+```bash
+TELEGRAM_BOT_TOKEN=op://Employee/Hermes Telegram/credential
+```
+
+You still need `secrets.onepassword.enabled: true` in `config.yaml`. Hermes treats that value as a reference and replaces it in the process environment; it does not write the resolved token back to `.env`.
+
+## Security notes
+
+- Do not store the real vendor secret in wrapper scripts as a reliability shortcut. The configured `op://` reference is the durable link for this backend; the resolved value is process-local only. If the machine-local source of truth is macOS Keychain instead, use the [Keychain backend](./keychain) explicitly so the boundary is visible in `config.yaml`.
+- `op` failures are fail-open and timeout-bounded. If the 1Password desktop app is locked, approve/unlock it or configure a headless service-account path, then restart Hermes.
+- Hermes reports only env-var names and redacted 1Password errors. It does not print secret values or the configured reference on failures.
+- This integration does not cache secret values on disk. If you need non-interactive fleet-wide startup with cache-like behavior, use a proper machine-account secret backend such as Bitwarden Secrets Manager or an external process supervisor that injects env vars safely.

--- a/website/docs/user-guide/secrets/index.md
+++ b/website/docs/user-guide/secrets/index.md
@@ -1,9 +1,11 @@
 # Secrets
 
-Hermes can pull API keys from external secret managers at process startup instead of storing them in `~/.hermes/.env`. The bootstrap token for the secret manager lives in `.env`; every other provider key (OpenAI, Anthropic, OpenRouter, etc.) can stay in the manager and rotate centrally.
+Hermes can pull API keys from external secret managers at process startup instead of storing them in `~/.hermes/.env`, launchd plists, systemd units, or wrapper scripts. Depending on the backend, `config.yaml` may hold only a non-secret reference while the real value stays in the manager.
 
 Supported:
 
 - [Bitwarden Secrets Manager](./bitwarden) — `bws` CLI, lazy-installed, free tier works.
+- [1Password CLI](./1password) — resolves `op://` references into process-local env vars without writing secret values to disk.
+- [macOS Keychain](./keychain) — resolves local generic-password items into process-local env vars without putting values in `.env` or wrappers.
 
-More backends (Vault, AWS Secrets Manager, 1Password CLI) are easy to add behind the same interface — the lift is one module in `agent/secret_sources/` and one CLI handler. File a request if you have a specific one in mind.
+More backends (Vault, AWS Secrets Manager, etc.) are easy to add behind the same interface — the lift is one module in `agent/secret_sources/` and, when needed, one CLI handler. File a request if you have a specific one in mind.

--- a/website/docs/user-guide/secrets/keychain.md
+++ b/website/docs/user-guide/secrets/keychain.md
@@ -1,0 +1,76 @@
+# macOS Keychain
+
+Hermes can resolve macOS Keychain generic-password items at process startup so local machine credentials do not live in plaintext `~/.hermes/.env`, launchd plists, systemd units, or wrapper scripts.
+
+This backend is useful when a credential is already managed by the Mac login/system Keychain, or when a headless local wrapper stores an access token in Keychain and should inject it only into the Hermes process environment.
+
+## How it works
+
+1. You store the real secret in macOS Keychain as a generic password.
+2. `config.yaml` stores only non-secret lookup metadata: service/account names.
+3. When `hermes`, the gateway, cron, ACP, or the desktop backend starts, Hermes runs `security find-generic-password -s <service> -a <account> -w` with a short timeout and sets the value in `os.environ` for that process only.
+4. The value is never written back to disk, logged, cached, or embedded in a wrapper.
+
+## Configuration
+
+Add this to `~/.hermes/config.yaml`:
+
+```yaml
+secrets:
+  keychain:
+    enabled: true
+    timeout_seconds: 6
+    override_existing: false
+    env:
+      TELEGRAM_BOT_TOKEN:
+        service: halvo-shared
+        account: HERMES_MBP_TELEGRAM_BOT_TOKEN
+```
+
+Supported keys:
+
+| Key | Default | What it does |
+|---|---:|---|
+| `enabled` | `false` | Master switch. When false, Keychain is never contacted. |
+| `env` | `{}` | Mapping of environment-variable names to Keychain lookup specs. `mappings` and `references` are accepted aliases. |
+| `timeout_seconds` | `6` | Per-item timeout for `security`. Prevents startup hangs. |
+| `override_existing` | `false` | When false, an existing env value wins. |
+| `security_path` | auto | Optional absolute path to the `security` binary. Defaults to `/usr/bin/security` / `PATH`. |
+
+A shorthand string is accepted too:
+
+```yaml
+secrets:
+  keychain:
+    enabled: true
+    env:
+      TELEGRAM_BOT_TOKEN: "halvo-shared/HERMES_MBP_TELEGRAM_BOT_TOKEN"
+```
+
+## Telegram example
+
+```yaml
+secrets:
+  keychain:
+    enabled: true
+    env:
+      TELEGRAM_BOT_TOKEN:
+        service: halvo-shared
+        account: HERMES_MBP_TELEGRAM_BOT_TOKEN
+```
+
+Keep only non-secret routing metadata in `.env`:
+
+```bash
+TELEGRAM_ALLOWED_USERS=123456789
+TELEGRAM_HOME_CHANNEL=123456789
+```
+
+Then restart the gateway. On startup, Hermes resolves `TELEGRAM_BOT_TOKEN` in memory before the Telegram adapter reads gateway config.
+
+## Security notes
+
+- Keychain is appropriate for local machine credentials and bootstrap tokens. For team/fleet machine workloads, prefer Google Secret Manager, Bitwarden Secrets Manager, or another workload-identity-backed service.
+- Keychain lookup metadata is not a secret, but it is still operationally sensitive: it identifies what Hermes may request from the local machine.
+- Hermes reports only env-var names and redacted Keychain errors. It does not print secret values.
+- This integration does not cache secret values on disk. If Keychain access requires user approval, Hermes may need a human-authenticated session or a pre-approved keychain access control policy.

--- a/website/scripts/prebuild.mjs
+++ b/website/scripts/prebuild.mjs
@@ -29,6 +29,7 @@ import { fileURLToPath } from "node:url";
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const websiteDir = resolve(scriptDir, "..");
+const repoDir = resolve(websiteDir, "..");
 const extractScript = join(scriptDir, "extract-skills.py");
 const llmsScript = join(scriptDir, "generate-llms-txt.py");
 const cronBlueprintsScript = join(scriptDir, "extract-automation-blueprints.py");
@@ -37,6 +38,20 @@ const unifiedIndexFile = join(websiteDir, "static", "api", "skills-index.json");
 const UNIFIED_INDEX_URL =
   "https://hermes-agent.nousresearch.com/docs/api/skills-index.json";
 const UNIFIED_INDEX_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24h
+
+const pythonCandidates = [
+  join(repoDir, ".venv", "bin", "python3"),
+  join(repoDir, ".venv", "bin", "python"),
+  join(repoDir, "venv", "bin", "python3"),
+  join(repoDir, "venv", "bin", "python"),
+  "python3",
+];
+const pythonCommand = pythonCandidates.find((candidate) => {
+  if (candidate === "python3") {
+    return true;
+  }
+  return existsSync(candidate);
+});
 
 function writeEmptyFallback(reason) {
   mkdirSync(dirname(outputFile), { recursive: true });
@@ -52,7 +67,7 @@ function runPython(script, label) {
     console.warn(`[prebuild] ${label} skipped (script missing)`);
     return false;
   }
-  const r = spawnSync("python3", [script], { stdio: "inherit", cwd: websiteDir });
+  const r = spawnSync(pythonCommand, [script], { stdio: "inherit", cwd: websiteDir });
   if (r.error && r.error.code === "ENOENT") {
     console.warn(`[prebuild] ${label} skipped (python3 not found)`);
     return false;
@@ -126,7 +141,7 @@ await ensureUnifiedIndex();
 if (!existsSync(extractScript)) {
   writeEmptyFallback("extract script missing");
 } else {
-  const r = spawnSync("python3", [extractScript], {
+  const r = spawnSync(pythonCommand, [extractScript], {
     stdio: "inherit",
     cwd: websiteDir,
   });


### PR DESCRIPTION
## Summary
- Add process-local 1Password `op://` secret reference resolution.
- Add process-local macOS Keychain generic-password resolution.
- Wire secret-source origin labels into `env_loader` for Bitwarden / 1Password / Keychain.
- Add launchd fallback coverage and docs for secret-source setup, Telegram guidance, and docs prebuild Python selection.

## Verification
- `scripts/run_tests.sh tests/test_onepassword_secrets.py tests/test_keychain_secrets.py tests/test_env_loader_secret_sources.py tests/test_bitwarden_secrets.py tests/hermes_cli/test_gateway_service.py` → 234 passed.
- `ruff check agent/secret_sources/onepassword.py agent/secret_sources/keychain.py hermes_cli/env_loader.py hermes_cli/gateway.py tests/test_onepassword_secrets.py tests/test_keychain_secrets.py tests/test_env_loader_secret_sources.py tests/hermes_cli/test_gateway_service.py` → passed.
- `node --check website/scripts/prebuild.mjs` → passed.
- `npm --prefix website run build` → exited 0 and generated both locales; Docusaurus reported pre-existing broken link/anchor warnings outside this change.
- `git diff --check` / `git diff HEAD^ HEAD --check` → passed.
- Added-lines security scans for hardcoded secrets, shell injection, eval/exec, and pickle loads → clean.

## Notes
- Full `scripts/run_tests.sh` was attempted after syncing local dev tooling; it timed out at 600s after ~62% and surfaced unrelated/baseline failures (missing optional ACP package before full-extra sync, macOS file-mode expectations, a SIGTERM timing flake, and custom-provider grouping tests). Focused changed-area tests pass.
