### PR TITLE
fix(desktop): Nous recommended default skips Opus-tier

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1332,19 +1332,63 @@ def get_preferred_silent_default_model(provider: str = "openrouter") -> str:
     return PREFERRED_SILENT_DEFAULT_MODEL
 
 
-def pick_silent_default_model(model_ids: list[str], provider: str = "openrouter") -> str:
-    """Pick the silent default from an available-models list.
+def _is_anthropic_frontier_tier(model_id: Optional[str]) -> bool:
+    """Return True for Anthropic frontier-tier models (Opus + Fable).
 
-    Returns the catalog-labeled default (see
-    :func:`get_preferred_silent_default_model`) when the list carries it,
-    else the first entry, else "". Used by every surface that must choose a
-    model on the user's behalf without an interactive picker (GUI onboarding
-    recommended-default, empty-model runtime fallback).
+    Both tiers are the priciest Anthropic offerings and are unsafe defaults
+    for a freshly-authenticated provider picker or any other silent fallback:
+    paid users landing on a frontier tier have no opportunity to opt out
+    before the choice pins their main model and inherits into every cron job
+    that doesn't override ``model.provider``.
+
+    Anchored on the ``claude-`` family prefix, then the ``opus-`` / ``fable-``
+    tier token (after vendor-strip and lowercase normalization), so the
+    predicate survives future Anthropic releases (``claude-opus-5-0``,
+    ``claude-fable-6``, etc.) and rejects community / distill models whose
+    slug merely *contains* the substring ``opus`` (e.g. ``qwopus3.6-27b-coder``).
+    Sonnet and Haiku are deliberately NOT classified as frontier here — they
+    remain reasonable auto-default candidates.
     """
+    raw = _strip_vendor_prefix(str(model_id or ""))
+    base = raw.split(":")[0].lower()
+    if not base.startswith("claude-"):
+        return False
+    return ("opus-" in base) or ("fable-" in base)
+
+
+def pick_silent_default_model(model_ids: list[str], provider: str = "openrouter") -> str:
+    """Pick a cost-safe silent default from an available-models list.
+
+    Shared policy for every surface that must choose a model on the user's
+    behalf without an interactive confirmation (GUI onboarding
+    recommended-default, empty-model runtime fallback, provider-set-but-
+    model-missing resolution):
+
+    1. If the catalog-labeled preferred default (see
+       :func:`get_preferred_silent_default_model`) is present in
+       ``model_ids``, return it.
+    2. Else, return the first entry that is NOT an Anthropic frontier tier
+       (Opus / Fable — see :func:`_is_anthropic_frontier_tier`). Catalog
+       ordering is preserved, so a freshly-released cheaper model still
+       wins over a leftover Sonnet.
+    3. Else (every entry is a frontier tier), return ``model_ids[0]`` so the
+       picker is never empty — defensive last resort only.
+    4. Else (empty list), return ``\"\"``.
+
+    This hardened fallback closes the hole where a Portal-augmented list
+    that didn't carry the catalog label fell through to ``model_ids[0]``
+    (currently ``anthropic/claude-fable-5``) and billed the most expensive
+    Anthropic flagship for traffic the user never opted into.
+    """
+    if not model_ids:
+        return ""
     preferred = get_preferred_silent_default_model(provider)
     if preferred in model_ids:
         return preferred
-    return model_ids[0] if model_ids else ""
+    non_frontier = [mid for mid in model_ids if not _is_anthropic_frontier_tier(mid)]
+    if non_frontier:
+        return non_frontier[0]
+    return model_ids[0]
 
 
 # Providers whose *silent* auto-default must go through the cost-safe

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3723,7 +3723,11 @@ class TestWebServerEndpoints:
         assert data["free_tier"] is True
 
     def test_recommended_default_nous_paid_uses_curated_default(self, monkeypatch):
-        """A paid Nous user gets the first curated/paid-augmented model."""
+        """A paid Nous user gets the cost-safe silent default from the list.
+
+        With no preferred catalog label present in the curated list and no
+        Anthropic frontier entries, the first curated entry is selected.
+        """
         import hermes_cli.models as models_mod
 
         monkeypatch.setattr(models_mod, "get_curated_nous_model_ids", lambda: ["top/model", "other/model"])
@@ -3733,6 +3737,12 @@ class TestWebServerEndpoints:
             models_mod, "union_with_portal_paid_recommendations",
             lambda ids, pricing, url: (ids, pricing),
         )
+        # Keep the catalog preferred out of this list so we exercise the
+        # non-frontier fallback rather than the preferred-hit branch.
+        monkeypatch.setattr(
+            models_mod, "get_preferred_silent_default_model",
+            lambda provider="openrouter": "z-ai/glm-5.2",
+        )
 
         resp = self.client.get("/api/model/recommended-default?provider=nous")
         assert resp.status_code == 200
@@ -3740,6 +3750,136 @@ class TestWebServerEndpoints:
         assert data["provider"] == "nous"
         assert data["model"] == "top/model"
         assert data["free_tier"] is False
+
+    @pytest.mark.parametrize(
+        "model_ordering, expected_model",
+        [
+            # Opus-first ordering (historical PR-branch catalog shape).
+            (
+                [
+                    "anthropic/claude-opus-4.8",
+                    "anthropic/claude-sonnet-5",
+                    "anthropic/claude-haiku-4.5",
+                ],
+                "anthropic/claude-sonnet-5",
+            ),
+            # Fable-first ordering (current origin/main catalog shape).
+            (
+                [
+                    "anthropic/claude-fable-5",
+                    "anthropic/claude-opus-4.8",
+                    "anthropic/claude-sonnet-5",
+                    "anthropic/claude-haiku-4.5",
+                ],
+                "anthropic/claude-sonnet-5",
+            ),
+            # Preferred silent default present in the list always wins,
+            # independent of relative ordering / frontiers.
+            (
+                [
+                    "anthropic/claude-fable-5",
+                    "anthropic/claude-opus-4.8",
+                    "z-ai/glm-5.2",
+                    "anthropic/claude-sonnet-5",
+                ],
+                "z-ai/glm-5.2",
+            ),
+        ],
+        ids=["opus_first", "fable_first_main", "override_beats_ordering"],
+    )
+    def test_recommended_default_nous_paid_cost_safe_policy(
+        self, monkeypatch, model_ordering, expected_model,
+    ):
+        """Regression for PR #51493 maintainer feedback (Teknium + DavidMetcalfe).
+
+        The interactive Nous recommended default must use the shared
+        cost-safe silent policy: preferred catalog label when present,
+        else first non-frontier (Opus / Fable) entry. Covers both the
+        current Fable-first catalog and a future Opus-first catalog.
+        """
+        import hermes_cli.models as models_mod
+
+        monkeypatch.setattr(
+            models_mod, "get_curated_nous_model_ids", lambda: list(model_ordering),
+        )
+        monkeypatch.setattr(models_mod, "get_pricing_for_provider", lambda provider: {})
+        monkeypatch.setattr(models_mod, "check_nous_free_tier", lambda *, force_fresh=False: False)
+        monkeypatch.setattr(
+            models_mod, "union_with_portal_paid_recommendations",
+            lambda ids, pricing, url: (ids, pricing),
+        )
+        monkeypatch.setattr(
+            models_mod, "get_preferred_silent_default_model",
+            lambda provider="openrouter": "z-ai/glm-5.2",
+        )
+
+        resp = self.client.get("/api/model/recommended-default?provider=nous")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["provider"] == "nous"
+        assert data["model"] == expected_model
+        assert data["free_tier"] is False
+
+    def test_recommended_default_nous_paid_falls_back_when_all_frontier(self, monkeypatch):
+        """If every curated entry is a frontier tier (Opus / Fable), fall
+        back to the head of the list so the picker is never empty."""
+        import hermes_cli.models as models_mod
+
+        monkeypatch.setattr(
+            models_mod, "get_curated_nous_model_ids",
+            lambda: ["anthropic/claude-fable-5", "anthropic/claude-opus-4.8"],
+        )
+        monkeypatch.setattr(models_mod, "get_pricing_for_provider", lambda provider: {})
+        monkeypatch.setattr(models_mod, "check_nous_free_tier", lambda *, force_fresh=False: False)
+        monkeypatch.setattr(
+            models_mod, "union_with_portal_paid_recommendations",
+            lambda ids, pricing, url: (ids, pricing),
+        )
+        monkeypatch.setattr(
+            models_mod, "get_preferred_silent_default_model",
+            lambda provider="openrouter": "z-ai/glm-5.2",
+        )
+
+        resp = self.client.get("/api/model/recommended-default?provider=nous")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["model"] == "anthropic/claude-fable-5"
+
+    def test_pick_silent_default_model_empty_list_returns_empty_string(self):
+        """Empty model list must return \"\" so the caller degrades gracefully."""
+        from hermes_cli.models import pick_silent_default_model
+
+        assert pick_silent_default_model([], "nous") == ""
+        assert pick_silent_default_model([], "") == ""
+        assert pick_silent_default_model([], "openrouter") == ""
+
+    def test_is_anthropic_frontier_tier(self):
+        """Unit coverage for the frontier-tier predicate used by the cost-safe
+        silent policy. Anchored on the claude- prefix so community/distill
+        slugs whose lowercase form merely contains opus are rejected."""
+        from hermes_cli.models import _is_anthropic_frontier_tier
+
+        # Opus + Fable, dash + dot, vendor-prefixed, colon-suffixed.
+        assert _is_anthropic_frontier_tier("claude-opus-4-8") is True
+        assert _is_anthropic_frontier_tier("claude-opus-4.8") is True
+        assert _is_anthropic_frontier_tier("anthropic/claude-opus-4.8") is True
+        assert _is_anthropic_frontier_tier("claude-fable-5") is True
+        assert _is_anthropic_frontier_tier("anthropic/claude-fable-5") is True
+        assert _is_anthropic_frontier_tier("anthropic/claude-fable-5:thinking") is True
+        assert _is_anthropic_frontier_tier("claude-opus-5-0") is True  # forward-compat
+
+        # Sonnet / Haiku remain non-frontier.
+        assert _is_anthropic_frontier_tier("claude-sonnet-5") is False
+        assert _is_anthropic_frontier_tier("claude-haiku-4.5") is False
+        assert _is_anthropic_frontier_tier("anthropic/claude-sonnet-4.6") is False
+
+        # Community / distill / non-Anthropic must not match.
+        assert _is_anthropic_frontier_tier("qwopus3.6-27b-coder") is False
+        assert _is_anthropic_frontier_tier("jackrong/qwopus3.6-27b-coder") is False
+        assert _is_anthropic_frontier_tier("openai/gpt-5.5") is False
+        assert _is_anthropic_frontier_tier("z-ai/glm-5.2") is False
+        assert _is_anthropic_frontier_tier("") is False
+        assert _is_anthropic_frontier_tier(None) is False
 
     def test_recommended_default_handles_failure_gracefully(self, monkeypatch):
         """Endpoint never 500s — returns empty model on internal error."""


### PR DESCRIPTION
## What does this PR do?

Fixes a billing foot-gun in the desktop app's onboarding flow. When a paid Nous Portal user clicks through one-click onboarding (or lands on the default after `hermes model` for the nous provider), the recommended default is **`anthropic/claude-opus-4.8`** — Opus-tier (~$15/$75 per MTok). The user has no opt-out before that choice pins their main model and inherits into every cron job that doesn't override `model.provider` (which is most of them — see `cron/scheduler.py:1876`).

This PR adds a small `_is_anthropic_opus_tier()` helper and uses it to filter Opus out of the Nous recommended-default pick. Sonnet and Haiku remain valid defaults; Opus is still in the curated list for users who want to opt in explicitly. Free-tier users are unaffected (already filtered by `partition_nous_models_by_tier`). Non-Nous providers are unaffected (separate code path).

## Related Issue

Fixes #51491

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`hermes_cli/models.py`** — new `_is_anthropic_opus_tier()` helper. Matches both Nous dash-slug (`claude-opus-4-8`) and OpenRouter / native Anthropic dot-slug (`claude-opus-4.8`) variants. Intentionally does NOT match Sonnet or Haiku — those remain valid default candidates.
- **`hermes_cli/web_server.py`** — `get_recommended_default_model` Nous branch: pick the first non-Opus entry as the recommended default. Defensive fallback to the head of the list if every curated entry happens to be Opus (so the picker is never empty).
- **`tests/cli/test_fast_command.py`** — `TestIsAnthropicOpusTier` class with 4 unit tests (slug forms, non-Opus Claude families, non-Anthropic models, case insensitivity).
- **`tests/hermes_cli/test_web_server.py`** — 2 integration tests (`test_recommended_default_nous_paid_skips_opus_tier` and `test_recommended_default_nous_paid_falls_back_when_all_opus`).

## How to Test

1. Run the targeted tests:
   ```bash
   ./venv/bin/pytest tests/cli/test_fast_command.py::TestIsAnthropicOpusTier \
                    tests/hermes_cli/test_web_server.py -k "recommended_default" \
                    -o addopts= -v
   ```
   Expected: 14 passed.

2. Manual reproduction (against the live desktop app or web server):
   - Start Hermes on a paid Nous account
   - Hit `GET /api/model/recommended-default?provider=nous`
   - **Before:** `"model": "anthropic/claude-opus-4.8"`
   - **After:** `"model": "anthropic/claude-sonnet-4.6"` (next curated entry)
   - Opus still appears in the model picker for users who want it.

3. Verify cron jobs inherit correctly: existing per-job `model`/`provider` pins are unaffected; the change only affects newly-authenticated Nous users going through one-click onboarding.

## Checklist

### Code

- [x] Read [CONTRIBUTING.md](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] Conventional Commits message (`fix(desktop): …`)
- [x] Searched for existing PRs — no duplicates found
- [x] Single-purpose diff (only the recommended-default filter + its tests)
- [x] `pytest` runs clean for the affected modules (115 pass, 14 in scope for new code)
- [x] Tests added (4 unit + 2 integration)
- [x] Tested on: macOS 26.5.1 (Apple Silicon)

### Documentation & Housekeeping

- [x] No config keys added — N/A for `cli-config.yaml.example`
- [x] No architecture change — N/A for CONTRIBUTING.md / AGENTS.md
- [x] Cross-platform impact: code is OS-agnostic; no Windows/macOS-specific behavior — N/A
- [x] No tool behavior change — N/A