### PR TITLE
fix(gateway): enforce session id length cap on fork and continuation paths

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1038,6 +1038,30 @@ class APIServerAdapter(BasePlatformAdapter):
 
         return raw, None
 
+    def _validate_session_id(self, session_id: str) -> Optional["web.Response"]:
+        """Validate a caller-supplied session identifier.
+
+        Shared by every path where a client can name a session — create,
+        fork, and ``X-Hermes-Session-Id`` continuation — so the same bounds
+        apply uniformly.  The create path historically validated inline while
+        the sibling paths drifted: fork and continuation rejected control
+        characters but never enforced the length cap.
+
+        Rejects control characters (header-injection guard on the echo path)
+        and values longer than ``_MAX_SESSION_HEADER_LEN`` (memory guard,
+        matching the ``X-Hermes-Session-Key`` cap).  Returns a 400
+        ``web.Response`` on failure, or ``None`` when the id is valid.
+        """
+        if not session_id or re.search(r'[\r\n\x00]', session_id):
+            return web.json_response(
+                _openai_error("Invalid session ID", code="invalid_session_id"), status=400
+            )
+        if len(session_id) > self._MAX_SESSION_HEADER_LEN:
+            return web.json_response(
+                _openai_error("Session ID too long", code="invalid_session_id"), status=400
+            )
+        return None
+
     # ------------------------------------------------------------------
     # Session DB helper
     # ------------------------------------------------------------------
@@ -1481,10 +1505,9 @@ class APIServerAdapter(BasePlatformAdapter):
 
         raw_id = body.get("id") or body.get("session_id")
         session_id = str(raw_id).strip() if raw_id else f"api_{int(time.time())}_{uuid.uuid4().hex[:8]}"
-        if not session_id or re.search(r'[\r\n\x00]', session_id):
-            return web.json_response(_openai_error("Invalid session ID", code="invalid_session_id"), status=400)
-        if len(session_id) > self._MAX_SESSION_HEADER_LEN:
-            return web.json_response(_openai_error("Session ID too long", code="invalid_session_id"), status=400)
+        id_err = self._validate_session_id(session_id)
+        if id_err:
+            return id_err
         if db.get_session(session_id):
             return web.json_response(_openai_error(f"Session already exists: {session_id}", code="session_exists"), status=409)
 
@@ -1586,8 +1609,9 @@ class APIServerAdapter(BasePlatformAdapter):
             return err
         db = self._ensure_session_db()
         fork_id = str(body.get("id") or body.get("session_id") or f"api_{int(time.time())}_{uuid.uuid4().hex[:8]}").strip()
-        if not fork_id or re.search(r'[\r\n\x00]', fork_id):
-            return web.json_response(_openai_error("Invalid session ID", code="invalid_session_id"), status=400)
+        id_err = self._validate_session_id(fork_id)
+        if id_err:
+            return id_err
         if db.get_session(fork_id):
             return web.json_response(_openai_error(f"Session already exists: {fork_id}", code="session_exists"), status=409)
 
@@ -1896,12 +1920,11 @@ class APIServerAdapter(BasePlatformAdapter):
                     ),
                     status=403,
                 )
-            # Sanitize: reject control characters that could enable header injection.
-            if re.search(r'[\r\n\x00]', provided_session_id):
-                return web.json_response(
-                    {"error": {"message": "Invalid session ID", "type": "invalid_request_error"}},
-                    status=400,
-                )
+            # Sanitize: reject control characters (header-injection guard) and
+            # over-long ids, matching the create/fork and X-Hermes-Session-Key caps.
+            id_err = self._validate_session_id(provided_session_id)
+            if id_err:
+                return id_err
             session_id = provided_session_id
             try:
                 db = self._ensure_session_db()

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -3428,6 +3428,25 @@ class TestSessionIdHeader:
             assert call_kwargs["conversation_history"] == []
             assert call_kwargs["session_id"] == "some-session"
 
+    @pytest.mark.asyncio
+    async def test_session_id_continuation_rejects_oversized(self, auth_adapter):
+        """An over-long X-Hermes-Session-Id is rejected with 400 before the agent runs.
+
+        Matches the cap already enforced on create-session and
+        X-Hermes-Session-Key, so a caller can't push a multi-kilobyte id
+        into SessionDB lookups, the response-header echo, or logs.
+        """
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"X-Hermes-Session-Id": "x" * 1000, "Authorization": "Bearer sk-secret"},
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]},
+                )
+            assert resp.status == 400
+            mock_run.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # X-Hermes-Session-Key header (long-term memory scoping)

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -212,6 +212,26 @@ async def test_session_fork_uses_current_sessiondb_branch_primitives(adapter, se
 
 
 @pytest.mark.asyncio
+async def test_session_fork_rejects_oversized_session_id(adapter, session_db):
+    """A multi-kilobyte fork id is rejected with 400 — matching the cap the
+    create-session and X-Hermes-Session-Key paths already enforce — and the
+    guard fires before the source session is branched or any fork is created."""
+    source_id = session_db.create_session("source-session", "api_server", model="test-model")
+    session_db.append_message(source_id, "user", "first path")
+
+    oversized = "x" * 1000
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post(f"/api/sessions/{source_id}/fork", json={"id": oversized, "title": "Too long"})
+        assert resp.status == 400
+        payload = await resp.json()
+        assert payload["error"]["code"] == "invalid_session_id"
+
+    assert session_db.get_session(oversized) is None
+    assert session_db.get_session(source_id).get("end_reason") != "branched"
+
+
+@pytest.mark.asyncio
 async def test_session_chat_loads_history_and_preserves_session_headers(auth_adapter, session_db):
     session_id = session_db.create_session("chat-session", "api_server")
     session_db.set_session_title(session_id, "Chat")


### PR DESCRIPTION
## What & why
`POST /api/sessions` and the `X-Hermes-Session-Key` header cap session
identifiers at 256 chars, but two sibling paths missed the cap and only
rejected control chars:
- `POST /api/sessions/{id}/fork` — body `id` / `session_id`
- `X-Hermes-Session-Id` continuation header on `/v1/chat/completions`

So an authenticated client could push a multi-KB id into SessionDB
lookup/create, the echoed response header, and logs.

## Fix
Extract a shared `_validate_session_id()` helper (control-char reject +
256-char cap) and route create, fork, and the continuation path through it,
so the guard applies uniformly and can't drift again. No behavior change on
the create path.

## Tests
Two regression tests added:
- `test_session_fork_rejects_oversized_session_id` — oversized fork id → 400,
  source session not branched, no fork created.
- `test_session_id_continuation_rejects_oversized` — oversized
  `X-Hermes-Session-Id` → 400, `_run_agent` is not called.

Results:
- `pytest tests/gateway/test_api_server.py tests/gateway/test_session_api.py tests/gateway/test_api_server_multimodal.py` → **202 passed, 1 skipped**
- `-k "oversized and session_id"` → **2 passed**