### PR TITLE
fix(file_safety): casefold credential deny-lists on case-insensitive filesystems (macOS/Windows)

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -3,8 +3,42 @@
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
 from typing import Optional
+
+
+def _fs_case_insensitive() -> bool:
+    """True when the host filesystem compares paths case-insensitively.
+
+    macOS (APFS/HFS+) and Windows default to case-insensitive filesystems, so a
+    credential path addressed via a case variant (``~/.SSH/authorized_keys`` vs
+    ``~/.ssh/authorized_keys``) resolves to the SAME on-disk file. The deny
+    comparisons below operate on ``os.path.realpath`` / ``Path.resolve`` output,
+    which preserves the typed case rather than canonicalizing it, so they must
+    casefold on these platforms or the guard is silently bypassed. On
+    case-sensitive POSIX filesystems (default Linux) the variants are genuinely
+    different files and are left untouched.
+    """
+    return sys.platform == "darwin" or os.name == "nt"
+
+
+def _denycmp(path) -> str:
+    """Normalize a path string for case-aware denylist comparison."""
+    text = os.fspath(path)
+    return text.casefold() if _fs_case_insensitive() else text
+
+
+def _denied_paths_equal(a, b) -> bool:
+    """Return True if two resolved paths refer to the same denylist entry."""
+    return _denycmp(a) == _denycmp(b)
+
+
+def _denied_path_within(child, root) -> bool:
+    """Return True if ``child`` equals or is contained under ``root``."""
+    c = _denycmp(child)
+    r = _denycmp(root)
+    return c == r or c.startswith(r + os.sep)
 
 
 def _hermes_home_path() -> Path:
@@ -92,11 +126,12 @@ def is_write_denied(path: str) -> bool:
     """Return True if path is blocked by the write denylist or safe root."""
     home = os.path.realpath(os.path.expanduser("~"))
     resolved = os.path.realpath(os.path.expanduser(str(path)))
+    rc = _denycmp(resolved)
 
-    if resolved in build_write_denied_paths(home):
+    if rc in {_denycmp(p) for p in build_write_denied_paths(home)}:
         return True
     for prefix in build_write_denied_prefixes(home):
-        if resolved.startswith(prefix):
+        if rc.startswith(_denycmp(prefix)):
             return True
 
     mcp_tokens_dir_name = "mcp-tokens"
@@ -113,19 +148,19 @@ def is_write_denied(path: str) -> bool:
     for base_real in hermes_dirs:
         try:
             mcp_real = os.path.realpath(os.path.join(base_real, mcp_tokens_dir_name))
-            if resolved == mcp_real or resolved.startswith(mcp_real + os.sep):
+            if _denied_path_within(resolved, mcp_real):
                 return True
         except Exception:
             pass
         try:
             pairing_real = os.path.realpath(os.path.join(base_real, "pairing"))
-            if resolved == pairing_real or resolved.startswith(pairing_real + os.sep):
+            if _denied_path_within(resolved, pairing_real):
                 return True
         except Exception:
             pass
 
     safe_root = get_safe_write_root()
-    if safe_root and not (resolved == safe_root or resolved.startswith(safe_root + os.sep)):
+    if safe_root and not _denied_path_within(resolved, safe_root):
         return True
 
     return False
@@ -213,9 +248,7 @@ def get_read_block_error(path: str) -> Optional[str]:
             hd / "skills" / ".hub",
         ]
         for blocked in blocked_dirs:
-            try:
-                resolved.relative_to(blocked)
-            except ValueError:
+            if not _denied_path_within(resolved, blocked):
                 continue
             return (
                 f"Access denied: {path} is an internal Hermes cache file "
@@ -243,7 +276,7 @@ def get_read_block_error(path: str) -> Optional[str]:
                 blocked = (hd / name).resolve()
             except Exception:
                 continue
-            if resolved == blocked:
+            if _denied_paths_equal(resolved, blocked):
                 return (
                     f"Access denied: {path} is a Hermes credential store "
                     "and cannot be read directly. Provider tools consume "
@@ -259,15 +292,13 @@ def get_read_block_error(path: str) -> Optional[str]:
             mcp_tokens = (hd / "mcp-tokens").resolve()
         except Exception:
             continue
-        if resolved == mcp_tokens:
+        if _denied_paths_equal(resolved, mcp_tokens):
             return (
                 f"Access denied: {path} is the Hermes MCP token directory "
                 "and cannot be read directly. (Defense-in-depth — not a "
                 "security boundary; the terminal tool can still bypass.)"
             )
-        try:
-            resolved.relative_to(mcp_tokens)
-        except ValueError:
+        if not _denied_path_within(resolved, mcp_tokens):
             continue
         return (
             f"Access denied: {path} is a Hermes MCP token file "
@@ -280,7 +311,7 @@ def get_read_block_error(path: str) -> Optional[str]:
     # .env contents — .env.example is the documented-shape substitute. The
     # terminal tool can still ``cat .env``; this is defense-in-depth, not a
     # boundary (see module docstring).
-    if resolved.name in _BLOCKED_PROJECT_ENV_BASENAMES:
+    if _denycmp(resolved.name) in {_denycmp(b) for b in _BLOCKED_PROJECT_ENV_BASENAMES}:
         return (
             f"Access denied: {path} is a secret-bearing environment file "
             "and cannot be read to prevent credential leakage. "

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1111,6 +1111,27 @@ def _media_delivery_denied_paths() -> List[Path]:
     return denied
 
 
+def _fs_case_insensitive() -> bool:
+    """True when the host filesystem compares paths case-insensitively.
+
+    macOS (APFS/HFS+) and Windows default to case-insensitive filesystems, so a
+    credential path addressed via a case variant (``~/.SSH/id_rsa`` vs
+    ``~/.ssh/id_rsa``) resolves to the SAME on-disk file while ``Path.resolve``
+    preserves the typed case. The denylist comparisons below must therefore
+    casefold on these platforms (mirroring the canonical guard in
+    agent/file_safety.py), or the media-delivery deny is silently bypassed. On
+    case-sensitive POSIX filesystems (default Linux) the variants are genuinely
+    different files and are left untouched.
+    """
+    return sys.platform == "darwin" or os.name == "nt"
+
+
+def _denycmp(path) -> str:
+    """Normalize a path string for case-aware denylist comparison."""
+    text = os.fspath(path)
+    return text.casefold() if _fs_case_insensitive() else text
+
+
 def _path_under_denied_prefix(resolved: Path) -> bool:
     """Return True if ``resolved`` lives under a deny-listed system path.
 
@@ -1138,7 +1159,7 @@ def _path_under_denied_prefix(resolved: Path) -> bool:
             continue
         # Allow the running user's own home tree; its credential sub-dirs are
         # caught by their own (more-specific) denylist entries above.
-        if home is not None and resolved_denied == home:
+        if home is not None and _denycmp(resolved_denied) == _denycmp(home):
             continue
         return True
     return False
@@ -1162,11 +1183,12 @@ def _file_is_recently_produced(resolved: Path, window_seconds: float) -> bool:
 
 
 def _path_is_within(path: Path, root: Path) -> bool:
-    try:
-        path.relative_to(root)
-        return True
-    except ValueError:
-        return False
+    # Casefold on case-insensitive filesystems (macOS/Windows) so a credential
+    # path addressed via a case variant can't slip past containment checks; an
+    # exact comparison on case-sensitive POSIX systems (default Linux).
+    p = _denycmp(path)
+    r = _denycmp(root)
+    return p == r or p.startswith(r + os.sep)
 
 
 def validate_media_delivery_path(path: str) -> Optional[str]:

--- a/tests/agent/test_file_safety_case_insensitive.py
+++ b/tests/agent/test_file_safety_case_insensitive.py
@@ -1,0 +1,95 @@
+"""Case-insensitive filesystem coverage for agent/file_safety.py deny guards.
+
+On macOS (APFS/HFS+) and Windows the filesystem is case-insensitive, so a
+credential path addressed through a case variant (``~/.SSH/authorized_keys``
+vs ``~/.ssh/authorized_keys``, or ``.ENV`` vs ``.env``) is the SAME on-disk
+file. ``os.path.realpath`` / ``Path.resolve`` preserve the typed case rather
+than canonicalizing it, so the deny comparisons must casefold on those
+platforms or the guard is silently bypassed. On case-sensitive POSIX
+filesystems (default Linux) the variants are genuinely different files, so the
+guards must stay exact-case. These tests pin both behaviors by forcing the
+``_fs_case_insensitive`` detector on and off, which keeps them deterministic on
+every CI host.
+
+Run with: python -m pytest tests/agent/test_file_safety_case_insensitive.py -v
+"""
+
+import os
+import sys
+
+import pytest
+
+import agent.file_safety as file_safety
+from agent.file_safety import get_read_block_error, is_write_denied
+
+
+def _force_case_insensitive(monkeypatch, value):
+    monkeypatch.setattr(file_safety, "_fs_case_insensitive", lambda: value)
+
+
+@pytest.fixture(autouse=True)
+def _no_safe_root(monkeypatch):
+    # HERMES_WRITE_SAFE_ROOT turns is_write_denied into an allowlist; keep it
+    # unset so these denylist assertions are deterministic.
+    monkeypatch.delenv("HERMES_WRITE_SAFE_ROOT", raising=False)
+
+
+class TestWriteDenyCaseInsensitive:
+    def test_ssh_exact_case_is_denied(self, monkeypatch):
+        _force_case_insensitive(monkeypatch, False)
+        target = os.path.join(os.path.expanduser("~"), ".ssh", "authorized_keys")
+        assert is_write_denied(target) is True
+
+    def test_ssh_case_variant_denied_on_case_insensitive_fs(self, monkeypatch):
+        _force_case_insensitive(monkeypatch, True)
+        # Same on-disk file on APFS/NTFS, so it must be denied.
+        target = os.path.join(os.path.expanduser("~"), ".SSH", "authorized_keys")
+        assert is_write_denied(target) is True
+
+    def test_aws_prefix_case_variant_denied_on_case_insensitive_fs(self, monkeypatch):
+        _force_case_insensitive(monkeypatch, True)
+        target = os.path.join(os.path.expanduser("~"), ".AWS", "credentials")
+        assert is_write_denied(target) is True
+
+    def test_etc_exact_path_case_variant_denied_on_case_insensitive_fs(self, monkeypatch):
+        _force_case_insensitive(monkeypatch, True)
+        assert is_write_denied("/etc/PASSWD") is True
+
+    def test_case_variant_not_denied_on_case_sensitive_fs(self, monkeypatch):
+        _force_case_insensitive(monkeypatch, False)
+        # On a case-sensitive FS these are genuinely different files: behavior
+        # must be unchanged (no over-blocking).
+        assert is_write_denied("/etc/SUDOERS") is False
+        target = os.path.join(os.path.expanduser("~"), ".SSH", "authorized_keys")
+        assert is_write_denied(target) is False
+
+
+class TestReadBlockCaseInsensitive:
+    def test_env_exact_case_is_blocked(self, monkeypatch):
+        _force_case_insensitive(monkeypatch, False)
+        assert get_read_block_error("/tmp/project/.env") is not None
+
+    def test_env_case_variant_blocked_on_case_insensitive_fs(self, monkeypatch):
+        _force_case_insensitive(monkeypatch, True)
+        assert get_read_block_error("/tmp/project/.ENV") is not None
+        assert get_read_block_error("/tmp/project/.Env") is not None
+
+    def test_env_case_variant_not_blocked_on_case_sensitive_fs(self, monkeypatch):
+        _force_case_insensitive(monkeypatch, False)
+        # Different file on Linux, so it must not be blocked.
+        assert get_read_block_error("/tmp/project/.ENV") is None
+
+
+@pytest.mark.skipif(
+    not (sys.platform == "darwin" or os.name == "nt"),
+    reason="real case-insensitive filesystem (macOS/Windows) only",
+)
+class TestRealCaseInsensitiveFilesystem:
+    """End-to-end on an actual case-insensitive FS, no monkeypatching."""
+
+    def test_real_ssh_variant_write_denied(self):
+        target = os.path.join(os.path.expanduser("~"), ".SSH", "authorized_keys")
+        assert is_write_denied(target) is True
+
+    def test_real_env_variant_read_blocked(self):
+        assert get_read_block_error("/tmp/project/.ENV") is not None

--- a/tests/gateway/test_media_delivery_case_insensitive.py
+++ b/tests/gateway/test_media_delivery_case_insensitive.py
@@ -1,0 +1,54 @@
+"""Case-insensitive filesystem coverage for the gateway media-delivery denylist.
+
+The media-delivery guard (gateway/platforms/base.py) is the read/exfil twin of
+agent/file_safety.py's write guard: its own comment notes the two must stay in
+lockstep so "the delivery side can't trail the write side". On a case-insensitive
+filesystem (macOS/APFS, Windows/NTFS) a model-emitted MEDIA path like
+``~/.SSH/id_rsa`` resolves to the same credential file as ``~/.ssh/id_rsa`` but
+preserves the typed case, so the denylist comparison must casefold there too.
+Otherwise a case variant auto-attaches a credential to a chat reply. On
+case-sensitive Linux the variants are distinct files and behavior is unchanged.
+
+Run with: python -m pytest tests/gateway/test_media_delivery_case_insensitive.py -v
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+import gateway.platforms.base as base
+from gateway.platforms.base import _path_under_denied_prefix
+
+
+def _force_case_insensitive(monkeypatch, value):
+    monkeypatch.setattr(base, "_fs_case_insensitive", lambda: value)
+
+
+def _home_path(*parts):
+    return Path(os.path.expanduser("~")).resolve(strict=False).joinpath(*parts)
+
+
+class TestMediaDeliveryDenyCaseInsensitive:
+    def test_ssh_exact_case_is_denied(self, monkeypatch):
+        _force_case_insensitive(monkeypatch, False)
+        assert _path_under_denied_prefix(_home_path(".ssh", "id_rsa")) is True
+
+    def test_ssh_case_variant_denied_on_case_insensitive_fs(self, monkeypatch):
+        _force_case_insensitive(monkeypatch, True)
+        assert _path_under_denied_prefix(_home_path(".SSH", "id_rsa")) is True
+
+    def test_aws_case_variant_denied_on_case_insensitive_fs(self, monkeypatch):
+        _force_case_insensitive(monkeypatch, True)
+        assert _path_under_denied_prefix(_home_path(".AWS", "credentials")) is True
+
+    def test_ssh_case_variant_not_denied_on_case_sensitive_fs(self, monkeypatch):
+        _force_case_insensitive(monkeypatch, False)
+        # Distinct file on Linux, so it must not be blocked (no over-blocking).
+        assert _path_under_denied_prefix(_home_path(".SSH", "id_rsa")) is False
+
+    def test_plain_home_file_still_deliverable(self, monkeypatch):
+        # A normal deliverable in the user's home stays allowed even with
+        # case-folding on, so the fix must not over-block ordinary files.
+        _force_case_insensitive(monkeypatch, True)
+        assert _path_under_denied_prefix(_home_path("report.pdf")) is False


### PR DESCRIPTION
## What does this PR do?

The credential-path deny heuristics compared paths case-sensitively, so on a case-insensitive filesystem (macOS APFS/HFS+, Windows NTFS) a case variant of a denied path slipped past the guard. `~/.SSH/authorized_keys` is the same file on disk as `~/.ssh/authorized_keys`, but `realpath`/`resolve` keep the case you typed, so the exact-string compare missed it.

This casefolds the comparisons only when the filesystem is case-insensitive, so case-sensitive POSIX (default Linux) behavior is unchanged. Both deny sites are fixed in lockstep:

- `agent/file_safety.py`: `is_write_denied()` / `get_read_block_error()` (the write/read guard).
- `gateway/platforms/base.py`: `validate_media_delivery_path()` / `_path_under_denied_prefix()` (the media-delivery twin, whose own comment requires it to mirror the canonical read guard so the delivery side can't trail the write side).

These are defense-in-depth heuristics, not a security boundary (SECURITY.md section 2.4), so this is the kind of in-process-heuristic hardening section 3.2 invites as a regular PR rather than a vulnerability report.

## Related Issue

Fixes #51474

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/file_safety.py`: added a `_fs_case_insensitive()` detector plus `_denycmp()`/`_denied_paths_equal()`/`_denied_path_within()` helpers, and routed `is_write_denied()` and `get_read_block_error()` comparisons through them (exact denied paths, prefixes, mcp-tokens/pairing, safe-root, hub cache, credential stores, and `.env` basenames).
- `gateway/platforms/base.py`: added the same `_fs_case_insensitive()`/`_denycmp()` helpers, and made `_path_is_within()` and the home exception in `_path_under_denied_prefix()` case-aware (covers both the deny and the cache/operator allowlist paths).
- `tests/agent/test_file_safety_case_insensitive.py` (new): write/read deny coverage that forces the detector on and off, so the fix and the unchanged case-sensitive behavior are both pinned deterministically on any CI host, plus a real-filesystem check gated to macOS/Windows.
- `tests/gateway/test_media_delivery_case_insensitive.py` (new): the same coverage for the media-delivery denylist.

## How to Test

```bash
python -m pytest tests/agent/test_file_safety_case_insensitive.py \
                 tests/gateway/test_media_delivery_case_insensitive.py -q
```

Before/after on macOS (default APFS):

```python
import os
from agent.file_safety import is_write_denied, get_read_block_error
h = os.path.expanduser("~")
is_write_denied(os.path.join(h, ".SSH", "authorized_keys"))  # before: False, after: True
get_read_block_error("/tmp/proj/.ENV")                       # before: None, after: blocked
```

Suites I ran locally (macOS 26, Python 3.13): the two new files (15 tests) plus the existing `tests/agent/test_file_safety*.py`, `tests/tools/test_write_deny.py`, and `tests/gateway/test_platform_base.py`, for 254 passed and 2 skipped with no regressions. `test_cross_profile_guard.py` and `test_file_write_safety.py` have pre-existing failures on macOS that are unrelated to this change (pytest's `tmp_path` under `/private/var/folders` trips a separate `/var` write guard, plus some BOM tests); the failing set is identical with and without this diff.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs/issues to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes (write guard and media-delivery guard)
- [x] I've tested on my platform: macOS 26 (APFS), Python 3.13
- [x] I've considered cross-platform impact: the change is a no-op on case-sensitive filesystems (default Linux); detection is `sys.platform == "darwin" or os.name == "nt"`

## Notes

Detection is by platform default (darwin/Windows). A case-sensitively formatted macOS volume or a case-insensitive Linux mount is rare, and erring toward casefolding on macOS/Windows only ever adds denials to a defense-in-depth heuristic; it never removes a legitimate write or read on Linux.
