### PR TITLE
fix(delegation): use target_model for bedrock api_mode routing (#49095)

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1750,7 +1750,7 @@ def resolve_runtime_provider(
         # Dual-path routing: Claude models use AnthropicBedrock SDK for full
         # feature parity (prompt caching, thinking budgets, adaptive thinking).
         # Non-Claude models use the Converse API for multi-model support.
-        _current_model = str(model_cfg.get("default") or "").strip()
+        _current_model = str(target_model or model_cfg.get("default") or "").strip()
         if is_anthropic_bedrock_model(_current_model):
             # Claude on Bedrock → AnthropicBedrock SDK → anthropic_messages path
             runtime = {

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -2835,3 +2835,61 @@ def test_host_derived_key_helper_basic_cases():
     for k in ("DEEPSEEK_API_KEY", "GROQ_API_KEY", "MISTRAL_API_KEY",
               "OPENAI_API_KEY", "OPENROUTER_API_KEY"):
         _os.environ.pop(k, None)
+
+
+def _patch_bedrock(monkeypatch, config_default=""):
+    """Stub the bedrock_adapter helpers resolve_runtime_provider imports.
+
+    Leaves the real ``is_anthropic_bedrock_model`` in place so the dual-path
+    routing decision is exercised for real. ``config_default`` is the persisted
+    ``model.default`` — kept non-Claude here to prove ``target_model`` (not the
+    stale config default) drives the api_mode decision.
+    """
+    import agent.bedrock_adapter as ba
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "bedrock")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"default": config_default})
+    monkeypatch.setattr(rp, "load_config", lambda: {"bedrock": {}})
+    monkeypatch.setattr(ba, "has_aws_credentials", lambda: True)
+    monkeypatch.setattr(ba, "resolve_aws_auth_env_var", lambda: "AWS_PROFILE")
+    monkeypatch.setattr(ba, "resolve_bedrock_region", lambda: "eu-north-1")
+
+
+def test_resolve_runtime_provider_bedrock_claude_target_model_uses_anthropic_messages(monkeypatch):
+    """Claude-on-Bedrock delegation must route through the AnthropicBedrock SDK.
+
+    Regression for #49095: the bedrock branch derived api_mode from the stale
+    persisted ``model.default`` instead of ``target_model``. When delegation
+    targets a Claude model but the parent's default is non-Claude, the wrong
+    branch (Converse) was picked, and the child silently fell back to
+    openrouter/free. ``target_model`` must win so Claude keeps the
+    anthropic_messages path (prompt caching, thinking budgets).
+    """
+    _patch_bedrock(monkeypatch, config_default="amazon.nova-pro-v1:0")
+
+    resolved = rp.resolve_runtime_provider(
+        requested="bedrock",
+        target_model="global.anthropic.claude-sonnet-4-6",
+    )
+
+    assert resolved["provider"] == "bedrock"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved.get("bedrock_anthropic") is True
+
+
+def test_resolve_runtime_provider_bedrock_nonclaude_target_model_uses_converse(monkeypatch):
+    """Non-Claude Bedrock target stays on the Converse API path.
+
+    Confirms the target_model fix doesn't over-correct: a Nova target must NOT
+    be forced onto anthropic_messages even when the persisted default is Claude.
+    """
+    _patch_bedrock(monkeypatch, config_default="global.anthropic.claude-sonnet-4-6")
+
+    resolved = rp.resolve_runtime_provider(
+        requested="bedrock",
+        target_model="amazon.nova-pro-v1:0",
+    )
+
+    assert resolved["provider"] == "bedrock"
+    assert resolved["api_mode"] == "bedrock_converse"
+    assert resolved.get("bedrock_anthropic") is not True


### PR DESCRIPTION
## Summary
Claude-on-Bedrock delegation now keeps the AnthropicBedrock SDK path (prompt caching, thinking budgets) instead of silently falling back to `openrouter/free`.

Root cause: the Bedrock branch in `resolve_runtime_provider` derived its dual-path `api_mode` from the *stale persisted* `model.default` rather than the delegation `target_model`. When `delegation.model` is a Claude model but the parent's default is non-Claude, the wrong branch (Converse) was chosen and the child mis-resolved. This was the only Bedrock site ignoring `target_model` — sibling branches already use the `target_model or model.default` pattern, and the param's own docstring exists for exactly this case.

Note: the reported "force `bedrock_converse`" fix is the wrong direction — it would route Claude through the Converse API and lose prompt caching + thinking parity. The fix preserves the dual-path: Claude → `anthropic_messages` (AnthropicBedrock SDK), non-Claude → `bedrock_converse`.

## Changes
- `hermes_cli/runtime_provider.py`: Bedrock branch derives `api_mode` from `target_model or model.default` (1-line, @kyssta-exe).
- `tests/hermes_cli/test_runtime_provider_resolution.py`: regression tests — Claude target → `anthropic_messages` + `bedrock_anthropic`; Nova target → `bedrock_converse` (both fail without the fix).

## Validation
| target_model | model.default | api_mode | bedrock_anthropic |
|---|---|---|---|
| `global.anthropic.claude-sonnet-4-6` | `amazon.nova-pro-v1:0` | `anthropic_messages` | True |
| `amazon.nova-pro-v1:0` | `global.anthropic.claude-sonnet-4-6` | `bedrock_converse` | — |

Verified both tests fail on the pre-fix line and pass after. Fixes #49095. Salvaged from #49155 (authorship preserved); supersedes the force-converse PR #49117.

## Infographic

![bedrock-delegation-routing-fix](https://v3b.fal.media/files/b/0a9f8c56/SsBjrbk7uaa2cbPhbaREi_nmyP4DCo.png)
