### PR TITLE
fix(gateway): add ask-mode busy-input buttons for Telegram

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2571,6 +2571,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._running_agents_ts: Dict[str, float] = {}  # start timestamp per session
         self._active_session_leases: Dict[str, Any] = {}
         self._pending_messages: Dict[str, str] = {}  # Queued messages during interrupt
+        # Busy-input ask mode: prompt records keyed by compact button IDs.
+        # The event is held out of the normal pending queue until the user
+        # chooses whether to queue, interrupt, steer, or ignore it.
+        self._busy_prompt_events: Dict[str, tuple[str, MessageEvent]] = {}
         # Last successfully-resolved (non-empty) model, keyed by session. Used
         # as a fallback when a fresh config read transiently returns an empty
         # model (e.g. an mtime-keyed config-cache miss during a post-interrupt
@@ -2650,6 +2654,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # some platforms).
         import itertools as _itertools
         self._slash_confirm_counter = _itertools.count(1)
+        self._busy_prompt_counter = _itertools.count(1)
 
         # Persistent Honcho managers keyed by gateway session key.
         # This preserves write_frequency="session" semantics across short-lived
@@ -3954,6 +3959,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return "queue"
         if mode == "steer":
             return "steer"
+        if mode == "ask":
+            return "ask"
         return "interrupt"
 
     @staticmethod
@@ -3967,7 +3974,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ``interrupt`` | ``queue`` (``steer`` is handled upstream by
         ``busy_input_mode`` and maps to non-queue text handling here).
         """
-        # Legacy explicit override wins for backward compat.
+        input_mode = GatewayRunner._load_busy_input_mode()
+        # ask/steer must reach the runner's busy handler. A stale legacy
+        # busy_text_mode=queue should not silently bypass the prompt/buttons.
+        if input_mode in {"ask", "steer"}:
+            return "interrupt"
+
+        # Legacy explicit override wins for backward compat when the primary
+        # busy_input_mode is queue/interrupt.
         legacy = os.getenv("HERMES_GATEWAY_BUSY_TEXT_MODE", "").strip().lower()
         if not legacy:
             cfg = _load_gateway_runtime_config()
@@ -3977,7 +3991,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if legacy == "queue":
             return "queue"
         # No explicit legacy knob → follow busy_input_mode.
-        input_mode = GatewayRunner._load_busy_input_mode()
         return "queue" if input_mode == "queue" else "interrupt"
 
     @staticmethod
@@ -4207,6 +4220,147 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         self._enqueue_fifo(session_key, event, adapter)
 
+    def _busy_prompt_id(self) -> str:
+        counter = getattr(self, "_busy_prompt_counter", None)
+        if counter is None:
+            import itertools as _itertools
+            counter = _itertools.count(1)
+            self._busy_prompt_counter = counter
+        return f"{next(counter)}"
+
+    def _register_busy_prompt_event(self, session_key: str, event: MessageEvent) -> str:
+        prompt_id = self._busy_prompt_id()
+        store = getattr(self, "_busy_prompt_events", None)
+        if store is None:
+            store = {}
+            self._busy_prompt_events = store
+        store[prompt_id] = (session_key, event)
+        # Bound memory if a user never clicks old prompts.
+        if len(store) > 64:
+            for old_id in list(store)[: len(store) - 64]:
+                store.pop(old_id, None)
+        return prompt_id
+
+    def _session_is_active(self, session_key: str, adapter: Any) -> bool:
+        if session_key in getattr(self, "_running_agents", {}):
+            return True
+        active_sessions = getattr(adapter, "_active_sessions", None)
+        return isinstance(active_sessions, dict) and session_key in active_sessions
+
+    async def resolve_busy_prompt_choice(self, prompt_id: str, choice: str) -> bool:
+        """Apply a Telegram/adapter busy-input prompt choice.
+
+        Returns True when the prompt was found and consumed. The stored user
+        message is deliberately not queued until the button click so ask mode
+        can implement Queue / Interrupt / Steer / Ignore without surprising the
+        user.
+        """
+        store = getattr(self, "_busy_prompt_events", None) or {}
+        record = store.pop(str(prompt_id), None)
+        if record is None:
+            return False
+
+        session_key, event = record
+        adapter = self.adapters.get(event.source.platform)
+        if adapter is None:
+            return True
+
+        choice = (choice or "").strip().lower()
+        running_agent = self._running_agents.get(session_key)
+
+        if choice == "ignore":
+            logger.info("Busy prompt ignored for session %s", session_key)
+            return True
+
+        if choice == "steer":
+            steer_text = (event.text or "").strip()
+            can_steer = (
+                steer_text
+                and running_agent is not None
+                and running_agent is not _AGENT_PENDING_SENTINEL
+                and hasattr(running_agent, "steer")
+            )
+            if can_steer:
+                try:
+                    if bool(running_agent.steer(steer_text)):
+                        logger.info("Busy prompt steered message into session %s", session_key)
+                        return True
+                except Exception as exc:
+                    logger.warning("Busy prompt steer failed for session %s: %s", session_key, exc)
+            choice = "queue"
+
+        if choice == "interrupt":
+            merge_pending_message_event(
+                adapter._pending_messages,
+                session_key,
+                event,
+                merge_text=event.message_type == MessageType.TEXT,
+            )
+            if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
+                try:
+                    running_agent.interrupt(event.text)
+                except Exception:
+                    pass
+            if not self._session_is_active(session_key, adapter) and hasattr(adapter, "_start_session_processing"):
+                adapter._start_session_processing(event, session_key)
+            logger.info("Busy prompt interrupted session %s", session_key)
+            return True
+
+        # Default/fallback: queue for the next turn, or start immediately if
+        # the original active run has already finished before the user clicked.
+        if self._session_is_active(session_key, adapter):
+            self._queue_or_replace_pending_event(session_key, event)
+        elif hasattr(adapter, "_start_session_processing"):
+            adapter._start_session_processing(event, session_key)
+        else:
+            self._queue_or_replace_pending_event(session_key, event)
+        logger.info("Busy prompt queued message for session %s", session_key)
+        return True
+
+    async def _send_busy_prompt(self, adapter: Any, event: MessageEvent, session_key: str) -> bool:
+        prompt_id = self._register_busy_prompt_event(session_key, event)
+        send_prompt = getattr(adapter, "send_busy_prompt", None)
+        if not callable(send_prompt):
+            # Non-interactive platform: fall back to queue semantics.
+            await self.resolve_busy_prompt_choice(prompt_id, "queue")
+            return True
+
+        running_agent = self._running_agents.get(session_key)
+        status_parts = []
+        if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
+            try:
+                summary = running_agent.get_activity_summary()
+                current_tool = summary.get("current_tool")
+                if current_tool:
+                    status_parts.append(f"running: {current_tool}")
+            except Exception:
+                pass
+        status_detail = f" ({', '.join(status_parts)})" if status_parts else ""
+        message = (
+            f"⏳ Hermes is still working{status_detail}. "
+            f"What should I do with your new message?"
+        )
+        reply_anchor = self._reply_anchor_for_event(event)
+        metadata = self._thread_metadata_for_source(event.source, reply_anchor)
+        result = await send_prompt(
+            chat_id=event.source.chat_id,
+            prompt=message,
+            prompt_id=prompt_id,
+            session_key=session_key,
+            can_steer=bool((event.text or "").strip()),
+            reply_to=(
+                reply_anchor
+                if event.source.platform == Platform.TELEGRAM
+                and event.source.chat_type == "dm"
+                and event.source.thread_id
+                else (None if event.source.platform == Platform.TELEGRAM and event.source.thread_id else event.message_id)
+            ),
+            metadata=metadata,
+        )
+        if not getattr(result, "success", False):
+            await self.resolve_busy_prompt_choice(prompt_id, "queue")
+        return True
+
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
         # --- Authorization gate (#17775) ---
         # The cold path (_handle_message) checks _is_user_authorized before
@@ -4274,6 +4428,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         running_agent = self._running_agents.get(session_key)
 
         effective_mode = self._busy_input_mode
+        if effective_mode == "ask":
+            return await self._send_busy_prompt(adapter, event, session_key)
+
         busy_text_mode = getattr(self, "_busy_text_mode", "interrupt")
         if (
             event.message_type == MessageType.TEXT

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1573,7 +1573,7 @@ DEFAULT_CONFIG = {
         # when an exchange was tool-heavy. Set False to restore the legacy
         # behavior of showing tool-call summaries inline.
         "resume_skip_tool_only": True,
-        "busy_input_mode": "interrupt",  # interrupt | queue | steer
+        "busy_input_mode": "interrupt",  # interrupt | queue | steer | ask
         # Which interface bare `hermes` (and `hermes chat`) launches by default:
         #   "cli" — the classic prompt_toolkit REPL (default, preserves prior behavior)
         #   "tui" — the modern Ink TUI (same as passing `--tui`)

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -109,7 +109,7 @@ TIPS = [
     "Set display.streaming: true to see tokens appear in real time as the model generates.",
     "Set display.show_reasoning: true to watch the model's chain-of-thought reasoning.",
     "Set display.compact: true to reduce whitespace in output for denser information.",
-    "Set display.busy_input_mode: queue to queue messages instead of interrupting the agent, or steer to inject them mid-run via /steer.",
+    "Set display.busy_input_mode: queue to queue messages, steer to inject mid-run, or ask to show buttons while Hermes is busy.",
     "Set display.resume_display: minimal to skip the full conversation recap on session resume.",
     "Set compression.threshold: 0.50 to control when auto-compression fires (default: 50% of context).",
     "Set agent.max_turns: 200 to let the agent take more tool-calling steps per turn.",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -556,7 +556,7 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     "display.busy_input_mode": {
         "type": "select",
         "description": "Input behavior while agent is running",
-        "options": ["interrupt", "queue", "steer"],
+        "options": ["interrupt", "queue", "steer", "ask"],
     },
     "memory.provider": {
         "type": "select",

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3576,6 +3576,58 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.warning("[%s] send_exec_approval failed: %s", self.name, e)
             return SendResult(success=False, error=str(e))
 
+    async def send_busy_prompt(
+        self,
+        chat_id: str,
+        prompt: str,
+        prompt_id: str,
+        session_key: str = "",
+        can_steer: bool = True,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Render a busy-input decision prompt with inline buttons."""
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+        try:
+            rows = [
+                [
+                    InlineKeyboardButton("➕ Queue", callback_data=f"bp:queue:{prompt_id}"),
+                    InlineKeyboardButton("⚡ Interrupt", callback_data=f"bp:interrupt:{prompt_id}"),
+                ]
+            ]
+            if can_steer:
+                rows.append([InlineKeyboardButton("⏩ Steer", callback_data=f"bp:steer:{prompt_id}")])
+            rows.append([InlineKeyboardButton("✖ Ignore", callback_data=f"bp:ignore:{prompt_id}")])
+            keyboard = InlineKeyboardMarkup(rows)
+
+            thread_id = self._metadata_thread_id(metadata)
+            reply_to_id = self._reply_to_message_id_for_send(
+                reply_to, metadata, reply_to_mode=self._reply_to_mode
+            )
+            kwargs: Dict[str, Any] = {
+                "chat_id": int(chat_id),
+                "text": self.format_message(prompt),
+                "parse_mode": ParseMode.MARKDOWN_V2,
+                "reply_markup": keyboard,
+                "reply_to_message_id": reply_to_id,
+                **self._link_preview_kwargs(),
+            }
+            kwargs.update(
+                self._thread_kwargs_for_send(
+                    chat_id,
+                    thread_id,
+                    metadata,
+                    reply_to_message_id=reply_to_id,
+                    reply_to_mode=self._reply_to_mode,
+                )
+            )
+            msg = await self._send_message_with_thread_fallback(**kwargs)
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            logger.warning("[%s] send_busy_prompt failed: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
     async def send_slash_confirm(
         self, chat_id: str, title: str, message: str, session_key: str,
         confirm_id: str, metadata: Optional[Dict[str, Any]] = None,
@@ -4202,6 +4254,61 @@ class TelegramAdapter(BasePlatformAdapter):
                 query_thread_id=query_thread_id,
                 query_user_name=query_user_name,
             )
+            return
+
+        # --- Busy-input callbacks (bp:choice:prompt_id) ---
+        if data.startswith("bp:"):
+            parts = data.split(":", 2)
+            if len(parts) == 3:
+                choice = parts[1]
+                prompt_id = parts[2]
+
+                caller_id = str(getattr(query.from_user, "id", ""))
+                if not self._is_callback_user_authorized(
+                    caller_id,
+                    chat_id=query_chat_id,
+                    chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                    thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                    user_name=query_user_name,
+                ):
+                    await query.answer(text="⛔ You are not authorized to answer this prompt.")
+                    return
+
+                label_map = {
+                    "queue": "➕ Queued",
+                    "interrupt": "⚡ Interrupting",
+                    "steer": "⏩ Steered",
+                    "ignore": "✖ Ignored",
+                }
+                label = label_map.get(choice, "Resolved")
+                user_display = getattr(query.from_user, "first_name", "User")
+
+                runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+                resolver = getattr(runner, "resolve_busy_prompt_choice", None)
+                if not callable(resolver):
+                    await query.answer(text="Busy prompt resolver unavailable.")
+                    return
+
+                resolved = await resolver(prompt_id, choice)
+                if not resolved:
+                    await query.answer(text="This prompt has already been resolved.")
+                    return
+
+                await query.answer(text=label)
+                try:
+                    await query.edit_message_text(
+                        text=self.format_message(f"{label} by {user_display}"),
+                        parse_mode=ParseMode.MARKDOWN_V2,
+                        reply_markup=None,
+                    )
+                except Exception:
+                    pass
+                logger.info(
+                    "Telegram busy prompt resolved (id=%s, choice=%s, user=%s)",
+                    prompt_id,
+                    choice,
+                    user_display,
+                )
             return
 
         # --- Exec approval callbacks (ea:choice:id) ---

--- a/tests/gateway/test_busy_input_ask.py
+++ b/tests/gateway/test_busy_input_ask.py
@@ -1,0 +1,148 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, SendResult
+from gateway.session import SessionSource, build_session_key
+from gateway.run import GatewayRunner
+
+
+class _PromptAdapter:
+    def __init__(self):
+        self._pending_messages = {}
+        self._active_sessions = {}
+        self.prompts = []
+        self.started = []
+
+    async def send_busy_prompt(self, **kwargs):
+        self.prompts.append(kwargs)
+        return SendResult(success=True, message_id="prompt-1")
+
+    def _start_session_processing(self, event, session_key):
+        self.started.append((session_key, event))
+        return True
+
+
+def _make_runner(adapter=None):
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")})
+    adapter = adapter or _PromptAdapter()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._queued_events = {}
+    runner._busy_prompt_events = {}
+    runner._busy_prompt_counter = iter(range(1, 100))
+    runner._busy_input_mode = "ask"
+    runner._busy_text_mode = "interrupt"
+    runner._draining = False
+    runner._restart_requested = False
+    runner._is_user_authorized = lambda _source: True
+    return runner, adapter
+
+
+def _event(text="follow up"):
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="u1",
+    )
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="m2",
+    )
+
+
+def test_busy_input_mode_accepts_ask(monkeypatch):
+    monkeypatch.setenv("HERMES_GATEWAY_BUSY_INPUT_MODE", "ask")
+    assert GatewayRunner._load_busy_input_mode() == "ask"
+
+
+def test_busy_text_mode_queue_does_not_bypass_ask(monkeypatch):
+    monkeypatch.setenv("HERMES_GATEWAY_BUSY_INPUT_MODE", "ask")
+    monkeypatch.setenv("HERMES_GATEWAY_BUSY_TEXT_MODE", "queue")
+    assert GatewayRunner._load_busy_text_mode() == "interrupt"
+
+
+@pytest.mark.asyncio
+async def test_busy_ask_sends_prompt_instead_of_queueing_immediately():
+    runner, adapter = _make_runner()
+    event = _event()
+    session_key = build_session_key(event.source)
+    running_agent = MagicMock()
+    running_agent.get_activity_summary.return_value = {"current_tool": "terminal"}
+    runner._running_agents[session_key] = running_agent
+
+    handled = await runner._handle_active_session_busy_message(event, session_key)
+
+    assert handled is True
+    assert adapter.prompts
+    assert adapter.prompts[0]["prompt_id"] == "1"
+    assert "still working" in adapter.prompts[0]["prompt"]
+    assert session_key not in adapter._pending_messages
+    assert runner._busy_prompt_events["1"] == (session_key, event)
+    running_agent.interrupt.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_busy_prompt_queue_choice_queues_when_session_active():
+    runner, adapter = _make_runner()
+    event = _event()
+    session_key = build_session_key(event.source)
+    runner._running_agents[session_key] = MagicMock()
+    runner._busy_prompt_events["7"] = (session_key, event)
+
+    resolved = await runner.resolve_busy_prompt_choice("7", "queue")
+
+    assert resolved is True
+    assert adapter._pending_messages[session_key] is event
+    assert "7" not in runner._busy_prompt_events
+
+
+@pytest.mark.asyncio
+async def test_busy_prompt_queue_choice_starts_if_original_run_finished():
+    runner, adapter = _make_runner()
+    event = _event()
+    session_key = build_session_key(event.source)
+    runner._busy_prompt_events["8"] = (session_key, event)
+
+    resolved = await runner.resolve_busy_prompt_choice("8", "queue")
+
+    assert resolved is True
+    assert adapter.started == [(session_key, event)]
+    assert session_key not in adapter._pending_messages
+
+
+@pytest.mark.asyncio
+async def test_busy_prompt_interrupt_choice_interrupts_running_agent():
+    runner, adapter = _make_runner()
+    event = _event("stop and do this")
+    session_key = build_session_key(event.source)
+    running_agent = MagicMock()
+    runner._running_agents[session_key] = running_agent
+    runner._busy_prompt_events["9"] = (session_key, event)
+
+    resolved = await runner.resolve_busy_prompt_choice("9", "interrupt")
+
+    assert resolved is True
+    assert adapter._pending_messages[session_key] is event
+    running_agent.interrupt.assert_called_once_with("stop and do this")
+
+
+@pytest.mark.asyncio
+async def test_busy_prompt_ignore_drops_event():
+    runner, adapter = _make_runner()
+    event = _event()
+    session_key = build_session_key(event.source)
+    runner._busy_prompt_events["10"] = (session_key, event)
+
+    resolved = await runner.resolve_busy_prompt_choice("10", "ignore")
+
+    assert resolved is True
+    assert session_key not in adapter._pending_messages
+    assert adapter.started == []


### PR DESCRIPTION
## Summary
- add `display.busy_input_mode: ask` support in the gateway runner
- render Telegram inline buttons for Queue / Interrupt / Steer / Ignore while Hermes is busy
- keep legacy `busy_text_mode=queue` from bypassing ask-mode prompts
- expose the new `ask` option in config metadata and add focused gateway tests

## Test Plan
- `python3 -m py_compile gateway/run.py plugins/platforms/telegram/adapter.py hermes_cli/config.py hermes_cli/tips.py hermes_cli/web_server.py`
- `python3 -m pytest tests/gateway/test_busy_input_ask.py -q -o 'addopts='`

## Notes
- prepared from a clean branch off current `origin/main`
- intentionally excludes local-only `/learn` work and unrelated dirty files from the main checkout
