### PR TITLE
fix(anthropic): validate converted tool names

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1666,25 +1666,42 @@ def convert_tools_to_anthropic(tools: List[Dict]) -> List[Dict]:
     result = []
     seen_names: set = set()
     for t in tools:
-        fn = t.get("function", {})
-        name = fn.get("name", "")
+        fn = t.get("function")
+        if not isinstance(fn, dict):
+            fn = {}
+        # Some MCP/plugin tools use the bare schema instead of an OpenAI
+        # ``function`` wrapper. Strict Anthropic-compatible endpoints reject
+        # the whole request if either shape contributes an invalid name.
+        name = fn.get("name")
+        if not isinstance(name, str) or not name:
+            name = t.get("name")
+        if not isinstance(name, str) or not name:
+            logger.warning(
+                "convert_tools_to_anthropic: skipping tool with no valid name "
+                "(function=%r, top-level=%r)",
+                fn.get("name"),
+                t.get("name"),
+            )
+            continue
         # Defensive dedup: Anthropic rejects requests with duplicate tool
         # names.  Upstream injection paths already dedup, but this guard
         # converts a hard API failure into a warning.  See: #18478
-        if name and name in seen_names:
+        if name in seen_names:
             logger.warning(
                 "convert_tools_to_anthropic: duplicate tool name '%s' "
                 "— dropping second occurrence",
                 name,
             )
             continue
-        if name:
-            seen_names.add(name)
+        seen_names.add(name)
         anthropic_tool: Dict[str, Any] = {
             "name": name,
-            "description": fn.get("description", ""),
+            "description": fn.get("description") or t.get("description", ""),
             "input_schema": _normalize_tool_input_schema(
-                fn.get("parameters", {"type": "object", "properties": {}})
+                fn.get("parameters")
+                or t.get("parameters")
+                or t.get("input_schema")
+                or {"type": "object", "properties": {}}
             ),
         }
         # Forward cache_control marker when present on the OpenAI-format

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -819,6 +819,55 @@ class TestConvertTools:
         }
         assert result[0]["input_schema"]["required"] == ["command"]
 
+    def test_tool_with_top_level_name_is_converted(self):
+        tools = [
+            {
+                "name": "flat_tool",
+                "description": "A tool without the function wrapper",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"q": {"type": "string"}},
+                    "required": ["q"],
+                },
+            }
+        ]
+        result = convert_tools_to_anthropic(tools)
+        assert len(result) == 1
+        assert result[0]["name"] == "flat_tool"
+        assert result[0]["description"] == "A tool without the function wrapper"
+        assert result[0]["input_schema"]["properties"]["q"]["type"] == "string"
+
+    def test_tool_without_resolvable_name_is_skipped(self):
+        tools = [
+            {"function": {"description": "no name", "parameters": {}}},
+            {
+                "type": "function",
+                "function": {
+                    "name": "ok",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+        ]
+        result = convert_tools_to_anthropic(tools)
+        assert [t["name"] for t in result] == ["ok"]
+
+    def test_tools_with_non_string_names_are_skipped(self):
+        tools = [
+            {"name": 123, "parameters": {"type": "object"}},
+            {"function": {"name": ["invalid"], "parameters": {}}},
+            {
+                "type": "function",
+                "function": {
+                    "name": "ok",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+        ]
+
+        result = convert_tools_to_anthropic(tools)
+
+        assert [tool["name"] for tool in result] == ["ok"]
+
 
 # ---------------------------------------------------------------------------
 # Message conversion


### PR DESCRIPTION
## What does this PR do?

It prevents malformed Anthropic tool payloads when an MCP or plugin tool arrives without the OpenAI `function` wrapper. The converter now accepts a valid top-level name and skips entries whose resolved name is missing, empty, or not a string, so one malformed tool cannot invalidate the complete request or crash duplicate detection.

## Related Issue

Fixes #51381

## Type of Change

- [x] Bug fix (non-breaking change)
- [x] Regression tests

## Changes Made

- `agent/anthropic_message_convert.py`: resolve names and schema fields from wrapped or bare tool definitions; require a non-empty string before deduplication and serialization; preserve valid tools when malformed entries are skipped.
- `tests/agent/test_anthropic_adapter.py`: add regressions for bare schemas, missing names, and non-string names alongside a valid tool.
- No dependencies, provider behavior, or retry/fallback policy changed.

## How to Test

- `scripts/run_tests.sh tests/agent/test_anthropic_adapter.py -q`: 98 passed on macOS arm64 with Python 3.11.
- `scripts/check.sh --project hermes-agent --worktree worktrees/hermes-agent/51381`: all blocking gates passed, including `uv lock --check`, Ruff, and the changed-file test runner.
- Final head: `b52ea3999ff102077669635110f19120efa5e320`, rebased onto `origin/main` `3aee290899e478c5fdfb6a241ef62758a49829b3`.
- The exact-base regression cases fail before this change and pass here; the full changed file has only the same credential-dependent failures as the base.

## Checklist

### Code

- [x] I have read the Contributing Guide.
- [x] The commit message follows Conventional Commits.
- [x] Existing related PRs were inspected; this updates the existing PR only.
- [x] The PR contains only changes related to this issue.
- [x] Regression tests cover the wrapped and bare schema paths.
- [x] Cross-platform impact was considered; this is provider-independent dictionary validation.

### Documentation & Housekeeping

- [x] No user-facing configuration, dependency, or tool schema changed.
- [x] No documentation update is required for this internal serialization guard.