### PR TITLE
fix(agent,cli): tool message spec compliance and callable entry point handling

### DIFF
--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -334,6 +334,14 @@ def make_tool_result_message(name: str, content: Any, tool_call_id: str) -> dict
     list structure stays valid for vision-capable adapters.
     """
     wrapped = _maybe_wrap_untrusted(name, content)
+    # Some providers (e.g. Ollama Cloud) reject dict-typed content in tool
+    # messages.  Stringify anything that is not already a string or a
+    # multimodal content list.
+    if not isinstance(wrapped, (str, list)):
+        try:
+            wrapped = json.dumps(wrapped, default=str)
+        except Exception:
+            wrapped = str(wrapped)
     return {
         "role": "tool",
         "name": name,

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1692,7 +1692,22 @@ class PluginManager:
 
         for ep in group_eps:
             if ep.name == manifest.name:
-                return ep.load()
+                obj = ep.load()
+                # Entry-point may target a module (``pkg``) or a callable
+                # (``module:function``).  The latter returns the function object
+                # directly, so we wrap it in a synthetic module so
+                # ``_load_plugin`` can discover ``register`` via getattr.
+                if isinstance(obj, types.ModuleType):
+                    return obj
+                if callable(obj):
+                    module = types.ModuleType(ep.module)
+                    setattr(module, "register", obj)
+                    sys.modules[ep.module] = module
+                    return module
+                raise ImportError(
+                    f"Entry point '{manifest.name}' resolved to unexpected type "
+                    f"{type(obj).__name__!r}; expected a module or callable"
+                )
 
         raise ImportError(
             f"Entry point '{manifest.name}' not found in group '{ENTRY_POINTS_GROUP}'"

--- a/tests/agent/test_tool_dispatch_helpers.py
+++ b/tests/agent/test_tool_dispatch_helpers.py
@@ -138,6 +138,18 @@ class TestMakeToolResultMessage:
             "tool_call_id": "call_1",
         }
 
+    def test_dict_content_stringified(self):
+        msg = make_tool_result_message("memory", {"name": "Alice"}, "call_4")
+        assert msg["role"] == "tool"
+        assert msg["name"] == "memory"
+        assert isinstance(msg["content"], str)
+        assert '"name": "Alice"' in msg["content"]
+
+    def test_list_content_preserved(self):
+        content = [{"type": "text", "text": "hello"}]
+        msg = make_tool_result_message("browser_snapshot", content, "call_5")
+        assert msg["content"] is content
+
     def test_high_risk_message_content_wrapped(self):
         msg = make_tool_result_message("web_extract", SAMPLE_LONG_TEXT, "call_2")
         assert msg["role"] == "tool"

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -428,7 +428,7 @@ class TestPluginDiscovery:
         fake_ep.group = ENTRY_POINTS_GROUP
         fake_ep.load.return_value = fake_module
 
-        def fake_entry_points():
+        def fake_entry_points(*args, **kwargs):
             result = MagicMock()
             result.select = MagicMock(return_value=[fake_ep])
             return result
@@ -438,6 +438,69 @@ class TestPluginDiscovery:
             mgr.discover_and_load()
 
         assert "ep_plugin" in mgr._plugins
+
+    def test_entry_point_callable_wrapped(self, tmp_path, monkeypatch):
+        """Callable entry points (module:function pattern) are wrapped in a synthetic module."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        # Enable the plugin in config so it attempts to load
+        cfg_path = tmp_path / "hermes_test" / "config.yaml"
+        cfg_path.parent.mkdir(parents=True, exist_ok=True)
+        cfg_path.write_text("plugins:\n  enabled:\n    - callable_plugin\n")
+
+        fake_register = lambda ctx: None  # type: ignore[attr-defined]
+
+        fake_ep = MagicMock()
+        fake_ep.name = "callable_plugin"
+        fake_ep.value = "some_pkg:register"
+        fake_ep.module = "some_pkg"
+        fake_ep.group = ENTRY_POINTS_GROUP
+        fake_ep.load.return_value = fake_register
+
+        def fake_entry_points(*args, **kwargs):
+            result = MagicMock()
+            result.select = MagicMock(return_value=[fake_ep])
+            return result
+
+        with patch("importlib.metadata.entry_points", fake_entry_points):
+            mgr = PluginManager()
+            mgr.discover_and_load()
+
+        assert "callable_plugin" in mgr._plugins
+        # The plugin should have loaded via the synthetic module wrapper
+        plugin = mgr._plugins["callable_plugin"]
+        assert plugin.manifest.name == "callable_plugin"
+        assert plugin.manifest.source == "entrypoint"
+
+    def test_entry_point_unexpected_type_recorded(self, tmp_path, monkeypatch):
+        """Entry points resolving to neither module nor callable are recorded as failed."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        # Enable the plugin in config so it attempts to load
+        cfg_path = tmp_path / "hermes_test" / "config.yaml"
+        cfg_path.parent.mkdir(parents=True, exist_ok=True)
+        cfg_path.write_text("plugins:\n  enabled:\n    - bad_plugin\n")
+
+        fake_ep = MagicMock()
+        fake_ep.name = "bad_plugin"
+        fake_ep.value = "some_pkg:bad"
+        fake_ep.module = "some_pkg"
+        fake_ep.group = ENTRY_POINTS_GROUP
+        fake_ep.load.return_value = 12345  # unexpected type
+
+        def fake_entry_points(*args, **kwargs):
+            result = MagicMock()
+            result.select = MagicMock(return_value=[fake_ep])
+            return result
+
+        with patch("importlib.metadata.entry_points", fake_entry_points):
+            mgr = PluginManager()
+            mgr.discover_and_load()
+
+        # Plugin is registered but flagged as failed
+        assert "bad_plugin" in mgr._plugins
+        assert mgr._plugins["bad_plugin"].error is not None
+        assert "unexpected type" in mgr._plugins["bad_plugin"].error
 
     def test_force_rediscover_clears_all_plugin_registries(self, monkeypatch):
         """force=True must clear every plugin-populated registry.


### PR DESCRIPTION
## Summary

This PR addresses two related plugin/dispatch reliability issues:

1. **Dict-typed tool results violate the standard schema** (Fixes #48244) — Some providers (e.g. Ollama Cloud) reject dict-typed `content` in tool messages. The spec expects `str` or `list[dict]`. This serializes dicts via `json.dumps()`.

2. **Callable entry points are silently ignored** — Some packages expose entry points as `module:function` callable references rather than module objects. The plugin loader now wraps them in a synthetic module so `register()` is discoverable, and raises `ImportError` for truly unexpected types instead of ignoring them.

## Changes

- `agent/tool_dispatch_helpers.py`: Stringify non-str/list tool content before building the message
- `hermes_cli/plugins.py`: Wrap callable entry points, raise on unexpected types
- Tests added for both fixes

## Checklist

- [x] Tests added for new behavior
- [x] Existing tests pass
- [x] Related issue #48244 referenced
