### PR TITLE
Add Google Tasks support to Google Workspace skill

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: google-workspace
-description: "Gmail, Calendar, Drive, Docs, Sheets via gws CLI or Python."
-version: 1.1.0
+description: "Gmail, Calendar, Drive, Docs, Sheets, Contacts, and Google Tasks via gws CLI or Python."
+version: 1.2.0
 author: Nous Research
 license: MIT
 platforms: [linux, macos, windows]
@@ -12,14 +12,14 @@ required_credential_files:
     description: Google OAuth2 client credentials (downloaded from Google Cloud Console)
 metadata:
   hermes:
-    tags: [Google, Gmail, Calendar, Drive, Sheets, Docs, Contacts, Email, OAuth]
+    tags: [Google, Gmail, Calendar, Drive, Sheets, Docs, Contacts, Tasks, Email, OAuth]
     homepage: https://github.com/NousResearch/hermes-agent
     related_skills: [himalaya]
 ---
 
 # Google Workspace
 
-Gmail, Calendar, Drive, Contacts, Sheets, and Docs — through Hermes-managed OAuth and a thin CLI wrapper. When `gws` is installed, the skill uses it as the execution backend for broader Google Workspace coverage; otherwise it falls back to the bundled Python client implementation.
+Gmail, Calendar, Drive, Contacts, Sheets, Docs, and Google Tasks — through Hermes-managed OAuth and a thin CLI wrapper. When `gws` is installed, the skill uses it as the execution backend for broader Google Workspace coverage; otherwise it falls back to the bundled Python client implementation.
 
 ## References
 
@@ -90,7 +90,7 @@ Tell the user:
 > 2. Enable the required APIs from the API Library:
 >    https://console.cloud.google.com/apis/library
 >    Enable: Gmail API, Google Calendar API, Google Drive API,
->    Google Sheets API, Google Docs API, People API
+>    Google Sheets API, Google Docs API, People API, Google Tasks API
 > 3. Create the OAuth client here:
 >    https://console.cloud.google.com/apis/credentials
 >    Credentials → Create Credentials → OAuth 2.0 Client ID
@@ -120,7 +120,7 @@ Use the service set chosen in Step 1. Examples:
 
 ```bash
 $GSETUP --auth-url --services email,calendar --format json
-$GSETUP --auth-url --services calendar,drive,sheets,docs --format json
+$GSETUP --auth-url --services calendar,drive,sheets,docs,tasks --format json
 $GSETUP --auth-url --services all --format json
 ```
 
@@ -286,6 +286,30 @@ $GAPI docs create --title "Draft" --body "First paragraph..."
 $GAPI docs append DOC_ID --text "Additional content to append"
 ```
 
+### Google Tasks
+
+```bash
+# Task lists
+$GAPI tasks lists
+$GAPI tasks create-list --title "Work"
+$GAPI tasks update-list TASKLIST_ID --title "Work Projects"
+$GAPI tasks delete-list TASKLIST_ID
+
+# Tasks
+$GAPI tasks list TASKLIST_ID --max 20
+$GAPI tasks list TASKLIST_ID --show-completed --show-hidden
+$GAPI tasks get TASKLIST_ID TASK_ID
+$GAPI tasks create TASKLIST_ID --title "Follow up" --notes "Call Alice" --due 2026-03-01
+$GAPI tasks create TASKLIST_ID --title "Subtask" --parent PARENT_TASK_ID
+$GAPI tasks update TASKLIST_ID TASK_ID --title "Updated" --notes "New notes" --due 2026-03-02 --status needsAction
+$GAPI tasks complete TASKLIST_ID TASK_ID
+$GAPI tasks move TASKLIST_ID TASK_ID --previous OTHER_TASK_ID
+$GAPI tasks delete TASKLIST_ID TASK_ID
+$GAPI tasks clear-completed TASKLIST_ID
+```
+
+`tasks delete`, `tasks delete-list`, and `tasks clear-completed` have no trash/undo path. Treat them as irreversible and confirm the exact task list/task IDs before running.
+
 ## Output Format
 
 All commands return JSON. Parse with `jq` or read directly. Key fields:
@@ -307,10 +331,13 @@ All commands return JSON. Parse with `jq` or read directly. Key fields:
 - **Sheets create**: `{status: "created", spreadsheetId, title, spreadsheetUrl}`
 - **Docs create**: `{status: "created", documentId, title, url}`
 - **Docs append**: `{status: "appended", documentId, inserted_at, characters}`
+- **Tasks lists**: `[{id, title, updated, selfLink}]`
+- **Tasks list**: `[{id, title, notes, status, due, completed, updated, parent, position, links, selfLink}]`
+- **Tasks create/update/get/complete/move**: `{id, title, notes, status, due, ...}`
 
 ## Rules
 
-1. **Never send email, create/delete calendar events, delete Drive files, share files, or modify Docs/Sheets without confirming with the user first.** Show what will be done (recipients, file IDs, content, share role) and ask for approval. For `drive delete`, prefer the default trash (reversible) over `--permanent`.
+1. **Never send email, create/delete calendar events, delete Drive files, share files, modify Docs/Sheets, or create/update/delete Google Tasks without confirming with the user first.** Show what will be done (recipients, file IDs, content, share role, task list/task IDs) and ask for approval. For `drive delete`, prefer the default trash (reversible) over `--permanent`. For Tasks, `delete`, `delete-list`, and `clear-completed` are irreversible.
 2. **Check auth before first use** — run `setup.py --check`. If it fails, guide the user through setup.
 3. **Use the Gmail search syntax reference** for complex queries — load it with `skill_view("google-workspace", file_path="references/gmail-search-syntax.md")`.
 4. **Calendar times must include timezone** — always use ISO 8601 with offset (e.g., `2026-03-01T10:00:00-06:00`) or UTC (`Z`).
@@ -323,7 +350,7 @@ All commands return JSON. Parse with `jq` or read directly. Key fields:
 | `NOT_AUTHENTICATED` | Run setup Steps 2-5 above |
 | `REFRESH_FAILED` | Token revoked or expired — redo Steps 3-5 |
 | `HttpError 403: Insufficient Permission` | Missing API scope — `$GSETUP --revoke` then redo Steps 3-5 |
-| `AUTHENTICATED (partial)` or "Token missing scopes" | New write capabilities (Drive write/delete, Docs create/edit) require re-authorization. `$GSETUP --revoke` then redo Steps 3-5 to grant the upgraded scopes. |
+| `AUTHENTICATED (partial)` or "Token missing scopes" | New write capabilities (Drive write/delete, Docs create/edit, Google Tasks) require re-authorization. `$GSETUP --revoke` then redo Steps 3-5 to grant the upgraded scopes. |
 | `HttpError 403: Access Not Configured` | API not enabled — user needs to enable it in Google Cloud Console |
 | `ModuleNotFoundError` | Run `$GSETUP --install-deps` |
 | Advanced Protection blocks auth | Workspace admin must allowlist the OAuth client ID |

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -51,6 +51,7 @@ SCOPES = [
     "https://www.googleapis.com/auth/contacts.readonly",
     "https://www.googleapis.com/auth/spreadsheets",
     "https://www.googleapis.com/auth/documents",
+    "https://www.googleapis.com/auth/tasks",
 ]
 
 
@@ -948,6 +949,215 @@ def sheets_create(args):
 
 
 # =========================================================================
+# Google Tasks
+# =========================================================================
+
+
+def _tasks_service():
+    return build_service("tasks", "v1")
+
+
+def _normalize_tasklist(item: dict) -> dict:
+    return {
+        "id": item.get("id", ""),
+        "title": item.get("title", ""),
+        "updated": item.get("updated", ""),
+        "selfLink": item.get("selfLink", ""),
+    }
+
+
+def _normalize_task(item: dict) -> dict:
+    return {
+        "id": item.get("id", ""),
+        "title": item.get("title", ""),
+        "notes": item.get("notes", ""),
+        "status": item.get("status", ""),
+        "due": item.get("due", ""),
+        "completed": item.get("completed", ""),
+        "updated": item.get("updated", ""),
+        "parent": item.get("parent", ""),
+        "position": item.get("position", ""),
+        "links": item.get("links", []),
+        "selfLink": item.get("selfLink", ""),
+    }
+
+
+def tasks_lists(args):
+    if _gws_binary():
+        result = _run_gws(["tasks", "tasklists", "list"], params={"maxResults": args.max})
+    else:
+        result = _tasks_service().tasklists().list(maxResults=args.max).execute()
+    print(json.dumps([_normalize_tasklist(item) for item in result.get("items", [])], indent=2, ensure_ascii=False))
+
+
+def tasks_list_create(args):
+    body = {"title": args.title}
+    if _gws_binary():
+        result = _run_gws(["tasks", "tasklists", "insert"], body=body)
+    else:
+        result = _tasks_service().tasklists().insert(body=body).execute()
+    output = _normalize_tasklist(result)
+    output["status"] = "created"
+    print(json.dumps(output, indent=2, ensure_ascii=False))
+
+
+def tasks_list_update(args):
+    body = {"title": args.title}
+    if _gws_binary():
+        result = _run_gws(["tasks", "tasklists", "patch"], params={"tasklist": args.tasklist_id}, body=body)
+    else:
+        result = _tasks_service().tasklists().patch(tasklist=args.tasklist_id, body=body).execute()
+    output = _normalize_tasklist(result)
+    output["status"] = "updated"
+    print(json.dumps(output, indent=2, ensure_ascii=False))
+
+
+def tasks_list_delete(args):
+    if _gws_binary():
+        _run_gws(["tasks", "tasklists", "delete"], params={"tasklist": args.tasklist_id})
+    else:
+        _tasks_service().tasklists().delete(tasklist=args.tasklist_id).execute()
+    print(json.dumps({"status": "deleted", "tasklistId": args.tasklist_id}, indent=2))
+
+
+def tasks_tasks(args):
+    params = {
+        "tasklist": args.tasklist_id,
+        "maxResults": args.max,
+        "showCompleted": args.show_completed,
+        "showHidden": args.show_hidden,
+    }
+    if args.updated_min:
+        params["updatedMin"] = args.updated_min
+    if args.due_min:
+        params["dueMin"] = args.due_min
+    if args.due_max:
+        params["dueMax"] = args.due_max
+
+    if _gws_binary():
+        result = _run_gws(["tasks", "tasks", "list"], params=params)
+    else:
+        result = _tasks_service().tasks().list(**params).execute()
+    print(json.dumps([_normalize_task(item) for item in result.get("items", [])], indent=2, ensure_ascii=False))
+
+
+def tasks_get(args):
+    params = {"tasklist": args.tasklist_id, "task": args.task_id}
+    if _gws_binary():
+        result = _run_gws(["tasks", "tasks", "get"], params=params)
+    else:
+        result = _tasks_service().tasks().get(**params).execute()
+    print(json.dumps(_normalize_task(result), indent=2, ensure_ascii=False))
+
+
+def _task_body_from_args(args, *, include_status: bool = True) -> dict:
+    body = {"title": args.title}
+    if args.notes:
+        body["notes"] = args.notes
+    if args.due:
+        body["due"] = _tasks_due(args.due)
+    if include_status and getattr(args, "status", ""):
+        body["status"] = args.status
+    return body
+
+
+def _tasks_due(value: str) -> str:
+    if not value:
+        return value
+    if "T" not in value:
+        return f"{value}T00:00:00.000Z"
+    normalized = _datetime_with_timezone(value)
+    if normalized.endswith("Z") and "." not in normalized.rsplit("T", 1)[-1]:
+        return normalized[:-1] + ".000Z"
+    return normalized
+
+
+def tasks_create(args):
+    body = _task_body_from_args(args, include_status=False)
+    params = {"tasklist": args.tasklist_id}
+    if args.parent:
+        params["parent"] = args.parent
+    if args.previous:
+        params["previous"] = args.previous
+
+    if _gws_binary():
+        result = _run_gws(["tasks", "tasks", "insert"], params=params, body=body)
+    else:
+        result = _tasks_service().tasks().insert(body=body, **params).execute()
+    output = _normalize_task(result)
+    output["operationStatus"] = "created"
+    print(json.dumps(output, indent=2, ensure_ascii=False))
+
+
+def tasks_update(args):
+    body = {}
+    if args.title:
+        body["title"] = args.title
+    if args.notes is not None:
+        body["notes"] = args.notes
+    if args.due is not None:
+        body["due"] = _tasks_due(args.due) if args.due else None
+    if args.status:
+        body["status"] = args.status
+    if not body:
+        print("ERROR: provide at least one of --title, --notes, --due, or --status", file=sys.stderr)
+        sys.exit(1)
+
+    params = {"tasklist": args.tasklist_id, "task": args.task_id}
+    if _gws_binary():
+        result = _run_gws(["tasks", "tasks", "patch"], params=params, body=body)
+    else:
+        result = _tasks_service().tasks().patch(body=body, **params).execute()
+    print(json.dumps(_normalize_task(result), indent=2, ensure_ascii=False))
+
+
+def tasks_complete(args):
+    body = {"status": "completed"}
+    params = {"tasklist": args.tasklist_id, "task": args.task_id}
+    if _gws_binary():
+        result = _run_gws(["tasks", "tasks", "patch"], params=params, body=body)
+    else:
+        result = _tasks_service().tasks().patch(body=body, **params).execute()
+    output = _normalize_task(result)
+    output["operationStatus"] = "completed"
+    print(json.dumps(output, indent=2, ensure_ascii=False))
+
+
+def tasks_delete(args):
+    params = {"tasklist": args.tasklist_id, "task": args.task_id}
+    if _gws_binary():
+        _run_gws(["tasks", "tasks", "delete"], params=params)
+    else:
+        _tasks_service().tasks().delete(**params).execute()
+    print(json.dumps({"status": "deleted", "tasklistId": args.tasklist_id, "taskId": args.task_id}, indent=2))
+
+
+def tasks_clear_completed(args):
+    params = {"tasklist": args.tasklist_id}
+    if _gws_binary():
+        _run_gws(["tasks", "tasks", "clear"], params=params)
+    else:
+        _tasks_service().tasks().clear(**params).execute()
+    print(json.dumps({"status": "cleared", "tasklistId": args.tasklist_id}, indent=2))
+
+
+def tasks_move(args):
+    params = {"tasklist": args.tasklist_id, "task": args.task_id}
+    if args.parent:
+        params["parent"] = args.parent
+    if args.previous:
+        params["previous"] = args.previous
+
+    if _gws_binary():
+        result = _run_gws(["tasks", "tasks", "move"], params=params)
+    else:
+        result = _tasks_service().tasks().move(**params).execute()
+    output = _normalize_task(result)
+    output["operationStatus"] = "moved"
+    print(json.dumps(output, indent=2, ensure_ascii=False))
+
+
+# =========================================================================
 # Docs
 # =========================================================================
 
@@ -1198,6 +1408,81 @@ def main():
     p.add_argument("--title", required=True, help="Spreadsheet title")
     p.add_argument("--sheet-name", default="", help="Name of the first tab (defaults to 'Sheet1')")
     p.set_defaults(func=sheets_create)
+
+    # --- Google Tasks ---
+    tsk = sub.add_parser("tasks")
+    tsk_sub = tsk.add_subparsers(dest="action", required=True)
+
+    p = tsk_sub.add_parser("lists")
+    p.add_argument("--max", type=int, default=100, help="Maximum task lists to return")
+    p.set_defaults(func=tasks_lists)
+
+    p = tsk_sub.add_parser("create-list")
+    p.add_argument("--title", required=True, help="Task list title")
+    p.set_defaults(func=tasks_list_create)
+
+    p = tsk_sub.add_parser("update-list")
+    p.add_argument("tasklist_id")
+    p.add_argument("--title", required=True, help="New task list title")
+    p.set_defaults(func=tasks_list_update)
+
+    p = tsk_sub.add_parser("delete-list")
+    p.add_argument("tasklist_id")
+    p.set_defaults(func=tasks_list_delete)
+
+    p = tsk_sub.add_parser("list")
+    p.add_argument("tasklist_id")
+    p.add_argument("--max", type=int, default=100, help="Maximum tasks to return")
+    p.add_argument("--show-completed", action="store_true", help="Include completed tasks")
+    p.add_argument("--show-hidden", action="store_true", help="Include hidden tasks")
+    p.add_argument("--updated-min", default="", help="Lower bound for updated time (RFC3339)")
+    p.add_argument("--due-min", default="", help="Lower bound for due time (RFC3339)")
+    p.add_argument("--due-max", default="", help="Upper bound for due time (RFC3339)")
+    p.set_defaults(func=tasks_tasks)
+
+    p = tsk_sub.add_parser("get")
+    p.add_argument("tasklist_id")
+    p.add_argument("task_id")
+    p.set_defaults(func=tasks_get)
+
+    p = tsk_sub.add_parser("create")
+    p.add_argument("tasklist_id")
+    p.add_argument("--title", required=True, help="Task title")
+    p.add_argument("--notes", default="", help="Task notes")
+    p.add_argument("--due", default="", help="Due time/date (RFC3339 or ISO 8601; date-only is accepted by Google)")
+    p.add_argument("--parent", default="", help="Parent task ID for subtasks")
+    p.add_argument("--previous", default="", help="Previous sibling task ID for positioning")
+    p.set_defaults(func=tasks_create)
+
+    p = tsk_sub.add_parser("update")
+    p.add_argument("tasklist_id")
+    p.add_argument("task_id")
+    p.add_argument("--title", default="", help="New task title")
+    p.add_argument("--notes", default=None, help="New task notes; pass empty string to clear")
+    p.add_argument("--due", default=None, help="New due time/date; pass empty string to clear")
+    p.add_argument("--status", choices=["needsAction", "completed"], default="", help="New task status")
+    p.set_defaults(func=tasks_update)
+
+    p = tsk_sub.add_parser("complete")
+    p.add_argument("tasklist_id")
+    p.add_argument("task_id")
+    p.set_defaults(func=tasks_complete)
+
+    p = tsk_sub.add_parser("move")
+    p.add_argument("tasklist_id")
+    p.add_argument("task_id")
+    p.add_argument("--parent", default="", help="New parent task ID")
+    p.add_argument("--previous", default="", help="Insert after this sibling task ID")
+    p.set_defaults(func=tasks_move)
+
+    p = tsk_sub.add_parser("delete")
+    p.add_argument("tasklist_id")
+    p.add_argument("task_id")
+    p.set_defaults(func=tasks_delete)
+
+    p = tsk_sub.add_parser("clear-completed")
+    p.add_argument("tasklist_id")
+    p.set_defaults(func=tasks_clear_completed)
 
     # --- Docs ---
     docs = sub.add_parser("docs")

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -43,6 +43,38 @@ TOKEN_PATH = HERMES_HOME / "google_token.json"
 CLIENT_SECRET_PATH = HERMES_HOME / "google_client_secret.json"
 PENDING_AUTH_PATH = HERMES_HOME / "google_oauth_pending.json"
 
+SERVICE_SCOPES = {
+    "email": [
+        "https://www.googleapis.com/auth/gmail.readonly",
+        "https://www.googleapis.com/auth/gmail.send",
+        "https://www.googleapis.com/auth/gmail.modify",
+    ],
+    "gmail": [
+        "https://www.googleapis.com/auth/gmail.readonly",
+        "https://www.googleapis.com/auth/gmail.send",
+        "https://www.googleapis.com/auth/gmail.modify",
+    ],
+    "calendar": [
+        "https://www.googleapis.com/auth/calendar",
+    ],
+    "drive": [
+        "https://www.googleapis.com/auth/drive",
+    ],
+    "contacts": [
+        "https://www.googleapis.com/auth/contacts.readonly",
+    ],
+    "sheets": [
+        "https://www.googleapis.com/auth/spreadsheets",
+    ],
+    "docs": [
+        "https://www.googleapis.com/auth/documents",
+    ],
+    "tasks": [
+        "https://www.googleapis.com/auth/tasks",
+    ],
+}
+
+
 SCOPES = [
     "https://www.googleapis.com/auth/gmail.readonly",
     "https://www.googleapis.com/auth/gmail.send",
@@ -52,6 +84,7 @@ SCOPES = [
     "https://www.googleapis.com/auth/contacts.readonly",
     "https://www.googleapis.com/auth/spreadsheets",
     "https://www.googleapis.com/auth/documents",
+    "https://www.googleapis.com/auth/tasks",
 ]
 
 REQUIRED_PACKAGES = ["google-api-python-client", "google-auth-oauthlib", "google-auth-httplib2"]
@@ -76,12 +109,20 @@ def _load_token_payload(path: Path = TOKEN_PATH) -> dict:
         return {}
 
 
+def _expected_scopes_from_payload(payload: dict) -> list[str]:
+    expected = payload.get("hermes_requested_scopes")
+    if isinstance(expected, list) and expected:
+        return [s for s in expected if isinstance(s, str) and s]
+    return list(SCOPES)
+
+
 def _missing_scopes_from_payload(payload: dict) -> list[str]:
     raw = payload.get("scopes") or payload.get("scope")
     if not raw:
         return []
     granted = {s.strip() for s in (raw.split() if isinstance(raw, str) else raw) if s.strip()}
-    return sorted(scope for scope in SCOPES if scope not in granted)
+    expected = _expected_scopes_from_payload(payload)
+    return sorted(scope for scope in expected if scope not in granted)
 
 
 def _format_missing_scopes(missing_scopes: list[str]) -> str:
@@ -274,7 +315,35 @@ def store_client_secret(path: str):
     print(f"OK: Client secret saved to {CLIENT_SECRET_PATH}")
 
 
-def _save_pending_auth(*, state: str, code_verifier: str):
+def _scopes_for_services(services: str | None) -> tuple[list[str], list[str]]:
+    """Resolve a comma-separated service list to OAuth scopes."""
+    raw = (services or "all").strip().lower()
+    if not raw or raw == "all":
+        return list(SCOPES), ["all"]
+
+    names = [part.strip() for part in raw.split(",") if part.strip()]
+    scopes: list[str] = []
+    unknown: list[str] = []
+    for name in names:
+        service_scopes = SERVICE_SCOPES.get(name)
+        if not service_scopes:
+            unknown.append(name)
+            continue
+        for scope in service_scopes:
+            if scope not in scopes:
+                scopes.append(scope)
+
+    if unknown:
+        valid = ", ".join(sorted(set(SERVICE_SCOPES) | {"all"}))
+        print(f"ERROR: Unknown service(s): {', '.join(unknown)}. Valid: {valid}")
+        sys.exit(1)
+    if not scopes:
+        print("ERROR: No OAuth scopes selected.")
+        sys.exit(1)
+    return scopes, names
+
+
+def _save_pending_auth(*, state: str, code_verifier: str, scopes: list[str], services: list[str]):
     """Persist the OAuth session bits needed for a later token exchange."""
     PENDING_AUTH_PATH.write_text(
         json.dumps(
@@ -282,6 +351,8 @@ def _save_pending_auth(*, state: str, code_verifier: str):
                 "state": state,
                 "code_verifier": code_verifier,
                 "redirect_uri": REDIRECT_URI,
+                "scopes": scopes,
+                "services": services,
             },
             indent=2,
         )
@@ -326,18 +397,21 @@ def _extract_code_and_state(code_or_url: str) -> tuple[str, str | None]:
     return params["code"][0], state
 
 
-def get_auth_url():
+
+def get_auth_url(services: str | None = None, output_format: str = "text"):
     """Print the OAuth authorization URL. User visits this in a browser."""
     if not CLIENT_SECRET_PATH.exists():
         print("ERROR: No client secret stored. Run --client-secret first.")
         sys.exit(1)
+    requested_scopes, service_names = _scopes_for_services(services)
 
     _ensure_deps()
     from google_auth_oauthlib.flow import Flow
+    scopes = requested_scopes
 
     flow = Flow.from_client_secrets_file(
         str(CLIENT_SECRET_PATH),
-        scopes=SCOPES,
+        scopes=scopes,
         redirect_uri=REDIRECT_URI,
         autogenerate_code_verifier=True,
     )
@@ -345,9 +419,12 @@ def get_auth_url():
         access_type="offline",
         prompt="consent",
     )
-    _save_pending_auth(state=state, code_verifier=flow.code_verifier)
-    # Print just the URL so the agent can extract it cleanly
-    print(auth_url)
+    _save_pending_auth(state=state, code_verifier=flow.code_verifier, scopes=scopes, services=service_names)
+    if output_format == "json":
+        print(json.dumps({"auth_url": auth_url, "services": service_names, "scopes": requested_scopes}, indent=2))
+    else:
+        # Print just the URL so the agent can extract it cleanly
+        print(auth_url)
 
 
 def exchange_auth_code(code: str):
@@ -368,7 +445,8 @@ def exchange_auth_code(code: str):
     from urllib.parse import parse_qs, urlparse
 
     # Extract granted scopes from the callback URL if the user pasted the full redirect URL.
-    granted_scopes = list(SCOPES)
+    requested_scopes = list(pending_auth.get("scopes") or SCOPES)
+    granted_scopes = list(requested_scopes)
     if isinstance(raw_callback, str) and raw_callback.startswith("http"):
         params = parse_qs(urlparse(raw_callback).query)
         scope_val = (params.get("scope") or [""])[0].strip()
@@ -401,10 +479,12 @@ def exchange_auth_code(code: str):
     actually_granted = list(creds.granted_scopes or []) if hasattr(creds, "granted_scopes") and creds.granted_scopes else []
     if actually_granted:
         token_payload["scopes"] = actually_granted
-    elif granted_scopes != SCOPES:
+    elif granted_scopes != requested_scopes:
         # granted_scopes was extracted from the callback URL
         token_payload["scopes"] = granted_scopes
 
+    token_payload["hermes_requested_scopes"] = requested_scopes
+    token_payload["hermes_requested_services"] = pending_auth.get("services", ["all"])
     missing_scopes = _missing_scopes_from_payload(token_payload)
     if missing_scopes:
         print(f"WARNING: Token missing some Google Workspace scopes: {', '.join(missing_scopes)}")
@@ -459,6 +539,8 @@ def main():
     group.add_argument("--auth-code", metavar="CODE", help="Exchange auth code for token")
     group.add_argument("--revoke", action="store_true", help="Revoke and delete stored token")
     group.add_argument("--install-deps", action="store_true", help="Install Python dependencies")
+    parser.add_argument("--services", default="all", help="Comma-separated services for --auth-url: email,calendar,drive,contacts,sheets,docs,tasks,all")
+    parser.add_argument("--format", choices=["text", "json"], default="text", help="Output format for --auth-url")
     args = parser.parse_args()
 
     if args.check:
@@ -468,7 +550,7 @@ def main():
     elif args.client_secret:
         store_client_secret(args.client_secret)
     elif args.auth_url:
-        get_auth_url()
+        get_auth_url(args.services, args.format)
     elif args.auth_code:
         exchange_auth_code(args.auth_code)
     elif args.revoke:

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -20,6 +20,10 @@ API_PATH = (
     Path(__file__).resolve().parents[2]
     / "skills/productivity/google-workspace/scripts/google_api.py"
 )
+SETUP_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "skills/productivity/google-workspace/scripts/setup.py"
+)
 
 
 @pytest.fixture
@@ -51,6 +55,19 @@ def api_module(monkeypatch, tmp_path):
     module._gws_binary = lambda: "/usr/bin/gws"
     # Bypass authentication check — no real token file in CI.
     module._ensure_authenticated = lambda: None
+    return module
+
+
+@pytest.fixture
+def setup_script_module(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    spec = importlib.util.spec_from_file_location("gws_setup_test", SETUP_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
     return module
 
 
@@ -484,3 +501,113 @@ def test_api_get_credentials_refresh_persists_authorized_user_type(api_module, m
     assert isinstance(creds, FakeCredentials)
     assert saved["token"] == "ya29.refreshed"
     assert saved["type"] == "authorized_user"
+
+def test_api_tasks_create_uses_gws_insert(api_module, capsys):
+    captured = {}
+
+    def fake_run_gws(parts, *, params=None, body=None):
+        captured["parts"] = parts
+        captured["params"] = params
+        captured["body"] = body
+        return {"id": "task-1", "title": "Follow up", "status": "needsAction"}
+
+    api_module._run_gws = fake_run_gws
+    args = api_module.argparse.Namespace(
+        tasklist_id="list-1",
+        title="Follow up",
+        notes="Call Alice",
+        due="2026-03-01",
+        parent="parent-1",
+        previous="prev-1",
+        func=api_module.tasks_create,
+    )
+
+    api_module.tasks_create(args)
+
+    assert captured["parts"] == ["tasks", "tasks", "insert"]
+    assert captured["params"] == {"tasklist": "list-1", "parent": "parent-1", "previous": "prev-1"}
+    assert captured["body"] == {
+        "title": "Follow up",
+        "notes": "Call Alice",
+        "due": "2026-03-01T00:00:00.000Z",
+    }
+    result = json.loads(capsys.readouterr().out)
+    assert result["operationStatus"] == "created"
+    assert result["id"] == "task-1"
+
+
+def test_api_tasks_move_uses_gws_move(api_module, capsys):
+    captured = {}
+
+    def fake_run_gws(parts, *, params=None, body=None):
+        captured["parts"] = parts
+        captured["params"] = params
+        captured["body"] = body
+        return {"id": "task-1", "title": "Moved", "status": "needsAction", "position": "0002"}
+
+    api_module._run_gws = fake_run_gws
+    args = api_module.argparse.Namespace(
+        tasklist_id="list-1",
+        task_id="task-1",
+        parent="parent-1",
+        previous="prev-1",
+        func=api_module.tasks_move,
+    )
+
+    api_module.tasks_move(args)
+
+    assert captured["parts"] == ["tasks", "tasks", "move"]
+    assert captured["params"] == {"tasklist": "list-1", "task": "task-1", "parent": "parent-1", "previous": "prev-1"}
+    assert captured["body"] is None
+    result = json.loads(capsys.readouterr().out)
+    assert result["operationStatus"] == "moved"
+    assert result["position"] == "0002"
+
+
+def test_api_tasks_update_list_uses_gws_patch(api_module, capsys):
+    captured = {}
+
+    def fake_run_gws(parts, *, params=None, body=None):
+        captured["parts"] = parts
+        captured["params"] = params
+        captured["body"] = body
+        return {"id": "list-1", "title": "Work Projects"}
+
+    api_module._run_gws = fake_run_gws
+    args = api_module.argparse.Namespace(
+        tasklist_id="list-1",
+        title="Work Projects",
+        func=api_module.tasks_list_update,
+    )
+
+    api_module.tasks_list_update(args)
+
+    assert captured["parts"] == ["tasks", "tasklists", "patch"]
+    assert captured["params"] == {"tasklist": "list-1"}
+    assert captured["body"] == {"title": "Work Projects"}
+    result = json.loads(capsys.readouterr().out)
+    assert result["status"] == "updated"
+    assert result["title"] == "Work Projects"
+
+
+def test_api_tasks_due_normalizes_date_and_naive_datetime(api_module):
+    assert api_module._tasks_due("2026-03-01") == "2026-03-01T00:00:00.000Z"
+    assert api_module._tasks_due("2026-03-01T12:30:00") == "2026-03-01T12:30:00.000Z"
+    assert api_module._tasks_due("2026-03-01T12:30:00Z") == "2026-03-01T12:30:00.000Z"
+
+
+def test_setup_tasks_service_scope_is_selectable(setup_script_module):
+    scopes, services = setup_script_module._scopes_for_services("tasks")
+    assert scopes == ["https://www.googleapis.com/auth/tasks"]
+    assert services == ["tasks"]
+
+
+def test_setup_requested_scope_metadata_limits_missing_scope_warning(setup_script_module):
+    payload = {
+        "scopes": ["https://www.googleapis.com/auth/tasks"],
+        "hermes_requested_scopes": ["https://www.googleapis.com/auth/tasks"],
+    }
+    assert setup_script_module._missing_scopes_from_payload(payload) == []
+
+    payload["scopes"] = []
+    assert setup_script_module._missing_scopes_from_payload(payload) == []


### PR DESCRIPTION
## Summary
- add Google Tasks task list/task CRUD commands to the Hermes Google Workspace skill
- add the Tasks OAuth scope and service-specific auth URL support
- document Tasks usage, output shapes, re-auth guidance, and irreversible operations
- make Google Tasks discoverable in the google-workspace skill description/tags

## Verification
- `venv/bin/python -m py_compile skills/productivity/google-workspace/scripts/google_api.py skills/productivity/google-workspace/scripts/setup.py skills/productivity/google-workspace/scripts/_hermes_home.py`
- `venv/bin/python skills/productivity/google-workspace/scripts/google_api.py tasks --help`
- focused import checks for Tasks due-date normalization, task normalization, service-scope selection, and requested-scope partial auth behavior
- `venv/bin/python skills/productivity/google-workspace/scripts/setup.py --auth-url --services tasks --format json`
- live local OAuth re-auth with `https://www.googleapis.com/auth/tasks` and `tasks lists` succeeded against a real Google Tasks account

## Notes
- Google Tasks remains part of the existing `google-workspace` umbrella skill rather than a separate `google-tasks` skill.