### PR TITLE
fix(skills): make oversize skill refusal actionable

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -10,6 +10,7 @@ import pytest
 from tools.skill_manager_tool import (
     _validate_name,
     _validate_category,
+    _validate_content_size,
     _validate_frontmatter,
     _validate_file_path,
     _create_skill,
@@ -20,6 +21,7 @@ from tools.skill_manager_tool import (
     _remove_file,
     skill_manage,
     MAX_NAME_LENGTH,
+    MAX_SKILL_CONTENT_CHARS,
 )
 
 
@@ -105,6 +107,27 @@ class TestValidateCategory:
     def test_absolute_path_rejected(self):
         err = _validate_category("/tmp/escape")
         assert "Invalid category '/tmp/escape'" in err
+
+
+# ---------------------------------------------------------------------------
+# _validate_content_size
+# ---------------------------------------------------------------------------
+
+
+class TestValidateContentSize:
+    def test_within_limit(self):
+        assert _validate_content_size("x" * MAX_SKILL_CONTENT_CHARS) is None
+
+    def test_oversize_error_refuses_marginal_retries(self):
+        err = _validate_content_size("x" * (MAX_SKILL_CONTENT_CHARS + 1))
+
+        assert err is not None
+        assert "REFUSED" in err
+        assert "DO NOT retry this call with marginally smaller content" in err
+        assert "Required fix: split the content into multiple files" in err
+        assert "skill_manage(action='write_file'" in err
+        assert "references/<topic>.md" in err
+        assert "Consider splitting" not in err
 
 
 # ---------------------------------------------------------------------------

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -334,10 +334,15 @@ def _validate_content_size(content: str, label: str = "SKILL.md") -> Optional[st
     """
     if len(content) > MAX_SKILL_CONTENT_CHARS:
         return (
-            f"{label} content is {len(content):,} characters "
-            f"(limit: {MAX_SKILL_CONTENT_CHARS:,}). "
-            f"Consider splitting into a smaller SKILL.md with supporting files "
-            f"in references/ or templates/."
+            f"REFUSED: {label} content is too large at {len(content):,} "
+            f"characters (limit: {MAX_SKILL_CONTENT_CHARS:,}). "
+            "DO NOT retry this call with marginally smaller content; it will "
+            "likely fail again. Required fix: split the content into multiple "
+            "files. Keep SKILL.md short and move bulky sections to "
+            "references/<topic>.md, templates/, scripts/, or assets/ using "
+            "skill_manage(action='write_file', name='<skill-name>', "
+            "file_path='references/<topic>.md', file_content='...'), then "
+            "link those support files from SKILL.md."
         )
     return None
 


### PR DESCRIPTION
## What does this PR do?

Fixes the `skill_manage` oversize-content error from #51470 so models get a hard refusal and a structural recovery path instead of a soft "Consider splitting..." hint that encourages repeated marginal retries.

The new message leads with `REFUSED`, explicitly says not to retry with slightly smaller content, and points the model at splitting bulky material into support files via `skill_manage(action='write_file')`.

## Related Issue

Fixes #51470

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `tools/skill_manager_tool.py` to make `_validate_content_size()` return a hard, actionable refusal for content above `MAX_SKILL_CONTENT_CHARS`.
- Added regression coverage in `tests/tools/test_skill_manager_tool.py` asserting the message includes the hard-refusal guidance and no longer uses the soft `Consider splitting` wording.

## How to Test

1. `uv sync --frozen --extra dev`
2. `uv run scripts/run_tests.sh tests/tools/test_skill_manager_tool.py -- --tb=long`
3. `uv run ruff check tools/skill_manager_tool.py tests/tools/test_skill_manager_tool.py`
4. `git diff --check`
5. `uv run python -m py_compile tools/skill_manager_tool.py`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run focused tests through `scripts/run_tests.sh`
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] Documentation update: N/A
- [x] `cli-config.yaml.example` update: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update: N/A
- [x] Cross-platform impact considered: message-only behavior, no path/process/shell changes
- [x] Tool descriptions/schemas update: N/A

## Screenshots / Logs

Focused validation passed locally:

```text
96 tests passed in tests/tools/test_skill_manager_tool.py
ruff: All checks passed
git diff --check: clean
py_compile: passed
```