### PR TITLE
feat(kanban): assignee profile enforcement + created_by canonicalization on the write path

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2305,6 +2305,20 @@ def _enforce_assignee_profile(assignee: Optional[str]) -> None:
     logging.getLogger(__name__).warning("kanban.assignee_enforcement: %s", msg)
 
 
+def _canonical_actor(actor: Optional[str]) -> Optional[str]:
+    """Lowercase-normalize a created_by/actor value for consistent attribution.
+
+    Unlike the assignee path this only canonicalizes case (so e.g. ``XO`` and
+    ``xo`` do not diverge in the tasks table); it does NOT enforce profile
+    existence — created_by may legitimately be a non-profile sentinel
+    (``worker``, ``user``, ``system``, automation).
+    """
+    if actor is None:
+        return None
+    s = str(actor).strip()
+    return s.lower() if s else None
+
+
 def create_task(
     conn: sqlite3.Connection,
     *,
@@ -2354,6 +2368,7 @@ def create_task(
     """
     assignee = _canonical_assignee(assignee)
     _enforce_assignee_profile(assignee)
+    created_by = _canonical_actor(created_by)
     if not title or not title.strip():
         raise ValueError("title is required")
     if initial_status not in VALID_INITIAL_STATUSES:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2239,6 +2239,72 @@ def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
     return normalize_profile_name(assignee)
 
 
+# ---------------------------------------------------------------------------
+# Assignee profile enforcement.
+#
+# A task assignee that does not correspond to an existing profile (a typo, or a
+# generic placeholder like "the reviewer") is accepted at write time but has no
+# profiles/<name>/ directory, so it silently stalls in 'ready' at dispatch
+# (spawn_ready_workers skips it via the profile_exists gate with no error
+# surfaced to the creator). WARN (the default) canonicalizes + logs so the stall
+# becomes a visible signal; REJECT raises at write so the caller must supply an
+# existing profile; OFF restores prior behavior.
+# Config: kanban.assignee_enforcement = off | warn | reject  (default 'warn').
+# ---------------------------------------------------------------------------
+
+_ASSIGNEE_ENFORCEMENT_MODES = ("off", "warn", "reject")
+
+
+def _assignee_enforcement_mode() -> str:
+    """Read kanban.assignee_enforcement (default 'warn'); unknown values -> 'warn'."""
+    try:
+        from hermes_cli.config import load_config
+
+        raw = (load_config().get("kanban") or {}).get("assignee_enforcement")
+    except Exception:
+        raw = None
+    mode = str(raw or "warn").strip().lower()
+    return mode if mode in _ASSIGNEE_ENFORCEMENT_MODES else "warn"
+
+
+def _assignee_enforcement_action(
+    canon: Optional[str], mode: str, profile_known: bool
+) -> tuple[bool, Optional[str]]:
+    """Pure decision: return ``(should_raise, message)`` for a canonical assignee.
+
+    ``message`` is None when nothing should be surfaced. ``should_raise`` is only
+    True in ``reject`` mode for an assignee with no matching profile.
+    """
+    if mode == "off" or not canon or profile_known:
+        return (False, None)
+    msg = (
+        f"kanban assignee {canon!r} is not an existing profile "
+        f"(no profiles/{canon}/ directory); the task would stall at dispatch."
+    )
+    return (mode == "reject", msg)
+
+
+def _enforce_assignee_profile(assignee: Optional[str]) -> None:
+    """WARN/REJECT-mode profile check for an already-canonicalized assignee."""
+    if assignee is None:
+        return
+    mode = _assignee_enforcement_mode()
+    if mode == "off":
+        return
+    try:
+        from hermes_cli.profiles import profile_exists
+
+        known = profile_exists(assignee)
+    except Exception:
+        known = False
+    should_raise, msg = _assignee_enforcement_action(assignee, mode, known)
+    if not msg:
+        return
+    if should_raise:
+        raise ValueError(msg)
+    logging.getLogger(__name__).warning("kanban.assignee_enforcement: %s", msg)
+
+
 def create_task(
     conn: sqlite3.Connection,
     *,
@@ -2287,6 +2353,7 @@ def create_task(
     translation skill regardless of the profile's default config).
     """
     assignee = _canonical_assignee(assignee)
+    _enforce_assignee_profile(assignee)
     if not title or not title.strip():
         raise ValueError("title is required")
     if initial_status not in VALID_INITIAL_STATUSES:

--- a/tests/hermes_cli/test_kanban_assignee_enforcement.py
+++ b/tests/hermes_cli/test_kanban_assignee_enforcement.py
@@ -99,3 +99,35 @@ def test_reject_mode_raises_for_unknown_assignee(isolated_kanban_home, monkeypat
         kb.create_board(slug="default", name="Test")
         with pytest.raises(ValueError):
             kb.create_task(conn, title="t1", assignee="The Reviewer")
+
+
+# --- created_by canonicalization (consistent attribution, no enforcement) ---
+
+def test_canonical_actor_lowercases_and_handles_empty(isolated_kanban_home):
+    kb, _ = isolated_kanban_home
+    assert kb._canonical_actor("XO") == "xo"
+    assert kb._canonical_actor("Orchestrator") == "orchestrator"
+    assert kb._canonical_actor("  worker ") == "worker"
+    assert kb._canonical_actor(None) is None
+    assert kb._canonical_actor("   ") is None
+
+
+def test_created_by_is_canonicalized_on_create(isolated_kanban_home):
+    kb, _ = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        tid = kb.create_task(conn, title="t", assignee="default", created_by="XO")
+        row = conn.execute("SELECT created_by FROM tasks WHERE id=?", (tid,)).fetchone()
+    assert row["created_by"] == "xo"  # 'XO' canonicalized, not stored mixed-case
+
+
+def test_created_by_sentinel_and_none_preserved(isolated_kanban_home):
+    kb, _ = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        t1 = kb.create_task(conn, title="t1", assignee="default", created_by="worker")
+        t2 = kb.create_task(conn, title="t2", assignee="default", created_by=None)
+        r1 = conn.execute("SELECT created_by FROM tasks WHERE id=?", (t1,)).fetchone()
+        r2 = conn.execute("SELECT created_by FROM tasks WHERE id=?", (t2,)).fetchone()
+    assert r1["created_by"] == "worker"
+    assert r2["created_by"] is None

--- a/tests/hermes_cli/test_kanban_assignee_enforcement.py
+++ b/tests/hermes_cli/test_kanban_assignee_enforcement.py
@@ -1,0 +1,101 @@
+"""Tests for kanban.assignee_enforcement.
+
+A task assignee that does not correspond to an existing profile is accepted at
+write time but has no profiles/<name>/ directory, so it silently stalls in
+'ready' at dispatch. WARN mode (the shipped default) canonicalizes + logs so the
+stall becomes visible and must NEVER break task creation; REJECT mode is opt-in
+and raises at write.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import tempfile
+
+import pytest
+
+
+@pytest.fixture()
+def isolated_kanban_home(monkeypatch):
+    """Fresh HERMES_HOME + clean kanban DB (mirrors test_kanban_default_assignee)."""
+    test_home = tempfile.mkdtemp(prefix="kanban_assignee_enforcement_test_")
+    monkeypatch.setenv("HERMES_HOME", test_home)
+    for mod in list(sys.modules.keys()):
+        if mod.startswith("hermes_cli") or mod.startswith("hermes_state") or mod == "hermes_constants":
+            del sys.modules[mod]
+    from hermes_cli import kanban_db
+    yield kanban_db, test_home
+
+
+# --- pure decision: (canon, mode, profile_known) -> (should_raise, message) ---
+
+def test_enforcement_off_never_flags(isolated_kanban_home):
+    kb, _ = isolated_kanban_home
+    assert kb._assignee_enforcement_action("the reviewer", "off", False) == (False, None)
+
+
+def test_enforcement_warn_flags_unknown_profile_without_raising(isolated_kanban_home):
+    kb, _ = isolated_kanban_home
+    should_raise, msg = kb._assignee_enforcement_action("the reviewer", "warn", False)
+    assert should_raise is False
+    assert msg and "the reviewer" in msg
+
+
+def test_enforcement_warn_silent_for_known_profile(isolated_kanban_home):
+    kb, _ = isolated_kanban_home
+    assert kb._assignee_enforcement_action("builder", "warn", True) == (False, None)
+
+
+def test_enforcement_reject_raises_for_unknown_profile(isolated_kanban_home):
+    kb, _ = isolated_kanban_home
+    should_raise, msg = kb._assignee_enforcement_action("reviewer-typo", "reject", False)
+    assert should_raise is True
+    assert msg
+
+
+def test_enforcement_reject_silent_for_known_profile(isolated_kanban_home):
+    kb, _ = isolated_kanban_home
+    assert kb._assignee_enforcement_action("ops", "reject", True) == (False, None)
+
+
+def test_enforcement_none_assignee_never_flags(isolated_kanban_home):
+    kb, _ = isolated_kanban_home
+    assert kb._assignee_enforcement_action(None, "warn", False) == (False, None)
+
+
+# --- integration: WARN must not break creation; REJECT is opt-in ---
+
+def test_warn_mode_keeps_unknown_assignee_and_warns(isolated_kanban_home, caplog, monkeypatch):
+    kb, _ = isolated_kanban_home
+    monkeypatch.setattr(kb, "_assignee_enforcement_mode", lambda: "warn")
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        with caplog.at_level(logging.WARNING):
+            task_id = kb.create_task(conn, title="t1", assignee="The Reviewer")
+        row = conn.execute("SELECT assignee FROM tasks WHERE id=?", (task_id,)).fetchone()
+    assert task_id  # WARN must NOT raise / break creation
+    assert row["assignee"] == "the reviewer"  # canonicalized, not rejected
+    assert any("the reviewer" in r.message.lower() for r in caplog.records)
+
+
+def test_warn_mode_silent_for_known_profile(isolated_kanban_home, caplog, monkeypatch):
+    kb, home = isolated_kanban_home
+    os.makedirs(os.path.join(home, "profiles", "builder"), exist_ok=True)
+    monkeypatch.setattr(kb, "_assignee_enforcement_mode", lambda: "warn")
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        with caplog.at_level(logging.WARNING):
+            task_id = kb.create_task(conn, title="t1", assignee="Builder")
+        row = conn.execute("SELECT assignee FROM tasks WHERE id=?", (task_id,)).fetchone()
+    assert row["assignee"] == "builder"
+    assert not any("not an existing profile" in r.message.lower() for r in caplog.records)
+
+
+def test_reject_mode_raises_for_unknown_assignee(isolated_kanban_home, monkeypatch):
+    kb, _ = isolated_kanban_home
+    monkeypatch.setattr(kb, "_assignee_enforcement_mode", lambda: "reject")
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        with pytest.raises(ValueError):
+            kb.create_task(conn, title="t1", assignee="The Reviewer")


### PR DESCRIPTION
## Summary

Two related fixes to the Kanban task **write path** (`create_task` / `_canonical_assignee`):

### 1. Assignee profile enforcement (`kanban.assignee_enforcement`)

A task assignee that does not correspond to an existing profile — a typo, or a generic placeholder like `the reviewer` — is accepted at write time but has no `profiles/<name>/` directory, so it **silently stalls in `ready` at dispatch** (`spawn_ready_workers` skips it via the `profile_exists` gate with no error surfaced to the creator).

New config `kanban.assignee_enforcement` (`off` | `warn` | `reject`, default **`warn`**):
- **`warn`** (default): canonicalize + log a warning so the silent stall becomes a visible signal. **Never raises; task creation is unaffected.**
- **`reject`**: raise at write so the caller must supply an existing profile.
- **`off`**: prior behavior.

### 2. `created_by` canonicalization

`created_by` was bound raw, so the same actor could land as both `XO` and `xo` (and `User`/`user`, …), fragmenting attribution and group-by reporting. It is now lowercase-canonicalized at the same chokepoint. This is **case-normalization only, not enforcement** — `created_by` may legitimately be a non-profile sentinel (`worker`, `user`, `system`).

## Testing

- New `tests/hermes_cli/test_kanban_assignee_enforcement.py` (12 tests): assignee enforcement decision logic (all three modes) + integration (WARN never breaks creation, REJECT raises), and `created_by` canonicalization (`XO`→`xo`; sentinels/None preserved).
- Existing `tests/hermes_cli/test_kanban_default_assignee.py` unchanged (6/6 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
