### PR TITLE
fix(agent,gateway): use time.monotonic() for duration measurement

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -352,7 +352,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
         agent._codex_stream_last_event_ts = None
         agent._codex_stream_last_progress_ts = None
 
-    _call_start = time.time()
+    _call_start = time.monotonic()
     agent._touch_activity("waiting for non-streaming API response")
 
     t = threading.Thread(target=_call, daemon=True)
@@ -365,12 +365,12 @@ def interruptible_api_call(agent, api_kwargs: dict):
         # Touch activity every ~30s so the gateway's inactivity
         # monitor knows we're alive while waiting for the response.
         if _poll_count % 100 == 0:  # 100 × 0.3s = 30s
-            _elapsed = time.time() - _call_start
+            _elapsed = time.monotonic() - _call_start
             agent._touch_activity(
                 f"waiting for non-streaming response ({int(_elapsed)}s elapsed)"
             )
 
-        _elapsed = time.time() - _call_start
+        _elapsed = time.monotonic() - _call_start
 
         # TTFB detector: the Codex stream has produced no event at all and
         # we're past the first-byte cutoff → the backend opened the
@@ -437,9 +437,9 @@ def interruptible_api_call(agent, api_kwargs: dict):
         if (
             _codex_idle_enabled
             and _last_codex_event_ts is not None
-            and (time.time() - _last_codex_event_ts) > _codex_idle_timeout
+            and (time.monotonic() - _last_codex_event_ts) > _codex_idle_timeout
         ):
-            _event_stale_elapsed = time.time() - _last_codex_event_ts
+            _event_stale_elapsed = time.monotonic() - _last_codex_event_ts
             logger.warning(
                 "Codex stream produced no SSE events for %.0fs after first byte "
                 "(threshold %.0fs, model=%s, context=~%s tokens). Killing "
@@ -1767,7 +1767,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     # Wall-clock timestamp of the last real streaming chunk.  The outer
     # poll loop uses this to detect stale connections that keep receiving
     # SSE keep-alive pings but no actual data.
-    last_chunk_time = {"t": time.time()}
+    last_chunk_time = {"t": time.monotonic()}
     # Stale-stream patience, shared between the httpx socket read timeout
     # (built in ``_call_chat_completions`` below) and the stale-stream detector
     # (computed further down, before the worker thread starts).  Initialized
@@ -1854,7 +1854,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         )
         # Reset stale-stream timer so the detector measures from this
         # attempt's start, not a previous attempt's last chunk.
-        last_chunk_time["t"] = time.time()
+        last_chunk_time["t"] = time.monotonic()
         agent._touch_activity("waiting for provider response (streaming)")
         # Initialize per-attempt stream diagnostics so the retry block can
         # reach for them after the stream dies.  Lives on
@@ -1891,7 +1891,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         reasoning_parts: list = []
         usage_obj = None
         for chunk in stream:
-            last_chunk_time["t"] = time.time()
+            last_chunk_time["t"] = time.monotonic()
             agent._touch_activity("receiving stream response")
 
             # Update per-attempt diagnostic counters.  Best-effort —
@@ -2170,7 +2170,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         has_tool_use = False
 
         # Reset stale-stream timer for this attempt
-        last_chunk_time["t"] = time.time()
+        last_chunk_time["t"] = time.monotonic()
         # Per-attempt diagnostic dict for the retry block to consume.
         _diag = agent._stream_diag_init()
         request_client_holder["diag"] = _diag
@@ -2201,7 +2201,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 # Opus streams after 180 s even when events are
                 # actively arriving (the chat_completions path
                 # already does this at the top of its chunk loop).
-                last_chunk_time["t"] = time.time()
+                last_chunk_time["t"] = time.monotonic()
                 agent._touch_activity("receiving stream response")
 
                 # Update per-attempt diagnostic counters (best-effort).
@@ -2564,7 +2564,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
 
     t = threading.Thread(target=_call, daemon=True)
     t.start()
-    _last_heartbeat = time.time()
+    _last_heartbeat = time.monotonic()
     _HEARTBEAT_INTERVAL = 30.0  # seconds between gateway activity touches
     while t.is_alive():
         t.join(timeout=0.3)
@@ -2577,7 +2577,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # activity on each chunk, but the gap between API call start
         # and first chunk can exceed the gateway timeout — especially
         # when the stale-stream timeout is disabled (local providers).
-        _hb_now = time.time()
+        _hb_now = time.monotonic()
         if _hb_now - _last_heartbeat >= _HEARTBEAT_INTERVAL:
             _last_heartbeat = _hb_now
             _waiting_secs = int(_hb_now - last_chunk_time["t"])
@@ -2588,7 +2588,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # Detect stale streams: connections kept alive by SSE pings
         # but delivering no real chunks.  Kill the client so the
         # inner retry loop can start a fresh connection.
-        _stale_elapsed = time.time() - last_chunk_time["t"]
+        _stale_elapsed = time.monotonic() - last_chunk_time["t"]
         if _stale_elapsed > _stream_stale_timeout:
             _est_ctx = estimate_request_context_tokens(api_kwargs)
             logger.warning(
@@ -2615,7 +2615,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 pass
             # Reset the timer so we don't kill repeatedly while
             # the inner thread processes the closure.
-            last_chunk_time["t"] = time.time()
+            last_chunk_time["t"] = time.monotonic()
             agent._touch_activity(
                 f"stale stream detected after {int(_stale_elapsed)}s, reconnecting"
             )

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -931,7 +931,7 @@ def run_conversation(
             logging.debug(f"Last message role: {messages[-1]['role'] if messages else 'none'}")
             logging.debug(f"Total message size: ~{approx_tokens:,} tokens")
         
-        api_start_time = time.time()
+        api_start_time = time.monotonic()
         retry_count = 0
         max_retries = agent._api_max_retries
         _retry = TurnRetryState()
@@ -1161,7 +1161,7 @@ def run_conversation(
                     middleware_trace=list(_llm_middleware_trace),
                 )
                 
-                api_duration = time.time() - api_start_time
+                api_duration = time.monotonic() - api_start_time
                 
                 # Stop thinking spinner silently -- the response box or tool
                 # execution messages that follow are more informative.
@@ -1391,9 +1391,9 @@ def run_conversation(
                     logger.warning(f"Invalid API response (retry {retry_count}/{max_retries}): {', '.join(error_details)} | Provider: {provider_name}")
                     
                     # Sleep in small increments to stay responsive to interrupts
-                    sleep_end = time.time() + wait_time
+                    sleep_end = time.monotonic() + wait_time
                     _backoff_touch_counter = 0
-                    while time.time() < sleep_end:
+                    while time.monotonic() < sleep_end:
                         if agent._interrupt_requested:
                             agent._vprint(f"{agent.log_prefix}⚡ Interrupt detected during retry wait, aborting.", force=True)
                             agent._persist_session(messages, conversation_history)
@@ -1412,7 +1412,7 @@ def run_conversation(
                         if _backoff_touch_counter % 150 == 0:  # 150 × 0.2s = 30s
                             agent._touch_activity(
                                 f"retry backoff ({retry_count}/{max_retries}), "
-                                f"{int(sleep_end - time.time())}s remaining"
+                                f"{int(sleep_end - time.monotonic())}s remaining"
                             )
                     continue  # Retry the API call
 
@@ -1969,7 +1969,7 @@ def run_conversation(
                     thinking_spinner = None
                 if agent.thinking_callback:
                     agent.thinking_callback("")
-                api_elapsed = time.time() - api_start_time
+                api_elapsed = time.monotonic() - api_start_time
                 agent._vprint(f"{agent.log_prefix}⚡ Interrupted during API call.", force=True)
                 agent._persist_session(messages, conversation_history)
                 interrupted = True
@@ -2606,7 +2606,7 @@ def run_conversation(
                     )
 
                 retry_count += 1
-                elapsed_time = time.time() - api_start_time
+                elapsed_time = time.monotonic() - api_start_time
                 agent._touch_activity(
                     f"API error recovery (attempt {retry_count}/{max_retries})"
                 )
@@ -3551,9 +3551,9 @@ def run_conversation(
                 )
                 # Sleep in small increments so we can respond to interrupts quickly
                 # instead of blocking the entire wait_time in one sleep() call
-                sleep_end = time.time() + wait_time
+                sleep_end = time.monotonic() + wait_time
                 _backoff_touch_counter = 0
-                while time.time() < sleep_end:
+                while time.monotonic() < sleep_end:
                     if agent._interrupt_requested:
                         agent._vprint(f"{agent.log_prefix}⚡ Interrupt detected during retry wait, aborting.", force=True)
                         agent._persist_session(messages, conversation_history)
@@ -3572,7 +3572,7 @@ def run_conversation(
                     if _backoff_touch_counter % 150 == 0:  # 150 × 0.2s = 30s
                         agent._touch_activity(
                             f"error retry backoff ({retry_count}/{max_retries}), "
-                            f"{int(sleep_end - time.time())}s remaining"
+                            f"{int(sleep_end - time.monotonic())}s remaining"
                         )
         
         # If the API call was interrupted, skip response processing

--- a/agent/display.py
+++ b/agent/display.py
@@ -753,7 +753,7 @@ class KawaiiSpinner:
                 time.sleep(0.1)
                 continue
             frame = self.spinner_frames[self.frame_idx % len(self.spinner_frames)]
-            elapsed = time.time() - self.start_time
+            elapsed = time.monotonic() - self.start_time
             if wings:
                 left, right = wings[self.frame_idx % len(wings)]
                 line = f"  {left} {frame} {self.message} {right} ({elapsed:.1f}s)"
@@ -769,7 +769,7 @@ class KawaiiSpinner:
         if self.running:
             return
         self.running = True
-        self.start_time = time.time()
+        self.start_time = time.monotonic()
         self.thread = threading.Thread(target=self._animate, daemon=True)
         self.thread.start()
 
@@ -806,7 +806,7 @@ class KawaiiSpinner:
             blanks = ' ' * max(self.last_line_len + 5, 40)
             self._write(f"\r{blanks}\r", end='', flush=True)
         if final_message:
-            elapsed = f" ({time.time() - self.start_time:.1f}s)" if self.start_time else ""
+            elapsed = f" ({time.monotonic() - self.start_time:.1f}s)" if self.start_time else ""
             if is_tty:
                 self._write(f"  {final_message}", flush=True)
             else:

--- a/agent/stream_diag.py
+++ b/agent/stream_diag.py
@@ -46,7 +46,7 @@ def stream_diag_init() -> Dict[str, Any]:
     survives across the closure boundary.
     """
     return {
-        "started_at": time.time(),
+        "started_at": time.monotonic(),
         "first_chunk_at": None,
         "chunks": 0,
         "bytes": 0,
@@ -156,7 +156,7 @@ def log_stream_retry(
             _chain = type(error).__name__
 
         # Per-attempt counters and upstream headers.
-        _now = time.time()
+        _now = time.monotonic()
         _bytes = 0
         _chunks = 0
         _elapsed = 0.0
@@ -254,7 +254,7 @@ def emit_stream_drop(
         try:
             started = diag.get("started_at")
             if started is not None:
-                _suffix = f" after {max(0.0, time.time() - float(started)):.1f}s"
+                _suffix = f" after {max(0.0, time.monotonic() - float(started)):.1f}s"
         except Exception:
             pass
     try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8870,7 +8870,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
         """Inner handler that runs under the _running_agents sentinel guard."""
-        _msg_start_time = time.time()
+        _msg_start_time = time.monotonic()
         _platform_name = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
         _msg_preview = (event.text or "")[:80].replace("\n", " ")
         _reply_id = getattr(event, "reply_to_message_id", None)
@@ -9675,7 +9675,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "rephrase your question."
                 )
             agent_messages = agent_result.get("messages", [])
-            _response_time = time.time() - _msg_start_time
+            _response_time = time.monotonic() - _msg_start_time
             _api_calls = agent_result.get("api_calls", 0)
             _resp_len = len(response)
             logger.info(
@@ -14288,7 +14288,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Make the HTTP request with SSE streaming -----------------------
         full_response = ""
-        _start = time.time()
+        _start = time.monotonic()
 
         try:
             _timeout = ClientTimeout(total=0, sock_read=1800)
@@ -14377,7 +14377,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 except (asyncio.TimeoutError, asyncio.CancelledError):
                     stream_task.cancel()
 
-        _elapsed = time.time() - _start
+        _elapsed = time.monotonic() - _start
         if not _run_still_current():
             logger.info(
                 "Discarding stale proxy result for %s — generation %d is no longer current",
@@ -16453,7 +16453,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
         ):
             _NOTIFY_INTERVAL = None
-        _notify_start = time.time()
+        _notify_start = time.monotonic()
 
         async def _notify_long_running():
             if _NOTIFY_INTERVAL is None:
@@ -16483,7 +16483,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     session_key, agent_holder[0], _exec_ref
                 ):
                     break
-                _elapsed_mins = int((time.time() - _notify_start) // 60)
+                _elapsed_mins = int((time.monotonic() - _notify_start) // 60)
                 # Include agent activity context if available. Default
                 # heartbeat is terse: elapsed + current tool. Verbose
                 # iteration counter is gated on busy_ack_detail so users


### PR DESCRIPTION
## What

Replace `time.time()` with `time.monotonic()` for all elapsed-time and duration calculations in agent and gateway modules.

## Why

`time.monotonic()` is immune to system clock adjustments (NTP jumps, manual `date` changes, leap seconds). Using `time.time()` for duration measurement can produce negative or wildly wrong intervals when the wall clock is adjusted mid-measurement.

This follows the same pattern as PR #51301 and #51144 which fixed `tool_executor.py`.

## Files changed (5 files, 36 lines)

| File | What was fixed |
|------|----------------|
| `agent/conversation_loop.py` | API call duration, retry backoff sleep loops, elapsed time tracking |
| `agent/chat_completion_helpers.py` | Stream stale detection, heartbeat intervals, TTFB detector, Codex idle timeout, last-chunk timestamps |
| `agent/display.py` | KawaiiSpinner elapsed time display |
| `agent/stream_diag.py` | Stream attempt duration tracking (`started_at`, `_now`, drop timing) |
| `gateway/run.py` | Message response time, proxy request duration, long-running notification timer |

## What was NOT changed (intentionally)

Remaining `time.time()` calls in `gateway/run.py` are **wall-clock timestamps** stored in DB or compared with DB values (e.g. `requested_at`, `_running_agents_ts`, `_last_activity_ts`). These must stay as `time.time()` to match stored Unix epoch values.

## Testing

- `python3 -m py_compile` passes for all 5 files
- All changes are mechanical `s/time.time()/time.monotonic()/` replacements