### PR TITLE
fix: recover Codex replay from unsupported content type

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -27,6 +27,7 @@ import time
 import uuid
 from typing import Any, Dict, List, Optional
 
+from agent.chat_completion_helpers import _is_openai_codex_backend
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
@@ -2533,18 +2534,37 @@ def run_conversation(
                 # ``codex_reasoning_items``; without replay state, the
                 # error is unrelated to our cache so the normal retry path
                 # handles it (the provider is rejecting something else).
+                # OpenAI's ChatGPT Codex backend can also surface stale
+                # encrypted reasoning replay as a generic HTTP 400
+                # ``Unsupported content type`` detail instead of the
+                # structured ``invalid_encrypted_content`` code.  Treat that
+                # wording as replay recovery only when we are on the Codex
+                # Responses backend and there is actual cached reasoning replay
+                # state to strip; otherwise leave generic content-shape bugs as
+                # normal non-retryable format errors.
+                _has_codex_reasoning_replay_state = any(
+                    isinstance(_m, dict)
+                    and _m.get("role") == "assistant"
+                    and isinstance(_m.get("codex_reasoning_items"), list)
+                    and _m.get("codex_reasoning_items")
+                    for _m in messages
+                )
+                _codex_unsupported_content_type_replay_error = (
+                    status_code == 400
+                    and classified.reason == FailoverReason.format_error
+                    and agent.api_mode == "codex_responses"
+                    and _is_openai_codex_backend(agent)
+                    and "unsupported content type" in f"{api_error} {_err_body}".lower()
+                )
                 if (
-                    classified.reason == FailoverReason.invalid_encrypted_content
+                    (
+                        classified.reason == FailoverReason.invalid_encrypted_content
+                        or _codex_unsupported_content_type_replay_error
+                    )
                     and not _retry.invalid_encrypted_content_retry_attempted
                     and agent.api_mode == "codex_responses"
                     and bool(getattr(agent, "_codex_reasoning_replay_enabled", True))
-                    and any(
-                        isinstance(_m, dict)
-                        and _m.get("role") == "assistant"
-                        and isinstance(_m.get("codex_reasoning_items"), list)
-                        and _m.get("codex_reasoning_items")
-                        for _m in messages
-                    )
+                    and _has_codex_reasoning_replay_state
                 ):
                     _retry.invalid_encrypted_content_retry_attempted = True
                     replay_stats = agent._disable_codex_reasoning_replay(messages)
@@ -2555,10 +2575,11 @@ def run_conversation(
                         force=True,
                     )
                     logger.warning(
-                        "%sInvalid encrypted reasoning recovery: disabled replay and stripped %d items from %d messages",
+                        "%sInvalid encrypted reasoning recovery: disabled replay and stripped %d items from %d messages (reason=%s)",
                         agent.log_prefix,
                         replay_stats["items"],
                         replay_stats["messages"],
+                        classified.reason.value,
                     )
                     continue
 

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -2392,6 +2392,80 @@ def test_run_conversation_codex_disables_reasoning_replay_after_invalid_encrypte
     assert agent._codex_reasoning_replay_enabled is False
 
 
+def test_run_conversation_codex_disables_reasoning_replay_after_unsupported_content_type(monkeypatch):
+    agent = _build_agent(monkeypatch)
+
+    request_payloads = []
+
+    class _UnsupportedContentTypeError(Exception):
+        def __init__(self):
+            super().__init__("HTTP 400: Error code: 400 - {'detail': 'Unsupported content type'}")
+            self.status_code = 400
+            self.body = {"detail": "Unsupported content type"}
+
+    responses = [_UnsupportedContentTypeError(), _codex_message_response("Recovered without replay.")]
+
+    def _fake_api_call(api_kwargs):
+        request_payloads.append(api_kwargs)
+        current = responses.pop(0)
+        if isinstance(current, Exception):
+            raise current
+        return current
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+
+    history = [
+        {
+            "role": "assistant",
+            "content": "",
+            "finish_reason": "incomplete",
+            "codex_reasoning_items": [
+                {"type": "reasoning", "id": "rs_001", "encrypted_content": "enc_bad", "summary": []},
+            ],
+        }
+    ]
+
+    result = agent.run_conversation("continue", conversation_history=history)
+
+    assert result["completed"] is True
+    assert result["final_response"] == "Recovered without replay."
+    assert len(request_payloads) == 2
+    assert any(item.get("type") == "reasoning" for item in request_payloads[0]["input"])
+    assert not any(item.get("type") == "reasoning" for item in request_payloads[1]["input"])
+    assert request_payloads[0].get("include") == ["reasoning.encrypted_content"]
+    assert request_payloads[1].get("include") == []
+    assert result["messages"][0].get("codex_reasoning_items") is None
+    assert agent._codex_reasoning_replay_enabled is False
+
+
+def test_run_conversation_codex_unsupported_content_type_without_replay_state_is_not_reclassified(monkeypatch):
+    agent = _build_agent(monkeypatch)
+
+    request_payloads = []
+
+    class _UnsupportedContentTypeError(Exception):
+        def __init__(self):
+            super().__init__("HTTP 400: Error code: 400 - {'detail': 'Unsupported content type'}")
+            self.status_code = 400
+            self.body = {"detail": "Unsupported content type"}
+
+    def _fake_api_call(api_kwargs):
+        request_payloads.append(api_kwargs)
+        raise _UnsupportedContentTypeError()
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+
+    result = agent.run_conversation(
+        "continue",
+        conversation_history=[{"role": "assistant", "content": "No replay state here."}],
+    )
+
+    assert result["completed"] is False
+    assert len(request_payloads) == 1
+    assert agent._codex_reasoning_replay_enabled is True
+    assert result["messages"][0].get("codex_reasoning_items") is None
+
+
 def test_run_conversation_codex_invalid_encrypted_content_without_replay_state_does_not_disable_replay(monkeypatch):
     agent = _build_agent(monkeypatch)
     agent.provider = "custom"


### PR DESCRIPTION
## What does this PR do?

Recovers from a ChatGPT Codex backend replay failure where stale encrypted Codex Responses reasoning state is returned as HTTP 400 `Unsupported content type` instead of structured `invalid_encrypted_content`.

The recovery is intentionally narrow: only `codex_responses` requests to the ChatGPT Codex backend with cached `codex_reasoning_items` are treated as replay failures. In that case Hermes disables reasoning replay, strips cached reasoning items, and retries once. Generic `Unsupported content type` failures without replay state still surface as non-retryable format errors.

## Related Issue

Refs revise-repeat/siva-os#315

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/conversation_loop.py`
  - Detects Codex backend HTTP 400 `Unsupported content type` as replay recovery only when cached Codex reasoning replay state exists.
  - Reuses the existing invalid-encrypted-content recovery path to disable replay, strip cached `codex_reasoning_items`, and retry once.
- `tests/run_agent/test_run_agent_codex_responses.py`
  - Adds regression coverage for `Unsupported content type` + cached reasoning replay state.
  - Adds guard coverage that the same error without replay state remains a non-retryable format error.

## How to Test

1. Reproduce the pre-fix failure with the new regression test:
   - `python3 -m pytest tests/run_agent/test_run_agent_codex_responses.py::test_run_conversation_codex_disables_reasoning_replay_after_unsupported_content_type -q -o 'addopts='`
   - Before the fix this failed with non-retryable HTTP 400 `Unsupported content type`.
2. Run the targeted Codex Responses test file:
   - `/Users/timbeaulac/.hermes/hermes-agent/venv/bin/python -m pytest tests/run_agent/test_run_agent_codex_responses.py -q -o 'addopts='`
   - Result: `79 passed, 1 warning` (`discord.player` `audioop` deprecation)
3. Run syntax/diff checks:
   - `/Users/timbeaulac/.hermes/hermes-agent/venv/bin/python -m py_compile agent/conversation_loop.py agent/codex_responses_adapter.py`
   - `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A: N/A, behavior covered by tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A: N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A: N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A: N/A, no OS-specific paths/process behavior changed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A: N/A

## For New Skills

N/A — this PR does not add a skill.

## Screenshots / Logs

Targeted test output:

```text
79 passed, 1 warning in 16.70s
```

## Notes

After this PR was opened, I found related upstream PRs/issues including:
- #51525, which appears to address the same Codex `Unsupported content type` replay symptom.
- #10144 / #33035 / #34360, related prior invalid encrypted reasoning replay recovery work.

If maintainers prefer #51525's classifier-level approach, this PR can be closed in favor of that one.
