### PR TITLE
fix(computer_use): resolve cua-driver in canonical install dirs under thin GUI PATH (#51393)

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1145,7 +1145,17 @@ class TestUpdateCheck:
     def _run_returning(stdout: str):
         fake = MagicMock()
         fake.stdout = stdout
-        return patch("tools.computer_use.cua_backend.subprocess.run", return_value=fake)
+        # update_check resolves the driver before spawning (#51393); the spawn
+        # itself is mocked, so pin resolution to a fixed path too.
+        from contextlib import ExitStack
+        stack = ExitStack()
+        stack.enter_context(patch(
+            "tools.computer_use.cua_backend.resolve_cua_driver_cmd",
+            return_value="/usr/bin/cua-driver",
+        ))
+        stack.enter_context(patch(
+            "tools.computer_use.cua_backend.subprocess.run", return_value=fake))
+        return stack
 
     def test_update_available(self):
         from tools.computer_use import cua_backend
@@ -2867,3 +2877,89 @@ class TestCuaToolCoverageExpansion:
         backend.call_tool("get_cursor_position")
         name, args = backend._session.call_tool.call_args.args
         assert args == {"session": backend._session_id}
+
+
+# ---------------------------------------------------------------------------
+# cua-driver resolution under a thin GUI/launchd PATH (#51393)
+# ---------------------------------------------------------------------------
+
+
+class TestCuaDriverResolution:
+    """resolve_cua_driver_cmd() must find cua-driver in canonical install
+    locations (e.g. ~/.local/bin) even when the inherited PATH omits them, as
+    happens for the macOS desktop GUI app launched under launchd. (#51393)"""
+
+    def test_which_hit_wins(self):
+        from tools.computer_use import cua_backend
+        with patch("tools.computer_use.cua_backend.shutil.which",
+                   return_value="/usr/bin/cua-driver"):
+            assert cua_backend.resolve_cua_driver_cmd() == "/usr/bin/cua-driver"
+            assert cua_backend.cua_driver_binary_available() is True
+
+    def test_falls_back_to_local_bin_when_path_misses(self):
+        # Reproduces the GUI-app bug: which() misses (~/.local/bin not on the
+        # launchd PATH) but the binary is installed there.
+        from tools.computer_use import cua_backend
+        home = os.path.expanduser("~")
+        local_bin = os.path.join(home, ".local", "bin", "cua-driver")
+
+        def fake_isfile(p):
+            return p == local_bin
+
+        def fake_access(p, _mode):
+            return p == local_bin
+
+        with patch("tools.computer_use.cua_backend.shutil.which",
+                   return_value=None), \
+             patch("tools.computer_use.cua_backend.os.path.isfile",
+                   side_effect=fake_isfile), \
+             patch("tools.computer_use.cua_backend.os.access",
+                   side_effect=fake_access), \
+             patch("tools.computer_use.cua_backend._CUA_DRIVER_CMD",
+                   "cua-driver"):
+            assert cua_backend.resolve_cua_driver_cmd() == local_bin
+            assert cua_backend.cua_driver_binary_available() is True
+
+    def test_missing_everywhere_is_unavailable(self):
+        from tools.computer_use import cua_backend
+        with patch("tools.computer_use.cua_backend.shutil.which",
+                   return_value=None), \
+             patch("tools.computer_use.cua_backend.os.path.isfile",
+                   return_value=False), \
+             patch("tools.computer_use.cua_backend.os.access",
+                   return_value=False), \
+             patch("tools.computer_use.cua_backend._CUA_DRIVER_CMD",
+                   "cua-driver"):
+            assert cua_backend.resolve_cua_driver_cmd() is None
+            assert cua_backend.cua_driver_binary_available() is False
+
+    def test_custom_cmd_does_not_silently_fall_back(self):
+        # A HERMES_CUA_DRIVER_CMD override that does not resolve must NOT
+        # silently resolve to a canonical cua-driver in ~/.local/bin -- that
+        # would run a different binary than the user asked for.
+        from tools.computer_use import cua_backend
+        home = os.path.expanduser("~")
+        local_bin = os.path.join(home, ".local", "bin", "cua-driver")
+
+        with patch("tools.computer_use.cua_backend.shutil.which",
+                   return_value=None), \
+             patch("tools.computer_use.cua_backend.os.path.isfile",
+                   side_effect=lambda p: p == local_bin), \
+             patch("tools.computer_use.cua_backend.os.access",
+                   side_effect=lambda p, _m: p == local_bin), \
+             patch("tools.computer_use.cua_backend._CUA_DRIVER_CMD",
+                   "my-custom-driver"):
+            assert cua_backend.resolve_cua_driver_cmd() is None
+
+    def test_explicit_path_override_used_even_off_path(self):
+        # An explicit override pointing at a real file is trusted even when
+        # which() rejects it (no exec bit / relative path).
+        from tools.computer_use import cua_backend
+        override = "/opt/custom/cua-driver"
+        with patch("tools.computer_use.cua_backend.shutil.which",
+                   return_value=None), \
+             patch("tools.computer_use.cua_backend.os.path.isfile",
+                   side_effect=lambda p: p == override), \
+             patch("tools.computer_use.cua_backend._CUA_DRIVER_CMD",
+                   override):
+            assert cua_backend.resolve_cua_driver_cmd() == override

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -213,9 +213,67 @@ def _is_macos() -> bool:
     return sys.platform == "darwin"
 
 
+# Canonical cua-driver install locations to fall back on when the inherited
+# PATH is too thin to find the binary. The macOS desktop GUI app launches
+# under launchd with a minimal PATH (typically just /usr/bin:/bin:/usr/sbin:
+# /sbin plus /opt/homebrew/bin or /usr/local/bin) that omits ~/.local/bin --
+# exactly where cua-driver installs its symlink. Without this fallback the
+# which()-only gate returns False under the GUI app and computer_use is
+# silently dropped from the toolset, even though it works fine from a shell
+# whose PATH includes ~/.local/bin. (NousResearch/hermes-agent#51393)
+def _cua_driver_fallback_paths() -> List[str]:
+    home = os.path.expanduser("~")
+    candidates = [
+        os.path.join(home, ".local", "bin", "cua-driver"),
+        "/opt/homebrew/bin/cua-driver",
+        "/usr/local/bin/cua-driver",
+    ]
+    if sys.platform == "darwin":
+        # cua-driver app bundle (the binary the ~/.local/bin symlink targets).
+        candidates.append(
+            "/Applications/CuaDriver.app/Contents/MacOS/cua-driver"
+        )
+    return candidates
+
+
+def resolve_cua_driver_cmd() -> Optional[str]:
+    """Resolve cua-driver to a runnable command (absolute path when possible).
+
+    Order:
+      1. ``shutil.which(_CUA_DRIVER_CMD)`` -- honours ``HERMES_CUA_DRIVER_CMD``
+         and the inherited PATH (the normal shell / CLI case).
+      2. If ``HERMES_CUA_DRIVER_CMD`` is an explicit existing path, use it.
+      3. Canonical install locations (``~/.local/bin/cua-driver``, the macOS
+         app bundle, brew / ``/usr/local`` bins) -- covers the GUI/launchd
+         minimal-PATH case where (1) misses. (#51393)
+
+    Returns the resolved command, or ``None`` when nothing is found.
+    """
+    found = shutil.which(_CUA_DRIVER_CMD)
+    if found:
+        return found
+    # An explicit override that points at a real file but is not on PATH
+    # (e.g. a relative or non-exec-bit path which() rejects): trust it if
+    # it exists, so user intent is never silently dropped.
+    if _CUA_DRIVER_CMD not in ("cua-driver", "") and os.path.isfile(
+        os.path.expanduser(_CUA_DRIVER_CMD)
+    ):
+        return os.path.expanduser(_CUA_DRIVER_CMD)
+    # Only probe canonical locations for the default command name -- a custom
+    # override that did not resolve above must not silently fall back to a
+    # different binary than the user asked for.
+    if _CUA_DRIVER_CMD == "cua-driver":
+        for path in _cua_driver_fallback_paths():
+            if os.path.isfile(path) and os.access(path, os.X_OK):
+                return path
+    return None
+
+
 def cua_driver_binary_available() -> bool:
-    """True if `cua-driver` is on $PATH or HERMES_CUA_DRIVER_CMD resolves."""
-    return bool(shutil.which(_CUA_DRIVER_CMD))
+    """True if `cua-driver` resolves on $PATH, via HERMES_CUA_DRIVER_CMD, or in
+    a canonical install location (e.g. ``~/.local/bin`` under the GUI app's
+    minimal launchd PATH). (#51393)"""
+    return resolve_cua_driver_cmd() is not None
 
 
 def cua_driver_update_check(*, timeout: float = 8.0) -> Optional[Dict[str, Any]]:
@@ -231,8 +289,11 @@ def cua_driver_update_check(*, timeout: float = 8.0) -> Optional[Dict[str, Any]]
     raises.
     """
     try:
+        driver_cmd = resolve_cua_driver_cmd()
+        if not driver_cmd:
+            return None
         proc = subprocess.run(
-            [_CUA_DRIVER_CMD, "check-update", "--json"],
+            [driver_cmd, "check-update", "--json"],
             capture_output=True, text=True, timeout=timeout,
             # Some older drivers don't have the verb and fall through to a
             # stdin-reading mode rather than erroring — DEVNULL gives them EOF
@@ -582,7 +643,11 @@ class _CuaDriverSession:
             # Surface 8: ask cua-driver itself which subcommand spawns
             # the MCP server, instead of hardcoding ["mcp"]. Falls back
             # transparently for older drivers / any discovery failure.
-            command, args = _resolve_mcp_invocation(_CUA_DRIVER_CMD)
+            # Use the resolved absolute path (not the bare command name) so the
+            # spawn succeeds under the GUI app's minimal PATH too. (#51393)
+            command, args = _resolve_mcp_invocation(
+                resolve_cua_driver_cmd() or _CUA_DRIVER_CMD
+            )
             params = StdioServerParameters(
                 command=command,
                 args=args,


### PR DESCRIPTION
Fixes #51393. The macOS desktop GUI app launches under launchd with a minimal PATH that omits `~/.local/bin`, where cua-driver installs its symlink. The availability gate was `shutil.which("cua-driver")` only, so under the GUI app it returned False and `computer_use` was silently dropped from the toolset — even though the same install works from a shell whose PATH includes `~/.local/bin`.

Adds `resolve_cua_driver_cmd()`: which() first (honouring `HERMES_CUA_DRIVER_CMD` and PATH), then an explicit override path, then canonical install locations. The availability gate, the check-update probe, and the MCP spawn all route through it, so the spawn uses the resolved absolute path. A custom `HERMES_CUA_DRIVER_CMD` that does not resolve is never silently swapped for a canonical binary. Adds regression tests for the `~/.local/bin` fallback, the no-silent-fallback guard, and the missing-everywhere case.
