### PR TITLE
chore: add npm allowScripts policy for install-script deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,15 @@
     "@assistant-ui/store": "0.2.13",
     "yauzl": "^3.3.1"
   },
+  "allowScripts": {
+    "agent-browser@0.26.0": true,
+    "electron@40.10.2": true,
+    "electron-winstaller@5.4.0": true,
+    "esbuild@0.28.1": true,
+    "fsevents@2.3.3": true,
+    "node-pty@1.1.0": true,
+    "unicode-animations@1.0.3": true
+  },
   "engines": {
     "node": ">=20.0.0"
   }


### PR DESCRIPTION
## Summary

This PR adds an explicit npm `allowScripts` policy for the dependency install scripts that are already present in the current lockfile.

npm 11 now warns when install-time lifecycle scripts are not covered by an `allowScripts` policy. The install still succeeds today, but npm documents this as the migration path toward stricter future behavior where unreviewed install scripts may be blocked.

During `hermes update`, the current update path can warn about these packages:

- `agent-browser@0.26.0`
- `esbuild@0.28.1`
- `fsevents@2.3.3`
- `unicode-animations@1.0.3`

The lockfile also contains desktop-related install-script dependencies:

- `electron@40.10.2`
- `electron-winstaller@5.4.0`
- `node-pty@1.1.0`

Those desktop packages are included because `npm install --strict-allow-scripts --workspaces=false` still reports them from the lockfile if they are not covered, even though the normal Hermes update path skips the desktop workspace.

## Why pinned approvals

The approvals are pinned to exact package versions, for example `esbuild@0.28.1`, instead of allowing every future version of the package name.

That keeps the policy narrow: if one of these packages changes version later, npm can ask maintainers to review the new install script behavior before approving it.

## Security note

This does not add new dependencies and does not introduce new lifecycle scripts. It makes the existing install-script policy explicit for dependencies already present in `package-lock.json`.

## Test plan

Ran the same npm install shapes used by `hermes update`:

```bash
npm install --no-fund --no-audit --progress=false --workspaces=false
npm install --no-fund --no-audit --progress=false --workspace ui-tui --workspace web
```

Both completed without the `npm warn allow-scripts` warnings.

Also verified strict future behavior:

```bash
npm install --strict-allow-scripts --no-fund --no-audit --progress=false --workspaces=false
npm install --strict-allow-scripts --no-fund --no-audit --progress=false --workspace ui-tui --workspace web
```

Both completed successfully.

Verified npm's pending-script check with npm 11.17.0:

```bash
npm exec -- npm@11.17.0 approve-scripts --allow-scripts-pending
```

Output:

```text
No packages with unreviewed install scripts.
```

Validated `package.json` parses:

```bash
python3 -m json.tool package.json
```

Only `package.json` is changed; `package-lock.json` was restored after install verification to avoid unrelated npm lockfile churn.
