### PR TITLE
feat(plugins): add static context prompt hook

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -961,6 +961,21 @@ def compress_context(
                 # refresh the stored system prompt and reset the flush cursor so the
                 # next turn re-bases its append diff.
                 agent._session_db.update_system_prompt(agent.session_id, new_system_prompt)
+                if hasattr(agent._session_db, "update_plugin_prompt_state"):
+                    try:
+                        from agent.system_prompt import serialize_plugin_prompt_state
+
+                        agent._session_db.update_plugin_prompt_state(
+                            agent.session_id,
+                            serialize_plugin_prompt_state(agent),
+                        )
+                    except Exception as plugin_state_error:
+                        logger.warning(
+                            "Compression persisted the system prompt but not its "
+                            "plugin snapshot for session %s: %s",
+                            agent.session_id,
+                            plugin_state_error,
+                        )
                 agent._last_flushed_db_idx = 0
             except Exception as e:
                 # If the rotation rolled back to the parent (orphan-avoidance

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -307,6 +307,7 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
     DB roundtrip).
     """
     stored_prompt = None
+    stored_plugin_prompt_state = None
     stored_state = "missing"
     if conversation_history and agent._session_db:
         try:
@@ -319,6 +320,7 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
                     stored_state = "empty"
                 else:
                     stored_prompt = raw_prompt
+                    stored_plugin_prompt_state = session_row.get("plugin_prompt_state")
                     stored_state = "present"
         except Exception as exc:
             logger.warning(
@@ -326,6 +328,18 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
                 "(session=%s): %s. Falling back to fresh build — prefix "
                 "cache will miss for this turn.",
                 agent.session_id, exc,
+            )
+
+    if stored_prompt and stored_plugin_prompt_state:
+        try:
+            from agent.system_prompt import restore_plugin_prompt_state
+
+            restore_plugin_prompt_state(agent, stored_plugin_prompt_state)
+        except Exception as exc:
+            logger.warning(
+                "Stored plugin prompt state could not be restored for session %s: %s",
+                agent.session_id,
+                exc,
             )
 
     if stored_prompt and _stored_prompt_matches_runtime(agent, stored_prompt):
@@ -401,6 +415,22 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
                 "miss the prefix cache.",
                 agent.session_id, exc,
             )
+        else:
+            try:
+                if hasattr(agent._session_db, "update_plugin_prompt_state"):
+                    from agent.system_prompt import serialize_plugin_prompt_state
+
+                    agent._session_db.update_plugin_prompt_state(
+                        agent.session_id,
+                        serialize_plugin_prompt_state(agent),
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "Session DB plugin prompt state write failed for session %s: %s. "
+                    "A later compression rebuild may re-evaluate plugin context.",
+                    agent.session_id,
+                    exc,
+                )
 
 
 def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -12,7 +12,8 @@ Three tiers are joined with ``\\n\\n``:
 * ``stable``   — identity (SOUL.md or DEFAULT_AGENT_IDENTITY), tool
   guidance, computer-use guidance, nous subscription block, tool-use
   enforcement guidance + per-model operational guidance, skills prompt,
-  alibaba model-name workaround, environment hints, platform hints.
+  alibaba model-name workaround, environment hints, platform hints,
+  plugin-owned frozen sections at constrained anchors.
 * ``context``  — caller-supplied ``system_message`` plus context files
   (AGENTS.md / .cursorrules / etc.) discovered under ``TERMINAL_CWD``.
 * ``volatile`` — memory snapshot, USER.md profile, external memory
@@ -24,6 +25,7 @@ Pure helpers that read the agent's state.  AIAgent keeps thin forwarders.
 from __future__ import annotations
 
 import json
+import logging
 import os
 from typing import Any, Dict, List, Optional
 
@@ -47,6 +49,10 @@ from agent.prompt_builder import (
 )
 from agent.runtime_cwd import resolve_context_cwd
 from utils import is_truthy_value
+
+
+logger = logging.getLogger(__name__)
+_PLUGIN_PROMPT_STATE_VERSION = 1
 
 
 def _ra():
@@ -143,6 +149,183 @@ def _tui_embedded_pane_clarifier(hint: str) -> str:
     return hint + _TUI_EMBEDDED_PANE_CLARIFIER
 
 
+def _plugin_session_info(agent: Any) -> Dict[str, str]:
+    """Return the immutable-at-render-time metadata exposed to plugins."""
+    try:
+        cwd = str(resolve_context_cwd() or "")
+    except Exception:
+        cwd = ""
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        profile_name = str(get_active_profile_name() or "default")
+    except Exception:
+        profile_name = "default"
+    return {
+        "session_id": str(getattr(agent, "session_id", None) or ""),
+        "model": str(getattr(agent, "model", None) or ""),
+        "provider": str(getattr(agent, "provider", None) or ""),
+        "platform": str(getattr(agent, "platform", None) or ""),
+        "profile_name": profile_name,
+        "cwd": cwd,
+    }
+
+
+def _frozen_plugin_prompt_sections(agent: Any) -> tuple:
+    attr = "_plugin_system_prompt_sections_snapshot"
+    if hasattr(agent, attr):
+        return getattr(agent, attr)
+    try:
+        from hermes_cli.plugins import render_system_prompt_sections
+
+        rendered = tuple(render_system_prompt_sections(_plugin_session_info(agent)))
+    except Exception as exc:
+        logger.warning("Plugin system prompt sections could not be rendered: %s", exc)
+        rendered = ()
+    setattr(agent, attr, rendered)
+    return rendered
+
+
+def _frozen_plugin_environment_hints(agent: Any, core_hints: str) -> tuple:
+    attr = "_plugin_environment_hints_snapshot"
+    if hasattr(agent, attr):
+        return getattr(agent, attr)
+    try:
+        from hermes_cli.plugins import collect_environment_hints
+
+        rows = tuple(
+            collect_environment_hints(core_hints, _plugin_session_info(agent))
+        )
+    except Exception as exc:
+        logger.warning("Plugin environment hints could not be rendered: %s", exc)
+        rows = ()
+    setattr(agent, attr, rows)
+    return rows
+
+
+def _plugin_section_blocks(sections: tuple, position: str) -> List[str]:
+    return [
+        f"## Plugin Context: {section.id}\n\n{section.content}"
+        for section in sections
+        if section.position == position
+    ]
+
+
+def serialize_plugin_prompt_state(agent: Any) -> Optional[str]:
+    """Serialize frozen plugin prompt output for session persistence."""
+    if not hasattr(agent, "_plugin_system_prompt_sections_snapshot"):
+        return None
+    sections = getattr(agent, "_plugin_system_prompt_sections_snapshot", ())
+    environment_hints = getattr(agent, "_plugin_environment_hints_snapshot", ())
+    payload = {
+        "version": _PLUGIN_PROMPT_STATE_VERSION,
+        "sections": [
+            {
+                "id": section.id,
+                "content": section.content,
+                "position": section.position,
+                "max_chars": section.max_chars,
+                "plugin": section.plugin,
+            }
+            for section in sections
+        ],
+        "environment_hints": [list(row) for row in environment_hints],
+    }
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+
+
+def restore_plugin_prompt_state(agent: Any, raw_state: Any) -> bool:
+    """Restore validated plugin output before a resumed-session rebuild."""
+    if not raw_state:
+        return False
+    try:
+        payload = json.loads(raw_state) if isinstance(raw_state, str) else raw_state
+        if not isinstance(payload, dict) or payload.get("version") != _PLUGIN_PROMPT_STATE_VERSION:
+            raise ValueError("unsupported plugin prompt state version")
+
+        from hermes_cli.plugins import (
+            MAX_PLUGIN_ENVIRONMENT_HINT_ROW_CHARS,
+            MAX_PLUGIN_ENVIRONMENT_HINT_ROWS,
+            MAX_PLUGIN_ENVIRONMENT_HINTS_TOTAL_CHARS,
+            MAX_SYSTEM_PROMPT_SECTION_CHARS,
+            MAX_SYSTEM_PROMPT_SECTIONS,
+            MAX_SYSTEM_PROMPT_SECTIONS_TOTAL_CHARS,
+            SYSTEM_PROMPT_SECTION_POSITIONS,
+            RenderedPluginSystemPromptSection,
+            is_valid_system_prompt_section_id,
+            system_prompt_section_rendered_chars,
+        )
+
+        section_items = payload.get("sections", [])
+        if not isinstance(section_items, list):
+            raise ValueError("sections must be a list")
+        if len(section_items) > MAX_SYSTEM_PROMPT_SECTIONS:
+            raise ValueError("too many system prompt sections")
+        sections = []
+        section_chars = 0
+        for item in section_items:
+            if not isinstance(item, dict):
+                raise ValueError("section entry must be an object")
+            section_id = item.get("id")
+            content = item.get("content")
+            position = item.get("position")
+            plugin = item.get("plugin")
+            max_chars = item.get("max_chars")
+            if not all(isinstance(value, str) for value in (section_id, content, plugin)):
+                raise ValueError("section id, content, and plugin must be strings")
+            if not is_valid_system_prompt_section_id(section_id) or not plugin:
+                raise ValueError("invalid section identity")
+            if position not in SYSTEM_PROMPT_SECTION_POSITIONS:
+                raise ValueError("invalid section position")
+            if (
+                isinstance(max_chars, bool)
+                or not isinstance(max_chars, int)
+                or not 0 < max_chars <= MAX_SYSTEM_PROMPT_SECTION_CHARS
+                or len(content) > max_chars
+            ):
+                raise ValueError("invalid section budget")
+            section_chars += system_prompt_section_rendered_chars(section_id, content)
+            if section_chars > MAX_SYSTEM_PROMPT_SECTIONS_TOTAL_CHARS:
+                raise ValueError("section total budget exceeded")
+            sections.append(
+                RenderedPluginSystemPromptSection(
+                    id=section_id,
+                    content=content,
+                    position=position,
+                    max_chars=max_chars,
+                    plugin=plugin,
+                )
+            )
+
+        hint_items = payload.get("environment_hints", [])
+        if not isinstance(hint_items, list) or len(hint_items) > MAX_PLUGIN_ENVIRONMENT_HINT_ROWS:
+            raise ValueError("invalid environment hints")
+        rows = []
+        hint_chars = 0
+        for row in hint_items:
+            if not isinstance(row, list) or len(row) != 2:
+                raise ValueError("invalid environment hint row")
+            key, value = row
+            if not isinstance(key, str) or not isinstance(value, str):
+                raise ValueError("environment hint values must be strings")
+            if not key.strip() or not value.strip() or "\n" in key or "\n" in value:
+                raise ValueError("invalid environment hint value")
+            row_chars = len(key) + len(value) + 2
+            if row_chars > MAX_PLUGIN_ENVIRONMENT_HINT_ROW_CHARS:
+                raise ValueError("environment hint row budget exceeded")
+            hint_chars += row_chars
+            if hint_chars > MAX_PLUGIN_ENVIRONMENT_HINTS_TOTAL_CHARS:
+                raise ValueError("environment hints total budget exceeded")
+            rows.append((key, value))
+    except Exception as exc:
+        logger.warning("Stored plugin prompt state was invalid and was ignored: %s", exc)
+        return False
+
+    agent._plugin_system_prompt_sections_snapshot = tuple(sections)
+    agent._plugin_environment_hints_snapshot = tuple(rows)
+    return True
+
+
 def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) -> Dict[str, str]:
     """Assemble the system prompt as three ordered parts.
 
@@ -177,6 +360,11 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         if isinstance(_cc_len, int) and _cc_len > 0:
             _ctx_len = _cc_len
 
+    # Plugin sections are evaluated at most once for this AIAgent. The frozen
+    # snapshot survives compression rebuilds and is persisted for process
+    # restarts by ``serialize_plugin_prompt_state``.
+    _plugin_sections = _frozen_plugin_prompt_sections(agent)
+
     # ── Stable tier ────────────────────────────────────────────────
     stable_parts: List[str] = []
 
@@ -196,6 +384,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
 
     # Pointer to the hermes-agent skill + docs for user questions about Hermes itself.
     stable_parts.append(HERMES_AGENT_HELP_GUIDANCE)
+    stable_parts.extend(_plugin_section_blocks(_plugin_sections, "after_identity"))
 
     # Universal task-completion / no-fabrication guidance.  Applied to ALL
     # models regardless of tool_use_enforcement gating — the failure modes
@@ -321,6 +510,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         skills_prompt = ""
     if skills_prompt:
         stable_parts.append(skills_prompt)
+    stable_parts.extend(_plugin_section_blocks(_plugin_sections, "after_tools"))
 
     # Alibaba Coding Plan API always returns "glm-4.7" as model name regardless
     # of the requested model. Inject explicit model identity into the system prompt
@@ -340,6 +530,14 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # execution environment so it can translate paths and adapt behavior.
     # Stable for the lifetime of the process.
     _env_hints = _r.build_environment_hints()
+    _plugin_env_rows = _frozen_plugin_environment_hints(agent, _env_hints)
+    if _plugin_env_rows:
+        _plugin_env_block = "\n".join(
+            f"{key}: {value}" for key, value in _plugin_env_rows
+        )
+        _env_hints = "\n\n".join(
+            part for part in (_env_hints, _plugin_env_block) if part
+        )
     if _env_hints:
         stable_parts.append(_env_hints)
 
@@ -492,6 +690,8 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         except Exception:
             pass
 
+    volatile_parts.extend(_plugin_section_blocks(_plugin_sections, "after_memory"))
+
     from hermes_time import now as _hermes_now
     now = _hermes_now()
     # Date-only (not minute-precision) so the system prompt is byte-stable
@@ -582,4 +782,6 @@ __all__ = [
     "build_system_prompt",
     "invalidate_system_prompt",
     "format_tools_for_system_message",
+    "serialize_plugin_prompt_state",
+    "restore_plugin_prompt_state",
 ]

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -26,7 +26,7 @@ def register(ctx):
     ctx.register_hook("post_tool_call", on_post_tool_call)
 ```
 
-Every hook callback receives keyword arguments. Plugins should accept
+Observer hook callbacks receive keyword arguments. Plugins should accept
 `**kwargs` so additive fields remain backward-compatible:
 
 ```python
@@ -36,7 +36,7 @@ def on_post_tool_call(**kwargs):
     result = kwargs.get("result")
 ```
 
-The plugin manager injects this field into every hook payload:
+The plugin manager injects this field into observer hook payloads:
 
 ```text
 telemetry_schema_version = "hermes.observer.v1"
@@ -44,6 +44,11 @@ telemetry_schema_version = "hermes.observer.v1"
 
 Hook callbacks are fail-open. Hermes catches callback exceptions, logs a
 warning, and keeps the agent loop running.
+
+The behavior-changing `build_environment_hints` hook and
+`ctx.register_system_prompt_section()` API are outside this observer contract.
+Their bounded output is evaluated once, frozen, and persisted with the session
+system prompt.
 
 Most observer hook return values are ignored. The exceptions are older
 behavior-affecting hooks:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -39,12 +39,13 @@ import importlib.util
 import inspect
 import logging
 import os
+import re
 import sys
 import threading
 import types
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Set, Union
+from typing import Any, Callable, Dict, List, Mapping, Optional, Set, Union
 
 from hermes_constants import get_hermes_home
 from utils import env_var_enabled, fast_safe_load
@@ -142,6 +143,9 @@ VALID_HOOKS: Set[str] = {
     # First non-None string wins. Useful for vocabulary/personality transformation.
     "transform_llm_output",
     "pre_llm_call",
+    # Additive execution-environment rows. Evaluated once and frozen with the
+    # session's persisted system prompt; callbacks cannot replace core hints.
+    "build_environment_hints",
     "post_llm_call",
     # Verification-loop gate. Fired once per turn when the agent has edited code
     # and is about to verify/finish (after the verify-on-stop guard). A callback
@@ -215,6 +219,31 @@ VALID_HOOKS: Set[str] = {
 }
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"
+
+SYSTEM_PROMPT_SECTION_POSITIONS = frozenset(
+    {"after_identity", "after_tools", "after_memory"}
+)
+DEFAULT_SYSTEM_PROMPT_SECTION_MAX_CHARS = 4_000
+MAX_SYSTEM_PROMPT_SECTION_CHARS = 8_000
+MAX_SYSTEM_PROMPT_SECTIONS = 32
+MAX_SYSTEM_PROMPT_SECTIONS_TOTAL_CHARS = 12_000
+MAX_PLUGIN_ENVIRONMENT_HINT_ROWS = 20
+MAX_PLUGIN_ENVIRONMENT_HINT_ROW_CHARS = 500
+MAX_PLUGIN_ENVIRONMENT_HINTS_TOTAL_CHARS = 2_000
+_SYSTEM_PROMPT_SECTION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_SYSTEM_PROMPT_SECTION_HEADING_PREFIX = "## Plugin Context: "
+
+
+def is_valid_system_prompt_section_id(value: Any) -> bool:
+    """Return whether *value* is safe to render in a prompt heading."""
+    return isinstance(value, str) and bool(
+        _SYSTEM_PROMPT_SECTION_ID_RE.fullmatch(value)
+    )
+
+
+def system_prompt_section_rendered_chars(section_id: str, content: str) -> int:
+    """Count the full rendered prompt block, including its audit heading."""
+    return len(_SYSTEM_PROMPT_SECTION_HEADING_PREFIX) + len(section_id) + 2 + len(content)
 
 _NS_PARENT = "hermes_plugins"
 
@@ -314,6 +343,28 @@ class PluginManifest:
     key: str = ""
 
 
+@dataclass(frozen=True)
+class PluginSystemPromptSection:
+    """A plugin-owned, session-stable system-prompt registration."""
+
+    id: str
+    content: Union[str, Callable[[Mapping[str, Any]], str]]
+    position: str
+    max_chars: int
+    plugin: str
+
+
+@dataclass(frozen=True)
+class RenderedPluginSystemPromptSection:
+    """Frozen output persisted with a session for cache-safe rebuilds."""
+
+    id: str
+    content: str
+    position: str
+    max_chars: int
+    plugin: str
+
+
 @dataclass
 class LoadedPlugin:
     """Runtime state for a single loaded plugin."""
@@ -324,6 +375,7 @@ class LoadedPlugin:
     hooks_registered: List[str] = field(default_factory=list)
     middleware_registered: List[str] = field(default_factory=list)
     commands_registered: List[str] = field(default_factory=list)
+    prompt_sections_registered: List[str] = field(default_factory=list)
     enabled: bool = False
     error: Optional[str] = None
     # True for a bundled platform plugin recorded as a deferred (not-yet-
@@ -1155,6 +1207,66 @@ class PluginContext:
             display_name,
         )
 
+    def register_system_prompt_section(
+        self,
+        id: str,
+        content: Union[str, Callable[[Mapping[str, Any]], str]],
+        *,
+        position: str = "after_tools",
+        max_chars: int = DEFAULT_SYSTEM_PROMPT_SECTION_MAX_CHARS,
+    ) -> None:
+        """Register cache-safe context evaluated once for each new session.
+
+        ``content`` may be a string or a callable receiving an immutable
+        session-info mapping. Rendered output is frozen and persisted with the
+        session, so plugin state changes do not alter an existing conversation.
+        """
+        section_id = id.strip() if isinstance(id, str) else ""
+        if not is_valid_system_prompt_section_id(section_id):
+            raise ValueError(
+                "system prompt section id must be 1-128 characters using "
+                "letters, numbers, '.', '_', or '-'"
+            )
+        if not isinstance(content, str) and not callable(content):
+            raise TypeError("system prompt section content must be a string or callable")
+        if position not in SYSTEM_PROMPT_SECTION_POSITIONS:
+            raise ValueError(
+                "system prompt section position must be one of: "
+                + ", ".join(sorted(SYSTEM_PROMPT_SECTION_POSITIONS))
+            )
+        if (
+            isinstance(max_chars, bool)
+            or not isinstance(max_chars, int)
+            or max_chars <= 0
+            or max_chars > MAX_SYSTEM_PROMPT_SECTION_CHARS
+        ):
+            raise ValueError(
+                "system prompt section max_chars must be between 1 and "
+                f"{MAX_SYSTEM_PROMPT_SECTION_CHARS}"
+            )
+        existing = self._manager._system_prompt_sections.get(section_id)
+        if existing is not None:
+            raise ValueError(
+                f"system prompt section {section_id!r} is already registered "
+                f"by plugin {existing.plugin!r}"
+            )
+
+        plugin_id = self.manifest.key or self.manifest.name
+        self._manager._system_prompt_sections[section_id] = PluginSystemPromptSection(
+            id=section_id,
+            content=content,
+            position=position,
+            max_chars=max_chars,
+            plugin=plugin_id,
+        )
+        logger.debug(
+            "Plugin %s registered system prompt section %s at %s (max_chars=%d)",
+            plugin_id,
+            section_id,
+            position,
+            max_chars,
+        )
+
     def register_hook(self, hook_name: str, callback: Callable) -> None:
         """Register a lifecycle hook callback.
 
@@ -1257,6 +1369,7 @@ class PluginManager:
         self._cli_commands: Dict[str, dict] = {}
         self._context_engine = None  # Set by a plugin via register_context_engine()
         self._plugin_commands: Dict[str, dict] = {}  # Slash commands registered by plugins
+        self._system_prompt_sections: Dict[str, PluginSystemPromptSection] = {}
         self._discovered: bool = False
         self._cli_ref = None  # Set by CLI after plugin discovery
         # Plugin skill registry: qualified name → metadata dict.
@@ -1297,6 +1410,7 @@ class PluginManager:
             self._plugin_platform_names.clear()
             self._cli_commands.clear()
             self._plugin_commands.clear()
+            self._system_prompt_sections.clear()
             self._plugin_skills.clear()
             self._aux_tasks.clear()
             self._slack_action_handlers.clear()
@@ -1789,6 +1903,7 @@ class PluginManager:
                 _mw_counts_before = {
                     kind: len(cbs) for kind, cbs in self._middleware.items()
                 }
+                _sections_before = set(self._system_prompt_sections)
                 register_fn(ctx)
                 loaded.tools_registered = [
                     t for t in self._plugin_tool_names
@@ -1808,12 +1923,19 @@ class PluginManager:
                     c for c in self._plugin_commands
                     if self._plugin_commands[c].get("plugin") == manifest.name
                 ]
+                loaded.prompt_sections_registered = [
+                    section_id
+                    for section_id in self._system_prompt_sections
+                    if section_id not in _sections_before
+                ]
                 loaded.enabled = True
                 logger.debug(
-                    "  registered: %d tool(s), %d hook(s), %d middleware, %d slash command(s), %d CLI command(s)",
+                    "  registered: %d tool(s), %d hook(s), %d middleware, "
+                    "%d prompt section(s), %d slash command(s), %d CLI command(s)",
                     len(loaded.tools_registered),
                     len(loaded.hooks_registered),
                     len(loaded.middleware_registered),
+                    len(loaded.prompt_sections_registered),
                     len(loaded.commands_registered),
                     sum(
                         1 for c in self._cli_commands
@@ -1930,6 +2052,189 @@ class PluginManager:
         """Return True when at least one callback is registered for a hook."""
         return bool(self._hooks.get(hook_name))
 
+    def render_system_prompt_sections(
+        self,
+        session_info: Dict[str, Any],
+    ) -> List[RenderedPluginSystemPromptSection]:
+        """Evaluate registered sections once for a new session.
+
+        The caller freezes and persists the returned values. Oversized,
+        invalid, or raising sections fail open with an audit warning.
+        """
+        frozen_info = types.MappingProxyType(dict(session_info))
+        rendered: List[RenderedPluginSystemPromptSection] = []
+        total_chars = 0
+        for section in self._system_prompt_sections.values():
+            if len(rendered) >= MAX_SYSTEM_PROMPT_SECTIONS:
+                logger.warning(
+                    "Plugin system prompt section %s (%s) exceeded the session "
+                    "section limit (%d) and was skipped",
+                    section.id,
+                    section.plugin,
+                    MAX_SYSTEM_PROMPT_SECTIONS,
+                )
+                continue
+            try:
+                value = (
+                    section.content(frozen_info)
+                    if callable(section.content)
+                    else section.content
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Plugin system prompt section %s (%s) raised and was skipped: %s",
+                    section.id,
+                    section.plugin,
+                    exc,
+                )
+                continue
+            if not isinstance(value, str):
+                logger.warning(
+                    "Plugin system prompt section %s (%s) returned %s, not str; skipped",
+                    section.id,
+                    section.plugin,
+                    type(value).__name__,
+                )
+                continue
+            text = value.strip()
+            if not text:
+                continue
+            if len(text) > section.max_chars:
+                logger.warning(
+                    "Plugin system prompt section %s (%s) exceeded max_chars "
+                    "(%d > %d) and was skipped",
+                    section.id,
+                    section.plugin,
+                    len(text),
+                    section.max_chars,
+                )
+                continue
+            rendered_chars = system_prompt_section_rendered_chars(section.id, text)
+            if total_chars + rendered_chars > MAX_SYSTEM_PROMPT_SECTIONS_TOTAL_CHARS:
+                logger.warning(
+                    "Plugin system prompt section %s (%s) exceeded the total "
+                    "session budget (%d chars) and was skipped",
+                    section.id,
+                    section.plugin,
+                    MAX_SYSTEM_PROMPT_SECTIONS_TOTAL_CHARS,
+                )
+                continue
+            frozen = RenderedPluginSystemPromptSection(
+                id=section.id,
+                content=text,
+                position=section.position,
+                max_chars=section.max_chars,
+                plugin=section.plugin,
+            )
+            rendered.append(frozen)
+            total_chars += rendered_chars
+            logger.info(
+                "Session plugin prompt section: id=%s plugin=%s position=%s chars=%d",
+                frozen.id,
+                frozen.plugin,
+                frozen.position,
+                len(frozen.content),
+            )
+        return rendered
+
+    def collect_environment_hints(
+        self,
+        core_hints: str,
+        session_info: Dict[str, Any],
+    ) -> List[tuple[str, str]]:
+        """Collect bounded key-value rows from environment-hint callbacks."""
+        frozen_hints = types.MappingProxyType({"text": core_hints})
+        frozen_info = types.MappingProxyType(dict(session_info))
+        rows: List[tuple[str, str]] = []
+        total_chars = 0
+
+        for callback in self._hooks.get("build_environment_hints", []):
+            try:
+                result = callback(
+                    hints=frozen_hints,
+                    session_info=frozen_info,
+                    telemetry_schema_version=OBSERVER_SCHEMA_VERSION,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Hook 'build_environment_hints' callback %s raised: %s",
+                    getattr(callback, "__name__", repr(callback)),
+                    exc,
+                )
+                continue
+            if result is None:
+                continue
+            candidates = result.get("hints") if isinstance(result, dict) else None
+            if not isinstance(candidates, (list, tuple)):
+                logger.warning(
+                    "Hook 'build_environment_hints' callback %s returned an "
+                    "invalid shape; expected {'hints': [(key, value), ...]}",
+                    getattr(callback, "__name__", repr(callback)),
+                )
+                continue
+            for candidate in candidates:
+                if len(rows) >= MAX_PLUGIN_ENVIRONMENT_HINT_ROWS:
+                    logger.warning(
+                        "Plugin environment hints exceeded the %d-row session budget; "
+                        "remaining rows were skipped",
+                        MAX_PLUGIN_ENVIRONMENT_HINT_ROWS,
+                    )
+                    return rows
+                if not isinstance(candidate, (list, tuple)) or len(candidate) != 2:
+                    logger.warning("Invalid plugin environment hint row %r; skipped", candidate)
+                    continue
+                key, value = candidate
+                key = str(key).strip()
+                value = str(value).strip()
+                if not key or not value:
+                    continue
+                if "\n" in key or "\r" in key or "\n" in value or "\r" in value:
+                    logger.warning(
+                        "Plugin environment hint %r was not a single key-value row; skipped",
+                        key,
+                    )
+                    continue
+                row_chars = len(key) + len(value) + 2
+                if row_chars > MAX_PLUGIN_ENVIRONMENT_HINT_ROW_CHARS:
+                    logger.warning(
+                        "Plugin environment hint %r exceeded the %d-character row budget; skipped",
+                        key,
+                        MAX_PLUGIN_ENVIRONMENT_HINT_ROW_CHARS,
+                    )
+                    continue
+                if total_chars + row_chars > MAX_PLUGIN_ENVIRONMENT_HINTS_TOTAL_CHARS:
+                    logger.warning(
+                        "Plugin environment hints exceeded the %d-character session budget; "
+                        "remaining rows were skipped",
+                        MAX_PLUGIN_ENVIRONMENT_HINTS_TOTAL_CHARS,
+                    )
+                    return rows
+                rows.append((key, value))
+                total_chars += row_chars
+                logger.info(
+                    "Session plugin environment hint: key=%s chars=%d",
+                    key,
+                    row_chars,
+                )
+        return rows
+
+    def list_system_prompt_sections(
+        self,
+        plugin: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Return registration metadata without evaluating section content."""
+        return [
+            {
+                "id": section.id,
+                "plugin": section.plugin,
+                "position": section.position,
+                "max_chars": section.max_chars,
+                "content_type": "callable" if callable(section.content) else "string",
+            }
+            for section in self._system_prompt_sections.values()
+            if plugin is None or section.plugin == plugin
+        ]
+
     def has_middleware(self, kind: str) -> bool:
         """Return True when at least one callback is registered for middleware."""
         return bool(self._middleware.get(kind))
@@ -1994,6 +2299,7 @@ class PluginManager:
                     "hooks": len(loaded.hooks_registered),
                     "middleware": len(loaded.middleware_registered),
                     "commands": len(loaded.commands_registered),
+                    "prompt_sections": len(loaded.prompt_sections_registered),
                     "error": loaded.error,
                 }
             )
@@ -2052,6 +2358,21 @@ def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
     Returns a list of non-``None`` return values from plugin callbacks.
     """
     return get_plugin_manager().invoke_hook(hook_name, **kwargs)
+
+
+def render_system_prompt_sections(
+    session_info: Dict[str, Any],
+) -> List[RenderedPluginSystemPromptSection]:
+    """Evaluate registered prompt sections for a new session."""
+    return get_plugin_manager().render_system_prompt_sections(session_info)
+
+
+def collect_environment_hints(
+    core_hints: str,
+    session_info: Dict[str, Any],
+) -> List[tuple[str, str]]:
+    """Collect plugin-owned environment rows for a new session."""
+    return get_plugin_manager().collect_environment_hints(core_hints, session_info)
 
 
 def invoke_middleware(kind: str, **kwargs: Any) -> List[Any]:

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1161,6 +1161,79 @@ def cmd_list(args: Any | None = None) -> None:
     console.print("[dim]Plugins are opt-in by default — only 'enabled' plugins load.[/dim]")
 
 
+def cmd_show(name: str, *, json_output: bool = False) -> None:
+    """Show active runtime registrations for one plugin."""
+    from hermes_cli.plugins import discover_plugins, get_plugin_manager
+
+    discover_plugins()
+    manager = get_plugin_manager()
+    matched_key = None
+    loaded = None
+    for key, candidate in manager._plugins.items():
+        if name in {key, candidate.manifest.name}:
+            matched_key = key
+            loaded = candidate
+            break
+
+    if loaded is None or matched_key is None:
+        message = (
+            f"Plugin '{name}' is not active. Enable it before inspecting "
+            "runtime prompt registrations."
+        )
+        if json_output:
+            print(json.dumps({"error": message}, indent=2))
+        else:
+            from rich.console import Console
+
+            Console().print(f"[red]{message}[/red]")
+        return
+
+    payload = {
+        "name": loaded.manifest.name,
+        "key": matched_key,
+        "version": loaded.manifest.version,
+        "source": loaded.manifest.source,
+        "enabled": loaded.enabled,
+        "hooks": list(loaded.hooks_registered),
+        "middleware": list(loaded.middleware_registered),
+        "commands": list(loaded.commands_registered),
+        "system_prompt_sections": manager.list_system_prompt_sections(matched_key),
+    }
+    if json_output:
+        print(json.dumps(payload, indent=2))
+        return
+
+    from rich.console import Console
+    from rich.table import Table
+
+    console = Console()
+    console.print(f"[bold]{payload['name']}[/bold] ({payload['key']})")
+    console.print(
+        f"status: {'enabled' if payload['enabled'] else 'disabled'}  "
+        f"source: {payload['source']}  version: {payload['version'] or '-'}"
+    )
+    console.print(
+        "hooks: " + (", ".join(payload["hooks"]) if payload["hooks"] else "none")
+    )
+    sections = payload["system_prompt_sections"]
+    if not sections:
+        console.print("system prompt sections: none")
+        return
+    table = Table(title="System prompt sections")
+    table.add_column("ID")
+    table.add_column("Position")
+    table.add_column("Max chars", justify="right")
+    table.add_column("Content")
+    for section in sections:
+        table.add_row(
+            section["id"],
+            section["position"],
+            str(section["max_chars"]),
+            section["content_type"],
+        )
+    console.print(table)
+
+
 # ---------------------------------------------------------------------------
 # Provider plugin discovery helpers
 # ---------------------------------------------------------------------------
@@ -2008,6 +2081,8 @@ def plugins_command(args) -> None:
         cmd_disable(args.name)
     elif action in {"list", "ls"}:
         cmd_list(args)
+    elif action == "show":
+        cmd_show(args.name, json_output=getattr(args, "json", False))
     elif action is None:
         cmd_toggle()
     else:

--- a/hermes_cli/subcommands/plugins.py
+++ b/hermes_cli/subcommands/plugins.py
@@ -13,8 +13,8 @@ def build_plugins_parser(subparsers, *, cmd_plugins: Callable) -> None:
     """Attach the ``plugins`` subcommand to ``subparsers``."""
     plugins_parser = subparsers.add_parser(
         "plugins",
-        help="Manage plugins — install, update, remove, list",
-        description="Install plugins from Git repositories, update, remove, or list them.",
+        help="Manage plugins — install, update, remove, list, inspect",
+        description="Install plugins from Git repositories, update, remove, list, or inspect them.",
     )
     plugins_subparsers = plugins_parser.add_subparsers(dest="plugins_action")
 
@@ -77,6 +77,16 @@ def build_plugins_parser(subparsers, *, cmd_plugins: Callable) -> None:
         help="Print compact plain-text output instead of a Rich table",
     )
     plugins_list.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable JSON",
+    )
+
+    plugins_show = plugins_subparsers.add_parser(
+        "show", help="Show active plugin hooks and prompt sections"
+    )
+    plugins_show.add_argument("name", help="Plugin name or registry key")
+    plugins_show.add_argument(
         "--json",
         action="store_true",
         help="Print machine-readable JSON",

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -761,6 +761,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     model TEXT,
     model_config TEXT,
     system_prompt TEXT,
+    plugin_prompt_state TEXT,
     parent_session_id TEXT,
     started_at REAL NOT NULL,
     ended_at REAL,
@@ -2551,6 +2552,19 @@ class SessionDB:
             )
         self._execute_write(_do)
 
+    def update_plugin_prompt_state(
+        self,
+        session_id: str,
+        plugin_prompt_state: Optional[str],
+    ) -> None:
+        """Store frozen plugin output used by compression-time rebuilds."""
+        def _do(conn):
+            conn.execute(
+                "UPDATE sessions SET plugin_prompt_state = ? WHERE id = ?",
+                (plugin_prompt_state, session_id),
+            )
+        self._execute_write(_do)
+
     def update_session_model(self, session_id: str, model: str) -> None:
         """Update the model for a session after a mid-session switch.
 
@@ -3299,7 +3313,7 @@ class SessionDB:
     # the projection is derived from SCHEMA_SQL so columns added later via
     # declarative reconciliation are included automatically instead of
     # silently dropping out of list rows.
-    _SESSION_COMPACT_EXCLUDED = frozenset({"system_prompt"})
+    _SESSION_COMPACT_EXCLUDED = frozenset({"system_prompt", "plugin_prompt_state"})
     _session_compact_cols_sql: Optional[str] = None
 
     @classmethod
@@ -5558,6 +5572,7 @@ class SessionDB:
             "user_id",
             "model",
             "system_prompt",
+            "plugin_prompt_state",
             "end_reason",
             "cwd",
             "git_branch",
@@ -5721,6 +5736,7 @@ class SessionDB:
                 conn.execute(
                     """INSERT INTO sessions (
                            id, source, user_id, model, model_config, system_prompt,
+                           plugin_prompt_state,
                            parent_session_id, started_at, ended_at, end_reason,
                            message_count, tool_call_count, input_tokens, output_tokens,
                            cache_read_tokens, cache_write_tokens, reasoning_tokens,
@@ -5731,7 +5747,7 @@ class SessionDB:
                        )
                        VALUES (
                            :id, :source, :user_id, :model, :model_config,
-                           :system_prompt, NULL, :started_at, :ended_at,
+                           :system_prompt, :plugin_prompt_state, NULL, :started_at, :ended_at,
                            :end_reason, 0, 0, :input_tokens, :output_tokens,
                            :cache_read_tokens, :cache_write_tokens,
                            :reasoning_tokens, :cwd, :git_branch, :git_repo_root,
@@ -5747,6 +5763,7 @@ class SessionDB:
                         "model": raw.get("model"),
                         "model_config": raw.get("model_config"),
                         "system_prompt": raw.get("system_prompt"),
+                        "plugin_prompt_state": raw.get("plugin_prompt_state"),
                         "started_at": started_at,
                         "ended_at": self._float_or_none(raw.get("ended_at")),
                         "end_reason": raw.get("end_reason"),

--- a/tests/agent/test_plugin_prompt_sections.py
+++ b/tests/agent/test_plugin_prompt_sections.py
@@ -1,0 +1,106 @@
+"""End-to-end cache-safety tests for plugin system-prompt sections."""
+
+from unittest.mock import patch
+
+from agent.conversation_loop import _restore_or_build_system_prompt
+from hermes_cli import plugins as plugins_module
+from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+from hermes_state import SessionDB
+from run_agent import AIAgent
+
+
+def _make_agent(session_id: str, db: SessionDB) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            session_id=session_id,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent._session_db = db
+    agent._session_db_created = True
+    return agent
+
+
+def test_plugin_prompt_is_persisted_and_byte_identical_after_resume(
+    tmp_path, monkeypatch
+):
+    state = {"value": "first", "section_calls": 0, "hint_calls": 0}
+
+    def section(session_info):
+        state["section_calls"] += 1
+        return f"Fixture state: {state['value']} ({session_info['session_id']})"
+
+    def environment_hints(**_kwargs):
+        state["hint_calls"] += 1
+        return {"hints": [("Fixture environment", state["value"])]}
+
+    def make_manager():
+        manager = PluginManager()
+        context = PluginContext(PluginManifest(name="fixture-plugin"), manager)
+        context.register_system_prompt_section(
+            "fixture.rules",
+            section,
+            position="after_memory",
+            max_chars=200,
+        )
+        context.register_hook("build_environment_hints", environment_hints)
+        return manager
+
+    manager = make_manager()
+    monkeypatch.setattr(plugins_module, "_plugin_manager", manager)
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("session-1", "cli")
+        first_agent = _make_agent("session-1", db)
+        _restore_or_build_system_prompt(first_agent, None, [])
+        first_prompt = first_agent._cached_system_prompt
+
+        stored = db.get_session("session-1")
+        assert stored["system_prompt"] == first_prompt
+        assert stored["plugin_prompt_state"]
+        assert state["section_calls"] == 1
+        assert state["hint_calls"] == 1
+
+        # Simulate a process restart with changed plugin state and a new agent.
+        state["value"] = "second"
+        monkeypatch.setattr(plugins_module, "_plugin_manager", make_manager())
+        resumed_agent = _make_agent("session-1", db)
+        _restore_or_build_system_prompt(
+            resumed_agent,
+            None,
+            [{"role": "user", "content": "continue"}],
+        )
+
+        assert resumed_agent._cached_system_prompt.encode(
+            "utf-8"
+        ) == first_prompt.encode("utf-8")
+        assert "Fixture state: first" in resumed_agent._cached_system_prompt
+        assert "Fixture environment: first" in resumed_agent._cached_system_prompt
+        assert state["section_calls"] == 1
+        assert state["hint_calls"] == 1
+
+        # Compression rebuilds use the separately persisted frozen outputs.
+        resumed_agent._invalidate_system_prompt()
+        rebuilt = resumed_agent._build_system_prompt()
+        assert rebuilt == first_prompt
+        assert state["section_calls"] == 1
+        assert state["hint_calls"] == 1
+
+        # A different session evaluates the plugin again and sees new state.
+        db.create_session("session-2", "cli")
+        next_agent = _make_agent("session-2", db)
+        _restore_or_build_system_prompt(next_agent, None, [])
+        assert "Fixture state: second" in next_agent._cached_system_prompt
+        assert "Fixture environment: second" in next_agent._cached_system_prompt
+        assert state["section_calls"] == 2
+        assert state["hint_calls"] == 2
+    finally:
+        db.close()

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -11,6 +11,8 @@ import yaml
 
 from hermes_cli.plugins import (
     ENTRY_POINTS_GROUP,
+    MAX_SYSTEM_PROMPT_SECTIONS,
+    MAX_SYSTEM_PROMPT_SECTIONS_TOTAL_CHARS,
     VALID_HOOKS,
     PluginContext,
     PluginManager,
@@ -634,6 +636,109 @@ class TestPluginHooks:
 
     def test_valid_hooks_include_pre_gateway_dispatch(self):
         assert "pre_gateway_dispatch" in VALID_HOOKS
+
+    def test_valid_hooks_include_environment_hints_not_legacy_static_context(self):
+        assert "build_environment_hints" in VALID_HOOKS
+        assert "static_context" not in VALID_HOOKS
+
+    def test_plugin_registers_named_bounded_system_prompt_section(self, tmp_path, monkeypatch):
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir,
+            "prompt_plugin",
+            register_body=(
+                'ctx.register_system_prompt_section('
+                '"prompt-plugin.rules", '
+                'lambda session_info: f"Session: {session_info[\'session_id\']}", '
+                'position="after_memory", max_chars=100)'
+            ),
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        rendered = mgr.render_system_prompt_sections({"session_id": "s-1"})
+
+        assert [(item.id, item.content, item.position) for item in rendered] == [
+            ("prompt-plugin.rules", "Session: s-1", "after_memory")
+        ]
+        assert mgr.list_system_prompt_sections("prompt_plugin") == [
+            {
+                "id": "prompt-plugin.rules",
+                "plugin": "prompt_plugin",
+                "position": "after_memory",
+                "max_chars": 100,
+                "content_type": "callable",
+            }
+        ]
+
+    def test_system_prompt_section_failures_and_budgets_warn_and_skip(
+        self, caplog
+    ):
+        mgr = PluginManager()
+        ctx = PluginContext(PluginManifest(name="budget-plugin"), mgr)
+
+        def raising(_session_info):
+            raise RuntimeError("boom")
+
+        ctx.register_system_prompt_section("budget.raises", raising)
+        ctx.register_system_prompt_section(
+            "budget.too-large",
+            "x" * 101,
+            max_chars=100,
+        )
+        ctx.register_system_prompt_section(
+            "budget.first",
+            "a" * (MAX_SYSTEM_PROMPT_SECTIONS_TOTAL_CHARS // 2 + 1),
+            max_chars=8_000,
+        )
+        ctx.register_system_prompt_section(
+            "budget.second",
+            "b" * (MAX_SYSTEM_PROMPT_SECTIONS_TOTAL_CHARS // 2 + 1),
+            max_chars=8_000,
+        )
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+            rendered = mgr.render_system_prompt_sections({"session_id": "s-1"})
+
+        assert [item.id for item in rendered] == ["budget.first"]
+        messages = [record.getMessage() for record in caplog.records]
+        assert any("raised and was skipped" in message for message in messages)
+        assert any("exceeded max_chars" in message for message in messages)
+        assert any("total session budget" in message for message in messages)
+
+    def test_system_prompt_section_count_is_bounded(self, caplog):
+        mgr = PluginManager()
+        ctx = PluginContext(PluginManifest(name="many-sections"), mgr)
+        for index in range(MAX_SYSTEM_PROMPT_SECTIONS + 1):
+            ctx.register_system_prompt_section(f"many.{index}", "x")
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+            rendered = mgr.render_system_prompt_sections({"session_id": "s-1"})
+
+        assert len(rendered) == MAX_SYSTEM_PROMPT_SECTIONS
+        assert any(
+            "section limit" in record.getMessage() for record in caplog.records
+        )
+
+    def test_environment_hint_hook_returns_bounded_key_value_rows(self):
+        mgr = PluginManager()
+        ctx = PluginContext(PluginManifest(name="env-plugin"), mgr)
+        ctx.register_hook(
+            "build_environment_hints",
+            lambda **kwargs: {
+                "hints": [
+                    ("Board", kwargs["session_info"]["session_id"]),
+                    ("Plan", "plan-7"),
+                ]
+            },
+        )
+
+        assert mgr.collect_environment_hints("Host: Linux", {"session_id": "s-1"}) == [
+            ("Board", "s-1"),
+            ("Plan", "plan-7"),
+        ]
 
     def test_pre_gateway_dispatch_collects_action_dicts(self, tmp_path, monkeypatch):
         """pre_gateway_dispatch callbacks return action dicts (skip/rewrite/allow)."""

--- a/tests/hermes_cli/test_plugins_cmd_list.py
+++ b/tests/hermes_cli/test_plugins_cmd_list.py
@@ -158,3 +158,43 @@ def test_cmd_list_json_output_includes_entrypoint_source(monkeypatch, capsys):
             "source": "entrypoint",
         }
     ]
+
+
+def test_cmd_show_json_lists_prompt_sections_for_audit(monkeypatch, capsys):
+    from hermes_cli import plugins as plugins_module
+
+    loaded = SimpleNamespace(
+        manifest=SimpleNamespace(name="fixture", version="1.0", source="user"),
+        enabled=True,
+        hooks_registered=["build_environment_hints"],
+        middleware_registered=[],
+        commands_registered=[],
+    )
+    manager = SimpleNamespace(
+        _plugins={"fixture": loaded},
+        list_system_prompt_sections=lambda plugin: [
+            {
+                "id": "fixture.rules",
+                "plugin": plugin,
+                "position": "after_memory",
+                "max_chars": 4000,
+                "content_type": "callable",
+            }
+        ],
+    )
+    monkeypatch.setattr(plugins_module, "discover_plugins", lambda: None)
+    monkeypatch.setattr(plugins_module, "get_plugin_manager", lambda: manager)
+
+    plugins_cmd.cmd_show("fixture", json_output=True)
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["hooks"] == ["build_environment_hints"]
+    assert payload["system_prompt_sections"] == [
+        {
+            "id": "fixture.rules",
+            "plugin": "fixture",
+            "position": "after_memory",
+            "max_chars": 4000,
+            "content_type": "callable",
+        }
+    ]

--- a/tests/hermes_cli/test_subcommands_followup.py
+++ b/tests/hermes_cli/test_subcommands_followup.py
@@ -64,3 +64,17 @@ def test_mcp_and_acp_accept_hooks_flag():
     # acp takes --accept-hooks at top level
     ns = parser.parse_args(["acp", "--accept-hooks"])
     assert ns.accept_hooks is True
+
+
+def test_plugins_show_parser_accepts_name_and_json():
+    parser = argparse.ArgumentParser(prog="hermes")
+    sub = parser.add_subparsers(dest="command")
+    handler = _h("plugins")
+    build_plugins_parser(sub, cmd_plugins=handler)
+
+    ns = parser.parse_args(["plugins", "show", "fixture", "--json"])
+
+    assert ns.plugins_action == "show"
+    assert ns.name == "fixture"
+    assert ns.json is True
+    assert ns.func is handler

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1394,6 +1394,58 @@ class TestBuildSystemPrompt:
         prompt = agent._build_system_prompt()
         assert "NOUS SUBSCRIPTION BLOCK" in prompt
 
+    def test_plugin_prompt_sections_are_positioned_and_evaluated_once(self, agent):
+        from hermes_cli.plugins import RenderedPluginSystemPromptSection
+
+        sections = [
+            RenderedPluginSystemPromptSection(
+                id="test.identity",
+                content="IDENTITY PLUGIN BLOCK",
+                position="after_identity",
+                max_chars=100,
+                plugin="test",
+            ),
+            RenderedPluginSystemPromptSection(
+                id="test.tools",
+                content="TOOLS PLUGIN BLOCK",
+                position="after_tools",
+                max_chars=100,
+                plugin="test",
+            ),
+            RenderedPluginSystemPromptSection(
+                id="test.memory",
+                content="MEMORY PLUGIN BLOCK",
+                position="after_memory",
+                max_chars=100,
+                plugin="test",
+            ),
+        ]
+        with patch(
+            "hermes_cli.plugins.render_system_prompt_sections",
+            return_value=sections,
+        ) as render_sections:
+            first = agent._build_system_prompt(system_message="Custom instruction")
+            second = agent._build_system_prompt(system_message="Custom instruction")
+
+        assert first == second
+        assert first.index("IDENTITY PLUGIN BLOCK") < first.index("Custom instruction")
+        assert first.index("TOOLS PLUGIN BLOCK") < first.index("Custom instruction")
+        assert first.index("Custom instruction") < first.index("MEMORY PLUGIN BLOCK")
+        assert first.index("MEMORY PLUGIN BLOCK") < first.index("Conversation started:")
+        render_sections.assert_called_once()
+
+    def test_plugin_environment_hint_rows_are_frozen(self, agent):
+        with patch(
+            "hermes_cli.plugins.collect_environment_hints",
+            return_value=[("Kanban board", "alpha")],
+        ) as collect_hints:
+            first = agent._build_system_prompt()
+            second = agent._build_system_prompt()
+
+        assert first == second
+        assert "Kanban board: alpha" in first
+        collect_hints.assert_called_once()
+
     def test_skills_prompt_derives_available_toolsets_from_loaded_tools(self):
         tools = _make_tool_defs("web_search", "skills_list", "skill_view", "skill_manage")
         toolset_map = {

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -235,6 +235,13 @@ class TestSessionLifecycle:
         session = db.get_session("s1")
         assert session["system_prompt"] == "You are a helpful assistant."
 
+    def test_update_plugin_prompt_state(self, db):
+        db.create_session(session_id="s1", source="cli")
+        state = '{"version":1,"sections":[],"environment_hints":[]}'
+        db.update_plugin_prompt_state("s1", state)
+
+        assert db.get_session("s1")["plugin_prompt_state"] == state
+
     def test_update_token_counts(self, db):
         db.create_session(session_id="s1", source="cli")
         db.update_token_counts("s1", input_tokens=200, output_tokens=100)
@@ -2184,6 +2191,10 @@ class TestDeleteAndExport:
             git_branch="feature/import",
             git_repo_root="/workspace/project",
         )
+        plugin_prompt_state = (
+            '{"version":1,"sections":[],"environment_hints":[]}'
+        )
+        db.update_plugin_prompt_state("s1", plugin_prompt_state)
         db.append_message("s1", role="user", content="Hello", timestamp=10)
         db.append_message(
             "s1",
@@ -2214,6 +2225,7 @@ class TestDeleteAndExport:
             assert imported["cwd"] == "/workspace/project"
             assert imported["git_branch"] == "feature/import"
             assert imported["git_repo_root"] == "/workspace/project"
+            assert imported["plugin_prompt_state"] == plugin_prompt_state
             assert imported["message_count"] == 2
             assert imported["tool_call_count"] == 1
             assert imported["handoff_state"] is None
@@ -5939,6 +5951,7 @@ class TestCompactRows:
         rows = db.list_sessions_rich(compact_rows=True)
         assert len(rows) == 1
         assert "system_prompt" not in rows[0]
+        assert "plugin_prompt_state" not in rows[0]
 
     def test_full_rows_include_system_prompt(self, db):
         self._create(db, "s1", system_prompt="keep me")
@@ -5990,12 +6003,13 @@ class TestCompactRows:
             row[1] for row in db._conn.execute("PRAGMA table_info(sessions)")
         }
         row = db.list_sessions_rich(compact_rows=True)[0]
-        # Hardcode the one sanctioned exclusion: if the excluded set ever
+        # Hardcode the sanctioned prompt-payload exclusions: if the set ever
         # widens (or the projection silently drops a column), this fails and
         # forces a conscious review of what list consumers lose.
-        missing = live_cols - set(row) - {"system_prompt"}
+        missing = live_cols - set(row) - {"system_prompt", "plugin_prompt_state"}
         assert not missing, f"compact projection lost schema columns: {missing}"
         assert "system_prompt" not in row
+        assert "plugin_prompt_state" not in row
 
     def test_compact_rows_tip_projection_omits_system_prompt(self, db):
         """Compression-tip projection must not reintroduce the blob: the

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2429,7 +2429,15 @@ def _persist_live_session_system_prompt(session: dict | None) -> None:
     try:
         prompt = agent._build_system_prompt(None)
         agent._cached_system_prompt = prompt
-        db.update_system_prompt(getattr(agent, "session_id", None) or session_key, prompt)
+        persisted_session_id = getattr(agent, "session_id", None) or session_key
+        db.update_system_prompt(persisted_session_id, prompt)
+        if hasattr(db, "update_plugin_prompt_state"):
+            from agent.system_prompt import serialize_plugin_prompt_state
+
+            db.update_plugin_prompt_state(
+                persisted_session_id,
+                serialize_plugin_prompt_state(agent),
+            )
     except Exception:
         logger.debug("failed to persist live session system prompt", exc_info=True)
 

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -362,16 +362,23 @@ def register(ctx):
     ctx.register_hook("pre_tool_call", my_tool_observer)
     ctx.register_hook("post_tool_call", my_tool_logger)
     ctx.register_hook("pre_llm_call", my_memory_callback)
+    ctx.register_hook("build_environment_hints", my_environment_hints)
     ctx.register_hook("post_llm_call", my_sync_callback)
     ctx.register_hook("on_session_start", my_init_callback)
     ctx.register_hook("on_session_end", my_cleanup_callback)
+    ctx.register_system_prompt_section(
+        id="myplugin.rules",
+        content=lambda session_info: "Stable plugin rules",
+        position="after_memory",
+        max_chars=4000,
+    )
 ```
 
 **General rules for all hooks:**
 
-- Callbacks receive **keyword arguments**. Always accept `**kwargs` for forward compatibility — new parameters may be added in future versions without breaking your plugin.
+- Hook callbacks receive **keyword arguments**. Always accept `**kwargs` for forward compatibility — new parameters may be added in future versions without breaking your plugin.
 - If a callback **crashes**, it's logged and skipped. Other hooks and the agent continue normally. A misbehaving plugin can never break the agent.
-- Two hooks' return values affect behavior: [`pre_tool_call`](#pre_tool_call) can **block** the tool, and [`pre_llm_call`](#pre_llm_call) can **inject context** into the LLM call. All other hooks are fire-and-forget observers.
+- Three hooks' return values affect behavior: [`pre_tool_call`](#pre_tool_call) can **block** the tool, [`pre_llm_call`](#pre_llm_call) can **inject context** into the LLM call, and [`build_environment_hints`](#build_environment_hints) can append bounded execution-environment rows. All other hooks are fire-and-forget observers or transforms.
 - Observer callbacks receive `telemetry_schema_version` automatically. When present, `turn_id`, `api_request_id`, `task_id`, `session_id`, and `api_call_count` are separate correlation fields. Treat `api_request_id` as an opaque identifier; do not parse its string format.
 
 ### Quick reference
@@ -381,6 +388,7 @@ def register(ctx):
 | [`pre_tool_call`](#pre_tool_call) | Before any tool executes | `{"action": "block", "message": str}` to veto the call |
 | [`post_tool_call`](#post_tool_call) | After any tool returns | ignored |
 | [`pre_llm_call`](#pre_llm_call) | Once per turn, before the tool-calling loop | `{"context": str}` to prepend context to the user message |
+| [`build_environment_hints`](#build_environment_hints) | Once during new-session prompt assembly | `{"hints": [(key, value), ...]}` to append rows |
 | [`post_llm_call`](#post_llm_call) | Once per turn, after the tool-calling loop | ignored |
 | [`pre_verify`](#pre_verify) | Once per turn when the agent edited code, before it verifies/finishes | `{"action": "continue", "message": str}` to keep going |
 | [`on_session_start`](#on_session_start) | New session created (first turn only) | ignored |
@@ -587,6 +595,71 @@ def guardrails(**kwargs):
 def register(ctx):
     ctx.register_hook("pre_llm_call", guardrails)
 ```
+
+---
+
+### Cache-safe system prompt sections
+
+Use `ctx.register_system_prompt_section()` for plugin context that should be
+available every turn without being re-injected through `pre_llm_call`:
+
+```python
+def register(ctx):
+    ctx.register_system_prompt_section(
+        id="myplugin.rules",
+        content=lambda session_info: (
+            f"## My Plugin Rules\nSession: {session_info['session_id']}"
+        ),
+        position="after_memory",
+        max_chars=4000,
+    )
+```
+
+The `id` must be unique and uses letters, numbers, `.`, `_`, or `-`. `content`
+may be a string or a callable that receives an immutable mapping containing
+`session_id`, `model`, `provider`, `platform`, `profile_name`, and `cwd`.
+
+Allowed positions are `after_identity`, `after_tools`, and `after_memory`.
+Hermes does not allow arbitrary replacement or reordering of core prompt
+content. A section can request at most 8,000 characters; the default is 4,000,
+Hermes accepts at most 32 sections, and all rendered blocks (including their
+headings) share a 12,000-character session budget. Raising, invalid, or
+over-budget sections are skipped with a warning.
+
+The callable is evaluated exactly once for a new session. Its rendered output
+is frozen, stored with the assembled prompt, restored after a process restart,
+and reused during compression rebuilds. Plugin state changes therefore affect
+the next session only. Use `pre_llm_call` for per-turn or recalled context.
+
+Run `hermes plugins show <name>` to inspect registered section IDs, positions,
+budgets, and content types without evaluating their content.
+
+---
+
+### `build_environment_hints`
+
+Fires once while Hermes assembles a new session's execution-environment block.
+It may append key-value rows but cannot replace core host/backend hints.
+
+```python
+def environment_hints(**kwargs):
+    session_info = kwargs["session_info"]
+    return {
+        "hints": [
+            ("Kanban board", "production"),
+            ("Session surface", session_info["platform"]),
+        ]
+    }
+
+def register(ctx):
+    ctx.register_hook("build_environment_hints", environment_hints)
+```
+
+Rows must be non-empty, single-line key/value pairs. Hermes accepts at most 20
+rows, 500 characters per row, and 2,000 characters total. Invalid,
+over-budget, or raising callbacks are skipped with warnings. Accepted rows use
+the same freeze, persistence, resume, and next-session-only rules as system
+prompt sections.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `static_context` as a no-argument plugin hook for plugin-owned static prompt documentation.
- Collect non-empty string returns into the cached system prompt stable tier under `## Plugin Static Context`.
- Document the hook and cover the no-argument contract plus stable-tier prompt placement with tests.

Fixes #50203

## Notes
This keeps dynamic plugin data in `pre_llm_call` user-message context. `static_context` is only for stable legends or documentation that should be cached with the session system prompt.

## Testing
- `uv run --extra dev pytest tests/hermes_cli/test_plugins.py tests/run_agent/test_run_agent.py::TestBuildSystemPrompt tests/agent/test_system_prompt_restore.py tests/run_agent/test_background_review_cache_parity.py -q`
- `uv run --extra dev ruff check hermes_cli/plugins.py agent/system_prompt.py tests/hermes_cli/test_plugins.py tests/run_agent/test_run_agent.py`
- `python -m py_compile hermes_cli/plugins.py agent/system_prompt.py`
- `git diff --check bb7ff7dc302cbcbe41cf6bc09424ffc9fb2d062f...HEAD`
- `git merge-tree --write-tree HEAD origin/main`