### PR TITLE
fix(mcp): refuse save when ${VAR} can't resolve at save time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to Hermes Agent are documented here.
+
+## Unreleased
+
+### Security / Reliability
+
+- **`hermes mcp add` now refuses to save when `${VAR}` can't be resolved.**
+  Any placeholder in a new MCP server entry (command, args, env, headers, url,
+  etc.) is resolved against the target profile's `.env`, the shared
+  `~/.hermes/.env`, and the current process environment — in that order,
+  matching the gateway's runtime resolution contract — before the entry is
+  written to `config.yaml`.  If any placeholder is unresolved the save is
+  refused with a one-line error per variable pointing the operator to the
+  per-profile `.env` (the least-privilege target).
+
+  Use `--allow-unresolved-env` to bypass the gate.  When bypassed, a warning
+  is emitted to stderr and the unresolved variable names are stored as a
+  `_unresolved_env_vars` advisory in the saved entry so `hermes doctor` can
+  surface them later.
+
+  The same gate fires on the dashboard's `POST /api/mcp/servers` endpoint
+  (HTTP 422 with structured `issues` list on failure).
+
+  **Root cause:** the ghost-MCP failure class from June 2026 (kanban
+  `t_4a884ba1` / `t_76e39214`): an MCP entry with `env.KEY=${UNSET_VAR}` was
+  saved and then crashed the gateway on every boot when the MCP child process
+  received the literal string `${UNSET_VAR}` as its credential.  106 ghost-MCP
+  failure events across 6 profiles in 24 hours before the operational fix.
+  This save-time gate prevents the next instance of the same shape.
+
+  **Implementation:** `hermes_cli/mcp_security.validate_mcp_server_secrets()`
+  — a new peer helper alongside the existing `validate_mcp_server_entry()`
+  exfiltration check.  Wired into `_save_mcp_server`, `cmd_mcp_add` (fast-fail
+  before the discovery probe), and `web_server.add_mcp_server`.

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -25,7 +25,7 @@ from hermes_cli.config import (
 )
 from hermes_cli.colors import Colors, color
 from hermes_constants import display_hermes_home
-from hermes_cli.mcp_security import validate_mcp_server_entry
+from hermes_cli.mcp_security import validate_mcp_server_entry, validate_mcp_server_secrets
 from tools.mcp_tool import _ENV_VAR_PATTERN
 
 logger = logging.getLogger(__name__)
@@ -85,12 +85,19 @@ def _get_mcp_servers(config: Optional[dict] = None) -> Dict[str, dict]:
     return servers
 
 
-def _save_mcp_server(name: str, server_config: dict) -> bool:
+def _save_mcp_server(name: str, server_config: dict, *, allow_unresolved_env: bool = False) -> bool:
     """Add or update a server entry in config.yaml.
 
     Returns False when a high-signal exfiltration-shaped stdio command is
     rejected. MCP stdio servers are user-chosen local commands, so this blocks
     shell+egress payloads rather than whitelisting command families.
+
+    Also refuses (by default) when any ``${VAR}`` placeholder in the config
+    cannot be resolved against the profile's effective env, to prevent entries
+    that will crash at gateway boot with a literal credential string.  Pass
+    ``allow_unresolved_env=True`` to bypass and save with a warning logged to
+    stderr and persisted as a ``_unresolved_env_vars`` advisory list in the
+    saved entry.
     """
     issues = validate_mcp_server_entry(name, server_config)
     if issues:
@@ -98,6 +105,46 @@ def _save_mcp_server(name: str, server_config: dict) -> bool:
             _warning(issue)
         _warning(f"Server '{name}' was NOT saved due to suspicious configuration.")
         return False
+
+    # Env-var placeholder gate: refuse if any ${VAR} won't resolve at runtime.
+    from hermes_constants import get_hermes_home as _get_hermes_home
+    _profile_dir = _get_hermes_home()
+    _shared_env = _profile_dir.parent / ".env"
+    secret_issues = validate_mcp_server_secrets(
+        name,
+        server_config,
+        profile_dir=_profile_dir,
+        shared_env_path=_shared_env,
+    )
+    if secret_issues:
+        if not allow_unresolved_env:
+            for issue in secret_issues:
+                _warning(issue)
+            _warning(
+                f"Server '{name}' was NOT saved. "
+                "Set the variable(s) above, then re-run `hermes mcp add`. "
+                "Use --allow-unresolved-env to bypass (not recommended)."
+            )
+            return False
+        else:
+            import sys as _sys
+            for issue in secret_issues:
+                print(f"WARNING: {issue}", file=_sys.stderr)
+            print(
+                f"WARNING: saving '{name}' with unresolved env vars "
+                "(--allow-unresolved-env override active).",
+                file=_sys.stderr,
+            )
+            # Persist advisory so `hermes doctor` can surface it later.
+            unresolved = [
+                iss.split("${", 1)[1].split("}")[0]
+                for iss in secret_issues
+                if "${" in iss
+            ]
+            if unresolved:
+                server_config = dict(server_config)
+                server_config["_unresolved_env_vars"] = unresolved
+
     config = load_config()
     config.setdefault("mcp_servers", {})[name] = server_config
     save_config(config)
@@ -310,6 +357,7 @@ def cmd_mcp_add(args):
     auth_type = getattr(args, "auth", None)
     preset_name = getattr(args, "preset", None)
     raw_env = getattr(args, "env", None)
+    allow_unresolved_env = getattr(args, "allow_unresolved_env", False)
 
     server_config: Dict[str, Any] = {}
     try:
@@ -362,6 +410,30 @@ def cmd_mcp_add(args):
             _warning(issue)
         _warning(f"Server '{name}' was NOT saved due to suspicious configuration.")
         return
+
+    # Peer check: refuse early if any ${VAR} placeholder won't resolve at
+    # save time.  This fires before the discovery probe so operators get a
+    # clear error message rather than a confusing connection failure or a
+    # broken saved entry.  --allow-unresolved-env bypasses the gate.
+    if not allow_unresolved_env:
+        from hermes_constants import get_hermes_home as _get_hermes_home
+        _profile_dir = _get_hermes_home()
+        _shared_env = _profile_dir.parent / ".env"
+        secret_issues = validate_mcp_server_secrets(
+            name,
+            server_config,
+            profile_dir=_profile_dir,
+            shared_env_path=_shared_env,
+        )
+        if secret_issues:
+            for issue in secret_issues:
+                _warning(issue)
+            _warning(
+                f"Server '{name}' was NOT saved. "
+                "Set the variable(s) above, then re-run `hermes mcp add`. "
+                "Use --allow-unresolved-env to bypass (not recommended)."
+            )
+            return
 
     # ── Authentication ────────────────────────────────────────────────
 
@@ -426,7 +498,7 @@ def cmd_mcp_add(args):
         _error(f"Failed to connect: {exc}")
         if _confirm("Save config anyway (you can test later)?", default=False):
             server_config["enabled"] = False
-            if _save_mcp_server(name, server_config):
+            if _save_mcp_server(name, server_config, allow_unresolved_env=allow_unresolved_env):
                 _success(f"Saved '{name}' to config (disabled)")
                 _info("Fix the issue, then: hermes mcp test " + name)
         return
@@ -434,7 +506,7 @@ def cmd_mcp_add(args):
     if not tools:
         _warning("Server connected but reported no tools.")
         if _confirm("Save config anyway?", default=True):
-            if _save_mcp_server(name, server_config):
+            if _save_mcp_server(name, server_config, allow_unresolved_env=allow_unresolved_env):
                 _success(f"Saved '{name}' to config")
         return
 
@@ -492,7 +564,7 @@ def cmd_mcp_add(args):
     # ── Save ──────────────────────────────────────────────────────────
 
     server_config["enabled"] = True
-    if _save_mcp_server(name, server_config):
+    if _save_mcp_server(name, server_config, allow_unresolved_env=allow_unresolved_env):
         print()
         _success(f"Saved '{name}' to {display_hermes_home()}/config.yaml ({tool_count}/{total} tools enabled)")
         _info("Start a new session to use these tools.")

--- a/hermes_cli/mcp_security.py
+++ b/hermes_cli/mcp_security.py
@@ -179,3 +179,133 @@ def validate_mcp_server_entry(name: str, entry: dict[str, Any]) -> list[str]:
 
 def is_mcp_server_entry_suspicious(name: str, entry: dict[str, Any]) -> bool:
     return bool(validate_mcp_server_entry(name, entry))
+
+
+# ---------------------------------------------------------------------------
+# Env-var placeholder resolution gate
+# ---------------------------------------------------------------------------
+
+# Matches the same pattern as tools/mcp_tool._ENV_VAR_PATTERN so save-time
+# checks stay in lock-step with the gateway resolver.
+_PLACEHOLDER_PATTERN = re.compile(r"\$\{([^}]+)\}")
+
+
+def _parse_dotenv_file(path: "str | os.PathLike[str] | None") -> dict[str, str]:
+    """Minimal .env parser: KEY=VALUE per line, comments + blanks ignored.
+
+    Mirrors the algorithm in the kanban audit script
+    ``hyg/mcp_secret_audit.py`` — same parse, same order — without
+    importing from the workspace.  Values with balanced surrounding
+    single/double quotes have those quotes stripped.
+    """
+    out: dict[str, str] = {}
+    if path is None:
+        return out
+    p = os.fspath(path)
+    if not os.path.isfile(p):
+        return out
+    try:
+        with open(p, encoding="utf-8") as fh:
+            text = fh.read()
+    except (OSError, UnicodeDecodeError):
+        try:
+            with open(p, encoding="latin-1") as fh:
+                text = fh.read()
+        except OSError:
+            return out
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+            value = value[1:-1]
+        if key:
+            out[key] = value
+    return out
+
+
+def _collect_placeholders(value: Any) -> set[str]:
+    """Recursively collect every ``${VAR}`` name from a config sub-tree."""
+    refs: set[str] = set()
+    if isinstance(value, str):
+        for m in _PLACEHOLDER_PATTERN.finditer(value):
+            refs.add(m.group(1))
+    elif isinstance(value, dict):
+        for v in value.values():
+            refs |= _collect_placeholders(v)
+    elif isinstance(value, list):
+        for v in value:
+            refs |= _collect_placeholders(v)
+    return refs
+
+
+def validate_mcp_server_secrets(
+    name: str,
+    cfg: dict[str, Any],
+    profile_dir: "os.PathLike[str] | str | None" = None,
+    shared_env_path: "os.PathLike[str] | str | None" = None,
+) -> list[str]:
+    """Check that every ``${VAR}`` placeholder in *cfg* resolves at save time.
+
+    Resolution order matches the gateway's ``_interpolate_env_vars`` contract:
+    1. target profile ``.env``  (``<profile_dir>/.env``)
+    2. shared ``~/.hermes/.env``
+    3. current process environment (``os.environ``)
+
+    Returns a list of human-readable issue strings — one per unresolved
+    variable — or an empty list when every placeholder resolves.  Secret
+    *values* are never read or included in the returned strings; we only
+    check presence.
+
+    ``profile_dir`` and ``shared_env_path`` are optional so callers can omit
+    them when the relevant paths are not yet known; in that case only
+    ``os.environ`` is consulted.
+    """
+    if not isinstance(cfg, dict):
+        return []
+
+    placeholders = _collect_placeholders(cfg)
+    if not placeholders:
+        return []
+
+    # Build the effective env in resolution order: process env first (lowest
+    # priority), then shared .env, then profile .env (highest priority).
+    # We merge into a plain dict so later entries override earlier ones — i.e.
+    # the last writer wins — which matches the gateway's behaviour.
+    effective: dict[str, str] = dict(os.environ)
+
+    # Shared ~/.hermes/.env
+    if shared_env_path:
+        shared = os.path.join(str(shared_env_path), ".env") if os.path.isdir(str(shared_env_path)) else str(shared_env_path)
+    else:
+        shared = os.path.join(_DEFAULT_HERMES_HOME(), ".env")
+    effective.update(_parse_dotenv_file(shared))
+
+    # Profile-specific .env (highest priority)
+    if profile_dir:
+        effective.update(_parse_dotenv_file(os.path.join(str(profile_dir), ".env")))
+
+    issues: list[str] = []
+    for var in sorted(placeholders):
+        if not effective.get(var):
+            # Suggest the per-profile .env as the least-privilege target.
+            if profile_dir:
+                target = os.path.join(str(profile_dir), ".env")
+            else:
+                target = os.path.join(_DEFAULT_HERMES_HOME(), ".env")
+            issues.append(
+                f"MCP server '{name}': ${{{var}}} is not set — "
+                f"add  {var}=<value>  to  {target}"
+            )
+    return issues
+
+
+def _DEFAULT_HERMES_HOME() -> str:
+    """Return the Hermes home path without importing hermes_constants."""
+    val = os.environ.get("HERMES_HOME", "").strip()
+    if val:
+        return val
+    return os.path.join(os.path.expanduser("~"), ".hermes")

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -66,6 +66,18 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
         default=[],
         help="Environment variables for stdio servers (KEY=VALUE)",
     )
+    mcp_add_p.add_argument(
+        "--allow-unresolved-env",
+        dest="allow_unresolved_env",
+        action="store_true",
+        default=False,
+        help=(
+            "Allow saving an MCP server even when one or more ${VAR} placeholders "
+            "cannot be resolved at save time. A warning is emitted to stderr and "
+            "the unresolved variable names are stored as an advisory. "
+            "Not recommended — the server will likely fail at gateway boot."
+        ),
+    )
 
     mcp_rm_p = mcp_sub.add_parser("remove", aliases=["rm"], help="Remove an MCP server")
     mcp_rm_p.add_argument("name", help="Server name to remove")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -8087,6 +8087,8 @@ async def list_mcp_servers(profile: Optional[str] = None):
 @app.post("/api/mcp/servers")
 async def add_mcp_server(body: MCPServerCreate, profile: Optional[str] = None):
     from hermes_cli.mcp_config import _get_mcp_servers, _save_mcp_server
+    from hermes_cli.mcp_security import validate_mcp_server_secrets
+    from hermes_constants import get_hermes_home as _get_hermes_home
 
     name = (body.name or "").strip()
     if not name:
@@ -8112,6 +8114,32 @@ async def add_mcp_server(body: MCPServerCreate, profile: Optional[str] = None):
         server_config["env"] = dict(body.env)
     if body.auth:
         server_config["auth"] = body.auth
+
+    # Env-var placeholder gate: refuse if any ${VAR} won't resolve at runtime.
+    # The dashboard has no interactive bypass; the caller must supply the secret
+    # first.  This mirrors the CLI gate in _save_mcp_server but fires here so
+    # the HTTP response carries a structured error that dashboard UI can surface.
+    with _profile_scope(body.profile or profile) as scoped_profile_dir:
+        _profile_dir = scoped_profile_dir or _get_hermes_home()
+        _shared_env = _profile_dir.parent / ".env"
+        secret_issues = validate_mcp_server_secrets(
+            name,
+            server_config,
+            profile_dir=_profile_dir,
+            shared_env_path=_shared_env,
+        )
+    if secret_issues:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": "unresolved_env_vars",
+                "message": (
+                    f"Server '{name}' references env vars that are not set. "
+                    "Add the secret(s) to the profile .env before saving."
+                ),
+                "issues": secret_issues,
+            },
+        )
 
     try:
         with _profile_scope(body.profile or profile):

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -754,3 +754,134 @@ class TestMcpLogin:
 
         assert "Authenticated — 3 tool(s) available" in out
         assert "no OAuth token" not in out
+
+
+# ---------------------------------------------------------------------------
+# Tests: save-gate — unresolved env-var placeholders (t_09d9a0f6)
+# ---------------------------------------------------------------------------
+
+class TestEnvVarSaveGate:
+    """The env-var gate must refuse saves when ${VAR} can't be resolved,
+    allow them with --allow-unresolved-env, and stay silent when every
+    variable is already in the effective env.
+
+    Behaviour contract (AGENTS.md: 'behavior contracts over snapshots'):
+      - Unresolved single var -> save refused, issue text mentions the var name.
+      - Unresolved var nested inside the 'env' dict -> same refusal.
+      - All vars resolved -> save proceeds silently.
+      - --allow-unresolved-env bypass -> save proceeds, warning on stderr,
+        advisory stored in saved config.
+    """
+
+    def _make_add_args(self, **kwargs):
+        defaults = {
+            "name": "myserver",
+            "url": None,
+            "mcp_command": "npx",
+            "args": ["@example/mcp-server"],
+            "auth": None,
+            "preset": None,
+            "env": None,
+            "allow_unresolved_env": False,
+            "mcp_action": None,
+        }
+        defaults.update(kwargs)
+        return argparse.Namespace(**defaults)
+
+    def test_unresolved_single_var_refused(self, tmp_path, monkeypatch, capsys):
+        """A ${VAR} in --env that is not in the effective env must block the save."""
+        monkeypatch.delenv("MY_SECRET", raising=False)
+        # Ensure no .env file supplies it either.
+        (tmp_path / ".env").write_text("OTHER_KEY=irrelevant\n")
+        # Patch get_hermes_home to point at tmp_path so _save_mcp_server
+        # resolves the profile .env from tmp_path.
+        monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+        # Stub out the probe so we don't need a live MCP server.
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda name, cfg: [("a_tool", "desc")],
+        )
+        monkeypatch.setattr("hermes_cli.mcp_config._confirm", lambda *a, **kw: True)
+
+        from hermes_cli.mcp_config import cmd_mcp_add
+        cmd_mcp_add(self._make_add_args(env=["MY_SECRET=${MY_SECRET}"]))
+
+        out, err = capsys.readouterr()
+        combined = out + err
+        # Save must have been refused.
+        assert "MY_SECRET" in combined
+        assert "NOT saved" in combined or "not set" in combined
+        # Nothing must have been written to config.yaml.
+        import yaml
+        cfg_path = tmp_path / "config.yaml"
+        if cfg_path.exists():
+            cfg = yaml.safe_load(cfg_path.read_text()) or {}
+            assert "myserver" not in (cfg.get("mcp_servers") or {})
+
+    def test_unresolved_var_in_nested_env_dict_refused(self, tmp_path, monkeypatch):
+        """${VAR} nested inside the env dict must also be caught."""
+        monkeypatch.delenv("NESTED_SECRET", raising=False)
+        monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+
+        from hermes_cli.mcp_security import validate_mcp_server_secrets
+        cfg = {
+            "command": "npx",
+            "args": ["@example/mcp"],
+            "env": {"API_KEY": "${NESTED_SECRET}"},
+        }
+        issues = validate_mcp_server_secrets("myserver", cfg, profile_dir=tmp_path)
+        assert any("NESTED_SECRET" in iss for iss in issues), (
+            f"Expected NESTED_SECRET in issues, got: {issues}"
+        )
+
+    def test_all_resolved_passes(self, tmp_path, monkeypatch):
+        """When every ${VAR} is present in the effective env, no issues returned."""
+        monkeypatch.setenv("RESOLVED_KEY", "actualvalue")
+        monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+
+        from hermes_cli.mcp_security import validate_mcp_server_secrets
+        cfg = {
+            "command": "npx",
+            "args": ["@example/mcp"],
+            "env": {"API_KEY": "${RESOLVED_KEY}"},
+        }
+        issues = validate_mcp_server_secrets("myserver", cfg, profile_dir=tmp_path)
+        assert issues == [], f"Expected no issues, got: {issues}"
+
+    def test_allow_unresolved_env_bypass_logs_and_proceeds(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """--allow-unresolved-env must bypass the gate, warn to stderr,
+        and persist the advisory in saved config."""
+        monkeypatch.delenv("GHOST_ADMIN_API_KEY", raising=False)
+        monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda name, cfg: [("a_tool", "desc")],
+        )
+        monkeypatch.setattr("hermes_cli.mcp_config._confirm", lambda *a, **kw: True)
+        # Stub the tool-selection input (Y/n/select) so the test doesn't read stdin.
+        monkeypatch.setattr("builtins.input", lambda _prompt="": "y")
+
+        from hermes_cli.mcp_config import cmd_mcp_add
+        cmd_mcp_add(
+            self._make_add_args(
+                env=["GHOST_ADMIN_API_KEY=${GHOST_ADMIN_API_KEY}"],
+                allow_unresolved_env=True,
+            )
+        )
+
+        _, err = capsys.readouterr()
+        # Warning must have been emitted to stderr.
+        assert "GHOST_ADMIN_API_KEY" in err or "unresolved" in err.lower()
+
+        # Advisory must be stored in saved config.
+        import yaml
+        cfg_path = tmp_path / "config.yaml"
+        assert cfg_path.exists(), "config.yaml was not written"
+        cfg = yaml.safe_load(cfg_path.read_text()) or {}
+        servers = cfg.get("mcp_servers") or {}
+        assert "myserver" in servers, f"myserver not saved; servers: {list(servers)}"
+        advisory = servers["myserver"].get("_unresolved_env_vars")
+        assert advisory is not None, "Advisory _unresolved_env_vars not stored"
+        assert "GHOST_ADMIN_API_KEY" in advisory


### PR DESCRIPTION
## Summary

Adds a save-time env-var resolution gate that prevents the ghost-MCP failure class where an unresolved `${VAR}` placeholder is written to `config.yaml` and then crashes the gateway on every boot.

### Root cause
`hermes mcp add` did not verify that any `${VAR}` reference in the server config is actually set in the profile's effective env before persisting it. The gateway's `_interpolate_env_vars` passes literal `${...}` strings through to child processes when the var is unset; most MCP servers then crash in their own validation layer on every startup. 106 ghost-MCP failure events across 6 profiles in 24 hours (kanban `t_76e39214`).

### Changes

- **`hermes_cli/mcp_security.py`**: new `validate_mcp_server_secrets()` peer helper alongside the existing exfiltration check. Resolution order matches the gateway contract: profile `.env` → shared `.env` → `os.environ`. Returns one issue string per unresolved var naming the per-profile `.env` as the least-privilege fix target.

- **`hermes_cli/mcp_config.py`**: gate wired into `cmd_mcp_add` (fast-fail before the discovery probe) and `_save_mcp_server` (second line of defence). `--allow-unresolved-env` bypass emits a loud stderr warning and stores an `_unresolved_env_vars` advisory in the saved entry for `hermes doctor` to surface later.

- **`hermes_cli/subcommands/mcp.py`**: `--allow-unresolved-env` flag added to the `mcp add` subparser with a discouraging help string.

- **`hermes_cli/web_server.py`**: same gate on the dashboard's `POST /api/mcp/servers` endpoint — HTTP 422 with a structured `issues` list; no interactive bypass on the API path.

- **`tests/hermes_cli/test_mcp_config.py`**: four behaviour-contract tests per AGENTS.md rubric: unresolved single var refused, nested env dict refused, all-resolved passes, bypass logs and stores advisory.

- **`CHANGELOG.md`**: release note explaining the gate and the root cause.

### AGENTS.md conformance
- No new `HERMES_*` env vars — the bypass is a CLI flag and the feature toggle lives in code, not env.
- Tests assert behaviour contracts, not frozen text snapshots.
- E2E path exercised against real temp `HERMES_HOME` (fixture in test file).

Closes kanban `t_09d9a0f6` (parent `t_4a884ba1` / operational fix `t_76e39214`).