### PR TITLE
fix(run_agent): skip OpenAI client rebuild on Anthropic-native sessions

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3631,6 +3631,24 @@ class AIAgent:
             )
 
     def _replace_primary_openai_client(self, *, reason: str) -> bool:
+        # Anthropic-native sessions use _anthropic_client, not self.client.
+        # Attempting to rebuild an OpenAI client here unconditionally fails
+        # with "OPENAI_API_KEY not set" on profiles that only have
+        # ANTHROPIC_API_KEY (e.g. reeve), and the error message is actively
+        # misleading — the real provider key is present, just not an OpenAI
+        # one.  Rebuild the correct client instead.
+        if getattr(self, "api_mode", "") == "anthropic_messages":
+            try:
+                self._rebuild_anthropic_client()
+            except Exception as exc:
+                logger.warning(
+                    "Failed to rebuild shared Anthropic client (%s) %s error=%s",
+                    reason,
+                    self._client_log_context(),
+                    exc,
+                )
+                return False
+            return True
         with self._openai_client_lock():
             old_client = getattr(self, "client", None)
             try:

--- a/tests/run_agent/test_anthropic_stream_pool_cleanup.py
+++ b/tests/run_agent/test_anthropic_stream_pool_cleanup.py
@@ -1,0 +1,144 @@
+"""Regression test for the stale-stream pool-cleanup misfiring on Anthropic sessions.
+
+Bug: ``_replace_primary_openai_client`` was called unconditionally by all three
+stream-cleanup paths in ``chat_completion_helpers``.  When the active
+``api_mode`` is ``"anthropic_messages"`` the agent uses ``_anthropic_client``
+and ``self.client`` is ``None``; ``_client_kwargs`` is an empty dict ``{}``.
+The unconditional ``OpenAI(**{})`` call inside the rebuild then raises
+``AuthenticationError`` / ``ValueError`` with the message
+  "The api_key client option must be set … by setting the OPENAI_API_KEY
+   environment variable"
+even though the provider is Anthropic and the correct key is present.
+
+Fix: ``_replace_primary_openai_client`` now short-circuits on
+``api_mode == "anthropic_messages"`` and calls ``_rebuild_anthropic_client``
+instead, which knows how to build the correct client type.
+
+See: reeve errors.log 2026-06-23 (task t_2ac53e81)
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+@pytest.fixture
+def anthropic_agent():
+    """Minimal AIAgent wired for provider=anthropic / api_mode=anthropic_messages.
+
+    We patch ``run_agent.OpenAI`` so the initial client construction
+    (chat_completions path) doesn't need a real key, then immediately flip the
+    agent into Anthropic-native mode by setting the relevant attributes
+    directly — the same state reached after a switch_model() to anthropic.
+    """
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="sk-openai-placeholder",
+            base_url="https://api.openai.com/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    # Simulate the state after switch_model() → anthropic:
+    a.provider = "anthropic"
+    a.api_mode = "anthropic_messages"
+    a.client = None
+    a._client_kwargs = {}          # empty — no OpenAI creds, by design
+    a._anthropic_api_key = "sk-ant-correct-key"
+    a._anthropic_base_url = "https://api.anthropic.com"
+    a._anthropic_client = MagicMock()
+    a._is_anthropic_oauth = False
+    return a
+
+
+class TestReplaceClientAnthropicNative:
+    """_replace_primary_openai_client must not attempt OpenAI construction on
+    Anthropic-native sessions."""
+
+    def test_does_not_call_openai_constructor(self, anthropic_agent):
+        """OpenAI() must never be invoked when api_mode=anthropic_messages."""
+        with (
+            patch("run_agent.OpenAI") as mock_openai,
+            patch.object(
+                anthropic_agent,
+                "_rebuild_anthropic_client",
+                return_value=None,
+            ),
+        ):
+            result = anthropic_agent._replace_primary_openai_client(
+                reason="stale_stream_pool_cleanup"
+            )
+
+        mock_openai.assert_not_called()
+        assert result is True
+
+    def test_calls_rebuild_anthropic_client(self, anthropic_agent):
+        """The Anthropic rebuild path must be called instead."""
+        with patch.object(
+            anthropic_agent,
+            "_rebuild_anthropic_client",
+        ) as mock_rebuild:
+            result = anthropic_agent._replace_primary_openai_client(
+                reason="stream_retry_pool_cleanup"
+            )
+
+        mock_rebuild.assert_called_once()
+        assert result is True
+
+    def test_returns_false_and_logs_warning_on_rebuild_failure(
+        self, anthropic_agent, caplog
+    ):
+        """If _rebuild_anthropic_client raises, return False and emit the right
+        warning — not an OPENAI_API_KEY error."""
+        import logging
+
+        with (
+            patch.object(
+                anthropic_agent,
+                "_rebuild_anthropic_client",
+                side_effect=ValueError("Anthropic API key missing"),
+            ),
+            caplog.at_level(logging.WARNING, logger="run_agent"),
+        ):
+            result = anthropic_agent._replace_primary_openai_client(
+                reason="stale_stream_pool_cleanup"
+            )
+
+        assert result is False
+        # Warning must name the Anthropic client, not the OpenAI one.
+        assert any(
+            "Anthropic client" in r.message for r in caplog.records
+        ), f"Expected 'Anthropic client' in warning; got: {[r.message for r in caplog.records]}"
+        # The misleading OPENAI_API_KEY phrase must NOT appear.
+        assert not any(
+            "OpenAI client" in r.message for r in caplog.records
+        ), "Unexpected 'OpenAI client' warning fired for Anthropic provider"
+
+    def test_openai_path_still_works_for_openai_provider(self, anthropic_agent):
+        """Regression guard: the OpenAI rebuild path still fires for non-Anthropic
+        sessions (i.e. the guard only skips on anthropic_messages)."""
+        anthropic_agent.api_mode = "chat_completions"
+        anthropic_agent.provider = "openai"
+        anthropic_agent._client_kwargs = {"api_key": "sk-openai-real", "base_url": "https://api.openai.com/v1"}
+        fake_new_client = MagicMock()
+        fake_new_client._client = MagicMock(is_closed=False)
+
+        with patch.object(
+            anthropic_agent,
+            "_create_openai_client",
+            return_value=fake_new_client,
+        ) as mock_create:
+            result = anthropic_agent._replace_primary_openai_client(
+                reason="stale_stream_pool_cleanup"
+            )
+
+        mock_create.assert_called_once()
+        assert result is True


### PR DESCRIPTION
## What

`_replace_primary_openai_client` was called unconditionally by all three stream-cleanup paths in `chat_completion_helpers` (`stale_stream_pool_cleanup`, `stream_retry_pool_cleanup`, `stream_mid_tool_retry_pool_cleanup`). When `api_mode=anthropic_messages` the agent owns `_anthropic_client` and `self.client` is `None`; `_client_kwargs` is an empty dict. The unconditional `OpenAI(**{})` call raised `AuthenticationError` with `"The api_key client option must be set … OPENAI_API_KEY"` even though the correct Anthropic key was present.

This produced a deterministic false-alarm `WARNING` in `errors.log` on every Anthropic stream stall for profiles that have `ANTHROPIC_API_KEY` but no `OPENAI_API_KEY` — which is correct configuration. 3 occurrences verified on a single session.

## Root cause

All three cleanup sites call `agent._replace_primary_openai_client()`. That method calls `_create_openai_client(self._client_kwargs, ...)` → `OpenAI(**{})`. The OpenAI SDK then reads the env for `OPENAI_API_KEY`, finds nothing, and raises. The exception is caught by the `except Exception: pass` guard at each call site (so the agent continues), but the `logger.warning` inside `_replace_primary_openai_client` fires first and lands in `errors.log` with a misleading message.

## Fix

Short-circuit on `api_mode == "anthropic_messages"` and call `_rebuild_anthropic_client()` instead — the existing method that already handles both direct Anthropic and Bedrock-hosted variants and honours `_oauth_1m_beta_disabled`. The OpenAI path is unchanged; the guard only fires on the Anthropic wire.

## Tests

4 new regression tests in `tests/run_agent/test_anthropic_stream_pool_cleanup.py`:
- `OpenAI()` constructor never called for Anthropic-native sessions
- `_rebuild_anthropic_client` is invoked instead
- Failure emits the right warning text (`Anthropic client`, not `OpenAI client`)
- OpenAI path still fires for `api_mode=chat_completions`

All 4 pass; 19 adjacent lifecycle/switch-model tests unaffected.