### PR TITLE
chore(desktop): sync package-lock version to apps/desktop 0.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
     },
     "apps/desktop": {
       "name": "hermes",
-      "version": "0.15.1",
+      "version": "0.17.0",
       "dependencies": {
         "@assistant-ui/react": "^0.12.28",
         "@assistant-ui/react-streamdown": "^0.1.11",


### PR DESCRIPTION
## Summary
`package-lock.json` now records the desktop workspace at `0.17.0`, matching `apps/desktop/package.json`. The manifest was bumped to 0.17.0 but the lock still said 0.15.1, so `npm install` reports the lock as out of date and rewrites it on every fresh install.

## Changes
- `package-lock.json`: desktop workspace `version` 0.15.1 → 0.17.0 (regenerated via `npm install --package-lock-only`; one line, no dependency-resolution churn).

## Validation
| | Before | After |
|---|---|---|
| lock vs manifest | 0.15.1 vs 0.17.0 (mismatch) | 0.17.0 vs 0.17.0 |
| fresh `npm install` | rewrites lock | clean, no changes |

## Infographic
![Lockfile Version Sync](https://v3b.fal.media/files/b/0a9f8cc4/ZJmqtEk74KpwZBQQnYk1H_79iqoOwZ.png)
