### PR TITLE
fix(computer_use): match window title as fallback when app_name is empty

### DIFF
--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -1090,7 +1090,11 @@ class CuaDriverBackend(ComputerUseBackend):
             )
         elif app:
             app_lower = app.lower()
-            filtered = [w for w in windows if app_lower in w["app_name"].lower()]
+            filtered = [
+                w for w in windows
+                if app_lower in w["app_name"].lower()
+                or app_lower in w.get("title", "").lower()
+            ]
             if not filtered:
                 return CaptureResult(
                     mode=mode, width=0, height=0, png_b64=None,


### PR DESCRIPTION
## Summary

On Linux (KDE Plasma, X11), Qt6 apps like FreeCAD report an empty `app_name` field from cua-driver's `list_windows`, while the `title` field is populated (e.g. "FreeCAD 1.1.1"). The app-name filter only matched against `app_name`, so `capture(app='freecad')` returned "no on-screen window matched" even though cua-driver listed the window correctly.

## Root Cause

`cua_backend.py` line 1093 filters windows with:
```python
filtered = [w for w in windows if app_lower in w["app_name"].lower()]
```

On Linux/KDE, Qt6 apps have `app_name: ""` but `title: "FreeCAD 1.1.1"`. The filter never matches.

## Fix

Fall back to matching against the window `title` when `app_name` does not contain the search term:

```python
filtered = [
    w for w in windows
    if app_lower in w["app_name"].lower()
    or app_lower in w.get("title", "").lower()
]
```

This makes the filter work for Qt6/GTK apps on Linux without affecting macOS behavior (where `app_name` is reliably populated).

## Test Plan

- [ ] `computer_use capture(app='freecad')` should match FreeCAD on KDE Plasma
- [ ] `computer_use capture(app='Calculator')` should still work on macOS
- [ ] Desktop/shell window detection is unaffected

Fixes #51578
