### PR TITLE
fix(credential-pool): gate copilot auto-seed behind explicit provider configuration (#51652)

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1776,6 +1776,19 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
             )
 
     elif provider == "copilot":
+        # Only auto-discover copilot credentials when the user has
+        # explicitly configured copilot as their provider.  Without this
+        # gate, a GitHub CLI login (extremely common, unrelated to Copilot
+        # as an LLM provider) silently injects a copilot credential that
+        # contaminates routing for unrelated providers via credential-pool
+        # rotation.  See #51652.
+        try:
+            from hermes_cli.auth import is_provider_explicitly_configured
+            if not is_provider_explicitly_configured("copilot"):
+                return changed, active_sources
+        except ImportError:
+            pass
+
         # Copilot tokens are resolved dynamically via `gh auth token` or
         # env vars (COPILOT_GITHUB_TOKEN / GH_TOKEN).  They don't live in
         # the auth store or credential pool, so we resolve them here.

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2275,9 +2275,10 @@ def test_load_pool_does_not_seed_claude_code_when_anthropic_not_configured(tmp_p
 
 
 def test_load_pool_seeds_copilot_via_gh_auth_token(tmp_path, monkeypatch):
-    """Copilot credentials from `gh auth token` should be seeded into the pool."""
+    """Copilot credentials from `gh auth token` should be seeded into the pool
+    when copilot is the explicitly configured provider.  #51652."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
-    _write_auth_store(tmp_path, {"version": 1, "credential_pool": {}})
+    _write_auth_store(tmp_path, {"version": 1, "active_provider": "copilot", "credential_pool": {}})
 
     monkeypatch.setattr(
         "hermes_cli.copilot_auth.resolve_copilot_token",

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -1685,6 +1685,66 @@ def test_seed_from_singletons_respects_copilot_suppression(tmp_path, monkeypatch
     assert active == set()
 
 
+def test_seed_from_singletons_copilot_consent_gate_blocks_unconfigured(tmp_path, monkeypatch):
+    """copilot credential must NOT be auto-seeded when the user has not
+    explicitly configured copilot as their provider.  A GitHub CLI login
+    alone should not inject a copilot credential into the pool.  #51652."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    # auth.json: active provider is nous, copilot NOT configured
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "active_provider": "nous",
+        "providers": {},
+    }))
+
+    # Stub resolve_copilot_token to return a valid token (as if gh auth login)
+    import hermes_cli.copilot_auth as ca
+    monkeypatch.setattr(ca, "resolve_copilot_token", lambda: ("ghp_fake", "gh auth token"))
+    monkeypatch.setattr(ca, "get_copilot_api_token", lambda t: "copilot_api_fake")
+
+    from agent.credential_pool import _seed_from_singletons
+    entries = []
+    changed, active = _seed_from_singletons("copilot", entries)
+
+    # Consent gate should block — no copilot entry created
+    assert changed is False
+    assert entries == []
+    assert active == set()
+
+
+def test_seed_from_singletons_copilot_consent_gate_allows_configured(tmp_path, monkeypatch):
+    """copilot credential MUST be seeded when the user has explicitly
+    configured copilot as their active provider.  #51652."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    # auth.json: active provider IS copilot
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "active_provider": "copilot",
+        "providers": {},
+    }))
+
+    # Stub resolve_copilot_token to return a valid token
+    import hermes_cli.copilot_auth as ca
+    monkeypatch.setattr(ca, "resolve_copilot_token", lambda: ("ghp_fake", "gh auth token"))
+    monkeypatch.setattr(ca, "get_copilot_api_token", lambda t: "copilot_api_fake")
+
+    from agent.credential_pool import _seed_from_singletons
+    entries = []
+    changed, active = _seed_from_singletons("copilot", entries)
+
+    # Consent gate passes — copilot entry should be created
+    assert changed is True
+    assert len(entries) == 1
+    assert entries[0].provider == "copilot"
+    assert "gh_cli" in active
+
+
 def test_seed_from_singletons_respects_qwen_suppression(tmp_path, monkeypatch):
     """qwen-oauth qwen-cli must not re-seed from ~/.qwen/oauth_creds.json when suppressed."""
     hermes_home = tmp_path / "hermes"
@@ -1846,6 +1906,7 @@ def test_auth_remove_copilot_suppresses_all_variants(tmp_path, monkeypatch):
         tmp_path,
         {
             "version": 1,
+            "active_provider": "copilot",
             "credential_pool": {"copilot": []},
         },
     )


### PR DESCRIPTION
## What does this PR do?

Gates copilot credential auto-seeding behind `is_provider_explicitly_configured("copilot")`, matching the existing anthropic consent gate (PR #4210). Previously, any `gh auth login` silently injected a copilot credential into the pool, contaminating routing for unrelated providers and causing `HTTP 400 model_not_supported` on subagent delegation.

## Related Issue

Fixes #51652

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/credential_pool.py`: Added `is_provider_explicitly_configured("copilot")` consent gate to the copilot branch of `_seed_from_singletons()`, preventing auto-seed when copilot is not the active provider
- `tests/hermes_cli/test_auth_commands.py`: Added `test_seed_from_singletons_copilot_consent_gate_blocks_unconfigured` and `test_seed_from_singletons_copilot_consent_gate_allows_configured`; updated `test_auth_remove_copilot_suppresses_all_variants` to set `active_provider: copilot`
- `tests/agent/test_credential_pool.py`: Updated `test_load_pool_seeds_copilot_via_gh_auth_token` to set `active_provider: copilot` since seed now requires explicit provider configuration

## How to Test

1. Run `python -m pytest tests/hermes_cli/test_auth_commands.py -x -q`
2. Observed result: `54 passed` — including `test_seed_from_singletons_copilot_consent_gate_blocks_unconfigured` and `test_seed_from_singletons_copilot_consent_gate_allows_configured`
3. Run `python -m pytest tests/agent/test_credential_pool.py -x -q`
4. Observed result: `79 passed` — including `test_load_pool_seeds_copilot_via_gh_auth_token`

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.5