### PR TITLE
fix(tui): guard slash_worker sys.path against local package shadowing

### DIFF
--- a/tests/tui_gateway/test_slash_worker_sys_path.py
+++ b/tests/tui_gateway/test_slash_worker_sys_path.py
@@ -1,0 +1,60 @@
+"""Regression tests for tui_gateway/slash_worker.py sys.path hardening (issue #51286).
+
+The slash-command worker is spawned as ``-m tui_gateway.slash_worker`` and
+inherits the user's CWD. A local package (e.g. ``utils/``) in that CWD shadows
+the installed hermes ``utils`` module and crashes the worker on ``import cli``
+(``ImportError: cannot import name 'atomic_replace' from 'utils'``).
+
+#15989 added this guard to the sibling entrypoint ``tui_gateway/entry.py`` but
+missed this child, so the crash still reproduced. slash_worker.py must sanitize
+sys.path before its first non-stdlib import.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_slash_worker_imports_from_cwd_with_colliding_utils(tmp_path):
+    """Importing the worker from a CWD that ships its own ``utils/`` package
+    must succeed — the guard strips CWD so the installed module wins."""
+    # Mimic the user's project (tg-ws-proxy ships utils/, proxy/, ui/).
+    for pkg in ("utils", "proxy", "ui"):
+        (tmp_path / pkg).mkdir()
+        (tmp_path / pkg / "__init__.py").write_text("")  # no atomic_replace, etc.
+
+    env = {k: v for k, v in os.environ.items() if k != "HERMES_PYTHON_SRC_ROOT"}
+    # Keep the source importable via PYTHONPATH; CWD ('') still precedes it on
+    # sys.path for ``-c``, so the shadow (and thus the guard) is still exercised.
+    env["PYTHONPATH"] = str(PROJECT_ROOT)
+
+    result = subprocess.run(
+        [sys.executable, "-c", "import tui_gateway.slash_worker"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode == 0, (
+        "slash_worker failed to import from a CWD containing a colliding "
+        "utils/ package — sys.path guard regressed (issue #51286).\n"
+        f"stderr:\n{result.stderr}"
+    )
+
+
+def test_sys_path_guard_runs_before_cli_import():
+    """The guard must execute before ``import cli`` — reordering it below the
+    import would re-introduce the shadowing crash."""
+    src = (PROJECT_ROOT / "tui_gateway" / "slash_worker.py").read_text()
+    guard = 'sys.path = [p for p in sys.path if p not in {"", "."}]'
+    cli_import = "import cli as cli_mod"
+    assert guard in src, "sys.path shadowing guard missing from slash_worker.py"
+    assert cli_import in src, "expected 'import cli as cli_mod' in slash_worker.py"
+    assert src.index(guard) < src.index(cli_import), (
+        "sys.path guard must run before 'import cli' (issue #51286)"
+    )

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -3,12 +3,25 @@
 Protocol: reads JSON lines from stdin {id, command}, writes {id, ok, output|error} to stdout.
 """
 
+import os
+import sys
+
+# Guard against a local ``utils/`` (or other) package in the spawn CWD shadowing
+# installed hermes modules. This worker is spawned as ``-m tui_gateway.slash_worker``
+# and inherits the user's CWD, so the ``import cli`` below would otherwise resolve
+# ``utils`` to a colliding local package and crash the child (issue #51286). The
+# sibling entrypoint ``tui_gateway/entry.py`` applies the same guard; #15989 added
+# it there but missed this child.
+_src_root = os.environ.get("HERMES_PYTHON_SRC_ROOT", "")
+if _src_root and _src_root not in sys.path:
+    sys.path.insert(0, _src_root)
+# '' and '.' both resolve to CWD at import time and can shadow installed packages.
+sys.path = [p for p in sys.path if p not in {"", "."}]
+
 import argparse
 import contextlib
 import io
 import json
-import os
-import sys
 import threading
 import time
 


### PR DESCRIPTION
## What does this PR do?

The slash-command worker (`tui_gateway/slash_worker.py`) is spawned as a separate
`-m tui_gateway.slash_worker` subprocess and inherits the user's working directory.
Python puts the CWD on `sys.path` for `-m`, so a local package in that directory
(e.g. a project that ships its own `utils/`, `proxy/`, or `ui/`) shadows the
installed hermes module and the worker crashes on `import cli` with:

```
ImportError: cannot import name 'atomic_replace' from 'utils'
```

The child then exits 1 and the parent retries it in a crash loop.

#15989 added a `sys.path` shadowing guard to the sibling entrypoint
`tui_gateway/entry.py`. The slash worker is a *separate* spawned process, so it
starts fresh with the CWD back on `sys.path` and was still affected. This applies
the same guard to the worker, before its first non-stdlib import.

## Related Issue

Fixes #51286

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/slash_worker.py`: at module top, insert `HERMES_PYTHON_SRC_ROOT`
  (when set) and strip `''`/`'.'` from `sys.path` before `import cli` — identical
  to the guard already in `tui_gateway/entry.py`.
- `tests/tui_gateway/test_slash_worker_sys_path.py`: regression test that imports
  the worker from a CWD containing colliding `utils/`/`proxy/`/`ui/` packages (must
  not crash), plus a static check that the guard runs before `import cli`.

## How to Test

Reproduce the crash and confirm the fix:

```bash
mkdir -p /tmp/collide/utils && : > /tmp/collide/utils/__init__.py
cd /tmp/collide && python -c "import tui_gateway.slash_worker"
# before this PR: ImportError: cannot import name 'atomic_replace' from 'utils'
# after this PR:  imports cleanly
```

Automated:

```bash
scripts/run_tests.sh tests/tui_gateway/test_slash_worker_sys_path.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(tui): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected-area tests via `scripts/run_tests.sh` — `tui_gateway/` + the `cli` import chain are green (9/9). The change introduces no regressions: the one nearby failure in the full local suite (`test_tui_gateway_server.py::test_browser_manage_connect_default_local_reports_launch_hint`) fails identically on `origin/main`, i.e. it is pre-existing and unrelated to this `sys.path` guard.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 24.6, arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal import hardening; no docs/API surface)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — the guard is pure `sys.path` logic, platform-agnostic (no `os.kill`/POSIX-tool assumptions)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
