### PR TITLE
fix(honcho): make tools eager init nonblocking

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -20,6 +20,7 @@ import logging
 import re
 import threading
 import time
+from collections import deque
 from typing import Any, Dict, List, Optional
 
 from agent.memory_manager import sanitize_context
@@ -191,6 +192,8 @@ ALL_TOOL_SCHEMAS = [PROFILE_SCHEMA, SEARCH_SCHEMA, REASONING_SCHEMA, CONTEXT_SCH
 class HonchoMemoryProvider(MemoryProvider):
     """Honcho AI-native memory with dialectic Q&A and persistent user modeling."""
 
+    _PENDING_OPERATION_LIMIT = 100
+
     def backup_paths(self) -> List[str]:
         """Honcho keeps its peer/session config under ~/.honcho when no
         profile-local honcho.json exists (see client.resolve_config_path)."""
@@ -244,6 +247,8 @@ class HonchoMemoryProvider(MemoryProvider):
         self._init_thread: Optional[threading.Thread] = None
         self._init_lock = threading.Lock()
         self._init_error = ""
+        self._pending_operations: deque[tuple[str, tuple[str, ...]]] = deque()
+        self._pending_operations_lock = threading.Lock()
 
         # Port #4053: cron guard — when True, plugin is fully inactive
         self._cron_skipped = False
@@ -347,14 +352,12 @@ class HonchoMemoryProvider(MemoryProvider):
             self._session_key = self._resolve_session_key(cfg, session_id, **kwargs)
 
             # Network-backed session creation can block on Honcho service or DB
-            # outages. Startup must fail open for context/hybrid modes, where
-            # Honcho is initialized only to enrich prompts. Tools-only mode has
-            # an explicit contract: init_on_session_start=False stays lazy until
-            # the first tool call, while init_on_session_start=True remains an
-            # eager, ready-on-return initialization path.
+            # outages. Startup must fail open for every recall mode. Tools-only
+            # with init_on_session_start=True starts the same background init path
+            # so configured eager startup can warm Honcho without blocking Hermes.
             if self._recall_mode == "tools":
                 if cfg.init_on_session_start:
-                    self._ensure_session()
+                    self._start_session_init_background()
                     return
                 logger.debug("Honcho tools-only mode — deferring session init until first tool call")
                 return
@@ -413,6 +416,7 @@ class HonchoMemoryProvider(MemoryProvider):
                     self._lazy_init_kwargs = None
                     self._lazy_init_session_id = None
                     self._init_error = ""
+                    self._flush_pending_operations()
                 except Exception as e:
                     self._init_error = str(e)
                     self._manager = None
@@ -537,6 +541,7 @@ class HonchoMemoryProvider(MemoryProvider):
             # Clear lazy refs
             self._lazy_init_kwargs = None
             self._lazy_init_session_id = None
+            self._flush_pending_operations()
             return self._manager is not None
         except Exception as e:
             self._manager = None
@@ -1211,20 +1216,54 @@ class HonchoMemoryProvider(MemoryProvider):
             ),
         }
 
-    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
-        """Record the conversation turn in Honcho (non-blocking).
+    def _defer_tools_operation(self, operation: str, *payload: str) -> bool:
+        """Queue an operation while eager tools-mode initialization is in flight.
 
-        Messages exceeding the Honcho API limit (default 25k chars) are
-        split into multiple messages with continuation markers.
+        Returns ``False`` only when initialization completed during the caller's
+        readiness check, so the caller should execute the operation immediately.
+        The oldest operation is dropped on overflow to keep startup fail-open
+        without retaining an unbounded conversation backlog.
         """
-        if self._cron_skipped:
-            return
-        if self._recall_mode == "tools" and not self._session_ready():
-            return
-        if not self._session_ready():
+        restart_init = False
+        with self._pending_operations_lock:
+            if self._session_ready():
+                return False
+            init_in_flight = bool(self._init_thread and self._init_thread.is_alive())
+            eager_tools_init = bool(
+                self._config and self._config.init_on_session_start
+            )
+            if not init_in_flight and not eager_tools_init:
+                return True
+            restart_init = not init_in_flight
+            if len(self._pending_operations) >= self._PENDING_OPERATION_LIMIT:
+                dropped_operation, _ = self._pending_operations.popleft()
+                logger.warning(
+                    "Honcho pending operation queue full (%d); dropping oldest %s operation",
+                    self._PENDING_OPERATION_LIMIT,
+                    dropped_operation,
+                )
+            self._pending_operations.append((operation, payload))
+        if restart_init:
             self._start_session_init_background()
-            return
+        return True
 
+    def _flush_pending_operations(self) -> None:
+        if not self._session_ready():
+            return
+        with self._pending_operations_lock:
+            if not self._session_ready():
+                return
+            pending = list(self._pending_operations)
+            self._pending_operations.clear()
+        for operation, payload in pending:
+            if operation == "turn":
+                self._sync_turn_ready(*payload)
+            elif operation == "memory_write":
+                self._memory_write_ready(*payload)
+
+    def _sync_turn_ready(self, user_content: str, assistant_content: str) -> None:
+        if not self._session_ready():
+            return
         msg_limit = self._config.message_max_chars if self._config else 25000
         clean_user_content = sanitize_context(user_content or "").strip()
         clean_assistant_content = sanitize_context(assistant_content or "").strip()
@@ -1247,6 +1286,36 @@ class HonchoMemoryProvider(MemoryProvider):
         )
         self._sync_thread.start()
 
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        """Record the conversation turn in Honcho (non-blocking).
+
+        Messages exceeding the Honcho API limit (default 25k chars) are
+        split into multiple messages with continuation markers.
+        """
+        if self._cron_skipped:
+            return
+        if self._recall_mode == "tools" and not self._session_ready():
+            if self._defer_tools_operation("turn", user_content, assistant_content):
+                return
+        if not self._session_ready():
+            self._start_session_init_background()
+            return
+
+        self._sync_turn_ready(user_content, assistant_content)
+
+    def _memory_write_ready(self, content: str) -> None:
+        if not self._session_ready():
+            return
+
+        def _write():
+            try:
+                self._manager.create_conclusion(self._session_key, content)
+            except Exception as e:
+                logger.debug("Honcho memory mirror failed: %s", e)
+
+        t = threading.Thread(target=_write, daemon=True, name="honcho-memwrite")
+        t.start()
+
     def on_memory_write(
         self,
         action: str,
@@ -1266,19 +1335,13 @@ class HonchoMemoryProvider(MemoryProvider):
         if self._cron_skipped:
             return
         if self._recall_mode == "tools" and not self._session_ready():
-            return
+            if self._defer_tools_operation("memory_write", content):
+                return
         if not self._session_ready():
             self._start_session_init_background()
             return
 
-        def _write():
-            try:
-                self._manager.create_conclusion(self._session_key, content)
-            except Exception as e:
-                logger.debug("Honcho memory mirror failed: %s", e)
-
-        t = threading.Thread(target=_write, daemon=True, name="honcho-memwrite")
-        t.start()
+        self._memory_write_ready(content)
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
         """Flush all pending messages to Honcho on session end."""

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -653,13 +653,179 @@ class TestToolsModeInitBehavior:
         assert provider._manager is None
         assert provider._lazy_init_kwargs is not None
 
-    def test_tools_eager_init(self):
-        """tools + initOnSessionStart=true → session IS initialized after initialize()."""
-        provider, _, _ = self._make_provider_with_config(
-            recall_mode="tools", init_on_session_start=True,
-        )
+    def test_tools_eager_init_starts_background_without_blocking(self):
+        """tools + initOnSessionStart=true starts init async and returns before Honcho is ready."""
+        import threading
+        from plugins.memory.honcho.client import HonchoClientConfig
+        from unittest.mock import patch
+
+        cfg = HonchoClientConfig(api_key="test-key", enabled=True, recall_mode="tools", init_on_session_start=True)
+        provider = HonchoMemoryProvider()
+        started = threading.Event()
+        release = threading.Event()
+
+        def slow_init(*_args, **_kwargs):
+            started.set()
+            release.wait(timeout=2.0)
+            provider._manager = MagicMock()
+            provider._session_initialized = True
+
+        with patch("plugins.memory.honcho.client.HonchoClientConfig.from_global_config", return_value=cfg):
+            provider._do_session_init = slow_init
+            provider.initialize(session_id="test-session-001")
+
+        assert started.wait(timeout=1.0)
+        assert provider._session_initialized is False
+        assert provider._manager is None
+        release.set()
+        provider._init_thread.join(timeout=1.0)
         assert provider._session_initialized is True
-        assert provider._manager is not None
+
+    def test_tools_async_init_flushes_pending_operations_when_ready(self):
+        import threading
+        from plugins.memory.honcho.client import HonchoClientConfig
+        from unittest.mock import patch
+
+        cfg = HonchoClientConfig(api_key="test-key", enabled=True, recall_mode="tools", init_on_session_start=True)
+        provider = HonchoMemoryProvider()
+        session = MagicMock()
+        manager = MagicMock()
+        manager.get_or_create.return_value = session
+        started = threading.Event()
+        release = threading.Event()
+        memory_write_done = threading.Event()
+
+        def create_conclusion(*_args, **_kwargs):
+            memory_write_done.set()
+
+        manager.create_conclusion.side_effect = create_conclusion
+
+        def slow_init(*_args, **_kwargs):
+            started.set()
+            release.wait(timeout=2.0)
+            provider._manager = manager
+            provider._session_key = "test-session-001"
+            provider._session_initialized = True
+
+        with patch("plugins.memory.honcho.client.HonchoClientConfig.from_global_config", return_value=cfg):
+            provider._do_session_init = slow_init
+            provider.initialize(session_id="test-session-001")
+
+        assert started.wait(timeout=1.0)
+        provider.sync_turn("hello", "hi")
+        provider.on_memory_write("add", "user", "Prefers dark mode")
+        session.add_message.assert_not_called()
+        manager.create_conclusion.assert_not_called()
+
+        release.set()
+        provider._init_thread.join(timeout=1.0)
+        if provider._sync_thread:
+            provider._sync_thread.join(timeout=1.0)
+
+        assert session.add_message.call_args_list[0].args == ("user", "hello")
+        assert session.add_message.call_args_list[1].args == ("assistant", "hi")
+        manager._flush_session.assert_called_once_with(session)
+        assert memory_write_done.wait(timeout=1.0)
+        manager.create_conclusion.assert_called_once_with(
+            "test-session-001", "Prefers dark mode"
+        )
+
+    def test_tools_async_init_pending_queue_drops_oldest_on_overflow(self):
+        import threading
+        from plugins.memory.honcho.client import HonchoClientConfig
+        from unittest.mock import patch
+
+        cfg = HonchoClientConfig(api_key="test-key", enabled=True, recall_mode="tools", init_on_session_start=True)
+        provider = HonchoMemoryProvider()
+        provider._PENDING_OPERATION_LIMIT = 2
+        session = MagicMock()
+        manager = MagicMock()
+        manager.get_or_create.return_value = session
+        started = threading.Event()
+        release = threading.Event()
+        memory_write_done = threading.Event()
+        manager.create_conclusion.side_effect = lambda *_args: memory_write_done.set()
+
+        def slow_init(*_args, **_kwargs):
+            started.set()
+            release.wait(timeout=2.0)
+            provider._manager = manager
+            provider._session_key = "test-session-001"
+            provider._session_initialized = True
+
+        with patch("plugins.memory.honcho.client.HonchoClientConfig.from_global_config", return_value=cfg):
+            provider._do_session_init = slow_init
+            provider.initialize(session_id="test-session-001")
+
+        assert started.wait(timeout=1.0)
+        provider.sync_turn("first", "one")
+        provider.on_memory_write("add", "user", "second")
+        provider.sync_turn("third", "three")
+
+        assert len(provider._pending_operations) == 2
+        release.set()
+        provider._init_thread.join(timeout=1.0)
+        if provider._sync_thread:
+            provider._sync_thread.join(timeout=1.0)
+
+        assert memory_write_done.wait(timeout=1.0)
+        manager.create_conclusion.assert_called_once_with("test-session-001", "second")
+        assert [call.args for call in session.add_message.call_args_list] == [
+            ("user", "third"),
+            ("assistant", "three"),
+        ]
+
+    def test_tools_eager_lifecycle_hooks_retry_failed_background_init(self):
+        import threading
+        from plugins.memory.honcho.client import HonchoClientConfig
+        from unittest.mock import patch
+
+        cfg = HonchoClientConfig(api_key="test-key", enabled=True, recall_mode="tools", init_on_session_start=True)
+        provider = HonchoMemoryProvider()
+        session = MagicMock()
+        manager = MagicMock()
+        manager.get_or_create.return_value = session
+        attempts = 0
+        retry_started = threading.Event()
+        release_retry = threading.Event()
+        memory_write_done = threading.Event()
+        manager.create_conclusion.side_effect = lambda *_args: memory_write_done.set()
+
+        def flaky_init(*_args, **_kwargs):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise RuntimeError("Honcho unavailable")
+            retry_started.set()
+            release_retry.wait(timeout=2.0)
+            provider._manager = manager
+            provider._session_key = "test-session-001"
+            provider._session_initialized = True
+
+        with patch("plugins.memory.honcho.client.HonchoClientConfig.from_global_config", return_value=cfg):
+            provider._do_session_init = flaky_init
+            provider.initialize(session_id="test-session-001")
+
+        provider._init_thread.join(timeout=1.0)
+        assert provider._init_error == "Honcho unavailable"
+
+        provider.sync_turn("retry", "succeeds")
+        assert retry_started.wait(timeout=1.0)
+        provider.on_memory_write("add", "user", "Retried write")
+        release_retry.set()
+        provider._init_thread.join(timeout=1.0)
+        if provider._sync_thread:
+            provider._sync_thread.join(timeout=1.0)
+
+        assert attempts == 2
+        assert memory_write_done.wait(timeout=1.0)
+        manager.create_conclusion.assert_called_once_with(
+            "test-session-001", "Retried write"
+        )
+        assert [call.args for call in session.add_message.call_args_list] == [
+            ("user", "retry"),
+            ("assistant", "succeeds"),
+        ]
 
     def test_tools_eager_prefetch_still_empty(self):
         """tools mode with eager init still returns empty from prefetch() (no auto-injection)."""


### PR DESCRIPTION
## Summary
- make Honcho tools-mode `initOnSessionStart` start session initialization in the existing background init path instead of blocking agent startup
- keep early turns and eligible user-memory writes that arrive while async init is in flight in a bounded 100-operation in-process queue; drop the oldest operation with a warning on overflow and flush retained operations when Honcho becomes ready
- retry eager background initialization when a later lifecycle write arrives after an initialization failure
- preserve tools-only behavior: no automatic context injection, and `initOnSessionStart: false` still defers session init until first Honcho tool call

Fixes #51492

## Why
`initOnSessionStart: true` currently calls `_ensure_session()` synchronously in tools-only mode. If a local/self-hosted Honcho service is still booting or unavailable, this can block Hermes Desktop resume/prompt startup long enough for the renderer's JSON-RPC request timeout even though the model itself is responsive.

Context/hybrid modes already use background session init/fail-open. This applies the same startup-safety invariant to tools mode without leaving the eager-init lifecycle hooks with an unbounded or turn-only backlog.

## Test plan
- [x] `python -m pytest tests/honcho_plugin/test_session.py::TestToolsModeInitBehavior -q` — 10 passed
- [x] `python -m pytest tests/honcho_plugin/test_session.py tests/test_honcho_client_config.py -q` — 128 passed, 1 skipped
- [x] isolated per-file runs with `TZ=UTC`, `LANG=C.UTF-8`, and `PYTHONHASHSEED=0` — 121 passed; 7 passed, 1 skipped

## Notes
- `python -m pytest tests/honcho_plugin -q` reaches 370 passed, 2 skipped, with two unrelated Windows baseline failures in config-path and path-separator expectations.
