### PR TITLE
fix(docker): make boot-time config migration transactional (#51579)

### DIFF
--- a/scripts/docker_config_migrate.py
+++ b/scripts/docker_config_migrate.py
@@ -28,16 +28,26 @@ def _backup_path(path: Path, stamp: str) -> Path:
     raise RuntimeError(f"could not choose a backup path for {path}")
 
 
-def _backup_existing(paths: Iterable[Path]) -> list[Path]:
+def _backup_existing(paths: Iterable[Path]) -> dict[Path, Path]:
     stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    backups: list[Path] = []
+    backups: dict[Path, Path] = {}
     for path in paths:
         if not path.is_file():
             continue
         dest = _backup_path(path, stamp)
         shutil.copy2(path, dest)
-        backups.append(dest)
+        backups[path] = dest
     return backups
+
+
+def _restore_backups(backups: dict[Path, Path]) -> list[Path]:
+    restored: list[Path] = []
+    for original, backup in backups.items():
+        if not backup.is_file():
+            continue
+        shutil.copy2(backup, original)
+        restored.append(original)
+    return restored
 
 
 def main() -> int:
@@ -50,12 +60,30 @@ def main() -> int:
         return 0
 
     backups = _backup_existing((get_config_path(), get_env_path()))
-    backup_text = ", ".join(str(path) for path in backups) if backups else "none"
+    backup_text = ", ".join(str(path) for path in backups.values()) if backups else "none"
     print(
         f"[config-migrate] Migrating config schema {current_ver} -> {latest_ver}; "
         f"backups: {backup_text}"
     )
-    migrate_config(interactive=False, quiet=False)
+    try:
+        migrate_config(interactive=False, quiet=False)
+    except Exception:
+        restored = _restore_backups(backups)
+        if restored:
+            print(
+                "[config-migrate] Migration failed; restored "
+                + ", ".join(str(path) for path in restored)
+            )
+        raise
+
+    post_ver, _ = check_config_version()
+    if post_ver < latest_ver:
+        restored = _restore_backups(backups)
+        restored_text = ", ".join(str(path) for path in restored) if restored else "none"
+        raise RuntimeError(
+            f"migration did not advance config version to {latest_ver} "
+            f"(still {post_ver}); restored: {restored_text}"
+        )
     return 0
 
 

--- a/tests/tools/test_docker_config_migrate.py
+++ b/tests/tools/test_docker_config_migrate.py
@@ -1,16 +1,26 @@
 from __future__ import annotations
 
+import importlib.util
 import os
 import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 import yaml
 
 from hermes_cli.config import DEFAULT_CONFIG
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "scripts" / "docker_config_migrate.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location("docker_config_migrate_test_module", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def _run_migration(hermes_home: Path, **env_overrides: str) -> subprocess.CompletedProcess[str]:
@@ -132,3 +142,63 @@ def test_docker_config_migrate_skip_env_leaves_config_unchanged(tmp_path: Path) 
     assert "skipping config migration" in proc.stdout
     assert config_path.read_text(encoding="utf-8") == original
     assert not list(tmp_path.glob("*.bak-*"))
+
+
+def test_docker_config_migrate_restores_backups_after_failed_migration(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _load_script_module()
+    config_path = tmp_path / "config.yaml"
+    env_path = tmp_path / ".env"
+    original_config = yaml.safe_dump({"_config_version": 11, "gateway": {"provider": "telegram"}})
+    original_env = "TELEGRAM_BOT_TOKEN=test-token\n"
+    config_path.write_text(original_config, encoding="utf-8")
+    env_path.write_text(original_env, encoding="utf-8")
+
+    monkeypatch.setattr(module, "check_config_version", lambda: (11, DEFAULT_CONFIG["_config_version"]))
+    monkeypatch.setattr(module, "get_config_path", lambda: config_path)
+    monkeypatch.setattr(module, "get_env_path", lambda: env_path)
+
+    def _failing_migrate(*, interactive: bool, quiet: bool):
+        config_path.write_text("gateway: {}\n", encoding="utf-8")
+        env_path.write_text("", encoding="utf-8")
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(module, "migrate_config", _failing_migrate)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        module.main()
+
+    assert config_path.read_text(encoding="utf-8") == original_config
+    assert env_path.read_text(encoding="utf-8") == original_env
+    assert list(tmp_path.glob("config.yaml.bak-*"))
+    assert list(tmp_path.glob(".env.bak-*"))
+
+
+def test_docker_config_migrate_restores_backups_when_version_does_not_advance(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _load_script_module()
+    config_path = tmp_path / "config.yaml"
+    env_path = tmp_path / ".env"
+    original_config = yaml.safe_dump({"_config_version": 11, "gateway": {"provider": "telegram"}})
+    original_env = "TELEGRAM_BOT_TOKEN=test-token\n"
+    config_path.write_text(original_config, encoding="utf-8")
+    env_path.write_text(original_env, encoding="utf-8")
+
+    calls = iter([(11, DEFAULT_CONFIG["_config_version"]), (11, DEFAULT_CONFIG["_config_version"])])
+    monkeypatch.setattr(module, "check_config_version", lambda: next(calls))
+    monkeypatch.setattr(module, "get_config_path", lambda: config_path)
+    monkeypatch.setattr(module, "get_env_path", lambda: env_path)
+
+    def _non_advancing_migrate(*, interactive: bool, quiet: bool):
+        config_path.write_text("gateway: {}\n", encoding="utf-8")
+        env_path.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(module, "migrate_config", _non_advancing_migrate)
+
+    with pytest.raises(RuntimeError, match="did not advance config version"):
+        module.main()
+
+    assert config_path.read_text(encoding="utf-8") == original_config
+    assert env_path.read_text(encoding="utf-8") == original_env

--- a/tests/tools/test_docker_config_migrate.py
+++ b/tests/tools/test_docker_config_migrate.py
@@ -202,3 +202,58 @@ def test_docker_config_migrate_restores_backups_when_version_does_not_advance(
 
     assert config_path.read_text(encoding="utf-8") == original_config
     assert env_path.read_text(encoding="utf-8") == original_env
+
+
+def test_docker_config_migrate_second_boot_preserves_env_byte_for_byte(tmp_path: Path) -> None:
+    """Regression for #51579: booting ``gateway run`` twice (i.e. a host
+    reboot under ``--restart unless-stopped``) must not strip or rewrite
+    ``$HERMES_HOME/.env``. The first boot migrates the stale config and bumps
+    ``_config_version``; the second boot must be a no-op that leaves ``.env``
+    byte-identical to what the user supplied.
+
+    This exercises the real script + real ``migrate_config`` + real file I/O
+    via subprocess — not mocks — so it covers the actual Docker boot path,
+    not just the failure-rollback shapes above.
+    """
+    config_path = tmp_path / "config.yaml"
+    env_path = tmp_path / ".env"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "_config_version": 11,
+                "gateway": {"provider": "telegram"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    original_env = (
+        "TELEGRAM_BOT_TOKEN=secret-bot-token\n"
+        "TELEGRAM_ALLOWED_USERS=123456789\n"
+        "OPENROUTER_API_KEY=sk-test-provider-key\n"
+    )
+    env_path.write_text(original_env, encoding="utf-8")
+    env_bytes_before = env_path.read_bytes()
+
+    # ── First boot: stale config migrates, version advances. ──
+    first = _run_migration(tmp_path)
+    assert first.returncode == 0, first.stderr
+    assert "Migrating config schema 11 ->" in first.stdout
+    raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert raw["_config_version"] == DEFAULT_CONFIG["_config_version"]
+    # The token (and every other credential) must survive the migration.
+    assert env_path.exists(), ".env must never be deleted by the boot migration"
+    assert env_path.read_bytes() == env_bytes_before
+
+    config_after_first = config_path.read_bytes()
+    first_boot_backups = sorted(tmp_path.glob("config.yaml.bak-*"))
+
+    # ── Second boot (host reboot): version is current, must be a no-op. ──
+    second = _run_migration(tmp_path)
+    assert second.returncode == 0, second.stderr
+    assert "Migrating config schema" not in second.stdout
+    # .env is still present and byte-for-byte identical to the original.
+    assert env_path.exists()
+    assert env_path.read_bytes() == env_bytes_before
+    # config.yaml is untouched by the second boot, and no new backup is made.
+    assert config_path.read_bytes() == config_after_first
+    assert sorted(tmp_path.glob("config.yaml.bak-*")) == first_boot_backups


### PR DESCRIPTION
## Summary
Makes the Docker boot-time config migration transactional, so a partial failure can no longer leave `config.yaml`/`.env` mangled with the schema version un-advanced — the failure shape that re-fired on every container restart and silently stripped `$HERMES_HOME/.env` (#51579).

Salvage of @LeonSGP43's #51615 (approved by @tonydwb), cherry-picked onto current `main`, plus the byte-identical double-boot regression test #51579 asked for.

## Root cause
`docker/stage2-hook.sh` → `scripts/docker_config_migrate.py` runs at every container start. It is version-guarded, so it should migrate once. But it was **non-transactional**: if `migrate_config()` mutated files and then raised (perm-locked volume — note the `-r--r--r--` 0444 perms in the report — or any mid-migration error), the version bump never persisted. Next boot saw a stale version, re-migrated, and compounded the damage until `.env` was gone and `config.yaml` was a stripped template.

## Changes
- `scripts/docker_config_migrate.py`: keep an `{original → backup}` map and **restore** both files when `migrate_config()` throws, or when `_config_version` did not advance after migrating. The latter aborts the destructive retry loop.
- `tests/tools/test_docker_config_migrate.py`: contributor's two rollback tests (exception + non-advancing) **plus** the #51579 regression test — boots the real script twice (host-reboot scenario) and asserts `.env` is byte-identical and the second boot is a no-op (no re-migration, no new backup). Real `migrate_config` + real file I/O via subprocess, no mocks.

## Scope note
Deliberately does NOT remove boot-time migration (the issue's suggestion #1). Boot migration is intentional self-healing across image upgrades; removing it breaks that. The defect was the non-transactional behavior, fixed here.

## Validation
| | Before | After |
|---|---|---|
| `migrate_config` raises mid-boot | files left mangled, version stale → re-fires every reboot | backups restored, version stays consistent |
| migration runs but version doesn't advance | silent destructive loop | aborts + restores |
| successful migration, then reboot | (claimed) `.env` stripped | `.env` byte-identical, 2nd boot is no-op |

`scripts/run_tests.sh tests/tools/test_docker_config_migrate.py` → 7 passed.

Closes #51579. Supersedes #51615 (contributor authorship preserved via rebase-merge).

## Infographic

![transactional-boot-migration](https://v3b.fal.media/files/b/0a9f89da/mSrMhVStSop7pkufnl-Al_XQb1UtGu.png)
