### PR TITLE
fix(gateway): include Yuanbao and plugin platforms in unauthorized-DM allowlist default

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -28,6 +28,35 @@ from gateway.whatsapp_identity import (
 )
 
 
+# Single source of truth for the per-platform "allowed users" env var.
+# Both ``_is_user_authorized`` and ``_get_unauthorized_dm_behavior`` read from
+# this map. Keeping it in one place prevents the recurring drift where a
+# configured allowlist still answered strangers with pairing codes because one
+# method's copy of the map lagged the other (#9337 QQBot regression; the same
+# gap had been left open for Yuanbao). Dynamic plugin platforms (e.g. SimpleX)
+# are resolved separately via ``_registry_auth_env``.
+_PLATFORM_ALLOWED_USERS_ENV = {
+    Platform.TELEGRAM: "TELEGRAM_ALLOWED_USERS",
+    Platform.DISCORD: "DISCORD_ALLOWED_USERS",
+    Platform.WHATSAPP: "WHATSAPP_ALLOWED_USERS",
+    Platform.WHATSAPP_CLOUD: "WHATSAPP_CLOUD_ALLOWED_USERS",
+    Platform.SLACK: "SLACK_ALLOWED_USERS",
+    Platform.SIGNAL: "SIGNAL_ALLOWED_USERS",
+    Platform.EMAIL: "EMAIL_ALLOWED_USERS",
+    Platform.SMS: "SMS_ALLOWED_USERS",
+    Platform.MATTERMOST: "MATTERMOST_ALLOWED_USERS",
+    Platform.MATRIX: "MATRIX_ALLOWED_USERS",
+    Platform.DINGTALK: "DINGTALK_ALLOWED_USERS",
+    Platform.FEISHU: "FEISHU_ALLOWED_USERS",
+    Platform.WECOM: "WECOM_ALLOWED_USERS",
+    Platform.WECOM_CALLBACK: "WECOM_CALLBACK_ALLOWED_USERS",
+    Platform.WEIXIN: "WEIXIN_ALLOWED_USERS",
+    Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOWED_USERS",
+    Platform.QQBOT: "QQ_ALLOWED_USERS",
+    Platform.YUANBAO: "YUANBAO_ALLOWED_USERS",
+}
+
+
 class GatewayAuthorizationMixin:
     """User/chat authorization methods for ``GatewayRunner``."""
 
@@ -173,6 +202,27 @@ class GatewayAuthorizationMixin:
             return any(str(item).strip() for item in sender_allow)
         return False
 
+    def _registry_auth_env(self, platform: Optional[Platform]) -> tuple[str, str]:
+        """Resolve ``(allowed_users_env, allow_all_env)`` for a plugin platform.
+
+        Built-in platforms live in ``_PLATFORM_ALLOWED_USERS_ENV``; dynamic
+        plugin platforms (e.g. SimpleX) declare their auth env var names on
+        their ``PlatformEntry``. Returns ``("", "")`` when the platform is
+        unknown or the registry lookup fails, so callers can treat an empty
+        name as "no allowlist env for this platform".
+        """
+        if platform is None:
+            return "", ""
+        try:
+            from gateway.platform_registry import platform_registry
+
+            entry = platform_registry.get(platform.value)
+            if entry:
+                return entry.allowed_users_env or "", entry.allow_all_env or ""
+        except Exception:
+            pass
+        return "", ""
+
     def _is_user_authorized(self, source: SessionSource) -> bool:
         """
         Check if a user is authorized to use the bot.
@@ -224,26 +274,7 @@ class GatewayAuthorizationMixin:
         if not user_id:
             return False
 
-        platform_env_map = {
-            Platform.TELEGRAM: "TELEGRAM_ALLOWED_USERS",
-            Platform.DISCORD: "DISCORD_ALLOWED_USERS",
-            Platform.WHATSAPP: "WHATSAPP_ALLOWED_USERS",
-            Platform.WHATSAPP_CLOUD: "WHATSAPP_CLOUD_ALLOWED_USERS",
-            Platform.SLACK: "SLACK_ALLOWED_USERS",
-            Platform.SIGNAL: "SIGNAL_ALLOWED_USERS",
-            Platform.EMAIL: "EMAIL_ALLOWED_USERS",
-            Platform.SMS: "SMS_ALLOWED_USERS",
-            Platform.MATTERMOST: "MATTERMOST_ALLOWED_USERS",
-            Platform.MATRIX: "MATRIX_ALLOWED_USERS",
-            Platform.DINGTALK: "DINGTALK_ALLOWED_USERS",
-            Platform.FEISHU: "FEISHU_ALLOWED_USERS",
-            Platform.WECOM: "WECOM_ALLOWED_USERS",
-            Platform.WECOM_CALLBACK: "WECOM_CALLBACK_ALLOWED_USERS",
-            Platform.WEIXIN: "WEIXIN_ALLOWED_USERS",
-            Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOWED_USERS",
-            Platform.QQBOT: "QQ_ALLOWED_USERS",
-            Platform.YUANBAO: "YUANBAO_ALLOWED_USERS",
-        }
+        platform_env_map = dict(_PLATFORM_ALLOWED_USERS_ENV)
         platform_group_user_env_map = {
             Platform.TELEGRAM: "TELEGRAM_GROUP_ALLOWED_USERS",
         }
@@ -279,16 +310,11 @@ class GatewayAuthorizationMixin:
 
         # Plugin platforms: check the registry for auth env var names
         if source.platform not in platform_env_map:
-            try:
-                from gateway.platform_registry import platform_registry
-                entry = platform_registry.get(source.platform.value)
-                if entry:
-                    if entry.allowed_users_env:
-                        platform_env_map[source.platform] = entry.allowed_users_env
-                    if entry.allow_all_env:
-                        platform_allow_all_map[source.platform] = entry.allow_all_env
-            except Exception:
-                pass
+            allowed_users_env, allow_all_env = self._registry_auth_env(source.platform)
+            if allowed_users_env:
+                platform_env_map[source.platform] = allowed_users_env
+            if allow_all_env:
+                platform_allow_all_map[source.platform] = allow_all_env
 
         # Per-platform allow-all flag (e.g., DISCORD_ALLOW_ALL_USERS=true)
         platform_allow_all_var = platform_allow_all_map.get(source.platform, "")
@@ -511,25 +537,13 @@ class GatewayAuthorizationMixin:
         # if any allowlist is configured for this platform, silently drop
         # unauthorized messages instead of sending pairing codes.
         if platform:
-            platform_env_map = {
-                Platform.TELEGRAM: "TELEGRAM_ALLOWED_USERS",
-                Platform.DISCORD:  "DISCORD_ALLOWED_USERS",
-                Platform.WHATSAPP: "WHATSAPP_ALLOWED_USERS",
-                Platform.WHATSAPP_CLOUD: "WHATSAPP_CLOUD_ALLOWED_USERS",
-                Platform.SLACK:    "SLACK_ALLOWED_USERS",
-                Platform.SIGNAL:   "SIGNAL_ALLOWED_USERS",
-                Platform.EMAIL:    "EMAIL_ALLOWED_USERS",
-                Platform.SMS:      "SMS_ALLOWED_USERS",
-                Platform.MATTERMOST: "MATTERMOST_ALLOWED_USERS",
-                Platform.MATRIX:   "MATRIX_ALLOWED_USERS",
-                Platform.DINGTALK: "DINGTALK_ALLOWED_USERS",
-                Platform.FEISHU:   "FEISHU_ALLOWED_USERS",
-                Platform.WECOM:    "WECOM_ALLOWED_USERS",
-                Platform.WECOM_CALLBACK: "WECOM_CALLBACK_ALLOWED_USERS",
-                Platform.WEIXIN:   "WEIXIN_ALLOWED_USERS",
-                Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOWED_USERS",
-                Platform.QQBOT:    "QQ_ALLOWED_USERS",
-            }
+            # Built-in platforms come from the shared map; dynamic plugin
+            # platforms (e.g. SimpleX) declare their allowlist env var on the
+            # registry. Resolving both here mirrors _is_user_authorized so a
+            # configured allowlist never falls through to pairing codes.
+            platform_allowlist_env = _PLATFORM_ALLOWED_USERS_ENV.get(platform, "")
+            if not platform_allowlist_env:
+                platform_allowlist_env, _ = self._registry_auth_env(platform)
             platform_group_env_map = {
                 Platform.TELEGRAM: (
                     "TELEGRAM_GROUP_ALLOWED_USERS",
@@ -537,7 +551,7 @@ class GatewayAuthorizationMixin:
                 ),
                 Platform.QQBOT: ("QQ_GROUP_ALLOWED_USERS",),
             }
-            if os.getenv(platform_env_map.get(platform, ""), "").strip():
+            if os.getenv(platform_allowlist_env, "").strip():
                 return "ignore"
             for env_key in platform_group_env_map.get(platform, ()):
                 if os.getenv(env_key, "").strip():

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -937,3 +937,69 @@ def test_qqbot_with_allowlist_ignores_unauthorized_dm(monkeypatch):
 
     behavior = runner._get_unauthorized_dm_behavior(Platform.QQBOT)
     assert behavior == "ignore"
+
+
+def test_yuanbao_with_allowlist_ignores_unauthorized_dm(monkeypatch):
+    """YUANBAO is included in the allowlist-aware default (YUANBAO_ALLOWED_USERS).
+
+    Regression guard, same drift class as the QQBOT test above: _is_user_authorized
+    maps YUANBAO to YUANBAO_ALLOWED_USERS, but _get_unauthorized_dm_behavior's
+    copy of the map omitted it — so a Yuanbao operator with a strict user
+    allowlist would still get pairing codes sent to strangers.
+    """
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("YUANBAO_ALLOWED_USERS", "allowed-yuanbao-1")
+
+    config = GatewayConfig(
+        platforms={Platform.YUANBAO: PlatformConfig(enabled=True)},
+    )
+    runner, _adapter = _make_runner(Platform.YUANBAO, config)
+
+    behavior = runner._get_unauthorized_dm_behavior(Platform.YUANBAO)
+    assert behavior == "ignore"
+
+
+def test_yuanbao_without_allowlist_returns_pair(monkeypatch):
+    """Sanity: with no allowlist configured, Yuanbao still defaults to 'pair'."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.delenv("YUANBAO_ALLOWED_USERS", raising=False)
+
+    config = GatewayConfig(
+        platforms={Platform.YUANBAO: PlatformConfig(enabled=True)},
+    )
+    runner, _adapter = _make_runner(Platform.YUANBAO, config)
+
+    assert runner._get_unauthorized_dm_behavior(Platform.YUANBAO) == "pair"
+
+
+def test_plugin_platform_with_allowlist_ignores_unauthorized_dm(monkeypatch):
+    """Dynamic plugin platforms must drive the allowlist-aware default too.
+
+    A plugin declares its allowlist env var on its PlatformEntry
+    (``allowed_users_env``). _is_user_authorized resolves that from the
+    registry; _get_unauthorized_dm_behavior must do the same so a configured
+    plugin allowlist silently drops strangers instead of answering them with
+    pairing codes (the SimpleX-style dynamic-platform analog of the QQBot/
+    Yuanbao drift).
+    """
+    _clear_auth_env(monkeypatch)
+    monkeypatch.delenv("FAKE_PLUGIN_ALLOWED_USERS", raising=False)
+    monkeypatch.setenv("FAKE_PLUGIN_ALLOWED_USERS", "allowed-1")
+
+    from gateway.platform_registry import platform_registry, PlatformEntry
+    platform_registry.register(PlatformEntry(
+        name="fakeplugin",
+        label="Fake Plugin",
+        adapter_factory=lambda cfg: None,
+        check_fn=lambda: True,
+        allowed_users_env="FAKE_PLUGIN_ALLOWED_USERS",
+        allow_all_env="FAKE_PLUGIN_ALLOW_ALL_USERS",
+    ))
+    try:
+        fake = Platform("fakeplugin")
+        config = GatewayConfig(platforms={fake: PlatformConfig(enabled=True)})
+        runner, _adapter = _make_runner(fake, config)
+
+        assert runner._get_unauthorized_dm_behavior(fake) == "ignore"
+    finally:
+        platform_registry.unregister("fakeplugin")


### PR DESCRIPTION
## What does this PR do?

`_get_unauthorized_dm_behavior()` decides whether an unauthorized DM is answered with a pairing code (`"pair"`) or silently dropped (`"ignore"`). When an allowlist is configured, the documented and intended behavior is `"ignore"` — the operator has deliberately restricted access, so spamming unknown contacts with pairing codes is both noise and an info-leak.

The problem: `_get_unauthorized_dm_behavior()` kept its **own copy** of the platform → `*_ALLOWED_USERS` env map, and that copy had drifted behind the one in `_is_user_authorized()`:

- `_is_user_authorized()` maps `Platform.YUANBAO → YUANBAO_ALLOWED_USERS` and, for dynamic plugin platforms (e.g. SimpleX), resolves `allowed_users_env` from the platform registry.
- `_get_unauthorized_dm_behavior()`'s copy stopped at `Platform.QQBOT` — no Yuanbao, and no registry lookup for plugin platforms.

Result: a Yuanbao operator (or a plugin-platform operator) who set a strict user allowlist still had pairing codes sent to unauthorized DMs instead of the silent `"ignore"` they configured.

This is the **same drift class** that was already fixed and regression-tested for QQBot in #9337 — see the existing `test_qqbot_with_allowlist_ignores_unauthorized_dm`, whose docstring documents the identical gap ("the initial #9337 fix omitted QQBOT from the env map inside `_get_unauthorized_dm_behavior`").

### Fix (root cause, not a one-off patch)

- Extract the platform → `*_ALLOWED_USERS` map into a single module-level source of truth, `_PLATFORM_ALLOWED_USERS_ENV`, used by **both** methods. The two copies can no longer drift apart.
- Add a shared `_registry_auth_env()` helper that resolves a dynamic plugin platform's `allowed_users_env` / `allow_all_env` from the registry. Both methods now use it, so plugin platforms get the same allowlist-aware treatment.
- `_is_user_authorized()` is refactored to consume both (behavior-neutral — its map already contained Yuanbao and it already did the registry lookup inline).

## Related Issue

No separate open issue. This is the Yuanbao + dynamic-plugin analog of the QQBot drift fixed in #9337; the regression test added there describes exactly this bug class.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/authz_mixin.py`
  - Add module-level `_PLATFORM_ALLOWED_USERS_ENV` — single source of truth for the per-platform allowed-users env var (includes `Platform.YUANBAO`).
  - Add `_registry_auth_env()` helper that resolves `(allowed_users_env, allow_all_env)` for dynamic plugin platforms from the registry.
  - `_is_user_authorized()` now builds its map from the shared constant and uses the helper for the registry lookup (behavior-neutral).
  - `_get_unauthorized_dm_behavior()` now reads the shared constant **and** falls back to the registry for plugin platforms — fixing Yuanbao and dynamic plugins.
- `tests/gateway/test_unauthorized_dm_behavior.py`
  - `test_yuanbao_with_allowlist_ignores_unauthorized_dm` — `YUANBAO_ALLOWED_USERS` set ⇒ `"ignore"`.
  - `test_yuanbao_without_allowlist_returns_pair` — sanity: no allowlist ⇒ `"pair"`.
  - `test_plugin_platform_with_allowlist_ignores_unauthorized_dm` — registry-driven plugin with `allowed_users_env` set ⇒ `"ignore"`.

## How to Test

Run the affected gateway authorization suites:

​```
pytest tests/gateway/test_unauthorized_dm_behavior.py tests/gateway/test_config_driven_access_policy.py -q
​```

Result:

​```
84 passed in 1.13s
​```

Additional regression run of the surrounding auth/gating suites (each file run independently):

| Test file | Result |
| --- | --- |
| tests/gateway/test_unauthorized_dm_behavior.py | 39 passed (incl. 3 new) |
| tests/gateway/test_config_driven_access_policy.py | 45 passed |
| tests/gateway/test_telegram_group_gating.py | 45 passed |
| tests/gateway/test_feishu_bot_auth_bypass.py | 6 passed |
| tests/gateway/test_discord_bot_auth_bypass.py | 9 passed |
| tests/gateway/test_busy_session_auth_bypass.py | 4 passed |
| tests/gateway/test_internal_event_bypass_pairing.py | 9 passed |
| tests/gateway/test_signal.py | 135 passed, 1 skipped |
| tests/gateway/test_slash_access_dispatch.py | 18 passed |

`ruff check gateway/authz_mixin.py tests/gateway/test_unauthorized_dm_behavior.py` — all checks passed.

Manual reproduction (before this PR): set `YUANBAO_ALLOWED_USERS=<id>`, send a DM from a non-allowlisted user → the gateway replies with a pairing code. After this PR → the message is silently ignored, matching every other allowlisted platform.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [ ] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected test suites and they pass (commands and results above)
- [x] I've added tests for my changes
- [x] I've tested in a local dev environment

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] cli-config.yaml.example — N/A
- [x] CONTRIBUTING.md / AGENTS.md — N/A
- [x] Cross-platform impact — N/A (pure dict/registry logic, no OS-specific code)
- [x] Tool descriptions/schemas — N/A