### PR TITLE
fix(skills): fall back to locale encoding in skill_view

### DIFF
--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -373,6 +373,31 @@ class TestSkillView:
         assert result["name"] == "my-skill"
         assert "Step 1" in result["content"]
 
+    def test_skill_view_falls_back_to_locale_encoding_for_skill_md(self, tmp_path):
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch(
+                "tools.skills_tool.locale.getpreferredencoding",
+                return_value="cp1252",
+            ),
+        ):
+            skill_dir = tmp_path / "windows-skill"
+            skill_dir.mkdir(parents=True, exist_ok=True)
+            content = (
+                "---\n"
+                "name: windows-skill\n"
+                "description: Description for windows-skill.\n"
+                "---\n\n"
+                "# windows-skill\n\n"
+                "Résumé – café.\n"
+            )
+            (skill_dir / "SKILL.md").write_bytes(content.encode("cp1252"))
+            raw = skill_view("windows-skill")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert "Résumé – café." in result["content"]
+
     def test_view_skill_by_frontmatter_name_when_dir_differs(self, tmp_path):
         # The on-disk directory ("alias-dir") differs from the skill's
         # frontmatter name ("real-skill-name"). skills_list() exposes the
@@ -476,6 +501,24 @@ class TestSkillView:
         result = json.loads(raw)
         assert result["success"] is True
         assert "Endpoint info" in result["content"]
+
+    def test_view_reference_file_falls_back_to_locale_encoding(self, tmp_path):
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch(
+                "tools.skills_tool.locale.getpreferredencoding",
+                return_value="cp1252",
+            ),
+        ):
+            skill_dir = _make_skill(tmp_path, "my-skill")
+            refs_dir = skill_dir / "references"
+            refs_dir.mkdir()
+            (refs_dir / "api.md").write_bytes("Résumé – endpoint info.".encode("cp1252"))
+            raw = skill_view("my-skill", file_path="references/api.md")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert "Résumé – endpoint info." in result["content"]
 
     def test_view_nonexistent_file(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -67,6 +67,7 @@ Usage:
 """
 
 import json
+import locale
 import logging
 
 from hermes_constants import get_hermes_home, display_hermes_home
@@ -136,6 +137,25 @@ def _skill_lookup_path_error(name: str) -> Optional[str]:
     if has_traversal_component(candidate):
         return "Skill name cannot contain '..' path traversal components."
     return None
+
+
+def _read_skill_text(path: Path) -> str:
+    """Read a skill text file with a narrow fallback for Windows locale files."""
+    encodings: list[str] = ["utf-8", "utf-8-sig"]
+    preferred = (locale.getpreferredencoding(False) or "").strip()
+    if preferred and preferred.lower() not in {"utf-8", "utf8", "utf-8-sig"}:
+        encodings.append(preferred)
+
+    last_error: UnicodeDecodeError | None = None
+    for encoding in encodings:
+        try:
+            return path.read_text(encoding=encoding)
+        except UnicodeDecodeError as exc:
+            last_error = exc
+
+    if last_error is not None:
+        raise last_error
+    return path.read_text(encoding="utf-8")
 
 
 def load_env() -> Dict[str, str]:
@@ -779,7 +799,7 @@ def _serve_plugin_skill(
         )
 
     try:
-        content = skill_md.read_text(encoding="utf-8")
+        content = _read_skill_text(skill_md)
     except Exception as e:
         return json.dumps(
             {"success": False, "error": f"Failed to read skill '{namespace}:{bare}': {e}"},
@@ -1120,7 +1140,7 @@ def skill_view(
 
         # Read the file once — reused for platform check and main content below
         try:
-            content = skill_md.read_text(encoding="utf-8")
+            content = _read_skill_text(skill_md)
         except Exception as e:
             return json.dumps(
                 {
@@ -1265,7 +1285,7 @@ def skill_view(
 
             # Read the file content
             try:
-                content = target_file.read_text(encoding="utf-8")
+                content = _read_skill_text(target_file)
             except UnicodeDecodeError:
                 # Binary file - return info about it instead
                 return json.dumps(


### PR DESCRIPTION
## Summary
- fall back from utf-8 to utf-8-sig and the local preferred encoding when skill_view reads skill text
- use the same reader for local skills, plugin skills, and linked files so Windows Desktop does not fail on locale-encoded markdown
- add regression tests for locale-encoded SKILL.md and linked files

## Testing
- uv run --frozen pytest -q tests/tools/test_skills_tool.py -k 'locale_encoding or view_reference_file or view_existing_skill or surfaces_skill_read_errors' -o addopts=''\n- uv run --frozen pytest -q tests/test_plugin_skills.py -k 'resolves_plugin_skill' -o addopts=''\n- uv run --frozen ruff check tools/skills_tool.py tests/tools/test_skills_tool.py\n- git diff --check HEAD^ HEAD\n\nFixes #51691