### PR TITLE
fix(models): surface live model-fetch failures instead of silent fallback

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 import urllib.parse
 import urllib.request
 import urllib.error
@@ -371,6 +372,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "trinity-mini",
     ],
     "gmi": [
+        "zai-org/GLM-5.2-FP8",
         "zai-org/GLM-5.1-FP8",
         "deepseek-ai/DeepSeek-V3.2",
         "moonshotai/Kimi-K2.5",
@@ -2422,6 +2424,16 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
                                 merged_lower.add(m.lower())
                         return merged
                     return live
+                # We had credentials but the live fetch came back empty.
+                # Re-probe once for a diagnostic reason (SSL / network /
+                # auth). If the endpoint actually recovered, use it; else
+                # tell the user *why* — instead of silently degrading to a
+                # stale fallback list that reads as "new models missing".
+                diag = probe_api_models(api_key, base_url or _p.base_url)
+                diag_models = diag.get("models")
+                if diag_models:
+                    return diag_models
+                _warn_live_model_fetch_failed(normalized, diag.get("error"))
             # Use profile's fallback_models if defined
             if _p.fallback_models:
                 return list(_p.fallback_models)
@@ -3441,6 +3453,7 @@ def probe_api_models(
     if normalized.startswith(COPILOT_BASE_URL):
         headers.update(copilot_default_headers())
 
+    last_error: Optional[str] = None
     for candidate_base, is_fallback in candidates:
         url = candidate_base.rstrip("/") + "/models"
         tried.append(url)
@@ -3454,8 +3467,13 @@ def probe_api_models(
                     "resolved_base_url": candidate_base.rstrip("/"),
                     "suggested_base_url": alternate_base if alternate_base != candidate_base else normalized,
                     "used_fallback": is_fallback,
+                    "error": None,
                 }
-        except Exception:
+        except Exception as exc:
+            # Keep the reason so callers can tell the user *why* the live
+            # list was unavailable (SSL cert, network, auth) instead of
+            # silently degrading to the static fallback list.
+            last_error = f"{type(exc).__name__}: {exc}"
             continue
 
     return {
@@ -3464,6 +3482,7 @@ def probe_api_models(
         "resolved_base_url": normalized,
         "suggested_base_url": alternate_base if alternate_base != normalized else None,
         "used_fallback": False,
+        "error": last_error,
     }
 
 
@@ -3479,6 +3498,45 @@ def fetch_api_models(
     be reached (network error, timeout, auth failure, etc.).
     """
     return probe_api_models(api_key, base_url, timeout=timeout, api_mode=api_mode).get("models")
+
+
+# Providers we've already warned about, so a persistently-broken endpoint
+# doesn't spam the picker on every refresh. Process-lifetime only.
+_LIVE_FETCH_WARNED: set[str] = set()
+
+
+def _warn_live_model_fetch_failed(provider: str, reason: Optional[str] = None) -> None:
+    """Emit a one-time stderr warning when a *credentialed* live model fetch fails.
+
+    Without this, a failed ``/models`` probe (e.g. an SSL certificate error on
+    a machine whose Python has no CA bundle) silently degrades to the static
+    fallback list — which looks to users like "this provider only supports a
+    handful of old models" (see GLM-5.2-on-GMI report). Surfacing the failure,
+    with the common macOS cert fix, turns a confusing report into a self-serve
+    fix. Best-effort: never let diagnostics break model resolution.
+    """
+    try:
+        if not provider or provider in _LIVE_FETCH_WARNED:
+            return
+        # Endpoint responded but has no catalog (or the method isn't
+        # allowed) — that's a provider that simply doesn't list models, not
+        # a silent degradation worth warning about.
+        if reason and any(code in reason for code in (" 404", " 405", " 501")):
+            return
+        _LIVE_FETCH_WARNED.add(provider)
+        detail = f" ({reason})" if reason else ""
+        sys.stderr.write(
+            f"⚠️  {provider}: could not fetch the live model list{detail}; "
+            "showing the built-in fallback list instead.\n"
+        )
+        if reason and ("CERTIFICATE" in reason.upper() or "SSL" in reason.upper()):
+            sys.stderr.write(
+                "   Looks like a TLS certificate problem (Python has no CA bundle). Fix with:\n"
+                "     export SSL_CERT_FILE=\"$(python3 -m certifi)\"\n"
+                "   (or run the 'Install Certificates.command' shipped with python.org Python).\n"
+            )
+    except Exception:
+        pass
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/model-providers/gmi/__init__.py
+++ b/plugins/model-providers/gmi/__init__.py
@@ -19,6 +19,7 @@ gmi = ProviderProfile(
     default_headers={"User-Agent": f"HermesAgent/{_HERMES_VERSION}"},
     default_aux_model="google/gemini-3.1-flash-lite-preview",
     fallback_models=(
+        "zai-org/GLM-5.2-FP8",
         "zai-org/GLM-5.1-FP8",
         "deepseek-ai/DeepSeek-V3.2",
         "moonshotai/Kimi-K2.5",

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -907,3 +907,47 @@ class TestNousRecommendedModels:
             patch("hermes_cli.models.check_nous_free_tier", side_effect=RuntimeError("boom")),
         ):
             assert get_nous_recommended_aux_model(vision=False) == "paid-model"
+
+
+class TestLiveModelFetchDiagnostics:
+    """A failed live /models probe must surface *why* instead of silently
+    degrading to the static fallback list (the GLM-5.2-on-GMI report)."""
+
+    def test_probe_surfaces_error_reason(self):
+        import ssl
+        err = ssl.SSLCertVerificationError(
+            "certificate verify failed: unable to get local issuer certificate"
+        )
+        with patch("hermes_cli.models.urllib.request.urlopen", side_effect=err):
+            res = _models_mod.probe_api_models("key", "https://example.com/v1")
+        assert res["models"] is None
+        assert res["error"] and "CERTIFICATE" in res["error"].upper()
+
+    def test_probe_success_has_null_error(self):
+        resp = MagicMock()
+        resp.read.return_value = b'{"data": [{"id": "m1"}, {"id": "m2"}]}'
+        resp.__enter__ = lambda s: resp
+        resp.__exit__ = lambda *a: False
+        with patch("hermes_cli.models.urllib.request.urlopen", return_value=resp):
+            res = _models_mod.probe_api_models("key", "https://example.com/v1")
+        assert res["models"] == ["m1", "m2"]
+        assert res["error"] is None
+
+    def test_warn_fires_once_with_ssl_hint(self, capsys):
+        _models_mod._LIVE_FETCH_WARNED.discard("gmi")
+        reason = "SSLCertVerificationError: certificate verify failed"
+        _models_mod._warn_live_model_fetch_failed("gmi", reason)
+        _models_mod._warn_live_model_fetch_failed("gmi", reason)  # deduped
+        err = capsys.readouterr().err
+        assert err.count("could not fetch the live model list") == 1
+        assert "SSL_CERT_FILE" in err
+
+    def test_warn_suppressed_for_no_catalog_404(self, capsys):
+        _models_mod._LIVE_FETCH_WARNED.discard("somesvc")
+        _models_mod._warn_live_model_fetch_failed(
+            "somesvc", "HTTPError: HTTP Error 404: Not Found"
+        )
+        assert capsys.readouterr().err == ""
+
+    def test_gmi_fallback_includes_glm_5_2(self):
+        assert "zai-org/GLM-5.2-FP8" in _models_mod._PROVIDER_MODELS["gmi"]

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -255,7 +255,7 @@ hermes chat --provider arcee --model trinity-large-thinking
 
 # GMI Cloud
 # Use the exact model ID returned by GMI's /v1/models endpoint.
-hermes chat --provider gmi --model zai-org/GLM-5.1-FP8
+hermes chat --provider gmi --model zai-org/GLM-5.2-FP8
 # Requires: GMI_API_KEY in ~/.hermes/.env
 ```
 
@@ -263,7 +263,7 @@ Or set the provider permanently in `config.yaml`:
 ```yaml
 model:
   provider: "gmi"
-  default: "zai-org/GLM-5.1-FP8"
+  default: "zai-org/GLM-5.2-FP8"
 ```
 
 Base URLs can be overridden with `NOVITA_BASE_URL`, `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `DASHSCOPE_BASE_URL`, `XIAOMI_BASE_URL`, `GMI_BASE_URL`, or `TOKENHUB_BASE_URL` environment variables.

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/integrations/providers.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/integrations/providers.md
@@ -243,7 +243,7 @@ hermes chat --provider arcee --model trinity-large-thinking
 
 # GMI Cloud
 # 使用 GMI /v1/models 端点返回的精确模型 ID。
-hermes chat --provider gmi --model zai-org/GLM-5.1-FP8
+hermes chat --provider gmi --model zai-org/GLM-5.2-FP8
 # 需要：~/.hermes/.env 中的 GMI_API_KEY
 ```
 
@@ -251,7 +251,7 @@ hermes chat --provider gmi --model zai-org/GLM-5.1-FP8
 ```yaml
 model:
   provider: "gmi"
-  default: "zai-org/GLM-5.1-FP8"
+  default: "zai-org/GLM-5.2-FP8"
 ```
 
 基础 URL 可通过 `NOVITA_BASE_URL`、`GLM_BASE_URL`、`KIMI_BASE_URL`、`MINIMAX_BASE_URL`、`MINIMAX_CN_BASE_URL`、`DASHSCOPE_BASE_URL`、`XIAOMI_BASE_URL`、`GMI_BASE_URL` 或 `TOKENHUB_BASE_URL` 环境变量覆盖。


### PR DESCRIPTION
## What does this PR do?

A GMI Cloud partner reported that GLM-5.2 was "not in the supporting list". GMI **does** serve it live (`zai-org/GLM-5.2-FP8`, confirmed against `GET /v1/models`). The real cause: on a machine whose Python has no CA bundle, the live `/models` probe throws `SSL: CERTIFICATE_VERIFY_FAILED`, and `probe_api_models` swallowed it with a bare `except: continue`. The picker then silently degraded to the 6-item static fallback list, which reads to users as "this provider only supports a handful of old models".

So a trivial local cert issue (or any network/auth hiccup) masquerades as "Hermes doesn't support model X", and it will recur for every provider/user that hits a transport problem. This PR makes the failure visible instead of silent. It does **not** touch cert logic or the GMI live-fetch special-case behaviour.

## Related Issue

N/A - reported via Slack by a GMI Cloud partner; no GitHub issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [x] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/models.py`
  - `probe_api_models()`: record the failure reason and return it as a new `error` field (purely additive; existing `.get("models")` callers unaffected).
  - `provider_model_ids()`: when a **credentialed** live fetch comes back empty, re-probe once. Use the result if the endpoint recovered, otherwise emit a **one-time** stderr warning naming the reason. TLS-cert failures additionally print the `SSL_CERT_FILE` / `Install Certificates.command` fix. HTTP 404/405 (no-catalog providers) are not treated as a degradation.
  - Added `_warn_live_model_fetch_failed()` helper plus a process-lifetime dedup set.
  - `_PROVIDER_MODELS["gmi"]`: lead with `zai-org/GLM-5.2-FP8`.
- `plugins/model-providers/gmi/__init__.py`: add `zai-org/GLM-5.2-FP8` to `fallback_models`.
- `website/docs/integrations/providers.md` and `website/i18n/zh-Hans/.../integrations/providers.md`: update GMI examples to `zai-org/GLM-5.2-FP8`.
- `tests/hermes_cli/test_models.py`: add `TestLiveModelFetchDiagnostics`.

## How to Test

1. Reproduce the silent degradation by simulating a broken-CA box: patch `urllib.request.urlopen` to raise `ssl.SSLCertVerificationError`, then call `probe_api_models("k", "https://api.gmi-serving.com/v1")`. It now returns `{'models': None, ..., 'error': 'SSLCertVerificationError: certificate verify failed'}` instead of dropping the reason.
2. With a real `GMI_API_KEY` and a working CA bundle, `provider_model_ids("gmi")` returns the full live list including `zai-org/GLM-5.2-FP8`; with a broken CA bundle it now prints a warning plus the `SSL_CERT_FILE` fix instead of silently showing 6 models.
3. `pytest tests/hermes_cli/test_models.py -q` -> 81 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant suites: `tests/hermes_cli/test_models.py` (81 passed) plus the provider/picker/merge suites (210 passed). Full `pytest tests/ -q` has pre-existing collection errors in unrelated `tests/acp/*` modules, not caused by this PR.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.5 (Darwin 24.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/...`, docstrings)
- [x] `cli-config.yaml.example`: N/A (no config keys changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A (no architecture/workflow change)
- [x] I've considered cross-platform impact: warning uses stderr plus a POSIX cert hint; behaviour is unchanged on Windows/Linux (the macOS-specific hint text is harmless elsewhere)
- [x] I've updated tool descriptions/schemas: N/A (no tool behavior changed)

## Screenshots / Logs

Warning emitted when the live fetch fails on a broken-CA machine:

    WARNING: gmi: could not fetch the live model list (SSLCertVerificationError: certificate verify failed: unable to get local issuer certificate); showing the built-in fallback list instead.
       Looks like a TLS certificate problem (Python has no CA bundle). Fix with:
         export SSL_CERT_FILE="$(python3 -m certifi)"
       (or run the 'Install Certificates.command' shipped with python.org Python).
