### PR TITLE
fix(gateway): keep email interim chatter opt-in

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -153,6 +153,19 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
     "api_server":      {**_TIER_HIGH, "tool_preview_length": 0},
 }
 
+_MINIMAL_DELIVERY_PLATFORMS = frozenset({
+    "email",
+    "sms",
+    "webhook",
+    "homeassistant",
+})
+
+_MINIMAL_DELIVERY_CHATTER_SETTINGS = frozenset({
+    "interim_assistant_messages",
+    "long_running_notifications",
+    "busy_ack_detail",
+})
+
 # Canonical set of per-platform overrideable keys (for validation).
 OVERRIDEABLE_KEYS = frozenset(_GLOBAL_DEFAULTS.keys())
 
@@ -198,6 +211,18 @@ def resolve_display_setting(
             val = legacy.get(platform_key)
             if val is not None:
                 return _normalise(setting, val)
+
+    # Minimal delivery platforms (email/SMS/webhook/Home Assistant) should
+    # stay final-answer-first by default. Their built-in "no chatter" policy
+    # must survive the global display defaults stored in config.yaml; opt-in
+    # requires an explicit per-platform override above.
+    if (
+        platform_key in _MINIMAL_DELIVERY_PLATFORMS
+        and setting in _MINIMAL_DELIVERY_CHATTER_SETTINGS
+    ):
+        plat_defaults = _PLATFORM_DEFAULTS.get(platform_key)
+        if plat_defaults and setting in plat_defaults:
+            return plat_defaults[setting]
 
     # 2. Global user setting (display.<key>).  Skip display.streaming because
     # that key controls only CLI terminal streaming; gateway token streaming is

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -228,6 +228,48 @@ class TestPlatformDefaults:
         for plat in ("email", "sms", "webhook", "homeassistant"):
             assert resolve_display_setting({}, plat, "tool_progress") == "off", plat
 
+    def test_minimal_tier_chatter_stays_off_even_with_global_true(self):
+        """Batch-delivery platforms should not inherit global chatty defaults.
+
+        Operators can still opt in with ``display.platforms.<plat>``; the
+        global toggle should not turn interim/status chatter into extra emails.
+        """
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "interim_assistant_messages": True,
+                "long_running_notifications": True,
+                "busy_ack_detail": True,
+            }
+        }
+
+        for plat in ("email", "sms", "webhook", "homeassistant"):
+            assert resolve_display_setting(config, plat, "interim_assistant_messages") is False, plat
+            assert resolve_display_setting(config, plat, "long_running_notifications") is False, plat
+            assert resolve_display_setting(config, plat, "busy_ack_detail") is False, plat
+
+    def test_minimal_tier_chatter_can_opt_in_per_platform(self):
+        """Per-platform override should still allow explicit email opt-in."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "interim_assistant_messages": True,
+                "platforms": {
+                    "email": {
+                        "interim_assistant_messages": True,
+                        "long_running_notifications": True,
+                        "busy_ack_detail": True,
+                    }
+                },
+            }
+        }
+
+        assert resolve_display_setting(config, "email", "interim_assistant_messages") is True
+        assert resolve_display_setting(config, "email", "long_running_notifications") is True
+        assert resolve_display_setting(config, "email", "busy_ack_detail") is True
+
     def test_low_tier_streaming_defaults_to_false(self):
         """Low-tier platforms default streaming to False."""
         from gateway.display_config import resolve_display_setting


### PR DESCRIPTION
## What does this PR do?

Keeps minimal-delivery platforms final-answer-first unless the operator explicitly opts in per platform. In particular, `email` should not inherit the global `display.interim_assistant_messages: true` default, because that turns interim commentary into extra emails and can produce the duplicate-reply behavior reported in #51605.

## Related Issue

Fixes #51605

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `gateway/display_config.py` so `email`, `sms`, `webhook`, and `homeassistant` keep `interim_assistant_messages`, `long_running_notifications`, and `busy_ack_detail` disabled unless there is an explicit `display.platforms.<platform>` override.
- Added resolver regression tests in `tests/gateway/test_display_config.py` covering both the forced-off default and explicit per-platform opt-in.

## How to Test

1. Run `PYTHONPATH=. /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/gateway/test_display_config.py -q`.
2. Confirm the new tests pass and that minimal-delivery platforms keep chatter off even when global `display.interim_assistant_messages`, `display.long_running_notifications`, and `display.busy_ack_detail` are `true`.
3. Confirm an explicit `display.platforms.email` override still re-enables those settings when an operator intentionally wants them.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x, Python 3.11.14 (shared Hermes `.venv`)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `git diff --check`
- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m py_compile gateway/display_config.py tests/gateway/test_display_config.py`
- `PYTHONPATH=. /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/gateway/test_display_config.py -q`
