### PR TITLE
fix(desktop): resolve @assistant-ui/tap react-shim build error

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -47,8 +47,8 @@
     "preview": "node scripts/assert-root-install.cjs && vite preview --host 127.0.0.1 --port 4174"
   },
   "dependencies": {
-    "@assistant-ui/react": "^0.12.28",
-    "@assistant-ui/react-streamdown": "^0.1.11",
+    "@assistant-ui/react": "^0.14.23",
+    "@assistant-ui/react-streamdown": "^0.3.4",
     "@audiowave/react": "^0.6.2",
     "@chenglou/pretext": "^0.0.6",
     "@dnd-kit/core": "^6.3.1",

--- a/apps/desktop/src/lib/incremental-external-store-runtime.ts
+++ b/apps/desktop/src/lib/incremental-external-store-runtime.ts
@@ -3,6 +3,8 @@ import {
   BaseAssistantRuntimeCore,
   ExternalStoreThreadListRuntimeCore,
   ExternalStoreThreadRuntimeCore,
+  fromThreadMessageLike,
+  generateId,
   hasUpcomingMessage
 } from '@assistant-ui/core/internal'
 import {
@@ -135,10 +137,13 @@ class IncrementalExternalStoreThreadRuntimeCore extends ExternalStoreThreadRunti
     }
 
     if (hasUpcomingMessage(isRunning, messages)) {
-      self._assistantOptimisticId = this.repository.appendOptimisticMessage(messages.at(-1)?.id ?? null, {
+      const optimisticId = generateId()
+      self._assistantOptimisticId = optimisticId
+      this.repository.addOrUpdateMessage(messages.at(-1)?.id ?? null, fromThreadMessageLike({
         role: 'assistant',
-        content: []
-      })
+        content: [],
+        metadata: { isOptimistic: true }
+      }, optimisticId, { type: 'running' }))
     }
 
     this.repository.resetHead(self._assistantOptimisticId ?? messages.at(-1)?.id ?? null)

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,10 +59,10 @@
     },
     "apps/desktop": {
       "name": "hermes",
-      "version": "0.15.1",
+      "version": "0.17.0",
       "dependencies": {
-        "@assistant-ui/react": "^0.12.28",
-        "@assistant-ui/react-streamdown": "^0.1.11",
+        "@assistant-ui/react": "^0.14.23",
+        "@assistant-ui/react-streamdown": "^0.3.4",
         "@audiowave/react": "^0.6.2",
         "@chenglou/pretext": "^0.0.6",
         "@dnd-kit/core": "^6.3.1",
@@ -149,6 +149,150 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "apps/desktop/node_modules/@assistant-ui/core": {
+      "version": "0.2.18",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/core/-/core-0.2.18.tgz",
+      "integrity": "sha512-qqK+qFmZ3fIpsBUz9QLHpLq2t4IOhs9JQIN5Nm0TLyeg4iytbd6d7V7fax01hEqr/ptPzFdAGR/nefPKr5SgyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "assistant-stream": "^0.3.23",
+        "nanoid": "^5.1.11"
+      },
+      "peerDependencies": {
+        "@assistant-ui/store": "^0.2.13",
+        "@assistant-ui/tap": "^0.9.0",
+        "@types/react": "*",
+        "assistant-cloud": "^0.1.31",
+        "react": "^18 || ^19",
+        "zustand": "^5.0.11"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "assistant-cloud": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "zustand": {
+          "optional": true
+        }
+      }
+    },
+    "apps/desktop/node_modules/@assistant-ui/react": {
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/react/-/react-0.14.23.tgz",
+      "integrity": "sha512-/aZmvnQXgEGNbBkb9xCIScvQv45PrxBToHHwOuuRBO0t6ANR/nBH04zOgMO+6UyTBQQbavgzVoCmy0S85qcoZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@assistant-ui/core": "^0.2.18",
+        "@assistant-ui/store": "^0.2.18",
+        "@assistant-ui/tap": "^0.9.2",
+        "@radix-ui/primitive": "^1.1.4",
+        "@radix-ui/react-compose-refs": "^1.1.3",
+        "@radix-ui/react-context": "^1.1.4",
+        "@radix-ui/react-primitive": "^2.1.5",
+        "@radix-ui/react-use-callback-ref": "^1.1.2",
+        "@radix-ui/react-use-escape-keydown": "^1.1.2",
+        "assistant-cloud": "^0.1.33",
+        "assistant-stream": "^0.3.23",
+        "nanoid": "^5.1.11",
+        "radix-ui": "^1.5.0",
+        "react-textarea-autosize": "^8.5.9",
+        "safe-content-frame": "^0.0.21",
+        "zod": "^4.4.3",
+        "zustand": "^5.0.14"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "apps/desktop/node_modules/@assistant-ui/react-streamdown": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/react-streamdown/-/react-streamdown-0.3.4.tgz",
+      "integrity": "sha512-AsyN/tuSktywlLEdvO41CiN4r92ZMIBngSU8muYYk6V+FcmgUDWRULK0RAojhna/erkZ6Mcw/ctcqjMbJKTvfw==",
+      "license": "MIT",
+      "dependencies": {
+        "rehype-harden": "^1.1.8",
+        "rehype-raw": "^7.0.0",
+        "rehype-sanitize": "^6.0.0",
+        "remend": "^1.3.0",
+        "streamdown": "^2.5.0"
+      },
+      "peerDependencies": {
+        "@assistant-ui/react": "^0.14.18",
+        "@streamdown/cjk": "^1.0.0",
+        "@streamdown/code": "^1.0.0",
+        "@streamdown/math": "^1.0.0",
+        "@streamdown/mermaid": "^1.0.0",
+        "@types/react": "*",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@streamdown/cjk": {
+          "optional": true
+        },
+        "@streamdown/code": {
+          "optional": true
+        },
+        "@streamdown/math": {
+          "optional": true
+        },
+        "@streamdown/mermaid": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "apps/desktop/node_modules/@assistant-ui/store": {
+      "version": "0.2.18",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/store/-/store-0.2.18.tgz",
+      "integrity": "sha512-5MiZXAXjsZuH3ZVEemuiD5L8wq/pXax8lSlaIsdTPEkDZDFupsiDwuOeum+h+ctX8H8oKgkCpN4iPUIiiLKuVg==",
+      "license": "MIT",
+      "dependencies": {
+        "use-effect-event": "^2.0.3"
+      },
+      "peerDependencies": {
+        "@assistant-ui/tap": "^0.9.0",
+        "@types/react": "*",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "apps/desktop/node_modules/@assistant-ui/tap": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/tap/-/tap-0.9.2.tgz",
+      "integrity": "sha512-wrvZqozwHH9o/buoaLeK1m9oRWEXyfeWDXqijUn0qdidLh5/6tR8aAfhrUgWPHvBpvU925rqjZ+8fFjewt20Gg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "apps/desktop/node_modules/@electron/get": {
@@ -382,151 +526,6 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@assistant-ui/core": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/@assistant-ui/core/-/core-0.1.17.tgz",
-      "integrity": "sha512-IWIP98UVQ9W+oF0yz8XqFRtaX8HtozWVUWt6D/BSV6cyKwLfJ8niHtLG74bSnllTnGcreU2El3GR/tIodR1XuA==",
-      "license": "MIT",
-      "dependencies": {
-        "assistant-stream": "^0.3.12",
-        "nanoid": "^5.1.9"
-      },
-      "peerDependencies": {
-        "@assistant-ui/store": "^0.2.9",
-        "@assistant-ui/tap": "^0.5.10",
-        "@types/react": "*",
-        "assistant-cloud": "^0.1.27",
-        "react": "^18 || ^19",
-        "zustand": "^5.0.11"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "assistant-cloud": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "zustand": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@assistant-ui/react": {
-      "version": "0.12.28",
-      "resolved": "https://registry.npmjs.org/@assistant-ui/react/-/react-0.12.28.tgz",
-      "integrity": "sha512-czjpexLK1lKnNDNM1YMJi8SufeKUWBICqiVUtiHMV+86PYGCwJykOZKkchI8MVbSQ62xZ8A1LfPO5W2IDjed3A==",
-      "license": "MIT",
-      "dependencies": {
-        "@assistant-ui/core": "^0.1.17",
-        "@assistant-ui/store": "^0.2.9",
-        "@assistant-ui/tap": "^0.5.10",
-        "@radix-ui/primitive": "^1.1.3",
-        "@radix-ui/react-compose-refs": "^1.1.2",
-        "@radix-ui/react-context": "^1.1.3",
-        "@radix-ui/react-primitive": "^2.1.4",
-        "@radix-ui/react-use-callback-ref": "^1.1.1",
-        "@radix-ui/react-use-escape-keydown": "^1.1.1",
-        "assistant-cloud": "^0.1.27",
-        "assistant-stream": "^0.3.12",
-        "nanoid": "^5.1.9",
-        "radix-ui": "^1.4.3",
-        "react-textarea-autosize": "^8.5.9",
-        "zod": "^4.3.6",
-        "zustand": "^5.0.12"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^18 || ^19",
-        "react-dom": "^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@assistant-ui/react-streamdown": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@assistant-ui/react-streamdown/-/react-streamdown-0.1.11.tgz",
-      "integrity": "sha512-9y+89ZxotYSt81hChSVjK2kwUYRKq7UW/r5qoqZTpcb7119gc0NOj0dx9xxuyXE2QfR6EY8rW6yBz3g+Y7RrhQ==",
-      "license": "MIT",
-      "dependencies": {
-        "rehype-harden": "^1.1.8",
-        "rehype-raw": "^7.0.0",
-        "rehype-sanitize": "^6.0.0",
-        "streamdown": "^2.5.0"
-      },
-      "peerDependencies": {
-        "@assistant-ui/react": "^0.12.26",
-        "@streamdown/cjk": "^1.0.0",
-        "@streamdown/code": "^1.0.0",
-        "@streamdown/math": "^1.0.0",
-        "@streamdown/mermaid": "^1.0.0",
-        "@types/react": "*",
-        "react": "^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@streamdown/cjk": {
-          "optional": true
-        },
-        "@streamdown/code": {
-          "optional": true
-        },
-        "@streamdown/math": {
-          "optional": true
-        },
-        "@streamdown/mermaid": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@assistant-ui/store": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/@assistant-ui/store/-/store-0.2.13.tgz",
-      "integrity": "sha512-7NL6HWMBxe1ndLWO4kHkjQ0Syyc0D/Aj+zxdpcy4yrplG71X04CzFimMBBSQAk+AnGBf+d96D7cuUZdjHkTavg==",
-      "license": "MIT",
-      "dependencies": {
-        "use-effect-event": "^2.0.3"
-      },
-      "peerDependencies": {
-        "@assistant-ui/tap": "^0.5.14",
-        "@types/react": "*",
-        "react": "^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@assistant-ui/tap": {
-      "version": "0.5.14",
-      "resolved": "https://registry.npmjs.org/@assistant-ui/tap/-/tap-0.5.14.tgz",
-      "integrity": "sha512-SAy0ip8nKo72U8K9MuU7gYUR4tzoIi6k+HAQgev3zA/sWN7hr/QDDUTblrn5QB9Y/yycRiq8s98WD1vnDy8WMQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@audiowave/core": {
       "version": "0.3.1",
@@ -1419,7 +1418,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1436,7 +1434,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1453,7 +1450,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1470,7 +1466,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1487,7 +1482,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1504,7 +1498,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1521,7 +1514,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1538,7 +1530,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1555,7 +1546,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1572,7 +1562,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1589,7 +1578,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1606,7 +1594,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1623,7 +1610,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1640,7 +1626,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1657,7 +1642,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1674,7 +1658,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1691,7 +1674,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1708,7 +1690,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1725,7 +1706,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1742,7 +1722,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1759,7 +1738,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1776,7 +1754,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1793,7 +1770,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1810,7 +1786,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1827,7 +1802,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1844,7 +1818,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16063,6 +16036,12 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safe-content-frame": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/safe-content-frame/-/safe-content-frame-0.0.21.tgz",
+      "integrity": "sha512-4LgYcX0lESOg9zVi6QCcqHaNGjZuc86w0IGRJij7lA4YG/6QHBblL2Jwh5OJBtkVSnhDOeARRpD3jvFNGiIWiw==",
       "license": "MIT"
     },
     "node_modules/safe-push-apply": {


### PR DESCRIPTION
## What does this PR do?

Fixes the desktop app build failure caused by `@assistant-ui/react@0.12.28` bundling internally inconsistent sub-packages. The `@assistant-ui/store@0.2.18` dependency requires `@assistant-ui/tap@^0.9.0` for its `./react-shim` import, but the other sub-packages (`core@0.1.17`, `react@0.12.28`) pin `tap@0.5.x`. npm dedupes to 0.5.14 which lacks the `./react-shim` export, causing 9 vite build errors.

## Related Issue

No existing issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/package.json` - bump `@assistant-ui/react` from `^0.12.28` to `^0.14.23`, `@assistant-ui/react-streamdown` from `^0.1.11` to `^0.3.4`
- `apps/desktop/src/lib/incremental-external-store-runtime.ts` - migrate `MessageRepository.appendOptimisticMessage` (removed in core@0.2.18) to `addOrUpdateMessage` + `fromThreadMessageLike` with `metadata.isOptimistic` flag
- `package-lock.json` - regenerated lockfile

## How to Test

1. `cd apps/desktop && npm run build` - should succeed with zero errors
2. Verify installed versions: `@assistant-ui/react@0.14.23`, `@assistant-ui/tap@0.9.2`, `@assistant-ui/core@0.2.18`, `@assistant-ui/store@0.2.18`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've tested on my platform: Arch Linux (CachyOS)

### Documentation & Housekeeping

- [x] N/A - no docs or config changes needed for a dependency bump
