### PR TITLE
fix: always show compression count in /usage

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3489,12 +3489,15 @@ class GatewaySlashCommandsMixin:
                 pass
 
             # Context window and compressions
-            ctx = agent.context_compressor
-            if ctx.last_prompt_tokens:
-                pct = min(100, ctx.last_prompt_tokens / ctx.context_length * 100) if ctx.context_length else 0
-                lines.append(t("gateway.usage.label_context", used=f"{ctx.last_prompt_tokens:,}", total=f"{ctx.context_length:,}", pct=f"{pct:.0f}"))
-            if ctx.compression_count:
-                lines.append(t("gateway.usage.label_compressions", count=ctx.compression_count))
+            ctx = getattr(agent, "context_compressor", None)
+            if ctx is not None:
+                last_prompt_tokens = int(getattr(ctx, "last_prompt_tokens", 0) or 0)
+                context_length = int(getattr(ctx, "context_length", 0) or 0)
+                compression_count = int(getattr(ctx, "compression_count", 0) or 0)
+                if last_prompt_tokens > 0:
+                    pct = min(100, last_prompt_tokens / context_length * 100) if context_length else 0
+                    lines.append(t("gateway.usage.label_context", used=f"{last_prompt_tokens:,}", total=f"{context_length:,}", pct=f"{pct:.0f}"))
+                lines.append(t("gateway.usage.label_compressions", count=compression_count))
 
             if account_lines:
                 lines.append("")
@@ -3512,10 +3515,25 @@ class GatewaySlashCommandsMixin:
             from agent.model_metadata import estimate_messages_tokens_rough
             msgs = [m for m in history if m.get("role") in {"user", "assistant"} and m.get("content")]
             approx = estimate_messages_tokens_rough(msgs)
+            compression_count = 0
+            session_db = getattr(self, "_session_db", None)
+            if session_db is not None:
+                try:
+                    from acp_adapter.provenance import build_session_provenance
+
+                    provenance = build_session_provenance(
+                        session_db,
+                        session_entry.session_id,
+                        session_entry.session_id,
+                    )
+                    compression_count = int((provenance or {}).get("compressionDepth", 0) or 0)
+                except Exception:
+                    compression_count = 0
             lines = [
                 t("gateway.usage.header_session_info"),
                 t("gateway.usage.label_messages", count=len(msgs)),
                 t("gateway.usage.label_estimated_context", count=f"{approx:,}"),
+                t("gateway.usage.label_compressions", count=compression_count),
                 t("gateway.usage.detailed_after_first"),
             ]
             if account_lines:

--- a/tests/gateway/test_usage_command.py
+++ b/tests/gateway/test_usage_command.py
@@ -92,6 +92,21 @@ class TestUsageCachedAgent:
         assert "Compressions: 1" in result
 
     @pytest.mark.asyncio
+    async def test_zero_compressions_are_shown(self):
+        """Compression count should be visible even before any compression fires."""
+        agent = _make_mock_agent()
+        agent.context_compressor.compression_count = 0
+        runner = _make_runner(SK, cached_agent=agent)
+        event = MagicMock()
+
+        with patch("agent.rate_limit_tracker.format_rate_limit_compact", return_value="RPM: 50/60"), \
+             patch("agent.usage_pricing.estimate_usage_cost") as mock_cost:
+            mock_cost.return_value = MagicMock(amount_usd=None, status="unknown")
+            result = await runner._handle_usage_command(event)
+
+        assert "Compressions: 0" in result
+
+    @pytest.mark.asyncio
     async def test_running_agent_preferred_over_cache(self):
         """When agent is in both dicts, the running one wins."""
         running = _make_mock_agent(session_api_calls=10, session_total_tokens=80_000)
@@ -145,6 +160,31 @@ class TestUsageCachedAgent:
         assert "Session Info" in result
         assert "Messages: 2" in result
         assert "~500" in result
+        assert "Compressions: 0" in result
+
+    @pytest.mark.asyncio
+    async def test_no_agent_history_shows_compression_depth(self):
+        """When only persisted history is available, derive compressions from session provenance."""
+        runner = _make_runner(SK)
+        runner._session_db = MagicMock()
+        runner._session_db.get_session.side_effect = lambda sid: {
+            "sess-child": {"parent_session_id": "sess-parent", "end_reason": None},
+            "sess-parent": {"parent_session_id": None, "end_reason": "compression"},
+        }.get(sid)
+        event = MagicMock()
+
+        session_entry = MagicMock()
+        session_entry.session_id = "sess-child"
+        runner.session_store.get_or_create_session.return_value = session_entry
+        runner.session_store.load_transcript.return_value = [
+            {"role": "user", "content": "after compression"},
+        ]
+
+        with patch("agent.model_metadata.estimate_messages_tokens_rough", return_value=250):
+            result = await runner._handle_usage_command(event)
+
+        assert "Session Info" in result
+        assert "Compressions: 1" in result
 
     @pytest.mark.asyncio
     async def test_cache_read_write_hidden_when_zero(self):


### PR DESCRIPTION
## Summary
- Always render the gateway /usage compression count, including 0 before the first compression.
- Show compression depth in the no-live-agent history fallback using existing session provenance.
- Add gateway /usage regression tests for zero compressions and persisted compression depth.

## Test Plan
- [x] uv run --with pytest --with pytest-asyncio python -m pytest tests/gateway/test_usage_command.py -q -o 'addopts='