### PR TITLE
feat(email): add auto_reply config to suppress automatic email replies

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -332,6 +332,13 @@ class EmailAdapter(BasePlatformAdapter):
         #       skip_attachments: true
         self._skip_attachments = extra.get("skip_attachments", False)
 
+        # Suppress auto-replies — configured via config.yaml:
+        #   platforms:
+        #     email:
+        #       extra:
+        #         auto_reply: false
+        self._auto_reply = extra.get("auto_reply", True)
+
         # Track message IDs we've already processed to avoid duplicates
         self._seen_uids: set = set()
         self._seen_uids_max: int = 2000   # cap to prevent unbounded memory growth
@@ -674,6 +681,9 @@ class EmailAdapter(BasePlatformAdapter):
         reply_to_msg_id: Optional[str] = None,
     ) -> str:
         """Send an email via SMTP. Runs in executor thread."""
+        if not self._auto_reply:
+            logger.info("[Email] Auto-reply disabled, skipping send to %s", to_addr)
+            return f"<skipped-{uuid.uuid4().hex[:12]}@{self._address.split('@')[1]}>"
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
@@ -789,6 +799,9 @@ class EmailAdapter(BasePlatformAdapter):
         file_paths: List[str],
     ) -> str:
         """Send an email with multiple file attachments via SMTP."""
+        if not self._auto_reply:
+            logger.info("[Email] Auto-reply disabled, skipping multi-attachment send to %s", to_addr)
+            return f"<skipped-{uuid.uuid4().hex[:12]}@{self._address.split('@')[1]}>"
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
@@ -869,6 +882,9 @@ class EmailAdapter(BasePlatformAdapter):
         file_name: Optional[str] = None,
     ) -> str:
         """Send an email with a file attachment via SMTP."""
+        if not self._auto_reply:
+            logger.info("[Email] Auto-reply disabled, skipping attachment send to %s", to_addr)
+            return f"<skipped-{uuid.uuid4().hex[:12]}@{self._address.split('@')[1]}>"
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr


### PR DESCRIPTION
## Summary

Adds an auto_reply configuration option under platforms.email.extra.
When set to false, the email adapter still receives and dispatches
incoming emails to the agent, but suppresses all outgoing replies.

Three send paths are guarded: _send_email (text replies),
_send_email_with_attachments (multi-image), and
_send_email_with_attachment (document attachments).

## Usage

  platforms:
    email:
      extra:
        auto_reply: false

Default is True (backward compatible).

## Changes

plugins/platforms/email/adapter.py - 16 insertions, 0 deletions