### PR TITLE
fix: send typed Codex Responses message content

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -776,7 +776,12 @@ def _preflight_codex_input_items(raw_items: Any) -> List[Dict[str, Any]]:
             if not isinstance(content, str):
                 content = str(content)
 
-            normalized.append({"role": role, "content": content})
+            # The Codex backend's Responses surface now rejects scalar message
+            # content with HTTP 400 "Unsupported content type".  Always send
+            # role-appropriate typed content parts, matching the list path
+            # above and the native Responses message schema.
+            text_type = "output_text" if role == "assistant" else "input_text"
+            normalized.append({"role": role, "content": [{"type": text_type, "text": content}]})
             continue
 
         raise ValueError(

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -2307,6 +2307,24 @@ def test_chat_messages_to_responses_input_deduplicates_reasoning_ids(monkeypatch
         assert "id" not in it
 
 
+def test_preflight_codex_input_converts_scalar_message_content_to_typed_parts(monkeypatch):
+    """Codex backend rejects scalar message content with 'Unsupported content type'."""
+    agent = _build_agent(monkeypatch)
+    raw_input = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "ok"},
+        {"type": "reasoning", "encrypted_content": "enc_a", "summary": []},
+        {"role": "assistant", "content": ""},
+    ]
+    from agent.codex_responses_adapter import _preflight_codex_input_items
+
+    normalized = _preflight_codex_input_items(raw_input)
+
+    assert normalized[0] == {"role": "user", "content": [{"type": "input_text", "text": "hello"}]}
+    assert normalized[1] == {"role": "assistant", "content": [{"type": "output_text", "text": "ok"}]}
+    assert normalized[3] == {"role": "assistant", "content": [{"type": "output_text", "text": ""}]}
+
+
 def test_preflight_codex_input_deduplicates_reasoning_ids(monkeypatch):
     """_preflight_codex_input_items should also deduplicate reasoning items by ID."""
     agent = _build_agent(monkeypatch)


### PR DESCRIPTION
## Summary
- Convert scalar user/assistant message content to typed Responses parts during Codex preflight
- Preserve role-specific text types (`input_text` for user, `output_text` for assistant)
- Add a regression test for the Codex backend's `Unsupported content type` rejection shape

## Why
The OpenAI Codex backend rejects scalar message content in Responses input items with HTTP 400 `Unsupported content type`. In gateway contexts this surfaces to users as the generic safe provider-failure message, making long-lived Codex sessions look unrecoverably broken.

Putting the normalization in the shared Codex Responses preflight path protects CLI, gateway, cron, and other Codex call paths.

## Test plan
- `git diff --check`
- `.venv/bin/python -m pytest tests/run_agent/test_run_agent_codex_responses.py::test_preflight_codex_input_converts_scalar_message_content_to_typed_parts -q`
- `.venv/bin/python -m pytest tests/run_agent/test_run_agent_codex_responses.py -q`

Live local smoke test before opening PR:
- `.venv/bin/python -m hermes_cli.main chat -q 'Reply with OK only.' --provider openai-codex --model gpt-5.5 -Q` → `OK`
