### PR TITLE
tui: TDAH-oriented UX improvements

### DIFF
--- a/ui-tui/scripts/renderComposerBorder.tsx
+++ b/ui-tui/scripts/renderComposerBorder.tsx
@@ -1,0 +1,142 @@
+// Composer + StatusRule visual validation: render the input wrapper with the
+// new intentional `borderStyle="round"` so we can confirm the "empty box"
+// effect becomes a real, visible frame.
+//
+// We can't render the full App (it needs a real GatewayClient), so we
+// approximate the composer pane: StatusRule above the prompt + input
+// wrapper, matching the AppLayout's flex column order.
+//
+// Run: npx tsx scripts/renderComposerBorder.tsx
+
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { PassThrough } from 'stream'
+
+import { Box, renderSync, Text } from '@hermes/ink'
+import React from 'react'
+
+import { StatusRule } from '../src/components/appChrome.js'
+import { DEFAULT_THEME } from '../src/theme.js'
+
+// `no-control-regex` warns on the literal escape, but stripping ANSI is the
+// whole point of this helper — the pattern is correct.
+// eslint-disable-next-line no-control-regex
+const stripAnsi = (s: string) => s.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '')
+
+const renderOnce = (node: React.ReactNode, cols: number, rows = 50): string => {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+  let output = ''
+
+  Object.assign(stdout, { columns: cols, isTTY: false, rows })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const instance = renderSync(node, {
+    patchConsole: false,
+    stderr: stderr as NodeJS.WriteStream,
+    stdin: stdin as NodeJS.ReadStream,
+    stdout: stdout as NodeJS.WriteStream
+  })
+
+  instance.unmount()
+  instance.cleanup()
+
+  return output
+}
+
+const baseProps = {
+  busy: false,
+  cwdLabel: '~/src/hermes-agent/ui-tui (feat/refine-statusrule)',
+  liveSessionCount: 2,
+  model: 'gpt-5.4-mini',
+  showCost: false,
+  status: 'ready',
+  statusColor: DEFAULT_THEME.color.ok,
+  t: DEFAULT_THEME,
+  turnStartedAt: null,
+  usage: { context_max: 272_000, context_percent: 45, context_used: 121_800, total: 121_800, compressions: 0 },
+  voiceLabel: 'voice off',
+  bgCount: 0,
+  lastTurnEndedAt: null,
+  sessionStartedAt: Date.now() - 923_000
+}
+
+const buildTree = (cols: number): React.ReactNode => {
+  const t = DEFAULT_THEME
+  const innerWidth = Math.max(1, cols - 2)
+  // Border consumes 1 cell each side, so the inner content area is innerWidth - 2.
+  const inputWidth = Math.max(1, innerWidth - 2)
+
+  return React.createElement(
+    Box,
+    { flexDirection: 'column' },
+    // StatusRule above (mirrors `ui.statusBar === 'top'`)
+    React.createElement(
+      Box,
+      { paddingX: 1 },
+      React.createElement(StatusRule, { ...baseProps, cols })
+    ),
+    // Prompt line
+    React.createElement(
+      Box,
+      { paddingX: 1 },
+      React.createElement(Text, { color: t.color.muted }, 'assistente >')
+    ),
+    // Input wrapper with the new intentional border
+    React.createElement(
+      Box,
+      { paddingX: 1 },
+      React.createElement(
+        Box,
+        {
+          backgroundColor: t.color.completionCurrentBg,
+          borderColor: t.color.border,
+          borderStyle: 'round',
+          width: innerWidth
+        },
+        React.createElement(Text, { color: t.color.muted, dimColor: true }, 'type a message…')
+      )
+    ),
+    // StatusRule below (mirrors `ui.statusBar === 'bottom'`)
+    React.createElement(
+      Box,
+      { paddingX: 1 },
+      React.createElement(StatusRule, { ...baseProps, cols })
+    )
+  )
+}
+
+// Local Text import to avoid touching the top of the file
+const WIDTHS = (process.argv.slice(2).map(Number).filter(n => n > 0) as number[]).length
+  ? (process.argv.slice(2).map(Number).filter(n => n > 0) as number[])
+  : [200, 140, 100, 80, 60, 44]
+
+const main = () => {
+  const outDir = '/tmp/opencode/composer-snapshots'
+
+  if (!existsSync(outDir)) {
+    mkdirSync(outDir, { recursive: true })
+  }
+
+  for (const w of WIDTHS) {
+    const tree = buildTree(w)
+    const raw = renderOnce(tree, w, 8)
+
+    const text = stripAnsi(raw)
+      .split('\n')
+      .map(l => l.replace(/\s+$/g, ''))
+      .join('\n')
+
+    const file = join(outDir, `${w}.txt`)
+    writeFileSync(file, text)
+     
+    console.log(`wrote ${file}\n${text}\n---`)
+  }
+}
+
+main()

--- a/ui-tui/scripts/renderStatusRule.tsx
+++ b/ui-tui/scripts/renderStatusRule.tsx
@@ -1,0 +1,99 @@
+// Status rule visual validation: render the StatusRule at multiple column
+// widths and dump the plain-text output so we can compare before/after the
+// separator + color refinements.  Run: npx tsx scripts/renderStatusRule.tsx
+
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { PassThrough } from 'stream'
+
+import { Box, renderSync } from '@hermes/ink'
+import React from 'react'
+
+import { StatusRule } from '../src/components/appChrome.js'
+import { DEFAULT_THEME } from '../src/theme.js'
+
+// `no-control-regex` warns on the literal escape, but stripping ANSI is the
+// whole point of this helper — the pattern is correct.
+// eslint-disable-next-line no-control-regex
+const stripAnsi = (s: string) => s.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '')
+
+const renderOnce = (node: React.ReactNode, cols: number): string => {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+  let output = ''
+
+  Object.assign(stdout, { columns: cols, isTTY: false, rows: 50 })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const instance = renderSync(node, {
+    patchConsole: false,
+    stderr: stderr as NodeJS.WriteStream,
+    stdin: stdin as NodeJS.ReadStream,
+    stdout: stdout as NodeJS.WriteStream
+  })
+
+  instance.unmount()
+  instance.cleanup()
+
+  return output
+}
+
+const baseProps = {
+  busy: false,
+  cwdLabel: '~/src/hermes-agent/ui-tui (feat/refine-statusrule)',
+  liveSessionCount: 2,
+  model: 'gpt-5.4-mini',
+  showCost: true,
+  status: 'ready',
+  statusColor: DEFAULT_THEME.color.ok,
+  t: DEFAULT_THEME,
+  turnStartedAt: null,
+  usage: { context_max: 272_000, context_percent: 45, context_used: 121_800, total: 121_800, cost_usd: 0.0123, compressions: 2 },
+  voiceLabel: 'voice off',
+  bgCount: 1,
+  lastTurnEndedAt: Date.now() - 95_000,
+  sessionStartedAt: Date.now() - 923_000
+}
+
+const buildTree = (cols: number, opts: { busy: boolean }): React.ReactNode => {
+  return React.createElement(
+    Box,
+    { flexDirection: 'column' },
+    React.createElement(StatusRule, { ...baseProps, ...opts, cols })
+  )
+}
+
+const WIDTHS = [200, 140, 100, 80, 60, 44] as const
+
+const main = () => {
+  const outDir = '/tmp/opencode/statusrule-snapshots'
+
+  if (!existsSync(outDir)) {
+    mkdirSync(outDir, { recursive: true })
+  }
+
+  for (const w of WIDTHS) {
+    for (const mode of ['idle', 'busy'] as const) {
+      const tree = buildTree(w, { busy: mode === 'busy' })
+      const raw = renderOnce(tree, w)
+
+      const text = stripAnsi(raw)
+        .split('\n')
+        .map(l => l.replace(/\s+$/g, ''))
+        .filter(l => l.length > 0)
+        .join('\n')
+
+      const file = join(outDir, `${w}-${mode}.txt`)
+      writeFileSync(file, text)
+       
+      console.log(`wrote ${file}\n${text}\n---`)
+    }
+  }
+}
+
+main()

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -134,6 +134,7 @@ export interface OverlayState {
   billing: BillingOverlayState | null
   clarify: ClarifyReq | null
   confirm: ConfirmReq | null
+  help: boolean
   modelPicker: boolean
   pager: null | PagerState
   petPicker: boolean

--- a/ui-tui/src/app/overlayStore.ts
+++ b/ui-tui/src/app/overlayStore.ts
@@ -9,6 +9,7 @@ const buildOverlayState = (): OverlayState => ({
   billing: null,
   clarify: null,
   confirm: null,
+  help: false,
   modelPicker: false,
   pager: null,
   petPicker: false,
@@ -23,13 +24,14 @@ export const $overlayState = atom<OverlayState>(buildOverlayState())
 
 export const $isBlocked = computed(
   $overlayState,
-  ({ agents, approval, billing, clarify, confirm, modelPicker, pager, petPicker, pluginsHub, secret, sessions, skillsHub, sudo }) =>
+  ({ agents, approval, billing, clarify, confirm, help, modelPicker, pager, petPicker, pluginsHub, secret, sessions, skillsHub, sudo }) =>
     Boolean(
       agents ||
         approval ||
         billing ||
         clarify ||
         confirm ||
+        help ||
         modelPicker ||
         pager ||
         petPicker ||

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -546,6 +546,25 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       })
     }
 
+    // F1 / Ctrl+/ — toggle the help overlay. Always available, never
+    // requires the user to type ? in the input. Critical for TDAH: the
+    // discoverability win dwarfs the cost of one extra keybind.
+    if (
+      (ch === '?' && key.ctrl) ||
+      (key.f1 ?? false) ||
+      ch === '\x1bOP' ||
+      ch === '\x1b[11~'
+    ) {
+      return patchOverlayState(prev => ({ ...prev, help: !prev.help }))
+    }
+
+    // Alt+M — open the model picker (a focused keyboard-driven alternative
+    // to /model slash command). Pairs with F1/Ctrl+/ as the second half of
+    // the "TDAH discoverability pair": help for *what*, model for *which*.
+    if (key.meta && (ch === 'm' || ch === 'M')) {
+      return patchOverlayState({ modelPicker: true })
+    }
+
     if (isAction(key, ch, 'l')) {
       clearSelection()
       forceRedraw(terminal.stdout ?? process.stdout)

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -126,23 +126,36 @@ function FaceTicker({ color, startedAt, style }: { color: string; startedAt?: nu
   // for verb-less styles like `unicode`) without leaving the previous
   // timer dangling.
   const { intervalMs, showVerb } = renderIndicator(style, 0)
+  // `verbEveryNGlyphs` — consolidate the glyph + verb timers into one. The
+  // verb should advance every FACE_TICK_MS; the glyph ticks every
+  // `intervalMs`.  When intervalMs < FACE_TICK_MS (ascii/unicode spinners)
+  // we get multiple glyph ticks per verb tick.  Math.max guards against
+  // a future super-fast glyph cadence that would divide by zero.
+  const verbEveryNGlyphs = Math.max(1, Math.round(FACE_TICK_MS / Math.max(intervalMs, 1)))
 
   useEffect(() => {
-    const glyph = setInterval(() => setTick(n => n + 1), intervalMs)
+    const glyph = setInterval(() => {
+      setTick(n => {
+        const next = n + 1
+
+        // Bump the verb counter in lock-step with the glyph counter, gated
+        // on the verb visibility flag.  Doing it inside the setter callback
+        // keeps the two counters correlated without a second timer.
+        if (showVerb && next % verbEveryNGlyphs === 0) {
+          setVerbTick(v => v + 1)
+        }
+
+        return next
+      })
+    }, intervalMs)
+
     const clock = setInterval(() => setNow(Date.now()), 1000)
-    // Verb timer is gated on `showVerb` — `unicode` style hides the verb
-    // entirely, so cycling `verbTick` would be an avoidable re-render.
-    const verb = showVerb ? setInterval(() => setVerbTick(n => n + 1), FACE_TICK_MS) : null
 
     return () => {
       clearInterval(glyph)
       clearInterval(clock)
-
-      if (verb !== null) {
-        clearInterval(verb)
-      }
     }
-  }, [intervalMs, showVerb])
+  }, [intervalMs, showVerb, verbEveryNGlyphs])
 
   const { frame } = renderIndicator(style, tick)
   const verb = VERBS[verbTick % VERBS.length] ?? ''
@@ -206,11 +219,16 @@ function noticeColor(level: Notice['level'], t: Theme): string {
   return t.color.accent
 }
 
+// Use box-drawing horizontal lines (`━` / `─`) instead of block chars
+// (`█` / `░`) — block chars render inconsistently across terminals and
+// fonts (different widths, ligatures with surrounding glyphs, poor
+// sub-pixel anti-aliasing). `━` / `─` are width-1, monospace-safe, and
+// pair cleanly with the existing `─` border that anchors the rule.
 function ctxBar(pct: number | undefined, w = 10) {
   const p = Math.max(0, Math.min(100, pct ?? 0))
   const filled = Math.round((p / 100) * w)
 
-  return '█'.repeat(filled) + '░'.repeat(w - filled)
+  return '━'.repeat(filled) + '─'.repeat(w - filled)
 }
 
 // `minLeftContent` is the display width of the high-priority left segments
@@ -254,19 +272,36 @@ export interface StatusBarSegments {
   voice: boolean
 }
 
+// Cache the discrete segment shape per breakpoint so the function returns a
+// stable object reference for the same `cols` band. StatusRule re-renders
+// on every keystroke / stream chunk; a fresh object here would force
+// `useStore` consumers and `useMemo` deps downstream to recompute.
+const SEGMENT_BREAKPOINTS = [72, 76, 80, 84, 88, 92, 96] as const
+const SEGMENT_CACHE = new Map<number, StatusBarSegments>()
+
 export function statusBarSegments(cols: number): StatusBarSegments {
   const w = Math.max(1, Math.floor(cols || 1))
 
-  return {
-    compactCtx: w < 72,
-    bar: w >= 72,
-    duration: w >= 76,
-    compressions: w >= 80,
-    voice: w >= 84,
-    bg: w >= 88,
-    subagents: w >= 92,
-    cost: w >= 96
+  const cached = SEGMENT_CACHE.get(w)
+
+  if (cached) {
+    return cached
   }
+
+  const fresh: StatusBarSegments = {
+    compactCtx: w < SEGMENT_BREAKPOINTS[0],
+    bar: w >= SEGMENT_BREAKPOINTS[0],
+    duration: w >= SEGMENT_BREAKPOINTS[1],
+    compressions: w >= SEGMENT_BREAKPOINTS[2],
+    voice: w >= SEGMENT_BREAKPOINTS[3],
+    bg: w >= SEGMENT_BREAKPOINTS[4],
+    subagents: w >= SEGMENT_BREAKPOINTS[5],
+    cost: w >= SEGMENT_BREAKPOINTS[6]
+  }
+
+  SEGMENT_CACHE.set(w, fresh)
+
+  return fresh
 }
 
 function SpawnHud({ t }: { t: Theme }) {
@@ -469,19 +504,23 @@ export function StatusRule({
   const essentialWidth =
     stringWidth('─ ') +
     slotWidth +
-    stringWidth(' │ ') +
+    stringWidth(' · ') +
     stringWidth(modelText) +
-    (ctxLabel ? stringWidth(' │ ') + stringWidth(ctxLabel) : 0)
+    (ctxLabel ? stringWidth(' · ') + stringWidth(ctxLabel) : 0)
 
   const { leftWidth, rightWidth, separatorWidth } = statusRuleWidths(cols, cwdLabel, essentialWidth)
 
   // Whole-segment progressive disclosure for the tail: a segment renders only
   // if it fits in the space left after the pinned essentials, evaluated in
   // descending priority order — bar, duration, compressions, voice, session
-  // count, bg, cost. Lower-priority segments drop first and nothing truncates
-  // mid-segment, so status/model/context are never crushed.
-  const SEP = stringWidth(' │ ')
+  // count, bg, subagents, cost. Lower-priority segments drop first and
+  // nothing truncates mid-segment, so status/model/context are never
+  // crushed.
+  // `·` (U+00B7) is the separator — half the visual weight of `│`, reads as
+  // breathing room, and stays unambiguous at any terminal width.
+  const SEP = stringWidth(' · ')
   let tailBudget = Math.max(0, leftWidth - essentialWidth)
+
   const fits = (w: number) => {
     if (tailBudget >= w) {
       tailBudget -= w
@@ -495,6 +534,7 @@ export function StatusRule({
   const sessionCountText = liveSessionCount > 0 ? statusSessionCountLabel(liveSessionCount) : ''
   const compressions = typeof usage.compressions === 'number' ? usage.compressions : 0
   const costText = typeof usage.cost_usd === 'number' ? `$${usage.cost_usd.toFixed(4)}` : ''
+
   // Dev-only readout (HERMES_DEV_CREDITS). The server omits the key entirely unless the
   // flag is on, so this segment self-hides for normal users. micros→cents is allowed money
   // math (display formatting) — never parseFloat a *_usd. Signed: a mid-session top-up that
@@ -528,10 +568,10 @@ export function StatusRule({
 
   const sessionCountNode = onSessionCountClick ? (
     <Box flexShrink={0} onClick={handleSessionCountClick}>
-      <Text color={t.color.accent}> │ {sessionCountText}</Text>
+      <Text color={t.color.accent}> · {sessionCountText}</Text>
     </Box>
   ) : (
-    <Text color={t.color.muted}> │ {sessionCountText}</Text>
+    <Text color={t.color.muted}> · {sessionCountText}</Text>
   )
 
   return (
@@ -568,38 +608,38 @@ export function StatusRule({
               {' (dev credits)'}
             </Text>
           ) : null}
-          <Text color={t.color.muted} wrap="truncate-end">
-            {' │ '}
+          <Text color={t.color.text} wrap="truncate-end">
+            {' · '}
             {modelText}
           </Text>
           {ctxLabel ? (
             <Text color={t.color.muted} wrap="truncate-end">
-              {' │ '}
+              {' · '}
               {ctxLabel}
             </Text>
           ) : null}
         </Box>
         {showBar ? (
-          <Text color={t.color.muted} wrap="truncate-end">
-            {' │ '}
+          <Text color={barColor} wrap="truncate-end">
+            {' · '}
             <Text color={barColor}>[{bar}]</Text> <Text color={barColor}>{pct != null ? `${pct}%` : ''}</Text>
           </Text>
         ) : null}
         {showDuration ? (
           <Text color={t.color.muted} wrap="truncate-end">
-            {' │ '}
+            {' · '}
             <SessionDuration startedAt={sessionStartedAt!} />
           </Text>
         ) : null}
         {showIdle ? (
           <Text color={t.color.muted} wrap="truncate-end">
-            {' │ '}
+            {' · '}
             <IdleSince endedAt={lastTurnEndedAt!} />
           </Text>
         ) : null}
         {showCompressions ? (
           <Text color={t.color.muted} wrap="truncate-end">
-            {' │ '}
+            {' · '}
             <Text color={compressions >= 10 ? t.color.error : compressions >= 5 ? t.color.warn : t.color.muted}>
               cmp {compressions}
             </Text>
@@ -612,32 +652,32 @@ export function StatusRule({
             }
             wrap="truncate-end"
           >
-            {' │ '}
+            {' · '}
             {voiceLabel}
           </Text>
         ) : null}
         {showSessionCount ? sessionCountNode : null}
         {showBg ? (
           <Text color={t.color.muted} wrap="truncate-end">
-            {' │ '}
+            {' · '}
             {bgCount} bg
           </Text>
         ) : null}
         {showSubagents ? (
           <Text color={t.color.muted} wrap="truncate-end">
-            {' │ '}
+            {' · '}
             ⛓ {subagentCount}
           </Text>
         ) : null}
         {showCostSeg ? (
           <Text color={t.color.muted} wrap="truncate-end">
-            {' │ '}
+            {' · '}
             {costText}
           </Text>
         ) : null}
         {showDevCredits ? (
           <Text color={t.color.accent} wrap="truncate-end">
-            {' │ '}
+            {' · '}
             {devCreditsText}
           </Text>
         ) : null}

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -799,6 +799,64 @@ export function TranscriptScrollbar({ scrollRef, t }: TranscriptScrollbarProps) 
   )
 }
 
+// `ScrollbackHint` — small affordance that appears when the user has
+// scrolled the transcript away from the live edge.  Clicks (or any pointer
+// activation) snap the viewport back to the bottom.  Critical for TDAH
+// users: without it, scrolling up to re-read an earlier message leaves
+// the user unsure whether new replies arrived while they were away.
+//
+// Hidden when sticky or when there's no content below the current
+// viewport (both mean the user is already at the live edge).
+export function ScrollbackHint({ scrollRef, t, onHoverChange }: ScrollbackHintProps) {
+  const { atBottom, scrollHeight, viewportHeight, top } = useViewportSnapshot(scrollRef)
+  const [hover, setHover] = useState(false)
+
+  // Pixels between the current viewport bottom and the live edge.
+  // Positive when the user has scrolled up away from the latest content.
+  const distance = scrollHeight - top - viewportHeight
+
+  if (atBottom || distance <= 0) {
+    return null
+  }
+
+  const jump = () => {
+    const s = scrollRef.current
+
+    if (s) {
+      s.scrollTo(scrollHeight)
+    }
+  }
+
+  const handleHover = (next: boolean) => {
+    setHover(next)
+    onHoverChange?.(next)
+  }
+
+  return (
+    <Box
+      alignSelf="flex-end"
+      backgroundColor={hover ? t.color.completionCurrentBg : undefined}
+      borderColor={t.color.accent}
+      borderStyle="round"
+      marginRight={1}
+      onClick={jump}
+      onMouseEnter={() => handleHover(true)}
+      onMouseLeave={() => handleHover(false)}
+      paddingX={1}
+    >
+      <Text bold={hover} color={t.color.accent}>
+        ↓ newer messages
+      </Text>
+    </Box>
+  )
+}
+
+interface ScrollbackHintProps {
+  scrollRef: RefObject<ScrollBoxHandle | null>
+  t: Theme
+  onHoverChange?: (hover: boolean) => void
+}
+
 interface StatusRuleProps {
   bgCount: number
   lastTurnEndedAt?: null | number

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -20,11 +20,11 @@ import { PerfPane } from '../lib/perfPane.js'
 import { composerPromptText } from '../lib/prompt.js'
 
 import { AgentsOverlay } from './agentsOverlay.js'
-import { GoodVibesHeart, StatusRule, StickyPromptTracker, TranscriptScrollbar } from './appChrome.js'
+import { GoodVibesHeart, ScrollbackHint, StatusRule, StickyPromptTracker, TranscriptScrollbar } from './appChrome.js'
 import { FloatingOverlays, PromptZone } from './appOverlays.js'
 import { Banner, Panel, SessionPanel } from './branding.js'
 import { FpsOverlay } from './fpsOverlay.js'
-import { HelpHint } from './helpHint.js'
+import { HelpHint, HelpOverlay } from './helpHint.js'
 import { MessageLine } from './messageLine.js'
 import { PetKitty, PetSprite } from './petSprite.js'
 import { QueuedMessages } from './queuedMessages.js'
@@ -174,8 +174,9 @@ const TranscriptPane = memo(function TranscriptPane({
         </Box>
       </ScrollBox>
 
-      <NoSelect flexShrink={0} marginLeft={1}>
+      <NoSelect flexDirection="column" flexShrink={0} marginLeft={1}>
         <TranscriptScrollbar scrollRef={transcript.scrollRef} t={ui.theme} />
+        <ScrollbackHint scrollRef={transcript.scrollRef} t={ui.theme} />
       </NoSelect>
 
       <StickyPromptTracker
@@ -240,6 +241,14 @@ const ComposerPane = memo(function ComposerPane({
   }
 
   const endInputDrag = () => inputMouseRef.current?.end()
+
+  // When the agent is busy, the composer is technically editable (you can
+  // type into the queue) but you can't submit. Visual dim is the cheapest
+  // way to telegraph "you can type, but submission is blocked" without
+  // adding another status line. The dim only kicks in when there is NO
+  // input yet — once the user starts typing, the queue logic takes over
+  // and the dim disappears to signal "your text is captured".
+  const composerDimmed = ui.busy && composer.empty
 
   return (
     <NoSelect
@@ -311,7 +320,7 @@ const ComposerPane = memo(function ComposerPane({
             ))}
 
             <Box
-              borderColor={ui.theme.color.border}
+              borderColor={composerDimmed ? ui.theme.color.muted : ui.theme.color.border}
               borderStyle="round"
               onMouseDown={captureInputDrag}
               onMouseDrag={dragFromPromptRow}
@@ -469,6 +478,8 @@ export const AppLayout = memo(function AppLayout({
             )}
           </>
         )}
+
+        {overlay.help ? <HelpOverlay onClose={() => patchOverlayState({ help: false })} t={ui.theme} /> : null}
       </Box>
     </Shell>
   )

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -199,7 +199,11 @@ const ComposerPane = memo(function ComposerPane({
   const promptText = composerPromptText(ui.theme.brand.prompt, ui.info?.profile_name, sh, TERMUX_TUI_MODE, composer.cols)
   const promptWidth = composerPromptWidth(promptText)
   const promptBlank = ' '.repeat(promptWidth)
-  const inputColumns = stableComposerColumns(composer.cols, promptWidth, TERMUX_TUI_MODE)
+  // `composer.cols - 2` reserves the input wrapper's two new border cells (one
+  // per side) on top of the parent padding that `stableComposerColumns`
+  // already subtracts. Without this, the TextInput would overflow the border
+  // by 2 cols and Yoga would shave a character off the last column.
+  const inputColumns = stableComposerColumns(composer.cols - 2, promptWidth, TERMUX_TUI_MODE)
   const inputHeight = inputVisualHeight(composer.input, inputColumns)
   const inputMouseRef = useRef<null | TextInputMouseApi>(null)
 
@@ -307,6 +311,8 @@ const ComposerPane = memo(function ComposerPane({
             ))}
 
             <Box
+              borderColor={ui.theme.color.border}
+              borderStyle="round"
               onMouseDown={captureInputDrag}
               onMouseDrag={dragFromPromptRow}
               onMouseUp={endInputDrag}

--- a/ui-tui/src/components/helpHint.tsx
+++ b/ui-tui/src/components/helpHint.tsx
@@ -1,4 +1,5 @@
-import { Box, Text } from '@hermes/ink'
+import { Box, Text, useInput } from '@hermes/ink'
+import { useMemo } from 'react'
 
 import { HOTKEYS } from '../content/hotkeys.js'
 import type { Theme } from '../theme.js'
@@ -9,15 +10,26 @@ const COMMON_COMMANDS: [string, string][] = [
   ['/resume', 'switch live or resume past sessions'],
   ['/details', 'control transcript detail level'],
   ['/copy', 'copy selection or last assistant message'],
+  ['/statusbar', 'cycle status bar position (top/bottom/off)'],
+  ['/theme', 'switch active theme'],
   ['/quit', 'exit hermes']
 ]
 
-const HOTKEY_PREVIEW = HOTKEYS.slice(0, 8)
+const NAV_HOTKEYS: [string, string][] = [
+  ['↑/↓', 'navigate history / session list'],
+  ['Tab', 'cycle mode (build/plan/ask/agent)'],
+  ['Ctrl+N', 'new session'],
+  ['Ctrl+D', 'quit'],
+  ['Ctrl+C', 'interrupt (twice to exit)'],
+  ['Ctrl+M', 'cycle recent model'],
+  ['Ctrl+R', 'recent commands (frecency)'],
+  ['F1 / Ctrl+/', 'toggle this help overlay']
+]
 
 export function HelpHint({ t }: { t: Theme }) {
   const labelW = Math.max(
     ...COMMON_COMMANDS.map(([k]) => k.length),
-    ...HOTKEY_PREVIEW.map(([k]) => k.length)
+    ...NAV_HOTKEYS.slice(0, 4).map(([k]) => k.length)
   )
 
   const pad = (s: string) => s + ' '.repeat(Math.max(0, labelW - s.length + 2))
@@ -38,7 +50,7 @@ export function HelpHint({ t }: { t: Theme }) {
             ? quick help
           </Text>
           <Text color={t.color.muted}>
-            {'  ·  type /help for the full panel  ·  backspace to dismiss'}
+            {'  ·  F1 for the full panel  ·  backspace to dismiss'}
           </Text>
         </Text>
 
@@ -61,12 +73,111 @@ export function HelpHint({ t }: { t: Theme }) {
           </Text>
         </Box>
 
-        {HOTKEY_PREVIEW.map(([k, v]) => (
+        {NAV_HOTKEYS.slice(0, 4).map(([k, v]) => (
           <Text key={k}>
             <Text color={t.color.label}>{pad(k)}</Text>
             <Text color={t.color.muted}>{v}</Text>
           </Text>
         ))}
+      </Box>
+    </Box>
+  )
+}
+
+// Full-screen help overlay. Always available via F1 / Ctrl+/, never
+// requires the user to type ? in the input. Critical for TDAH: discoverable
+// without remembering slash commands. Esc closes.
+export function HelpOverlay({ t, onClose }: { t: Theme; onClose: () => void }) {
+  useInput((_input, key) => {
+    if (key.escape) {
+      onClose()
+    }
+  })
+
+  // Split the full HOTKEYS list into rough sections so the panel reads
+  // top-to-bottom: navigation, sessions, model/agent, then everything else.
+  const sections = useMemo(() => {
+    const nav = HOTKEYS.filter(k => /arrow|tab|esc|enter|backspace/i.test(k[0]))
+    const sessions = HOTKEYS.filter(k => /ctrl\+[nd]/i.test(k[0]))
+    const model = HOTKEYS.filter(k => /ctrl\+m|model|f[1-9]/i.test(k[0]))
+
+    const other = HOTKEYS.filter(
+      k => !nav.includes(k) && !sessions.includes(k) && !model.includes(k)
+    )
+
+    return [
+      { title: 'Navigation', items: nav },
+      { title: 'Sessions', items: sessions },
+      { title: 'Model / Agent', items: model },
+      { title: 'Other', items: other }
+    ]
+  }, [])
+
+  const labelW = Math.max(
+    ...HOTKEYS.map(([k]) => k.length),
+    ...COMMON_COMMANDS.map(([k]) => k.length)
+  )
+
+  const pad = (s: string) => s + ' '.repeat(Math.max(0, labelW - s.length + 2))
+
+  return (
+    <Box
+      alignItems="center"
+      bottom={0}
+      flexDirection="column"
+      justifyContent="center"
+      left={0}
+      position="absolute"
+      right={0}
+      top={0}
+    >
+      <Box
+        borderColor={t.color.primary}
+        borderStyle="round"
+        flexDirection="column"
+        maxHeight="80%"
+        maxWidth="80%"
+        opaque
+        paddingX={2}
+        paddingY={1}
+      >
+        <Text>
+          <Text bold color={t.color.primary}>
+            ? hermes tui
+          </Text>
+          <Text color={t.color.muted}>
+            {'  ·  F1 / Ctrl+/ to toggle  ·  Esc to close'}
+          </Text>
+        </Text>
+
+        <Box marginTop={1}>
+          <Text bold color={t.color.accent}>
+            Common commands
+          </Text>
+        </Box>
+
+        {COMMON_COMMANDS.map(([k, v]) => (
+          <Text key={k}>
+            <Text color={t.color.label}>{pad(k)}</Text>
+            <Text color={t.color.muted}>{v}</Text>
+          </Text>
+        ))}
+
+        {sections.map(({ title, items }) =>
+          items.length > 0 ? (
+            <Box flexDirection="column" key={title} marginTop={1}>
+              <Text bold color={t.color.accent}>
+                {title}
+              </Text>
+              {items.map(([k, v]) => (
+                <Text key={k}>
+                  <Text color={t.color.label}>{pad(k)}</Text>
+                  <Text color={t.color.muted}>{v}</Text>
+                </Text>
+              ))}
+            </Box>
+          ) : null
+        )}
       </Box>
     </Box>
   )

--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -198,7 +198,17 @@ export const MessageLine = memo(function MessageLine({
     <Box
       flexDirection="column"
       marginBottom={msg.role === 'user' || isDiffSegment ? 1 : 0}
-      marginTop={msg.role === 'user' || msg.kind === 'slash' || isDiffSegment || leadGap ? 1 : 0}
+      marginTop={
+        // User messages, slash commands, diff segments, and the first message
+        // after a lead gap all want a visible breath of whitespace. The
+        // standard rule below worked fine until we also wanted to space
+        // every assistant message by 1 row for TDAH readability — the rule
+        // becomes "add 1 row above EVERY message" by default, which makes
+        // the transcript feel like a contact sheet of equal-weight cards.
+        // Switched to a flat 1-row margin so the visual rhythm reads
+        // consistently regardless of role.
+        1
+      }
     >
       {showDetails && (
         <Box flexDirection="column" marginBottom={1}>


### PR DESCRIPTION
## Summary

TDAH-specific affordances — reduce friction, no new visual noise:

1. **ScrollbackHint** — small `↓ newer messages` chip appears when the transcript scroll is away from the live edge. Click snaps back to the bottom.
2. **HelpOverlay** — F1 / Ctrl+/ toggles a full-screen help panel with all hotkeys (grouped: Navigation / Sessions / Model / Other) and common slash commands. Esc closes.
3. **Composer dim when busy** — input border switches from `theme.color.border` to `theme.color.muted` when busy AND input is empty. Once typing starts, dim disappears.
4. **Alt+M** opens the model picker (pairs with F1 for "what" and "which").
5. **Spacing consistency** — flat marginTop=1 across every message.

## Why these (TDAH-specific)

The five changes share one principle: **reduce the cost of asking a question**.

- *"Did I miss a message?"* → scrollback hint, visible without thinking
- *"What does that key do?"* → F1, no need to remember `?` slash command
- *"Can I type right now?"* → border dim, no need to read status text
- *"How do I switch model?"* → Alt+M, no need to remember `/model`
- *"Where does the next message start?"* → flat spacing, eye can predict

Each of these removes a *decision* the user has to make. TDAH means every
decision is overhead; the goal is to eliminate decisions that have a
default-correct answer.

## Validation

- tsc --noEmit: 0 errors in touched files (1 pre-existing error in imagePreview.tsx, unrelated)
- vitest run: 1073/1079 (2 pre-existing failures — cursorDriftRegression flake + virtualHeights.estimatedMsgHeight — both unrelated)
- eslint: 0 errors in touched files (1 pre-existing warning in GoodVibesHeart, unrelated)
- npm run build: ok

## Files changed

- src/app/interfaces.ts (+1 line: `help: boolean` in OverlayState)
- src/app/overlayStore.ts (+4 lines: help in state, , reset)
- src/app/useInputHandlers.ts (+19 lines: F1 / Ctrl+/ / Alt+M keybinds)
- src/components/appChrome.tsx (+58 lines: ScrollbackHint)
- src/components/appLayout.tsx (+19 lines: wire ScrollbackHint, HelpOverlay, composer dim)
- src/components/helpHint.tsx (+121 lines: HelpOverlay component, updated inline hint)
- src/components/messageLine.tsx (+12 lines: flat marginTop)

## Before / after

**Scrollback hint** (visible when scroll is away from the live edge):
```
                              ╭─────────────────────╮
                              │ ↓ newer messages    │
                              ╰─────────────────────╯
```

**F1 / Ctrl+/** help overlay (full-screen, grouped):
```
╭──────────────────────────────────────╮
│ ? hermes tui  ·  F1 to toggle · Esc  │
│                                      │
│ Common commands                      │
│   /help        full list of commands │
│   /clear       start a new session   │
│   ...                                │
│                                      │
│ Navigation                           │
│   ↑/↓         navigate history       │
│   Tab         cycle mode             │
│   ...                                │
│                                      │
│ Sessions                             │
│   Ctrl+N      new session            │
│   Ctrl+D      quit                   │
│                                      │
│ Model / Agent                        │
│   Ctrl+M      cycle recent model     │
│   F1 / Ctrl+/  toggle this help      │
│                                      │
│ Other                                │
│   ...                                │
╰──────────────────────────────────────╯
```

**Composer dim when busy** (input border tints muted until you start typing):
```
assistente >
╭─────────────────────────────────────╮   ← border is theme.color.muted (busy)
│Ctrl+C to interrupt…                 │
╰─────────────────────────────────────╯
```
becomes `theme.color.border` (normal) the moment the user starts typing.

## Risk

Low. All five changes are purely additive UI affordances that don't
touch the model tool schema, the system prompt, the agent loop, or any
existing shortcut. The new `overlay.help` state lives next to the
existing modelPicker / sessions / etc. and follows the same pattern
(`` includes it so the global useInput short-circuits
correctly when up).