### PR TITLE
fix(vision): route opencode-go / opencode-zen captures to native fast path

### DIFF
--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -133,6 +133,14 @@ opencode_zen = ProviderProfile(
     env_vars=("OPENCODE_ZEN_API_KEY",),
     base_url="https://opencode.ai/zen/v1",
     default_aux_model="gemini-3-flash",
+    # Flat-namespace reseller that fronts vision-capable frontier models
+    # (Claude, GPT, Gemini). The provider API accepts image content inside
+    # tool-result messages, mirroring openrouter/nous semantics. Set here
+    # so ``_supports_media_in_tool_results`` returns True and the vision
+    # fast-path stays enabled for vision-capable models served through
+    # this proxy. Users who want aux-vision routing can still opt in via
+    # ``auxiliary.vision.provider`` in config.yaml.
+    supports_vision=True,
 )
 
 opencode_go = OpenCodeGoProfile(
@@ -141,6 +149,16 @@ opencode_go = OpenCodeGoProfile(
     env_vars=("OPENCODE_GO_API_KEY",),
     base_url="https://opencode.ai/zen/go/v1",
     default_aux_model="glm-5",
+    # Flat-namespace reseller. Anthropic Messages surface (used by MiniMax
+    # and Qwen 3.7 on this proxy) accepts image content inside tool-result
+    # messages; OpenAI Chat Completions surface (used by GLM/Kimi) accepts
+    # image_url parts on user and tool messages. Treat the provider as
+    # vision-capable for routing decisions; per-model vision still
+    # resolves through models.dev or the ``model.supports_vision`` /
+    # ``providers.<name>.models.<model>.supports_vision`` config
+    # overrides. Users who want aux-vision routing can still opt in via
+    # ``auxiliary.vision.provider`` in config.yaml.
+    supports_vision=True,
 )
 
 register_provider(opencode_zen)

--- a/tests/tools/test_computer_use_capture_routing.py
+++ b/tests/tools/test_computer_use_capture_routing.py
@@ -262,6 +262,44 @@ class TestRoutingDecisionWiring:
                           side_effect=ValueError("policy bug")):
             assert cu_tool._should_route_through_aux_vision() is False
 
+    def test_opencode_go_vision_capable_model_keeps_multimodal(self):
+        """Regression: opencode-go + a vision-capable model must take the
+        native fast path, not the aux vision text path.
+
+        Without the fix in tools/vision_tools.py and
+        plugins/model-providers/opencode-zen/__init__.py,
+        ``_supports_media_in_tool_results("opencode-go", ...)`` returns
+        False, which causes ``should_route_capture_to_aux_vision`` to
+        return True and screenshots get pre-described by an auxiliary
+        LLM instead of being delivered to the main model natively.
+        """
+        from tools.computer_use import tool as cu_tool
+
+        cfg = {
+            "model": {"default": "minimax-m3", "provider": "opencode-go"},
+        }
+        with patch("agent.auxiliary_client._read_main_provider",
+                   return_value="opencode-go"), \
+             patch("agent.auxiliary_client._read_main_model",
+                   return_value="minimax-m3"), \
+             patch("hermes_cli.config.load_config", return_value=cfg):
+            assert cu_tool._should_route_through_aux_vision() is False
+
+    def test_opencode_zen_vision_capable_model_keeps_multimodal(self):
+        """Regression: opencode-zen + a vision-capable model takes the
+        native fast path, same as opencode-go (sibling provider)."""
+        from tools.computer_use import tool as cu_tool
+
+        cfg = {
+            "model": {"default": "claude-sonnet-4-6", "provider": "opencode-zen"},
+        }
+        with patch("agent.auxiliary_client._read_main_provider",
+                   return_value="opencode-zen"), \
+             patch("agent.auxiliary_client._read_main_model",
+                   return_value="claude-sonnet-4-6"), \
+             patch("hermes_cli.config.load_config", return_value=cfg):
+            assert cu_tool._should_route_through_aux_vision() is False
+
 
 # ---------------------------------------------------------------------------
 # Bug reproduction marker — proves the fix is needed.

--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -38,6 +38,41 @@ class TestSupportsMediaInToolResults:
     def test_openrouter_yes(self):
         assert _supports_media_in_tool_results("openrouter", "anthropic/claude-opus-4.6") is True
 
+    def test_nous_yes(self):
+        assert _supports_media_in_tool_results("nous", "anthropic/claude-sonnet-4.6") is True
+
+    def test_opencode_go_anthropic_surface_yes(self):
+        # opencode-go routes MiniMax/Qwen via anthropic_messages; that surface
+        # accepts image content inside tool-result messages. Users on this
+        # provider were previously falling through to aux vision because
+        # opencode-go was missing from both the _AGGREGATORS whitelist and
+        # the OpenCodeGoProfile.supports_vision flag.
+        assert _supports_media_in_tool_results("opencode-go", "minimax-m3") is True
+
+    def test_opencode_go_chat_completions_surface_yes(self):
+        # opencode-go routes GLM/Kimi via chat_completions; that surface
+        # also accepts image content inside tool-result messages.
+        assert _supports_media_in_tool_results("opencode-go", "glm-5") is True
+
+    def test_opencode_zen_yes(self):
+        # opencode-zen fronts Claude / GPT / Gemini / Qwen via the same
+        # vision-capable wire shapes; treat it as an aggregator.
+        assert _supports_media_in_tool_results("opencode-zen", "claude-sonnet-4-6") is True
+
+    def test_openai_chat_yes(self):
+        assert _supports_media_in_tool_results("openai", "gpt-5.4") is True
+
+    def test_openai_codex_yes(self):
+        assert _supports_media_in_tool_results("openai-codex", "gpt-5-codex") is True
+
+    def test_gemini_3_yes(self):
+        assert _supports_media_in_tool_results("google", "gemini-3-flash-preview") is True
+
+    def test_gemini_2_no(self):
+        assert _supports_media_in_tool_results("google", "gemini-2.5-pro") is False
+
+    def test_unknown_provider_conservative_no(self):
+        assert _supports_media_in_tool_results("brand-new-provider", "any-model") is False
 
     def test_empty_provider_no(self):
         assert _supports_media_in_tool_results("", "anything") is False

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -810,10 +810,12 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
     # Aggregators that route to multiple vendors — assume support since
     # users on these aggregators are typically using vision-capable
     # frontier models. Falling back to text would be a regression for
-    # them.
+    # them. opencode-go and opencode-zen are flat-namespace resellers
+    # that front Anthropic / OpenAI / Gemini / MiniMax / Qwen models
+    # with vision support; treat them the same as openrouter/nous.
     _AGGREGATORS = {
         "openrouter", "nous", "vertex", "bedrock", "anthropic-vertex",
-        "google-vertex",
+        "google-vertex", "opencode-go", "opencode-zen",
     }
     if p in _AGGREGATORS:
         return True


### PR DESCRIPTION
## Summary

OpenCode providers were taking the auxiliary vision path for screenshots even when the selected model could accept images natively. This PR makes `opencode-go` and `opencode-zen` use the same native image path as the other multi-provider backends.

## Why

Both providers sit in front of multiple model vendors, but Hermes did not recognize them as image-capable when it built tool results. As a result, `computer_use` captures and `vision_analyze` could be converted into a text description by the auxiliary model instead of being sent to the main model.

There were two missing pieces:

- neither provider was in the aggregator allowlist in `tools/vision_tools.py`
- both provider profiles still used the default `supports_vision=False`

The provider APIs already accept image content in tool-result messages. `opencode-go` uses Anthropic Messages for MiniMax/Qwen and Chat Completions for GLM/Kimi; `opencode-zen` exposes Claude, GPT, Gemini, and Qwen. Adding both routing hints fixes the shared decision without changing the auxiliary-vision opt-out (`auxiliary.vision.provider`).

## Changes

- Add `opencode-go` and `opencode-zen` to `_AGGREGATORS`.
- Mark both provider profiles as `supports_vision=True`.
- Add regression coverage for the two transport modes and the `computer_use` routing decision.

Per-model metadata and the existing `model.supports_vision` / `providers.<name>.models.<model>.supports_vision` overrides still apply. This change only allows these provider transports to carry native image tool results.

## Related

Supersedes [#37153](https://github.com/NousResearch/hermes-agent/pull/37153). That PR only added `opencode-go` to `_AGGREGATORS`; it did not cover `opencode-zen`, the provider profile flags, or the end-to-end routing tests.

## Test plan

- `python -m pytest tests/tools/test_vision_native_fast_path.py tests/tools/test_computer_use_capture_routing.py -q` (30 passed)
- Manual check with `opencode-go` + `minimax-m3`: `computer_use(action='capture', mode='som')` returns native multimodal content instead of `vision_analysis_routed_via=auxiliary.vision`.
