### PR TITLE
fix(cron): deduplicate cross-profile jobs in GET /api/cron/jobs

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7692,12 +7692,21 @@ async def list_cron_jobs(profile: str = "all"):
         return _call_cron_for_profile(requested, "list_jobs", True)
 
     jobs: List[Dict[str, Any]] = []
+    seen_ids: set = set()
     for item in _cron_profile_dicts():
         name = str(item.get("name") or "")
         if not name:
             continue
         try:
-            jobs.extend(_call_cron_for_profile(name, "list_jobs", True))
+            for job in _call_cron_for_profile(name, "list_jobs", True):
+                if not isinstance(job, dict):
+                    continue
+                jid = job.get("id") or job.get("job_id")
+                if jid and jid in seen_ids:
+                    continue
+                if jid:
+                    seen_ids.add(jid)
+                jobs.append(job)
         except Exception:
             _log.exception("Failed to list cron jobs for profile %s", name)
     return jobs


### PR DESCRIPTION
## What

Deduplicate cron jobs by ID when aggregating across all profiles (`profile=all`).

## Why

When the desktop/dashboard calls `GET /api/cron/jobs` with `profile=all` (the default), jobs from every profile are merged into a single list. If the same job ID exists in multiple profiles (e.g., copied during `hermes profile create`), duplicates are returned, inflating the sidebar count and showing duplicate rows.

## Fix

Track seen job IDs in a `set`. When a job ID has already been seen, skip it. First occurrence wins (preserves the profile ordering from `_cron_profile_dicts()`).

## Changes

- `hermes_cli/web_server.py`: 1 file, 10 insertions, 1 deletion
- Adds `isinstance(job, dict)` guard for type safety

Closes #51721