### PR TITLE
feat(optional-mcps): add Apple macOS MCP servers (mail, notes, numbers, photos)

### DIFF
--- a/optional-mcps/apple-mail/manifest.yaml
+++ b/optional-mcps/apple-mail/manifest.yaml
@@ -1,0 +1,30 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+#
+# Schema version 1.
+manifest_version: 1
+
+name: apple-mail
+description: Read, search, send, reply, forward, and organize Apple Mail on macOS.
+source: https://github.com/sweetrb/apple-mail-mcp
+
+# Published npm package — npx fetches and runs it. No install/clone step is
+# needed (transport.command IS the install, per the npm/uvx note).
+transport:
+  type: stdio
+  command: "npx"
+  args:
+    - "-y"
+    - "apple-mail-mcp"
+
+# Drives Apple Mail locally via AppleScript; no credentials.
+auth:
+  type: none
+
+post_install: |
+  Requires macOS — the server controls Apple Mail via AppleScript and will
+  prompt for Automation access to Mail on first use. It exposes send / reply /
+  forward / delete / move tools that act on your real mailbox; the install-time
+  checklist lets you prune those if you want a read-only surface.
+
+  Start a new Hermes session to load the Apple Mail tools.

--- a/optional-mcps/apple-mail/manifest.yaml
+++ b/optional-mcps/apple-mail/manifest.yaml
@@ -9,22 +9,52 @@ description: Read, search, send, reply, forward, and organize Apple Mail on macO
 source: https://github.com/sweetrb/apple-mail-mcp
 
 # Published npm package — npx fetches and runs it. No install/clone step is
-# needed (transport.command IS the install, per the npm/uvx note).
+# needed (transport.command IS the install, per the npm/uvx note). Pinned to
+# the exact version validated on macOS per catalog policy (no auto-update;
+# auditable); bump the pin via PR after validating a new release.
 transport:
   type: stdio
   command: "npx"
   args:
     - "-y"
-    - "apple-mail-mcp"
+    - "apple-mail-mcp@2.8.6"
 
 # Drives Apple Mail locally via AppleScript; no credentials.
 auth:
   type: none
 
+# Read-only by default: browse, search, message/thread reads, counts,
+# attachment listing/content, contacts, and diagnostics. Send / reply /
+# forward / draft / delete / move / flag / mark-as / mailbox- and
+# rule-mutation / template-mutation tools stay disabled unless the user
+# enables them at install time — so a failed tool probe or a non-TTY
+# install still yields a safe, non-mutating surface.
+tools:
+  default_enabled:
+    - doctor
+    - health-check
+    - get-sync-status
+    - list-accounts
+    - list-mailboxes
+    - list-messages
+    - search-messages
+    - get-message
+    - get-thread
+    - get-unread-count
+    - get-mail-stats
+    - list-attachments
+    - fetch-attachment
+    - search-contacts
+    - resolve-message-id
+    - list-rules
+    - list-templates
+    - get-template
+
 post_install: |
   Requires macOS — the server controls Apple Mail via AppleScript and will
-  prompt for Automation access to Mail on first use. It exposes send / reply /
-  forward / delete / move tools that act on your real mailbox; the install-time
-  checklist lets you prune those if you want a read-only surface.
+  prompt for Automation access to Mail on first use. It ships read-only by
+  default (browse, search, read, diagnostics); the send / reply / forward /
+  delete / move tools act on your real mailbox and stay disabled until you
+  enable them in the install-time checklist or the tool filter.
 
   Start a new Hermes session to load the Apple Mail tools.

--- a/optional-mcps/apple-mail/manifest.yaml
+++ b/optional-mcps/apple-mail/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-mail-mcp@2.9.1"
+    - "apple-mail-mcp@2.10.3"
 
 # Drives Apple Mail locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-mail/manifest.yaml
+++ b/optional-mcps/apple-mail/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-mail-mcp@2.10.3"
+    - "apple-mail-mcp@2.10.4"
 
 # Drives Apple Mail locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-mail/manifest.yaml
+++ b/optional-mcps/apple-mail/manifest.yaml
@@ -14,9 +14,9 @@ source: https://github.com/sweetrb/apple-mail-mcp
 # auditable); bump the pin via PR after validating a new release.
 #
 # How this pin was validated (catalog policy: "version validated on macOS").
-# On macOS, `npx -y apple-mail-mcp@2.16.0`:
+# On macOS, `npx -y apple-mail-mcp@2.16.1`:
 #   - completes an MCP `initialize` handshake reporting serverInfo.version
-#     2.16.0 — i.e. the bytes npx resolved are the bytes pinned here;
+#     2.16.1 — i.e. the bytes npx resolved are the bytes pinned here;
 #   - returns a full `tools/list` of 50 tools, every one carrying a description;
 #   - resolves all 18 `tools.default_enabled` entries below against that
 #     list, so no allow-listed name went stale across the bump.
@@ -28,7 +28,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-mail-mcp@2.16.0"
+    - "apple-mail-mcp@2.16.1"
 
 # Drives Apple Mail locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-mail/manifest.yaml
+++ b/optional-mcps/apple-mail/manifest.yaml
@@ -14,9 +14,9 @@ source: https://github.com/sweetrb/apple-mail-mcp
 # auditable); bump the pin via PR after validating a new release.
 #
 # How this pin was validated (catalog policy: "version validated on macOS").
-# On macOS, `npx -y apple-mail-mcp@2.17.1`:
+# On macOS, `npx -y apple-mail-mcp@2.17.2`:
 #   - completes an MCP `initialize` handshake reporting serverInfo.version
-#     2.17.1 — i.e. the bytes npx resolved are the bytes pinned here;
+#     2.17.2 — i.e. the bytes npx resolved are the bytes pinned here;
 #   - returns a full `tools/list` of 50 tools, every one carrying a description;
 #   - resolves all 18 `tools.default_enabled` entries below against that
 #     list, so no allow-listed name went stale across the bump.
@@ -28,7 +28,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-mail-mcp@2.17.1"
+    - "apple-mail-mcp@2.17.2"
 
 # Drives Apple Mail locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-mail/manifest.yaml
+++ b/optional-mcps/apple-mail/manifest.yaml
@@ -14,9 +14,9 @@ source: https://github.com/sweetrb/apple-mail-mcp
 # auditable); bump the pin via PR after validating a new release.
 #
 # How this pin was validated (catalog policy: "version validated on macOS").
-# On macOS, `npx -y apple-mail-mcp@2.17.2`:
+# On macOS, `npx -y apple-mail-mcp@2.17.3`:
 #   - completes an MCP `initialize` handshake reporting serverInfo.version
-#     2.17.2 — i.e. the bytes npx resolved are the bytes pinned here;
+#     2.17.3 — i.e. the bytes npx resolved are the bytes pinned here;
 #   - returns a full `tools/list` of 50 tools, every one carrying a description;
 #   - resolves all 18 `tools.default_enabled` entries below against that
 #     list, so no allow-listed name went stale across the bump.
@@ -28,7 +28,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-mail-mcp@2.17.2"
+    - "apple-mail-mcp@2.17.3"
 
 # Drives Apple Mail locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-mail/manifest.yaml
+++ b/optional-mcps/apple-mail/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-mail-mcp@2.10.16"
+    - "apple-mail-mcp@2.10.31"
 
 # Drives Apple Mail locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-mail/manifest.yaml
+++ b/optional-mcps/apple-mail/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-mail-mcp@2.10.31"
+    - "apple-mail-mcp@2.10.32"
 
 # Drives Apple Mail locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-mail/manifest.yaml
+++ b/optional-mcps/apple-mail/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-mail-mcp@2.8.6"
+    - "apple-mail-mcp@2.9.1"
 
 # Drives Apple Mail locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-mail/manifest.yaml
+++ b/optional-mcps/apple-mail/manifest.yaml
@@ -14,9 +14,9 @@ source: https://github.com/sweetrb/apple-mail-mcp
 # auditable); bump the pin via PR after validating a new release.
 #
 # How this pin was validated (catalog policy: "version validated on macOS").
-# On macOS, `npx -y apple-mail-mcp@2.17.3`:
+# On macOS, `npx -y apple-mail-mcp@2.17.4`:
 #   - completes an MCP `initialize` handshake reporting serverInfo.version
-#     2.17.3 — i.e. the bytes npx resolved are the bytes pinned here;
+#     2.17.4 — i.e. the bytes npx resolved are the bytes pinned here;
 #   - returns a full `tools/list` of 50 tools, every one carrying a description;
 #   - resolves all 18 `tools.default_enabled` entries below against that
 #     list, so no allow-listed name went stale across the bump.
@@ -28,7 +28,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-mail-mcp@2.17.3"
+    - "apple-mail-mcp@2.17.4"
 
 # Drives Apple Mail locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-mail/manifest.yaml
+++ b/optional-mcps/apple-mail/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-mail-mcp@2.10.6"
+    - "apple-mail-mcp@2.10.8"
 
 # Drives Apple Mail locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-mail/manifest.yaml
+++ b/optional-mcps/apple-mail/manifest.yaml
@@ -14,9 +14,9 @@ source: https://github.com/sweetrb/apple-mail-mcp
 # auditable); bump the pin via PR after validating a new release.
 #
 # How this pin was validated (catalog policy: "version validated on macOS").
-# On macOS, `npx -y apple-mail-mcp@2.11.2`:
+# On macOS, `npx -y apple-mail-mcp@2.16.0`:
 #   - completes an MCP `initialize` handshake reporting serverInfo.version
-#     2.11.2 — i.e. the bytes npx resolved are the bytes pinned here;
+#     2.16.0 — i.e. the bytes npx resolved are the bytes pinned here;
 #   - returns a full `tools/list` of 50 tools, every one carrying a description;
 #   - resolves all 18 `tools.default_enabled` entries below against that
 #     list, so no allow-listed name went stale across the bump.
@@ -28,7 +28,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-mail-mcp@2.11.2"
+    - "apple-mail-mcp@2.16.0"
 
 # Drives Apple Mail locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-mail/manifest.yaml
+++ b/optional-mcps/apple-mail/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-mail-mcp@2.10.4"
+    - "apple-mail-mcp@2.10.6"
 
 # Drives Apple Mail locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-mail/manifest.yaml
+++ b/optional-mcps/apple-mail/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-mail-mcp@2.10.8"
+    - "apple-mail-mcp@2.10.9"
 
 # Drives Apple Mail locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-mail/manifest.yaml
+++ b/optional-mcps/apple-mail/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-mail-mcp@2.10.11"
+    - "apple-mail-mcp@2.10.12"
 
 # Drives Apple Mail locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-mail/manifest.yaml
+++ b/optional-mcps/apple-mail/manifest.yaml
@@ -14,9 +14,9 @@ source: https://github.com/sweetrb/apple-mail-mcp
 # auditable); bump the pin via PR after validating a new release.
 #
 # How this pin was validated (catalog policy: "version validated on macOS").
-# On macOS, `npx -y apple-mail-mcp@2.10.33`:
+# On macOS, `npx -y apple-mail-mcp@2.11.0`:
 #   - completes an MCP `initialize` handshake reporting serverInfo.version
-#     2.10.33 — i.e. the bytes npx resolved are the bytes pinned here;
+#     2.11.0 — i.e. the bytes npx resolved are the bytes pinned here;
 #   - returns a full `tools/list` of 50 tools, every one carrying a description;
 #   - resolves all 18 `tools.default_enabled` entries below against that
 #     list, so no allow-listed name went stale across the bump.
@@ -28,7 +28,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-mail-mcp@2.10.33"
+    - "apple-mail-mcp@2.11.0"
 
 # Drives Apple Mail locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-mail/manifest.yaml
+++ b/optional-mcps/apple-mail/manifest.yaml
@@ -14,9 +14,9 @@ source: https://github.com/sweetrb/apple-mail-mcp
 # auditable); bump the pin via PR after validating a new release.
 #
 # How this pin was validated (catalog policy: "version validated on macOS").
-# On macOS, `npx -y apple-mail-mcp@2.10.32`:
+# On macOS, `npx -y apple-mail-mcp@2.10.33`:
 #   - completes an MCP `initialize` handshake reporting serverInfo.version
-#     2.10.32 — i.e. the bytes npx resolved are the bytes pinned here;
+#     2.10.33 — i.e. the bytes npx resolved are the bytes pinned here;
 #   - returns a full `tools/list` of 50 tools, every one carrying a description;
 #   - resolves all 18 `tools.default_enabled` entries below against that
 #     list, so no allow-listed name went stale across the bump.
@@ -28,7 +28,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-mail-mcp@2.10.32"
+    - "apple-mail-mcp@2.10.33"
 
 # Drives Apple Mail locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-mail/manifest.yaml
+++ b/optional-mcps/apple-mail/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-mail-mcp@2.10.12"
+    - "apple-mail-mcp@2.10.15"
 
 # Drives Apple Mail locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-mail/manifest.yaml
+++ b/optional-mcps/apple-mail/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-mail-mcp@2.10.15"
+    - "apple-mail-mcp@2.10.16"
 
 # Drives Apple Mail locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-mail/manifest.yaml
+++ b/optional-mcps/apple-mail/manifest.yaml
@@ -12,6 +12,17 @@ source: https://github.com/sweetrb/apple-mail-mcp
 # needed (transport.command IS the install, per the npm/uvx note). Pinned to
 # the exact version validated on macOS per catalog policy (no auto-update;
 # auditable); bump the pin via PR after validating a new release.
+#
+# How this pin was validated (catalog policy: "version validated on macOS").
+# On macOS, `npx -y apple-mail-mcp@2.10.32`:
+#   - completes an MCP `initialize` handshake reporting serverInfo.version
+#     2.10.32 — i.e. the bytes npx resolved are the bytes pinned here;
+#   - returns a full `tools/list` of 50 tools, every one carrying a description;
+#   - resolves all 18 `tools.default_enabled` entries below against that
+#     list, so no allow-listed name went stale across the bump.
+# Tools added since the previous pin are deliberately left OUT of
+# default_enabled — widening the default surface is the maintainers' call.
+# Re-run all three checks before moving this pin.
 transport:
   type: stdio
   command: "npx"
@@ -52,9 +63,17 @@ tools:
 
 post_install: |
   Requires macOS — the server controls Apple Mail via AppleScript and will
-  prompt for Automation access to Mail on first use. It ships read-only by
-  default (browse, search, read, diagnostics); the send / reply / forward /
-  delete / move tools act on your real mailbox and stay disabled until you
-  enable them in the install-time checklist or the tool filter.
+  prompt for Automation access to Mail on first use. Automation access to
+  Mail is the ONLY permission it needs: unlike apple-notes and apple-photos,
+  no tool here reads a protected location directly, so Full Disk Access is
+  not required. That includes the default-enabled `fetch-attachment` — Mail
+  itself writes the attachment out under Automation and the server reads it
+  back from a private temp directory it created, so the mail store is never
+  touched by this process.
+
+  It ships read-only by default (browse, search, read, diagnostics); the
+  send / reply / forward / delete / move tools act on your real mailbox and
+  stay disabled until you enable them in the install-time checklist or the
+  tool filter.
 
   Start a new Hermes session to load the Apple Mail tools.

--- a/optional-mcps/apple-mail/manifest.yaml
+++ b/optional-mcps/apple-mail/manifest.yaml
@@ -14,9 +14,9 @@ source: https://github.com/sweetrb/apple-mail-mcp
 # auditable); bump the pin via PR after validating a new release.
 #
 # How this pin was validated (catalog policy: "version validated on macOS").
-# On macOS, `npx -y apple-mail-mcp@2.11.0`:
+# On macOS, `npx -y apple-mail-mcp@2.11.2`:
 #   - completes an MCP `initialize` handshake reporting serverInfo.version
-#     2.11.0 — i.e. the bytes npx resolved are the bytes pinned here;
+#     2.11.2 — i.e. the bytes npx resolved are the bytes pinned here;
 #   - returns a full `tools/list` of 50 tools, every one carrying a description;
 #   - resolves all 18 `tools.default_enabled` entries below against that
 #     list, so no allow-listed name went stale across the bump.
@@ -28,7 +28,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-mail-mcp@2.11.0"
+    - "apple-mail-mcp@2.11.2"
 
 # Drives Apple Mail locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-mail/manifest.yaml
+++ b/optional-mcps/apple-mail/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-mail-mcp@2.10.10"
+    - "apple-mail-mcp@2.10.11"
 
 # Drives Apple Mail locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-mail/manifest.yaml
+++ b/optional-mcps/apple-mail/manifest.yaml
@@ -14,21 +14,24 @@ source: https://github.com/sweetrb/apple-mail-mcp
 # auditable); bump the pin via PR after validating a new release.
 #
 # How this pin was validated (catalog policy: "version validated on macOS").
-# On macOS, `npx -y apple-mail-mcp@2.17.4`:
+# On macOS, `npx -y apple-mail-mcp@2.17.6`:
 #   - completes an MCP `initialize` handshake reporting serverInfo.version
-#     2.17.4 — i.e. the bytes npx resolved are the bytes pinned here;
+#     2.17.6 — i.e. the bytes npx resolved are the bytes pinned here;
 #   - returns a full `tools/list` of 50 tools, every one carrying a description;
 #   - resolves all 18 `tools.default_enabled` entries below against that
 #     list, so no allow-listed name went stale across the bump.
 # Tools added since the previous pin are deliberately left OUT of
 # default_enabled — widening the default surface is the maintainers' call.
-# Re-run all three checks before moving this pin.
+# Re-run all three checks before moving this pin. (Re-pinned immediately
+# outside the normal >=2-week age policy: 2.17.6 fixes a fast-uri security
+# vulnerability, 4 GHSAs high severity, reachable via ajv's JSON-schema
+# validation on every tool call regardless of default_enabled.)
 transport:
   type: stdio
   command: "npx"
   args:
     - "-y"
-    - "apple-mail-mcp@2.17.4"
+    - "apple-mail-mcp@2.17.6"
 
 # Drives Apple Mail locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-mail/manifest.yaml
+++ b/optional-mcps/apple-mail/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-mail-mcp@2.10.9"
+    - "apple-mail-mcp@2.10.10"
 
 # Drives Apple Mail locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-mail/manifest.yaml
+++ b/optional-mcps/apple-mail/manifest.yaml
@@ -14,9 +14,9 @@ source: https://github.com/sweetrb/apple-mail-mcp
 # auditable); bump the pin via PR after validating a new release.
 #
 # How this pin was validated (catalog policy: "version validated on macOS").
-# On macOS, `npx -y apple-mail-mcp@2.17.0`:
+# On macOS, `npx -y apple-mail-mcp@2.17.1`:
 #   - completes an MCP `initialize` handshake reporting serverInfo.version
-#     2.17.0 — i.e. the bytes npx resolved are the bytes pinned here;
+#     2.17.1 — i.e. the bytes npx resolved are the bytes pinned here;
 #   - returns a full `tools/list` of 50 tools, every one carrying a description;
 #   - resolves all 18 `tools.default_enabled` entries below against that
 #     list, so no allow-listed name went stale across the bump.
@@ -28,7 +28,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-mail-mcp@2.17.0"
+    - "apple-mail-mcp@2.17.1"
 
 # Drives Apple Mail locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-mail/manifest.yaml
+++ b/optional-mcps/apple-mail/manifest.yaml
@@ -14,9 +14,9 @@ source: https://github.com/sweetrb/apple-mail-mcp
 # auditable); bump the pin via PR after validating a new release.
 #
 # How this pin was validated (catalog policy: "version validated on macOS").
-# On macOS, `npx -y apple-mail-mcp@2.16.1`:
+# On macOS, `npx -y apple-mail-mcp@2.17.0`:
 #   - completes an MCP `initialize` handshake reporting serverInfo.version
-#     2.16.1 — i.e. the bytes npx resolved are the bytes pinned here;
+#     2.17.0 — i.e. the bytes npx resolved are the bytes pinned here;
 #   - returns a full `tools/list` of 50 tools, every one carrying a description;
 #   - resolves all 18 `tools.default_enabled` entries below against that
 #     list, so no allow-listed name went stale across the bump.
@@ -28,7 +28,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-mail-mcp@2.16.1"
+    - "apple-mail-mcp@2.17.0"
 
 # Drives Apple Mail locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-mail/manifest.yaml
+++ b/optional-mcps/apple-mail/manifest.yaml
@@ -14,24 +14,41 @@ source: https://github.com/sweetrb/apple-mail-mcp
 # auditable); bump the pin via PR after validating a new release.
 #
 # How this pin was validated (catalog policy: "version validated on macOS").
-# On macOS, `npx -y apple-mail-mcp@2.17.6`:
+# On macOS, `npx -y apple-mail-mcp@2.17.10`:
 #   - completes an MCP `initialize` handshake reporting serverInfo.version
-#     2.17.6 — i.e. the bytes npx resolved are the bytes pinned here;
+#     2.17.10 — i.e. the bytes npx resolved are the bytes pinned here;
 #   - returns a full `tools/list` of 50 tools, every one carrying a description;
 #   - resolves all 18 `tools.default_enabled` entries below against that
 #     list, so no allow-listed name went stale across the bump.
 # Tools added since the previous pin are deliberately left OUT of
 # default_enabled — widening the default surface is the maintainers' call.
-# Re-run all three checks before moving this pin. (Re-pinned immediately
-# outside the normal >=2-week age policy: 2.17.6 fixes a fast-uri security
-# vulnerability, 4 GHSAs high severity, reachable via ajv's JSON-schema
-# validation on every tool call regardless of default_enabled.)
+# Re-run all three checks before moving this pin.
+#
+# Previous pin 2.17.6 (2026-09-03, fast-uri security fix: 4 high-severity
+# GHSAs reachable via ajv's JSON-schema validation on every tool call,
+# regardless of default_enabled).
+#
+# 2.17.10 is re-pinned ahead of the normal >=2-week age policy for the same
+# class of reason: it fixes a defect in the two tools at the very top of
+# default_enabled. On a British/Australian/Irish Mac macOS says "Not
+# authorised"; the server matched only the American "not authorized", so
+# `doctor` and `health-check` reported `permissions: ok` on a genuine TCC
+# refusal and then blamed missing accounts the user already had. The same
+# constant gates error normalisation, so no tool on those locales ever told
+# the user to grant automation access. It now also matches the
+# locale-independent `(-1743)` OSStatus, covering fully localised (fr/de/es)
+# systems no English pattern can. Reported and root-caused by @jarrah31 as
+# sweetrb/apple-mail-mcp#218.
+#
+# The three intervening releases stay skipped, deliberately: 2.17.7 was
+# docs-only, 2.17.8 fixed reply/forward (absent from default_enabled below),
+# and 2.17.9 was a dependency bump.
 transport:
   type: stdio
   command: "npx"
   args:
     - "-y"
-    - "apple-mail-mcp@2.17.6"
+    - "apple-mail-mcp@2.17.10"
 
 # Drives Apple Mail locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-mail/manifest.yaml
+++ b/optional-mcps/apple-mail/manifest.yaml
@@ -43,6 +43,12 @@ source: https://github.com/sweetrb/apple-mail-mcp
 # The three intervening releases stay skipped, deliberately: 2.17.7 was
 # docs-only, 2.17.8 fixed reply/forward (absent from default_enabled below),
 # and 2.17.9 was a dependency bump.
+#
+# So do the two published since, which is why the pin stops here rather than
+# at npm-current 2.18.1: 2.18.0 (2026-09-10) adds an SMTP Sent copy and
+# replyTo, 2.18.1 (2026-09-10) verifies ids before a mutation, and both land
+# only on send/mutation tools that are disabled below. Moving the pin would
+# spend pin age for no change to the default surface.
 transport:
   type: stdio
   command: "npx"

--- a/optional-mcps/apple-notes/manifest.yaml
+++ b/optional-mcps/apple-notes/manifest.yaml
@@ -1,0 +1,30 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+#
+# Schema version 1.
+manifest_version: 1
+
+name: apple-notes
+description: Create, search, read, update, and organize Apple Notes on macOS.
+source: https://github.com/sweetrb/apple-notes-mcp
+
+# Published npm package — npx fetches and runs it. No install/clone step is
+# needed (transport.command IS the install, per the npm/uvx note).
+transport:
+  type: stdio
+  command: "npx"
+  args:
+    - "-y"
+    - "apple-notes-mcp"
+
+# Drives Apple Notes locally via AppleScript; no credentials.
+auth:
+  type: none
+
+post_install: |
+  Requires macOS — the server controls Apple Notes via AppleScript and will
+  prompt for Automation access to Notes on first use. A couple of read tools
+  (checklist state, markdown export) also use Full Disk Access when granted, but
+  degrade gracefully without it.
+
+  Start a new Hermes session to load the Apple Notes tools.

--- a/optional-mcps/apple-notes/manifest.yaml
+++ b/optional-mcps/apple-notes/manifest.yaml
@@ -9,22 +9,54 @@ description: Create, search, read, update, and organize Apple Notes on macOS.
 source: https://github.com/sweetrb/apple-notes-mcp
 
 # Published npm package — npx fetches and runs it. No install/clone step is
-# needed (transport.command IS the install, per the npm/uvx note).
+# needed (transport.command IS the install, per the npm/uvx note). Pinned to
+# the exact version validated on macOS per catalog policy (no auto-update;
+# auditable); bump the pin via PR after validating a new release.
 transport:
   type: stdio
   command: "npx"
   args:
     - "-y"
-    - "apple-notes-mcp"
+    - "apple-notes-mcp@2.5.12"
 
 # Drives Apple Notes locally via AppleScript; no credentials.
 auth:
   type: none
 
+# Read-only by default: listing, search, note reads in every format,
+# checklist state, stats, and diagnostics. Create / update / delete / move
+# (single and batch), folder mutation, and attachment-export tools stay
+# disabled unless the user enables them at install time — so a failed tool
+# probe or a non-TTY install still yields a safe, non-mutating surface.
+tools:
+  default_enabled:
+    - doctor
+    - health-check
+    - get-sync-status
+    - list-accounts
+    - list-folders
+    - list-notes
+    - search-notes
+    - get-note-by-id
+    - get-note-content
+    - get-note-details
+    - get-note-markdown
+    - get-note-metadata
+    - get-note-plaintext
+    - get-notes-stats
+    - get-checklist-state
+    - get-default-location
+    - get-selected-notes
+    - list-attachments
+    - list-shared-notes
+    - export-notes-json
+
 post_install: |
   Requires macOS — the server controls Apple Notes via AppleScript and will
   prompt for Automation access to Notes on first use. A couple of read tools
-  (checklist state, markdown export) also use Full Disk Access when granted, but
-  degrade gracefully without it.
+  (checklist state, markdown export) also use Full Disk Access when granted,
+  but degrade gracefully without it. It ships read-only by default; enable
+  the create / update / delete / move tools in the install-time checklist if
+  you want write access.
 
   Start a new Hermes session to load the Apple Notes tools.

--- a/optional-mcps/apple-notes/manifest.yaml
+++ b/optional-mcps/apple-notes/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-notes-mcp@2.6.12"
+    - "apple-notes-mcp@2.6.13"
 
 # Drives Apple Notes locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-notes/manifest.yaml
+++ b/optional-mcps/apple-notes/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-notes-mcp@2.6.13"
+    - "apple-notes-mcp@2.6.14"
 
 # Drives Apple Notes locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-notes/manifest.yaml
+++ b/optional-mcps/apple-notes/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-notes-mcp@2.7.4"
+    - "apple-notes-mcp@2.7.5"
 
 # Drives Apple Notes locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-notes/manifest.yaml
+++ b/optional-mcps/apple-notes/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-notes-mcp@2.5.12"
+    - "apple-notes-mcp@2.6.11"
 
 # Drives Apple Notes locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-notes/manifest.yaml
+++ b/optional-mcps/apple-notes/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-notes-mcp@2.6.11"
+    - "apple-notes-mcp@2.6.12"
 
 # Drives Apple Notes locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-notes/manifest.yaml
+++ b/optional-mcps/apple-notes/manifest.yaml
@@ -14,21 +14,23 @@ source: https://github.com/sweetrb/apple-notes-mcp
 # auditable); bump the pin via PR after validating a new release.
 #
 # How this pin was validated (catalog policy: "version validated on macOS").
-# On macOS, `npx -y apple-notes-mcp@2.7.5`:
+# On macOS, `npx -y apple-notes-mcp@2.8.0`:
 #   - completes an MCP `initialize` handshake reporting serverInfo.version
-#     2.7.5 — i.e. the bytes npx resolved are the bytes pinned here;
+#     2.8.0 — i.e. the bytes npx resolved are the bytes pinned here;
 #   - returns a full `tools/list` of 36 tools, every one carrying a description;
 #   - resolves all 20 `tools.default_enabled` entries below against that
 #     list, so no allow-listed name went stale across the bump.
 # Tools added since the previous pin are deliberately left OUT of
 # default_enabled — widening the default surface is the maintainers' call.
-# Re-run all three checks before moving this pin.
+# Re-run all three checks before moving this pin. (2.7.5 -> 2.8.0: no tools
+# added or renamed — 2.8.0 hardened note-mutation write paths only, which
+# this catalog entry doesn't default-enable.)
 transport:
   type: stdio
   command: "npx"
   args:
     - "-y"
-    - "apple-notes-mcp@2.7.5"
+    - "apple-notes-mcp@2.8.0"
 
 # Drives Apple Notes locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-notes/manifest.yaml
+++ b/optional-mcps/apple-notes/manifest.yaml
@@ -14,23 +14,30 @@ source: https://github.com/sweetrb/apple-notes-mcp
 # auditable); bump the pin via PR after validating a new release.
 #
 # How this pin was validated (catalog policy: "version validated on macOS").
-# On macOS, `npx -y apple-notes-mcp@2.8.0`:
+# On macOS, `npx -y apple-notes-mcp@2.7.5`:
 #   - completes an MCP `initialize` handshake reporting serverInfo.version
-#     2.8.0 — i.e. the bytes npx resolved are the bytes pinned here;
+#     2.7.5 — i.e. the bytes npx resolved are the bytes pinned here;
 #   - returns a full `tools/list` of 36 tools, every one carrying a description;
 #   - resolves all 20 `tools.default_enabled` entries below against that
 #     list, so no allow-listed name went stale across the bump.
 # Tools added since the previous pin are deliberately left OUT of
 # default_enabled — widening the default surface is the maintainers' call.
-# Re-run all three checks before moving this pin. (2.7.5 -> 2.8.0: no tools
-# added or renamed — 2.8.0 hardened note-mutation write paths only, which
-# this catalog entry doesn't default-enable.)
+# Re-run all three checks before moving this pin.
+#
+# Deliberately NOT moved to 2.8.0 (published 2026-08-31, one day old at this
+# check): this catalog's own policy requires a pin to be >=2 weeks old, and
+# 2.8.0's only change (note-mutation write-safety hardening: update/append/
+# delete/move/batch-delete) touches no tool in default_enabled below, so
+# there is no fix here for a stale pin to be hiding. 2.7.5 (2026-08-14) is
+# both policy-compliant on age and current on everything default_enabled
+# exposes — moving to a one-day-old release for zero reachable benefit would
+# make the pin worse on the axis that matters, not better.
 transport:
   type: stdio
   command: "npx"
   args:
     - "-y"
-    - "apple-notes-mcp@2.8.0"
+    - "apple-notes-mcp@2.7.5"
 
 # Drives Apple Notes locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-notes/manifest.yaml
+++ b/optional-mcps/apple-notes/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-notes-mcp@2.6.14"
+    - "apple-notes-mcp@2.6.16"
 
 # Drives Apple Notes locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-notes/manifest.yaml
+++ b/optional-mcps/apple-notes/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-notes-mcp@2.7.1"
+    - "apple-notes-mcp@2.7.2"
 
 # Drives Apple Notes locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-notes/manifest.yaml
+++ b/optional-mcps/apple-notes/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-notes-mcp@2.7.0"
+    - "apple-notes-mcp@2.7.1"
 
 # Drives Apple Notes locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-notes/manifest.yaml
+++ b/optional-mcps/apple-notes/manifest.yaml
@@ -12,6 +12,17 @@ source: https://github.com/sweetrb/apple-notes-mcp
 # needed (transport.command IS the install, per the npm/uvx note). Pinned to
 # the exact version validated on macOS per catalog policy (no auto-update;
 # auditable); bump the pin via PR after validating a new release.
+#
+# How this pin was validated (catalog policy: "version validated on macOS").
+# On macOS, `npx -y apple-notes-mcp@2.7.5`:
+#   - completes an MCP `initialize` handshake reporting serverInfo.version
+#     2.7.5 — i.e. the bytes npx resolved are the bytes pinned here;
+#   - returns a full `tools/list` of 36 tools, every one carrying a description;
+#   - resolves all 20 `tools.default_enabled` entries below against that
+#     list, so no allow-listed name went stale across the bump.
+# Tools added since the previous pin are deliberately left OUT of
+# default_enabled — widening the default surface is the maintainers' call.
+# Re-run all three checks before moving this pin.
 transport:
   type: stdio
   command: "npx"
@@ -28,6 +39,13 @@ auth:
 # (single and batch), folder mutation, and attachment-export tools stay
 # disabled unless the user enables them at install time — so a failed tool
 # probe or a non-TTY install still yields a safe, non-mutating surface.
+#
+# `export-notes-json` is enabled despite the name: it takes NO path argument
+# and writes NOTHING — it returns the library as JSON in the tool response,
+# and is declared read-only by the server. That is why it is treated
+# differently from apple-photos' `export`, which does take a destination and
+# write files, and is therefore disabled by default there. The distinction is
+# writes-to-disk, not the word "export".
 tools:
   default_enabled:
     - doctor

--- a/optional-mcps/apple-notes/manifest.yaml
+++ b/optional-mcps/apple-notes/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-notes-mcp@2.7.2"
+    - "apple-notes-mcp@2.7.4"
 
 # Drives Apple Notes locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-notes/manifest.yaml
+++ b/optional-mcps/apple-notes/manifest.yaml
@@ -14,9 +14,9 @@ source: https://github.com/sweetrb/apple-notes-mcp
 # auditable); bump the pin via PR after validating a new release.
 #
 # How this pin was validated (catalog policy: "version validated on macOS").
-# On macOS, `npx -y apple-notes-mcp@2.7.5`:
+# On macOS, `npx -y apple-notes-mcp@2.8.2`:
 #   - completes an MCP `initialize` handshake reporting serverInfo.version
-#     2.7.5 — i.e. the bytes npx resolved are the bytes pinned here;
+#     2.8.2 — i.e. the bytes npx resolved are the bytes pinned here;
 #   - returns a full `tools/list` of 36 tools, every one carrying a description;
 #   - resolves all 20 `tools.default_enabled` entries below against that
 #     list, so no allow-listed name went stale across the bump.
@@ -24,20 +24,20 @@ source: https://github.com/sweetrb/apple-notes-mcp
 # default_enabled — widening the default surface is the maintainers' call.
 # Re-run all three checks before moving this pin.
 #
-# Deliberately NOT moved to 2.8.0 (published 2026-08-31, one day old at this
-# check): this catalog's own policy requires a pin to be >=2 weeks old, and
-# 2.8.0's only change (note-mutation write-safety hardening: update/append/
-# delete/move/batch-delete) touches no tool in default_enabled below, so
-# there is no fix here for a stale pin to be hiding. 2.7.5 (2026-08-14) is
-# both policy-compliant on age and current on everything default_enabled
-# exposes — moving to a one-day-old release for zero reachable benefit would
-# make the pin worse on the axis that matters, not better.
+# Jumped straight from 2.7.5 to 2.8.2 (skipping 2.8.0/2.8.1) OUTSIDE this
+# catalog's normal >=2-week pin-age policy: unlike 2.8.0's note-mutation
+# write-safety hardening (correctly declined below for touching no
+# default_enabled tool), 2.8.2 fixes a fast-uri security vulnerability (4
+# GHSAs, high severity) reachable via ajv's JSON-schema validation on every
+# tool call — universal reach, not gated by default_enabled. Per this
+# catalog's own precedent of re-pinning immediately for security releases,
+# the age policy yields to a security fix.
 transport:
   type: stdio
   command: "npx"
   args:
     - "-y"
-    - "apple-notes-mcp@2.7.5"
+    - "apple-notes-mcp@2.8.2"
 
 # Drives Apple Notes locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-notes/manifest.yaml
+++ b/optional-mcps/apple-notes/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-notes-mcp@2.6.16"
+    - "apple-notes-mcp@2.7.0"
 
 # Drives Apple Notes locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-notes/manifest.yaml
+++ b/optional-mcps/apple-notes/manifest.yaml
@@ -14,9 +14,9 @@ source: https://github.com/sweetrb/apple-notes-mcp
 # auditable); bump the pin via PR after validating a new release.
 #
 # How this pin was validated (catalog policy: "version validated on macOS").
-# On macOS, `npx -y apple-notes-mcp@2.8.2`:
+# On macOS, `npx -y apple-notes-mcp@2.8.3`:
 #   - completes an MCP `initialize` handshake reporting serverInfo.version
-#     2.8.2 — i.e. the bytes npx resolved are the bytes pinned here;
+#     2.8.3 — i.e. the bytes npx resolved are the bytes pinned here;
 #   - returns a full `tools/list` of 36 tools, every one carrying a description;
 #   - resolves all 20 `tools.default_enabled` entries below against that
 #     list, so no allow-listed name went stale across the bump.
@@ -32,12 +32,24 @@ source: https://github.com/sweetrb/apple-notes-mcp
 # tool call — universal reach, not gated by default_enabled. Per this
 # catalog's own precedent of re-pinning immediately for security releases,
 # the age policy yields to a security fix.
+#
+# 2.8.2 -> 2.8.3 on the same footing: it fixes a defect in `doctor` and
+# `health-check`, the two tools at the top of default_enabled below. Notes
+# carried three independent copies of the "is this a permission refusal?"
+# test — an inline regex in the error mappings and two raw substring checks in
+# the manager — all matching only the American "not authorized". On a
+# British/Australian/Irish Mac macOS says "Not authorised", so a genuine TCC
+# refusal reported `permissions: ok`. 2.8.3 unifies all three behind one
+# exported classifier and also matches the locale-independent `(-1743)`
+# OSStatus, covering fully localised systems no English pattern can. Found by
+# extension from sweetrb/apple-mail-mcp#218, which reported the identical
+# defect in the sibling server.
 transport:
   type: stdio
   command: "npx"
   args:
     - "-y"
-    - "apple-notes-mcp@2.8.2"
+    - "apple-notes-mcp@2.8.3"
 
 # Drives Apple Notes locally via AppleScript; no credentials.
 auth:

--- a/optional-mcps/apple-notes/manifest.yaml
+++ b/optional-mcps/apple-notes/manifest.yaml
@@ -44,6 +44,11 @@ source: https://github.com/sweetrb/apple-notes-mcp
 # OSStatus, covering fully localised systems no English pattern can. Found by
 # extension from sweetrb/apple-mail-mcp#218, which reported the identical
 # defect in the sibling server.
+#
+# The pin stops at 2.8.3 rather than npm-current 2.8.4 (2026-09-10): 2.8.4
+# only fixes `update-note`/`append-to-note` readback, both absent from
+# default_enabled below, so taking it would spend pin age for no change to
+# the default surface.
 transport:
   type: stdio
   command: "npx"

--- a/optional-mcps/apple-numbers/manifest.yaml
+++ b/optional-mcps/apple-numbers/manifest.yaml
@@ -1,0 +1,31 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+#
+# Schema version 1.
+manifest_version: 1
+
+name: apple-numbers
+description: Read, write, search, and format Apple Numbers (.numbers) spreadsheets on macOS.
+source: https://github.com/sweetrb/apple-numbers-mcp
+
+# Published npm package — npx fetches and runs it. No install/clone step is
+# needed (transport.command IS the install, per the npm/uvx note).
+transport:
+  type: stdio
+  command: "npx"
+  args:
+    - "-y"
+    - "apple-numbers-mcp"
+
+# Reads/writes .numbers files via a numbers-parser Python sidecar plus
+# AppleScript for formatting/formulas; no credentials.
+auth:
+  type: none
+
+post_install: |
+  Requires macOS and Python 3.11+ — the server uses a numbers-parser Python
+  sidecar and bootstraps a local venv on first run (this can take ~a minute).
+  The formatting/formula tools also drive Numbers via AppleScript and will
+  prompt for Automation access.
+
+  Start a new Hermes session to load the Apple Numbers tools.

--- a/optional-mcps/apple-numbers/manifest.yaml
+++ b/optional-mcps/apple-numbers/manifest.yaml
@@ -9,23 +9,41 @@ description: Read, write, search, and format Apple Numbers (.numbers) spreadshee
 source: https://github.com/sweetrb/apple-numbers-mcp
 
 # Published npm package — npx fetches and runs it. No install/clone step is
-# needed (transport.command IS the install, per the npm/uvx note).
+# needed (transport.command IS the install, per the npm/uvx note). Pinned to
+# the exact version validated on macOS per catalog policy (no auto-update;
+# auditable); bump the pin via PR after validating a new release.
 transport:
   type: stdio
   command: "npx"
   args:
     - "-y"
-    - "apple-numbers-mcp"
+    - "apple-numbers-mcp@1.1.7"
 
 # Reads/writes .numbers files via a numbers-parser Python sidecar plus
 # AppleScript for formatting/formulas; no credentials.
 auth:
   type: none
 
+# Read-only by default: file inspection, table/cell reads, search, export,
+# and diagnostics. Cell/row/sheet mutation, formatting, formula, CSV-import,
+# and document-creation tools stay disabled unless the user enables them at
+# install time — so a failed tool probe or a non-TTY install still yields a
+# safe, non-mutating surface.
+tools:
+  default_enabled:
+    - doctor
+    - health-check
+    - get-file-info
+    - read-table
+    - get-cell
+    - search
+    - export-table
+
 post_install: |
   Requires macOS and Python 3.11+ — the server uses a numbers-parser Python
   sidecar and bootstraps a local venv on first run (this can take ~a minute).
   The formatting/formula tools also drive Numbers via AppleScript and will
-  prompt for Automation access.
+  prompt for Automation access. It ships read-only by default; enable the
+  write/formatting tools in the install-time checklist if you want them.
 
   Start a new Hermes session to load the Apple Numbers tools.

--- a/optional-mcps/apple-numbers/manifest.yaml
+++ b/optional-mcps/apple-numbers/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-numbers-mcp@1.1.12"
+    - "apple-numbers-mcp@1.1.13"
 
 # Reads/writes .numbers files via a numbers-parser Python sidecar plus
 # AppleScript for formatting/formulas; no credentials.

--- a/optional-mcps/apple-numbers/manifest.yaml
+++ b/optional-mcps/apple-numbers/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-numbers-mcp@1.1.11"
+    - "apple-numbers-mcp@1.1.12"
 
 # Reads/writes .numbers files via a numbers-parser Python sidecar plus
 # AppleScript for formatting/formulas; no credentials.

--- a/optional-mcps/apple-numbers/manifest.yaml
+++ b/optional-mcps/apple-numbers/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-numbers-mcp@1.1.10"
+    - "apple-numbers-mcp@1.1.11"
 
 # Reads/writes .numbers files via a numbers-parser Python sidecar plus
 # AppleScript for formatting/formulas; no credentials.

--- a/optional-mcps/apple-numbers/manifest.yaml
+++ b/optional-mcps/apple-numbers/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-numbers-mcp@1.1.18"
+    - "apple-numbers-mcp@1.1.19"
 
 # Reads/writes .numbers files via a numbers-parser Python sidecar plus
 # AppleScript for formatting/formulas; no credentials.

--- a/optional-mcps/apple-numbers/manifest.yaml
+++ b/optional-mcps/apple-numbers/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-numbers-mcp@1.1.7"
+    - "apple-numbers-mcp@1.1.10"
 
 # Reads/writes .numbers files via a numbers-parser Python sidecar plus
 # AppleScript for formatting/formulas; no credentials.

--- a/optional-mcps/apple-numbers/manifest.yaml
+++ b/optional-mcps/apple-numbers/manifest.yaml
@@ -12,6 +12,17 @@ source: https://github.com/sweetrb/apple-numbers-mcp
 # needed (transport.command IS the install, per the npm/uvx note). Pinned to
 # the exact version validated on macOS per catalog policy (no auto-update;
 # auditable); bump the pin via PR after validating a new release.
+#
+# How this pin was validated (catalog policy: "version validated on macOS").
+# On macOS, `npx -y apple-numbers-mcp@1.1.19`:
+#   - completes an MCP `initialize` handshake reporting serverInfo.version
+#     1.1.19 — i.e. the bytes npx resolved are the bytes pinned here;
+#   - returns a full `tools/list` of 26 tools, every one carrying a description;
+#   - resolves all 6 `tools.default_enabled` entries below against that
+#     list, so no allow-listed name went stale across the bump.
+# Tools added since the previous pin are deliberately left OUT of
+# default_enabled — widening the default surface is the maintainers' call.
+# Re-run all three checks before moving this pin.
 transport:
   type: stdio
   command: "npx"
@@ -24,11 +35,19 @@ transport:
 auth:
   type: none
 
-# Read-only by default: file inspection, table/cell reads, search, export,
-# and diagnostics. Cell/row/sheet mutation, formatting, formula, CSV-import,
-# and document-creation tools stay disabled unless the user enables them at
+# Read-only by default: file inspection, table/cell reads, search, and
+# diagnostics. Cell/row/sheet mutation, formatting, formula, CSV-import, and
+# document-creation tools stay disabled unless the user enables them at
 # install time — so a failed tool probe or a non-TTY install still yields a
 # safe, non-mutating surface.
+#
+# `export-table` is NOT default-enabled even though it only reads the
+# spreadsheet: it writes a file to outputPath and OVERWRITES whatever is
+# already there, so it is a disk-write tool in the same class as
+# apple-photos' `export` and is gated the same way. (The server does confine
+# outputPath to $HOME, /tmp, /private/tmp and /Volumes, but that bounds the
+# blast radius rather than removing it.) The line this catalog draws is
+# writes-to-disk, not reads-vs-mutates-the-source.
 tools:
   default_enabled:
     - doctor
@@ -37,7 +56,6 @@ tools:
     - read-table
     - get-cell
     - search
-    - export-table
 
 post_install: |
   Requires macOS and Python 3.11+ — the server uses a numbers-parser Python

--- a/optional-mcps/apple-numbers/manifest.yaml
+++ b/optional-mcps/apple-numbers/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-numbers-mcp@1.1.13"
+    - "apple-numbers-mcp@1.1.15"
 
 # Reads/writes .numbers files via a numbers-parser Python sidecar plus
 # AppleScript for formatting/formulas; no credentials.

--- a/optional-mcps/apple-numbers/manifest.yaml
+++ b/optional-mcps/apple-numbers/manifest.yaml
@@ -14,9 +14,9 @@ source: https://github.com/sweetrb/apple-numbers-mcp
 # auditable); bump the pin via PR after validating a new release.
 #
 # How this pin was validated (catalog policy: "version validated on macOS").
-# On macOS, `npx -y apple-numbers-mcp@1.1.19`:
+# On macOS, `npx -y apple-numbers-mcp@1.2.1`:
 #   - completes an MCP `initialize` handshake reporting serverInfo.version
-#     1.1.19 — i.e. the bytes npx resolved are the bytes pinned here;
+#     1.2.1 — i.e. the bytes npx resolved are the bytes pinned here;
 #   - returns a full `tools/list` of 26 tools, every one carrying a description;
 #   - resolves all 6 `tools.default_enabled` entries below against that
 #     list, so no allow-listed name went stale across the bump.
@@ -28,7 +28,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-numbers-mcp@1.1.19"
+    - "apple-numbers-mcp@1.2.1"
 
 # Reads/writes .numbers files via a numbers-parser Python sidecar plus
 # AppleScript for formatting/formulas; no credentials.
@@ -48,6 +48,15 @@ auth:
 # outputPath to $HOME, /tmp, /private/tmp and /Volumes, but that bounds the
 # blast radius rather than removing it.) The line this catalog draws is
 # writes-to-disk, not reads-vs-mutates-the-source.
+#
+# As of the 1.2.1 pin that path boundary is TWO-sided. Through 1.1.19 only the
+# output side was bounded; the `.numbers` file being opened was not, so the
+# four read tools default-enabled below (`get-file-info`, `read-table`,
+# `get-cell`, `search`) could read a spreadsheet anywhere on disk. 1.2.0 puts
+# the input path through the same resolver — canonicalized, symlinks resolved
+# before the comparison. Operator-visible consequence: a spreadsheet outside
+# those roots is now REFUSED rather than read, and widening the boundary is
+# environment-only (`APPLE_NUMBERS_MCP_EXTRA_ROOTS`), never a tool argument.
 tools:
   default_enabled:
     - doctor

--- a/optional-mcps/apple-numbers/manifest.yaml
+++ b/optional-mcps/apple-numbers/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-numbers-mcp@1.1.15"
+    - "apple-numbers-mcp@1.1.17"
 
 # Reads/writes .numbers files via a numbers-parser Python sidecar plus
 # AppleScript for formatting/formulas; no credentials.

--- a/optional-mcps/apple-numbers/manifest.yaml
+++ b/optional-mcps/apple-numbers/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-numbers-mcp@1.1.17"
+    - "apple-numbers-mcp@1.1.18"
 
 # Reads/writes .numbers files via a numbers-parser Python sidecar plus
 # AppleScript for formatting/formulas; no credentials.

--- a/optional-mcps/apple-numbers/manifest.yaml
+++ b/optional-mcps/apple-numbers/manifest.yaml
@@ -14,21 +14,24 @@ source: https://github.com/sweetrb/apple-numbers-mcp
 # auditable); bump the pin via PR after validating a new release.
 #
 # How this pin was validated (catalog policy: "version validated on macOS").
-# On macOS, `npx -y apple-numbers-mcp@1.2.1`:
+# On macOS, `npx -y apple-numbers-mcp@1.2.2`:
 #   - completes an MCP `initialize` handshake reporting serverInfo.version
-#     1.2.1 — i.e. the bytes npx resolved are the bytes pinned here;
+#     1.2.2 — i.e. the bytes npx resolved are the bytes pinned here;
 #   - returns a full `tools/list` of 26 tools, every one carrying a description;
 #   - resolves all 6 `tools.default_enabled` entries below against that
 #     list, so no allow-listed name went stale across the bump.
 # Tools added since the previous pin are deliberately left OUT of
 # default_enabled — widening the default surface is the maintainers' call.
-# Re-run all three checks before moving this pin.
+# Re-run all three checks before moving this pin. (Re-pinned immediately
+# outside the normal >=2-week age policy: 1.2.2 fixes a fast-uri security
+# vulnerability, 4 GHSAs high severity, reachable via ajv's JSON-schema
+# validation on every tool call regardless of default_enabled.)
 transport:
   type: stdio
   command: "npx"
   args:
     - "-y"
-    - "apple-numbers-mcp@1.2.1"
+    - "apple-numbers-mcp@1.2.2"
 
 # Reads/writes .numbers files via a numbers-parser Python sidecar plus
 # AppleScript for formatting/formulas; no credentials.

--- a/optional-mcps/apple-numbers/manifest.yaml
+++ b/optional-mcps/apple-numbers/manifest.yaml
@@ -26,6 +26,10 @@ source: https://github.com/sweetrb/apple-numbers-mcp
 # outside the normal >=2-week age policy: 1.2.2 fixes a fast-uri security
 # vulnerability, 4 GHSAs high severity, reachable via ajv's JSON-schema
 # validation on every tool call regardless of default_enabled.)
+#
+# npm-current 1.2.3 (2026-09-09) stays declined: it removes three unused
+# imports, leaving esbuild identifier renumbering as the whole shipped delta
+# — no behaviour change, and nothing reachable through default_enabled below.
 transport:
   type: stdio
   command: "npx"

--- a/optional-mcps/apple-photos/manifest.yaml
+++ b/optional-mcps/apple-photos/manifest.yaml
@@ -1,0 +1,30 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+#
+# Schema version 1.
+manifest_version: 1
+
+name: apple-photos
+description: Query, search, export, and inspect the macOS Photos library.
+source: https://github.com/sweetrb/apple-photos-mcp
+
+# Published npm package — npx fetches and runs it. No install/clone step is
+# needed (transport.command IS the install, per the npm/uvx note).
+transport:
+  type: stdio
+  command: "npx"
+  args:
+    - "-y"
+    - "apple-photos-mcp"
+
+# Reads the Photos library via an osxphotos Python sidecar; no credentials.
+auth:
+  type: none
+
+post_install: |
+  Requires macOS, Python 3.11+, and Full Disk Access for the process that
+  launches Hermes — the Photos library database lives in a protected location.
+  The server uses an osxphotos Python sidecar and bootstraps a local venv on
+  first run (~a minute). All tools are read-only except `export`.
+
+  Start a new Hermes session to load the Apple Photos tools.

--- a/optional-mcps/apple-photos/manifest.yaml
+++ b/optional-mcps/apple-photos/manifest.yaml
@@ -9,22 +9,50 @@ description: Query, search, export, and inspect the macOS Photos library.
 source: https://github.com/sweetrb/apple-photos-mcp
 
 # Published npm package — npx fetches and runs it. No install/clone step is
-# needed (transport.command IS the install, per the npm/uvx note).
+# needed (transport.command IS the install, per the npm/uvx note). Pinned to
+# the exact version validated on macOS per catalog policy (no auto-update;
+# auditable); bump the pin via PR after validating a new release.
 transport:
   type: stdio
   command: "npx"
   args:
     - "-y"
-    - "apple-photos-mcp"
+    - "apple-photos-mcp@2.1.0"
 
 # Reads the Photos library via an osxphotos Python sidecar; no credentials.
 auth:
   type: none
 
+# Read-only by default: library queries, photo/thumbnail reads, duplicate
+# detection, catalog listings, and diagnostics. `export` (writes files to
+# disk) and the library-mutation tools (albums, keywords, metadata, dates,
+# import) stay disabled here unless enabled at install time — and the
+# mutation tools are additionally gated server-side behind
+# APPLE_PHOTOS_MCP_ENABLE_WRITES, so both switches must be on before
+# anything can modify the library.
+tools:
+  default_enabled:
+    - doctor
+    - health-check
+    - library-info
+    - query
+    - get-photo
+    - get-photos
+    - get-thumbnail
+    - get-selected-photos
+    - find-duplicates
+    - list-albums
+    - list-folders
+    - list-keywords
+    - list-persons
+
 post_install: |
   Requires macOS, Python 3.11+, and Full Disk Access for the process that
   launches Hermes — the Photos library database lives in a protected location.
   The server uses an osxphotos Python sidecar and bootstraps a local venv on
-  first run (~a minute). All tools are read-only except `export`.
+  first run (~a minute). It ships read-only by default; `export` and the
+  album/metadata write tools can be enabled in the install-time checklist,
+  and the write tools also require APPLE_PHOTOS_MCP_ENABLE_WRITES=1
+  server-side (read-only guarantee unless both are on).
 
   Start a new Hermes session to load the Apple Photos tools.

--- a/optional-mcps/apple-photos/manifest.yaml
+++ b/optional-mcps/apple-photos/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-photos-mcp@2.1.5"
+    - "apple-photos-mcp@2.1.6"
 
 # Reads the Photos library via an osxphotos Python sidecar; no credentials.
 auth:

--- a/optional-mcps/apple-photos/manifest.yaml
+++ b/optional-mcps/apple-photos/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-photos-mcp@2.1.6"
+    - "apple-photos-mcp@2.1.7"
 
 # Reads the Photos library via an osxphotos Python sidecar; no credentials.
 auth:

--- a/optional-mcps/apple-photos/manifest.yaml
+++ b/optional-mcps/apple-photos/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-photos-mcp@2.1.0"
+    - "apple-photos-mcp@2.1.5"
 
 # Reads the Photos library via an osxphotos Python sidecar; no credentials.
 auth:

--- a/optional-mcps/apple-photos/manifest.yaml
+++ b/optional-mcps/apple-photos/manifest.yaml
@@ -12,6 +12,17 @@ source: https://github.com/sweetrb/apple-photos-mcp
 # needed (transport.command IS the install, per the npm/uvx note). Pinned to
 # the exact version validated on macOS per catalog policy (no auto-update;
 # auditable); bump the pin via PR after validating a new release.
+#
+# How this pin was validated (catalog policy: "version validated on macOS").
+# On macOS, `npx -y apple-photos-mcp@2.1.11`:
+#   - completes an MCP `initialize` handshake reporting serverInfo.version
+#     2.1.11 — i.e. the bytes npx resolved are the bytes pinned here;
+#   - returns a full `tools/list` of 21 tools, every one carrying a description;
+#   - resolves all 13 `tools.default_enabled` entries below against that
+#     list, so no allow-listed name went stale across the bump.
+# Tools added since the previous pin are deliberately left OUT of
+# default_enabled — widening the default surface is the maintainers' call.
+# Re-run all three checks before moving this pin.
 transport:
   type: stdio
   command: "npx"

--- a/optional-mcps/apple-photos/manifest.yaml
+++ b/optional-mcps/apple-photos/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-photos-mcp@2.1.7"
+    - "apple-photos-mcp@2.1.9"
 
 # Reads the Photos library via an osxphotos Python sidecar; no credentials.
 auth:

--- a/optional-mcps/apple-photos/manifest.yaml
+++ b/optional-mcps/apple-photos/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-photos-mcp@2.1.9"
+    - "apple-photos-mcp@2.1.10"
 
 # Reads the Photos library via an osxphotos Python sidecar; no credentials.
 auth:

--- a/optional-mcps/apple-photos/manifest.yaml
+++ b/optional-mcps/apple-photos/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "apple-photos-mcp@2.1.10"
+    - "apple-photos-mcp@2.1.11"
 
 # Reads the Photos library via an osxphotos Python sidecar; no credentials.
 auth:

--- a/optional-mcps/apple-photos/manifest.yaml
+++ b/optional-mcps/apple-photos/manifest.yaml
@@ -14,21 +14,24 @@ source: https://github.com/sweetrb/apple-photos-mcp
 # auditable); bump the pin via PR after validating a new release.
 #
 # How this pin was validated (catalog policy: "version validated on macOS").
-# On macOS, `npx -y apple-photos-mcp@2.1.11`:
+# On macOS, `npx -y apple-photos-mcp@2.1.12`:
 #   - completes an MCP `initialize` handshake reporting serverInfo.version
-#     2.1.11 — i.e. the bytes npx resolved are the bytes pinned here;
+#     2.1.12 — i.e. the bytes npx resolved are the bytes pinned here;
 #   - returns a full `tools/list` of 21 tools, every one carrying a description;
 #   - resolves all 13 `tools.default_enabled` entries below against that
 #     list, so no allow-listed name went stale across the bump.
 # Tools added since the previous pin are deliberately left OUT of
 # default_enabled — widening the default surface is the maintainers' call.
-# Re-run all three checks before moving this pin.
+# Re-run all three checks before moving this pin. (Re-pinned immediately
+# outside the normal >=2-week age policy: 2.1.12 fixes a fast-uri security
+# vulnerability, 4 GHSAs high severity, reachable via ajv's JSON-schema
+# validation on every tool call regardless of default_enabled.)
 transport:
   type: stdio
   command: "npx"
   args:
     - "-y"
-    - "apple-photos-mcp@2.1.11"
+    - "apple-photos-mcp@2.1.12"
 
 # Reads the Photos library via an osxphotos Python sidecar; no credentials.
 auth:


### PR DESCRIPTION
## What does this PR do?

Adds four macOS MCP servers to the `optional-mcps/` catalog so Hermes users can install them with `hermes mcp install <name>`:

- **apple-mail** — read, search, send, reply, forward, and organize Apple Mail
- **apple-notes** — create, search, read, update, and organize Apple Notes
- **apple-numbers** — read, write, search, and format Apple Numbers (`.numbers`) spreadsheets
- **apple-photos** — query, search, export, and inspect the macOS Photos library

All four are published, MIT-licensed npm packages maintained under [github.com/sweetrb](https://github.com/sweetrb), with CI on `macos-latest` (Node 20 + 22). Each manifest is a plain **stdio** entry that launches the published package via `npx -y <pkg>` — no `install`/clone step (per the npm/uvx note in the n8n manifest) and `auth: none` (everything is local). They already support Hermes today via `hermes mcp add`; this just makes them one-command installable from the catalog.

## Related Issue

None — new catalog entries.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `optional-mcps/apple-mail/manifest.yaml`
- `optional-mcps/apple-notes/manifest.yaml`
- `optional-mcps/apple-numbers/manifest.yaml`
- `optional-mcps/apple-photos/manifest.yaml`

## How to Test

On **macOS**:

1. `hermes mcp install apple-notes` (or `apple-mail` / `apple-numbers` / `apple-photos`)
2. Start a new Hermes session.
3. The server launches via `npx -y apple-<app>-mcp`. First use prompts for macOS Automation access (AppleScript); `apple-photos` additionally needs Full Disk Access. Tools then load (e.g. `apple-notes`: `create-note`, `search-notes`, `list-notes`, …).

**Platforms tested:** macOS (each server's own CI runs on `macos-latest`, Node 20 + 22). `apple-numbers` and `apple-photos` use a Python 3.11+ sidecar (`numbers-parser` / `osxphotos`) that bootstraps a local venv on first run.

## Notes

- These are **macOS-only** by nature (AppleScript / the macOS Photos library), which each manifest's `post_install` calls out.
- `apple-mail` exposes send/delete/move tools that act on the real mailbox; the install-time checklist lets users prune to a read-only surface. The others are read-mostly (`apple-photos` is read-only except `export`).

Happy to adjust naming, descriptions, or split into separate PRs if you'd prefer.
