### PR TITLE
fix(desktop): scope cron job list to the active profile

### DIFF
--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -10,7 +10,8 @@ import {
   getSessionMessages,
   getStatus,
   listAllProfileSessions,
-  listSessions
+  listSessions,
+  setApiRequestProfile
 } from './hermes'
 import { refreshActiveProfile } from './store/profile'
 
@@ -33,6 +34,7 @@ describe('Hermes REST session helpers', () => {
   })
 
   afterEach(() => {
+    setApiRequestProfile(null)
     vi.restoreAllMocks()
     Reflect.deleteProperty(window, 'hermesDesktop')
   })
@@ -94,6 +96,7 @@ describe('Hermes REST session helpers', () => {
   })
 
   it('gives the whole startup data burst the long timeout, not just profiles', async () => {
+    setApiRequestProfile(null)
     api.mockResolvedValue({})
 
     const bootCalls: [() => Promise<unknown>, string][] = [
@@ -151,6 +154,79 @@ describe('Hermes REST session helpers', () => {
     expect(api).toHaveBeenCalledWith(
       expect.objectContaining({
         path: '/api/model/options?refresh=1&include_unconfigured=1'
+      })
+    )
+  })
+})
+
+describe('Hermes REST cron helpers honour the active profile', () => {
+  let api: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    api = vi.fn().mockResolvedValue([])
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { api }
+    })
+  })
+
+  afterEach(() => {
+    // _apiProfile is module-level state in hermes.ts; reset so it never leaks
+    // into the session helpers describe above (or another suite entirely).
+    setApiRequestProfile(null)
+    vi.restoreAllMocks()
+    Reflect.deleteProperty(window, 'hermesDesktop')
+  })
+
+  it('scopes the cron job listing to the active profile', async () => {
+    setApiRequestProfile('worker_alpha')
+
+    await getCronJobs()
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/api/cron/jobs?profile=worker_alpha',
+        timeoutMs: 60_000
+      })
+    )
+  })
+
+  it('omits the profile query when no profile is set (single-profile / legacy)', async () => {
+    // _apiProfile defaults to null; the unscoped path is preserved so the
+    // legacy single-profile install behaves identically to before the fix.
+    await getCronJobs()
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/api/cron/jobs',
+        timeoutMs: 60_000
+      })
+    )
+  })
+
+  it('treats empty-string profiles as null (still unscoped)', async () => {
+    // setApiRequestProfile coerces '' to null via `profile || null`.
+    setApiRequestProfile('')
+
+    await getCronJobs()
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/api/cron/jobs',
+        timeoutMs: 60_000
+      })
+    )
+  })
+
+  it('url-encodes profile names with reserved characters', async () => {
+    setApiRequestProfile('team a/b')
+
+    await getCronJobs()
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/api/cron/jobs?profile=team%20a%2Fb',
+        timeoutMs: 60_000
       })
     )
   })

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -852,8 +852,9 @@ export function testMessagingPlatform(platformId: string): Promise<MessagingPlat
 }
 
 export function getCronJobs(): Promise<CronJob[]> {
+  const suffix = _apiProfile ? `?profile=${encodeURIComponent(_apiProfile)}` : ''
   return window.hermesDesktop.api<CronJob[]>({
-    path: '/api/cron/jobs',
+    path: `/api/cron/jobs${suffix}`,
     timeoutMs: STARTUP_REQUEST_TIMEOUT_MS
   })
 }


### PR DESCRIPTION
## Summary

The desktop cron sidebar shows the union of all profiles' cron jobs, regardless of which profile is selected in the switcher.

## Root cause

`getCronJobs()` in `apps/desktop/src/hermes.ts` calls `/api/cron/jobs` with no profile parameter. The backend endpoint defaults to `"all"` and aggregates across every profile via `_cron_profile_dicts()`.

## Fix

Append `?profile=<active>` using the already-tracked `_apiProfile` variable (set by the profile switcher via `setApiRequestProfile`). When `_apiProfile` is null (single-profile / primary), the suffix is empty and the endpoint falls back to `"all"` — preserving existing behaviour for single-profile users.

The `request.profile` field (consumed by Electron main for backend-process routing) is intentionally **not** included here — the `?profile=` query param is what the endpoint reads, matching the pattern used by `getSession`/`getSessionMessages`.

Per-job operations (`getCronJob`, `pauseCronJob`, `resumeCronJob`, `triggerCronJob`, `deleteCronJob`) are unaffected — the backend resolves the owning profile by job ID via `_find_cron_job_profile()`.

## How to Verify

1. Have two profiles each with cron jobs (e.g. profile A: 7, profile B: 4).
2. Open desktop app → select profile A → cron list shows 7 jobs.
3. Switch to profile B → cron list shows 4 jobs.
4. Switch to a single-profile setup → cron list shows all jobs (unchanged).

## Risk Assessment

Low — 4-line change in the desktop client only. The `_apiProfile` variable is already populated by the profile switcher for other profile-scoped endpoints (config, skills, env). Single-profile users see no change (empty suffix → `"all"` default).

Fixes #51520
