### PR TITLE
fix(gateway): scope idempotency fingerprint to session/memory context

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -670,9 +670,28 @@ class _IdempotencyCache:
 _idem_cache = _IdempotencyCache()
 
 
-def _make_request_fingerprint(body: Dict[str, Any], keys: List[str]) -> str:
+def _make_request_fingerprint(
+    body: Dict[str, Any],
+    keys: List[str],
+    extra: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Hash the request inputs that determine the agent's response.
+
+    ``keys`` selects fields from the JSON body. ``extra`` carries semantic
+    context that lives *outside* the body — session-continuity and
+    memory-scope headers — but still changes what the agent produces.
+
+    The idempotency cache reuses a stored response whenever the key and
+    fingerprint match, so anything that alters the response must be folded
+    in here. Otherwise two requests that share an Idempotency-Key and body
+    but differ in session/memory scope (or in explicit conversation history)
+    collide, and the second caller receives the first caller's answer
+    computed under a different context.
+    """
     from hashlib import sha256
-    subset = {k: body.get(k) for k in keys}
+    subset: Dict[str, Any] = {k: body.get(k) for k in keys}
+    if extra:
+        subset["__ctx__"] = extra
     return sha256(repr(subset).encode("utf-8")).hexdigest()
 
 
@@ -2032,7 +2051,19 @@ class APIServerAdapter(BasePlatformAdapter):
 
         idempotency_key = request.headers.get("Idempotency-Key")
         if idempotency_key:
-            fp = _make_request_fingerprint(body, keys=["model", "messages", "tools", "tool_choice", "stream"])
+            # session_id (from X-Hermes-Session-Id, else derived from the
+            # conversation) selects which history is loaded, and
+            # gateway_session_key (X-Hermes-Session-Key) scopes long-term
+            # memory.  Both change the agent's answer but live in headers,
+            # not the body, so they must be part of the fingerprint.
+            fp = _make_request_fingerprint(
+                body,
+                keys=["model", "messages", "tools", "tool_choice", "stream"],
+                extra={
+                    "session_id": session_id,
+                    "gateway_session_key": gateway_session_key,
+                },
+            )
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_completion)
             except Exception as e:
@@ -3083,9 +3114,28 @@ class APIServerAdapter(BasePlatformAdapter):
 
         idempotency_key = request.headers.get("Idempotency-Key")
         if idempotency_key:
+            # conversation_history (explicit body history, which takes
+            # precedence over previous_response_id) and truncation both
+            # change the context fed to the agent, and gateway_session_key
+            # scopes long-term memory — none of which the original key set
+            # captured.  session_id is intentionally excluded: for a new
+            # response it is a fresh random UUID, so folding it in would
+            # defeat idempotency for legitimate retries; the chaining that
+            # makes it deterministic is already covered by
+            # previous_response_id / conversation.
             fp = _make_request_fingerprint(
                 body,
-                keys=["input", "instructions", "previous_response_id", "conversation", "model", "tools"],
+                keys=[
+                    "input",
+                    "instructions",
+                    "previous_response_id",
+                    "conversation",
+                    "conversation_history",
+                    "truncation",
+                    "model",
+                    "tools",
+                ],
+                extra={"gateway_session_key": gateway_session_key},
             )
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_response)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -30,6 +30,7 @@ from gateway.platforms.api_server import (
     ResponseStore,
     _IdempotencyCache,
     _derive_chat_session_id,
+    _make_request_fingerprint,
     check_api_server_requirements,
     cors_middleware,
     security_headers_middleware,
@@ -248,6 +249,182 @@ class TestIdempotencyCache:
 
         gate.set()
         assert await second == "response"
+
+
+# ---------------------------------------------------------------------------
+# _make_request_fingerprint
+# ---------------------------------------------------------------------------
+
+
+class TestRequestFingerprint:
+    """The fingerprint must distinguish requests that produce different
+    responses, and only those.  Body-only differences and header/context
+    differences must each change the hash; identical inputs must not.
+    """
+
+    def test_identical_inputs_match(self):
+        body = {"model": "m", "messages": [{"role": "user", "content": "hi"}]}
+        keys = ["model", "messages"]
+        extra = {"session_id": "s1", "gateway_session_key": None}
+        assert _make_request_fingerprint(body, keys, extra) == \
+            _make_request_fingerprint(body, keys, extra)
+
+    def test_extra_context_changes_fingerprint(self):
+        body = {"model": "m", "messages": [{"role": "user", "content": "hi"}]}
+        keys = ["model", "messages"]
+        fp_a = _make_request_fingerprint(body, keys, {"session_id": "s1"})
+        fp_b = _make_request_fingerprint(body, keys, {"session_id": "s2"})
+        assert fp_a != fp_b
+
+    def test_omitting_extra_is_backward_compatible(self):
+        """Callers that pass no extra get the original body-only hash."""
+        body = {"model": "m", "messages": []}
+        keys = ["model", "messages"]
+        assert _make_request_fingerprint(body, keys) == \
+            _make_request_fingerprint(body, keys, None)
+
+    def test_extra_key_cannot_collide_with_body_field(self):
+        """A body field literally named __ctx__ must not be confused with
+        the namespaced context slot."""
+        keys = ["__ctx__"]
+        fp_body = _make_request_fingerprint({"__ctx__": "x"}, keys)
+        fp_ctx = _make_request_fingerprint({}, keys, {"session_id": "x"})
+        assert fp_body != fp_ctx
+
+
+# ---------------------------------------------------------------------------
+# Idempotency-Key fingerprint scoping (endpoint-level regression)
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotencyRequestContext:
+    """An Idempotency-Key may only short-circuit a request whose full
+    semantic context — not just its JSON body — matches a stored one.
+
+    Regression for the fingerprint omitting session/memory-scope headers
+    (chat) and explicit conversation_history (responses): two requests that
+    shared a key and body but differed in that context collided, so the
+    second caller received the first's answer instead of running the agent.
+    """
+
+    @staticmethod
+    def _ok():
+        return (
+            {"final_response": "ok", "messages": [], "api_calls": 1},
+            {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+        )
+
+    @pytest.mark.asyncio
+    async def test_chat_different_session_id_runs_twice(self, auth_adapter):
+        mock_db = MagicMock()
+        mock_db.get_messages_as_conversation.return_value = []
+        auth_adapter._session_db = mock_db
+        body = {"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]}
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch("gateway.platforms.api_server._idem_cache", _IdempotencyCache()), \
+                 patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = self._ok()
+                r1 = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"Idempotency-Key": "k-sid", "X-Hermes-Session-Id": "session-A", "Authorization": "Bearer sk-secret"},
+                    json=body,
+                )
+                r2 = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"Idempotency-Key": "k-sid", "X-Hermes-Session-Id": "session-B", "Authorization": "Bearer sk-secret"},
+                    json=body,
+                )
+            assert r1.status == 200 and r2.status == 200
+            assert mock_run.call_count == 2
+            assert {c.kwargs["session_id"] for c in mock_run.call_args_list} == {"session-A", "session-B"}
+
+    @pytest.mark.asyncio
+    async def test_chat_different_session_key_runs_twice(self, auth_adapter):
+        body = {"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]}
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch("gateway.platforms.api_server._idem_cache", _IdempotencyCache()), \
+                 patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = self._ok()
+                r1 = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"Idempotency-Key": "k-key", "X-Hermes-Session-Key": "scope-A", "Authorization": "Bearer sk-secret"},
+                    json=body,
+                )
+                r2 = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"Idempotency-Key": "k-key", "X-Hermes-Session-Key": "scope-B", "Authorization": "Bearer sk-secret"},
+                    json=body,
+                )
+            assert r1.status == 200 and r2.status == 200
+            assert mock_run.call_count == 2
+            assert {c.kwargs["gateway_session_key"] for c in mock_run.call_args_list} == {"scope-A", "scope-B"}
+
+    @pytest.mark.asyncio
+    async def test_chat_same_context_runs_once(self, auth_adapter):
+        """The cache still short-circuits a genuine duplicate (same key, body,
+        and session context) — the fix must not simply disable caching."""
+        mock_db = MagicMock()
+        mock_db.get_messages_as_conversation.return_value = []
+        auth_adapter._session_db = mock_db
+        headers = {"Idempotency-Key": "k-dup", "X-Hermes-Session-Id": "session-A", "Authorization": "Bearer sk-secret"}
+        body = {"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]}
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch("gateway.platforms.api_server._idem_cache", _IdempotencyCache()), \
+                 patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = self._ok()
+                r1 = await cli.post("/v1/chat/completions", headers=headers, json=body)
+                r2 = await cli.post("/v1/chat/completions", headers=headers, json=body)
+            assert r1.status == 200 and r2.status == 200
+            assert mock_run.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_responses_different_conversation_history_runs_twice(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch("gateway.platforms.api_server._idem_cache", _IdempotencyCache()), \
+                 patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = self._ok()
+                r1 = await cli.post(
+                    "/v1/responses",
+                    headers={"Idempotency-Key": "k-hist", "Authorization": "Bearer sk-secret"},
+                    json={
+                        "model": "hermes-agent",
+                        "input": "hello",
+                        "conversation_history": [{"role": "user", "content": "ctx-A"}],
+                    },
+                )
+                r2 = await cli.post(
+                    "/v1/responses",
+                    headers={"Idempotency-Key": "k-hist", "Authorization": "Bearer sk-secret"},
+                    json={
+                        "model": "hermes-agent",
+                        "input": "hello",
+                        "conversation_history": [{"role": "user", "content": "ctx-B"}],
+                    },
+                )
+            assert r1.status == 200 and r2.status == 200
+            assert mock_run.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_responses_same_request_runs_once(self, auth_adapter):
+        """Identical responses requests (no chaining, same body) must still
+        dedupe — proving session_id's random UUID was correctly excluded."""
+        req = {
+            "headers": {"Idempotency-Key": "k-resp-dup", "Authorization": "Bearer sk-secret"},
+            "json": {"model": "hermes-agent", "input": "hello", "store": False},
+        }
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch("gateway.platforms.api_server._idem_cache", _IdempotencyCache()), \
+                 patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = self._ok()
+                r1 = await cli.post("/v1/responses", **req)
+                r2 = await cli.post("/v1/responses", **req)
+            assert r1.status == 200 and r2.status == 200
+            assert mock_run.call_count == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What & why
The Idempotency-Key cache fingerprinted only selected JSON body fields,
ignoring request context that lives outside the body. Two requests with
the same key and body but different `X-Hermes-Session-Id`,
`X-Hermes-Session-Key`, or explicit `conversation_history` produced the
same fingerprint — so the second caller got the first's cached response,
computed under a different session / memory / history context.

## Fix
- **Chat:** fold the effective `session_id` and `gateway_session_key`
  into the fingerprint.
- **Responses:** add `conversation_history` + `truncation` to the keys
  and `gateway_session_key` as context. `session_id` is deliberately
  excluded — it's a fresh UUID per new response and would break
  legitimate retries; its chaining is already covered by
  `previous_response_id` / `conversation`.
- `_make_request_fingerprint` gains an optional `extra` arg; omitting it
  is byte-for-byte backward compatible.

Genuine duplicates (same key, body, and context) still dedupe.

## Tests
Added `TestRequestFingerprint` (4 unit) and `TestIdempotencyRequestContext`
(5 endpoint) regression tests. Confirmed the "runs twice" cases fail on the
pre-fix code (agent called once) and pass after.

`pytest tests/gateway/test_api_server.py` → **174 passed, 1 skipped**.