### PR TITLE
fix(plugins/hermes-achievements): add plugin.yaml for plugin loader discovery

### DIFF
--- a/plugins/hermes-achievements/plugin.yaml
+++ b/plugins/hermes-achievements/plugin.yaml
@@ -1,0 +1,5 @@
+name: hermes-achievements
+version: 0.4.0
+description: "Steam-style achievements for vibe coding and agentic Hermes workflows."
+author: "@PCinkusz (original), NousResearch (vendored)"
+kind: dashboard


### PR DESCRIPTION
## Problem

```
$ hermes plugins enable hermes-achievements
Plugin 'hermes-achievements' is not installed or bundled.
```

The vendored copy at `plugins/hermes-achievements/` ships with
`dashboard/manifest.json` (drives the dashboard UI) but **no
`plugin.yaml`** at the repo root. Hermes's plugin loader
(`hermes_cli.plugins_cmd._read_manifest_info`) only recognizes
`plugin.yaml`/`plugin.yml`, so it skips the directory entirely.

The dashboard's own `web_server` scans `dashboard/manifest.json`
directly and mounts API routes fine, so the dashboard tab works — but
`hermes plugins list`/`enable`/`disable` all miss the plugin.

## Fix

Add a minimal `plugin.yaml` at `plugins/hermes-achievements/` root
with the fields the loader actually reads: `name`, `version`,
`description`, plus `author` and `kind: dashboard`. The dashboard's
`manifest.json` is untouched.

Mirrors the matching fix on the upstream
[PCinkusz/hermes-achievements#6](https://github.com/PCinkusz/hermes-achievements/pull/6)
so the next vendor sync preserves it instead of stripping it.

## Verification

Before:
```
$ hermes plugins list | grep hermes-achievements
$ hermes plugins enable hermes-achievements
Plugin 'hermes-achievements' is not installed or bundled.
```

After:
```
$ hermes plugins list | grep hermes-achievements
│ hermes-achievements  │ not enabled │ 0.4.0 │ Steam-style achievements … │ bundled │
$ hermes plugins enable hermes-achievements
✓ Plugin hermes-achievements enabled. Takes effect on next session.
```

## Notes

- 1 file changed, 5 insertions(+). Intentionally minimal.
- `kind: dashboard` matches the convention other vendored dashboard
  plugins use.
- The vendored copy's other files are unchanged. No code-side changes;
  this is a metadata fix the CLI loader needs.