### PR TITLE
fix(blank-slate): align prompt-size with resolved toolsets

### DIFF
--- a/hermes_cli/prompt_size.py
+++ b/hermes_cli/prompt_size.py
@@ -34,10 +34,14 @@ def _build_inspection_agent(platform: str) -> Any:
     """
     from run_agent import AIAgent
     from hermes_cli.config import load_config
+    from hermes_cli.tools_config import _get_platform_tools
 
     cfg = load_config()
     model_cfg = cfg.get("model", {}) if isinstance(cfg.get("model"), dict) else {}
     model = model_cfg.get("default") or model_cfg.get("model") or ""
+    agent_cfg = cfg.get("agent", {}) if isinstance(cfg.get("agent"), dict) else {}
+    disabled_toolsets = agent_cfg.get("disabled_toolsets") or []
+    enabled_toolsets = sorted(_get_platform_tools(cfg, platform))
 
     return AIAgent(
         model=model,
@@ -46,6 +50,8 @@ def _build_inspection_agent(platform: str) -> Any:
         quiet_mode=True,
         save_trajectories=False,
         platform=platform,
+        enabled_toolsets=enabled_toolsets,
+        disabled_toolsets=disabled_toolsets,
     )
 
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -3019,6 +3019,8 @@ def _blank_slate_minimal_toolsets(config: dict):
                 continue  # platform composites — not user-facing toolsets
             if isinstance(tdef, dict) and tdef.get("includes"):
                 continue  # composite groupings, not leaf toolsets
+            if isinstance(tdef, dict) and tdef.get("posture"):
+                continue  # posture bundles overlap leaf toolsets like file/terminal
             all_keys.add(k)
 
         disabled = sorted(all_keys - keep)

--- a/model_tools.py
+++ b/model_tools.py
@@ -30,7 +30,7 @@ import time
 from typing import Dict, Any, List, Optional, Tuple
 
 from tools.registry import discover_builtin_tools, registry
-from toolsets import resolve_toolset, validate_toolset
+from toolsets import get_toolset, resolve_toolset, validate_toolset
 
 logger = logging.getLogger(__name__)
 
@@ -396,6 +396,14 @@ def _compute_tool_definitions(
     if disabled_toolsets:
         for toolset_name in disabled_toolsets:
             if validate_toolset(toolset_name):
+                ts_def = get_toolset(toolset_name)
+                if (
+                    enabled_toolsets is not None
+                    and toolset_name not in enabled_toolsets
+                    and isinstance(ts_def, dict)
+                    and ts_def.get("posture")
+                ):
+                    continue
                 if toolset_name.startswith("hermes-"):
                     # Platform bundles (hermes-*) include _HERMES_CORE_TOOLS, so
                     # subtracting the whole bundle would strip core tools shared

--- a/tests/hermes_cli/test_prompt_size.py
+++ b/tests/hermes_cli/test_prompt_size.py
@@ -1,11 +1,14 @@
 """Tests for the ``hermes prompt-size`` diagnostic (issue #34667)."""
 
 import json
+import sys
+from types import SimpleNamespace
 
 import pytest
 
 from hermes_cli.prompt_size import (
     _SKILLS_BLOCK_RE,
+    _build_inspection_agent,
     compute_prompt_breakdown,
     render_breakdown,
 )
@@ -68,6 +71,56 @@ def test_runs_offline_without_credentials(isolated_home, monkeypatch):
         monkeypatch.delenv(var, raising=False)
     data = compute_prompt_breakdown("cli")
     assert data["system_prompt"]["bytes"] > 0
+
+
+def test_inspection_agent_uses_resolved_platform_toolsets(monkeypatch):
+    """Inspection must match real CLI tool resolution, including disables."""
+    captured = {}
+
+    class FakeAIAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    cfg = {
+        "model": {"default": "test/model"},
+        "agent": {"disabled_toolsets": ["memory"]},
+    }
+
+    monkeypatch.setitem(
+        sys.modules,
+        "run_agent",
+        SimpleNamespace(AIAgent=FakeAIAgent),
+    )
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_platform_tools",
+        lambda passed_cfg, platform: {"terminal", "file"},
+    )
+
+    _build_inspection_agent("cli")
+
+    assert captured["model"] == "test/model"
+    assert captured["platform"] == "cli"
+    assert captured["enabled_toolsets"] == ["file", "terminal"]
+    assert captured["disabled_toolsets"] == ["memory"]
+
+
+def test_blank_slate_prompt_size_counts_only_minimal_tools(isolated_home):
+    """Blank Slate prompt-size should report file + terminal schemas only."""
+    from hermes_cli.config import save_config
+    from hermes_cli.setup import (
+        _blank_slate_minimal_toolsets,
+        _blank_slate_minimize_config,
+    )
+
+    cfg = {"model": {"default": "MiniMax-M2.7"}}
+    _blank_slate_minimal_toolsets(cfg)
+    _blank_slate_minimize_config(cfg)
+    save_config(cfg)
+
+    data = compute_prompt_breakdown("cli")
+
+    assert data["tools"]["count"] == 6
 
 
 def test_skills_index_reflects_installed_skills(isolated_home):

--- a/tests/hermes_cli/test_setup_blank_slate.py
+++ b/tests/hermes_cli/test_setup_blank_slate.py
@@ -27,6 +27,9 @@ class TestBlankSlateMinimalToolsets:
         # The two kept toolsets must NOT be in the disabled list.
         assert "file" not in disabled
         assert "terminal" not in disabled
+        # Posture bundles overlap the kept leaf toolsets and must not be used
+        # as hard disables, or model_tools would subtract file/terminal too.
+        assert "coding" not in disabled
         # A representative spread of capabilities must be suppressed.
         for ts in ("web", "browser", "code_execution", "vision", "memory",
                    "delegation", "cronjob", "skills", "image_gen"):
@@ -51,7 +54,9 @@ class TestBlankSlateMinimalToolsets:
         _blank_slate_minimize_config(cfg)
         enabled = sorted(_get_platform_tools(cfg, "cli"))
         defs = model_tools.get_tool_definitions(
-            enabled_toolsets=enabled, disabled_toolsets=None, quiet_mode=True
+            enabled_toolsets=enabled,
+            disabled_toolsets=cfg["agent"]["disabled_toolsets"],
+            quiet_mode=True,
         )
         names = sorted(
             {(d.get("function") or {}).get("name") or d.get("name") for d in defs}

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -520,6 +520,25 @@ class TestDisabledToolsetsPlatformBundle:
             f"Web tools not removed: {present_web - removed}"
         )
 
+    def test_inactive_posture_disable_does_not_strip_leaf_toolsets(self):
+        """A stale Blank Slate ``coding`` disable must not erase file/terminal."""
+        from model_tools import get_tool_definitions
+
+        tools = get_tool_definitions(
+            enabled_toolsets=["file", "terminal"],
+            disabled_toolsets=["coding"],
+            quiet_mode=True,
+        )
+        names = sorted(t["function"]["name"] for t in tools)
+
+        assert names == [
+            "patch",
+            "process",
+            "read_file",
+            "search_files",
+            "terminal",
+            "write_file",
+        ]
 
     def test_disabling_bundle_removes_platform_tools_but_keeps_core(self):
         """Disabling hermes-discord (when enabled) removes discord/discord_admin


### PR DESCRIPTION
## What does this PR do?

Fixes Blank Slate tool-schema accounting and a related stale deny-list edge case.

`hermes prompt-size` builds an offline inspection agent, but it did not pass the platform-resolved `enabled_toolsets` into `AIAgent`. For Blank Slate profiles, that made the diagnostic report the broader default tool surface instead of the actual file + terminal surface.

While adding the diagnostic parity coverage, I found a related compatibility issue: Blank Slate profiles can contain stale posture toolsets such as `coding` in `agent.disabled_toolsets`. Because `coding` overlaps file/terminal schemas, passing that raw deny-list into `model_tools` can erase the minimal tools Blank Slate is supposed to keep.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/prompt_size.py`: resolve platform toolsets with `_get_platform_tools()` and pass them into the offline inspection `AIAgent`.
- `hermes_cli/setup.py`: skip posture bundles when generating Blank Slate hard-disabled toolsets.
- `model_tools.py`: avoid subtracting inactive posture toolsets from an explicitly enabled leaf-toolset surface, preserving existing Blank Slate profiles with stale `coding` disables.
- Added regression coverage for prompt-size parity, Blank Slate minimal schema count, and stale posture disables.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_prompt_size.py tests/hermes_cli/test_setup_blank_slate.py tests/test_model_tools.py -- -q`
2. Confirm the targeted clean-env run reports `49 tests passed`.
3. For a Blank Slate config, confirm both runtime `AIAgent` and `prompt-size` report 6 tools: `patch`, `process`, `read_file`, `search_files`, `terminal`, `write_file`.

I also attempted `scripts/run_tests.sh -- -q`. The local full-suite run was not completed because it hit unrelated failures in `tests/agent/test_anthropic_adapter.py::TestRunOauthSetupToken*` (`TypeError: the JSON object must be str, bytes or bytearray, not MagicMock`) before completion, so I am leaving the full-suite checkbox unchecked.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted canonical test run:

```text
scripts/run_tests.sh tests/hermes_cli/test_prompt_size.py tests/hermes_cli/test_setup_blank_slate.py tests/test_model_tools.py -- -q
=== Summary: 3 files, 49 tests passed, 0 failed in 8.1s ===
```