### PR TITLE
feat(photon): upgrade spectrum-ts sidecar to v5.2.0

### DIFF
--- a/plugins/platforms/photon/README.md
+++ b/plugins/platforms/photon/README.md
@@ -152,7 +152,7 @@ All env vars are documented in `plugin.yaml`. The most important:
   as a synthetic `reaction:added:<emoji>` event. Removal after a sidecar
   restart is best-effort — the live reaction handle is lost, so a stale
   tapback heals when the next reaction replaces it. Group spaces stay
-  reachable across restarts via spectrum-ts v3's `space.get(id)`.
+  reachable across restarts via spectrum-ts' `space.get(id)`.
 - **Message effects, polls** — supported by `spectrum-ts` but not yet
   exposed; the sidecar is the natural place to add them.
 
@@ -160,20 +160,33 @@ All env vars are documented in `plugin.yaml`. The most important:
 
 `spectrum-ts` is pinned to an **exact version** in `sidecar/package.json`
 (no `^` range) and installed with `npm ci`, because the SDK ships breaking
-majors (v2 removed `defineFusorPlatform`; v3 reworked space construction).
-A floating range or `npm install spectrum-ts@latest` would let a breaking
-release take down fresh setups silently. Upgrades are deliberate:
+majors (v2 removed `defineFusorPlatform`; v3 reworked space construction; v5
+split the SDK into a batteries-included `spectrum-ts` meta-package plus scoped
+`@spectrum-ts/*` packages). A floating range or `npm install spectrum-ts@latest`
+would let a breaking release take down fresh setups silently. Upgrades are
+deliberate:
 
 1. Read the [SDK release notes](https://github.com/photon-hq/spectrum-ts/releases)
-   for every version between the current pin and the target.
+   for every version between the current pin and the target. Verify claims
+   against the installed code — the release notes can lag or misstate (e.g. a
+   "gRPC → WebSocket" note that didn't land in the version we pin).
 2. Bump the exact pin in `sidecar/package.json`, then run `npm install`
-   inside `sidecar/` to regenerate `package-lock.json`. Commit both.
-3. Migrate `sidecar/index.mjs` against the new typings
-   (`sidecar/node_modules/spectrum-ts/dist/*.d.ts` is the source of truth —
-   the hosted docs can lag).
-4. Run `pytest tests/plugins/platforms/photon/`.
-5. Verify end-to-end: `hermes photon status`, a DM and a group roundtrip,
-   and an agent reply into a group right after a gateway restart (exercises
-   `space.get` rehydration).
+   inside `sidecar/` to regenerate `package-lock.json`. Commit both. Re-check
+   `engines.node` against the new dep tree (`npm ls`), and the `overrides`
+   block (`protobufjs`, the `@opentelemetry/*` exporters) — drop or bump any
+   that the tree no longer pulls in.
+3. Migrate `sidecar/index.mjs` against the new typings — the scoped
+   `sidecar/node_modules/@spectrum-ts/core/dist/*.d.ts` and
+   `@spectrum-ts/imessage/dist/*.d.ts` are the source of truth (the hosted
+   docs can lag).
+4. Re-target `sidecar/patch-spectrum-mixed-attachments.mjs` if the iMessage
+   inbound mapper moved or changed shape. As of v5 it lives in the bundled
+   `@spectrum-ts/imessage/dist/index.js`; the patch resolves that file and its
+   `replaceOnce` guards fail loudly if upstream reformats the branches.
+5. Run `pytest tests/plugins/platforms/photon/`.
+6. Verify end-to-end: `hermes photon status`, a DM and a group roundtrip,
+   a mixed text+attachment inbound message (exercises the patch), and an agent
+   reply into a group right after a gateway restart (exercises `space.get`
+   rehydration).
 
 [photon]: https://photon.codes/

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -85,6 +85,12 @@ _DEDUP_WINDOW_SECONDS = 48 * 3600
 
 _SIDECAR_DIR = Path(__file__).parent / "sidecar"
 
+# Minimum Node major the spectrum-ts SDK supports. The SDK itself declares no
+# engines, but its deps do — `@photon-ai/otel` requires Node >=20. On older
+# Node the sidecar dies at SDK import with a cryptic module error, so we check
+# up front and fail with an actionable message instead.
+_MIN_NODE_MAJOR = 20
+
 # Photon / Envoy / spectrum-ts error substrings that indicate a transient
 # upstream overload rather than a permanent failure.  These are not in the
 # core _RETRYABLE_ERROR_PATTERNS because they are specific to this adapter.
@@ -824,12 +830,47 @@ class PhotonAdapter(BasePlatformAdapter):
                 f"PHOTON_SIDECAR_PORT to a different port"
             )
 
+    def _check_node_version(self) -> None:
+        """Fail fast if `node` is too old for the spectrum-ts SDK.
+
+        Surfaces a clear setup error rather than letting the sidecar crash-loop
+        on a cryptic SDK import failure under an unsupported Node.
+        """
+        try:
+            out = subprocess.run(  # noqa: S603
+                [self._node_bin, "--version"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+        except Exception as exc:
+            raise RuntimeError(
+                f"could not run Node ({self._node_bin!r}): {exc} — install "
+                f"Node {_MIN_NODE_MAJOR}+ or set PHOTON_NODE_BIN"
+            ) from exc
+        raw = (out.stdout or "").strip()
+        match = re.match(r"v?(\d+)\.", raw)
+        if not match:
+            # An unparseable version isn't worth hard-failing on; let the SDK
+            # import surface any real incompatibility.
+            logger.warning("[photon] could not parse Node version %r", raw)
+            return
+        major = int(match.group(1))
+        if major < _MIN_NODE_MAJOR:
+            raise RuntimeError(
+                f"Photon's spectrum-ts SDK requires Node {_MIN_NODE_MAJOR}+, "
+                f"but {self._node_bin} is {raw}. Install Node {_MIN_NODE_MAJOR}+ "
+                f"or point PHOTON_NODE_BIN at a newer Node."
+            )
+
     async def _start_sidecar(self) -> None:
         if not (_SIDECAR_DIR / "node_modules").exists():
             raise RuntimeError(
                 f"Photon sidecar deps not installed. Run: "
                 f"cd {_SIDECAR_DIR} && npm install   (or `hermes photon setup`)"
             )
+        self._check_node_version()
         await self._reap_stale_sidecar()
 
         env = os.environ.copy()

--- a/plugins/platforms/photon/cli.py
+++ b/plugins/platforms/photon/cli.py
@@ -311,7 +311,7 @@ def _cmd_status(_args: argparse.Namespace) -> int:
     photon_auth.print_credential_summary(print)
     node_bin = os.getenv("PHOTON_NODE_BIN") or shutil.which("node")
     sidecar_installed = (_SIDECAR_DIR / "node_modules").exists()
-    print(f"  node binary         : {node_bin or '✗ missing (install Node 18+)'}")
+    print(f"  node binary         : {node_bin or '✗ missing (install Node 20+)'}")
     print(f"  sidecar deps        : {'✓ installed' if sidecar_installed else '✗ run `hermes photon install-sidecar`'}")
     print(f"  telemetry           : {'on' if _telemetry_enabled() else 'off'} (`hermes photon telemetry on|off`)")
     return 0
@@ -369,7 +369,7 @@ def _install_sidecar() -> int:
     npm = shutil.which("npm") or "npm"
     if not shutil.which(npm):
         print(
-            "npm is not on PATH. Install Node.js 18+ (https://nodejs.org/) "
+            "npm is not on PATH. Install Node.js 20+ (https://nodejs.org/) "
             "and re-run.",
             file=sys.stderr,
         )

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -38,7 +38,7 @@
 // On SIGINT/SIGTERM the sidecar calls `app.stop()` (3s graceful) before
 // exiting. Logs go to stderr; Python supervises restart.
 //
-// Requires spectrum-ts 3.x — pinned exactly in package.json because the SDK
+// Requires spectrum-ts 5.x — pinned exactly in package.json because the SDK
 // ships breaking majors; see README "Upgrading spectrum-ts".
 //
 // Env vars (required):

--- a/plugins/platforms/photon/sidecar/package-lock.json
+++ b/plugins/platforms/photon/sidecar/package-lock.json
@@ -9,16 +9,16 @@
       "version": "0.3.0",
       "hasInstallScript": true,
       "dependencies": {
-        "spectrum-ts": "3.1.0"
+        "spectrum-ts": "5.2.0"
       },
       "engines": {
-        "node": ">=18.17"
+        "node": ">=22"
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
-      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
+      "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@grpc/grpc-js": {
@@ -62,15 +62,6 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
-    "node_modules/@msgpack/msgpack": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.3.tgz",
-      "integrity": "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
@@ -81,9 +72,9 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.216.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.216.0.tgz",
-      "integrity": "sha512-KmGTgvxTJ0J01d4mOeX1wMV5NUTNf9HebIuOOGDfIn0a/IrnXIQbOnlylDyl9tkDv4h0DUpdI/GqCdLzfTkUXg==",
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
+      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
@@ -93,9 +84,9 @@
       }
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.7.1.tgz",
-      "integrity": "sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.8.0.tgz",
+      "integrity": "sha512-/3FIraneMcng67SUJCxvyInk/oxzwsxyadufk0wwfOBLf5wqtAGX4MoQASwSbndBPeARzBryUM9Azr5kHIdWLw==",
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -123,6 +114,7 @@
       "version": "0.218.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.218.0.tgz",
       "integrity": "sha512-Qx+4rpVHzgg89dawcWRHyt+XRXeLnhFz/qBtvggmjkcgPUdr+NAB0/u/eIPA8yAeJV0J80Vz43JZCh/XFvZFGw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api-logs": "0.218.0",
         "@opentelemetry/core": "2.7.1",
@@ -137,38 +129,11 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/api-logs": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
-      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz",
-      "integrity": "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.218.0",
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/resources": "2.7.1",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
       "version": "0.218.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.218.0.tgz",
       "integrity": "sha512-8dqezsmPhtKitIK/eTipZhYl9EX2/gNQ5zUMhaz3uxEURwfkNf8IPvo6yNfrzbxdtpAOybS/+h7wmIWYqFSpiw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "2.7.1",
         "@opentelemetry/otlp-exporter-base": "0.218.0",
@@ -183,69 +148,7 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.218.0.tgz",
-      "integrity": "sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA==",
-      "dependencies": {
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/otlp-transformer": "0.218.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.218.0.tgz",
-      "integrity": "sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.218.0",
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/resources": "2.7.1",
-        "@opentelemetry/sdk-logs": "0.218.0",
-        "@opentelemetry/sdk-metrics": "2.7.1",
-        "@opentelemetry/sdk-trace-base": "2.7.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/api-logs": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
-      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz",
-      "integrity": "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.218.0",
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/resources": "2.7.1",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/resources": {
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/resources": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
       "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
@@ -261,40 +164,7 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.216.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.216.0.tgz",
-      "integrity": "sha512-KB3rcwQuitq0JbbsCcNdqMhRJX3kArAYz/ovb0jGRaBQAIrt2roik3xQXuhYxS37zx0jSkUZcJu1z3Y2UCxbDA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.216.0",
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/resources": "2.7.1",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz",
-      "integrity": "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==",
-      "dependencies": {
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/resources": "2.7.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.9.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-base": {
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
       "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
@@ -309,6 +179,204 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.218.0.tgz",
+      "integrity": "sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-transformer": "0.218.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.218.0.tgz",
+      "integrity": "sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-logs": "0.218.0",
+        "@opentelemetry/sdk-metrics": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
+      "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
+      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz",
+      "integrity": "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz",
+      "integrity": "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+      "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
@@ -369,18 +437,18 @@
       }
     },
     "node_modules/@photon-ai/otel": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@photon-ai/otel/-/otel-0.1.1.tgz",
-      "integrity": "sha512-t/NVepO5+fHOLWDI+Eht+RC8PTik0wi7HQsKhU4yPqBjY5JncXmoBZLnWFvG+/qJ/pn6w+tveabKG9pykfkqKg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@photon-ai/otel/-/otel-1.0.0.tgz",
+      "integrity": "sha512-5fACVHN7BtGS+phglVAxun5QLckNUSS4p750oCxR//m9JNVzFQMoLFWfC6DnWBP/W0/+B2yP75+3NMVLodEJEg==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
-        "@opentelemetry/api-logs": "^0.216.0",
+        "@opentelemetry/api-logs": "^0.218.0",
         "@opentelemetry/context-async-hooks": "^2.7.1",
-        "@opentelemetry/exporter-logs-otlp-http": "^0.216.0",
-        "@opentelemetry/exporter-trace-otlp-http": "^0.216.0",
+        "@opentelemetry/exporter-logs-otlp-http": "^0.218.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
         "@opentelemetry/resources": "^2.7.1",
-        "@opentelemetry/sdk-logs": "^0.216.0",
+        "@opentelemetry/sdk-logs": "^0.218.0",
         "@opentelemetry/sdk-trace-base": "^2.7.1"
       },
       "engines": {
@@ -442,10 +510,122 @@
       }
     },
     "node_modules/@repeaterjs/repeater": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.6.tgz",
-      "integrity": "sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.1.0.tgz",
+      "integrity": "sha512-TaoVksZRSx2KWYYpyLQtMQXXeS98VsgZImzW65xmiVgbYhXLk+aEsmzPLirqVuE4/XuUapH2iMtxUzaBNDzdSQ==",
       "license": "MIT"
+    },
+    "node_modules/@spectrum-ts/core": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-aQSWZ75B9eEiJ00Wa72T/GEEPX9RVIlOPXnsdp0lWWgT5K9+twnL25Kob7L1pgQPbzrgoLH/rjQf3iVktriEwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@photon-ai/otel": "^1.0.0",
+        "@photon-ai/proto": "^0.2.4",
+        "@repeaterjs/repeater": "^3.0.6",
+        "marked": "^18.0.5",
+        "mime-types": "^3.0.1",
+        "open-graph-scraper": "^6.11.0",
+        "vcf": "^2.1.2",
+        "zod": "^4.2.1"
+      },
+      "peerDependencies": {
+        "elysia": "^1",
+        "express": "^4 || ^5",
+        "ffmpeg-static": "^5",
+        "hono": "^4",
+        "typescript": "^5 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "elysia": {
+          "optional": true
+        },
+        "express": {
+          "optional": true
+        },
+        "ffmpeg-static": {
+          "optional": true
+        },
+        "hono": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@spectrum-ts/imessage": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/imessage/-/imessage-5.2.0.tgz",
+      "integrity": "sha512-AZztks7jex8J3dnK7xUdjcN87xsXcZK+LCDlhC/gwZ4defH4mxPVcxFKUVND/CO7W3tN4pBD0LDfKUO7jx9uaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@photon-ai/advanced-imessage": "^0.11.0",
+        "@photon-ai/imessage-kit": "^3.0.0",
+        "@photon-ai/otel": "^1.0.0",
+        "lru-cache": "^11.0.0",
+        "marked": "^18.0.5",
+        "zod": "^4.2.1"
+      },
+      "peerDependencies": {
+        "@spectrum-ts/core": "^5.0.0",
+        "typescript": "^5 || ^6.0.0"
+      }
+    },
+    "node_modules/@spectrum-ts/slack": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/slack/-/slack-5.2.0.tgz",
+      "integrity": "sha512-ql6pHuEOxq7xAd9iIfVV9xXqpdmy5T8kUK+87HE8R87YFJm5L6z7df0wE0g0vpgQ6J7FkmTII0XNw/X7//odiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@photon-ai/slack": "^0.2.0",
+        "zod": "^4.2.1"
+      },
+      "peerDependencies": {
+        "@spectrum-ts/core": "^5.0.0",
+        "typescript": "^5 || ^6.0.0"
+      }
+    },
+    "node_modules/@spectrum-ts/telegram": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/telegram/-/telegram-5.2.0.tgz",
+      "integrity": "sha512-ofG2OKK/63Sxkv3a7MEJWkjtCy3Rs8HLEB2pxHSSlofQmAP7SDkXlBEzfgEr1SeM/mIFvE3gXNpIhb97Nz1Dog==",
+      "license": "MIT",
+      "dependencies": {
+        "@photon-ai/telegram-ts": "10.0.0",
+        "marked": "^18.0.5",
+        "zod": "^4.2.1"
+      },
+      "peerDependencies": {
+        "@spectrum-ts/core": "^5.0.0",
+        "typescript": "^5 || ^6.0.0"
+      }
+    },
+    "node_modules/@spectrum-ts/terminal": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/terminal/-/terminal-5.2.0.tgz",
+      "integrity": "sha512-OHSg4HKOgLXhv3mzm0M9eIPiwxdKel9yZglfUWGfUyafibnpCnF2XI069zc9hkDgdvCHynLfxM+TsPXPzdiMbw==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.1"
+      },
+      "peerDependencies": {
+        "@spectrum-ts/core": "^5.0.0",
+        "typescript": "^5 || ^6.0.0"
+      }
+    },
+    "node_modules/@spectrum-ts/whatsapp-business": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/whatsapp-business/-/whatsapp-business-5.2.0.tgz",
+      "integrity": "sha512-JZJwzug6UviSe7FqWb8y9f1Frq3RJ9IOQ/TgCYhijm5uchXtym/HdC+FAmCG06njcFx+ea7boUhwFs8579V4Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@photon-ai/whatsapp-business": "^0.1.1",
+        "mime-types": "^3.0.1",
+        "zod": "^4.2.1"
+      },
+      "peerDependencies": {
+        "@spectrum-ts/core": "^5.0.0",
+        "typescript": "^5 || ^6.0.0"
+      }
     },
     "node_modules/abort-controller-x": {
       "version": "0.5.0",
@@ -477,15 +657,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/async-mutex": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
-      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -507,29 +678,10 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/better-grpc": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/better-grpc/-/better-grpc-0.3.2.tgz",
-      "integrity": "sha512-e+u6C4zHwjE5g7vOvDpFeMe7Nas7FU+xa6FktiheRTcOpEdD5nag+uoIw7L5bPXdxxg995feBAXLwIay/npEqw==",
-      "license": "MIT",
-      "dependencies": {
-        "@msgpack/msgpack": "^3.1.2",
-        "async-mutex": "^0.5.0",
-        "it-pushable": "^3.2.3",
-        "nice-grpc": "^2.1.13",
-        "zod": "^4.1.12"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5"
-      }
-    },
     "node_modules/better-sqlite3": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
-      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -604,9 +756,9 @@
       }
     },
     "node_modules/chardet": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
-      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
       "license": "MIT"
     },
     "node_modules/cheerio": {
@@ -1008,15 +1160,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/it-pushable": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.2.4.tgz",
-      "integrity": "sha512-WSD7Ss4oCRfDZJT4ldLWr0Bom/muY90xxoJ5PQnU3uSKf0kxCOeehqZtiJX1ARqn+ymXGh1bxpDW9bDNHp2ivQ==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "p-defer": "^4.0.0"
-      }
-    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -1182,18 +1325,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/p-defer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.1.tgz",
-      "integrity": "sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -1275,6 +1406,7 @@
       "version": "8.6.1",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.1.tgz",
       "integrity": "sha512-s4qQPr4pU0W95iYnUInh95skjIg+3aM2sakYsw60QYanU+qWRDY2zQxOAQV6zU7ROJpSNDG9B+VSmk4dqdWWSA==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "long": "^5.3.2"
       },
@@ -1361,9 +1493,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -1421,38 +1553,17 @@
       }
     },
     "node_modules/spectrum-ts": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/spectrum-ts/-/spectrum-ts-3.1.0.tgz",
-      "integrity": "sha512-Dv5rsXATxGUXFnKf3VPK0VpkMPyVkf4HHUYkti0V2AKhz2m+ut3I1UPNMsvZOsiqmF+5hW8Xvrw+u/I82+XcDA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/spectrum-ts/-/spectrum-ts-5.2.0.tgz",
+      "integrity": "sha512-CfHz7ZhKP9Cmunb3i7m4r5stXOGl1HNKOkBp/Fkl1DwDmhnGl+PRDy97FC5JBY+XYxAKxKnMRSbVTl8ldczTNg==",
       "license": "MIT",
       "dependencies": {
-        "@photon-ai/advanced-imessage": "^0.11.0",
-        "@photon-ai/imessage-kit": "^3.0.0",
-        "@photon-ai/otel": "^0.1.1",
-        "@photon-ai/proto": "^0.2.4",
-        "@photon-ai/slack": "^0.2.0",
-        "@photon-ai/telegram-ts": "10.0.0",
-        "@photon-ai/whatsapp-business": "^0.1.1",
-        "@repeaterjs/repeater": "^3.0.6",
-        "better-grpc": "^0.3.2",
-        "lru-cache": "^11.0.0",
-        "marked": "^18.0.5",
-        "mime-types": "^3.0.1",
-        "nice-grpc": "^2.1.16",
-        "nice-grpc-common": "^2.0.2",
-        "open-graph-scraper": "^6.11.0",
-        "type-fest": "^5.4.1",
-        "vcf": "^2.1.2",
-        "zod": "^4.2.1"
-      },
-      "peerDependencies": {
-        "ffmpeg-static": "^5",
-        "typescript": "^5 || ^6.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ffmpeg-static": {
-          "optional": true
-        }
+        "@spectrum-ts/core": "5.2.0",
+        "@spectrum-ts/imessage": "5.2.0",
+        "@spectrum-ts/slack": "5.2.0",
+        "@spectrum-ts/telegram": "5.2.0",
+        "@spectrum-ts/terminal": "5.2.0",
+        "@spectrum-ts/whatsapp-business": "5.2.0"
       }
     },
     "node_modules/string_decoder": {
@@ -1501,18 +1612,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/tagged-tag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
-      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -1549,12 +1648,6 @@
       "integrity": "sha512-tLJxacIQUM82IR7JO1UUkKlYuUTmoY9HBJAmNWFzheSlDS5SPMcNIepejHJa4BpPQLAcbRhRf3GDJzyj6rbKvA==",
       "license": "MIT"
     },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -1568,25 +1661,10 @@
         "node": "*"
       }
     },
-    "node_modules/type-fest": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
-      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
-      "license": "(MIT OR CC0-1.0)",
-      "dependencies": {
-        "tagged-tag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -1598,9 +1676,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.26.0.tgz",
-      "integrity": "sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -1691,9 +1769,9 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",

--- a/plugins/platforms/photon/sidecar/package.json
+++ b/plugins/platforms/photon/sidecar/package.json
@@ -10,10 +10,10 @@
     "postinstall": "node patch-spectrum-mixed-attachments.mjs"
   },
   "engines": {
-    "node": ">=18.17"
+    "node": ">=20"
   },
   "dependencies": {
-    "spectrum-ts": "3.1.0"
+    "spectrum-ts": "5.2.0"
   },
   "overrides": {
     "protobufjs": "8.6.1",

--- a/plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs
+++ b/plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs
@@ -1,10 +1,20 @@
 #!/usr/bin/env node
 // Patch spectrum-ts' iMessage inbound mapper until upstream preserves mixed
-// text + attachment Apple events. The current spectrum-ts mapper returns only
-// buildAttachmentMessage(...) whenever attachments are present, which drops
-// event.message.content.text before Hermes can see it.
+// text + attachment Apple events. The mapper returns only the attachment
+// Message whenever attachments are present, dropping `message.content.text`
+// before Hermes can see it. We rewrite both inbound entry points
+// (`toInboundMessages`, the live-stream path, and `rebuildFromAppleMessage`,
+// the on-demand `getMessage`/cache path) to re-emit a grouped message whose
+// first child is the dropped text.
+//
+// As of spectrum-ts 5.x the SDK is a package split: the iMessage provider — and
+// this mapper — live in `@spectrum-ts/imessage`, shipped as a single bundled
+// `dist/index.js` (tab-indented). We resolve and patch that file. The sidecar
+// consumes already-mapped `Message` objects off `app.messages`, so the dropped
+// text is unrecoverable downstream; patching the bundle is the only fix point.
 import fs from "node:fs";
 import path from "node:path";
+import { createRequire } from "node:module";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const MARKER = "Hermes patch: Preserve mixed text + attachment iMessage payloads";
@@ -13,6 +23,36 @@ function scriptDir() {
   return path.dirname(fileURLToPath(import.meta.url));
 }
 
+// Resolve `@spectrum-ts/imessage`'s bundled entry. Prefer the install under
+// `root` (so tests can point at a fixture and the committed install resolves
+// without ambiguity); fall back to Node resolution, which follows npm hoisting
+// and the nested `spectrum-ts/node_modules/...` case.
+function resolveImessageBundle(root) {
+  const direct = path.join(
+    root,
+    "node_modules",
+    "@spectrum-ts",
+    "imessage",
+    "dist",
+    "index.js"
+  );
+  if (fs.existsSync(direct)) return direct;
+  try {
+    const require = createRequire(import.meta.url);
+    return require.resolve("@spectrum-ts/imessage");
+  } catch {
+    return null;
+  }
+}
+
+// Tab-indented line builder — the bundle uses hard tabs, so matches must too.
+const TAB = "\t";
+const ind = (depth, code) => TAB.repeat(depth) + code;
+const block = (lines) => lines.map(([depth, code]) => ind(depth, code)).join("\n");
+
+// Replace exactly one occurrence; throw if the count isn't 1 so a shape change
+// in a new spectrum-ts release fails closed (loud at install time) instead of
+// silently leaving the mixed-attachment bug — or double-patching — in place.
 function replaceOnce(source, from, to, label) {
   const count = source.split(from).length - 1;
   if (count !== 1) {
@@ -21,122 +61,202 @@ function replaceOnce(source, from, to, label) {
   return source.replace(from, to);
 }
 
-function replaceFirst(source, from, to, label) {
-  if (!source.includes(from)) {
-    throw new Error(`expected at least one ${label} match, found 0`);
-  }
-  return source.replace(from, to);
-}
+// A text child message, partIndex 0, parented to the Apple message guid.
+const textChild = (depth, lead, textExpr) =>
+  block([
+    [depth, `${lead}{`],
+    [depth + 1, "...base,"],
+    [depth + 1, "id: formatChildId(0, messageGuidStr),"],
+    [depth + 1, `content: asText(${textExpr}),`],
+    [depth + 1, "partIndex: 0,"],
+    [depth + 1, "parentId: messageGuidStr"],
+    [depth, lead.startsWith("items.push(") ? "});" : "};"],
+  ]);
 
-function addTextChildSnippet(messageExpr) {
-  return `if (text2) {\n      items.unshift({\n        ...base,\n        id: formatChildId(0, messageGuidStr),\n        content: asText(text2),\n        partIndex: 0,\n        parentId: messageGuidStr\n      });\n    }`;
-}
+// --- rebuildFromAppleMessage (on-demand path, returns a single Message) ------
 
-function patchRebuild(source) {
-  source = replaceOnce(
-    source,
-    `  const attachments = messageAttachments(message);\n  if (attachments.length === 1) {`,
-    `  const attachments = messageAttachments(message);\n  const text2 = message.content.text;\n  if (attachments.length === 1) {`,
-    "rebuild text capture"
-  );
-  source = replaceOnce(
-    source,
-    `    return buildAttachmentMessage(client, base, info, messageGuidStr, 0);`,
-    `    const msg2 = await buildAttachmentMessage(\n      client,\n      base,\n      info,\n      text2 ? formatChildId(1, messageGuidStr) : messageGuidStr,\n      text2 ? 1 : 0,\n      text2 ? messageGuidStr : void 0\n    );\n    if (text2) {\n      const textMsg = {\n        ...base,\n        id: formatChildId(0, messageGuidStr),\n        content: asText(text2),\n        partIndex: 0,\n        parentId: messageGuidStr\n      };\n      return {\n        ...base,\n        id: messageGuidStr,\n        content: asProviderGroup([textMsg, msg2])\n      };\n    }\n    return msg2;`,
-    "rebuild single attachment"
-  );
-  source = replaceFirst(
-    source,
-    `          formatChildId(i, messageGuidStr),\n          i,\n          messageGuidStr`,
-    `          formatChildId(text2 ? i + 1 : i, messageGuidStr),\n          text2 ? i + 1 : i,\n          messageGuidStr`,
-    "rebuild multi attachment child index"
-  );
-  source = replaceFirst(
-    source,
-    `    return {\n      ...base,\n      id: messageGuidStr,\n      content: asProviderGroup(items)\n    };\n  }\n  if (getBalloonBundleId(message) === URL_BALLOON_BUNDLE_ID) {`,
-    `    ${addTextChildSnippet("message")}\n    return {\n      ...base,\n      id: messageGuidStr,\n      content: asProviderGroup(items)\n    };\n  }\n  if (getBalloonBundleId(message) === URL_BALLOON_BUNDLE_ID) {`,
-    "rebuild multi attachment text child"
-  );
-  source = replaceFirst(
-    source,
-    `  const text2 = message.content.text;\n  return {\n    ...base,`,
-    `  return {\n    ...base,`,
-    "rebuild duplicate text declaration"
-  );
-  return source;
-}
+const REBUILD_SINGLE_FROM = block([
+  [1, "if (attachments.length === 1) {"],
+  [2, "const info = attachments[0];"],
+  [2, 'if (!info) throw new Error("Unreachable: attachments.length === 1 but no element");'],
+  [2, "return buildAttachmentMessage(client, base, info, messageGuidStr, 0);"],
+  [1, "}"],
+]);
 
-function patchInbound(source) {
-  source = replaceOnce(
-    source,
-    `  const attachments = messageAttachments(event.message);\n  if (attachments.length === 1) {`,
-    `  const attachments = messageAttachments(event.message);\n  const text2 = event.message.content.text;\n  if (attachments.length === 1) {`,
-    "inbound text capture"
-  );
-  source = replaceOnce(
-    source,
-    `      messageGuidStr,\n      0\n    );\n    cacheMessage(cache, msg2);\n    return [msg2];`,
-    `      text2 ? formatChildId(1, messageGuidStr) : messageGuidStr,\n      text2 ? 1 : 0,\n      text2 ? messageGuidStr : void 0\n    );\n    if (text2) {\n      const textMsg = {\n        ...base,\n        id: formatChildId(0, messageGuidStr),\n        content: asText(text2),\n        partIndex: 0,\n        parentId: messageGuidStr\n      };\n      const parent = {\n        ...base,\n        id: messageGuidStr,\n        content: asProviderGroup([textMsg, msg2])\n      };\n      cacheMessage(cache, parent);\n      return [parent];\n    }\n    cacheMessage(cache, msg2);\n    return [msg2];`,
-    "inbound single attachment"
-  );
-  source = replaceOnce(
-    source,
-    `          formatChildId(i, messageGuidStr),\n          i,\n          messageGuidStr`,
-    `          formatChildId(text2 ? i + 1 : i, messageGuidStr),\n          text2 ? i + 1 : i,\n          messageGuidStr`,
-    "inbound multi attachment child index"
-  );
-  source = replaceOnce(
-    source,
-    `    const parent = {\n      ...base,\n      id: messageGuidStr,\n      content: asProviderGroup(items)\n    };`,
-    `    ${addTextChildSnippet("event.message")}\n    const parent = {\n      ...base,\n      id: messageGuidStr,\n      content: asProviderGroup(items)\n    };`,
-    "inbound multi attachment text child"
-  );
-  source = replaceOnce(
-    source,
-    `  const text2 = event.message.content.text;\n  const msg = {`,
-    `  const msg = {`,
-    "inbound duplicate text declaration"
-  );
+const REBUILD_SINGLE_TO = [
+  ind(1, "if (attachments.length === 1) {"),
+  ind(2, "const info = attachments[0];"),
+  ind(2, 'if (!info) throw new Error("Unreachable: attachments.length === 1 but no element");'),
+  ind(2, "const text = message.content.text;"),
+  ind(2, "const attachmentMsg = await buildAttachmentMessage(client, base, info, text ? formatChildId(1, messageGuidStr) : messageGuidStr, text ? 1 : 0, text ? messageGuidStr : void 0);"),
+  ind(2, "if (text) {"),
+  textChild(3, "const textMsg = ", "text"),
+  ind(3, "return {"),
+  ind(4, "...base,"),
+  ind(4, "id: messageGuidStr,"),
+  ind(4, "content: asProviderGroup([textMsg, attachmentMsg])"),
+  ind(3, "};"),
+  ind(2, "}"),
+  ind(2, "return attachmentMsg;"),
+  ind(1, "}"),
+].join("\n");
+
+const MULTI_LOOP = (textExpr) =>
+  [
+    ind(2, "const items = [];"),
+    ind(2, "if (text) {"),
+    textChild(3, "items.push(", "text"),
+    ind(2, "}"),
+    ind(2, "for (let i = 0; i < attachments.length; i++) {"),
+    ind(3, "const info = attachments[i];"),
+    ind(3, "if (!info) continue;"),
+    ind(3, "const partIndex = text ? i + 1 : i;"),
+    ind(3, "items.push(await buildAttachmentMessage(client, base, info, formatChildId(partIndex, messageGuidStr), partIndex, messageGuidStr));"),
+    ind(2, "}"),
+  ].join("\n");
+
+const REBUILD_MULTI_FROM = block([
+  [1, "if (attachments.length > 1) {"],
+  [2, "const items = [];"],
+  [2, "for (let i = 0; i < attachments.length; i++) {"],
+  [3, "const info = attachments[i];"],
+  [3, "if (!info) continue;"],
+  [3, "items.push(await buildAttachmentMessage(client, base, info, formatChildId(i, messageGuidStr), i, messageGuidStr));"],
+  [2, "}"],
+  [2, "return {"],
+  [3, "...base,"],
+  [3, "id: messageGuidStr,"],
+  [3, "content: asProviderGroup(items)"],
+  [2, "};"],
+  [1, "}"],
+]);
+
+const REBUILD_MULTI_TO = [
+  ind(1, "if (attachments.length > 1) {"),
+  ind(2, "const text = message.content.text;"),
+  MULTI_LOOP("message.content.text"),
+  ind(2, "return {"),
+  ind(3, "...base,"),
+  ind(3, "id: messageGuidStr,"),
+  ind(3, "content: asProviderGroup(items)"),
+  ind(2, "};"),
+  ind(1, "}"),
+].join("\n");
+
+// --- toInboundMessages (live-stream path, returns Message[] + caches) --------
+
+const INBOUND_SINGLE_FROM = block([
+  [1, "if (attachments.length === 1) {"],
+  [2, "const info = attachments[0];"],
+  [2, 'if (!info) throw new Error("Unreachable: attachments.length === 1 but no element");'],
+  [2, "const msg = await buildAttachmentMessage(client, base, info, messageGuidStr, 0);"],
+  [2, "cacheMessage(cache, msg);"],
+  [2, "return [msg];"],
+  [1, "}"],
+]);
+
+const INBOUND_SINGLE_TO = [
+  ind(1, "if (attachments.length === 1) {"),
+  ind(2, "const info = attachments[0];"),
+  ind(2, 'if (!info) throw new Error("Unreachable: attachments.length === 1 but no element");'),
+  ind(2, "const text = event.message.content.text;"),
+  ind(2, "const attachmentMsg = await buildAttachmentMessage(client, base, info, text ? formatChildId(1, messageGuidStr) : messageGuidStr, text ? 1 : 0, text ? messageGuidStr : void 0);"),
+  ind(2, "if (text) {"),
+  textChild(3, "const textMsg = ", "text"),
+  ind(3, "const parent = {"),
+  ind(4, "...base,"),
+  ind(4, "id: messageGuidStr,"),
+  ind(4, "content: asProviderGroup([textMsg, attachmentMsg])"),
+  ind(3, "};"),
+  ind(3, "cacheMessage(cache, parent);"),
+  ind(3, "return [parent];"),
+  ind(2, "}"),
+  ind(2, "cacheMessage(cache, attachmentMsg);"),
+  ind(2, "return [attachmentMsg];"),
+  ind(1, "}"),
+].join("\n");
+
+const INBOUND_MULTI_FROM = block([
+  [1, "if (attachments.length > 1) {"],
+  [2, "const items = [];"],
+  [2, "for (let i = 0; i < attachments.length; i++) {"],
+  [3, "const info = attachments[i];"],
+  [3, "if (!info) continue;"],
+  [3, "items.push(await buildAttachmentMessage(client, base, info, formatChildId(i, messageGuidStr), i, messageGuidStr));"],
+  [2, "}"],
+  [2, "const parent = {"],
+  [3, "...base,"],
+  [3, "id: messageGuidStr,"],
+  [3, "content: asProviderGroup(items)"],
+  [2, "};"],
+  [2, "cacheMessage(cache, parent);"],
+  [2, "return [parent];"],
+  [1, "}"],
+]);
+
+const INBOUND_MULTI_TO = [
+  ind(1, "if (attachments.length > 1) {"),
+  ind(2, "const text = event.message.content.text;"),
+  MULTI_LOOP("event.message.content.text"),
+  ind(2, "const parent = {"),
+  ind(3, "...base,"),
+  ind(3, "id: messageGuidStr,"),
+  ind(3, "content: asProviderGroup(items)"),
+  ind(2, "};"),
+  ind(2, "cacheMessage(cache, parent);"),
+  ind(2, "return [parent];"),
+  ind(1, "}"),
+].join("\n");
+
+function applyPatch(source) {
+  source = replaceOnce(source, REBUILD_SINGLE_FROM, REBUILD_SINGLE_TO, "rebuild single attachment");
+  source = replaceOnce(source, REBUILD_MULTI_FROM, REBUILD_MULTI_TO, "rebuild multi attachment");
+  source = replaceOnce(source, INBOUND_SINGLE_FROM, INBOUND_SINGLE_TO, "inbound single attachment");
+  source = replaceOnce(source, INBOUND_MULTI_FROM, INBOUND_MULTI_TO, "inbound multi attachment");
   return source;
 }
 
 export function patchSpectrumTs(root = scriptDir()) {
-  const dist = path.join(root, "node_modules", "spectrum-ts", "dist");
-  if (!fs.existsSync(dist)) {
-    throw new Error(`spectrum-ts dist not found: ${dist}`);
+  const file = resolveImessageBundle(root);
+  if (!file || !fs.existsSync(file)) {
+    throw new Error(
+      `@spectrum-ts/imessage bundle not found (looked under ${root}). ` +
+        "Run `npm install` inside plugins/platforms/photon/sidecar/."
+    );
   }
-  const files = fs.readdirSync(dist)
-    .filter((name) => name.endsWith(".js"))
-    .map((name) => path.join(dist, name));
 
-  for (const file of files) {
-    const raw = fs.readFileSync(file, "utf8");
-    if (raw.includes(MARKER)) {
-      return { patched: false, file, reason: "already patched" };
-    }
-    // Normalize to LF for matching so the patch works regardless of the
-    // checkout's line-ending style (Windows git autocrlf produces CRLF,
-    // which would otherwise defeat the \n-based search strings). The
-    // original EOL style is restored on write.
-    const CR = String.fromCharCode(13);
-    const CRLF = CR + "\n";
-    const usedCRLF = raw.includes(CRLF);
-    const original = usedCRLF ? raw.split(CRLF).join("\n") : raw;
-    if (!original.includes("var toInboundMessages = async") ||
-        !original.includes("var rebuildFromAppleMessage = async")) {
-      continue;
-    }
-    let patched = original;
-    patched = patchRebuild(patched);
-    patched = patchInbound(patched);
-    patched = `// ${MARKER}\n${patched}`;
-    if (usedCRLF) {
-      patched = patched.split("\n").join(CRLF);
-    }
-    fs.writeFileSync(file, patched, "utf8");
-    return { patched: true, file };
+  const raw = fs.readFileSync(file, "utf8");
+  if (raw.includes(MARKER)) {
+    return { patched: false, file, reason: "already patched" };
   }
-  throw new Error("could not find spectrum-ts iMessage inbound chunk to patch");
+
+  // Normalize to LF for matching so the patch works regardless of the
+  // checkout's line-ending style (Windows git autocrlf produces CRLF, which
+  // would otherwise defeat the \n-based search strings). The original EOL
+  // style is restored on write.
+  const CR = String.fromCharCode(13);
+  const CRLF = CR + "\n";
+  const usedCRLF = raw.includes(CRLF);
+  const original = usedCRLF ? raw.split(CRLF).join("\n") : raw;
+
+  if (
+    !original.includes("const toInboundMessages = async") ||
+    !original.includes("const rebuildFromAppleMessage = async")
+  ) {
+    throw new Error(
+      `${file} does not look like the spectrum-ts iMessage inbound mapper ` +
+        "(missing toInboundMessages/rebuildFromAppleMessage) — the SDK shape " +
+        "changed; update patch-spectrum-mixed-attachments.mjs for this version."
+    );
+  }
+
+  let patched = applyPatch(original);
+  patched = `// ${MARKER}\n${patched}`;
+  if (usedCRLF) {
+    patched = patched.split("\n").join(CRLF);
+  }
+  fs.writeFileSync(file, patched, "utf8");
+  return { patched: true, file };
 }
 
 const _invokedDirectly =

--- a/tests/plugins/platforms/photon/test_sidecar_lifecycle.py
+++ b/tests/plugins/platforms/photon/test_sidecar_lifecycle.py
@@ -134,6 +134,10 @@ async def test_start_sidecar_spawns_with_stdin_pipe(
         pass
 
     monkeypatch.setattr(adapter, "_reap_stale_sidecar", _no_reap)
+    # The Node-version preflight is exercised separately; stub it here so the
+    # fake Popen (which can't act as a context manager for subprocess.run)
+    # doesn't trip the unrelated `node --version` probe.
+    monkeypatch.setattr(adapter, "_check_node_version", lambda: None)
     (tmp_path / "node_modules").mkdir()
     monkeypatch.setattr(photon_adapter, "_SIDECAR_DIR", tmp_path)
 
@@ -169,3 +173,26 @@ async def test_start_sidecar_spawns_with_stdin_pipe(
     kwargs = spawned["kwargs"]
     assert kwargs["stdin"] is subprocess.PIPE
     assert kwargs["env"]["PHOTON_SIDECAR_WATCH_STDIN"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_start_sidecar_rejects_unsupported_node(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """An old Node must fail fast with a clear error, not a crash-loop."""
+    adapter = _make_adapter(monkeypatch)
+    (tmp_path / "node_modules").mkdir()
+    monkeypatch.setattr(photon_adapter, "_SIDECAR_DIR", tmp_path)
+
+    class _VersionProc:
+        stdout = "v18.20.4\n"
+        returncode = 0
+
+    def _fake_run(cmd: List[str], **kwargs: Any) -> _VersionProc:
+        assert cmd[1:] == ["--version"]
+        return _VersionProc()
+
+    monkeypatch.setattr(photon_adapter.subprocess, "run", _fake_run)
+
+    with pytest.raises(RuntimeError, match="requires Node 20"):
+        await adapter._start_sidecar()

--- a/tests/plugins/platforms/photon/test_spectrum_patch.py
+++ b/tests/plugins/platforms/photon/test_spectrum_patch.py
@@ -1,9 +1,11 @@
 """Regression tests for Hermes' Spectrum mixed text+attachment workaround."""
 from __future__ import annotations
 
+import shutil
 import subprocess
-import textwrap
 from pathlib import Path
+
+import pytest
 
 
 _PATCHER = Path("plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs")
@@ -52,128 +54,88 @@ def test_sidecar_labels_catchup_internal_errors_as_upstream_photon() -> None:
     assert "PHOTON_ALLOWED_USERS" in index
 
 
-def test_spectrum_patch_preserves_text_when_single_attachment(tmp_path: Path) -> None:
-    """The sidecar dependency patch must turn text+one attachment into group content."""
-    dist = tmp_path / "node_modules" / "spectrum-ts" / "dist"
+# spectrum-ts 5.x ships the iMessage inbound mapper in the bundled, tab-indented
+# `@spectrum-ts/imessage/dist/index.js`. This fixture mirrors the upstream shape
+# of the two branches the patch rewrites (`rebuildFromAppleMessage`, the
+# on-demand path, and `toInboundMessages`, the live-stream path) so the patch's
+# exact-match `replaceOnce` guards are exercised without a real npm install.
+def _v5_imessage_fixture() -> str:
+    t = "\t"
+    lines = [
+        "const buildMessageBase = () => ({});",
+        "const rebuildFromAppleMessage = async (client, message, phone, chatGuidHint) => {",
+        f"{t}const messageGuidStr = message.guid;",
+        f"{t}const base = buildMessageBase(message, chatGuidHint, message.dateCreated ?? new Date(), phone);",
+        f"{t}const attachments = messageAttachments(message);",
+        f"{t}if (attachments.length === 1) {{",
+        f"{t}{t}const info = attachments[0];",
+        f'{t}{t}if (!info) throw new Error("Unreachable: attachments.length === 1 but no element");',
+        f"{t}{t}return buildAttachmentMessage(client, base, info, messageGuidStr, 0);",
+        f"{t}}}",
+        f"{t}if (attachments.length > 1) {{",
+        f"{t}{t}const items = [];",
+        f"{t}{t}for (let i = 0; i < attachments.length; i++) {{",
+        f"{t}{t}{t}const info = attachments[i];",
+        f"{t}{t}{t}if (!info) continue;",
+        f"{t}{t}{t}items.push(await buildAttachmentMessage(client, base, info, formatChildId(i, messageGuidStr), i, messageGuidStr));",
+        f"{t}{t}}}",
+        f"{t}{t}return {{",
+        f"{t}{t}{t}...base,",
+        f"{t}{t}{t}id: messageGuidStr,",
+        f"{t}{t}{t}content: asProviderGroup(items)",
+        f"{t}{t}}};",
+        f"{t}}}",
+        f"{t}const text = message.content.text;",
+        f"{t}return {{ ...base, id: messageGuidStr, content: text ? asText(text) : asCustom(message) }};",
+        "};",
+        "const toInboundMessages = async (client, cache, event, phone) => {",
+        f"{t}const base = buildMessageBase(event.message, event.chatGuid, event.occurredAt, phone);",
+        f"{t}const messageGuidStr = event.message.guid;",
+        f"{t}const attachments = messageAttachments(event.message);",
+        f"{t}if (attachments.length === 1) {{",
+        f"{t}{t}const info = attachments[0];",
+        f'{t}{t}if (!info) throw new Error("Unreachable: attachments.length === 1 but no element");',
+        f"{t}{t}const msg = await buildAttachmentMessage(client, base, info, messageGuidStr, 0);",
+        f"{t}{t}cacheMessage(cache, msg);",
+        f"{t}{t}return [msg];",
+        f"{t}}}",
+        f"{t}if (attachments.length > 1) {{",
+        f"{t}{t}const items = [];",
+        f"{t}{t}for (let i = 0; i < attachments.length; i++) {{",
+        f"{t}{t}{t}const info = attachments[i];",
+        f"{t}{t}{t}if (!info) continue;",
+        f"{t}{t}{t}items.push(await buildAttachmentMessage(client, base, info, formatChildId(i, messageGuidStr), i, messageGuidStr));",
+        f"{t}{t}}}",
+        f"{t}{t}const parent = {{",
+        f"{t}{t}{t}...base,",
+        f"{t}{t}{t}id: messageGuidStr,",
+        f"{t}{t}{t}content: asProviderGroup(items)",
+        f"{t}{t}}};",
+        f"{t}{t}cacheMessage(cache, parent);",
+        f"{t}{t}return [parent];",
+        f"{t}}}",
+        f"{t}const text = event.message.content.text;",
+        f"{t}const msg = {{ ...base, id: messageGuidStr, content: text ? asText(text) : asCustom(event.message) }};",
+        f"{t}cacheMessage(cache, msg);",
+        f"{t}return [msg];",
+        "};",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _write_fixture(tmp_path: Path) -> Path:
+    dist = tmp_path / "node_modules" / "@spectrum-ts" / "imessage" / "dist"
     dist.mkdir(parents=True)
-    chunk = dist / "chunk-test.js"
-    chunk.write_text(
-        textwrap.dedent(
-            """
-            var rebuildFromAppleMessage = async (client, message, phone, chatGuidHint) => {
-              const messageGuidStr = message.guid;
-              const timestamp = message.dateCreated ?? /* @__PURE__ */ new Date();
-              const base = buildMessageBase(message, chatGuidHint, timestamp, phone);
-              const attachments = messageAttachments(message);
-              if (attachments.length === 1) {
-                const info = attachments[0];
-                if (!info) {
-                  throw new Error("Unreachable: attachments.length === 1 but no element");
-                }
-                return buildAttachmentMessage(client, base, info, messageGuidStr, 0);
-              }
-              if (attachments.length > 1) {
-                const items = [];
-                for (let i = 0; i < attachments.length; i++) {
-                  const info = attachments[i];
-                  if (!info) {
-                    continue;
-                  }
-                  items.push(
-                    await buildAttachmentMessage(
-                      client,
-                      base,
-                      info,
-                      formatChildId(i, messageGuidStr),
-                      i,
-                      messageGuidStr
-                    )
-                  );
-                }
-                return {
-                  ...base,
-                  id: messageGuidStr,
-                  content: asProviderGroup(items)
-                };
-              }
-              if (getBalloonBundleId(message) === URL_BALLOON_BUNDLE_ID) {
-                return toRichlinkMessage(message, base, messageGuidStr);
-              }
-              const text2 = message.content.text;
-              return {
-                ...base,
-                id: messageGuidStr,
-                content: text2 ? asText(text2) : asCustom(message)
-              };
-            };
-            var toInboundMessages = async (client, cache, event, phone) => {
-              const base = buildMessageBase(
-                event.message,
-                event.chatGuid,
-                event.occurredAt,
-                phone
-              );
-              const messageGuidStr = event.message.guid;
-              if (getBalloonBundleId(event.message) === URL_BALLOON_BUNDLE_ID) {
-                const msg2 = toRichlinkMessage(event.message, base, messageGuidStr);
-                cacheMessage(cache, msg2);
-                return [msg2];
-              }
-              const attachments = messageAttachments(event.message);
-              if (attachments.length === 1) {
-                const info = attachments[0];
-                if (!info) {
-                  throw new Error("Unreachable: attachments.length === 1 but no element");
-                }
-                const msg2 = await buildAttachmentMessage(
-                  client,
-                  base,
-                  info,
-                  messageGuidStr,
-                  0
-                );
-                cacheMessage(cache, msg2);
-                return [msg2];
-              }
-              if (attachments.length > 1) {
-                const items = [];
-                for (let i = 0; i < attachments.length; i++) {
-                  const info = attachments[i];
-                  if (!info) {
-                    continue;
-                  }
-                  items.push(
-                    await buildAttachmentMessage(
-                      client,
-                      base,
-                      info,
-                      formatChildId(i, messageGuidStr),
-                      i,
-                      messageGuidStr
-                    )
-                  );
-                }
-                const parent = {
-                  ...base,
-                  id: messageGuidStr,
-                  content: asProviderGroup(items)
-                };
-                cacheMessage(cache, parent);
-                return [parent];
-              }
-              const text2 = event.message.content.text;
-              const msg = {
-                ...base,
-                id: messageGuidStr,
-                content: text2 ? asText(text2) : asCustom(event.message)
-              };
-              cacheMessage(cache, msg);
-              return [msg];
-            };
-            """
-        ),
-        encoding="utf-8",
-    )
+    bundle = dist / "index.js"
+    bundle.write_text(_v5_imessage_fixture(), encoding="utf-8")
+    return bundle
+
+
+def test_spectrum_patch_preserves_text_with_attachments(tmp_path: Path) -> None:
+    """The sidecar dependency patch must turn text+attachment into group content."""
+    if not shutil.which("node"):
+        pytest.skip("node not available")
+    bundle = _write_fixture(tmp_path)
 
     result = subprocess.run(
         ["node", str(_PATCHER), str(tmp_path)],
@@ -182,10 +144,45 @@ def test_spectrum_patch_preserves_text_when_single_attachment(tmp_path: Path) ->
         capture_output=True,
         check=False,
     )
-
     assert result.returncode == 0, result.stderr
-    patched = chunk.read_text(encoding="utf-8")
+
+    patched = bundle.read_text(encoding="utf-8")
     assert "Preserve mixed text + attachment iMessage payloads" in patched
-    assert "content: asProviderGroup([textMsg, msg2])" in patched
+    # Single attachment + text -> a group whose first child is the dropped text.
+    assert "content: asProviderGroup([textMsg, attachmentMsg])" in patched
+    assert "content: asText(text)" in patched
+    assert "id: formatChildId(0, messageGuidStr)" in patched
+    # Multi attachment + text -> text child at partIndex 0, attachments shifted.
+    assert "const partIndex = text ? i + 1 : i;" in patched
     assert "content: asProviderGroup(items)" in patched
-    assert "formatChildId(text2 ? i + 1 : i, messageGuidStr)" in patched
+
+    # The patched bundle must still be syntactically valid JavaScript.
+    check = subprocess.run(
+        ["node", "--check", str(bundle)],
+        cwd=Path.cwd(),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert check.returncode == 0, check.stderr
+
+
+def test_spectrum_patch_is_idempotent(tmp_path: Path) -> None:
+    """A second run must no-op (marker guard), not double-apply or throw."""
+    if not shutil.which("node"):
+        pytest.skip("node not available")
+    bundle = _write_fixture(tmp_path)
+
+    first = subprocess.run(
+        ["node", str(_PATCHER), str(tmp_path)],
+        cwd=Path.cwd(), text=True, capture_output=True, check=False,
+    )
+    assert first.returncode == 0, first.stderr
+    after_first = bundle.read_text(encoding="utf-8")
+
+    second = subprocess.run(
+        ["node", str(_PATCHER), str(tmp_path)],
+        cwd=Path.cwd(), text=True, capture_output=True, check=False,
+    )
+    assert second.returncode == 0, second.stderr
+    assert bundle.read_text(encoding="utf-8") == after_first


### PR DESCRIPTION
## What does this PR do?

Upgrades the Photon iMessage sidecar's `spectrum-ts` SDK from **3.1.0 → 5.2.0**.

v5 is a package split: the monolithic `spectrum-ts` became a batteries-included
meta-package plus scoped `@spectrum-ts/*` packages. The new dependency tree pulls
in `@photon-ai/otel`, which requires **Node 20+** — so an unsupported Node would
previously crash-loop the sidecar with a cryptic SDK-import error. This PR raises
the Node floor, fails fast with an actionable message when Node is too old, and
re-targets our local mixed-attachment patch to the SDK's new bundle layout.

`spectrum-ts` is intentionally pinned to an exact version (no `^` range) because
the SDK ships breaking majors; this is a deliberate, reviewed bump.

## Type of Change

- [x] ✨ New feature (dependency upgrade + supporting preflight)
- [x] ♻️ Refactor (re-target the iMessage mixed-attachment patch)

## Changes Made

- **`sidecar/package.json`** — pin `spectrum-ts` `3.1.0 → 5.2.0`; raise
  `engines.node` `>=18.17 → >=20`. Regenerated `package-lock.json` (`npm install`).
- **`adapter.py`** — add `_MIN_NODE_MAJOR = 20` and a `_check_node_version()`
  preflight, invoked at the top of `_start_sidecar()`. Probes `node --version`
  and raises a clear setup error on Node < 20 (unparseable versions warn and
  defer to the SDK import rather than hard-failing).
- **`cli.py`** — update "install Node 18+" hints to "20+" in `photon status`
  and the `install-sidecar` npm-missing path.
- **`sidecar/index.mjs`** — header comment now documents spectrum-ts **5.x**.
- **`sidecar/patch-spectrum-mixed-attachments.mjs`** — re-target the iMessage
  inbound mapper patch to the bundled `@spectrum-ts/imessage/dist/index.js`
  (resolved via a direct path with a Node-resolution fallback). Now patches
  **both** inbound entry points — `toInboundMessages` (live stream) and
  `rebuildFromAppleMessage` (on-demand `getMessage`/cache path). `replaceOnce`
  fails loudly (count must be exactly 1) so a shape change in a future
  spectrum-ts release breaks install instead of silently dropping text.
- **`README.md`** — rewrite the "Upgrading spectrum-ts" checklist for the v5
  package split: re-check `engines.node`/`overrides` against the new tree, the
  scoped `@spectrum-ts/*` typings as source of truth, the patch re-targeting
  step, and a note that release notes can lag the actual code.
- **Tests** — add `test_start_sidecar_rejects_unsupported_node` (old Node fails
  fast); stub `_check_node_version` in the existing lifecycle test to isolate it
  from the fake Popen; update `test_spectrum_patch.py` for the new bundle layout.

## How to Test

1. `cd plugins/platforms/photon/sidecar && npm ci` — runs the `postinstall`
   patch; it fails loud if the `@spectrum-ts/imessage` bundle shape changed.
2. `uv run pytest tests/plugins/platforms/photon/` → **108 passed**.
3. `hermes photon status` reports "install Node 20+" when node is missing; with
   Node < 20 on PATH, sidecar start fails fast with the preflight error rather
   than a crash-loop.
4. End-to-end: send a mixed text + attachment inbound iMessage and confirm the
   text is preserved (exercises the re-targeted patch on both entry points).

## Checklist

### Code

- [x] Commit message follows Conventional Commits (`feat(photon): …`)
- [x] PR contains only changes related to this upgrade
- [x] Ran `pytest tests/plugins/platforms/photon/` — 108 passed
- [x] Added tests for the new behavior (Node preflight; patch re-targeting)
- [x] Tested on macOS

### Documentation & Housekeeping

- [x] Updated relevant documentation (plugin `README.md`, docstrings)
- [x] No new/changed config keys — `cli-config.yaml.example` N/A
- [x] No architecture/workflow change to `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] Considered cross-platform impact — Node-version probe is platform-neutral
