### PR TITLE
fix: require explicit URL intent for browser tools

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1694,6 +1694,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             skip_pre_tool_call_hook=True,
             enabled_toolsets=getattr(agent, "enabled_toolsets", None),
             disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+            user_task=getattr(agent, "_current_user_message", None),
         )
 
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -428,6 +428,10 @@ def run_conversation(
     agent._stream_callback = stream_callback
     agent._persist_user_message_idx = None
     agent._persist_user_message_override = persist_user_message
+    # Expose the current user turn to tool-dispatch hard gates. Some safety
+    # decisions need to distinguish an explicit instruction from a passive
+    # pasted URL/note before navigation or fetch tools execute.
+    agent._current_user_message = user_message
     # Generate unique task_id if not provided to isolate VMs between concurrent tasks
     effective_task_id = task_id or str(uuid.uuid4())
     # Expose the active task_id so tools running mid-turn (e.g. delegate_task
@@ -4399,6 +4403,11 @@ def run_conversation(
                     _kanban_task,
                     exc_info=True,
                 )
+
+    # Tool dispatch is over for this turn. Clear the current-turn intent context
+    # before post-turn hooks/cleanup so an explicit URL instruction cannot stick
+    # on the agent object and authorize later out-of-turn URL actions.
+    agent._current_user_message = None
 
     # Determine if conversation completed successfully
     completed = (

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -854,6 +854,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     skip_pre_tool_call_hook=True,
                     enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                     disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                    user_task=getattr(agent, "_current_user_message", None),
                 )
                 _spinner_result = function_result
             except Exception as tool_error:
@@ -876,6 +877,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     skip_pre_tool_call_hook=True,
                     enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                     disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                    user_task=getattr(agent, "_current_user_message", None),
                 )
             except Exception as tool_error:
                 function_result = f"Error executing tool '{function_name}': {tool_error}"

--- a/model_tools.py
+++ b/model_tools.py
@@ -799,6 +799,15 @@ def _coerce_boolean(value: str):
     return value
 
 
+from tools.url_intent_guard import ambiguous_user_pasted_url_block as _shared_url_intent_block
+
+
+def _ambiguous_user_pasted_url_block(function_name: str, function_args: Dict[str, Any], user_task: Optional[str]) -> Optional[str]:
+    """Compatibility wrapper for URL-intent guard tests and callers."""
+
+    return _shared_url_intent_block(function_name, function_args, user_task)
+
+
 def handle_function_call(
     function_name: str,
     function_args: Dict[str, Any],
@@ -837,6 +846,13 @@ def handle_function_call(
     """
     # Coerce string arguments to their schema-declared types (e.g. "42"→42)
     function_args = coerce_tool_args(function_name, function_args)
+
+    # Hard gate: a URL pasted in the current user turn is not automatically a
+    # navigation/fetch target. This prevents evidence/browser loops where the
+    # model treats "복사해놓음" or URL-only messages as permission to browse.
+    _ambiguous_url_block = _ambiguous_user_pasted_url_block(function_name, function_args, user_task)
+    if _ambiguous_url_block is not None:
+        return json.dumps({"error": _ambiguous_url_block}, ensure_ascii=False)
 
     # ── Tool Search bridge dispatch ──────────────────────────────────
     # tool_search and tool_describe are pure catalog reads — handle them
@@ -981,6 +997,7 @@ def handle_function_call(
                 function_name, function_args,
                 task_id=task_id,
                 enabled_tools=sandbox_enabled,
+                user_task=user_task,
             )
         else:
             result = registry.dispatch(

--- a/run_agent.py
+++ b/run_agent.py
@@ -4568,7 +4568,13 @@ class AIAgent:
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
         from agent.conversation_loop import run_conversation
-        return run_conversation(self, user_message, system_message, conversation_history, task_id, stream_callback, persist_user_message)
+        try:
+            return run_conversation(self, user_message, system_message, conversation_history, task_id, stream_callback, persist_user_message)
+        finally:
+            # URL-intent context is scoped to exactly one run_conversation call.
+            # Clear it even when the loop raises, so a prior explicit URL turn
+            # cannot authorize later out-of-turn browser/web actions.
+            self._current_user_message = None
 
     def chat(self, message: str, stream_callback: Optional[callable] = None) -> str:
         """

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2151,6 +2151,25 @@ class TestExecuteToolCalls:
 
         mock_print.assert_not_called()
 
+    def test_run_conversation_clears_current_user_message_after_turn(self, agent):
+        agent._interruptible_api_call = lambda _kwargs: _mock_response(content="Done")
+        agent._persist_session = lambda *args, **kwargs: None
+        agent._save_trajectory = lambda *args, **kwargs: None
+
+        result = agent.run_conversation("https://example.com 열어줘")
+
+        assert result["completed"] is True
+        assert result["final_response"] == "Done"
+        assert getattr(agent, "_current_user_message", None) is None
+
+    def test_run_conversation_clears_current_user_message_on_exception(self, agent):
+        agent._current_user_message = "https://example.com 열어줘"
+        with patch("agent.conversation_loop.run_conversation", side_effect=RuntimeError("boom")):
+            with pytest.raises(RuntimeError, match="boom"):
+                agent.run_conversation("next turn")
+
+        assert getattr(agent, "_current_user_message", None) is None
+
     def test_run_conversation_suppresses_retry_noise_in_parseable_quiet_mode(self, agent):
         class _RateLimitError(Exception):
             status_code = 429

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -111,6 +111,82 @@ class TestHandleFunctionCall:
         # pre_tool_call does NOT get duration_ms (nothing has run yet).
         assert "duration_ms" not in kwargs_by_hook["pre_tool_call"]
 
+    def test_passive_pasted_url_is_blocked_before_browser_navigation(self):
+        result = json.loads(handle_function_call(
+            "browser_navigate",
+            {"url": "https://flannels-throat-footpad.ngrok-free.dev"},
+            user_task="flannels-throat-footpad.ngrok-free.dev\n복사해놓음",
+        ))
+        assert "error" in result
+        assert "Ambiguous pasted URL" in result["error"]
+
+    def test_url_only_message_is_blocked_before_web_extract(self):
+        result = json.loads(handle_function_call(
+            "web_extract",
+            {"url": "https://example.com/path"},
+            user_task="example.com/path",
+        ))
+        assert "error" in result
+        assert "Ambiguous pasted URL" in result["error"]
+
+    def test_passive_pasted_host_blocks_path_suffix_navigation(self):
+        result = json.loads(handle_function_call(
+            "browser_navigate",
+            {"url": "https://flannels-throat-footpad.ngrok-free.dev/admin?x=1"},
+            user_task="flannels-throat-footpad.ngrok-free.dev\n복사해놓음",
+        ))
+        assert "error" in result
+        assert "Ambiguous pasted URL" in result["error"]
+
+    def test_url_action_without_user_task_fails_closed(self):
+        result = json.loads(handle_function_call(
+            "browser_navigate",
+            {"url": "https://example.com"},
+            user_task=None,
+        ))
+        assert "error" in result
+        assert "Missing user intent context" in result["error"]
+
+    def test_explicit_url_instruction_allows_browser_navigation(self):
+        with patch("model_tools.registry.dispatch", return_value='{"ok":true}') as dispatch:
+            result = json.loads(handle_function_call(
+                "browser_navigate",
+                {"url": "https://example.com"},
+                user_task="https://example.com 열어봐",
+            ))
+        assert result == {"ok": True}
+        dispatch.assert_called_once()
+
+    def test_tool_call_bridge_to_browser_navigation_preserves_url_intent_guard(self):
+        current_defs = [{"function": {"name": "browser_navigate", "parameters": {}}}]
+        with (
+            patch("model_tools.get_tool_definitions", return_value=current_defs),
+            patch("tools.tool_search.is_deferrable_tool_name", return_value=True),
+            patch("model_tools.registry.dispatch", return_value='{"unexpected":true}') as dispatch,
+        ):
+            result = json.loads(handle_function_call(
+                "tool_call",
+                {
+                    "name": "browser_navigate",
+                    "arguments": {"url": "https://flannels-throat-footpad.ngrok-free.dev"},
+                },
+                user_task="flannels-throat-footpad.ngrok-free.dev\n복사해놓음",
+            ))
+
+        assert "error" in result
+        assert "Ambiguous pasted URL" in result["error"]
+        dispatch.assert_not_called()
+
+    def test_explicit_summarize_url_instruction_allows_web_extract(self):
+        with patch("model_tools.registry.dispatch", return_value='{"ok":true}') as dispatch:
+            result = json.loads(handle_function_call(
+                "web_extract",
+                {"urls": ["https://example.com/post"]},
+                user_task="https://example.com/post 요약해줘",
+            ))
+        assert result == {"ok": True}
+        dispatch.assert_called_once()
+
 
 # =========================================================================
 # Agent loop tools

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -230,6 +230,41 @@ print(f"file lines: {r2['total_lines']}")
         self.assertEqual(result["status"], "success")
         self.assertEqual(result["tool_calls_made"], 2)
 
+    def test_sandbox_web_extract_rpc_preserves_user_task(self):
+        """Nested URL-action RPC calls keep current-turn intent context."""
+        captured = []
+
+        def capture_dispatch(function_name, function_args, task_id=None, user_task=None):
+            captured.append({
+                "function_name": function_name,
+                "function_args": function_args,
+                "task_id": task_id,
+                "user_task": user_task,
+            })
+            return json.dumps({"ok": True})
+
+        code = """
+from hermes_tools import web_extract
+result = web_extract(["https://example.com/path"])
+print(result)
+"""
+        with patch("model_tools.handle_function_call", side_effect=capture_dispatch):
+            raw = execute_code(
+                code=code,
+                task_id="test-user-task-rpc",
+                enabled_tools=["web_extract"],
+                user_task="https://example.com/path 요약해줘",
+            )
+
+        result = json.loads(raw)
+        self.assertEqual(result["status"], "success", msg=result)
+        self.assertEqual(result["tool_calls_made"], 1)
+        self.assertEqual(len(captured), 1)
+        self.assertEqual(captured[0]["function_name"], "web_extract")
+        self.assertEqual(captured[0]["function_args"], {"urls": ["https://example.com/path"]})
+        self.assertEqual(captured[0]["task_id"], "test-user-task-rpc")
+        self.assertEqual(captured[0]["user_task"], "https://example.com/path 요약해줘")
+
     def test_syntax_error(self):
         """Script with a syntax error returns error status."""
         result = self._run("def broken(")

--- a/tests/tools/test_url_intent_guard.py
+++ b/tests/tools/test_url_intent_guard.py
@@ -1,0 +1,518 @@
+import pytest
+
+from tools.url_intent_guard import ambiguous_user_pasted_url_block
+
+
+def test_passive_host_blocks_path_query_scheme_variant():
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": "https://FLANNELS-THROAT-FOOTPAD.ngrok-free.dev/admin?x=1"},
+        "flannels-throat-footpad.ngrok-free.dev\n복사해놓음",
+    )
+    assert reason is not None
+    assert "Ambiguous pasted URL" in reason
+
+
+def test_passive_paste_marker_plus_generic_check_does_not_authorize_url():
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": "https://example.com"},
+        "example.com 복사해놓음. 확인해줘",
+    )
+    assert reason is not None
+    assert "Ambiguous pasted URL" in reason
+
+
+@pytest.mark.parametrize("user_task", [
+    "https://example.com 읽지 마",
+    "https://example.com 열지 마",
+    "do not open https://example.com",
+    "don't fetch https://example.com",
+])
+def test_negative_url_action_is_not_treated_as_explicit_permission(user_task):
+    reason = ambiguous_user_pasted_url_block(
+        "web_extract",
+        {"urls": ["https://example.com/path"]},
+        user_task,
+    )
+    assert reason is not None
+    assert "Ambiguous pasted URL" in reason
+
+
+@pytest.mark.parametrize("user_task", [
+    "https://example.com 요약해줘",
+    "https://example.com 읽어줘",
+    "summarize https://example.com",
+    "read https://example.com",
+])
+def test_affirmative_url_action_is_explicit_permission(user_task):
+    reason = ambiguous_user_pasted_url_block(
+        "web_extract",
+        {"urls": ["https://example.com"]},
+        user_task,
+    )
+    assert reason is None
+
+
+def test_target_url_not_mentioned_in_user_task_fails_closed_without_url_scoped_permission():
+    reason = ambiguous_user_pasted_url_block(
+        "web_extract",
+        {"urls": ["https://result.example/path"]},
+        "ngrok 관련 오픈소스 리서치해줘",
+    )
+    assert reason is not None
+    assert "Ambiguous pasted URL" in reason
+
+
+def test_different_target_url_not_authorized_by_current_turn_url():
+    reason = ambiguous_user_pasted_url_block(
+        "web_extract",
+        {"urls": ["https://evil.example/path"]},
+        "https://example.com 요약해줘",
+    )
+    assert reason is not None
+    assert "Ambiguous pasted URL" in reason
+
+
+@pytest.mark.parametrize("user_task", [
+    "I already copied https://example.com",
+    "because https://example.com was copied",
+    "https://example.com 확인용으로 복사해놓음",
+    "https://example.com 미확인 메모",
+])
+def test_substring_action_words_do_not_create_permission(user_task):
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": "https://example.com/path"},
+        user_task,
+    )
+    assert reason is not None
+    assert "Ambiguous pasted URL" in reason
+
+
+def test_pasted_parent_domain_blocks_www_variant():
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": "https://www.example.com/path"},
+        "example.com\n복사해놓음",
+    )
+    assert reason is not None
+    assert "Ambiguous pasted URL" in reason
+
+
+@pytest.mark.parametrize("url", [
+    "file:///etc/passwd",
+    "javascript:alert(1)",
+    "data:text/html,<script>alert(1)</script>",
+])
+def test_non_http_scheme_url_actions_fail_closed(url):
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": url},
+        "이건 복사만 해둠",
+    )
+    assert reason is not None
+
+
+def test_action_for_second_url_does_not_authorize_first_pasted_url():
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": "https://evil.example/path"},
+        "evil.example 복사해놨고 https://google.com 열어줘",
+    )
+    assert reason is not None
+    assert "Ambiguous pasted URL" in reason
+
+
+def test_action_for_second_url_authorizes_second_url_only():
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": "https://google.com"},
+        "evil.example 복사해놨고 https://google.com 열어줘",
+    )
+    assert reason is None
+
+
+def test_english_prefix_action_for_second_url_authorizes_second_url_only():
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": "https://google.com"},
+        "evil.example copied and open google.com",
+    )
+    assert reason is None
+
+
+def test_action_for_first_url_does_not_authorize_second_pasted_url():
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": "https://evil.example/path"},
+        "https://google.com 열어줘 evil.example 복사해놓음",
+    )
+    assert reason is not None
+    assert "Ambiguous pasted URL" in reason
+
+
+def test_non_string_user_task_fails_closed_instead_of_crashing():
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": "https://example.com"},
+        [{"type": "text", "text": "https://example.com 열어봐"}],
+    )
+    assert reason is not None
+
+
+def test_english_action_between_urls_does_not_authorize_previous_url():
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": "https://evil.example"},
+        "evil.example open google.com",
+    )
+    assert reason is not None
+    assert "Ambiguous pasted URL" in reason
+
+
+@pytest.mark.parametrize("user_task", [
+    "https://example.com 들어가지 마",
+    "https://example.com 접속 안 함",
+    "https://example.com 접속 금지",
+    "Never open https://example.com",
+    "I will not open https://example.com",
+    "https://example.com no need to open",
+    "https://example.com I won't open",
+    "https://example.com not necessary to fetch",
+])
+def test_additional_negative_url_actions_are_not_permission(user_task):
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": "https://example.com"},
+        user_task,
+    )
+    assert reason is not None
+    assert "Ambiguous pasted URL" in reason
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "localhost"])
+def test_passive_ip_or_localhost_mentions_block_matching_navigation(host):
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": f"http://{host}:8080/admin"},
+        f"{host}\n복사해놓음",
+    )
+    assert reason is not None
+    assert "Ambiguous pasted URL" in reason
+
+
+def test_unrelated_later_browser_word_does_not_authorize_pasted_url():
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": "https://evil.example"},
+        "evil.example 복사해놓음. 그런데 다른 브라우저 켜줄래?",
+    )
+    assert reason is not None
+    assert "Ambiguous pasted URL" in reason
+
+
+@pytest.mark.parametrize("user_task", [
+    "https://example.com 증거 복사해놓음",
+    "https://example.com 스크린샷 복사해둠",
+    "https://example.com 접속 기록 복사",
+    "https://example.com 분석 메모",
+    "https://example.com 추출 후보",
+])
+def test_bare_action_nouns_do_not_create_permission(user_task):
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": "https://example.com"},
+        user_task,
+    )
+    assert reason is not None
+    assert "Ambiguous pasted URL" in reason
+
+
+@pytest.mark.parametrize("user_task", [
+    "https://example.com 접속해줘",
+    "https://example.com 스크린샷 찍어줘",
+    "https://example.com 증거 수집해줘",
+    "https://example.com 분석해줘",
+    "https://example.com 추출해줘",
+])
+def test_suffixed_korean_action_words_are_permission(user_task):
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": "https://example.com"},
+        user_task,
+    )
+    assert reason is None
+
+
+def test_passive_localhost_with_port_blocks_matching_navigation():
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": "http://localhost:8080/admin"},
+        "localhost:8080\n복사해놓음",
+    )
+    assert reason is not None
+    assert "Ambiguous pasted URL" in reason
+
+
+def test_unrelated_later_check_code_request_does_not_authorize_pasted_url():
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": "https://evil.example"},
+        "evil.example 복사해놨어. 그리고 내 코드 확인해줘",
+    )
+    assert reason is not None
+    assert "Ambiguous pasted URL" in reason
+
+
+@pytest.mark.parametrize("user_task", [
+    "evil.example 복사. 메뉴 열어줘",
+    "evil.example 복사. 브라우저 열어줘",
+    "example.com 복사. 결과 요약해줘",
+])
+def test_unrelated_later_object_action_does_not_authorize_pasted_url(user_task):
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": "https://evil.example" if "evil" in user_task else "https://example.com"},
+        user_task,
+    )
+    assert reason is not None
+    assert "Ambiguous pasted URL" in reason
+
+
+def test_web_extract_batch_requires_each_target_url_to_be_explicitly_authorized():
+    reason = ambiguous_user_pasted_url_block(
+        "web_extract",
+        {"urls": ["https://google.com", "https://evil.example"]},
+        "https://google.com 요약해줘 evil.example 복사해놓음",
+    )
+    assert reason is not None
+    assert "Ambiguous pasted URL" in reason
+
+
+def test_web_extract_batch_allows_when_each_target_url_is_explicitly_authorized():
+    reason = ambiguous_user_pasted_url_block(
+        "web_extract",
+        {"urls": ["https://google.com", "https://example.com"]},
+        "https://google.com 요약해줘 https://example.com 읽어줘",
+    )
+    assert reason is None
+
+
+def test_web_extract_batch_same_host_different_path_requires_each_path_authorized():
+    reason = ambiguous_user_pasted_url_block(
+        "web_extract",
+        {"urls": ["https://example.com/a", "https://example.com/b"]},
+        "https://example.com/a 요약해줘 https://example.com/b 복사해놓음",
+    )
+    assert reason is not None
+    assert "Ambiguous pasted URL" in reason
+
+
+def test_explicit_localhost_port_does_not_authorize_different_port():
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": "http://localhost:9000/admin"},
+        "localhost:3000 열어줘",
+    )
+    assert reason is not None
+    assert "Ambiguous pasted URL" in reason
+
+
+@pytest.mark.parametrize("user_task", [
+    "코드 좀 봐줘. evil.example 복사해놨어",
+    "check my code. evil.example copied",
+    "파일 확인해줘. evil.example 복사해놨어",
+])
+def test_unrelated_prefix_action_does_not_authorize_following_pasted_url(user_task):
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": "https://evil.example"},
+        user_task,
+    )
+    assert reason is not None
+    assert "Ambiguous pasted URL" in reason
+
+
+def test_explicit_domain_port_does_not_authorize_different_port():
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": "http://example.com:9000/admin"},
+        "example.com:3000 열어줘",
+    )
+    assert reason is not None
+    assert "Ambiguous pasted URL" in reason
+
+
+@pytest.mark.parametrize("path", ["read", "check", "open", "verify", "extract"])
+def test_action_words_inside_url_path_do_not_create_permission(path):
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": f"https://evil.example/{path}"},
+        f"https://evil.example/{path}\n복사해놓음",
+    )
+    assert reason is not None
+    assert "Ambiguous pasted URL" in reason
+
+
+@pytest.mark.parametrize("user_task", [
+    "example.com 읽고 메모해놨어",
+    "example.com 데이터 가져와서 정리함",
+])
+def test_korean_descriptive_past_actions_do_not_create_permission(user_task):
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": "https://example.com"},
+        user_task,
+    )
+    assert reason is not None
+    assert "Ambiguous pasted URL" in reason
+
+
+@pytest.mark.parametrize("user_task", [
+    "example.com 읽고 요약해줘",
+    "example.com 가져와줘",
+])
+def test_korean_imperative_read_fetch_forms_are_permission(user_task):
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": "https://example.com"},
+        user_task,
+    )
+    assert reason is None
+
+
+@pytest.mark.parametrize("user_task", [
+    "example.com good read",
+    "example.com for reference, use later",
+    "example.com check later",
+])
+def test_english_descriptive_actions_after_url_do_not_create_permission(user_task):
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": "https://example.com"},
+        user_task,
+    )
+    assert reason is not None
+    assert "Ambiguous pasted URL" in reason
+
+
+@pytest.mark.parametrize("user_task", [
+    "read example.com",
+    "summarize https://example.com",
+    "open example.com",
+])
+def test_english_prefix_imperatives_are_permission(user_task):
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": "https://example.com"},
+        user_task,
+    )
+    assert reason is None
+
+
+@pytest.mark.parametrize("url", [
+    "http://example.com:bad/path",
+    "http://example.com:99999/path",
+])
+def test_malformed_ports_fail_closed_by_validation(url):
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": url},
+        "example.com 복사해놓음",
+    )
+    assert reason is not None
+
+
+@pytest.mark.parametrize("url", [
+    "https://",
+    "http://",
+    "http:///path",
+])
+def test_malformed_http_urls_without_host_fail_closed(url):
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": url},
+        "복사해놓음",
+    )
+    assert reason is not None
+
+
+def test_explicit_port_does_not_authorize_same_host_without_port():
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": "http://localhost/admin"},
+        "localhost:3000 열어줘",
+    )
+    assert reason is not None
+    assert "Ambiguous pasted URL" in reason
+
+
+def test_passive_marker_before_url_does_not_authorize_generic_check():
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": "https://example.com"},
+        "복사해놓음: example.com 확인해줘",
+    )
+    assert reason is not None
+    assert "Ambiguous pasted URL" in reason
+
+
+@pytest.mark.parametrize(("url", "user_task"), [
+    ("https://네이버.com", "네이버.com 복사해놓음"),
+    ("http://[2001:db8::1]", "2001:db8::1 복사해놓음"),
+    ("http://my-dev-server", "my-dev-server 복사해놓음"),
+])
+def test_tool_target_host_literal_mentions_not_matched_by_url_regex_still_block(url, user_task):
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": url},
+        user_task,
+    )
+    assert reason is not None
+    assert "Ambiguous pasted URL" in reason
+
+
+def test_parent_domain_permission_does_not_authorize_subdomain_target():
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": "https://evil.example.com"},
+        "https://example.com 열어봐",
+    )
+    assert reason is not None
+    assert "Ambiguous pasted URL" in reason
+
+
+def test_root_path_permission_does_not_authorize_unmentioned_deeper_path():
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": "https://example.com/admin"},
+        "https://example.com 열어봐",
+    )
+    assert reason is not None
+    assert "Ambiguous pasted URL" in reason
+
+
+def test_passive_marker_before_second_url_blocks_generic_check_for_second_url():
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate",
+        {"url": "https://evil.example"},
+        "https://ok.com 열어줘. 복사해놓음: evil.example 확인해줘",
+    )
+    assert reason is not None
+    assert "Ambiguous pasted URL" in reason
+
+
+@pytest.mark.parametrize("args", [
+    {"url": ""},
+    {"urls": [""]},
+    {"url": None},
+    {"urls": []},
+])
+def test_empty_or_missing_tool_url_fails_closed(args):
+    reason = ambiguous_user_pasted_url_block(
+        "browser_navigate" if "url" in args else "web_extract",
+        args,
+        "https://example.com 열어봐",
+    )
+    assert reason is not None

--- a/tests/tools/test_website_policy.py
+++ b/tests/tools/test_website_policy.py
@@ -1,4 +1,5 @@
 import json
+import asyncio
 from pathlib import Path
 
 import pytest
@@ -318,10 +319,168 @@ def test_browser_navigate_returns_policy_block(monkeypatch):
         lambda *args, **kwargs: pytest.fail("browser command should not run for blocked URL"),
     )
 
-    result = json.loads(browser_tool.browser_navigate("https://blocked.test"))
+    result = json.loads(browser_tool.browser_navigate(
+        "https://blocked.test",
+        user_task="https://blocked.test 열어봐",
+    ))
 
     assert result["success"] is False
     assert result["blocked_by_policy"]["rule"] == "blocked.test"
+
+
+def test_browser_navigate_blocks_passive_pasted_url_before_browser_command(monkeypatch):
+    from tools import browser_tool
+
+    monkeypatch.setattr(
+        browser_tool,
+        "_run_browser_command",
+        lambda *args, **kwargs: pytest.fail("browser command should not run for passive pasted URL"),
+    )
+
+    result = json.loads(browser_tool.browser_navigate(
+        "https://flannels-throat-footpad.ngrok-free.dev/",
+        user_task="flannels-throat-footpad.ngrok-free.dev\n복사해놓음",
+    ))
+
+    assert result["success"] is False
+    assert "Ambiguous pasted URL" in result["error"]
+
+
+def test_browser_navigate_fails_closed_without_user_task_before_browser_command(monkeypatch):
+    from tools import browser_tool
+
+    monkeypatch.setattr(
+        browser_tool,
+        "_run_browser_command",
+        lambda *args, **kwargs: pytest.fail("browser command should not run without user intent context"),
+    )
+
+    result = json.loads(browser_tool.browser_navigate("https://example.com"))
+
+    assert result["success"] is False
+    assert "Missing user intent context" in result["error"]
+
+
+def test_browser_registry_passes_user_task_to_navigate(monkeypatch):
+    from tools import browser_tool
+
+    captured = {}
+
+    def fake_browser_navigate(*, url, task_id=None, user_task=None):
+        captured.update({"url": url, "task_id": task_id, "user_task": user_task})
+        return json.dumps({"success": True})
+
+    monkeypatch.setattr(browser_tool, "browser_navigate", fake_browser_navigate)
+
+    result = browser_tool.registry.dispatch(
+        "browser_navigate",
+        {"url": "https://example.com"},
+        task_id="t1",
+        user_task="https://example.com\n복사해놓음",
+    )
+
+    assert json.loads(result) == {"success": True}
+    assert captured == {
+        "url": "https://example.com",
+        "task_id": "t1",
+        "user_task": "https://example.com\n복사해놓음",
+    }
+
+
+def test_handle_function_call_passes_user_task_through_registry_to_browser_navigate(monkeypatch):
+    from model_tools import handle_function_call
+    from tools import browser_tool
+
+    calls = []
+
+    monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: True)
+    monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+    monkeypatch.setattr(browser_tool, "check_website_access", lambda url: None)
+    monkeypatch.setattr(browser_tool, "_get_session_info", lambda key: {"_first_nav": False})
+    monkeypatch.setattr(browser_tool, "_get_command_timeout", lambda: 1)
+
+    def fake_run_browser_command(session_key, command, args, timeout=None):
+        calls.append({
+            "session_key": session_key,
+            "command": command,
+            "args": args,
+            "timeout": timeout,
+        })
+        return {"success": True, "data": {"title": "OK", "url": args[0] if args else ""}}
+
+    monkeypatch.setattr(browser_tool, "_run_browser_command", fake_run_browser_command)
+
+    result = json.loads(handle_function_call(
+        "browser_navigate",
+        {"url": "https://example.com"},
+        task_id="t-e2e",
+        user_task="https://example.com 열어봐",
+    ))
+
+    assert result["success"] is True
+    assert result["url"] == "https://example.com"
+    assert any(call["command"] == "open" and call["args"] == ["https://example.com"] for call in calls)
+
+
+def test_web_extract_tool_blocks_passive_pasted_url_before_provider(monkeypatch):
+    import agent.web_search_registry as web_search_registry
+    from tools import web_tools
+
+    monkeypatch.setattr(
+        web_search_registry,
+        "get_active_extract_provider",
+        lambda: pytest.fail("extract provider should not run for passive pasted URL"),
+    )
+
+    result = json.loads(asyncio.run(web_tools.web_extract_tool(
+        ["https://example.com/path"],
+        user_task="example.com/path",
+    )))
+
+    assert result["success"] is False
+    assert "Ambiguous pasted URL" in result["error"]
+
+
+def test_web_extract_tool_fails_closed_without_user_task_before_provider(monkeypatch):
+    import agent.web_search_registry as web_search_registry
+    from tools import web_tools
+
+    monkeypatch.setattr(
+        web_search_registry,
+        "get_active_extract_provider",
+        lambda: pytest.fail("extract provider should not run without user intent context"),
+    )
+
+    result = json.loads(asyncio.run(web_tools.web_extract_tool(["https://example.com/path"])))
+
+    assert result["success"] is False
+    assert "Missing user intent context" in result["error"]
+
+
+def test_web_extract_registry_passes_user_task(monkeypatch):
+    from tools import web_tools
+
+    captured = {}
+
+    async def fake_web_extract_tool(urls, format=None, use_llm_processing=True, model=None, min_length=0, user_task=None):
+        captured.update({"urls": urls, "format": format, "user_task": user_task})
+        return json.dumps({"success": True})
+
+    monkeypatch.setattr(web_tools, "web_extract_tool", fake_web_extract_tool)
+
+    result = web_tools.registry.dispatch(
+        "web_extract",
+        {"urls": ["https://example.com"]},
+        task_id="t1",
+        user_task="https://example.com\n복사해놓음",
+    )
+
+    assert json.loads(result) == {"success": True}
+    assert captured == {
+        "urls": ["https://example.com"],
+        "format": "markdown",
+        "user_task": "https://example.com\n복사해놓음",
+    }
 
 
 def test_browser_navigate_allows_when_shared_file_missing(monkeypatch, tmp_path):
@@ -395,7 +554,11 @@ class TestWebToolPolicy:
         # Force the firecrawl plugin to be the active extract provider.
         monkeypatch.setenv("FIRECRAWL_API_KEY", "fake-key")
 
-        result = json.loads(await web_tools.web_extract_tool(["https://blocked.test"], use_llm_processing=False))
+        result = json.loads(await web_tools.web_extract_tool(
+            ["https://blocked.test"],
+            use_llm_processing=False,
+            user_task="https://blocked.test 읽어줘",
+        ))
 
         assert result["results"][0]["url"] == "https://blocked.test"
         assert "Blocked by website policy" in result["results"][0]["error"]
@@ -437,7 +600,11 @@ class TestWebToolPolicy:
         monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
         monkeypatch.setenv("FIRECRAWL_API_KEY", "fake-key")
 
-        result = json.loads(await web_tools.web_extract_tool(["https://allowed.test"], use_llm_processing=False))
+        result = json.loads(await web_tools.web_extract_tool(
+            ["https://allowed.test"],
+            use_llm_processing=False,
+            user_task="https://allowed.test 읽어줘",
+        ))
 
         assert result["results"][0]["url"] == "https://blocked.test/final"
         assert result["results"][0]["content"] == ""

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2286,17 +2286,27 @@ def _truncate_snapshot(snapshot_text: str, max_chars: int = 8000) -> str:
 # Browser Tool Functions
 # ============================================================================
 
-def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
+def browser_navigate(url: str, task_id: Optional[str] = None, user_task: Optional[str] = None) -> str:
     """
     Navigate to a URL in the browser.
 
     Args:
         url: The URL to navigate to
         task_id: Task identifier for session isolation
+        user_task: Current user turn, used to distinguish passive pasted URLs
+            from explicit navigation instructions before any browser action.
 
     Returns:
         JSON string with navigation result (includes stealth features info on first nav)
     """
+    from tools.url_intent_guard import ambiguous_user_pasted_url_block
+
+    _intent_block = ambiguous_user_pasted_url_block(
+        "browser_navigate", {"url": url}, user_task
+    )
+    if _intent_block is not None:
+        return json.dumps({"success": False, "error": _intent_block}, ensure_ascii=False)
+
     # Secret exfiltration protection — block URLs that embed API keys or
     # tokens in query parameters. A prompt injection could trick the agent
     # into navigating to https://evil.com/steal?key=sk-ant-... to exfil secrets.
@@ -3783,7 +3793,8 @@ registry.register(
     name="browser_navigate",
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_navigate"],
-    handler=lambda args, **kw: browser_navigate(url=args.get("url", ""), task_id=kw.get("task_id")),
+    handler=lambda args, **kw: browser_navigate(
+        url=args.get("url", ""), task_id=kw.get("task_id"), user_task=kw.get("user_task")),
     check_fn=check_browser_requirements,
     emoji="🌐",
 )

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -468,6 +468,7 @@ _TERMINAL_BLOCKED_PARAMS = {"background", "pty", "notify_on_complete", "watch_pa
 def _rpc_server_loop(
     server_sock: socket.socket,
     task_id: str,
+    user_task: Optional[str],
     tool_call_log: list,
     tool_call_counter: list,   # mutable [int] so the thread can increment
     max_tool_calls: int,
@@ -551,7 +552,7 @@ def _rpc_server_loop(
                         sys.stdout = devnull
                         sys.stderr = devnull
                         result = handle_function_call(
-                            tool_name, tool_args, task_id=task_id
+                            tool_name, tool_args, task_id=task_id, user_task=user_task
                         )
                     finally:
                         sys.stdout, sys.stderr = _real_stdout, _real_stderr
@@ -728,6 +729,7 @@ def _rpc_poll_loop(
     env,
     rpc_dir: str,
     task_id: str,
+    user_task: Optional[str],
     tool_call_log: list,
     tool_call_counter: list,
     max_tool_calls: int,
@@ -824,7 +826,7 @@ def _rpc_poll_loop(
                             sys.stdout = devnull
                             sys.stderr = devnull
                             tool_result = handle_function_call(
-                                tool_name, tool_args, task_id=task_id
+                                tool_name, tool_args, task_id=task_id, user_task=user_task
                             )
                         finally:
                             sys.stdout, sys.stderr = _real_stdout, _real_stderr
@@ -870,6 +872,7 @@ def _execute_remote(
     code: str,
     task_id: Optional[str],
     enabled_tools: Optional[List[str]],
+    user_task: Optional[str] = None,
 ) -> str:
     """Run a script on the remote terminal backend via file-based RPC.
 
@@ -938,7 +941,7 @@ def _execute_remote(
         rpc_thread = threading.Thread(
             target=propagate_context_to_thread(_rpc_poll_loop),
             args=(
-                env, f"{sandbox_dir}/rpc", effective_task_id,
+                env, f"{sandbox_dir}/rpc", effective_task_id, user_task,
                 tool_call_log, tool_call_counter, max_tool_calls,
                 sandbox_tools, stop_event,
             ),
@@ -1067,6 +1070,7 @@ def execute_code(
     code: str,
     task_id: Optional[str] = None,
     enabled_tools: Optional[List[str]] = None,
+    user_task: Optional[str] = None,
 ) -> str:
     """
     Run a Python script in a sandboxed child process with RPC access
@@ -1080,6 +1084,8 @@ def execute_code(
         task_id:       Session task ID for tool isolation (terminal env, etc.).
         enabled_tools: Tool names enabled in the current session. The sandbox
                        gets the intersection with SANDBOX_ALLOWED_TOOLS.
+        user_task:     Current user turn propagated to sandbox RPC tool calls
+                       so URL-intent guards remain active inside execute_code.
 
     Returns:
         JSON string with execution results.
@@ -1112,7 +1118,7 @@ def execute_code(
         }, ensure_ascii=False)
 
     if env_type != "local":
-        return _execute_remote(code, task_id, enabled_tools)
+        return _execute_remote(code, task_id, enabled_tools, user_task=user_task)
 
     # --- Local execution path (UDS) --- below this line is unchanged ---
 
@@ -1203,7 +1209,7 @@ def execute_code(
         rpc_thread = threading.Thread(
             target=propagate_context_to_thread(_rpc_server_loop),
             args=(
-                server_sock, task_id, tool_call_log,
+                server_sock, task_id, user_task, tool_call_log,
                 tool_call_counter, max_tool_calls, sandbox_tools,
             ),
             daemon=True,
@@ -1824,7 +1830,8 @@ registry.register(
     handler=lambda args, **kw: execute_code(
         code=args.get("code", ""),
         task_id=kw.get("task_id"),
-        enabled_tools=kw.get("enabled_tools")),
+        enabled_tools=kw.get("enabled_tools"),
+        user_task=kw.get("user_task")),
     check_fn=check_sandbox_requirements,
     emoji="🐍",
     max_result_size_chars=100_000,

--- a/tools/url_intent_guard.py
+++ b/tools/url_intent_guard.py
@@ -1,0 +1,400 @@
+"""Shared URL-intent guard for browser/web side-effect tools.
+
+A URL in the current user turn is not permission to fetch or navigate it. This
+module intentionally has no imports from model_tools or tool implementations so
+it can be used from the model dispatcher and low-level tool entry points without
+circular imports or fail-open fallback paths.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+from urllib.parse import urlsplit
+
+URL_ACTION_TOOLS = {"browser_navigate", "web_extract"}
+
+_URL_RE = re.compile(
+    r"https?://[^\s)\]>\"'`]+|"
+    r"\b(?:localhost|(?:\d{1,3}\.){3}\d{1,3})(?::\d+)?(?:/[^\s)\]>\"'`]*)?|"
+    r"\b[a-z0-9][a-z0-9.-]+\.[a-z]{2,}(?::\d+)?(?:/[^\s)\]>\"'`]*)?",
+    re.I,
+)
+_ENGLISH_EXPLICIT_URL_ACTION_RE = re.compile(
+    r"\b(?:open|browse|visit|navigate|fetch|check|verify|screenshot|use|summari[sz]e|read|extract)\b",
+    re.I,
+)
+_EXPLICIT_URL_ACTION_RE = re.compile(
+    r"("
+    r"열어(?:줘|봐|주세요)|접속(?:해|해줘|해주세요|시켜|시켜줘)|들어가(?:줘|봐|주세요)|"
+    r"확인(?:해|해줘|해주세요)|검증(?:해|해줘|해주세요)|"
+    r"캡처(?:해|해줘|해주세요)|스크린샷\s*(?:찍어|찍어줘|캡처|해줘)|증거\s*(?:(?:확보|수집)(?:해|해줘|해주세요)?|봐줘)|"
+    r"봐줘|살펴(?:봐|봐줘|줘)|분석(?:해|해줘|해주세요)|사용(?:해|해줘|해주세요)|"
+    r"써줘|요약(?:해|해줘|해주세요)|읽어(?:줘|봐|주세요)|읽고\s*(?:요약|정리|분석|설명)(?:해|해줘|해주세요)?|가져와(?:줘|주세요)|추출(?:해|해줘|해주세요)|"
+    r"\b(?:open|browse|visit|navigate|fetch|check|verify|screenshot|use|summari[sz]e|read|extract)\b"
+    r")",
+    re.I,
+)
+_NEGATED_URL_ACTION_RE = re.compile(
+    r"("
+    r"열지\s*마|읽지\s*마|들어가지\s*마|접속하지\s*마|가져오지\s*마|추출하지\s*마|"
+    r"요약하지\s*마|확인하지\s*마|검증하지\s*마|사용하지\s*마|"
+    r"접속\s*(?:안\s*함|금지)|"
+    r"do\s+not\s+(?:open|browse|visit|navigate|fetch|check|verify|screenshot|use|summari[sz]e|read|extract)|"
+    r"don['’]?t\s+(?:open|browse|visit|navigate|fetch|check|verify|screenshot|use|summari[sz]e|read|extract)|"
+    r"won['’]?t\s+(?:open|browse|visit|navigate|fetch|check|verify|screenshot|use|summari[sz]e|read|extract)|"
+    r"no\s+need\s+to\s+(?:open|browse|visit|navigate|fetch|check|verify|screenshot|use|summari[sz]e|read|extract)|"
+    r"not\s+necessary\s+to\s+(?:open|browse|visit|navigate|fetch|check|verify|screenshot|use|summari[sz]e|read|extract)|"
+    r"never\s+(?:open|browse|visit|navigate|fetch|check|verify|screenshot|use|summari[sz]e|read|extract)|"
+    r"will\s+not\s+(?:open|browse|visit|navigate|fetch|check|verify|screenshot|use|summari[sz]e|read|extract)"
+    r")",
+    re.I,
+)
+_PASSIVE_PASTE_MARKER_RE = re.compile(r"복사|cop(?:y|ied)|메모|기록|후보", re.I)
+_PASSIVE_MARKER_IMMEDIATELY_BEFORE_URL_RE = re.compile(
+    r"(?:복사(?:해놓음|해둠|해놨음|함|만)?|cop(?:y|ied)|메모|기록|후보)\s*[:：-]?\s*$",
+    re.I,
+)
+_OTHER_OBJECT_AFTER_PASTE_RE = re.compile(
+    r"(?:(?:내|다른)\s*(?:코드|브라우저|파일|문서|앱)|메뉴|브라우저|결과)",
+    re.I,
+)
+_ACTION_TO_URL_PREFIX_RE = re.compile(
+    r"(?:^|[\s:：;,.!?。！？])(?:"
+    r"open|browse|visit|navigate|fetch|check|verify|screenshot|use|summari[sz]e|read|extract"
+    r")\s*$",
+    re.I,
+)
+
+AMBIGUOUS_PASTED_URL_ERROR = (
+    "Ambiguous pasted URL: the current user message contains a URL but does not "
+    "explicitly ask to open, browse, verify, summarize, read, or use it. Do not "
+    "navigate or fetch it. Ask a concise clarification first if using that URL "
+    "is necessary."
+)
+NON_HTTP_SCHEME_URL_ERROR = (
+    "Blocked non-http URL action: browser/web URL tools must not navigate or "
+    "fetch file:, javascript:, data:, or other non-http schemes from this path."
+)
+MALFORMED_URL_ERROR = (
+    "Blocked malformed URL action: browser/web URL tools require a valid http(s) "
+    "URL or host before navigation/fetch."
+)
+MISSING_USER_INTENT_CONTEXT_ERROR = (
+    "Missing user intent context: URL navigation/fetch tools require the current "
+    "user message so Hermes can distinguish a passive pasted URL from an explicit "
+    "instruction. Do not navigate or fetch the URL from this path."
+)
+
+
+@dataclass(frozen=True)
+class UrlIntentTarget:
+    """Normalized URL-ish target for intent comparison.
+
+    Matching is host-based on purpose: if the user merely pasted ``example.com``,
+    navigating to ``https://example.com/path`` is still using that pasted URL.
+    """
+
+    host: str
+    port: int | None = None
+    path: str = ""
+
+
+@dataclass(frozen=True)
+class UrlIntentMention:
+    """URL-like mention plus its span in the original user text."""
+
+    target: UrlIntentTarget
+    start: int
+    end: int
+
+
+def _strip_urlish_punctuation(value: str) -> str:
+    return str(value or "").strip().strip("<>(){}.,;:'\"`")
+
+
+def _normalize_target(value: str) -> Optional[UrlIntentTarget]:
+    text = _strip_urlish_punctuation(value)
+    if not text:
+        return None
+    scheme_match = re.match(r"^([a-z][a-z0-9+.-]*):", text, flags=re.I)
+    looks_like_host_port = bool(re.match(r"^[a-z0-9.-]+:\d+(?:/|$)", text, flags=re.I))
+    if scheme_match and not looks_like_host_port and not text.lower().startswith(("http://", "https://")):
+        return UrlIntentTarget(host=f"__non_http_scheme__:{scheme_match.group(1).lower()}")
+    if not re.match(r"^[a-z][a-z0-9+.-]*://", text, flags=re.I):
+        text = f"http://{text}"
+    try:
+        parsed = urlsplit(text)
+        host = (parsed.hostname or "").lower().strip(".")
+    except ValueError:
+        return UrlIntentTarget(host="__malformed_url__")
+    if not host:
+        if text.lower().startswith(("http://", "https://")):
+            return UrlIntentTarget(host="__malformed_url__")
+        return None
+    path = parsed.path or ""
+    if path == "/":
+        path = ""
+    try:
+        port = parsed.port
+    except ValueError:
+        return UrlIntentTarget(host="__malformed_url__")
+    return UrlIntentTarget(host=host, port=port, path=path)
+
+
+def _normalize_host(value: str) -> Optional[str]:
+    target = _normalize_target(value)
+    return target.host if target else None
+
+
+def extract_url_intent_targets(text: str) -> set[UrlIntentTarget]:
+    """Extract URL-like hosts from free text for current-turn intent matching."""
+
+    if not text:
+        return set()
+    targets: set[UrlIntentTarget] = set()
+    for match in _URL_RE.finditer(text):
+        target = _normalize_target(match.group(0))
+        if target:
+            targets.add(target)
+    return targets
+
+
+def extract_url_intent_mentions(text: str) -> list[UrlIntentMention]:
+    """Extract URL-like mentions with spans for URL-scoped action matching."""
+
+    if not text:
+        return []
+    mentions: list[UrlIntentMention] = []
+    for match in _URL_RE.finditer(text):
+        target = _normalize_target(match.group(0))
+        if target:
+            mentions.append(UrlIntentMention(
+                target=target,
+                start=match.start(),
+                end=match.end(),
+            ))
+    return mentions
+
+
+def _target_from_tool_value(value: str) -> set[UrlIntentTarget]:
+    """Extract a target from a tool argument, including non-http schemes."""
+
+    text = str(value or "")
+    target = _normalize_target(text)
+    if target:
+        return {target}
+    return extract_url_intent_targets(text)
+
+
+def tool_target_url_intents(function_name: str, function_args: Mapping[str, Any] | None) -> set[UrlIntentTarget]:
+    """Extract target URL hosts from a URL-action tool's arguments."""
+
+    args = function_args or {}
+    if function_name == "browser_navigate":
+        return _target_from_tool_value(str(args.get("url", "")))
+    if function_name == "web_extract":
+        urls = args.get("urls") or args.get("url") or ""
+        if isinstance(urls, list):
+            values: set[UrlIntentTarget] = set()
+            for item in urls:
+                values.update(_target_from_tool_value(str(item)))
+            return values
+        return _target_from_tool_value(str(urls))
+    return set()
+
+
+def _canonical_www_host(host: str) -> str:
+    return host[4:] if host.startswith("www.") else host
+
+
+def _hosts_overlap(left: str, right: str) -> bool:
+    """Return True for the exact same host, treating only www. as cosmetic."""
+
+    if left.startswith("__non_http_scheme__:") or right.startswith("__non_http_scheme__:"):
+        return left == right
+    return _canonical_www_host(left) == _canonical_www_host(right)
+
+
+def _paths_compatible(left: str, right: str) -> bool:
+    return (left or "") == (right or "")
+
+
+def _targets_compatible(left: UrlIntentTarget, right: UrlIntentTarget) -> bool:
+    if not _hosts_overlap(left.host, right.host):
+        return False
+    if left.port != right.port:
+        return False
+    return _paths_compatible(left.path, right.path)
+
+
+def _target_sets_overlap(left: set[UrlIntentTarget], right: set[UrlIntentTarget]) -> bool:
+    for a in left:
+        for b in right:
+            if _hosts_overlap(a.host, b.host):
+                return True
+    return False
+
+
+def _action_context_for_mention(text: str, mentions: list[UrlIntentMention], index: int) -> str:
+    """Return the text segment whose action words apply to one URL mention.
+
+    The URL itself plus the text after it up to the next URL belongs to that
+    URL. For any URL, an immediately adjacent imperative prefix like
+    ``open example.com`` is included. For later URLs this prefix starts after
+    the previous URL, so it cannot authorize both sides.
+    """
+
+    mention = mentions[index]
+    next_start = mentions[index + 1].start if index + 1 < len(mentions) else len(text)
+    suffix = text[mention.end:next_start]
+    prefix_start = 0 if index == 0 else mentions[index - 1].end
+    prefix = text[prefix_start:mention.start]
+    if _ACTION_TO_URL_PREFIX_RE.search(prefix):
+        return prefix + suffix
+    return suffix
+
+
+def _has_action_prefix_for_mention(text: str, mentions: list[UrlIntentMention], index: int) -> bool:
+    prefix_start = 0 if index == 0 else mentions[index - 1].end
+    return bool(_ACTION_TO_URL_PREFIX_RE.search(text[prefix_start:mentions[index].start]))
+
+
+def _has_passive_marker_after_mention(text: str, mentions: list[UrlIntentMention], index: int) -> bool:
+    next_start = mentions[index + 1].start if index + 1 < len(mentions) else len(text)
+    return bool(_PASSIVE_PASTE_MARKER_RE.search(text[mentions[index].end:next_start]))
+
+
+def _has_passive_marker_before_mention(text: str, mentions: list[UrlIntentMention], index: int) -> bool:
+    prefix_start = 0 if index == 0 else mentions[index - 1].end
+    prefix = text[prefix_start:mentions[index].start]
+    return bool(_PASSIVE_MARKER_IMMEDIATELY_BEFORE_URL_RE.search(prefix)) and not _has_action_prefix_for_mention(text, mentions, index)
+
+
+def _literal_mentions_for_tool_targets(text: str, targets: set[UrlIntentTarget]) -> list[UrlIntentMention]:
+    """Recover exact target-host mentions that the generic URL regex misses.
+
+    This covers IDN hosts, bare IPv6 literals, and single-label local hostnames
+    without teaching the broad URL regex to classify arbitrary words as URLs.
+    """
+
+    lowered = text.lower()
+    mentions: list[UrlIntentMention] = []
+    for target in targets:
+        if target.host.startswith("__"):
+            continue
+        needle = target.host.lower()
+        if not needle:
+            continue
+        start = 0
+        while True:
+            found = lowered.find(needle, start)
+            if found == -1:
+                break
+            end = found + len(needle)
+            before = lowered[found - 1] if found > 0 else ""
+            after = lowered[end] if end < len(lowered) else ""
+            before_is_inner = bool(before) and (before.isalnum() or before in ".-_:")
+            after_is_inner = bool(after) and (after.isalnum() or after in ".-_:")
+            if not (before_is_inner or after_is_inner):
+                mentions.append(UrlIntentMention(UrlIntentTarget(host=target.host), found, end))
+            start = end
+    return mentions
+
+
+def ambiguous_user_pasted_url_block(
+    function_name: str,
+    function_args: Mapping[str, Any] | None,
+    user_task: Any,
+    *,
+    require_user_task: bool = True,
+) -> Optional[str]:
+    """Return a block reason for passive pasted URL use, else ``None``.
+
+    ``require_user_task=True`` is fail-closed for live tool paths: a URL action
+    without current-turn context cannot prove that the user explicitly asked for
+    the URL to be fetched.
+    """
+
+    if function_name not in URL_ACTION_TOOLS:
+        return None
+
+    target_urls = tool_target_url_intents(function_name, function_args)
+    if not target_urls:
+        return MALFORMED_URL_ERROR
+
+    if any(target.host.startswith("__non_http_scheme__:") for target in target_urls):
+        return NON_HTTP_SCHEME_URL_ERROR
+    if any(target.host == "__malformed_url__" for target in target_urls):
+        return MALFORMED_URL_ERROR
+
+    if not user_task:
+        return MISSING_USER_INTENT_CONTEXT_ERROR if require_user_task else None
+    if not isinstance(user_task, str):
+        return MISSING_USER_INTENT_CONTEXT_ERROR if require_user_task else None
+
+    user_mentions = extract_url_intent_mentions(user_task)
+    user_mentions.extend(_literal_mentions_for_tool_targets(user_task, target_urls))
+    deduped_mentions: list[UrlIntentMention] = []
+    for mention in sorted(user_mentions, key=lambda item: (-(item.end - item.start), item.start)):
+        overlaps_existing = any(
+            _hosts_overlap(mention.target.host, existing.target.host)
+            and mention.start < existing.end
+            and existing.start < mention.end
+            for existing in deduped_mentions
+        )
+        if not overlaps_existing:
+            deduped_mentions.append(mention)
+    user_mentions = sorted(deduped_mentions, key=lambda mention: (mention.start, mention.end))
+    user_urls = {mention.target for mention in user_mentions}
+    if not user_urls or not _target_sets_overlap(target_urls, user_urls):
+        return AMBIGUOUS_PASTED_URL_ERROR
+
+    for target in target_urls:
+        same_host_mentions = [
+            (index, mention)
+            for index, mention in enumerate(user_mentions)
+            if _hosts_overlap(target.host, mention.target.host)
+        ]
+        target_contexts = [
+            (
+                index,
+                _action_context_for_mention(user_task, user_mentions, index),
+                _has_action_prefix_for_mention(user_task, user_mentions, index),
+            )
+            for index, mention in same_host_mentions
+            if _targets_compatible(target, mention.target)
+        ]
+        # Every URL-action target must be explicitly authorized by the current
+        # user turn. A generic follow-up like "확인해줘" or a different URL in
+        # the same turn is not enough to browse/fetch this target.
+        if not same_host_mentions:
+            return AMBIGUOUS_PASTED_URL_ERROR
+        # If the same host was mentioned but only at a different explicit path
+        # or port, fail closed instead of sharing permission across targets.
+        if not target_contexts:
+            return AMBIGUOUS_PASTED_URL_ERROR
+
+        # English imperatives normally precede their URL ("open example.com").
+        # When an English action word appears between two URL mentions, do not
+        # let it authorize the previous URL; fail closed instead of guessing.
+        if any(
+            _ENGLISH_EXPLICIT_URL_ACTION_RE.search(context)
+            and (index + 1 < len(user_mentions) or not has_action_prefix)
+            for index, context, has_action_prefix in target_contexts
+        ):
+            return AMBIGUOUS_PASTED_URL_ERROR
+
+        contexts = [context for _, context, _ in target_contexts]
+        if any(_NEGATED_URL_ACTION_RE.search(context) for context in contexts):
+            return AMBIGUOUS_PASTED_URL_ERROR
+        if any(
+            _has_passive_marker_after_mention(user_task, user_mentions, index)
+            or _has_passive_marker_before_mention(user_task, user_mentions, index)
+            for index, _, _ in target_contexts
+        ):
+            return AMBIGUOUS_PASTED_URL_ERROR
+        if not any(_EXPLICIT_URL_ACTION_RE.search(context) for context in contexts):
+            return AMBIGUOUS_PASTED_URL_ERROR
+    return None

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -874,7 +874,8 @@ async def web_extract_tool(
     format: str = None,
     use_llm_processing: bool = True,
     model: Optional[str] = None,
-    min_length: int = DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION
+    min_length: int = DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION,
+    user_task: Optional[str] = None,
 ) -> str:
     """
     Extract content from specific web pages using available extraction API backend.
@@ -898,6 +899,16 @@ async def web_extract_tool(
     Raises:
         Exception: If extraction fails or API key is not set
     """
+    # Block passive pasted/copied URLs before any fetch backend runs. This is
+    # defense in depth for direct web_extract calls that bypass model_tools.
+    from tools.url_intent_guard import ambiguous_user_pasted_url_block
+
+    _intent_block = ambiguous_user_pasted_url_block(
+        "web_extract", {"urls": urls}, user_task
+    )
+    if _intent_block is not None:
+        return json.dumps({"success": False, "error": _intent_block}, ensure_ascii=False)
+
     # Block URLs containing embedded secrets (exfiltration prevention).
     # URL-decode first so percent-encoded secrets (%73k- = sk-) are caught.
     from agent.redact import _PREFIX_RE
@@ -1338,7 +1349,10 @@ registry.register(
     toolset="web",
     schema=WEB_EXTRACT_SCHEMA,
     handler=lambda args, **kw: web_extract_tool(
-        args.get("urls", [])[:5] if isinstance(args.get("urls"), list) else [], "markdown"),
+        args.get("urls", [])[:5] if isinstance(args.get("urls"), list) else [],
+        "markdown",
+        user_task=kw.get("user_task"),
+    ),
     check_fn=check_web_api_key,
     requires_env=_web_requires_env(),
     is_async=True,


### PR DESCRIPTION
## Summary

- Adds a shared URL-intent guard for `browser_navigate` and `web_extract`.
- Blocks passive pasted URLs/hosts unless the current user turn explicitly authorizes the exact URL target.
- Propagates `user_task` through model dispatch, registry dispatch, low-level browser/web tools, and `execute_code` nested web RPCs.
- Clears current-turn URL intent context after each `run_conversation` call, including exception paths.

## Safety behavior

- Passive notes like `flannels-throat-footpad.ngrok-free.dev 복사해놓음` fail closed before navigation/fetch side effects.
- Missing/invalid `user_task`, malformed/non-http URLs, negative commands, multi-URL action leakage, subdomain widening, unmentioned deeper paths, and empty tool URL args fail closed.
- Explicit current-turn URL-scoped commands still work for the mentioned URL target.

## Test plan

- `python -m py_compile tools/url_intent_guard.py agent/conversation_loop.py run_agent.py model_tools.py tools/browser_tool.py tools/web_tools.py tools/code_execution_tool.py`
- `python -m pytest tests/tools/test_url_intent_guard.py -q -o 'addopts='`
- `python -m pytest tests/tools/test_url_intent_guard.py tests/test_model_tools.py tests/tools/test_website_policy.py tests/tools/test_code_execution.py tests/run_agent/test_run_agent.py -k 'not test_run_agent.py or clears_current_user_message' -q -o 'addopts='`

## Notes

- Live gateway processes must be restarted before this guard affects Telegram/browser tool paths in an already-running service.
- PR #863 was checked and is already closed/superseded by later Mistral tool-call PRs; this PR is for the separate passive URL guard work.
