### PR TITLE
fix(zai): strip anthropic sdk identity headers

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -592,6 +592,42 @@ def _is_azure_anthropic_endpoint(base_url: str | None) -> bool:
     return (is_foundry_host or is_legacy_azoai_host) and "/anthropic" in path
 
 
+def _is_zai_anthropic_endpoint(base_url: str | None) -> bool:
+    """Return True for Z.AI's Anthropic-compatible endpoint family.
+
+    Z.AI's GLM Anthropic wire endpoints currently reject requests when the
+    Anthropic Python SDK advertises itself via ``User-Agent`` and the
+    ``X-Stainless-*`` identity headers. The OpenAI-compatible Z.AI endpoints are
+    unaffected; restrict this match to Z.AI hosts whose path actually routes to
+    an Anthropic-compatible surface.
+    """
+    normalized = _normalize_base_url_text(base_url)
+    if not normalized:
+        return False
+    parsed = urlparse(normalized)
+    host = (parsed.hostname or "").lower().rstrip(".")
+    path = (parsed.path or "").lower()
+    return host in {"api.z.ai", "open.bigmodel.cn"} and "/anthropic" in path
+
+
+def _build_header_sanitizing_http_client(*, timeout, user_agent: str | None = None):
+    """Return an ``httpx.Client`` that strips SDK identity headers per request."""
+    import httpx
+
+    def _sanitize_request(request: "httpx.Request") -> None:
+        for header_name in list(request.headers.keys()):
+            lowered = header_name.lower()
+            if lowered == "user-agent" or lowered == "x-stainless" or lowered.startswith("x-stainless-"):
+                request.headers.pop(header_name, None)
+        if user_agent:
+            request.headers["User-Agent"] = user_agent
+
+    return httpx.Client(
+        timeout=timeout,
+        event_hooks={"request": [_sanitize_request]},
+    )
+
+
 def _common_betas_for_base_url(
     base_url: str | None,
     *,
@@ -800,6 +836,11 @@ def build_anthropic_client(
         kwargs["api_key"] = api_key
         if common_betas:
             kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
+        if _is_zai_anthropic_endpoint(normalized_base_url):
+            kwargs["http_client"] = _build_header_sanitizing_http_client(
+                timeout=kwargs["timeout"],
+                user_agent="python-httpx",
+            )
     elif _is_oauth_token(api_key):
         # OAuth access token / setup-token → Bearer auth + Claude Code identity.
         # Anthropic routes OAuth requests based on user-agent and headers;

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -6,12 +6,14 @@ import time
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
+import httpx
 import pytest
 
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.anthropic_adapter import (
     _is_azure_anthropic_endpoint,
     _is_oauth_token,
+    _is_zai_anthropic_endpoint,
     _refresh_oauth_token,
     _to_plain_data,
     _write_claude_code_credentials,
@@ -200,6 +202,47 @@ class TestBuildAnthropicClient:
             # Azure keeps the 1M-context beta (it's not MiniMax).
             betas = kwargs["default_headers"]["anthropic-beta"]
             assert "context-1m-2025-08-07" in betas
+
+    def test_zai_anthropic_endpoint_uses_header_sanitizing_http_client(self):
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client(
+                "zai-secret-123",
+                base_url="https://open.bigmodel.cn/api/anthropic",
+            )
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert kwargs["api_key"] == "zai-secret-123"
+            assert kwargs["default_headers"] == {
+                "anthropic-beta": "interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14"
+            }
+
+            http_client = kwargs["http_client"]
+            try:
+                hook = http_client.event_hooks["request"][0]
+                request = httpx.Request(
+                    "POST",
+                    "https://open.bigmodel.cn/api/anthropic/v1/messages",
+                    headers={
+                        "User-Agent": "anthropic-python/0.86.0",
+                        "X-Stainless-Lang": "python",
+                        "X-Stainless-Package-Version": "0.86.0",
+                        "x-api-key": "zai-secret-123",
+                    },
+                )
+                hook(request)
+                assert request.headers["User-Agent"] == "python-httpx"
+                assert request.headers["x-api-key"] == "zai-secret-123"
+                assert not any(
+                    header.lower() == "x-stainless" or header.lower().startswith("x-stainless-")
+                    for header in request.headers
+                )
+            finally:
+                http_client.close()
+
+    def test_zai_anthropic_endpoint_detection_is_host_and_path_scoped(self):
+        assert _is_zai_anthropic_endpoint("https://open.bigmodel.cn/api/anthropic") is True
+        assert _is_zai_anthropic_endpoint("https://api.z.ai/api/coding/anthropic") is True
+        assert _is_zai_anthropic_endpoint("https://api.z.ai/api/paas/v4") is False
+        assert _is_zai_anthropic_endpoint("https://example.com/anthropic") is False
 
 
 class TestReadClaudeCodeCredentials:


### PR DESCRIPTION
## Summary
- detect Z.AI Anthropic-compatible endpoints separately from other third-party Anthropic wires
- attach a request hook that strips Anthropic SDK `X-Stainless-*` identity headers and overrides the SDK user agent on those endpoints
- add regression coverage for the endpoint detector and header-sanitizing client behavior

## Testing
- `uv run --frozen pytest -q tests/agent/test_anthropic_adapter.py -k 'zai_anthropic_endpoint_uses_header_sanitizing_http_client or zai_anthropic_endpoint_detection_is_host_and_path_scoped or custom_base_url' -o addopts=''`
- `uv run --frozen ruff check agent/anthropic_adapter.py tests/agent/test_anthropic_adapter.py`
- `git diff --check HEAD^ HEAD`
