### PR TITLE
fix(delegation): fix opencode-go subagents ignoring delegation.model config

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -432,6 +432,7 @@ def _resolve_runtime_from_pool_entry(
         "source": getattr(entry, "source", "pool"),
         "credential_pool": pool,
         "requested_provider": requested_provider,
+        "model": target_model,
     }
 
 
@@ -1831,6 +1832,7 @@ def resolve_runtime_provider(
             "api_key": creds.get("api_key", ""),
             "source": creds.get("source", "env"),
             "requested_provider": requested_provider,
+            "model": target_model,
         }
 
     runtime = _resolve_openrouter_runtime(

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1506,6 +1506,19 @@ def test_opencode_go_model_derivation_beats_stale_persisted_api_mode(monkeypatch
     assert resolved["api_mode"] == "anthropic_messages"
 
 
+def test_opencode_go_returns_target_model_in_delegation(monkeypatch):
+    """resolve_runtime_provider must include model in return dict so delegation.model
+    is not lost when subagents are built. Regression for #51540."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "opencode-go")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"default": "deepseek-v4-pro"})
+    monkeypatch.setenv("OPENCODE_GO_API_KEY", "test-opencode-go-key")
+    monkeypatch.delenv("OPENCODE_GO_BASE_URL", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="opencode-go", target_model="deepseek-v4-flash")
+
+    assert resolved.get("model") == "deepseek-v4-flash"
+
+
 def test_named_custom_provider_anthropic_api_mode(monkeypatch):
     """Custom providers should accept api_mode: anthropic_messages."""
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "my-anthropic-proxy")

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -949,7 +949,7 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         }
         creds = _resolve_delegation_credentials(cfg, parent)
         self.assertEqual(creds["model"], "qwen2.5-coder")
-        self.assertEqual(creds["provider"], "custom")
+        self.assertEqual(creds["provider"], "openrouter")
         self.assertEqual(creds["base_url"], "http://localhost:1234/v1")
         self.assertEqual(creds["api_key"], "local-key")
         self.assertEqual(creds["api_mode"], "chat_completions")

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -954,6 +954,19 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertEqual(creds["api_key"], "local-key")
         self.assertEqual(creds["api_mode"], "chat_completions")
 
+    def test_opencode_go_provider_preserved_when_base_url_set(self):
+        # Regression for #51540: provider must not be hardcoded to "custom" when
+        # delegation.base_url is set alongside delegation.provider.
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "deepseek-v4-flash",
+            "provider": "opencode-go",
+            "base_url": "https://opencode.ai/zen/go/v1",
+        }
+        creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["provider"], "opencode-go")
+        self.assertEqual(creds["model"], "deepseek-v4-flash")
+
     def test_direct_endpoint_auto_detects_anthropic_messages_suffix(self):
         # Issue #10213: Azure AI Foundry exposes Anthropic-compatible models at
         # a /anthropic URL suffix. Subagents must pick anthropic_messages

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2739,7 +2739,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         from hermes_cli.runtime_provider import _detect_api_mode_for_url
 
         base_lower = configured_base_url.lower()
-        provider = "custom"
+        provider = configured_provider or "custom"
         api_mode = _detect_api_mode_for_url(configured_base_url) or "chat_completions"
         if (
             base_url_hostname(configured_base_url) == "chatgpt.com"


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->
Fixes two bugs that caused `delegation.model` to be silently ignored when using the `opencode-go` provider, causing subagents to always inherit the parent's model instead of using the configured one

Bug 1: `_resolve_delegation_credentials()` hardcoded `provider = "custom"` when `delegation.base_url` was set, discarding the configured provider entirely.
Bug 2: `resolve_runtime_provider()` used `target_model` internally to compute routing, but never included it in the returned dict, causing the delegation layer to fall back to the parent model.

The configured provider and model were already being parsed from the config; they just weren't being passed through to where they were needed. No new behavior is introduced; only the intended behavior is restored.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #51540 

## Type of Change

<!-- Check the one that applies. -->

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/delegate_tool.py:2742` — Changed `provider = "custom"` to `provider = configured_provider or "custom"` so the configured provider is no longer discarded when `delegation.base_url` is set
- `hermes_cli/runtime_provider.py` — Added `"model": target_model` to the return dict in both `_resolve_runtime_from_pool_entry` (line 435) and `resolve_runtime_provider` (line 1835) so the delegation layer receives the correct model instead of falling back to the parent's model
- `tests/tools/test_delegate.py` — Updated existing assertion to reflect correct behavior and added a regression test for Bug 1 (opencode-go provider preservation)
- `tests/hermes_cli/test_runtime_provider_resolution.py` — Added regression test for Bug 2 (model returned from `resolve_runtime_provider`)


## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Set `delegation.model: deepseek-v4-flash` and `delegation.provider: opencode-go` in config.yaml
2. Run Hermes with parent model `deepseek-v4-pro` via `opencode-go`
3. Call `delegate_task()` — subagent should now use `deepseek-v4-flash` instead of inheriting `deepseek-v4-pro`

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [X] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [X] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [X] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [X] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [X] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

```
270 passed, 2 deselected, 8 warnings in 8.09s

ruff check tools/delegate_tool.py hermes_cli/runtime_provider.py tests/tools/test_delegate.py tests/hermes_cli/test_runtime_provider_resolution.py
All checks passed!
```

