### PR TITLE
fix: replace 5 assert statements with explicit guards in production code

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4381,7 +4381,6 @@ class APIServerAdapter(BasePlatformAdapter):
         try:
             mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
             self._app = web.Application(middlewares=mws, client_max_size=MAX_REQUEST_BYTES)
-            assert self._app is not None
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/health/detailed", self._handle_health_detailed)
             self._app.router.add_get("/v1/health", self._handle_health)

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -399,7 +399,8 @@ class WebSocketRelayTransport:
         await self._ws.send(json.dumps(frame) + "\n")
 
     async def _read_loop(self) -> None:
-        assert self._ws is not None
+        if self._ws is None:
+            raise RuntimeError("_read_loop called before connect()")
         buf = ""
         try:
             async for chunk in self._ws:

--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -374,7 +374,8 @@ def _run_bootstrap(cwd: Path, commands: List[str]) -> None:
 def _do_git_install(entry: CatalogEntry) -> Path:
     """Clone the entry's repo into ``~/.hermes/mcp-installs/<name>`` and run
     bootstrap commands. Returns the install directory."""
-    assert entry.install is not None and entry.install.type == "git"
+    if entry.install is None or entry.install.type != "git":
+        raise CatalogError(f"Entry '{entry.name}' has no git install configuration")
     install = entry.install
     dest = _install_root() / entry.name
 

--- a/hermes_cli/mcp_picker.py
+++ b/hermes_cli/mcp_picker.py
@@ -219,7 +219,8 @@ def _handle_row(row: _Row) -> None:
                 print(color(f"  '{row.name}' was not installed", Colors.DIM))
     elif choice == 3:
         try:
-            assert row.entry is not None
+            if row.entry is None:
+                raise ValueError("Selected row has no catalog entry")
             install_entry(row.entry, enable=True)
         except CatalogError as exc:
             print(color(f"  ✗ reinstall failed: {exc}", Colors.RED))

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -810,7 +810,8 @@ class CDPSupervisor:
 
     async def _read_loop(self) -> None:
         """Continuously dispatch incoming CDP frames."""
-        assert self._ws is not None
+        if self._ws is None:
+            raise RuntimeError("_read_loop called before WebSocket connected")
         try:
             async for raw in self._ws:
                 if self._stop_requested:


### PR DESCRIPTION
## What

Replace 5 `assert` statements in production code with proper error handling that works even when Python runs with `-O` (optimize) flag.

## Why

`assert` statements are **silently stripped** when Python runs with `-O` or `-OO`. This means these checks disappear entirely in optimized builds, leading to:
- `NoneType` attribute errors instead of clear error messages
- Silent corruption instead of early failure
- Unreachable defensive code that gives false confidence

## Changes (5 files, 8 insertions, 5 deletions)

| File | Change |
|------|--------|
| `gateway/platforms/api_server.py` | Remove dead assert — `web.Application()` always returns non-None |
| `gateway/relay/ws_transport.py` | `assert self._ws` → `RuntimeError` before `_read_loop` |
| `hermes_cli/mcp_catalog.py` | `assert entry.install` → `CatalogError` for missing git config |
| `hermes_cli/mcp_picker.py` | `assert row.entry` → `ValueError` before reinstall |
| `tools/browser_supervisor.py` | `assert self._ws` → `RuntimeError` before `_read_loop` |

Follows the same pattern as PRs #51379, #51191, #51154, #51169.

## Testing

- `python3 -m py_compile` passes for all 5 files
- All replacements are mechanical: `assert X` → `if not X: raise ErrorType(msg)`