### PR TITLE
fix(agent): recover codex unsupported content replay errors

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -511,7 +511,9 @@ def classify_api_error(
                     except (json.JSONDecodeError, TypeError):
                         pass
         if not _body_msg:
-            _body_msg = str(body.get("message") or "").lower()
+            _body_msg = str(
+                body.get("message") or body.get("detail") or ""
+            ).lower()
     # Combine all message sources for pattern matching
     parts = [_raw_msg]
     if _body_msg and _body_msg not in _raw_msg:
@@ -976,6 +978,10 @@ def _classify_400(
         or (
             "encrypted content for item" in error_msg
             and "could not be verified" in error_msg
+        )
+        or (
+            "unsupported content type" in error_msg
+            and provider == "openai-codex"
         )
     ):
         return result_fn(

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -718,6 +718,28 @@ class TestClassifyApiError:
         assert result.retryable is True
         assert result.should_fallback is False
 
+    def test_openai_codex_unsupported_content_type_classified_as_replay_failure(self):
+        e = MockAPIError(
+            "Error code: 400 - Bad request",
+            status_code=400,
+            body={"detail": "Unsupported content type"},
+        )
+        result = classify_api_error(e, provider="openai-codex", model="gpt-5.5")
+        assert result.reason == FailoverReason.invalid_encrypted_content
+        assert result.retryable is True
+        assert result.should_fallback is False
+
+    def test_unsupported_content_type_not_replayed_for_non_codex_provider(self):
+        e = MockAPIError(
+            "Error code: 400 - Bad request",
+            status_code=400,
+            body={"detail": "Unsupported content type"},
+        )
+        result = classify_api_error(e, provider="custom", model="gpt-5.5")
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+        assert result.should_fallback is True
+
     def test_invalid_encrypted_content_broad_message_match_does_not_catch_generic_parse_error(self):
         message = "Encrypted content could not be decrypted or parsed."
         e = MockAPIError(

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -2392,6 +2392,58 @@ def test_run_conversation_codex_disables_reasoning_replay_after_invalid_encrypte
     assert agent._codex_reasoning_replay_enabled is False
 
 
+def test_run_conversation_codex_recovers_from_unsupported_content_type_reasoning_replay(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    agent.provider = "openai-codex"
+    agent.api_mode = "codex_responses"
+
+    request_payloads = []
+
+    class _UnsupportedContentTypeError(Exception):
+        def __init__(self):
+            super().__init__("Error code: 400 - Bad request")
+            self.status_code = 400
+            self.body = {"detail": "Unsupported content type"}
+
+    responses = [
+        _UnsupportedContentTypeError(),
+        _codex_message_response("Recovered after unsupported content retry."),
+    ]
+
+    def _fake_api_call(api_kwargs):
+        request_payloads.append(api_kwargs)
+        current = responses.pop(0)
+        if isinstance(current, Exception):
+            raise current
+        return current
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+
+    history = [
+        {
+            "role": "assistant",
+            "content": "",
+            "finish_reason": "incomplete",
+            "codex_reasoning_items": [
+                {"type": "reasoning", "id": "rs_unsupported", "encrypted_content": "enc_bad", "summary": []},
+            ],
+        }
+    ]
+
+    result = agent.run_conversation("continue", conversation_history=history)
+
+    assert result["completed"] is True
+    assert result["final_response"] == "Recovered after unsupported content retry."
+    assert len(request_payloads) == 2
+    assert responses == []
+    assert any(item.get("type") == "reasoning" for item in request_payloads[0]["input"])
+    assert not any(item.get("type") == "reasoning" for item in request_payloads[1]["input"])
+    assert request_payloads[0].get("include") == ["reasoning.encrypted_content"]
+    assert request_payloads[1].get("include") == []
+    assert result["messages"][0].get("codex_reasoning_items") is None
+    assert agent._codex_reasoning_replay_enabled is False
+
+
 def test_run_conversation_codex_invalid_encrypted_content_without_replay_state_does_not_disable_replay(monkeypatch):
     agent = _build_agent(monkeypatch)
     agent.provider = "custom"


### PR DESCRIPTION
## Summary
- classify the OpenAI Codex backend 400 `{"detail":"Unsupported content type"}` replay rejection as `invalid_encrypted_content`
- include top-level `detail` bodies in classifier message matching
- keep the recovery scoped to `provider="openai-codex"` so other providers still fail fast as `format_error`
- add loop-level Codex responses coverage proving replay is stripped/disabled and retried once for this terse error shape

Fixes #51512.

## Testing
- `./.venv/bin/python -m pytest tests/run_agent/test_run_agent_codex_responses.py::test_run_conversation_codex_recovers_from_unsupported_content_type_reasoning_replay -q`
- `./.venv/bin/python -m pytest tests/run_agent/test_run_agent_codex_responses.py -q`
- `./.venv/bin/python -m pytest tests/agent/test_error_classifier.py -q`
- `git diff --check`

## Platforms
- macOS local test environment