### PR TITLE
fix(agent): handle concurrent tool submit shutdown

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -94,6 +94,10 @@ def _ra():
     return run_agent
 
 
+def _is_interpreter_shutdown_submit_error(exc: RuntimeError) -> bool:
+    return "cannot schedule new futures after interpreter shutdown" in str(exc)
+
+
 def _emit_terminal_post_tool_call(
     agent,
     *,
@@ -605,13 +609,40 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         if runnable_calls:
             max_workers = min(len(runnable_calls), _MAX_TOOL_WORKERS)
             with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-                for i, tc, name, args in runnable_calls:
+                for submit_index, (i, tc, name, args) in enumerate(runnable_calls):
                     # Propagate the agent turn's ContextVars (e.g.
                     # _approval_session_key) AND thread-local approval/sudo
                     # callbacks into the worker thread; clears callbacks on exit.
-                    f = executor.submit(
-                        propagate_context_to_thread(_run_tool), i, tc, name, args, parsed_calls[i][3]
-                    )
+                    try:
+                        f = executor.submit(
+                            propagate_context_to_thread(_run_tool), i, tc, name, args, parsed_calls[i][3]
+                        )
+                    except RuntimeError as submit_error:
+                        if not _is_interpreter_shutdown_submit_error(submit_error):
+                            raise
+                        skipped_calls = runnable_calls[submit_index:]
+                        logger.warning(
+                            "interpreter shutdown while scheduling concurrent tools; "
+                            "skipping %d unsubmitted tool(s)",
+                            len(skipped_calls),
+                        )
+                        for skipped_i, _tc, skipped_name, skipped_args in skipped_calls:
+                            if results[skipped_i] is None:
+                                middleware_trace = parsed_calls[skipped_i][3]
+                                result = (
+                                    f"Error executing tool '{skipped_name}': "
+                                    "Python interpreter is shutting down; tool was not started"
+                                )
+                                results[skipped_i] = (
+                                    skipped_name,
+                                    skipped_args,
+                                    result,
+                                    0.0,
+                                    True,
+                                    False,
+                                    middleware_trace,
+                                )
+                        break
                     futures.append(f)
 
                 # Wait for all to complete with periodic heartbeats so the

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2493,6 +2493,35 @@ class TestConcurrentToolExecution:
         assert messages[1]["tool_call_id"] == "c2"
         assert "success" in messages[1]["content"]
 
+    def test_concurrent_submit_shutdown_error_returns_tool_errors(self, agent):
+        """Submit-time interpreter shutdown should not escape the outer loop."""
+
+        class ShutdownExecutor:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def submit(self, *args, **kwargs):
+                raise RuntimeError("cannot schedule new futures after interpreter shutdown")
+
+        tc1 = _mock_tool_call(name="web_search", arguments='{"q": "alpha"}', call_id="c1")
+        tc2 = _mock_tool_call(name="web_search", arguments='{"q": "beta"}', call_id="c2")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2])
+        messages = []
+
+        with patch("agent.tool_executor.concurrent.futures.ThreadPoolExecutor", ShutdownExecutor):
+            agent._execute_tool_calls_concurrent(mock_msg, messages, "task-1")
+
+        assert len(messages) == 2
+        assert messages[0]["tool_call_id"] == "c1"
+        assert messages[1]["tool_call_id"] == "c2"
+        assert all("Python interpreter is shutting down" in m["content"] for m in messages)
+
     def test_concurrent_interrupt_before_start(self, agent):
         """If interrupt is requested before concurrent execution, all tools are skipped."""
         tc1 = _mock_tool_call(name="web_search", arguments='{}', call_id="c1")


### PR DESCRIPTION
## Summary
Concurrent tool batches no longer crash the conversation loop when Python is shutting down the interpreter mid-batch.

`ThreadPoolExecutor.submit()` can raise `RuntimeError: cannot schedule new futures after interpreter shutdown`. In `_execute_tool_calls_concurrent()` the submit loop was unguarded, so that error escaped the function and took down the outer agent loop (reported on v0.17.0, macOS/TUI, opencode-go/deepseek-v4-pro, large response at ~91s).

The fix catches only that specific submit-time error: it records ordered failed tool-results for the not-yet-submitted calls and breaks the loop, letting already-submitted futures finish through the existing wait + post-processing path.

## Changes
- `agent/tool_executor.py`: wrap `executor.submit()`; on the interpreter-shutdown `RuntimeError`, mark the unsubmitted tail (`runnable_calls[submit_index:]`) as ordered failed results and stop scheduling. Non-matching `RuntimeError`s re-raise unchanged.
- `tests/run_agent/test_run_agent.py`: regression test — `submit()` raising the shutdown error yields ordered tool-result messages instead of escaping.

## Validation
| Check | Result |
|---|---|
| Bug reproduced on main | yes — unwrapped `executor.submit()` |
| Targeted concurrent tests | 35 passed |
| E2E (real AIAgent, real path, mid-batch submit failure) | no escape; 3 ordered msgs; submitted tool returns real result; unsubmitted tail carries shutdown error |
| ruff | clean |

E2E exercised the genuine path: a real `AIAgent._execute_tool_calls_concurrent` with a real `ThreadPoolExecutor` whose 2nd `submit()` raises the actual shutdown `RuntimeError` mid-batch — the in-flight future completed with its real result while the unsubmitted calls became ordered failed results, and nothing propagated out of the function.

Salvage of #51537 — cherry-picked to preserve @helix4u's authorship.

Closes #51537
