### PR TITLE
revert(profiles): don't clone auth.json — duplicating OAuth grant causes sibling revocation (#48415)

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -53,21 +53,9 @@ _PROFILE_DIRS = [
 ]
 
 # Files copied during --clone (if they exist in the source)
-#
-# auth.json carries the per-profile credential pool — including OAuth tokens
-# (Anthropic `claude /login`, Codex, xAI) that never land in .env. Cloning
-# .env but not auth.json silently dropped those credentials from the clone,
-# so a profile cloned from an OAuth-authenticated default resolved a
-# different provider (or none) than the source. The global-root fallback in
-# read_credential_pool only masks this while the clone's HERMES_HOME still
-# resolves to the same default root and the user hasn't run `hermes auth add`
-# locally. Copying it here makes selective --clone match `.env` semantics and
-# the full --clone-all copytree (which already carries auth.json). Both are
-# credential files and get tightened to owner-only (0o600) after copy.
 _CLONE_CONFIG_FILES = [
     "config.yaml",
     ".env",
-    "auth.json",
     "SOUL.md",
 ]
 
@@ -950,12 +938,11 @@ def create_profile(
                 if src.exists():
                     dst = profile_dir / filename
                     shutil.copy2(src, dst)
-                    # Tighten credential files to owner-only after copy.
-                    # shutil.copy2 preserves source mode bits, but if the
-                    # source's .env / auth.json was loose (host umask 0o022
-                    # leaving 0o644), tighten explicitly so the clone doesn't
-                    # inherit weak perms.
-                    if filename in {".env", "auth.json"}:
+                    # Tighten .env to owner-only after copy. shutil.copy2
+                    # preserves source mode bits, but if the source's .env
+                    # was loose (host umask 0o022 leaving 0o644), tighten
+                    # explicitly so the clone doesn't inherit weak perms.
+                    if filename == ".env":
                         try:
                             os.chmod(str(dst), 0o600)
                         except OSError:

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -7,7 +7,6 @@ and shell completion generation.
 
 import json
 import io
-import os
 import tarfile
 from pathlib import Path
 from unittest.mock import patch, MagicMock
@@ -215,27 +214,6 @@ class TestCreateProfile:
         assert cloned_config["model"] == "test"
         assert (profile_dir / ".env").read_text().strip() == "KEY=val"
         assert (profile_dir / "SOUL.md").read_text() == "Be helpful."
-
-    def test_clone_config_copies_auth_json(self, profile_env):
-        # auth.json holds the credential pool (incl. OAuth tokens that never
-        # land in .env). Selective --clone must carry it so a profile cloned
-        # from an OAuth-authenticated source keeps the same credentials,
-        # matching --clone-all and .env semantics.
-        tmp_path = profile_env
-        default_home = tmp_path / ".hermes"
-        (default_home / "auth.json").write_text(
-            '{"credential_pool": {"anthropic": [{"access_token": "tok"}]}}'
-        )
-
-        profile_dir = create_profile("coder", clone_config=True, no_alias=True)
-
-        cloned_auth = profile_dir / "auth.json"
-        assert cloned_auth.exists()
-        cloned = json.loads(cloned_auth.read_text())
-        assert cloned["credential_pool"]["anthropic"][0]["access_token"] == "tok"
-        # Credential file must be tightened to owner-only, like .env.
-        if os.name == "posix":
-            assert (cloned_auth.stat().st_mode & 0o777) == 0o600
 
     def test_clone_config_migrates_legacy_config_version(self, profile_env):
         tmp_path = profile_env


### PR DESCRIPTION
## Summary
Reverts #51719. Copying `auth.json` into a cloned profile was the wrong fix — it physically duplicates the OAuth credential pool (incl. single-use refresh tokens), which is exactly the multi-store mutual-revocation hazard described in #48415 (and #43589 for xAI).

The credential subsystem is designed around **one canonical grant at the global root**: a profile with no own `providers.<p>` / `credential_pool` block borrows root read-only via the fallback in `read_credential_pool` (#18594), and rotations write *through to root* so the canonical store stays coherent. A cloned profile under `~/.hermes/profiles/<name>` shares that same default root, so a fresh clone already inherits root's credentials — no copy needed. Copying `auth.json` defeats that fallback and seeds a competing refresh-token chain: when one profile rotates the single-use grant, every sibling holding a stale copy dies with `refresh_token_reused`.

For static API keys (`.env`, pooled keys) duplication is harmless; for OAuth providers it is actively harmful. Reverting restores `.env`-only clone behavior and leaves the global-root fallback as the single source of truth.

## Changes
- Revert `hermes_cli/profiles.py`: drop `auth.json` from `_CLONE_CONFIG_FILES` and its 0o600 chmod.
- Revert the `test_clone_config_copies_auth_json` test.

## Validation
- `scripts/run_tests.sh tests/hermes_cli/test_profiles.py` → 140 passed.

## Follow-up
The real bug (#48415 — Codex rotated grant not written through to root, the analog of #43589) is a separate credential-pool write-through fix and will be its own PR.

## Infographic

![revert-dont-duplicate-oauth-grant](https://v3b.fal.media/files/b/0a9f8c8e/t5sgTGyNo9ffcRYq4yzD8_5Bbrvp2G.png)
