### PR TITLE
fix(discord): authorize pairing-approved users for component button clicks (#50627)

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5709,7 +5709,8 @@ def _component_check_auth(
 
     Mirrors the gateway's external-surface authorization model: component
     button clicks must be explicitly authorized by a Discord user/role
-    allowlist, a global user allowlist, or an explicit allow-all flag.
+    allowlist, a global user allowlist, an explicit allow-all flag, or
+    the pairing store (``hermes pairing approve``).
 
     Behavior:
 
@@ -5719,6 +5720,7 @@ def _component_check_auth(
       - role allowlist set + interaction.user has no resolvable
         ``roles`` attribute (e.g. DM context with a role policy active)
         -> reject (fail closed)
+      - user is approved in the pairing store -> allow
       - otherwise -> reject
     """
     if os.getenv("DISCORD_ALLOW_ALL_USERS", "").strip().lower() in {"true", "1", "yes"}:
@@ -5740,11 +5742,13 @@ def _component_check_auth(
     if user is None:
         return False
 
+    # Resolve user ID once for both allowlist and pairing checks.
+    try:
+        uid = str(user.id)
+    except AttributeError:
+        uid = ""
+
     if has_users:
-        try:
-            uid = str(user.id)
-        except AttributeError:
-            uid = ""
         if "*" in user_set or (uid and uid in user_set):
             return True
 
@@ -5762,6 +5766,18 @@ def _component_check_auth(
             return False
         if user_role_ids & role_set:
             return True
+
+    # Check pairing store — mirrors ``authz_mixin._check_authorization``
+    # so users approved via ``hermes pairing approve`` can interact with
+    # component buttons even without DISCORD_ALLOWED_USERS set.
+    if uid:
+        try:
+            from gateway.pairing import PairingStore
+            store = PairingStore()
+            if store.is_approved("discord", uid):
+                return True
+        except Exception:
+            pass
 
     return False
 

--- a/tests/gateway/test_discord_component_auth.py
+++ b/tests/gateway/test_discord_component_auth.py
@@ -30,12 +30,21 @@ from plugins.platforms.discord.adapter import (  # noqa: E402
 
 @pytest.fixture(autouse=True)
 def _clear_component_auth_env(monkeypatch):
+    from unittest.mock import MagicMock, patch
+
     for name in (
         "DISCORD_ALLOW_ALL_USERS",
         "GATEWAY_ALLOW_ALL_USERS",
         "GATEWAY_ALLOWED_USERS",
     ):
         monkeypatch.delenv(name, raising=False)
+
+    # Default-mock PairingStore so tests don't hit the filesystem.
+    # Pairing-specific tests override this with explicit mock values.
+    mock_store = MagicMock()
+    mock_store.is_approved.return_value = False
+    with patch("gateway.pairing.PairingStore", return_value=mock_store):
+        yield
 
 
 # ---------------------------------------------------------------------------
@@ -304,3 +313,39 @@ def test_view_empty_allowlists_allow_with_explicit_allow_all(monkeypatch):
     monkeypatch.setenv("DISCORD_ALLOW_ALL_USERS", "true")
     view = ExecApprovalView(session_key="s", allowed_user_ids=set())
     assert view._check_auth(_interaction(99999)) is True
+
+
+# ---------------------------------------------------------------------------
+# Pairing store: users approved via ``hermes pairing approve`` must be
+# authorized even without DISCORD_ALLOWED_USERS / DISCORD_ALLOWED_ROLES.
+# ---------------------------------------------------------------------------
+
+
+def test_component_check_pairing_approved_user_passes(monkeypatch):
+    """User approved in pairing store passes even without allowlists."""
+    from unittest.mock import MagicMock, patch
+
+    mock_store = MagicMock()
+    mock_store.is_approved.return_value = True
+    # Override the autouse fixture's mock with approved=True
+    with patch("gateway.pairing.PairingStore", return_value=mock_store):
+        interaction = _interaction(11111)
+        assert _component_check_auth(interaction, set(), set()) is True
+    mock_store.is_approved.assert_called_once_with("discord", "11111")
+
+
+def test_component_check_pairing_not_approved_user_rejected(monkeypatch):
+    """User NOT in pairing store is still rejected (fail-closed)."""
+    # The autouse fixture already mocks is_approved=False, so this
+    # just verifies the fail-closed path still works.
+    interaction = _interaction(99999)
+    assert _component_check_auth(interaction, set(), set()) is False
+
+
+def test_component_check_pairing_import_error_graceful(monkeypatch):
+    """If PairingStore import fails, fall through to fail-closed."""
+    from unittest.mock import patch
+
+    with patch("gateway.pairing.PairingStore", side_effect=ImportError("simulated")):
+        interaction = _interaction(11111)
+        assert _component_check_auth(interaction, set(), set()) is False


### PR DESCRIPTION
Salvage of #50633 (@liuhao1024) onto current `main`. Fixes #50627.

## Summary
Discord approval/component buttons now authorize pairing-approved users again, restoring the v0.16 behavior that the v0.17 bundled-plugin migration regressed.

## Root cause
The v0.17 bundled-plugin migration (`cc8e5ec2a`) routed Discord component (button) interactions through `_component_check_auth`, which authorizes only against `DISCORD_ALLOWED_USERS` / `GATEWAY_ALLOWED_USERS` / role allowlists. The gateway **message** path (`gateway/authz_mixin`) is broader — it *always* consults the pairing store (`is_approved`) regardless of allowlists. So a user paired via `hermes pairing approve` but not in `DISCORD_ALLOWED_USERS` could send messages (accepted at the message gate) yet was rejected at approval buttons with "You're not authorized to approve commands."

## Fix
`_component_check_auth` now consults the pairing store as a fallback after the existing allowlist/role checks — mirroring the message path. `PairingStore` is stateless and file-backed (`PAIRING_DIR`), so a fresh instance reads the same approved set the gateway runner uses. All five component views (Exec approval, slash confirm, update prompt, model picker, clarify) are fixed at the single shared chokepoint. Fails closed: an import/lookup error falls through to allowlist-only behavior. Allow-all and allowlist paths are untouched, and admin/slash-access scope (`slash_access.py`) is deliberately not involved — button clicks are a user-scope admission action, exactly as the message path treats them.

## Changes
- `plugins/platforms/discord/adapter.py`: pairing-store fallback in `_component_check_auth`; resolve user id once for both allowlist and pairing checks.
- `tests/gateway/test_discord_component_auth.py`: +3 tests (pairing-approved authorized without allowlist, non-approved rejected, import-error fails closed).

## Validation
| Case | Before | After |
|---|---|---|
| Paired user, no allowlist | rejected at buttons | authorized |
| Unpaired user, no allowlist | rejected | rejected (fail closed) |
| Allowlisted user | authorized | authorized |

Targeted suite green (31/31). E2E verified against a real file-backed `PairingStore` with real imports and a temp `HERMES_HOME`.

Co-authored credit: @liuhao1024 (implementation). Also reported-to-PR by @LeonSGP43 (#50628) and @ahmadalzaro1 (#50714).

## Infographic

![discord-button-auth-restored](https://v3b.fal.media/files/b/0a9f8c81/-SLWjeTHuqN8bQA1CK4tn_V6UbCsBS.png)
