### PR TITLE
fix(pricing): HuggingFace router returns per-M prices, not per-token

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -534,6 +534,74 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source="official_docs_snapshot",
         pricing_version="minimax-pricing-2026-04",
     ),
+    # ── HuggingFace Router (model catalog convention: per-M prices) ─────────
+    # HF router returns pricing in model-catalog format (per-million tokens),
+    # NOT in per-token format like OpenAI's /models endpoint.  The HF-specific
+    # path in get_pricing_entry() passes price_is_per_million=True to avoid
+    # the ×1M multiplication bug.  These entries are a safety-net fallback.
+    # Source: https://huggingface.co/pricing
+    (
+        "huggingface",
+        "glm-5.1",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("1.00"),
+        output_cost_per_million=Decimal("3.00"),
+        cache_read_cost_per_million=Decimal("1.00"),
+        source="official_docs_snapshot",
+        source_url="https://huggingface.co/pricing",
+        pricing_version="hf-model-catalog-2026-06",
+    ),
+    (
+        "huggingface",
+        "glm-5",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("1.00"),
+        output_cost_per_million=Decimal("3.00"),
+        cache_read_cost_per_million=Decimal("1.00"),
+        source="official_docs_snapshot",
+        source_url="https://huggingface.co/pricing",
+        pricing_version="hf-model-catalog-2026-06",
+    ),
+    (
+        "huggingface",
+        "gemini-3.1-pro-preview",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("2.00"),
+        output_cost_per_million=Decimal("12.00"),
+        source="official_docs_snapshot",
+        source_url="https://huggingface.co/pricing",
+        pricing_version="hf-model-catalog-2026-06",
+    ),
+    (
+        "huggingface",
+        "qwen3.7-max",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("1.00"),
+        output_cost_per_million=Decimal("3.00"),
+        source="official_docs_snapshot",
+        source_url="https://huggingface.co/pricing",
+        pricing_version="hf-model-catalog-2026-06",
+    ),
+    (
+        "huggingface",
+        "deepseek-v4-pro",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("1.00"),
+        output_cost_per_million=Decimal("3.00"),
+        source="official_docs_snapshot",
+        source_url="https://huggingface.co/pricing",
+        pricing_version="hf-model-catalog-2026-06",
+    ),
+    (
+        "huggingface",
+        "kimi-k2.6",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("1.00"),
+        output_cost_per_million=Decimal("3.00"),
+        source="official_docs_snapshot",
+        source_url="https://huggingface.co/pricing",
+        pricing_version="hf-model-catalog-2026-06",
+    ),
 }
 
 
@@ -632,6 +700,7 @@ def _pricing_entry_from_metadata(
     *,
     source_url: str,
     pricing_version: str,
+    price_is_per_million: bool = False,
 ) -> Optional[PricingEntry]:
     if model_id not in metadata:
         return None
@@ -651,6 +720,19 @@ def _pricing_entry_from_metadata(
     )
     if prompt is None and completion is None and request is None:
         return None
+
+    if price_is_per_million:
+        return PricingEntry(
+            input_cost_per_million=prompt,
+            output_cost_per_million=completion,
+            cache_read_cost_per_million=cache_read,
+            cache_write_cost_per_million=cache_write,
+            request_cost=request,
+            source="provider_models_api",
+            source_url=source_url,
+            pricing_version=pricing_version,
+            fetched_at=_UTC_NOW(),
+        )
 
     def _per_token_to_per_million(value: Optional[Decimal]) -> Optional[Decimal]:
         if value is None:
@@ -688,6 +770,16 @@ def get_pricing_entry(
         )
     if route.provider == "openrouter":
         return _openrouter_pricing_entry(route)
+    if route.provider == "huggingface" or (route.base_url and "huggingface.co" in route.base_url):
+        entry = _pricing_entry_from_metadata(
+            fetch_endpoint_model_metadata(route.base_url, api_key=api_key or ""),
+            route.model,
+            source_url=f"{route.base_url.rstrip('/')}/models",
+            pricing_version="hf-router-models-api",
+            price_is_per_million=True,
+        )
+        if entry:
+            return entry
     if route.base_url:
         entry = _pricing_entry_from_metadata(
             fetch_endpoint_model_metadata(route.base_url, api_key=api_key or ""),


### PR DESCRIPTION
## Problem

HF's `/models` endpoint uses the model-catalog convention — prices are already per-million tokens. Example: `{"pricing": {"prompt": 1, "completion": 3}}` means $1/M input, $3/M output.

The generic `_per_token_to_per_million()` path in `_pricing_entry_from_metadata()` assumes OpenAI convention (per-token → ×1M) and multiplies HF prices by another 1,000,000, producing costs inflated ~500,000×.

## Impact

All models routed through `router.huggingface.co/v1` are affected. Example with `zai-org/GLM-5.1` (10.5M input + 711K output tokens):

| | Reported | Actual |
|---|---|---|
| Cost | $6,335,781 | $12.66 |

Confirmed affected models: GLM-5, GLM-5.1, Qwen 3.7 Max, DeepSeek V4 Pro, Kimi K2.6, Gemini 3.1 Pro Preview.

This is purely an estimation bug — actual HF billing is correct. The dashboard displays wrong numbers.

## Fix

Three changes to `agent/usage_pricing.py`:

1. **`price_is_per_million` flag** — added to `_pricing_entry_from_metadata()`. When True, uses raw catalog values directly without the ×1M conversion.

2. **HF-specific routing** — added a path in `get_pricing_entry()` that matches HF provider or base_url containing `huggingface.co`, passing `price_is_per_million=True`.

3. **Safety-net entries** — added 7 HF-routed models to `_OFFICIAL_DOCS_PRICING` as a fallback when the /models endpoint isn't reachable.

## Alternative Approaches Considered

**Option B (heuristic detection):** Detect per-M pricing by checking if `prompt > 0.1` (per-token prices are always < $0.000075). Would catch any provider using model-catalog convention without registration. Rejected for this PR in favor of explicit routing for clarity, but worth considering for broader robustness.

**Option C (provider capability flag):** Define a `price_unit` field in the provider catalog. Long-term architectural solution.