### PR TITLE
fix: clean exit on terminal CLI paths (oneshot + config) to avoid aiohttp/websockets teardown abort/hang

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4087,6 +4087,12 @@ def cmd_config(args):
     from hermes_cli.config import config_command
 
     config_command(args)
+    # Same teardown issue as the oneshot path: the config subcommands finish
+    # their work, but the aiohttp/websockets event loop is still open and the
+    # process hangs (or aborts) during interpreter finalization. Exit cleanly.
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(0)
 
 
 def cmd_backup(args):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10436,14 +10436,15 @@ def _try_termux_fast_cli_launch() -> bool:
         _prepare_agent_startup(args)
         from hermes_cli.oneshot import run_oneshot
 
-        sys.exit(
-            run_oneshot(
-                args.oneshot,
-                model=getattr(args, "model", None),
-                provider=getattr(args, "provider", None),
-                toolsets=getattr(args, "toolsets", None),
-            )
+        _rc = run_oneshot(
+            args.oneshot,
+            model=getattr(args, "model", None),
+            provider=getattr(args, "provider", None),
+            toolsets=getattr(args, "toolsets", None),
         )
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os._exit(_rc if isinstance(_rc, int) else 0)
 
     if (args.resume or args.continue_last) and args.command is None:
         args.command = "chat"
@@ -11570,14 +11571,15 @@ def main():
     if getattr(args, "oneshot", None):
         from hermes_cli.oneshot import run_oneshot
 
-        sys.exit(
-            run_oneshot(
-                args.oneshot,
-                model=getattr(args, "model", None),
-                provider=getattr(args, "provider", None),
-                toolsets=getattr(args, "toolsets", None),
-            )
+        _rc = run_oneshot(
+            args.oneshot,
+            model=getattr(args, "model", None),
+            provider=getattr(args, "provider", None),
+            toolsets=getattr(args, "toolsets", None),
         )
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os._exit(_rc if isinstance(_rc, int) else 0)
 
     # Handle top-level --resume / --continue as shortcut to chat
     if (args.resume or args.continue_last) and args.command is None:


### PR DESCRIPTION
## Problem

`hermes -z` / `--oneshot` exits with code **134 (SIGABRT)** even on a fully successful run:

```
Fatal Python error: Aborted

Thread 0x... (most recent call first):
  <no Python frame>

Extension modules: ... aiohttp._http_writer, aiohttp._http_parser,
aiohttp._websocket.mask, aiohttp._websocket.reader_c, ... websockets.speedups
```

The agent produces its output correctly first — the abort happens during interpreter shutdown, so callers that only check stdout work, but the non-zero/abort exit is misleading and trips up any supervisor or webhook that inspects the return code.

## Root cause

The oneshot path runs `sys.exit(run_oneshot(...))`. `sys.exit` raises `SystemExit`, which triggers normal interpreter finalization. During finalization the **aiohttp / websockets C-extensions** (the event loop plus still-open client sessions) are torn down dirty and call `abort()`. The `<no Python frame>` in the fault report confirms it's a native teardown crash, not application code.

## Fix

Flush stdout/stderr and `os._exit(rc)` at the end of the oneshot path, bypassing the finalization that crashes. All oneshot work and output complete before this point, so nothing is lost. Applied to both oneshot dispatch sites (the normal CLI path and the Termux light-parser path). Interactive TUI and the daemon/gateway paths are unchanged.

## Testing

- **Before:** `hermes -z "ping"` → exit `134`, `Fatal Python error: Aborted` on stderr.
- **After:** `hermes -z "ping"` → exit `0`, identical stdout, clean stderr.
- Environment: Debian LXC, CPython 3.11.15, aiohttp 3.13.4, websockets 15.0.1.

## Scope / risk

Touches only the `-z/--oneshot` exit. No behavior change to interactive or gateway modes.

---

**Second commit — same root cause, `config` subcommands.** `hermes config set` (and `show`/`path`/etc.) finish their work and print, then *hang* (rather than abort) during the same interpreter finalization, because the aiohttp/websockets event loop is still open. `cmd_config` gets the identical `flush + os._exit(0)` once `config_command` returns. Both are terminal CLI paths where all work completes before exit; the interactive TUI and the daemon gateway are untouched.
