### PR TITLE
fix(docker): avoid overlayfs copy-up storm in chmod/chown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -203,13 +203,22 @@ RUN uv pip install --no-cache-dir --no-deps -e "."
 # /opt/data instead. Root can still repair the image during build/boot, but
 # supervised Hermes processes drop to the non-root hermes user.
 USER root
+# overlayfs-optimized: only chown/chmod inodes that actually need changing, so
+# each build layer records a minimal diff instead of copying up every inode in
+# the tree (a naive `chown -R`/`chmod -R` rewrites the metadata of every file,
+# bloating the layer and crawling on a busy host). Net result is identical to:
+#   chown -R root:root /opt/hermes   # everything root-owned
+#   chmod -R a+rX     /opt/hermes    # dirs 0555, already-exec files 0555, rest 0444
+#   chmod -R a-w      /opt/hermes    # then strip all write bits -> immutable
 RUN mkdir -p /opt/hermes/bin && \
     cp /opt/hermes/docker/hermes-exec-shim.sh /opt/hermes/bin/hermes && \
     chmod 0755 /opt/hermes/bin/hermes && \
     printf 'docker\n' > /opt/hermes/.install_method && \
-    chown -R root:root /opt/hermes && \
-    chmod -R a+rX /opt/hermes && \
-    chmod -R a-w /opt/hermes
+    find /opt/hermes \( ! -user root -o ! -group root \) -exec chown root:root {} + && \
+    find /opt/hermes -type d ! -perm -555 -exec chmod a+rX {} + && \
+    find /opt/hermes -type f ! -perm -444 -exec chmod a+r {} + && \
+    find /opt/hermes -type f -perm /111 ! -perm -111 -exec chmod a+x {} + && \
+    find /opt/hermes -perm /222 -exec chmod a-w {} +
 # The ``.install_method`` stamp is baked next to the running code (the install
 # tree), NOT into $HERMES_HOME. $HERMES_HOME (/opt/data) is a shared data
 # volume that is commonly bind-mounted from the host and even shared with a


### PR DESCRIPTION
## What does this PR do?

The final permissions pass in the Docker build runs three full recursive
walks over `/opt/hermes`:

```dockerfile
chown -R root:root /opt/hermes && \
chmod -R a+rX /opt/hermes && \
chmod -R a-w /opt/hermes
```

Each `-R` pass rewrites the metadata of **every** inode in the tree. On
overlayfs (the default Docker storage driver) a metadata change forces a
copy-up of the inode into the build layer, so this records a near-full
copy of the install tree as a layer diff — bloating the image and making
the step crawl on a busy host, even though the vast majority of files are
already root-owned and already have the target mode.

This PR replaces each blanket `-R` pass with a targeted `find ... ! -perm`
/ `! -user` invocation that touches **only** the inodes whose ownership or
mode actually differs from the desired end state. The resulting tree is
identical, but unchanged inodes are never rewritten, so the layer diff is
minimal.

## Related Issue

Fixes #

## Type of Change

- [x] ♻️ Refactor (no behavior change)

## Changes Made

- `Dockerfile`: replace the `chown -R` / `chmod -R a+rX` / `chmod -R a-w`
  permissions block with equivalent `find`-targeted passes:
  - `find ... \( ! -user root -o ! -group root \) -exec chown root:root` — only non-root inodes
  - `find ... -type d ! -perm -555 -exec chmod a+rX` — only dirs missing r-x
  - `find ... -type f ! -perm -444 -exec chmod a+r` — only files missing read
  - `find ... -type f -perm /111 ! -perm -111 -exec chmod a+x` — normalize partially-exec files
  - `find ... -perm /222 -exec chmod a-w` — only inodes that still have a write bit

## How to Test

The end-state permissions are byte-for-byte identical to the original
`chmod -R a+rX` + `chmod -R a-w`. Verified with a synthetic tree covering
dirs and files with modes 0644/0744/0600/0640/0777/0700/0755:

```sh
A=$(mktemp -d); B=$(mktemp -d)
# populate A and B identically, then:
chmod -R a+rX "$A"; chmod -R a-w "$A"                       # naive reference
find "$B" -type d ! -perm -555 -exec chmod a+rX {} +        # optimized
find "$B" -type f ! -perm -444 -exec chmod a+r {} +
find "$B" -type f -perm /111 ! -perm -111 -exec chmod a+x {} +
find "$B" -perm /222 -exec chmod a-w {} +
diff <(cd "$A" && find . | sort | xargs stat -c '%n %a') \
     <(cd "$B" && find . | sort | xargs stat -c '%n %a')    # -> empty (identical)
```

**Platforms tested:** Ubuntu (Linux 6.8), GNU coreutils `find`/`chmod`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` — N/A: Docker-build-only change, no Python code path exercised by the test suite
- [ ] I've added tests — N/A: no automated harness for Dockerfile build semantics; equivalence verified manually (above)
- [x] I've tested on my platform: Ubuntu 24.04 (Linux 6.8)

### Documentation & Housekeeping

- [x] Documentation — N/A (inline comment in Dockerfile explains the rationale and the equivalent naive form)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — the `find` predicates use POSIX-portable `-perm -NNN` / `-perm /NNN` and run only inside the Linux build image
- [x] Tool descriptions/schemas — N/A
