### PR TITLE
fix(gateway): preserve runtime status owner identity

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -307,6 +307,54 @@ def _build_runtime_status_record() -> dict[str, Any]:
     return payload
 
 
+def _resolve_runtime_status_identity(
+    current_record: dict[str, Any],
+    payload: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    """Choose which process identity should own gateway_state.json.
+
+    The gateway runtime owner is the process behind ``gateway.pid`` /
+    ``gateway.lock``. Auxiliary writers such as the desktop dashboard backend
+    may legitimately update platform substate, but they must not overwrite the
+    live gateway's pid/argv metadata in the shared runtime-status file.
+    """
+    owner_pid = get_running_pid(cleanup_stale=False)
+    if owner_pid is None or owner_pid == current_record["pid"]:
+        return current_record
+
+    existing_payload = payload if isinstance(payload, dict) else {}
+    for record in (_read_pid_record(), _read_gateway_lock_record()):
+        if _pid_from_record(record) != owner_pid:
+            continue
+        owner_record = dict(record)
+        owner_record.setdefault("pid", owner_pid)
+        owner_record.setdefault(
+            "kind",
+            existing_payload.get("kind") if existing_payload.get("pid") == owner_pid else _GATEWAY_KIND,
+        )
+        owner_record.setdefault(
+            "argv",
+            existing_payload.get("argv")
+            if existing_payload.get("pid") == owner_pid and isinstance(existing_payload.get("argv"), list)
+            else [],
+        )
+        owner_record.setdefault(
+            "start_time",
+            existing_payload.get("start_time") if existing_payload.get("pid") == owner_pid else None,
+        )
+        return owner_record
+
+    if existing_payload.get("pid") == owner_pid:
+        return {
+            "pid": owner_pid,
+            "kind": existing_payload.get("kind", _GATEWAY_KIND),
+            "argv": existing_payload.get("argv", []),
+            "start_time": existing_payload.get("start_time"),
+        }
+
+    return current_record
+
+
 def _read_json_file(path: Path) -> Optional[dict[str, Any]]:
     if not path.exists():
         return None
@@ -606,11 +654,12 @@ def write_runtime_status(
     path = _get_runtime_status_path()
     payload = _read_json_file(path) or _build_runtime_status_record()
     current_record = _build_pid_record()
+    identity_record = _resolve_runtime_status_identity(current_record, payload)
     payload.setdefault("platforms", {})
-    payload["kind"] = current_record["kind"]
-    payload["pid"] = current_record["pid"]
-    payload["argv"] = current_record["argv"]
-    payload["start_time"] = current_record["start_time"]
+    payload["kind"] = identity_record["kind"]
+    payload["pid"] = identity_record["pid"]
+    payload["argv"] = identity_record["argv"]
+    payload["start_time"] = identity_record["start_time"]
     payload["updated_at"] = _utc_now_iso()
 
     if gateway_state is not _UNSET:

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -311,6 +311,35 @@ class TestGatewayRuntimeStatus:
         assert payload["pid"] == os.getpid()
         assert payload["start_time"] == 2000
 
+    def test_write_runtime_status_preserves_live_gateway_identity_for_non_owner_writer(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        gateway_record = {
+            "pid": 4242,
+            "kind": "hermes-gateway",
+            "argv": ["/real/hermes", "gateway", "run", "--replace"],
+            "start_time": 777,
+        }
+        dashboard_record = {
+            "pid": os.getpid(),
+            "kind": "hermes-gateway",
+            "argv": ["/real/hermes", "dashboard", "--no-open"],
+            "start_time": 888,
+        }
+
+        monkeypatch.setattr(status, "_build_pid_record", lambda: dict(dashboard_record))
+        monkeypatch.setattr(status, "get_running_pid", lambda cleanup_stale=False: gateway_record["pid"])
+        monkeypatch.setattr(status, "_read_pid_record", lambda pid_path=None: dict(gateway_record))
+        monkeypatch.setattr(status, "_read_gateway_lock_record", lambda lock_path=None: None)
+
+        status.write_runtime_status(platform="discord", platform_state="connected")
+
+        payload = status.read_runtime_status()
+        assert payload["pid"] == gateway_record["pid"]
+        assert payload["argv"] == gateway_record["argv"]
+        assert payload["start_time"] == gateway_record["start_time"]
+        assert payload["platforms"]["discord"]["state"] == "connected"
+
     def test_write_runtime_status_records_platform_failure(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 


### PR DESCRIPTION
Fixes #51420

## Summary
- preserve the live gateway owner pid/argv/start_time when non-owner processes update gateway_state.json
- keep platform substate writes working for auxiliary writers like the desktop dashboard backend
- add a regression test covering non-owner runtime status writes

## Testing
- uv run --frozen pytest -q tests/gateway/test_status.py -o addopts=''
- uv run --frozen ruff check gateway/status.py tests/gateway/test_status.py
- git diff --check HEAD^ HEAD