### PR TITLE
fix(cron): route origin deliveries back to live tui sessions

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -764,6 +764,23 @@ def _confirm_adapter_delivery(send_result) -> bool:
     return bool(getattr(send_result, "success"))
 
 
+def _deliver_to_tui_session(session_key: str, content: str) -> bool:
+    """Deliver cron output into a live TUI/desktop session, if one exists."""
+    key = str(session_key or "").strip()
+    if not key:
+        return False
+    try:
+        from tui_gateway.server import deliver_live_system_message
+    except Exception:
+        logger.debug("TUI delivery helper unavailable for session %s", key, exc_info=True)
+        return False
+    try:
+        return bool(deliver_live_system_message(key, content))
+    except Exception:
+        logger.warning("TUI delivery to %s failed", key, exc_info=True)
+        return False
+
+
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
@@ -797,9 +814,6 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         logger.warning("Job '%s': %s", job["id"], msg)
         return msg
 
-    from tools.send_message_tool import _send_to_platform
-    from gateway.config import load_gateway_config, Platform
-
     # Optionally wrap the content with a header/footer so the user knows this
     # is a cron delivery.  Wrapping is on by default; set cron.wrap_response: false
     # in config.yaml for clean output.
@@ -828,19 +842,25 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(delivery_content)
     media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
 
-    try:
-        config = load_gateway_config()
-    except Exception as e:
-        msg = f"failed to load gateway config: {e}"
-        logger.error("Job '%s': %s", job["id"], msg)
-        return msg
+    from tools.send_message_tool import _send_to_platform
 
+    config = None
+    Platform = None
     delivery_errors = []
 
     for target in targets:
         platform_name = target["platform"]
         chat_id = target["chat_id"]
         thread_id = target.get("thread_id")
+
+        if str(platform_name).lower() == "tui":
+            if _deliver_to_tui_session(str(chat_id), delivery_content):
+                logger.info("Job '%s': delivered to tui session %s", job["id"], chat_id)
+            else:
+                msg = f"tui session '{chat_id}' is not live"
+                logger.warning("Job '%s': %s", job["id"], msg)
+                delivery_errors.append(msg)
+            continue
 
         # Diagnostic: log thread_id for topic-aware delivery debugging
         origin = _resolve_origin(job) or {}
@@ -856,6 +876,17 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 "Job '%s': delivering to %s:%s thread_id=%s",
                 job["id"], platform_name, chat_id, thread_id,
             )
+
+        if config is None or Platform is None:
+            try:
+                from gateway.config import load_gateway_config, Platform as GatewayPlatform
+
+                config = load_gateway_config()
+                Platform = GatewayPlatform
+            except Exception as e:
+                msg = f"failed to load gateway config: {e}"
+                logger.error("Job '%s': %s", job["id"], msg)
+                return msg
 
         # Built-in names resolve to their enum member; plugin platform names
         # create dynamic members via Platform._missing_().

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -551,6 +551,40 @@ class TestRoutingIntents:
             assert platforms == ["discord", "telegram"], f"token={token!r} -> {platforms}"
 
 
+class TestTuiDelivery:
+    def test_origin_delivery_to_tui_uses_live_session_helper(self):
+        job = {
+            "id": "tui-job",
+            "name": "daily-report",
+            "deliver": "origin",
+            "origin": {"platform": "tui", "chat_id": "tui-session-abc"},
+        }
+
+        with patch("cron.scheduler._deliver_to_tui_session", return_value=True) as deliver_tui, \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock()) as send_mock:
+            result = _deliver_result(job, "Here is today's summary.")
+
+        assert result is None
+        deliver_tui.assert_called_once()
+        session_key, sent_content = deliver_tui.call_args.args
+        assert session_key == "tui-session-abc"
+        assert "Cronjob Response: daily-report" in sent_content
+        assert "Here is today's summary." in sent_content
+        send_mock.assert_not_called()
+
+    def test_tui_delivery_reports_missing_live_session(self):
+        job = {
+            "id": "tui-job",
+            "deliver": "origin",
+            "origin": {"platform": "tui", "chat_id": "tui-session-abc"},
+        }
+
+        with patch("cron.scheduler._deliver_to_tui_session", return_value=False):
+            result = _deliver_result(job, "Output.")
+
+        assert result == "tui session 'tui-session-abc' is not live"
+
+
 class TestDeliverResultWrapping:
     """Verify that cron deliveries are wrapped with header/footer and no longer mirrored."""
 

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -4,6 +4,7 @@ import json
 import pytest
 
 from tools.cronjob_tools import (
+    _origin_from_env,
     _scan_cron_prompt,
     check_cronjob_requirements,
     cronjob,
@@ -177,6 +178,31 @@ class TestScanCronSkillAssembled:
         assert _scan_cron_skill_assembled(
             'curl -s -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/user'
         )[1] == ""
+
+
+class TestOriginFromEnv:
+    def test_tui_session_key_falls_back_to_tui_origin(self, monkeypatch):
+        monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+        monkeypatch.delenv("HERMES_SESSION_CHAT_ID", raising=False)
+        monkeypatch.delenv("HERMES_SESSION_THREAD_ID", raising=False)
+        monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+        monkeypatch.setenv("HERMES_SESSION_KEY", "tui-session-abc")
+
+        assert _origin_from_env() == {
+            "platform": "tui",
+            "chat_id": "tui-session-abc",
+            "chat_name": None,
+            "thread_id": None,
+        }
+
+    def test_session_id_alone_does_not_look_like_tui_origin(self, monkeypatch):
+        monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+        monkeypatch.delenv("HERMES_SESSION_CHAT_ID", raising=False)
+        monkeypatch.delenv("HERMES_SESSION_THREAD_ID", raising=False)
+        monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
+        monkeypatch.setenv("HERMES_SESSION_ID", "cli-session-123")
+
+        assert _origin_from_env() is None
 
 
 class TestCronjobRequirements:

--- a/tests/tui_gateway/test_review_summary_callback.py
+++ b/tests/tui_gateway/test_review_summary_callback.py
@@ -99,6 +99,50 @@ def test_init_session_attaches_background_review_callback(server, monkeypatch):
     }
 
 
+def test_deliver_live_system_message_appends_history_and_emits_review_summary(
+    server, monkeypatch
+):
+    monkeypatch.setattr(server, "_SlashWorker", lambda *a, **kw: object())
+    monkeypatch.setattr(server, "_wire_callbacks", lambda sid: None)
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "_session_info", lambda agent, session=None: {"model": "m"})
+    monkeypatch.setattr(server, "_load_show_reasoning", lambda: False)
+    monkeypatch.setattr(server, "_load_tool_progress_mode", lambda: "all")
+
+    captured_emits: list = []
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, sid, payload=None: captured_emits.append((event, sid, payload)),
+    )
+
+    fake_db = MagicMock()
+
+    class FakeAgent:
+        model = "fake/model"
+        _session_db = fake_db
+
+    server._init_session("sid-abc", "session-key", FakeAgent(), [], cols=80)
+    captured_emits.clear()
+
+    assert server.deliver_live_system_message("session-key", "Cron output ready") is True
+
+    session = server._sessions["sid-abc"]
+    assert session["history"][-1] == {"role": "system", "content": "Cron output ready"}
+    assert captured_emits == [
+        ("review.summary", "sid-abc", {"text": "Cron output ready"})
+    ]
+    fake_db.append_message.assert_called_once_with(
+        session_id="session-key",
+        role="system",
+        content="Cron output ready",
+    )
+
+
+def test_deliver_live_system_message_returns_false_without_live_session(server):
+    assert server.deliver_live_system_message("missing-session", "Cron output ready") is False
+
+
 def test_review_summary_callback_survives_agent_without_attribute(server, monkeypatch):
     """If the agent is a bare object that doesn't allow attribute
     assignment (e.g. some stubbed test double), _init_session must not
@@ -164,4 +208,3 @@ def test_load_memory_notifications_normalization(server, monkeypatch, raw, expec
     display = {} if raw is None else {"memory_notifications": raw}
     monkeypatch.setattr(server, "_load_cfg", lambda: {"display": display})
     assert server._load_memory_notifications() == expected
-

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -295,6 +295,17 @@ def _origin_from_env() -> Optional[Dict[str, str]]:
             "chat_name": get_session_env("HERMES_SESSION_CHAT_NAME") or None,
             "thread_id": thread_id,
         }
+    # TUI/desktop sessions intentionally leave platform/chat_id empty. The
+    # live session key is the only safe local fallback here; HERMES_SESSION_ID
+    # is broader and would misclassify plain CLI runs as deliverable origins.
+    session_key = get_session_env("HERMES_SESSION_KEY")
+    if session_key:
+        return {
+            "platform": "tui",
+            "chat_id": session_key,
+            "chat_name": None,
+            "thread_id": None,
+        }
     return None
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4946,6 +4946,62 @@ def _find_live_session_by_key(session_key: str) -> tuple[str, dict] | None:
     return None
 
 
+def deliver_live_system_message(session_key: str, text: str) -> bool:
+    """Surface an out-of-band system line inside a live TUI/desktop session.
+
+    Cron deliveries and similar background events are not agent turns, so they
+    must not arrive as assistant text that would create assistant-to-assistant
+    transcript seams.  Emit them through the existing ``review.summary`` system
+    line path instead.  When the session is idle we also persist the message in
+    the backend history/DB so a later resume still shows it.  When the session
+    is mid-turn we skip the history mutation to avoid invalidating that turn's
+    ``history_version`` snapshot; the live UI still receives the system line.
+    """
+    key = str(session_key or "").strip()
+    body = str(text or "")
+    if not key or not body.strip():
+        return False
+
+    live = _find_live_session_by_key(key)
+    if live is None:
+        return False
+
+    sid, session = live
+    persisted = False
+    entry = {"role": "system", "content": body}
+
+    lock = session.get("history_lock")
+    if lock is not None:
+        with lock:
+            if not session.get("running"):
+                session.setdefault("history", []).append(entry)
+                session["history_version"] = int(session.get("history_version", 0)) + 1
+                persisted = True
+    elif not session.get("running"):
+        session.setdefault("history", []).append(entry)
+        session["history_version"] = int(session.get("history_version", 0)) + 1
+        persisted = True
+
+    if persisted:
+        try:
+            agent = session.get("agent")
+            db = getattr(agent, "_session_db", None) if agent is not None else None
+            if db is not None:
+                db.append_message(session_id=key, role="system", content=body)
+            else:
+                _ensure_session_db_row(session)
+                with _session_db(session) as scoped_db:
+                    if scoped_db is not None:
+                        scoped_db.append_message(
+                            session_id=key, role="system", content=body
+                        )
+        except Exception:
+            logger.debug("failed to persist live system message", exc_info=True)
+
+    _emit("review.summary", sid, {"text": body})
+    return True
+
+
 def _fallback_session_info(session: dict) -> dict:
     agent = session.get("agent")
     if agent is not None:


### PR DESCRIPTION
## What does this PR do?

Cron jobs created from a live TUI/desktop session with `deliver=\"origin\"` (or omitted `deliver`) were being stored without a deliverable local origin and later had no TUI-specific delivery path, so the job ran but never surfaced back in the originating session.

This PR fixes that by capturing `HERMES_SESSION_KEY` as a local `tui` origin for TUI/desktop sessions and routing `platform=\"tui\"` deliveries back into the live session as a persistent system line. The fix stays narrowly scoped to sessions that actually have a live local return channel.

## Related Issue

Refs #51568

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Why this is the right fix

The broken chain was source-level:

- `tools/cronjob_tools.py::_origin_from_env()` only captured origin when `HERMES_SESSION_PLATFORM` and `HERMES_SESSION_CHAT_ID` were set.
- TUI/desktop sessions do not populate those fields, but they do carry `HERMES_SESSION_KEY`.
- Even if a local `tui` origin existed, the scheduler had no path for routing a cron delivery back into a live TUI session.

This patch fixes those two exact gaps without widening unrelated session semantics:

- the local fallback is pinned to `HERMES_SESSION_KEY`, not `HERMES_SESSION_ID`, so plain CLI runs are not misclassified as deliverable live sessions;
- the live delivery is emitted through the existing `review.summary` system-line path, so cron output does not create assistant-to-assistant transcript seams;
- classic gateway/platform delivery paths are unchanged.

## Changes Made

- Add a TUI/desktop-safe fallback in `tools/cronjob_tools.py::_origin_from_env()` that reconstructs local origin from `HERMES_SESSION_KEY` only.
- Add `_deliver_to_tui_session()` in `cron/scheduler.py` so `deliver=\"origin\"` with `platform=\"tui\"` routes to the live local session instead of gateway platform delivery.
- Add `tui_gateway.server.deliver_live_system_message()` to emit the cron result through the existing system-line path and persist it when the session is idle.
- Add targeted regressions for origin capture, TUI delivery routing, and live-session persistence/emission.

## How to Test

1. Repro on `bb7ff7dc3` before this patch:
   - `tests/tools/test_cronjob_tools.py::TestOriginFromEnv::test_tui_session_key_falls_back_to_tui_origin` fails because `_origin_from_env()` returns `None`.
   - `tests/cron/test_scheduler.py::TestTuiDelivery::*` fails because the scheduler has no TUI delivery helper.
   - `tests/tui_gateway/test_review_summary_callback.py::test_deliver_live_system_message_*` fails because the live system-message helper does not exist.
2. In a live TUI or desktop chat session, create a cron job with `deliver=\"origin\"` (or omit `deliver`).
3. Let the cron job fire and confirm the result appears back in the originating session as a system line.
4. Run:
   ```bash
   pytest tests/tools/test_cronjob_tools.py tests/cron/test_scheduler.py tests/tui_gateway/test_review_summary_callback.py -q
   ```

## Compatibility Notes

- TUI/desktop sessions now capture local origin from `HERMES_SESSION_KEY` and can route cron results back into the live session.
- Gateway/platform sessions are unchanged; explicit platform/chat/thread origin still wins.
- Classic CLI remains local-only here: this PR does not invent a live return channel where one does not exist.

## Validation Logs

```text
Pre-fix targeted regressions:
- _origin_from_env() returned None for HERMES_SESSION_KEY-only local sessions
- cron.scheduler had no _deliver_to_tui_session path
- tui_gateway.server had no deliver_live_system_message helper

Post-fix checks:
- pytest tests/tools/test_cronjob_tools.py tests/cron/test_scheduler.py tests/tui_gateway/test_review_summary_callback.py -q
  -> 241 passed
```

## Remaining Risks

- I did not run a full end-to-end cron fire inside a live TUI/desktop runtime in this branch.
- I did not run the full `pytest tests/ -q` suite.
- Classic CLI `deliver=origin` remains local-only because there is still no persistent live session return channel there.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (targeted pytest validation)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A