### PR TITLE
fix(desktop): interrupt running turn when user sends a message while busy

### DIFF
--- a/apps/desktop/src/app/chat/composer/enter-submit-dom-race.test.tsx
+++ b/apps/desktop/src/app/chat/composer/enter-submit-dom-race.test.tsx
@@ -73,6 +73,7 @@ function Harness({
     if (busy) {
       if (payloadPresent) {
         onQueue(text)
+        onCancel()
       } else {
         onCancel()
       }
@@ -142,7 +143,7 @@ describe('composer Enter submit — live DOM vs stale composer state (#39630)', 
     expect(onSubmit).toHaveBeenCalledWith('hello world')
   })
 
-  it('queues a fast-typed message while busy instead of draining the queue or cancelling', async () => {
+  it('queues a fast-typed message while busy and interrupts the running turn', async () => {
     const onQueue = vi.fn()
     const onDrain = vi.fn()
     const onCancel = vi.fn()
@@ -158,7 +159,7 @@ describe('composer Enter submit — live DOM vs stale composer state (#39630)', 
 
     expect(onQueue).toHaveBeenCalledWith('urgent follow-up')
     expect(onDrain).not.toHaveBeenCalled()
-    expect(onCancel).not.toHaveBeenCalled()
+    expect(onCancel).toHaveBeenCalledTimes(1)
   })
 
   it('treats an empty Enter while busy as a no-op (never an accidental Stop)', async () => {

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -1144,8 +1144,8 @@ export function ChatBar({
         return
       }
 
-      // Empty Enter while busy is a no-op — interrupting is explicit (Stop/Esc),
-      // never a stray Enter after sending. With a payload, submitDraft queues it.
+      // Empty Enter while busy is a no-op — interrupting requires a payload
+      // or Esc/Stop. With a payload, submitDraft queues it and interrupts.
       // Gate on the live DOM payload (not the render-lagged composer state) so a
       // message typed fast / via IME while busy still reaches submitDraft() and
       // gets queued instead of being mistaken for an empty Enter.
@@ -1721,7 +1721,16 @@ export function ChatBar({
         clearDraft()
         dispatchSubmit(text)
       } else if (payloadPresent) {
+        // Queue the draft, then interrupt the running turn so the queued
+        // message drains immediately — instead of waiting for the current
+        // (potentially long) turn to finish while the user's correction
+        // sits ignored.  Mirrors sendQueuedNow's busy-path: queue → onCancel()
+        // → auto-drain on busy→false.  The CLI achieves the same via
+        // busy_input_mode: interrupt; the desktop app has no such knob, so
+        // we wire it directly here.
         queueCurrentDraft()
+        triggerHaptic('cancel')
+        void Promise.resolve(onCancel())
       } else {
         // Stop button (the only way to reach here while busy with an empty
         // composer — empty Enter is short-circuited in the keydown handler).


### PR DESCRIPTION
## Problem

When the agent is busy and the user types a correction + Enter, the desktop composer queues the message but never interrupts the running turn. The agent keeps going for minutes, ignoring the user's input. The queue counter grows ("4 queued", "5 queued"...) and only ONE message drains after the turn finally ends — leaving the rest stranded and often sending the agent off on a tangent based on a single out-of-context message.

The CLI has `busy_input_mode: interrupt` (the default) which fires `agent.interrupt()` on Enter. The desktop app had no equivalent — it only queued.

## Fix

When the user presses Enter with a payload while busy, the composer now **both queues the message AND fires `onCancel()`** to interrupt the running turn. This mirrors:
- The CLI's `busy_input_mode: interrupt` behaviour
- The existing `sendQueuedNow` busy-path (line ~1568): promote to head → `onCancel()` → auto-drain on busy→false

The auto-drain mechanism (`shouldAutoDrain` in `composer-queue.ts`) then sends the queued message as soon as the agent reports `busy: false`.

## Changes

- `apps/desktop/src/app/chat/composer/index.tsx`: In `submitDraft()`, the `busy && payloadPresent` branch now calls `queueCurrentDraft()` + `onCancel()` instead of just `queueCurrentDraft()`
- `apps/desktop/src/app/chat/composer/enter-submit-dom-race.test.tsx`: Updated test harness and assertion to expect `onCancel` to be called when queueing while busy

## Related issue

Closes #51665

## Note

This PR addresses issue #1 from the issue (queue-not-interrupt). The WebSocket stall (#2) and reconnect queue recovery (#3) need separate investigation.