### PR TITLE
fix(hermes_state): explicitly set active=1 in INSERT statements

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2556,8 +2556,8 @@ class SessionDB:
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   codex_message_items, platform_message_id, observed, active)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -2575,6 +2575,7 @@ class SessionDB:
                     codex_message_items_json,
                     platform_message_id,
                     1 if observed else 0,
+                    1,
                 ),
             )
             msg_id = cursor.lastrowid
@@ -2647,8 +2648,8 @@ class SessionDB:
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   codex_message_items, platform_message_id, observed, active)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -2666,6 +2667,7 @@ class SessionDB:
                     codex_message_items_json,
                     platform_msg_id,
                     1 if msg.get("observed") else 0,
+                    1,
                 ),
             )
             inserted += 1


### PR DESCRIPTION
## Summary

Both `append_message()` and `_insert_message_rows()` in `hermes_state.py` omit the `active` column when inserting into the `messages` table. While the schema defines `active INTEGER NOT NULL DEFAULT 1`, databases created **before the v12 migration** may lack the DEFAULT constraint on the actual table definition (SQLite's `ADD COLUMN` does not retroactively apply defaults).

This means new rows get `active = NULL`, and the transcript loader's `WHERE active = 1` filter excludes them — causing the agent to lose conversation context within a few exchanges on gateway-connected platforms (Discord, dashboard).

## Changes

- Explicitly include `active` column with value `1` in both INSERT statements:
  - `append_message()` (line ~2556) — single message insert
  - `_insert_message_rows()` (line ~2647) — bulk insert used by `replace_messages()` and `archive_and_compact()`

## Why explicit instead of relying on DEFAULT

The DEFAULT clause works for databases created with the current schema. But for databases that existed before v12 and had the `active` column added via `_reconcile_columns()` + `ALTER TABLE ADD COLUMN`, the DEFAULT may not be present in the table definition. Explicit insertion guarantees correctness regardless of database creation history.

Fixes #51646
