### PR TITLE
fix(desktop): correct stop-button popup during busy session

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -176,7 +176,7 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           }
 
           if (busyRef.current) {
-            renderSlashOutput('session busy — /interrupt the current turn before sending this command')
+            renderSlashOutput('session busy — use the Stop button or Esc to interrupt the current turn')
 
             return
           }


### PR DESCRIPTION
Fixes #51576

## What

When a user clicks the Stop button while an Hermes Desktop session is mid-turn, the popup tells them to run `/interrupt` in the chat. `/interrupt` is not a registered slash command on any desktop surface — the user hits "no such command."

## Reproduction

1. Launch Hermes Desktop, start a conversation.
2. Send a message that keeps the agent busy (long-running tool call).
3. Click the red Stop button in the composer while the turn is in-flight.
4. The popup says `session busy — /interrupt the current turn before sending this command`.
5. Typing `/interrupt` in the composer returns an error.

## Root cause

The message lives at `apps/desktop/src/app/session/hooks/use-prompt-actions.ts:965`:

```ts
renderSlashOutput('session busy — /interrupt the current turn before sending this command')
```

The string was apparently copied from TUI gateway error messages (`tui_gateway/server.py`), which use `/interrupt` in internal hints — but those hints fire in a TUI context where the user is on a terminal. On the desktop surface `/interrupt` is not listed in `apps/desktop/src/lib/desktop-slash-commands.ts` and produces an unknown-command error.

The desktop's actual live-turn abort controls are the Stop button and <kbd>Esc</kbd>, which both call `session.interrupt` via `onCancel()` (`apps/desktop/src/app/chat/composer/index.tsx:1161–1175`).

## Fix

Replace the hardcoded string to point at the real controls:

```diff
- renderSlashOutput('session busy — /interrupt the current turn before sending this command')
+ renderSlashOutput('session busy — use the Stop button or Esc to interrupt the current turn')
```

## Why this approach

- Pointing users to `/stop` would also be wrong — `/stop` terminates *background processes*, not the live turn (`desktop-slash-commands.ts:137`).
- Pointing users to the Stop button or Esc is accurate: the desktop already renders both controls, and both call `session.interrupt` (the same internal RPC the TUI's interrupt path uses).
- No tests assert the old string (verified via `use-prompt-actions.test.tsx`). No other desktop-frontend code path references `/interrupt` as a user-facing command. This is the only site.

## Verification

- `git diff --stat origin/main..HEAD` confirms one file changed, one line touched.
- Branch rebased onto current `origin/main` (0ba1dfed7) with no unrelated commits.
- LSP check: only pre-existing `@assistant-ui/react` type-declaration missing errors, not introduced by this change.
