### PR TITLE
fix(skills): make size-limit recovery actionable

### DIFF
--- a/tests/tools/test_skill_size_limits.py
+++ b/tests/tools/test_skill_size_limits.py
@@ -48,7 +48,23 @@ class TestValidateContentSize:
 
     def test_custom_label(self):
         err = _validate_content_size("a" * (MAX_SKILL_CONTENT_CHARS + 1), label="references/api.md")
-        assert "references/api.md" in err
+        assert err is not None
+        assert "Reduce it by at least 1 character in one edit." in err
+        assert "split references/api.md into smaller supporting files" in err
+        assert "update the skill to reference them" in err
+
+    def test_small_overage_message_allows_one_shot_reduction(self):
+        err = _validate_content_size("a" * (MAX_SKILL_CONTENT_CHARS + 1))
+        assert err is not None
+        assert "Reduce it by at least 1 character in one edit." in err
+        assert "Do not repeatedly trim small amounts and retry." in err
+
+    def test_structural_overage_message_directs_content_to_supporting_files(self):
+        err = _validate_content_size("a" * (MAX_SKILL_CONTENT_CHARS + 250))
+        assert err is not None
+        assert "Reduce it by at least 250 characters in one edit." in err
+        assert "move whole sections" in err
+        assert "references/ or templates/" in err
 
 
 class TestCreateSkillSizeLimit:
@@ -59,6 +75,14 @@ class TestCreateSkillSizeLimit:
         result = json.loads(skill_manage(action="create", name="small-skill", content=content))
         assert result["success"] is True
 
+    def test_create_over_limit(self, isolate_skills):
+        content = _make_skill_content(MAX_SKILL_CONTENT_CHARS + 100)
+        result = json.loads(skill_manage(action="create", name="huge-skill", content=content))
+        assert result["success"] is False
+        assert "100,000" in result["error"]
+        over = len(content) - MAX_SKILL_CONTENT_CHARS
+        assert f"Reduce it by at least {over:,} characters in one edit." in result["error"]
+        assert "move whole sections" in result["error"]
 
     def test_create_at_limit(self, isolate_skills):
         # Content at exactly the limit should succeed
@@ -126,7 +150,8 @@ class TestPatchSkillSizeLimit:
             file_path="references/data.md",
         ))
         assert result["success"] is False
-        assert "references/data.md" in result["error"]
+        assert "split references/data.md into smaller supporting files" in result["error"]
+        assert "Do not repeatedly trim small amounts and retry." in result["error"]
 
 
 class TestWriteFileSizeLimit:
@@ -144,6 +169,8 @@ class TestWriteFileSizeLimit:
         ))
         assert result["success"] is False
         assert "100,000" in result["error"]
+        assert "split references/huge.md into smaller supporting files" in result["error"]
+        assert "Do not repeatedly trim small amounts and retry." in result["error"]
 
     def test_write_file_within_limit(self, isolate_skills):
         small = _make_skill_content(1000)

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -626,11 +626,23 @@ def _validate_content_size(content: str, label: str = "SKILL.md") -> Optional[st
     Returns an error message or None if within bounds.
     """
     if len(content) > MAX_SKILL_CONTENT_CHARS:
+        over = len(content) - MAX_SKILL_CONTENT_CHARS
+        unit = "character" if over == 1 else "characters"
+        if label == "SKILL.md":
+            recovery = (
+                "If that would discard useful content, move whole sections into "
+                "files under references/ or templates/ and link to them."
+            )
+        else:
+            recovery = (
+                f"If that would discard useful content, split {label} into smaller "
+                "supporting files and update the skill to reference them."
+            )
         return (
-            f"{label} content is {len(content):,} characters "
-            f"(limit: {MAX_SKILL_CONTENT_CHARS:,}). "
-            f"Consider splitting into a smaller SKILL.md with supporting files "
-            f"in references/ or templates/."
+            f"{label} content is {len(content):,} characters, {over:,} over the "
+            f"{MAX_SKILL_CONTENT_CHARS:,} limit. Reduce it by at least {over:,} "
+            f"{unit} in one edit. {recovery} "
+            f"Do not repeatedly trim small amounts and retry."
         )
     return None
 


### PR DESCRIPTION
## What does this PR do?

When `skill_manage` rejects content above `MAX_SKILL_CONTENT_CHARS` (100,000),
the current soft suggestion is easy to interpret as "trim a little and retry".
That can produce repeated marginal retries instead of one sufficient reduction
or a structural split.

This reworks the rejection message to break that loop at the tool layer:

- quantifies the exact overage and permits one sufficient reduction,
- explicitly rejects repeated piecemeal trimming, and
- gives target-aware recovery guidance: move sections out of `SKILL.md`, or
  split an oversized supporting file into smaller supporting files.

It's a message-layer fix on purpose: `_validate_content_size` is stateless, so
cross-call retry detection / a hard-stop would need session state (out of scope).
The change targets the documented root cause: the message being misinterpreted.

## Related Issue

Fixes #51470

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skill_manager_tool.py`: make `_validate_content_size` report the exact
  required reduction and select actionable recovery guidance from its target.
- `tests/tools/test_skill_size_limits.py`: pin the one-shot, anti-loop,
  `SKILL.md`, and supporting-file behavior at validator and tool boundaries.

## How to Test

```bash
scripts/run_tests.sh tests/tools/test_skill_size_limits.py
```

Current `main` retains the soft, target-agnostic message and does not satisfy
the directive assertions. On this branch, all 13 tests in the current file
pass. `uv lock --check` and
repository-wide Ruff also pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(skills): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected-area tests via `scripts/run_tests.sh` - `tests/tools/test_skill_size_limits.py` is green (13/13).
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 24.6, arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation - N/A (user-facing tool message, self-describing; no docs/config surface)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact - pure Python string logic, platform-agnostic
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A (error-message wording only; tool signature unchanged)