### PR TITLE
fix(gateway): stop tokenless-profile s6 crash-loop (exit 78 + finish script + propagation)

### DIFF
--- a/gateway/restart.py
+++ b/gateway/restart.py
@@ -6,6 +6,12 @@ from hermes_cli.config import DEFAULT_CONFIG
 # the gateway after a graceful drain/reload path completes.
 GATEWAY_SERVICE_RESTART_EXIT_CODE = 75
 
+# EX_CONFIG from sysexits.h — fatal configuration error (e.g. token
+# collision, no messaging platforms).  The s6 finish script translates
+# this into exit 125 (permanent failure) so the supervisor stops
+# restarting the gateway.  See #51228.
+GATEWAY_FATAL_CONFIG_EXIT_CODE = 78
+
 DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT = float(
     DEFAULT_CONFIG["agent"]["restart_drain_timeout"]
 )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17783,6 +17783,15 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     if runner.should_exit_cleanly:
         if runner.exit_reason:
             logger.error("Gateway exiting cleanly: %s", runner.exit_reason)
+        # A clean exit that carries an explicit exit code (e.g. a fatal
+        # config error stamped with GATEWAY_FATAL_CONFIG_EXIT_CODE) must
+        # propagate that code to the process so the s6 finish script can
+        # translate it (78 → 125) and stop the supervisor restart loop.
+        # Without this, the early `return True` below makes main() exit 0,
+        # the finish script's `[ "$1" = "78" ]` check never matches, and
+        # s6 crash-loops the gateway anyway (#51228).
+        if runner.exit_code is not None:
+            raise SystemExit(runner.exit_code)
         return True
     
     # Start the background cron scheduler via the resolved provider so

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1701,6 +1701,7 @@ from gateway.platforms.base import (
 )
 from gateway.restart import (
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
+    GATEWAY_FATAL_CONFIG_EXIT_CODE,
     GATEWAY_SERVICE_RESTART_EXIT_CODE,
     parse_restart_drain_timeout,
 )
@@ -5747,6 +5748,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 write_runtime_status(gateway_state="startup_failed", exit_reason=reason)
             except Exception:
                 pass
+            self._exit_code = GATEWAY_FATAL_CONFIG_EXIT_CODE
             self._request_clean_exit(reason)
             self._startup_restore_in_progress = False
             return True
@@ -5762,6 +5764,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     write_runtime_status(gateway_state="startup_failed", exit_reason=reason)
                 except Exception:
                     pass
+                self._exit_code = GATEWAY_FATAL_CONFIG_EXIT_CODE
                 self._request_clean_exit(reason)
                 self._startup_restore_in_progress = False
                 return True

--- a/hermes_cli/container_boot.py
+++ b/hermes_cli/container_boot.py
@@ -398,6 +398,10 @@ def _register_service(scandir: Path, profile: str, *, start: bool) -> None:
         run.write_text(S6ServiceManager._render_run_script(profile, extra_env={}))
         run.chmod(0o755)
 
+        finish = tmp_dir / "finish"
+        finish.write_text(S6ServiceManager._render_finish_script())
+        finish.chmod(0o755)
+
         # Persistent log rotation (OQ8-C).
         log_subdir = tmp_dir / "log"
         log_subdir.mkdir()

--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -710,6 +710,30 @@ class S6ServiceManager:
         return "\n".join(lines) + "\n"
 
     @staticmethod
+    def _render_finish_script() -> str:
+        """Generate the finish script for a profile-gateway s6 service.
+
+        When the gateway exits with EX_CONFIG (78) — a fatal
+        configuration error such as a token collision or no messaging
+        platforms — we tell s6-supervise to stop restarting by exiting
+        125 (permanent failure).  Any other exit code lets s6 restart
+        normally.  See #51228.
+        """
+        from gateway.restart import GATEWAY_FATAL_CONFIG_EXIT_CODE
+
+        code = GATEWAY_FATAL_CONFIG_EXIT_CODE
+        return (
+            "#!/command/with-contenv sh\n"
+            "# shellcheck shell=sh\n"
+            "# $1 = exit code from the run script.\n"
+            f"# Exit {code} (EX_CONFIG) = fatal config error — don't restart.\n"
+            f'if [ "$1" = "{code}" ]; then\n'
+            "  exit 125\n"
+            "fi\n"
+            "exit 0\n"
+        )
+
+    @staticmethod
     def _render_log_run(profile: str) -> str:
         """Generate the log/run script for a profile-gateway service.
 
@@ -955,6 +979,10 @@ class S6ServiceManager:
             run_path = tmp_dir / "run"
             run_path.write_text(run_script)
             run_path.chmod(0o755)
+
+            finish_path = tmp_dir / "finish"
+            finish_path.write_text(self._render_finish_script())
+            finish_path.chmod(0o755)
 
             # Persistent log rotation (OQ8-C).
             log_subdir = tmp_dir / "log"

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -130,6 +130,7 @@ AUTHOR_MAP = {
     "290859878+synapsesx@users.noreply.github.com": "synapsesx",
     "157689911+itsflownium@users.noreply.github.com": "itsflownium",
     "dirtyren@users.noreply.github.com": "dirtyren",
+    "mucio@mucio.net": "francescomucio",
     "tkwong@inspiresynergy.com": "tkwong",
     "buihongduc132@gmail.com": "buihongduc132",
     "etheraura@protonmail.com": "EtherAura",  # PR #45205 salvage (Linux in-app update relaunch / GUI-skew terminal state)

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -152,6 +152,7 @@ async def test_start_gateway_verbosity_imports_redacting_formatter(monkeypatch, 
             self.config = config
             self.should_exit_cleanly = True
             self.exit_reason = None
+            self.exit_code = None
             self.adapters = {}
 
         async def start(self):
@@ -186,6 +187,7 @@ async def test_start_gateway_replace_force_uses_terminate_pid(monkeypatch, tmp_p
             self.config = config
             self.should_exit_cleanly = True
             self.exit_reason = None
+            self.exit_code = None
             self.adapters = {}
 
         async def start(self):
@@ -334,6 +336,7 @@ async def test_start_gateway_replace_writes_takeover_marker_before_sigterm(
             self.config = config
             self.should_exit_cleanly = True
             self.exit_reason = None
+            self.exit_code = None
             self.adapters = {}
 
         async def start(self):
@@ -505,6 +508,46 @@ async def test_runner_exits_with_ex_config_on_nonretryable_startup_error(monkeyp
     assert runner.exit_code == GATEWAY_FATAL_CONFIG_EXIT_CODE
     state = read_runtime_status()
     assert state["gateway_state"] == "startup_failed"
+
+
+@pytest.mark.asyncio
+async def test_start_gateway_propagates_fatal_config_exit_code(monkeypatch, tmp_path):
+    """A clean exit carrying GATEWAY_FATAL_CONFIG_EXIT_CODE must surface as a
+    process-level SystemExit(78) — NOT a truthy return — so main() exits 78
+    and the s6 finish script can translate it to 125 (no restart).
+
+    This guards the propagation gap: runner.start() stamps exit_code=78 and
+    requests a clean exit, but start_gateway()'s clean-exit branch used to
+    `return True` before the SystemExit(exit_code) site, so main() exited 0
+    and s6 crash-looped anyway (#51228)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    class _FatalConfigRunner:
+        def __init__(self, config):
+            self.config = config
+            self.should_exit_cleanly = True
+            self.exit_reason = "discord: Discord bot token already in use"
+            self.exit_code = GATEWAY_FATAL_CONFIG_EXIT_CODE
+            self.adapters = {}
+
+        async def start(self):
+            return True
+
+        async def stop(self):
+            return None
+
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet=True: None)
+    monkeypatch.setattr("hermes_logging.setup_logging", lambda hermes_home, mode: tmp_path)
+    monkeypatch.setattr("hermes_logging._add_rotating_handler", lambda *args, **kwargs: None)
+    monkeypatch.setattr("gateway.run.GatewayRunner", _FatalConfigRunner)
+
+    from gateway.run import start_gateway
+
+    with pytest.raises(SystemExit) as exc_info:
+        await start_gateway(config=GatewayConfig(), replace=False, verbosity=0)
+
+    assert exc_info.value.code == GATEWAY_FATAL_CONFIG_EXIT_CODE
 
 
 def test_runner_warns_when_docker_gateway_lacks_explicit_output_mount(monkeypatch, tmp_path, caplog):

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter
+from gateway.restart import GATEWAY_FATAL_CONFIG_EXIT_CODE
 from gateway.run import GatewayRunner
 from gateway.status import read_runtime_status
 
@@ -456,6 +457,54 @@ async def test_runner_degrades_gracefully_when_all_adapters_missing(monkeypatch,
         "No adapter could be created" in record.message
         for record in caplog.records
     ), "Expected degraded-mode warning when all adapters are missing"
+
+
+class _NonRetryableFailureAdapter(BasePlatformAdapter):
+    """Simulates a fatal config error like token collision."""
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="***"), Platform.DISCORD)
+
+    async def connect(self) -> bool:
+        self._set_fatal_error(
+            "discord-bot-token_lock",
+            "Discord bot token already in use (PID 999). Stop the other gateway first.",
+            retryable=False,
+        )
+        return False
+
+    async def disconnect(self) -> None:
+        self._mark_disconnected()
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        raise NotImplementedError
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+
+@pytest.mark.asyncio
+async def test_runner_exits_with_ex_config_on_nonretryable_startup_error(monkeypatch, tmp_path):
+    """Non-retryable startup errors (token collision, no platforms) must
+    set exit_code to 78 (EX_CONFIG) so the s6 finish script can translate
+    it to exit 125 (permanent failure).  See #51228."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = GatewayConfig(
+        platforms={
+            Platform.DISCORD: PlatformConfig(enabled=True, token="***")
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+
+    monkeypatch.setattr(runner, "_create_adapter", lambda platform, platform_config: _NonRetryableFailureAdapter())
+
+    ok = await runner.start()
+
+    assert ok is True  # start() returns True (clean exit requested)
+    assert runner.should_exit_cleanly is True
+    assert runner.exit_code == GATEWAY_FATAL_CONFIG_EXIT_CODE
+    state = read_runtime_status()
+    assert state["gateway_state"] == "startup_failed"
 
 
 def test_runner_warns_when_docker_gateway_lacks_explicit_output_mount(monkeypatch, tmp_path, caplog):

--- a/tests/hermes_cli/test_container_boot.py
+++ b/tests/hermes_cli/test_container_boot.py
@@ -128,6 +128,24 @@ def test_running_profile_is_registered_and_autostarted(tmp_path: Path) -> None:
     assert not (svc / "down").exists()
 
 
+def test_registered_profile_has_finish_script(tmp_path: Path) -> None:
+    """The finish script must be written so s6 stops restarting on
+    fatal config errors (exit 78 → exit 125).  See #51228."""
+    scandir = tmp_path / "run-service"; scandir.mkdir()
+    _make_profile(tmp_path, "coder", state="running")
+
+    reconcile_profile_gateways(
+        hermes_home=tmp_path, scandir=scandir, dry_run=False,
+    )
+
+    finish = scandir / "gateway-coder" / "finish"
+    assert finish.exists()
+    assert finish.stat().st_mode & 0o111  # executable
+    text = finish.read_text()
+    assert "78" in text
+    assert "125" in text
+
+
 def test_stopped_profile_is_registered_but_not_started(tmp_path: Path) -> None:
     scandir = tmp_path / "run-service"; scandir.mkdir()
     _make_profile(tmp_path, "writer", state="stopped")

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -673,6 +673,30 @@ def test_render_run_script_uses_replace_to_take_over_stale_holder() -> None:
     )
 
 
+def test_render_finish_script_exits_125_on_ex_config() -> None:
+    """The finish script must translate exit 78 (EX_CONFIG) into exit 125
+    (permanent failure) so s6 stops restarting on fatal config errors.
+    See #51228."""
+    text = S6ServiceManager._render_finish_script()
+    assert '[ "$1" = "78" ]' in text
+    assert "exit 125" in text
+    assert "exit 0" in text
+
+
+def test_s6_register_writes_finish_script(
+    s6_scandir, fake_subprocess_run,
+) -> None:
+    """The finish script must be written alongside the run script."""
+    mgr = S6ServiceManager(scandir=s6_scandir)
+    mgr.register_profile_gateway("coder")
+
+    finish_path = s6_scandir / "gateway-coder" / "finish"
+    assert finish_path.is_file()
+    assert finish_path.stat().st_mode & 0o111  # executable
+    assert "78" in finish_path.read_text()
+    assert "125" in finish_path.read_text()
+
+
 def test_s6_register_rejects_invalid_profile_name(s6_scandir) -> None:
     mgr = S6ServiceManager(scandir=s6_scandir)
     with pytest.raises(ValueError):


### PR DESCRIPTION
Tokenless profile gateways no longer crash-loop under s6 — fatal config errors now exit with a code s6 treats as permanent failure, so the disk no longer fills with orphaned tirith dirs.

Salvages #51357 by @francescomucio (also the issue reporter, #51228) onto current `main`, plus the propagation fix that made the original PR a no-op as shipped.

## Root cause of the disk-fill (the real bug, #51228)
A profile gateway with no messaging token inherits the default profile's Discord token, detects the collision, and exits `startup_failed`. s6 restarts it immediately (~2/sec); each restart spawns a ~30MB tirith sandbox in `/tmp`. Measured: **1,886 dirs / 23GB on a cx23 in ~6 hours** → ENOSPC breaks ALL profiles. Effectively data-loss.

## Why the original PR was incomplete
The contributor's commit stamped `runner._exit_code = 78` (EX_CONFIG) on the two non-retryable startup-error sites and added an s6 `finish` script translating 78→125. Correct approach — but `start_gateway()`'s clean-exit branch `return True`d **before** the `raise SystemExit(runner.exit_code)` site (run.py:17783 vs 17849). So `main()` saw a truthy return, skipped `sys.exit`, and the process exited **0**. The finish script's `[ "$1" = "78" ]` never matched and s6 crash-looped anyway. The PR's three tests passed only because they asserted `runner.exit_code == 78` at the object level — none exercised the process-exit path.

## Changes
- `gateway/restart.py`, `gateway/run.py`, `hermes_cli/service_manager.py`, `hermes_cli/container_boot.py`: contributor's exit-78 + s6 finish-script work (cherry-picked, authorship preserved).
- `gateway/run.py` (follow-up): the clean-exit branch now `raise SystemExit(runner.exit_code)` when an exit code is set, else `return True` (normal `/restart` clean exit unchanged).
- `tests/gateway/test_runner_startup_failures.py`: added `test_start_gateway_propagates_fatal_config_exit_code` exercising `start_gateway()` → `SystemExit(78)` — the gap the object-level test missed; added `exit_code=None` to the existing `_CleanExitRunner` mocks so they model the real runner.

## Validation
| Path | Before | After |
|---|---|---|
| New propagation test on contributor HEAD | FAIL (no SystemExit) | — |
| New propagation test with fix | — | PASS |
| `start_gateway()` process exit on token collision | 0 (s6 restarts → disk fills) | 78 → finish 125 (s6 stops) |
| Transient error (exit 75 / 1) | restart | restart (unchanged) |
| Targeted suites (runner-startup + service-manager + container-boot) | — | 128/128 pass |

End-to-end shell verification of the rendered finish script: run-exit 78 → finish-exit **125** (stop restart); 75/0/1/125 → finish-exit **0** (allow restart), so real failures still recover.

Fixes #51228.

## Infographic

![gateway-crash-loop-stopped](https://v3b.fal.media/files/b/0a9f8ac2/dnorAyfiCEhGIZ8GxhMPL_71VUYBwC.png)
