### PR TITLE
Clear stale base_url on gateway model switches

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1274,7 +1274,7 @@ class GatewaySlashCommandsMixin:
                                 if result.base_url:
                                     _persist_model_cfg["base_url"] = result.base_url
                                 if str(result.target_provider or "").strip().lower() != "custom":
-                                    clear_model_endpoint_credentials(_persist_model_cfg)
+                                    clear_model_endpoint_credentials(_persist_model_cfg, clear_base_url=True)
                                 from hermes_cli.config import save_config
                                 save_config(_persist_cfg)
                             except Exception as e:
@@ -1497,7 +1497,7 @@ class GatewaySlashCommandsMixin:
                     if result.base_url:
                         model_cfg["base_url"] = result.base_url
                     if str(result.target_provider or "").strip().lower() != "custom":
-                        clear_model_endpoint_credentials(model_cfg)
+                        clear_model_endpoint_credentials(model_cfg, clear_base_url=True)
                     from hermes_cli.config import save_config
                     save_config(cfg)
                 except Exception as e:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3979,6 +3979,7 @@ def clear_model_endpoint_credentials(
     *,
     clear_api_key: bool = True,
     clear_api_mode: bool = True,
+    clear_base_url: bool = False,
 ) -> Dict[str, Any]:
     """Remove stale inline endpoint credentials from a model config.
 
@@ -3995,6 +3996,8 @@ def clear_model_endpoint_credentials(
         model_cfg.pop("api", None)
     if clear_api_mode:
         model_cfg.pop("api_mode", None)
+    if clear_base_url:
+        model_cfg.pop("base_url", None)
     return model_cfg
 
 

--- a/tests/gateway/test_model_command_flat_string_config.py
+++ b/tests/gateway/test_model_command_flat_string_config.py
@@ -102,7 +102,7 @@ async def test_model_global_persists_when_config_has_flat_string_model(tmp_path,
     )
     assert written["model"]["default"] == "gpt-5.5"
     assert written["model"]["provider"] == "openrouter"
-    assert written["model"]["base_url"] == "https://openrouter.ai/api/v1"
+    assert "base_url" not in written["model"]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_model_picker_persist.py
+++ b/tests/gateway/test_model_picker_persist.py
@@ -171,7 +171,7 @@ async def test_picker_tap_persists_by_default(tmp_path, monkeypatch, seed_model)
     )
     assert written["model"]["default"] == "gpt-5.5"
     assert written["model"]["provider"] == "openrouter"
-    assert written["model"]["base_url"] == "https://openrouter.ai/api/v1"
+    assert "base_url" not in written["model"]
     assert "api_key" not in written["model"]
     assert "api_mode" not in written["model"]
 


### PR DESCRIPTION
## What does this PR do?

Clears stale inline `model.base_url` values when gateway model switches persist non-`custom` providers.

This is a focused follow-up to merged PR #49380. That PR added shared stale endpoint cleanup and wired it into gateway model-switch persistence, but the shared helper clears `api_key`, legacy `api`, and `api_mode` only. It does not clear `base_url`, so a gateway `/model` switch can still re-save an old inline endpoint for a built-in provider.

In my local repro, switching models from Telegram rewrote `config.yaml` with:

```yaml
model:
  default: minimax-m3
  provider: opencode-go
  base_url: https://opencode.ai/zen/go
```

The provider profile endpoint is `https://opencode.ai/zen/go/v1`, so later gateway-spawned agents inherited the stale inline endpoint and failed even though TUI/direct provider calls worked.

This PR keeps existing helper behavior backward-compatible by making `base_url` clearing opt-in, then enables it only in the gateway persistence paths for non-`custom` providers.

## Relationship to existing work

- Completes the remaining `base_url` cleanup gap from #49380 for gateway model switches.
- Targets the current `gateway/slash_commands.py` persistence paths, not the older `gateway/run.py` path referenced by some historical PRs.
- Complements #47533: that PR adds runtime-provider protection against stale stock endpoints, while this PR prevents the gateway from persisting the stale inline endpoint in the first place.
- The duplicate issue I opened (#51486) has been closed in favor of canonical issue #25107.

## Related Issue

Fixes #25107

Refs #47533 and #51486.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/config.py`: add optional `clear_base_url` support to `clear_model_endpoint_credentials(...)`.
- `gateway/slash_commands.py`: clear inline `base_url` when persisting gateway model switches for non-`custom` providers.
- `tests/gateway/test_model_picker_persist.py`: assert picker-based built-in provider switches do not persist `model.base_url`.
- `tests/gateway/test_model_command_flat_string_config.py`: assert typed `/model` built-in provider switches do not persist `model.base_url`.

## How to Test

1. Run the focused gateway regression tests:

   ```bash
   python -m pytest tests/gateway/test_model_picker_persist.py tests/gateway/test_model_command_flat_string_config.py -q
   ```

2. Confirm the result:

   ```text
   8 passed, 2 warnings
   ```

3. Manual repro used before this patch: switch an `opencode-go` model from Telegram and inspect `config.yaml`; the stale root `model.base_url` was reintroduced before this fix.

## Checklist

### Code

- [ ] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I have run `pytest tests/ -q` and all tests pass
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: Ubuntu 24.04.4 LTS

### Documentation & Housekeeping

- [x] I have updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I have updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I have considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A
- [x] I have updated tool descriptions/schemas if I changed tool behavior - or N/A

## For New Skills

N/A

## Screenshots / Logs

Sanitized failing endpoint before the fix:

```text
Provider: opencode-go
Endpoint: https://opencode.ai/zen/go
Error: APIConnectionError / HTTP 404 depending on attempt
```
