### PR TITLE
fix(dashboard): scope ChatSidebar tool feed to the live session

### DIFF
--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -35,6 +35,10 @@ import { ToolCall, type ToolEntry } from "@/components/ToolCall";
 import { GatewayClient, type ConnectionState } from "@/lib/gatewayClient";
 import { api, HERMES_BASE_PATH, buildWsAuthParam } from "@/lib/api";
 import { titleFromSessionInfoPayload } from "@/lib/chat-title";
+import {
+  nextLiveSessionId,
+  shouldDropSidebarEvent,
+} from "@/lib/sidebar-event-routing";
 
 import { cn } from "@/lib/utils";
 import { AlertCircle, ChevronDown, RefreshCw } from "lucide-react";
@@ -50,7 +54,7 @@ interface SessionInfo {
 
 interface RpcEnvelope {
   method?: string;
-  params?: { type?: string; payload?: unknown };
+  params?: { type?: string; session_id?: string; payload?: unknown };
 }
 
 const TOOL_LIMIT = 20;
@@ -155,6 +159,14 @@ export function ChatSidebar({
   // socket's close handler can leave a stale error banner after a switch.
   const scopeKey = `${channel}\0${profile ?? ""}`;
   const prevScopeKey = useRef<string | null>(null);
+  // The PTY child's live runtime session id, learned from `session.info`
+  // frames on the channel feed. Used as the match target so a backgrounded
+  // session's `tool.*` (which carry their OWN session_id) don't render in the
+  // focused session's tool list — the web analogue of the desktop/TUI
+  // match-by-id guard. Stays null until the first `session.info` arrives;
+  // while null (and for any frame without a session_id) we let events through
+  // so we never swallow the legitimate live feed (the #42359 regression).
+  const liveSessionIdRef = useRef<string | null>(null);
   useEffect(() => {
     if (prevScopeKey.current === null) {
       prevScopeKey.current = scopeKey;
@@ -162,6 +174,7 @@ export function ChatSidebar({
     }
     if (prevScopeKey.current === scopeKey) return;
     prevScopeKey.current = scopeKey;
+    liveSessionIdRef.current = null;
     setError(null);
     setTools([]);
     setVersion((v) => v + 1);
@@ -282,7 +295,25 @@ export function ChatSidebar({
           return;
         }
 
-        const { type, payload } = frame.params;
+        const { type, session_id: frameSid, payload } = frame.params;
+
+        // Learn the PTY child's live runtime session id from its `session.info`
+        // heartbeats (mirrored onto this channel feed) — the match target for
+        // the guard below, NOT `resumeParam` (which can differ after descendant
+        // resolution + PTY-side resume).
+        liveSessionIdRef.current = nextLiveSessionId(
+          type,
+          frameSid,
+          liveSessionIdRef.current,
+        );
+
+        // Match-by-id: drop a scoped frame from a DIFFERENT session (a
+        // backgrounded session in the same PTY child still emits its `tool.*`
+        // on this shared channel). Unscoped frames and pre-learning frames
+        // fall through so the live feed is never swallowed (#42359).
+        if (shouldDropSidebarEvent(type, frameSid, liveSessionIdRef.current)) {
+          return;
+        }
 
         if (type === "session.info") {
           const title = titleFromSessionInfoPayload(payload);

--- a/web/src/lib/sidebar-event-routing.test.ts
+++ b/web/src/lib/sidebar-event-routing.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  nextLiveSessionId,
+  shouldDropSidebarEvent,
+} from "./sidebar-event-routing";
+
+describe("nextLiveSessionId", () => {
+  it("learns the live id from a session.info frame", () => {
+    expect(nextLiveSessionId("session.info", "sess-A", null)).toBe("sess-A");
+  });
+
+  it("updates the live id when session.info changes (e.g. /new)", () => {
+    expect(nextLiveSessionId("session.info", "sess-B", "sess-A")).toBe("sess-B");
+  });
+
+  it("ignores session.info frames with no session_id", () => {
+    expect(nextLiveSessionId("session.info", undefined, "sess-A")).toBe(
+      "sess-A",
+    );
+  });
+
+  it("leaves the live id unchanged for non-session.info frames", () => {
+    expect(nextLiveSessionId("tool.start", "sess-B", "sess-A")).toBe("sess-A");
+  });
+});
+
+describe("shouldDropSidebarEvent", () => {
+  it("drops a scoped frame from a different session (the leak)", () => {
+    // Background session sess-B emits tool.start while sess-A is live.
+    expect(shouldDropSidebarEvent("tool.start", "sess-B", "sess-A")).toBe(true);
+  });
+
+  it("keeps a scoped frame from the live session", () => {
+    expect(shouldDropSidebarEvent("tool.start", "sess-A", "sess-A")).toBe(
+      false,
+    );
+  });
+
+  it("keeps an unscoped frame (no session_id) — never swallow the live feed", () => {
+    // #42359: dropping unscoped events swallowed the live answer.
+    expect(shouldDropSidebarEvent("tool.start", undefined, "sess-A")).toBe(
+      false,
+    );
+    expect(shouldDropSidebarEvent("tool.complete", "", "sess-A")).toBe(false);
+  });
+
+  it("keeps every frame before the live id is learned", () => {
+    expect(shouldDropSidebarEvent("tool.start", "sess-B", null)).toBe(false);
+  });
+
+  it("never gates the unscoped control event", () => {
+    expect(
+      shouldDropSidebarEvent(
+        "dashboard.new_session_requested",
+        undefined,
+        "sess-A",
+      ),
+    ).toBe(false);
+    // even if some future broadcaster stamps a stray id on it, it stays through
+    expect(
+      shouldDropSidebarEvent(
+        "dashboard.new_session_requested",
+        "sess-B",
+        "sess-A",
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps the session.info frame that establishes a new live id", () => {
+    // The component learns the id first (nextLiveSessionId), then this guard
+    // runs against the updated id — so the establishing frame is never dropped.
+    const live = nextLiveSessionId("session.info", "sess-A", null);
+    expect(shouldDropSidebarEvent("session.info", "sess-A", live)).toBe(false);
+  });
+});

--- a/web/src/lib/sidebar-event-routing.ts
+++ b/web/src/lib/sidebar-event-routing.ts
@@ -1,0 +1,64 @@
+/**
+ * Pure session-routing decisions for the dashboard ChatSidebar's event feed.
+ *
+ * The sidebar subscribes to one PTY child's channel via `/api/events`. A single
+ * embedded `hermes --tui` can hold several sessions at once (the user runs
+ * `/new` or switches sessions inside it), and EVERY session in that child emits
+ * its `tool.*` frames on the SAME channel. Without filtering, a backgrounded
+ * session's tool calls render in the focused session's tool list — the web
+ * analogue of the desktop/TUI cross-session bleed (issue #49106 / #47709).
+ *
+ * The fix mirrors the TUI's match-by-id guard
+ * (`ui-tui/src/app/createGatewayEventHandler.ts`): learn the live runtime
+ * session id from `session.info` frames, then drop any scoped frame whose
+ * `session_id` differs from it. Frames without a `session_id`, and every frame
+ * arriving before the live id is learned, fall through — so we never swallow
+ * the legitimate live feed (the #42359 regression that reverted #42178).
+ */
+
+/** Control events that are never session-scoped and must never be gated. */
+const UNSCOPED_CONTROL_EVENTS = new Set<string>(["dashboard.new_session_requested"]);
+
+/**
+ * Whether a channel-feed frame must be dropped because it belongs to a
+ * different session than the one currently live in this sidebar's PTY child.
+ *
+ * @param eventType        the frame's `type` (e.g. "tool.start", "session.info")
+ * @param frameSessionId   the frame's `session_id`, if the gateway stamped one
+ * @param liveSessionId    the live runtime session id learned from `session.info`
+ */
+export function shouldDropSidebarEvent(
+  eventType: string | undefined,
+  frameSessionId: string | undefined,
+  liveSessionId: string | null,
+): boolean {
+  if (eventType && UNSCOPED_CONTROL_EVENTS.has(eventType)) {
+    return false;
+  }
+
+  // Unscoped frame, or we haven't learned the live id yet: let it through so
+  // the legitimate live feed is never swallowed.
+  if (!frameSessionId || !liveSessionId) {
+    return false;
+  }
+
+  return frameSessionId !== liveSessionId;
+}
+
+/**
+ * The live runtime session id after observing one frame. The sidebar tracks
+ * this in a ref; this helper keeps the "learn from session.info" rule in one
+ * testable place. Returns the new id when a `session.info` frame carries one,
+ * otherwise the unchanged previous value.
+ */
+export function nextLiveSessionId(
+  eventType: string | undefined,
+  frameSessionId: string | undefined,
+  prev: string | null,
+): string | null {
+  if (eventType === "session.info" && frameSessionId) {
+    return frameSessionId;
+  }
+
+  return prev;
+}


### PR DESCRIPTION
## Summary
The dashboard ChatSidebar now scopes its tool feed to the live session, fixing the last unguarded surface of the cross-session bleed in #49106 / #47709.

A single embedded `hermes --tui` can hold several sessions at once. Every session emits its `tool.*` frames on the **same** `/api/events` channel, and the sidebar applied them with no session filter — so a backgrounded session's tool calls rendered in the focused session's tool list.

The desktop (`use-session-state-cache.ts`) and TUI (`createGatewayEventHandler.ts`) already guard this with match-by-id; the web sidebar was the remaining gap.

## Changes
- `web/src/lib/sidebar-event-routing.ts` (new): pure `nextLiveSessionId` + `shouldDropSidebarEvent` helpers — learn the live runtime session id from `session.info` frames, drop scoped frames whose `session_id` differs.
- `web/src/components/ChatSidebar.tsx`: surface `session_id` on the event envelope, track the live id in a ref (reset on channel/profile switch), apply the guard before rendering tool events.
- `web/src/lib/sidebar-event-routing.test.ts` (new): 10 unit tests.

## Why this is #42359-safe
Unscoped frames (no `session_id`) and every frame before the live id is learned **fall through** — they are never dropped. Dropping unscoped events is exactly what #42178 did and #42359 reverted (it swallowed the live answer). The relay already carries `session_id` on every frame (`tui_gateway._emit` always stamps it; `/api/pub → /api/events` forwards verbatim), and the live id is learned from `session.info` frames the sidebar already receives on the channel — not from `resumeParam`, which can differ after descendant resolution + PTY-side resume.

## Validation
| | Before | After |
|---|---|---|
| Background session `tool.*` while another is focused | renders in focused session's tool list | dropped |
| Live session `tool.*` | renders | renders |
| Unscoped frame / pre-learning frame | renders | renders (never swallowed) |
| `dashboard.new_session_requested` | handled | handled (never gated) |

`tsc --noEmit` clean · `eslint` clean (one pre-existing unrelated `profile`-dep warning) · 10/10 new unit tests pass.

## Note on the desktop half
The desktop-client cross-session transcript bleed is already fixed on `main` by `28f1590b7`. This PR closes the remaining web `ChatSidebar` surface.

Closes #49106. Related: #47709.
## Infographic

![session-scoped-tool-feed](https://v3b.fal.media/files/b/0a9f8c69/M8IY0E-EeTnscQTzfqZ0l_jjJyoInq.png)
