### PR TITLE
Fix Slack peer bot-user routing loops

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -428,6 +428,7 @@ class SlackAdapter(BasePlatformAdapter):
         self._handler: Optional[Any] = None
         self._bot_user_id: Optional[str] = None
         self._user_name_cache: Dict[str, str] = {}  # user_id → display name
+        self._user_is_bot_cache: Dict[str, bool] = {}  # user_id → Slack bot identity
         self._socket_mode_task: Optional[asyncio.Task] = None
         # Multi-workspace support
         self._team_clients: Dict[str, Any] = {}  # team_id → WebClient
@@ -1427,6 +1428,28 @@ class SlackAdapter(BasePlatformAdapter):
             return True  # default: each DM thread is its own session
         return str(raw).strip().lower() in {"1", "true", "yes", "on"}
 
+    def _slack_allow_bots(self) -> str:
+        """Return normalized Slack bot-message policy."""
+        raw = self.config.extra.get("allow_bots", "")
+        if not raw:
+            raw = os.getenv("SLACK_ALLOW_BOTS", "none")
+        value = str(raw).lower().strip()
+        if value not in {"none", "mentions", "all"}:
+            logger.warning("[Slack] Unknown allow_bots=%r; treating as 'none'", raw)
+            return "none"
+        return value
+
+    def _event_declares_bot_sender(self, event: dict) -> bool:
+        """Return True when the Slack event itself identifies a bot sender."""
+        if event.get("bot_id") or event.get("bot_profile"):
+            return True
+        if event.get("subtype") == "bot_message":
+            return True
+        profile = event.get("user_profile")
+        if isinstance(profile, dict) and bool(profile.get("is_bot")):
+            return True
+        return False
+
     def _resolve_thread_ts(
         self,
         reply_to: Optional[str] = None,
@@ -1858,9 +1881,18 @@ class SlackAdapter(BasePlatformAdapter):
         try:
             client = self._get_client(chat_id) if chat_id else self._app.client
             result = await client.users_info(user=user_id)
+            if not isinstance(result, dict):
+                self._user_is_bot_cache[user_id] = False
+                self._user_name_cache[user_id] = user_id
+                return user_id
             user = result.get("user", {})
+            profile = user.get("profile", {}) if isinstance(user, dict) else {}
+            self._user_is_bot_cache[user_id] = bool(
+                user.get("is_bot")
+                or user.get("is_workflow_bot")
+                or (isinstance(profile, dict) and profile.get("bot_id"))
+            )
             # Prefer display_name → real_name → user_id
-            profile = user.get("profile", {})
             name = (
                 profile.get("display_name")
                 or profile.get("real_name")
@@ -1874,6 +1906,48 @@ class SlackAdapter(BasePlatformAdapter):
             logger.debug("[Slack] users.info failed for %s: %s", user_id, e)
             self._user_name_cache[user_id] = user_id
             return user_id
+
+    async def _resolve_user_is_bot(self, user_id: str, chat_id: str = "") -> bool:
+        """Resolve whether a Slack user ID is a bot account, with caching."""
+        if not user_id:
+            return False
+        if user_id in self._user_is_bot_cache:
+            return self._user_is_bot_cache[user_id]
+        if not self._app:
+            self._user_is_bot_cache[user_id] = False
+            return False
+
+        try:
+            client = self._get_client(chat_id) if chat_id else self._app.client
+            result = await client.users_info(user=user_id)
+            if not isinstance(result, dict):
+                self._user_is_bot_cache[user_id] = False
+                self._user_name_cache.setdefault(user_id, user_id)
+                return False
+            user = result.get("user", {})
+            profile = user.get("profile", {}) if isinstance(user, dict) else {}
+            is_bot = bool(
+                user.get("is_bot")
+                or user.get("is_workflow_bot")
+                or (isinstance(profile, dict) and profile.get("bot_id"))
+            )
+            self._user_is_bot_cache[user_id] = is_bot
+
+            # Populate the name cache from the same users.info response so the
+            # later source construction does not need a second API lookup.
+            name = (
+                profile.get("display_name")
+                or profile.get("real_name")
+                or user.get("real_name")
+                or user.get("name")
+                or user_id
+            )
+            self._user_name_cache[user_id] = name
+            return is_bot
+        except Exception as e:
+            logger.debug("[Slack] users.info bot check failed for %s: %s", user_id, e)
+            self._user_is_bot_cache[user_id] = False
+            return False
 
     async def send_image_file(
         self,
@@ -2360,11 +2434,8 @@ class SlackAdapter(BasePlatformAdapter):
         #   "none"     — ignore all bot messages (default, backward-compatible)
         #   "mentions" — accept bot messages only when they @mention us
         #   "all"      — accept all bot messages (except our own)
-        if event.get("bot_id") or event.get("subtype") == "bot_message":
-            allow_bots = self.config.extra.get("allow_bots", "")
-            if not allow_bots:
-                allow_bots = os.getenv("SLACK_ALLOW_BOTS", "none")
-            allow_bots = str(allow_bots).lower().strip()
+        if self._event_declares_bot_sender(event):
+            allow_bots = self._slack_allow_bots()
             if allow_bots == "none":
                 return
             elif allow_bots == "mentions":
@@ -2585,6 +2656,30 @@ class SlackAdapter(BasePlatformAdapter):
         )
         event_thread_ts = event.get("thread_ts")
         is_thread_reply = bool(event_thread_ts and event_thread_ts != ts)
+
+        # Some Slack bot posts arrive as ordinary-looking message events with a
+        # bot *user* id but without ``bot_id``/``subtype=bot_message``.  This is
+        # the shape produced by peer Hermes agents in Socket Mode on some
+        # workspaces.  If we let those fall through as human users, an old
+        # thread mention or active session will re-trigger the target agent on
+        # every peer status/error/ack message, causing agent-agent loops.  Apply
+        # the same allow_bots policy to resolved bot users, and in
+        # ``allow_bots: mentions`` require the current message text to mention
+        # this bot — thread history, reply parents, and active sessions do not
+        # count as a bot-to-bot summons.
+        if user_id and user_id != bot_uid:
+            sender_is_bot_user = self._event_declares_bot_sender(event)
+            if not sender_is_bot_user:
+                sender_is_bot_user = await self._resolve_user_is_bot(
+                    user_id,
+                    chat_id=channel_id,
+                )
+            if sender_is_bot_user:
+                allow_bots = self._slack_allow_bots()
+                if allow_bots == "none":
+                    return
+                if allow_bots == "mentions" and not is_mentioned:
+                    return
 
         if not is_dm and bot_uid:
             # Check allowed channels — if set, only respond in these channels (whitelist)

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2002,6 +2002,72 @@ class TestMessageRouting:
         adapter.handle_message.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_allow_bots_mentions_ignores_bot_user_without_current_mention(
+        self, adapter
+    ):
+        """Bot users need a fresh @mention even in an already-mentioned thread.
+
+        Slack peer-agent posts can arrive as normal-looking message events with
+        only a bot user id, no bot_id/subtype=bot_message.  Those must still obey
+        allow_bots=mentions; otherwise status/error/ack posts from one agent can
+        retrigger another agent through old thread state.
+        """
+        adapter.config.extra["allow_bots"] = "mentions"
+        adapter._mentioned_threads.add("123.000")
+        adapter._app.client.users_info = AsyncMock(
+            return_value={
+                "user": {
+                    "is_bot": True,
+                    "profile": {"display_name": "AIDx Engineer"},
+                }
+            }
+        )
+        event = {
+            "text": ":warning: Codex response remained incomplete after 3 continuation attempts",
+            "user": "U_PEER_BOT",
+            "channel": "C123",
+            "channel_type": "channel",
+            "ts": "123.456",
+            "thread_ts": "123.000",
+        }
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_allow_bots_mentions_processes_bot_user_with_current_mention(
+        self, adapter
+    ):
+        """Explicit peer-agent @mentions still route when allow_bots=mentions."""
+        adapter.config.extra["allow_bots"] = "mentions"
+        adapter._fetch_thread_context = AsyncMock(return_value="")
+        adapter._fetch_thread_parent_text = AsyncMock(return_value=None)
+        adapter._app.client.users_info = AsyncMock(
+            return_value={
+                "user": {
+                    "is_bot": True,
+                    "profile": {"display_name": "AIDx Engineer"},
+                }
+            }
+        )
+        event = {
+            "text": "<@U_BOT> please answer exactly BOT_OK",
+            "user": "U_PEER_BOT",
+            "channel": "C123",
+            "channel_type": "channel",
+            "ts": "123.789",
+            "thread_ts": "123.000",
+        }
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_called_once()
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "please answer exactly BOT_OK"
+        assert msg_event.source.user_name == "AIDx Engineer"
+
+    @pytest.mark.asyncio
     async def test_message_edits_ignored(self, adapter):
         """Message edits should be ignored."""
         event = {
@@ -2797,6 +2863,8 @@ class TestThreadReplyHandling:
         a._bot_user_id = "U_BOT"
         a._team_bot_user_ids = {"T_TEAM": "U_BOT"}
         a._running = True
+        a._fetch_thread_parent_text = AsyncMock(return_value=None)
+        a._fetch_thread_context = AsyncMock(return_value="")
         a.handle_message = AsyncMock()
         a.set_session_store(mock_session_store)
         return a
@@ -2935,6 +3003,8 @@ class TestAssistantThreadLifecycle:
         a._bot_user_id = "U_BOT"
         a._team_bot_user_ids = {"T_TEAM": "U_BOT"}
         a._running = True
+        a._fetch_thread_parent_text = AsyncMock(return_value=None)
+        a._fetch_thread_context = AsyncMock(return_value="")
         a.handle_message = AsyncMock()
         a.set_session_store(mock_session_store)
         return a

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -384,6 +384,8 @@ def test_config_bridges_slack_free_response_channels(monkeypatch, tmp_path):
     import os as _os
     assert _os.environ["SLACK_REQUIRE_MENTION"] == "false"
     assert _os.environ["SLACK_FREE_RESPONSE_CHANNELS"] == "C0AQWDLHY9M,C9999999999"
+    _os.environ.pop("SLACK_REQUIRE_MENTION", None)
+    _os.environ.pop("SLACK_FREE_RESPONSE_CHANNELS", None)
 
 
 def test_top_level_slack_settings_do_not_disable_env_token_setup(monkeypatch, tmp_path):
@@ -520,6 +522,7 @@ def test_config_bridges_slack_strict_mention(monkeypatch, tmp_path):
     assert config is not None
     import os as _os
     assert _os.environ["SLACK_STRICT_MENTION"] == "true"
+    _os.environ.pop("SLACK_STRICT_MENTION", None)
 
 
 # ---------------------------------------------------------------------------
@@ -671,6 +674,7 @@ def test_config_bridges_slack_allowed_channels(monkeypatch, tmp_path):
 
     import os as _os
     assert _os.environ["SLACK_ALLOWED_CHANNELS"] == f"{CHANNEL_ID},{OTHER_CHANNEL_ID}"
+    _os.environ.pop("SLACK_ALLOWED_CHANNELS", None)
 
 
 def test_config_bridges_slack_allowed_channels_env_takes_precedence(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Fix Slack peer-agent routing so Slack bot-user identities are handled by the `allow_bots` policy even when Slack delivers the event as a normal `message` without `bot_id`, `bot_profile`, or `subtype=bot_message`.

This prevents peer-agent status/error/control posts from waking another agent through stale thread/session context unless the current message explicitly mentions that target bot.

## Root cause

In a live peer-agent Slack incident, operational warning messages from one agent were delivered as ordinary Slack `message` events with a bot `user` id but no bot-message event shape. The adapter only treated messages as bot-originated when fields like `bot_id`, `bot_profile`, or `subtype=bot_message` were present.

With `allow_bots: mentions`, those bot-user messages could therefore be treated like normal users. In a thread where the parent already mentioned a target agent, active session/thread routing could accept warning/status posts that did not freshly mention the target, causing bot-to-bot wakeups and poisoned session turns.

## Fix

- Resolve and cache Slack user bot identity through the existing `users.info` path.
- Apply `allow_bots` behavior to bot-user senders, not only Slack events with explicit bot-message fields.
- For `allow_bots: mentions`, require a fresh current-message mention for bot-user senders.
- Preserve legitimate explicit peer-bot mentions.
- Harden mocked/malformed `users_info` responses in tests so they are treated conservatively as non-bot.
- Fix Slack mention/config-bridge test hygiene so `SLACK_*` env mutations do not leak into later routing tests.

## Verification

Run on a clean branch based on current `origin/main`:

- `pytest tests/gateway/test_slack.py::TestMessageRouting tests/gateway/test_slack_mention.py -q`
  - `70 passed in 4.14s`
- `pytest tests/gateway/test_slack.py -q`
  - `211 passed, 4 warnings in 9.86s`

The warnings are pre-existing AsyncMock/thread fixture warnings in unrelated Slack tests; the new routing regressions pass.

## Operational note

A separate live deployment normalized affected peer-agent profiles to direct-mention-only Slack behavior:

- `slack.require_mention: true`
- `slack.strict_mention: true`
- `slack.allow_bots: mentions`
- `slack.allowed_channels: ''`

This PR addresses the source-level routing bug that made `allow_bots: mentions` insufficient for bot-user-shaped Slack events.
