### PR TITLE
fix(kanban): require explicit approval after clarify timeout

### DIFF
--- a/hermes_cli/callbacks.py
+++ b/hermes_cli/callbacks.py
@@ -58,8 +58,9 @@ def clarify_callback(cli, question, choices):
         cli._app.invalidate()
     cprint(f"\n{_DIM}(clarify timed out after {timeout}s — agent will decide){_RST}")
     return (
-        "The user did not provide a response within the time limit. "
-        "Use your best judgement to make the choice and proceed."
+        "Explicit human approval is required. "
+        "Call `kanban_block(reason=\"approval-required: explicit human decision needed\")` and stop. "
+        "Do not proceed."
     )
 
 


### PR DESCRIPTION
## Summary

When the clarify callback times out (user doesn't respond within the time limit), the agent previously instructed itself to "Use your best judgement to make the choice and proceed." This violated the no-silence approval rule - timing out was effectively treated as implicit approval.

This fix replaces the permissive fallback with an explicit kanban_block(approval-required) instruction, requiring human sign-off before the agent can proceed.

## Change

**Modified:** `hermes_cli/callbacks.py` (3 insertions, 2 deletions)

The clarify timeout handler now returns:
- kanban_block(reason="approval-required: explicit human decision needed") instruction
- Explicit prohibition: "Do not proceed."

Previously returned:
- "Use your best judgement to make the choice and proceed."

## Evidence

- **Local implementation** isolated by Mars on clean origin/main base
- **Independent review** (Saturn): APPROVED with zero blocking findings
- **Commit:** 54bd44f17 - single file, 5 lines changed, no other changes
- **Compile check:** python3 -m py_compile hermes_cli/callbacks.py passed
- **Git diff check:** clean

## Scope

This PR is intentionally narrow - it changes only the clarify-timeout fallback message. It does not address related approval-gating patterns elsewhere in the codebase, which are tracked separately in Lane A (H0-H6 engineering hardening specs).

## Rodrigo approval

This push and PR were explicitly approved by Rodrigo (recorded in Kanban task t_2aa83208).
