### PR TITLE
fix(transports): propagate bare reasoning field in chat_completions (vLLM >=0.23)

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -653,8 +653,18 @@ class ChatCompletionsTransport(ProviderTransport):
         reasoning_content = getattr(msg, "reasoning_content", None)
         if reasoning_content is None and hasattr(msg, "model_extra"):
             model_extra = getattr(msg, "model_extra", None) or {}
-            if isinstance(model_extra, dict) and "reasoning_content" in model_extra:
-                reasoning_content = model_extra["reasoning_content"]
+            if isinstance(model_extra, dict):
+                # vLLM 0.23+ renamed the OpenAI reasoning field
+                # reasoning_content -> reasoning; accept either key.
+                reasoning_content = (
+                    model_extra.get("reasoning_content")
+                    or model_extra.get("reasoning")
+                )
+
+        # Fall back to the bare `reasoning` field (vLLM >= 0.23, and other
+        # providers that only set `reasoning`) so it is not silently dropped.
+        if reasoning_content is None:
+            reasoning_content = reasoning
 
         provider_data: Dict[str, Any] = {}
         if reasoning_content is not None:


### PR DESCRIPTION
## What

`agent/transports/chat_completions.py` read the assistant message's `reasoning` field into a local variable but never propagated it — only `reasoning_content` was written to `provider_data`. Providers that return reasoning under the `reasoning` key (vLLM ≥ 0.23, which renamed `reasoning_content` → `reasoning`) had their chain-of-thought silently dropped on the non-streaming path, so `NormalizedResponse.reasoning_content` came back `None` and the reasoning was never persisted, displayed, or replayed.

## Fix

When `reasoning_content` is absent, also look for the `reasoning` key in `model_extra`, and fall back to the bare `reasoning` field — matching what the streaming accumulator in `chat_completion_helpers.py` already does (`getattr(delta, "reasoning_content", None) or getattr(delta, "reasoning", None)`).

## Verification

Against vLLM 0.23.x (Qwen3, `--reasoning-parser qwen3`) with `openai` SDK 2.24.0, where `message.reasoning` holds the CoT and `message.reasoning_content` is `None`:

- before: extracted `reasoning_content` = 0 chars (reasoning lost)
- after: extracted `reasoning_content` = full CoT

The streaming path was already correct; this only touches the non-streaming transport.

Fixes #51528
