### PR TITLE
fix(prompt): keep pasted session IDs as reference anchors

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -167,7 +167,10 @@ MEMORY_GUIDANCE = (
 SESSION_SEARCH_GUIDANCE = (
     "When the user references something from a past conversation or you suspect "
     "relevant cross-session context exists, use session_search to recall it before "
-    "asking them to repeat themselves."
+    "asking them to repeat themselves. Treat pasted session IDs and session links "
+    "as reference/evidence anchors by default, not as instructions to resume or "
+    "switch sessions. Preserve the current active task/topic unless the user "
+    "explicitly asks to resume, switch to, or continue from the referenced session."
 )
 
 SKILLS_GUIDANCE = (

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -50,8 +50,11 @@ class TestGuidanceConstants:
         assert "like a diary" not in MEMORY_GUIDANCE
         assert ">80%" not in MEMORY_GUIDANCE
 
-    def test_session_search_guidance_is_simple_cross_session_recall(self):
+    def test_session_search_guidance_preserves_reference_anchor_semantics(self):
         assert "relevant cross-session context exists" in SESSION_SEARCH_GUIDANCE
+        assert "reference/evidence anchors by default" in SESSION_SEARCH_GUIDANCE
+        assert "resume or switch sessions" in SESSION_SEARCH_GUIDANCE
+        assert "Preserve the current active task/topic" in SESSION_SEARCH_GUIDANCE
         assert "recent turns of the current session" not in SESSION_SEARCH_GUIDANCE
 
 
@@ -1545,5 +1548,4 @@ class TestParallelToolCallGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
 


### PR DESCRIPTION
Summary:
- extend SESSION_SEARCH_GUIDANCE so pasted session IDs and session links default to reference/evidence semantics
- preserve the current active task unless the user explicitly asks to resume or switch to the referenced session
- tighten the prompt-builder regression test around this guidance

Testing:
- uv run --frozen pytest -q tests/agent/test_prompt_builder.py -k session_search_guidance\ or\ memory_guidance_discourages_task_logs -o addopts=
- uv run --frozen ruff check agent/prompt_builder.py tests/agent/test_prompt_builder.py
- git diff --check HEAD^ HEAD

Attribution:
- the full tests/agent/test_prompt_builder.py file is currently red on preexisting unrelated TestBuildSkillsSystemPrompt::test_excludes_disabled_skills
