### PR TITLE
fix(weixin): harden iLink delivery backoff

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -104,7 +104,39 @@ def _is_stale_session_ret(
     a genuine rate limit."""
     if ret != RATE_LIMIT_ERRCODE and errcode != RATE_LIMIT_ERRCODE:
         return False
-    return (errmsg or "").lower() == "unknown error"
+    msg = (errmsg or "").strip().lower()
+    return not msg or msg in {"unknown error", "rate limited"}
+
+
+def _parse_retry_after_seconds(response: Optional[Dict[str, Any]]) -> Optional[float]:
+    """Extract an iLink retry-after hint from a rate-limit response.
+
+    iLink responses are not fully stable across deployments.  Accept the
+    common second-based spellings plus millisecond variants when present.
+    """
+    if not isinstance(response, dict):
+        return None
+    for key in ("retry_after", "retry_after_seconds", "backoff", "backoff_seconds"):
+        value = response.get(key)
+        if value is None:
+            continue
+        try:
+            parsed = float(value)
+        except (TypeError, ValueError):
+            continue
+        if parsed > 0:
+            return parsed
+    for key in ("retry_after_ms", "backoff_ms"):
+        value = response.get(key)
+        if value is None:
+            continue
+        try:
+            parsed = float(value) / 1000.0
+        except (TypeError, ValueError):
+            continue
+        if parsed > 0:
+            return parsed
+    return None
 
 
 MEDIA_IMAGE = 1
@@ -1175,12 +1207,26 @@ class WeixinAdapter(BasePlatformAdapter):
             extra.get("send_chunk_retry_delay_seconds")
             or os.getenv("WEIXIN_SEND_CHUNK_RETRY_DELAY_SECONDS", "1.0")
         )
+        try:
+            self._long_reply_chunk_threshold = max(
+                0,
+                int(extra.get("long_reply_chunk_threshold", 10)),
+            )
+        except (TypeError, ValueError):
+            self._long_reply_chunk_threshold = 10
+        try:
+            self._long_reply_chunk_delay_seconds = max(
+                0.0,
+                float(extra.get("long_reply_chunk_delay_seconds", 6.0)),
+            )
+        except (TypeError, ValueError):
+            self._long_reply_chunk_delay_seconds = 6.0
         self._send_text_gate = asyncio.Lock()
         self._rate_limit_circuit_threshold = max(
             1,
             int(
                 extra.get("rate_limit_circuit_threshold")
-                or os.getenv("WEIXIN_RATE_LIMIT_CIRCUIT_THRESHOLD", "1")
+                or os.getenv("WEIXIN_RATE_LIMIT_CIRCUIT_THRESHOLD", str(self._send_chunk_retries + 1))
             ),
         )
         self._rate_limit_circuit_window_seconds = float(
@@ -1697,6 +1743,23 @@ class WeixinAdapter(BasePlatformAdapter):
         self._rate_limit_events.clear()
         self._rate_limit_circuit_until = 0.0
 
+    def _rate_limit_retry_delay(self, attempt: int, response: Optional[Dict[str, Any]] = None) -> float:
+        """Return the sleep before the next retry after an iLink rate limit."""
+        base = max(0.0, self._send_chunk_retry_delay_seconds * 3)
+        exponential = base * (2 ** max(0, attempt))
+        hinted = _parse_retry_after_seconds(response)
+        wait = max(exponential, hinted) if hinted is not None else exponential
+        return min(wait, 60.0)
+
+    def _inter_chunk_delay(self, total_chunks: int) -> float:
+        delay = self._send_chunk_delay_seconds
+        if (
+            self._long_reply_chunk_threshold > 0
+            and total_chunks >= self._long_reply_chunk_threshold
+        ):
+            delay = max(delay, self._long_reply_chunk_delay_seconds)
+        return delay
+
     async def _send_text_chunk(
         self,
         *,
@@ -1755,7 +1818,7 @@ class WeixinAdapter(BasePlatformAdapter):
                             or _is_stale_session_ret(ret, errcode, resp.get("errmsg"))
                         )
                         # Session expired — strip token and retry once
-                        if is_session_expired and not retried_without_token and context_token:
+                        if is_session_expired and not retried_without_token:
                             retried_without_token = True
                             context_token = None
                             self._token_store._cache.pop(
@@ -1784,7 +1847,7 @@ class WeixinAdapter(BasePlatformAdapter):
                                 break
                             if attempt >= self._send_chunk_retries:
                                 break
-                            wait = self._send_chunk_retry_delay_seconds * 3  # 3x backoff for rate limit
+                            wait = self._rate_limit_retry_delay(attempt, resp)
                             logger.warning(
                                 "[%s] rate limited for %s; backing off %.1fs before retry",
                                 self.name, _safe_id(chat_id), wait,
@@ -1867,6 +1930,7 @@ class WeixinAdapter(BasePlatformAdapter):
 
             # Deliver text content.
             chunks = [c for c in self._split_text(self.format_message(final_content)) if c and c.strip()]
+            inter_chunk_delay = self._inter_chunk_delay(len(chunks))
             for idx, chunk in enumerate(chunks):
                 client_id = f"hermes-weixin-{uuid.uuid4().hex}"
                 await self._send_text_chunk(
@@ -1876,8 +1940,8 @@ class WeixinAdapter(BasePlatformAdapter):
                     client_id=client_id,
                 )
                 last_message_id = client_id
-                if idx < len(chunks) - 1 and self._send_chunk_delay_seconds > 0:
-                    await asyncio.sleep(self._send_chunk_delay_seconds)
+                if idx < len(chunks) - 1 and inter_chunk_delay > 0:
+                    await asyncio.sleep(inter_chunk_delay)
             return SendResult(success=True, message_id=last_message_id)
         except Exception as exc:
             logger.error("[%s] send failed to=%s: %s", self.name, _safe_id(chat_id), exc)

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -22,7 +22,7 @@ def _make_adapter() -> WeixinAdapter:
         PlatformConfig(
             enabled=True,
             token="test-token",
-            extra={"account_id": "test-account"},
+            extra={"account_id": "test-account", "dm_policy": "open"},
         )
     )
 
@@ -410,6 +410,76 @@ class TestWeixinChunkDelivery:
         retry = send_message_mock.await_args_list[2].kwargs
         assert first_try["text"] == retry["text"]
         assert first_try["client_id"] == retry["client_id"]
+
+    @patch("gateway.platforms.weixin.asyncio.sleep", new_callable=AsyncMock)
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_send_retries_transient_rate_limit_with_default_circuit_threshold(self, send_message_mock, sleep_mock):
+        adapter = self._connected_adapter()
+        adapter._send_chunk_retries = 4
+        adapter._send_chunk_retry_delay_seconds = 0
+        # The production default is retries + 1, so a single iLink frequency
+        # response should exercise the retry path instead of opening the
+        # breaker immediately and dropping cron pushes.
+        adapter._rate_limit_circuit_threshold = adapter._send_chunk_retries + 1
+
+        send_message_mock.side_effect = [
+            {
+                "ret": weixin.RATE_LIMIT_ERRCODE,
+                "errcode": weixin.RATE_LIMIT_ERRCODE,
+                "errmsg": "frequency limit",
+            },
+            {"errcode": 0},
+        ]
+
+        result = asyncio.run(adapter.send("wxid_test123", "brief text"))
+
+        assert result.success is True
+        assert send_message_mock.await_count == 2
+        assert sleep_mock.await_count == 1
+        assert adapter._rate_limit_events == []
+        assert adapter._rate_limit_circuit_until == 0.0
+
+    def test_stale_session_detection_includes_empty_and_rate_limited_messages(self):
+        assert weixin._is_stale_session_ret(weixin.RATE_LIMIT_ERRCODE, None, "") is True
+        assert weixin._is_stale_session_ret(None, weixin.RATE_LIMIT_ERRCODE, None) is True
+        assert weixin._is_stale_session_ret(weixin.RATE_LIMIT_ERRCODE, None, "unknown error") is True
+        assert weixin._is_stale_session_ret(weixin.RATE_LIMIT_ERRCODE, None, "rate limited") is True
+        assert weixin._is_stale_session_ret(weixin.RATE_LIMIT_ERRCODE, None, "frequency limit") is False
+
+    @patch("gateway.platforms.weixin.asyncio.sleep", new_callable=AsyncMock)
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_rate_limit_retries_use_exponential_backoff(self, send_message_mock, sleep_mock):
+        adapter = self._connected_adapter()
+        adapter._send_chunk_retries = 4
+        adapter._send_chunk_retry_delay_seconds = 1.0
+        adapter._rate_limit_circuit_threshold = 10
+
+        send_message_mock.side_effect = [
+            {"ret": weixin.RATE_LIMIT_ERRCODE, "errcode": weixin.RATE_LIMIT_ERRCODE, "errmsg": "frequency limit"},
+            {"ret": weixin.RATE_LIMIT_ERRCODE, "errcode": weixin.RATE_LIMIT_ERRCODE, "errmsg": "frequency limit"},
+            {"errcode": 0},
+        ]
+
+        result = asyncio.run(adapter.send("wxid_test123", "brief text"))
+
+        assert result.success is True
+        assert [call.args[0] for call in sleep_mock.await_args_list] == [3.0, 6.0]
+
+    @patch("gateway.platforms.weixin.asyncio.sleep", new_callable=AsyncMock)
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_long_replies_use_slower_inter_chunk_pacing(self, send_message_mock, sleep_mock):
+        adapter = self._connected_adapter()
+        setattr(adapter, "MAX_MESSAGE_LENGTH", 5)
+        adapter._send_chunk_delay_seconds = 0.1
+        adapter._long_reply_chunk_threshold = 3
+        adapter._long_reply_chunk_delay_seconds = 5.0
+        send_message_mock.return_value = {"errcode": 0}
+
+        result = asyncio.run(adapter.send("wxid_test123", "one\n\ntwo\n\nthree\n\nfour"))
+
+        assert result.success is True
+        assert send_message_mock.await_count == 4
+        assert [call.args[0] for call in sleep_mock.await_args_list] == [5.0, 5.0, 5.0]
 
     @patch("gateway.platforms.weixin.asyncio.sleep", new_callable=AsyncMock)
     @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
@@ -923,9 +993,9 @@ class TestIsStaleSessionRet:
         # Genuine rate limit — must NOT be treated as stale session.
         assert weixin._is_stale_session_ret(-2, None, "freq limit") is False
 
-    def test_ret_minus_2_with_no_errmsg_is_not_stale(self):
-        assert weixin._is_stale_session_ret(-2, None, None) is False
-        assert weixin._is_stale_session_ret(-2, None, "") is False
+    def test_ret_minus_2_with_no_errmsg_is_stale(self):
+        assert weixin._is_stale_session_ret(-2, None, None) is True
+        assert weixin._is_stale_session_ret(-2, None, "") is True
 
     def test_errcode_minus_14_is_not_matched_here(self):
         # -14 is handled by the separate SESSION_EXPIRED_ERRCODE path; the


### PR DESCRIPTION
# fix(weixin): harden iLink delivery backoff

## Summary

Harden the Weixin/iLink text delivery path against the failure modes reported in the existing iLink issues:

- Treat `ret=-2` / `errcode=-2` with empty errmsg or `"rate limited"` as a stale-session signal, not only `"unknown error"`.
- Retry stale-session sends without `context_token` even when no cached token was present.
- Change rate-limit retry delay from a fixed wait to bounded exponential backoff, honoring retry-after/backoff hints when iLink provides them.
- Keep the existing rate-limit circuit breaker, but default its threshold to `send_chunk_retries + 1` so a single transient iLink rate-limit response can exercise the retry path instead of opening the breaker immediately.
- Pace long multi-chunk replies more conservatively by using a configurable long-reply inter-chunk delay once the chunk count reaches the long-reply threshold.
- Make Weixin tests independent of local `WEIXIN_DM_POLICY` env settings.

## Tests

```bash
venv/bin/python -m pytest tests/gateway/test_weixin.py -q -o 'addopts='
# 73 passed, 7 warnings in 3.44s

venv/bin/python -m pytest tests/gateway/test_weixin.py -q -k 'stale_session_detection or exponential_backoff or long_replies or default_circuit_threshold or IsStaleSessionRet' -o 'addopts='
# 11 passed, 62 deselected in 0.17s

git diff --check -- gateway/platforms/weixin.py tests/gateway/test_weixin.py
# no output
```

## Notes

This PR intentionally stays at the Weixin/iLink channel layer. It does not add cron-specific behavior, content summarization, or workflow-specific delivery policy.
