### PR TITLE
fix(update): reuse an existing uv on Termux instead of source-building

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7736,7 +7736,13 @@ def _ensure_uv_for_termux(pip_cmd: list[str]) -> str | None:
         return None
     try:
         print("  → Termux detected: trying to install uv for faster dependency updates...")
-        subprocess.run(pip_cmd + ["install", "uv"], cwd=PROJECT_ROOT, check=False)
+        result = subprocess.run(
+            pip_cmd + ["install", "uv", "--only-binary", ":all:"],
+            cwd=PROJECT_ROOT,
+            check=False,
+        )
+        if result.returncode != 0:
+            return None
     except Exception:
         pass
     # After pip install, check managed path first, then PATH

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7724,8 +7724,9 @@ def _ensure_uv_for_termux(pip_cmd: list[str]) -> str | None:
 
     The normal path (``ensure_uv()`` in managed_uv) installs the managed
     standalone uv into ``$HERMES_HOME/bin/uv``, but on Termux the official
-    installer may not work (glibc vs bionic).  Fall back to ``pip install uv``
-    which gets a Termux-compatible binary.
+    installer may not work (glibc vs bionic).  Prefer a uv already on PATH
+    (e.g. ``pkg install uv``); only if there is none do we fall back to a
+    wheel-only ``pip install uv`` so we never source-build the Rust crate.
     """
     from hermes_cli.managed_uv import resolve_uv
 
@@ -7734,6 +7735,12 @@ def _ensure_uv_for_termux(pip_cmd: list[str]) -> str | None:
         return existing
     if not _is_termux_env():
         return None
+    # A Termux-packaged uv lands on PATH but not in the managed bin dir, so
+    # resolve_uv() misses it. Use it before pip, which has no Android wheel and
+    # would otherwise build uv from source on a low-memory device.
+    system_uv = shutil.which("uv")
+    if system_uv:
+        return system_uv
     try:
         print("  → Termux detected: trying to install uv for faster dependency updates...")
         result = subprocess.run(

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -983,6 +983,7 @@ AUTHOR_MAP = {
     "hmbown@gmail.com": "Hmbown",
     "iacobs@m0n5t3r.info": "m0n5t3r",
     "jiayuw794@gmail.com": "JiayuuWang",
+    "jinhyuk9714@gmail.com": "sjh9714",
     "jonny@nousresearch.com": "yoniebans",
     "jake@nousresearch.com": "simpolism",
     "juan.ovalle@mistral.ai": "jjovalle99",

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -138,6 +138,23 @@ class TestCmdUpdateTermuxUvBootstrap:
         assert mock_run.call_args.kwargs["cwd"] == PROJECT_ROOT
         assert mock_run.call_args.kwargs["check"] is False
 
+    @patch("subprocess.run")
+    def test_termux_reuses_existing_path_uv_without_pip(self, mock_run, monkeypatch):
+        """A uv already on PATH (e.g. ``pkg install uv``) is reused before pip runs."""
+        from hermes_cli import main as hm
+
+        pkg_uv = "/data/data/com.termux/files/usr/bin/uv"
+        monkeypatch.setattr(hm, "_is_termux_env", lambda env=None: True)
+        # Production resolve_uv only checks $HERMES_HOME/bin/uv; model an empty
+        # managed dir so the PATH probe is what surfaces the packaged uv.
+        monkeypatch.setattr("hermes_cli.managed_uv.resolve_uv", lambda: None)
+        monkeypatch.setattr("shutil.which", lambda name: pkg_uv if name == "uv" else None)
+
+        uv_bin = hm._ensure_uv_for_termux(["/termux/python", "-m", "pip"])
+
+        assert uv_bin == pkg_uv
+        mock_run.assert_not_called()
+
 
 class TestCmdUpdateBranchFallback:
     """cmd_update falls back to main when current branch has no remote counterpart."""

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -109,6 +109,36 @@ class TestCmdUpdatePip:
         assert "env" not in mock_run.call_args.kwargs
 
 
+class TestCmdUpdateTermuxUvBootstrap:
+    """Regression tests for Termux-specific uv bootstrap behavior."""
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_termux_uv_bootstrap_uses_binary_only_install(
+        self, mock_run, _mock_which, monkeypatch
+    ):
+        from hermes_cli import main as hm
+
+        mock_run.return_value = subprocess.CompletedProcess([], 1, stdout="", stderr="")
+        monkeypatch.setattr(hm, "_is_termux_env", lambda env=None: True)
+
+        uv_bin = hm._ensure_uv_for_termux(["/termux/python", "-m", "pip"])
+
+        assert uv_bin is None
+        assert mock_run.call_count == 1
+        assert mock_run.call_args.args[0] == [
+            "/termux/python",
+            "-m",
+            "pip",
+            "install",
+            "uv",
+            "--only-binary",
+            ":all:",
+        ]
+        assert mock_run.call_args.kwargs["cwd"] == PROJECT_ROOT
+        assert mock_run.call_args.kwargs["check"] is False
+
+
 class TestCmdUpdateBranchFallback:
     """cmd_update falls back to main when current branch has no remote counterpart."""
 


### PR DESCRIPTION
## Summary
On Termux, `hermes update` now reuses a `uv` already on PATH (e.g. `pkg install uv`) instead of source-building the Rust crate, which OOM-killed low-memory Android devices.

Root cause: `_ensure_uv_for_termux` resolved uv only via `resolve_uv()` (managed `$HERMES_HOME/bin/uv`, never PATH), so a packaged uv was invisible and the helper went straight to bare `pip install uv` — which has no Android wheel and built from source. The old `which` catch was dropped in the single-managed-path refactor (4df280d5).

## Changes
- `hermes_cli/main.py`: `shutil.which("uv")` probe right after the Termux guard reuses an existing uv before any pip attempt; the pip fallback now uses `--only-binary :all:` and returns `None` on failure so it can never source-build. Stays inside `_ensure_uv_for_termux` — `resolve_uv` untouched, single-managed-path invariant preserved.
- `scripts/release.py`: AUTHOR_MAP entry for jinhyuk9714.
- `tests/hermes_cli/test_cmd_update.py`: regression tests for both branches (reuse PATH uv without pip; binary-only pip + None on failure).

## Validation
| | Before | After |
|---|---|---|
| Termux, uv on PATH | source-builds via pip, OOM | reuses PATH uv, no pip |
| Termux, no uv | bare `pip install uv` → source-build | `--only-binary :all:`, None on failure |
| Managed uv present | short-circuits | short-circuits (unchanged) |

27/27 `test_cmd_update.py` pass; E2E-verified all three branches with real imports.

Salvage of #48626 (@pefontana), which supersedes #39152 (@sjh9714). Both authorships preserved via cherry-pick. Fixes #39118.

## Infographic

![termux-uv-reuse](https://v3b.fal.media/files/b/0a9f8475/fnanxcubMcmvahkRToSZ4_pU1huHrW.png)
