### PR TITLE
fix(gateway): preserve runtime provider model (#48061)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1087,6 +1087,7 @@ class APIServerAdapter(BasePlatformAdapter):
         """
         from run_agent import AIAgent
         from gateway.run import (
+            _consume_runtime_model,
             _current_max_iterations,
             _resolve_runtime_agent_kwargs,
             _resolve_gateway_model,
@@ -1098,6 +1099,7 @@ class APIServerAdapter(BasePlatformAdapter):
         runtime_kwargs = _resolve_runtime_agent_kwargs()
         reasoning_config = GatewayRunner._load_reasoning_config()
         model = _resolve_gateway_model()
+        model, runtime_kwargs = _consume_runtime_model(model, runtime_kwargs)
 
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1790,7 +1790,44 @@ def _resolve_runtime_agent_kwargs() -> dict:
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
         "max_tokens": max_tokens,
+        "model": runtime.get("model"),
+        "name": runtime.get("name"),
     }
+
+
+def _consume_runtime_model(model: str, runtime_kwargs: dict) -> tuple[str, dict]:
+    """Apply and remove a runtime-provider model from agent kwargs.
+
+    Runtime provider resolution may supply an explicit model in addition to
+    credentials. AIAgent still receives ``model`` as a separate constructor
+    argument, so callers must consume this handoff key instead of forwarding it
+    through ``**runtime_kwargs`` where it would collide with ``model=...``.
+
+    Precedence mirrors the canonical CLI path
+    (``hermes_cli/cli_agent_setup_mixin.py``) and the delegation path
+    (``tools/delegate_tool.py``): an explicit ``model.default`` WINS over the
+    provider's ``model`` field. The runtime model is only applied when the
+    configured model is empty or is just the provider slug / display name
+    (i.e. the user never picked a real model), so the gateway does not silently
+    diverge from the CLI for a user who set ``model.default`` (#48061 review).
+    """
+    runtime_model = runtime_kwargs.pop("model", None)
+    provider_slug = runtime_kwargs.get("provider")
+    provider_name = runtime_kwargs.pop("name", None)
+    if runtime_model and isinstance(runtime_model, str):
+        should_use_runtime_model = (
+            not model
+            or model == provider_slug
+            or model == provider_name
+        )
+        if should_use_runtime_model:
+            logger.info(
+                "Runtime provider supplied model (config model empty/provider-name): %s -> %s",
+                model,
+                runtime_model,
+            )
+            model = runtime_model
+    return model, runtime_kwargs
 
 
 def _try_resolve_fallback_provider() -> dict | None:
@@ -3358,14 +3395,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
 
         runtime_kwargs = _resolve_runtime_agent_kwargs()
-        runtime_model = runtime_kwargs.pop("model", None)
-        if runtime_model:
-            logger.info(
-                "Runtime provider supplied explicit model override: %s -> %s",
-                model,
-                runtime_model,
-            )
-            model = runtime_model
+        model, runtime_kwargs = _consume_runtime_model(model, runtime_kwargs)
         if override and resolved_session_key:
             model, runtime_kwargs = self._apply_session_model_override(
                 resolved_session_key, model, runtime_kwargs

--- a/plugins/platforms/feishu/feishu_comment.py
+++ b/plugins/platforms/feishu/feishu_comment.py
@@ -979,8 +979,9 @@ def _resolve_model_and_runtime() -> Tuple[str, dict]:
     user_config = _load_gateway_config()
     model = _resolve_gateway_model(user_config)
 
-    from gateway.run import _resolve_runtime_agent_kwargs
+    from gateway.run import _consume_runtime_model, _resolve_runtime_agent_kwargs
     runtime_kwargs = _resolve_runtime_agent_kwargs()
+    model, runtime_kwargs = _consume_runtime_model(model, runtime_kwargs)
 
     # Fall back to provider's default model if none configured
     if not model and runtime_kwargs.get("provider"):

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -337,6 +337,41 @@ class TestAdapterInit:
         assert isinstance(agent, FakeAgent)
         assert captured["reasoning_config"] == {"enabled": True, "effort": "xhigh"}
 
+    def test_create_agent_consumes_runtime_provider_model(self, monkeypatch):
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        monkeypatch.setattr(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            lambda: {
+                "provider": "custom-runtime",
+                "base_url": "https://example.test/v1",
+                "api_mode": "openai",
+                "model": "runtime/model-from-provider",
+            },
+        )
+        monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "")
+        monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {})
+        monkeypatch.setattr(
+            "gateway.run.GatewayRunner._load_reasoning_config",
+            staticmethod(lambda: {}),
+        )
+        monkeypatch.setattr("gateway.run.GatewayRunner._load_fallback_model", staticmethod(lambda: None))
+        monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_: set())
+
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+
+        agent = adapter._create_agent(session_id="api-session")
+
+        assert isinstance(agent, FakeAgent)
+        assert captured["model"] == "runtime/model-from-provider"
+        assert captured["provider"] == "custom-runtime"
+
     def test_create_agent_refreshes_max_iterations_from_runtime_config(self, monkeypatch):
         captured = {}
 

--- a/tests/gateway/test_runtime_provider_model_handoff.py
+++ b/tests/gateway/test_runtime_provider_model_handoff.py
@@ -1,0 +1,133 @@
+from gateway import run as gateway_run
+
+
+def _runner():
+    runner = gateway_run.GatewayRunner.__new__(gateway_run.GatewayRunner)
+    runner._session_model_overrides = {}
+    runner._last_resolved_model = {}
+    return runner
+
+
+def test_runtime_agent_kwargs_preserves_explicit_provider_model(monkeypatch):
+    def fake_resolve_runtime_provider():
+        return {
+            "api_key": "sk-test",
+            "base_url": "https://example.test/v1",
+            "provider": "custom-runtime",
+            "api_mode": "openai",
+            "model": "runtime/model-from-provider",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        fake_resolve_runtime_provider,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider._get_model_config",
+        lambda: {"default": ""},
+    )
+
+    kwargs = gateway_run._resolve_runtime_agent_kwargs()
+
+    assert kwargs["provider"] == "custom-runtime"
+    assert kwargs["model"] == "runtime/model-from-provider"
+
+
+def test_session_runtime_uses_provider_model_when_config_model_empty(monkeypatch):
+    def fake_resolve_runtime_provider():
+        return {
+            "api_key": "sk-test",
+            "base_url": "https://example.test/v1",
+            "provider": "custom-runtime",
+            "api_mode": "openai",
+            "model": "runtime/model-from-provider",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        fake_resolve_runtime_provider,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider._get_model_config",
+        lambda: {"default": ""},
+    )
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda _cfg=None: "")
+
+    model, runtime_kwargs = _runner()._resolve_session_agent_runtime(session_key="sid")
+
+    assert model == "runtime/model-from-provider"
+    assert "model" not in runtime_kwargs
+    assert runtime_kwargs["provider"] == "custom-runtime"
+
+
+def test_consume_runtime_model_leaves_kwargs_safe_for_agent_constructor():
+    model, runtime_kwargs = gateway_run._consume_runtime_model(
+        "",
+        {
+            "provider": "custom-runtime",
+            "model": "runtime/model-from-provider",
+        },
+    )
+
+    assert model == "runtime/model-from-provider"
+    assert runtime_kwargs == {"provider": "custom-runtime"}
+
+
+def test_consume_runtime_model_explicit_default_wins_over_provider_model():
+    """Precedence: an explicit model.default WINS over a provider's model field
+    (mirrors the CLI guard in cli_agent_setup_mixin.py). The runtime model only
+    applies when the configured model is empty or is just the provider slug/name
+    — otherwise the gateway would silently diverge from the CLI (#48061 review)."""
+    # Explicit, real model configured → runtime model must NOT override it.
+    model, kwargs = gateway_run._consume_runtime_model(
+        "anthropic/claude-opus",
+        {"provider": "custom-runtime", "name": "My Provider",
+         "model": "runtime/model-from-provider"},
+    )
+    assert model == "anthropic/claude-opus"  # explicit default preserved
+    assert "model" not in kwargs and "name" not in kwargs  # handoff keys consumed
+
+    # Model equals the provider slug (user never picked a real model) → override.
+    model, _ = gateway_run._consume_runtime_model(
+        "custom-runtime",
+        {"provider": "custom-runtime", "name": "My Provider",
+         "model": "runtime/model-from-provider"},
+    )
+    assert model == "runtime/model-from-provider"
+
+    # Model equals the provider display name → override.
+    model, _ = gateway_run._consume_runtime_model(
+        "My Provider",
+        {"provider": "custom-runtime", "name": "My Provider",
+         "model": "runtime/model-from-provider"},
+    )
+    assert model == "runtime/model-from-provider"
+
+
+def test_session_runtime_keeps_provider_default_fallback_without_runtime_model(monkeypatch):
+    def fake_resolve_runtime_provider():
+        return {
+            "api_key": "sk-test",
+            "base_url": "https://example.test/v1",
+            "provider": "custom-runtime",
+            "api_mode": "openai",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        fake_resolve_runtime_provider,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider._get_model_config",
+        lambda: {"default": ""},
+    )
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda _cfg=None: "")
+    monkeypatch.setattr(
+        "hermes_cli.models.get_default_model_for_provider",
+        lambda provider: "catalog/default" if provider == "custom-runtime" else "",
+    )
+
+    model, runtime_kwargs = _runner()._resolve_session_agent_runtime(session_key="sid")
+
+    assert model == "catalog/default"
+    assert runtime_kwargs["provider"] == "custom-runtime"


### PR DESCRIPTION
## Summary

Closes #48061 — gateway builds the agent with an empty model when relying on a runtime/custom provider.

`resolve_runtime_provider()` returns a `"model"` key for custom/runtime providers, but `_resolve_runtime_agent_kwargs()` (`gateway/run.py`) dropped it — its return dict never copied `runtime.get("model")`. So when `model.default` is unset, the agent is built with `model=""` → the reported `MODEL: '' / PROVIDER: None`.

Verified still live on current `main` (`64131bf97`): the omission at `gateway/run.py` is unfixed, and the session path's `runtime_kwargs.pop("model", None)` is dead code today because the key is never present. Recent provider/model churn (anthropic pool, model-switch PRs) did not touch this.

## Fix

Add the missing `"model"` to `_resolve_runtime_agent_kwargs()`'s return, and introduce a shared `_consume_runtime_model()` helper wired through all three sibling call paths (session, `api_server._create_agent`, feishu) — fixes the whole bug class, not one site.

## Salvage / attribution

Salvaged from #49899 (@Tranquil-Flow), cherry-picked onto current `main`; authored by @Tranquil-Flow. Applies cleanly (no conflicts).

## Tests

New `tests/gateway/test_runtime_provider_model_handoff.py` (invariant-style) + `test_api_server.py::TestAdapterInit` additions — 25 tests pass across the runtime-model / api-server / feishu suites.

Fixes #48061
