### PR TITLE
fix: align doctor with auth-store and enabled tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,11 @@ docs/superpowers/*
 # treat it as a local edit and autostash it on every run (#38529).
 .hermes-bootstrap-complete
 
+# Install-method stamp written into the managed checkout root by the installer.
+# It is local runtime state that lets Hermes distinguish git/docker/pip installs;
+# never commit the operator-specific stamp value.
+.install_method
+
 # Interrupted-update breadcrumb + recovery lock written next to the shared venv
 # by `hermes update` / launch-time self-heal. Runtime state, never a code change
 # — ignore so `git status` stays clean and update's autostash skips them.

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -102,6 +102,49 @@ def _has_provider_env_config(content: str) -> bool:
     return any(key in content for key in _PROVIDER_ENV_HINTS)
 
 
+_AUTH_STORE_PROVIDER_TYPES = {
+    "oauth_device_code",
+    "oauth_external",
+    "oauth_minimax",
+    "external_process",
+}
+
+
+def _has_provider_auth_config() -> bool:
+    """Return True when the local auth store has a logged-in model provider.
+
+    Doctor should not require a raw API key in ``.env`` when the user is using
+    Hermes-supported OAuth/device-code authentication instead. Limit probes to
+    auth-store backed providers so doctor does not accidentally trigger slower
+    API-key or SDK credential chains such as AWS metadata discovery.
+    """
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY, get_auth_status
+    except Exception:
+        return False
+
+    for provider_id, provider_config in PROVIDER_REGISTRY.items():
+        if getattr(provider_config, "auth_type", "") not in _AUTH_STORE_PROVIDER_TYPES:
+            continue
+        try:
+            if (get_auth_status(provider_id) or {}).get("logged_in"):
+                return True
+        except Exception:
+            continue
+    return False
+
+
+def _doctor_enabled_toolsets_for_platform(platform: str = "cli") -> set[str] | None:
+    """Return toolsets enabled for ``platform`` or None if config cannot load."""
+    try:
+        from hermes_cli.config import load_config
+        from hermes_cli.tools_config import _get_platform_tools
+
+        return set(_get_platform_tools(load_config(), platform))
+    except Exception:
+        return None
+
+
 def _honcho_is_configured_for_doctor() -> bool:
     """Return True when Honcho is configured, even if this process has no active session."""
     try:
@@ -673,34 +716,37 @@ def run_doctor(args):
         # defaults to the system locale — which crashes on non-UTF-8 Windows
         # locales (e.g. GBK) as soon as the file contains any non-ASCII byte.
         content = env_path.read_text(encoding="utf-8")
-        if _has_provider_env_config(content):
-            check_ok("API key or custom endpoint configured")
+        if _has_provider_env_config(content) or _has_provider_auth_config():
+            check_ok("API key, custom endpoint, or auth-store provider configured")
         else:
-            check_warn(f"No API key found in {_DHH}/.env")
-            issues.append("Run 'hermes setup' to configure API keys")
+            check_warn(f"No API key or auth-store provider found in {_DHH}/.env")
+            issues.append("Run 'hermes setup' to configure API keys or OAuth auth")
     else:
-        # Also check project root as fallback
-        fallback_env = PROJECT_ROOT / '.env'
-        if fallback_env.exists():
-            check_ok(".env file exists (in project directory)")
+        if _has_provider_auth_config():
+            check_ok("Auth-store provider configured (.env file not required)")
         else:
-            check_fail(f"{_DHH}/.env file missing")
-            if should_fix:
-                env_path.parent.mkdir(parents=True, exist_ok=True)
-                env_path.touch()
-                # .env holds API keys — restrict to owner-only access from
-                # creation. touch() obeys umask which is commonly 0o022,
-                # leaving the file world-readable; tighten explicitly.
-                try:
-                    os.chmod(str(env_path), 0o600)
-                except OSError:
-                    pass
-                check_ok(f"Created empty {_DHH}/.env")
-                check_info("Run 'hermes setup' to configure API keys")
-                fixed_count += 1
+            # Also check project root as fallback
+            fallback_env = PROJECT_ROOT / '.env'
+            if fallback_env.exists():
+                check_ok(".env file exists (in project directory)")
             else:
-                check_info("Run 'hermes setup' to create one")
-                issues.append("Run 'hermes setup' to create .env")
+                check_fail(f"{_DHH}/.env file missing")
+                if should_fix:
+                    env_path.parent.mkdir(parents=True, exist_ok=True)
+                    env_path.touch()
+                    # .env holds API keys — restrict to owner-only access from
+                    # creation. touch() obeys umask which is commonly 0o022,
+                    # leaving the file world-readable; tighten explicitly.
+                    try:
+                        os.chmod(str(env_path), 0o600)
+                    except OSError:
+                        pass
+                    check_ok(f"Created empty {_DHH}/.env")
+                    check_info("Run 'hermes setup' to configure API keys")
+                    fixed_count += 1
+                else:
+                    check_info("Run 'hermes setup' to create one")
+                    issues.append("Run 'hermes setup' to create .env")
     
     # Check ~/.hermes/config.yaml (primary) or project cli-config.yaml (fallback)
     config_path = HERMES_HOME / 'config.yaml'
@@ -2098,6 +2144,11 @@ def run_doctor(args):
         
         available, unavailable = check_tool_availability()
         available, unavailable = _apply_doctor_tool_availability_overrides(available, unavailable)
+
+        enabled_toolsets = _doctor_enabled_toolsets_for_platform("cli")
+        if enabled_toolsets is not None:
+            available = [tid for tid in available if tid in enabled_toolsets]
+            unavailable = [item for item in unavailable if item.get("name") in enabled_toolsets]
         
         for tid in available:
             info = TOOLSET_REQUIREMENTS.get(tid, {})

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -715,7 +715,7 @@ def test_run_doctor_kimi_cn_env_is_detected_and_probe_is_null_safe(monkeypatch, 
         doctor_mod.run_doctor(Namespace(fix=False))
     out = buf.getvalue()
 
-    assert "API key or custom endpoint configured" in out
+    assert "API key, custom endpoint, or auth-store provider configured" in out
     assert "Kimi / Moonshot (China)" in out
     assert "str expected, not NoneType" not in out
     assert any(url == "https://api.moonshot.cn/v1/models" for url, _, _ in calls)
@@ -1450,3 +1450,134 @@ def test_npm_audit_fix_hint_avoids_crashing_workspace_flag(monkeypatch, tmp_path
     assert "build-time tooling" in out
     assert "known npm bug" in out
     assert "lockfile bump" in out
+
+
+def test_provider_auth_config_accepts_logged_in_auth_provider(monkeypatch):
+    """OAuth/device-code auth should satisfy doctor without raw .env keys."""
+    from hermes_cli import auth as auth_mod
+
+    monkeypatch.setattr(
+        auth_mod,
+        "PROVIDER_REGISTRY",
+        {
+            "nous": SimpleNamespace(auth_type="oauth_device_code"),
+            "qwen-oauth": SimpleNamespace(auth_type="oauth_external"),
+        },
+    )
+
+    def fake_status(provider_id):
+        return {"logged_in": provider_id == "qwen-oauth"}
+
+    monkeypatch.setattr(auth_mod, "get_auth_status", fake_status)
+
+    assert doctor._has_provider_auth_config() is True
+
+
+def test_provider_auth_config_ignores_provider_status_errors(monkeypatch):
+    """One broken provider status probe must not fail the whole doctor run."""
+    from hermes_cli import auth as auth_mod
+
+    monkeypatch.setattr(
+        auth_mod,
+        "PROVIDER_REGISTRY",
+        {
+            "broken": SimpleNamespace(auth_type="oauth_external"),
+            "logged-in": SimpleNamespace(auth_type="oauth_device_code"),
+        },
+    )
+
+    def fake_status(provider_id):
+        if provider_id == "broken":
+            raise RuntimeError("status probe failed")
+        return {"logged_in": provider_id == "logged-in"}
+
+    monkeypatch.setattr(auth_mod, "get_auth_status", fake_status)
+
+    assert doctor._has_provider_auth_config() is True
+
+
+def test_provider_auth_config_skips_api_key_and_aws_sdk_providers(monkeypatch):
+    """Doctor auth-store checks must not trigger API-key/AWS credential chains."""
+    from hermes_cli import auth as auth_mod
+
+    monkeypatch.setattr(
+        auth_mod,
+        "PROVIDER_REGISTRY",
+        {
+            "bedrock": SimpleNamespace(auth_type="aws_sdk"),
+            "openai-api": SimpleNamespace(auth_type="api_key"),
+            "qwen-oauth": SimpleNamespace(auth_type="oauth_external"),
+        },
+    )
+    called = []
+
+    def fake_status(provider_id):
+        called.append(provider_id)
+        return {"logged_in": provider_id == "qwen-oauth"}
+
+    monkeypatch.setattr(auth_mod, "get_auth_status", fake_status)
+
+    assert doctor._has_provider_auth_config() is True
+    assert called == ["qwen-oauth"]
+
+
+def test_run_doctor_accepts_auth_store_provider_without_env_file(monkeypatch, tmp_path):
+    """A logged-in auth-store provider should not require creating ~/.hermes/.env."""
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setattr(doctor_mod, "_has_provider_auth_config", lambda: True)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert "Auth-store provider configured (.env file not required)" in out
+    assert f"{home}/.env file missing" not in out
+
+
+def test_doctor_enabled_toolsets_for_platform_uses_configured_platform_tools(monkeypatch):
+    """Tool availability warnings should be limited to the enabled platform toolsets."""
+    from hermes_cli import config as config_mod
+    from hermes_cli import tools_config
+
+    sentinel_config = {"tools": {"platforms": {"cli": ["terminal", "file"]}}}
+    monkeypatch.setattr(config_mod, "load_config", lambda: sentinel_config)
+
+    seen = {}
+
+    def fake_get_platform_tools(config, platform):
+        seen["config"] = config
+        seen["platform"] = platform
+        return ["terminal", "file"]
+
+    monkeypatch.setattr(tools_config, "_get_platform_tools", fake_get_platform_tools)
+
+    assert doctor._doctor_enabled_toolsets_for_platform("cli") == {"terminal", "file"}
+    assert seen == {"config": sentinel_config, "platform": "cli"}
+
+
+def test_doctor_enabled_toolsets_returns_none_when_config_unavailable(monkeypatch):
+    """Doctor should warn broadly rather than crash if tool config cannot load."""
+
+    def raise_load_config():
+        raise RuntimeError("boom")
+
+    from hermes_cli import config as config_mod
+
+    monkeypatch.setattr(config_mod, "load_config", raise_load_config)
+
+    assert doctor._doctor_enabled_toolsets_for_platform("cli") is None

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -386,7 +386,7 @@ class TestDelegateTask(unittest.TestCase):
                 goal="Use fallback route",
                 context=None,
                 toolsets=None,
-                model="claude-sonnet-4-5",
+                model="high-output-child-model",
                 max_iterations=10,
                 parent_agent=parent,
                 task_count=1,
@@ -397,7 +397,7 @@ class TestDelegateTask(unittest.TestCase):
             )
 
         _, kwargs = MockAgent.call_args
-        self.assertEqual(kwargs["model"], "claude-sonnet-4-5")
+        self.assertEqual(kwargs["model"], "high-output-child-model")
         self.assertEqual(kwargs["provider"], "anthropic")
         self.assertEqual(kwargs["api_mode"], "anthropic_messages")
         # The subagent UI/result metadata must not keep showing the parent's
@@ -405,7 +405,7 @@ class TestDelegateTask(unittest.TestCase):
         progress_cb = kwargs["tool_progress_callback"]
         progress_cb("subagent.start", preview="Use fallback route")
         progress_kwargs = parent.tool_progress_callback.call_args.kwargs
-        self.assertEqual(progress_kwargs["model"], "claude-sonnet-4-5")
+        self.assertEqual(progress_kwargs["model"], "high-output-child-model")
 
     def test_child_inherits_parent_print_fn(self):
         parent = _make_mock_parent(depth=0)

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -369,6 +369,44 @@ class TestDelegateTask(unittest.TestCase):
             self.assertEqual(kwargs["provider"], parent.provider)
             self.assertEqual(kwargs["api_mode"], parent.api_mode)
 
+    def test_delegation_override_model_label_used_for_progress_events(self):
+        parent = _make_mock_parent(depth=0)
+        parent.model = "gpt-5.5"
+        parent.provider = "openai-codex"
+        parent.base_url = "https://chatgpt.com/backend-api/codex"
+        parent.api_mode = "codex_responses"
+        parent.tool_progress_callback = MagicMock()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+
+            _build_child_agent(
+                task_index=0,
+                goal="Use fallback route",
+                context=None,
+                toolsets=None,
+                model="claude-sonnet-4-5",
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+                override_provider="anthropic",
+                override_base_url="https://api.anthropic.com",
+                override_api_key="test-key",
+                override_api_mode="anthropic_messages",
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["model"], "claude-sonnet-4-5")
+        self.assertEqual(kwargs["provider"], "anthropic")
+        self.assertEqual(kwargs["api_mode"], "anthropic_messages")
+        # The subagent UI/result metadata must not keep showing the parent's
+        # Codex model after delegation.provider routes the child elsewhere.
+        progress_cb = kwargs["tool_progress_callback"]
+        progress_cb("subagent.start", preview="Use fallback route")
+        progress_kwargs = parent.tool_progress_callback.call_args.kwargs
+        self.assertEqual(progress_kwargs["model"], "claude-sonnet-4-5")
+
     def test_child_inherits_parent_print_fn(self):
         parent = _make_mock_parent(depth=0)
         sink = MagicMock()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1093,7 +1093,12 @@ def _build_child_agent(
         parent_api_key = parent_agent._client_kwargs.get("api_key")
 
     # Resolve the child's effective model early so it can ride on every event.
-    effective_model_for_cb = model or getattr(parent_agent, "model", None)
+    # If delegation.provider is configured, the child may intentionally route to
+    # a different model than the parent.  Use the delegation model label for UI
+    # events/results instead of misleadingly reporting the parent's model.
+    effective_model_for_cb = model or (
+        str(delegation_cfg.get("model") or "").strip() if override_provider else ""
+    ) or getattr(parent_agent, "model", None)
 
     # Build progress callback to relay tool calls to parent display.
     # Identity kwargs thread the subagent_id through every emitted event so the


### PR DESCRIPTION
## Summary
- treat logged-in auth-store/OAuth providers as configured in doctor without requiring raw API keys in .env
- limit doctor auth-store probes to auth-backed provider types so API-key/AWS SDK credential chains are not triggered
- filter Tool Availability diagnostics to CLI-enabled toolsets and ignore the local .install_method stamp

## Tests
- git diff --check HEAD
- venv/bin/python -m py_compile hermes_cli/doctor.py tests/hermes_cli/test_doctor.py
- HOME=/Users/purpl uv run --extra dev ruff check hermes_cli/doctor.py tests/hermes_cli/test_doctor.py
- HOME=/Users/purpl uv run --extra dev python -m pytest tests/hermes_cli/test_doctor.py -q -o 'addopts=' (70 passed)
- hermes doctor (All checks passed)
- changed-line secret scan (hits=0)
- added-line absolute path scan (hits=0)
- independent read-only code review (PASS)