### PR TITLE
fix(cron): reject invalid deliver targets on job writes

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -199,6 +199,54 @@ def _coerce_job_text(value: Any, fallback: str = "") -> str:
     return str(value)
 
 
+def _normalize_and_validate_deliver(deliver: Any) -> str:
+    """Canonicalize ``deliver`` and reject malformed / truncated targets.
+
+    Cron jobs persist ``deliver`` into ``jobs.json`` and only resolve it at run
+    time. A truncated tool-call payload can therefore silently corrupt the
+    stored routing target (for example ``"telegram"`` becoming ``"telegr"``)
+    even though the surrounding JSON stays valid. Reject unknown platform names
+    at write time so large-payload tool-call truncation fails closed instead of
+    poisoning the job record.
+    """
+    if deliver is None or deliver == "":
+        return "local"
+
+    if isinstance(deliver, (list, tuple)):
+        parts = [str(p).strip() for p in deliver if str(p).strip()]
+    else:
+        parts = [p.strip() for p in str(deliver).split(",") if p.strip()]
+
+    if not parts:
+        return "local"
+
+    from cron.scheduler import _is_known_delivery_platform
+
+    normalized_parts: List[str] = []
+    for part in parts:
+        lower = part.lower()
+        if lower in {"local", "origin", "all"}:
+            normalized_parts.append(lower)
+            continue
+
+        platform, sep, rest = part.partition(":")
+        platform = platform.strip()
+        if not platform or not _is_known_delivery_platform(platform):
+            raise ValueError(
+                f"Invalid cron deliver target {part!r}. Use 'local', 'origin', "
+                "'all', a known platform name like 'telegram', or an explicit "
+                "target like 'telegram:<chat_id>'."
+            )
+        if sep and not rest.strip():
+            raise ValueError(
+                f"Invalid cron deliver target {part!r}. Explicit delivery "
+                "targets must include a non-empty destination after ':'."
+            )
+        normalized_parts.append(part)
+
+    return ",".join(normalized_parts)
+
+
 def _schedule_display_for_job(job: Dict[str, Any]) -> str:
     display = _coerce_job_text(job.get("schedule_display")).strip()
     if display:
@@ -799,6 +847,7 @@ def create_job(
     # Default delivery to origin if available, otherwise local
     if deliver is None:
         deliver = "origin" if origin else "local"
+    deliver = _normalize_and_validate_deliver(deliver)
 
     job_id = uuid.uuid4().hex[:12]
     now = _hermes_now().isoformat()
@@ -959,6 +1008,9 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updates["workdir"] = None
                 else:
                     updates["workdir"] = _normalize_workdir(_wd)
+
+            if "deliver" in updates:
+                updates["deliver"] = _normalize_and_validate_deliver(updates["deliver"])
 
             updated = _apply_skill_fields({**job, **updates})
             schedule_changed = "schedule" in updates

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -293,6 +293,32 @@ class TestCronjobToolScript:
         assert update_result["success"] is True
         assert "script" not in update_result["job"]
 
+    def test_update_rejects_invalid_deliver_without_mutating_job(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from cron.jobs import get_job
+        from tools.cronjob_tools import cronjob
+
+        create_result = json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="Monitor things",
+            deliver="origin",
+        ))
+        job_id = create_result["job_id"]
+
+        update_result = json.loads(cronjob(
+            action="update",
+            job_id=job_id,
+            prompt="x" * 12000,
+            deliver="telegr",
+        ))
+        assert update_result["success"] is False
+        assert "Invalid cron deliver target" in update_result["error"]
+
+        stored = get_job(job_id)
+        assert stored is not None
+        assert stored["deliver"] == "origin"
+
     def test_list_shows_script(self, cron_env, monkeypatch):
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
         from tools.cronjob_tools import cronjob

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -325,6 +325,28 @@ class TestUpdateJob:
         assert get_job(job["id"]) is not None
         assert get_job("../escape") is None
 
+    def test_create_rejects_unknown_deliver_target(self, tmp_cron_dir):
+        with pytest.raises(ValueError, match="Invalid cron deliver target"):
+            create_job(
+                prompt="Notify me",
+                schedule="every 1h",
+                deliver="telegr",
+            )
+
+    def test_update_rejects_invalid_deliver_and_preserves_existing_value(self, tmp_cron_dir):
+        job = create_job(
+            prompt="Notify me",
+            schedule="every 1h",
+            deliver="origin",
+        )
+
+        with pytest.raises(ValueError, match="Invalid cron deliver target"):
+            update_job(job["id"], {"deliver": "telegr"})
+
+        fetched = get_job(job["id"])
+        assert fetched is not None
+        assert fetched["deliver"] == "origin"
+
 
 class TestPauseResumeJob:
     def test_pause_sets_state(self, tmp_cron_dir):


### PR DESCRIPTION
## Summary
- validate cron `deliver` values during create/update instead of persisting unknown or truncated platform names
- fail closed when a large `cronjob(action="update")` tool payload corrupts the later `deliver` field, preserving the existing job route
- add regression coverage for direct job updates and the `cronjob` tool update path

## Testing
- `uv run --frozen pytest -q tests/cron/test_jobs.py -k 'deliver_target or invalid_deliver' -o addopts=\"\"`\n- `uv run --frozen pytest -q tests/cron/test_cron_script.py -k 'invalid_deliver_without_mutating_job' -o addopts=\"\"`\n- `uv run --frozen ruff check cron/jobs.py tests/cron/test_jobs.py tests/cron/test_cron_script.py`\n- `git diff --check`\n\nAddresses #51612.