### PR TITLE
fix(desktop): fetch missing pinned sessions on sidebar refresh (#51685)

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -13,7 +13,7 @@ import { useMediaQuery } from '@/hooks/use-media-query'
 import { useSkinCommand } from '@/themes/use-skin-command'
 
 import { formatRefValue } from '../components/assistant-ui/directive-text'
-import { getCronJobs, getSessionMessages, listAllProfileSessions, type SessionInfo, triggerCronJob } from '../hermes'
+import { getCronJobs, getSession, getSessionMessages, listAllProfileSessions, type SessionInfo, triggerCronJob } from '../hermes'
 import { type ChatMessage, chatMessageText, preserveLocalAssistantErrors, toChatMessages } from '../lib/chat-messages'
 import { storedSessionIdForNotification } from '../lib/session-ids'
 import {
@@ -459,11 +459,32 @@ export function DesktopController() {
         excludeSources: SIDEBAR_EXCLUDED_SOURCES
       })
 
-      if (refreshSessionsRequestRef.current === requestId) {
-        setSessions(prev => mergeSessionPage(prev, result.sessions, sessionsToKeep()))
-        setSessionsTotal(typeof result.total === 'number' ? result.total : result.sessions.length)
-        setSessionProfileTotals(result.profile_totals ?? {})
+      if (refreshSessionsRequestRef.current !== requestId) {
+        return
       }
+
+      // Pinned sessions that fell outside the recent page are not returned by
+      // the list API and mergeSessionPage can only preserve rows already in
+      // memory.  Fetch any missing pins individually so the Pinned sidebar
+      // section never goes empty for aged-off sessions.
+      const incomingIds = new Set(result.sessions.map(s => s.id))
+      const missingPins = $pinnedSessionIds.get().filter(id => !incomingIds.has(id))
+      let allIncoming = result.sessions
+
+      if (missingPins.length > 0) {
+        const fetched = await Promise.all(
+          missingPins.map(id => getSession(id).catch(() => null))
+        )
+        const pinSessions = fetched.filter((s): s is SessionInfo => s !== null)
+
+        if (pinSessions.length > 0) {
+          allIncoming = [...pinSessions, ...result.sessions]
+        }
+      }
+
+      setSessions(prev => mergeSessionPage(prev, allIncoming, sessionsToKeep()))
+      setSessionsTotal(typeof result.total === 'number' ? result.total : result.sessions.length)
+      setSessionProfileTotals(result.profile_totals ?? {})
     } finally {
       if (refreshSessionsRequestRef.current === requestId) {
         setSessionsLoading(false)

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -166,6 +166,19 @@ describe('mergeSessionPage', () => {
     expect(merged.find(s => s.id === 'tip-5')?._lineage_root_id).toBe('root')
   })
 
+  it('cannot rescue a pinned session that was never in previous', () => {
+    // Documents the gap that refreshSessions() must fill: if a pinned session
+    // fell off the loaded page before being captured in `previous`,
+    // mergeSessionPage has no row to resurrect.  The caller must pre-fetch
+    // missing pins and include them in the incoming array.
+    const previous = [session({ id: 'recent' })]
+    const incoming = [session({ id: 'recent' })]
+
+    const merged = mergeSessionPage(previous, incoming, ['never-loaded-pin'])
+
+    expect(merged.map(s => s.id)).toEqual(['recent'])
+  })
+
   it('preserves an unrelated pinned session even when lineage dedup is active', () => {
     // Regression guard: lineage dedup must not accidentally evict sessions
     // from a different lineage that happen to be in the keep set.


### PR DESCRIPTION
## What does this PR do?

Fixes pinned sessions silently disappearing from the Desktop sidebar when they fall outside the initial page of loaded sessions. After the main session list fetch, any pinned session IDs missing from the result are now fetched individually via `getSession()` and injected into the incoming array before `mergeSessionPage()` runs.

## Related Issue

Fixes #51685

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/desktop-controller.tsx`: Add `getSession` import; in `refreshSessions()`, after fetching the main session list, check for pinned IDs missing from the result and fetch them individually before calling `mergeSessionPage()`
- `apps/desktop/src/store/session.test.ts`: Add regression test documenting that `mergeSessionPage()` cannot rescue a pinned session never present in `previous`

## How to Test

1. Run `cd apps/desktop && npx vitest run src/store/session.test.ts --environment jsdom --reporter=verbose`
2. Observed result: All 21 tests pass, including the new `cannot rescue a pinned session that was never in previous` test
3. Manual verification: With 200+ active sessions, pin a session outside the top 50 by activity, restart the app — the pinned session should remain visible in the Pinned sidebar section

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.5
