### PR TITLE
fix(docker): restore boot-migration backups on failure

### DIFF
--- a/scripts/docker_config_migrate.py
+++ b/scripts/docker_config_migrate.py
@@ -28,16 +28,26 @@ def _backup_path(path: Path, stamp: str) -> Path:
     raise RuntimeError(f"could not choose a backup path for {path}")
 
 
-def _backup_existing(paths: Iterable[Path]) -> list[Path]:
+def _backup_existing(paths: Iterable[Path]) -> dict[Path, Path]:
     stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    backups: list[Path] = []
+    backups: dict[Path, Path] = {}
     for path in paths:
         if not path.is_file():
             continue
         dest = _backup_path(path, stamp)
         shutil.copy2(path, dest)
-        backups.append(dest)
+        backups[path] = dest
     return backups
+
+
+def _restore_backups(backups: dict[Path, Path]) -> list[Path]:
+    restored: list[Path] = []
+    for original, backup in backups.items():
+        if not backup.is_file():
+            continue
+        shutil.copy2(backup, original)
+        restored.append(original)
+    return restored
 
 
 def main() -> int:
@@ -50,12 +60,30 @@ def main() -> int:
         return 0
 
     backups = _backup_existing((get_config_path(), get_env_path()))
-    backup_text = ", ".join(str(path) for path in backups) if backups else "none"
+    backup_text = ", ".join(str(path) for path in backups.values()) if backups else "none"
     print(
         f"[config-migrate] Migrating config schema {current_ver} -> {latest_ver}; "
         f"backups: {backup_text}"
     )
-    migrate_config(interactive=False, quiet=False)
+    try:
+        migrate_config(interactive=False, quiet=False)
+    except Exception:
+        restored = _restore_backups(backups)
+        if restored:
+            print(
+                "[config-migrate] Migration failed; restored "
+                + ", ".join(str(path) for path in restored)
+            )
+        raise
+
+    post_ver, _ = check_config_version()
+    if post_ver < latest_ver:
+        restored = _restore_backups(backups)
+        restored_text = ", ".join(str(path) for path in restored) if restored else "none"
+        raise RuntimeError(
+            f"migration did not advance config version to {latest_ver} "
+            f"(still {post_ver}); restored: {restored_text}"
+        )
     return 0
 
 

--- a/tests/tools/test_docker_config_migrate.py
+++ b/tests/tools/test_docker_config_migrate.py
@@ -1,16 +1,26 @@
 from __future__ import annotations
 
+import importlib.util
 import os
 import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 import yaml
 
 from hermes_cli.config import DEFAULT_CONFIG
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "scripts" / "docker_config_migrate.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location("docker_config_migrate_test_module", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def _run_migration(hermes_home: Path, **env_overrides: str) -> subprocess.CompletedProcess[str]:
@@ -132,3 +142,63 @@ def test_docker_config_migrate_skip_env_leaves_config_unchanged(tmp_path: Path) 
     assert "skipping config migration" in proc.stdout
     assert config_path.read_text(encoding="utf-8") == original
     assert not list(tmp_path.glob("*.bak-*"))
+
+
+def test_docker_config_migrate_restores_backups_after_failed_migration(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _load_script_module()
+    config_path = tmp_path / "config.yaml"
+    env_path = tmp_path / ".env"
+    original_config = yaml.safe_dump({"_config_version": 11, "gateway": {"provider": "telegram"}})
+    original_env = "TELEGRAM_BOT_TOKEN=test-token\n"
+    config_path.write_text(original_config, encoding="utf-8")
+    env_path.write_text(original_env, encoding="utf-8")
+
+    monkeypatch.setattr(module, "check_config_version", lambda: (11, DEFAULT_CONFIG["_config_version"]))
+    monkeypatch.setattr(module, "get_config_path", lambda: config_path)
+    monkeypatch.setattr(module, "get_env_path", lambda: env_path)
+
+    def _failing_migrate(*, interactive: bool, quiet: bool):
+        config_path.write_text("gateway: {}\n", encoding="utf-8")
+        env_path.write_text("", encoding="utf-8")
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(module, "migrate_config", _failing_migrate)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        module.main()
+
+    assert config_path.read_text(encoding="utf-8") == original_config
+    assert env_path.read_text(encoding="utf-8") == original_env
+    assert list(tmp_path.glob("config.yaml.bak-*"))
+    assert list(tmp_path.glob(".env.bak-*"))
+
+
+def test_docker_config_migrate_restores_backups_when_version_does_not_advance(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _load_script_module()
+    config_path = tmp_path / "config.yaml"
+    env_path = tmp_path / ".env"
+    original_config = yaml.safe_dump({"_config_version": 11, "gateway": {"provider": "telegram"}})
+    original_env = "TELEGRAM_BOT_TOKEN=test-token\n"
+    config_path.write_text(original_config, encoding="utf-8")
+    env_path.write_text(original_env, encoding="utf-8")
+
+    calls = iter([(11, DEFAULT_CONFIG["_config_version"]), (11, DEFAULT_CONFIG["_config_version"])])
+    monkeypatch.setattr(module, "check_config_version", lambda: next(calls))
+    monkeypatch.setattr(module, "get_config_path", lambda: config_path)
+    monkeypatch.setattr(module, "get_env_path", lambda: env_path)
+
+    def _non_advancing_migrate(*, interactive: bool, quiet: bool):
+        config_path.write_text("gateway: {}\n", encoding="utf-8")
+        env_path.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(module, "migrate_config", _non_advancing_migrate)
+
+    with pytest.raises(RuntimeError, match="did not advance config version"):
+        module.main()
+
+    assert config_path.read_text(encoding="utf-8") == original_config
+    assert env_path.read_text(encoding="utf-8") == original_env


### PR DESCRIPTION
## What does this PR do?

Makes the Docker boot-time config migration transactional. `scripts/docker_config_migrate.py` already snapshots `config.yaml` and `.env` before calling `migrate_config()`, but a mid-migration failure previously left those partially rewritten while `docker/stage2-hook.sh` continued container startup. This change restores the backups when the migration throws or when it returns without actually advancing `_config_version`, which is the failure shape that would re-fire on every restart.

## Related Issue

Fixes #51579

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Made `scripts/docker_config_migrate.py` keep a `{original -> backup}` map so it can restore `config.yaml` and `.env` after a failed boot migration.
- Added a post-migration version check so the Docker path aborts and restores backups if `_config_version` did not advance, preventing destructive retry loops on every container restart.
- Extended `tests/tools/test_docker_config_migrate.py` with rollback coverage for both exception and non-advancing migration cases.

## How to Test

1. Run `.venv/bin/python -m pytest tests/tools/test_docker_config_migrate.py -q`.
2. Confirm the new rollback tests cover both a thrown migration and a migration that mutates files without advancing `_config_version`.
3. Confirm `git diff --check` stays clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5 (targeted Python test coverage only)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A.

## Screenshots / Logs

- `.venv/bin/python -m pytest tests/tools/test_docker_config_migrate.py -q` → `6 passed in 0.59s`
- `git diff --check` → clean
