### PR TITLE
fix(config): write config.yaml as UTF-8 to stop emoji/personality corruption

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2030,7 +2030,13 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
                 try:
                     with os.fdopen(fd, "w", encoding="utf-8") as f:
-                        _yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+                        _yaml.dump(
+                            config,
+                            f,
+                            default_flow_style=False,
+                            sort_keys=False,
+                            allow_unicode=True,
+                        )
                         f.flush()
                         os.fsync(f.fileno())
                     atomic_replace(tmp_path, config_path)

--- a/tests/hermes_cli/test_atomic_yaml_write.py
+++ b/tests/hermes_cli/test_atomic_yaml_write.py
@@ -41,3 +41,36 @@ class TestAtomicYamlWrite:
         text = target.read_text(encoding="utf-8")
         assert "key: value" in text
         assert "# comment" in text
+
+    def test_writes_unicode_unescaped_and_round_trips(self, tmp_path):
+        """Emoji/kaomoji are written as real UTF-8, not fragile escape sequences.
+
+        Regression for GitHub #51356: without allow_unicode=True, PyYAML emitted
+        astral-plane chars (emoji) as 8-digit `\\UXXXXXXXX` escapes inside
+        multi-line double-quoted strings wrapped with `\\` continuations, which
+        stricter/non-PyYAML parsers and hand-edits broke into unclosed quotes,
+        corrupting the entire config.
+        """
+        target = tmp_path / "config.yaml"
+        # Mirrors the default personalities + skin cursor shipped in cli.py.
+        data = {
+            "personalities": {
+                "kawaii": "kawaii desu~! (◕‿◕) ★ ♪ ヽ(>∀<☆)ノ",
+                "catgirl": "nya~! (=^･ω･^=) ฅ^•ﻌ•^ฅ",
+                "surfer": "Cowabunga! 🤙 totally rad bro",
+                "hype": "LET'S GOOOO!!! 🔥 LEGENDARY!",
+            },
+            "display": {"cursor": " ▉"},
+        }
+
+        atomic_yaml_write(target, data)
+
+        text = target.read_text(encoding="utf-8")
+        # No escape artifacts of any kind — real characters on disk.
+        assert "\\U" not in text
+        assert "\\u" not in text
+        # Real glyphs are present verbatim.
+        assert "🔥" in text
+        assert "(=^･ω･^=)" in text
+        # And it reloads to exactly what was written.
+        assert yaml.safe_load(text) == data

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1541,7 +1541,7 @@ def _save_cfg(cfg: dict):
 
     path = _hermes_home / "config.yaml"
     with open(path, "w", encoding="utf-8") as f:
-        yaml.safe_dump(cfg, f)
+        yaml.safe_dump(cfg, f, allow_unicode=True)
     with _cfg_lock:
         _cfg_cache = copy.deepcopy(cfg)
         _cfg_path = path

--- a/utils.py
+++ b/utils.py
@@ -211,7 +211,20 @@ def atomic_yaml_write(
     )
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
-            yaml.dump(data, f, default_flow_style=default_flow_style, sort_keys=sort_keys)
+            # allow_unicode=True writes emoji/kaomoji (e.g. personalities, skin
+            # cursors) as real UTF-8 instead of fragile escape sequences. Without
+            # it, PyYAML emits astral-plane chars as `\UXXXXXXXX` (8-digit) escapes
+            # inside multi-line double-quoted strings wrapped with `\`
+            # continuations — a structure that stricter/non-PyYAML parsers and
+            # hand-edits routinely break into unclosed quotes, corrupting the whole
+            # config (GitHub #51356).
+            yaml.dump(
+                data,
+                f,
+                default_flow_style=default_flow_style,
+                sort_keys=sort_keys,
+                allow_unicode=True,
+            )
             if extra_content:
                 f.write(extra_content)
             f.flush()


### PR DESCRIPTION
## Summary
Config is written as readable UTF-8 again, so the shipped personalities (emoji/kaomoji) no longer corrupt `config.yaml` on write.

**Root cause:** `utils.atomic_yaml_write` — the canonical config writer used by config/auth/gateway/onboarding — called `yaml.dump()` without `allow_unicode=True`. The default personalities in `cli.py` (`kawaii`/`catgirl`/`surfer`/`hype`) contain emoji + kaomoji, so PyYAML emitted astral-plane chars as 8-digit `\UXXXXXXXX` escapes inside multi-line double-quoted strings wrapped with `\` line-continuations. Stricter/non-PyYAML parsers, editors, and hand-edits break that structure into unclosed quotes → the whole config fails to parse → silent fallback to defaults → `custom_providers` (e.g. `custom:llmbase`) silently ignored. Fixes #51356.

## Changes
- `utils.py`: `atomic_yaml_write` now passes `allow_unicode=True`.
- `tui_gateway/server.py`: config writer gets `allow_unicode=True` (same bug class).
- `plugins/platforms/telegram/adapter.py`: its atomic config write gets `allow_unicode=True` (same bug class).
- `tests/hermes_cli/test_atomic_yaml_write.py`: regression test — round-trips the default personalities + skin cursor, asserts no `\U`/`\u` escapes and a clean reload.

(`hermes_cli/xai_retirement.py` uses ruamel.yaml, which defaults to unicode — unaffected.)

## Validation
| | Before | After |
|---|---|---|
| emoji on disk | `\U0001F525` in folded `"..."` | `🔥` verbatim |
| config reparse | breaks in strict parsers / hand-edits | clean |
| `custom_providers` after rewrite | lost (fallback to defaults) | survives |

E2E: ran the real `save_config`/`load_config` path against a temp `HERMES_HOME` with the actual default personalities + a `custom:llmbase` entry — no `\U`, parses clean, providers survive. New regression test + 136 existing config/auth/persistence tests pass.


## Infographic

![CONFIG WRITER: UTF-8 ENFORCED](https://v3b.fal.media/files/b/0a9f89df/rXCNnimr1MAM_oP7lGsEM_auyc5YXo.png)
