### PR TITLE
feat(kanban): support project-local temp worker profiles

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2403,6 +2403,19 @@ DEFAULT_CONFIG = {
         # worker process (if still running host-locally) is terminated
         # before the reclaim.  0 disables stale detection entirely.
         "dispatch_stale_timeout_seconds": 14400,
+        # Optional project-local temp profiles for dispatcher-spawned workers.
+        # When enabled, each worker attempt gets a fresh HERMES_HOME under the
+        # task workspace/project (``.hermes/tmp-profiles/...``) instead of
+        # writing sessions, memories, cron, and caches into the main
+        # ``~/.hermes/profiles`` registry. The temp profile clones config,
+        # secrets, SOUL, and skills from the assigned durable profile when it
+        # exists, else from the dispatcher's active profile. Runtime state is
+        # disposable and swept by age on later spawns.
+        "temp_profiles": {
+            "enabled": False,
+            "cleanup_after_seconds": 7 * 24 * 60 * 60,
+            "root_dir": ".hermes/tmp-profiles",
+        },
     },
 
     # execute_code settings — controls the tool used for programmatic tool calls.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6496,6 +6496,14 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
     return None
 
 
+def _temp_assignee_spawnable(assignee: str) -> bool:
+    try:
+        _temp_worker_profile_name(assignee)
+        return True
+    except Exception:
+        return False
+
+
 def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
     """Return True iff there is at least one ready+assigned+unclaimed task
     whose assignee maps to a real Hermes profile or project-local temp profiles
@@ -6519,7 +6527,7 @@ def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
     if not rows:
         return False
     if _temp_profiles_enabled():
-        return True
+        return any(_temp_assignee_spawnable(row["assignee"] or "") for row in rows)
     try:
         from hermes_cli.profiles import profile_exists  # local import: avoids cycle
     except Exception:
@@ -6548,7 +6556,7 @@ def has_spawnable_review(conn: sqlite3.Connection) -> bool:
     if not rows:
         return False
     if _temp_profiles_enabled():
-        return True
+        return any(_temp_assignee_spawnable(row["assignee"] or "") for row in rows)
     try:
         from hermes_cli.profiles import profile_exists  # local import: avoids cycle
     except Exception:
@@ -6828,9 +6836,13 @@ def _dispatch_once_locked(
             from hermes_cli.profiles import profile_exists  # local import: avoids cycle
         except Exception:
             profile_exists = None  # type: ignore[assignment]
+        temp_profiles_enabled = _temp_profiles_enabled()
+        if temp_profiles_enabled and not _temp_assignee_spawnable(row_assignee):
+            result.skipped_nonspawnable.append(row["id"])
+            continue
         if (
             profile_exists is not None
-            and not _temp_profiles_enabled()
+            and not temp_profiles_enabled
             and not profile_exists(row_assignee)
         ):
             # Bucket separately from skipped_unassigned: the operator
@@ -6972,9 +6984,13 @@ def _dispatch_once_locked(
             from hermes_cli.profiles import profile_exists
         except Exception:
             profile_exists = None  # type: ignore[assignment]
+        temp_profiles_enabled = _temp_profiles_enabled()
+        if temp_profiles_enabled and not _temp_assignee_spawnable(row["assignee"]):
+            result.skipped_nonspawnable.append(row["id"])
+            continue
         if (
             profile_exists is not None
-            and not _temp_profiles_enabled()
+            and not temp_profiles_enabled
             and not profile_exists(row["assignee"])
         ):
             result.skipped_nonspawnable.append(row["id"])
@@ -7306,29 +7322,54 @@ def _workspace_project_root(workspace: str) -> Path:
     return git_root or ws
 
 
+def _path_is_relative_to(child: Path, parent: Path) -> bool:
+    try:
+        child.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
 def _temp_profiles_root_for_workspace(workspace: str, cfg: Optional[dict[str, Any]] = None) -> Path:
     cfg = cfg or _temp_profiles_config()
+    project_root = _workspace_project_root(workspace).resolve()
     root_dir = Path(str(cfg.get("root_dir") or ".hermes/tmp-profiles")).expanduser()
     if not root_dir.is_absolute():
-        root_dir = _workspace_project_root(workspace) / root_dir
+        root_dir = (project_root / root_dir).resolve()
+        if not _path_is_relative_to(root_dir, project_root):
+            raise ValueError(
+                f"kanban.temp_profiles.root_dir must stay under the project root when relative: {root_dir}"
+            )
+    else:
+        root_dir = root_dir.resolve()
     return root_dir
 
 
-def _safe_temp_profile_component(value: str, *, fallback: str = "run") -> str:
+def _safe_temp_profile_component(value: str, *, fallback: str = "run", max_len: int = 80) -> str:
     safe = re.sub(r"[^a-zA-Z0-9_.-]+", "-", str(value or "").strip()).strip(".-_")
-    return (safe or fallback)[:80]
+    return (safe or fallback)[:max_len]
 
 
 def _temp_worker_profile_name(profile_arg: str) -> str:
-    """Return a valid local profile id for a durable or ad-hoc assignee name."""
-    try:
-        from hermes_cli.profiles import normalize_profile_name, validate_profile_name
+    """Return a valid local profile id for a durable or ad-hoc assignee name.
 
+    Durable profile IDs pass through after canonical validation. Free-form role
+    labels are converted to safe profile IDs, then validated before any path is
+    constructed. Path-like input never reaches the filesystem as a separator.
+    """
+    from hermes_cli.profiles import normalize_profile_name, validate_profile_name
+
+    try:
         normalized = normalize_profile_name(profile_arg)
         validate_profile_name(normalized)
         return normalized
-    except Exception:
-        return _safe_temp_profile_component(profile_arg, fallback="worker").lower()
+    except ValueError:
+        slug = re.sub(r"[^a-z0-9_-]+", "-", str(profile_arg or "").strip().lower()).strip("-_")
+        if not slug or not re.match(r"^[a-z0-9]", slug):
+            slug = f"worker-{slug}" if slug else "worker"
+        slug = slug[:64].rstrip("-_") or "worker"
+        validate_profile_name(slug)
+        return slug
 
 
 def _copytree_contents(src: Path, dst: Path) -> None:
@@ -7417,6 +7458,19 @@ def ensure_temp_worker_profile(task: Task, workspace: str, profile_arg: str) -> 
     nonce = secrets.token_hex(4)
     temp_root = root_parent / f"{task_part}-{run_part}-{profile_part}-{nonce}"
     profile_home = temp_root / "profiles" / profile_name
+    resolved_temp_root = temp_root.resolve()
+    resolved_profiles_root = (resolved_temp_root / "profiles").resolve()
+    resolved_profile_home = (resolved_profiles_root / profile_name).resolve()
+    if not _path_is_relative_to(resolved_profile_home, resolved_profiles_root):
+        raise ValueError(f"temporary profile path escaped temp root: {resolved_profile_home}")
+    profile_home = resolved_profile_home
+
+    # Defense in depth for copied .env secrets: keep the temp-profile tree
+    # untracked even in projects whose root .gitignore does not ignore .hermes/.
+    root_parent.mkdir(parents=True, exist_ok=True)
+    ignore_file = root_parent / ".gitignore"
+    if not ignore_file.exists():
+        ignore_file.write_text("*\n!.gitignore\n", encoding="utf-8")
 
     # Minimal profile skeleton matching hermes_cli.profiles._PROFILE_DIRS, plus
     # cron/plugins/cache dirs commonly created at runtime. Keep this local to

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6498,7 +6498,8 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
 
 def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
     """Return True iff there is at least one ready+assigned+unclaimed task
-    whose assignee maps to a real Hermes profile.
+    whose assignee maps to a real Hermes profile or project-local temp profiles
+    are enabled.
 
     Used by the gateway- and CLI-embedded dispatchers' health telemetry to
     decide whether ``0 spawned`` is a "stuck" condition (real spawnable
@@ -6517,6 +6518,8 @@ def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
     ).fetchall()
     if not rows:
         return False
+    if _temp_profiles_enabled():
+        return True
     try:
         from hermes_cli.profiles import profile_exists  # local import: avoids cycle
     except Exception:
@@ -6530,7 +6533,8 @@ def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
 
 def has_spawnable_review(conn: sqlite3.Connection) -> bool:
     """Return True iff there is at least one review+assigned+unclaimed task
-    whose assignee maps to a real Hermes profile.
+    whose assignee maps to a real Hermes profile or project-local temp profiles
+    are enabled.
 
     Mirror of :func:`has_spawnable_ready` for the review column —
     used by the health telemetry to decide whether the dispatcher
@@ -6543,6 +6547,8 @@ def has_spawnable_review(conn: sqlite3.Connection) -> bool:
     ).fetchall()
     if not rows:
         return False
+    if _temp_profiles_enabled():
+        return True
     try:
         from hermes_cli.profiles import profile_exists  # local import: avoids cycle
     except Exception:
@@ -6822,7 +6828,11 @@ def _dispatch_once_locked(
             from hermes_cli.profiles import profile_exists  # local import: avoids cycle
         except Exception:
             profile_exists = None  # type: ignore[assignment]
-        if profile_exists is not None and not profile_exists(row_assignee):
+        if (
+            profile_exists is not None
+            and not _temp_profiles_enabled()
+            and not profile_exists(row_assignee)
+        ):
             # Bucket separately from skipped_unassigned: the operator
             # cannot fix this by assigning a profile (the assignee IS the
             # intended owner — a terminal lane). Health telemetry uses
@@ -6962,7 +6972,11 @@ def _dispatch_once_locked(
             from hermes_cli.profiles import profile_exists
         except Exception:
             profile_exists = None  # type: ignore[assignment]
-        if profile_exists is not None and not profile_exists(row["assignee"]):
+        if (
+            profile_exists is not None
+            and not _temp_profiles_enabled()
+            and not profile_exists(row["assignee"])
+        ):
             result.skipped_nonspawnable.append(row["id"])
             continue
         if dry_run:
@@ -7249,6 +7263,228 @@ def _worker_terminal_timeout_env(
     return str(desired)
 
 
+def _temp_profiles_config() -> dict[str, Any]:
+    """Return normalized kanban.temp_profiles config."""
+    try:
+        from hermes_cli.config import load_config
+
+        raw = (load_config().get("kanban") or {}).get("temp_profiles") or {}
+    except Exception:
+        raw = {}
+    if not isinstance(raw, dict):
+        raw = {}
+    enabled = bool(raw.get("enabled", False))
+    try:
+        cleanup_after = int(raw.get("cleanup_after_seconds", 7 * 24 * 60 * 60))
+    except (TypeError, ValueError):
+        cleanup_after = 7 * 24 * 60 * 60
+    cleanup_after = max(0, cleanup_after)
+    root_dir = str(raw.get("root_dir") or ".hermes/tmp-profiles").strip() or ".hermes/tmp-profiles"
+    return {
+        "enabled": enabled,
+        "cleanup_after_seconds": cleanup_after,
+        "root_dir": root_dir,
+    }
+
+
+def _temp_profiles_enabled() -> bool:
+    return bool(_temp_profiles_config().get("enabled"))
+
+
+def _workspace_project_root(workspace: str) -> Path:
+    """Return the project directory that should own a worker's temp Hermes home."""
+    ws = Path(workspace).expanduser()
+    try:
+        ws = ws.resolve()
+    except OSError:
+        ws = ws.absolute()
+    if ws.is_file():
+        ws = ws.parent
+    if not ws.exists():
+        return ws
+    git_root = _git_toplevel(ws)
+    return git_root or ws
+
+
+def _temp_profiles_root_for_workspace(workspace: str, cfg: Optional[dict[str, Any]] = None) -> Path:
+    cfg = cfg or _temp_profiles_config()
+    root_dir = Path(str(cfg.get("root_dir") or ".hermes/tmp-profiles")).expanduser()
+    if not root_dir.is_absolute():
+        root_dir = _workspace_project_root(workspace) / root_dir
+    return root_dir
+
+
+def _safe_temp_profile_component(value: str, *, fallback: str = "run") -> str:
+    safe = re.sub(r"[^a-zA-Z0-9_.-]+", "-", str(value or "").strip()).strip(".-_")
+    return (safe or fallback)[:80]
+
+
+def _temp_worker_profile_name(profile_arg: str) -> str:
+    """Return a valid local profile id for a durable or ad-hoc assignee name."""
+    try:
+        from hermes_cli.profiles import normalize_profile_name, validate_profile_name
+
+        normalized = normalize_profile_name(profile_arg)
+        validate_profile_name(normalized)
+        return normalized
+    except Exception:
+        return _safe_temp_profile_component(profile_arg, fallback="worker").lower()
+
+
+def _copytree_contents(src: Path, dst: Path) -> None:
+    if not src.is_dir():
+        return
+    shutil.copytree(src, dst, dirs_exist_ok=True, ignore=shutil.ignore_patterns(
+        "__pycache__", "*.pyc", ".DS_Store",
+    ))
+
+
+def _profile_clone_source(profile_arg: str) -> Path:
+    """Pick the durable profile/config source for a temp worker profile."""
+    try:
+        from hermes_cli.profiles import resolve_profile_env
+
+        return Path(resolve_profile_env(profile_arg))
+    except Exception:
+        pass
+    try:
+        from hermes_constants import get_hermes_home
+
+        return Path(get_hermes_home())
+    except Exception:
+        return Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes")
+
+
+def cleanup_stale_temp_profile_roots(workspace: str, *, now: Optional[int] = None) -> list[Path]:
+    """Remove project-local temp profile roots older than the configured TTL.
+
+    Best-effort and deliberately scoped to the configured temp root under the
+    task workspace/project. Durable ``~/.hermes/profiles`` entries are never
+    considered by this sweeper.
+    """
+    cfg = _temp_profiles_config()
+    ttl = int(cfg.get("cleanup_after_seconds") or 0)
+    if ttl <= 0:
+        return []
+    root = _temp_profiles_root_for_workspace(workspace, cfg)
+    if not root.is_dir():
+        return []
+    cutoff = int(now if now is not None else time.time()) - ttl
+    removed: list[Path] = []
+    for entry in root.iterdir():
+        if not entry.is_dir():
+            continue
+        marker = entry / ".hermes-kanban-temp-profile.json"
+        if not marker.is_file():
+            continue
+        try:
+            data = json.loads(marker.read_text(encoding="utf-8") or "{}")
+            created_at = int(data.get("created_at") or entry.stat().st_mtime)
+        except Exception:
+            try:
+                created_at = int(entry.stat().st_mtime)
+            except OSError:
+                continue
+        if created_at > cutoff:
+            continue
+        try:
+            shutil.rmtree(entry)
+            removed.append(entry)
+        except OSError:
+            _log.debug("kanban temp profiles: failed to remove stale root %s", entry, exc_info=True)
+    return removed
+
+
+def ensure_temp_worker_profile(task: Task, workspace: str, profile_arg: str) -> Path:
+    """Create a fresh project-local Hermes profile for one worker attempt.
+
+    Layout:
+        <project>/.hermes/tmp-profiles/<task/run/profile>/<profiles>/<profile>
+
+    The returned path is the profile's HERMES_HOME and is suitable for passing
+    to a child process that still uses ``hermes -p <profile>``. Because the env
+    already points inside ``.../profiles/<profile>``, Hermes resolves ``-p``
+    against the project-local root, not the main ``~/.hermes`` registry.
+    """
+    cfg = _temp_profiles_config()
+    root_parent = _temp_profiles_root_for_workspace(workspace, cfg)
+    cleanup_stale_temp_profile_roots(workspace)
+
+    profile_name = _temp_worker_profile_name(profile_arg)
+    run_part = _safe_temp_profile_component(str(task.current_run_id or "run"), fallback="run")
+    task_part = _safe_temp_profile_component(task.id, fallback="task")
+    profile_part = _safe_temp_profile_component(profile_name, fallback="profile")
+    nonce = secrets.token_hex(4)
+    temp_root = root_parent / f"{task_part}-{run_part}-{profile_part}-{nonce}"
+    profile_home = temp_root / "profiles" / profile_name
+
+    # Minimal profile skeleton matching hermes_cli.profiles._PROFILE_DIRS, plus
+    # cron/plugins/cache dirs commonly created at runtime. Keep this local to
+    # avoid profile-create side effects (aliases, s6 service registration).
+    for rel in (
+        "memories", "sessions", "skills", "skins", "logs", "plans",
+        "workspace", "cron", "plugins", "cache", "audio_cache",
+        "image_cache", "document_cache", "checkpoints", "sandboxes",
+    ):
+        (profile_home / rel).mkdir(parents=True, exist_ok=True)
+
+    source = _profile_clone_source(profile_arg)
+    for filename in ("config.yaml", ".env", "SOUL.md"):
+        src = source / filename
+        if src.is_file():
+            dst = profile_home / filename
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dst)
+            if filename == ".env":
+                try:
+                    os.chmod(dst, 0o600)
+                except OSError:
+                    pass
+    if not (profile_home / ".env").exists():
+        env_path = profile_home / ".env"
+        env_path.write_text(
+            "# Temporary kanban worker profile secrets.\n"
+            "# Created from dispatcher context; deleted by temp-profile GC.\n",
+            encoding="utf-8",
+        )
+        try:
+            os.chmod(env_path, 0o600)
+        except OSError:
+            pass
+    if not (profile_home / "SOUL.md").exists():
+        try:
+            from hermes_cli.default_soul import DEFAULT_SOUL_MD
+            base_soul = DEFAULT_SOUL_MD
+        except Exception:
+            base_soul = "You are a Hermes Agent worker.\n"
+        (profile_home / "SOUL.md").write_text(base_soul, encoding="utf-8")
+
+    _copytree_contents(source / "skills", profile_home / "skills")
+    _copytree_contents(source / "skins", profile_home / "skins")
+
+    profile_meta = profile_home / "profile.yaml"
+    if not profile_meta.exists():
+        profile_meta.write_text(
+            "description: >-\n"
+            f"  Temporary project-local kanban worker profile for assignee {profile_arg}.\n"
+            "description_auto: false\n",
+            encoding="utf-8",
+        )
+
+    marker = temp_root / ".hermes-kanban-temp-profile.json"
+    marker.write_text(json.dumps({
+        "kind": "hermes-kanban-temp-profile",
+        "created_at": int(time.time()),
+        "task_id": task.id,
+        "run_id": task.current_run_id,
+        "assignee": profile_arg,
+        "workspace": workspace,
+        "source": str(source),
+        "profile_home": str(profile_home),
+    }, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return profile_home
+
+
 def _resolve_worker_cli_toolsets(hermes_home: Optional[str]) -> Optional[list[str]]:
     """Return the assigned profile's effective CLI toolsets for a worker.
 
@@ -7307,29 +7543,29 @@ def _default_spawn(
 
     from hermes_cli.profiles import normalize_profile_name
 
-    profile_arg = normalize_profile_name(task.assignee)
+    assignee_name = normalize_profile_name(task.assignee)
+    profile_arg = _temp_worker_profile_name(assignee_name) if _temp_profiles_enabled() else assignee_name
 
     prompt = f"work kanban task {task.id}"
     env = dict(os.environ)
 
     # Inject HERMES_HOME so the worker reads the profile-scoped config.yaml
     # (fallback_providers, toolsets, agent settings, etc.) instead of the root
-    # config.  Without this, `env = dict(os.environ)` copies only the parent's
-    # env, and when the child process starts `hermes -p <name>` the
-    # _apply_profile_override() runs *before* hermes_constants is imported.
-    # If HERMES_HOME is absent from the child's env, get_hermes_home() falls
-    # back to Path.home() / ".hermes" (the DEFAULT profile root), ignoring the
-    # profile-specific config entirely.  Fixes profile-scoped fallback_providers
-    # being invisible to kanban workers.
-    from hermes_cli.profiles import resolve_profile_env
-    try:
-        env["HERMES_HOME"] = resolve_profile_env(profile_arg)
-    except FileNotFoundError:
-        # Profile dir doesn't exist — defer resolution to the CLI's
-        # _apply_profile_override() via HERMES_PROFILE (set below).
-        # This only happens in test fixtures where the isolated
-        # HERMES_HOME never had profiles created.
-        pass
+    # config. With kanban.temp_profiles.enabled, create a fresh project-local
+    # profile for this worker attempt and point the child at that disposable
+    # HERMES_HOME. Otherwise preserve the durable-profile behavior.
+    if _temp_profiles_enabled():
+        env["HERMES_HOME"] = str(ensure_temp_worker_profile(task, workspace, profile_arg))
+    else:
+        from hermes_cli.profiles import resolve_profile_env
+        try:
+            env["HERMES_HOME"] = resolve_profile_env(profile_arg)
+        except FileNotFoundError:
+            # Profile dir doesn't exist — defer resolution to the CLI's
+            # _apply_profile_override() via HERMES_PROFILE (set below).
+            # This only happens in test fixtures where the isolated
+            # HERMES_HOME never had profiles created.
+            pass
     if task.tenant:
         env["HERMES_TENANT"] = task.tenant
     env["HERMES_KANBAN_TASK"] = task.id

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1677,6 +1677,136 @@ def test_dispatch_skips_nonspawnable_into_separate_bucket(kanban_home, monkeypat
     assert not res.spawned
 
 
+def test_dispatch_temp_profiles_allow_unregistered_assignee(kanban_home, monkeypatch):
+    """When project-local temp profiles are enabled, synthetic role names are
+    spawnable without pre-creating durable ~/.hermes/profiles entries."""
+    from hermes_cli import profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda name: False)
+    monkeypatch.setattr(
+        kb,
+        "_temp_profiles_config",
+        lambda: {
+            "enabled": True,
+            "cleanup_after_seconds": 7 * 24 * 60 * 60,
+            "root_dir": ".hermes/tmp-profiles",
+        },
+    )
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="market sizing", assignee="mckinsey-style")
+        res = kb.dispatch_once(conn, dry_run=True)
+    assert res.spawned == [(t, "mckinsey-style", "")]
+    assert t not in res.skipped_nonspawnable
+
+
+def test_default_spawn_uses_project_local_temp_profile(kanban_home, tmp_path, monkeypatch):
+    """Temp-profile mode gives each worker attempt a fresh HERMES_HOME under
+    the task project instead of the main profile registry."""
+    source_home = Path(os.environ["HERMES_HOME"])
+    (source_home / "config.yaml").write_text("model: test-model\n", encoding="utf-8")
+    (source_home / ".env").write_text("DUMMY_ENV=1\n", encoding="utf-8")
+    (source_home / "SOUL.md").write_text("Base soul\n", encoding="utf-8")
+    (source_home / "skills" / "research").mkdir(parents=True)
+    (source_home / "skills" / "research" / "SKILL.md").write_text("---\nname: research\n---\n", encoding="utf-8")
+
+    project = tmp_path / "project"
+    _init_git_repo(project)
+    workspace = project / "work"
+    workspace.mkdir()
+
+    monkeypatch.setattr(
+        kb,
+        "_temp_profiles_config",
+        lambda: {
+            "enabled": True,
+            "cleanup_after_seconds": 7 * 24 * 60 * 60,
+            "root_dir": ".hermes/tmp-profiles",
+        },
+    )
+    monkeypatch.setattr(kb, "_resolve_worker_cli_toolsets", lambda _home: None)
+    monkeypatch.setattr(kb, "_git_toplevel", lambda _path: project)
+
+    captured = []
+
+    class FakeProc:
+        pid = 4242
+
+    def fake_popen(cmd, **kwargs):
+        captured.append((cmd, kwargs))
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="scrape niche source", assignee="Unique Scraper")
+        task = kb.claim_task(conn, task_id)
+        assert task is not None
+        pid = kb._default_spawn(task, str(workspace))
+
+    assert pid == 4242
+    assert captured
+    cmd, kwargs = captured[0]
+    assert "-p" in cmd and "unique-scraper" in cmd
+    hermes_home = Path(kwargs["env"]["HERMES_HOME"])
+    assert hermes_home.parent.name == "profiles"
+    assert hermes_home.name == "unique-scraper"
+    assert project / ".hermes" / "tmp-profiles" in hermes_home.parents
+    assert source_home / "profiles" not in hermes_home.parents
+    assert (hermes_home / "config.yaml").read_text(encoding="utf-8") == "model: test-model\n"
+    assert (hermes_home / ".env").read_text(encoding="utf-8") == "DUMMY_ENV=1\n"
+    assert (hermes_home / "SOUL.md").read_text(encoding="utf-8") == "Base soul\n"
+    assert (hermes_home / "skills" / "research" / "SKILL.md").is_file()
+
+
+def test_cleanup_stale_temp_profiles_only_removes_marked_roots(kanban_home, tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    project.mkdir()
+    workspace = project
+    root = project / ".hermes" / "tmp-profiles"
+    stale = root / "stale"
+    fresh = root / "fresh"
+    durable_like = root / "durable-like"
+    stale.mkdir(parents=True)
+    fresh.mkdir(parents=True)
+    durable_like.mkdir(parents=True)
+    (stale / ".hermes-kanban-temp-profile.json").write_text('{"created_at": 100}\n', encoding="utf-8")
+    (fresh / ".hermes-kanban-temp-profile.json").write_text('{"created_at": 195}\n', encoding="utf-8")
+
+    monkeypatch.setattr(
+        kb,
+        "_temp_profiles_config",
+        lambda: {
+            "enabled": True,
+            "cleanup_after_seconds": 50,
+            "root_dir": ".hermes/tmp-profiles",
+        },
+    )
+
+    removed = kb.cleanup_stale_temp_profile_roots(str(workspace), now=200)
+    assert stale in removed
+    assert not stale.exists()
+    assert fresh.exists()
+    assert durable_like.exists()
+
+
+def test_has_spawnable_ready_true_when_temp_profiles_enabled(kanban_home, monkeypatch):
+    from hermes_cli import profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda name: False)
+    monkeypatch.setattr(
+        kb,
+        "_temp_profiles_config",
+        lambda: {
+            "enabled": True,
+            "cleanup_after_seconds": 7 * 24 * 60 * 60,
+            "root_dir": ".hermes/tmp-profiles",
+        },
+    )
+    with kb.connect() as conn:
+        kb.create_task(conn, title="t", assignee="bespoke-role")
+        assert kb.has_spawnable_ready(conn) is True
+
+
 def test_has_spawnable_ready_false_when_only_terminal_lanes(kanban_home, monkeypatch):
     """``has_spawnable_ready`` returns False when every ready task is
     assigned to a control-plane lane — used by gateway/CLI dispatchers

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1756,6 +1756,72 @@ def test_default_spawn_uses_project_local_temp_profile(kanban_home, tmp_path, mo
     assert (hermes_home / ".env").read_text(encoding="utf-8") == "DUMMY_ENV=1\n"
     assert (hermes_home / "SOUL.md").read_text(encoding="utf-8") == "Base soul\n"
     assert (hermes_home / "skills" / "research" / "SKILL.md").is_file()
+    assert (project / ".hermes" / "tmp-profiles" / ".gitignore").read_text(encoding="utf-8") == "*\n!.gitignore\n"
+
+
+def test_temp_worker_profile_name_sanitizes_path_like_assignee():
+    temp_worker_profile_name = getattr(kb, "_temp_worker_profile_name")
+    assert temp_worker_profile_name("../../Outside Role") == "outside-role"
+    assert temp_worker_profile_name("/tmp/leak") == "tmp-leak"
+
+
+def test_dispatch_temp_profiles_skip_reserved_invalid_assignee(kanban_home, monkeypatch):
+    from hermes_cli import profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda name: False)
+    monkeypatch.setattr(
+        kb,
+        "_temp_profiles_config",
+        lambda: {
+            "enabled": True,
+            "cleanup_after_seconds": 7 * 24 * 60 * 60,
+            "root_dir": ".hermes/tmp-profiles",
+        },
+    )
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="bad", assignee="root")
+        res = kb.dispatch_once(conn, dry_run=True)
+    assert t in res.skipped_nonspawnable
+    assert not res.spawned
+
+
+def test_temp_profiles_relative_root_cannot_escape_project(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    project.mkdir()
+    workspace = project / "work"
+    workspace.mkdir()
+    monkeypatch.setattr(kb, "_git_toplevel", lambda _path: project)
+    with pytest.raises(ValueError, match="must stay under the project root"):
+        kb._temp_profiles_root_for_workspace(
+            str(workspace),
+            {"enabled": True, "cleanup_after_seconds": 1, "root_dir": "../outside"},
+        )
+
+
+def test_temp_profile_home_is_contained_for_path_like_assignee(kanban_home, tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    _init_git_repo(project)
+    workspace = project / "work"
+    workspace.mkdir()
+    monkeypatch.setattr(
+        kb,
+        "_temp_profiles_config",
+        lambda: {
+            "enabled": True,
+            "cleanup_after_seconds": 7 * 24 * 60 * 60,
+            "root_dir": ".hermes/tmp-profiles",
+        },
+    )
+    monkeypatch.setattr(kb, "_git_toplevel", lambda _path: project)
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="bad path", assignee="../../outside")
+        task = kb.claim_task(conn, task_id)
+        assert task is not None
+        assert task.assignee is not None
+        hermes_home = kb.ensure_temp_worker_profile(task, str(workspace), task.assignee)
+    assert hermes_home.name == "outside"
+    assert project / ".hermes" / "tmp-profiles" in hermes_home.parents
+    assert tmp_path / "outside" not in hermes_home.parents
 
 
 def test_cleanup_stale_temp_profiles_only_removes_marked_roots(kanban_home, tmp_path, monkeypatch):

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -509,8 +509,8 @@ Config knobs (all under `kanban:` in `~/.hermes/config.yaml`):
 | `orchestrator_profile` | `""` | Profile assigned to the root/orchestration task after decomposition. Empty = fall back to active default profile. |
 | `default_assignee` | `""` | Where a child task lands when the LLM picks an unknown profile. Empty = fall back to active default. |
 | `auto_subscribe_on_create` | `true` | When a worker calls `kanban_create` from inside a session with a persistent delivery channel (messaging gateway or TUI), the originating session is auto-subscribed to the new task's completion/block events. The dispatcher still drives the delivery — this only changes whether the caller's chat/key shows up in the notify-sub table. Set to `false` to require explicit `kanban_notify-subscribe` calls per task. |
-| `temp_profiles.enabled` | `false` | Spawn each worker attempt with a fresh project-local temp `HERMES_HOME` instead of the durable profile home. Useful for orchestrators that assign ad-hoc roles (`mckinsey-style`, one-off scrapers) without polluting `~/.hermes/profiles`. |
-| `temp_profiles.root_dir` | `.hermes/tmp-profiles` | Directory for temp Hermes homes. Relative paths are rooted at the task project/git root, so repo runs keep their worker state under the project folder. |
+| `temp_profiles.enabled` | `false` | Spawn each worker attempt with a fresh project-local temp `HERMES_HOME` instead of the durable profile home. Useful for orchestrators that assign ad-hoc roles (`mckinsey-style`, one-off scrapers) without polluting `~/.hermes/profiles`. The dispatcher validates/sanitizes role names before creating paths. |
+| `temp_profiles.root_dir` | `.hermes/tmp-profiles` | Directory for temp Hermes homes. Relative paths are rooted at the task project/git root and may not escape it; absolute paths are trusted operator overrides. The dispatcher writes a local `.gitignore` in this directory because cloned `.env` secrets can live in temp profiles. |
 | `temp_profiles.cleanup_after_seconds` | `604800` | Best-effort GC age for marked temp-profile roots. Only directories with the kanban temp-profile marker are removed. |
 
 And the two auxiliary LLM slots:

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -37,7 +37,7 @@ They look similar; they are not the same primitive.
 |---|---|---|
 | Shape | RPC call (fork → join) | Durable message queue + state machine |
 | Parent | Blocks until child returns | Fire-and-forget after `create` |
-| Child identity | Anonymous subagent | Named profile with persistent memory |
+| Child identity | Anonymous subagent | Named profile; optionally fresh project-local temp profile per run |
 | Resumability | None — failed = failed | Block → unblock → re-run; crash → reclaim |
 | Human in the loop | Not supported | Comment / unblock at any point |
 | Agents per task | One call = one subagent | N agents over task's life (retry, review, follow-up) |
@@ -66,7 +66,7 @@ They coexist: a kanban worker may call `delegate_task` internally during its run
   - `scratch` (default) — fresh tmp dir under `~/.hermes/kanban/workspaces/<id>/` (or `~/.hermes/kanban/boards/<slug>/workspaces/<id>/` on non-default boards). **Deleted when the task completes** — scratch is ephemeral by design, so the dir is wiped the moment the worker (or `hermes kanban complete <id>`) marks the task done. If you want to keep the worker's output, use `worktree:` or `dir:<path>` instead. The first time a scratch workspace is created on an install, the dispatcher logs a warning and emits a `tip_scratch_workspace` event on the task (visible via `hermes kanban show <id>`).
   - `dir:<path>` — an existing shared directory (Obsidian vault, mail ops dir, per-account folder). **Must be an absolute path.** Relative paths like `dir:../tenants/foo/` are rejected at dispatch because they'd resolve against whatever CWD the dispatcher happens to be in, which is ambiguous and a confused-deputy escape vector. The path is otherwise trusted — it's your box, your filesystem, the worker runs with your uid. This is the trusted-local-user threat model; kanban is single-host by design. **Preserved on completion.**
   - `worktree` — a git worktree under `.worktrees/<id>/` for coding tasks. Use `worktree:<path>` to pin the exact target path. Worker-side `git worktree add` creates it, using `--branch` when provided. **Preserved on completion.**
-- **Dispatcher** — a long-lived loop that, every N seconds (default 60): reclaims stale claims, reclaims crashed workers (PID gone but TTL not yet expired), promotes ready tasks, atomically claims, spawns assigned profiles. Runs **inside the gateway** by default (`kanban.dispatch_in_gateway: true`). One dispatcher sweeps all boards per tick; workers are spawned with `HERMES_KANBAN_BOARD` pinned so they can't see other boards. After `kanban.failure_limit` consecutive spawn failures on the same task (default: 2) the dispatcher auto-blocks it with the last error as the reason — prevents thrashing on tasks whose profile doesn't exist, workspace can't mount, etc.
+- **Dispatcher** — a long-lived loop that, every N seconds (default 60): reclaims stale claims, reclaims crashed workers (PID gone but TTL not yet expired), promotes ready tasks, atomically claims, spawns assigned profiles. Runs **inside the gateway** by default (`kanban.dispatch_in_gateway: true`). One dispatcher sweeps all boards per tick; workers are spawned with `HERMES_KANBAN_BOARD` pinned so they can't see other boards. After `kanban.failure_limit` consecutive spawn failures on the same task/profile, the task is blocked until a human intervenes. If `kanban.temp_profiles.enabled` is true, the dispatcher clones the assigned profile's config into a fresh project-local temp `HERMES_HOME` for each worker attempt instead of writing runtime state into the main profile registry.
 - **Tenant** — optional string namespace *within* a board. One specialist fleet can serve multiple businesses (`--tenant business-a`) with data isolation by workspace path and memory key prefix. Tenants are a soft filter; boards are the hard isolation boundary.
 
 ## Boards (multi-project)
@@ -509,6 +509,9 @@ Config knobs (all under `kanban:` in `~/.hermes/config.yaml`):
 | `orchestrator_profile` | `""` | Profile assigned to the root/orchestration task after decomposition. Empty = fall back to active default profile. |
 | `default_assignee` | `""` | Where a child task lands when the LLM picks an unknown profile. Empty = fall back to active default. |
 | `auto_subscribe_on_create` | `true` | When a worker calls `kanban_create` from inside a session with a persistent delivery channel (messaging gateway or TUI), the originating session is auto-subscribed to the new task's completion/block events. The dispatcher still drives the delivery — this only changes whether the caller's chat/key shows up in the notify-sub table. Set to `false` to require explicit `kanban_notify-subscribe` calls per task. |
+| `temp_profiles.enabled` | `false` | Spawn each worker attempt with a fresh project-local temp `HERMES_HOME` instead of the durable profile home. Useful for orchestrators that assign ad-hoc roles (`mckinsey-style`, one-off scrapers) without polluting `~/.hermes/profiles`. |
+| `temp_profiles.root_dir` | `.hermes/tmp-profiles` | Directory for temp Hermes homes. Relative paths are rooted at the task project/git root, so repo runs keep their worker state under the project folder. |
+| `temp_profiles.cleanup_after_seconds` | `604800` | Best-effort GC age for marked temp-profile roots. Only directories with the kanban temp-profile marker are removed. |
 
 And the two auxiliary LLM slots:
 


### PR DESCRIPTION
## Summary
- add opt-in Kanban temp profile mode that creates fresh project-local HERMES_HOME trees for worker attempts
- allow ad-hoc assignee names in temp mode without durable ~/.hermes/profile entries
- add marker-based GC for stale temp profile roots and docs/tests

## Test Plan
- pytest -q tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_profiles.py tests/hermes_cli/test_kanban_dispatch_lock.py
- python -m py_compile hermes_cli/kanban_db.py hermes_cli/config.py tests/hermes_cli/test_kanban_db.py
- git diff --check
- manual temp-profile proof: generated profile under project .hermes/tmp-profiles and confirmed global ~/.hermes/profiles unchanged
