### PR TITLE
fix(delegation): reload live config before reading limits

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -11,8 +11,10 @@ Run with:  python -m pytest tests/test_delegate.py -v
 
 import json
 import os
+import sys
 import threading
 import time
+import types
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -22,6 +24,7 @@ from tools.delegate_tool import (
     DelegateEvent,
     _get_max_concurrent_children,
     _LEGACY_EVENT_MAP,
+    _load_config,
     MAX_DEPTH,
     check_delegate_requirements,
     delegate_task,
@@ -2194,6 +2197,119 @@ class TestConcurrencyDefaults(unittest.TestCase):
            return_value={"max_concurrent_children": 6})
     def test_configured_value_returned(self, mock_cfg):
         self.assertEqual(_get_max_concurrent_children(), 6)
+
+    def test_persistent_config_wins_over_stale_cli_snapshot(self):
+        """Long-lived CLI sessions must see config.yaml edits made after startup."""
+        fake_cli = types.ModuleType("cli")
+        fake_cli.CLI_CONFIG = {"delegation": {"max_concurrent_children": 3}}
+
+        with patch.dict(sys.modules, {"cli": fake_cli}), patch(
+            "hermes_cli.config.load_config",
+            return_value={"delegation": {"max_concurrent_children": 5}},
+        ), patch(
+            "hermes_cli.config.read_raw_config",
+            return_value={"delegation": {"max_concurrent_children": 5}},
+        ):
+            self.assertEqual(_load_config()["max_concurrent_children"], 5)
+            self.assertEqual(_get_max_concurrent_children(), 5)
+
+    def test_merged_defaults_do_not_shadow_env_fallback(self):
+        """Merged persistent defaults must not block DELEGATION_* fallbacks."""
+        fake_cli = types.ModuleType("cli")
+        fake_cli.CLI_CONFIG = {"delegation": {}}
+
+        with patch.dict(sys.modules, {"cli": fake_cli}), patch.dict(
+            os.environ,
+            {"DELEGATION_MAX_CONCURRENT_CHILDREN": "12"},
+        ), patch(
+            "hermes_cli.config.load_config",
+            return_value={"delegation": {"max_concurrent_children": 3}},
+        ), patch(
+            "hermes_cli.config.read_raw_config",
+            return_value={},
+        ):
+            self.assertNotIn("max_concurrent_children", _load_config())
+            self.assertEqual(_get_max_concurrent_children(), 12)
+
+    def test_managed_delegation_limit_wins_over_env_fallback(self):
+        """Admin-managed delegation limits must remain config-authoritative."""
+        fake_cli = types.ModuleType("cli")
+        fake_cli.CLI_CONFIG = {"delegation": {}}
+
+        with patch.dict(sys.modules, {"cli": fake_cli}), patch.dict(
+            os.environ,
+            {"DELEGATION_MAX_CONCURRENT_CHILDREN": "12"},
+        ), patch(
+            "hermes_cli.config.load_config",
+            return_value={"delegation": {"max_concurrent_children": 6}},
+        ), patch(
+            "hermes_cli.config.read_raw_config",
+            return_value={},
+        ), patch(
+            "hermes_cli.managed_scope.load_managed_config",
+            return_value={"delegation": {"max_concurrent_children": 6}},
+        ):
+            self.assertEqual(_load_config()["max_concurrent_children"], 6)
+            self.assertEqual(_get_max_concurrent_children(), 6)
+
+    def test_project_cli_snapshot_fallback_is_preserved(self):
+        """Repo-local cli-config.yaml fallback values live only in CLI_CONFIG."""
+        fake_cli = types.ModuleType("cli")
+        fake_cli.CLI_CONFIG = {
+            "delegation": {
+                "model": "google/gemini-3-flash-preview",
+                "provider": "openrouter",
+                "max_iterations": 90,
+            }
+        }
+
+        with patch.dict(sys.modules, {"cli": fake_cli}), patch(
+            "hermes_cli.config.load_config",
+            return_value={
+                "delegation": {
+                    "model": "",
+                    "provider": "",
+                    "max_iterations": 50,
+                }
+            },
+        ), patch(
+            "hermes_cli.config.read_raw_config",
+            return_value={},
+        ), patch(
+            "hermes_cli.managed_scope.load_managed_config",
+            return_value={},
+        ):
+            cfg = _load_config()
+            self.assertEqual(cfg["model"], "google/gemini-3-flash-preview")
+            self.assertEqual(cfg["provider"], "openrouter")
+            self.assertEqual(cfg["max_iterations"], 90)
+
+    def test_ignore_user_config_keeps_cli_snapshot(self):
+        """--ignore-user-config must not reload user delegation settings."""
+        fake_cli = types.ModuleType("cli")
+        fake_cli.CLI_CONFIG = {"delegation": {"max_concurrent_children": 3}}
+
+        with patch.dict(sys.modules, {"cli": fake_cli}), patch.dict(
+            os.environ,
+            {"HERMES_IGNORE_USER_CONFIG": "1"},
+        ), patch(
+            "hermes_cli.config.load_config",
+            return_value={"delegation": {"max_concurrent_children": 5}},
+        ) as load_config:
+            self.assertEqual(_load_config()["max_concurrent_children"], 3)
+            self.assertEqual(_get_max_concurrent_children(), 3)
+            load_config.assert_not_called()
+
+    def test_cli_snapshot_fallback_when_persistent_config_fails(self):
+        fake_cli = types.ModuleType("cli")
+        fake_cli.CLI_CONFIG = {"delegation": {"max_concurrent_children": 7}}
+
+        with patch.dict(sys.modules, {"cli": fake_cli}), patch(
+            "hermes_cli.config.load_config",
+            side_effect=RuntimeError("config unavailable"),
+        ):
+            self.assertEqual(_load_config()["max_concurrent_children"], 7)
+            self.assertEqual(_get_max_concurrent_children(), 7)
 
 
 # =========================================================================

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2809,28 +2809,49 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
 
 
 def _load_config() -> dict:
-    """Load delegation config from CLI_CONFIG or persistent config.
+    """Load the current delegation config.
 
-    Checks the runtime config (cli.py CLI_CONFIG) first, then falls back
-    to the persistent config (hermes_cli/config.py load_config()) so that
-    ``delegation.model`` / ``delegation.provider`` are picked up regardless
-    of the entry point (CLI, gateway, cron).
+    Prefer the persistent config loader for user-configured delegation keys
+    because it invalidates its cache on ``config.yaml`` mtime changes.
+    ``cli.CLI_CONFIG`` is a process-start snapshot, so using it first makes
+    long-lived CLI/TUI sessions ignore mid-session edits such as raising
+    ``max_concurrent_children``.
     """
-    try:
-        from cli import CLI_CONFIG
+    def _cli_snapshot() -> dict:
+        try:
+            from cli import CLI_CONFIG
 
-        cfg = CLI_CONFIG.get("delegation") or {}
+            return CLI_CONFIG.get("delegation") or {}
+        except Exception:
+            return {}
+
+    if os.environ.get("HERMES_IGNORE_USER_CONFIG") == "1":
+        return _cli_snapshot()
+
+    cfg = dict(_cli_snapshot())
+
+    try:
+        from hermes_cli.config import load_config, read_raw_config
+
+        from hermes_cli import managed_scope
+
+        full = load_config()
+        live_cfg = dict(full.get("delegation") or {})
+        raw = read_raw_config().get("delegation") or {}
+        managed = managed_scope.load_managed_config().get("delegation") or {}
+        raw_keys = set(raw) if isinstance(raw, dict) else set()
+        managed_keys = set(managed) if isinstance(managed, dict) else set()
+        configured_keys = raw_keys | managed_keys
+        for key in configured_keys:
+            if key in live_cfg:
+                cfg[key] = live_cfg[key]
+            else:
+                cfg.pop(key, None)
         if cfg:
             return cfg
     except Exception:
         pass
-    try:
-        from hermes_cli.config import load_config
-
-        full = load_config()
-        return full.get("delegation") or {}
-    except Exception:
-        return {}
+    return cfg
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes long-lived CLI/TUI sessions continuing to enforce stale delegation config after `config.yaml` changes mid-session.

`delegate_task` now keeps the CLI/project snapshot as the base config, respects `--ignore-user-config`, and overlays live user/managed delegation keys from the persistent config loader before reading delegation limits, model/provider settings, and budget settings.

## Related Issue

Fixes #51435

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests only

## Changes Made

- Updated `tools/delegate_tool.py` so `_load_config()` can pick up live user/managed delegation edits without discarding CLI/project fallback config.
- Added regression coverage for stale CLI snapshots, env fallback precedence, managed config precedence, project-level fallback preservation, `--ignore-user-config`, and persistent-load fallback behavior.

## How to Test

1. `uv sync --frozen --extra dev`
2. `uv run scripts/run_tests.sh tests/tools/test_delegate.py -- --tb=long`
3. `uv run scripts/run_tests.sh tests/hermes_cli/test_ignore_user_config_flags.py tests/hermes_cli/test_safe_mode.py -- --tb=long`
4. `uv run scripts/run_tests.sh tests/run_agent/test_agent_guardrails.py -- --tb=long`
5. `uv run ruff check tools/delegate_tool.py tests/tools/test_delegate.py`
6. `git diff --check origin/main...HEAD`

Local validation passed for all commands above. The focused regression test simulates a stale startup `cli.CLI_CONFIG` limit of `3` and a live persistent config limit of `5`, then verifies `delegate_task` reads the live limit.

## Checklist

- [x] I have read the contributing guidelines
- [x] My commit follows the conventional commit format
- [x] I searched existing issues/PRs for overlap
- [x] I kept the change scoped to the reported bug
- [x] I added or updated tests covering the change
- [x] I ran focused validation locally
- [x] I considered cross-platform impact; this is pure Python config lookup with no shell/path/process changes
- [x] No new config key or tool schema change is introduced
- [ ] Documentation update needed
