### PR TITLE
fix(desktop): make update relaunch tests portable

### DIFF
--- a/apps/desktop/electron/update-relaunch.cjs
+++ b/apps/desktop/electron/update-relaunch.cjs
@@ -57,11 +57,12 @@ function unpackedDirName(platform) {
  */
 function resolveUnpackedRelease(execPath, updateRoot, platform) {
   if (!execPath || !updateRoot) return null
-  const releaseDir = path.join(updateRoot, 'apps', 'desktop', 'release')
-  const unpacked = path.join(releaseDir, unpackedDirName(platform))
-  const normalizedExec = path.resolve(String(execPath))
+  const pathApi = platform === 'win32' ? path.win32 : path.posix
+  const releaseDir = pathApi.join(updateRoot, 'apps', 'desktop', 'release')
+  const unpacked = pathApi.join(releaseDir, unpackedDirName(platform))
+  const normalizedExec = pathApi.resolve(String(execPath))
   // execPath must be the unpacked dir itself or a descendant of it.
-  const withSep = unpacked.endsWith(path.sep) ? unpacked : unpacked + path.sep
+  const withSep = unpacked.endsWith(pathApi.sep) ? unpacked : unpacked + pathApi.sep
   if (normalizedExec === unpacked || normalizedExec.startsWith(withSep)) {
     return unpacked
   }

--- a/apps/desktop/electron/update-relaunch.test.cjs
+++ b/apps/desktop/electron/update-relaunch.test.cjs
@@ -37,7 +37,7 @@ const {
 } = require('./update-relaunch.cjs')
 
 const ROOT = '/home/u/.hermes/hermes-agent'
-const UNPACKED = path.join(ROOT, 'apps', 'desktop', 'release', 'linux-unpacked')
+const UNPACKED = path.posix.join(ROOT, 'apps', 'desktop', 'release', 'linux-unpacked')
 
 // ---------------------------------------------------------------------------
 // 1) The execPath split — the heart of the GUI/backend skew guard.
@@ -49,7 +49,7 @@ test('unpackedDirName maps platform to the electron-builder dir', () => {
 })
 
 test('resolveUnpackedRelease returns the dir for a binary UNDER release/<plat>-unpacked', () => {
-  const exec = path.join(UNPACKED, 'hermes')
+  const exec = path.posix.join(UNPACKED, 'hermes')
   assert.equal(resolveUnpackedRelease(exec, ROOT, 'linux'), UNPACKED)
   // The unpacked dir itself also counts.
   assert.equal(resolveUnpackedRelease(UNPACKED, ROOT, 'linux'), UNPACKED)
@@ -65,12 +65,12 @@ test('resolveUnpackedRelease is null for AppImage / .deb / .rpm / dev / unresolv
   assert.equal(resolveUnpackedRelease('/home/u/.hermes/hermes-agent/node_modules/electron/dist/electron', ROOT, 'linux'), null)
   // empty / missing
   assert.equal(resolveUnpackedRelease('', ROOT, 'linux'), null)
-  assert.equal(resolveUnpackedRelease(path.join(UNPACKED, 'hermes'), '', 'linux'), null)
+  assert.equal(resolveUnpackedRelease(path.posix.join(UNPACKED, 'hermes'), '', 'linux'), null)
 })
 
 test('resolveUnpackedRelease is not fooled by a sibling prefix dir', () => {
   // `.../release/linux-unpacked-evil` must NOT match `.../release/linux-unpacked`.
-  const sneaky = path.join(ROOT, 'apps', 'desktop', 'release', 'linux-unpacked-evil', 'hermes')
+  const sneaky = path.posix.join(ROOT, 'apps', 'desktop', 'release', 'linux-unpacked-evil', 'hermes')
   assert.equal(resolveUnpackedRelease(sneaky, ROOT, 'linux'), null)
 })
 
@@ -201,13 +201,16 @@ test('buildRelaunchScript embeds pid/exec/args/env/cwd and is valid bash', () =>
   assert.match(script, /cd '\/home\/u\/work dir'/)
   assert.match(script, /exec '.*\/linux-unpacked\/Hermes' 'hermes:\/\/open\/agent\/42' '--note=it'\\''s fine'/)
 
-  // It must be syntactically valid bash (`bash -n`). Write to a temp file and lint.
-  const tmp = path.join(os.tmpdir(), `hermes-relaunch-test-${Date.now()}.sh`)
-  fs.writeFileSync(tmp, script)
-  try {
-    execFileSync('bash', ['-n', tmp], { stdio: 'pipe' })
-  } finally {
-    fs.rmSync(tmp, { force: true })
+  // It must be syntactically valid bash (`bash -n`). On Windows, bare `bash`
+  // often resolves to WSL, which cannot consume a Windows temp path directly.
+  if (process.platform !== 'win32') {
+    const tmp = path.join(os.tmpdir(), `hermes-relaunch-test-${Date.now()}.sh`)
+    fs.writeFileSync(tmp, script)
+    try {
+      execFileSync('bash', ['-n', tmp], { stdio: 'pipe' })
+    } finally {
+      fs.rmSync(tmp, { force: true })
+    }
   }
 })
 
@@ -219,12 +222,14 @@ test('buildRelaunchScript with no args/env still lints clean', () => {
     env: {},
     cwd: ''
   })
-  const tmp = path.join(os.tmpdir(), `hermes-relaunch-test2-${Date.now()}.sh`)
-  fs.writeFileSync(tmp, script)
-  try {
-    execFileSync('bash', ['-n', tmp], { stdio: 'pipe' })
-  } finally {
-    fs.rmSync(tmp, { force: true })
+  if (process.platform !== 'win32') {
+    const tmp = path.join(os.tmpdir(), `hermes-relaunch-test2-${Date.now()}.sh`)
+    fs.writeFileSync(tmp, script)
+    try {
+      execFileSync('bash', ['-n', tmp], { stdio: 'pipe' })
+    } finally {
+      fs.rmSync(tmp, { force: true })
+    }
   }
   // exec line has no trailing args.
   assert.match(script, /exec '\/opt\/Hermes\/Hermes'\n/)

--- a/apps/desktop/electron/windows-child-process.test.cjs
+++ b/apps/desktop/electron/windows-child-process.test.cjs
@@ -22,20 +22,30 @@ function requireHiddenChildOptions(source, needle) {
   )
 }
 
+function requireHiddenChildOptionsNear(source, pattern, label) {
+  const match = source.match(pattern)
+  assert.ok(match && typeof match.index === 'number', `missing call site: ${label}`)
+  const snippet = source.slice(match.index, match.index + 900)
+  assert.match(
+    snippet,
+    /hiddenWindowsChildOptions\(/,
+    `expected ${label} to wrap child-process options with hiddenWindowsChildOptions`
+  )
+}
+
 test('desktop background child processes opt into hidden Windows consoles', () => {
   const source = readElectronFile('main.cjs')
 
   assert.match(source, /function hiddenWindowsChildOptions\(options = \{\}\)/)
 
   requireHiddenChildOptions(source, "execFileSync(\n          'reg'")
-  requireHiddenChildOptions(source, 'execFileSync(pyExe')
-  requireHiddenChildOptions(source, 'spawn(resolveGitBinary()')
+  requireHiddenChildOptionsNear(source, /execFileSync\(\s*pyExe/, 'execFileSync(pyExe')
+  requireHiddenChildOptionsNear(source, /spawn\(\s*resolveGitBinary\(\)/, 'spawn(resolveGitBinary()')
   requireHiddenChildOptions(source, "execFileSync('taskkill'")
-  requireHiddenChildOptions(source, 'spawn(command, args')
   requireHiddenChildOptions(source, "spawn('curl'")
-  requireHiddenChildOptions(source, 'spawn(backend.command, backend.args')
-  requireHiddenChildOptions(source, 'hermesProcess = spawn(backend.command, backend.args')
-  requireHiddenChildOptions(source, "spawn(py, ['-m', 'hermes_cli.main', 'uninstall', '--gui-summary']")
+  requireHiddenChildOptionsNear(source, /const child = spawn\(\s*backend\.command,\s*backend\.args/, 'spawn(backend.command, backend.args')
+  requireHiddenChildOptionsNear(source, /hermesProcess = spawn\(\s*backend\.command,\s*backend\.args/, 'hermesProcess = spawn(backend.command, backend.args')
+  requireHiddenChildOptionsNear(source, /spawn\(\s*py,\s*\[\s*'-m',\s*'hermes_cli\.main',\s*'uninstall',\s*'--gui-summary'\s*\]/, "spawn(py, ['-m', 'hermes_cli.main', 'uninstall', '--gui-summary']")
 })
 
 test('intentional or interactive desktop child processes stay documented', () => {


### PR DESCRIPTION
## Resumo

Este PR corrige a portabilidade dos testes de update relaunch no desktop do Hermes e valida a branch upstream no Windows.

## Problema

A suíte `test:desktop:platforms` falhava no Windows por misturar APIs de path do host com caminhos Linux simulados, por usar `bash -n` com temp files Windows via WSL e por asserts textuais frágeis em testes de child process.

## Solução

A função `resolveUnpackedRelease` agora escolhe `path.win32` ou `path.posix` conforme o `platform` alvo. Os testes usam `path.posix` para os cenários Linux, pulam a lintagem bash no Windows onde o caminho temporário não é compatível com WSL e relaxam buscas textuais para aceitar chamadas multiline. O teste de child process foi ajustado para não depender de uma chamada obsoleta que já foi substituída por `nodePty.spawn` documentado como interativo.

## Arquivos principais alterados

- `apps/desktop/electron/update-relaunch.cjs`: corrige a resolução de caminhos por plataforma.
- `apps/desktop/electron/update-relaunch.test.cjs`: torna os casos Linux portáveis no Windows.
- `apps/desktop/electron/windows-child-process.test.cjs`: deixa as asserções menos frágeis e alinhadas ao formato atual do código.

## Impacto esperado

A branch deixa de falhar na suíte de plataforma em Windows, preservando o comportamento esperado do fluxo de update relaunch e das verificações de child process.

## Riscos

O risco é baixo. A mudança é focada em utilitários e testes de desktop, sem alterar o fluxo de runtime além da escolha correta da API de path por plataforma.

## Como testar

```powershell
npm run typecheck --workspace apps/desktop
npm run test:desktop:platforms --workspace apps/desktop
npm run build --workspace apps/desktop
```

Resultados obtidos localmente:
- `npm run typecheck --workspace apps/desktop` passou.
- `npm run test:desktop:platforms --workspace apps/desktop` passou com `225 passed, 0 failed`.
- `npm run build --workspace apps/desktop` passou.