### PR TITLE
fix(models): use certifi CA bundle for live model-list probes

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3389,6 +3389,38 @@ def github_model_reasoning_efforts(
     return _github_reasoning_efforts_for_model_id(str(model_id or normalized))
 
 
+def _models_ssl_context():
+    """SSL context that trusts the system store *and* certifi's CA bundle.
+
+    Hermes's hand-rolled ``urllib`` probes otherwise rely on Python's default
+    OpenSSL trust store, which on many macOS python.org installs is empty (the
+    "Install Certificates.command" was never run). The live ``/models`` fetch
+    then fails with ``CERTIFICATE_VERIFY_FAILED`` even though the cert is valid
+    — and the picker silently degrades to the static fallback list. curl and
+    the chat path both work because the OpenAI SDK / httpx / requests already
+    bundle certifi; only these hand-rolled probes were left out.
+
+    ``certifi`` is a pinned dependency, so we union it *on top of* the system
+    roots: this fixes the empty-store case without dropping a corporate or
+    internal CA that only lives in the system store. Returns ``None`` (use
+    urllib's default) if anything goes wrong, so a probe that worked before
+    can never start failing.
+    """
+    try:
+        import ssl
+
+        ctx = ssl.create_default_context()
+        try:
+            import certifi
+
+            ctx.load_verify_locations(cafile=certifi.where())
+        except Exception:
+            pass
+        return ctx
+    except Exception:
+        return None
+
+
 def probe_api_models(
     api_key: Optional[str],
     base_url: Optional[str],
@@ -3441,12 +3473,13 @@ def probe_api_models(
     if normalized.startswith(COPILOT_BASE_URL):
         headers.update(copilot_default_headers())
 
+    ssl_ctx = _models_ssl_context()
     for candidate_base, is_fallback in candidates:
         url = candidate_base.rstrip("/") + "/models"
         tried.append(url)
         req = urllib.request.Request(url, headers=headers)
         try:
-            with urllib.request.urlopen(req, timeout=timeout) as resp:
+            with urllib.request.urlopen(req, timeout=timeout, context=ssl_ctx) as resp:
                 data = json.loads(resp.read().decode())
                 return {
                     "models": [m.get("id", "") for m in data.get("data", [])],

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -291,7 +291,7 @@ class TestFetchApiModels:
 
         calls = []
 
-        def _fake_urlopen(req, timeout=5.0):
+        def _fake_urlopen(req, timeout=5.0, context=None):
             calls.append(req.full_url)
             if req.full_url.endswith("/v1/models"):
                 return _Resp()

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -907,3 +907,29 @@ class TestNousRecommendedModels:
             patch("hermes_cli.models.check_nous_free_tier", side_effect=RuntimeError("boom")),
         ):
             assert get_nous_recommended_aux_model(vision=False) == "paid-model"
+
+
+class TestModelsSSLContext:
+    """The live /models probe must use certifi so it doesn't fail with
+    CERTIFICATE_VERIFY_FAILED on machines whose Python has an empty default
+    trust store (the common macOS python.org case)."""
+
+    def test_ssl_context_trusts_certifi_even_if_system_store_empty(self):
+        import ssl
+        ctx = _models_mod._models_ssl_context()
+        assert isinstance(ctx, ssl.SSLContext)
+        # certifi is unioned on top of the system store, so the trust store is
+        # never empty — the exact failure mode this fixes.
+        assert ctx.get_ca_certs(), "expected a non-empty trust store (certifi)"
+
+    def test_probe_passes_ssl_context_to_urlopen(self):
+        import ssl
+        captured = {}
+
+        def fake_urlopen(req, timeout=None, context=None):
+            captured["context"] = context
+            raise OSError("stop after capturing")
+
+        with patch("hermes_cli.models.urllib.request.urlopen", side_effect=fake_urlopen):
+            _models_mod.probe_api_models("k", "https://example.com/v1")
+        assert isinstance(captured.get("context"), ssl.SSLContext)


### PR DESCRIPTION
## What does this PR do?

The live `/models` probe (`probe_api_models`) is a hand-rolled `urllib` call that trusts Python's default OpenSSL trust store. On python.org macOS installs that never ran "Install Certificates.command" that store is empty, so the probe fails with `CERTIFICATE_VERIFY_FAILED` even though the server cert is valid - and the picker silently degrades to the static fallback list. That is exactly how a GMI partner concluded GLM-5.2 was "not supported" when GMI does serve it live (`zai-org/GLM-5.2-FP8`).

`curl` and Hermes's own chat path both work on the same machine, because the OpenAI SDK / httpx / requests already bundle and use `certifi`. Only these hand-rolled `urllib` probes were left relying on the (often empty) system store. This PR brings the straggler in line.

## Related Issue

Related to #51533 (the visibility/warning + GLM-5.2 catalog change). This PR is the root-cause fix; #51533 makes any *residual* fetch failure visible. Both touch `probe_api_models`, so whichever merges second needs a one-line conflict resolution (the line just before the probe loop and the `urlopen(...)` call).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/models.py`
  - Add `_models_ssl_context()`: builds `ssl.create_default_context()` (system trust store) and unions `certifi.where()` on top of it. Returns `None` on any error so the probe falls back to urllib's exact previous behaviour.
  - `probe_api_models()`: pass that context to `urllib.request.urlopen(...)`.
- `tests/hermes_cli/test_models.py`: add `TestModelsSSLContext` (context has a non-empty trust store; the probe passes an `SSLContext` to `urlopen`).

## How to Test

1. `pytest tests/hermes_cli/test_models.py -q` -> passes.
2. End-to-end: with **no** `SSL_CERT_FILE` set on a machine whose Python has an empty default trust store, `provider_model_ids("gmi")` now returns the full live list (incl. `zai-org/GLM-5.2-FP8`) instead of the static fallback. Before this change the same call returned only the static fallback.

## Why union (not replace)?

Using `create_default_context(cafile=certifi.where())` would *replace* the trust store and drop any corporate/internal root that only lives in the system store. Starting from `create_default_context()` and adding certifi via `load_verify_locations` makes the trust set a **superset** of the old default - it can only add trust, never remove it - so no probe that verified before can start failing.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant suite: `tests/hermes_cli/test_models.py` (78 passed). Full `pytest tests/ -q` has pre-existing collection errors in unrelated `tests/acp/*` modules, not caused by this PR.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.5 (Darwin 24.5.0)

### Documentation & Housekeeping

- [x] Documentation: N/A (no user-facing config/behaviour to document beyond the docstring)
- [x] `cli-config.yaml.example`: N/A (no config keys changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A (no architecture/workflow change)
- [x] I've considered cross-platform impact: union trust store is a superset of the default on every platform; `certifi` is already a pinned dependency; helper returns `None` on error
- [x] I've updated tool descriptions/schemas: N/A (no tool behavior changed)

## Screenshots / Logs

Before (empty default trust store): `provider_model_ids("gmi")` -> 6 static models, no GLM-5.2.
After: `provider_model_ids("gmi")` -> 65 live models incl. `zai-org/GLM-5.2-FP8`, with no `SSL_CERT_FILE` set.
