### PR TITLE
fix(anthropic): use platform.claude.com for OAuth login token exchange

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1297,7 +1297,15 @@ def run_oauth_setup_token() -> Optional[str]:
 # Stores credentials in ~/.hermes/.anthropic_oauth.json (our own file).
 
 _OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
-_OAUTH_TOKEN_URL = "https://console.anthropic.com/v1/oauth/token"
+# Anthropic migrated the OAuth token endpoint to platform.claude.com;
+# console.anthropic.com now 404s. Callers should iterate _OAUTH_TOKEN_URLS
+# (new host first, console fallback). _OAUTH_TOKEN_URL is kept as the primary
+# for backward compatibility with existing imports and now points at the live host.
+_OAUTH_TOKEN_URLS = [
+    "https://platform.claude.com/v1/oauth/token",
+    "https://console.anthropic.com/v1/oauth/token",
+]
+_OAUTH_TOKEN_URL = _OAUTH_TOKEN_URLS[0]
 _OAUTH_REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback"
 _OAUTH_SCOPES = "org:create_api_key user:profile user:inference"
 _HERMES_OAUTH_FILE = get_hermes_home() / ".anthropic_oauth.json"
@@ -1395,18 +1403,34 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
             "code_verifier": verifier,
         }).encode()
 
-        req = urllib.request.Request(
-            _OAUTH_TOKEN_URL,
-            data=exchange_data,
-            headers={
-                "Content-Type": "application/json",
-                "User-Agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
-            },
-            method="POST",
-        )
+        # Anthropic migrated the OAuth token endpoint to platform.claude.com;
+        # console.anthropic.com now 404s. Try the new host first, then fall
+        # back to console for older deployments (mirrors the refresh path).
+        result = None
+        last_error = None
+        for endpoint in _OAUTH_TOKEN_URLS:
+            req = urllib.request.Request(
+                endpoint,
+                data=exchange_data,
+                headers={
+                    "Content-Type": "application/json",
+                    "User-Agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
+                },
+                method="POST",
+            )
+            try:
+                with urllib.request.urlopen(req, timeout=15) as resp:
+                    result = json.loads(resp.read().decode())
+                break
+            except Exception as exc:
+                last_error = exc
+                logger.debug("Anthropic token exchange failed at %s: %s", endpoint, exc)
+                continue
 
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            result = json.loads(resp.read().decode())
+        if result is None:
+            raise last_error if last_error is not None else ValueError(
+                "Anthropic token exchange failed"
+            )
     except Exception as e:
         print(f"Token exchange failed: {e}")
         return None

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6123,6 +6123,7 @@ try:
     from agent.anthropic_adapter import (
         _OAUTH_CLIENT_ID as _ANTHROPIC_OAUTH_CLIENT_ID,
         _OAUTH_TOKEN_URL as _ANTHROPIC_OAUTH_TOKEN_URL,
+        _OAUTH_TOKEN_URLS as _ANTHROPIC_OAUTH_TOKEN_URLS,
         _OAUTH_REDIRECT_URI as _ANTHROPIC_OAUTH_REDIRECT_URI,
         _OAUTH_SCOPES as _ANTHROPIC_OAUTH_SCOPES,
         _generate_pkce as _generate_pkce_pair,
@@ -6311,22 +6312,31 @@ def _submit_anthropic_pkce(
         "redirect_uri": _ANTHROPIC_OAUTH_REDIRECT_URI,
         "code_verifier": sess["verifier"],
     }).encode()
-    req = urllib.request.Request(
-        _ANTHROPIC_OAUTH_TOKEN_URL,
-        data=exchange_data,
-        headers={
-            "Content-Type": "application/json",
-            "User-Agent": "hermes-dashboard/1.0",
-        },
-        method="POST",
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=20) as resp:
-            result = json.loads(resp.read().decode())
-    except Exception as e:
+    # Anthropic migrated the OAuth token endpoint to platform.claude.com;
+    # console.anthropic.com now 404s. Try the new host first, then fall back.
+    result = None
+    last_exc = None
+    for _endpoint in _ANTHROPIC_OAUTH_TOKEN_URLS:
+        req = urllib.request.Request(
+            _endpoint,
+            data=exchange_data,
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent": "hermes-dashboard/1.0",
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=20) as resp:
+                result = json.loads(resp.read().decode())
+            break
+        except Exception as e:
+            last_exc = e
+            continue
+    if result is None:
         with _oauth_sessions_lock:
             sess["status"] = "error"
-            sess["error_message"] = f"Token exchange failed: {e}"
+            sess["error_message"] = f"Token exchange failed: {last_exc}"
         return {"ok": False, "status": "error", "message": sess["error_message"]}
 
     access_token = result.get("access_token", "")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -47,6 +47,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 AUTHOR_MAP = {
     "145739220+wgu9@users.noreply.github.com": "wgu9",  # PR #51468 salvage (WSL/no-systemd orphan gateway tracking, #51325)
     "165020384+uperLu@users.noreply.github.com": "uperLu",  # PR #50958 salvage (rename plugins/cron → plugins/cron_providers; #50872)
+    "277269729+yusekiotacode@users.noreply.github.com": "yusekiotacode",  # PR #48706 salvage (anthropic OAuth login token endpoint → platform.claude.com; #45250/#49821)
     "minz0721@outlook.com": "s010mn",  # PR #29221 salvage (ollama-cloud reasoning_effort xhigh→max)
     "jeevesassistant00@gmail.com": "jeeves-assistant",  # PR #50771 (computer-use CuaDriver vision capture routing)
     "21178861+ScotterMonk@users.noreply.github.com": "ScotterMonk",  # PR #50145 salvage (cron output truncation: adapter-aware chunking, #50126)

--- a/tests/agent/test_anthropic_oauth_pkce.py
+++ b/tests/agent/test_anthropic_oauth_pkce.py
@@ -148,6 +148,111 @@ def test_authorization_url_state_is_not_pkce_verifier(monkeypatch, tmp_path):
     )
 
 
+def test_login_token_exchange_uses_platform_claude_host(monkeypatch, tmp_path):
+    """The login token exchange must hit ``platform.claude.com`` first.
+
+    Anthropic migrated the OAuth token endpoint to ``platform.claude.com``;
+    ``console.anthropic.com`` now 404s, so a hardcoded console host makes a
+    fresh login impossible (issue #45250 / #49821). The refresh path already
+    iterates the new host first — the login path must do the same.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    captured_token: Dict[str, Any] = {}
+    captured_url: Dict[str, str] = {}
+    _patch_oauth_flow(
+        monkeypatch,
+        callback_code="placeholder",
+        capture_token_request=captured_token,
+        capture_auth_url=captured_url,
+    )
+
+    import builtins
+
+    def fake_input(*_a, **_kw):
+        qs = parse_qs(urlparse(captured_url.get("url", "")).query)
+        state = qs.get("state", [""])[0]
+        return f"auth-code#{state}"
+
+    monkeypatch.setattr(builtins, "input", fake_input)
+
+    from agent.anthropic_adapter import run_hermes_oauth_login_pure
+
+    result = run_hermes_oauth_login_pure()
+
+    assert result is not None, "login should succeed against the live host"
+    assert captured_token["url"] == "https://platform.claude.com/v1/oauth/token", (
+        "login token exchange must target platform.claude.com first, not the "
+        "dead console.anthropic.com host (regression of #45250 / #49821)"
+    )
+
+
+def test_login_token_exchange_falls_back_to_console_host(monkeypatch, tmp_path):
+    """If ``platform.claude.com`` is unreachable, the login path must fall back
+    to the legacy ``console.anthropic.com`` host — mirroring the refresh path's
+    fallback list — rather than failing outright.
+    """
+    import urllib.request
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    captured_url: Dict[str, str] = {}
+    _patch_oauth_flow(
+        monkeypatch,
+        callback_code="placeholder",
+        capture_auth_url=captured_url,
+    )
+
+    attempts: list[str] = []
+
+    class _FakeResponse:
+        def __init__(self, body: bytes) -> None:
+            self._body = body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def read(self):
+            return self._body
+
+    def fake_urlopen(req, *_a, **_kw):
+        attempts.append(req.full_url)
+        if req.full_url.startswith("https://platform.claude.com"):
+            raise RuntimeError("HTTP Error 404: Not Found")
+        body = json.dumps(
+            {
+                "access_token": "sk-ant-test-access",
+                "refresh_token": "sk-ant-test-refresh",
+                "expires_in": 3600,
+            }
+        ).encode()
+        return _FakeResponse(body)
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    import builtins
+
+    def fake_input(*_a, **_kw):
+        qs = parse_qs(urlparse(captured_url.get("url", "")).query)
+        state = qs.get("state", [""])[0]
+        return f"auth-code#{state}"
+
+    monkeypatch.setattr(builtins, "input", fake_input)
+
+    from agent.anthropic_adapter import run_hermes_oauth_login_pure
+
+    result = run_hermes_oauth_login_pure()
+
+    assert result is not None, "login should succeed via the console fallback"
+    assert attempts == [
+        "https://platform.claude.com/v1/oauth/token",
+        "https://console.anthropic.com/v1/oauth/token",
+    ], "login must try platform.claude.com first, then fall back to console"
+
+
 def test_callback_state_mismatch_aborts(monkeypatch, tmp_path, caplog):
     """If the state returned in the callback does not match the one we sent
     in the authorization URL, the flow must abort before exchanging the code.


### PR DESCRIPTION
## Summary
Fresh Anthropic Claude Pro/Max OAuth login completes again — the login token exchange now targets the live `platform.claude.com` host instead of the migrated-away `console.anthropic.com` (404).

Root cause: the *refresh* path already iterated `platform.claude.com` first with `console.anthropic.com` as fallback, but the *login* path (`run_hermes_oauth_login_pure()`) and the dashboard OAuth path (`hermes_cli/web_server.py`) hardcoded the dead console host via `_OAUTH_TOKEN_URL`, so a fresh login 404'd at token exchange.

## Changes
- `agent/anthropic_adapter.py`: add `_OAUTH_TOKEN_URLS = [platform.claude.com, console.anthropic.com]`; the login path iterates it (new host first, console fallback) mirroring the refresh path. `_OAUTH_TOKEN_URL` kept as a back-compat alias = `_OAUTH_TOKEN_URLS[0]`. `_OAUTH_REDIRECT_URI` left on `console.anthropic.com` — it's the registered callback for this `client_id`; changing it would trigger `redirect_uri_mismatch`.
- `hermes_cli/web_server.py`: dashboard PKCE exchange (`_submit_anthropic_pkce`) iterates the same fallback list.
- `tests/agent/test_anthropic_oauth_pkce.py`: two regression tests — login targets `platform.claude.com` first, and falls back to `console.anthropic.com` when the new host is unreachable.

## Validation
| | Before | After |
|---|---|---|
| `console.anthropic.com/v1/oauth/token` | 404 (dead), login fails | tried only as fallback |
| `platform.claude.com/v1/oauth/token` | never tried on login | tried first |
| `tests/agent/test_anthropic_oauth_pkce.py` | 2 tests | 4/4 passing |

E2E-verified against current `main` (real imports): `_OAUTH_TOKEN_URLS` ordering, back-compat alias, redirect_uri unchanged, and `web_server._submit_anthropic_pkce` import all resolve.

## Attribution
Salvage of #48706 by @yusekiotacode (cleanest of the duplicate cluster, and the only one fixing both the CLI and dashboard sites). Cherry-picked with authorship preserved; test + AUTHOR_MAP follow-up added on top.

Closes #49821, #45250 (tracking), #47692. Supersedes the duplicate-fix cluster: #48706, #48704, #48957, #49356, #47765.

## Infographic

![anthropic-oauth-login-token-endpoint-fix](https://v3b.fal.media/files/b/0a9f8c52/TaVEx8baIxexyogX4nF-a_etJ0UpcP.png)
