### PR TITLE
fix(desktop): guard composer mutations when the composer core isn't bound (#49903)

### DIFF
--- a/apps/desktop/src/app/chat/composer/composer-text-guard.test.tsx
+++ b/apps/desktop/src/app/chat/composer/composer-text-guard.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { act, cleanup, render } from '@testing-library/react'
+import { useCallback, useRef } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+afterEach(cleanup)
+
+// Regression repro for #49903: on desktop v0.17.0 the composer threw an
+// uncaught `Error: Composer is not available` at startup and the input went
+// unresponsive. The throw comes from @assistant-ui/core's composer-runtime —
+// every *mutator* (setText/send/…) does `if (!core) throw new Error("Composer
+// is not available")` when the thread's composer core isn't bound yet. Unlike
+// the read path (`s.composer.text`, which is null-safe: `runtime?.text ?? ""`),
+// the mutators have no graceful fallback. ChatBar's mount-time effects (draft
+// restore, clearDraft, external inserts) push text via `aui.composer().setText`
+// before the core binds, and the popout refactor (#49488) widened that window,
+// so the throw surfaced as an uncaught error that wedged the input.
+//
+// The fix wraps every `aui.composer().setText` call in a `setComposerText`
+// helper that swallows the unbound-core throw — the contentEditable DOM +
+// draftRef already hold the text and the draft⇄editor sync re-applies it once
+// the core attaches, so nothing is lost. This Harness mirrors that helper
+// faithfully (same try/catch shape) over a fake `aui` whose composer can be
+// toggled bound/unbound, the way the assistant-ui runtime behaves across mount.
+
+interface FakeComposer {
+  setText: (value: string) => void
+}
+
+// Mirror of index.tsx's `useAui()` composer surface: composer() returns a
+// runtime whose setText throws exactly like @assistant-ui/core when unbound.
+function makeFakeAui(bound: { current: boolean }, applied: string[]) {
+  const composer: FakeComposer = {
+    setText(value: string) {
+      if (!bound.current) {
+        throw new Error('Composer is not available')
+      }
+
+      applied.push(value)
+    }
+  }
+
+  return { composer: () => composer }
+}
+
+function Harness({
+  bound,
+  applied,
+  onError
+}: {
+  applied: string[]
+  bound: { current: boolean }
+  onError: (err: unknown) => void
+}) {
+  const aui = useRef(makeFakeAui(bound, applied)).current
+
+  // Verbatim mirror of the production `setComposerText` helper in index.tsx.
+  const setComposerText = useCallback(
+    (value: string) => {
+      try {
+        aui.composer().setText(value)
+      } catch {
+        // Composer core not bound yet — swallow so the input stays usable.
+      }
+    },
+    [aui]
+  )
+
+  // A draft-restore-on-mount that fires while the core may still be unbound,
+  // exactly like loadIntoComposer/clearDraft do on startup.
+  try {
+    setComposerText('restored draft')
+  } catch (err) {
+    onError(err)
+  }
+
+  return null
+}
+
+describe('setComposerText guard (#49903)', () => {
+  it('swallows the unbound-core throw at startup instead of crashing the renderer', () => {
+    const applied: string[] = []
+    const bound = { current: false }
+    const onError = vi.fn()
+
+    expect(() => render(<Harness applied={applied} bound={bound} onError={onError} />)).not.toThrow()
+
+    // The guard absorbed the throw — nothing escaped to the renderer, and no
+    // assistant-ui write landed (core was unbound).
+    expect(onError).not.toHaveBeenCalled()
+    expect(applied).toEqual([])
+  })
+
+  it('writes through to the composer once the core is bound', () => {
+    const applied: string[] = []
+    const bound = { current: true }
+    const onError = vi.fn()
+
+    act(() => {
+      render(<Harness applied={applied} bound={bound} onError={onError} />)
+    })
+
+    expect(onError).not.toHaveBeenCalled()
+    expect(applied).toEqual(['restored draft'])
+  })
+})

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -193,6 +193,32 @@ export function ChatBar({
 }: ChatBarProps) {
   const aui = useAui()
   const draft = useAuiState(s => s.composer.text)
+
+  // assistant-ui's composer *mutators* (setText/send/…) throw "Composer is not
+  // available" when the thread's composer core isn't bound yet — and unlike the
+  // read path (`s.composer.text`, which is null-safe), there's no graceful
+  // fallback. There's a startup/thread-swap window where this ChatBar's mount
+  // effects (draft restore, clearDraft, external inserts) run before the core
+  // binds; the popout refactor (#49488) widened it by moving the composer out
+  // of the contain wrapper into a sibling of the thread, so the throw began
+  // surfacing as an uncaught error that wedged the desktop input (#49903).
+  //
+  // Guard every mutation: if the core isn't ready, no-op the assistant-ui write.
+  // The contentEditable DOM + draftRef already hold the text, and the
+  // draft⇄editor sync reconciles composer state once the core attaches, so the
+  // draft is never lost — only the (premature) state push is skipped.
+  const setComposerText = useCallback(
+    (value: string) => {
+      try {
+        aui.composer().setText(value)
+      } catch {
+        // Composer core not bound yet — DOM/draftRef carry the text; the sync
+        // effect re-applies it after bind. Swallow so the input stays usable.
+      }
+    },
+    [aui]
+  )
+
   const attachments = useStore($composerAttachments)
   const queuedPromptsBySession = useStore($queuedPromptsBySession)
   const statusItemsBySession = useStore($statusItemsBySession)
@@ -370,7 +396,7 @@ export function ChatBar({
       const next = `${base}${sep}${value}`
 
       draftRef.current = next
-      aui.composer().setText(next)
+      setComposerText(next)
 
       const editor = editorRef.current
 
@@ -381,7 +407,7 @@ export function ChatBar({
 
       setFocusRequestId(id => id + 1)
     },
-    [aui]
+    [setComposerText]
   )
 
   useEffect(() => {
@@ -591,7 +617,7 @@ export function ChatBar({
     const nextDraft = `${currentDraft}${sep}${text}`
 
     draftRef.current = nextDraft
-    aui.composer().setText(nextDraft)
+    setComposerText(nextDraft)
 
     // Push the new text into the contentEditable editor directly. Setting the
     // assistant-ui composer state alone is not enough: the draft→editor sync
@@ -624,7 +650,7 @@ export function ChatBar({
     }
 
     draftRef.current = nextDraft
-    aui.composer().setText(nextDraft)
+    setComposerText(nextDraft)
     requestMainFocus()
 
     return true
@@ -710,7 +736,7 @@ export function ChatBar({
 
     if (nextDraft !== draftRef.current) {
       draftRef.current = nextDraft
-      aui.composer().setText(nextDraft)
+      setComposerText(nextDraft)
     }
 
     window.setTimeout(refreshTrigger, 0)
@@ -836,7 +862,7 @@ export function ChatBar({
       renderComposerContents(editor, prefix)
       placeCaretEnd(editor)
       draftRef.current = composerPlainText(editor)
-      aui.composer().setText(draftRef.current)
+      setComposerText(draftRef.current)
       closeTrigger()
       runAction()
       requestMainFocus()
@@ -864,7 +890,7 @@ export function ChatBar({
 
     const finish = () => {
       draftRef.current = composerPlainText(editor)
-      aui.composer().setText(draftRef.current)
+      setComposerText(draftRef.current)
       requestMainFocus()
       keepTriggerOpen ? window.setTimeout(refreshTrigger, 0) : closeTrigger()
     }
@@ -1316,17 +1342,17 @@ export function ChatBar({
   }
 
   const clearDraft = useCallback(() => {
-    aui.composer().setText('')
+    setComposerText('')
     draftRef.current = ''
 
     if (editorRef.current) {
       editorRef.current.replaceChildren()
     }
-  }, [aui])
+  }, [setComposerText])
 
   const loadIntoComposer = (text: string, attachments: ComposerAttachment[]) => {
     draftRef.current = text
-    aui.composer().setText(text)
+    setComposerText(text)
     $composerAttachments.set(cloneAttachments(attachments))
 
     const editor = editorRef.current
@@ -1699,7 +1725,7 @@ export function ChatBar({
 
       if (domText !== draftRef.current) {
         draftRef.current = domText
-        aui.composer().setText(domText)
+        setComposerText(domText)
       }
     }
 


### PR DESCRIPTION
## Summary
The desktop composer no longer throws `Uncaught Error: Composer is not available` at startup, and the input stays interactive after upgrading to v0.17.0. Fixes #49903.

Root cause: assistant-ui's composer *mutators* (`setText`/`send`/…) throw `Composer is not available` when the thread's composer core isn't bound yet (`@assistant-ui/core` composer-runtime.ts). The *read* path (`useAuiState(s => s.composer.text)`) is null-safe, but the writes are not. `ChatBar` pushes draft text via `aui.composer().setText()` from mount-time effects (draft restore → `loadIntoComposer`, `clearDraft`, external inserts). The v0.17.0 popout refactor (#49488) widened the unbound window by moving the composer out of the `contain` wrapper into a sibling of the thread, so the throw began surfacing as an uncaught error that wedged the input — emitted twice (initial mount + session-resolve), matching the report's back-to-back errors.

## Changes
- `apps/desktop/src/app/chat/composer/index.tsx`: add a `setComposerText` helper that wraps `aui.composer().setText()` in a try/catch swallowing the unbound-core throw; route all 9 `setText` call sites through it. The contentEditable DOM + `draftRef` already hold the text and the draft⇄editor sync re-applies it once the core attaches, so the draft is never lost — only the premature state push is skipped.
- `composer-text-guard.test.tsx`: regression test — the guard absorbs the throw at startup (no uncaught error, input usable) and writes through once the core is bound.

## Validation
| | Before | After |
|---|---|---|
| Startup with unbound composer core | uncaught `Composer is not available`, input dead | guard no-ops, input stays usable |
| Composer core bound | setText applied | setText applied (unchanged) |

- `npm run typecheck` (apps/desktop): clean
- `npm run --prefix apps/desktop build`: ✓ built
- `vitest run composer-text-guard.test.tsx`: 2/2 passed

## Infographic
![Composer Mutation Guard](https://v3b.fal.media/files/b/0a9f8c65/3dgzQH-AywOHmu80SUdSC_SMTrx0Ec.png)
