### PR TITLE
fix(agent): fall back to max_context_length in LM Studio probe

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1351,6 +1351,11 @@ def _query_local_context_length(model: str, base_url: str, api_key: str = "") ->
                                 ctx = cfg.get("context_length")
                                 if ctx and isinstance(ctx, (int, float)):
                                     return int(ctx)
+                            # Fall back to model-level max_context_length
+                            # when no instances are loaded (model unloaded).
+                            ctx = m.get("max_context_length")
+                            if ctx and isinstance(ctx, (int, float)):
+                                return int(ctx)
                             break
 
             # LM Studio / vLLM / llama.cpp: try /v1/models/{model}


### PR DESCRIPTION
## Summary

The LM Studio context-window probe in `model_metadata.py` checks `loaded_instances` for `context_length`, but when no instances are loaded (model is unloaded), it `break`s out of the loop without checking the model-level `max_context_length` field that LM Studio also provides in its `/api/v1/models` response.

This causes the probe to return `None` for unloaded models, falling back to the default context size instead of using the model's actual context window.

## Changes

- Added fallback to `m.get("max_context_length")` after the `loaded_instances` loop in the LM Studio probe section of `_probe_context_length()`.

## Why this matters

When a user configures LM Studio with a model that has a large context window (e.g. 128K), but the model isn't currently loaded, Hermes falls back to the default context size (often much smaller). This causes unnecessary context compression and degraded performance. The model's `max_context_length` is always available in the API response regardless of load state.

Fixes #47698
