### PR TITLE
feat(gateway): route WhatsApp chats to profiles

### DIFF
--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -248,6 +248,12 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 or os.getenv("WHATSAPP_CLOUD_GROUP_ALLOW_FROM")
             )
         )
+        self._profile_routes: dict[str, str] = self._coerce_profile_routes(
+            extra.get("profile_routes")
+            or extra.get("profileRoutes")
+            or extra.get("group_profile_routes")
+            or extra.get("groupProfileRoutes")
+        )
         self._mention_patterns = self._compile_mention_patterns()
 
         # Webhook dedup state — wamid → True. OrderedDict gives O(1) FIFO
@@ -1934,6 +1940,11 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             user_id=sender_id,
             user_name=sender_name or None,
         )
+        routed_profile = self._profile_for_whatsapp_chat(
+            {"chatId": chat_id, "from": sender_id, "senderId": sender_id}
+        )
+        if routed_profile:
+            source.profile = routed_profile
 
         # Cloud API timestamps are unix seconds (string). MessageEvent
         # doesn't enforce a type but downstream code formats with it.

--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -107,6 +107,79 @@ class WhatsAppBehaviorMixin:
             return {str(part).strip() for part in raw if str(part).strip()}
         return {part.strip() for part in str(raw).split(",") if part.strip()}
 
+    @classmethod
+    def _coerce_profile_routes(cls, raw) -> dict[str, str]:
+        """Parse WhatsApp chat/group → Hermes profile routing config.
+
+        Supported shapes under ``platforms.whatsapp.extra.profile_routes``:
+        mapping (``chat_id: profile``), list of dicts
+        (``{chat_id, profile}``), list of ``chat_id=profile`` strings, or a
+        comma/newline-separated string. Invalid rows are ignored. Empty config
+        is a no-op, preserving the legacy single-profile WhatsApp behavior.
+        """
+        if raw is None:
+            return {}
+        if isinstance(raw, str):
+            stripped = raw.strip()
+            if not stripped:
+                return {}
+            try:
+                raw = json.loads(stripped)
+            except Exception:
+                raw = [part.strip() for part in re.split(r"[\n,]", stripped) if part.strip()]
+
+        routes: dict[str, str] = {}
+
+        def _add(chat_id: Any, profile: Any) -> None:
+            cid = cls._normalize_whatsapp_id(str(chat_id or "").strip())
+            prof = str(profile or "").strip()
+            if cid and prof:
+                routes[cid] = prof
+
+        if isinstance(raw, dict):
+            for chat_id, profile in raw.items():
+                _add(chat_id, profile)
+            return routes
+
+        if isinstance(raw, list):
+            for item in raw:
+                if isinstance(item, dict):
+                    _add(
+                        item.get("chat_id")
+                        or item.get("chatId")
+                        or item.get("group_id")
+                        or item.get("groupId")
+                        or item.get("id"),
+                        item.get("profile")
+                        or item.get("profile_name")
+                        or item.get("profileName"),
+                    )
+                elif isinstance(item, str) and "=" in item:
+                    chat_id, profile = item.split("=", 1)
+                    _add(chat_id, profile)
+            return routes
+
+        return routes
+
+    def _profile_for_whatsapp_chat(self, data: Dict[str, Any]) -> Optional[str]:
+        """Return the configured Hermes profile for this WhatsApp chat, if any."""
+        routes = getattr(self, "_profile_routes", None) or {}
+        if not routes:
+            return None
+        candidates = []
+        for key in ("chatId", "from", "senderId"):
+            normalized = self._normalize_whatsapp_id(str(data.get(key) or "").strip())
+            if normalized:
+                candidates.append(normalized)
+                bare = normalized.split("@", 1)[0]
+                if bare and bare != normalized:
+                    candidates.append(bare)
+        for candidate in candidates:
+            profile = routes.get(candidate)
+            if profile:
+                return profile
+        return None
+
     @staticmethod
     def _coerce_allow_list(raw) -> set[str]:
         """Parse allow_from / group_allow_from from config or env var."""
@@ -123,7 +196,8 @@ class WhatsAppBehaviorMixin:
             return ""
         normalized = str(value).strip()
         if ":" in normalized and "@" in normalized:
-            normalized = normalized.replace(":", "@", 1)
+            local, domain = normalized.split("@", 1)
+            normalized = f"{local.split(':', 1)[0]}@{domain}"
         return normalized
 
     @staticmethod

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -751,6 +751,11 @@ class MessagingPlatformUpdate(BaseModel):
     profile: Optional[str] = None
 
 
+class WhatsAppProfileRouteUpdate(BaseModel):
+    routes: Dict[str, str] = {}
+    profile: Optional[str] = None
+
+
 class TelegramOnboardingStart(BaseModel):
     bot_name: Optional[str] = None
 
@@ -5041,6 +5046,102 @@ def _write_platform_enabled(platform_id: str, enabled: bool) -> None:
     write_platform_config_field(platform_id, "enabled", enabled)
 
 
+def _platform_extra_config(config: dict, platform_id: str, *, create: bool = False) -> dict:
+    """Return ``platforms.<id>.extra`` from config.yaml, optionally creating it."""
+    platforms = config.get("platforms")
+    if not isinstance(platforms, dict):
+        if not create:
+            return {}
+        platforms = {}
+        config["platforms"] = platforms
+    platform_cfg = platforms.get(platform_id)
+    if not isinstance(platform_cfg, dict):
+        if not create:
+            return {}
+        platform_cfg = {}
+        platforms[platform_id] = platform_cfg
+    extra = platform_cfg.get("extra")
+    if not isinstance(extra, dict):
+        if not create:
+            return {}
+        extra = {}
+        platform_cfg["extra"] = extra
+    return extra
+
+
+def _normalize_whatsapp_profile_routes(raw: Any) -> Dict[str, str]:
+    """Normalize dashboard WhatsApp profile-route payloads without importing adapters."""
+    if raw is None:
+        return {}
+    if isinstance(raw, str):
+        stripped = raw.strip()
+        if not stripped:
+            return {}
+        try:
+            raw = json.loads(stripped)
+        except Exception:
+            raw = [part.strip() for part in re.split(r"[\n,]", stripped) if part.strip()]
+
+    routes: Dict[str, str] = {}
+
+    def _add(chat_id: Any, profile_name: Any) -> None:
+        cid = str(chat_id or "").strip()
+        prof = str(profile_name or "").strip()
+        if ":" in cid and "@" in cid:
+            local, domain = cid.split("@", 1)
+            cid = f"{local.split(':', 1)[0]}@{domain}"
+        if cid and prof:
+            routes[cid] = prof
+
+    if isinstance(raw, dict):
+        for chat_id, profile_name in raw.items():
+            _add(chat_id, profile_name)
+    elif isinstance(raw, list):
+        for item in raw:
+            if isinstance(item, dict):
+                _add(
+                    item.get("chat_id")
+                    or item.get("chatId")
+                    or item.get("group_id")
+                    or item.get("groupId")
+                    or item.get("id"),
+                    item.get("profile")
+                    or item.get("profile_name")
+                    or item.get("profileName"),
+                )
+            elif isinstance(item, str) and "=" in item:
+                chat_id, profile_name = item.split("=", 1)
+                _add(chat_id, profile_name)
+    return routes
+
+
+def _read_whatsapp_profile_routes() -> Dict[str, str]:
+    cfg = load_config()
+    extra = _platform_extra_config(cfg, "whatsapp", create=False)
+    raw = (
+        extra.get("profile_routes")
+        or extra.get("profileRoutes")
+        or extra.get("group_profile_routes")
+        or extra.get("groupProfileRoutes")
+        or {}
+    )
+    if isinstance(raw, dict):
+        return _normalize_whatsapp_profile_routes(raw)
+    return _normalize_whatsapp_profile_routes(raw)
+
+
+def _write_whatsapp_profile_routes(routes: Dict[str, str]) -> Dict[str, str]:
+    normalized = _normalize_whatsapp_profile_routes(routes)
+    cfg = load_config()
+    extra = _platform_extra_config(cfg, "whatsapp", create=True)
+    extra["profile_routes"] = normalized
+    # Collapse legacy aliases so the UI has one source of truth after saving.
+    for alias in ("profileRoutes", "group_profile_routes", "groupProfileRoutes"):
+        extra.pop(alias, None)
+    save_config(cfg)
+    return normalized
+
+
 _TELEGRAM_ONBOARDING_DEFAULT_URL = "https://setup.hermes-agent.nousresearch.com"
 _TELEGRAM_ONBOARDING_USER_AGENT = f"HermesDashboard/{__version__}"
 _TELEGRAM_USER_ID_RE = re.compile(r"^\d+$")
@@ -5429,6 +5530,31 @@ async def get_messaging_platforms(profile: Optional[str] = None):
                 for entry in _messaging_platform_catalog()
             ]
         }
+
+
+@app.get("/api/messaging/whatsapp/profile-routes")
+async def get_whatsapp_profile_routes(profile: Optional[str] = None):
+    """Return WhatsApp chat/group → Hermes profile routing for the scoped profile."""
+    with _profile_scope(profile):
+        return {"routes": _read_whatsapp_profile_routes()}
+
+
+@app.put("/api/messaging/whatsapp/profile-routes")
+async def update_whatsapp_profile_routes(
+    body: WhatsAppProfileRouteUpdate, profile: Optional[str] = None
+):
+    """Persist WhatsApp chat/group → Hermes profile routing.
+
+    Existing WhatsApp groups keep the default profile unless a route is
+    explicitly added here, so enabling the UI is backward-compatible.
+    """
+    try:
+        with _profile_scope(body.profile or profile):
+            routes = _write_whatsapp_profile_routes(body.routes)
+        return {"ok": True, "routes": routes}
+    except Exception:
+        _log.exception("PUT /api/messaging/whatsapp/profile-routes failed")
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @app.put("/api/messaging/platforms/{platform_id}")

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -360,6 +360,12 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self._allow_from = self._coerce_allow_list(config.extra.get("allow_from") or config.extra.get("allowFrom"))
         self._group_policy = str(config.extra.get("group_policy") or os.getenv("WHATSAPP_GROUP_POLICY", "open")).strip().lower()
         self._group_allow_from = self._coerce_allow_list(config.extra.get("group_allow_from") or config.extra.get("groupAllowFrom"))
+        self._profile_routes = self._coerce_profile_routes(
+            config.extra.get("profile_routes")
+            or config.extra.get("profileRoutes")
+            or config.extra.get("group_profile_routes")
+            or config.extra.get("groupProfileRoutes")
+        )
         self._mention_patterns = self._compile_mention_patterns()
         self._message_queue: asyncio.Queue = asyncio.Queue()
         self._bridge_log_fh = None
@@ -1090,6 +1096,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             event.source,
             group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
             thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
+            profile=getattr(event.source, "profile", None),
         )
 
     def _enqueue_text_event(self, event: MessageEvent) -> None:
@@ -1170,6 +1177,9 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 user_id=data.get("senderId"),
                 user_name=data.get("senderName"),
             )
+            routed_profile = self._profile_for_whatsapp_chat(data)
+            if routed_profile:
+                source.profile = routed_profile
             
             # Download media URLs to the local cache so agent tools
             # can access them reliably regardless of URL expiration.

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from unittest.mock import AsyncMock
 
@@ -5,7 +6,8 @@ from gateway.config import Platform, PlatformConfig, load_gateway_config
 
 
 def _make_adapter(require_mention=None, mention_patterns=None, free_response_chats=None,
-                  dm_policy=None, allow_from=None, group_policy=None, group_allow_from=None):
+                  dm_policy=None, allow_from=None, group_policy=None, group_allow_from=None,
+                  profile_routes=None):
     from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
 
     extra = {}
@@ -23,6 +25,8 @@ def _make_adapter(require_mention=None, mention_patterns=None, free_response_cha
         extra["group_policy"] = group_policy
     if group_allow_from is not None:
         extra["group_allow_from"] = group_allow_from
+    if profile_routes is not None:
+        extra["profile_routes"] = profile_routes
 
     adapter = object.__new__(WhatsAppAdapter)
     adapter.platform = Platform.WHATSAPP
@@ -32,6 +36,7 @@ def _make_adapter(require_mention=None, mention_patterns=None, free_response_cha
     adapter._allow_from = WhatsAppAdapter._coerce_allow_list(extra.get("allow_from"))
     adapter._group_policy = str(extra.get("group_policy", "open")).strip().lower()
     adapter._group_allow_from = WhatsAppAdapter._coerce_allow_list(extra.get("group_allow_from"))
+    adapter._profile_routes = WhatsAppAdapter._coerce_profile_routes(extra.get("profile_routes"))
     adapter._mention_patterns = adapter._compile_mention_patterns()
     adapter._free_response_chats = adapter._whatsapp_free_response_chats()
     return adapter
@@ -370,3 +375,67 @@ def test_is_broadcast_chat_helper_recognizes_common_jids():
     assert WhatsAppAdapter._is_broadcast_chat("120363001234567890@g.us") is False
     assert WhatsAppAdapter._is_broadcast_chat("") is False
     assert WhatsAppAdapter._is_broadcast_chat(None) is False  # type: ignore[arg-type]
+
+
+def test_profile_routes_parse_mapping_list_and_string_shapes():
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    assert WhatsAppAdapter._coerce_profile_routes({
+        "120363001234567890@g.us": "client-a",
+    }) == {"120363001234567890@g.us": "client-a"}
+    assert WhatsAppAdapter._coerce_profile_routes([
+        {"group_id": "120363001234567890@g.us", "profile_name": "client-a"},
+        "6281234567890@s.whatsapp.net=client-dm",
+    ]) == {
+        "120363001234567890@g.us": "client-a",
+        "6281234567890@s.whatsapp.net": "client-dm",
+    }
+    assert WhatsAppAdapter._coerce_profile_routes(
+        "120363001234567890@g.us=client-a,6281234567890=client-dm"
+    ) == {
+        "120363001234567890@g.us": "client-a",
+        "6281234567890": "client-dm",
+    }
+
+
+def test_build_message_event_stamps_profile_for_routed_group():
+    adapter = _make_adapter(
+        require_mention=False,
+        profile_routes={"120363001234567890@g.us": "client-a"},
+    )
+    data = _group_message("hello", _hermes_should_process=True)
+
+    event = asyncio.run(adapter._build_message_event(data))
+
+    assert event is not None
+    assert event.source.profile == "client-a"
+    assert event.source.chat_id == "120363001234567890@g.us"
+
+
+def test_build_message_event_leaves_unrouted_group_on_default_profile():
+    adapter = _make_adapter(
+        require_mention=False,
+        profile_routes={"999999@g.us": "client-a"},
+    )
+    data = _group_message("hello", _hermes_should_process=True)
+
+    event = asyncio.run(adapter._build_message_event(data))
+
+    assert event is not None
+    assert event.source.profile is None
+
+
+def test_text_batch_key_includes_routed_profile_namespace():
+    from gateway.session import build_session_key
+
+    adapter = _make_adapter(require_mention=False)
+    data = _group_message("hello", _hermes_should_process=True)
+    event = asyncio.run(adapter._build_message_event(data))
+    assert event is not None
+    event.source.profile = "client-a"
+
+    assert adapter._text_batch_key(event) == build_session_key(
+        event.source,
+        profile="client-a",
+    )
+    assert adapter._text_batch_key(event).startswith("agent:client-a:whatsapp:")

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -309,6 +309,56 @@ class TestWebhookEndpoints:
         assert load_config()["platforms"]["webhook"]["enabled"] is True
 
 
+class TestWhatsAppProfileRoutesEndpoints:
+    @pytest.fixture(autouse=True)
+    def _setup(self, _isolate_hermes_home):
+        self.client, _ = _client()
+
+    def test_routes_roundtrip_writes_config(self):
+        from hermes_cli.config import load_config
+
+        assert self.client.get("/api/messaging/whatsapp/profile-routes").json() == {
+            "routes": {}
+        }
+
+        r = self.client.put(
+            "/api/messaging/whatsapp/profile-routes",
+            json={
+                "routes": {
+                    "120363001234567890@g.us": "whatsapp-client-a",
+                    "15551234567:4@s.whatsapp.net": "whatsapp-client-dm",
+                    "": "ignored",
+                }
+            },
+        )
+
+        assert r.status_code == 200
+        assert r.json()["routes"] == {
+            "120363001234567890@g.us": "whatsapp-client-a",
+            "15551234567@s.whatsapp.net": "whatsapp-client-dm",
+        }
+        cfg = load_config()
+        assert cfg["platforms"]["whatsapp"]["extra"]["profile_routes"] == r.json()["routes"]
+        assert self.client.get("/api/messaging/whatsapp/profile-routes").json()["routes"] == r.json()["routes"]
+
+    def test_routes_parser_accepts_legacy_list_config(self):
+        from hermes_cli.config import load_config, save_config
+
+        cfg = load_config()
+        cfg.setdefault("platforms", {}).setdefault("whatsapp", {})["extra"] = {
+            "group_profile_routes": [
+                {"group_id": "120363001234567890@g.us", "profile_name": "client-a"},
+                "15551234567@s.whatsapp.net=client-dm",
+            ]
+        }
+        save_config(cfg)
+
+        assert self.client.get("/api/messaging/whatsapp/profile-routes").json()["routes"] == {
+            "120363001234567890@g.us": "client-a",
+            "15551234567@s.whatsapp.net": "client-dm",
+        }
+
+
 class TestOpsEndpoints:
     @pytest.fixture(autouse=True)
     def _setup(self, _isolate_hermes_home):

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -72,6 +72,7 @@ const PROFILE_SCOPED_PREFIXES = [
   "/api/env",
   "/api/mcp",
   "/api/messaging/platforms",
+  "/api/messaging/whatsapp",
   "/api/messaging/telegram/onboarding",
   "/api/model/info",
   "/api/model/set",
@@ -809,6 +810,19 @@ export const api = {
       `/api/messaging/platforms/${encodeURIComponent(id)}/test`,
       { method: "POST" },
     ),
+  getWhatsAppProfileRoutes: () =>
+    fetchJSON<WhatsAppProfileRoutesResponse>(
+      "/api/messaging/whatsapp/profile-routes",
+    ),
+  updateWhatsAppProfileRoutes: (routes: Record<string, string>) =>
+    fetchJSON<WhatsAppProfileRoutesUpdateResponse>(
+      "/api/messaging/whatsapp/profile-routes",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ routes }),
+      },
+    ),
   startTelegramOnboarding: (body: { bot_name?: string }) =>
     fetchJSON<TelegramOnboardingStartResponse>(
       "/api/messaging/telegram/onboarding/start",
@@ -1400,6 +1414,15 @@ export interface MessagingPlatformTestResult {
   ok: boolean;
   state: string;
   message: string;
+}
+
+export interface WhatsAppProfileRoutesResponse {
+  routes: Record<string, string>;
+}
+
+export interface WhatsAppProfileRoutesUpdateResponse {
+  ok: boolean;
+  routes: Record<string, string>;
 }
 
 export interface PairingUser {

--- a/web/src/pages/ChannelsPage.tsx
+++ b/web/src/pages/ChannelsPage.tsx
@@ -102,6 +102,29 @@ function isTerminalTelegramOnboardingError(error: unknown): boolean {
   return /\b410\b/.test(message) && /\b(expired|claimed|gone)\b/i.test(message);
 }
 
+function stringifyWhatsAppRoutes(routes: Record<string, string>): string {
+  return Object.entries(routes)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([chatId, profile]) => `${chatId}=${profile}`)
+    .join("\n");
+}
+
+function parseWhatsAppRoutes(text: string): Record<string, string> {
+  const routes: Record<string, string> = {};
+  text
+    .split(/\n+/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .forEach((line) => {
+      const idx = line.indexOf("=");
+      if (idx === -1) return;
+      const chatId = line.slice(0, idx).trim();
+      const profile = line.slice(idx + 1).trim();
+      if (chatId && profile) routes[chatId] = profile;
+    });
+  return routes;
+}
+
 export default function ChannelsPage() {
   const [platforms, setPlatforms] = useState<MessagingPlatform[]>([]);
   const [envPath, setEnvPath] = useState("~/.hermes/.env");
@@ -128,16 +151,21 @@ export default function ChannelsPage() {
   const [testingId, setTestingId] = useState<string | null>(null);
   const [restartNeeded, setRestartNeeded] = useState(false);
   const [restarting, setRestarting] = useState(false);
+  const [whatsAppRouteDraft, setWhatsAppRouteDraft] = useState("");
+  const [savingWhatsAppRoutes, setSavingWhatsAppRoutes] = useState(false);
 
   const gatewayRunning = platforms.length > 0 && platforms[0].gateway_running;
 
   const load = useCallback(() => {
-    return api
-      .getMessagingPlatforms()
-      .then((res) => {
+    return Promise.all([
+      api.getMessagingPlatforms(),
+      api.getWhatsAppProfileRoutes().catch(() => ({ routes: {} })),
+    ])
+      .then(([res, routeRes]) => {
         setPlatforms(res.platforms);
         setEnvPath(res.env_path || "~/.hermes/.env");
         setGatewayStartCommand(res.gateway_start_command || "hermes gateway start");
+        setWhatsAppRouteDraft(stringifyWhatsAppRoutes(routeRes.routes || {}));
       })
       .catch((e) => showToast(`Error: ${e}`, "error"));
   }, [showToast]);
@@ -244,6 +272,21 @@ export default function ChannelsPage() {
       showToast(`Failed to restart: ${e}`, "error");
     } finally {
       setRestarting(false);
+    }
+  };
+
+  const handleSaveWhatsAppRoutes = async () => {
+    setSavingWhatsAppRoutes(true);
+    try {
+      const routes = parseWhatsAppRoutes(whatsAppRouteDraft);
+      const res = await api.updateWhatsAppProfileRoutes(routes);
+      setWhatsAppRouteDraft(stringifyWhatsAppRoutes(res.routes || {}));
+      setRestartNeeded(true);
+      showToast("WhatsApp profile routes saved. Restart gateway to apply.", "success");
+    } catch (e) {
+      showToast(`Failed to save WhatsApp routes: ${e}`, "error");
+    } finally {
+      setSavingWhatsAppRoutes(false);
     }
   };
 
@@ -532,6 +575,35 @@ export default function ChannelsPage() {
                     setRestartNeeded={setRestartNeeded}
                     showToast={showToast}
                   />
+                )}
+                {platform.id === "whatsapp" && (
+                  <div className="rounded border border-border/70 bg-muted/20 p-3">
+                    <div className="mb-2 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                      <div>
+                        <div className="text-xs font-medium uppercase tracking-wider">
+                          Group → profile routing
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          One route per line: <code>120363...@g.us=client-profile</code>. Unlisted groups keep the current/default bot.
+                        </div>
+                      </div>
+                      <Button
+                        size="sm"
+                        className="uppercase shrink-0"
+                        onClick={handleSaveWhatsAppRoutes}
+                        disabled={savingWhatsAppRoutes}
+                        prefix={savingWhatsAppRoutes ? <Spinner /> : <Save className="h-4 w-4" />}
+                      >
+                        {savingWhatsAppRoutes ? "Saving…" : "Save routes"}
+                      </Button>
+                    </div>
+                    <textarea
+                      className="min-h-[96px] w-full border border-border bg-background px-3 py-2 font-courier text-xs outline-none focus:border-primary"
+                      placeholder={"120363001234567890@g.us=whatsapp-client-a\n6281234567890@s.whatsapp.net=whatsapp-client-dm"}
+                      value={whatsAppRouteDraft}
+                      onChange={(event) => setWhatsAppRouteDraft(event.target.value)}
+                    />
+                  </div>
                 )}
               </CardContent>
             </Card>


### PR DESCRIPTION
## Summary
- Add WhatsApp chat/group -> Hermes profile routing config with backward-compatible fallback to the current/default profile.
- Wire routed profiles into WhatsApp bridge and WhatsApp Cloud message sources and text batching.
- Add dashboard API + Channels UI for editing WhatsApp profile routes.

## Test Plan
- uv run --extra dev --extra messaging pytest tests/gateway/test_whatsapp_group_gating.py tests/gateway/test_whatsapp_cloud.py tests/gateway/test_multiplex_phase0.py tests/hermes_cli/test_dashboard_admin_endpoints.py::TestWhatsAppProfileRoutesEndpoints -q -o 'addopts='
- python -m py_compile gateway/platforms/whatsapp_common.py gateway/platforms/whatsapp.py gateway/platforms/whatsapp_cloud.py hermes_cli/web_server.py
- npm run typecheck
- npm run build

## Notes
- Existing WhatsApp groups keep the current/default bot unless a route is explicitly configured.
- Local worktree had unrelated pre-existing dirty files; this branch stages only the WhatsApp profile routing scope.