### PR TITLE
fix(gateway): allow session headers in API server CORS preflight

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -542,7 +542,7 @@ class ResponseStore:
 
 _CORS_HEADERS = {
     "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
-    "Access-Control-Allow-Headers": "Authorization, Content-Type, Idempotency-Key",
+    "Access-Control-Allow-Headers": "Authorization, Content-Type, Idempotency-Key, X-Hermes-Session-Id, X-Hermes-Session-Key",
 }
 
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -3121,6 +3121,31 @@ class TestCORS:
             assert "Idempotency-Key" in resp.headers.get("Access-Control-Allow-Headers", "")
 
     @pytest.mark.asyncio
+    async def test_cors_allows_session_headers(self):
+        """Browser preflight may request the advertised session headers.
+
+        /v1/capabilities advertises X-Hermes-Session-Id and
+        X-Hermes-Session-Key, so an allowed origin's preflight requesting
+        them must see both echoed in Access-Control-Allow-Headers — otherwise
+        the browser blocks the real request before it reaches the handler.
+        """
+        adapter = _make_adapter(cors_origins=["http://localhost:3000"])
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.options(
+                "/v1/chat/completions",
+                headers={
+                    "Origin": "http://localhost:3000",
+                    "Access-Control-Request-Method": "POST",
+                    "Access-Control-Request-Headers": "X-Hermes-Session-Id, X-Hermes-Session-Key",
+                },
+            )
+            assert resp.status == 200
+            allow_headers = resp.headers.get("Access-Control-Allow-Headers", "")
+            assert "X-Hermes-Session-Id" in allow_headers
+            assert "X-Hermes-Session-Key" in allow_headers
+
+    @pytest.mark.asyncio
     async def test_cors_sets_vary_origin_header(self):
         adapter = _make_adapter(cors_origins=["http://localhost:3000"])
         app = _create_app(adapter)


### PR DESCRIPTION
### Problem
`/v1/capabilities` advertises `X-Hermes-Session-Id` and `X-Hermes-Session-Key`, and the
request handlers read both — but the static `Access-Control-Allow-Headers` preflight
response only listed `Authorization, Content-Type, Idempotency-Key`. A browser on an
allowed origin (`API_SERVER_CORS_ORIGINS`) that sends those headers has its preflight
rejected, so the real request is blocked before it ever reaches the handler.

### Fix
Add `X-Hermes-Session-Id` and `X-Hermes-Session-Key` to `_CORS_HEADERS`. One-line change:
the origin allowlist is untouched — only headers the handlers already accept become
preflight-allowed.

### Tests
Added `TestCORS.test_cors_allows_session_headers`: an allowed-origin preflight requesting
both headers asserts both are echoed back in `Access-Control-Allow-Headers`.
- New test fails without the fix, passes with it (verified).
- `pytest tests/gateway/test_api_server.py -k cors` → **16 passed**
- `pytest tests/gateway/test_api_server.py` → **166 passed, 1 skipped**