### PR TITLE
fix: align Fireworks model picker with setup flow

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2413,6 +2413,8 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
                     # the top of the picker; live-only entries are appended
                     # afterwards for discovery.  (#46850)
                     curated = list(_PROVIDER_MODELS.get(normalized, []))
+                    if normalized in _MODELS_DEV_PREFERRED and not curated:
+                        curated = _merge_with_models_dev(normalized, curated)
                     if curated:
                         merged = list(curated)
                         merged_lower = {m.lower() for m in curated}

--- a/tests/hermes_cli/test_provider_live_curated_merge.py
+++ b/tests/hermes_cli/test_provider_live_curated_merge.py
@@ -79,19 +79,47 @@ class TestGenericProviderLiveCuratedMerge:
         # Curated-first: curated casing wins for models present in both.
         assert result == ["glm-5.1", "GLM-5", "glm-4.5"]
 
-    def test_empty_curated_returns_live_only(self):
-        """When no curated list exists, live is returned as-is."""
+    def test_empty_curated_returns_live_only_for_non_models_dev_preferred_provider(self):
+        """When no curated or models.dev-preferred list exists, live is returned as-is."""
         live = ["model-a", "model-b"]
         profile = self._make_profile(live)
 
         with (
             patch("providers.get_provider_profile", return_value=profile),
             patch("hermes_cli.auth.resolve_api_key_provider_credentials", return_value={"api_key": "k", "base_url": ""}),
-            patch.dict("hermes_cli.models._PROVIDER_MODELS", {"zai": []}),
+            patch.dict("hermes_cli.models._PROVIDER_MODELS", {"test-provider": []}),
         ):
-            result = provider_model_ids("zai")
+            result = provider_model_ids("test-provider")
 
         assert result == ["model-a", "model-b"]
+
+    def test_models_dev_preferred_provider_merges_models_dev_before_live(self):
+        """Fireworks should keep setup-flow models.dev entries ahead of live-only API models."""
+        live = [
+            "accounts/fireworks/models/cogito-v1-preview-llama-3b",
+            "accounts/fireworks/models/deepseek-v4-flash",
+        ]
+        models_dev = [
+            "accounts/fireworks/routers/kimi-k2p6-turbo",
+            "accounts/fireworks/models/deepseek-v4-flash",
+            "accounts/fireworks/models/qwen3p7-plus",
+        ]
+        profile = self._make_profile(live)
+
+        with (
+            patch("providers.get_provider_profile", return_value=profile),
+            patch("hermes_cli.auth.resolve_api_key_provider_credentials", return_value={"api_key": "k", "base_url": ""}),
+            patch.dict("hermes_cli.models._PROVIDER_MODELS", {"fireworks": []}),
+            patch("agent.models_dev.list_agentic_models", return_value=models_dev),
+        ):
+            result = provider_model_ids("fireworks")
+
+        assert result == [
+            "accounts/fireworks/routers/kimi-k2p6-turbo",
+            "accounts/fireworks/models/deepseek-v4-flash",
+            "accounts/fireworks/models/qwen3p7-plus",
+            "accounts/fireworks/models/cogito-v1-preview-llama-3b",
+        ]
 
     def test_live_empty_falls_back_to_curated(self):
         """When live returns nothing, curated static list is used.


### PR DESCRIPTION
## Summary

Fixes a Fireworks model-picker discrepancy between the standalone setup flow and the in-session `/model` picker.

The setup flow (`hermes setup model` / `hermes model`) shows Fireworks models from the curated models.dev agentic list, with routers like:

```text
accounts/fireworks/routers/kimi-k2p6-turbo
accounts/fireworks/routers/kimi-k2p7-code-fast
accounts/fireworks/routers/glm-5p1-fast
```

But the in-session `/model` picker was going through the generic live provider catalog path first. For Fireworks, that live list could start with older/live-only model IDs such as:

```text
accounts/fireworks/models/cogito-v1-preview-llama-3b
```

So the two model-selection surfaces appeared to offer different Fireworks model lists.

## Change

For generic API-key providers that have no static curated list but are marked as models.dev-preferred, use the models.dev agentic list as the curated base before appending live-only API models.

This keeps Fireworks in the same top/order as the setup flow while still preserving live-only discovery after the curated agentic models.

The change is intentionally narrow:

- Existing providers with non-empty static curated lists keep their previous curated-first behavior.
- Non-models.dev-preferred providers with no curated list still return live models as-is.
- Fireworks now gets models.dev entries first, matching setup-model order.

## Test plan

Confirmed the new regression test fails before the fix.

Then ran:

```bash
./venv/bin/python -m pytest tests/hermes_cli/test_provider_live_curated_merge.py -q
```

Result:

```text
10 passed
```

Ran the model-options parity guard too:

```bash
./venv/bin/python -m pytest \
  tests/hermes_cli/test_provider_live_curated_merge.py \
  tests/test_tui_gateway_server.py::test_model_options_does_not_overwrite_curated_models \
  -q
```

Result:

```text
11 passed
```

Compiled touched Python files:

```bash
./venv/bin/python -m py_compile hermes_cli/models.py tests/hermes_cli/test_provider_live_curated_merge.py
```

Ran a live local comparison against the current Fireworks catalog path:

```text
setup_count 15
provider_count 28
payload_count 28
first15_match True
```

The `/model` payload now starts with the same first 15 Fireworks entries shown by the setup flow, including the Fireworks routers from the screenshot.
