### PR TITLE
fix(photon): restart sidecar on stream interruptions

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -35,6 +35,7 @@ import signal
 import subprocess
 import sys
 import time
+from collections import deque
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
@@ -98,6 +99,19 @@ _PHOTON_RETRYABLE_PATTERNS = (
 # iMessage is a personal channel — suppressing rapid repeats reduces
 # upstream gRPC pressure during Photon overflow events.
 _TYPING_COOLDOWN_SECONDS = 5.0
+
+# The Spectrum SDK normally reconnects its gRPC streams internally. In practice
+# the iMessage stream can sometimes wedge after a burst of "stream interrupted"
+# messages: local /healthz stays green and outbound sends keep working, but no
+# inbound messages are delivered. Restart only the Node sidecar after a short
+# burst of these SDK warnings; the Python adapter's /inbound loop reconnects to
+# the replacement sidecar with the same token, avoiding a full gateway restart.
+_SIDECAR_STREAM_RESET_WINDOW_SECONDS = 120.0
+_SIDECAR_STREAM_RESET_THRESHOLD = 4
+_SIDECAR_STREAM_RESET_PATTERNS = (
+    "[spectrum.stream] stream interrupted; reconnecting",
+    "[spectrum.stream] stream persistently failing",
+)
 
 # Group-chat mention wake words. When ``require_mention`` is enabled, group
 # messages are ignored unless they match one of these patterns — same
@@ -250,6 +264,9 @@ class PhotonAdapter(BasePlatformAdapter):
         self._last_inbound_by_chat: Dict[str, str] = {}
         # Last time we sent a typing indicator per chat, for cooldown gating.
         self._typing_last_sent: Dict[str, float] = {}
+        # Recent upstream stream warnings emitted by spectrum-ts. Used to
+        # self-heal the sidecar when the SDK reconnect loop appears wedged.
+        self._sidecar_stream_warning_times: deque[float] = deque()
 
         # Group-chat mention gating (parity with BlueBubbles). When enabled,
         # group messages are ignored unless they match a wake word; DMs are
@@ -847,29 +864,100 @@ class PhotonAdapter(BasePlatformAdapter):
             return
         stdout = proc.stdout
         loop = asyncio.get_event_loop()
+        restart_reason: Optional[str] = None
         try:
             while True:
                 line = await loop.run_in_executor(None, stdout.readline)
                 if not line:
                     break
-                logger.info("[photon-sidecar] %s", line.decode("utf-8", "replace").rstrip())
+                text = line.decode("utf-8", "replace").rstrip()
+                logger.info("[photon-sidecar] %s", text)
+                if self._record_sidecar_stream_warning(text):
+                    restart_reason = (
+                        "persistent Spectrum stream interruptions "
+                        f"({len(self._sidecar_stream_warning_times)} in "
+                        f"{int(_SIDECAR_STREAM_RESET_WINDOW_SECONDS)}s)"
+                    )
+                    logger.warning(
+                        "[photon] %s — restarting Photon sidecar only",
+                        restart_reason,
+                    )
+                    await self._terminate_sidecar_process(proc)
+                    break
         except Exception as e:  # pragma: no cover - defensive
             logger.warning("[photon-sidecar] supervisor exited: %s", e)
-        if self._inbound_running:
+        if self._inbound_running and self._sidecar_proc is proc:
             exit_code = proc.poll()
-            logger.error(
-                "[photon] sidecar exited unexpectedly (code %s) — triggering reconnect",
-                exit_code,
-            )
+            if restart_reason is None:
+                restart_reason = f"unexpected sidecar exit (code {exit_code})"
+                logger.error(
+                    "[photon] sidecar exited unexpectedly (code %s) — restarting",
+                    exit_code,
+                )
+            self._sidecar_proc = None
+            await self._restart_sidecar_after_failure(restart_reason)
+
+    def _record_sidecar_stream_warning(
+        self, line: str, now: Optional[float] = None,
+    ) -> bool:
+        """Return True when recent Spectrum stream warnings warrant a reset."""
+        if not any(pattern in line for pattern in _SIDECAR_STREAM_RESET_PATTERNS):
+            return False
+        current = time.time() if now is None else now
+        window_start = current - _SIDECAR_STREAM_RESET_WINDOW_SECONDS
+        warnings = self._sidecar_stream_warning_times
+        while warnings and warnings[0] < window_start:
+            warnings.popleft()
+        warnings.append(current)
+        return len(warnings) >= _SIDECAR_STREAM_RESET_THRESHOLD
+
+    async def _terminate_sidecar_process(self, proc: subprocess.Popen) -> None:
+        """Terminate a sidecar process without cancelling this supervisor task."""
+        if proc.poll() is not None:
+            return
+        try:
+            if proc.stdin is not None:
+                try:
+                    proc.stdin.close()
+                except Exception:
+                    pass
+            if sys.platform != "win32":
+                try:
+                    os.killpg(os.getpgid(proc.pid), signal.SIGTERM)  # windows-footgun: ok
+                except (ProcessLookupError, PermissionError):
+                    proc.terminate()
+            else:
+                proc.terminate()
+            deadline = time.time() + 3.0
+            while proc.poll() is None and time.time() < deadline:
+                await asyncio.sleep(0.1)
+            if proc.poll() is None:
+                proc.kill()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("[photon] failed to terminate sidecar: %s", exc)
+
+    async def _restart_sidecar_after_failure(self, reason: str) -> None:
+        """Start a fresh sidecar after a crash or upstream-stream self-heal."""
+        self._sidecar_stream_warning_times.clear()
+        await asyncio.sleep(1.0)
+        if not self._inbound_running:
+            return
+        try:
+            await self._start_sidecar()
+            logger.info("[photon] sidecar restarted after %s", reason)
+        except Exception as exc:
+            logger.exception("[photon] failed to restart sidecar after %s", reason)
             self._set_fatal_error(
                 "SIDECAR_CRASHED",
-                f"Photon sidecar exited unexpectedly (code {exit_code})",
+                f"Photon sidecar failed after {reason}: {exc}",
                 retryable=True,
             )
             try:
                 await self._notify_fatal_error()
-            except Exception as exc:  # pragma: no cover - defensive
-                logger.warning("[photon] fatal-error notification failed: %s", exc)
+            except Exception as notify_exc:  # pragma: no cover - defensive
+                logger.warning(
+                    "[photon] fatal-error notification failed: %s", notify_exc
+                )
 
     async def _stop_sidecar(self) -> None:
         proc = self._sidecar_proc

--- a/tests/plugins/platforms/photon/test_inbound.py
+++ b/tests/plugins/platforms/photon/test_inbound.py
@@ -356,6 +356,41 @@ def test_is_duplicate_hard_size_bound(monkeypatch: pytest.MonkeyPatch) -> None:
     assert adapter._is_duplicate("id-0") is False  # oldest evicted
 
 
+def test_sidecar_stream_warning_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
+    import plugins.platforms.photon.adapter as ad
+
+    monkeypatch.setattr(ad, "_SIDECAR_STREAM_RESET_THRESHOLD", 4)
+    monkeypatch.setattr(ad, "_SIDECAR_STREAM_RESET_WINDOW_SECONDS", 120.0)
+    adapter = _make_adapter(monkeypatch)
+    line = "[spectrum.stream] stream interrupted; reconnecting"
+
+    assert adapter._record_sidecar_stream_warning(line, now=1000.0) is False
+    assert adapter._record_sidecar_stream_warning(line, now=1010.0) is False
+    assert adapter._record_sidecar_stream_warning(line, now=1020.0) is False
+    assert adapter._record_sidecar_stream_warning(line, now=1030.0) is True
+
+
+def test_sidecar_stream_warning_window_expires(monkeypatch: pytest.MonkeyPatch) -> None:
+    import plugins.platforms.photon.adapter as ad
+
+    monkeypatch.setattr(ad, "_SIDECAR_STREAM_RESET_THRESHOLD", 4)
+    monkeypatch.setattr(ad, "_SIDECAR_STREAM_RESET_WINDOW_SECONDS", 30.0)
+    adapter = _make_adapter(monkeypatch)
+    line = "[spectrum.stream] stream persistently failing ConnectionError"
+
+    assert adapter._record_sidecar_stream_warning(line, now=1000.0) is False
+    assert adapter._record_sidecar_stream_warning(line, now=1010.0) is False
+    assert adapter._record_sidecar_stream_warning(line, now=1020.0) is False
+    # The first warning has aged out, so this is only three within the window.
+    assert adapter._record_sidecar_stream_warning(line, now=1031.0) is False
+
+
+def test_sidecar_stream_warning_ignores_unrelated_lines(monkeypatch: pytest.MonkeyPatch) -> None:
+    adapter = _make_adapter(monkeypatch)
+    assert adapter._record_sidecar_stream_warning("ordinary sidecar log", now=1000.0) is False
+    assert list(adapter._sidecar_stream_warning_times) == []
+
+
 def test_check_requirements_without_node(monkeypatch: pytest.MonkeyPatch) -> None:
     # If no node binary on PATH the adapter should refuse to start.
     from plugins.platforms.photon import adapter as adapter_mod


### PR DESCRIPTION
## Summary

- restart the Photon Node sidecar when Spectrum stream interruption/failure logs repeat within a short window
- preserve the existing Python `/inbound` reconnect path so only the sidecar is recycled, not the full gateway
- restart the sidecar after unexpected sidecar exits instead of only setting a fatal error
- add regression coverage for the stream-warning threshold, expiry window, and ignored unrelated log lines

## Why

Photon/iMessage inbound can wedge while local health remains green: `/healthz` returns OK, outbound sends still work, and the gateway-sidecar socket remains established, but inbound iMessages stop reaching Hermes. In the observed failure, the sidecar logged repeated `[spectrum.stream] stream interrupted; reconnecting` messages before inbound delivery stopped.

Restarting only the sidecar is a smaller recovery action than restarting the gateway and lets the adapter reconnect to the replacement `/inbound` stream with the same sidecar token.

## Test plan

```text
/home/cypherblue/hermes-src/venv/bin/python -m pytest tests/plugins/platforms/photon/test_inbound.py -q -o 'addopts='
16 passed in 0.62s
```

## Risk

Low-to-moderate. The reset only triggers after repeated Spectrum stream warnings in a 120-second window or after an unexpected sidecar exit. It does not change normal outbound send behavior.
