### PR TITLE
fix(desktop): preserve dismissed preview state on re-registration (#51687)

### DIFF
--- a/apps/desktop/src/store/preview.test.ts
+++ b/apps/desktop/src/store/preview.test.ts
@@ -83,7 +83,10 @@ describe('preview store', () => {
 
     setCurrentSessionPreviewTarget(target, 'tool-result')
 
-    expect(getSessionPreviewRecord('session-1')?.dismissedAt).toBeUndefined()
+    // After dismissal, re-registering the same target should preserve the
+    // dismissed state — the preview must not resurrect from tool events.
+    expect(getSessionPreviewRecord('session-1')).toBeNull()
+    expect($sessionPreviewRegistry.get()['session-1']?.[0]?.dismissedAt).toEqual(expect.any(Number))
   })
 
   it('replaces the session preview instead of keeping a back stack', () => {
@@ -134,5 +137,31 @@ describe('preview store', () => {
     expect($filePreviewTarget.get()).toBeNull()
     expect($rightRailActiveTabId.get()).toBe(RIGHT_RAIL_PREVIEW_TAB_ID)
     expect($previewTarget.get()).toEqual(withRenderMode(live, 'preview'))
+  })
+
+  it('does not resurrect a dismissed preview on re-registration (#51687)', () => {
+    const target = previewTarget('/work/demo.html')
+
+    // Open preview via tool result
+    setCurrentSessionPreviewTarget(target, 'tool-result')
+    expect($previewTarget.get()).toEqual(withRenderMode(target, 'preview'))
+
+    // User dismisses the preview
+    dismissPreviewTarget()
+    expect($previewTarget.get()).toBeNull()
+    expect(getSessionPreviewRecord('session-1')).toBeNull()
+
+    // Simulate a tool event re-registering the same target (e.g. streaming
+    // update). The dismissed state must be preserved.
+    setCurrentSessionPreviewTarget(target, 'tool-result')
+    expect($previewTarget.get()).toBeNull()
+    expect(getSessionPreviewRecord('session-1')).toBeNull()
+    expect($sessionPreviewRegistry.get()['session-1']?.[0]?.dismissedAt).toEqual(expect.any(Number))
+
+    // A *different* target should still work normally
+    const other = previewTarget('/work/other.html')
+    setCurrentSessionPreviewTarget(other, 'tool-result')
+    expect($previewTarget.get()).toEqual(withRenderMode(other, 'preview'))
+    expect(getSessionPreviewRecord('session-1')?.normalized).toEqual(withRenderMode(other, 'preview'))
   })
 })

--- a/apps/desktop/src/store/preview.ts
+++ b/apps/desktop/src/store/preview.ts
@@ -279,6 +279,13 @@ export function registerSessionPreview(
   const now = Date.now()
   const records = current[id] ?? []
   const existing = records.find(record => record.normalized.url === target.url)
+
+  // If the user already dismissed this preview, respect that dismissal.
+  // Subsequent tool events for the same file should not resurrect it.
+  if (existing?.dismissedAt) {
+    return existing
+  }
+
   const normalized = previewTargetForSource(target, source)
 
   const nextRecord: SessionPreviewRecord = {
@@ -313,7 +320,11 @@ export function setSessionPreviewTarget(
 
   const record = registerSessionPreview(sessionId, target, source, rawTarget)
 
-  setPreviewTarget(record?.normalized ?? previewTargetForSource(target, source))
+  // Don't resurrect a dismissed preview — only set the active target when
+  // the record is genuinely new or was never dismissed.
+  if (record && !record.dismissedAt) {
+    setPreviewTarget(record.normalized)
+  }
 
   return record
 }


### PR DESCRIPTION
## What does this PR do?

Fixes dismissed preview artifacts reappearing after any tool event triggers a re-render. When a user dismisses a preview from the tool row, subsequent streaming updates (tool events) re-register the same preview target, overwriting the dismissed state and causing the preview to reappear.

## Related Issue

Fixes #51687

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/store/preview.ts`: In `registerSessionPreview`, return early when the existing record has been dismissed (`dismissedAt` is set) instead of overwriting it with a new `autoOpen: true` record. In `setSessionPreviewTarget`, skip calling `setPreviewTarget` when the returned record is dismissed.
- `apps/desktop/src/store/preview.test.ts`: Updated existing test to match corrected behavior (dismissed state is preserved on re-registration). Added regression test `does not resurrect a dismissed preview on re-registration (#51687)` that verifies: dismissed preview stays dismissed after re-registration, and different targets still work normally.

## How to Test

1. Run `cd apps/desktop && npx vitest run src/store/preview.test.ts --environment jsdom --reporter=verbose`
2. Observed result: All 6 tests pass, including the new `does not resurrect a dismissed preview on re-registration (#51687)` test. The test verifies that after dismissing a preview and re-registering the same target (simulating a tool event), the preview stays dismissed and a different target can still be opened normally.

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.5