### PR TITLE
fix(gateway/windows): restart() must relaunch a manually-run gateway

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -1333,6 +1333,13 @@ def restart() -> None:
     _assert_windows()
     from hermes_cli.gateway import kill_gateway_processes
 
+    # Capture the run mode BEFORE stopping so we relaunch the gateway the SAME
+    # way it was running. A manually-run gateway (no scheduled task / startup
+    # entry) must be relaunched directly: routing it through start() would hit
+    # the "service not installed" branch, prompt to install, and return without
+    # starting -- leaving the gateway DOWN on every manual-gateway restart.
+    service_installed = is_task_registered() or is_startup_entry_installed()
+
     stop()
 
     if not _wait_for_gateway_absent(timeout_s=30.0):
@@ -1346,7 +1353,11 @@ def restart() -> None:
 
     # Give Windows a moment to release the listening port.
     time.sleep(1.0)
-    start()
+    if service_installed:
+        start()
+    else:
+        pid = _spawn_detached()
+        _report_gateway_start(f"direct spawn (PID {pid})")
 
     if not _wait_for_gateway_ready(timeout_s=15.0):
         raise RuntimeError(

--- a/tests/hermes_cli/test_gateway_restart_run_mode.py
+++ b/tests/hermes_cli/test_gateway_restart_run_mode.py
@@ -1,0 +1,53 @@
+"""Regression: `hermes gateway restart` must relaunch a manually-run gateway.
+
+Bug: ``restart()`` did ``stop()`` then ``start()``, and ``start()``'s
+"service not installed" branch prompts to install and returns WITHOUT starting.
+So restarting a manually-run gateway (no scheduled task / startup entry) left it
+DOWN -- a silent outage on every manual-gateway restart.
+
+``restart()`` must preserve the run mode: relaunch a manual gateway directly via
+``_spawn_detached()``, only routing through ``start()`` when a service/startup
+entry is installed.
+"""
+import hermes_cli.gateway_windows as gw
+
+
+def _neutralize(monkeypatch, calls):
+    monkeypatch.setattr(gw, "_assert_windows", lambda: None)
+    monkeypatch.setattr(gw, "stop", lambda: None)
+    monkeypatch.setattr(gw, "_wait_for_gateway_absent", lambda **k: True)
+    monkeypatch.setattr(gw, "_wait_for_gateway_ready", lambda **k: True)
+    monkeypatch.setattr(gw, "_report_gateway_start", lambda *a, **k: None)
+    monkeypatch.setattr(gw.time, "sleep", lambda *a, **k: None)
+    monkeypatch.setattr(gw, "_spawn_detached", lambda: calls.__setitem__("spawn", calls["spawn"] + 1) or 4321)
+    monkeypatch.setattr(gw, "start", lambda: calls.__setitem__("start", calls["start"] + 1))
+
+
+def test_restart_relaunches_manual_gateway_directly(monkeypatch):
+    calls = {"spawn": 0, "start": 0}
+    _neutralize(monkeypatch, calls)
+    monkeypatch.setattr(gw, "is_task_registered", lambda: False)
+    monkeypatch.setattr(gw, "is_startup_entry_installed", lambda: False)
+    gw.restart()
+    assert calls["spawn"] == 1, "manual gateway must be relaunched via _spawn_detached"
+    assert calls["start"] == 0, "manual restart must NOT route through start() (install prompt)"
+
+
+def test_restart_uses_start_when_task_installed(monkeypatch):
+    calls = {"spawn": 0, "start": 0}
+    _neutralize(monkeypatch, calls)
+    monkeypatch.setattr(gw, "is_task_registered", lambda: True)
+    monkeypatch.setattr(gw, "is_startup_entry_installed", lambda: False)
+    gw.restart()
+    assert calls["start"] == 1, "an installed-service gateway must restart via start()"
+    assert calls["spawn"] == 0
+
+
+def test_restart_uses_start_when_startup_entry_installed(monkeypatch):
+    calls = {"spawn": 0, "start": 0}
+    _neutralize(monkeypatch, calls)
+    monkeypatch.setattr(gw, "is_task_registered", lambda: False)
+    monkeypatch.setattr(gw, "is_startup_entry_installed", lambda: True)
+    gw.restart()
+    assert calls["start"] == 1
+    assert calls["spawn"] == 0


### PR DESCRIPTION
## Summary

`hermes gateway restart` leaves a **manually-run** gateway **down**.

`restart()` does `stop()` then `start()`, but `start()`'s "service not installed" branch prints `✗ Gateway service is not installed`, prompts `Install it now…?`, and **returns without starting** when there is no scheduled task / startup entry. So a gateway that was running manually (e.g. via `hermes gateway run` or a detached launcher) gets stopped and then never relaunched — a silent outage. In a non-interactive context it just aborts at the prompt.

## Fix

`restart()` now captures the run mode **before** stopping and relaunches the gateway the same way it was running:
- **Manual** (no scheduled task / startup entry) → relaunch directly via the existing `_spawn_detached()`.
- **Service / startup entry installed** → `start()` (unchanged service path).

No interactive prompt, no outage.

## Testing

New `tests/hermes_cli/test_gateway_restart_run_mode.py` (3 tests, cross-platform via a mocked `_assert_windows`): manual mode relaunches via `_spawn_detached` and does **not** route through `start()`; scheduled-task and startup-entry modes route through `start()`. Existing `test_gateway_windows.py` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
