### PR TITLE
fix(gateway): track + reap no-systemd gateway restart runtimes (WSL orphan)

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -190,8 +190,8 @@ def _read_process_cmdline(pid: int) -> Optional[str]:
     return None
 
 
-def looks_like_gateway_command_line(command: str | None) -> bool:
-    """Return True only for a real ``gateway run`` process command line.
+def _gateway_command_subcommand(command: str | None) -> str | None:
+    """Return the Hermes gateway lifecycle subcommand from a command line.
 
     Lifecycle decisions (is the gateway up? did restart relaunch it?) must not
     fire on loose substring matches.  The previous ``"... gateway" in cmdline``
@@ -211,7 +211,7 @@ def looks_like_gateway_command_line(command: str | None) -> bool:
     either side of the ``gateway`` subcommand.
     """
     if not command:
-        return False
+        return None
 
     try:
         raw_tokens = shlex.split(command, posix=False)
@@ -220,15 +220,15 @@ def looks_like_gateway_command_line(command: str | None) -> bool:
     # Strip surrounding quotes, normalize slashes + case per token.
     tokens = [t.strip("\"'").replace("\\", "/").lower() for t in raw_tokens]
     if not tokens:
-        return False
+        return None
 
     # Gateway-dedicated entrypoints carry no subcommand to inspect.
     for token in tokens:
         if token == "gateway/run.py" or token.endswith("/gateway/run.py"):
-            return True
+            return "run"
         basename = token.rsplit("/", 1)[-1]
         if basename in ("hermes-gateway", "hermes-gateway.exe"):
-            return True
+            return "run"
 
     joined = " ".join(tokens)
     has_gateway_entry = (
@@ -237,7 +237,7 @@ def looks_like_gateway_command_line(command: str | None) -> bool:
         or any(t.rsplit("/", 1)[-1] in ("hermes", "hermes.exe") for t in tokens)
     )
     if not has_gateway_entry:
-        return False
+        return None
 
     # Drop profile selectors anywhere: --profile X / -p X / --profile=X / -p=X.
     # This consumes a profile VALUE of "gateway" too, so the real subcommand
@@ -259,9 +259,28 @@ def looks_like_gateway_command_line(command: str | None) -> bool:
         if token != "gateway":
             continue
         if i + 1 >= len(filtered):
-            return True  # bare `hermes gateway` defaults to `run`
-        return filtered[i + 1] == "run"
-    return False
+            return "run"  # bare `hermes gateway` defaults to `run`
+        return filtered[i + 1]
+    return None
+
+
+def looks_like_gateway_command_line(command: str | None) -> bool:
+    """Return True only for a real ``gateway run`` process command line."""
+    return _gateway_command_subcommand(command) == "run"
+
+
+def looks_like_gateway_runtime_command_line(command: str | None) -> bool:
+    """Return True for command lines that can host the gateway runtime.
+
+    ``gateway restart`` is normally a management command, not the gateway
+    runtime. On hosts without a service manager, though, the manual restart
+    fallback executes ``run_gateway()`` in that same process, so its argv stays
+    as ``gateway restart`` while it owns the webhook port and writes runtime
+    state. Keep the public ``looks_like_gateway_command_line()`` strict, and
+    use this broader matcher only when validating Hermes-owned runtime records
+    or no-supervisor cleanup scans.
+    """
+    return _gateway_command_subcommand(command) in {"run", "restart"}
 
 
 def _looks_like_gateway_process(pid: int) -> bool:
@@ -282,7 +301,7 @@ def _record_looks_like_gateway(record: dict[str, Any]) -> bool:
         return False
 
     cmdline = " ".join(str(part) for part in argv)
-    return looks_like_gateway_command_line(cmdline)
+    return looks_like_gateway_runtime_command_line(cmdline)
 
 
 def _build_pid_record() -> dict:
@@ -1213,6 +1232,10 @@ def get_running_pid(
     resolved_lock_path = _get_gateway_lock_path(resolved_pid_path)
     lock_active = is_gateway_runtime_lock_active(resolved_lock_path)
     if not lock_active:
+        if pid_path is None:
+            runtime_pid = get_runtime_status_running_pid()
+            if runtime_pid is not None:
+                return runtime_pid
         _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
         return None
 
@@ -1236,6 +1259,10 @@ def get_running_pid(
             return pid
 
     _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
+    if pid_path is None:
+        runtime_pid = get_runtime_status_running_pid()
+        if runtime_pid is not None:
+            return runtime_pid
     return None
 
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -13,6 +13,7 @@ import signal
 import subprocess
 import sys
 import textwrap
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -1344,12 +1345,85 @@ def kill_gateway_processes(
     return killed
 
 
+def _reap_unsupervised_gateway_orphans() -> bool:
+    """Kill no-supervisor gateway orphans the pidfile/runtime record can't see.
+
+    On WSL/no-systemd hosts the manual restart fallback runs the gateway
+    in-process under a ``gateway restart`` argv (hermes_cli/gateway.py restart
+    branch → ``run_gateway()``). If its pidfile or runtime record goes missing
+    or stale, ``get_running_pid()`` returns ``None`` even though a live orphan
+    still holds the webhook port, so a follow-up restart stacks a duplicate on
+    the same port (#51325). This is a no-op on hosts WITH a service supervisor,
+    where a ``gateway restart`` argv is a transient management command, not the
+    running gateway — gating on ``supports_systemd_services()`` keeps the
+    orphan-aware scan from killing live management processes there.
+
+    Returns True if at least one orphan was reaped.
+    """
+    try:
+        if supports_systemd_services():
+            return False
+    except Exception:
+        return False
+
+    from gateway.status import _pid_exists, write_planned_stop_marker
+
+    own = {os.getpid()}
+    try:
+        # find_gateway_pids() includes no-supervisor `gateway restart` runtimes
+        # for the current profile when no systemd supervisor is present.
+        orphans = [p for p in find_gateway_pids(exclude_pids=own) if p and p > 0]
+    except Exception:
+        return False
+    if not orphans:
+        return False
+
+    reaped = False
+    for pid in orphans:
+        try:
+            write_planned_stop_marker(pid)
+        except Exception:
+            pass
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            continue
+        except PermissionError:
+            print(f"⚠ Permission denied to kill orphaned gateway PID {pid}")
+            continue
+        reaped = True
+
+    # SIGTERM released the port in the field report but the orphan kept
+    # running until a follow-up SIGKILL — wait briefly, then force-kill
+    # any survivor so the replacement can bind the port cleanly.
+    deadline = time.monotonic() + 5.0
+    survivors = list(orphans)
+    while survivors and time.monotonic() < deadline:
+        survivors = [p for p in survivors if _pid_exists(p)]
+        if survivors:
+            time.sleep(0.2)
+    for pid in survivors:
+        try:
+            os.kill(pid, getattr(signal, "SIGKILL", signal.SIGTERM))
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
+
+    return reaped
+
+
 def stop_profile_gateway() -> bool:
     """Stop only the gateway for the current profile (HERMES_HOME-scoped).
 
     Uses the PID file written by start_gateway(), so it only kills the
     gateway belonging to this profile — not gateways from other profiles.
     Returns True if a process was stopped, False if none was found.
+
+    On hosts without a service supervisor (e.g. WSL/no-systemd, where the
+    manual restart fallback runs the gateway in-process under a ``gateway
+    restart`` argv), the pidfile/runtime record can be missing or stale while
+    a live orphan still holds the webhook port. In that case fall back to the
+    orphan-aware process scan so the replacement reaps the prior instance
+    instead of stacking a duplicate on the same port (#51325).
     """
     try:
         from gateway.status import get_running_pid, remove_pid_file
@@ -1358,7 +1432,7 @@ def stop_profile_gateway() -> bool:
 
     pid = get_running_pid()
     if pid is None:
-        return False
+        return _reap_unsupervised_gateway_orphans()
 
     try:
         from gateway.status import write_planned_stop_marker

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -308,7 +308,11 @@ def _append_unique_pid(
     pids.append(pid)
 
 
-def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> list[int]:
+def _scan_gateway_pids(
+    exclude_pids: set[int],
+    all_profiles: bool = False,
+    include_restart_managers: bool = False,
+) -> list[int]:
     """Best-effort process-table scan for gateway PIDs.
 
     This supplements the profile-scoped PID file so status views can still spot
@@ -325,7 +329,10 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
     # scan no longer false-matches ``gateway status``/``dashboard`` siblings or
     # unrelated processes like ``python -m tui_gateway``. Lazy import mirrors the
     # circular-import avoidance used elsewhere in this module.
-    from gateway.status import looks_like_gateway_command_line
+    from gateway.status import (
+        looks_like_gateway_command_line,
+        looks_like_gateway_runtime_command_line,
+    )
     current_home = str(get_hermes_home().resolve())
     current_home_lc = current_home.lower()
     current_profile_arg = _profile_arg(current_home)
@@ -356,6 +363,11 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
         ):
             return False
         return True
+
+    def _matches_gateway_runtime(command: str) -> bool:
+        if looks_like_gateway_command_line(command):
+            return True
+        return include_restart_managers and looks_like_gateway_runtime_command_line(command)
 
     try:
         if is_windows():
@@ -420,7 +432,7 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
                     current_cmd = line[len("CommandLine=") :]
                 elif line.startswith("ProcessId="):
                     pid_str = line[len("ProcessId=") :]
-                    if looks_like_gateway_command_line(current_cmd) and (
+                    if _matches_gateway_runtime(current_cmd) and (
                         all_profiles or _matches_current_profile(current_cmd)
                     ):
                         try:
@@ -445,7 +457,7 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
                             with open(f"/proc/{pid}/cmdline", "rb") as _f:
                                 cmdline = _f.read().decode("utf-8", errors="replace")
                             cmdline = cmdline.replace("\x00", " ")
-                            if looks_like_gateway_command_line(cmdline) and (
+                            if _matches_gateway_runtime(cmdline) and (
                                 all_profiles or _matches_current_profile(cmdline)
                             ):
                                 _append_unique_pid(pids, pid, exclude_pids)
@@ -488,7 +500,7 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
 
                     if pid is None:
                         continue
-                    if looks_like_gateway_command_line(command) and (
+                    if _matches_gateway_runtime(command) and (
                         all_profiles or _matches_current_profile(command)
                     ):
                         _append_unique_pid(pids, pid, exclude_pids)
@@ -567,7 +579,15 @@ def find_gateway_pids(
             pass
     for pid in _get_service_pids():
         _append_unique_pid(pids, pid, _exclude)
-    for pid in _scan_gateway_pids(_exclude, all_profiles=all_profiles):
+    try:
+        include_restart_managers = not supports_systemd_services()
+    except Exception:
+        include_restart_managers = False
+    for pid in _scan_gateway_pids(
+        _exclude,
+        all_profiles=all_profiles,
+        include_restart_managers=include_restart_managers,
+    ):
         _append_unique_pid(pids, pid, _exclude)
     return pids
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "145739220+wgu9@users.noreply.github.com": "wgu9",  # PR #51468 salvage (WSL/no-systemd orphan gateway tracking, #51325)
     "minz0721@outlook.com": "s010mn",  # PR #29221 salvage (ollama-cloud reasoning_effort xhigh→max)
     "jeevesassistant00@gmail.com": "jeeves-assistant",  # PR #50771 (computer-use CuaDriver vision capture routing)
     "21178861+ScotterMonk@users.noreply.github.com": "ScotterMonk",  # PR #50145 salvage (cron output truncation: adapter-aware chunking, #50126)

--- a/tests/gateway/test_gateway_command_line_matcher.py
+++ b/tests/gateway/test_gateway_command_line_matcher.py
@@ -11,7 +11,10 @@ from __future__ import annotations
 
 import pytest
 
-from gateway.status import looks_like_gateway_command_line as matches
+from gateway.status import (
+    looks_like_gateway_command_line as matches,
+    looks_like_gateway_runtime_command_line as matches_runtime,
+)
 
 
 ACCEPT = [
@@ -58,3 +61,9 @@ def test_accepts_real_gateway_run(cmd):
 @pytest.mark.parametrize("cmd", REJECT)
 def test_rejects_non_gateway_run(cmd):
     assert matches(cmd) is False
+
+
+def test_runtime_matcher_accepts_no_supervisor_restart_process():
+    assert matches("python -m hermes_cli.main gateway restart") is False
+    assert matches_runtime("python -m hermes_cli.main gateway restart") is True
+    assert matches_runtime("python -m hermes_cli.main gateway status") is False

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -174,6 +174,54 @@ class TestGatewayPidState:
         assert status.get_running_pid() is None
         assert not pid_path.exists()
 
+    def test_get_running_pid_accepts_no_supervisor_restart_runtime(self, tmp_path, monkeypatch):
+        """WSL/no-systemd restart fallback runs the gateway in a restart argv process."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        record = {
+            "pid": os.getpid(),
+            "kind": "hermes-gateway",
+            "argv": ["python", "-m", "hermes_cli.main", "gateway", "restart"],
+            "start_time": 123,
+        }
+        pid_path.write_text(json.dumps(record))
+
+        monkeypatch.setattr(status.os, "kill", lambda pid, sig: None)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
+        monkeypatch.setattr(
+            status,
+            "_read_process_cmdline",
+            lambda pid: "python -m hermes_cli.main gateway restart",
+        )
+
+        assert status.acquire_gateway_runtime_lock() is True
+        try:
+            assert status.get_running_pid() == os.getpid()
+        finally:
+            status.release_gateway_runtime_lock()
+
+    def test_get_running_pid_falls_back_to_no_supervisor_runtime_state(self, tmp_path, monkeypatch):
+        """A live gateway_state.json PID should keep status accurate without a pidfile."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        state_path = tmp_path / "gateway_state.json"
+        state_path.write_text(json.dumps({
+            "gateway_state": "running",
+            "pid": os.getpid(),
+            "kind": "hermes-gateway",
+            "argv": ["python", "-m", "hermes_cli.main", "gateway", "restart"],
+            "start_time": 123,
+        }))
+
+        monkeypatch.setattr(status.os, "kill", lambda pid, sig: None)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
+        monkeypatch.setattr(
+            status,
+            "_read_process_cmdline",
+            lambda pid: "python -m hermes_cli.main gateway restart",
+        )
+
+        assert status.get_running_pid() == os.getpid()
+
     def test_get_running_pid_cleans_stale_metadata_from_dead_foreign_pid(self, tmp_path, monkeypatch):
         """Stale PID file from a *different* PID (crashed process) must still be cleaned.
 

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -1,6 +1,7 @@
 """Tests for hermes_cli.gateway."""
 
 import argparse
+import signal
 import sys
 from types import ModuleType, SimpleNamespace
 
@@ -836,6 +837,53 @@ def test_find_gateway_pids_includes_restart_managers_without_systemd(monkeypatch
 
     assert gateway.find_gateway_pids(all_profiles=True) == [708]
     assert calls == [(set(), True, True)]
+
+
+def test_reap_unsupervised_orphans_noop_on_systemd_hosts(monkeypatch):
+    """On supervised hosts a `gateway restart` argv is transient — never reap."""
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: True)
+    killed = []
+    monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: killed.append((pid, sig)))
+    # Should not even consult the scan when a supervisor is present.
+    monkeypatch.setattr(
+        gateway, "find_gateway_pids",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("scanned on systemd host")),
+    )
+
+    assert gateway._reap_unsupervised_gateway_orphans() is False
+    assert killed == []
+
+
+def test_reap_unsupervised_orphans_sigterms_then_sigkills_survivor(monkeypatch):
+    """No-systemd: orphan gets SIGTERM, and a survivor is force-killed."""
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(gateway, "find_gateway_pids", lambda exclude_pids=None: [708])
+    monkeypatch.setattr("gateway.status.write_planned_stop_marker", lambda pid: True)
+    # Orphan ignores SIGTERM (matches the field report) and stays alive, so the
+    # follow-up SIGKILL must fire.
+    monkeypatch.setattr("gateway.status._pid_exists", lambda pid: True)
+
+    sent = []
+    monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: sent.append((pid, sig)))
+    # Collapse the drain window: no real sleeping, and jump past the deadline
+    # after the first check so the loop exits immediately.
+    monkeypatch.setattr(gateway.time, "sleep", lambda _s: None)
+    ticks = iter([0.0, 100.0, 200.0])
+    monkeypatch.setattr(gateway.time, "monotonic", lambda: next(ticks, 200.0))
+
+    assert gateway._reap_unsupervised_gateway_orphans() is True
+    assert (708, signal.SIGTERM) in sent
+    assert (708, signal.SIGKILL) in sent
+
+
+def test_reap_unsupervised_orphans_returns_false_when_none_found(monkeypatch):
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(gateway, "find_gateway_pids", lambda exclude_pids=None: [])
+    killed = []
+    monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: killed.append((pid, sig)))
+
+    assert gateway._reap_unsupervised_gateway_orphans() is False
+    assert killed == []
 
 
 def test_scan_gateway_pids_detects_windows_hermes_exe_case_variants(monkeypatch):

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -821,6 +821,23 @@ def test_find_gateway_pids_falls_back_to_pid_file_when_process_scan_fails(monkey
     assert gateway.find_gateway_pids() == [321]
 
 
+def test_find_gateway_pids_includes_restart_managers_without_systemd(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(gateway, "_get_service_pids", lambda: set())
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+
+    def fake_scan(exclude_pids, all_profiles=False, include_restart_managers=False):
+        calls.append((set(exclude_pids), all_profiles, include_restart_managers))
+        return [708] if include_restart_managers else []
+
+    monkeypatch.setattr(gateway, "_scan_gateway_pids", fake_scan)
+
+    assert gateway.find_gateway_pids(all_profiles=True) == [708]
+    assert calls == [(set(), True, True)]
+
+
 def test_scan_gateway_pids_detects_windows_hermes_exe_case_variants(monkeypatch):
     monkeypatch.setattr(gateway, "is_windows", lambda: True)
     monkeypatch.setattr(gateway, "_get_ancestor_pids", lambda: set())

--- a/tests/hermes_cli/test_gateway_proc_fallback.py
+++ b/tests/hermes_cli/test_gateway_proc_fallback.py
@@ -77,6 +77,43 @@ class TestProcFallback:
         assert 99999 not in pids
         mock_ps.assert_not_called()  # ps must NOT be called when /proc worked
 
+    def test_detects_no_supervisor_restart_process_only_when_enabled(self):
+        entries = {
+            12345: "python -m hermes_cli.main gateway restart",
+            99999: _OTHER_CMD,
+        }
+        _isdir, _listdir, _open = _fake_proc_dir(entries)
+
+        with (
+            patch("hermes_cli.gateway.is_windows", return_value=False),
+            patch("os.path.isdir", side_effect=_isdir),
+            patch("os.listdir", side_effect=_listdir),
+            patch("builtins.open", side_effect=_open),
+            patch("hermes_cli.gateway._get_ancestor_pids", return_value=set()),
+            patch("subprocess.run") as mock_ps,
+        ):
+            strict_pids = gateway_mod._scan_gateway_pids(set(), all_profiles=True)
+
+        _isdir, _listdir, _open = _fake_proc_dir(entries)
+        with (
+            patch("hermes_cli.gateway.is_windows", return_value=False),
+            patch("os.path.isdir", side_effect=_isdir),
+            patch("os.listdir", side_effect=_listdir),
+            patch("builtins.open", side_effect=_open),
+            patch("hermes_cli.gateway._get_ancestor_pids", return_value=set()),
+            patch("subprocess.run") as mock_ps_enabled,
+        ):
+            fallback_pids = gateway_mod._scan_gateway_pids(
+                set(),
+                all_profiles=True,
+                include_restart_managers=True,
+            )
+
+        assert strict_pids == []
+        assert fallback_pids == [12345]
+        mock_ps.assert_not_called()
+        mock_ps_enabled.assert_not_called()
+
     def test_excludes_own_pid_from_proc_scan(self):
         my_pid = os.getpid()
         entries = {my_pid: _GATEWAY_CMD}


### PR DESCRIPTION
## Summary
On WSL/no-systemd hosts, a tracked gateway now survives `gateway restart` / `/restart` / dashboard / `hermes update` without leaving an orphaned, untracked listener on `:8644` — status reports it accurately, `stop` can see it, and a follow-up restart reaps the prior instance instead of stacking duplicates.

**Root cause (#51325):** With no service supervisor, `hermes gateway restart` falls to `run_gateway()` in the *same* process (`hermes_cli/gateway.py` restart branch), so the live gateway's argv stays `… gateway restart`. The strict `looks_like_gateway_command_line()` matcher only accepts `gateway run`, so process scans and the runtime-record validator both reject the live gateway → `status` says "stopped", `stop --all` can't find it, restarts can't reap the prior orphan → duplicates pile up on the port.

## Changes
- `gateway/status.py` (**@wgu9**): add `looks_like_gateway_runtime_command_line()` accepting `restart`; use it for runtime-record validation; `get_running_pid()` falls back to a validated live `gateway_state.json` PID when no pidfile path is given. Strict matcher unchanged for everything else.
- `hermes_cli/gateway.py` (**@wgu9**): `_scan_gateway_pids(include_restart_managers=…)`; `find_gateway_pids()` enables it only when `not supports_systemd_services()`, so supervised hosts never false-match a transient `gateway restart`.
- `hermes_cli/gateway.py` (follow-up): `stop_profile_gateway()` now falls back to `_reap_unsupervised_gateway_orphans()` when the pidfile/runtime record yields nothing — a profile-scoped, no-systemd-gated SIGTERM→SIGKILL of the orphan, closing the duplicate-accumulation path (suggested fix #3 in the issue). SIGKILL mirrors the field report where SIGTERM released the port but the process kept running.

## Validation
| | Before | After |
|---|---|---|
| `status` on no-systemd restart runtime | "Stopped" (alive) | accurate (running) |
| `stop` / scan sees orphan | no | yes (no-systemd only) |
| follow-up restart | stacks duplicate on `:8644` | reaps prior orphan |
| systemd host behavior | — | unchanged (gated off) |

- Targeted suite: `tests/hermes_cli/test_gateway.py tests/gateway/test_gateway_command_line_matcher.py tests/gateway/test_status.py tests/hermes_cli/test_gateway_proc_fallback.py` → **159 passed**.
- E2E (real `/proc` entry + real process, temp `HERMES_HOME`): strict matcher rejects `gateway restart`, runtime matcher accepts; `find_gateway_pids(all_profiles=True)` finds the live orphan; reaper SIGTERM/SIGKILLs it; foreign-`--profile` process is correctly **excluded** from the profile-scoped reap.

Salvage of #51468 by @wgu9 (cherry-picked, authorship preserved) + follow-up reap.

Fixes #51325. Closes #51468.

## Infographic

![gateway-orphan-reaper](https://v3b.fal.media/files/b/0a9f89fb/VhRLQ_yJB-jjvhfWR15wj_kAqxgWUI.png)
