### PR TITLE
feat(ollama-cloud): add reasoning_effort support (xhigh->max)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3080,6 +3080,54 @@ def lmstudio_model_reasoning_options(
     return []
 
 
+def ollama_model_supports_thinking(
+    model: str,
+    base_url: Optional[str],
+    api_key: Optional[str] = None,
+    timeout: float = 5.0,
+) -> Optional[bool]:
+    """Return True if an Ollama (Cloud or local) model advertises ``thinking``.
+
+    Probes the native ``/api/show`` endpoint and checks the ``capabilities``
+    list, which Ollama populates from the model's metadata (e.g.
+    ``deepseek-v4-pro`` → ``["completion", "tools", "thinking"]`` while
+    ``gemma3:27b`` → ``["completion", "vision"]``). This is the authoritative
+    capability source — the OpenAI-compat ``/v1/models`` endpoint omits it.
+
+    Returns:
+        True  — the model declares the ``thinking`` capability.
+        False — ``/api/show`` succeeded but the model has no ``thinking`` cap.
+        None  — the probe failed (unreachable / non-Ollama / error); the caller
+                decides the fallback (we treat None as "don't emit").
+    """
+    import httpx
+
+    server_url = (base_url or "").strip().rstrip("/")
+    if server_url.endswith("/v1"):
+        server_url = server_url[:-3]
+    if not server_url:
+        return None
+
+    bare_model = _strip_ollama_cloud_suffix((model or "").strip())
+    if not bare_model:
+        return None
+
+    token = str(api_key or "").strip()
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+
+    try:
+        with httpx.Client(timeout=timeout, headers=headers) as client:
+            resp = client.post(f"{server_url}/api/show", json={"name": bare_model})
+            if resp.status_code != 200:
+                return None
+            caps = resp.json().get("capabilities")
+            if isinstance(caps, list):
+                return "thinking" in caps
+    except Exception:
+        return None
+    return None
+
+
 def _fetch_github_models(api_key: Optional[str] = None, timeout: float = 5.0) -> Optional[list[str]]:
     catalog = fetch_github_model_catalog(api_key=api_key, timeout=timeout)
     if not catalog:

--- a/plugins/model-providers/ollama-cloud/__init__.py
+++ b/plugins/model-providers/ollama-cloud/__init__.py
@@ -1,9 +1,68 @@
-"""Ollama Cloud provider profile."""
+"""Ollama Cloud provider profile.
+
+Ollama Cloud's OpenAI-compatible ``/v1/chat/completions`` endpoint
+supports top-level ``reasoning_effort`` with values ``none``, ``low``,
+``medium``, ``high``, and ``max`` (the last being undocumented but
+empirically confirmed for DeepSeek V4 — ``max`` produces ~2.5× more
+thinking tokens than ``high``).
+
+This profile maps Hermes's ``xhigh`` → ``max`` to unlock DeepSeek V4's
+"Max thinking" tier through Ollama Cloud.  ``low`` / ``medium`` / ``high``
+pass through unchanged.
+
+When reasoning is explicitly disabled (``enabled: false`` or
+``effort: "none"``), ``reasoning_effort`` is omitted entirely so the
+model runs in non-thinking mode.
+"""
+
+from __future__ import annotations
+
+from typing import Any
 
 from providers import register_provider
 from providers.base import ProviderProfile
 
-ollama_cloud = ProviderProfile(
+
+class OllamaCloudProfile(ProviderProfile):
+    """Ollama Cloud — maps xhigh→max via top-level reasoning_effort."""
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        **ctx: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Emit top-level ``reasoning_effort`` for Ollama Cloud.
+
+        The ``supports_reasoning`` flag passed by the transport is
+        deliberately ignored — this profile always handles reasoning
+        when ``reasoning_config`` is present.
+        """
+        top_level: dict[str, Any] = {}
+
+        if reasoning_config and isinstance(reasoning_config, dict):
+            enabled = reasoning_config.get("enabled", True)
+            if enabled is False:
+                return {}, {}  # omit → model runs without thinking
+
+            effort = (reasoning_config.get("effort") or "").strip().lower()
+            if not effort:
+                # No explicit effort requested — let the model decide
+                return {}, {}
+            if effort == "none":
+                return {}, {}  # explicit none → suppress thinking
+            if effort in ("xhigh", "max"):
+                top_level["reasoning_effort"] = "max"
+            elif effort in ("low", "medium", "high"):
+                top_level["reasoning_effort"] = effort
+            else:
+                # Unknown value — forward as-is, let the API decide
+                top_level["reasoning_effort"] = effort
+
+        return {}, top_level
+
+
+ollama_cloud = OllamaCloudProfile(
     name="ollama-cloud",
     aliases=("ollama_cloud",),
     default_aux_model="nemotron-3-nano:30b",

--- a/plugins/model-providers/ollama-cloud/__init__.py
+++ b/plugins/model-providers/ollama-cloud/__init__.py
@@ -30,34 +30,50 @@ class OllamaCloudProfile(ProviderProfile):
         self,
         *,
         reasoning_config: dict | None = None,
+        supports_reasoning: bool = False,
         **ctx: Any,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
-        """Emit top-level ``reasoning_effort`` for Ollama Cloud.
+        """Emit top-level ``reasoning_effort`` for Ollama Cloud thinking models.
 
-        The ``supports_reasoning`` flag passed by the transport is
-        deliberately ignored — this profile always handles reasoning
-        when ``reasoning_config`` is present.
+        Gated on ``supports_reasoning``, which the transport resolves from the
+        model's native ``/api/show`` ``capabilities`` (``thinking``). Models
+        without the thinking capability (e.g. ``gemma3``, ``qwen3-coder``) get
+        no ``reasoning_effort`` at all — emitting it there is a no-op the API
+        ignores, and gating avoids sending a meaningless field.
         """
         top_level: dict[str, Any] = {}
+
+        if not supports_reasoning:
+            return {}, {}
 
         if reasoning_config and isinstance(reasoning_config, dict):
             enabled = reasoning_config.get("enabled", True)
             if enabled is False:
-                return {}, {}  # omit → model runs without thinking
+                # Ollama Cloud defaults to thinking ON, and ignores the
+                # extra_body.thinking:{type:disabled} shape (verified live).
+                # The ONLY way to actually suppress thinking on its
+                # /v1/chat/completions endpoint is top-level
+                # reasoning_effort:"none" — omitting the field leaves
+                # thinking on.
+                return {}, {"reasoning_effort": "none"}
 
             effort = (reasoning_config.get("effort") or "").strip().lower()
             if not effort:
                 # No explicit effort requested — let the model decide
+                # (Ollama Cloud's server default is thinking ON).
                 return {}, {}
             if effort == "none":
-                return {}, {}  # explicit none → suppress thinking
+                return {}, {"reasoning_effort": "none"}  # explicit off switch
             if effort in ("xhigh", "max"):
                 top_level["reasoning_effort"] = "max"
             elif effort in ("low", "medium", "high"):
                 top_level["reasoning_effort"] = effort
-            else:
-                # Unknown value — forward as-is, let the API decide
-                top_level["reasoning_effort"] = effort
+            # Any other value (including "minimal", which Ollama Cloud's
+            # /v1/chat/completions rejects with HTTP 400 — its accepted set is
+            # {low, medium, high, max, none}) is omitted so the model applies
+            # its own default rather than triggering a hard 400. Matches the
+            # sibling deepseek / opencode-zen profiles, which target the same
+            # backend and omit unrecognized efforts rather than send garbage.
 
         return {}, top_level
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -4880,6 +4880,12 @@ class AIAgent:
             opts = self._lmstudio_reasoning_options_cached()
             # "off-only" (or absent) means no real reasoning capability.
             return any(opt and opt != "off" for opt in opts)
+        # Ollama Cloud (and any Ollama-compatible server): the native
+        # /api/show capabilities list is authoritative — emit reasoning_effort
+        # only for models that declare the "thinking" capability. deepseek-v4
+        # has it; gemma3 / qwen3-coder don't. Cached per (model, base_url).
+        if base_url_host_matches(self._base_url_lower, "ollama.com"):
+            return self._ollama_supports_thinking_cached()
         if "openrouter" not in self._base_url_lower:
             return False
         if "api.mistral.ai" in self._base_url_lower:
@@ -4932,6 +4938,37 @@ class AIAgent:
             opts = []
         cache[key] = (opts, _time.monotonic())
         return opts
+
+    def _ollama_supports_thinking_cached(self) -> bool:
+        """Probe Ollama's ``/api/show`` capabilities once per (model, base_url).
+
+        Returns True only when the model declares the ``thinking`` capability.
+        Caching mirrors the LM Studio probe: a True/False result is permanent
+        (capabilities don't change), while a probe failure (None) is cached
+        with a 60-second TTL so a transient outage doesn't suppress reasoning
+        for the rest of the session but also doesn't round-trip every turn.
+        """
+        import time as _time
+
+        cache = getattr(self, "_ollama_thinking_cache", None)
+        if cache is None:
+            cache = self._ollama_thinking_cache = {}
+        key = (self.model, self.base_url)
+        cached = cache.get(key)
+        if cached is not None:
+            supported, ts = cached
+            # Definitive True/False → permanent. Unknown (None) → 60s TTL.
+            if supported is not None or (_time.monotonic() - ts) < 60:
+                return bool(supported)
+        try:
+            from hermes_cli.models import ollama_model_supports_thinking
+            supported = ollama_model_supports_thinking(
+                self.model, self.base_url, getattr(self, "api_key", "")
+            )
+        except Exception:
+            supported = None
+        cache[key] = (supported, _time.monotonic())
+        return bool(supported)
 
     def _resolve_lmstudio_summary_reasoning_effort(self) -> Optional[str]:
         """Resolve a safe top-level ``reasoning_effort`` for LM Studio.

--- a/tests/plugins/model_providers/test_ollama_cloud_profile.py
+++ b/tests/plugins/model_providers/test_ollama_cloud_profile.py
@@ -1,0 +1,153 @@
+"""Unit tests for the Ollama Cloud provider profile's reasoning-effort wiring.
+
+Ollama Cloud's ``/v1/chat/completions`` endpoint supports top-level
+``reasoning_effort`` with values ``none``, ``low``, ``medium``, ``high``,
+and (undocumented but empirically confirmed) ``max``.  The profile maps
+Hermes's ``xhigh`` → ``max`` to unlock DeepSeek V4's "Max thinking" tier
+and passes the standard levels through unchanged.
+
+These tests pin the profile's wire-shape contract so Ollama Cloud
+requests carry the correct ``reasoning_effort`` field.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def ollama_cloud_profile():
+    """Resolve the registered Ollama Cloud profile.
+
+    Going through ``providers.get_provider_profile`` keeps the test
+    honest — if someone replaces the registered class with a plain
+    ``ProviderProfile``, every assertion below collapses.
+    """
+    # ``model_tools`` triggers plugin discovery on import, which is what
+    # registers the Ollama Cloud profile in the global provider registry.
+    import model_tools  # noqa: F401
+    import providers
+
+    profile = providers.get_provider_profile("ollama-cloud")
+    assert profile is not None, "ollama-cloud provider profile must be registered"
+    return profile
+
+
+class TestOllamaCloudReasoningEffort:
+    """``build_api_kwargs_extras`` emits correct top-level ``reasoning_effort``."""
+
+    # ── xhigh / max → max ──────────────────────────────────────────
+
+    @pytest.mark.parametrize("effort", ["xhigh", "max", "MAX", "  Max  "])
+    def test_xhigh_and_max_normalize_to_max(self, ollama_cloud_profile, effort):
+        extra_body, top_level = ollama_cloud_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": effort},
+        )
+        assert extra_body == {}
+        assert top_level == {"reasoning_effort": "max"}
+
+    # ── low / medium / high pass through ───────────────────────────
+
+    @pytest.mark.parametrize("effort", ["low", "medium", "high"])
+    def test_standard_efforts_pass_through(self, ollama_cloud_profile, effort):
+        _, top_level = ollama_cloud_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": effort},
+        )
+        assert top_level == {"reasoning_effort": effort}
+
+    # ── disabled → no reasoning_effort emitted ─────────────────────
+
+    def test_explicitly_disabled_emits_nothing(self, ollama_cloud_profile):
+        extra_body, top_level = ollama_cloud_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+    def test_disabled_ignores_effort_field(self, ollama_cloud_profile):
+        """Effort silently dropped when thinking is off."""
+        _, top_level = ollama_cloud_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False, "effort": "high"},
+        )
+        assert top_level == {}
+
+    # ── none effort → no reasoning_effort ──────────────────────────
+
+    def test_none_effort_emits_nothing(self, ollama_cloud_profile):
+        extra_body, top_level = ollama_cloud_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "none"},
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+    # ── missing / empty effort → let model default ─────────────────
+
+    def test_no_reasoning_config_emits_nothing(self, ollama_cloud_profile):
+        extra_body, top_level = ollama_cloud_profile.build_api_kwargs_extras(
+            reasoning_config=None,
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+    def test_empty_effort_emits_nothing(self, ollama_cloud_profile):
+        _, top_level = ollama_cloud_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": ""},
+        )
+        assert top_level == {}
+
+    def test_no_effort_key_emits_nothing(self, ollama_cloud_profile):
+        """When effort key is absent, let the model use its default."""
+        _, top_level = ollama_cloud_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True},
+        )
+        assert top_level == {}
+
+    # ── unknown effort → forwarded as-is ───────────────────────────
+
+    def test_unknown_effort_forwarded(self, ollama_cloud_profile):
+        _, top_level = ollama_cloud_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "ultra"},
+        )
+        assert top_level == {"reasoning_effort": "ultra"}
+
+
+class TestOllamaCloudFullKwargsIntegration:
+    """End-to-end: the transport's full kwargs include reasoning_effort."""
+
+    def test_full_kwargs_with_xhigh(self, ollama_cloud_profile):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="deepseek-v4-pro:cloud",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=ollama_cloud_profile,
+            reasoning_config={"enabled": True, "effort": "xhigh"},
+            base_url="https://ollama.com/v1",
+            provider_name="ollama-cloud",
+        )
+        assert kwargs["model"] == "deepseek-v4-pro:cloud"
+        assert kwargs["reasoning_effort"] == "max"
+        # No extra_body — Ollama Cloud uses top-level reasoning_effort
+        assert "extra_body" not in kwargs or "reasoning" not in kwargs.get("extra_body", {})
+
+    def test_full_kwargs_with_disabled(self, ollama_cloud_profile):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="deepseek-v4-pro:cloud",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=ollama_cloud_profile,
+            reasoning_config={"enabled": False},
+            base_url="https://ollama.com/v1",
+            provider_name="ollama-cloud",
+        )
+        assert "reasoning_effort" not in kwargs
+
+
+class TestOllamaCloudAuxModel:
+    """Ollama Cloud aux model is set on the profile."""
+
+    def test_profile_advertises_aux_model(self, ollama_cloud_profile):
+        assert ollama_cloud_profile.default_aux_model == "nemotron-3-nano:30b"

--- a/tests/plugins/model_providers/test_ollama_cloud_profile.py
+++ b/tests/plugins/model_providers/test_ollama_cloud_profile.py
@@ -41,6 +41,7 @@ class TestOllamaCloudReasoningEffort:
     @pytest.mark.parametrize("effort", ["xhigh", "max", "MAX", "  Max  "])
     def test_xhigh_and_max_normalize_to_max(self, ollama_cloud_profile, effort):
         extra_body, top_level = ollama_cloud_profile.build_api_kwargs_extras(
+            supports_reasoning=True,
             reasoning_config={"enabled": True, "effort": effort},
         )
         assert extra_body == {}
@@ -51,39 +52,47 @@ class TestOllamaCloudReasoningEffort:
     @pytest.mark.parametrize("effort", ["low", "medium", "high"])
     def test_standard_efforts_pass_through(self, ollama_cloud_profile, effort):
         _, top_level = ollama_cloud_profile.build_api_kwargs_extras(
+            supports_reasoning=True,
             reasoning_config={"enabled": True, "effort": effort},
         )
         assert top_level == {"reasoning_effort": effort}
 
-    # ── disabled → no reasoning_effort emitted ─────────────────────
+    # ── disabled → reasoning_effort:"none" (the only working off switch) ──
 
-    def test_explicitly_disabled_emits_nothing(self, ollama_cloud_profile):
+    def test_explicitly_disabled_sends_none(self, ollama_cloud_profile):
+        """Ollama Cloud defaults to thinking ON and ignores extra_body.thinking,
+        so disabling requires top-level reasoning_effort:"none" (verified live);
+        omitting the field would leave thinking on."""
         extra_body, top_level = ollama_cloud_profile.build_api_kwargs_extras(
+            supports_reasoning=True,
             reasoning_config={"enabled": False},
         )
         assert extra_body == {}
-        assert top_level == {}
+        assert top_level == {"reasoning_effort": "none"}
 
     def test_disabled_ignores_effort_field(self, ollama_cloud_profile):
-        """Effort silently dropped when thinking is off."""
+        """Effort is overridden by the disable off switch when thinking is off."""
         _, top_level = ollama_cloud_profile.build_api_kwargs_extras(
+            supports_reasoning=True,
             reasoning_config={"enabled": False, "effort": "high"},
         )
-        assert top_level == {}
+        assert top_level == {"reasoning_effort": "none"}
 
-    # ── none effort → no reasoning_effort ──────────────────────────
+    # ── none effort → reasoning_effort:"none" ──────────────────────
 
-    def test_none_effort_emits_nothing(self, ollama_cloud_profile):
+    def test_none_effort_sends_none(self, ollama_cloud_profile):
         extra_body, top_level = ollama_cloud_profile.build_api_kwargs_extras(
+            supports_reasoning=True,
             reasoning_config={"enabled": True, "effort": "none"},
         )
         assert extra_body == {}
-        assert top_level == {}
+        assert top_level == {"reasoning_effort": "none"}
 
     # ── missing / empty effort → let model default ─────────────────
 
     def test_no_reasoning_config_emits_nothing(self, ollama_cloud_profile):
         extra_body, top_level = ollama_cloud_profile.build_api_kwargs_extras(
+            supports_reasoning=True,
             reasoning_config=None,
         )
         assert extra_body == {}
@@ -91,6 +100,7 @@ class TestOllamaCloudReasoningEffort:
 
     def test_empty_effort_emits_nothing(self, ollama_cloud_profile):
         _, top_level = ollama_cloud_profile.build_api_kwargs_extras(
+            supports_reasoning=True,
             reasoning_config={"enabled": True, "effort": ""},
         )
         assert top_level == {}
@@ -98,17 +108,32 @@ class TestOllamaCloudReasoningEffort:
     def test_no_effort_key_emits_nothing(self, ollama_cloud_profile):
         """When effort key is absent, let the model use its default."""
         _, top_level = ollama_cloud_profile.build_api_kwargs_extras(
+            supports_reasoning=True,
             reasoning_config={"enabled": True},
         )
         assert top_level == {}
 
-    # ── unknown effort → forwarded as-is ───────────────────────────
+    # ── unknown / minimal effort → omitted (server default) ────────
 
-    def test_unknown_effort_forwarded(self, ollama_cloud_profile):
+    def test_unknown_effort_omitted(self, ollama_cloud_profile):
+        """Unrecognized effort is omitted, not forwarded verbatim, so the
+        model applies its own default. Matches the sibling deepseek profile,
+        which targets the same backend."""
         _, top_level = ollama_cloud_profile.build_api_kwargs_extras(
+            supports_reasoning=True,
             reasoning_config={"enabled": True, "effort": "ultra"},
         )
-        assert top_level == {"reasoning_effort": "ultra"}
+        assert top_level == {}
+
+    def test_minimal_effort_omitted(self, ollama_cloud_profile):
+        """``minimal`` is a real Hermes effort level but is not documented for
+        Ollama Cloud's /v1/chat/completions, so it is omitted rather than sent
+        verbatim (which could trigger a 400)."""
+        _, top_level = ollama_cloud_profile.build_api_kwargs_extras(
+            supports_reasoning=True,
+            reasoning_config={"enabled": True, "effort": "minimal"},
+        )
+        assert top_level == {}
 
 
 class TestOllamaCloudFullKwargsIntegration:
@@ -125,6 +150,7 @@ class TestOllamaCloudFullKwargsIntegration:
             reasoning_config={"enabled": True, "effort": "xhigh"},
             base_url="https://ollama.com/v1",
             provider_name="ollama-cloud",
+            supports_reasoning=True,
         )
         assert kwargs["model"] == "deepseek-v4-pro:cloud"
         assert kwargs["reasoning_effort"] == "max"
@@ -142,8 +168,101 @@ class TestOllamaCloudFullKwargsIntegration:
             reasoning_config={"enabled": False},
             base_url="https://ollama.com/v1",
             provider_name="ollama-cloud",
+            supports_reasoning=True,
         )
-        assert "reasoning_effort" not in kwargs
+        # Disabling requires the explicit off switch — Ollama Cloud defaults to
+        # thinking ON, so omitting reasoning_effort would NOT disable it.
+        assert kwargs["reasoning_effort"] == "none"
+
+
+class TestOllamaCloudCapabilityGating:
+    """reasoning_effort is gated on the model's thinking capability."""
+
+    def test_non_thinking_model_emits_nothing(self, ollama_cloud_profile):
+        """A model that doesn't support thinking (supports_reasoning=False)
+        gets no reasoning_effort, even when an effort is requested — Ollama
+        resolves thinking capability from /api/show, and we don't send a
+        meaningless field to e.g. gemma3 / qwen3-coder."""
+        extra_body, top_level = ollama_cloud_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "xhigh"},
+            supports_reasoning=False,
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+    def test_non_thinking_model_ignores_disable(self, ollama_cloud_profile):
+        """Even a disable request is a no-op for a non-thinking model."""
+        _, top_level = ollama_cloud_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            supports_reasoning=False,
+        )
+        assert top_level == {}
+
+
+class TestOllamaModelSupportsThinking:
+    """The /api/show capability probe used to resolve supports_reasoning."""
+
+    def _patch_show(self, monkeypatch, *, status=200, capabilities=None, raise_exc=None):
+        import httpx
+
+        class _Resp:
+            status_code = status
+
+            def json(self):
+                return {"capabilities": capabilities} if capabilities is not None else {}
+
+        class _Client:
+            def __init__(self, *a, **k):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def post(self, *a, **k):
+                if raise_exc:
+                    raise raise_exc
+                return _Resp()
+
+        monkeypatch.setattr(httpx, "Client", _Client)
+
+    def test_thinking_capability_true(self, monkeypatch):
+        from hermes_cli.models import ollama_model_supports_thinking
+
+        self._patch_show(monkeypatch, capabilities=["completion", "tools", "thinking"])
+        assert (
+            ollama_model_supports_thinking(
+                "deepseek-v4-pro", "https://ollama.com/v1", "key"
+            )
+            is True
+        )
+
+    def test_no_thinking_capability_false(self, monkeypatch):
+        from hermes_cli.models import ollama_model_supports_thinking
+
+        self._patch_show(monkeypatch, capabilities=["completion", "vision"])
+        assert (
+            ollama_model_supports_thinking("gemma3:27b", "https://ollama.com/v1", "key")
+            is False
+        )
+
+    def test_probe_failure_returns_none(self, monkeypatch):
+        from hermes_cli.models import ollama_model_supports_thinking
+
+        self._patch_show(monkeypatch, status=404)
+        assert (
+            ollama_model_supports_thinking("x", "https://ollama.com/v1", "key") is None
+        )
+
+    def test_exception_returns_none(self, monkeypatch):
+        from hermes_cli.models import ollama_model_supports_thinking
+
+        self._patch_show(monkeypatch, raise_exc=RuntimeError("boom"))
+        assert (
+            ollama_model_supports_thinking("x", "https://ollama.com/v1", "key") is None
+        )
 
 
 class TestOllamaCloudAuxModel:


### PR DESCRIPTION
## Summary

Hermes can now send `reasoning_effort` to Ollama Cloud's OpenAI-compatible `/v1/chat/completions` endpoint — but **only for models that actually support thinking** — unlocking DeepSeek V4's "Max thinking" tier via `reasoning_effort: "max"`. Previously the bare ollama-cloud profile silently dropped all reasoning config.

Salvage of #29221 by @s010mn onto current `main` (cherry-picked, authorship preserved), plus one follow-up commit from me with three correctness fixes — all verified live against `ollama.com`.

## Changes

- **`plugins/model-providers/ollama-cloud/__init__.py`** (@s010mn + my follow-up): `OllamaCloudProfile` overrides `build_api_kwargs_extras` to emit top-level `reasoning_effort`. `xhigh`/`max` → `max`; `low`/`medium`/`high` pass through.
- **follow-up (me), all live-verified on `deepseek-v4-pro` / `gemma3` / `qwen3-coder`:**
  1. **Capability-gated.** Only models whose native `/api/show` `capabilities` list contains `thinking` get `reasoning_effort`. Resolved once per `(model, base_url)` in `run_agent._supports_reasoning_extra_body` via a cached probe (`hermes_cli.models.ollama_model_supports_thinking`), threaded into the profile as `supports_reasoning` — **no live HTTP in the per-request path**. Mirrors the existing LM Studio capability pattern. The original ignored the flag and emitted for every model.
  2. **Disable actually disables.** Ollama Cloud defaults to thinking **ON** and **ignores** `extra_body.thinking:{disabled}` (verified). The only off switch is top-level `reasoning_effort: "none"`. The original returned `({}, {})` on disable → thinking stayed on. Now emits `{"reasoning_effort": "none"}`.
  3. **Omit unrecognized effort.** The original forwarded unknown strings verbatim, including `minimal` (a real Hermes level). Ollama Cloud **hard-400s** unrecognized values (accepted set: `{low, medium, high, max, none}`). Now omitted → model default.

## Why the core touches

`run_agent.py` + `hermes_cli/models.py` gain the capability probe (where reasoning-capability resolution already lives, e.g. LM Studio). The plugin profile only *consumes* the resolved `supports_reasoning` flag — it doesn't reach into core.

## Validation (live against `ollama.com`)

| model / input | result |
|---|---|
| `deepseek-v4-pro` `/api/show` | `capabilities: [...,"thinking"]` → gated ON |
| `gemma3:27b`, `qwen3-coder:480b` | no `thinking` cap → no `reasoning_effort` |
| thinking + `xhigh` | top-level `reasoning_effort="max"` |
| thinking + `enabled:false` | `reasoning_effort="none"` (real off switch) |
| `extra_body.thinking:{disabled}` | ignored (thinking stayed ON) |
| `reasoning_effort:"ultra"` | HTTP 400 → justifies omitting unknowns |

- **24/24** profile tests pass; **194** provider/transport tests unaffected; ruff clean.
- E2E verified through real imports + the real transport.

## Credit

Salvaged from #29221 by @s010mn. Cherry-picked with authorship preserved; one follow-up commit on top.
