### PR TITLE
fix(mcp): skip connection probe when OAuth just configured in `mcp add`

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -365,6 +365,7 @@ def cmd_mcp_add(args):
 
     # ── Authentication ────────────────────────────────────────────────
 
+    oauth_just_configured = False
     if url and auth_type == "oauth":
         print()
         _info(f"Starting OAuth flow for '{name}'...")
@@ -389,6 +390,8 @@ def cmd_mcp_add(args):
             else:
                 _info("Cancelled.")
                 return
+        else:
+            oauth_just_configured = True
 
     elif url:
         # Prompt for API key / Bearer token for HTTP servers
@@ -416,6 +419,16 @@ def cmd_mcp_add(args):
                     }
 
     # ── Discovery: connect and list tools ─────────────────────────────
+    # Skip the connection probe when OAuth was just configured but tokens
+    # haven't been acquired yet — the server will return 405/401 for
+    # unauthenticated requests.  Tokens are obtained on first real
+    # connection (triggered by the agent), so save the server as enabled.
+    if oauth_just_configured:
+        server_config["enabled"] = True
+        if _save_mcp_server(name, server_config):
+            _success(f"Saved '{name}' to config (OAuth — tokens will be acquired on first use)")
+            _info("Test later with: hermes mcp test " + name)
+        return
 
     print()
     print(color(f"  Connecting to '{name}'...", Colors.CYAN))


### PR DESCRIPTION
## Summary

When running `hermes mcp add --auth oauth`, the command configures OAuth correctly but then immediately probes the server before OAuth tokens have been acquired. Servers that require authentication return 405/401 for unauthenticated requests, causing the probe to fail and the command to abort before the server is saved.

## Root Cause

In `hermes_cli/mcp_config.py` `cmd_mcp_add()`, after OAuth setup (line ~368-391), the code falls through to the discovery/probe section (line ~418) which calls `_probe_single_server()`. Since no OAuth tokens exist yet, the server rejects the unauthenticated request with 405/401.

## Fix

Skip the connection probe when OAuth was just configured and save the server as enabled. OAuth tokens will be acquired on first real connection (triggered by the agent at runtime). This matches the message already shown to the user: "tokens will be acquired on first connection".

## Changes

- `hermes_cli/mcp_config.py`: Track when OAuth is just configured (`oauth_just_configured` flag). When set, skip the probe and save the server as enabled with an informative message.

## Test Plan

- [ ] `hermes mcp add testserver --url https://example.com/sse --auth oauth` should save the server without probing
- [ ] `hermes mcp test testserver` should work after tokens are acquired
- [ ] Non-OAuth `hermes mcp add` should still probe as before

Fixes #51535
