### PR TITLE
fix(gateway): honor "open access" choice in interactive platform setup

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1690,6 +1690,39 @@ def _prompt_telegram_bot_token() -> str | None:
         return token
 
 
+def _configure_open_access_or_pairing(allow_all_env: str) -> None:
+    """Resolve unauthorized-user handling when the operator left the allowlist empty.
+
+    An empty allowlist is NOT open access on its own. The gateway default-denies
+    unknown senders — an allowlist is required for every network-exposed adapter
+    (SECURITY.md §2.6) — and runtime auth only treats a sender as authorized when
+    an explicit allow-all flag is set (gateway/authz_mixin.py). Without this
+    opt-in the bot silently stays in deny / DM-pairing mode, contradicting the
+    "leave empty for open access" prompt these wizards used to show.
+
+    Mirror the modern hermes_cli.gateway._configure_platform() flow: offer an
+    explicit choice and enable open access only when the operator picks it —
+    never as a silent fail-open default.
+    """
+    access_idx = prompt_choice(
+        "How should unauthorized users be handled?",
+        [
+            "Enable open access (anyone can message the bot)",
+            "Use DM pairing (unknown users request access, you approve with 'hermes pairing approve')",
+            "Skip for now (bot will deny all users until configured)",
+        ],
+        default=1,
+    )
+    if access_idx == 0:
+        save_env_value(allow_all_env, "true")
+        print_warning("Open access enabled — anyone can use your bot!")
+    elif access_idx == 1:
+        print_success("DM pairing mode — users will receive a code to request access.")
+        print_info("   Approve with: hermes pairing approve <platform> <code>")
+    else:
+        print_info("   Skipped — configure later with 'hermes gateway setup'")
+
+
 def _setup_telegram():
     """Configure Telegram bot credentials and allowlist."""
     print_header("Telegram")
@@ -1765,11 +1798,11 @@ def _setup_telegram():
             allowed_users = ",".join(ids)
         else:
             allowed_users = prompt(
-                "Allowed user IDs (comma-separated, leave empty for open access)"
+                "Allowed user IDs (comma-separated, leave empty to choose access mode)"
             )
     else:
         allowed_users = prompt(
-            "Allowed user IDs (comma-separated, leave empty for open access)"
+            "Allowed user IDs (comma-separated, leave empty to choose access mode)"
         )
 
     if allowed_users:
@@ -1777,7 +1810,7 @@ def _setup_telegram():
         save_env_value("TELEGRAM_ALLOWED_USERS", allowed_users)
         print_success("Telegram allowlist configured - only listed users can use the bot")
     else:
-        print_info("⚠️  No allowlist set - anyone who finds your bot can use it!")
+        _configure_open_access_or_pairing("TELEGRAM_ALLOW_ALL_USERS")
 
     print()
     print_info("📬 Home Channel: where Hermes delivers cron job results,")
@@ -1843,12 +1876,12 @@ def _setup_bluebubbles():
     print_info("🔒 Security: Restrict who can message your bot")
     print_info("   Use iMessage addresses: email (user@icloud.com) or phone (+15551234567)")
     print()
-    allowed_users = prompt("Allowed iMessage addresses (comma-separated, leave empty for open access)")
+    allowed_users = prompt("Allowed iMessage addresses (comma-separated, leave empty to choose access mode)")
     if allowed_users:
         save_env_value("BLUEBUBBLES_ALLOWED_USERS", allowed_users.replace(" ", ""))
         print_success("BlueBubbles allowlist configured")
     else:
-        print_info("⚠️  No allowlist set — anyone who can iMessage you can use the bot!")
+        _configure_open_access_or_pairing("BLUEBUBBLES_ALLOW_ALL_USERS")
 
     print()
     print_info("📬 Home Channel: phone or email for cron job delivery and notifications.")

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -6967,14 +6967,15 @@ def interactive_setup() -> None:
     print_info("   You can also use Discord usernames (resolved on gateway start).")
     print()
     allowed_users = prompt(
-        "Allowed user IDs or usernames (comma-separated, leave empty for open access)"
+        "Allowed user IDs or usernames (comma-separated, leave empty to choose access mode)"
     )
     if allowed_users:
         cleaned_ids = _clean_discord_user_ids(allowed_users)
         save_env_value("DISCORD_ALLOWED_USERS", ",".join(cleaned_ids))
         print_success("Discord allowlist configured")
     else:
-        print_info("⚠️  No allowlist set - anyone in servers with your bot can use it!")
+        from hermes_cli.setup import _configure_open_access_or_pairing
+        _configure_open_access_or_pairing("DISCORD_ALLOW_ALL_USERS")
 
     print()
     print_info("📬 Home Channel: where Hermes delivers cron job results,")

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -4271,12 +4271,13 @@ def interactive_setup() -> None:
 
         print_info("🔒 Security: Restrict who can use your bot")
         print_info("   Matrix user IDs look like @username:server")
-        allowed_users = prompt("Allowed user IDs (comma-separated, leave empty for open access)")
+        allowed_users = prompt("Allowed user IDs (comma-separated, leave empty to choose access mode)")
         if allowed_users:
             save_env_value("MATRIX_ALLOWED_USERS", allowed_users.replace(" ", ""))
             print_success("Matrix allowlist configured")
         else:
-            print_info("⚠️  No allowlist set - anyone who can message the bot can use it!")
+            from hermes_cli.setup import _configure_open_access_or_pairing
+            _configure_open_access_or_pairing("MATRIX_ALLOW_ALL_USERS")
 
         print_info("📬 Home Room: where Hermes delivers cron job results and notifications.")
         print_info("   Room IDs look like !abc123:server (shown in Element room settings)")

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -1141,12 +1141,13 @@ def interactive_setup() -> None:
     print_info("   To find your user ID: click your avatar → Profile")
     print_info("   or use the API: GET /api/v4/users/me")
     print()
-    allowed_users = prompt("Allowed user IDs (comma-separated, leave empty for open access)")
+    allowed_users = prompt("Allowed user IDs (comma-separated, leave empty to choose access mode)")
     if allowed_users:
         save_env_value("MATTERMOST_ALLOWED_USERS", allowed_users.replace(" ", ""))
         print_success("Mattermost allowlist configured")
     else:
-        print_info("⚠️  No allowlist set - anyone who can message the bot can use it!")
+        from hermes_cli.setup import _configure_open_access_or_pairing
+        _configure_open_access_or_pairing("MATTERMOST_ALLOW_ALL_USERS")
 
     print()
     print_info("📬 Home Channel: where Hermes delivers cron job results and notifications.")

--- a/tests/hermes_cli/test_setup_open_access.py
+++ b/tests/hermes_cli/test_setup_open_access.py
@@ -1,0 +1,208 @@
+"""Regression tests for the "leave empty = open access" gateway setup bug.
+
+The interactive platform setup wizards told operators that leaving the user
+allowlist empty meant "open access". The empty branch, however, only printed a
+warning and never wrote an allow-all flag. Runtime auth
+(``gateway/authz_mixin.py``) requires an explicit allow-all to treat unknown
+senders as authorized, so the bot silently stayed in default-deny / DM-pairing
+mode — the opposite of what setup advertised.
+
+The fix routes every empty-allowlist branch through
+``hermes_cli.setup._configure_open_access_or_pairing``, which offers an explicit
+choice and only enables open access when the operator picks it (never a silent
+fail-open, per SECURITY.md §2.6). These tests pin that behavior for the shared
+helper and for every affected wizard.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli.config import get_env_value
+
+
+# Every env var these wizards read ("already configured" sentinels) or write.
+# ``save_env_value`` also mutates ``os.environ`` directly (config.py), which
+# pytest's monkeypatch can't auto-revert, so clear them per-test to stop one
+# wizard run from leaking into the next.
+_PLATFORM_VARS = [
+    "TELEGRAM_ALLOW_ALL_USERS", "DISCORD_ALLOW_ALL_USERS", "MATRIX_ALLOW_ALL_USERS",
+    "MATTERMOST_ALLOW_ALL_USERS", "BLUEBUBBLES_ALLOW_ALL_USERS", "GATEWAY_ALLOW_ALL_USERS",
+    "TELEGRAM_ALLOWED_USERS", "DISCORD_ALLOWED_USERS", "MATRIX_ALLOWED_USERS",
+    "MATTERMOST_ALLOWED_USERS", "BLUEBUBBLES_ALLOWED_USERS",
+    "TELEGRAM_BOT_TOKEN", "TELEGRAM_HOME_CHANNEL",
+    "DISCORD_BOT_TOKEN", "DISCORD_HOME_CHANNEL",
+    "MATTERMOST_TOKEN", "MATTERMOST_URL", "MATTERMOST_HOME_CHANNEL",
+    "MATRIX_ACCESS_TOKEN", "MATRIX_PASSWORD", "MATRIX_HOMESERVER", "MATRIX_USER_ID",
+    "MATRIX_ENCRYPTION", "MATRIX_HOME_ROOM",
+    "BLUEBUBBLES_SERVER_URL", "BLUEBUBBLES_PASSWORD", "BLUEBUBBLES_HOME_CHANNEL",
+    "BLUEBUBBLES_WEBHOOK_PORT",
+]
+
+
+@pytest.fixture(autouse=True)
+def _isolated_platform_env(monkeypatch):
+    """Start each test from a clean slate and never block on stdin.
+
+    Clears the platform env vars (defeating the ``os.environ`` write-through in
+    ``save_env_value``) and stubs every ``prompt_yes_no`` to a non-interactive
+    ``False`` so optional/advanced wizard branches don't read from stdin.
+    """
+    import hermes_cli.setup as setup_mod
+    import hermes_cli.cli_output as cli_output
+
+    for var in _PLATFORM_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(setup_mod, "prompt_yes_no", lambda *a, **k: False)
+    monkeypatch.setattr(cli_output, "prompt_yes_no", lambda *a, **k: False)
+
+
+# ---------------------------------------------------------------------------
+# Shared helper — the heart of the fix.
+# ---------------------------------------------------------------------------
+
+ALLOW_ALL_VARS = [
+    "TELEGRAM_ALLOW_ALL_USERS",
+    "DISCORD_ALLOW_ALL_USERS",
+    "MATRIX_ALLOW_ALL_USERS",
+    "MATTERMOST_ALLOW_ALL_USERS",
+    "BLUEBUBBLES_ALLOW_ALL_USERS",
+]
+
+
+@pytest.mark.parametrize("allow_all_env", ALLOW_ALL_VARS)
+def test_helper_open_access_writes_allow_all(monkeypatch, allow_all_env):
+    """Picking "open access" (index 0) writes the platform allow-all flag."""
+    from hermes_cli import setup as setup_mod
+
+    monkeypatch.setattr(setup_mod, "prompt_choice", lambda *a, **k: 0)
+    setup_mod._configure_open_access_or_pairing(allow_all_env)
+
+    assert get_env_value(allow_all_env) == "true"
+
+
+@pytest.mark.parametrize("choice_idx", [1, 2])
+def test_helper_pairing_or_skip_never_fails_open(monkeypatch, choice_idx):
+    """Pairing (the default) and Skip must NOT write an allow-all flag.
+
+    This is the security-critical half: an operator who accepts the default or
+    skips must never silently get an open bot (SECURITY.md §2.6).
+    """
+    from hermes_cli import setup as setup_mod
+
+    monkeypatch.setattr(setup_mod, "prompt_choice", lambda *a, **k: choice_idx)
+    setup_mod._configure_open_access_or_pairing("TELEGRAM_ALLOW_ALL_USERS")
+
+    assert not get_env_value("TELEGRAM_ALLOW_ALL_USERS")
+
+
+# ---------------------------------------------------------------------------
+# End-to-end wizard wiring — the empty-allowlist branch reaches the helper.
+# ---------------------------------------------------------------------------
+
+
+def _make_prompt():
+    """A stand-in for the interactive ``prompt`` that drives each wizard to the
+    empty-allowlist branch: supplies required URLs/tokens, leaves the allowlist
+    (and every optional field) empty."""
+
+    def _prompt(question, default=None, password=False):
+        q = str(question).lower()
+        if "choice" in q:           # Telegram "Choice [1/2]" — pick automatic.
+            return "1"
+        if "url" in q:              # homeserver / server URL fields.
+            return "https://example.test"
+        if "token" in q or "password" in q:
+            return "secret-token"
+        return ""                   # allowlist + home channel + advanced → empty.
+
+    return _prompt
+
+
+def _run_telegram(monkeypatch):
+    from hermes_cli import setup as setup_mod
+
+    monkeypatch.setattr(setup_mod, "prompt", _make_prompt())
+    monkeypatch.setattr(
+        setup_mod,
+        "_setup_telegram_auto_result",
+        lambda: SimpleNamespace(token="123456789:token", owner_user_id=None),
+    )
+    monkeypatch.setattr(setup_mod, "_is_valid_telegram_bot_token", lambda *a, **k: True)
+    setup_mod._setup_telegram()
+
+
+def _run_bluebubbles(monkeypatch):
+    from hermes_cli import setup as setup_mod
+
+    monkeypatch.setattr(setup_mod, "prompt", _make_prompt())
+    setup_mod._setup_bluebubbles()
+
+
+def _run_discord(monkeypatch):
+    import hermes_cli.cli_output as cli_output
+    from plugins.platforms.discord import adapter
+
+    monkeypatch.setattr(cli_output, "prompt", _make_prompt())
+    adapter.interactive_setup()
+
+
+def _run_mattermost(monkeypatch):
+    import hermes_cli.cli_output as cli_output
+    from plugins.platforms.mattermost import adapter
+
+    monkeypatch.setattr(cli_output, "prompt", _make_prompt())
+    adapter.interactive_setup()
+
+
+def _run_matrix(monkeypatch):
+    import hermes_cli.cli_output as cli_output
+    import tools.lazy_deps as lazy_deps
+    from plugins.platforms.matrix import adapter
+
+    monkeypatch.setattr(cli_output, "prompt", _make_prompt())
+    # Don't attempt the mautrix install when the access-token branch runs.
+    monkeypatch.setattr(lazy_deps, "feature_missing", lambda *a, **k: ())
+    adapter.interactive_setup()
+
+
+WIZARDS = [
+    ("telegram", "TELEGRAM_ALLOW_ALL_USERS", _run_telegram),
+    ("discord", "DISCORD_ALLOW_ALL_USERS", _run_discord),
+    ("matrix", "MATRIX_ALLOW_ALL_USERS", _run_matrix),
+    ("mattermost", "MATTERMOST_ALLOW_ALL_USERS", _run_mattermost),
+    ("bluebubbles", "BLUEBUBBLES_ALLOW_ALL_USERS", _run_bluebubbles),
+]
+
+
+@pytest.mark.parametrize(
+    "name, allow_all_env, runner", WIZARDS, ids=[w[0] for w in WIZARDS]
+)
+def test_wizard_open_access_enables_allow_all(monkeypatch, name, allow_all_env, runner):
+    """Empty allowlist + explicit "open access" → allow-all flag is written."""
+    from hermes_cli import setup as setup_mod
+
+    monkeypatch.setattr(setup_mod, "prompt_choice", lambda *a, **k: 0)
+    runner(monkeypatch)
+
+    assert get_env_value(allow_all_env) == "true", name
+
+
+@pytest.mark.parametrize(
+    "name, allow_all_env, runner", WIZARDS, ids=[w[0] for w in WIZARDS]
+)
+def test_wizard_pairing_default_does_not_fail_open(monkeypatch, name, allow_all_env, runner):
+    """Empty allowlist + the default (DM pairing) → no allow-all flag.
+
+    Reproduces the original bug's safe side: leaving the allowlist empty must
+    not silently open the bot. Before the fix the wizard wrote nothing here too,
+    but it also wrote nothing for the *open access* case — so "open access" was
+    a broken promise. The companion test above covers that half.
+    """
+    from hermes_cli import setup as setup_mod
+
+    monkeypatch.setattr(setup_mod, "prompt_choice", lambda *a, **k: 1)
+    runner(monkeypatch)
+
+    assert not get_env_value(allow_all_env), name


### PR DESCRIPTION
## What does this PR do?

The interactive gateway setup wizards told operators that **leaving the user allowlist empty meant "open access"**, but the empty branch only printed a warning and never wrote an allow-all flag. Runtime authorization (`gateway/authz_mixin.py`) only treats unknown senders as authorized when an explicit allow-all flag is set, so the bot silently stayed in **default-deny / DM-pairing** mode — the opposite of what setup promised. Operators following the "open access" instruction ended up with Discord guild messages silently dropped and Telegram DMs answered with pairing codes.

The modern `hermes_cli/gateway.py::_configure_platform()` already solved this correctly by offering an **explicit choice** instead of treating empty input as open access. This PR brings the legacy per-platform wizards in line with that flow.

The fix is deliberately **not** a silent fail-open: an empty allowlist still defaults to DM pairing. Open access is written only when the operator explicitly selects it — consistent with `SECURITY.md` §2.6 ("code paths that fail open when no allowlist is configured are code bugs").

## Related Issue

No existing issue — surfaced while auditing setup-vs-runtime authorization consistency. Searched open/merged PRs; no duplicate found.

Fixes #N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/setup.py` — add shared `_configure_open_access_or_pairing(allow_all_env)` helper that mirrors `gateway._configure_platform()`: explicit choice (open access / DM pairing / skip), **defaults to pairing**, writes the per-platform `*_ALLOW_ALL_USERS` flag **only** on explicit open-access selection. Wire it into the Telegram and BlueBubbles wizards; fix the misleading "leave empty for open access" prompt text.
- `plugins/platforms/discord/adapter.py` — route the empty-allowlist branch through the shared helper (`DISCORD_ALLOW_ALL_USERS`).
- `plugins/platforms/matrix/adapter.py` — same for `MATRIX_ALLOW_ALL_USERS`.
- `plugins/platforms/mattermost/adapter.py` — same for `MATTERMOST_ALLOW_ALL_USERS`.
- `tests/hermes_cli/test_setup_open_access.py` — new regression tests (helper branches + all five wizards).

## How to Test

1. Run `hermes gateway setup` and select Telegram (or Discord/Matrix/Mattermost/BlueBubbles).
2. At the "Allowed user IDs … leave empty to choose access mode" prompt, leave it empty.
3. You are now asked explicitly how to handle unauthorized users:
   - **Before this PR:** nothing was written; `~/.hermes/.env` had no `*_ALLOW_ALL_USERS`, and the bot denied unknown senders / replied with pairing codes despite the "open access" promise.
   - **After this PR:** choosing **"Enable open access"** writes `TELEGRAM_ALLOW_ALL_USERS=true` (etc.); choosing **DM pairing** (the default) or **Skip** writes nothing and keeps the secure default-deny behavior.

### Test Results

```
pytest tests/hermes_cli/test_setup_open_access.py -q
=> 17 passed      # helper open/pairing/skip + all 5 wizards (open-access + pairing-default)

pytest tests/gateway/test_unauthorized_dm_behavior.py -q
=> 36 passed      # runtime authorization unchanged

pytest tests/hermes_cli/test_setup_open_access.py \
       tests/hermes_cli/test_setup_reconfigure.py \
       tests/hermes_cli/test_setup_noninteractive.py \
       tests/hermes_cli/test_setup_prompt_menus.py -q
=> 74 passed      # surrounding setup-wizard suites
```

New tests assert that an empty allowlist + explicit "open access" writes the platform allow-all flag, and that the default (DM pairing) and Skip never do — pinning the no-fail-open guarantee.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gateway): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the change-relevant test suites and they pass (see Test Results)
- [x] I've added tests for my changes
- [x] Validated via the automated tests above

### Documentation & Housekeeping

- [x] N/A — prompt text lives in-code; no docs reference it
- [x] N/A — no new/changed config keys (the `*_ALLOW_ALL_USERS` env vars already exist)
- [x] N/A — no architecture/workflow change
- [x] N/A — pure-Python flow, no OS-specific paths
- [x] N/A — no tool description/schema changes

## Screenshots / Logs

```
tests/hermes_cli/test_setup_open_access.py::test_helper_open_access_writes_allow_all[TELEGRAM_ALLOW_ALL_USERS] PASSED
tests/hermes_cli/test_setup_open_access.py::test_helper_pairing_or_skip_never_fails_open[1] PASSED
tests/hermes_cli/test_setup_open_access.py::test_wizard_open_access_enables_allow_all[discord] PASSED
tests/hermes_cli/test_setup_open_access.py::test_wizard_pairing_default_does_not_fail_open[matrix] PASSED
...
53 passed
```