### PR TITLE
fix(gateway): detect launchd in /restart service-manager probe (#43475)

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -960,7 +960,15 @@ class GatewaySlashCommandsMixin:
         # us.  The detached subprocess approach (setsid + bash) doesn't work
         # under systemd (KillMode=mixed kills the cgroup) or Docker (tini
         # exits when the gateway dies, taking the detached helper with it).
-        _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
+        # systemd sets INVOCATION_ID; launchd sets XPC_SERVICE_NAME to the
+        # job label.  Without the launchd check, macOS /restart takes the
+        # detached path and exits 0, which KeepAlive.SuccessfulExit=false
+        # treats as a deliberate stop — the gateway stays dead until next
+        # login.  Interactive macOS shells inherit XPC_SERVICE_NAME=0, so
+        # "0" must count as not-under-launchd.
+        _under_service = bool(os.environ.get("INVOCATION_ID")) or os.environ.get(
+            "XPC_SERVICE_NAME", "0"
+        ) not in ("", "0")
         _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
         if _under_service or _in_container:
             self.request_restart(detached=False, via_service=True)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1547,6 +1547,7 @@ AUTHOR_MAP = {
     "6666242+bird@users.noreply.github.com": "bird",  # PR #25219 (gateway docker exit-75 restart)
     "david@loadmagic.ai": "davidcampbelldc",  # PR #26834 (web_server proxy_headers=False)
     "165905879+davidcampbelldc@users.noreply.github.com": "davidcampbelldc",
+    "chazmaniandinkle@gmail.com": "chazmaniandinkle",  # PR #43888 (launchd /restart detection)
     "hoangv.pham0803@gmail.com": "hehehe0803",  # PR #26212 salvage (codex kanban writable root)
     "26063003+hehehe0803@users.noreply.github.com": "hehehe0803",
     "kasunvinod@users.noreply.github.com": "kasunvinod",  # PR #24126 salvage (codex timeout propagation)

--- a/tests/gateway/test_restart_service_detection.py
+++ b/tests/gateway/test_restart_service_detection.py
@@ -1,0 +1,85 @@
+"""Tests for /restart service-manager detection (launchd vs interactive).
+
+The /restart handler routes through ``request_restart(via_service=True)``
+when a service manager supervises the gateway, so the process exits with
+the service-restart code and the manager relaunches it.  Under macOS
+launchd the plist uses ``KeepAlive.SuccessfulExit=false`` — a clean exit 0
+is treated as a deliberate stop and the gateway stays dead (#43475) — so
+launchd must be detected here in the handler, not only at the exit-code
+site (which never runs unless ``via_service=True`` is already set).
+
+launchd sets ``XPC_SERVICE_NAME`` to the job label for processes it
+spawns.  Interactive macOS shells inherit ``XPC_SERVICE_NAME=0`` (a
+truthy string), so the probe must treat ``"0"`` as not-under-launchd:
+routing an unsupervised interactive gateway to the service path would
+make it exit non-zero with nothing to revive it.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.platforms.base import MessageEvent, MessageType
+from tests.gateway.restart_test_helpers import make_restart_runner, make_restart_source
+
+
+def _make_restart_event(update_id: int | None = 100) -> MessageEvent:
+    return MessageEvent(
+        text="/restart",
+        message_type=MessageType.TEXT,
+        source=make_restart_source(),
+        message_id="m1",
+        platform_update_id=update_id,
+    )
+
+
+def _make_runner_with_mock_restart(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.delenv("XPC_SERVICE_NAME", raising=False)
+    runner, _adapter = make_restart_runner()
+    runner.request_restart = MagicMock(return_value=True)
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_restart_under_launchd_uses_service_path(tmp_path, monkeypatch):
+    """launchd job label in XPC_SERVICE_NAME routes /restart via the service path."""
+    runner = _make_runner_with_mock_restart(tmp_path, monkeypatch)
+    monkeypatch.setenv("XPC_SERVICE_NAME", "ai.hermes.gateway")
+
+    await runner._handle_restart_command(_make_restart_event())
+
+    runner.request_restart.assert_called_once_with(detached=False, via_service=True)
+
+
+@pytest.mark.asyncio
+async def test_restart_in_interactive_macos_shell_uses_detached_path(tmp_path, monkeypatch):
+    """XPC_SERVICE_NAME=0 (inherited by interactive macOS shells) is NOT a service."""
+    runner = _make_runner_with_mock_restart(tmp_path, monkeypatch)
+    monkeypatch.setenv("XPC_SERVICE_NAME", "0")
+
+    await runner._handle_restart_command(_make_restart_event())
+
+    runner.request_restart.assert_called_once_with(detached=True, via_service=False)
+
+
+@pytest.mark.asyncio
+async def test_restart_without_service_env_uses_detached_path(tmp_path, monkeypatch):
+    """No service-manager env at all falls back to the detached restart."""
+    runner = _make_runner_with_mock_restart(tmp_path, monkeypatch)
+
+    await runner._handle_restart_command(_make_restart_event())
+
+    runner.request_restart.assert_called_once_with(detached=True, via_service=False)
+
+
+@pytest.mark.asyncio
+async def test_restart_under_systemd_uses_service_path(tmp_path, monkeypatch):
+    """INVOCATION_ID (systemd) still routes via the service path."""
+    runner = _make_runner_with_mock_restart(tmp_path, monkeypatch)
+    monkeypatch.setenv("INVOCATION_ID", "abc123")
+
+    await runner._handle_restart_command(_make_restart_event())
+
+    runner.request_restart.assert_called_once_with(detached=False, via_service=True)


### PR DESCRIPTION
## Summary
`/restart` on a launchd-managed macOS gateway now relaunches instead of going silently offline.

Root cause: the `/restart` service-manager probe (`gateway/slash_commands.py`) only detected systemd (`INVOCATION_ID`) and containers, so under launchd it took the **detached** path and exited 0 — which `KeepAlive.SuccessfulExit=false` treats as a deliberate stop. The gateway stayed dead until a manual `launchctl kickstart`. The darwin exit-75 code already in `gateway/run.py` was dead for this path because it only fires when `via_service=True`, which the handler never set on launchd.

## Changes
- `gateway/slash_commands.py`: detect launchd via `XPC_SERVICE_NAME` (the job label launchd sets on spawned processes), routing `/restart` through `via_service=True`. Excludes the literal `"0"` that interactive macOS shells inherit, so an unsupervised interactive gateway still takes the detached path.
- `tests/gateway/test_restart_service_detection.py`: regression tests for all four routings (launchd, interactive `XPC_SERVICE_NAME=0`, no service env, systemd).
- `scripts/release.py`: AUTHOR_MAP entry for the contributor.

Routing through `via_service=True` (rather than forcing a non-zero exit on the detached path, as #43498/#43596 do) is the correct layer: the detached path also spawns a helper that relaunches the gateway, so exiting non-zero there would have **both** the helper and launchd respawn it — two gateways racing for the same bot tokens. The service path spawns no helper; launchd is the single respawner.

## Validation
E2E across all four scenarios (real handler probe logic + downstream exit-code decision):

| Scenario | via_service | exit code | revived? |
|---|---|---|---|
| macOS launchd-managed | True | 75 | ✓ KeepAlive revives |
| macOS interactive shell (`XPC_SERVICE_NAME=0`) | False | 0 | detached, no double-spawn |
| macOS no service env | False | 0 | detached |
| linux systemd | True | 0 | Restart=always, unchanged |

4/4 regression tests pass.

Salvages #43888 by @chazmaniandinkle (running in production on two launchd-managed gateways). Fixes #43475. Supersedes #43498 (@liuhao1024) and #43596 (@alt-glitch), which fix the symptom at the exit-code site but risk the double-spawn described above. Closes duplicate #48746 (@yichao2022).

## Infographic

![launchd-restart-revival](https://v3b.fal.media/files/b/0a9f8c90/6MiDipcGzOaqG69NNeoNQ_YNareKEC.png)
