### PR TITLE
fix(tui): accurate YOLO status badge (gateway truth + status-bar display)

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1364,6 +1364,14 @@ DEFAULT_CONFIG = {
         # starts delegating, nudging the user toward the live spawn-tree
         # dashboard. Set false to suppress the hint.
         "tui_agents_nudge": True,
+        # The TUI status bar shows a "⚠ YOLO" / "⚠ APPROVALS OFF" badge
+        # whenever this session bypasses approval prompts (process --yolo,
+        # a per-session /yolo toggle, or approvals.mode=off). It is a
+        # deliberate, always-on safety reminder that dangerous commands run
+        # without asking. Set true to hide only that badge. This is a purely
+        # visual change: hiding the reminder does NOT alter approval behavior,
+        # the bypass still applies exactly as configured.
+        "tui_hide_yolo_badge": False,
         "bell_on_complete": False,
         # Stream the model's reasoning/thinking live before the response.
         # Default ON: on thinking models the reasoning phase can run tens of

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4503,6 +4503,86 @@ def _session(agent=None, **extra):
     }
 
 
+@pytest.mark.parametrize(
+    "frozen, session_yolo, approval_mode, expected_yolo, expected_source",
+    [
+        # A global `approvals.mode: off` auto-approves every dangerous command
+        # (tools/approval.py is_approval_bypass_active_for_session ORs it in),
+        # so the badge MUST report a bypass even when /yolo was never toggled.
+        # It is surfaced as source="config" so the UI can label it distinctly
+        # ("⚠ APPROVALS OFF") from an explicit per-session/process YOLO.
+        (False, False, "off", True, "config"),
+        # A real process-start --yolo / HERMES_YOLO_MODE (frozen at import).
+        (True, False, "manual", True, "session"),
+        # An explicit per-session `/yolo on` toggle.
+        (False, True, "manual", True, "session"),
+        # Both a session toggle AND config off: "session" wins the label since
+        # it is the stronger, explicitly-chosen signal (badge still on).
+        (False, True, "off", True, "session"),
+        (True, False, "off", True, "session"),
+        # Normal approvals: no bypass anywhere -> badge stays off, no source.
+        (False, False, "manual", False, ""),
+        (False, False, "smart", False, ""),
+    ],
+)
+def test_session_info_yolo_reflects_effective_bypass(
+    monkeypatch, frozen, session_yolo, approval_mode,
+    expected_yolo, expected_source,
+):
+    """_session_info().yolo mirrors the canonical three-source bypass check.
+
+    The TUI YOLO badge surfaces the *effective* approval-bypass state, the
+    same three sources tools.approval.is_approval_bypass_active_for_session()
+    ORs together: the frozen process --yolo flag, the per-session /yolo toggle,
+    and `approvals.mode: off`. Regression guard: `approvals.mode: off` must
+    keep lighting the badge (it silently auto-approves dangerous commands), so
+    it may NOT be dropped from the yolo calc. `yolo_source` disambiguates the
+    reason without ever hiding a real bypass.
+    """
+    import tools.approval as approval
+
+    monkeypatch.setattr(approval, "_YOLO_MODE_FROZEN", frozen)
+    monkeypatch.setattr(
+        approval, "is_session_yolo_enabled", lambda _key: session_yolo
+    )
+    monkeypatch.setattr(server, "_load_approval_mode", lambda: approval_mode)
+
+    info = server._session_info(None, _session())
+
+    assert info["yolo"] is expected_yolo
+    assert info["yolo_source"] == expected_source
+    assert info["approval_mode"] == approval_mode
+
+
+@pytest.mark.parametrize("hide", [True, False])
+def test_session_info_hide_yolo_badge_is_display_only(monkeypatch, hide):
+    """`display.tui_hide_yolo_badge` toggles only the reported UI flag.
+
+    Hiding the badge is a purely visual opt-out: `_session_info` still reports
+    the honest bypass state (`yolo`/`yolo_source`), it just also forwards the
+    user's request to suppress the reminder. Nothing about the approval-bypass
+    calc changes when the badge is hidden.
+    """
+    import tools.approval as approval
+
+    monkeypatch.setattr(approval, "_YOLO_MODE_FROZEN", True)
+    monkeypatch.setattr(
+        approval, "is_session_yolo_enabled", lambda _key: False
+    )
+    monkeypatch.setattr(server, "_load_approval_mode", lambda: "manual")
+    monkeypatch.setattr(
+        server, "_load_cfg", lambda: {"display": {"tui_hide_yolo_badge": hide}}
+    )
+
+    info = server._session_info(None, _session())
+
+    # Approval-bypass truth is unaffected by the visibility toggle.
+    assert info["yolo"] is True
+    assert info["yolo_source"] == "session"
+    # Only the display flag tracks the config.
+    assert info["hide_yolo_badge"] is hide
+
+
 def test_session_close_commits_memory_and_fires_finalize_hook(monkeypatch):
     calls = {"hooks": []}
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2743,14 +2743,20 @@ def _session_info(agent, session: dict | None = None) -> dict:
     try:
         from tools.approval import (
             _YOLO_MODE_FROZEN,
-            _get_approval_mode,
             is_session_yolo_enabled,
         )
 
-        session_yolo = (
-            bool(is_session_yolo_enabled(session_key)) if session_key else False
-        )
-        yolo = bool(_YOLO_MODE_FROZEN) or session_yolo or _get_approval_mode() == "off"
+        session_key = (session or {}).get("session_key")
+        session_yolo = bool(is_session_yolo_enabled(session_key)) if session_key else False
+        # YOLO badge reflects ONLY a real approval-bypass: the process-start
+        # --yolo flag (frozen) or an explicit per-session `/yolo on`. Do NOT OR
+        # in `_get_approval_mode() == "off"`: a global `approvals.mode: off`
+        # config means "don't prompt for approvals", which is a separate concept
+        # from YOLO (per-session bypass). Conflating them lit the TUI's ⚠ YOLO
+        # badge permanently for anyone who set approvals.mode: off (note YAML
+        # parses bare `off` as False, which _normalize_approval_mode maps back to
+        # "off"), even though /yolo was never enabled.
+        yolo = bool(_YOLO_MODE_FROZEN) or session_yolo
     except Exception:
         yolo = False
     info: dict = {

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6311,7 +6311,16 @@ def _session_info(agent, session: dict | None = None) -> dict:
     # per-session flag. Reporting only the per-session flag here would lie to
     # the desktop status bar (it would show YOLO "off" while approvals.mode=off
     # silently auto-approves every dangerous command).
+    #
+    # `yolo` stays the honest OR of all three sources so the badge can never
+    # hide a live bypass. `yolo_source` disambiguates *why* it is on so the UI
+    # can label it accurately — a per-session/process YOLO ("⚠ YOLO", the user
+    # opted in for this run) reads differently from a standing config
+    # approvals.mode=off ("⚠ APPROVALS OFF", every session auto-approves). When
+    # both are active, "session" wins the label since it is the stronger,
+    # explicitly-chosen signal.
     yolo = False
+    yolo_source = ""
     approval_mode = "manual"
     try:
         from tools.approval import _YOLO_MODE_FROZEN, is_session_yolo_enabled
@@ -6320,9 +6329,25 @@ def _session_info(agent, session: dict | None = None) -> dict:
             bool(is_session_yolo_enabled(session_key)) if session_key else False
         )
         approval_mode = _load_approval_mode()
-        yolo = bool(_YOLO_MODE_FROZEN) or session_yolo or approval_mode == "off"
+        frozen = bool(_YOLO_MODE_FROZEN)
+        config_off = approval_mode == "off"
+        yolo = frozen or session_yolo or config_off
+        if frozen or session_yolo:
+            yolo_source = "session"
+        elif config_off:
+            yolo_source = "config"
     except Exception:
         yolo = False
+        yolo_source = ""
+    # Purely visual opt-out for the status-bar badge. Hiding the reminder does
+    # NOT change `yolo`/`approval_mode` or any approval behavior — the bypass
+    # still applies. The TUI reads this flag to suppress only the badge.
+    try:
+        hide_yolo_badge = bool(
+            ((_load_cfg().get("display") or {}).get("tui_hide_yolo_badge"))
+        )
+    except Exception:
+        hide_yolo_badge = False
     # A model switch queued mid-turn (pending_model_switch) applies at the next
     # turn start, so agent.model still reads the OLD model until then. Report the
     # pending pick instead — it's the model the next turn will run, and it stops
@@ -6349,6 +6374,8 @@ def _session_info(agent, session: dict | None = None) -> dict:
         "service_tier": service_tier,
         "fast": service_tier == "priority",
         "yolo": yolo,
+        "yolo_source": yolo_source,
+        "hide_yolo_badge": hide_yolo_badge,
         "approval_mode": approval_mode,
         "tools": dict(mirror.get("tools") or {}) if isinstance(mirror.get("tools"), dict) else {},
         "skills": dict(mirror.get("skills") or {}) if isinstance(mirror.get("skills"), dict) else {},

--- a/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
+++ b/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
@@ -201,6 +201,56 @@ describe('StatusRule session count click target', () => {
     expect(rendered).not.toContain('3 sessions')
     expect(rendered).not.toContain('$0.5000')
   })
+
+  it('renders the YOLO indicator when enabled', () => {
+    const element = StatusRule({
+      bgCount: 0,
+      busy: false,
+      cols: 160,
+      cwdLabel: '~/repo',
+      liveSessionCount: 1,
+      model: 'opus-4.8',
+      onSessionCountClick: vi.fn(),
+      sessionStartedAt: null,
+      showCost: false,
+      status: 'ready',
+      statusColor: DEFAULT_THEME.color.ok,
+      t: DEFAULT_THEME,
+      turnStartedAt: null,
+      usage: { total: 0 },
+      voiceLabel: '',
+      yolo: true
+    })
+
+    const rendered = textContent(element)
+
+    expect(rendered).toContain('YOLO')
+  })
+
+  it('omits the YOLO indicator when disabled', () => {
+    const element = StatusRule({
+      bgCount: 0,
+      busy: false,
+      cols: 160,
+      cwdLabel: '~/repo',
+      liveSessionCount: 1,
+      model: 'opus-4.8',
+      onSessionCountClick: vi.fn(),
+      sessionStartedAt: null,
+      showCost: false,
+      status: 'ready',
+      statusColor: DEFAULT_THEME.color.ok,
+      t: DEFAULT_THEME,
+      turnStartedAt: null,
+      usage: { total: 0 },
+      voiceLabel: '',
+      yolo: false
+    })
+
+    const rendered = textContent(element)
+
+    expect(rendered).not.toContain('YOLO')
+  })
 })
 
 describe('StatusRule credits notice render priority', () => {

--- a/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
+++ b/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
@@ -491,3 +491,81 @@ describe('StatusRule idle-since read-out', () => {
     expect(findComponentByName(element, 'IdleSince')).toBeNull()
   })
 })
+
+describe('StatusRule YOLO / approval-bypass reminder', () => {
+  it('shows "⚠ YOLO" for a session bypass (--yolo / /yolo on)', () => {
+    const element = StatusRule({
+      ...baseProps,
+      yolo: true,
+      yoloSource: 'session'
+    })
+
+    const rendered = textContent(element)
+
+    expect(rendered).toContain('⚠ YOLO')
+    expect(rendered).not.toContain('APPROVALS OFF')
+  })
+
+  it('shows "⚠ APPROVALS OFF" for a config approvals.mode=off bypass', () => {
+    const element = StatusRule({
+      ...baseProps,
+      yolo: true,
+      yoloSource: 'config'
+    })
+
+    const rendered = textContent(element)
+
+    // The config source is labelled distinctly so a standing
+    // approvals.mode=off never masquerades as a per-session /yolo toggle.
+    expect(rendered).toContain('⚠ APPROVALS OFF')
+    expect(rendered).not.toContain('⚠ YOLO')
+  })
+
+  it('falls back to "⚠ YOLO" when the source is unknown but bypass is on', () => {
+    const element = StatusRule({
+      ...baseProps,
+      yolo: true
+    })
+
+    expect(textContent(element)).toContain('⚠ YOLO')
+  })
+
+  it('renders the badge in the warn colour', () => {
+    const element = StatusRule({
+      ...baseProps,
+      yolo: true,
+      yoloSource: 'session'
+    })
+
+    const badge = findElementWithText(element, '⚠ YOLO')
+    expect(badge?.props.color).toBe(DEFAULT_THEME.color.warn)
+  })
+
+  it('omits the badge entirely when no bypass is active', () => {
+    const element = StatusRule({
+      ...baseProps,
+      yolo: false
+    })
+
+    const rendered = textContent(element)
+
+    expect(rendered).not.toContain('YOLO')
+    expect(rendered).not.toContain('APPROVALS OFF')
+  })
+
+  it('hides the badge when hideYoloBadge is set, even though bypass is ON', () => {
+    const element = StatusRule({
+      ...baseProps,
+      hideYoloBadge: true,
+      yolo: true,
+      yoloSource: 'session'
+    })
+
+    const rendered = textContent(element)
+
+    // The visual reminder is suppressed by user config. This is display-only:
+    // the gateway still reports yolo=true; approval behaviour is unchanged.
+    expect(rendered).not.toContain('YOLO')
+    expect(rendered).not.toContain('APPROVALS OFF')
+  })
+})

--- a/ui-tui/src/__tests__/appChromeYoloNarrowWidth.test.tsx
+++ b/ui-tui/src/__tests__/appChromeYoloNarrowWidth.test.tsx
@@ -1,0 +1,163 @@
+import { PassThrough } from 'stream'
+
+import { renderSync } from '@hermes/ink'
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+// Stub useInput so nothing tries to enter raw mode under renderSync.
+vi.mock('@hermes/ink', async importOriginal => {
+  const mod = await importOriginal<typeof import('@hermes/ink')>()
+
+  return { ...mod, useInput: () => {} }
+})
+
+import { StatusRule } from '../components/appChrome.js'
+import { stripAnsi } from '../lib/text.js'
+import { DEFAULT_THEME } from '../theme.js'
+
+// Exact-narrow-width screen-buffer regression for the YOLO safety badge.
+//
+// lucapohl-angel's narrow-width QA (an exact 28x44 PTY) found the reminder
+// clipped to `⚠ YO` while idle and vanished entirely while busy, because the
+// badge trailed model/context and its width was never reserved. This suite
+// paints the REAL terminal frame (Yoga layout + truncation applied) at 44
+// columns and asserts the FULL `⚠ YOLO` survives in BOTH idle and busy — the
+// element-tree tests in appChromeStatusRule.test.tsx can't catch a mid-segment
+// clip because clipping only happens when the frame is actually rendered to a
+// fixed-width buffer.
+//
+// 44 columns is the clip-triggering width they reported. The cwd/branch label
+// is intentionally long so it competes for the row and would, before the fix,
+// shove the badge off-screen.
+
+const NARROW_COLS = 44
+
+// A realistic long cwd/branch so the right-hand label genuinely contends for
+// columns at 44 wide (mirrors the existing narrow-terminal test's fixture).
+const LONG_CWD = '~/src/hermes-agent/apps/desktop (bb/tui-statusbar-responsive)'
+
+const baseProps = {
+  bgCount: 0,
+  busy: false,
+  cols: NARROW_COLS,
+  cwdLabel: LONG_CWD,
+  liveSessionCount: 3,
+  model: 'opus-4.8',
+  sessionStartedAt: Date.now() - 60_000,
+  status: 'ready',
+  statusColor: DEFAULT_THEME.color.ok,
+  t: DEFAULT_THEME,
+  turnStartedAt: null,
+  usage: { context_max: 200_000, context_percent: 25, context_used: 50_000, total: 50_000 },
+  // Inactive voice renders zero-width now, so it must NOT appear or consume
+  // columns. Passing '' models the app's own zero-width inactive-voice output.
+  voiceLabel: ''
+}
+
+// Render the StatusRule to a real fixed-width terminal buffer and return the
+// ANSI-stripped frame text, exactly as it would paint in a 44-column PTY.
+function renderFrame(props: Parameters<typeof StatusRule>[0]): string {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+
+  let output = ''
+
+  Object.assign(stdout, { columns: NARROW_COLS, isTTY: false, rows: 24 })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const instance = renderSync(React.createElement(StatusRule, props), {
+    patchConsole: false,
+    stderr: stderr as NodeJS.WriteStream,
+    stdin: stdin as NodeJS.ReadStream,
+    stdout: stdout as NodeJS.WriteStream
+  })
+
+  instance.unmount()
+  instance.cleanup()
+
+  return stripAnsi(output)
+}
+
+describe('StatusRule YOLO badge — exact narrow-width (44 col) screen buffer', () => {
+  it('paints the FULL "⚠ YOLO" while idle (never clips to "⚠ YO")', () => {
+    const frame = renderFrame({
+      ...baseProps,
+      busy: false,
+      yolo: true,
+      yoloSource: 'session'
+    })
+
+    // The whole warning must be present in the painted buffer …
+    expect(frame).toContain('⚠ YOLO')
+    // … and it must not have been truncated mid-word to the dangerous stub.
+    expect(frame).not.toMatch(/⚠ YO(?!LO)/)
+  })
+
+  it('paints the FULL "⚠ YOLO" while busy (never omits the warning)', () => {
+    const frame = renderFrame({
+      ...baseProps,
+      busy: true,
+      turnStartedAt: Date.now(),
+      yolo: true,
+      yoloSource: 'session'
+    })
+
+    // Under load the FaceTicker occupies the status slot, yet the safety badge
+    // must still render in full — a bypass warning that vanishes while the
+    // agent works is exactly when it matters most.
+    expect(frame).toContain('⚠ YOLO')
+    expect(frame).not.toMatch(/⚠ YO(?!LO)/)
+  })
+
+  it('paints the FULL "⚠ APPROVALS OFF" config-bypass label while idle', () => {
+    const frame = renderFrame({
+      ...baseProps,
+      busy: false,
+      yolo: true,
+      yoloSource: 'config'
+    })
+
+    expect(frame).toContain('⚠ APPROVALS OFF')
+  })
+
+  it('keeps the badge ahead of model/context so the tail yields first', () => {
+    const frame = renderFrame({
+      ...baseProps,
+      busy: false,
+      yolo: true,
+      yoloSource: 'session'
+    })
+
+    // The badge is pinned; the model may or may not survive at 44 cols, but the
+    // safety warning always must. Assert the badge is positioned before the
+    // context read-out in the painted row (higher render priority).
+    const badgeAt = frame.indexOf('⚠ YOLO')
+    const ctxAt = frame.indexOf(' tok')
+
+    expect(badgeAt).toBeGreaterThanOrEqual(0)
+
+    if (ctxAt >= 0) {
+      expect(badgeAt).toBeLessThan(ctxAt)
+    }
+  })
+
+  it('renders nothing for an inactive voice (zero-width) so it cannot crowd the badge', () => {
+    const frame = renderFrame({
+      ...baseProps,
+      busy: false,
+      voiceLabel: '',
+      yolo: true,
+      yoloSource: 'session'
+    })
+
+    // Inactive voice contributes no columns at all …
+    expect(frame).not.toContain('voice off')
+    // … while the badge it could have crowded out survives in full.
+    expect(frame).toContain('⚠ YOLO')
+  })
+})

--- a/ui-tui/src/__tests__/appChromeYoloNarrowWidth.test.tsx
+++ b/ui-tui/src/__tests__/appChromeYoloNarrowWidth.test.tsx
@@ -1,12 +1,13 @@
 import { PassThrough } from 'stream'
 
+import type * as HermesInk from '@hermes/ink'
 import { renderSync } from '@hermes/ink'
 import React from 'react'
 import { describe, expect, it, vi } from 'vitest'
 
 // Stub useInput so nothing tries to enter raw mode under renderSync.
 vi.mock('@hermes/ink', async importOriginal => {
-  const mod = await importOriginal<typeof import('@hermes/ink')>()
+  const mod = await importOriginal<typeof HermesInk>()
 
   return { ...mod, useInput: () => {} }
 })

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -1247,12 +1247,21 @@ export function useMainApp(gw: GatewayClient) {
       stickyPrompt,
       turnStartedAt: ui.sid ? turnStartedAt : null,
       // CLI parity: the classic prompt_toolkit status bar shows a red dot
-      // on REC (cli.py:_get_voice_status_fragments line 2344).
+      // on REC (cli.py:_get_voice_status_fragments line 2344). An INACTIVE
+      // voice (off, and not mid record/STT) is rendered as zero width — an
+      // empty label the status rule drops entirely — so a disabled voice
+      // subsystem never consumes columns that could push the pinned YOLO
+      // safety badge off-screen on a narrow terminal. Only a live/enabled
+      // voice (or a standing TTS flag) earns a segment.
       voiceLabel: voiceRecording
         ? '● REC'
         : voiceProcessing
           ? '◉ STT'
-          : `voice ${voiceEnabled ? 'on' : 'off'}${voiceTts ? ' [tts]' : ''}`
+          : voiceEnabled
+            ? `voice on${voiceTts ? ' [tts]' : ''}`
+            : voiceTts
+              ? 'voice off [tts]'
+              : ''
     }),
     [
       cwd,

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -423,6 +423,7 @@ export function StatusRule({
   showCost,
   turnStartedAt,
   voiceLabel,
+  yolo,
   onSessionCountClick,
   t
 }: StatusRuleProps) {
@@ -576,6 +577,12 @@ export function StatusRule({
             <Text color={t.color.muted} wrap="truncate-end">
               {' │ '}
               {ctxLabel}
+            </Text>
+          ) : null}
+          {yolo ? (
+            <Text color={t.color.warn} wrap="truncate-end">
+              {' │ '}
+              {'⚠ YOLO'}
             </Text>
           ) : null}
         </Box>
@@ -779,6 +786,7 @@ interface StatusRuleProps {
   turnStartedAt?: null | number
   usage: Usage
   voiceLabel?: string
+  yolo?: boolean
   onSessionCountClick?: () => void
 }
 

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -507,6 +507,16 @@ export function StatusRule({
   const bar = !segs.compactCtx && usage.context_max ? ctxBar(pct) : ''
   const modelText = modelLabel(model, modelReasoningEffort, modelFast)
 
+  // YOLO / approval-bypass reminder. This is a SAFETY affordance: while a
+  // bypass is live, dangerous-command auto-approval is in effect, so the full
+  // warning must always be visible and can never be allowed to clip to `⚠ YO`
+  // or vanish under load. It is therefore treated as a pinned essential (below)
+  // and rendered AHEAD of model/context so it is the LAST thing to yield, not
+  // the first. `hide_yolo_badge` is a purely visual opt-out — it suppresses the
+  // reminder only, never the underlying bypass (the gateway still reports
+  // yolo=true and approvals behave exactly as configured).
+  const yoloBadgeText = yolo && !hideYoloBadge ? (yoloSource === 'config' ? '⚠ APPROVALS OFF' : '⚠ YOLO') : ''
+
   // Battery read-out — the first (pinned) status-bar element when enabled.
   const showBattery = !!battery && battery.available && battery.percent != null
   const batteryText = showBattery ? batteryLabel(battery!) : ''
@@ -540,6 +550,10 @@ export function StatusRule({
     stringWidth('─ ') +
     batteryWidth +
     slotWidth +
+    // The YOLO badge is pinned AHEAD of model/context (it renders first below),
+    // so reserve its full width here — this is what guarantees the complete
+    // `⚠ YOLO` survives on a narrow terminal instead of clipping to `⚠ YO`.
+    (yoloBadgeText ? stringWidth(' │ ') + stringWidth(yoloBadgeText) : 0) +
     stringWidth(' │ ') +
     stringWidth(modelText) +
     (ctxLabel ? stringWidth(' │ ') + stringWidth(ctxLabel) : 0)
@@ -658,8 +672,18 @@ export function StatusRule({
             </Text>
           </Box>
         ) : null}
-        {/* Pinned essentials — model + context never shrink, always visible. */}
+        {/* Pinned essentials — the YOLO safety badge, model, and context never
+            shrink and are always visible. The badge renders FIRST so, if the
+            terminal is too narrow for everything, model/context yield before the
+            warning ever clips (a bypass reminder that reads `⚠ YO` or vanishes
+            defeats its purpose). */}
         <Box flexDirection="row" flexShrink={0}>
+          {yoloBadgeText ? (
+            <Text color={t.color.warn} wrap="truncate-end">
+              {' │ '}
+              {yoloBadgeText}
+            </Text>
+          ) : null}
           {DEV_CREDITS_MODE ? (
             <Text color={t.color.warn} wrap="truncate-end">
               {' (dev credits)'}
@@ -673,12 +697,6 @@ export function StatusRule({
             <Text color={t.color.muted} wrap="truncate-end">
               {' │ '}
               {ctxLabel}
-            </Text>
-          ) : null}
-          {yolo && !hideYoloBadge ? (
-            <Text color={t.color.warn} wrap="truncate-end">
-              {' │ '}
-              {yoloSource === 'config' ? '⚠ APPROVALS OFF' : '⚠ YOLO'}
             </Text>
           ) : null}
         </Box>

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -484,6 +484,9 @@ export function StatusRule({
   sessionStartedAt,
   turnStartedAt,
   voiceLabel,
+  yolo,
+  yoloSource,
+  hideYoloBadge,
   onSessionCountClick,
   t
 }: StatusRuleProps) {
@@ -670,6 +673,12 @@ export function StatusRule({
             <Text color={t.color.muted} wrap="truncate-end">
               {' │ '}
               {ctxLabel}
+            </Text>
+          ) : null}
+          {yolo && !hideYoloBadge ? (
+            <Text color={t.color.warn} wrap="truncate-end">
+              {' │ '}
+              {yoloSource === 'config' ? '⚠ APPROVALS OFF' : '⚠ YOLO'}
             </Text>
           ) : null}
         </Box>
@@ -877,6 +886,9 @@ interface StatusRuleProps {
   turnStartedAt?: null | number
   usage: Usage
   voiceLabel?: string
+  yolo?: boolean
+  yoloSource?: string
+  hideYoloBadge?: boolean
   onSessionCountClick?: () => void
 }
 

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -381,6 +381,7 @@ const StatusRulePane = memo(function StatusRulePane({
         turnStartedAt={status.turnStartedAt}
         usage={ui.usage}
         voiceLabel={status.voiceLabel}
+        yolo={ui.info?.yolo}
       />
     </Box>
   )

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -511,6 +511,9 @@ const StatusRulePane = memo(function StatusRulePane({
         turnStartedAt={status.turnStartedAt}
         usage={ui.usage}
         voiceLabel={status.voiceLabel}
+        yolo={ui.info?.yolo}
+        yoloSource={ui.info?.yolo_source}
+        hideYoloBadge={ui.info?.hide_yolo_badge}
       />
     </Box>
   )

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -495,6 +495,7 @@ const StatusRulePane = memo(function StatusRulePane({
         cols={composer.cols}
         cwdLabel={status.cwdLabel}
         focusView={ui.focusView}
+        hideYoloBadge={ui.info?.hide_yolo_badge}
         indicatorStyle={ui.indicatorStyle}
         lastTurnEndedAt={status.lastTurnEndedAt}
         liveSessionCount={ui.liveSessionCount}
@@ -513,7 +514,6 @@ const StatusRulePane = memo(function StatusRulePane({
         voiceLabel={status.voiceLabel}
         yolo={ui.info?.yolo}
         yoloSource={ui.info?.yolo_source}
-        hideYoloBadge={ui.info?.hide_yolo_badge}
       />
     </Box>
   )

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -164,6 +164,7 @@ export interface SessionInfo {
   update_command?: string
   usage?: Usage
   version?: string
+  yolo?: boolean
 }
 
 export interface Usage {

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -201,6 +201,9 @@ export interface SessionInfo {
   update_command?: string
   usage?: Usage
   version?: string
+  yolo?: boolean
+  yolo_source?: string
+  hide_yolo_badge?: boolean
 }
 
 export interface Usage {


### PR DESCRIPTION
## Summary

The TUI now shows a persistent warning whenever dangerous command approvals are bypassed. The display distinguishes an explicit process or session YOLO setting from `approvals.mode: off`, and it preserves that warning at narrow terminal widths.

## What changed

* The gateway reports the effective approval bypass as the OR of process YOLO, session YOLO, and `approvals.mode: off`.
* `yolo_source` distinguishes explicit YOLO from configuration based approval bypass. Explicit YOLO displays `⚠ YOLO`; `approvals.mode: off` displays `⚠ APPROVALS OFF`.
* If both sources apply, the explicit process or session YOLO source has label priority.
* `display.tui_hide_yolo_badge` can hide the status bar reminder without changing approval behavior or the gateway's effective bypass state.
* The warning appears before model and context chrome, and its full width is reserved. Lower priority chrome yields before the warning can be clipped.
* Inactive voice status uses no width. Active recording, speech processing, enabled voice, and TTS status still render normally.

## Narrow width regression

The regression test renders the real status rule into an exact 44 column screen buffer. It verifies that the complete `⚠ YOLO` badge remains visible while idle and busy, that the configuration label remains complete, and that badge placement precedes model and context chrome.

`test_session_info_yolo_reflects_effective_bypass` covers `approvals.mode: off`, process YOLO, session YOLO, and the source priority when more than one bypass applies. The screen buffer case `keeps the badge ahead of model/context so the tail yields first` checks the warning's rendered position rather than only checking its presence.

## Tests

Local verification on the rebased branch:

* Exact 44 column screen buffer regression: 5 passed.
* Full TUI suite with `NODE_ENV=test`: 1,724 passed across 160 files.
* Gateway YOLO selection using `scripts/run_tests.sh tests/test_tui_gateway_server.py -k yolo -q`: 13 passed.
* TUI typecheck: passed.
* TUI build: passed.
* TUI lint: passed with zero errors and two preexisting React hook warnings in `useSessionLifecycle.ts` and `textInput.tsx`.

The branch is rebased onto upstream `main` at `16c67248d4e413748ffae3c1df3325dfe3e9d2e5`.
