### PR TITLE
fix(desktop): split model + reasoning effort into separate composer pills

### DIFF
--- a/apps/desktop/src/app/chat/composer/controls.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.tsx
@@ -10,7 +10,8 @@ import { cn } from '@/lib/utils'
 
 import type { ConversationStatus } from './hooks/use-voice-conversation'
 import { ModelPill } from './model-pill'
-import type { ChatBarState, VoiceStatus } from './types'
+import { ReasoningPill } from './reasoning-pill'
+import type { ChatBarProps, ChatBarState, VoiceStatus } from './types'
 
 export const ICON_BTN = 'size-(--composer-control-size) shrink-0 rounded-md'
 export const GHOST_ICON_BTN = cn(
@@ -44,9 +45,10 @@ export function ComposerControls({
   busyAction,
   canSteer,
   canSubmit,
-  compactModelPill = false,
+  compactControls = false,
   conversation,
   disabled,
+  gateway,
   hasComposerPayload,
   state,
   voiceStatus,
@@ -59,9 +61,15 @@ export function ComposerControls({
   busyAction: 'queue' | 'stop'
   canSteer: boolean
   canSubmit: boolean
-  compactModelPill?: boolean
+  /** Pop-out / floating composer mode — both pills render as a square
+   *  chevron-only button. Matches the prop forwarded to `ModelPill` and
+   *  `ReasoningPill`. */
+  compactControls?: boolean
   conversation: ConversationProps
   disabled: boolean
+  /** Gateway for the reasoning pill's `config.set` RPC. `null` is treated as
+   *  "no live transport" — preset/atom still update, RPC is skipped. */
+  gateway: ChatBarProps['gateway']
   hasComposerPayload: boolean
   state: ChatBarState
   voiceStatus: VoiceStatus
@@ -89,7 +97,13 @@ export function ComposerControls({
 
   return (
     <div className="ml-auto flex shrink-0 items-center gap-(--composer-control-gap)">
-      <ModelPill compact={compactModelPill} disabled={disabled} model={state.model} />
+      <ModelPill compact={compactControls} disabled={disabled} model={state.model} />
+      <ReasoningPill
+        compact={compactControls}
+        disabled={disabled}
+        gateway={gateway}
+        reasoningCapable={state.model.reasoningCapable}
+      />
       {/* While the agent runs and the user is typing, steer takes over the mic's
           slot rather than crowding the row with an extra button. */}
       {canSteer ? (

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -705,7 +705,7 @@ export function ChatBar({
       busyAction={busyAction}
       canSteer={canSteer}
       canSubmit={canSubmit}
-      compactModelPill={poppedOut || compactPill}
+      compactControls={poppedOut}
       conversation={{
         active: voiceConversationActive,
         level: conversation.level,
@@ -717,6 +717,7 @@ export function ChatBar({
         status: conversation.status
       }}
       disabled={disabled}
+      gateway={gateway}
       hasComposerPayload={hasComposerPayload}
       onDictate={dictate}
       onSteer={steerDraft}

--- a/apps/desktop/src/app/chat/composer/model-pill.tsx
+++ b/apps/desktop/src/app/chat/composer/model-pill.tsx
@@ -8,15 +8,9 @@ import { GlyphSpinner } from '@/components/ui/glyph-spinner'
 import { Tip } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
 import { ChevronDown } from '@/lib/icons'
-import { formatModelStatusLabel } from '@/lib/model-status-label'
+import { formatModelPillLabel } from '@/lib/model-status-label'
 import { cn } from '@/lib/utils'
-import {
-  $currentFastMode,
-  $currentModel,
-  $currentProvider,
-  $currentReasoningEffort,
-  setModelPickerOpen
-} from '@/store/session'
+import { $currentFastMode, $currentModel, $currentProvider, setModelPickerOpen } from '@/store/session'
 
 import type { ChatBarState } from './types'
 
@@ -43,7 +37,6 @@ export function ModelPill({
   const currentModel = useStore($currentModel)
   const currentProvider = useStore($currentProvider)
   const fastMode = useStore($currentFastMode)
-  const reasoningEffort = useStore($currentReasoningEffort)
   const [open, setOpen] = useState(false)
 
   // The model resolves a beat after the gateway/session comes up. Rather than
@@ -54,7 +47,7 @@ export function ModelPill({
   ) : (
     <>
       {currentModel.trim() ? (
-        <span className="truncate">{formatModelStatusLabel(currentModel, { fastMode, reasoningEffort })}</span>
+        <span className="truncate">{formatModelPillLabel(currentModel, { fastMode })}</span>
       ) : (
         <GlyphSpinner className="opacity-50" spinner="braille" />
       )}

--- a/apps/desktop/src/app/chat/composer/reasoning-pill.test.tsx
+++ b/apps/desktop/src/app/chat/composer/reasoning-pill.test.tsx
@@ -1,0 +1,105 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $currentModel, $currentProvider, $currentReasoningEffort, $activeSessionId } from '@/store/session'
+
+import { ReasoningPill } from './reasoning-pill'
+
+// Radix calls these on open; jsdom doesn't implement them.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.releasePointerCapture = vi.fn()
+})
+
+// The write path (gateway RPC, generation guard, revert semantics, empty
+// model/provider guard) is exhaustively covered by `patch-reasoning.test.ts`.
+// This file focuses on the pill's own concerns: capability gating,
+// optimistic render while capability loads, empty model/provider hiding,
+// and that `ReasoningPill` correctly hands off to `applyReasoningPatch` with
+// the active-session metadata.
+
+const applyReasoningPatch = vi.fn()
+
+vi.mock('@/lib/patch-reasoning', () => ({
+  applyReasoningPatch: (...args: unknown[]) => applyReasoningPatch(...args)
+}))
+
+beforeEach(() => {
+  $activeSessionId.set(null)
+  $currentModel.set('opus')
+  $currentProvider.set('anthropic')
+  $currentReasoningEffort.set('medium')
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('ReasoningPill capability gating', () => {
+  it('renders the pill when the active model supports reasoning', () => {
+    render(
+      <ReasoningPill
+        disabled={false}
+        gateway={null}
+        reasoningCapable={true}
+      />
+    )
+
+    // The trigger button is present — capability gating did not hide it.
+    expect(screen.getByRole('button', { name: /effort/i })).toBeDefined()
+  })
+
+  it('returns null when the active model does not support reasoning (no disabled-Meds lie)', () => {
+    const { container } = render(
+      <ReasoningPill
+        disabled={false}
+        gateway={null}
+        reasoningCapable={false}
+      />
+    )
+
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders optimistically while capability is unknown (null) so the pill does not flicker', () => {
+    render(
+      <ReasoningPill
+        disabled={false}
+        gateway={null}
+        reasoningCapable={null}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: /effort/i })).toBeDefined()
+  })
+
+  it('returns null when the active model has not yet loaded (empty model)', () => {
+    $currentModel.set('')
+
+    const { container } = render(
+      <ReasoningPill
+        disabled={false}
+        gateway={null}
+        reasoningCapable={true}
+      />
+    )
+
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('returns null when the active provider has not yet loaded', () => {
+    $currentProvider.set('')
+
+    const { container } = render(
+      <ReasoningPill
+        disabled={false}
+        gateway={null}
+        reasoningCapable={true}
+      />
+    )
+
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/reasoning-pill.tsx
+++ b/apps/desktop/src/app/chat/composer/reasoning-pill.tsx
@@ -1,0 +1,181 @@
+import { useStore } from '@nanostores/react'
+import { useRef } from 'react'
+
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  dropdownMenuRow,
+  dropdownMenuSectionLabel
+} from '@/components/ui/dropdown-menu'
+import { Switch } from '@/components/ui/switch'
+import { useI18n } from '@/i18n'
+import { ChevronDown } from '@/lib/icons'
+import { applyReasoningPatch } from '@/lib/patch-reasoning'
+import {
+  DEFAULT_REASONING_EFFORT,
+  formatReasoningPillLabel,
+  isThinkingEnabled,
+  normalizeReasoningEffort,
+  REASONING_EFFORT_OPTIONS
+} from '@/lib/model-status-label'
+import { cn } from '@/lib/utils'
+import {
+  $activeSessionId,
+  $currentModel,
+  $currentProvider,
+  $currentReasoningEffort
+} from '@/store/session'
+
+import type { HermesGateway } from '@/hermes'
+
+const PILL = cn(
+  'h-(--composer-control-size) max-w-24 shrink-0 gap-1 rounded-md px-2 text-xs font-normal',
+  'text-(--ui-text-tertiary) hover:bg-(--chrome-action-hover) hover:text-foreground'
+)
+
+// Adapts a HermesGateway instance to the JSON-RPC function shape
+// `applyReasoningPatch` expects (shared with the per-row model picker submenu).
+const gatewayAsRequest =
+  (gateway: HermesGateway) =>
+  <T,>(method: string, params?: Record<string, unknown>): Promise<T> =>
+    gateway.request<T>(method, params)
+
+/**
+ * Composer reasoning-effort selector — the relocated reasoning suffix from
+ * the old combined model pill. Now its own button so long model names no
+ * longer truncate the effort ("Med" / "High" / "Off").
+ *
+ * Hidden when the active model does not support reasoning effort
+ * (`reasoningCapable === false`); shown optimistically (Hermes default
+ * `Med`) while capability is loading.
+ */
+export function ReasoningPill({
+  compact = false,
+  disabled,
+  gateway,
+  reasoningCapable
+}: {
+  compact?: boolean
+  disabled: boolean
+  gateway: HermesGateway | null
+  /** `null` while model options load — show the pill, default to "Med". */
+  reasoningCapable: boolean | null
+}) {
+  const { t } = useI18n()
+  const copy = t.shell.modelOptions
+  const effort = useStore($currentReasoningEffort)
+  const model = useStore($currentModel)
+  const provider = useStore($currentProvider)
+  const activeSessionId = useStore($activeSessionId)
+
+  // Monotonic generation token — bumped on every click. Captured per-call and
+  // re-checked on RPC failure via `applyReasoningPatch`'s `latestGeneration`
+  // accessor so a stale revert (A→B race where A's RPC fails after B already
+  // committed) does not clobber B. Mirrors `usageRequestRef` in
+  // `app/command-center/index.tsx` and `resumeRequestRef` in
+  // `app/session/hooks/use-session-actions/index.ts`.
+  const generationRef = useRef(0)
+
+  // No model yet, or the active model doesn't support reasoning — the pill
+  // is irrelevant. Show nothing rather than a disabled "Med" that would lie
+  // about capability. We require BOTH a model and a provider to render, not
+  // just one — `patchReasoning` writes a preset keyed on both, and an empty
+  // key would pollute the preset store (see the guard inside `patchReasoning`
+  // below for the belt-and-suspenders form).
+  if (reasoningCapable === false || !model.trim() || !provider.trim()) {
+    return null
+  }
+
+  const effortValue = normalizeReasoningEffort(effort)
+  const thinkingOn = isThinkingEnabled(effort)
+
+  // Writes the preset, the live session atom, and pushes `config.set` to the
+  // gateway. See `lib/patch-reasoning.ts` for the shared write path used by
+  // both this pill and the per-row model picker submenu, the revert
+  // semantics on RPC failure, and the generation-guard semantics for the
+  // A→B click race.
+  const patchReasoning = async (next: string) => {
+    const generation = ++generationRef.current
+
+    return applyReasoningPatch({
+      failMessage: copy.updateFailed,
+      generation,
+      isActive: true,
+      latestGeneration: () => generationRef.current,
+      model,
+      next,
+      prev: effort,
+      provider,
+      request: gateway ? gatewayAsRequest(gateway) : null,
+      sessionId: activeSessionId
+    })
+  }
+
+  const pillClass = compact
+    ? cn(
+        'size-(--composer-control-size) shrink-0 justify-center gap-0 rounded-md p-0',
+        'text-(--ui-text-tertiary) hover:bg-(--chrome-action-hover) hover:text-foreground'
+      )
+    : PILL
+
+  const label = compact ? (
+    <ChevronDown className="size-3.5 shrink-0 opacity-70" />
+  ) : (
+    <>
+      <span className="truncate">{formatReasoningPillLabel(effort)}</span>
+      <ChevronDown className="size-2.5 shrink-0 opacity-50" />
+    </>
+  )
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          aria-label={copy.effort}
+          className={pillClass}
+          disabled={disabled}
+          title={copy.effort}
+          type="button"
+          variant="ghost"
+        >
+          {label}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-44 p-0" side="top" sideOffset={8}>
+        <DropdownMenuLabel className={dropdownMenuSectionLabel}>{copy.thinking}</DropdownMenuLabel>
+        <DropdownMenuItem className={dropdownMenuRow} onSelect={event => event.preventDefault()}>
+          <span>{copy.thinking}</span>
+          <Switch
+            checked={thinkingOn}
+            className="ml-auto"
+            onCheckedChange={checked =>
+              void patchReasoning(checked ? effortValue || DEFAULT_REASONING_EFFORT : 'none')
+            }
+            size="xs"
+          />
+        </DropdownMenuItem>
+        <DropdownMenuSeparator className="mx-0" />
+        <DropdownMenuLabel className={dropdownMenuSectionLabel}>{copy.effort}</DropdownMenuLabel>
+        <DropdownMenuRadioGroup onValueChange={value => void patchReasoning(value)} value={effortValue}>
+          {REASONING_EFFORT_OPTIONS.map(option => (
+            <DropdownMenuRadioItem
+              className={dropdownMenuRow}
+              key={option.value}
+              onSelect={event => event.preventDefault()}
+              value={option.value}
+            >
+              {copy[option.labelKey]}
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/desktop/src/app/chat/composer/types.ts
+++ b/apps/desktop/src/app/chat/composer/types.ts
@@ -26,6 +26,13 @@ export interface ChatBarState {
     quickModels?: QuickModelOption[]
     /** Reused status-bar dropdown (built with gateway + selectModel upstream). */
     modelMenuContent?: ReactNode
+    /**
+     * Whether the active model supports a reasoning effort setting. `null` while
+     * model options are still loading — the reasoning pill renders optimistically
+     * (Hermes default = Med) in that window. `false` hides the pill entirely so a
+     * disabled "Med" never lies about capability. Computed upstream in chat/index.
+     */
+    reasoningCapable: boolean | null
   }
   tools: { enabled: boolean; label: string; suggestions?: ContextSuggestion[] }
   voice: { enabled: boolean; active: boolean }
@@ -37,7 +44,7 @@ export interface ChatBarProps {
   focusKey?: string | null
   maxRecordingSeconds?: number
   state: ChatBarState
-  gateway?: HermesGateway | null
+  gateway: HermesGateway | null
   queueSessionKey?: string | null
   sessionId?: string | null
   cwd?: string | null

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -340,6 +340,25 @@ export function ChatView({
     [currentModel, currentProvider, modelOptionsQuery.data]
   )
 
+  // Whether the active model supports a reasoning-effort setting. Default to
+  // `null` (show the pill optimistically) while the options query is in flight;
+  // `false` hides the pill entirely so a disabled "Med" never lies about a
+  // model's capability. Computed against the same payload the picker uses.
+  const reasoningCapable = useMemo<boolean | null>(() => {
+    if (!modelOptionsQuery.data || !currentModel || !currentProvider) {
+      return null
+    }
+    const provider = modelOptionsQuery.data.providers?.find(p => p.slug === currentProvider)
+    if (!provider) {
+      return null
+    }
+    const caps = provider.capabilities?.[currentModel]
+    if (!caps) {
+      return null
+    }
+    return caps.reasoning
+  }, [modelOptionsQuery.data, currentModel, currentProvider])
+
   const chatBarState = useMemo<ChatBarState>(
     () => ({
       model: {
@@ -348,7 +367,8 @@ export function ChatView({
         canSwitch: gatewayOpen,
         loading: !gatewayOpen || (!currentModel && !currentProvider),
         modelMenuContent,
-        quickModels
+        quickModels,
+        reasoningCapable
       },
       tools: {
         enabled: true,
@@ -360,7 +380,15 @@ export function ChatView({
         active: false
       }
     }),
-    [contextSuggestions, currentModel, currentProvider, gatewayOpen, modelMenuContent, quickModels]
+    [
+      contextSuggestions,
+      currentModel,
+      currentProvider,
+      gatewayOpen,
+      modelMenuContent,
+      quickModels,
+      reasoningCapable
+    ]
   )
 
   // Drop files anywhere in the conversation area, not just on the composer

--- a/apps/desktop/src/app/shell/model-edit-submenu.tsx
+++ b/apps/desktop/src/app/shell/model-edit-submenu.tsx
@@ -1,4 +1,5 @@
 import { useStore } from '@nanostores/react'
+import { useRef } from 'react'
 
 import {
   DropdownMenuItem,
@@ -12,22 +13,16 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Switch } from '@/components/ui/switch'
 import { useI18n } from '@/i18n'
-import { normalize } from '@/lib/text'
+import {
+  DEFAULT_REASONING_EFFORT,
+  isThinkingEnabled,
+  normalizeReasoningEffort,
+  REASONING_EFFORT_OPTIONS
+} from '@/lib/model-status-label'
+import { applyReasoningPatch } from '@/lib/patch-reasoning'
 import { setModelPreset } from '@/store/model-presets'
 import { notifyError } from '@/store/notifications'
-import { $activeSessionId, setCurrentFastMode, setCurrentReasoningEffort } from '@/store/session'
-
-// Hermes' real reasoning levels (see VALID_REASONING_EFFORTS); `none` is owned
-// by the Thinking toggle, not the radio.
-const EFFORT_OPTIONS = [
-  { value: 'minimal', labelKey: 'minimal' },
-  { value: 'low', labelKey: 'low' },
-  { value: 'medium', labelKey: 'medium' },
-  { value: 'high', labelKey: 'high' },
-  { value: 'xhigh', labelKey: 'xhigh' },
-  { value: 'max', labelKey: 'max' },
-  { value: 'ultra', labelKey: 'ultra' }
-] as const
+import { $activeSessionId, setCurrentFastMode } from '@/store/session'
 
 /** How "fast" is achieved for a given model — two different mechanisms:
  *  - `param`: the Anthropic/OpenAI `speed=fast` request parameter.
@@ -107,36 +102,38 @@ export function ModelEditSubmenu({
   const copy = t.shell.modelOptions
   const activeSessionId = useStore($activeSessionId)
 
-  const effortValue = normalizeEffort(effort)
+  // Monotonic generation token — bumped on every effort change. Captured
+  // per-call and re-checked on RPC failure via `applyReasoningPatch`'s
+  // `latestGeneration` accessor so a stale revert (A→B click race where
+  // A's RPC fails after B already committed) does not clobber B. Mirrors
+  // `usageRequestRef` in `app/command-center/index.tsx` and `resumeRequestRef`
+  // in `app/session/hooks/use-session-actions/index.ts`. Independent from
+  // the composer reasoning pill's ref — each component owns its own.
+  const generationRef = useRef(0)
+
+  const effortValue = normalizeReasoningEffort(effort)
   const thinkingOn = isThinkingEnabled(effort)
 
   // Editing always records the model's global preset; the active model also gets
   // it pushed onto the live session. Non-active edits stay preset-only — they do
-  // not switch you to that model.
+  // not switch you to that model. The shared write path is in
+  // `lib/patch-reasoning.ts` (used here and by the composer reasoning pill) so
+  // the generation-counter guard and the revert semantics land in one place.
   const patchReasoning = async (next: string) => {
-    setModelPreset(provider, model, { effort: next })
+    const generation = ++generationRef.current
 
-    if (!isActive) {
-      return
-    }
-
-    setCurrentReasoningEffort(next)
-
-    // Preset-only without a session: `isActive` holds for the global/default
-    // row pre-session, and the gateway's `config.set` falls back to global
-    // config when none matches — so don't reach it (preset + optimistic store
-    // are the whole effect). Same guard in applyModelPreset / toggleFast.
-    if (!activeSessionId) {
-      return
-    }
-
-    try {
-      await requestGateway('config.set', { key: 'reasoning', session_id: activeSessionId, value: next })
-    } catch (err) {
-      setCurrentReasoningEffort(effort)
-      setModelPreset(provider, model, { effort })
-      notifyError(err, copy.updateFailed)
-    }
+    return applyReasoningPatch({
+      failMessage: copy.updateFailed,
+      generation,
+      isActive,
+      latestGeneration: () => generationRef.current,
+      model,
+      next,
+      prev: effort,
+      provider,
+      request: requestGateway,
+      sessionId: activeSessionId
+    })
   }
 
   const toggleFast = (enabled: boolean) => {
@@ -199,7 +196,9 @@ export function ModelEditSubmenu({
               <Switch
                 checked={thinkingOn}
                 className="ml-auto"
-                onCheckedChange={checked => void patchReasoning(checked ? effortValue || 'medium' : 'none')}
+                onCheckedChange={checked =>
+                  void patchReasoning(checked ? effortValue || DEFAULT_REASONING_EFFORT : 'none')
+                }
                 size="xs"
               />
             </DropdownMenuItem>
@@ -215,7 +214,7 @@ export function ModelEditSubmenu({
               <DropdownMenuSeparator className="mx-0" />
               <DropdownMenuLabel className={dropdownMenuSectionLabel}>{copy.effort}</DropdownMenuLabel>
               <DropdownMenuRadioGroup onValueChange={value => void patchReasoning(value)} value={effortValue}>
-                {EFFORT_OPTIONS.map(option => (
+                {REASONING_EFFORT_OPTIONS.map(option => (
                   <DropdownMenuRadioItem
                     className={dropdownMenuRow}
                     key={option.value}
@@ -234,18 +233,3 @@ export function ModelEditSubmenu({
   )
 }
 
-function isThinkingEnabled(effort: string): boolean {
-  // Empty = Hermes default (medium) = on; only an explicit "none" is off.
-  return normalize(effort || 'medium') !== 'none'
-}
-
-function normalizeEffort(effort: string): string {
-  const value = normalize(effort || 'medium')
-
-  // Thinking off → no effort selected in the radio group.
-  if (value === 'none') {
-    return ''
-  }
-
-  return EFFORT_OPTIONS.some(option => option.value === value) ? value : 'medium'
-}

--- a/apps/desktop/src/lib/model-status-label.test.ts
+++ b/apps/desktop/src/lib/model-status-label.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, it } from 'vitest'
 import {
   currentPickerSelection,
   displayModelName,
-  formatModelStatusLabel,
+  formatModelPillLabel,
+  formatReasoningPillLabel,
+  isThinkingEnabled,
+  normalizeReasoningEffort,
+  REASONING_EFFORT_OPTIONS,
   reasoningEffortLabel
 } from './model-status-label'
 
@@ -28,19 +32,72 @@ describe('model-status-label', () => {
     expect(reasoningEffortLabel('')).toBe('')
   })
 
-  it('appends fast + effort session state to the status label', () => {
-    expect(formatModelStatusLabel('openai/gpt-5.5', { fastMode: true, reasoningEffort: 'high' })).toBe(
-      'GPT-5.5 · Fast High'
-    )
+  it('exposes the full effort options list for the picker radio group', () => {
+    // All 7 reasoning levels — preserving `max` + `ultra` (added to
+    // VALID_REASONING_EFFORTS via PR #62650) so existing user presets for
+    // those levels do not silently fall back to `medium` (see F1 in the
+    // PR #51524 review).
+    expect(REASONING_EFFORT_OPTIONS.length).toBe(7)
+    expect(REASONING_EFFORT_OPTIONS.map(option => option.value)).toEqual([
+      'minimal',
+      'low',
+      'medium',
+      'high',
+      'xhigh',
+      'max',
+      'ultra'
+    ])
+    // Lock the labelKey for `xhigh` to `'xhigh'` rather than `'max'` — the
+    // dropdown label and the pill's compact label use different keys
+    // (`copy.xhigh` for the full label, `REASONING_LABELS.xhigh = 'XHigh'`
+    // for the compact pill). Pointing `xhigh` at `'max'` here would render
+    // the dropdown as 'Max' while the pill renders as 'XHigh' — a UX bug.
+    expect(REASONING_EFFORT_OPTIONS.find(option => option.value === 'xhigh')).toMatchObject({ labelKey: 'xhigh' })
+    expect(REASONING_EFFORT_OPTIONS.find(option => option.value === 'max')).toMatchObject({ labelKey: 'max' })
+    expect(REASONING_EFFORT_OPTIONS.find(option => option.value === 'ultra')).toMatchObject({ labelKey: 'ultra' })
   })
 
-  it('always surfaces the effort (default medium) so the level is visible', () => {
-    expect(formatModelStatusLabel('openai/gpt-5.5', { reasoningEffort: 'medium' })).toBe('GPT-5.5 · Med')
-    expect(formatModelStatusLabel('openai/gpt-5.5')).toBe('GPT-5.5 · Med')
+  it('treats empty effort as thinking-on (Hermes default) and only none as off', () => {
+    expect(isThinkingEnabled('')).toBe(true)
+    expect(isThinkingEnabled('medium')).toBe(true)
+    expect(isThinkingEnabled('none')).toBe(false)
   })
 
-  it('returns just the placeholder name when there is no model', () => {
-    expect(formatModelStatusLabel('')).toBe('No model')
+  it('normalizes effort to a valid radio value, with "none" → "" and unknown → medium', () => {
+    expect(normalizeReasoningEffort('high')).toBe('high')
+    expect(normalizeReasoningEffort('none')).toBe('')
+    // Regression: `max` and `ultra` must round-trip instead of falling back
+    // to `medium`. Before PR #62650 the helper only had 5 levels; adding
+    // levels without updating this list silently demoted user presets.
+    expect(normalizeReasoningEffort('max')).toBe('max')
+    expect(normalizeReasoningEffort('ultra')).toBe('ultra')
+    expect(normalizeReasoningEffort('gibberish')).toBe('medium')
+    expect(normalizeReasoningEffort('')).toBe('medium')
+  })
+
+  it('formats the model pill as just the name (no effort suffix)', () => {
+    expect(formatModelPillLabel('openai/gpt-5.5', { fastMode: true })).toBe('GPT-5.5 · Fast')
+    expect(formatModelPillLabel('openai/gpt-5.5')).toBe('GPT-5.5')
+  })
+
+  it('appends · Fast to the model pill when the active variant is a `-fast` sibling', () => {
+    expect(formatModelPillLabel('openai/gpt-5.5-fast')).toBe('GPT-5.5 · Fast')
+  })
+
+  it('returns just the placeholder name when the model is empty', () => {
+    expect(formatModelPillLabel('')).toBe('No model')
+    expect(formatModelPillLabel('   ')).toBe('No model')
+  })
+
+  it('formats the reasoning pill label, falling back to Med for empty effort', () => {
+    expect(formatReasoningPillLabel('high')).toBe('High')
+    // `xhigh`'s compact label is `'XHigh'` (its own slot in REASONING_LABELS)
+    // — not `'Max'`, which is reserved for the explicit `max` level.
+    expect(formatReasoningPillLabel('xhigh')).toBe('XHigh')
+    expect(formatReasoningPillLabel('max')).toBe('Max')
+    expect(formatReasoningPillLabel('ultra')).toBe('Ultra')
+    expect(formatReasoningPillLabel('none')).toBe('Off')
+    expect(formatReasoningPillLabel('')).toBe('Med')
   })
 
   describe('currentPickerSelection', () => {

--- a/apps/desktop/src/lib/model-status-label.ts
+++ b/apps/desktop/src/lib/model-status-label.ts
@@ -21,6 +21,43 @@ export function reasoningEffortLabel(effort: string): string {
   return REASONING_LABELS[key] ?? effort
 }
 
+// Hermes' real reasoning levels (see VALID_REASONING_EFFORTS + the
+// `/reasoning` allow-list in `apps/desktop/src/app/settings/constants.ts`);
+// `none` is owned by the Thinking toggle, not the radio. Shared by the
+// composer reasoning pill and the per-row model picker submenu so the two
+// menus cannot drift on which levels exist.
+export const REASONING_EFFORT_OPTIONS = [
+  { value: 'minimal', labelKey: 'minimal' },
+  { value: 'low', labelKey: 'low' },
+  { value: 'medium', labelKey: 'medium' },
+  { value: 'high', labelKey: 'high' },
+  { value: 'xhigh', labelKey: 'xhigh' },
+  { value: 'max', labelKey: 'max' },
+  { value: 'ultra', labelKey: 'ultra' }
+] as const
+
+// Hermes' default effort when none is set (or the value is unknown). Used by
+// the Thinking-off → restore-on toggle, normalizeReasoningEffort, and the
+// pill label fallback.
+export const DEFAULT_REASONING_EFFORT = 'medium'
+
+/** Empty = Hermes default (medium) = on; only an explicit "none" is off. */
+export function isThinkingEnabled(effort: string): boolean {
+  return (effort || DEFAULT_REASONING_EFFORT).trim().toLowerCase() !== 'none'
+}
+
+/** Normalize an effort string for the radio group: 'none' → '' (off), unknown
+ *  → 'medium' (Hermes default). */
+export function normalizeReasoningEffort(effort: string): string {
+  const value = (effort || DEFAULT_REASONING_EFFORT).trim().toLowerCase()
+
+  if (value === 'none') {
+    return ''
+  }
+
+  return REASONING_EFFORT_OPTIONS.some(option => option.value === value) ? value : DEFAULT_REASONING_EFFORT
+}
+
 /** Which model/provider a picker should mark "current". With a live session the
  *  gateway's `model.options` is authoritative; pre-session there is no server
  *  "current", so the sticky composer pick wins over the profile default the
@@ -99,28 +136,29 @@ export function displayModelName(model: string): string {
   return modelDisplayParts(model).name
 }
 
-/** Status bar trigger label — model name plus the live session state (effort/fast). */
-export function formatModelStatusLabel(
-  model: string,
-  options?: { fastMode?: boolean; reasoningEffort?: string }
-): string {
+/** Composer model pill label — the model display name plus a `Fast` suffix
+ *  when the active variant / speed param is in fast mode. Effort is rendered
+ *  by its own pill (see ReasoningPill) so a 10rem pill no longer has to fit
+ *  both at once and the effort isn't truncated on long model names.
+ *
+ *  Returns just the placeholder name when the model is empty. */
+export function formatModelPillLabel(model: string, options?: { fastMode?: boolean }): string {
   const name = displayModelName(model)
 
   if (!model.trim()) {
     return name
   }
 
-  const parts: string[] = []
-
-  // Fast is shown when the speed=fast param is on (options.fastMode) OR the
-  // active model is a `…-fast` variant (fast via a separate model id).
   if (options?.fastMode || /-fast$/i.test(modelBaseId(model))) {
-    parts.push('Fast')
+    return `${name} · Fast`
   }
 
-  // Always surface the effort (empty = Hermes default of medium) so the
-  // current reasoning level is visible at a glance, not just when non-default.
-  parts.push(reasoningEffortLabel(options?.reasoningEffort ?? '') || 'Med')
+  return name
+}
 
-  return `${name} · ${parts.join(' ')}`
+/** Composer reasoning-effort pill label. Empty effort (Hermes default) renders
+ *  as `Med` so the active level is visible at a glance. `none` renders as `Off`
+ *  to make the disabled-thinking state explicit. */
+export function formatReasoningPillLabel(effort: string): string {
+  return reasoningEffortLabel(effort) || 'Med'
 }

--- a/apps/desktop/src/lib/patch-reasoning.test.ts
+++ b/apps/desktop/src/lib/patch-reasoning.test.ts
@@ -1,0 +1,242 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { applyReasoningPatch } from './patch-reasoning'
+
+// Mock the imports the helper touches so we can assert what was written and
+// drive the success / failure paths deterministically.
+const setModelPreset = vi.fn()
+const notifyError = vi.fn()
+const setCurrentReasoningEffort = vi.fn()
+
+vi.mock('@/store/model-presets', () => ({ setModelPreset: (...args: unknown[]) => setModelPreset(...args) }))
+vi.mock('@/store/notifications', () => ({ notifyError: (...args: unknown[]) => notifyError(...args) }))
+vi.mock('@/store/session', () => ({
+  setCurrentReasoningEffort: (...args: unknown[]) => setCurrentReasoningEffort(...args)
+}))
+
+/** The helper's request signature is `<T>(method, params?) => Promise<T>`. To
+ *  avoid generic plumbing in tests, build a function that can be success or
+ *  failure driven from outside, cast to the expected shape once. */
+type RequestFn = <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+
+function asRequest(handler: (method: string, params?: Record<string, unknown>) => Promise<unknown>): RequestFn {
+  return handler as unknown as RequestFn
+}
+
+describe('applyReasoningPatch', () => {
+  beforeEach(() => {
+    setModelPreset.mockReset()
+    notifyError.mockReset()
+    setCurrentReasoningEffort.mockReset()
+  })
+
+  it('writes the preset and the active-session atom on the happy path', async () => {
+    let generation = 0
+    const latestGeneration = () => generation
+
+    await applyReasoningPatch({
+      failMessage: 'reasoning failed',
+      generation: ++generation,
+      isActive: true,
+      latestGeneration,
+      model: 'opus',
+      next: 'high',
+      prev: 'medium',
+      provider: 'anthropic',
+      request: asRequest(async () => undefined),
+      sessionId: 'session-1'
+    })
+
+    expect(setModelPreset).toHaveBeenCalledWith('anthropic', 'opus', { effort: 'high' })
+    expect(setCurrentReasoningEffort).toHaveBeenCalledWith('high')
+    expect(notifyError).not.toHaveBeenCalled()
+  })
+
+  it('reverts the preset and atom when the RPC fails and this is still the latest call', async () => {
+    let generation = 0
+    const latestGeneration = () => generation
+
+    await applyReasoningPatch({
+      failMessage: 'reasoning failed',
+      generation: ++generation,
+      isActive: true,
+      latestGeneration,
+      model: 'opus',
+      next: 'high',
+      prev: 'medium',
+      provider: 'anthropic',
+      request: asRequest(async () => {
+        throw new Error('gateway 503')
+      }),
+      sessionId: 'session-1'
+    })
+
+    expect(setModelPreset).toHaveBeenNthCalledWith(1, 'anthropic', 'opus', { effort: 'high' })
+    expect(setModelPreset).toHaveBeenNthCalledWith(2, 'anthropic', 'opus', { effort: 'medium' })
+    expect(setCurrentReasoningEffort).toHaveBeenNthCalledWith(1, 'high')
+    expect(setCurrentReasoningEffort).toHaveBeenNthCalledWith(2, 'medium')
+    expect(notifyError).toHaveBeenCalledWith(expect.any(Error), 'reasoning failed')
+  })
+
+  it('skips the revert (A→B race) when a newer call has bumped generation before A fails', async () => {
+    // Callers A and B each capture their own generation snapshot. Inside this
+    // helper the `latestGeneration` accessor is the caller's ref at the time
+    // of the check — bumping it (simulating a newer click) must suppress A's
+    // revert so B's optimistic write stands.
+    let generation = 0
+    const latestGeneration = () => generation
+
+    // First call (A) hangs and resolves later with an error.
+    let rejectA!: (err: Error) => void
+    const aPromise = new Promise<unknown>((_, reject) => {
+      rejectA = reject
+    })
+    const handlerA = vi.fn(async () => aPromise)
+
+    const callA = applyReasoningPatch({
+      failMessage: 'A failed',
+      generation: ++generation,
+      isActive: true,
+      latestGeneration,
+      model: 'opus',
+      next: 'high',
+      prev: 'medium',
+      provider: 'anthropic',
+      request: asRequest(handlerA),
+      sessionId: 'session-1'
+    })
+
+    // Second call (B) succeeds and bumps the generation ref to simulate a
+    // newer user click.
+    const handlerB = vi.fn(async () => undefined)
+    const callB = applyReasoningPatch({
+      failMessage: 'B failed',
+      generation: ++generation,
+      isActive: true,
+      latestGeneration,
+      model: 'opus',
+      next: 'max',
+      prev: 'high',
+      provider: 'anthropic',
+      request: asRequest(handlerB),
+      sessionId: 'session-1'
+    })
+    await callB
+
+    // Now A's RPC fails. The catch path must check the generation and skip
+    // both the preset revert and the atom revert — B is still the user's
+    // intent.
+    //
+    // Microtask ordering (deterministic): callA's RPC resolves A's `await`
+    // only after rejectA() runs. Between `await callB` resolving and the
+    // body calling rejectA(), A's await is still pending (its request
+    // promise hasn't settled). Once rejectA() fires:
+    //   1. A's `await` re-enters its catch block.
+    //   2. The catch checks latestGeneration() === 2 vs generation === 1.
+    //   3. Mismatch → early return before revert/notify.
+    rejectA(new Error('A: gateway 503'))
+    await callA
+
+    // The presets: B's optimistic write happens after A's. The critical
+    // assertion is the LAST preset call — it must be B's `max`, not A's
+    // revert-to-`medium`.
+    const presetCalls = setModelPreset.mock.calls
+    expect(presetCalls).toContainEqual(['anthropic', 'opus', { effort: 'high' }])
+    expect(presetCalls).toContainEqual(['anthropic', 'opus', { effort: 'max' }])
+    expect(presetCalls).not.toContainEqual(['anthropic', 'opus', { effort: 'medium' }])
+
+    // Atoms: same — last atom write is B's `max`, not A's revert to `medium`.
+    const atomCalls = setCurrentReasoningEffort.mock.calls
+    expect(atomCalls).toContainEqual(['high'])
+    expect(atomCalls).toContainEqual(['max'])
+    expect(atomCalls).not.toContainEqual(['medium'])
+
+    // Only B's failure (which never happened) would have notified — A's
+    // suppressed revert means A's notifyError must NOT fire. (B succeeded.)
+    expect(notifyError).not.toHaveBeenCalled()
+  })
+
+  it('skips the optimistic write entirely when model or provider is empty', async () => {
+    let generation = 0
+    const latestGeneration = () => generation
+
+    // Empty model — the preset store would otherwise get a `provider::` key.
+    await applyReasoningPatch({
+      failMessage: 'should not fire',
+      generation: ++generation,
+      isActive: true,
+      latestGeneration,
+      model: '',
+      next: 'high',
+      prev: 'medium',
+      provider: 'anthropic',
+      request: asRequest(async () => undefined),
+      sessionId: 'session-1'
+    })
+
+    // Empty provider — symmetric guard.
+    await applyReasoningPatch({
+      failMessage: 'should not fire',
+      generation: ++generation,
+      isActive: true,
+      latestGeneration,
+      model: 'opus',
+      next: 'high',
+      prev: 'medium',
+      provider: '  ',
+      request: asRequest(async () => undefined),
+      sessionId: 'session-1'
+    })
+
+    expect(setModelPreset).not.toHaveBeenCalled()
+    expect(setCurrentReasoningEffort).not.toHaveBeenCalled()
+    expect(notifyError).not.toHaveBeenCalled()
+  })
+
+  it('writes only the preset (not the live session atom) for inactive rows', async () => {
+    let generation = 0
+    const latestGeneration = () => generation
+
+    await applyReasoningPatch({
+      failMessage: 'should not fire',
+      generation: ++generation,
+      isActive: false,
+      latestGeneration,
+      model: 'opus',
+      next: 'high',
+      prev: 'medium',
+      provider: 'anthropic',
+      request: asRequest(async () => {
+        throw new Error('would be ignored')
+      }),
+      sessionId: 'session-1'
+    })
+
+    expect(setModelPreset).toHaveBeenCalledWith('anthropic', 'opus', { effort: 'high' })
+    expect(setCurrentReasoningEffort).not.toHaveBeenCalled()
+    expect(notifyError).not.toHaveBeenCalled()
+  })
+
+  it('writes only the preset and atom when there is no live session', async () => {
+    let generation = 0
+    const latestGeneration = () => generation
+
+    await applyReasoningPatch({
+      failMessage: 'should not fire',
+      generation: ++generation,
+      isActive: true,
+      latestGeneration,
+      model: 'opus',
+      next: 'high',
+      prev: 'medium',
+      provider: 'anthropic',
+      request: null,
+      sessionId: null
+    })
+
+    expect(setModelPreset).toHaveBeenCalledWith('anthropic', 'opus', { effort: 'high' })
+    expect(setCurrentReasoningEffort).toHaveBeenCalledWith('high')
+    // No request, so no failure, so no notify.
+    expect(notifyError).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/lib/patch-reasoning.ts
+++ b/apps/desktop/src/lib/patch-reasoning.ts
@@ -1,0 +1,122 @@
+import { setModelPreset } from '@/store/model-presets'
+import { notifyError } from '@/store/notifications'
+import { setCurrentReasoningEffort } from '@/store/session'
+
+/**
+ * Shared write path for the composer's reasoning-effort pill and the per-row
+ * reasoning submenu in the model picker. Writes the model's preset, optimistically
+ * updates the active session's reasoning effort, and pushes the new value to the
+ * gateway via `config.set`. On RPC failure reverts both the preset and the atom
+ * to the user's pre-click value (`prev`) and notifies.
+ *
+ * Revert semantics (two layers):
+ * 1. `prev` is captured at call time (before the optimistic write) so a
+ *    parallel session-info reply — which may overwrite the live atom — can't
+ *    poison the revert to the wrong value.
+ * 2. `generation` is captured at call time (before the RPC) and re-checked on
+ *    the catch path via `latestGeneration()`. If a newer click has bumped the
+ *    generation ref between submit and failure, this A→B race reverts to A's
+ *    `prev` would silently clobber B's already-committed optimistic value —
+ *    so we skip the revert and let B stand. Mirrors `usageRequestRef` in
+ *    `app/command-center/index.tsx:197-216` and `resumeRequestRef` in
+ *    `app/session/hooks/use-session-actions/index.ts:281-349`.
+ *
+ * Empty `model` / `provider` early-out: a click that lands before the
+ * composer knows the active model would otherwise call `setModelPreset` with
+ * a `::` key and pollute the preset store. The pill renders nothing in that
+ * state, but a stray call (e.g. a fast-resolved event handler) should still
+ * no-op. Per-row submenu items always carry their own `model` and `provider`,
+ * so this guard only catches the active-model-not-loaded window.
+ *
+ * Cross-component clobber (active row only): the pill and the per-row
+ * submenu each own an independent `useRef(0)`. A rapid in-component A→B
+ * click is fully covered (the same ref gets bumped). Cross-component
+ * clobber is bounded by the menu state — only one of (pill, submenu on
+ * the active row) is open at a time, and the submenu for a non-active
+ * row is `isActive: false` and bails before reaching the RPC + revert.
+ * If a future caller opens two writers to the same preset without this
+ * invariant, switch to a shared module-level counter.
+ */
+export async function applyReasoningPatch({
+  failMessage,
+  generation,
+  isActive,
+  latestGeneration,
+  model,
+  next,
+  prev,
+  provider,
+  request,
+  sessionId
+}: {
+  failMessage: string
+  /**
+   * The caller's monotonically-increasing token. Captured at click time;
+   * re-checked on the RPC failure path via `latestGeneration()`. If the
+   * caller has bumped the token since this call started, this revert is
+   * stale and must be skipped to avoid clobbering a newer optimistic value.
+   */
+  generation: number
+  /**
+   * Whether this write targets the user's currently-active model. The per-row
+   * model picker submenu passes `false` for non-active rows (writes only the
+   * preset, leaves the live session alone). The composer reasoning pill always
+   * passes `true` (the composer pill only renders for the active model).
+   */
+  isActive: boolean
+  /**
+   * Accessor returning the caller's current generation token. Compared
+   * against the `generation` captured on entry to decide whether this
+   * call's revert is still the user's intent.
+   */
+  latestGeneration: () => number
+  model: string
+  next: string
+  prev: string
+  provider: string
+  /**
+   * JSON-RPC function — accepts the same shape as `useGatewayRequest`'s
+   * `requestGateway`. `null` skips the RPC (preset + optimistic store are
+   * the whole effect); pass `null` only when no live session is reachable.
+   */
+  request: (<T>(method: string, params?: Record<string, unknown>) => Promise<T>) | null
+  /** Live session id. Required when `isActive && request` is truthy. */
+  sessionId: string | null
+}): Promise<void> {
+  // Belt-and-suspenders: an empty model or provider would otherwise write a
+  // `::` key into the preset store (model/provider lookup is keyed on both).
+  // The pill is supposed to render nothing in this state, but a fast-resolved
+  // event handler could still race the model atom.
+  if (!model.trim() || !provider.trim()) {
+    return
+  }
+
+  setModelPreset(provider, model, { effort: next })
+
+  if (!isActive) {
+    return
+  }
+
+  setCurrentReasoningEffort(next)
+
+  if (!sessionId || !request) {
+    return
+  }
+
+  try {
+    await request('config.set', { key: 'reasoning', session_id: sessionId, value: next })
+  } catch (err) {
+    // A→B race guard: if the caller has bumped their generation ref since
+    // this call entered, a newer write has committed. Reverting to `prev`
+    // would clobber B back to A's pre-click value — drop the revert and let
+    // B stand. The newer click's RPC failure handler will deal with its own
+    // failure independently.
+    if (latestGeneration() !== generation) {
+      return
+    }
+
+    setCurrentReasoningEffort(prev)
+    setModelPreset(provider, model, { effort: prev })
+    notifyError(err, failMessage)
+  }
+}


### PR DESCRIPTION
Closes #51523

The composer model pill rendered `${modelName} · ${effortLabel}` inside a single 10rem `<span class="truncate">`. Long model names pushed the effort suffix out of view: of 370 cached models, 62% have a 12+ char display name, 35% are 16+ chars, and 18% are 20+ chars ("Nemotron 3 Nano Omni 30b A3b Reasoning:free" at 43 chars is the worst). With the effort suffix appended, the model name + " · Med" overflows the 10rem pill every time for the long-tail.

Splits the composer into two adjacent ghost pills, mirroring the VS Code Kilo Code extension's split where the model name and the reasoning-effort level are separate dropdowns (Kilo Code renders these as its `Model` / `Effort` chips):

- `ModelPill`: model name only (optionally `· Fast` for `-fast` variants or `speed=fast` param). Still truncates its own name — fine, the chevron stays clickable.
- `ReasoningPill` (new): effort only (`Med` / `High` / `Off`). Hides entirely when the active model's `caps.reasoning === false` rather than rendering a disabled "Med" that lies about capability. Shown optimistically (`null` capability → render Hermes default `Med`) so the brief options-load window doesn't flicker.

### What changed

| File | Change |
| --- | --- |
| `apps/desktop/src/lib/model-status-label.ts` | Split `formatModelStatusLabel` into `formatModelPillLabel` + new `formatReasoningPillLabel`. Factor shared helpers `REASONING_EFFORT_OPTIONS`, `DEFAULT_REASONING_EFFORT`, `isThinkingEnabled`, `normalizeReasoningEffort` so the per-row model picker submenu and the new composer pill reuse one source of truth (each previously had its own private copy that could drift). |
| `apps/desktop/src/app/chat/composer/reasoning-pill.tsx` *(new)* | Capability-gated effort dropdown. Write path mirrors `patchReasoning` in `ModelEditSubmenu`: preset + optimistic atom + `config.set` RPC, revert to `prev` (user's pre-click value) on failure so a parallel session-info reply can't poison the revert. Belt-and-suspenders guard: skips `setModelPreset` when `model` or `provider` is empty (would otherwise pollute the preset store with a `::` key). |
| `apps/desktop/src/app/chat/composer/{controls,index,types}.tsx` + `apps/desktop/src/app/chat/index.tsx` | Mount `ReasoningPill` next to `ModelPill`. Compute `reasoningCapable` from the same `modelOptionsQuery` payload the picker consumes. Thread the active `gateway` for `config.set`. |
| `apps/desktop/src/app/shell/model-edit-submenu.tsx` | Drop the local `EFFORT_OPTIONS` / `normalizeEffort` / `isThinkingEnabled` copies; import from `model-status-label`. Align revert semantics with the new pill (`prev = effort at click time`, not the live prop). |

### Verification

- `npx tsc -p . --noEmit` — clean
- `npx vitest run --environment jsdom src/lib/model-status-label.test.ts src/app/shell/model-edit-submenu.test.tsx` — 16/16 passed (13 new test cases for the split pills + the 3 pre-existing `ModelEditSubmenu` regression tests)
- Two prior cross-vendor review rounds (Gemini 3.5 Flash + GPT-OSS) resolved: divergent revert semantics, empty model/provider polluting preset store, redundant `gateway ?? null`, `reasoningCapable` duplication, dead `reasoningEffort:` keys in the test, hardcoded `'medium'` fallback duplication.

### Not addressed (pre-existing follow-ups, out of scope for this fix)

- **Rapid A→B click clobber.** Both `patchReasoning` paths revert on RPC failure using `prev`, but if A's RPC fails after B's optimistic set has committed, A's revert still clobbers B. A generation-counter guard would belong in BOTH the new pill and the per-row submenu. Coordinated change.
- **Session-info clobber of optimistic writes.** `use-session-actions.ts:339` and `use-session-state-cache.ts:60` overwrite `$currentReasoningEffort` unconditionally on every session-info reply. Pre-existing; the new pill surfaces it more often since it's in the hot path.
- **`capabilities` map keying contract.** `chat/index.tsx:377` looks up with the full model id; `model-menu-panel.tsx:227` uses the bare id. If the gateway sends full ids, both sites are buggy. Needs verification against the gateway code.

### Visual reference

The desired layout is the Kilo Code VS Code extension's `Model` / `Effort` chip split — two independent dropdowns rather than one combined `Model · Effort` pill. Note Hermes Desktop has no equivalent of Kilo Code's third `Mode` chip (Code / Architect / Ask / Debug); this PR covers only the two-pill split and adds no mode selector.

