### PR TITLE
fix(desktop): lazy resume chats and harden backend cleanup

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -4770,12 +4770,22 @@ function resetBootProgressForReconnect() {
   )
 }
 
+function stopBackendProcessTree(child) {
+  if (!child || child.killed) return
+  try {
+    child.kill('SIGTERM')
+  } catch {
+    // Already gone.
+  }
+  if (IS_WINDOWS && Number.isInteger(child.pid)) {
+    forceKillProcessTree(child.pid)
+  }
+}
+
 function resetHermesConnection() {
   connectionPromise = null
 
-  if (hermesProcess && !hermesProcess.killed) {
-    hermesProcess.kill('SIGTERM')
-  }
+  stopBackendProcessTree(hermesProcess)
 
   hermesProcess = null
   resetBootProgressForReconnect()
@@ -5016,13 +5026,7 @@ function stopPoolBackend(profile) {
   const entry = backendPool.get(profile)
   if (!entry) return
   backendPool.delete(profile)
-  if (entry.process && !entry.process.killed) {
-    try {
-      entry.process.kill('SIGTERM')
-    } catch {
-      // Already gone.
-    }
-  }
+  stopBackendProcessTree(entry.process)
 }
 
 async function teardownPoolBackendAndWait(profile) {
@@ -5030,13 +5034,7 @@ async function teardownPoolBackendAndWait(profile) {
   if (!entry) return
   backendPool.delete(profile)
 
-  if (entry.process && !entry.process.killed) {
-    try {
-      entry.process.kill('SIGTERM')
-    } catch {
-      // Already gone.
-    }
-  }
+  stopBackendProcessTree(entry.process)
 
   await waitForBackendExit(entry.process)
 }
@@ -6794,9 +6792,7 @@ app.on('before-quit', () => {
     disposeTerminalSession(id)
   }
 
-  if (hermesProcess && !hermesProcess.killed) {
-    hermesProcess.kill('SIGTERM')
-  }
+  stopBackendProcessTree(hermesProcess)
   stopAllPoolBackends()
 })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -706,7 +706,10 @@ export function useSessionActions({
         const resumePromise = requestGateway<SessionResumeResponse>('session.resume', {
           session_id: storedSessionId,
           cols: 96,
-          ...(watchWindow ? { lazy: true } : {}),
+          // Resume should paint history and bind a runtime id, not block on a
+          // full AIAgent build. The gateway upgrades lazy sessions on the first
+          // prompt/RPC that actually needs the agent.
+          lazy: true,
           ...(sessionProfile ? { profile: sessionProfile } : {})
         })
         // The rejection is consumed by the `await` below; this guard only

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3874,6 +3874,37 @@ def test_image_attach_appends_local_image(monkeypatch):
     assert len(server._sessions["sid"]["attached_images"]) == 1
 
 
+def test_image_attach_does_not_wait_for_lazy_agent_build(monkeypatch):
+    fake_cli = types.ModuleType("cli")
+    fake_cli._IMAGE_EXTENSIONS = {".png"}
+    fake_cli._detect_file_drop = lambda raw: None
+    fake_cli._split_path_input = lambda raw: (raw, "")
+    fake_cli._resolve_attachment_path = lambda raw: Path("/tmp/cat.png")
+
+    never_ready = threading.Event()
+    server._sessions["sid"] = _session(agent_ready=never_ready)
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+
+    def fail_if_build_started(*_args, **_kwargs):
+        raise AssertionError("image.attach should not start/wait for agent build")
+
+    monkeypatch.setattr(server, "_start_agent_build", fail_if_build_started)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "image.attach",
+                "params": {"session_id": "sid", "path": "/tmp/cat.png"},
+            }
+        )
+
+        assert resp["result"]["attached"] is True
+        assert len(server._sessions["sid"]["attached_images"]) == 1
+    finally:
+        server._sessions.pop("sid", None)
+
+
 def test_image_attach_accepts_unquoted_screenshot_path_with_spaces(monkeypatch):
     screenshot = Path("/tmp/Screenshot 2026-04-21 at 1.04.43 PM.png")
     fake_cli = types.ModuleType("cli")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7051,7 +7051,10 @@ def _(rid, params: dict) -> dict:
 
 @method("image.attach")
 def _(rid, params: dict) -> dict:
-    session, err = _sess(params, rid)
+    # Staging a local image only mutates the queued attachment list. Do not start
+    # or wait for lazy agent construction here; prompt.submit will build the
+    # agent when it actually needs to consume the queued attachment.
+    session, err = _sess_nowait(params, rid)
     if err:
         return err
     raw = str(params.get("path", "") or "").strip()


### PR DESCRIPTION
## Summary
- resume Desktop chats lazily so `session.resume` can paint history without blocking on `_make_agent()`
- let `image.attach` stage local images without starting/waiting for lazy agent construction
- make Desktop/backend teardown tree-aware on Windows so app close/restart is less likely to leave backend grandchildren alive

Fixes #51492
Related: #48643, #48656

## Scope
This PR intentionally does **not** change `tui_gateway._SlashWorker.close()`. #48656 already covers the broader slash-worker lifecycle/orphan cleanup work. This PR is limited to Desktop resume/attachment latency and the Desktop-owned backend process tree.

## Test plan
- [x] `python -m pytest tests/test_tui_gateway_server.py::test_slash_worker_close_reaps_zombie_and_closes_fds tests/test_tui_gateway_server.py::test_finalize_session_closes_slash_worker tests/test_tui_gateway_server.py::test_close_session_by_id_is_idempotent_and_full tests/test_tui_gateway_server.py::test_shutdown_sessions_closes_every_session_via_helper tests/test_tui_gateway_server.py::test_image_attach_does_not_wait_for_lazy_agent_build tests/test_tui_gateway_server.py::test_image_attach_appends_local_image tests/test_tui_gateway_server.py::test_image_attach_accepts_unquoted_screenshot_path_with_spaces -q`
- [x] `npm run typecheck` from `apps/desktop`
- [x] `node --test electron/backend-ready.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs` from `apps/desktop`
