### PR TITLE
fix(computer_use): resolve app filters via list_apps metadata

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1391,6 +1391,43 @@ def _make_cua_backend_with_windows(windows: List[Dict[str, Any]]):
     return backend
 
 
+def _make_cua_backend_with_windows_and_apps(
+    windows: List[Dict[str, Any]], apps: List[Dict[str, Any]]
+):
+    """Construct a backend whose mocked session serves list_windows/list_apps."""
+    from tools.computer_use.cua_backend import CuaDriverBackend
+
+    backend = CuaDriverBackend()
+    backend._session = MagicMock()
+
+    def _call_tool(name, args):
+        if name == "list_windows":
+            return {
+                "data": "",
+                "images": [],
+                "structuredContent": {"windows": windows},
+                "isError": False,
+            }
+        if name == "list_apps":
+            return {
+                "data": {"apps": apps},
+                "images": [],
+                "structuredContent": None,
+                "isError": False,
+            }
+        if name == "get_window_state":
+            return {
+                "data": '✅ FreeCAD — 0 elements\n',
+                "images": [],
+                "structuredContent": None,
+                "isError": False,
+            }
+        raise AssertionError(f"unexpected tool call: {name}")
+
+    backend._session.call_tool.side_effect = _call_tool
+    return backend
+
+
 class TestCuaDriverSessionReconnect:
     """Verify reconnect-once on a closed-resource error. After the
     lifecycle-owner refactor (Sun Jun 21 2026) the session no longer goes
@@ -1522,6 +1559,22 @@ class TestCaptureAppFilterNoMatch:
         assert backend._active_pid == 200
         assert backend._active_window_id == 2
 
+    def test_app_filter_falls_back_to_list_apps_metadata(self):
+        windows = [
+            {"app_name": "Qt6Application", "pid": 7675, "window_id": 42,
+             "is_on_screen": True, "title": "FreeCAD 1.1.1", "z_index": 0},
+        ]
+        apps = [
+            {"name": "FreeCAD", "bundle_id": "org.freecad.FreeCAD", "pid": 7675},
+        ]
+        backend = _make_cua_backend_with_windows_and_apps(windows, apps)
+
+        cap = backend.capture(mode="ax", app="org.freecad.FreeCAD")
+
+        assert cap.app == "Qt6Application"
+        assert backend._active_pid == 7675
+        assert backend._active_window_id == 42
+
     def test_no_app_filter_still_picks_frontmost(self):
         """When no app= is given, capture continues to pick the frontmost
         window — the no-match early-return must not fire on the empty case."""
@@ -1579,6 +1632,22 @@ class TestFocusAppFilterNoMatch:
         assert res.ok is True
         assert backend._active_pid == 200
         assert backend._active_window_id == 2
+
+    def test_focus_app_falls_back_to_list_apps_metadata(self):
+        windows = [
+            {"app_name": "Qt6Application", "pid": 7675, "window_id": 42,
+             "is_on_screen": True, "title": "FreeCAD 1.1.1", "z_index": 0},
+        ]
+        apps = [
+            {"name": "FreeCAD", "bundle_id": "org.freecad.FreeCAD", "pid": 7675},
+        ]
+        backend = _make_cua_backend_with_windows_and_apps(windows, apps)
+
+        res = backend.focus_app("FreeCAD")
+
+        assert res.ok is True
+        assert backend._active_pid == 7675
+        assert backend._active_window_id == 42
 
 
 class TestCuaEnvironmentScrubbing:

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -1008,6 +1008,48 @@ class CuaDriverBackend(ComputerUseBackend):
             return False
         return cua_driver_binary_available()
 
+    def _match_windows_for_app(
+        self, windows: List[Dict[str, Any]], app: str
+    ) -> List[Dict[str, Any]]:
+        """Resolve an ``app=`` filter against window names, then app metadata."""
+
+        def _matches_alias(query: str, candidate: str) -> bool:
+            return query in candidate or candidate in query
+
+        app_lower = app.lower()
+        direct = [w for w in windows if app_lower in w["app_name"].lower()]
+        if direct:
+            return direct
+
+        try:
+            running_apps = self.list_apps()
+        except Exception as exc:
+            logger.debug("computer_use list_apps fallback failed for %r: %s", app, exc)
+            return []
+
+        matching_pids: set[int] = set()
+        for raw_app in running_apps:
+            if not isinstance(raw_app, dict):
+                continue
+            raw_pid = raw_app.get("pid")
+            try:
+                pid = int(raw_pid)
+            except (TypeError, ValueError):
+                continue
+            aliases = []
+            for key in ("name", "bundle_id", "bundleId", "app_name", "display_name"):
+                value = raw_app.get(key)
+                if isinstance(value, str):
+                    lowered = value.strip().lower()
+                    if lowered:
+                        aliases.append(lowered)
+            if any(_matches_alias(app_lower, alias) for alias in aliases):
+                matching_pids.add(pid)
+
+        if not matching_pids:
+            return []
+        return [w for w in windows if w["pid"] in matching_pids]
+
     # ── Capture ────────────────────────────────────────────────────
     def capture(self, mode: str = "som", app: Optional[str] = None) -> CaptureResult:
         """Capture the frontmost on-screen window (optionally filtered by app name).
@@ -1089,17 +1131,17 @@ class CuaDriverBackend(ComputerUseBackend):
                 ) else 1,
             )
         elif app:
-            app_lower = app.lower()
-            filtered = [w for w in windows if app_lower in w["app_name"].lower()]
+            filtered = self._match_windows_for_app(windows, app)
             if not filtered:
                 return CaptureResult(
                     mode=mode, width=0, height=0, png_b64=None,
                     elements=[], app="",
                     window_title=(
                         f"<no on-screen window matched app={app!r}; "
-                        f"call list_apps to see available app names "
+                        f"call list_apps to see available app names or bundle IDs "
                         f"(macOS reports localized names, e.g. '計算機' "
-                        f"instead of 'Calculator')>"
+                        f"instead of 'Calculator'; some Linux/Qt apps only "
+                        f"resolve via list_apps metadata)>"
                     ),
                     png_bytes_len=0,
                 )
@@ -1444,8 +1486,7 @@ class CuaDriverBackend(ComputerUseBackend):
         ]
         windows.sort(key=lambda w: w["z_index"])
 
-        app_lower = app.lower()
-        matched = [w for w in windows if app_lower in w["app_name"].lower()]
+        matched = self._match_windows_for_app(windows, app)
         # Don't silently fall back to the frontmost window when the filter
         # matches nothing — that hides the real failure (often a localized
         # macOS app name mismatch, e.g. caller passed "Calculator" but


### PR DESCRIPTION
## Summary
- fall back from `list_windows` app-name matching to `list_apps` metadata when resolving `capture(app=...)` and `focus_app(app=...)`
- rejoin on pid so Qt6/Linux apps can be targeted even when `list_windows` exposes a generic launcher-facing name
- extend the regression suite to cover both `capture` and `focus_app` metadata fallback paths

## Testing
- `uv run --frozen pytest -q tests/tools/test_computer_use.py -k 'CaptureAppFilterNoMatch or FocusAppFilterNoMatch'`
- `uv run --frozen ruff check tools/computer_use/cua_backend.py tests/tools/test_computer_use.py`
- `git diff --check`

Closes #51578.
