### PR TITLE
fix(profiles): clone auth.json so OAuth credentials carry to cloned profiles

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -53,9 +53,21 @@ _PROFILE_DIRS = [
 ]
 
 # Files copied during --clone (if they exist in the source)
+#
+# auth.json carries the per-profile credential pool — including OAuth tokens
+# (Anthropic `claude /login`, Codex, xAI) that never land in .env. Cloning
+# .env but not auth.json silently dropped those credentials from the clone,
+# so a profile cloned from an OAuth-authenticated default resolved a
+# different provider (or none) than the source. The global-root fallback in
+# read_credential_pool only masks this while the clone's HERMES_HOME still
+# resolves to the same default root and the user hasn't run `hermes auth add`
+# locally. Copying it here makes selective --clone match `.env` semantics and
+# the full --clone-all copytree (which already carries auth.json). Both are
+# credential files and get tightened to owner-only (0o600) after copy.
 _CLONE_CONFIG_FILES = [
     "config.yaml",
     ".env",
+    "auth.json",
     "SOUL.md",
 ]
 
@@ -914,11 +926,12 @@ def create_profile(
                 if src.exists():
                     dst = profile_dir / filename
                     shutil.copy2(src, dst)
-                    # Tighten .env to owner-only after copy. shutil.copy2
-                    # preserves source mode bits, but if the source's .env
-                    # was loose (host umask 0o022 leaving 0o644), tighten
-                    # explicitly so the clone doesn't inherit weak perms.
-                    if filename == ".env":
+                    # Tighten credential files to owner-only after copy.
+                    # shutil.copy2 preserves source mode bits, but if the
+                    # source's .env / auth.json was loose (host umask 0o022
+                    # leaving 0o644), tighten explicitly so the clone doesn't
+                    # inherit weak perms.
+                    if filename in {".env", "auth.json"}:
                         try:
                             os.chmod(str(dst), 0o600)
                         except OSError:

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -7,6 +7,7 @@ and shell completion generation.
 
 import json
 import io
+import os
 import tarfile
 from pathlib import Path
 from unittest.mock import patch, MagicMock
@@ -214,6 +215,27 @@ class TestCreateProfile:
         assert cloned_config["model"] == "test"
         assert (profile_dir / ".env").read_text().strip() == "KEY=val"
         assert (profile_dir / "SOUL.md").read_text() == "Be helpful."
+
+    def test_clone_config_copies_auth_json(self, profile_env):
+        # auth.json holds the credential pool (incl. OAuth tokens that never
+        # land in .env). Selective --clone must carry it so a profile cloned
+        # from an OAuth-authenticated source keeps the same credentials,
+        # matching --clone-all and .env semantics.
+        tmp_path = profile_env
+        default_home = tmp_path / ".hermes"
+        (default_home / "auth.json").write_text(
+            '{"credential_pool": {"anthropic": [{"access_token": "tok"}]}}'
+        )
+
+        profile_dir = create_profile("coder", clone_config=True, no_alias=True)
+
+        cloned_auth = profile_dir / "auth.json"
+        assert cloned_auth.exists()
+        cloned = json.loads(cloned_auth.read_text())
+        assert cloned["credential_pool"]["anthropic"][0]["access_token"] == "tok"
+        # Credential file must be tightened to owner-only, like .env.
+        if os.name == "posix":
+            assert (cloned_auth.stat().st_mode & 0o777) == 0o600
 
     def test_clone_config_migrates_legacy_config_version(self, profile_env):
         tmp_path = profile_env


### PR DESCRIPTION
## Summary
Cloning a profile now carries the source's `auth.json`, so OAuth-authenticated providers (Anthropic `claude /login`, Codex, xAI) survive the clone — previously they were silently dropped and a cloned profile resolved a different provider (or none) under `provider: auto`.

Root cause: selective `--clone` / `--clone-from` / `--clone-config` copied `.env` but not `auth.json`. OAuth tokens live in `auth.json` (the credential pool), never in `.env`, so the clone lost them. `--clone-all` already carried `auth.json` via its full copytree; only the selective path missed it.

## Changes
- `hermes_cli/profiles.py`: add `auth.json` to `_CLONE_CONFIG_FILES`; extend the post-copy 0o600 chmod to cover it (same as `.env`).
- `tests/hermes_cli/test_profiles.py`: behavior test asserting a cloned profile's `auth.json` carries the credential pool with owner-only perms.

## Context — issue #50420
Reported as "`hermes -z` produces no response for any non-default profile" on v0.16.0/v0.17.0 (June 5/19). The headline symptom does **not** reproduce on current `main`: oneshot under a non-default `HERMES_HOME` returns normally, the `--provider X --model vendor/slug` edge is already normalized in `AIAgent` init (`agent/agent_init.py`), and `provider: auto` falls back cleanly. A batch of auth / cross-profile-credential fixes landed since those versions. The one concrete, machine-independent gap that remained was this `auth.json` clone omission, which this PR closes.

## Validation
- `scripts/run_tests.sh tests/hermes_cli/test_profiles.py` → 139 passed (incl. new test).
- `scripts/run_tests.sh tests/hermes_cli/test_web_server.py` → 315 passed.
- E2E: real `create_profile(clone_from="default")` against a temp `HERMES_HOME` seeded with an OAuth-style `auth.json` → cloned profile's `auth.json` contains the token, perms `0o600`.

## Infographic

![profile-clone-credential-carryover](https://v3b.fal.media/files/b/0a9f8c3e/b-UQkzTGrh26TczcAEUP3_bKKAmn5y.png)
