### PR TITLE
fix(kanban): route builder review-required without explicit owner to researcher

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -737,6 +737,20 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="With --state-type: keep runs whose column equals this value",
     )
 
+    # --- liveness (read-only board health digest) ---
+    p_live = sub.add_parser(
+        "liveness",
+        help="Read-only board liveness scanner / health digest",
+    )
+    p_live.add_argument("--tenant", default=None, help="Only scan tasks for this tenant")
+    p_live.add_argument(
+        "--ready-sla-minutes",
+        type=int,
+        default=240,
+        help="Ready-task age threshold before reporting a stale-ready finding",
+    )
+    p_live.add_argument("--json", action="store_true", help="Emit hermes.kanban_liveness.v1 JSON")
+
     # --- heartbeat (worker liveness signal) ---
     p_hb = sub.add_parser(
         "heartbeat",
@@ -950,6 +964,7 @@ def kanban_command(args: argparse.Namespace) -> int:
             "stats":    _cmd_stats,
             "log":      _cmd_log,
             "runs":     _cmd_runs,
+            "liveness": _cmd_liveness,
             "heartbeat": _cmd_heartbeat,
             "assignees": _cmd_assignees,
             "notify-subscribe":   _cmd_notify_subscribe,
@@ -1250,6 +1265,35 @@ def _cmd_init(args: argparse.Namespace) -> int:
         "by default (config: kanban.dispatch_interval_seconds). Without a\n"
         "running gateway, tasks stay in 'ready' forever."
     )
+    return 0
+
+
+def _cmd_liveness(args: argparse.Namespace) -> int:
+    from hermes_cli import kanban_liveness
+
+    with kb.connect_closing() as conn:
+        payload = kanban_liveness.scan_liveness(
+            conn,
+            tenant=getattr(args, "tenant", None),
+            ready_sla_minutes=getattr(args, "ready_sla_minutes", 240),
+        )
+    if getattr(args, "json", False):
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+        return 0
+    summary = payload.get("summary") or {}
+    print(
+        f"Board health: {summary.get('health')} "
+        f"({summary.get('finding_count', 0)} finding(s), "
+        f"{summary.get('active_count', 0)} active task(s))"
+    )
+    for finding in payload.get("findings") or []:
+        print(
+            f"- [{finding.get('severity')}] {finding.get('kind')}: "
+            f"{finding.get('task_id')} {finding.get('title')}"
+        )
+        detail = finding.get("detail")
+        if detail:
+            print(f"  {detail}")
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -103,6 +103,16 @@ VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
 _IS_WINDOWS = sys.platform == "win32"
 
+# Legacy board language used role names before Brian's live mesh settled on
+# profile IDs. Keep the translation close to Kanban ingress/dispatch so old
+# cards and decomposer choices do not strand work in non-spawnable lanes.
+ROLE_ASSIGNEE_ALIASES: dict[str, str] = {
+    "operator": "winston",
+    "researcher": "brennan",
+    "builder": "stark",
+    "steward": "pepper",
+}
+
 
 def _fire_kanban_lifecycle_hook(event: str, task_id: str, **fields: Any) -> None:
     """Fire a kanban lifecycle plugin hook, fully best-effort.
@@ -127,6 +137,7 @@ def _fire_kanban_lifecycle_hook(event: str, task_id: str, **fields: Any) -> None
         invoke_hook(event, task_id=task_id, profile_name=profile_name, **fields)
     except Exception as exc:  # pragma: no cover - defensive
         _log.debug("kanban lifecycle hook %s failed: %s", event, exc)
+
 
 
 # A running task's claim is valid for 15 minutes by default; after that the
@@ -2231,12 +2242,86 @@ def _claimer_id() -> str:
 # ---------------------------------------------------------------------------
 
 def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
-    """Lowercase-assignee normalization for Kanban rows (dashboard/CLI parity)."""
+    """Normalize Kanban assignee names to real spawnable profile IDs.
+
+    Besides ordinary profile-name canonicalization, this maps the legacy role
+    labels that still appear in older board/task language onto the current live
+    profile IDs. That keeps both new cards and old rows from falling into the
+    dispatcher's ``skipped_nonspawnable`` bucket purely because they said
+    ``operator`` instead of ``winston``.
+    """
     if assignee is None:
+        return None
+    if not str(assignee).strip():
         return None
     from hermes_cli.profiles import normalize_profile_name
 
-    return normalize_profile_name(assignee)
+    normalized = normalize_profile_name(assignee)
+    alias_target = ROLE_ASSIGNEE_ALIASES.get(normalized)
+    if alias_target:
+        try:
+            from hermes_cli.profiles import profile_exists
+
+            if profile_exists(normalized):
+                return normalized
+        except Exception:
+            pass
+        return alias_target
+    return normalized
+
+
+def canonical_assignee(assignee: Optional[str]) -> Optional[str]:
+    """Public wrapper for callers that need Kanban's assignee alias contract."""
+    return _canonical_assignee(assignee)
+
+
+def _alias_for_assignee(assignee: Optional[str]) -> tuple[Optional[str], Optional[str]]:
+    """Return ``(canonical, alias_used)`` for an assignee-like value."""
+    if assignee is None:
+        return None, None
+    if not str(assignee).strip():
+        return None, None
+    from hermes_cli.profiles import normalize_profile_name
+
+    normalized = normalize_profile_name(assignee)
+    canonical = _canonical_assignee(normalized)
+    return canonical, (normalized if canonical != normalized else None)
+
+
+def _apply_assignee_alias_unlocked(
+    conn: sqlite3.Connection,
+    task_id: str,
+    assignee: Optional[str],
+    *,
+    dry_run: bool = False,
+) -> Optional[str]:
+    """Canonicalize an existing task row's assignee, emitting an audit event.
+
+    ``create_task`` canonicalizes new rows, but long-lived boards may already
+    contain role-name assignees. The dispatcher calls this before profile
+    validation so legacy ``operator``/``researcher`` cards route to their live
+    profiles instead of being skipped as non-spawnable.
+    """
+    canonical, alias = _alias_for_assignee(assignee)
+    if canonical is None:
+        return None
+    if alias and not dry_run:
+        with write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET assignee = ? WHERE id = ? AND assignee = ?",
+                (canonical, task_id, assignee),
+            )
+            _append_event(
+                conn,
+                task_id,
+                "assigned",
+                {
+                    "assignee": canonical,
+                    "source": "kanban.role_alias",
+                    "alias": alias,
+                },
+            )
+    return canonical
 
 
 def create_task(
@@ -2469,6 +2554,13 @@ def create_task(
                         "goal_mode": bool(goal_mode) or None,
                     },
                 )
+                for pid in parents:
+                    _inherit_notify_subs_unlocked(
+                        conn,
+                        source_task_id=pid,
+                        target_task_id=task_id,
+                        source="parent",
+                    )
             return task_id
         except sqlite3.IntegrityError:
             if attempt == 1:
@@ -4756,6 +4848,12 @@ def decompose_triage_task(
                 conn, new_id, "created",
                 {"by": author or "decomposer", "from_decompose_of": task_id},
             )
+            _inherit_notify_subs_unlocked(
+                conn,
+                source_task_id=task_id,
+                target_task_id=new_id,
+                source="decompose_root",
+            )
             child_ids.append(new_id)
 
         # Link children to their sibling parents (within the decomposed graph).
@@ -6523,7 +6621,8 @@ def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
         # Can't introspect — assume spawnable, preserve legacy behavior.
         return True
     for row in rows:
-        if profile_exists(row["assignee"]):
+        assignee = _canonical_assignee(row["assignee"])
+        if assignee and profile_exists(assignee):
             return True
     return False
 
@@ -6548,7 +6647,8 @@ def has_spawnable_review(conn: sqlite3.Connection) -> bool:
     except Exception:
         return True
     for row in rows:
-        if profile_exists(row["assignee"]):
+        assignee = _canonical_assignee(row["assignee"])
+        if assignee and profile_exists(assignee):
             return True
     return False
 
@@ -6748,7 +6848,7 @@ def _dispatch_once_locked(
     # Normalize default_assignee once: empty/whitespace string → None so the
     # rest of the loop can use ``if default_assignee:`` as a single check.
     # We also resolve profile_exists once here for the same reason.
-    _default_assignee = (default_assignee or "").strip() or None
+    _default_assignee = _canonical_assignee(default_assignee)
     _default_assignee_resolved = False
     if _default_assignee:
         try:
@@ -6764,7 +6864,9 @@ def _dispatch_once_locked(
     for row in ready_rows:
         if max_spawn is not None and running_count + spawned >= max_spawn:
             break
-        row_assignee = row["assignee"]
+        row_assignee = _apply_assignee_alias_unlocked(
+            conn, row["id"], row["assignee"], dry_run=dry_run,
+        )
         if not row_assignee:
             # Honour kanban.default_assignee: when the dispatcher hits an
             # unassigned ready task and an operator-configured fallback
@@ -6955,18 +7057,21 @@ def _dispatch_once_locked(
     for row in review_rows:
         if max_spawn is not None and running_count + spawned >= max_spawn:
             break
-        if not row["assignee"]:
+        row_assignee = _apply_assignee_alias_unlocked(
+            conn, row["id"], row["assignee"], dry_run=dry_run,
+        )
+        if not row_assignee:
             result.skipped_unassigned.append(row["id"])
             continue
         try:
             from hermes_cli.profiles import profile_exists
         except Exception:
             profile_exists = None  # type: ignore[assignment]
-        if profile_exists is not None and not profile_exists(row["assignee"]):
+        if profile_exists is not None and not profile_exists(row_assignee):
             result.skipped_nonspawnable.append(row["id"])
             continue
         if dry_run:
-            result.spawned.append((row["id"], row["assignee"], ""))
+            result.spawned.append((row["id"], row_assignee, ""))
             continue
         claimed = claim_review_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
@@ -7829,6 +7934,70 @@ def task_age(task: Task) -> dict:
 # ---------------------------------------------------------------------------
 # Notification subscriptions (used by the gateway kanban-notifier)
 # ---------------------------------------------------------------------------
+
+def _inherit_notify_subs_unlocked(
+    conn: sqlite3.Connection,
+    *,
+    source_task_id: str,
+    target_task_id: str,
+    source: str,
+) -> int:
+    """Copy gateway terminal-event subscriptions from one card to another.
+
+    The gateway auto-subscribes the original front-door ``/kanban create``
+    card. Follow-up/successor cards created later (decomposition, controller
+    repair cards, parent-linked continuations) must inherit that subscription
+    or their terminal GO / changes-requested / blocked events become silent.
+
+    Call only from an existing write transaction; this helper deliberately does
+    not open ``write_txn`` so create/decompose operations stay atomic.
+    """
+    if not source_task_id or not target_task_id or source_task_id == target_task_id:
+        return 0
+    cursor_row = conn.execute(
+        "SELECT COALESCE(MAX(id), 0) AS max_id FROM task_events WHERE task_id = ?",
+        (target_task_id,),
+    ).fetchone()
+    target_cursor = int(cursor_row["max_id"] if cursor_row else 0)
+    now = int(time.time())
+    inserted = 0
+    rows = conn.execute(
+        "SELECT platform, chat_id, thread_id, user_id, notifier_profile "
+        "FROM kanban_notify_subs WHERE task_id = ?",
+        (source_task_id,),
+    ).fetchall()
+    for row in rows:
+        cur = conn.execute(
+            """
+            INSERT OR IGNORE INTO kanban_notify_subs
+                (task_id, platform, chat_id, thread_id, user_id,
+                 notifier_profile, created_at, last_event_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                target_task_id,
+                row["platform"],
+                row["chat_id"],
+                row["thread_id"] or "",
+                row["user_id"],
+                row["notifier_profile"],
+                now,
+                target_cursor,
+            ),
+        )
+        inserted += max(0, cur.rowcount)
+    if inserted:
+        _append_event(
+            conn,
+            target_task_id,
+            "notify_sub_inherited",
+            {
+                "from_task_id": source_task_id,
+                "source": source,
+                "count": inserted,
+            },
+        )
+    return inserted
 
 def add_notify_sub(
     conn: sqlite3.Connection,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2332,6 +2332,7 @@ def create_task(
     parents: Iterable[str] = (),
     triage: bool = False,
     idempotency_key: Optional[str] = None,
+    idempotency_exclude_parent: Optional[str] = None,
     max_runtime_seconds: Optional[int] = None,
     skills: Optional[Iterable[str]] = None,
     max_retries: Optional[int] = None,
@@ -2431,16 +2432,31 @@ def create_task(
     # duplicate. The preflight keeps the common duplicate path fast; the
     # same lookup is repeated inside the write transaction below so a racing
     # creator that wins after this check but before our INSERT cannot produce
-    # a second non-archived row with the same key.
-    if idempotency_key:
-        row = conn.execute(
+    # a second non-archived row with the same key.  Review-required routing can
+    # exclude parent-linked matches so a deadlocked child with the right
+    # idempotency key is not mistaken for an independent reviewer successor.
+    def _existing_idempotent_task() -> Optional[sqlite3.Row]:
+        if not idempotency_key:
+            return None
+        query = (
             "SELECT id FROM tasks WHERE idempotency_key = ? "
             "AND status != 'archived' "
-            "ORDER BY created_at DESC LIMIT 1",
-            (idempotency_key,),
-        ).fetchone()
-        if row:
-            return row["id"]
+        )
+        params: list[Any] = [idempotency_key]
+        if idempotency_exclude_parent:
+            query += (
+                "AND NOT EXISTS ("
+                "  SELECT 1 FROM task_links "
+                "  WHERE parent_id = ? AND child_id = tasks.id"
+                ") "
+            )
+            params.append(idempotency_exclude_parent)
+        query += "ORDER BY created_at DESC LIMIT 1"
+        return conn.execute(query, tuple(params)).fetchone()
+
+    row = _existing_idempotent_task()
+    if row:
+        return row["id"]
 
     now = int(time.time())
 
@@ -2465,15 +2481,9 @@ def create_task(
         task_id = _new_task_id()
         try:
             with write_txn(conn):
-                if idempotency_key:
-                    row = conn.execute(
-                        "SELECT id FROM tasks WHERE idempotency_key = ? "
-                        "AND status != 'archived' "
-                        "ORDER BY created_at DESC LIMIT 1",
-                        (idempotency_key,),
-                    ).fetchone()
-                    if row:
-                        return row["id"]
+                row = _existing_idempotent_task()
+                if row:
+                    return row["id"]
 
                 # Determine task status from parent status, unless the caller
                 # parks it directly in blocked for human-ops review or in
@@ -5469,6 +5479,80 @@ class DispatchResult:
     DB writes this tick — the lock holder is making progress on the same
     board. This is the steady-state signal that a single-writer guard is
     actively preventing two dispatchers from racing on ``kanban.db``."""
+    created_review_required_successors: list[str] = field(default_factory=list)
+    """Blocked review-required source task ids for which this dispatch tick
+    created an independent reviewer/triage successor."""
+    consumed_review_verdicts: list[str] = field(default_factory=list)
+    """Blocked source task ids whose completed reviewer verdicts were consumed
+    this dispatch tick."""
+    created_review_verdict_followups: list[str] = field(default_factory=list)
+    """Follow-up task ids created from consumed reviewer verdicts."""
+
+
+_LIVENESS_AUTHOR = "kanban-liveness"
+_REVIEW_REQUIRED_OWNER_KEYS = (
+    "review_owner",
+    "review_assignee",
+    "needed_review_owner",
+    "needed_profile",
+    "awaiting_profile",
+)
+_REVIEW_REQUIRED_SUCCESSOR_KEYS = (
+    "successor_task_ids",
+    "review_successor_task_ids",
+    "reviewer_task_ids",
+)
+_REVIEW_REQUIRED_RECEIPT_KEYS = (
+    "changed_files",
+    "tests_run",
+    "tests_passed",
+    "test_commands",
+    "commands",
+    "diff_path",
+    "artifacts",
+    "risk_class",
+    "review_type",
+    "review_kind",
+    "requested_verdict",
+    "decisions",
+)
+_REVIEW_REQUIRED_NEGATED_RED_GATE_PATTERNS = (
+    re.compile(
+        r"\bno\s+(?:active\s+|remaining\s+)?red[-\s]?gates?\s*"
+        r"(?:remains?|remaining|required|needed|present|left|appl(?:y|ies))?\b"
+    ),
+    re.compile(r"\bnot\s+(?:a\s+)?red[-\s]?gates?\b"),
+    re.compile(r"\bnot\s+red[-\s]?gated\b"),
+    re.compile(r"\bwithout\s+(?:a\s+)?red[-\s]?gates?\b"),
+    re.compile(r"\bnon[-\s]?red[-\s]?gated\b"),
+    re.compile(
+        r"\bno\s+stop\s*/\s*human\s+boundary\s*"
+        r"(?:remains?|remaining|required|needed|present|left)?\b"
+    ),
+    re.compile(
+        r"\bno\s+human\s+approval\s*"
+        r"(?:remains?|remaining|required|needed|present|left)?\b"
+    ),
+    re.compile(
+        r"\bhuman\s+approval\s+(?:is\s+)?(?:not|no\s+longer)\s+"
+        r"(?:required|needed|present|remaining)\b"
+    ),
+)
+_REVIEW_REQUIRED_RED_GATE_PATTERNS = (
+    re.compile(r"\bred[-\s]?gated\b"),
+    re.compile(r"\bred[-\s]?gates?\b"),
+    re.compile(r"\bhuman\s+approval\b"),
+    re.compile(r"\bstop\s*/\s*human\s+boundary\b"),
+)
+
+
+@dataclass
+class LivenessScanResult:
+    """Mutating liveness repairs performed by one scanner pass."""
+
+    created_review_required_successors: list[str] = field(default_factory=list)
+    consumed_review_verdicts: list[str] = field(default_factory=list)
+    created_review_verdict_followups: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -5478,6 +5562,448 @@ class ReviewVerdictConsumptionResult:
     consumed_review_verdicts: list[str] = field(default_factory=list)
     created_review_verdict_followups: list[str] = field(default_factory=list)
     skipped_review_verdicts: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class _ReviewRequiredRoute:
+    assignee: str
+    owner_source: str
+    triage: bool = False
+    red_gated: bool = False
+
+
+def _parse_json_dict(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if not isinstance(value, str) or not value.strip():
+        return {}
+    try:
+        parsed = json.loads(value)
+    except Exception:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _metadata_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    if isinstance(value, set):
+        return list(value)
+    return [value]
+
+
+def _latest_block_reason(conn: sqlite3.Connection, task_id: str) -> str:
+    row = conn.execute(
+        "SELECT payload FROM task_events "
+        "WHERE task_id = ? AND kind = 'blocked' "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    if row:
+        reason = _parse_json_dict(row["payload"]).get("reason")
+        if isinstance(reason, str):
+            return reason
+    row = conn.execute(
+        "SELECT summary FROM task_runs "
+        "WHERE task_id = ? AND outcome = 'blocked' "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    return str(row["summary"] or "") if row else ""
+
+
+def _is_review_required_block(conn: sqlite3.Connection, task_id: str) -> bool:
+    return _latest_block_reason(conn, task_id).strip().lower().startswith("review-required:")
+
+
+def _latest_blocked_review_runs(conn: sqlite3.Connection) -> list[sqlite3.Row]:
+    return conn.execute(
+        """
+        SELECT t.id AS task_id,
+               t.title AS task_title,
+               t.body AS task_body,
+               t.assignee AS task_assignee,
+               t.workspace_kind AS workspace_kind,
+               t.workspace_path AS workspace_path,
+               t.tenant AS tenant,
+               r.id AS run_id,
+               r.summary AS summary,
+               r.metadata AS metadata
+          FROM tasks t
+          JOIN task_runs r ON r.id = (
+                SELECT r2.id
+                  FROM task_runs r2
+                 WHERE r2.task_id = t.id
+                   AND r2.outcome = 'blocked'
+                   AND r2.ended_at IS NOT NULL
+                 ORDER BY r2.id DESC
+                 LIMIT 1
+          )
+         WHERE t.status = 'blocked'
+        """
+    ).fetchall()
+
+
+def _review_required_idempotency_key(task_id: str, run_id: int) -> str:
+    return f"review-required:{task_id}:{int(run_id)}"
+
+
+def _task_has_successor_for_review_required(
+    conn: sqlite3.Connection,
+    task_id: str,
+    run_id: int,
+    metadata: dict[str, Any],
+) -> bool:
+    declared = [
+        str(v).strip()
+        for key in _REVIEW_REQUIRED_SUCCESSOR_KEYS
+        for v in _metadata_list(metadata.get(key))
+        if str(v).strip()
+    ]
+    if declared:
+        placeholders = ",".join("?" * len(declared))
+        if conn.execute(
+            f"SELECT 1 FROM tasks WHERE id IN ({placeholders}) "
+            "AND status != 'archived' "
+            "AND NOT EXISTS ("
+            "  SELECT 1 FROM task_links "
+            "  WHERE parent_id = ? AND child_id = tasks.id"
+            ") LIMIT 1",
+            tuple(declared) + (task_id,),
+        ).fetchone():
+            return True
+
+    idem = _review_required_idempotency_key(task_id, run_id)
+    if conn.execute(
+        "SELECT 1 FROM tasks WHERE idempotency_key = ? "
+        "AND status != 'archived' "
+        "AND NOT EXISTS ("
+        "  SELECT 1 FROM task_links "
+        "  WHERE parent_id = ? AND child_id = tasks.id"
+        ") LIMIT 1",
+        (idem, task_id),
+    ).fetchone():
+        return True
+
+    rows = conn.execute(
+        "SELECT payload FROM task_events "
+        "WHERE task_id = ? AND kind = 'review_required_successor_created' "
+        "ORDER BY id DESC",
+        (task_id,),
+    ).fetchall()
+    for event in rows:
+        payload = _parse_json_dict(event["payload"])
+        if int(payload.get("run_id") or -1) != int(run_id):
+            continue
+        successor_id = str(payload.get("successor_task_id") or "").strip()
+        if not successor_id:
+            continue
+        if conn.execute(
+            "SELECT 1 FROM tasks WHERE id = ? AND status != 'archived' "
+            "AND NOT EXISTS ("
+            "  SELECT 1 FROM task_links "
+            "  WHERE parent_id = ? AND child_id = tasks.id"
+            ") LIMIT 1",
+            (successor_id, task_id),
+        ).fetchone():
+            return True
+    return False
+
+
+def _json_dict_from_text(text: str) -> dict[str, Any]:
+    parsed = _parse_json_dict(text)
+    if parsed:
+        return parsed
+    decoder = json.JSONDecoder()
+    for match in re.finditer(r"\{", text or ""):
+        try:
+            value, _end = decoder.raw_decode(text[match.start() :])
+        except Exception:
+            continue
+        if isinstance(value, dict):
+            return value
+    return {}
+
+
+def _latest_review_required_comment_metadata(
+    conn: sqlite3.Connection,
+    task_id: str,
+) -> dict[str, Any]:
+    rows = conn.execute(
+        "SELECT body FROM task_comments WHERE task_id = ? ORDER BY id DESC",
+        (task_id,),
+    ).fetchall()
+    owner_needles = tuple(key.lower() for key in _REVIEW_REQUIRED_OWNER_KEYS)
+    receipt_needles = tuple(key.lower() for key in _REVIEW_REQUIRED_RECEIPT_KEYS)
+    for row in rows:
+        body = str(row["body"] or "")
+        body_l = body.lower()
+        if (
+            "review-required" not in body_l
+            and not any(key in body_l for key in owner_needles)
+            and not any(key in body_l for key in receipt_needles)
+        ):
+            continue
+        parsed = _json_dict_from_text(body)
+        if parsed:
+            return parsed
+    return {}
+
+
+def _review_required_owner_from_text(text: str) -> Optional[str]:
+    if not text:
+        return None
+    for key in _REVIEW_REQUIRED_OWNER_KEYS:
+        match = re.search(rf"\b{re.escape(key)}\s*[:=]\s*([A-Za-z0-9_.-]+)", text)
+        if match:
+            return match.group(1).strip()
+    return None
+
+
+_REVIEW_REQUIRED_NESTED_DICT_KEYS = (
+    "review_required",
+    "review",
+    "successor_action",
+    "successor",
+    "block_reason",
+    "owner_hint",
+)
+
+
+def _review_required_nested_dicts(metadata: dict[str, Any]) -> list[dict[str, Any]]:
+    dicts: list[dict[str, Any]] = []
+    seen: set[int] = set()
+
+    def visit(item: dict[str, Any]) -> None:
+        marker = id(item)
+        if marker in seen:
+            return
+        seen.add(marker)
+        dicts.append(item)
+        for key in _REVIEW_REQUIRED_NESTED_DICT_KEYS:
+            value = item.get(key)
+            if isinstance(value, dict):
+                visit(value)
+
+    visit(metadata)
+    return dicts
+
+
+def _review_required_first_owner(metadata: dict[str, Any]) -> Optional[str]:
+    for item in _review_required_nested_dicts(metadata):
+        for key in _REVIEW_REQUIRED_OWNER_KEYS:
+            value = item.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    for item in _review_required_nested_dicts(metadata)[1:]:
+        for key in ("assignee", "profile", "owner"):
+            value = item.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return None
+
+
+def _review_required_metadata_is_red_gated(metadata: dict[str, Any]) -> bool:
+    for item in _review_required_nested_dicts(metadata):
+        if item.get("requires_approval") or item.get("red_gate"):
+            return True
+        if _metadata_list(item.get("red_gates")):
+            return True
+        status_class = str(item.get("status_class") or "").strip().lower()
+        if status_class in {"red", "red-gated"}:
+            return True
+    return False
+
+
+def _review_required_reason_is_red_gated(reason: str) -> bool:
+    reason_l = (reason or "").lower()
+    for pattern in _REVIEW_REQUIRED_NEGATED_RED_GATE_PATTERNS:
+        reason_l = pattern.sub(" ", reason_l)
+    return any(pattern.search(reason_l) for pattern in _REVIEW_REQUIRED_RED_GATE_PATTERNS)
+
+
+def _review_required_is_red_gated(metadata: dict[str, Any], reason: str) -> bool:
+    if _review_required_reason_is_red_gated(reason):
+        return True
+    return _review_required_metadata_is_red_gated(metadata)
+
+
+def _review_required_has_code_change_receipts(metadata: dict[str, Any]) -> bool:
+    code_receipt_present = any(
+        _metadata_list(item.get(key))
+        for item in _review_required_nested_dicts(metadata)
+        for key in ("changed_files", "diff_path")
+    )
+    test_receipt_present = any(
+        _metadata_list(item.get(key))
+        for item in _review_required_nested_dicts(metadata)
+        for key in ("tests_run", "tests_passed", "test_commands", "commands")
+    )
+    return code_receipt_present and test_receipt_present
+
+
+def _review_required_route(
+    metadata: dict[str, Any],
+    reason: str,
+    comment_metadata: Optional[dict[str, Any]] = None,
+    source_assignee: Optional[str] = None,
+) -> _ReviewRequiredRoute:
+    comment_metadata = comment_metadata or {}
+    effective_metadata = {**comment_metadata, **metadata}
+    if _review_required_is_red_gated(effective_metadata, reason):
+        return _ReviewRequiredRoute(
+            assignee="default",
+            owner_source="red-gated",
+            red_gated=True,
+        )
+    explicit = _review_required_first_owner(metadata)
+    if explicit:
+        return _ReviewRequiredRoute(_canonical_assignee(explicit) or explicit, "explicit-metadata")
+    explicit = _review_required_first_owner(comment_metadata)
+    if explicit:
+        return _ReviewRequiredRoute(_canonical_assignee(explicit) or explicit, "explicit-comment")
+    explicit = _review_required_owner_from_text(reason)
+    if explicit:
+        return _ReviewRequiredRoute(_canonical_assignee(explicit) or explicit, "explicit-reason")
+    if (
+        _canonical_assignee(source_assignee) in {"builder", "stark"}
+        and _review_required_has_code_change_receipts(effective_metadata)
+    ):
+        return _ReviewRequiredRoute(
+            _canonical_assignee("researcher") or "researcher",
+            "code-review-receipts",
+        )
+    return _ReviewRequiredRoute("default", "router-triage", triage=True)
+
+
+def _review_required_card_body(
+    *,
+    source_id: str,
+    source_title: str,
+    source_assignee: Optional[str],
+    run_id: int,
+    reason: str,
+    metadata: dict[str, Any],
+    route: _ReviewRequiredRoute,
+) -> str:
+    lines = [
+        f"Review-required routed card created from source task {source_id}: {source_title}",
+        f"Source run: {run_id}",
+        f"Source assignee: {source_assignee or 'unassigned'}",
+        f"Block reason: {reason}",
+        f"Selected reviewer assignee: {route.assignee} ({route.owner_source})",
+        "",
+        "Review the source task handoff and return one of: approve/unblock source; "
+        "changes requested; stop/rollback/human approval required; insufficient evidence.",
+    ]
+    if route.triage:
+        lines.extend([
+            "",
+            "No explicit review owner was inferable; this is a router/triage packet, not executable review work.",
+        ])
+    if route.red_gated:
+        lines.extend(["", "RED-GATED: do not execute the gated action; route/approve explicitly first."])
+    red_gates = _metadata_list(metadata.get("red_gates"))
+    if red_gates:
+        lines.extend(["Red gates:"] + [f"- {gate}" for gate in red_gates])
+
+    receipt_lines: list[str] = []
+    for key in _REVIEW_REQUIRED_RECEIPT_KEYS:
+        value = metadata.get(key)
+        if value in (None, "", [], {}):
+            continue
+        try:
+            rendered = (
+                str(value)
+                if isinstance(value, (str, int, float, bool))
+                else json.dumps(value, ensure_ascii=False, sort_keys=True)
+            )
+        except TypeError:
+            rendered = str(value)
+        receipt_lines.append(f"- {key}: {rendered}")
+    if receipt_lines:
+        lines.extend(["", "Source receipt excerpts:"] + receipt_lines)
+    return "\n".join(lines)
+
+
+def _create_review_required_successor(
+    conn: sqlite3.Connection,
+    row: sqlite3.Row,
+    metadata: dict[str, Any],
+    comment_metadata: Optional[dict[str, Any]] = None,
+) -> Optional[str]:
+    source_id = row["task_id"]
+    run_id = int(row["run_id"])
+    comment_metadata = comment_metadata or {}
+    effective_metadata = {**comment_metadata, **metadata}
+    if _task_has_successor_for_review_required(conn, source_id, run_id, effective_metadata):
+        return None
+
+    reason = _latest_block_reason(conn, source_id)
+    route = _review_required_route(
+        metadata,
+        reason,
+        comment_metadata,
+        source_assignee=row["task_assignee"],
+    )
+    title = f"Review required: {row['task_title'] or source_id}"
+    if route.triage:
+        title = f"Route review-required: {row['task_title'] or source_id}"
+    if route.red_gated:
+        title = f"RED-GATED routing needed: {title}"
+
+    source_kind = row["workspace_kind"] or "scratch"
+    source_workspace = row["workspace_path"] if source_kind in {"dir", "worktree"} else None
+    successor_id = create_task(
+        conn,
+        title=title,
+        body=_review_required_card_body(
+            source_id=source_id,
+            source_title=row["task_title"] or "",
+            source_assignee=row["task_assignee"],
+            run_id=run_id,
+            reason=reason,
+            metadata=effective_metadata,
+            route=route,
+        ),
+        assignee=route.assignee,
+        created_by=_LIVENESS_AUTHOR,
+        workspace_kind=source_kind,
+        workspace_path=source_workspace,
+        tenant=row["tenant"],
+        idempotency_key=_review_required_idempotency_key(source_id, run_id),
+        idempotency_exclude_parent=source_id,
+        triage=route.triage and not route.red_gated,
+        initial_status="blocked" if route.red_gated else "running",
+    )
+    with write_txn(conn):
+        if route.red_gated:
+            _append_event(
+                conn,
+                successor_id,
+                "blocked",
+                {"reason": "red-gated: approval/routing required before execution"},
+            )
+        _append_event(
+            conn,
+            source_id,
+            "review_required_successor_created",
+            {
+                "successor_task_id": successor_id,
+                "run_id": run_id,
+                "idempotency_key": _review_required_idempotency_key(source_id, run_id),
+                "assignee": route.assignee,
+                "owner_source": route.owner_source,
+                "triage": route.triage,
+                "red_gated": route.red_gated,
+            },
+            run_id=run_id,
+        )
+    return successor_id
 
 
 def _extract_review_verdict(metadata: Any) -> Optional[dict[str, Any]]:
@@ -5779,6 +6305,53 @@ def consume_review_verdicts(conn: sqlite3.Connection) -> ReviewVerdictConsumptio
         result.consumed_review_verdicts.append(source_id)
         if created_followup:
             result.created_review_verdict_followups.append(created_followup)
+    return result
+
+
+def _source_has_independent_reviewer(conn: sqlite3.Connection, source_id: str) -> bool:
+    rows = conn.execute(
+        """
+        SELECT DISTINCT r.task_id AS reviewer_task_id,
+               r.metadata AS metadata
+          FROM task_runs r
+          JOIN tasks rt ON rt.id = r.task_id
+         WHERE rt.status != 'archived'
+           AND r.metadata IS NOT NULL
+         ORDER BY r.id DESC
+        """
+    ).fetchall()
+    for row in rows:
+        verdict_doc = _extract_review_verdict(_parse_json_dict(row["metadata"]))
+        if not verdict_doc or verdict_doc.get("source_task_id") != source_id:
+            continue
+        reviewer_task_id = row["reviewer_task_id"]
+        if source_id not in parent_ids(conn, reviewer_task_id):
+            return True
+    return False
+
+
+def scan_liveness(conn: sqlite3.Connection) -> LivenessScanResult:
+    """Apply cheap Kanban liveness repairs used by the dispatcher.
+
+    Current mutating scope is intentionally narrow: completed review verdicts
+    are consumed first, then blocked sources whose latest block reason starts
+    with ``review-required:`` receive exactly one independent review/triage
+    successor.  The source remains blocked for successor creation and the
+    successor is not parent-linked to the source, avoiding review deadlock.
+    """
+    result = LivenessScanResult()
+    verdict_result = consume_review_verdicts(conn)
+    result.consumed_review_verdicts.extend(verdict_result.consumed_review_verdicts)
+    result.created_review_verdict_followups.extend(verdict_result.created_review_verdict_followups)
+    for row in _latest_blocked_review_runs(conn):
+        source_id = row["task_id"]
+        if not _is_review_required_block(conn, source_id):
+            continue
+        metadata = _parse_json_dict(row["metadata"])
+        comment_metadata = _latest_review_required_comment_metadata(conn, source_id)
+        successor_id = _create_review_required_successor(conn, row, metadata, comment_metadata)
+        if successor_id:
+            result.created_review_required_successors.append(source_id)
     return result
 
 
@@ -7103,6 +7676,17 @@ def _dispatch_once_locked(
         result.rate_limited.extend(_crash_rate_limited)
     result.timed_out = enforce_max_runtime(conn)
     result.promoted = recompute_ready(conn, failure_limit=failure_limit)
+    if not dry_run:
+        liveness_result = scan_liveness(conn)
+        if liveness_result.created_review_verdict_followups:
+            recompute_ready(conn, failure_limit=failure_limit)
+        result.consumed_review_verdicts.extend(liveness_result.consumed_review_verdicts)
+        result.created_review_verdict_followups.extend(
+            liveness_result.created_review_verdict_followups
+        )
+        result.created_review_required_successors.extend(
+            liveness_result.created_review_required_successors
+        )
 
     # Count tasks already running so max_spawn enforces concurrency rather
     # than a per-tick spawn budget. See the docstring above for the full

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5468,6 +5468,191 @@ class DispatchResult:
     actively preventing two dispatchers from racing on ``kanban.db``."""
 
 
+@dataclass
+class ReviewVerdictConsumptionResult:
+    """Summary returned by :func:`consume_review_verdicts`."""
+
+    consumed_review_verdicts: list[str] = field(default_factory=list)
+    created_review_verdict_followups: list[str] = field(default_factory=list)
+    skipped_review_verdicts: list[dict[str, Any]] = field(default_factory=list)
+
+
+def _extract_review_verdict(metadata: Any) -> Optional[dict[str, Any]]:
+    if not isinstance(metadata, dict):
+        return None
+    source = (
+        metadata.get("review_of")
+        or metadata.get("subject_task_id")
+        or metadata.get("source_task_id")
+    )
+    if not source:
+        return None
+    raw_verdict = metadata.get("verdict")
+    if not raw_verdict and metadata.get("approved") is True:
+        raw_verdict = "APPROVED"
+    verdict = str(raw_verdict or "").strip().upper()
+    if verdict in {"GO", "PASS"}:
+        verdict = "APPROVED"
+    if verdict in {"REJECTED", "REQUEST_CHANGES", "REQUESTED_CHANGES"}:
+        verdict = "CHANGES_REQUESTED"
+    if verdict not in {
+        "APPROVED",
+        "CHANGES_REQUESTED",
+        "INSUFFICIENT_EVIDENCE",
+        "STOP_RED_HUMAN",
+    }:
+        return None
+    return {
+        "source_task_id": str(source).strip(),
+        "verdict": verdict,
+        "summary": str(metadata.get("summary") or metadata.get("review_summary") or "").strip(),
+    }
+
+
+def _review_verdict_already_consumed(conn: sqlite3.Connection, review_task_id: str) -> bool:
+    return bool(conn.execute(
+        "SELECT 1 FROM task_events "
+        "WHERE task_id = ? AND kind = 'review_verdict_consumed' LIMIT 1",
+        (review_task_id,),
+    ).fetchone())
+
+
+def _latest_completed_review_verdict_rows(conn: sqlite3.Connection) -> list[sqlite3.Row]:
+    return conn.execute(
+        """
+        SELECT r.id AS run_id, r.task_id AS review_task_id, r.metadata,
+               r.summary, r.ended_at, t.title AS review_title
+          FROM task_runs r
+          JOIN tasks t ON t.id = r.task_id
+         WHERE r.outcome = 'completed'
+           AND r.metadata IS NOT NULL
+         ORDER BY COALESCE(r.ended_at, r.started_at, 0) ASC, r.id ASC
+        """
+    ).fetchall()
+
+
+def consume_review_verdicts(conn: sqlite3.Connection) -> ReviewVerdictConsumptionResult:
+    """Consume completed independent-review verdicts exactly once.
+
+    The reconciler and dispatcher need a canonical Python primitive, not a
+    removed CLI verb. Completed review tasks advertise their source with
+    ``metadata.review_of`` / ``subject_task_id`` / ``source_task_id`` and a
+    normalized verdict. This function is idempotent via a
+    ``review_verdict_consumed`` event on the review task.
+    """
+    result = ReviewVerdictConsumptionResult()
+    for row in _latest_completed_review_verdict_rows(conn):
+        review_task_id = str(row["review_task_id"])
+        if _review_verdict_already_consumed(conn, review_task_id):
+            continue
+        try:
+            metadata = json.loads(row["metadata"] or "{}")
+        except Exception:
+            result.skipped_review_verdicts.append({
+                "review_task_id": review_task_id,
+                "reason": "metadata_parse_failed",
+            })
+            continue
+        verdict_doc = _extract_review_verdict(metadata)
+        if not verdict_doc:
+            continue
+        source_id = verdict_doc["source_task_id"]
+        source = get_task(conn, source_id)
+        if source is None:
+            result.skipped_review_verdicts.append({
+                "review_task_id": review_task_id,
+                "source_task_id": source_id,
+                "reason": "missing_source_task",
+            })
+            with write_txn(conn):
+                _append_event(
+                    conn,
+                    review_task_id,
+                    "review_verdict_consumed",
+                    {**verdict_doc, "action": "skipped_missing_source"},
+                    run_id=int(row["run_id"]),
+                )
+            continue
+        verdict = verdict_doc["verdict"]
+        payload = {
+            **verdict_doc,
+            "review_task_id": review_task_id,
+            "review_run_id": int(row["run_id"]),
+        }
+        created_followup: Optional[str] = None
+        if verdict in {"CHANGES_REQUESTED", "INSUFFICIENT_EVIDENCE"}:
+            title_prefix = (
+                "Address review changes for"
+                if verdict == "CHANGES_REQUESTED"
+                else "Provide review evidence for"
+            )
+            followup_body = (
+                "Created by kanban verdict consumer.\n"
+                f"source_task_id={source_id}\n"
+                f"review_task_id={review_task_id}\n"
+                f"review_run_id={int(row['run_id'])}\n"
+                f"verdict={verdict}\n\n"
+                f"Review summary: {verdict_doc.get('summary') or row['summary'] or ''}\n\n"
+                "Do not treat this as approval to apply/restart/deploy/push/merge. Preserve Red gates."
+            )
+            created_followup = create_task(
+                conn,
+                title=f"{title_prefix} {source_id}",
+                body=followup_body,
+                assignee=source.assignee,
+                created_by="kanban-verdict-consumer",
+                tenant=source.tenant,
+                priority=source.priority,
+                initial_status="blocked",
+                idempotency_key=f"review-verdict:{review_task_id}:{source_id}:{verdict}",
+            )
+            payload["created_followup"] = created_followup
+        with write_txn(conn):
+            if verdict == "APPROVED":
+                if source.status in {"blocked", "scheduled"}:
+                    next_status = "ready"
+                    # Preserve dependency semantics: if any parent is still open,
+                    # park in todo until recompute_ready can promote it.
+                    open_parent = conn.execute(
+                        "SELECT 1 FROM task_links l JOIN tasks p ON p.id = l.parent_id "
+                        "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived') LIMIT 1",
+                        (source_id,),
+                    ).fetchone()
+                    if open_parent:
+                        next_status = "todo"
+                    conn.execute(
+                        "UPDATE tasks SET status = ?, claim_lock = NULL, claim_expires = NULL, worker_pid = NULL "
+                        "WHERE id = ? AND status IN ('blocked', 'scheduled')",
+                        (next_status, source_id),
+                    )
+                _append_event(conn, source_id, "review_verdict_approved", payload)
+            elif verdict in {"CHANGES_REQUESTED", "INSUFFICIENT_EVIDENCE"}:
+                _append_event(conn, source_id, "review_verdict_followup_created", payload)
+            elif verdict == "STOP_RED_HUMAN":
+                _append_event(conn, source_id, "review_verdict_red_hold", payload)
+            _append_event(
+                conn,
+                review_task_id,
+                "review_verdict_consumed",
+                payload,
+                run_id=int(row["run_id"]),
+            )
+            conn.execute(
+                "INSERT INTO task_comments (task_id, author, body, created_at) VALUES (?, ?, ?, ?)",
+                (
+                    source_id,
+                    "kanban-verdict-consumer",
+                    f"Consumed review verdict {verdict} from {review_task_id}."
+                    + (f" Created follow-up {created_followup}." if created_followup else ""),
+                    int(time.time()),
+                ),
+            )
+        result.consumed_review_verdicts.append(source_id)
+        if created_followup:
+            result.created_review_verdict_followups.append(created_followup)
+    return result
+
+
 # Bounded registry of recently-reaped worker child exits, populated by the
 # reap loop at the top of ``dispatch_once`` and consulted by
 # ``detect_crashed_workers`` to classify a dead-pid task.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -111,6 +111,7 @@ ROLE_ASSIGNEE_ALIASES: dict[str, str] = {
     "researcher": "brennan",
     "builder": "stark",
     "steward": "pepper",
+    "studio": "taylor",
 }
 
 
@@ -5510,11 +5511,38 @@ _REVIEW_REQUIRED_RECEIPT_KEYS = (
     "commands",
     "diff_path",
     "artifacts",
+    "output_image",
+    "output_images",
+    "image_path",
+    "image_paths",
     "risk_class",
     "review_type",
     "review_kind",
     "requested_verdict",
     "decisions",
+)
+_REVIEW_REQUIRED_VISUAL_OUTPUT_KEYS = frozenset(
+    {
+        "artifact",
+        "artifacts",
+        "output_image",
+        "output_images",
+        "image",
+        "images",
+        "image_path",
+        "image_paths",
+        "preview_image",
+        "preview_images",
+        "contact_sheet",
+        "contact_sheets",
+    }
+)
+_REVIEW_REQUIRED_VISUAL_OUTPUT_RE = re.compile(
+    r"\b(?:ai[-\s]?influencer|comfyui|instantid|identity[-\s]?control|"
+    r"one[-\s]?image|generated\s+image|output\s+image|image\s+(?:smoke|output|artifact|packet|review)|"
+    r"visual\s+(?:qa|review|handoff)|contact\s+sheet|avatar|face\s+family|"
+    r"synthetic\s+(?:brand|reference|image))\b",
+    re.IGNORECASE,
 )
 _REVIEW_REQUIRED_NEGATED_RED_GATE_PATTERNS = (
     re.compile(
@@ -5846,11 +5874,59 @@ def _review_required_has_code_change_receipts(metadata: dict[str, Any]) -> bool:
     return code_receipt_present and test_receipt_present
 
 
+def _review_required_visual_text_fragments(value: Any) -> list[str]:
+    if value in (None, "", [], {}):
+        return []
+    if isinstance(value, dict):
+        fragments: list[str] = []
+        for key, nested in value.items():
+            fragments.append(str(key))
+            fragments.extend(_review_required_visual_text_fragments(nested))
+        return fragments
+    if isinstance(value, (list, tuple, set)):
+        fragments = []
+        for nested in value:
+            fragments.extend(_review_required_visual_text_fragments(nested))
+        return fragments
+    return [str(value)]
+
+
+def _review_required_has_visual_artifact_hint(metadata: dict[str, Any]) -> bool:
+    for item in _review_required_nested_dicts(metadata):
+        for key, value in item.items():
+            normalized_key = str(key).strip().lower()
+            if normalized_key in _REVIEW_REQUIRED_VISUAL_OUTPUT_KEYS and _metadata_list(value):
+                return True
+            if normalized_key.endswith(("_image", "_images", "_image_path", "_image_paths")) and _metadata_list(value):
+                return True
+    return False
+
+
+def _review_required_has_visual_output_review(
+    metadata: dict[str, Any],
+    reason: str,
+    *,
+    source_title: Optional[str] = None,
+    source_body: Optional[str] = None,
+) -> bool:
+    if not _review_required_has_visual_artifact_hint(metadata):
+        return False
+    text = "\n".join(
+        fragment
+        for fragment in [reason or "", source_title or "", source_body or ""]
+        + _review_required_visual_text_fragments(metadata)
+        if fragment
+    )
+    return bool(_REVIEW_REQUIRED_VISUAL_OUTPUT_RE.search(text))
+
+
 def _review_required_route(
     metadata: dict[str, Any],
     reason: str,
     comment_metadata: Optional[dict[str, Any]] = None,
     source_assignee: Optional[str] = None,
+    source_title: Optional[str] = None,
+    source_body: Optional[str] = None,
 ) -> _ReviewRequiredRoute:
     comment_metadata = comment_metadata or {}
     effective_metadata = {**comment_metadata, **metadata}
@@ -5869,6 +5945,19 @@ def _review_required_route(
     explicit = _review_required_owner_from_text(reason)
     if explicit:
         return _ReviewRequiredRoute(_canonical_assignee(explicit) or explicit, "explicit-reason")
+    if (
+        not _review_required_has_code_change_receipts(effective_metadata)
+        and _review_required_has_visual_output_review(
+            effective_metadata,
+            reason,
+            source_title=source_title,
+            source_body=source_body,
+        )
+    ):
+        return _ReviewRequiredRoute(
+            _canonical_assignee("studio") or "taylor",
+            "visual-output-review",
+        )
     if (
         _canonical_assignee(source_assignee) in {"builder", "stark"}
         and _review_required_has_code_change_receipts(effective_metadata)
@@ -5949,6 +6038,8 @@ def _create_review_required_successor(
         reason,
         comment_metadata,
         source_assignee=row["task_assignee"],
+        source_title=row["task_title"],
+        source_body=row["task_body"],
     )
     title = f"Review required: {row['task_title'] or source_id}"
     if route.triage:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2259,13 +2259,6 @@ def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
     normalized = normalize_profile_name(assignee)
     alias_target = ROLE_ASSIGNEE_ALIASES.get(normalized)
     if alias_target:
-        try:
-            from hermes_cli.profiles import profile_exists
-
-            if profile_exists(normalized):
-                return normalized
-        except Exception:
-            pass
         return alias_target
     return normalized
 
@@ -2435,10 +2428,10 @@ def create_task(
         skills_list = cleaned
 
     # Idempotency check — return the existing task instead of creating a
-    # duplicate. Done BEFORE entering write_txn to keep the fast path fast
-    # and to avoid holding a write lock during the lookup. Race is
-    # acceptable: two concurrent creators with the same key might both
-    # insert, at which point both rows exist but the next lookup stabilises.
+    # duplicate. The preflight keeps the common duplicate path fast; the
+    # same lookup is repeated inside the write transaction below so a racing
+    # creator that wins after this check but before our INSERT cannot produce
+    # a second non-archived row with the same key.
     if idempotency_key:
         row = conn.execute(
             "SELECT id FROM tasks WHERE idempotency_key = ? "
@@ -2472,6 +2465,16 @@ def create_task(
         task_id = _new_task_id()
         try:
             with write_txn(conn):
+                if idempotency_key:
+                    row = conn.execute(
+                        "SELECT id FROM tasks WHERE idempotency_key = ? "
+                        "AND status != 'archived' "
+                        "ORDER BY created_at DESC LIMIT 1",
+                        (idempotency_key,),
+                    ).fetchone()
+                    if row:
+                        return row["id"]
+
                 # Determine task status from parent status, unless the caller
                 # parks it directly in blocked for human-ops review or in
                 # triage for a specifier.
@@ -5509,6 +5512,24 @@ def _extract_review_verdict(metadata: Any) -> Optional[dict[str, Any]]:
     }
 
 
+_REVIEW_OUTPUT_STOP_RED_HUMAN_RE = re.compile(
+    r"\b(?:STOP|RED|HUMAN(?:\s+APPROVAL)?\s+REQUIRED|ROLLBACK)\b",
+    re.IGNORECASE,
+)
+
+
+def _review_output_has_stop_red_human(text: str) -> bool:
+    """Return True for reviewer-authored STOP/RED/HUMAN gate language.
+
+    This is intentionally applied only to completed review output (run summary
+    and explicit metadata summary), not review-card bodies/source prose, so the
+    normal review instructions do not become verdict text.  Within actual
+    reviewer output it preserves fail-closed precedence: STOP/RED/HUMAN beats a
+    lower-severity explicit verdict such as CHANGES_REQUESTED.
+    """
+    return bool(_REVIEW_OUTPUT_STOP_RED_HUMAN_RE.search(text or ""))
+
+
 def _review_verdict_already_consumed(conn: sqlite3.Connection, review_task_id: str) -> bool:
     return bool(conn.execute(
         "SELECT 1 FROM task_events "
@@ -5529,6 +5550,103 @@ def _latest_completed_review_verdict_rows(conn: sqlite3.Connection) -> list[sqli
          ORDER BY COALESCE(r.ended_at, r.started_at, 0) ASC, r.id ASC
         """
     ).fetchall()
+
+
+def _payload_has_typed_red_or_human_hold(payload: Any) -> bool:
+    """Return True only for structured red/human hold metadata.
+
+    Free-text block reasons are intentionally ignored here: review handoff
+    prose often says things like "no red gate remains" and must not be used as
+    control-plane state for APPROVED verdict routing.
+    """
+    if not isinstance(payload, dict):
+        return False
+    for key in (
+        "red_gate",
+        "red_gated",
+        "human_approval_required",
+        "human_required",
+        "stop_red_human",
+    ):
+        if payload.get(key) is True:
+            return True
+    for key in ("gate", "hold", "severity", "verdict", "route", "status"):
+        value = str(payload.get(key) or "").strip().lower().replace("-", "_")
+        if value in {"red", "human", "red_human", "stop_red_human"}:
+            return True
+    return False
+
+
+def _source_has_typed_red_or_human_hold(
+    conn: sqlite3.Connection,
+    source_id: str,
+) -> bool:
+    rows = conn.execute(
+        "SELECT payload FROM task_events WHERE task_id = ? AND kind = 'blocked' "
+        "ORDER BY created_at DESC, id DESC",
+        (source_id,),
+    ).fetchall()
+    return any(
+        _payload_has_typed_red_or_human_hold(
+            json.loads(row["payload"] or "{}")
+        )
+        for row in rows
+    )
+
+
+def _review_verdict_followup_idempotency_key(
+    source_id: str,
+    review_run_id: int,
+    verdict: str,
+) -> str:
+    return f"review-verdict:{source_id}:{review_run_id}:{verdict.lower()}"
+
+
+def _red_human_packet_idempotency_key(source_id: str) -> str:
+    return f"review-verdict:{source_id}:red-human-hold"
+
+
+def _create_review_verdict_followup(
+    conn: sqlite3.Connection,
+    *,
+    source: Task,
+    review_task_id: str,
+    review_run_id: int,
+    verdict: str,
+    summary: str,
+) -> str:
+    if verdict == "CHANGES_REQUESTED":
+        title_prefix = "Address review changes for"
+        assignee = source.assignee
+        key = _review_verdict_followup_idempotency_key(source.id, review_run_id, verdict)
+    elif verdict == "INSUFFICIENT_EVIDENCE":
+        title_prefix = "Provide review evidence for"
+        assignee = source.assignee
+        key = _review_verdict_followup_idempotency_key(source.id, review_run_id, verdict)
+    else:
+        title_prefix = "STOP_RED_HUMAN routing needed:"
+        assignee = "default"
+        key = _red_human_packet_idempotency_key(source.id)
+    body = (
+        "Created by kanban verdict consumer.\n"
+        f"source_task_id={source.id}\n"
+        f"review_task_id={review_task_id}\n"
+        f"review_run_id={review_run_id}\n"
+        f"verdict={verdict}\n\n"
+        f"Review summary: {summary}\n\n"
+        "Do not treat this as approval to apply/restart/deploy/push/merge. Preserve Red gates."
+    )
+    return create_task(
+        conn,
+        title=f"{title_prefix} {source.id}",
+        body=body,
+        assignee=assignee or "default",
+        created_by="kanban-verdict-consumer",
+        tenant=source.tenant,
+        priority=source.priority,
+        initial_status="blocked",
+        idempotency_key=key,
+    )
 
 
 def consume_review_verdicts(conn: sqlite3.Connection) -> ReviewVerdictConsumptionResult:
@@ -5574,41 +5692,45 @@ def consume_review_verdicts(conn: sqlite3.Connection) -> ReviewVerdictConsumptio
                 )
             continue
         verdict = verdict_doc["verdict"]
+        review_run_id = int(row["run_id"])
+        summary = str(verdict_doc.get("summary") or row["summary"] or "")
+        review_output = "\n".join(
+            part
+            for part in (
+                str(verdict_doc.get("summary") or ""),
+                str(row["summary"] or ""),
+            )
+            if part
+        )
+        if verdict in {"CHANGES_REQUESTED", "INSUFFICIENT_EVIDENCE"} and _review_output_has_stop_red_human(review_output):
+            verdict = "STOP_RED_HUMAN"
+            verdict_doc["verdict"] = verdict
         payload = {
             **verdict_doc,
             "review_task_id": review_task_id,
-            "review_run_id": int(row["run_id"]),
+            "review_run_id": review_run_id,
         }
         created_followup: Optional[str] = None
-        if verdict in {"CHANGES_REQUESTED", "INSUFFICIENT_EVIDENCE"}:
-            title_prefix = (
-                "Address review changes for"
-                if verdict == "CHANGES_REQUESTED"
-                else "Provide review evidence for"
-            )
-            followup_body = (
-                "Created by kanban verdict consumer.\n"
-                f"source_task_id={source_id}\n"
-                f"review_task_id={review_task_id}\n"
-                f"review_run_id={int(row['run_id'])}\n"
-                f"verdict={verdict}\n\n"
-                f"Review summary: {verdict_doc.get('summary') or row['summary'] or ''}\n\n"
-                "Do not treat this as approval to apply/restart/deploy/push/merge. Preserve Red gates."
-            )
-            created_followup = create_task(
+        approved_red_hold = verdict == "APPROVED" and _source_has_typed_red_or_human_hold(
+            conn,
+            source_id,
+        )
+        if (
+            verdict in {"CHANGES_REQUESTED", "INSUFFICIENT_EVIDENCE", "STOP_RED_HUMAN"}
+            or approved_red_hold
+        ):
+            followup_verdict = "STOP_RED_HUMAN" if approved_red_hold else verdict
+            created_followup = _create_review_verdict_followup(
                 conn,
-                title=f"{title_prefix} {source_id}",
-                body=followup_body,
-                assignee=source.assignee,
-                created_by="kanban-verdict-consumer",
-                tenant=source.tenant,
-                priority=source.priority,
-                initial_status="blocked",
-                idempotency_key=f"review-verdict:{review_task_id}:{source_id}:{verdict}",
+                source=source,
+                review_task_id=review_task_id,
+                review_run_id=review_run_id,
+                verdict=followup_verdict,
+                summary=summary,
             )
             payload["created_followup"] = created_followup
         with write_txn(conn):
-            if verdict == "APPROVED":
+            if verdict == "APPROVED" and not approved_red_hold:
                 if source.status in {"blocked", "scheduled"}:
                     next_status = "ready"
                     # Preserve dependency semantics: if any parent is still open,
@@ -5626,6 +5748,13 @@ def consume_review_verdicts(conn: sqlite3.Connection) -> ReviewVerdictConsumptio
                         (next_status, source_id),
                     )
                 _append_event(conn, source_id, "review_verdict_approved", payload)
+            elif verdict == "APPROVED" and approved_red_hold:
+                _append_event(
+                    conn,
+                    source_id,
+                    "review_verdict_red_hold",
+                    {**payload, "action": "typed_red_human_hold"},
+                )
             elif verdict in {"CHANGES_REQUESTED", "INSUFFICIENT_EVIDENCE"}:
                 _append_event(conn, source_id, "review_verdict_followup_created", payload)
             elif verdict == "STOP_RED_HUMAN":
@@ -5635,7 +5764,7 @@ def consume_review_verdicts(conn: sqlite3.Connection) -> ReviewVerdictConsumptio
                 review_task_id,
                 "review_verdict_consumed",
                 payload,
-                run_id=int(row["run_id"]),
+                run_id=review_run_id,
             )
             conn.execute(
                 "INSERT INTO task_comments (task_id, author, body, created_at) VALUES (?, ?, ?, ?)",

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5498,6 +5498,16 @@ _REVIEW_REQUIRED_OWNER_KEYS = (
     "needed_profile",
     "awaiting_profile",
 )
+
+# Canonical reviewer for a review-required source task when no explicit owner is
+# declared.  This is the "assignee directory" fallback: independent review of
+# builder work goes to the researcher.  Other profiles (operator, steward,
+# studio/visual) either have their own routing heuristics or genuinely need
+# triage when no reviewer is inferable.
+_REVIEW_REQUIRED_SOURCE_REVIEWER: dict[str, str] = {
+    "stark": "brennan",  # builder -> researcher (alias builder canonicalizes to stark)
+}
+
 _REVIEW_REQUIRED_SUCCESSOR_KEYS = (
     "successor_task_ids",
     "review_successor_task_ids",
@@ -5965,6 +5975,13 @@ def _review_required_route(
         return _ReviewRequiredRoute(
             _canonical_assignee("researcher") or "researcher",
             "code-review-receipts",
+        )
+    source_canon = _canonical_assignee(source_assignee)
+    directory_reviewer = _REVIEW_REQUIRED_SOURCE_REVIEWER.get(source_canon) if source_canon else None
+    if directory_reviewer:
+        return _ReviewRequiredRoute(
+            _canonical_assignee(directory_reviewer) or directory_reviewer,
+            "source-assignee-directory",
         )
     return _ReviewRequiredRoute("default", "router-triage", triage=True)
 

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -36,6 +36,7 @@ Design notes
 
 from __future__ import annotations
 
+import importlib
 import json
 import logging
 import os
@@ -44,7 +45,6 @@ from dataclasses import dataclass
 from typing import Optional
 
 from hermes_cli import kanban_db as kb
-from hermes_cli import profiles as profiles_mod
 
 logger = logging.getLogger(__name__)
 
@@ -124,6 +124,17 @@ Default assignee (used when no profile fits a task): {default_assignee}
 _FENCE_RE = re.compile(r"^```(?:json)?\s*|\s*```$", re.MULTILINE)
 
 
+def _profiles():
+    """Return the current profiles module, tolerating test env re-imports.
+
+    Some Kanban tests reset ``sys.modules['hermes_cli.*']`` to move
+    ``HERMES_HOME`` between temp dirs. Resolve the module lazily at call time so
+    monkeypatches on ``hermes_cli.profiles`` still reach the decomposer even if
+    this module was imported before that reset.
+    """
+    return importlib.import_module("hermes_cli.profiles")
+
+
 @dataclass
 class DecomposeOutcome:
     """Result of decomposing a single triage task."""
@@ -184,16 +195,16 @@ def _resolve_orchestrator_profile(cfg: dict) -> str:
     is unset, so a task is never stranded for lack of an orchestrator.
     """
     kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
-    explicit = (kanban_cfg.get("orchestrator_profile") or "").strip()
+    explicit = kb.canonical_assignee(kanban_cfg.get("orchestrator_profile"))
     if explicit:
         try:
-            if profiles_mod.profile_exists(explicit):
+            if _profiles().profile_exists(explicit):
                 return explicit
         except Exception:
             pass
     # Fall back to the active default profile.
     try:
-        return profiles_mod.get_active_profile_name() or "default"
+        return _profiles().get_active_profile_name() or "default"
     except Exception:
         return "default"
 
@@ -201,15 +212,15 @@ def _resolve_orchestrator_profile(cfg: dict) -> str:
 def _resolve_default_assignee(cfg: dict) -> str:
     """Resolve which profile catches child tasks the orchestrator can't route."""
     kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
-    explicit = (kanban_cfg.get("default_assignee") or "").strip()
+    explicit = kb.canonical_assignee(kanban_cfg.get("default_assignee"))
     if explicit:
         try:
-            if profiles_mod.profile_exists(explicit):
+            if _profiles().profile_exists(explicit):
                 return explicit
         except Exception:
             pass
     try:
-        return profiles_mod.get_active_profile_name() or "default"
+        return _profiles().get_active_profile_name() or "default"
     except Exception:
         return "default"
 
@@ -224,7 +235,7 @@ def _build_roster() -> tuple[list[dict], set[str]]:
     roster: list[dict] = []
     valid: set[str] = set()
     try:
-        all_profiles = profiles_mod.list_profiles()
+        all_profiles = _profiles().list_profiles()
     except Exception as exc:
         logger.warning("decompose: failed to list profiles: %s", exc)
         return roster, valid
@@ -262,7 +273,10 @@ def _normalize_assignee_choice(
     """
     if not isinstance(assignee, str) or not assignee.strip():
         return default_assignee
-    chosen = assignee.strip()
+    raw_choice = _profiles().normalize_profile_name(assignee)
+    if raw_choice in valid_names:
+        return raw_choice
+    chosen = kb.canonical_assignee(assignee)
     if chosen not in valid_names:
         return default_assignee
     return chosen

--- a/hermes_cli/kanban_liveness.py
+++ b/hermes_cli/kanban_liveness.py
@@ -1,0 +1,167 @@
+"""Read-only Kanban board liveness scanner.
+
+This module intentionally does not mutate board state. It is used by
+``hermes kanban liveness`` and by external no-agent health wrappers that need a
+small, stable JSON contract instead of scraping ``kanban list``.
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from hermes_cli import kanban_db as kb
+
+
+@dataclass
+class LivenessFinding:
+    kind: str
+    severity: str
+    task_id: str
+    title: str
+    status: str
+    detail: str
+    assignee: Optional[str] = None
+    age_minutes: Optional[float] = None
+    data: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        doc: dict[str, Any] = {
+            "kind": self.kind,
+            "severity": self.severity,
+            "task_id": self.task_id,
+            "title": self.title,
+            "status": self.status,
+            "detail": self.detail,
+        }
+        if self.assignee:
+            doc["assignee"] = self.assignee
+        if self.age_minutes is not None:
+            doc["age_minutes"] = round(float(self.age_minutes), 1)
+        if self.data:
+            doc["data"] = self.data
+        return doc
+
+
+def _task_age_minutes(row, now: int) -> float:
+    started = row["started_at"] if "started_at" in row.keys() else None
+    created = row["created_at"] if "created_at" in row.keys() else None
+    base = int(started or created or now)
+    return max(0.0, (now - base) / 60.0)
+
+
+def _health(findings: list[LivenessFinding]) -> str:
+    if not findings:
+        return "ok"
+    if any(f.severity == "critical" for f in findings):
+        return "critical"
+    if any(f.severity == "error" for f in findings):
+        return "degraded"
+    return "warning"
+
+
+def scan_liveness(
+    conn,
+    *,
+    tenant: Optional[str] = None,
+    ready_sla_minutes: int = 240,
+    now: Optional[int] = None,
+) -> dict[str, Any]:
+    """Return a read-only board health digest.
+
+    Findings are deliberately conservative and operator-actionable:
+    blocked tasks, stale ready tasks, and running tasks whose claim has expired
+    or whose heartbeat is stale. No state transitions happen here.
+    """
+    now = int(now or time.time())
+    params: list[Any] = []
+    where = "status IN ('blocked', 'ready', 'running', 'triage', 'todo')"
+    if tenant is not None:
+        where += " AND tenant = ?"
+        params.append(tenant)
+    rows = conn.execute(
+        f"""
+        SELECT id, title, assignee, status, created_at, started_at,
+               claim_lock, claim_expires, worker_pid, last_heartbeat_at,
+               tenant, priority
+          FROM tasks
+         WHERE {where}
+         ORDER BY priority DESC, created_at ASC
+        """,
+        params,
+    ).fetchall()
+
+    findings: list[LivenessFinding] = []
+    counts: dict[str, int] = {}
+    for row in rows:
+        status = str(row["status"])
+        counts[status] = counts.get(status, 0) + 1
+        age_min = _task_age_minutes(row, now)
+        title = str(row["title"] or "")
+        assignee = row["assignee"]
+        task_id = str(row["id"])
+
+        if status == "blocked":
+            findings.append(LivenessFinding(
+                kind="blocked_task",
+                severity="warning",
+                task_id=task_id,
+                title=title,
+                status=status,
+                assignee=assignee,
+                age_minutes=age_min,
+                detail="Task is blocked and needs review, unblock, reroute, or an explicit decision.",
+            ))
+        elif status == "ready" and age_min >= max(0, int(ready_sla_minutes)):
+            findings.append(LivenessFinding(
+                kind="ready_sla_exceeded",
+                severity="error",
+                task_id=task_id,
+                title=title,
+                status=status,
+                assignee=assignee,
+                age_minutes=age_min,
+                detail=f"Task has been ready for >= {int(ready_sla_minutes)} minutes without being claimed.",
+            ))
+        elif status == "running":
+            claim_expires = row["claim_expires"]
+            last_hb = row["last_heartbeat_at"]
+            if claim_expires is not None and int(claim_expires) < now:
+                findings.append(LivenessFinding(
+                    kind="expired_running_claim",
+                    severity="critical",
+                    task_id=task_id,
+                    title=title,
+                    status=status,
+                    assignee=assignee,
+                    age_minutes=age_min,
+                    detail="Running task claim has expired; dispatcher should reclaim or extend it on the next tick.",
+                    data={"claim_expires": int(claim_expires), "claim_lock": row["claim_lock"]},
+                ))
+            elif last_hb is not None and (now - int(last_hb)) > kb.DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS:
+                findings.append(LivenessFinding(
+                    kind="stale_running_heartbeat",
+                    severity="critical",
+                    task_id=task_id,
+                    title=title,
+                    status=status,
+                    assignee=assignee,
+                    age_minutes=age_min,
+                    detail="Running task heartbeat is stale; worker may be wedged.",
+                    data={"last_heartbeat_at": int(last_hb)},
+                ))
+
+    finding_docs = [f.to_dict() for f in findings]
+    summary = {
+        "health": _health(findings),
+        "finding_count": len(finding_docs),
+        "active_count": len(rows),
+        "by_status": counts,
+        "tenant": tenant,
+        "ready_sla_minutes": int(ready_sla_minutes),
+    }
+    return {
+        "schema": "hermes.kanban_liveness.v1",
+        "summary": summary,
+        "findings": finding_docs,
+    }

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -173,6 +173,66 @@ def test_kanban_notifier_rewinds_claim_on_send_exception(tmp_path, monkeypatch):
     assert [ev.kind for ev in _unseen_terminal_events(tid)] == ["completed"]
 
 
+def test_decomposed_child_inherits_parent_thread_subscription(tmp_path, monkeypatch):
+    """Child/successor terminal events should notify the card's front-door thread.
+
+    The gateway auto-subscribes the original /kanban-created card, but follow-up
+    work can be created later by decomposition/controller code. Those successors
+    must inherit the parent/root notification subscription so GO / blocked /
+    changes-requested terminal events are visible without periodic polling.
+    """
+    db_path = tmp_path / "inherited-sub.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        root = kb.create_task(conn, title="front-door card", triage=True, assignee="molly")
+        kb.add_notify_sub(
+            conn,
+            task_id=root,
+            platform="telegram",
+            chat_id="chat-1",
+            thread_id="thread-7",
+            notifier_profile="default",
+        )
+        child_ids = kb.decompose_triage_task(
+            conn,
+            root,
+            root_assignee="molly",
+            children=[
+                {
+                    "title": "ship the weld",
+                    "body": "Do the work and report back.",
+                    "assignee": "stark",
+                    "parents": [],
+                }
+            ],
+        )
+        assert child_ids
+        child = child_ids[0]
+        subs = kb.list_notify_subs(conn, child)
+        assert len(subs) == 1
+        assert subs[0]["chat_id"] == "chat-1"
+        assert subs[0]["thread_id"] == "thread-7"
+        assert subs[0]["notifier_profile"] == "default"
+        kb.complete_task(conn, child, summary="GO — child done")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    runner._kanban_notifier_profile = "default"
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    assert child in adapter.sent[0]["text"]
+    assert "GO" in adapter.sent[0]["text"]
+    assert adapter.sent[0]["metadata"] == {"thread_id": "thread-7"}
+
+
+
 def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
     """A retry cycle (crashed → reclaimed → crashed) notifies the user twice.
 

--- a/tests/hermes_cli/test_kanban_decompose_db.py
+++ b/tests/hermes_cli/test_kanban_decompose_db.py
@@ -38,7 +38,7 @@ def test_decompose_creates_children_and_promotes_root(kanban_home):
         assert kb.get_task(conn, tid).status == "triage"
 
     children = [
-        {"title": "research", "body": "look at prior art", "assignee": "researcher", "parents": []},
+        {"title": "research", "body": "look at prior art", "assignee": "analyst", "parents": []},
         {"title": "build it", "body": "write code", "assignee": "engineer", "parents": [0]},
     ]
     with kb.connect() as conn:
@@ -62,7 +62,7 @@ def test_decompose_creates_children_and_promotes_root(kanban_home):
     assert root.assignee == "orchestrator"
     # First child has no internal parents → ready on recompute_ready.
     assert c0.status == "ready"
-    assert c0.assignee == "researcher"
+    assert c0.assignee == "analyst"
     # Second child has parents=[0] → stays in todo until c0 completes.
     assert c1.status == "todo"
     assert c1.assignee == "engineer"

--- a/tests/hermes_cli/test_kanban_liveness_and_verdict_drift.py
+++ b/tests/hermes_cli/test_kanban_liveness_and_verdict_drift.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import argparse
-import json
 from pathlib import Path
 
 from hermes_cli import kanban as kc
@@ -110,6 +109,120 @@ def test_consume_review_verdicts_approved_unblocks_source_once(tmp_path: Path, m
         assert len(events) == 1
 
 
+def test_consume_review_verdicts_approved_ignores_negated_red_human_prose(tmp_path: Path, monkeypatch) -> None:
+    _isolated_home(tmp_path, monkeypatch)
+    with kb.connect_closing() as conn:
+        source = kb.create_task(
+            conn,
+            title="source with negated red prose",
+            assignee="stark",
+            tenant="molly-v2-working-system",
+        )
+        assert kb.block_task(
+            conn,
+            source,
+            reason="review-required: no red gate remains; no human approval required",
+        )
+        with kb.write_txn(conn):
+            kb._append_event(
+                conn,
+                source,
+                "blocked",
+                {"reason": "review-required", "gate": "yellow", "owner_hint": "stark"},
+            )
+        review = kb.create_task(conn, title="review source", assignee="brennan")
+        assert kb.complete_task(
+            conn,
+            review,
+            summary="APPROVED: no typed hold",
+            metadata={"review_of": source, "verdict": "APPROVED"},
+        )
+
+        result = kb.consume_review_verdicts(conn)
+
+        assert result.consumed_review_verdicts == [source]
+        assert result.created_review_verdict_followups == []
+        source_task = kb.get_task(conn, source)
+        assert source_task is not None
+        assert source_task.status == "ready"
+
+
+def test_consume_review_verdicts_approved_preserves_typed_red_human_hold(tmp_path: Path, monkeypatch) -> None:
+    _isolated_home(tmp_path, monkeypatch)
+    with kb.connect_closing() as conn:
+        source = kb.create_task(
+            conn,
+            title="source with typed red hold",
+            assignee="stark",
+            tenant="molly-v2-working-system",
+        )
+        assert kb.block_task(conn, source, reason="review-required: needs review")
+        with kb.write_txn(conn):
+            kb._append_event(
+                conn,
+                source,
+                "blocked",
+                {"reason": "review-required", "gate": "red", "human_approval_required": True},
+            )
+        review = kb.create_task(conn, title="review source", assignee="brennan")
+        assert kb.complete_task(
+            conn,
+            review,
+            summary="APPROVED: code is fine but red hold remains",
+            metadata={"review_of": source, "verdict": "APPROVED"},
+        )
+
+        result = kb.consume_review_verdicts(conn)
+
+        assert result.consumed_review_verdicts == [source]
+        assert len(result.created_review_verdict_followups) == 1
+        source_task = kb.get_task(conn, source)
+        assert source_task is not None
+        assert source_task.status == "blocked"
+        packet = kb.get_task(conn, result.created_review_verdict_followups[0])
+        assert packet is not None
+        assert packet.status == "blocked"
+        assert packet.assignee == "default"
+        assert packet.idempotency_key == f"review-verdict:{source}:red-human-hold"
+
+
+def test_consume_review_verdicts_composite_changes_requested_stop_routes_red_human(tmp_path: Path, monkeypatch) -> None:
+    _isolated_home(tmp_path, monkeypatch)
+    with kb.connect_closing() as conn:
+        source = kb.create_task(
+            conn,
+            title="source with composite stop review",
+            assignee="stark",
+            tenant="molly-v2-working-system",
+        )
+        assert kb.block_task(conn, source, reason="review-required: needs independent review")
+        review = kb.create_task(conn, title="review source", assignee="brennan")
+        assert kb.complete_task(
+            conn,
+            review,
+            summary="CHANGES REQUESTED / STOP: human approval required before unblock.",
+            metadata={
+                "schema": "hermes.review_verdict.v1",
+                "review_of": source,
+                "verdict": "CHANGES_REQUESTED",
+            },
+        )
+
+        result = kb.consume_review_verdicts(conn)
+
+        assert result.consumed_review_verdicts == [source]
+        assert len(result.created_review_verdict_followups) == 1
+        packet = kb.get_task(conn, result.created_review_verdict_followups[0])
+        assert packet is not None
+        assert packet.assignee == "default"
+        assert packet.status == "blocked"
+        assert packet.idempotency_key == f"review-verdict:{source}:red-human-hold"
+        assert "verdict=STOP_RED_HUMAN" in (packet.body or "")
+        source_task = kb.get_task(conn, source)
+        assert source_task is not None
+        assert source_task.status == "blocked"
+
+
 def test_consume_review_verdicts_changes_requested_creates_one_followup(tmp_path: Path, monkeypatch) -> None:
     _isolated_home(tmp_path, monkeypatch)
     with kb.connect_closing() as conn:
@@ -152,8 +265,51 @@ def test_consume_review_verdicts_changes_requested_creates_one_followup(tmp_path
 
         second = kb.consume_review_verdicts(conn)
         assert second.created_review_verdict_followups == []
+        review_run = conn.execute(
+            "SELECT id FROM task_runs WHERE task_id = ? ORDER BY id DESC LIMIT 1",
+            (review,),
+        ).fetchone()
+        assert review_run is not None
         rows = conn.execute(
             "SELECT id FROM tasks WHERE idempotency_key = ?",
-            (f"review-verdict:{review}:{source}:CHANGES_REQUESTED",),
+            (f"review-verdict:{source}:{review_run['id']}:changes_requested",),
         ).fetchall()
         assert len(rows) == 1
+
+
+def test_create_task_rechecks_idempotency_inside_write_transaction(tmp_path: Path, monkeypatch) -> None:
+    _isolated_home(tmp_path, monkeypatch)
+    key = "review-verdict:t_source:2:changes_requested"
+    original_new_task_id = kb._new_task_id
+    injected = {"done": False}
+
+    def racing_new_task_id() -> str:
+        if not injected["done"]:
+            injected["done"] = True
+            monkeypatch.setattr(kb, "_new_task_id", original_new_task_id)
+            with kb.connect_closing() as contender:
+                kb.create_task(
+                    contender,
+                    title="concurrent winner",
+                    assignee="stark",
+                    idempotency_key=key,
+                )
+            monkeypatch.setattr(kb, "_new_task_id", racing_new_task_id)
+        return original_new_task_id()
+
+    monkeypatch.setattr(kb, "_new_task_id", racing_new_task_id)
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="late loser",
+            assignee="stark",
+            idempotency_key=key,
+        )
+        rows = conn.execute(
+            "SELECT id, title FROM tasks WHERE idempotency_key = ? ORDER BY created_at ASC, id ASC",
+            (key,),
+        ).fetchall()
+
+    assert len(rows) == 1
+    assert rows[0]["title"] == "concurrent winner"
+    assert task_id == rows[0]["id"]

--- a/tests/hermes_cli/test_kanban_liveness_and_verdict_drift.py
+++ b/tests/hermes_cli/test_kanban_liveness_and_verdict_drift.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from hermes_cli import kanban as kc
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_liveness
+
+
+def _isolated_home(tmp_path: Path, monkeypatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def test_liveness_subcommand_is_registered() -> None:
+    parser = argparse.ArgumentParser(prog="hermes")
+    sub = parser.add_subparsers(dest="command")
+    kc.build_parser(sub)
+
+    args = parser.parse_args([
+        "kanban",
+        "liveness",
+        "--tenant",
+        "molly-v2-working-system",
+        "--ready-sla-minutes",
+        "15",
+        "--json",
+    ])
+
+    assert args.command == "kanban"
+    assert args.kanban_action == "liveness"
+    assert args.tenant == "molly-v2-working-system"
+    assert args.ready_sla_minutes == 15
+    assert args.json is True
+
+
+def test_liveness_scanner_reports_blocked_tenant_task(tmp_path: Path, monkeypatch) -> None:
+    _isolated_home(tmp_path, monkeypatch)
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="blocked lane",
+            assignee="stark",
+            tenant="molly-v2-working-system",
+            initial_status="blocked",
+        )
+        payload = kanban_liveness.scan_liveness(
+            conn,
+            tenant="molly-v2-working-system",
+            ready_sla_minutes=240,
+            now=2_000_000,
+        )
+
+    assert payload["schema"] == "hermes.kanban_liveness.v1"
+    assert payload["summary"]["health"] == "warning"
+    assert payload["summary"]["finding_count"] == 1
+    assert payload["findings"][0]["task_id"] == task_id
+    assert payload["findings"][0]["kind"] == "blocked_task"
+
+
+def test_consume_review_verdicts_approved_unblocks_source_once(tmp_path: Path, monkeypatch) -> None:
+    _isolated_home(tmp_path, monkeypatch)
+    with kb.connect_closing() as conn:
+        source = kb.create_task(
+            conn,
+            title="source needing review",
+            assignee="stark",
+            tenant="molly-v2-working-system",
+        )
+        assert kb.block_task(conn, source, reason="review-required: needs independent review")
+        review = kb.create_task(
+            conn,
+            title="review source",
+            assignee="brennan",
+            tenant="molly-v2-working-system",
+        )
+        assert kb.complete_task(
+            conn,
+            review,
+            summary="APPROVED: looks good",
+            metadata={
+                "schema": "hermes.review_verdict.v1",
+                "review_of": source,
+                "verdict": "APPROVED",
+                "approved": True,
+            },
+        )
+
+        result = kb.consume_review_verdicts(conn)
+        assert result.consumed_review_verdicts == [source]
+        assert result.created_review_verdict_followups == []
+        source_task = kb.get_task(conn, source)
+        assert source_task is not None
+        assert source_task.status == "ready"
+
+        second = kb.consume_review_verdicts(conn)
+        assert second.consumed_review_verdicts == []
+        events = conn.execute(
+            "SELECT kind FROM task_events WHERE task_id = ? AND kind = 'review_verdict_consumed'",
+            (review,),
+        ).fetchall()
+        assert len(events) == 1
+
+
+def test_consume_review_verdicts_changes_requested_creates_one_followup(tmp_path: Path, monkeypatch) -> None:
+    _isolated_home(tmp_path, monkeypatch)
+    with kb.connect_closing() as conn:
+        source = kb.create_task(
+            conn,
+            title="source needing changes",
+            assignee="stark",
+            tenant="molly-v2-working-system",
+        )
+        assert kb.block_task(conn, source, reason="review-required: needs changes review")
+        review = kb.create_task(
+            conn,
+            title="review source",
+            assignee="brennan",
+            tenant="molly-v2-working-system",
+        )
+        assert kb.complete_task(
+            conn,
+            review,
+            summary="CHANGES_REQUESTED: add tests",
+            metadata={
+                "schema": "hermes.review_verdict.v1",
+                "subject_task_id": source,
+                "verdict": "CHANGES_REQUESTED",
+                "summary": "add tests",
+            },
+        )
+
+        result = kb.consume_review_verdicts(conn)
+        assert result.consumed_review_verdicts == [source]
+        assert len(result.created_review_verdict_followups) == 1
+        followup = kb.get_task(conn, result.created_review_verdict_followups[0])
+        assert followup is not None
+        assert followup.status == "blocked"
+        assert followup.assignee == "stark"
+        assert "source_task_id=" + source in (followup.body or "")
+        source_task = kb.get_task(conn, source)
+        assert source_task is not None
+        assert source_task.status == "blocked"
+
+        second = kb.consume_review_verdicts(conn)
+        assert second.created_review_verdict_followups == []
+        rows = conn.execute(
+            "SELECT id FROM tasks WHERE idempotency_key = ?",
+            (f"review-verdict:{review}:{source}:CHANGES_REQUESTED",),
+        ).fetchall()
+        assert len(rows) == 1

--- a/tests/hermes_cli/test_kanban_review_required_successor.py
+++ b/tests/hermes_cli/test_kanban_review_required_successor.py
@@ -147,6 +147,63 @@ def test_review_required_missing_owner_routes_to_default_triage_not_researcher_g
         assert "Selected reviewer assignee: default (router-triage)" in successor["body"]
 
 
+def test_ai_influencer_visual_output_without_owner_routes_to_taylor_not_default_triage(
+    kanban_home: Path,
+) -> None:
+    with kb.connect() as conn:
+        source = kb.create_task(
+            conn,
+            title="Build real identity-control workflow for American cheer/gymnast Nia reset",
+            body=(
+                "AI Influencer / Nia ComfyUI InstantID identity-control smoke: "
+                "review the one generated image before accepting the reset."
+            ),
+            assignee="builder",
+            tenant="molly-v2-working-system",
+        )
+        _block_review_required(
+            conn,
+            source,
+            reason=(
+                "review-required: one-image InstantID smoke completed on Jarvis; "
+                "output is adult blonde/light-brown collegiate fitness lane but "
+                "soft/low-res, needs human decision before accepting identity reset."
+            ),
+            metadata={
+                "output_image": "/Volumes/Jarvis/Molly/content/ai-influencer/03-generations/nia.png",
+                "artifacts": [
+                    "/Volumes/Jarvis/Molly/content/ai-influencer/03-generations/nia.png"
+                ],
+                "accepted_scope": "identity-control path smoke only, not final avatar",
+            },
+        )
+
+        result = kb.scan_liveness(conn)
+
+        assert result.created_review_required_successors == [source]
+        successor = _only_successor(conn, source)
+        assert successor["title"] == "Review required: Build real identity-control workflow for American cheer/gymnast Nia reset"
+        assert successor["assignee"] == "taylor"
+        assert successor["status"] == "ready"
+        assert "No explicit review owner was inferable" not in successor["body"]
+        assert "Selected reviewer assignee: taylor (visual-output-review)" in successor["body"]
+
+
+def test_explicit_studio_review_owner_canonicalizes_to_taylor(
+    kanban_home: Path,
+) -> None:
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="Studio-routed image review", assignee="builder")
+        _block_review_required(conn, source, metadata={"review_assignee": "studio"})
+
+        result = kb.scan_liveness(conn)
+
+        assert result.created_review_required_successors == [source]
+        successor = _only_successor(conn, source)
+        assert successor["assignee"] == "taylor"
+        assert "Selected reviewer assignee: taylor (explicit-metadata)" in successor["body"]
+
+
 def test_review_required_successor_creation_is_idempotent(kanban_home: Path) -> None:
     with kb.connect() as conn:
         source = kb.create_task(conn, title="Idempotent review", assignee="builder")

--- a/tests/hermes_cli/test_kanban_review_required_successor.py
+++ b/tests/hermes_cli/test_kanban_review_required_successor.py
@@ -1,0 +1,711 @@
+"""Regression tests for review-required successor routing.
+
+Blocked source cards whose latest worker handoff starts with ``review-required:``
+need a separate runnable reviewer/triage card.  The successor must not be a
+parent-linked child of the blocked source, because parent links wait for the
+source to become terminal and deadlock review execution.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _latest_run_id(conn, task_id: str) -> int:
+    row = conn.execute(
+        "SELECT id FROM task_runs WHERE task_id = ? ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _block_review_required(
+    conn,
+    task_id: str,
+    *,
+    reason: str = "review-required: inspect the handoff",
+    metadata: dict | None = None,
+) -> int:
+    assert kb.claim_task(conn, task_id) is not None
+    assert kb.block_task(
+        conn,
+        task_id,
+        reason=reason,
+        expected_run_id=kb.get_task(conn, task_id).current_run_id,
+    )
+    run_id = _latest_run_id(conn, task_id)
+    if metadata is not None:
+        conn.execute(
+            "UPDATE task_runs SET metadata = ? WHERE id = ?",
+            (json.dumps(metadata), run_id),
+        )
+        conn.commit()
+    return run_id
+
+
+def _only_successor(conn, source_id: str):
+    rows = conn.execute(
+        "SELECT id, title, body, assignee, status, created_by, idempotency_key "
+        "FROM tasks WHERE id != ?",
+        (source_id,),
+    ).fetchall()
+    assert len(rows) == 1
+    return rows[0]
+
+
+def _created_successors(conn, source_id: str):
+    rows = conn.execute(
+        "SELECT id, title, body, assignee, status, created_by, idempotency_key "
+        "FROM tasks WHERE idempotency_key LIKE ? ORDER BY created_at ASC",
+        (f"review-required:{source_id}:%",),
+    ).fetchall()
+    return rows
+
+
+def test_review_required_needed_profile_creates_independent_reviewer_card(
+    kanban_home: Path,
+) -> None:
+    with kb.connect() as conn:
+        source = kb.create_task(
+            conn,
+            title="Patch router",
+            body="Code diff is ready; needs independent review.",
+            assignee="builder",
+            workspace_kind="dir",
+            workspace_path="/tmp/project",
+            tenant="review-required-router",
+        )
+        run_id = _block_review_required(
+            conn,
+            source,
+            metadata={
+                "needed_profile": "researcher",
+                "changed_files": ["router.py"],
+                "tests_run": 5,
+            },
+        )
+
+        result = kb.scan_liveness(conn)
+
+        assert result.created_review_required_successors == [source]
+        successor = _only_successor(conn, source)
+        assert successor["title"] == "Review required: Patch router"
+        assert successor["assignee"] == "brennan"
+        assert successor["status"] == "ready"
+        assert successor["created_by"] == "kanban-liveness"
+        assert successor["idempotency_key"] == f"review-required:{source}:{run_id}"
+        assert source in successor["body"]
+        assert f"Source run: {run_id}" in successor["body"]
+        assert "changed_files" in successor["body"]
+        assert kb.get_task(conn, source).status == "blocked"
+
+        # Critical deadlock guard: the review successor is not a child of the
+        # blocked source.  Parent-linked children cannot run until the source is
+        # done, which is exactly what the review is supposed to decide.
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_links WHERE parent_id = ? AND child_id = ?",
+            (source, successor["id"]),
+        ).fetchone()[0] == 0
+
+
+def test_review_required_missing_owner_routes_to_default_triage_not_researcher_guess(
+    kanban_home: Path,
+) -> None:
+    with kb.connect() as conn:
+        source = kb.create_task(
+            conn,
+            title="Ambiguous human review",
+            body="Needs human review but no reviewer/needed_profile is declared.",
+            assignee="builder",
+        )
+        _block_review_required(conn, source, metadata={"tests_run": 1})
+
+        result = kb.scan_liveness(conn)
+
+        assert result.created_review_required_successors == [source]
+        successor = _only_successor(conn, source)
+        assert successor["title"] == "Route review-required: Ambiguous human review"
+        assert successor["assignee"] == "default"
+        assert successor["status"] == "triage"
+        assert "No explicit review owner was inferable" in successor["body"]
+        assert "Selected reviewer assignee: default (router-triage)" in successor["body"]
+
+
+def test_review_required_successor_creation_is_idempotent(kanban_home: Path) -> None:
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="Idempotent review", assignee="builder")
+        _block_review_required(
+            conn,
+            source,
+            metadata={"review_assignee": "researcher"},
+        )
+
+        first = kb.scan_liveness(conn)
+        second = kb.scan_liveness(conn)
+
+        assert first.created_review_required_successors == [source]
+        assert second.created_review_required_successors == []
+        assert conn.execute("SELECT COUNT(*) FROM tasks WHERE id != ?", (source,)).fetchone()[0] == 1
+
+
+def test_review_required_ignores_unrelated_parent_linked_child(
+    kanban_home: Path,
+) -> None:
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="Patch with unrelated child", assignee="builder")
+        unrelated_child = kb.create_task(
+            conn,
+            title="Unrelated child work",
+            assignee="builder",
+            parents=[source],
+        )
+        run_id = _block_review_required(
+            conn,
+            source,
+            metadata={"needed_profile": "researcher"},
+        )
+
+        result = kb.scan_liveness(conn)
+
+        assert result.created_review_required_successors == [source]
+        successors = _created_successors(conn, source)
+        assert len(successors) == 1
+        successor = successors[0]
+        assert successor["assignee"] == "brennan"
+        assert successor["idempotency_key"] == f"review-required:{source}:{run_id}"
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_links WHERE parent_id = ? AND child_id = ?",
+            (source, successor["id"]),
+        ).fetchone()[0] == 0
+        assert kb.parent_ids(conn, unrelated_child) == [source]
+
+
+def test_review_required_idempotency_key_collision_with_parent_linked_child_creates_independent_successor(
+    kanban_home: Path,
+) -> None:
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="Patch with colliding child", assignee="builder")
+        run_id = _block_review_required(
+            conn,
+            source,
+            metadata={"needed_profile": "researcher"},
+        )
+        idem = f"review-required:{source}:{run_id}"
+        colliding_child = kb.create_task(
+            conn,
+            title="Deadlocked child with review idempotency key",
+            assignee="builder",
+            parents=[source],
+            idempotency_key=idem,
+        )
+
+        result = kb.scan_liveness(conn)
+
+        assert result.created_review_required_successors == [source]
+        successors = _created_successors(conn, source)
+        independent_successors = [
+            row
+            for row in successors
+            if conn.execute(
+                "SELECT COUNT(*) FROM task_links WHERE parent_id = ? AND child_id = ?",
+                (source, row["id"]),
+            ).fetchone()[0]
+            == 0
+        ]
+        assert len(independent_successors) == 1
+        successor = independent_successors[0]
+        assert successor["id"] != colliding_child
+        assert successor["assignee"] == "brennan"
+        assert successor["status"] == "ready"
+        assert successor["idempotency_key"] == idem
+        assert kb.parent_ids(conn, colliding_child) == [source]
+
+        second = kb.scan_liveness(conn)
+        assert second.created_review_required_successors == []
+        assert _created_successors(conn, source) == successors
+
+
+def test_review_required_owner_can_come_from_latest_handoff_comment(
+    kanban_home: Path,
+) -> None:
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="Comment-routed review", assignee="builder")
+        kb.add_comment(
+            conn,
+            source,
+            "builder",
+            "review-required handoff:\n"
+            + json.dumps(
+                {
+                    "needed_review_owner": "researcher",
+                    "changed_files": ["hermes_cli/kanban_db.py"],
+                }
+            ),
+        )
+        _block_review_required(conn, source)
+
+        result = kb.scan_liveness(conn)
+
+        assert result.created_review_required_successors == [source]
+        successor = _only_successor(conn, source)
+        assert successor["title"] == "Review required: Comment-routed review"
+        assert successor["assignee"] == "brennan"
+        assert "Selected reviewer assignee: brennan (explicit-comment)" in successor["body"]
+        assert "changed_files" in successor["body"]
+
+
+def test_builder_code_change_receipts_without_owner_route_to_researcher(
+    kanban_home: Path,
+) -> None:
+    with kb.connect() as conn:
+        source = kb.create_task(
+            conn,
+            title="Builder code handoff",
+            body="Code patch is ready; no explicit reviewer owner was set.",
+            assignee="builder",
+        )
+        _block_review_required(
+            conn,
+            source,
+            metadata={
+                "changed_files": [
+                    "hermes_cli/kanban_db.py",
+                    "tests/hermes_cli/test_kanban_review_required_successor.py",
+                ],
+                "tests_run": [
+                    {
+                        "command": "python -m pytest tests/hermes_cli/test_kanban_review_required_successor.py",
+                        "exit_code": 0,
+                    }
+                ],
+            },
+        )
+
+        result = kb.scan_liveness(conn)
+
+        assert result.created_review_required_successors == [source]
+        successor = _only_successor(conn, source)
+        assert successor["title"] == "Review required: Builder code handoff"
+        assert successor["assignee"] == "brennan"
+        assert successor["status"] == "ready"
+        assert (
+            "Selected reviewer assignee: brennan (code-review-receipts)"
+            in successor["body"]
+        )
+        assert "RED-GATED: do not execute" not in successor["body"]
+
+
+def test_declared_independent_review_successor_suppresses_router_default_triage(
+    kanban_home: Path,
+) -> None:
+    with kb.connect() as conn:
+        source = kb.create_task(
+            conn,
+            title="Already has reviewer",
+            assignee="builder",
+        )
+        reviewer = kb.create_task(
+            conn,
+            title="Manual reviewer successor",
+            assignee="researcher",
+        )
+        _block_review_required(
+            conn,
+            source,
+            metadata={"successor_task_ids": [reviewer], "tests_run": 1},
+        )
+
+        result = kb.scan_liveness(conn)
+
+        assert result.created_review_required_successors == []
+        rows = conn.execute("SELECT id FROM tasks ORDER BY created_at ASC").fetchall()
+        assert [row["id"] for row in rows] == [source, reviewer]
+
+
+@pytest.mark.parametrize(
+    "reason_fragment",
+    [
+        "no red gate remains",
+        "not a red gate",
+        "without red gates",
+        "non-red-gated",
+    ],
+)
+def test_review_required_negated_red_gate_prose_with_code_receipts_routes_to_researcher(
+    kanban_home: Path,
+    reason_fragment: str,
+) -> None:
+    with kb.connect() as conn:
+        source = kb.create_task(
+            conn,
+            title="Negated red prose code patch",
+            body="Code patch is ready; the handoff states no Red boundary remains.",
+            assignee="builder",
+        )
+        _block_review_required(
+            conn,
+            source,
+            reason=(
+                f"review-required: code review needed; {reason_fragment} "
+                "and no STOP/HUMAN boundary remains"
+            ),
+            metadata={
+                "changed_files": [
+                    "hermes_cli/kanban_db.py",
+                    "tests/hermes_cli/test_kanban_review_required_successor.py",
+                ],
+                "tests_run": [
+                    {
+                        "command": "python -m pytest tests/hermes_cli/test_kanban_review_required_successor.py",
+                        "exit_code": 0,
+                    }
+                ],
+            },
+        )
+
+        result = kb.scan_liveness(conn)
+
+        assert result.created_review_required_successors == [source]
+        successor = _only_successor(conn, source)
+        assert successor["title"] == "Review required: Negated red prose code patch"
+        assert successor["assignee"] == "brennan"
+        assert successor["status"] == "ready"
+        assert (
+            "Selected reviewer assignee: brennan (code-review-receipts)"
+            in successor["body"]
+        )
+        assert "RED-GATED: do not execute" not in successor["body"]
+
+
+@pytest.mark.parametrize(
+    "reason_fragment",
+    [
+        "no red gate remains",
+        "not a red gate",
+        "without red gates",
+        "non-red-gated",
+    ],
+)
+def test_review_required_negated_red_gate_prose_preserves_explicit_owner(
+    kanban_home: Path,
+    reason_fragment: str,
+) -> None:
+    with kb.connect() as conn:
+        source = kb.create_task(
+            conn,
+            title="Typed non-red owner",
+            body="Metadata declares a typed non-Red reviewer owner.",
+            assignee="builder",
+        )
+        _block_review_required(
+            conn,
+            source,
+            reason=(
+                f"review-required: {reason_fragment}; "
+                "no STOP/HUMAN boundary remains; peer review only"
+            ),
+            metadata={
+                "review_assignee": "researcher",
+                "status_class": "yellow",
+                "red_gate": False,
+                "changed_files": ["hermes_cli/kanban_db.py"],
+                "tests_run": 1,
+            },
+        )
+
+        result = kb.scan_liveness(conn)
+
+        assert result.created_review_required_successors == [source]
+        successor = _only_successor(conn, source)
+        assert successor["title"] == "Review required: Typed non-red owner"
+        assert successor["assignee"] == "brennan"
+        assert successor["status"] == "ready"
+        assert (
+            "Selected reviewer assignee: brennan (explicit-metadata)"
+            in successor["body"]
+        )
+        assert "RED-GATED: do not execute" not in successor["body"]
+
+
+@pytest.mark.parametrize(
+    "reason_fragment",
+    [
+        "no red gate remains",
+        "not a red gate",
+        "without red gates",
+        "non-red-gated",
+    ],
+)
+def test_review_required_block_reason_owner_hint_preserves_typed_non_red_owner(
+    kanban_home: Path,
+    reason_fragment: str,
+) -> None:
+    with kb.connect() as conn:
+        source = kb.create_task(
+            conn,
+            title="Canonical typed owner hint",
+            body="Metadata declares the reviewer in block_reason.owner_hint.",
+            assignee="builder",
+        )
+        _block_review_required(
+            conn,
+            source,
+            reason=(
+                f"review-required: {reason_fragment}; "
+                "no STOP/HUMAN boundary remains; peer review only"
+            ),
+            metadata={
+                "block_reason": {
+                    "owner_hint": {
+                        "profile": "researcher",
+                        "status_class": "yellow",
+                        "red_gate": False,
+                    }
+                },
+                "changed_files": ["hermes_cli/kanban_db.py"],
+                "tests_run": 1,
+            },
+        )
+
+        result = kb.scan_liveness(conn)
+
+        assert result.created_review_required_successors == [source]
+        successor = _only_successor(conn, source)
+        assert successor["title"] == "Review required: Canonical typed owner hint"
+        assert successor["assignee"] == "brennan"
+        assert successor["status"] == "ready"
+        assert "Selected reviewer assignee: brennan (explicit-metadata)" in successor["body"]
+        assert "RED-GATED: do not execute" not in successor["body"]
+
+
+def test_review_required_block_reason_owner_hint_red_gate_blocks_default(
+    kanban_home: Path,
+) -> None:
+    with kb.connect() as conn:
+        source = kb.create_task(
+            conn,
+            title="Typed red owner hint",
+            body="Metadata owner hint says human approval is still required.",
+            assignee="builder",
+        )
+        _block_review_required(
+            conn,
+            source,
+            reason="review-required: typed routing packet awaits review",
+            metadata={
+                "block_reason": {
+                    "owner_hint": {
+                        "profile": "researcher",
+                        "status_class": "red",
+                        "red_gate": True,
+                    }
+                },
+                "changed_files": ["hermes_cli/kanban_db.py"],
+                "tests_run": 1,
+            },
+        )
+
+        result = kb.scan_liveness(conn)
+
+        assert result.created_review_required_successors == [source]
+        successor = _only_successor(conn, source)
+        assert successor["title"] == "RED-GATED routing needed: Review required: Typed red owner hint"
+        assert successor["assignee"] == "default"
+        assert successor["status"] == "blocked"
+        assert "RED-GATED: do not execute" in successor["body"]
+
+
+def test_review_required_stop_human_boundary_prose_blocks_default_with_code_receipts(
+    kanban_home: Path,
+) -> None:
+    with kb.connect() as conn:
+        source = kb.create_task(
+            conn,
+            title="Concrete human boundary",
+            body="Code patch is ready but a STOP/HUMAN boundary remains.",
+            assignee="builder",
+        )
+        _block_review_required(
+            conn,
+            source,
+            reason="review-required: STOP/HUMAN boundary remains before production deploy",
+            metadata={
+                "changed_files": ["hermes_cli/kanban_db.py"],
+                "tests_run": [
+                    {
+                        "command": "python -m pytest tests/hermes_cli/test_kanban_review_required_successor.py",
+                        "exit_code": 0,
+                    }
+                ],
+            },
+        )
+
+        result = kb.scan_liveness(conn)
+
+        assert result.created_review_required_successors == [source]
+        successor = _only_successor(conn, source)
+        assert (
+            successor["title"]
+            == "RED-GATED routing needed: Review required: Concrete human boundary"
+        )
+        assert successor["assignee"] == "default"
+        assert successor["status"] == "blocked"
+        assert "RED-GATED: do not execute" in successor["body"]
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        "review-required: RED gate / human approval before production deploy",
+        "review-required: STOP/HUMAN boundary remains before production deploy",
+    ],
+)
+def test_review_required_red_or_human_gate_creates_blocked_default_packet(
+    kanban_home: Path,
+    reason: str,
+) -> None:
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="Production apply", assignee="builder")
+        _block_review_required(
+            conn,
+            source,
+            reason=reason,
+            metadata={
+                "needed_profile": "researcher",
+                "red_gates": ["production deploy requires Brian approval"],
+            },
+        )
+
+        result = kb.scan_liveness(conn)
+
+        assert result.created_review_required_successors == [source]
+        successor = _only_successor(conn, source)
+        assert successor["title"] == "RED-GATED routing needed: Review required: Production apply"
+        assert successor["assignee"] == "default"
+        assert successor["status"] == "blocked"
+        assert "RED-GATED: do not execute" in successor["body"]
+        assert "production deploy requires Brian approval" in successor["body"]
+        assert kb.get_task(conn, source).status == "blocked"
+
+
+def test_review_required_comment_receipts_without_owner_route_code_review(
+    kanban_home: Path,
+) -> None:
+    with kb.connect() as conn:
+        source = kb.create_task(
+            conn,
+            title="Comment-only code receipt",
+            assignee="builder",
+        )
+        kb.add_comment(
+            conn,
+            source,
+            "builder",
+            json.dumps(
+                {
+                    "changed_files": ["hermes_cli/kanban_db.py"],
+                    "tests_run": [
+                        {
+                            "command": "python -m pytest tests/hermes_cli/test_kanban_review_required_successor.py",
+                            "exit_code": 0,
+                        }
+                    ],
+                }
+            ),
+        )
+        _block_review_required(conn, source)
+
+        result = kb.scan_liveness(conn)
+
+        assert result.created_review_required_successors == [source]
+        successor = _only_successor(conn, source)
+        assert successor["title"] == "Review required: Comment-only code receipt"
+        assert successor["assignee"] == "brennan"
+        assert "Selected reviewer assignee: brennan (code-review-receipts)" in successor["body"]
+
+
+def test_review_required_new_block_run_after_old_review_gets_new_successor(
+    kanban_home: Path,
+) -> None:
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="Repeat review cycle", assignee="builder")
+        first_run = _block_review_required(conn, source, metadata={"needed_profile": "researcher"})
+        first = kb.scan_liveness(conn)
+        assert first.created_review_required_successors == [source]
+        first_successor = _created_successors(conn, source)[0]
+        assert kb.claim_task(conn, first_successor["id"]) is not None
+        assert kb.complete_task(
+            conn,
+            first_successor["id"],
+            summary="APPROVED: first cycle done",
+            metadata={"review_of": source, "verdict": "APPROVED"},
+            expected_run_id=kb.get_task(conn, first_successor["id"]).current_run_id,
+        )
+        verdicts = kb.scan_liveness(conn)
+        assert verdicts.consumed_review_verdicts == [source]
+        assert kb.get_task(conn, source).status == "ready"
+
+        second_run = _block_review_required(conn, source, metadata={"needed_profile": "researcher"})
+        second = kb.scan_liveness(conn)
+
+        assert second_run != first_run
+        assert second.created_review_required_successors == [source]
+        successors = _created_successors(conn, source)
+        assert {row["idempotency_key"] for row in successors} == {
+            f"review-required:{source}:{first_run}",
+            f"review-required:{source}:{second_run}",
+        }
+        assert len(successors) == 2
+
+
+def test_dispatch_once_dry_run_does_not_create_review_required_successor(
+    kanban_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda _profile: True)
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="Dry run review", assignee="builder")
+        _block_review_required(conn, source, metadata={"needed_profile": "researcher"})
+
+        result = kb.dispatch_once(conn, spawn_fn=lambda *args, **kwargs: None, max_spawn=1, dry_run=True)
+
+        assert result.created_review_required_successors == []
+        assert conn.execute("SELECT COUNT(*) FROM tasks WHERE id != ?", (source,)).fetchone()[0] == 0
+
+
+def test_dispatch_once_runs_review_required_router_before_spawning(
+    kanban_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    spawned: list[tuple[str, str]] = []
+
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda _profile: True)
+
+    def fake_spawn(task, workspace, board=None):
+        spawned.append((task.id, task.assignee or ""))
+        return None
+
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="Dispatch-integrated review", assignee="builder")
+        _block_review_required(conn, source, metadata={"needed_profile": "researcher"})
+
+        result = kb.dispatch_once(conn, spawn_fn=fake_spawn, max_spawn=1)
+
+        successor = _only_successor(conn, source)
+        assert result.created_review_required_successors == [source]
+        assert spawned == [(successor["id"], "brennan")]
+        assert kb.get_task(conn, source).status == "blocked"

--- a/tests/hermes_cli/test_kanban_review_required_successor.py
+++ b/tests/hermes_cli/test_kanban_review_required_successor.py
@@ -124,7 +124,7 @@ def test_review_required_needed_profile_creates_independent_reviewer_card(
         ).fetchone()[0] == 0
 
 
-def test_review_required_missing_owner_routes_to_default_triage_not_researcher_guess(
+def test_review_required_missing_owner_builder_source_routes_to_researcher_from_directory(
     kanban_home: Path,
 ) -> None:
     with kb.connect() as conn:
@@ -140,11 +140,54 @@ def test_review_required_missing_owner_routes_to_default_triage_not_researcher_g
 
         assert result.created_review_required_successors == [source]
         successor = _only_successor(conn, source)
-        assert successor["title"] == "Route review-required: Ambiguous human review"
+        assert successor["title"] == "Review required: Ambiguous human review"
+        assert successor["assignee"] == "brennan"
+        assert successor["status"] == "ready"
+        assert "Selected reviewer assignee: brennan (source-assignee-directory)" in successor["body"]
+
+
+def test_review_required_missing_owner_unmapped_source_routes_to_default_triage(
+    kanban_home: Path,
+) -> None:
+    with kb.connect() as conn:
+        source = kb.create_task(
+            conn,
+            title="Ambiguous non-builder review",
+            body="Needs human review but no reviewer/needed_profile is declared.",
+            assignee="default",
+        )
+        _block_review_required(conn, source, metadata={"tests_run": 1})
+
+        result = kb.scan_liveness(conn)
+
+        assert result.created_review_required_successors == [source]
+        successor = _only_successor(conn, source)
+        assert successor["title"] == "Route review-required: Ambiguous non-builder review"
         assert successor["assignee"] == "default"
         assert successor["status"] == "triage"
         assert "No explicit review owner was inferable" in successor["body"]
         assert "Selected reviewer assignee: default (router-triage)" in successor["body"]
+
+
+def test_review_required_stark_source_without_owner_routes_to_researcher(
+    kanban_home: Path,
+) -> None:
+    with kb.connect() as conn:
+        source = kb.create_task(
+            conn,
+            title="Stark source needs review",
+            body="Builder work without explicit reviewer.",
+            assignee="stark",
+        )
+        _block_review_required(conn, source)
+
+        result = kb.scan_liveness(conn)
+
+        assert result.created_review_required_successors == [source]
+        successor = _only_successor(conn, source)
+        assert successor["assignee"] == "brennan"
+        assert successor["status"] == "ready"
+        assert "Selected reviewer assignee: brennan (source-assignee-directory)" in successor["body"]
 
 
 def test_ai_influencer_visual_output_without_owner_routes_to_taylor_not_default_triage(

--- a/tests/hermes_cli/test_kanban_role_aliases.py
+++ b/tests/hermes_cli/test_kanban_role_aliases.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _fake_spawn(*args, **kwargs):
+    return 12345
+
+
+def test_create_task_canonicalizes_legacy_role_assignee_aliases(kanban_home: Path) -> None:
+    with kb.connect() as conn:
+        operator_id = kb.create_task(conn, title="ops lane", assignee="operator")
+        researcher_id = kb.create_task(conn, title="research lane", assignee="researcher")
+        builder_id = kb.create_task(conn, title="build lane", assignee="builder")
+        steward_id = kb.create_task(conn, title="steward lane", assignee="steward")
+
+        assert kb.get_task(conn, operator_id).assignee == "winston"
+        assert kb.get_task(conn, researcher_id).assignee == "brennan"
+        assert kb.get_task(conn, builder_id).assignee == "stark"
+        assert kb.get_task(conn, steward_id).assignee == "pepper"
+
+
+def test_dispatch_rewrites_existing_role_alias_rows_before_spawn(
+    kanban_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hermes_cli import profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda name: name == "winston")
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="legacy operator row", assignee="default")
+        conn.execute("UPDATE tasks SET assignee = 'operator' WHERE id = ?", (task_id,))
+        conn.commit()
+
+        res = kb.dispatch_once(conn, spawn_fn=_fake_spawn)
+
+        assert res.spawned == [(task_id, "winston", str(kb.resolve_workspace(kb.get_task(conn, task_id))))]
+        assert kb.get_task(conn, task_id).assignee == "winston"
+        assigned = conn.execute(
+            "SELECT payload FROM task_events WHERE task_id = ? AND kind = 'assigned' "
+            "ORDER BY id DESC LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        payload = json.loads(assigned["payload"])
+        assert payload == {
+            "assignee": "winston",
+            "source": "kanban.role_alias",
+            "alias": "operator",
+        }
+
+
+def test_default_assignee_uses_role_alias_before_profile_validation(
+    kanban_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hermes_cli import profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda name: name == "brennan")
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="unassigned")
+        res = kb.dispatch_once(
+            conn,
+            spawn_fn=_fake_spawn,
+            default_assignee="researcher",
+        )
+
+        assert res.auto_assigned_default == [task_id]
+        assert res.spawned[0][1] == "brennan"
+        assert kb.get_task(conn, task_id).assignee == "brennan"
+
+
+def test_decomposer_routes_role_name_choice_to_live_profile_instead_of_default() -> None:
+    from hermes_cli.kanban_decompose import _normalize_assignee_choice
+
+    assert _normalize_assignee_choice(
+        "builder",
+        default_assignee="default",
+        valid_names={"default", "stark"},
+    ) == "stark"

--- a/tests/hermes_cli/test_kanban_role_aliases.py
+++ b/tests/hermes_cli/test_kanban_role_aliases.py
@@ -35,6 +35,18 @@ def test_create_task_canonicalizes_legacy_role_assignee_aliases(kanban_home: Pat
         assert kb.get_task(conn, steward_id).assignee == "pepper"
 
 
+def test_create_task_canonicalizes_legacy_role_assignee_aliases_even_when_legacy_profile_exists(
+    kanban_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hermes_cli import profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda name: name in {"builder", "stark"})
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="build lane", assignee="builder")
+
+        assert kb.get_task(conn, task_id).assignee == "stark"
 def test_dispatch_rewrites_existing_role_alias_rows_before_spawn(
     kanban_home: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/hermes_cli/test_kanban_role_aliases.py
+++ b/tests/hermes_cli/test_kanban_role_aliases.py
@@ -28,11 +28,13 @@ def test_create_task_canonicalizes_legacy_role_assignee_aliases(kanban_home: Pat
         researcher_id = kb.create_task(conn, title="research lane", assignee="researcher")
         builder_id = kb.create_task(conn, title="build lane", assignee="builder")
         steward_id = kb.create_task(conn, title="steward lane", assignee="steward")
+        studio_id = kb.create_task(conn, title="studio lane", assignee="studio")
 
         assert kb.get_task(conn, operator_id).assignee == "winston"
         assert kb.get_task(conn, researcher_id).assignee == "brennan"
         assert kb.get_task(conn, builder_id).assignee == "stark"
         assert kb.get_task(conn, steward_id).assignee == "pepper"
+        assert kb.get_task(conn, studio_id).assignee == "taylor"
 
 
 def test_create_task_canonicalizes_legacy_role_assignee_aliases_even_when_legacy_profile_exists(


### PR DESCRIPTION
## Change\n- Adds a source-assignee-directory fallback so builder/stark review-required tasks with no explicit reviewer route to brennan (researcher) instead of default triage.\n- Keeps explicit owner keys and code-review-receipts routing first.\n- Unmapped source assignees still fall through to default router-triage.\n\n## Verification\n- 32 tests passed in tests/hermes_cli/test_kanban_review_required_successor.py\n- 255 tests passed across review-required + kanban_db suites\n- Review approved by @brennan in task t_fd77bf89 (commit ebfaee118)\n\n## Authority boundary\n- This PR is opened from a fork because direct push to upstream was denied.\n- Merge/deploy remains a separate Red gate.\n