### PR TITLE
fix(installer): avoid Windows venv lock failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 /venv/
 /venv.old/
+/venv.pre-recreate-*/
 /_pycache/
 *.pyc*
 __pycache__/

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1538,6 +1538,109 @@ function Install-Repository {
     Write-Success "Repository ready"
 }
 
+function Test-PathStartsWith {
+    param(
+        [string]$Path,
+        [string]$BasePath
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path) -or [string]::IsNullOrWhiteSpace($BasePath)) {
+        return $false
+    }
+
+    try {
+        $fullPath = [System.IO.Path]::GetFullPath($Path)
+        $fullBase = [System.IO.Path]::GetFullPath($BasePath).TrimEnd(
+            [System.IO.Path]::DirectorySeparatorChar,
+            [System.IO.Path]::AltDirectorySeparatorChar
+        )
+        return $fullPath.StartsWith($fullBase + [System.IO.Path]::DirectorySeparatorChar, [System.StringComparison]::OrdinalIgnoreCase) -or
+            $fullPath.Equals($fullBase, [System.StringComparison]::OrdinalIgnoreCase)
+    } catch {
+        return $false
+    }
+}
+
+function Stop-WindowsHermesVenvProcesses {
+    param([string]$VenvPath)
+
+    if ($env:OS -ne "Windows_NT" -or -not (Test-Path -LiteralPath $VenvPath)) {
+        return
+    }
+
+    $venvFull = (Resolve-Path -LiteralPath $VenvPath).Path
+    $myPid = $PID
+
+    Write-Info "Stopping Hermes processes using the old venv before recreating it..."
+
+    # Keep the broad desktop kill: Electron's parent/renderer processes live
+    # outside venv\ but can own backend children that keep Python DLLs loaded.
+    & taskkill /F /T /IM hermes.exe /FI "PID ne $myPid" 2>$null | Out-Null
+
+    $processes = @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue)
+    if ($processes.Count -eq 0) {
+        Start-Sleep -Milliseconds 800
+        return
+    }
+
+    $targetPids = @{}
+    foreach ($proc in $processes) {
+        if ([int]$proc.ProcessId -eq $myPid) { continue }
+        $exe = [string]$proc.ExecutablePath
+        $cmd = [string]$proc.CommandLine
+        if ((Test-PathStartsWith -Path $exe -BasePath $venvFull) -or $cmd.IndexOf($venvFull, [System.StringComparison]::OrdinalIgnoreCase) -ge 0) {
+            $targetPids[[int]$proc.ProcessId] = $true
+        }
+    }
+
+    # Include descendants of venv processes. On Windows, console shims can
+    # launch a system python.exe/pythonw.exe child whose image path is outside
+    # venv\, while the child still imports from the old venv and holds .pyd
+    # files open.
+    $changed = $true
+    while ($changed) {
+        $changed = $false
+        foreach ($proc in $processes) {
+            $procPid = [int]$proc.ProcessId
+            $parentPid = [int]$proc.ParentProcessId
+            if ($procPid -eq $myPid -or $targetPids.ContainsKey($procPid)) { continue }
+            if ($targetPids.ContainsKey($parentPid)) {
+                $targetPids[$procPid] = $true
+                $changed = $true
+            }
+        }
+    }
+
+    $targets = @($targetPids.Keys | Sort-Object -Descending)
+    foreach ($targetPid in $targets) {
+        try {
+            Stop-Process -Id $targetPid -Force -ErrorAction SilentlyContinue
+        } catch { }
+    }
+
+    Start-Sleep -Milliseconds 1200
+}
+
+function Move-WindowsVenvAside {
+    param([string]$VenvPath)
+
+    if ($env:OS -ne "Windows_NT") {
+        Remove-Item -Recurse -Force $VenvPath
+        return
+    }
+
+    Stop-WindowsHermesVenvProcesses -VenvPath $VenvPath
+
+    $stamp = Get-Date -Format "yyyyMMdd-HHmmss"
+    $destination = Join-Path $InstallDir "venv.pre-recreate-$stamp"
+    Write-Info "Moving old venv aside to $destination"
+    try {
+        Move-Item -LiteralPath $VenvPath -Destination $destination -Force -ErrorAction Stop
+    } catch {
+        throw "Failed to move old venv aside before recreation: $_"
+    }
+}
+
 function Install-Venv {
     if ($NoVenv) {
         Write-Info "Skipping virtual environment (-NoVenv)"
@@ -1562,16 +1665,11 @@ function Install-Venv {
     
     if (Test-Path "venv") {
         Write-Info "Virtual environment already exists, recreating..."
-        # On Windows, native Python extensions (e.g. _bcrypt.pyd) are loaded as
-        # DLLs by any running hermes process. Windows denies deletion of loaded
-        # DLLs, so kill any hermes.exe tree before removing the venv.
-        if ($env:OS -eq "Windows_NT") {
-            $myPid = $PID
-            Write-Info "Stopping any running hermes processes before recreating venv..."
-            & taskkill /F /T /IM hermes.exe /FI "PID ne $myPid" 2>$null | Out-Null
-            Start-Sleep -Milliseconds 800
-        }
-        Remove-Item -Recurse -Force "venv"
+        # On Windows, Python .exe/.pyd files are mandatory-locked while loaded.
+        # Move the old venv aside instead of recursively deleting it in place;
+        # this avoids failing halfway through when a just-stopped process or
+        # scanner still has a short-lived handle open.
+        Move-WindowsVenvAside -VenvPath "venv"
     }
     
     # uv creates the venv and pins the Python version in one step.  uv emits

--- a/tests/test_install_ps1_windows_venv_locks.py
+++ b/tests/test_install_ps1_windows_venv_locks.py
@@ -1,0 +1,62 @@
+"""Regression coverage for Windows venv lock handling in install.ps1.
+
+The Windows installer previously tried to recreate ``venv`` by killing only
+``hermes.exe`` and then running ``Remove-Item -Recurse -Force venv``. That does
+not cover gateway/dashboard children running as ``python.exe`` or
+``pythonw.exe`` from the venv, and Windows refuses to delete loaded ``.exe`` /
+``.pyd`` files.
+
+These tests are source-level because CI may not execute install.ps1 on Windows,
+but they lock the important contracts around the PowerShell implementation.
+"""
+
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+_INSTALL_PS1 = _ROOT / "scripts" / "install.ps1"
+_GITIGNORE = _ROOT / ".gitignore"
+
+
+@pytest.fixture(scope="module")
+def source() -> str:
+    return _INSTALL_PS1.read_text(encoding="utf-8")
+
+
+def _function_body(source: str, name: str) -> str:
+    start = source.index(f"function {name}")
+    brace = source.index("{", start)
+    depth = 0
+    for i in range(brace, len(source)):
+        if source[i] == "{":
+            depth += 1
+        elif source[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[brace : i + 1]
+    raise AssertionError(f"unterminated function body for {name}")
+
+
+def test_install_venv_moves_existing_venv_aside(source: str):
+    body = _function_body(source, "Install-Venv")
+    assert 'Move-WindowsVenvAside -VenvPath "venv"' in body
+    assert 'Remove-Item -Recurse -Force "venv"' not in body
+
+
+def test_windows_venv_stop_targets_processes_by_venv_path_and_descendants(
+    source: str,
+):
+    body = _function_body(source, "Stop-WindowsHermesVenvProcesses")
+    assert "Get-CimInstance Win32_Process" in body
+    assert "Test-PathStartsWith -Path $exe -BasePath $venvFull" in body
+    assert "$cmd.IndexOf($venvFull" in body
+    assert "$targetPids.ContainsKey($parentPid)" in body
+    assert "Stop-Process -Id $targetPid" in body
+
+
+def test_windows_venv_move_uses_ignored_timestamped_directory(source: str):
+    body = _function_body(source, "Move-WindowsVenvAside")
+    assert "venv.pre-recreate-$stamp" in body
+    assert "Move-Item -LiteralPath $VenvPath" in body
+    assert "/venv.pre-recreate-*/" in _GITIGNORE.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Fixes the Windows installer venv recreation path so updates do not fail when Hermes gateway/dashboard/Desktop child processes keep old venv binaries or native `.pyd` files locked.

This addresses the failure class reported in:

- https://github.com/NousResearch/hermes-agent/issues/47910
- https://github.com/NousResearch/hermes-agent/issues/47557
- https://github.com/NousResearch/hermes-agent/issues/39431
- https://github.com/NousResearch/hermes-agent/issues/38789
- https://github.com/NousResearch/hermes-agent/issues/37731
- https://github.com/NousResearch/hermes-agent/issues/43268
- https://github.com/NousResearch/hermes-agent/issues/48100

## Problem observed

On Windows, `scripts/install.ps1` currently recreates an existing venv by:

1. killing `hermes.exe` once with `taskkill`,
2. waiting briefly,
3. running `Remove-Item -Recurse -Force "venv"`.

That still fails when gateway/dashboard workers are running as `python.exe` / `pythonw.exe`, or when just-stopped processes/scanners still hold short-lived handles to files in the old venv.

Observed local failures included:

```text
Access to the path '...\venv\Scripts\pythonw.exe' is denied.
Access to the path '...\venv\Lib\site-packages\tornado\speedups.pyd' is denied.
Access to the path '...\venv\Scripts\python.exe' is denied.
```

## Changes

- Add a Windows-specific venv process cleanup helper that:
  - finds processes whose executable path or command line points into the old `venv`,
  - includes descendants of those venv-backed processes, covering system `python.exe` / `pythonw.exe` children launched by venv shims,
  - keeps the existing broad `hermes.exe` taskkill for Electron Desktop process trees.
- Move the old Windows venv aside to `venv.pre-recreate-<timestamp>` before creating a new venv, instead of recursively deleting the old venv in place.
- Ignore `venv.pre-recreate-*` so interrupted/recovered update state does not dirty the managed checkout.
- Add source-level regression tests for the installer contract.

## Validation

```text
python -m pytest tests/test_install_ps1_windows_venv_locks.py tests/test_install_ps1_python_fallback_venv.py -q
7 passed

PowerShell parser check for scripts/install.ps1
PowerShell parse OK

git diff --check
no output

pwsh -NoProfile -ExecutionPolicy Bypass -File scripts\tests\test-install-ps1-stage-protocol.ps1
All smoke tests passed.
```

## Notes

I also ran `scripts\tests\test-install-ps1-longpath.ps1`, but it fails before exercising this patch because the test harness passes `$null` into a mandatory `Assert-Equal -Expected` parameter. That looks like a separate existing test issue.
