### PR TITLE
fix(config): honor terminal.working_dir alias

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5618,6 +5618,20 @@ def cfg_get(cfg: Optional[Dict[str, Any]], *keys: str, default: Any = None) -> A
     return node
 
 
+def _normalize_terminal_working_dir_alias(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """Map legacy ``terminal.working_dir`` onto canonical ``terminal.cwd``."""
+    if not isinstance(cfg, dict):
+        return cfg
+    terminal_cfg = cfg.get("terminal")
+    if not isinstance(terminal_cfg, dict):
+        return cfg
+    if "cwd" not in terminal_cfg and "working_dir" in terminal_cfg:
+        terminal_cfg = dict(terminal_cfg)
+        terminal_cfg["cwd"] = terminal_cfg["working_dir"]
+        cfg = dict(cfg)
+        cfg["terminal"] = terminal_cfg
+    return cfg
+
 
 def read_raw_config() -> Dict[str, Any]:
     """Read ~/.hermes/config.yaml as-is, without merging defaults or migrating.
@@ -5653,6 +5667,7 @@ def read_raw_config() -> Dict[str, Any]:
 
         if not isinstance(data, dict):
             data = {}
+        data = _normalize_terminal_working_dir_alias(data)
         _RAW_CONFIG_CACHE[path_key] = (cache_key[0], cache_key[1], copy.deepcopy(data))
         return data
 
@@ -5862,6 +5877,7 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
             try:
                 with open(config_path, encoding="utf-8") as f:
                     user_config = yaml.safe_load(f) or {}
+                user_config = _normalize_terminal_working_dir_alias(user_config)
 
                 if "max_turns" in user_config:
                     agent_user_config = dict(user_config.get("agent") or {})
@@ -6856,6 +6872,9 @@ def set_config_value(key: str, value: str):
                 user_config = yaml.safe_load(f) or {}
         except Exception:
             user_config = {}
+
+    if key == "terminal.working_dir":
+        key = "terminal.cwd"
     
     # Handle nested keys (e.g., "tts.provider") including numeric list
     # indices (e.g., "custom_providers.0.api_key").  Delegates to

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from hermes_cli.config import set_config_value, config_command
+from hermes_cli.config import config_command, load_config, set_config_value
 
 
 @pytest.fixture(autouse=True)
@@ -123,6 +123,22 @@ class TestConfigYamlRouting:
             "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE=true" in env_content
             or "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE=True" in env_content
         )
+
+    def test_terminal_working_dir_alias_writes_canonical_cwd(self, _isolated_hermes_home):
+        set_config_value("terminal.working_dir", "/tmp/project")
+        config = _read_config(_isolated_hermes_home)
+        assert "cwd: /tmp/project" in config
+        assert "working_dir" not in config
+
+    def test_load_config_accepts_legacy_terminal_working_dir(self, _isolated_hermes_home):
+        (_isolated_hermes_home / "config.yaml").write_text(
+            "terminal:\n"
+            "  working_dir: /tmp/legacy-project\n"
+        )
+
+        config = load_config()
+
+        assert config["terminal"]["cwd"] == "/tmp/legacy-project"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- normalize `terminal.working_dir` to canonical `terminal.cwd` when users run `hermes config set`
- keep reading legacy `terminal.working_dir` from existing `config.yaml` files so already-written profiles recover automatically
- add regression tests for both the write path and the legacy read path

## Problem
`hermes config set` currently accepts arbitrary nested keys. If a user follows an older/incorrect `terminal.working_dir` path, Hermes writes that key into `config.yaml`, but runtime config loading only honors `terminal.cwd`. The command succeeds, the config file changes, and new sessions still start from the default directory.

## Fix
- map `terminal.working_dir` -> `terminal.cwd` inside `set_config_value()`
- normalize legacy `terminal.working_dir` to `terminal.cwd` while reading config so existing broken configs start working after upgrade

## Testing
- `uv run --frozen pytest -q tests/hermes_cli/test_set_config_value.py -o addopts=''`
- `uv run --frozen ruff check hermes_cli/config.py tests/hermes_cli/test_set_config_value.py`
- `git diff --check`

Fixes #51636
