### PR TITLE
fix(tui): route /learn to command.dispatch so it runs in the desktop app

### DIFF
--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1433,7 +1433,18 @@ class CLICommandsMixin:
             print("\n⚡ Learning a skill from what you described...")
         else:
             print("\n⚡ Learning a skill from this conversation...")
-        if hasattr(self, "_pending_input"):
+        # Run the learn prompt as the next agent turn via the one-shot
+        # _pending_agent_seed the interactive loop consumes immediately after
+        # process_command() returns (same reliable path as /blueprint and
+        # /prompt). The earlier _pending_input.put() approach broke in the
+        # desktop/TUI app: that surface dispatches slash commands on the UI
+        # thread (_submit_buffer_text) and via the Enter handler, and the
+        # requeued message could be dropped before process_loop re-drained it,
+        # so the "⚡ Learning..." line printed but no agent turn ever started.
+        if hasattr(self, "_pending_agent_seed"):
+            self._pending_agent_seed = msg
+        elif hasattr(self, "_pending_input"):
+            # Fallback for any caller without the seed attribute.
             self._pending_input.put(msg)
         else:  # pragma: no cover - defensive (no live input loop)
             print("  /learn needs an active chat session to run.")

--- a/tests/agent/test_learn_prompt.py
+++ b/tests/agent/test_learn_prompt.py
@@ -71,3 +71,39 @@ class TestLearnRegistryWiring:
         from hermes_cli.commands import resolve_command
 
         assert not resolve_command("learn").cli_only
+
+
+class TestLearnDispatchSeedsAgentTurn:
+    """Regression: /learn must seed the next agent turn via _pending_agent_seed.
+
+    The desktop/TUI app dispatches slash commands on the UI thread
+    (_submit_buffer_text) and through the Enter handler. The original handler
+    used self._pending_input.put(msg), which the interactive loop could drop
+    before re-draining — the "Learning..." line printed but no turn ran. The
+    interactive loop consumes _pending_agent_seed immediately after
+    process_command() returns (same path as /blueprint, /prompt), so the
+    handler must set that attribute.
+    """
+
+    def _make_handler(self):
+        from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+        class _Fake(CLICommandsMixin):
+            def __init__(self):
+                self._pending_agent_seed = None
+
+        return _Fake()
+
+    def test_learn_sets_pending_agent_seed_to_the_built_prompt(self):
+        h = self._make_handler()
+        h._handle_learn_command("/learn the auth flow in ~/projects/acme")
+        assert h._pending_agent_seed is not None
+        # It must be the standards-bearing prompt, not the raw user text.
+        assert "skill_manage" in h._pending_agent_seed
+        assert "~/projects/acme" in h._pending_agent_seed
+
+    def test_bare_learn_seeds_a_conversation_distillation_turn(self):
+        h = self._make_handler()
+        h._handle_learn_command("/learn")
+        assert h._pending_agent_seed is not None
+        assert "conversation" in h._pending_agent_seed.lower()

--- a/tests/tui_gateway/test_learn_command.py
+++ b/tests/tui_gateway/test_learn_command.py
@@ -1,0 +1,118 @@
+"""Tests for /learn handling in tui_gateway.
+
+The TUI/desktop app routes slash commands through ``slash.exec`` (the slash
+worker subprocess) by default. ``/learn``'s CLI handler
+(``_handle_learn_command``) seeds the kickoff prompt onto the agent's input
+queue, which the slash-worker subprocess has no reader for — so when ``learn``
+was missing from ``_PENDING_INPUT_COMMANDS`` the worker ran the handler, the
+"Learning a skill..." line printed, and the prompt was dropped: nothing
+happened. ``/learn`` must instead route to ``command.dispatch``, which returns
+a ``{"type": "send", "message": <build_learn_prompt(arg)>}`` payload the TUI
+fires as a normal agent turn (same path as /goal, /queue, /retry).
+
+Regression guard for that gap.
+"""
+
+from __future__ import annotations
+
+import importlib
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    yield home
+
+
+@pytest.fixture()
+def server(hermes_home):
+    with patch.dict(
+        "sys.modules",
+        {
+            "hermes_cli.env_loader": MagicMock(),
+            "hermes_cli.banner": MagicMock(),
+        },
+    ):
+        mod = importlib.import_module("tui_gateway.server")
+        yield mod
+        mod._sessions.clear()
+        mod._pending.clear()
+        mod._answers.clear()
+
+
+@pytest.fixture()
+def session(server):
+    sid = "sid-test"
+    s = {
+        "session_key": "tui-learn-session-1",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "attached_images": [],
+        "cols": 120,
+    }
+    server._sessions[sid] = s
+    return sid, s
+
+
+def _call(server, method, **params):
+    handler = server._methods[method]
+    return handler(1, params)
+
+
+# ── command.dispatch /learn ───────────────────────────────────────────
+
+
+def test_learn_returns_send_with_built_prompt(server, session):
+    sid, _ = session
+    r = _call(
+        server,
+        "command.dispatch",
+        name="learn",
+        arg="the auth flow in ~/projects/acme",
+        session_id=sid,
+    )
+    result = r["result"]
+    assert result["type"] == "send"
+    # The message is the standards-guided prompt, not the raw user text.
+    assert "skill_manage" in result["message"]
+    assert "~/projects/acme" in result["message"]
+
+
+def test_bare_learn_falls_back_to_the_conversation(server, session):
+    sid, _ = session
+    r = _call(server, "command.dispatch", name="learn", arg="", session_id=sid)
+    result = r["result"]
+    assert result["type"] == "send"
+    assert "conversation" in result["message"].lower()
+
+
+# ── slash.exec /learn routing ─────────────────────────────────────────
+
+
+def test_slash_exec_routes_learn_to_command_dispatch(server, session):
+    """slash.exec must route /learn to command.dispatch internally rather
+    than to the slash worker. The worker would run the CLI handler, which
+    queues onto _pending_input — a queue the worker subprocess can't drain —
+    so the prompt would be silently dropped ("Learning..." prints, nothing
+    runs)."""
+    sid, _ = session
+    r = _call(server, "slash.exec", command="learn what we just did", session_id=sid)
+    assert "result" in r
+    assert r["result"]["type"] == "send"
+    assert "skill_manage" in r["result"]["message"]
+
+
+def test_pending_input_commands_includes_learn(server):
+    """Guard: _PENDING_INPUT_COMMANDS must list 'learn' — removing it sends
+    /learn to the slash worker and silently drops the prompt."""
+    assert "learn" in server._PENDING_INPUT_COMMANDS

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9289,6 +9289,7 @@ _PENDING_INPUT_COMMANDS: frozenset[str] = frozenset(
         "plan",
         "goal",
         "undo",
+        "learn",
     }
 )
 


### PR DESCRIPTION
## Problem

`/learn` printed `⚡ Learning a skill from what you described...` in the desktop/TUI app and then **silently did nothing** — no agent turn ever started. It worked in the plain CLI, which is why the gap went unnoticed.

## Root cause — two independent gaps

**1. Missing routing-set entry (`tui_gateway/server.py`).**
`command.dispatch` already had a correct inline `learn` handler that returns a `{"type": "send", "message": build_learn_prompt(arg)}` payload the TUI fires as a normal agent turn. But `"learn"` was **missing from `_PENDING_INPUT_COMMANDS`**, the allow-list that diverts a command away from the slash-worker subprocess. Without that membership, `slash.exec` sent `/learn` to the worker, which runs the CLI handler that queues onto `_pending_input` — a queue the worker subprocess has no reader for — so the prompt was dropped. This is the classic "handler exists but nothing routes to it" dispatch gap. Adding `"learn"` to the set routes it through `command.dispatch` exactly like `/goal`, `/queue`, and `/retry`.

**2. Fragile queue hand-off in the CLI handler (`hermes_cli/cli_commands_mixin.py`).**
`_handle_learn_command` used `self._pending_input.put(msg)`. On the desktop/TUI surface, slash commands dispatch on the prompt_toolkit UI thread (`_submit_buffer_text`) and via the Enter handler, and the requeued message could be dropped before `process_loop` re-drained it. Switched to the one-shot `_pending_agent_seed` that the interactive loop consumes immediately after `process_command()` returns — the same reliable path `/blueprint` and `/prompt` already use. A `_pending_input` fallback is kept for any caller without the seed attribute.

## Fix

- `tui_gateway/server.py` — add `"learn"` to `_PENDING_INPUT_COMMANDS` (1 line).
- `hermes_cli/cli_commands_mixin.py` — seed the next agent turn via `_pending_agent_seed`.

## Tests

- `tests/tui_gateway/test_learn_command.py` (new) — asserts `/learn` routes through `command.dispatch`, returns the built standards-guided prompt for both an explicit source and the bare/conversation fallback, and a guard test asserting `_PENDING_INPUT_COMMANDS` membership so a future removal re-breaks loudly.
- `tests/agent/test_learn_prompt.py` — asserts the CLI handler sets `_pending_agent_seed` to the standards-bearing prompt (verbatim user source preserved, conversation fallback when bare).

All 17 tests pass.

## Verification

```
$ python -m pytest tests/agent/test_learn_prompt.py tests/tui_gateway/test_learn_command.py -q
17 passed
```

Manually confirmed in the desktop app: `/learn <description>` now kicks off a real agent turn that gathers the source and authors a skill via `skill_manage`, instead of printing the "Learning..." line and stalling.
