### PR TITLE
fix(clarify): reject non-string choices instead of silently str()-ing them

### DIFF
--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -111,16 +111,46 @@ class TestClarifyToolChoicesValidation:
         assert "error" in result
         assert "list" in result["error"].lower()
 
-    def test_choices_converted_to_strings(self):
-        """Non-string choices should be converted to strings."""
-        choices_received = []
+    def test_choices_must_be_strings(self):
+        """Non-string choices should be rejected with a clear error.
 
-        def mock_callback(question: str, choices: Optional[List[str]]) -> str:
-            choices_received.extend(choices or [])
-            return "answer"
+        Previously the tool coerced non-string choices with str(), which on
+        dict choices (e.g. {"description": ..., "key": ..., "label": ...})
+        rendered the dict's repr in the user-facing Telegram message and
+        echoed the dict back as the response. The schema (items.type=string)
+        already declares strings only, so reject anything else.
+        """
+        def callback(question: str, choices: Optional[List[str]]) -> str:
+            return "should not reach"
 
-        clarify_tool("Pick", choices=[1, 2, 3], callback=mock_callback)  # type: ignore
-        assert choices_received == ["1", "2", "3"]
+        # Dict choices — the original bug
+        result = json.loads(clarify_tool(
+            "Pick",
+            choices=[{"description": "Pick A", "key": "a", "label": "Pick A"}],  # type: ignore
+            callback=callback,
+        ))
+        assert "error" in result
+        assert "list of strings" in result["error"]
+        assert "got dict" in result["error"]
+        assert "label" in result["error"]  # points the caller at the fix
+
+        # Mixed list — should error on first non-string
+        result = json.loads(clarify_tool(
+            "Pick",
+            choices=["ok", {"key": "nope"}],  # type: ignore
+            callback=callback,
+        ))
+        assert "error" in result
+        assert "got dict" in result["error"]
+
+        # Int choices — also rejected (schema says strings only)
+        result = json.loads(clarify_tool(
+            "Pick",
+            choices=[1, 2, 3],  # type: ignore
+            callback=callback,
+        ))
+        assert "error" in result
+        assert "got int" in result["error"]
 
 
 class TestClarifyToolCallbackHandling:

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -48,11 +48,20 @@ def clarify_tool(
     if choices is not None:
         if not isinstance(choices, list):
             return tool_error("choices must be a list of strings.")
-        choices = [str(c).strip() for c in choices if str(c).strip()]
-        if len(choices) > MAX_CHOICES:
-            choices = choices[:MAX_CHOICES]
-        if not choices:
-            choices = None  # empty list → open-ended
+        cleaned = []
+        for c in choices:
+            if not isinstance(c, str):
+                return tool_error(
+                    "choices must be a list of strings — "
+                    f"got {type(c).__name__} ({c!r}). "
+                    "Use the 'label' field as the choice string instead of passing a dict."
+                )
+            s = c.strip()
+            if s:
+                cleaned.append(s)
+        if len(cleaned) > MAX_CHOICES:
+            cleaned = cleaned[:MAX_CHOICES]
+        choices = cleaned if cleaned else None  # empty list → open-ended
 
     if callback is None:
         return json.dumps(


### PR DESCRIPTION
## Summary

`tools/clarify_tool.py` was coercing non-string choices with `str(c).strip()`, contradicting the schema (`items: {type: string}`). On dict choices like `{description, key, label}` this rendered the dict's repr in the user-facing Telegram message and echoed the dict back as the user response — making the question unreadable and the response unusable for downstream code.

Replace the silent coercion with explicit validation that returns a clear error pointing the caller at the `label` field.

## Before

```
❓ How should I restart?

1. {'description': "You'll restart from your own terminal", 'key': 'restart-manual', 'label': "I'll restart from my terminal"}
2. {'description': 'Use launchctl unload + load', 'key': 'launchctl', 'label': 'launchctl'}
3. {'description': 'Leave on disk, pick up later', 'key': 'leave-on-disk', 'label': 'Leave on disk'}
```

User picked button 2 → response came back as the raw dict `{"description": ..., "key": ..., "label": ...}` instead of the chosen label string.

## After

```json
{"error": "choices must be a list of strings — got dict ({'description': ..., 'key': ..., 'label': ...}). Use the 'label' field as the choice string instead of passing a dict."}
```

## Changes

- `tools/clarify_tool.py`: replace `[str(c).strip() for c in choices if str(c).strip()]` with explicit type check that returns a clear error on first non-string element.
- `tests/tools/test_clarify_tool.py`: replace `test_choices_converted_to_strings` (which asserted int coercion — wrong, contradicts the schema) with `test_choices_must_be_strings` that covers dict, mixed-list, and int rejection cases.

## Verification

- All 20 tests in `tests/tools/test_clarify_tool.py` pass.
- Live-tested against the running gateway: dict choices are rejected at the tool layer before reaching the Telegram renderer.

## Notes for reviewers

The error message intentionally mentions the `label` field because the most common misuse (and the one that triggered this fix) is passing `[{description, key, label}, ...]` from a tool-spec that uses that shape. Pointing at `label` tells the caller exactly what to extract.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>