### PR TITLE
fix(feishu): include MIME type in file upload multipart body

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4833,15 +4833,19 @@ class FeishuAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _build_file_upload_body(*, file_type: str, file_name: str, file: Any) -> Any:
+        mime, _ = mimetypes.guess_type(file_name)
+        if mime is None:
+            mime = "application/octet-stream"
+        file_tuple = (file_name, file, mime)
         if "CreateFileRequestBody" in globals():
             return (
                 CreateFileRequestBody.builder()
                 .file_type(file_type)
                 .file_name(file_name)
-                .file(file)
+                .file(file_tuple)
                 .build()
             )
-        return SimpleNamespace(file_type=file_type, file_name=file_name, file=file)
+        return SimpleNamespace(file_type=file_type, file_name=file_name, file=file_tuple)
 
     @staticmethod
     def _build_file_upload_request(request_body: Any) -> Any:


### PR DESCRIPTION
## Problem

The Feishu/Lark file upload API returns error `99992402` when the multipart file field lacks a Content-Type header. This causes file uploads (images, PDFs, etc.) to fail silently or with an opaque error.

## Root Cause

`_build_file_upload_body` passes the raw file object without a MIME type. The `requests` library needs a `(filename, file, content_type)` tuple to set the `Content-Type` header on the multipart part.

## Fix

Use `mimetypes.guess_type()` to infer the MIME type from the filename and pass it as a 3-tuple. Falls back to `application/octet-stream` when the type cannot be determined.

The `mimetypes` module is already imported at the top of the file (line 57), so no new dependency is needed.

## Testing

- Verified file uploads succeed for PDF, PNG, and XLSX files after the fix
- Before the fix: `99992402` error on every file upload
- After the fix: all uploads return valid `file_key`