### PR TITLE
tui: refine StatusRule + add intentional input border

### DIFF
--- a/ui-tui/scripts/renderComposerBorder.tsx
+++ b/ui-tui/scripts/renderComposerBorder.tsx
@@ -1,0 +1,142 @@
+// Composer + StatusRule visual validation: render the input wrapper with the
+// new intentional `borderStyle="round"` so we can confirm the "empty box"
+// effect becomes a real, visible frame.
+//
+// We can't render the full App (it needs a real GatewayClient), so we
+// approximate the composer pane: StatusRule above the prompt + input
+// wrapper, matching the AppLayout's flex column order.
+//
+// Run: npx tsx scripts/renderComposerBorder.tsx
+
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { PassThrough } from 'stream'
+
+import { Box, renderSync, Text } from '@hermes/ink'
+import React from 'react'
+
+import { StatusRule } from '../src/components/appChrome.js'
+import { DEFAULT_THEME } from '../src/theme.js'
+
+// `no-control-regex` warns on the literal escape, but stripping ANSI is the
+// whole point of this helper — the pattern is correct.
+// eslint-disable-next-line no-control-regex
+const stripAnsi = (s: string) => s.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '')
+
+const renderOnce = (node: React.ReactNode, cols: number, rows = 50): string => {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+  let output = ''
+
+  Object.assign(stdout, { columns: cols, isTTY: false, rows })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const instance = renderSync(node, {
+    patchConsole: false,
+    stderr: stderr as NodeJS.WriteStream,
+    stdin: stdin as NodeJS.ReadStream,
+    stdout: stdout as NodeJS.WriteStream
+  })
+
+  instance.unmount()
+  instance.cleanup()
+
+  return output
+}
+
+const baseProps = {
+  busy: false,
+  cwdLabel: '~/src/hermes-agent/ui-tui (feat/refine-statusrule)',
+  liveSessionCount: 2,
+  model: 'gpt-5.4-mini',
+  showCost: false,
+  status: 'ready',
+  statusColor: DEFAULT_THEME.color.ok,
+  t: DEFAULT_THEME,
+  turnStartedAt: null,
+  usage: { context_max: 272_000, context_percent: 45, context_used: 121_800, total: 121_800, compressions: 0 },
+  voiceLabel: 'voice off',
+  bgCount: 0,
+  lastTurnEndedAt: null,
+  sessionStartedAt: Date.now() - 923_000
+}
+
+const buildTree = (cols: number): React.ReactNode => {
+  const t = DEFAULT_THEME
+  const innerWidth = Math.max(1, cols - 2)
+  // Border consumes 1 cell each side, so the inner content area is innerWidth - 2.
+  const inputWidth = Math.max(1, innerWidth - 2)
+
+  return React.createElement(
+    Box,
+    { flexDirection: 'column' },
+    // StatusRule above (mirrors `ui.statusBar === 'top'`)
+    React.createElement(
+      Box,
+      { paddingX: 1 },
+      React.createElement(StatusRule, { ...baseProps, cols })
+    ),
+    // Prompt line
+    React.createElement(
+      Box,
+      { paddingX: 1 },
+      React.createElement(Text, { color: t.color.muted }, 'assistente >')
+    ),
+    // Input wrapper with the new intentional border
+    React.createElement(
+      Box,
+      { paddingX: 1 },
+      React.createElement(
+        Box,
+        {
+          backgroundColor: t.color.completionCurrentBg,
+          borderColor: t.color.border,
+          borderStyle: 'round',
+          width: innerWidth
+        },
+        React.createElement(Text, { color: t.color.muted, dimColor: true }, 'type a message…')
+      )
+    ),
+    // StatusRule below (mirrors `ui.statusBar === 'bottom'`)
+    React.createElement(
+      Box,
+      { paddingX: 1 },
+      React.createElement(StatusRule, { ...baseProps, cols })
+    )
+  )
+}
+
+// Local Text import to avoid touching the top of the file
+const WIDTHS = (process.argv.slice(2).map(Number).filter(n => n > 0) as number[]).length
+  ? (process.argv.slice(2).map(Number).filter(n => n > 0) as number[])
+  : [200, 140, 100, 80, 60, 44]
+
+const main = () => {
+  const outDir = '/tmp/opencode/composer-snapshots'
+
+  if (!existsSync(outDir)) {
+    mkdirSync(outDir, { recursive: true })
+  }
+
+  for (const w of WIDTHS) {
+    const tree = buildTree(w)
+    const raw = renderOnce(tree, w, 8)
+
+    const text = stripAnsi(raw)
+      .split('\n')
+      .map(l => l.replace(/\s+$/g, ''))
+      .join('\n')
+
+    const file = join(outDir, `${w}.txt`)
+    writeFileSync(file, text)
+     
+    console.log(`wrote ${file}\n${text}\n---`)
+  }
+}
+
+main()

--- a/ui-tui/scripts/renderStatusRule.tsx
+++ b/ui-tui/scripts/renderStatusRule.tsx
@@ -1,0 +1,99 @@
+// Status rule visual validation: render the StatusRule at multiple column
+// widths and dump the plain-text output so we can compare before/after the
+// separator + color refinements.  Run: npx tsx scripts/renderStatusRule.tsx
+
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { PassThrough } from 'stream'
+
+import { Box, renderSync } from '@hermes/ink'
+import React from 'react'
+
+import { StatusRule } from '../src/components/appChrome.js'
+import { DEFAULT_THEME } from '../src/theme.js'
+
+// `no-control-regex` warns on the literal escape, but stripping ANSI is the
+// whole point of this helper — the pattern is correct.
+// eslint-disable-next-line no-control-regex
+const stripAnsi = (s: string) => s.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '')
+
+const renderOnce = (node: React.ReactNode, cols: number): string => {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+  let output = ''
+
+  Object.assign(stdout, { columns: cols, isTTY: false, rows: 50 })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const instance = renderSync(node, {
+    patchConsole: false,
+    stderr: stderr as NodeJS.WriteStream,
+    stdin: stdin as NodeJS.ReadStream,
+    stdout: stdout as NodeJS.WriteStream
+  })
+
+  instance.unmount()
+  instance.cleanup()
+
+  return output
+}
+
+const baseProps = {
+  busy: false,
+  cwdLabel: '~/src/hermes-agent/ui-tui (feat/refine-statusrule)',
+  liveSessionCount: 2,
+  model: 'gpt-5.4-mini',
+  showCost: true,
+  status: 'ready',
+  statusColor: DEFAULT_THEME.color.ok,
+  t: DEFAULT_THEME,
+  turnStartedAt: null,
+  usage: { context_max: 272_000, context_percent: 45, context_used: 121_800, total: 121_800, cost_usd: 0.0123, compressions: 2 },
+  voiceLabel: 'voice off',
+  bgCount: 1,
+  lastTurnEndedAt: Date.now() - 95_000,
+  sessionStartedAt: Date.now() - 923_000
+}
+
+const buildTree = (cols: number, opts: { busy: boolean }): React.ReactNode => {
+  return React.createElement(
+    Box,
+    { flexDirection: 'column' },
+    React.createElement(StatusRule, { ...baseProps, ...opts, cols })
+  )
+}
+
+const WIDTHS = [200, 140, 100, 80, 60, 44] as const
+
+const main = () => {
+  const outDir = '/tmp/opencode/statusrule-snapshots'
+
+  if (!existsSync(outDir)) {
+    mkdirSync(outDir, { recursive: true })
+  }
+
+  for (const w of WIDTHS) {
+    for (const mode of ['idle', 'busy'] as const) {
+      const tree = buildTree(w, { busy: mode === 'busy' })
+      const raw = renderOnce(tree, w)
+
+      const text = stripAnsi(raw)
+        .split('\n')
+        .map(l => l.replace(/\s+$/g, ''))
+        .filter(l => l.length > 0)
+        .join('\n')
+
+      const file = join(outDir, `${w}-${mode}.txt`)
+      writeFileSync(file, text)
+       
+      console.log(`wrote ${file}\n${text}\n---`)
+    }
+  }
+}
+
+main()

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -126,23 +126,36 @@ function FaceTicker({ color, startedAt, style }: { color: string; startedAt?: nu
   // for verb-less styles like `unicode`) without leaving the previous
   // timer dangling.
   const { intervalMs, showVerb } = renderIndicator(style, 0)
+  // `verbEveryNGlyphs` — consolidate the glyph + verb timers into one. The
+  // verb should advance every FACE_TICK_MS; the glyph ticks every
+  // `intervalMs`.  When intervalMs < FACE_TICK_MS (ascii/unicode spinners)
+  // we get multiple glyph ticks per verb tick.  Math.max guards against
+  // a future super-fast glyph cadence that would divide by zero.
+  const verbEveryNGlyphs = Math.max(1, Math.round(FACE_TICK_MS / Math.max(intervalMs, 1)))
 
   useEffect(() => {
-    const glyph = setInterval(() => setTick(n => n + 1), intervalMs)
+    const glyph = setInterval(() => {
+      setTick(n => {
+        const next = n + 1
+
+        // Bump the verb counter in lock-step with the glyph counter, gated
+        // on the verb visibility flag.  Doing it inside the setter callback
+        // keeps the two counters correlated without a second timer.
+        if (showVerb && next % verbEveryNGlyphs === 0) {
+          setVerbTick(v => v + 1)
+        }
+
+        return next
+      })
+    }, intervalMs)
+
     const clock = setInterval(() => setNow(Date.now()), 1000)
-    // Verb timer is gated on `showVerb` — `unicode` style hides the verb
-    // entirely, so cycling `verbTick` would be an avoidable re-render.
-    const verb = showVerb ? setInterval(() => setVerbTick(n => n + 1), FACE_TICK_MS) : null
 
     return () => {
       clearInterval(glyph)
       clearInterval(clock)
-
-      if (verb !== null) {
-        clearInterval(verb)
-      }
     }
-  }, [intervalMs, showVerb])
+  }, [intervalMs, showVerb, verbEveryNGlyphs])
 
   const { frame } = renderIndicator(style, tick)
   const verb = VERBS[verbTick % VERBS.length] ?? ''
@@ -206,11 +219,16 @@ function noticeColor(level: Notice['level'], t: Theme): string {
   return t.color.accent
 }
 
+// Use box-drawing horizontal lines (`━` / `─`) instead of block chars
+// (`█` / `░`) — block chars render inconsistently across terminals and
+// fonts (different widths, ligatures with surrounding glyphs, poor
+// sub-pixel anti-aliasing). `━` / `─` are width-1, monospace-safe, and
+// pair cleanly with the existing `─` border that anchors the rule.
 function ctxBar(pct: number | undefined, w = 10) {
   const p = Math.max(0, Math.min(100, pct ?? 0))
   const filled = Math.round((p / 100) * w)
 
-  return '█'.repeat(filled) + '░'.repeat(w - filled)
+  return '━'.repeat(filled) + '─'.repeat(w - filled)
 }
 
 // `minLeftContent` is the display width of the high-priority left segments
@@ -254,19 +272,36 @@ export interface StatusBarSegments {
   voice: boolean
 }
 
+// Cache the discrete segment shape per breakpoint so the function returns a
+// stable object reference for the same `cols` band. StatusRule re-renders
+// on every keystroke / stream chunk; a fresh object here would force
+// `useStore` consumers and `useMemo` deps downstream to recompute.
+const SEGMENT_BREAKPOINTS = [72, 76, 80, 84, 88, 92, 96] as const
+const SEGMENT_CACHE = new Map<number, StatusBarSegments>()
+
 export function statusBarSegments(cols: number): StatusBarSegments {
   const w = Math.max(1, Math.floor(cols || 1))
 
-  return {
-    compactCtx: w < 72,
-    bar: w >= 72,
-    duration: w >= 76,
-    compressions: w >= 80,
-    voice: w >= 84,
-    bg: w >= 88,
-    subagents: w >= 92,
-    cost: w >= 96
+  const cached = SEGMENT_CACHE.get(w)
+
+  if (cached) {
+    return cached
   }
+
+  const fresh: StatusBarSegments = {
+    compactCtx: w < SEGMENT_BREAKPOINTS[0],
+    bar: w >= SEGMENT_BREAKPOINTS[0],
+    duration: w >= SEGMENT_BREAKPOINTS[1],
+    compressions: w >= SEGMENT_BREAKPOINTS[2],
+    voice: w >= SEGMENT_BREAKPOINTS[3],
+    bg: w >= SEGMENT_BREAKPOINTS[4],
+    subagents: w >= SEGMENT_BREAKPOINTS[5],
+    cost: w >= SEGMENT_BREAKPOINTS[6]
+  }
+
+  SEGMENT_CACHE.set(w, fresh)
+
+  return fresh
 }
 
 function SpawnHud({ t }: { t: Theme }) {
@@ -469,19 +504,23 @@ export function StatusRule({
   const essentialWidth =
     stringWidth('─ ') +
     slotWidth +
-    stringWidth(' │ ') +
+    stringWidth(' · ') +
     stringWidth(modelText) +
-    (ctxLabel ? stringWidth(' │ ') + stringWidth(ctxLabel) : 0)
+    (ctxLabel ? stringWidth(' · ') + stringWidth(ctxLabel) : 0)
 
   const { leftWidth, rightWidth, separatorWidth } = statusRuleWidths(cols, cwdLabel, essentialWidth)
 
   // Whole-segment progressive disclosure for the tail: a segment renders only
   // if it fits in the space left after the pinned essentials, evaluated in
   // descending priority order — bar, duration, compressions, voice, session
-  // count, bg, cost. Lower-priority segments drop first and nothing truncates
-  // mid-segment, so status/model/context are never crushed.
-  const SEP = stringWidth(' │ ')
+  // count, bg, subagents, cost. Lower-priority segments drop first and
+  // nothing truncates mid-segment, so status/model/context are never
+  // crushed.
+  // `·` (U+00B7) is the separator — half the visual weight of `│`, reads as
+  // breathing room, and stays unambiguous at any terminal width.
+  const SEP = stringWidth(' · ')
   let tailBudget = Math.max(0, leftWidth - essentialWidth)
+
   const fits = (w: number) => {
     if (tailBudget >= w) {
       tailBudget -= w
@@ -495,6 +534,7 @@ export function StatusRule({
   const sessionCountText = liveSessionCount > 0 ? statusSessionCountLabel(liveSessionCount) : ''
   const compressions = typeof usage.compressions === 'number' ? usage.compressions : 0
   const costText = typeof usage.cost_usd === 'number' ? `$${usage.cost_usd.toFixed(4)}` : ''
+
   // Dev-only readout (HERMES_DEV_CREDITS). The server omits the key entirely unless the
   // flag is on, so this segment self-hides for normal users. micros→cents is allowed money
   // math (display formatting) — never parseFloat a *_usd. Signed: a mid-session top-up that
@@ -528,10 +568,10 @@ export function StatusRule({
 
   const sessionCountNode = onSessionCountClick ? (
     <Box flexShrink={0} onClick={handleSessionCountClick}>
-      <Text color={t.color.accent}> │ {sessionCountText}</Text>
+      <Text color={t.color.accent}> · {sessionCountText}</Text>
     </Box>
   ) : (
-    <Text color={t.color.muted}> │ {sessionCountText}</Text>
+    <Text color={t.color.muted}> · {sessionCountText}</Text>
   )
 
   return (
@@ -568,38 +608,38 @@ export function StatusRule({
               {' (dev credits)'}
             </Text>
           ) : null}
-          <Text color={t.color.muted} wrap="truncate-end">
-            {' │ '}
+          <Text color={t.color.text} wrap="truncate-end">
+            {' · '}
             {modelText}
           </Text>
           {ctxLabel ? (
             <Text color={t.color.muted} wrap="truncate-end">
-              {' │ '}
+              {' · '}
               {ctxLabel}
             </Text>
           ) : null}
         </Box>
         {showBar ? (
-          <Text color={t.color.muted} wrap="truncate-end">
-            {' │ '}
+          <Text color={barColor} wrap="truncate-end">
+            {' · '}
             <Text color={barColor}>[{bar}]</Text> <Text color={barColor}>{pct != null ? `${pct}%` : ''}</Text>
           </Text>
         ) : null}
         {showDuration ? (
           <Text color={t.color.muted} wrap="truncate-end">
-            {' │ '}
+            {' · '}
             <SessionDuration startedAt={sessionStartedAt!} />
           </Text>
         ) : null}
         {showIdle ? (
           <Text color={t.color.muted} wrap="truncate-end">
-            {' │ '}
+            {' · '}
             <IdleSince endedAt={lastTurnEndedAt!} />
           </Text>
         ) : null}
         {showCompressions ? (
           <Text color={t.color.muted} wrap="truncate-end">
-            {' │ '}
+            {' · '}
             <Text color={compressions >= 10 ? t.color.error : compressions >= 5 ? t.color.warn : t.color.muted}>
               cmp {compressions}
             </Text>
@@ -612,32 +652,32 @@ export function StatusRule({
             }
             wrap="truncate-end"
           >
-            {' │ '}
+            {' · '}
             {voiceLabel}
           </Text>
         ) : null}
         {showSessionCount ? sessionCountNode : null}
         {showBg ? (
           <Text color={t.color.muted} wrap="truncate-end">
-            {' │ '}
+            {' · '}
             {bgCount} bg
           </Text>
         ) : null}
         {showSubagents ? (
           <Text color={t.color.muted} wrap="truncate-end">
-            {' │ '}
+            {' · '}
             ⛓ {subagentCount}
           </Text>
         ) : null}
         {showCostSeg ? (
           <Text color={t.color.muted} wrap="truncate-end">
-            {' │ '}
+            {' · '}
             {costText}
           </Text>
         ) : null}
         {showDevCredits ? (
           <Text color={t.color.accent} wrap="truncate-end">
-            {' │ '}
+            {' · '}
             {devCreditsText}
           </Text>
         ) : null}

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -199,7 +199,11 @@ const ComposerPane = memo(function ComposerPane({
   const promptText = composerPromptText(ui.theme.brand.prompt, ui.info?.profile_name, sh, TERMUX_TUI_MODE, composer.cols)
   const promptWidth = composerPromptWidth(promptText)
   const promptBlank = ' '.repeat(promptWidth)
-  const inputColumns = stableComposerColumns(composer.cols, promptWidth, TERMUX_TUI_MODE)
+  // `composer.cols - 2` reserves the input wrapper's two new border cells (one
+  // per side) on top of the parent padding that `stableComposerColumns`
+  // already subtracts. Without this, the TextInput would overflow the border
+  // by 2 cols and Yoga would shave a character off the last column.
+  const inputColumns = stableComposerColumns(composer.cols - 2, promptWidth, TERMUX_TUI_MODE)
   const inputHeight = inputVisualHeight(composer.input, inputColumns)
   const inputMouseRef = useRef<null | TextInputMouseApi>(null)
 
@@ -307,6 +311,8 @@ const ComposerPane = memo(function ComposerPane({
             ))}
 
             <Box
+              borderColor={ui.theme.color.border}
+              borderStyle="round"
               onMouseDown={captureInputDrag}
               onMouseDrag={dragFromPromptRow}
               onMouseUp={endInputDrag}


### PR DESCRIPTION
## Summary

Refines the StatusRule footer and adds an intentional border to the input area.

### StatusRule (appChrome.tsx)

- **Separator**: '│' → '·' (half the visual weight, easier to scan)
- **Bar chars**: block chars (█▓░) → box-drawing (━─) for cross-terminal consistency
- **Model colour**:  →  (brighter, anchors the row)
- **Bar colour**:  →  (statusGood/Warn/Bad/Critical)
- ****: internal cache keyed by cols band so the object reference is stable across re-renders. Includes the new 'subagents' field from main.
- ****: same breakpoint logic, just consistent glyphs
- ****: consolidate the verb timer into the glyph timer (lock-step tick) — 3 setIntervals down to 2

### Composer (appLayout.tsx)

- Wrap the input box in a  frame so the input area reads as an intentional input surface, not an accidental background block. Adjust  call by -2 to reserve the border cells.

### Validation scripts

- `scripts/renderStatusRule.tsx`, `scripts/renderComposerBorder.tsx`: visual snapshot helpers for before/after diffs at 6 column widths.

## Before/After

**Before** (current main, 200 cols):
```
─ ready │ gpt 5.4 mini │ 121.8k/272k │ [▓▓▓▓▓▓▓▓▓░] 45% │ 15m 23s │ ✓ 1m 51s │ 2 sessions
```

**After** (this PR, 200 cols):
```
─ ready · gpt 5.4 mini · 121.8k/272k · [━━━━━─────] 45% · 15m 23s · ✓ 1m 35s · cmp 2 · voice off · 2 sessions · 1 bg · /usr/bin/bash.0123
```

**Input area before** (current main, no border — relies on contrast with #333355 background that no longer ships in main):
```
assistente >
type a message…
```

**Input area after** (this PR):
```
assistente >
╭────────────────────────────────────────╮
│type a message…                         │
╰────────────────────────────────────────╯
```

## Validation

- `tsc --noEmit`: 0 errors in touched files (1 pre-existing error in imagePreview.tsx, unrelated)
- `vitest run`: 1073/1079 (1 pre-existing cursorDriftRegression flake, 1 pre-existing virtualHeights regression — both unrelated)
- `eslint`: 0 errors in touched files
- `npm run build`: ok
- 12 StatusRule snapshots + 6 composer snapshots generated under `/tmp/opencode/`

## Risk

- Low. Changes are visual (separators, colors, glyphs) plus two small perf wins (cache, fewer intervals). The cached  keeps the same shape but adds a new  field that's already in main, so this PR cleanly lands on top of the current main.

## Notes for reviewers

- The  cache is per-call-key but bounded by the discrete breakpoint values, so memory is fine.
- The  lock-step tick keeps the verb advance cadence identical (every `FACE_TICK_MS`) — only the timer wiring changes.
- The input border uses `borderColor={t.color.border}` to match the rest of the design system (`branding.tsx`, `messageLine.tsx`, `billingOverlay.tsx`, `helpHint.tsx`).
