### PR TITLE
fix(matrix): preserve newlines when normalizing whitespace after mention strip

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -3892,9 +3892,12 @@ class MatrixAdapter(BasePlatformAdapter):
                     flags=re.IGNORECASE,
                 )
 
-        # Normalize spacing after mention removal.
+        # Normalize spacing after mention removal. Use a horizontal-only class
+        # ([ \t]) so the stray space left where a mention sat before punctuation
+        # is removed without collapsing newlines — \s+ here would swallow \n/\r
+        # and silently merge a user's multi-line message into one line.
         body = re.sub(r'[ \t]{2,}', ' ', body)
-        body = re.sub(r'\s+([,.;:!?])', r'\1', body)
+        body = re.sub(r'[ \t]+([,.;:!?])', r'\1', body)
         return body.strip()
 
     async def _get_display_name(self, room_id: str, user_id: str) -> str:

--- a/tests/gateway/test_matrix_mention.py
+++ b/tests/gateway/test_matrix_mention.py
@@ -180,6 +180,16 @@ class TestStripMention:
         result = self.adapter._strip_mention("@hermes:example.org")
         assert result == ""
 
+    def test_newline_before_punctuation_preserved(self):
+        # \n before punctuation must NOT be collapsed (regression: \s+ swallowed newlines)
+        result = self.adapter._strip_mention("@hermes:example.org line one\n: line two")
+        assert result == "line one\n: line two"
+
+    def test_stray_space_before_punct_still_removed(self):
+        # the intended horizontal-space strip after mention removal still works
+        result = self.adapter._strip_mention("@hermes:example.org done ?")
+        assert result == "done?"
+
 
 # ---------------------------------------------------------------------------
 # Outbound mention payloads


### PR DESCRIPTION
## What does this PR do?

Fixes a silent data-loss bug in the Matrix adapter's `_strip_mention`. After removing bot mentions from an inbound message, the function runs a whitespace-normalization pass whose second regex used `\s+([,.;:!?])`. Because `\s` matches `\n`/`\r`, any line break immediately preceding one of `,.;:!?` was deleted together with the punctuation's leading whitespace — silently merging two of the user's lines into one.

In `require_mention` rooms the stripped body **is** the agent prompt (call site `plugins/platforms/matrix/adapter.py:2560`), so a multi-line message where any line begins with `:` / `?` / `!` / `,` / `;` / `.` (a colon list, a trailing question-only line, an emphatic line) lost those line breaks before the model ever saw it.

The fix scopes the regex to horizontal whitespace `[ \t]+`, matching the intentionally horizontal-only `[ \t]{2,}` pass directly above it. The stray space left where a mention sat before punctuation is still removed (`@hermes ?` -> `?`); newlines are now preserved.

## Related Issue

None — code-originated regression found by inspection.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/matrix/adapter.py` — in `_strip_mention`, change the post-mention spacing regex from `re.sub(r'\s+([,.;:!?])', r'\1', body)` to `re.sub(r'[ \t]+([,.;:!?])', r'\1', body)` so it no longer collapses newlines.
- `tests/gateway/test_matrix_mention.py` — add two regression tests to `TestStripMention`.

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/gateway/test_matrix_mention.py -v`
2. Regression guard (fails before / passes after): `test_newline_before_punctuation_preserved` asserts `_strip_mention("@hermes:example.org line one\n: line two") == "line one\n: line two"`. On the old `\s+` regex it returns `"line one: line two"` (newline gone).
3. Companion `test_stray_space_before_punct_still_removed` asserts `_strip_mention("@hermes:example.org done ?") == "done?"` — passes both before and after, locking in the intended horizontal-space strip so the fix can't over-correct.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_matrix_mention.py -q` and all tests pass (54 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure-Python regex, platform-independent)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
