### PR TITLE
fix(agent): avoid closing shared Anthropic client on interrupt

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -500,8 +500,11 @@ def interruptible_api_call(agent, api_kwargs: dict):
                 )
             try:
                 if agent.api_mode == "anthropic_messages":
-                    agent._anthropic_client.close()
-                    agent._rebuild_anthropic_client()
+                    logger.warning(
+                        "Anthropic Messages non-streaming call stale; not closing "
+                        "shared _anthropic_client from the poll thread to avoid "
+                        "#29507 TLS FD recycle corruption. Waiting for SDK timeout."
+                    )
                 else:
                     _close_request_client_once("stale_call_kill")
             except Exception:
@@ -536,11 +539,16 @@ def interruptible_api_call(agent, api_kwargs: dict):
             )
             # Force-close the in-flight worker-local HTTP connection to stop
             # token generation without poisoning the shared client used to
-            # seed future retries.
+            # seed future retries. For Anthropic Messages the SDK client is
+            # shared; closing it here would release TLS FDs from the poll
+            # thread and can resurrect #29507 (TLS bytes written into SQLite).
             try:
                 if agent.api_mode == "anthropic_messages":
-                    agent._anthropic_client.close()
-                    agent._rebuild_anthropic_client()
+                    logger.warning(
+                        "Anthropic Messages call interrupted; not closing shared "
+                        "_anthropic_client from the poll thread to avoid #29507 "
+                        "TLS FD recycle corruption. Waiting for SDK timeout."
+                    )
                 else:
                     _close_request_client_once("interrupt_abort")
             except Exception:
@@ -2632,8 +2640,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             )
             try:
                 if agent.api_mode == "anthropic_messages":
-                    agent._anthropic_client.close()
-                    agent._rebuild_anthropic_client()
+                    logger.warning(
+                        "Anthropic Messages stream interrupted; not closing shared "
+                        "_anthropic_client from the poll thread to avoid #29507 "
+                        "TLS FD recycle corruption. Waiting for stream context cleanup."
+                    )
                 else:
                     _close_request_client_once("stream_interrupt_abort")
             except Exception:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -138,6 +138,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
     """
     result = {"response": None, "error": None}
     request_client_holder = {"client": None, "owner_tid": None}
+    request_client_kind = {"value": "openai"}
     request_client_lock = threading.Lock()
     # Request-local cancellation flag. Distinct from agent._interrupt_requested
     # because that flag is cleared at run_conversation() turn boundaries, but
@@ -149,9 +150,10 @@ def interruptible_api_call(agent, api_kwargs: dict):
     # hang.)
     _request_cancelled = {"value": False}
 
-    def _set_request_client(client):
+    def _set_request_client(client, *, kind: str = "openai"):
         with request_client_lock:
             request_client_holder["client"] = client
+            request_client_kind["value"] = kind
             # #29507: stamp the owning thread so a stranger-thread interrupt
             # only shuts the connection down rather than racing the worker
             # for FD ownership during ``client.close()``.
@@ -185,7 +187,13 @@ def interruptible_api_call(agent, api_kwargs: dict):
                 request_client_holder["owner_tid"] = None
         if request_client is None:
             return
-        if stranger_thread:
+        kind = request_client_kind.get("value", "openai")
+        if kind == "anthropic_messages":
+            if stranger_thread:
+                agent._abort_request_anthropic_client(request_client, reason=reason)
+            else:
+                agent._close_request_anthropic_client(request_client, reason=reason)
+        elif stranger_thread:
             agent._abort_request_openai_client(request_client, reason=reason)
         else:
             agent._close_request_openai_client(request_client, reason=reason)
@@ -205,7 +213,16 @@ def interruptible_api_call(agent, api_kwargs: dict):
                     on_first_delta=getattr(agent, "_codex_on_first_delta", None),
                 )
             elif agent.api_mode == "anthropic_messages":
-                result["response"] = agent._anthropic_messages_create(api_kwargs)
+                request_client = _set_request_client(
+                    agent._create_request_anthropic_client(
+                        reason="anthropic_messages_request"
+                    ),
+                    kind="anthropic_messages",
+                )
+                result["response"] = agent._anthropic_messages_create(
+                    api_kwargs,
+                    client=request_client,
+                )
             elif agent.api_mode == "bedrock_converse":
                 # Bedrock uses boto3 directly — no OpenAI client needed.
                 # normalize_converse_response produces an OpenAI-compatible
@@ -499,14 +516,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
                     f"Aborting call."
                 )
             try:
-                if agent.api_mode == "anthropic_messages":
-                    logger.warning(
-                        "Anthropic Messages non-streaming call stale; not closing "
-                        "shared _anthropic_client from the poll thread to avoid "
-                        "#29507 TLS FD recycle corruption. Waiting for SDK timeout."
-                    )
-                else:
-                    _close_request_client_once("stale_call_kill")
+                _close_request_client_once("stale_call_kill")
             except Exception:
                 pass
             agent._touch_activity(
@@ -543,14 +553,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
             # shared; closing it here would release TLS FDs from the poll
             # thread and can resurrect #29507 (TLS bytes written into SQLite).
             try:
-                if agent.api_mode == "anthropic_messages":
-                    logger.warning(
-                        "Anthropic Messages call interrupted; not closing shared "
-                        "_anthropic_client from the poll thread to avoid #29507 "
-                        "TLS FD recycle corruption. Waiting for SDK timeout."
-                    )
-                else:
-                    _close_request_client_once("interrupt_abort")
+                _close_request_client_once("interrupt_abort")
             except Exception:
                 pass
             raise InterruptedError("Agent interrupted during API call")
@@ -1730,6 +1733,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
 
     result = {"response": None, "error": None, "partial_tool_names": []}
     request_client_holder = {"client": None, "diag": None, "owner_tid": None}
+    request_client_kind = {"value": "openai"}
     request_client_lock = threading.Lock()
     # Request-local cancellation flag — see interruptible_api_call for the full
     # rationale. The streaming retry loop is where the 7-minute cascading-
@@ -1740,9 +1744,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     # exit immediately instead of retrying. (PR #6600.)
     _request_cancelled = {"value": False}
 
-    def _set_request_client(client):
+    def _set_request_client(client, *, kind: str = "openai"):
         with request_client_lock:
             request_client_holder["client"] = client
+            request_client_kind["value"] = kind
             # See #29507 explanation in the non-streaming variant above.
             request_client_holder["owner_tid"] = threading.get_ident()
         return client
@@ -1765,7 +1770,13 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 request_client_holder["owner_tid"] = None
         if request_client is None:
             return
-        if stranger_thread:
+        kind = request_client_kind.get("value", "openai")
+        if kind == "anthropic_messages":
+            if stranger_thread:
+                agent._abort_request_anthropic_client(request_client, reason=reason)
+            else:
+                agent._close_request_anthropic_client(request_client, reason=reason)
+        elif stranger_thread:
             agent._abort_request_openai_client(request_client, reason=reason)
         else:
             agent._close_request_openai_client(request_client, reason=reason)
@@ -2167,7 +2178,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             usage=usage_obj,
         )
 
-    def _call_anthropic():
+    def _call_anthropic(request_client):
         """Stream an Anthropic Messages API response.
 
         Fires delta callbacks for real-time token delivery, but returns
@@ -2191,7 +2202,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             api_kwargs, log_prefix=getattr(agent, "log_prefix", "")
         )
         # Use the Anthropic SDK's streaming context manager
-        with agent._anthropic_client.messages.stream(**api_kwargs) as stream:
+        with request_client.messages.stream(**api_kwargs) as stream:
             # The Anthropic SDK exposes the raw httpx response on
             # ``stream.response``.  Snapshot diagnostic headers
             # immediately so they survive a stream that dies before the
@@ -2225,7 +2236,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     pass
 
                 if agent._interrupt_requested:
-                    break
+                    raise InterruptedError("Agent interrupted during Anthropic stream")
 
                 event_type = getattr(event, "type", None)
 
@@ -2274,8 +2285,13 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     raise InterruptedError("Agent interrupted before stream retry")
                 try:
                     if agent.api_mode == "anthropic_messages":
-                        agent._try_refresh_anthropic_client_credentials()
-                        result["response"] = _call_anthropic()
+                        request_client = _set_request_client(
+                            agent._create_request_anthropic_client(
+                                reason="anthropic_stream_request"
+                            ),
+                            kind="anthropic_messages",
+                        )
+                        result["response"] = _call_anthropic(request_client)
                     else:
                         result["response"] = _call_chat_completions()
                     return  # success
@@ -2639,14 +2655,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 "(not a network error)."
             )
             try:
-                if agent.api_mode == "anthropic_messages":
-                    logger.warning(
-                        "Anthropic Messages stream interrupted; not closing shared "
-                        "_anthropic_client from the poll thread to avoid #29507 "
-                        "TLS FD recycle corruption. Waiting for stream context cleanup."
-                    )
-                else:
-                    _close_request_client_once("stream_interrupt_abort")
+                _close_request_client_once("stream_interrupt_abort")
             except Exception:
                 pass
             raise InterruptedError("Agent interrupted during streaming API call")

--- a/run_agent.py
+++ b/run_agent.py
@@ -3762,6 +3762,86 @@ class AIAgent:
                 exc,
             )
 
+    def _create_request_anthropic_client(self, *, reason: str) -> Any:
+        """Build a request-local Anthropic client for one in-flight call.
+
+        The shared ``_anthropic_client`` remains the long-lived primary, but
+        stale/interrupt handling must not close it from the poll thread.  A
+        per-request client lets the stranger thread abort sockets while the
+        owning worker performs the SDK-level close, matching the #29507 close
+        discipline used by OpenAI-wire requests.
+        """
+        if self.api_mode == "anthropic_messages":
+            self._try_refresh_anthropic_client_credentials()
+        _drop_1m = bool(getattr(self, "_oauth_1m_beta_disabled", False))
+        if getattr(self, "provider", None) == "bedrock":
+            from agent.anthropic_adapter import build_anthropic_bedrock_client
+            region = getattr(self, "_bedrock_region", "us-east-1") or "us-east-1"
+            client = build_anthropic_bedrock_client(region)
+        else:
+            from agent.anthropic_adapter import build_anthropic_client
+            client = build_anthropic_client(
+                self._anthropic_api_key,
+                getattr(self, "_anthropic_base_url", None),
+                timeout=get_provider_request_timeout(self.provider, self.model),
+                drop_context_1m_beta=_drop_1m,
+            )
+        logger.debug(
+            "Anthropic request client created (%s, shared=False) provider=%s model=%s",
+            reason,
+            getattr(self, "provider", None),
+            getattr(self, "model", None),
+        )
+        return client
+
+    def _close_request_anthropic_client(self, client: Any, *, reason: str) -> None:
+        if client is None:
+            return
+        try:
+            client.close()
+            logger.info(
+                "Anthropic client closed (%s, shared=False) provider=%s model=%s",
+                reason,
+                getattr(self, "provider", None),
+                getattr(self, "model", None),
+            )
+        except Exception as exc:
+            logger.debug(
+                "Anthropic client close failed (%s, shared=False) provider=%s model=%s error=%s",
+                reason,
+                getattr(self, "provider", None),
+                getattr(self, "model", None),
+                exc,
+            )
+
+    def _abort_request_anthropic_client(self, client: Any, *, reason: str) -> None:
+        """Cross-thread abort for request-local Anthropic clients.
+
+        As with OpenAI request clients, stranger threads must not call the SDK
+        ``close()`` method because that can release TLS FDs while the owning
+        worker's SSL BIO is still unwinding (#29507).
+        """
+        if client is None:
+            return
+        try:
+            shutdown_count = self._force_close_tcp_sockets(client)
+            logger.info(
+                "Anthropic client aborted (%s, shared=False, tcp_force_closed=%d, "
+                "deferred_close=stranger_thread) provider=%s model=%s",
+                reason,
+                shutdown_count,
+                getattr(self, "provider", None),
+                getattr(self, "model", None),
+            )
+        except Exception as exc:
+            logger.debug(
+                "Anthropic client abort failed (%s, shared=False) provider=%s model=%s error=%s",
+                reason,
+                getattr(self, "provider", None),
+                getattr(self, "model", None),
+                exc,
+            )
+
     def _run_codex_stream(self, api_kwargs: dict, client: Any = None, on_first_delta: callable = None):
         """Forwarder — see ``agent.codex_runtime.run_codex_stream``."""
         from agent.codex_runtime import run_codex_stream
@@ -4101,15 +4181,16 @@ class AIAgent:
             return False
         return pool.has_available()
 
-    def _anthropic_messages_create(self, api_kwargs: dict):
-        if self.api_mode == "anthropic_messages":
+    def _anthropic_messages_create(self, api_kwargs: dict, *, client: Any = None):
+        if client is None and self.api_mode == "anthropic_messages":
             self._try_refresh_anthropic_client_credentials()
         # Defensive: strip Responses-only kwargs that can leak in under an
         # api_mode-flip race (the Anthropic SDK raises a non-retryable
         # TypeError on them). See #31673.
         from agent.anthropic_adapter import create_anthropic_message
+        request_client = client or self._anthropic_client
         return create_anthropic_message(
-            self._anthropic_client,
+            request_client,
             api_kwargs,
             log_prefix=getattr(self, "log_prefix", ""),
             prefer_stream=not bool(getattr(self, "_disable_streaming", False)),

--- a/tests/agent/test_cascading_interrupt_6600.py
+++ b/tests/agent/test_cascading_interrupt_6600.py
@@ -141,7 +141,19 @@ def _make_anthropic_agent():
     agent._anthropic_client = MagicMock()
     agent._rebuild_anthropic_client = MagicMock()
     agent._anthropic_messages_create = MagicMock()
+    agent._create_request_anthropic_client = MagicMock()
+    agent._close_request_anthropic_client = MagicMock()
+    agent._abort_request_anthropic_client = MagicMock()
     return agent
+
+
+def _wait_for_mock_call(mock, timeout=2.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if mock.called:
+            return
+        time.sleep(0.02)
+    raise AssertionError(f"{mock!r} was not called within {timeout}s")
 
 
 def test_anthropic_non_streaming_interrupt_does_not_close_shared_client():
@@ -152,10 +164,13 @@ def test_anthropic_non_streaming_interrupt_does_not_close_shared_client():
     BIO write a TLS record into state.db's header.
     """
     agent = _make_anthropic_agent()
+    request_client = MagicMock()
+    agent._create_request_anthropic_client.return_value = request_client
 
-    def _create(_api_kwargs):
+    def _create(_api_kwargs, *, client):
+        assert client is request_client
         agent._interrupt_requested = True
-        time.sleep(0.3)
+        time.sleep(1.0)
         raise httpx.RemoteProtocolError("forced close would have happened")
 
     agent._anthropic_messages_create.side_effect = _create
@@ -168,15 +183,27 @@ def test_anthropic_non_streaming_interrupt_does_not_close_shared_client():
     assert elapsed < 3.0, f"interrupt took {elapsed:.1f}s — should be near-instant"
     agent._anthropic_client.close.assert_not_called()
     agent._rebuild_anthropic_client.assert_not_called()
+    agent._abort_request_anthropic_client.assert_called_once_with(
+        request_client,
+        reason="interrupt_abort",
+    )
+    _wait_for_mock_call(agent._close_request_anthropic_client)
+    agent._close_request_anthropic_client.assert_called_with(
+        request_client,
+        reason="request_complete",
+    )
 
 
 def test_anthropic_non_streaming_stale_does_not_close_shared_client(monkeypatch):
     """#29507: stale-call polling must not close/rebuild shared Anthropic client."""
     agent = _make_anthropic_agent()
+    request_client = MagicMock()
+    agent._create_request_anthropic_client.return_value = request_client
     agent._compute_non_stream_stale_timeout.return_value = 0.05
     agent._codex_silent_hang_hint = MagicMock(return_value=None)
 
-    def _create(_api_kwargs):
+    def _create(_api_kwargs, *, client):
+        assert client is request_client
         time.sleep(2.5)
         return object()
 
@@ -187,35 +214,67 @@ def test_anthropic_non_streaming_stale_does_not_close_shared_client(monkeypatch)
 
     agent._anthropic_client.close.assert_not_called()
     agent._rebuild_anthropic_client.assert_not_called()
+    agent._abort_request_anthropic_client.assert_called_once_with(
+        request_client,
+        reason="stale_call_kill",
+    )
+    _wait_for_mock_call(agent._close_request_anthropic_client)
+    agent._close_request_anthropic_client.assert_called_with(
+        request_client,
+        reason="request_complete",
+    )
 
 
 def test_anthropic_streaming_interrupt_does_not_close_shared_client(monkeypatch):
     """#29507: streaming interrupt must not close/rebuild shared Anthropic client."""
     agent = _make_anthropic_agent()
+    request_client = MagicMock()
+    agent._create_request_anthropic_client.return_value = request_client
     agent._compute_stream_stale_timeout.return_value = 5.0
     agent._invoke_bedrock_stream = MagicMock()
     agent.provider = "anthropic"
 
     class _Chunk:
         type = "content_block_delta"
-        delta = types.SimpleNamespace(text="hello")
+        delta = types.SimpleNamespace(type="text_delta", text="hello")
 
     class _Stream:
+        def __init__(self):
+            self.exited = threading.Event()
+            self.get_final_message = MagicMock(
+                side_effect=AssertionError(
+                    "get_final_message() must not run after interrupt"
+                )
+            )
+
         def __enter__(self):
             return self
 
         def __exit__(self, exc_type, exc, tb):
+            self.exited.set()
             return False
 
         def __iter__(self):
             agent._interrupt_requested = True
-            time.sleep(0.3)
+            time.sleep(1.0)
             yield _Chunk()
 
-    agent._anthropic_client.messages.stream.return_value = _Stream()
+    stream = _Stream()
+    request_client.messages.stream.return_value = stream
 
     with pytest.raises(InterruptedError):
         cch.interruptible_streaming_api_call(agent, {"model": "x", "messages": []})
 
     agent._anthropic_client.close.assert_not_called()
     agent._rebuild_anthropic_client.assert_not_called()
+    agent._abort_request_anthropic_client.assert_called_once_with(
+        request_client,
+        reason="stream_interrupt_abort",
+    )
+    _wait_for_mock_call(agent._close_request_anthropic_client)
+    agent._close_request_anthropic_client.assert_called_with(
+        request_client,
+        reason="stream_request_complete",
+    )
+    assert stream.exited.wait(1.0)
+    stream.get_final_message.assert_not_called()

--- a/tests/agent/test_cascading_interrupt_6600.py
+++ b/tests/agent/test_cascading_interrupt_6600.py
@@ -132,3 +132,90 @@ def test_request_cancelled_token_is_request_local():
 
     with pytest.raises(httpx.RemoteProtocolError):
         cch.interruptible_api_call(agent, {"model": "x", "messages": []})
+
+
+
+def _make_anthropic_agent():
+    agent = _make_agent()
+    agent.api_mode = "anthropic_messages"
+    agent._anthropic_client = MagicMock()
+    agent._rebuild_anthropic_client = MagicMock()
+    agent._anthropic_messages_create = MagicMock()
+    return agent
+
+
+def test_anthropic_non_streaming_interrupt_does_not_close_shared_client():
+    """#29507: interrupt polling must not close the shared Anthropic SDK client.
+
+    The shared client may be in use on the worker thread. Closing it from the
+    poll thread can release a TLS FD that SQLite later reuses, letting the SSL
+    BIO write a TLS record into state.db's header.
+    """
+    agent = _make_anthropic_agent()
+
+    def _create(_api_kwargs):
+        agent._interrupt_requested = True
+        time.sleep(0.3)
+        raise httpx.RemoteProtocolError("forced close would have happened")
+
+    agent._anthropic_messages_create.side_effect = _create
+
+    t0 = time.time()
+    with pytest.raises(InterruptedError):
+        cch.interruptible_api_call(agent, {"model": "x", "messages": []})
+    elapsed = time.time() - t0
+
+    assert elapsed < 3.0, f"interrupt took {elapsed:.1f}s — should be near-instant"
+    agent._anthropic_client.close.assert_not_called()
+    agent._rebuild_anthropic_client.assert_not_called()
+
+
+def test_anthropic_non_streaming_stale_does_not_close_shared_client(monkeypatch):
+    """#29507: stale-call polling must not close/rebuild shared Anthropic client."""
+    agent = _make_anthropic_agent()
+    agent._compute_non_stream_stale_timeout.return_value = 0.05
+    agent._codex_silent_hang_hint = MagicMock(return_value=None)
+
+    def _create(_api_kwargs):
+        time.sleep(2.5)
+        return object()
+
+    agent._anthropic_messages_create.side_effect = _create
+
+    with pytest.raises(TimeoutError):
+        cch.interruptible_api_call(agent, {"model": "x", "messages": []})
+
+    agent._anthropic_client.close.assert_not_called()
+    agent._rebuild_anthropic_client.assert_not_called()
+
+
+def test_anthropic_streaming_interrupt_does_not_close_shared_client(monkeypatch):
+    """#29507: streaming interrupt must not close/rebuild shared Anthropic client."""
+    agent = _make_anthropic_agent()
+    agent._compute_stream_stale_timeout.return_value = 5.0
+    agent._invoke_bedrock_stream = MagicMock()
+    agent.provider = "anthropic"
+
+    class _Chunk:
+        type = "content_block_delta"
+        delta = types.SimpleNamespace(text="hello")
+
+    class _Stream:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def __iter__(self):
+            agent._interrupt_requested = True
+            time.sleep(0.3)
+            yield _Chunk()
+
+    agent._anthropic_client.messages.stream.return_value = _Stream()
+
+    with pytest.raises(InterruptedError):
+        cch.interruptible_streaming_api_call(agent, {"model": "x", "messages": []})
+
+    agent._anthropic_client.close.assert_not_called()
+    agent._rebuild_anthropic_client.assert_not_called()


### PR DESCRIPTION
Anthropic Messages uses a shared SDK client, unlike the request-local OpenAI-wire clients protected by the existing #29507 owner-thread close discipline. The stale/interrupt poll loop was still closing and rebuilding that shared client from a non-owner thread, which can release TLS file descriptors while a worker thread is still unwinding the SSL BIO. If SQLite reuses that descriptor, pending TLS bytes can clobber a database header.

Skip shared Anthropic client close/rebuild from non-streaming stale, non-streaming interrupt, and streaming interrupt paths. The in-flight SDK call is left to its timeout or stream context cleanup while the existing OpenAI request-local close path remains unchanged.

Add regression coverage for the Anthropic-compatible paths so future interrupt/stale changes do not reintroduce shared client close/rebuild.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

