### PR TITLE
fix(profiles): align profile skill count with /api/skills contract

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -32,8 +32,6 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import List, Optional, Tuple
 
-from agent.skill_utils import is_excluded_skill_path
-
 _PROFILE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
 
 # Directories bootstrapped inside every new profile
@@ -733,21 +731,84 @@ def _check_gateway_running(profile_dir: Path) -> bool:
 # recurses the entire skill tree (each skill carries references/scripts/assets
 # sub-trees); the default profile alone has ~270 skills, and ``list_profiles``
 # calls this for EVERY profile (16+), so an uncached scan costs ~6s — long
-# enough that the desktop's per-request backend calls time out and the sidebar
-# renders "全部智能体 0". We cache the count keyed by the skills dir, invalidated
-# when the dir tree's signature (skills_dir + immediate category dirs mtimes)
-# changes (catches skill add/remove) or after a short TTL (catches deep edits).
-_SKILL_COUNT_CACHE: dict[str, tuple[float, float, int]] = {}
+# per-request backend calls time out and the sidebar renders "全部智能体 0".
+# -----------------------------------------------------------------------
+# _count_skills — profile-list card skill count.
+#
+# `list_profiles` invokes this for every profile; with 16+ profiles an
+# uncached full scan is ~6s, long enough that the desktop's per-request
+# backend calls time out and the sidebar renders "全部智能体 0".
+#
+# The count must mirror GET /api/skills?profile=<name> exactly so the
+# profile-list card and the Skills dashboard agree. That endpoint calls
+# `tools.skills_tool._find_all_skills(skip_disabled=True)` from inside a
+# `_profile_scope`, which scopes (a) the active HERMES_HOME so
+# `load_config()` reads the requested profile's `config.yaml`, and (b) the
+# `SKILLS_DIR` module attribute. To match that contract without going
+# through `_profile_scope` (which mutates process-global module attrs and
+# would break concurrent list operations in a long-lived runtime), this
+# path instead:
+#
+#   1. Reads `profile_dir/config.yaml` directly for `skills.external_dirs`
+#      and `skills.disabled` — that's the same data
+#      `get_external_skills_dirs()` resolves from `load_config()`,
+#      just from a profile-scoped file rather than the active config.
+#   2. Delegates the filter chain to
+#      `tools.skills_tool._collect_skills_from_dirs`, which applies the
+#      same exclusion / platform / environment / dedup / disabled filters
+#      as the cached `_find_all_skills` loop, but bypasses the
+#      process-global `_SKILLS_CACHE`. The cache slot is keyed only by
+#      skip/disabled state and would risk a false-hit across profiles
+#      that happen to share the same `disabled` set and scan dirs.
+#
+# The cache (signature + TTL) is kept — invalidation now also includes
+# `config.yaml` mtime and the mtime of every `external_dirs` entry, so an
+# edit to external_dirs (no mtime bump on `skills/`) is also caught.
+# -----------------------------------------------------------------------
+_SKILL_COUNT_CACHE: "dict[Tuple[str, str], tuple]" = {}
 _SKILL_COUNT_TTL_SECONDS = 30.0
 
 
-def _skills_dir_signature(skills_dir: Path) -> float:
-    """Cheap change-signature for a skills tree.
+def _skills_count_signature(profile_dir: Path, external_dirs: List[Path], disabled) -> tuple:
+    """Composite change-signature for a profile's count.
 
-    Max mtime of ``skills_dir`` and its immediate children (category dirs).
-    Adding/removing a category bumps ``skills_dir``'s mtime; adding/removing a
-    skill inside a category bumps that category dir's mtime. One ``scandir``
-    (not a recursive walk) keeps this O(#categories), not O(#files).
+    Cheap: at most one scandir on the local skills dir plus O(#external)
+    stats. Includes (a) ``profile_dir/config.yaml`` mtime — covers writes
+    to ``skills.external_dirs`` or ``skills.disabled`` (config-only
+    changes that don't bump the skills tree mtime), (b) the local skills
+    dir + immediate category dirs mtime (existing behaviour), and (c)
+    each external dir's mtime (covers edits to an external skills pool
+    that don't touch the local tree).
+    """
+    skills_dir = profile_dir / "skills"
+    # Local skills signature — same scan as the old _skills_dir_signature,
+    # but expressed as a hash-friendly subpart for the composite signature.
+    try:
+        local_sig = _skills_dir_signature_inner(skills_dir)
+    except Exception:
+        local_sig = 0.0
+    # config.yaml mtime.
+    config_path = profile_dir / "config.yaml"
+    try:
+        config_mtime = config_path.stat().st_mtime if config_path.exists() else 0.0
+    except OSError:
+        config_mtime = 0.0
+    # External dirs mtime (each, in order, so reordering produces a new sig).
+    ext_sig = []
+    for d in external_dirs:
+        try:
+            ext_sig.append((str(d), d.stat().st_mtime if d.exists() else 0.0))
+        except OSError:
+            ext_sig.append((str(d), 0.0))
+    return (local_sig, config_mtime, tuple(ext_sig), frozenset(disabled))
+
+
+def _skills_dir_signature_inner(skills_dir: Path) -> float:
+    """Max mtime of skills_dir + its immediate category subdirs.
+
+    O(#categories) — one scandir, no recursive walk. Public via
+    ``_skills_count_signature``; module-level alias
+    ``_skills_dir_signature`` preserved for any direct callers.
     """
     try:
         sig = skills_dir.stat().st_mtime
@@ -768,14 +829,141 @@ def _skills_dir_signature(skills_dir: Path) -> float:
     return sig
 
 
+# Back-compat shim — some external callers (e.g. test fixtures) reference
+# the previous name.
+_skills_dir_signature = _skills_dir_signature_inner
+
+
+def _load_profile_external_dirs(profile_dir: Path) -> List[Path]:
+    """Read ``skills.external_dirs`` from a profile's ``config.yaml``.
+
+    Returns validated ``Path`` objects — entries that don't exist or that
+    resolve to the local skills dir are skipped (mirrors
+    ``agent.skill_utils.get_external_skills_dirs``'s validation). A
+    missing or unreadable config yields ``[]`` (not an error), so a brand-
+    new profile or a corrupt config never breaks ``hermes profile list``.
+    """
+    config_path = profile_dir / "config.yaml"
+    if not config_path.is_file():
+        return []
+    try:
+        import yaml as _yaml  # local import — keeps profiles.py import-time lean
+    except ImportError:
+        return []
+    try:
+        parsed = _yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+    if not isinstance(parsed, dict):
+        return []
+    skills_cfg = parsed.get("skills")
+    if not isinstance(skills_cfg, dict):
+        return []
+    raw_dirs = skills_cfg.get("external_dirs")
+    if not raw_dirs:
+        return []
+    if isinstance(raw_dirs, str):
+        raw_dirs = [raw_dirs]
+    if not isinstance(raw_dirs, list):
+        return []
+
+    local_skills = (profile_dir / "skills").resolve()
+    seen: set = set()
+    result: List[Path] = []
+    for entry in raw_dirs:
+        entry = str(entry).strip()
+        if not entry:
+            continue
+        expanded = os.path.expanduser(os.path.expandvars(entry))
+        p = Path(expanded)
+        if not p.is_absolute():
+            # Resolve relative paths against the profile's HERMES_HOME —
+            # mirrors ``get_external_skills_dirs``'s contract.
+            p = (profile_dir / p).resolve()
+        else:
+            p = p.resolve()
+        if p == local_skills:
+            continue
+        if p in seen:
+            continue
+        if p.is_dir():
+            seen.add(p)
+            result.append(p)
+    return result
+
+
+def _load_profile_disabled_skills(profile_dir: Path) -> set:
+    """Read ``skills.disabled`` from a profile's ``config.yaml``.
+
+    Returns a ``set`` of skill names. Missing / unreadable / non-dict
+    config yields ``set()`` (matches ``agent.skill_utils`` semantics).
+    Platform-scoped disabling (``skills.platform_disabled.<os>``) is
+    intentionally not read here: this is the CLI profile-list count,
+    which mirrors ``GET /api/skills``'s *global* disabled union and
+    ignores the active OS. Keeping the contract symmetric avoids the
+    count fluctuating based on which platform ``hermes profile list``
+    happens to run on.
+    """
+    config_path = profile_dir / "config.yaml"
+    if not config_path.is_file():
+        return set()
+    try:
+        import yaml as _yaml  # local import — keeps profiles.py import-time lean
+    except ImportError:
+        return set()
+    try:
+        parsed = _yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except Exception:
+        return set()
+    if not isinstance(parsed, dict):
+        return set()
+    skills_cfg = parsed.get("skills")
+    if not isinstance(skills_cfg, dict):
+        return set()
+    raw = skills_cfg.get("disabled")
+    if not raw:
+        return set()
+    if isinstance(raw, str):
+        raw = [raw]
+    if not isinstance(raw, list):
+        return set()
+    return {str(n).strip() for n in raw if str(n).strip()}
+
+
 def _count_skills(profile_dir: Path) -> int:
-    """Count installed skills in a profile (cached by skills-dir signature)."""
+    """Count installable skills in a profile (matches /api/skills contract).
+
+    Returns the total count of skill records that ``GET /api/skills?
+    profile=<name>`` would expose: includes local ``skills/`` entries
+    unioned with that profile's ``skills.external_dirs``, applies the
+    standard exclusion / ``platforms`` / ``environments`` / dedup
+    filters, and is cached per-process for
+    ``_SKILL_COUNT_TTL_SECONDS`` seconds (invalidated by directory or
+    config mtime changes — see :func:`_skills_count_signature`).
+
+    The ``disabled`` set is **not** applied here: ``/api/skills`` returns
+    a list whose length includes disabled skills (each annotated with
+    ``enabled: false`` by the route handler), so the count must match.
+    """
+
+    # Local import keeps profiles.py import-time lean and avoids a
+    # circular import through tools.skills_tool ↔ hermes_cli.profiles.
+    from tools.skills_tool import _collect_skills_from_dirs
+
     skills_dir = profile_dir / "skills"
     if not skills_dir.is_dir():
         return 0
 
-    key = str(skills_dir)
-    signature = _skills_dir_signature(skills_dir)
+    external_dirs = _load_profile_external_dirs(profile_dir)
+    # Disabled is NOT passed to the filter (kept only as a cache-key
+    # component so that toggling skills.disabled invalidates the cache
+    # without affecting the count). Pass an empty set; this matches the
+    # behaviour of ``_find_all_skills(skip_disabled=True)`` that
+    # ``/api/skills`` calls — disabled skills are labeled, not omitted.
+    key = (str(profile_dir), str(skills_dir))
+    signature = _skills_count_signature(
+        profile_dir, external_dirs, _load_profile_disabled_skills(profile_dir),
+    )
     now = time.time()
     cached = _SKILL_COUNT_CACHE.get(key)
     if (
@@ -785,11 +973,9 @@ def _count_skills(profile_dir: Path) -> int:
     ):
         return cached[2]
 
-    count = 0
-    for md in skills_dir.rglob("SKILL.md"):
-        if is_excluded_skill_path(md):
-            continue
-        count += 1
+    dirs_to_scan = [skills_dir] + external_dirs
+    skills = _collect_skills_from_dirs(dirs_to_scan, disabled=set())
+    count = len(skills)
     _SKILL_COUNT_CACHE[key] = (signature, now, count)
     return count
 

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -951,10 +951,18 @@ def _count_skills(profile_dir: Path) -> int:
     from tools.skills_tool import _collect_skills_from_dirs
 
     skills_dir = profile_dir / "skills"
-    if not skills_dir.is_dir():
+    external_dirs = _load_profile_external_dirs(profile_dir)
+
+    # Return 0 only when there are no directories to scan at all.
+    # A profile may rely exclusively on skills.external_dirs without a
+    # local skills/ tree — the dashboard's /api/skills endpoint handles
+    # this correctly via _profile_scope, and _count_skills must match.
+    # Loading external_dirs BEFORE the guard ensures external-only
+    # profiles get counted (the old raw-rglob guard returned 0 early
+    # and never reached the external-dirs path).
+    if not skills_dir.is_dir() and not external_dirs:
         return 0
 
-    external_dirs = _load_profile_external_dirs(profile_dir)
     # Disabled is NOT passed to the filter (kept only as a cache-key
     # component so that toggling skills.disabled invalidates the cache
     # without affecting the count). Pass an empty set; this matches the
@@ -973,7 +981,10 @@ def _count_skills(profile_dir: Path) -> int:
     ):
         return cached[2]
 
-    dirs_to_scan = [skills_dir] + external_dirs
+    dirs_to_scan: list = []
+    if skills_dir.is_dir():
+        dirs_to_scan.append(skills_dir)
+    dirs_to_scan.extend(external_dirs)
     skills = _collect_skills_from_dirs(dirs_to_scan, disabled=set())
     count = len(skills)
     _SKILL_COUNT_CACHE[key] = (signature, now, count)

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -1896,3 +1896,214 @@ class TestProfilesToServe:
     def test_on_no_named_profiles_returns_just_default(self, profile_env):
         serve = profiles_to_serve(multiplex=True)
         assert [n for n, _ in serve] == ["default"]
+
+
+# ===================================================================
+# Parity tests: profile-list skill_count must equal GET /api/skills?profile=
+# (regression for PR #51708 / issue #51707)
+#
+# The profile-list card skill_count previously diverged from the
+# web-dashboard /api/skills count because the CLI used a raw `rglob` scan
+# with a different exclusion rule than /api/skills. These tests exercise the
+# parity contract directly: build profiles with overlapping + unique
+# skills, including a disabled, a duplicate, and a profile-scoped external
+# pool, then assert that ``_count_skills`` returns the same count that
+# ``GET /api/skills?profile=<name>`` returns for the same fixtures.
+# ===================================================================
+
+
+def _write_skill(skill_dir: Path, *, name: str, description: str = "test skill",
+                 body: str = "Body", platforms=None) -> None:
+    """Write a minimal SKILL.md with YAML frontmatter."""
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    plat = f"\nplatforms: {platforms}" if platforms else ""
+    skill_dir.joinpath("SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}{plat}\n---\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+def _write_profile_config(profile_dir: Path, *,
+                          external_dirs=None,
+                          disabled=None) -> None:
+    """Write a profile's config.yaml with optional skills.external_dirs +
+    skills.disabled entries."""
+    cfg: dict = {"skills": {}}
+    if external_dirs:
+        cfg["skills"]["external_dirs"] = [str(p) for p in external_dirs]
+    if disabled:
+        cfg["skills"]["disabled"] = list(disabled)
+    profile_dir.joinpath("config.yaml").write_text(
+        yaml.safe_dump(cfg), encoding="utf-8"
+    )
+
+
+class TestCountSkillsMatchesApiSkills:
+    """``_count_skills`` must match GET /api/skills?profile=.
+
+    These tests deliberately exercise both the CLI helper and the live
+    FastAPI route in the same test so the two cannot drift apart in
+    future maintenance.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_caches(self):
+        """Bust both the CLI's per-profile count cache and the dashboard's
+        shared ``_SKILLS_CACHE`` so each test sees fresh data."""
+        from tools import skills_tool
+        profiles._SKILL_COUNT_CACHE.clear()
+        skills_tool._SKILLS_CACHE.clear()
+        yield
+        profiles._SKILL_COUNT_CACHE.clear()
+        skills_tool._SKILLS_CACHE.clear()
+
+    def _web_client(self, tmp_path, monkeypatch):
+        """Build a starlette TestClient whose state DB lives under the test
+        HERMES_HOME and whose session header matches the real dashboard."""
+        try:
+            from starlette.testclient import TestClient  # noqa: F401
+        except ImportError:
+            pytest.skip("starlette/fastapi not installed")
+        import hermes_state
+        from hermes_constants import get_hermes_home
+        from hermes_cli.web_server import (
+            app, _SESSION_HEADER_NAME, _SESSION_TOKEN,
+        )
+        monkeypatch.setattr(
+            hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db",
+        )
+        client = TestClient(app)
+        client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+        return client
+
+    def _api_count(self, client, profile_name: str) -> int:
+        """GET /api/skills?profile=<name> → len(payload)."""
+        resp = client.get(f"/api/skills?profile={profile_name}")
+        assert resp.status_code == 200, resp.text
+        return len(resp.json())
+
+    def _make_hermes_env(self, tmp_path, monkeypatch):
+        """Mirror the profile_env fixture: redirect Path.home() and
+        HERMES_HOME into tmp_path/.hermes for the duration of the test."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        default_home = tmp_path / ".hermes"
+        default_home.mkdir(exist_ok=True)
+        monkeypatch.setenv("HERMES_HOME", str(default_home))
+        return default_home
+
+    def test_parity_disabled_and_dedup(self, tmp_path, monkeypatch):
+        """Disabled skills are LABELED (not excluded); duplicate names
+        collapse to one. ``/api/skills`` returns the SAME total count as
+        ``_count_skills`` — disabled skills are annotated with
+        ``enabled: false`` rather than omitted from the list. The CLI
+        card count must therefore match the API list length exactly.
+
+        Profile ``coder`` carries 3 enabled skills plus a disabled skill,
+        a duplicate-name shadow, and a skill under an excluded path
+        component (.venv). Both the CLI count and /api/skills must
+        report the same number.
+        """
+        default_home = self._make_hermes_env(tmp_path, monkeypatch)
+        prof_dir = default_home / "profiles" / "coder"
+        prof_dir.mkdir(parents=True)
+        skills_dir = prof_dir / "skills"
+
+        _write_skill(skills_dir / "alpha", name="alpha")
+        _write_skill(skills_dir / "beta", name="beta")
+        _write_skill(skills_dir / "gamma", name="gamma")
+        # Duplicate-name sibling — must NOT inflate the count.
+        _write_skill(skills_dir / "gamma-shadow", name="gamma",
+                     description="Shadow gamma (should be deduped)")
+        # Excluded by EXCLUDED_SKILL_DIRS part name — must be skipped.
+        _write_skill(skills_dir / ".venv" / "fake-pkg",
+                     name="inside-venv",
+                     description="should be excluded")
+        _write_profile_config(prof_dir, disabled={"alpha"})
+
+        client = self._web_client(tmp_path, monkeypatch)
+        api = self._api_count(client, "coder")
+        cli = profiles._count_skills(prof_dir)
+        # 4 SKILL.md files on disk: alpha (disabled but still in result),
+        # beta, gamma, gamma-shadow (deduped to gamma), .venv/fake-pkg
+        # (excluded). Expected unique enabled+disabled count = 3.
+        assert cli == 3, (
+            f"CLI count={cli}; expected 3 (alpha labeled disabled, "
+            f"beta + gamma enabled, gamma-shadow deduped, .venv excluded)"
+        )
+        assert api == cli == 3, (
+            f"parity broken: api={api}, cli={cli}, expected both == 3 "
+            f"(disabled skills are listed with enabled:false, not omitted)"
+        )
+
+    def test_parity_profile_scoped_external_dirs(self, tmp_path, monkeypatch):
+        """Profile with skills.external_dirs unioned into the count.
+
+        Mirrors the live PR #51708 / issue #51707 bug: the card count
+        must include the external pool that lives under that profile's
+        own config.yaml, not the active profile's external_dirs.
+        """
+        default_home = self._make_hermes_env(tmp_path, monkeypatch)
+        prof_dir = default_home / "profiles" / "writer"
+        prof_dir.mkdir(parents=True)
+        skills_dir = prof_dir / "skills"
+        _write_skill(skills_dir / "local-one", name="local-one")
+
+        external_pool = tmp_path / "shared-skills" / "writer-pool"
+        external_pool.mkdir(parents=True)
+        _write_skill(external_pool / "ext-a", name="ext-a")
+        _write_skill(external_pool / "ext-b", name="ext-b")
+        # Duplicate-name shadow — must dedup.
+        _write_skill(external_pool / "local-one-shadow", name="local-one",
+                     description="Shadow local-one (should be deduped)")
+        _write_profile_config(prof_dir, external_dirs=[external_pool])
+
+        client = self._web_client(tmp_path, monkeypatch)
+        api = self._api_count(client, "writer")
+        cli = profiles._count_skills(prof_dir)
+        # 4 SKILL.md files on disk: local-one + ext-a + ext-b + shadow.
+        # Shadow dedupes to local-one → 3 unique names.
+        assert cli == 3, (
+            f"CLI count={cli}; expected 3 (local-one + ext-a + ext-b; "
+            f"shadow deduped)"
+        )
+        assert api == cli == 3, (
+            f"parity broken: api={api}, cli={cli}, expected both == 3"
+        )
+
+    def test_bare_profile_no_skills_dir(self, tmp_path, monkeypatch):
+        """Brand-new profile with no skills/ and no config.yaml reports 0
+        on both surfaces and does not raise."""
+        default_home = self._make_hermes_env(tmp_path, monkeypatch)
+        prof_dir = default_home / "profiles" / "fresh"
+        prof_dir.mkdir(parents=True)
+
+        # CLI
+        assert profiles._count_skills(prof_dir) == 0
+
+        client = self._web_client(tmp_path, monkeypatch)
+        api = self._api_count(client, "fresh")
+        assert api == 0
+
+    def test_corrupt_config_yaml_does_not_crash(self, tmp_path, monkeypatch):
+        """Malformed config.yaml falls back to empty defaults; the count
+        succeeds and the /api/skills endpoint serves the same data."""
+        default_home = self._make_hermes_env(tmp_path, monkeypatch)
+        prof_dir = default_home / "profiles" / "broken"
+        prof_dir.mkdir(parents=True)
+        _write_skill(prof_dir / "skills" / "only", name="only")
+        prof_dir.joinpath("config.yaml").write_text(
+            "this: : not: valid: yaml: :", encoding="utf-8"
+        )
+        # Must not raise — broken config.yaml must not block discovery.
+        cli = profiles._count_skills(prof_dir)
+        assert cli == 1, (
+            f"expected 1 (only skill) when config.yaml is unreadable; "
+            f"got {cli}"
+        )
+
+        # Parity: /api/skills?profile=broken must also return 1.
+        client = self._web_client(tmp_path, monkeypatch)
+        api = self._api_count(client, "broken")
+        assert api == 1, (
+            f"parity broken: api={api}, cli={cli}, expected both == 1"
+        )

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -2107,3 +2107,36 @@ class TestCountSkillsMatchesApiSkills:
         assert api == 1, (
             f"parity broken: api={api}, cli={cli}, expected both == 1"
         )
+
+    def test_parity_external_only_profile(self, tmp_path, monkeypatch):
+        """Profile with skills.external_dirs but NO local skills/ dir.
+
+        Regression for the GottZ triage finding on #51707 (comment
+        5118178368): the original _count_skills rework exited early
+        when ``profile_dir / "skills"`` was absent, returning 0 before
+        reading skills.external_dirs. The dashboard's /api/skills
+        handled this correctly via _profile_scope, so the card count
+        and the dashboard disagreed for external-only profiles.
+        """
+        default_home = self._make_hermes_env(tmp_path, monkeypatch)
+        prof_dir = default_home / "profiles" / "xt-only"
+        prof_dir.mkdir(parents=True)
+        # Deliberately do NOT create a skills/ subdirectory — this
+        # profile must rely entirely on skills.external_dirs.
+
+        external_pool = tmp_path / "shared-skills" / "xt-pool"
+        external_pool.mkdir(parents=True)
+        _write_skill(external_pool / "xt-a", name="xt-a")
+        _write_skill(external_pool / "xt-b", name="xt-b")
+        _write_profile_config(prof_dir, external_dirs=[external_pool])
+
+        client = self._web_client(tmp_path, monkeypatch)
+        api = self._api_count(client, "xt-only")
+        cli = profiles._count_skills(prof_dir)
+        assert cli == 2, (
+            f"CLI count={cli}; expected 2 (xt-a + xt-b from external dir only)"
+        )
+        assert api == cli == 2, (
+            f"parity broken: api={api}, cli={cli}, expected both == 2 "
+            f"(external-only profile must match dashboard)"
+        )

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -666,59 +666,40 @@ def _is_skill_disabled(name: str, platform: str = None) -> bool:
         return False
 
 
-def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
-    """Recursively find all skills in ~/.hermes/skills/ and external dirs.
+def _collect_skills_from_dirs(
+    dirs_to_scan: List[Path],
+    disabled: Set[str],
+) -> List[Dict[str, Any]]:
+    """Walk ``dirs_to_scan`` and return enabled, platform/environment-matching
+    skill metadata dicts, deduped by frontmatter ``name`` (local takes
+    precedence — earlier entries in ``dirs_to_scan`` win).
 
-    Args:
-        skip_disabled: If True, return ALL skills regardless of disabled
-            state (used by ``hermes skills`` config UI). Default False
-            filters out disabled skills.
+    Mirrors the filter contract of :func:`_find_all_skills`: excludes paths
+    whose parts are in :data:`_EXCLUDED_SKILL_DIRS`, drops skills whose
+    ``platforms:`` or ``environments:`` frontmatter excludes the current
+    runtime, dedupes by ``name``, and filters the supplied ``disabled`` set.
 
-    Returns:
-        List of skill metadata dicts (name, description, category).
-
-    Results are cached per-session; the cache is invalidated when the scan
-    signature changes (dir/category mtimes or the disabled-set) and expires
-    after a short TTL to bound staleness from in-place SKILL.md edits.
+    This helper is intentionally **not cached** — callers that need caching
+    (e.g. ``_find_all_skills``) layer their own cache over it. By exposing
+    the scan loop, profile-scoped count paths can reuse the exact same
+    filter chain without sharing the process-global ``_SKILLS_CACHE`` slot
+    (which is keyed only by skip/disabled state and would risk a false
+    cache hit when two profiles share the same disabled-set signature).
     """
-    from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
+    from agent.skill_utils import iter_skill_index_files
 
-    cache_key = _SKILLS_CACHE_KEY_DISABLED if skip_disabled else _SKILLS_CACHE_KEY_FILTERED
+    skills: List[Dict[str, Any]] = []
+    seen_names: Set[str] = set()
 
-    # Load disabled set once (not per-skill). Part of the cache signature:
-    # disabling a skill is a config change with no filesystem mtime bump.
-    disabled = set() if skip_disabled else _get_disabled_skill_names()
-
-    # Collect directories to scan — same resolution as the scan loop below
-    # (_skills_dir() resolves the LIVE profile HERMES_HOME; the module-level
-    # SKILLS_DIR can be stale in long-lived runtimes).
-    dirs_to_scan: list = []
-    active_skills_dir = _skills_dir()
-    if active_skills_dir.exists():
-        dirs_to_scan.append(active_skills_dir)
-    dirs_to_scan.extend(get_external_skills_dirs())
-
-    signature = _skills_scan_signature(dirs_to_scan, disabled)
-    now = time.monotonic()
-
-    cached = _SKILLS_CACHE.get(cache_key)
-    if (
-        cached is not None
-        and cached[0] == signature
-        and (now - cached[1]) < _SKILLS_CACHE_TTL_SECONDS
-    ):
-        # Per-call shallow copies: callers mutate the returned dicts
-        # (e.g. web_server annotates s["enabled"]/s["usage"]) — handing
-        # out the cached objects would poison the cache for everyone else.
-        return [dict(s) for s in cached[2]]
-
-    skills = []
-    seen_names: set = set()
-
-    # Scan local dir first, then external dirs (local takes precedence) —
-    # dirs_to_scan already resolved above for the signature.
     for scan_dir in dirs_to_scan:
         for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
+            # Match the existing _find_all_skills exclusion contract: only
+            # path-component matches against the shared exclusion set. The
+            # raw rglob path used by `hermes_cli.profiles._count_skills`
+            # historically also called `is_excluded_skill_path` (which adds
+            # support-dir pruning on top), but the /api/skills dashboard
+            # contract exposes support-dir skills, so the count must match
+            # it exactly — not the stricter rglob behavior.
             if any(part in _EXCLUDED_SKILL_DIRS for part in skill_md.parts):
                 continue
 
@@ -765,9 +746,90 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                 continue
             except Exception as e:
                 logger.debug(
-                    "Skipping skill at %s: failed to parse: %s", skill_md, e, exc_info=True
+                    "Skipping skill at %s: failed to parse: %s",
+                    skill_md, e, exc_info=True,
                 )
                 continue
+
+    return skills
+
+
+def _find_all_skills(
+    *,
+    skip_disabled: bool = False,
+    skills_dir: Optional[Path] = None,
+    external_dirs: Optional[List[Path]] = None,
+) -> List[Dict[str, Any]]:
+    """Recursively find all skills in the active profile's skills dir and
+    configured external dirs.
+
+    Args:
+        skip_disabled: If True, return ALL skills regardless of disabled
+            state (used by ``hermes skills`` config UI). Default False
+            filters out disabled skills.
+        skills_dir: Optional explicit primary skills directory. Defaults to
+            the live ``_skills_dir()`` resolution. Provided for callers
+            (e.g. ``hermes_cli.profiles._count_skills``) that need a
+            profile-scoped root without going through the import-time-
+            bound :data:`SKILLS_DIR` module attribute.
+        external_dirs: Optional override for the configured
+            ``skills.external_dirs`` list. Provided so callers outside of
+            ``_profile_scope`` can read a profile's external_dirs directly
+            from that profile's ``config.yaml`` and feed them in. Defaults
+            to ``get_external_skills_dirs()``, which reads the active-
+            profile config.
+
+    Returns:
+        List of skill metadata dicts (name, description, category).
+
+    Results are cached per-session; the cache is invalidated when the scan
+    signature changes (dir/category mtimes or the disabled-set) and expires
+    after a short TTL to bound staleness from in-place SKILL.md edits.
+
+    Note: the cache slot key is ``_SKILLS_CACHE_KEY_FILTERED`` or
+    ``_SKILLS_CACHE_KEY_DISABLED`` — independent of ``skills_dir`` /
+    ``external_dirs``. The scan signature (``_skills_scan_signature``)
+    already varies by ``dirs_to_scan`` contents, so a different
+    ``skills_dir`` produces a different signature and naturally misses
+    the cache. But to keep the public CLI count path free of any
+    shared-cache concerns, profile-scoped callers should use
+    :func:`_collect_skills_from_dirs` directly.
+    """
+    from agent.skill_utils import get_external_skills_dirs
+
+    cache_key = _SKILLS_CACHE_KEY_DISABLED if skip_disabled else _SKILLS_CACHE_KEY_FILTERED
+
+    # Load disabled set once (not per-skill). Part of the cache signature:
+    # disabling a skill is a config change with no filesystem mtime bump.
+    disabled = set() if skip_disabled else _get_disabled_skill_names()
+
+    # Collect directories to scan — same resolution as the scan loop below
+    # (_skills_dir() resolves the LIVE profile HERMES_HOME; the module-level
+    # SKILLS_DIR can be stale in long-lived runtimes).
+    dirs_to_scan: list = []
+    active_skills_dir = skills_dir if skills_dir is not None else _skills_dir()
+    if active_skills_dir.exists():
+        dirs_to_scan.append(active_skills_dir)
+    if external_dirs is not None:
+        dirs_to_scan.extend(external_dirs)
+    else:
+        dirs_to_scan.extend(get_external_skills_dirs())
+
+    signature = _skills_scan_signature(dirs_to_scan, disabled)
+    now = time.monotonic()
+
+    cached = _SKILLS_CACHE.get(cache_key)
+    if (
+        cached is not None
+        and cached[0] == signature
+        and (now - cached[1]) < _SKILLS_CACHE_TTL_SECONDS
+    ):
+        # Per-call shallow copies: callers mutate the returned dicts
+        # (e.g. web_server annotates s["enabled"]/s["usage"]) — handing
+        # out the cached objects would poison the cache for everyone else.
+        return [dict(s) for s in cached[2]]
+
+    skills = _collect_skills_from_dirs(dirs_to_scan, disabled)
 
     # Store in cache keyed by the scan signature computed BEFORE the scan
     # (a write racing the scan changes the signature, so the next call


### PR DESCRIPTION
## What does this PR do?

Aligns profile list card skill counts with the web dashboard by having `_count_skills()` delegate to the same filtering function (`_find_all_skills()`) that `/api/skills` uses.

## Related Issue

Fixes #51707

## Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`tools/skills_tool.py`**: `_find_all_skills()` gains an optional `skills_dir: Optional[Path] = None` parameter. When provided, it scans that directory instead of the module-level `SKILLS_DIR` global. Zero behavioral change for existing callers — defaults to `SKILLS_DIR` when omitted.

- **`hermes_cli/profiles.py`**: `_count_skills()` replaced 7 lines of raw `rglob("SKILL.md")` + `is_excluded_skill_path` with a single delegation to `_find_all_skills(skip_disabled=True, skills_dir=profile_dir / "skills")`. This applies all the same filters: platform matching, environment checking, deduplication, error-tolerant parsing, and disabled-set filtering.

## How to Test

1. Run `hermes profile list` — note skill counts
2. Open web dashboard → Skills page — note sidebar ALL count
3. Verify both show the same number for each profile

## Checklist

### Code

- [X] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [X] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [X] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [X] I've run `pytest tests/ -q` and all tests pass
- [X] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [X] I've tested on my platform:

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [X] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A