### PR TITLE
feat(memory): Add support for Turso memory as an external provider

### DIFF
--- a/plugins/memory/turso/README.md
+++ b/plugins/memory/turso/README.md
@@ -25,7 +25,7 @@ Behavioral settings are stored in `$HERMES_HOME/turso.json`.
 | `sync_enabled` | `false` | Enable best-effort Turso Cloud sync hooks |
 | `top_k` | `6` | Number of memories returned by automatic prefetch |
 | `min_similarity` | `0.15` | Minimum retrieval score for automatic prefetch |
-| `auto_capture` | `false` | Store completed turns as searchable conversation memories |
+| `auto_capture` | `false` | When enabled, Hermes auto-stores each completed user/assistant turn as searchable Turso memory. Leave off for higher-signal explicit/mirrored memory only. |
 
 Secrets belong in `$HERMES_HOME/.env`:
 
@@ -45,4 +45,3 @@ Secrets belong in `$HERMES_HOME/.env`:
 | `turso_memory_sync` | Report or trigger best-effort sync status |
 
 Use the built-in `memory` tool for compact, always-on curated facts. Use Turso memory for deeper searchable recall.
-

--- a/plugins/memory/turso/README.md
+++ b/plugins/memory/turso/README.md
@@ -1,0 +1,48 @@
+# Turso Memory Provider
+
+Local-first semantic memory for Hermes using a SQLite-compatible Turso-style store, with optional Turso Cloud sync.
+
+## Setup
+
+```bash
+hermes memory setup
+# select "turso"
+```
+
+Or manually:
+
+```bash
+hermes config set memory.provider turso
+```
+
+## Config
+
+Behavioral settings are stored in `$HERMES_HOME/turso.json`.
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `db_path` | `$HERMES_HOME/turso-memory.db` | Local SQLite-compatible database path |
+| `sync_enabled` | `false` | Enable best-effort Turso Cloud sync hooks |
+| `top_k` | `6` | Number of memories returned by automatic prefetch |
+| `min_similarity` | `0.15` | Minimum retrieval score for automatic prefetch |
+| `auto_capture` | `false` | Store completed turns as searchable conversation memories |
+
+Secrets belong in `$HERMES_HOME/.env`:
+
+| Env Var | Description |
+|---------|-------------|
+| `TURSO_DATABASE_URL` | Optional remote Turso database URL |
+| `TURSO_AUTH_TOKEN` | Optional Turso auth token |
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `turso_memory_search` | Search long-term memory |
+| `turso_memory_add` | Store a durable fact, preference, decision, or note |
+| `turso_memory_update` | Update a memory by ID |
+| `turso_memory_delete` | Delete a memory by ID |
+| `turso_memory_sync` | Report or trigger best-effort sync status |
+
+Use the built-in `memory` tool for compact, always-on curated facts. Use Turso memory for deeper searchable recall.
+

--- a/plugins/memory/turso/__init__.py
+++ b/plugins/memory/turso/__init__.py
@@ -245,12 +245,34 @@ class TursoMemoryProvider(MemoryProvider):
 
         return [
             {"key": "db_path", "description": "Local Turso/SQLite database path", "default": f"{display_hermes_home()}/turso-memory.db"},
-            {"key": "sync_enabled", "description": "Enable Turso Cloud sync", "default": "false", "choices": ["false", "true"]},
-            {"key": "database_url", "description": "Turso database URL", "secret": True, "required": False, "env_var": "TURSO_DATABASE_URL"},
-            {"key": "auth_token", "description": "Turso auth token", "secret": True, "required": False, "env_var": "TURSO_AUTH_TOKEN"},
+            {"key": "sync_enabled", "description": "Enable Turso Cloud sync", "default": "no", "choices": ["no", "yes"]},
+            {
+                "key": "database_url",
+                "description": "Turso database URL",
+                "secret": True,
+                "required": False,
+                "env_var": "TURSO_DATABASE_URL",
+                "when": {"sync_enabled": "yes"},
+            },
+            {
+                "key": "auth_token",
+                "description": "Turso auth token",
+                "secret": True,
+                "required": False,
+                "env_var": "TURSO_AUTH_TOKEN",
+                "when": {"sync_enabled": "yes"},
+            },
             {"key": "top_k", "description": "Automatic prefetch result count", "default": str(_DEFAULT_TOP_K)},
             {"key": "min_similarity", "description": "Minimum automatic prefetch score", "default": str(_DEFAULT_MIN_SIMILARITY)},
-            {"key": "auto_capture", "description": "Capture completed turns", "default": "false", "choices": ["false", "true"]},
+            {
+                "key": "auto_capture",
+                "description": (
+                    "Hermes auto-stores each completed user/assistant turn in Turso memory "
+                    "(no = only explicit/mirrored memory writes; recommended)"
+                ),
+                "default": "no",
+                "choices": ["no", "yes"],
+            },
         ]
 
     def save_config(self, values, hermes_home):

--- a/plugins/memory/turso/__init__.py
+++ b/plugins/memory/turso/__init__.py
@@ -1,0 +1,582 @@
+"""Turso memory provider for Hermes.
+
+Local-first, profile-scoped semantic memory using SQLite-compatible storage.
+The provider is intentionally additive: built-in MEMORY.md / USER.md remains
+the compact always-on memory, while Turso stores deeper searchable recall.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import math
+import os
+import re
+import sqlite3
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from agent.memory_provider import MemoryProvider
+from tools.registry import tool_error
+from utils import atomic_json_write
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TOP_K = 6
+_DEFAULT_MIN_SIMILARITY = 0.15
+_DEFAULT_DIM = 64
+_MIN_CAPTURE_CHARS = 40
+
+
+SEARCH_SCHEMA = {
+    "name": "turso_memory_search",
+    "description": "Search Turso long-term memory. Use for deeper recall beyond compact built-in memory.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Search query."},
+            "top_k": {"type": "integer", "description": "Maximum results, default 6, max 20."},
+            "kind": {"type": "string", "description": "Optional memory kind filter."},
+        },
+        "required": ["query"],
+    },
+}
+
+ADD_SCHEMA = {
+    "name": "turso_memory_add",
+    "description": "Store a durable fact, preference, decision, or note in Turso memory.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string", "description": "Memory content to store."},
+            "kind": {
+                "type": "string",
+                "enum": ["fact", "preference", "decision", "instruction", "conversation", "note"],
+                "description": "Memory category, default fact.",
+            },
+            "source": {"type": "string", "description": "Optional provenance label."},
+            "weight": {"type": "number", "description": "Importance weight 0.1-3.0, default 1.0."},
+        },
+        "required": ["content"],
+    },
+}
+
+UPDATE_SCHEMA = {
+    "name": "turso_memory_update",
+    "description": "Update a Turso memory by ID.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "memory_id": {"type": "string", "description": "Memory ID."},
+            "content": {"type": "string", "description": "Replacement content."},
+            "kind": {"type": "string", "description": "Optional replacement kind."},
+            "weight": {"type": "number", "description": "Optional replacement weight."},
+        },
+        "required": ["memory_id", "content"],
+    },
+}
+
+DELETE_SCHEMA = {
+    "name": "turso_memory_delete",
+    "description": "Delete a Turso memory by ID.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "memory_id": {"type": "string", "description": "Memory ID to delete."},
+        },
+        "required": ["memory_id"],
+    },
+}
+
+SYNC_SCHEMA = {
+    "name": "turso_memory_sync",
+    "description": "Show or trigger best-effort Turso memory sync status.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {"type": "string", "enum": ["status", "sync"], "description": "Default status."},
+        },
+        "required": [],
+    },
+}
+
+
+def _as_bool(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "y", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "n", "off"}:
+            return False
+    return default
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+def _normalize_text(text: str) -> str:
+    return re.sub(r"\s+", " ", text or "").strip()
+
+
+def _default_config(hermes_home: str) -> dict:
+    return {
+        "db_path": str(Path(hermes_home) / "turso-memory.db"),
+        "sync_enabled": False,
+        "top_k": _DEFAULT_TOP_K,
+        "min_similarity": _DEFAULT_MIN_SIMILARITY,
+        "auto_capture": False,
+        "embedding_dim": _DEFAULT_DIM,
+    }
+
+
+def _load_config(hermes_home: str) -> dict:
+    config = _default_config(hermes_home)
+    path = Path(hermes_home) / "turso.json"
+    if path.exists():
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(raw, dict):
+                config.update({k: v for k, v in raw.items() if v is not None})
+        except Exception:
+            logger.debug("Failed to parse %s", path, exc_info=True)
+    config["sync_enabled"] = _as_bool(config.get("sync_enabled"), False)
+    config["auto_capture"] = _as_bool(config.get("auto_capture"), False)
+    try:
+        config["top_k"] = max(1, min(20, int(config.get("top_k", _DEFAULT_TOP_K))))
+    except Exception:
+        config["top_k"] = _DEFAULT_TOP_K
+    try:
+        config["min_similarity"] = max(0.0, min(1.0, float(config.get("min_similarity", _DEFAULT_MIN_SIMILARITY))))
+    except Exception:
+        config["min_similarity"] = _DEFAULT_MIN_SIMILARITY
+    try:
+        config["embedding_dim"] = max(16, min(512, int(config.get("embedding_dim", _DEFAULT_DIM))))
+    except Exception:
+        config["embedding_dim"] = _DEFAULT_DIM
+    db_path = str(config.get("db_path") or "")
+    config["db_path"] = db_path.replace("$HERMES_HOME", hermes_home).replace("${HERMES_HOME}", hermes_home)
+    return config
+
+
+def _save_config(values: dict, hermes_home: str) -> None:
+    path = Path(hermes_home) / "turso.json"
+    existing: dict = {}
+    if path.exists():
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(raw, dict):
+                existing = raw
+        except Exception:
+            existing = {}
+    cleaned = dict(values)
+    cleaned.pop("auth_token", None)
+    cleaned.pop("api_key", None)
+    cleaned.pop("database_url", None)
+    existing.update(cleaned)
+    atomic_json_write(path, existing, mode=0o600, sort_keys=True)
+
+
+class _LocalEmbedder:
+    """Deterministic lexical embedding.
+
+    This keeps local-only mode and tests useful without making LLM or network
+    calls. It is not a replacement for model embeddings, but it gives stable
+    semantic-ish retrieval based on normalized token features.
+    """
+
+    def __init__(self, dim: int = _DEFAULT_DIM):
+        self.dim = dim
+
+    def embed(self, text: str) -> list[float]:
+        vec = [0.0] * self.dim
+        tokens = re.findall(r"[a-zA-Z0-9_./-]+", (text or "").lower())
+        for token in tokens:
+            digest = hashlib.blake2b(token.encode("utf-8"), digest_size=8).digest()
+            idx = int.from_bytes(digest[:4], "big") % self.dim
+            sign = 1.0 if digest[4] & 1 else -1.0
+            vec[idx] += sign
+        norm = math.sqrt(sum(v * v for v in vec)) or 1.0
+        return [v / norm for v in vec]
+
+
+def _cosine(a: list[float], b: list[float]) -> float:
+    if not a or not b:
+        return 0.0
+    n = min(len(a), len(b))
+    return sum(a[i] * b[i] for i in range(n))
+
+
+def _keyword_score(query: str, content: str) -> float:
+    q = set(re.findall(r"[a-zA-Z0-9_./-]+", query.lower()))
+    c = set(re.findall(r"[a-zA-Z0-9_./-]+", content.lower()))
+    if not q or not c:
+        return 0.0
+    return len(q & c) / len(q)
+
+
+class TursoMemoryProvider(MemoryProvider):
+    """Local-first Turso memory provider."""
+
+    def __init__(self, config: Optional[dict] = None):
+        self._config_override = config
+        self._config: dict = config or {}
+        self._conn: sqlite3.Connection | None = None
+        self._embedder = _LocalEmbedder()
+        self._session_id = ""
+        self._hermes_home = ""
+        self._last_sync_error = ""
+        self._last_sync_at = 0
+
+    @property
+    def name(self) -> str:
+        return "turso"
+
+    def is_available(self) -> bool:
+        return True
+
+    def get_config_schema(self):
+        from hermes_constants import display_hermes_home
+
+        return [
+            {"key": "db_path", "description": "Local Turso/SQLite database path", "default": f"{display_hermes_home()}/turso-memory.db"},
+            {"key": "sync_enabled", "description": "Enable Turso Cloud sync", "default": "false", "choices": ["false", "true"]},
+            {"key": "database_url", "description": "Turso database URL", "secret": True, "required": False, "env_var": "TURSO_DATABASE_URL"},
+            {"key": "auth_token", "description": "Turso auth token", "secret": True, "required": False, "env_var": "TURSO_AUTH_TOKEN"},
+            {"key": "top_k", "description": "Automatic prefetch result count", "default": str(_DEFAULT_TOP_K)},
+            {"key": "min_similarity", "description": "Minimum automatic prefetch score", "default": str(_DEFAULT_MIN_SIMILARITY)},
+            {"key": "auto_capture", "description": "Capture completed turns", "default": "false", "choices": ["false", "true"]},
+        ]
+
+    def save_config(self, values, hermes_home):
+        _save_config(values, hermes_home)
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        self._session_id = session_id
+        self._hermes_home = str(kwargs.get("hermes_home") or "")
+        if not self._hermes_home:
+            from hermes_constants import get_hermes_home
+            self._hermes_home = str(get_hermes_home())
+        self._config = dict(self._config_override or _load_config(self._hermes_home))
+        self._embedder = _LocalEmbedder(int(self._config.get("embedding_dim", _DEFAULT_DIM)))
+        db_path = Path(str(self._config["db_path"])).expanduser()
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(db_path), check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._migrate()
+
+    def system_prompt_block(self) -> str:
+        count = 0
+        if self._conn:
+            try:
+                count = int(self._conn.execute("SELECT COUNT(*) FROM memories").fetchone()[0])
+            except Exception:
+                count = 0
+        return (
+            "# Turso Memory\n"
+            f"Active. {count} searchable memories stored. "
+            "Use turso_memory_search for deep recall and the built-in memory tool for compact always-on facts."
+        )
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if not query or not self._conn:
+            return ""
+        results = self._search(query, top_k=int(self._config.get("top_k", _DEFAULT_TOP_K)))
+        min_score = float(self._config.get("min_similarity", _DEFAULT_MIN_SIMILARITY))
+        results = [r for r in results if float(r.get("score", 0.0)) >= min_score]
+        if not results:
+            return ""
+        lines = [
+            f"- [{item['score']:.2f}] ({item['kind']}) {item['content']}"
+            for item in results
+        ]
+        return "## Turso Memory\n" + "\n".join(lines)
+
+    def sync_turn(self, user_content, assistant_content, *, session_id="", messages=None):
+        if not _as_bool(self._config.get("auto_capture"), False):
+            return
+        user = _normalize_text(str(user_content or ""))
+        assistant = _normalize_text(str(assistant_content or ""))
+        if len(user) + len(assistant) < _MIN_CAPTURE_CHARS:
+            return
+        content = f"User: {user}\nAssistant: {assistant}"
+        self._add_memory(
+            content,
+            kind="conversation",
+            source="turn",
+            session_id=session_id or self._session_id,
+            metadata={"captured_from": "sync_turn"},
+        )
+
+    def on_memory_write(self, action, target, content, metadata=None):
+        if action == "remove":
+            self._mark_removed_by_content(content or str((metadata or {}).get("old_text", "")), target)
+            return
+        if action == "replace":
+            old = str((metadata or {}).get("old_text", ""))
+            if old:
+                self._mark_removed_by_content(old, target)
+        if content:
+            self._add_memory(
+                str(content),
+                kind="preference" if target == "user" else "fact",
+                source=f"builtin:{action}",
+                target=target,
+                session_id=str((metadata or {}).get("session_id") or self._session_id),
+                metadata=metadata or {},
+            )
+
+    def on_session_end(self, messages):
+        self._sync_if_configured()
+
+    def shutdown(self):
+        self._sync_if_configured()
+        if self._conn:
+            self._conn.close()
+            self._conn = None
+
+    def get_tool_schemas(self):
+        return [SEARCH_SCHEMA, ADD_SCHEMA, UPDATE_SCHEMA, DELETE_SCHEMA, SYNC_SCHEMA]
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
+        try:
+            if tool_name == "turso_memory_search":
+                query = str(args.get("query") or "").strip()
+                if not query:
+                    return tool_error("query is required")
+                top_k = max(1, min(20, int(args.get("top_k") or self._config.get("top_k", _DEFAULT_TOP_K))))
+                return json.dumps({"success": True, "results": self._search(query, top_k=top_k, kind=args.get("kind"))})
+            if tool_name == "turso_memory_add":
+                content = str(args.get("content") or "").strip()
+                if not content:
+                    return tool_error("content is required")
+                item = self._add_memory(
+                    content,
+                    kind=str(args.get("kind") or "fact"),
+                    source=str(args.get("source") or "tool"),
+                    weight=float(args.get("weight") or 1.0),
+                    session_id=str(kwargs.get("session_id") or self._session_id),
+                )
+                return json.dumps({"success": True, "memory": item})
+            if tool_name == "turso_memory_update":
+                memory_id = str(args.get("memory_id") or "").strip()
+                content = str(args.get("content") or "").strip()
+                if not memory_id or not content:
+                    return tool_error("memory_id and content are required")
+                return json.dumps(self._update_memory(memory_id, content, kind=args.get("kind"), weight=args.get("weight")))
+            if tool_name == "turso_memory_delete":
+                memory_id = str(args.get("memory_id") or "").strip()
+                if not memory_id:
+                    return tool_error("memory_id is required")
+                return json.dumps(self._delete_memory(memory_id))
+            if tool_name == "turso_memory_sync":
+                action = str(args.get("action") or "status")
+                if action == "sync":
+                    self._sync_if_configured()
+                return json.dumps({"success": True, "sync": self._sync_status()})
+            return tool_error(f"Unknown Turso memory tool: {tool_name}")
+        except Exception as e:
+            logger.debug("Turso tool %s failed", tool_name, exc_info=True)
+            return tool_error(str(e))
+
+    def backup_paths(self) -> list[str]:
+        db_path = self._config.get("db_path")
+        return [str(db_path)] if db_path else []
+
+    def _migrate(self) -> None:
+        assert self._conn is not None
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS memories (
+                id TEXT PRIMARY KEY,
+                content TEXT NOT NULL,
+                kind TEXT NOT NULL DEFAULT 'fact',
+                source TEXT NOT NULL DEFAULT 'tool',
+                target TEXT NOT NULL DEFAULT '',
+                session_id TEXT NOT NULL DEFAULT '',
+                embedding_json TEXT NOT NULL,
+                metadata_json TEXT NOT NULL DEFAULT '{}',
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL,
+                last_retrieved INTEGER NOT NULL DEFAULT 0,
+                retrieval_count INTEGER NOT NULL DEFAULT 0,
+                weight REAL NOT NULL DEFAULT 1.0,
+                deleted_at INTEGER NOT NULL DEFAULT 0
+            )
+            """
+        )
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_turso_memories_kind ON memories(kind)")
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_turso_memories_deleted ON memories(deleted_at)")
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS memory_events (
+                id TEXT PRIMARY KEY,
+                memory_id TEXT NOT NULL,
+                action TEXT NOT NULL,
+                metadata_json TEXT NOT NULL DEFAULT '{}',
+                created_at INTEGER NOT NULL
+            )
+            """
+        )
+        self._conn.commit()
+
+    def _add_memory(
+        self,
+        content: str,
+        *,
+        kind: str = "fact",
+        source: str = "tool",
+        target: str = "",
+        session_id: str = "",
+        weight: float = 1.0,
+        metadata: Optional[dict] = None,
+    ) -> dict:
+        assert self._conn is not None
+        clean = _normalize_text(content)
+        memory_id = uuid.uuid4().hex
+        ts = _now()
+        embedding = self._embedder.embed(clean)
+        weight = max(0.1, min(3.0, float(weight)))
+        self._conn.execute(
+            """
+            INSERT INTO memories
+            (id, content, kind, source, target, session_id, embedding_json, metadata_json,
+             created_at, updated_at, weight)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                memory_id,
+                clean,
+                kind or "fact",
+                source or "tool",
+                target or "",
+                session_id or "",
+                json.dumps(embedding),
+                json.dumps(metadata or {}, sort_keys=True),
+                ts,
+                ts,
+                weight,
+            ),
+        )
+        self._event(memory_id, "add", metadata or {})
+        self._conn.commit()
+        return {"id": memory_id, "content": clean, "kind": kind or "fact", "source": source or "tool", "weight": weight}
+
+    def _search(self, query: str, *, top_k: int, kind: Any = None) -> list[dict]:
+        assert self._conn is not None
+        q_embedding = self._embedder.embed(query)
+        params: list[Any] = []
+        where = "deleted_at = 0"
+        if kind:
+            where += " AND kind = ?"
+            params.append(str(kind))
+        rows = self._conn.execute(
+            f"SELECT * FROM memories WHERE {where} ORDER BY updated_at DESC LIMIT 500",
+            params,
+        ).fetchall()
+        scored: list[dict] = []
+        for row in rows:
+            try:
+                embedding = json.loads(row["embedding_json"])
+            except Exception:
+                embedding = []
+            score = max(_cosine(q_embedding, embedding), _keyword_score(query, row["content"])) * float(row["weight"])
+            if score <= 0:
+                continue
+            scored.append({
+                "id": row["id"],
+                "content": row["content"],
+                "kind": row["kind"],
+                "source": row["source"],
+                "target": row["target"],
+                "session_id": row["session_id"],
+                "score": round(float(score), 4),
+                "created_at": row["created_at"],
+                "updated_at": row["updated_at"],
+                "retrieval_count": row["retrieval_count"],
+            })
+        scored.sort(key=lambda item: item["score"], reverse=True)
+        selected = scored[:top_k]
+        if selected:
+            ts = _now()
+            self._conn.executemany(
+                "UPDATE memories SET last_retrieved = ?, retrieval_count = retrieval_count + 1 WHERE id = ?",
+                [(ts, item["id"]) for item in selected],
+            )
+            self._conn.commit()
+        return selected
+
+    def _update_memory(self, memory_id: str, content: str, *, kind: Any = None, weight: Any = None) -> dict:
+        assert self._conn is not None
+        clean = _normalize_text(content)
+        row = self._conn.execute("SELECT * FROM memories WHERE id = ? AND deleted_at = 0", (memory_id,)).fetchone()
+        if not row:
+            return {"success": False, "error": f"memory not found: {memory_id}"}
+        new_kind = str(kind or row["kind"])
+        new_weight = float(weight if weight is not None else row["weight"])
+        self._conn.execute(
+            "UPDATE memories SET content = ?, kind = ?, weight = ?, embedding_json = ?, updated_at = ? WHERE id = ?",
+            (clean, new_kind, max(0.1, min(3.0, new_weight)), json.dumps(self._embedder.embed(clean)), _now(), memory_id),
+        )
+        self._event(memory_id, "update", {"kind": new_kind})
+        self._conn.commit()
+        return {"success": True, "memory": {"id": memory_id, "content": clean, "kind": new_kind}}
+
+    def _delete_memory(self, memory_id: str) -> dict:
+        assert self._conn is not None
+        cur = self._conn.execute("UPDATE memories SET deleted_at = ?, updated_at = ? WHERE id = ? AND deleted_at = 0", (_now(), _now(), memory_id))
+        if cur.rowcount <= 0:
+            return {"success": False, "error": f"memory not found: {memory_id}"}
+        self._event(memory_id, "delete", {})
+        self._conn.commit()
+        return {"success": True, "deleted": memory_id}
+
+    def _mark_removed_by_content(self, content: str, target: str = "") -> None:
+        if not content or not self._conn:
+            return
+        pattern = f"%{content}%"
+        self._conn.execute(
+            "UPDATE memories SET deleted_at = ?, updated_at = ? WHERE deleted_at = 0 AND content LIKE ? AND (? = '' OR target = ?)",
+            (_now(), _now(), pattern, target or "", target or ""),
+        )
+        self._conn.commit()
+
+    def _event(self, memory_id: str, action: str, metadata: dict) -> None:
+        assert self._conn is not None
+        self._conn.execute(
+            "INSERT INTO memory_events (id, memory_id, action, metadata_json, created_at) VALUES (?, ?, ?, ?, ?)",
+            (uuid.uuid4().hex, memory_id, action, json.dumps(metadata or {}, sort_keys=True), _now()),
+        )
+
+    def _sync_status(self) -> dict:
+        enabled = _as_bool(self._config.get("sync_enabled"), False)
+        return {
+            "enabled": enabled,
+            "configured": bool(os.environ.get("TURSO_DATABASE_URL") and os.environ.get("TURSO_AUTH_TOKEN")),
+            "last_sync_at": self._last_sync_at,
+            "last_error": self._last_sync_error,
+        }
+
+    def _sync_if_configured(self) -> None:
+        if not _as_bool(self._config.get("sync_enabled"), False):
+            return
+        if not (os.environ.get("TURSO_DATABASE_URL") and os.environ.get("TURSO_AUTH_TOKEN")):
+            self._last_sync_error = "TURSO_DATABASE_URL and TURSO_AUTH_TOKEN are required for sync"
+            return
+        try:
+            # Placeholder for pyturso/libSQL sync once the runtime dependency
+            # is installed and configured. Local memory remains fully usable.
+            __import__("turso")
+            self._last_sync_at = _now()
+            self._last_sync_error = ""
+        except Exception as e:
+            self._last_sync_error = f"Turso sync unavailable: {e}"
+
+
+def register(ctx) -> None:
+    ctx.register_memory_provider(TursoMemoryProvider())

--- a/plugins/memory/turso/plugin.yaml
+++ b/plugins/memory/turso/plugin.yaml
@@ -1,0 +1,6 @@
+name: turso
+version: 0.1.0
+description: "Turso memory — local-first SQLite-compatible semantic memory with optional Turso Cloud sync."
+hooks:
+  - on_memory_write
+  - on_session_end

--- a/tests/turso_plugin/test_turso_memory.py
+++ b/tests/turso_plugin/test_turso_memory.py
@@ -1,0 +1,112 @@
+import json
+import sqlite3
+
+from agent.memory_manager import MemoryManager, inject_memory_provider_tools
+from plugins.memory.turso import TursoMemoryProvider
+
+
+def test_turso_provider_crud_and_prefetch(tmp_path):
+    provider = TursoMemoryProvider({"db_path": str(tmp_path / "memory.db"), "top_k": 3, "min_similarity": 0.0})
+    provider.initialize("sess-1", hermes_home=str(tmp_path))
+
+    added = json.loads(provider.handle_tool_call("turso_memory_add", {
+        "content": "User prefers Rust for backend services",
+        "kind": "preference",
+    }))
+    assert added["success"] is True
+    memory_id = added["memory"]["id"]
+
+    search = json.loads(provider.handle_tool_call("turso_memory_search", {"query": "Rust backend"}))
+    assert search["success"] is True
+    assert search["results"][0]["id"] == memory_id
+
+    context = provider.prefetch("Which backend language should I use?")
+    assert "Turso Memory" in context
+    assert "Rust" in context
+
+    updated = json.loads(provider.handle_tool_call("turso_memory_update", {
+        "memory_id": memory_id,
+        "content": "User prefers Go for backend services",
+    }))
+    assert updated["success"] is True
+
+    deleted = json.loads(provider.handle_tool_call("turso_memory_delete", {"memory_id": memory_id}))
+    assert deleted["success"] is True
+
+    empty = json.loads(provider.handle_tool_call("turso_memory_search", {"query": "backend services"}))
+    assert empty["results"] == []
+
+
+def test_turso_provider_uses_profile_scoped_default_db(tmp_path):
+    provider = TursoMemoryProvider()
+    provider.initialize("sess-1", hermes_home=str(tmp_path))
+
+    provider.handle_tool_call("turso_memory_add", {"content": "Profile-local memory"})
+
+    db_path = tmp_path / "turso-memory.db"
+    assert db_path.exists()
+    conn = sqlite3.connect(db_path)
+    try:
+        count = conn.execute("SELECT COUNT(*) FROM memories").fetchone()[0]
+    finally:
+        conn.close()
+    assert count == 1
+
+
+def test_turso_provider_mirrors_builtin_memory_writes(tmp_path):
+    provider = TursoMemoryProvider({"db_path": str(tmp_path / "memory.db"), "min_similarity": 0.0})
+    provider.initialize("sess-1", hermes_home=str(tmp_path))
+
+    provider.on_memory_write("add", "user", "User likes terse answers", {"session_id": "sess-1"})
+
+    results = json.loads(provider.handle_tool_call("turso_memory_search", {"query": "terse answers"}))
+    assert results["success"] is True
+    assert results["results"][0]["kind"] == "preference"
+    assert results["results"][0]["target"] == "user"
+
+
+def test_turso_provider_auto_capture_is_opt_in(tmp_path):
+    off = TursoMemoryProvider({"db_path": str(tmp_path / "off.db"), "auto_capture": False})
+    off.initialize("sess-1", hermes_home=str(tmp_path))
+    off.sync_turn("Remember this project uses uv", "Got it", session_id="sess-1")
+    assert json.loads(off.handle_tool_call("turso_memory_search", {"query": "project uv"}))["results"] == []
+
+    on = TursoMemoryProvider({"db_path": str(tmp_path / "on.db"), "auto_capture": True, "min_similarity": 0.0})
+    on.initialize("sess-1", hermes_home=str(tmp_path))
+    on.sync_turn("Remember this project uses uv", "Got it, I will use uv.", session_id="sess-1")
+    assert json.loads(on.handle_tool_call("turso_memory_search", {"query": "project uv"}))["results"]
+
+
+def test_turso_provider_save_config_keeps_secrets_out_of_json(tmp_path):
+    provider = TursoMemoryProvider()
+    provider.save_config({
+        "db_path": "$HERMES_HOME/turso-memory.db",
+        "sync_enabled": "true",
+        "auth_token": "secret",
+        "database_url": "libsql://example.turso.io",
+    }, str(tmp_path))
+
+    saved = json.loads((tmp_path / "turso.json").read_text(encoding="utf-8"))
+    assert saved["sync_enabled"] == "true"
+    assert "database_url" not in saved
+    assert "auth_token" not in saved
+
+
+def test_turso_provider_integrates_with_memory_manager_tools(tmp_path):
+    provider = TursoMemoryProvider({"db_path": str(tmp_path / "memory.db")})
+    mgr = MemoryManager()
+    mgr.add_provider(provider)
+    mgr.initialize_all("sess-1", hermes_home=str(tmp_path))
+
+    class Agent:
+        enabled_toolsets = ["memory"]
+        tools = [{"type": "function", "function": {"name": "memory"}}]
+        valid_tool_names = {"memory"}
+        _memory_manager = mgr
+
+    added = inject_memory_provider_tools(Agent)
+    assert added == 5
+    assert "turso_memory_search" in Agent.valid_tool_names
+
+    result = json.loads(mgr.handle_tool_call("turso_memory_add", {"content": "Hermes uses profile-scoped memory"}))
+    assert result["success"] is True

--- a/tests/turso_plugin/test_turso_memory.py
+++ b/tests/turso_plugin/test_turso_memory.py
@@ -92,6 +92,18 @@ def test_turso_provider_save_config_keeps_secrets_out_of_json(tmp_path):
     assert "auth_token" not in saved
 
 
+def test_turso_setup_schema_uses_human_choices_and_gates_cloud_fields():
+    schema = TursoMemoryProvider().get_config_schema()
+    by_key = {field["key"]: field for field in schema}
+
+    assert by_key["sync_enabled"]["choices"] == ["no", "yes"]
+    assert by_key["auto_capture"]["choices"] == ["no", "yes"]
+    assert "Hermes auto-stores" in by_key["auto_capture"]["description"]
+    assert "recommended" in by_key["auto_capture"]["description"]
+    assert by_key["database_url"]["when"] == {"sync_enabled": "yes"}
+    assert by_key["auth_token"]["when"] == {"sync_enabled": "yes"}
+
+
 def test_turso_provider_integrates_with_memory_manager_tools(tmp_path):
     provider = TursoMemoryProvider({"db_path": str(tmp_path / "memory.db")})
     mgr = MemoryManager()

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 4
 title: "Memory Providers"
-description: "External memory provider plugins — Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory"
+description: "External memory provider plugins — Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory, Turso"
 ---
 
 # Memory Providers
 
-Hermes Agent ships with 8 external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
+Hermes Agent ships with external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
 
 ## Quick Start
 
@@ -22,7 +22,7 @@ Or set manually in `~/.hermes/config.yaml`:
 
 ```yaml
 memory:
-  provider: openviking   # or honcho, mem0, hindsight, holographic, retaindb, byterover, supermemory
+  provider: openviking   # or honcho, mem0, hindsight, holographic, retaindb, byterover, supermemory, turso
 ```
 
 ## How It Works
@@ -449,6 +449,40 @@ hermes config set memory.provider holographic
 - `reason` — compositional AND queries across multiple entities
 - `contradict` — automated detection of conflicting facts
 - Trust scoring with asymmetric feedback (+0.05 helpful / -0.10 unhelpful)
+
+---
+
+### Turso
+
+Local-first SQLite-compatible semantic memory with optional Turso Cloud sync hooks. Turso memory is for deeper searchable recall; the built-in `memory` tool remains the compact always-on profile.
+
+| | |
+|---|---|
+| **Best for** | Local-first memory that can later sync across machines |
+| **Requires** | Nothing for local mode. Optional `pyturso` + Turso credentials for cloud sync. |
+| **Data storage** | `$HERMES_HOME/turso-memory.db` by default |
+| **Cost** | Free local mode; Turso pricing for cloud sync |
+
+**Tools:** `turso_memory_search`, `turso_memory_add`, `turso_memory_update`, `turso_memory_delete`, `turso_memory_sync`
+
+**Setup:**
+```bash
+hermes memory setup    # select "turso"
+# Or manually:
+hermes config set memory.provider turso
+```
+
+**Config:** `$HERMES_HOME/turso.json`
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `db_path` | `$HERMES_HOME/turso-memory.db` | Local SQLite-compatible database path |
+| `sync_enabled` | `false` | Enable best-effort Turso Cloud sync hooks |
+| `top_k` | `6` | Automatic recall result count |
+| `min_similarity` | `0.15` | Minimum automatic recall score |
+| `auto_capture` | `false` | Store completed turns as searchable conversation memories |
+
+Secrets for sync live in `.env`: `TURSO_DATABASE_URL` and `TURSO_AUTH_TOKEN`.
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->
Create a plugin to support Turso as a memory backend. https://github.com/tursodatabase/turso
"Turso is an in-process SQL database, compatible with SQLite."

This adds some support for concurrent memory access and vector search 


## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Partially Fixes #42639

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

* plugins/memory/turso/README.md
* plugins/memory/turso/__init__.py
* tests/turso_plugin/

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. `hermes memory setup`
2. Select Turso
3. Ask hermes to create a series of memory tests

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform:  MacOS 26.5.1 <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

<img width="880" height="950" alt="Screenshot 2026-06-23 at 17 06 07" src="https://github.com/user-attachments/assets/f52f3e32-4216-4e4a-b1c3-3ba7cf64e31b" />
