### PR TITLE
fix(auth): persist detected Z.AI endpoint cache

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -675,9 +675,10 @@ def _resolve_zai_base_url(api_key: str, default_url: str, env_override: str) -> 
         return default_url
 
     # Check provider-state cache for a previously-detected endpoint.
-    auth_store = _load_auth_store()
-    state = _load_provider_state(auth_store, "zai") or {}
-    cached = state.get("detected_endpoint")
+    with _auth_store_lock():
+        auth_store = _load_auth_store()
+        state = _load_provider_state(auth_store, "zai") or {}
+        cached = state.get("detected_endpoint")
     if isinstance(cached, dict) and cached.get("base_url"):
         key_hash = cached.get("key_hash", "")
         if key_hash == hashlib.sha256(api_key.encode()).hexdigest()[:16]:
@@ -689,14 +690,18 @@ def _resolve_zai_base_url(api_key: str, default_url: str, env_override: str) -> 
     if detected and detected.get("base_url"):
         # Persist the detection result keyed on the API key hash.
         key_hash = hashlib.sha256(api_key.encode()).hexdigest()[:16]
-        state["detected_endpoint"] = {
-            "base_url": detected["base_url"],
-            "endpoint_id": detected.get("id", ""),
-            "model": detected.get("model", ""),
-            "label": detected.get("label", ""),
-            "key_hash": key_hash,
-        }
-        _save_provider_state(auth_store, "zai", state)
+        with _auth_store_lock():
+            auth_store = _load_auth_store()
+            state = _load_provider_state(auth_store, "zai") or {}
+            state["detected_endpoint"] = {
+                "base_url": detected["base_url"],
+                "endpoint_id": detected.get("id", ""),
+                "model": detected.get("model", ""),
+                "label": detected.get("label", ""),
+                "key_hash": key_hash,
+            }
+            _save_provider_state(auth_store, "zai", state)
+            _save_auth_store(auth_store)
         logger.info("Z.AI: auto-detected endpoint %s (%s)", detected["label"], detected["base_url"])
         return detected["base_url"]
 

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -1,6 +1,8 @@
 """Tests for API-key provider support (z.ai/GLM, Kimi, MiniMax)."""
 
+import copy
 import os
+from contextlib import nullcontext
 
 import pytest
 
@@ -17,6 +19,7 @@ from hermes_cli.auth import (
     STEPFUN_STEP_PLAN_INTL_BASE_URL,
     STEPFUN_STEP_PLAN_CN_BASE_URL,
     _resolve_kimi_base_url,
+    _resolve_zai_base_url,
 )
 from hermes_cli.copilot_auth import _try_gh_cli_token
 
@@ -995,6 +998,51 @@ class TestZaiEndpointAutoDetect:
         monkeypatch.setattr("hermes_cli.auth.detect_zai_endpoint", lambda *a, **kw: None)
         creds = resolve_api_key_provider_credentials("zai")
         assert creds["api_key"] == ""
+
+    def test_probe_success_persists_cache_and_reuses_it(self, monkeypatch):
+        store = {}
+        saves = []
+
+        monkeypatch.setattr("hermes_cli.auth._auth_store_lock", lambda: nullcontext())
+        monkeypatch.setattr("hermes_cli.auth._load_auth_store", lambda: store)
+        monkeypatch.setattr(
+            "hermes_cli.auth._save_auth_store",
+            lambda auth_store: saves.append(copy.deepcopy(auth_store)),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.auth.detect_zai_endpoint",
+            lambda *a, **kw: {
+                "id": "coding-global",
+                "base_url": "https://api.z.ai/api/coding/paas/v4",
+                "model": "glm-4.7",
+                "label": "Global (Coding Plan)",
+            },
+        )
+
+        first = _resolve_zai_base_url(
+            "glm-coding-key",
+            "https://api.z.ai/api/paas/v4",
+            "",
+        )
+
+        assert first == "https://api.z.ai/api/coding/paas/v4"
+        assert saves, "successful auto-detection should persist auth store"
+        cached = store["providers"]["zai"]["detected_endpoint"]
+        assert cached["base_url"] == "https://api.z.ai/api/coding/paas/v4"
+        assert cached["endpoint_id"] == "coding-global"
+
+        def _never_called(*_args, **_kwargs):
+            raise AssertionError("cached endpoint should skip probe")
+
+        monkeypatch.setattr("hermes_cli.auth.detect_zai_endpoint", _never_called)
+        second = _resolve_zai_base_url(
+            "glm-coding-key",
+            "https://api.z.ai/api/paas/v4",
+            "",
+        )
+
+        assert second == "https://api.z.ai/api/coding/paas/v4"
+        assert len(saves) == 1
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary\n- persist auto-detected Z.AI endpoint cache state to auth.json instead of leaving it in-memory only\n- re-read provider state under the auth-store lock before cache read/write so fresh processes can reuse the saved endpoint\n- add a regression test covering first-run persistence and second-run cache hits without re-probing\n\n## Testing\n- uv run --frozen pytest -q tests/hermes_cli/test_api_key_providers.py -o addopts=''\n- uv run --frozen ruff check hermes_cli/auth.py tests/hermes_cli/test_api_key_providers.py\n- git diff --check\n\n## Attribution\n- candidate-specific local proof is green; no shared baseline blocker was introduced by this diff