### PR TITLE
fix: harden gateway maintenance paths

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -309,10 +309,14 @@ def interruptible_api_call(agent, api_kwargs: dict):
     if _ttfb_timeout <= 0:
         _ttfb_enabled = False
     elif _openai_codex_backend:
-        _ttfb_disable_above = _env_float("HERMES_CODEX_TTFB_DISABLE_ABOVE_TOKENS", 25_000.0)
+        _ttfb_disable_above = _env_float("HERMES_CODEX_TTFB_DISABLE_ABOVE_TOKENS", 0.0)
         _ttfb_strict = os.environ.get("HERMES_CODEX_TTFB_STRICT", "").strip().lower() in {
             "1", "true", "yes", "on"
         }
+        # Old default disabled the no-byte watchdog for any large Codex request,
+        # exactly when the gateway most needs a deadman. Keep an explicit opt-out
+        # env var for operators, but otherwise scale to a bounded large-request
+        # timeout instead of turning protection off.
         if (
             not _ttfb_strict
             and _ttfb_disable_above > 0
@@ -320,18 +324,23 @@ def interruptible_api_call(agent, api_kwargs: dict):
         ):
             _ttfb_enabled = False
             logger.info(
-                "Disabling openai-codex no-byte TTFB watchdog for large request "
-                "(context=~%s tokens >= %.0f). Waiting for backend response instead. "
-                "Set HERMES_CODEX_TTFB_STRICT=1 to force early reconnects.",
+                "Disabling openai-codex no-byte TTFB watchdog by explicit env "
+                "(context=~%s tokens >= %.0f).",
                 f"{_est_tokens_for_codex_watchdog:,}",
                 _ttfb_disable_above,
             )
         else:
             _ttfb_cap = _env_float("HERMES_CODEX_TTFB_MAX_SECONDS", 120.0)
+            if (not _ttfb_strict) and _est_tokens_for_codex_watchdog >= 25_000:
+                _large_cap = _env_float("HERMES_CODEX_TTFB_LARGE_MAX_SECONDS", 300.0)
+                if _large_cap > 0:
+                    _ttfb_cap = max(_ttfb_cap, _large_cap)
+                    _ttfb_timeout = max(_ttfb_timeout, _large_cap)
             if _ttfb_cap > 0 and _ttfb_timeout > _ttfb_cap:
                 logger.info(
                     "Capping openai-codex no-byte TTFB timeout from %.0fs to %.0fs "
-                    "(context=~%s tokens). Set HERMES_CODEX_TTFB_MAX_SECONDS to tune.",
+                    "(context=~%s tokens). Set HERMES_CODEX_TTFB_MAX_SECONDS / "
+                    "HERMES_CODEX_TTFB_LARGE_MAX_SECONDS to tune.",
                     _ttfb_timeout,
                     _ttfb_cap,
                     f"{_est_tokens_for_codex_watchdog:,}",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3959,6 +3959,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         msg = f"⚠️ Gateway {action} — {hint}"
 
         notified: set[tuple[str, str, Optional[str]]] = set()
+        # Track parent chats reached through active thread/topic notices. If a
+        # thread in the same parent chat was notified, do not also post a root/home
+        # shutdown notice into that parent chat. That preserves thread_ts/topic
+        # locality and avoids the visible double-post that makes restarts look
+        # noisier than they are.
+        notified_parent_chats: set[tuple[str, str]] = set()
         for session_key in active:
             source = None
             try:
@@ -4042,6 +4048,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     continue
 
                 notified.add(dedup_key)
+                notified_parent_chats.add((platform_str, chat_id))
                 logger.info(
                     "Sent shutdown notification to active chat %s:%s",
                     platform_str, chat_id,
@@ -4076,6 +4083,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             dedup_key = (platform.value, str(home.chat_id), str(home.thread_id) if home.thread_id else None)
             if dedup_key in notified:
+                continue
+            # If an active session in this parent chat already received a
+            # thread/topic-scoped shutdown notice, do not also send the root/home
+            # fallback into the same parent. Identical target dedupe above still
+            # handles home channels with their own thread_id.
+            if (platform.value, str(home.chat_id)) in notified_parent_chats:
                 continue
 
             try:

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -1245,7 +1245,7 @@ async def test_restart_home_channel_notification_dedupes_active_chat():
 
 
 @pytest.mark.asyncio
-async def test_restart_home_channel_notification_not_deduped_across_threads():
+async def test_restart_home_channel_notification_dedupes_parent_chat_after_thread_notice():
     runner, adapter = make_restart_runner()
     runner._restart_requested = True
     session_key = "agent:main:telegram:group:999"
@@ -1267,9 +1267,8 @@ async def test_restart_home_channel_notification_not_deduped_across_threads():
 
     await runner._notify_active_sessions_of_shutdown()
 
-    assert len(adapter.sent) == 2
+    assert len(adapter.sent) == 1
     assert adapter.sent_calls[0][2] == {"thread_id": "topic-7"}
-    assert adapter.sent_calls[1][2] is None
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -17,6 +17,7 @@ from tools.session_search_tool import (
     SESSION_SEARCH_SCHEMA,
     _HIDDEN_SESSION_SOURCES,
     _format_timestamp,
+    _shape_message,
     session_search,
 )
 
@@ -102,6 +103,15 @@ class TestSchema:
 class TestHiddenSources:
     def test_tool_source_hidden(self):
         assert "tool" in _HIDDEN_SESSION_SOURCES
+
+
+class TestPayloadShaping:
+    def test_large_message_content_is_truncated_with_metadata(self, monkeypatch):
+        monkeypatch.setenv("HERMES_SESSION_SEARCH_FIELD_CHAR_LIMIT", "1000")
+        shaped = _shape_message({"id": 1, "role": "tool", "content": "x" * 2500})
+        assert len(shaped["content"]) < 1200
+        assert shaped["content_truncated_chars"] == 1500
+        assert "session_search truncated" in shaped["content"]
 
 
 class TestFormatTimestamp:

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -31,12 +31,53 @@ support.
 
 import json
 import logging
+import os
 from typing import Any, Dict, List, Optional, Union
 
 # Sources that are excluded from session browsing/searching by default.
 # Third-party integrations tag their sessions with HERMES_SESSION_SOURCE=tool
 # so they don't clutter the user's session history.
 _HIDDEN_SESSION_SOURCES = ("tool",)
+
+
+def _payload_char_limit() -> int:
+    """Per-field character cap for session_search payloads.
+
+    Session transcripts can contain giant tool results. Returning them verbatim
+    inside live gateway turns can produce hundreds of thousands of characters,
+    starving the gateway and forcing context compression. Keep search/read useful
+    by defaulting to bounded previews; callers can scroll for more surrounding
+    rows, but individual fields remain capped.
+    """
+    raw = os.getenv("HERMES_SESSION_SEARCH_FIELD_CHAR_LIMIT", "4000").strip()
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        value = 4000
+    # 0 disables only for explicit operator/debug use; otherwise clamp to a
+    # range that protects interactive gateways from pathological rows.
+    if value == 0:
+        return 0
+    return max(500, min(value, 20_000))
+
+
+def _truncate_payload_value(value: Any, limit: int) -> tuple[Any, int]:
+    """Return (possibly truncated value, omitted_char_count)."""
+    if value is None or limit == 0:
+        return value, 0
+    if not isinstance(value, str):
+        try:
+            value = json.dumps(value, ensure_ascii=False)
+        except Exception:
+            value = str(value)
+    if len(value) <= limit:
+        return value, 0
+    omitted = len(value) - limit
+    return (
+        value[:limit]
+        + f"\n…[session_search truncated {omitted:,} chars; use a narrower query/window or read the source session directly]",
+        omitted,
+    )
 
 
 def _format_timestamp(ts: Union[int, float, str, None]) -> str:
@@ -88,16 +129,23 @@ def _resolve_to_parent(db, session_id: str) -> str:
 
 def _shape_message(m: Dict[str, Any], anchor_id: Optional[int] = None) -> Dict[str, Any]:
     """Slim a message row for the tool response. Keeps content even if empty."""
+    limit = _payload_char_limit()
+    content, content_omitted = _truncate_payload_value(m.get("content"), limit)
     entry = {
         "id": m.get("id"),
         "role": m.get("role"),
-        "content": m.get("content"),
+        "content": content,
         "timestamp": m.get("timestamp"),
     }
+    if content_omitted:
+        entry["content_truncated_chars"] = content_omitted
     if m.get("tool_name"):
         entry["tool_name"] = m.get("tool_name")
     if m.get("tool_calls"):
-        entry["tool_calls"] = m.get("tool_calls")
+        tool_calls, tool_calls_omitted = _truncate_payload_value(m.get("tool_calls"), limit)
+        entry["tool_calls"] = tool_calls
+        if tool_calls_omitted:
+            entry["tool_calls_truncated_chars"] = tool_calls_omitted
     if m.get("tool_call_id"):
         entry["tool_call_id"] = m.get("tool_call_id")
     if anchor_id is not None and m.get("id") == anchor_id:


### PR DESCRIPTION
## Summary
- cap oversized session_search message/tool payload fields with truncation metadata
- keep Codex no-byte TTFB protection for large requests by using a bounded large-request cap instead of disabling the watchdog by default
- avoid duplicate root/home shutdown notices when an active thread/topic in the same parent chat was already notified

## Verification
- uv run --with pytest --with pytest-asyncio --with pytest-timeout --with pytest-xdist pytest tests/tools/test_session_search.py tests/agent/test_codex_ttfb_watchdog.py tests/gateway/test_restart_resume_pending.py -q
- 124 passed in 95.13s