### PR TITLE
fix(workflow): harden Discord recovery and cron background paths

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -411,13 +411,21 @@ def _chat_messages_to_responses_input(
                             # Responses API cannot look up items by ID and
                             # returns 404.  The encrypted_content blob is
                             # self-contained for reasoning chain continuity.
-                            # Also strip the internal "_issuer_kind" stamp;
-                            # it is a Hermes-side metadata key and not part
-                            # of the Responses API schema.
+                            # Also strip output-only / Hermes-only metadata.
+                            # ``summary`` is required by the ChatGPT Codex
+                            # backend on replay, but provider output summaries
+                            # contain ``summary_text`` parts that some
+                            # Responses-compatible gateways reject as input
+                            # content (HTTP 400 ``Unsupported content type``).
+                            # Send the required field as an empty list: the
+                            # encrypted_content blob is the replay payload,
+                            # while the previous summary text is only display
+                            # metadata. ``_issuer_kind`` is Hermes metadata.
                             replay_item = {
                                 k: v for k, v in ri.items()
-                                if k not in ("id", "_issuer_kind")
+                                if k not in ("id", "summary", "_issuer_kind")
                             }
+                            replay_item["summary"] = []
                             items.append(replay_item)
                             if item_id:
                                 seen_item_ids.add(item_id)
@@ -676,11 +684,11 @@ def _preflight_codex_input_items(raw_items: Any) -> List[Dict[str, Any]]:
                 # store=False (our default) the API tries to resolve the
                 # id server-side and returns 404.  The id is still used
                 # above for local deduplication via seen_ids.
-                summary = item.get("summary")
-                if isinstance(summary, list):
-                    reasoning_item["summary"] = summary
-                else:
-                    reasoning_item["summary"] = []
+                # Include the required ``summary`` field, but sanitize it to an
+                # empty list.  The encrypted_content blob is sufficient for
+                # reasoning replay, while output ``summary_text`` parts caused
+                # deterministic Responses 400s on some worker/synth backends.
+                reasoning_item["summary"] = []
                 normalized.append(reasoning_item)
             continue
 

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1537,7 +1537,9 @@ because the user did not issue an imperative command; reserve "None" for the
 rare case where the last exchange was fully resolved and the user said
 something like "thanks, that's all".
 If multiple items are outstanding, list only the ones NOT yet completed.
-Continuation should pick up exactly here. Examples:
+Record this as historical context only; do not write instructions that tell the
+next agent to resume or continue from this section. The latest user message
+after the compaction summary is the only active instruction. Examples:
 "User asked: 'Now refactor the auth module to use JWT instead of sessions'"
 "User asked: 'Waarom stond provider ineens op openrouter?' — needs investigation + answer"
 "User chose option A; awaiting implementation of step 2"
@@ -1611,7 +1613,7 @@ PREVIOUS SUMMARY:
 NEW TURNS TO INCORPORATE:
 {content_to_summarize}
 
-Update the summary using this exact structure. PRESERVE all existing information that is still relevant. ADD new completed actions to the numbered list (continue numbering). Move items from "In Progress" to "Completed Actions" when done. Move answered questions to "Resolved Questions". Update "Active State" to reflect current state. Remove information only if it is clearly obsolete. CRITICAL: Update "## Active Task" to reflect the user's most recent unfulfilled input — this includes any question, decision request, or discussion turn that the assistant has not yet answered. Only write "None" if the last exchange was fully resolved.
+Update the summary using this exact structure. PRESERVE all existing information that is still relevant. ADD new completed actions to the numbered list (continue numbering). Move items from "In Progress" to "Completed Actions" when done. Move answered questions to "Resolved Questions". Update "Active State" to reflect current state. Remove information only if it is clearly obsolete. CRITICAL: Update the historical task snapshot to reflect the user's most recent unfulfilled input within the compacted turns — this includes any question, decision request, or discussion turn that the assistant has not yet answered. Only write "None" if the last exchange was fully resolved. Do not phrase the snapshot as a live instruction to resume; it is reference-only unless the latest post-summary user message explicitly asks to continue it.
 
 {_template_sections}"""
         else:

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -749,6 +749,7 @@ def create_job(
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
     no_agent: bool = False,
+    background: bool = False,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -793,6 +794,10 @@ def create_job(
                 and deliver its stdout directly. Empty stdout = silent (no
                 delivery). Requires ``script`` to be set. Ideal for classic
                 watchdogs and periodic alerts that don't need LLM reasoning.
+        background: When True, run this LLM-driven cron job through the live
+                gateway background surface instead of the standalone cron
+                agent path. Requires a concrete delivery target and a running
+                gateway scheduler; incompatible with ``no_agent``.
 
     Returns:
         The created job dict
@@ -827,6 +832,7 @@ def create_job(
     normalized_toolsets = normalized_toolsets or None
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
+    normalized_background = bool(background)
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -835,6 +841,11 @@ def create_job(
         raise ValueError(
             "no_agent=True requires a script — with no agent and no script "
             "there is nothing for the job to run."
+        )
+    if normalized_no_agent and normalized_background:
+        raise ValueError(
+            "background=True is only valid for LLM-driven cron jobs; "
+            "it cannot be combined with no_agent=True."
         )
 
     # Normalize context_from: accept str or list of str, store as list or None
@@ -858,6 +869,7 @@ def create_job(
         "base_url": normalized_base_url,
         "script": normalized_script,
         "no_agent": normalized_no_agent,
+        "background": normalized_background,
         "context_from": context_from,
         "schedule": parsed_schedule,
         "schedule_display": parsed_schedule.get("display", schedule),

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -21,6 +21,7 @@ import subprocess
 import sys
 import threading
 
+
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 try:
     import fcntl
@@ -31,7 +32,7 @@ except ImportError:
     except ImportError:
         msvcrt = None
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, List, Optional
 
 # Add parent directory to path for imports BEFORE repo-level imports.
 # Without this, standalone invocations (e.g. after `hermes update` reloads
@@ -44,6 +45,36 @@ from hermes_cli.config import load_config, _expand_env_vars
 from hermes_time import now as _hermes_now
 
 logger = logging.getLogger(__name__)
+
+
+_gateway_background_runner: Any = None
+
+
+def register_gateway_background_runner(runner: Any) -> None:
+    """Register the live gateway runner for opt-in cron background jobs.
+
+    Cron can also run outside the gateway (manual ticks, external providers,
+    tests), so this is intentionally a soft process-local registration rather
+    than a required scheduler-provider constructor argument. Jobs with
+    ``background: true`` fail clearly when no live runner is registered instead
+    of silently falling back to the old cron-agent path.
+    """
+
+    global _gateway_background_runner
+    _gateway_background_runner = runner
+
+
+def unregister_gateway_background_runner(runner: Any = None) -> None:
+    """Clear the live gateway runner registration.
+
+    If ``runner`` is provided, only clear when it is still the registered
+    instance; this protects restart races where a new gateway has already
+    registered itself while an old shutdown path is unwinding.
+    """
+
+    global _gateway_background_runner
+    if runner is None or _gateway_background_runner is runner:
+        _gateway_background_runner = None
 
 
 def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
@@ -679,6 +710,112 @@ def _resolve_delivery_target(job: dict) -> Optional[dict]:
     """Resolve the concrete auto-delivery target for a cron job, if any."""
     targets = _resolve_delivery_targets(job)
     return targets[0] if targets else None
+
+
+def _cron_job_uses_background_surface(job: dict) -> bool:
+    """Whether this job should launch through gateway /background semantics."""
+
+    value = job.get("background") or job.get("run_as_background")
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _session_source_for_cron_background(job: dict):
+    """Build a live gateway SessionSource from a cron delivery target."""
+
+    target = _resolve_delivery_target(job)
+    if not target:
+        raise RuntimeError(
+            "background cron job requires a concrete delivery target; "
+            "use deliver='origin' with a saved origin or deliver='platform:chat[:thread]'"
+        )
+
+    platform_name = str(target.get("platform") or "").strip().lower()
+    chat_id = str(target.get("chat_id") or "").strip()
+    if not platform_name or not chat_id:
+        raise RuntimeError("background cron delivery target is missing platform/chat_id")
+
+    from gateway.config import Platform
+    from gateway.session import SessionSource
+
+    platform = Platform(platform_name)
+    thread_id = target.get("thread_id")
+    has_thread = thread_id not in {None, ""}
+    return SessionSource(
+        platform=platform,
+        chat_id=chat_id,
+        thread_id=str(thread_id) if has_thread else None,
+        chat_type="thread" if has_thread else "channel",
+        user_id=f"cron:{job.get('id', '')}",
+        user_name="Hermes Cron",
+        chat_name=str(job.get("name") or job.get("id") or "cron background"),
+    )
+
+
+def _launch_cron_background_job(job: dict, prompt: str, *, loop=None) -> tuple[bool, str, str, Optional[str]]:
+    """Launch an opt-in cron job via the live gateway /background runner.
+
+    The scheduler records a launch artifact and marks the cron fire complete;
+    the spawned gateway background task owns the final user-facing delivery.
+    """
+
+    if _gateway_background_runner is None:
+        raise RuntimeError(
+            "background cron job cannot run because no live GatewayRunner is registered"
+        )
+    if loop is None or not getattr(loop, "is_running", lambda: False)():
+        raise RuntimeError("background cron job requires the live gateway asyncio loop")
+
+    runner = _gateway_background_runner
+    if not hasattr(runner, "_run_background_task"):
+        raise RuntimeError("registered gateway runner has no _run_background_task method")
+
+    source = _session_source_for_cron_background(job)
+    task_id = f"bgcron_{job.get('id', 'job')}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
+
+    from agent.async_utils import safe_schedule_threadsafe
+
+    future = safe_schedule_threadsafe(
+        runner._run_background_task(prompt, source, task_id),
+        loop,
+        logger=logger,
+        log_message=f"Failed to schedule background cron job {job.get('id', '?')}",
+    )
+    if future is None:
+        raise RuntimeError("failed to schedule background task on gateway loop")
+
+    tasks = getattr(runner, "_background_tasks", None)
+    if tasks is not None:
+        tasks.add(future)
+        future.add_done_callback(tasks.discard)
+
+    now_iso = _hermes_now().strftime("%Y-%m-%d %H:%M:%S")
+    target_label = (
+        f"{getattr(source.platform, 'value', source.platform)}:{source.chat_id}"
+        f"{':' + str(source.thread_id) if source.thread_id else ''}"
+    )
+    output = f"""# Cron Job: {job.get('name') or job.get('id') or 'cron job'}
+
+**Job ID:** {job.get('id')}
+**Run Time:** {now_iso}
+**Mode:** gateway-background
+**Background Task ID:** {task_id}
+**Delivery Target:** {target_label}
+
+The scheduler launched this cron fire through the live gateway background
+runner. The user-facing result will be delivered by the background task when it
+finishes; this cron artifact is only the launch audit record.
+
+## Prompt
+
+{prompt}
+"""
+    final_response = (
+        f"🔁 Cron background task started: `{task_id}`\n"
+        "The result will post here from the gateway background lane when complete."
+    )
+    return True, output, final_response, None
 
 
 # Media extension sets — audio routing is centralized in gateway.platforms.base
@@ -1594,7 +1731,7 @@ def _scan_assembled_cron_prompt(
     return assembled
 
 
-def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
+def run_job(job: dict, *, loop=None) -> tuple[bool, str, str, Optional[str]]:
     """
     Execute a single cron job.
     
@@ -1603,6 +1740,17 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     """
     job_id = job["id"]
     job_name = str(job.get("name") or job.get("prompt") or job_id or "cron job")
+
+    if _cron_job_uses_background_surface(job) and job.get("no_agent"):
+        err = "background=True is only valid for agent cron jobs, not no_agent script jobs"
+        now_iso = _hermes_now().strftime("%Y-%m-%d %H:%M:%S")
+        doc = (
+            f"# Cron Job: {job_name} (FAILED)\n\n"
+            f"**Job ID:** {job_id}\n"
+            f"**Run Time:** {now_iso}\n\n"
+            f"## Error\n\n```\n{err}\n```\n"
+        )
+        return False, doc, "", err
 
     # ---------------------------------------------------------------
     # no_agent short-circuit — the script IS the job, no LLM involvement.
@@ -1774,6 +1922,30 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     if prompt is None:
         logger.info("Job '%s': script produced no output, skipping AI call.", job_name)
         return True, "", SILENT_MARKER, None
+    if _cron_job_uses_background_surface(job):
+        try:
+            return _launch_cron_background_job(job, prompt, loop=loop)
+        except Exception as e:
+            error_msg = f"{type(e).__name__}: {str(e)}"
+            logger.exception("Background cron job '%s' failed to launch: %s", job_name, error_msg)
+            output = f"""# Cron Job: {job_name} (FAILED)
+
+**Job ID:** {job_id}
+**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}
+**Schedule:** {job.get('schedule_display', 'N/A')}
+**Mode:** gateway-background
+
+## Prompt
+
+{prompt}
+
+## Error
+
+```
+{error_msg}
+```
+"""
+            return False, output, "", error_msg
     origin = _resolve_origin(job)
     _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
 
@@ -2321,7 +2493,13 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
     failure is recorded via ``mark_job_run``), False only if processing raised.
     """
     try:
-        success, output, final_response, error = run_job(job)
+        if loop is None:
+            # Preserve the long-standing processor contract for tests and
+            # integrations that monkeypatch or wrap run_job(job).  The gateway
+            # supplies loop explicitly when live adapter delivery needs it.
+            success, output, final_response, error = run_job(job)
+        else:
+            success, output, final_response, error = run_job(job, loop=loop)
 
         output_file = save_job_output(job["id"], output)
         if verbose:
@@ -2334,8 +2512,10 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         # Treat whitespace-only final responses the same as empty
         # responses: do not deliver a blank message, and let the
         # empty-response guard below mark the run as a soft failure.
-        should_deliver = bool(deliver_content.strip())
-        if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
+        stripped_delivery = deliver_content.strip()
+        should_deliver = bool(stripped_delivery)
+        silent_marker_match = re.search(r"(?im)(?:^|\n)\s*\[SILENT\](?:\s|$)", stripped_delivery)
+        if should_deliver and success and silent_marker_match:
             logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
             should_deliver = False
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -403,6 +403,60 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
     return text
 
 
+def _is_compaction_lifecycle_status(text: str) -> bool:
+    """Return True for transient compression progress text.
+
+    Messaging platforms without status-message editing (notably Discord) turn
+    every lifecycle callback into a permanent chat message. Compression can be
+    retried by preflight, overflow recovery, and subagents in the same run; if
+    the auxiliary summarizer is unhealthy, those retries used to spam repeated
+    "Compacting context" bubbles while making no progress.
+    """
+    normalized = str(text or "").lower()
+    return (
+        "compacting context" in normalized
+        or "preflight compression" in normalized
+        or ("context too large" in normalized and "compressing" in normalized)
+    )
+
+
+def _is_compaction_abort_status(text: str) -> bool:
+    normalized = str(text or "").lower()
+    return "compression aborted" in normalized or "context compression aborted" in normalized
+
+
+def _should_deliver_gateway_status(
+    platform: Any,
+    event_type: str,
+    message: str,
+    state: dict,
+) -> bool:
+    """Per-run status de-dupe for append-only messaging platforms.
+
+    Telegram status messages are edited in-place via ``send_or_update_status``;
+    Discord falls back to append-only ``send`` and therefore needs a local guard
+    so one failed compression cycle produces at most one progress notice and one
+    abort notice in the chat.
+    """
+    if _gateway_platform_value(platform) == "telegram":
+        return True
+    text = str(message or "")
+    seen = state.setdefault("seen", set())
+    if _is_compaction_lifecycle_status(text):
+        if state.get("compaction_lifecycle_sent"):
+            return False
+        state["compaction_lifecycle_sent"] = True
+    if _is_compaction_abort_status(text):
+        if state.get("compaction_abort_sent"):
+            return False
+        state["compaction_abort_sent"] = True
+    key = (str(event_type or ""), text)
+    if key in seen:
+        return False
+    seen.add(key)
+    return True
+
+
 def render_notice_line(notice) -> str:
     """Render an AgentNotice to a single plaintext line for messaging platforms.
 
@@ -2590,6 +2644,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # /new and /reset.  /model and other mid-session operations
         # preserve the queue.
         self._queued_events: Dict[str, List[MessageEvent]] = {}
+        # One-shot same-thread continuity capsules prepared by native /new.
+        # The next normal message for the session key consumes this into
+        # event.channel_context, preserving automatic context injection while
+        # still starting a fresh Hermes session.
+        self._pending_same_thread_rebase_context: Dict[str, Dict[str, Any]] = {}
         self._pending_native_image_paths_by_session: Dict[str, List[str]] = {}
         self._busy_ack_ts: Dict[str, float] = {}  # last busy-ack timestamp per session (debounce)
         self._session_run_generation: Dict[str, int] = {}
@@ -4281,7 +4340,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             and busy_text_mode == "queue"
             and effective_mode != "steer"
         ):
-            return False
+            # Keep normal busy text in the runner-owned FIFO path instead of
+            # falling back to the adapter's single-slot debounce path. The
+            # adapter debounce is only safe before a message is accepted into
+            # an active session; once the gateway has a running agent, every
+            # accepted user turn must be preserved and drained in order. This
+            # aligns legacy busy_text_mode=queue with busy_input_mode=queue and
+            # /queue semantics so Discord text, media, and later follow-ups do
+            # not cross different queueing policies during context-pressure or
+            # restart/rebase recovery.
+            effective_mode = "queue"
 
         # Steer mode: inject mid-run via running_agent.steer() instead of
         # queueing + interrupting.  If the agent isn't running yet
@@ -8989,6 +9057,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         
         # Build session context
         context = build_session_context(source, self.config, session_entry)
+
+        # Native /new captures a bounded same-thread rebase capsule before it
+        # resets the session. Apply it automatically to the first normal turn
+        # after the reset so `/new` remains useful in the same Discord thread
+        # without requiring Dionysus to paste a manual capsule.
+        try:
+            self._apply_pending_native_new_rebase_context(event, session_key)
+        except Exception as exc:
+            logger.warning(
+                "Failed to apply pending native /new same-thread rebase capsule for %s: %s",
+                session_key,
+                exc,
+                exc_info=True,
+            )
         
         # Set session context variables for tools (task-local, concurrency-safe)
         _session_env_tokens = self._set_session_env(context)
@@ -15271,6 +15353,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Bridge sync status_callback → async adapter.send for context pressure
         _status_adapter = self.adapters.get(source.platform)
         _status_chat_id = source.chat_id
+        _status_delivery_state: dict = {"seen": set()}
         if source.platform == Platform.FEISHU and source.thread_id and event_message_id:
             # Feishu topics only keep messages inside the topic when they are
             # sent via the reply API with reply_in_thread=true. Status/interim,
@@ -15294,6 +15377,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if prepared_message is None:
                 logger.debug(
                     "status_callback suppressed for %s/%s: %s",
+                    source.platform.value if source.platform else "unknown",
+                    event_type,
+                    _redact_gateway_user_facing_secrets(str(message or ""))[:160],
+                )
+                return
+            if not _should_deliver_gateway_status(
+                source.platform,
+                event_type,
+                prepared_message,
+                _status_delivery_state,
+            ):
+                logger.debug(
+                    "status_callback de-duped for %s/%s: %s",
                     source.platform.value if source.platform else "unknown",
                     event_type,
                     _redact_gateway_user_facing_secrets(str(message or ""))[:160],

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import hashlib
+import importlib.util
 import inspect
 import logging
 import os
@@ -77,6 +78,113 @@ def _model_switch_skew_guard() -> Optional[str]:
 class GatewaySlashCommandsMixin:
     """In-session slash-command handlers for GatewayRunner."""
 
+    def _load_same_thread_rebase_module(self) -> Any:
+        """Load the profile-owned same-thread rebase helper if installed.
+
+        The helper intentionally lives under ``~/.hermes/plugins`` so local
+        workflow policy survives package upgrades. Native ``/new`` remains owned
+        by the gateway, but it can reuse the deterministic capsule renderer so a
+        same-thread fresh session is not context-blind.
+        """
+        home = Path(
+            os.environ.get("HERMES_HOME")
+            or os.environ.get("HERMES_PROFILE_HOME")
+            or Path.home() / ".hermes"
+        )
+        module_path = home / "plugins" / "auto-context-management" / "session_rebase.py"
+        spec = importlib.util.spec_from_file_location(
+            "auto_context_management_session_rebase", module_path
+        )
+        if spec is None or spec.loader is None:
+            raise RuntimeError(f"same-thread rebase helper not available at {module_path}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)  # type: ignore[union-attr]
+        return module
+
+    def _remember_native_new_rebase_handoff(
+        self,
+        *,
+        event: MessageEvent,
+        session_key: str,
+        old_session_id: str = "",
+    ) -> None:
+        """Prepare automatic capsule injection for the first turn after ``/new``.
+
+        Manual ``/new`` has no user message to forward immediately. Without this
+        pending handoff, the next same-thread message starts a fresh session with
+        no continuity context, defeating the purpose of same-thread reset for
+        long-running Discord work. The pending value is consumed once by
+        ``_apply_pending_native_new_rebase_context`` in the normal text path.
+        """
+        if not session_key or not old_session_id:
+            return
+        try:
+            module = self._load_same_thread_rebase_module()
+            source = event.source
+            source_payload = source.to_dict() if hasattr(source, "to_dict") else {}
+            result = module.build_rebase_dry_run_capsule(
+                session_key=session_key,
+                session_id=old_session_id,
+                trigger_text="",
+                source=source_payload,
+                dry_run=False,
+            )
+            capsule = result.get("capsule") or {}
+            handoff = module.capsule_to_handoff_context(
+                capsule,
+                json_path=str(result.get("json_path") or ""),
+                markdown_path=str(result.get("markdown_path") or ""),
+            )
+            if not handoff:
+                return
+            pending = getattr(self, "_pending_same_thread_rebase_context", None)
+            if not isinstance(pending, dict):
+                pending = {}
+                self._pending_same_thread_rebase_context = pending
+            pending[session_key] = {
+                "handoff_context": handoff,
+                "old_session_id": old_session_id,
+                "json_path": result.get("json_path"),
+                "markdown_path": result.get("markdown_path"),
+                "created_at": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+            }
+            logger.info(
+                "Prepared native /new same-thread rebase capsule for %s old=%s artifact=%s",
+                session_key,
+                old_session_id,
+                result.get("json_path"),
+            )
+        except Exception as exc:
+            # Do not break /new if the optional local helper is unavailable;
+            # visible verification/logs will catch the missing handoff.
+            logger.warning(
+                "Native /new same-thread rebase capsule preparation failed for %s: %s",
+                session_key,
+                exc,
+                exc_info=True,
+            )
+
+    def _apply_pending_native_new_rebase_context(self, event: MessageEvent, session_key: str) -> bool:
+        """Merge a pending native-``/new`` handoff into the next same-thread turn."""
+        pending = getattr(self, "_pending_same_thread_rebase_context", None)
+        if not isinstance(pending, dict) or not session_key:
+            return False
+        payload = pending.pop(session_key, None)
+        if not isinstance(payload, dict):
+            return False
+        handoff = str(payload.get("handoff_context") or "").strip()
+        if not handoff:
+            return False
+        existing = str(getattr(event, "channel_context", "") or "").strip()
+        event.channel_context = f"{handoff}\n\n{existing}" if existing else handoff
+        logger.info(
+            "Injected pending native /new same-thread rebase capsule for %s old=%s artifact=%s",
+            session_key,
+            payload.get("old_session_id"),
+            payload.get("json_path"),
+        )
+        return True
+
     def _typed_command_prefix_for(self, platform) -> str:
         """Return the prefix users can always type to reach Hermes commands.
 
@@ -107,6 +215,17 @@ class GatewaySlashCommandsMixin:
         # Snapshot the old entry so on_session_finalize can report the
         # expiring session id before reset_session() rotates it.
         old_entry = self.session_store._entries.get(session_key)
+        old_session_id = old_entry.session_id if old_entry else ""
+
+        # Native /new must keep same-thread continuity automatic. Capture a
+        # bounded capsule from the old session before the reset, then inject it
+        # into the first normal message after the reset. This preserves the
+        # clean-session boundary while avoiding manual copy/paste capsules.
+        self._remember_native_new_rebase_handoff(
+            event=event,
+            session_key=session_key,
+            old_session_id=old_session_id,
+        )
 
         # Close tool resources on the old agent (terminal sandboxes, browser
         # daemons, background processes) before evicting from cache.
@@ -154,7 +273,7 @@ class GatewaySlashCommandsMixin:
         # previous conversation must not survive the reset.
         self._clear_session_boundary_security_state(session_key)
 
-        _old_sid = old_entry.session_id if old_entry else None
+        _old_sid = old_session_id or None
 
         # Fire plugin on_session_finalize hook (session boundary)
         try:

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -141,6 +141,8 @@ def cron_list(show_all: bool = False):
             print(f"    Script:    {script}")
         if job.get("no_agent"):
             print(f"    Mode:      {color('no-agent', Colors.DIM)} (script stdout delivered directly)")
+        elif job.get("background"):
+            print(f"    Mode:      {color('gateway-background', Colors.DIM)} (/background-style lane)")
         workdir = job.get("workdir")
         if workdir:
             print(f"    Workdir:   {workdir}")
@@ -278,6 +280,7 @@ def cron_create(args):
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
         no_agent=getattr(args, "no_agent", False) or None,
+        background=getattr(args, "background", False) or None,
     )
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -67,6 +67,16 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         ),
     )
     cron_create.add_argument(
+        "--background",
+        action="store_true",
+        default=False,
+        help=(
+            "Run this LLM-driven job through the live gateway /background-style "
+            "surface. Requires a running gateway and a concrete delivery target; "
+            "incompatible with --no-agent."
+        ),
+    )
+    cron_create.add_argument(
         "--workdir",
         help="Absolute path for the job to run from. Injects AGENTS.md / CLAUDE.md / .cursorrules from that directory and uses it as the cwd for terminal/file/code_exec tools. Omit to preserve old behaviour (no project context files).",
     )
@@ -129,6 +139,21 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         action="store_const",
         const=False,
         help="Disable no-agent mode on this job (reverts to LLM-driven execution).",
+    )
+    cron_edit.add_argument(
+        "--background",
+        dest="background",
+        action="store_const",
+        const=True,
+        default=None,
+        help="Enable gateway /background-style execution for this LLM-driven cron job.",
+    )
+    cron_edit.add_argument(
+        "--foreground",
+        dest="background",
+        action="store_const",
+        const=False,
+        help="Disable gateway background execution and use normal cron execution.",
     )
     cron_edit.add_argument(
         "--workdir",

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1261,31 +1261,41 @@ class DiscordAdapter(BasePlatformAdapter):
 
     def _record_command_sync_attempt(self, app_id: Any, fingerprint: str) -> None:
         state = self._read_command_sync_state()
-        state[self._command_sync_state_key(app_id)] = {
-            **(
-                state.get(self._command_sync_state_key(app_id))
-                if isinstance(state.get(self._command_sync_state_key(app_id)), dict)
-                else {}
-            ),
+        key = self._command_sync_state_key(app_id)
+        previous = state.get(key) if isinstance(state.get(key), dict) else {}
+        same_fingerprint = previous.get("fingerprint") == fingerprint
+        entry = {
+            **previous,
             "fingerprint": fingerprint,
             "last_attempt_at": time.time(),
         }
+        if not same_fingerprint:
+            # A previous successful sync only proves that exact desired command
+            # fingerprint.  If startup is interrupted after recording an
+            # attempt for a NEW fingerprint, preserving the old last_success_at
+            # makes the next restart falsely skip the unsynced command set.
+            entry.pop("last_success_at", None)
+            entry.pop("summary", None)
+        state[key] = entry
         self._write_command_sync_state(state)
 
     def _record_command_sync_rate_limit(self, app_id: Any, fingerprint: str, retry_after: float) -> None:
         retry_after = max(1.0, float(retry_after))
         state = self._read_command_sync_state()
-        state[self._command_sync_state_key(app_id)] = {
-            **(
-                state.get(self._command_sync_state_key(app_id))
-                if isinstance(state.get(self._command_sync_state_key(app_id)), dict)
-                else {}
-            ),
+        key = self._command_sync_state_key(app_id)
+        previous = state.get(key) if isinstance(state.get(key), dict) else {}
+        same_fingerprint = previous.get("fingerprint") == fingerprint
+        entry = {
+            **previous,
             "fingerprint": fingerprint,
             "last_attempt_at": time.time(),
             "retry_after_until": time.time() + retry_after,
             "retry_after": retry_after,
         }
+        if not same_fingerprint:
+            entry.pop("last_success_at", None)
+            entry.pop("summary", None)
+        state[key] = entry
         self._write_command_sync_state(state)
 
     def _record_command_sync_success(self, app_id: Any, fingerprint: str, summary: dict) -> None:

--- a/tests/agent/test_context_compressor_summary_continuity.py
+++ b/tests/agent/test_context_compressor_summary_continuity.py
@@ -2,7 +2,11 @@
 
 from unittest.mock import MagicMock, patch
 
-from agent.context_compressor import ContextCompressor, SUMMARY_PREFIX
+from agent.context_compressor import (
+    ContextCompressor,
+    HISTORICAL_TASK_HEADING,
+    SUMMARY_PREFIX,
+)
 
 
 def _compressor() -> ContextCompressor:
@@ -85,3 +89,100 @@ def test_handoff_in_protected_head_populates_previous_summary_before_update():
     assert compressor._previous_summary == old_summary
     assert seen_turns
     assert all(old_summary not in str(msg.get("content", "")) for msg in seen_turns)
+
+
+def test_summary_prompt_keeps_task_snapshot_reference_only():
+    """The summarizer prompt must not write live-resume directives into summaries.
+
+    SUMMARY_PREFIX says historical task sections are reference-only unless the
+    latest post-summary user message asks to continue.  The summary body must
+    not contradict that by telling the next model to "pick up exactly here".
+    """
+    compressor = _compressor()
+
+    with patch("agent.context_compressor.call_llm", return_value=_response("summary")) as mock_call:
+        compressor._generate_summary([
+            {"role": "user", "content": "older task"},
+            {"role": "assistant", "content": "working"},
+        ])
+
+    prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+    assert HISTORICAL_TASK_HEADING in prompt
+    assert "Continuation should pick up exactly here" not in prompt
+    assert "Update \"## Active Task\"" not in prompt
+    assert "latest user message" in prompt
+    assert "historical context only" in prompt
+
+
+def test_iterative_summary_prompt_does_not_revive_active_task_heading():
+    """Iterative update wording must use the historical snapshot heading too."""
+    compressor = _compressor()
+    compressor._previous_summary = "old summary"
+
+    with patch("agent.context_compressor.call_llm", return_value=_response("summary")) as mock_call:
+        compressor._generate_summary([
+            {"role": "user", "content": "new compacted turn"},
+        ])
+
+    prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+    assert "Update \"## Active Task\"" not in prompt
+    assert "historical task snapshot" in prompt
+    assert "reference-only" in prompt
+
+
+def test_incident_shape_preserves_newer_thread_work_as_new_turns():
+    """Older stale summaries must not swallow newer thread-local audit work.
+
+    Regression shape from the Discord workflow incident: a protected-head
+    handoff points at an older Part 86 recovery lane, but later turns in the
+    same thread contain the broad workflow/VPS/gateway/MCP audit and a user
+    correction that the assistant was bypassing workflow.  Re-compression must
+    treat the old handoff as PREVIOUS SUMMARY and feed the newer turns through
+    NEW TURNS TO INCORPORATE instead of serializing the handoff as a fresh user
+    instruction or losing the newer correction/task list.
+    """
+    compressor = _compressor()
+    stale_part86_summary = (
+        f"{HISTORICAL_TASK_HEADING}\n"
+        "User asked: 'Continue Part 86 /new smoke recovery'\n\n"
+        "## Historical Remaining Work\n"
+        "Run live /new smoke for Part 86 after background proof."
+    )
+    messages = [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": f"{SUMMARY_PREFIX}\n{stale_part86_summary}"},
+        {"role": "assistant", "content": "Part 86 recovery handoff acknowledged"},
+        {
+            "role": "user",
+            "content": (
+                "Review the workflow and all of its pieces. Build the active "
+                "audit task list: map_gateway, map_workflow_mcp, map_vps, "
+                "map_all_aspects."
+            ),
+        },
+        {"role": "assistant", "content": "Started mapping gateway and workflow surfaces."},
+        {
+            "role": "user",
+            "content": (
+                "Yeah, the workflow definitely needs a lot of work. Im watching "
+                "you bypass almost every single part of it as we speak."
+            ),
+        },
+        {"role": "assistant", "content": "I will correct the workflow and use Kanban gates."},
+        {
+            "role": "user",
+            "content": "Review the end of the previous session from this thread and continue properly.",
+        },
+    ]
+
+    with patch("agent.context_compressor.call_llm", return_value=_response("updated summary")) as mock_call:
+        compressor.compress(messages, current_tokens=90000)
+
+    prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+    assert "PREVIOUS SUMMARY:" in prompt
+    assert "NEW TURNS TO INCORPORATE:" in prompt
+    assert prompt.count(stale_part86_summary) == 1
+    assert f"[USER]: {SUMMARY_PREFIX}" not in prompt
+    assert "map_gateway, map_workflow_mcp, map_vps, map_all_aspects" in prompt
+    assert "bypass almost every single part" in prompt
+    assert "Review the end of the previous session" in prompt

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -402,6 +402,36 @@ def _isolate_hermes_home(_hermetic_environment):
     return None
 
 
+@pytest.fixture(autouse=True)
+def _reset_gateway_session_contextvars():
+    """Start and end every test with gateway session ContextVars unset.
+
+    Production gateway handlers get a fresh asyncio task context, but a plain
+    pytest process reuses one thread context across tests. A test that calls
+    ``clear_session_vars()`` deliberately sets the ContextVars to empty strings
+    to suppress ``os.environ`` fallback; without a reset, later tests that set
+    ``HERMES_SESSION_*`` via monkeypatch still see the stale explicit-empty
+    ContextVar. Resetting here preserves production semantics while making
+    direct multi-file pytest runs match the per-file subprocess test runner.
+    """
+    try:
+        from gateway import session_context as _session_context
+    except Exception:
+        yield
+        return
+
+    def _reset() -> None:
+        for var in _session_context._VAR_MAP.values():
+            var.set(_session_context._UNSET)
+        _session_context._SESSION_ASYNC_DELIVERY.set(_session_context._UNSET)
+
+    _reset()
+    try:
+        yield
+    finally:
+        _reset()
+
+
 # ── Module-level state reset — replaced by per-file process isolation ──────
 #
 # Each test FILE runs in a freshly-spawned ``python -m pytest <file>``

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -220,7 +220,7 @@ class TestTickWorkdirPartition:
         calls: list[tuple[str, str]] = []
         order_lock = threading.Lock()
 
-        def fake_run_job(job):
+        def fake_run_job(job, **_kwargs):
             # Return a minimal tuple matching run_job's signature.
             with order_lock:
                 calls.append((job["id"], threading.current_thread().name))

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -10,6 +10,10 @@ The first test characterizes the sequence as driven through `tick()` (proving
 the extraction didn't change `tick`'s behavior); the rest unit-test the
 extracted helper directly.
 """
+import asyncio
+
+import pytest
+
 import cron.scheduler as s
 
 
@@ -18,7 +22,7 @@ def _patch_pipeline(monkeypatch, *, success=True, output="out", final="final res
     """Patch the job pipeline primitives and record the call order."""
     calls = []
 
-    def fake_run_job(job):
+    def fake_run_job(job, **_kwargs):
         calls.append(("run_job", job["id"]))
         fr = final if silent_marker_in is None else silent_marker_in
         return (success, output, fr, error)
@@ -78,6 +82,25 @@ def test_run_one_job_silent_skips_delivery(monkeypatch):
     assert "deliver" not in kinds
 
 
+def test_run_one_job_report_that_mentions_silent_marker_still_delivers(monkeypatch):
+    """Only an exact [SILENT] response suppresses delivery.
+
+    A real status report may explain the [SILENT] policy or mention the marker
+    while still containing user-visible information. That report must deliver.
+    """
+    calls = _patch_pipeline(
+        monkeypatch,
+        final="Part 55 report: delivery policy mentions [SILENT], but this is real output.",
+    )
+
+    s.run_one_job({"id": "j3b", "name": "t"})
+
+    kinds = [c[0] for c in calls]
+    assert "deliver" in kinds
+    assert [c[0] for c in calls] == ["run_job", "save", "deliver", "mark"]
+    assert calls[-1] == ("mark", "j3b", True)
+
+
 def test_run_one_job_empty_response_is_soft_failure(monkeypatch):
     """An empty final response marks the run as NOT ok (issue #8585)."""
     calls = _patch_pipeline(monkeypatch, final="   ")
@@ -103,7 +126,7 @@ def test_run_one_job_failed_job_delivers_error(monkeypatch):
 def test_run_one_job_exception_marks_failure(monkeypatch):
     """If run_job raises, the helper marks the run failed and returns False
     rather than propagating."""
-    def boom(job):
+    def boom(job, **_kwargs):
         raise RuntimeError("kaboom")
 
     monkeypatch.setattr(s, "run_job", boom)
@@ -117,3 +140,107 @@ def test_run_one_job_exception_marks_failure(monkeypatch):
 
     assert ok is False
     assert marks == [("j6", False)]
+
+
+@pytest.mark.asyncio
+async def test_run_one_job_background_mode_launches_gateway_background(monkeypatch):
+    """Opt-in cron background mode schedules the live gateway /background path.
+
+    The cron run saves/delivers only a launch acknowledgement; the real result
+    is owned by GatewayRunner._run_background_task.
+    """
+    monkeypatch.setattr(s, "_build_job_prompt", lambda job, prerun_script=None: "assembled prompt")
+
+    saved = []
+    delivered = []
+    marks = []
+    monkeypatch.setattr(s, "save_job_output", lambda jid, out: saved.append((jid, out)) or f"/tmp/{jid}.md")
+    monkeypatch.setattr(
+        s,
+        "_deliver_result",
+        lambda job, content, adapters=None, loop=None: delivered.append(content) or None,
+    )
+    monkeypatch.setattr(
+        s,
+        "mark_job_run",
+        lambda jid, ok, err=None, delivery_error=None: marks.append((jid, ok, err, delivery_error)),
+    )
+
+    launched = []
+
+    class FakeRunner:
+        def __init__(self):
+            self._background_tasks = set()
+
+        async def _run_background_task(self, prompt, source, task_id):
+            launched.append((prompt, source, task_id))
+
+    runner = FakeRunner()
+    s.register_gateway_background_runner(runner)
+    try:
+        ok = s.run_one_job(
+            {
+                "id": "bg1",
+                "name": "background job",
+                "background": True,
+                "deliver": "origin",
+                "origin": {
+                    "platform": "discord",
+                    "chat_id": "1518605229694914680",
+                    "thread_id": "thread-1",
+                },
+            },
+            loop=asyncio.get_running_loop(),
+        )
+        for _ in range(20):
+            if launched:
+                break
+            await asyncio.sleep(0.01)
+    finally:
+        s.unregister_gateway_background_runner(runner)
+
+    assert ok is True
+    assert launched
+    prompt, source, task_id = launched[0]
+    assert prompt == "assembled prompt"
+    assert source.platform.value == "discord"
+    assert source.chat_id == "1518605229694914680"
+    assert source.thread_id == "thread-1"
+    assert task_id.startswith("bgcron_bg1_")
+    assert saved and "**Mode:** gateway-background" in saved[0][1]
+    assert delivered and "Cron background task started" in delivered[0]
+    assert marks == [("bg1", True, None, None)]
+
+
+def test_run_one_job_background_mode_requires_live_gateway_runner(monkeypatch):
+    """A background cron job must not silently fall back to the old cron agent."""
+    monkeypatch.setattr(s, "_build_job_prompt", lambda job, prerun_script=None: "assembled prompt")
+    s.unregister_gateway_background_runner()
+    calls = []
+    monkeypatch.setattr(s, "save_job_output", lambda jid, out: calls.append(("save", out)) or f"/tmp/{jid}.md")
+    monkeypatch.setattr(
+        s,
+        "_deliver_result",
+        lambda job, content, adapters=None, loop=None: calls.append(("deliver", content)) or None,
+    )
+    monkeypatch.setattr(
+        s,
+        "mark_job_run",
+        lambda jid, ok, err=None, delivery_error=None: calls.append(("mark", ok, err)),
+    )
+
+    ok = s.run_one_job(
+        {
+            "id": "bg2",
+            "name": "background job",
+            "background": True,
+            "deliver": "origin",
+            "origin": {"platform": "discord", "chat_id": "1518605229694914680"},
+        }
+    )
+
+    assert ok is True
+    assert calls[0][0] == "save"
+    assert "no live GatewayRunner is registered" in calls[0][1]
+    assert calls[-1][0] == "mark"
+    assert calls[-1][1] is False

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -240,11 +240,19 @@ class TestBusySessionAck:
         assert "Interrupting" not in content
 
     @pytest.mark.asyncio
-    async def test_busy_text_mode_queue_delegates_to_adapter_handle_message(self):
-        """busy_text_mode=queue lets the adapter debounce text silently."""
+    async def test_busy_text_mode_queue_uses_runner_fifo_not_adapter_debounce(self):
+        """busy_text_mode=queue preserves accepted busy text in runner FIFO.
+
+        Regression guard for the Discord/context incident: once a text message
+        is accepted while a session is active, it must not be bounced back to an
+        adapter-specific debounce/single-slot path.  It should follow the same
+        lossless FIFO semantics as busy_input_mode=queue and /queue, so later
+        media/reply events and context-pressure recovery cannot displace it.
+        """
         runner, sentinel = _make_runner()
         runner._busy_input_mode = "interrupt"
         runner._busy_text_mode = "queue"
+        runner._queued_events = {}
         adapter = _make_adapter()
 
         first = _make_event(text="part one")
@@ -259,11 +267,55 @@ class TestBusySessionAck:
         result1 = await runner._handle_active_session_busy_message(first, sk)
         result2 = await runner._handle_active_session_busy_message(second, sk)
 
-        assert result1 is False
-        assert result2 is False
-        assert sk not in adapter._pending_messages
+        assert result1 is True
+        assert result2 is True
+        assert adapter._pending_messages[sk].text == "part one"
+        assert [event.text for event in runner._queued_events[sk]] == ["part two"]
         agent.interrupt.assert_not_called()
-        adapter._send_with_retry.assert_not_called()
+        # First accepted busy message gets an ack; the second is within the
+        # busy-ack cooldown but is still preserved in FIFO.
+        adapter._send_with_retry.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_busy_text_then_media_preserves_text_and_attachment(self):
+        """A later media/reply event must not displace an earlier text @mention.
+
+        This mirrors the Discord incident shape: a valid text mention arrived
+        while the session was busy, then a later screenshot/reply arrived. The
+        integrated queue policy must preserve the text and attach the media to
+        the same pending turn rather than treating media as a bypass that hides
+        the first user message.
+        """
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        runner._queued_events = {}
+        adapter = _make_adapter()
+
+        text_event = _make_event(text="Review the previous messages")
+        media_event = MessageEvent(
+            text="screenshot attached",
+            message_type=MessageType.PHOTO,
+            source=text_event.source,
+            message_id="photo-1",
+            media_urls=["/tmp/screenshot.png"],
+            media_types=["image/png"],
+        )
+        sk = build_session_key(text_event.source)
+
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {"seconds_since_activity": 0.0}
+        runner._running_agents[sk] = agent
+        runner.adapters[text_event.source.platform] = adapter
+
+        assert await runner._handle_active_session_busy_message(text_event, sk) is True
+        assert await runner._handle_active_session_busy_message(media_event, sk) is True
+
+        pending = adapter._pending_messages[sk]
+        assert "Review the previous messages" in pending.text
+        assert "screenshot attached" in pending.text
+        assert pending.media_urls == ["/tmp/screenshot.png"]
+        assert pending.media_types == ["image/png"]
+        assert pending.message_type == MessageType.PHOTO
 
     @pytest.mark.asyncio
     async def test_steer_mode_calls_agent_steer_no_interrupt_no_queue(self):
@@ -512,8 +564,11 @@ class TestBusySessionAck:
         assert "10 min" in content  # elapsed
 
     @pytest.mark.asyncio
-    async def test_telegram_omits_status_detail_by_default(self):
+    async def test_telegram_omits_status_detail_by_default(self, monkeypatch):
         """Telegram busy acks stay concise unless busy_ack_detail is enabled."""
+        import gateway.run as _gr
+
+        monkeypatch.setattr(_gr, "_load_gateway_config", lambda: {})
         runner, sentinel = _make_runner()
         runner._busy_input_mode = "interrupt"
         adapter = _make_adapter()

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -749,6 +749,71 @@ async def test_post_connect_initialization_reraises_non_rate_limit_exceptions(tm
     assert "retry_after" not in entry
 
 
+def test_changed_command_fingerprint_does_not_reuse_stale_success(tmp_path, monkeypatch):
+    """A successful sync only proves the fingerprint that actually synced.
+
+    Regression: recording an attempt for a new desired command fingerprint
+    used to preserve the previous ``last_success_at``. If startup was then
+    interrupted before the Discord API sync finished, the next restart saw the
+    new fingerprint plus the stale success timestamp and skipped the missing
+    slash-command registration.
+    """
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+
+    state_path = (
+        tmp_path
+        / discord_platform._DISCORD_COMMAND_SYNC_STATE_SUBDIR
+        / discord_platform._DISCORD_COMMAND_SYNC_STATE_FILENAME
+    )
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps({
+        "999": {
+            "fingerprint": "old-fingerprint",
+            "last_attempt_at": 100.0,
+            "last_success_at": 101.0,
+            "summary": {"total": 12},
+        }
+    }))
+
+    adapter._record_command_sync_attempt(999, "new-fingerprint")
+
+    entry = json.loads(state_path.read_text())["999"]
+    assert entry["fingerprint"] == "new-fingerprint"
+    assert "last_success_at" not in entry
+    assert "summary" not in entry
+    assert adapter._command_sync_skip_reason(999, "new-fingerprint") is None
+
+
+def test_rate_limited_changed_fingerprint_does_not_reuse_stale_success(tmp_path, monkeypatch):
+    """Rate-limit records for a new fingerprint must also clear stale success."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+
+    state_path = (
+        tmp_path
+        / discord_platform._DISCORD_COMMAND_SYNC_STATE_SUBDIR
+        / discord_platform._DISCORD_COMMAND_SYNC_STATE_FILENAME
+    )
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps({
+        "999": {
+            "fingerprint": "old-fingerprint",
+            "last_attempt_at": 100.0,
+            "last_success_at": 101.0,
+            "summary": {"total": 12},
+        }
+    }))
+
+    adapter._record_command_sync_rate_limit(999, "new-fingerprint", 1.0)
+
+    entry = json.loads(state_path.read_text())["999"]
+    assert entry["fingerprint"] == "new-fingerprint"
+    assert "last_success_at" not in entry
+    assert "summary" not in entry
+    assert entry["retry_after"] == 1.0
+
+
 @pytest.mark.asyncio
 async def test_safe_sync_slash_commands_paces_mutation_writes(monkeypatch):
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))

--- a/tests/gateway/test_gateway_status_dedupe.py
+++ b/tests/gateway/test_gateway_status_dedupe.py
@@ -1,0 +1,54 @@
+"""Gateway status de-dupe policy tests for append-only platforms."""
+
+from gateway.config import Platform
+from gateway.run import _should_deliver_gateway_status
+
+
+def test_discord_compaction_lifecycle_status_is_delivered_once_per_run():
+    state = {"seen": set()}
+
+    assert _should_deliver_gateway_status(
+        Platform.DISCORD,
+        "lifecycle",
+        "🗜️ Compacting context — summarizing earlier conversation so I can continue...",
+        state,
+    ) is True
+    assert _should_deliver_gateway_status(
+        Platform.DISCORD,
+        "lifecycle",
+        "📦 Preflight compression: 138920 tokens >= 136000 threshold.",
+        state,
+    ) is False
+
+
+def test_discord_compaction_abort_status_is_delivered_once_per_run():
+    state = {"seen": set()}
+
+    assert _should_deliver_gateway_status(
+        Platform.DISCORD,
+        "warn",
+        "Context compression aborted after auxiliary model failure.",
+        state,
+    ) is True
+    assert _should_deliver_gateway_status(
+        Platform.DISCORD,
+        "warn",
+        "Compression aborted after retry.",
+        state,
+    ) is False
+
+
+def test_discord_exact_duplicate_status_is_suppressed():
+    state = {"seen": set()}
+    message = "Waiting for provider retry."
+
+    assert _should_deliver_gateway_status(Platform.DISCORD, "lifecycle", message, state) is True
+    assert _should_deliver_gateway_status(Platform.DISCORD, "lifecycle", message, state) is False
+
+
+def test_telegram_status_is_not_deduped_by_gateway_policy():
+    state = {"seen": set()}
+    message = "🗜️ Compacting context — summarizing earlier conversation."
+
+    assert _should_deliver_gateway_status(Platform.TELEGRAM, "lifecycle", message, state) is True
+    assert _should_deliver_gateway_status(Platform.TELEGRAM, "lifecycle", message, state) is True

--- a/tests/gateway/test_native_new_rebase.py
+++ b/tests/gateway/test_native_new_rebase.py
@@ -1,0 +1,132 @@
+"""Tests for native /new same-thread rebase handoff behavior."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, build_session_key
+
+
+def _source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="guild-thread",
+        chat_type="thread",
+        user_id="user-1",
+        user_name="Dionysus",
+        thread_id="thread-1",
+    )
+
+
+def _event(text: str = "/new") -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        source=_source(),
+        message_id="msg-1",
+    )
+
+
+def _runner() -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner._pending_same_thread_rebase_context = {}
+    return runner
+
+
+class _FakeRebaseModule:
+    @staticmethod
+    def build_rebase_dry_run_capsule(**kwargs):
+        assert kwargs["dry_run"] is False
+        assert kwargs["trigger_text"] == ""
+        return {
+            "capsule": {"latest_user_request": "keep going"},
+            "json_path": "/tmp/rebase.json",
+            "markdown_path": "/tmp/rebase.md",
+        }
+
+    @staticmethod
+    def capsule_to_handoff_context(capsule, *, json_path: str = "", markdown_path: str = "") -> str:
+        assert capsule == {"latest_user_request": "keep going"}
+        assert json_path == "/tmp/rebase.json"
+        assert markdown_path == "/tmp/rebase.md"
+        return "[Hermes same-thread session rebase capsule]\nkeep going"
+
+
+def test_remember_native_new_rebase_handoff_stores_one_shot_capsule(monkeypatch):
+    runner = _runner()
+    event = _event()
+    session_key = build_session_key(event.source)
+    monkeypatch.setattr(
+        runner,
+        "_load_same_thread_rebase_module",
+        lambda: _FakeRebaseModule,
+    )
+
+    runner._remember_native_new_rebase_handoff(
+        event=event,
+        session_key=session_key,
+        old_session_id="old-session-id",
+    )
+
+    pending = runner._pending_same_thread_rebase_context[session_key]
+    assert pending["handoff_context"].startswith("[Hermes same-thread session rebase capsule]")
+    assert pending["old_session_id"] == "old-session-id"
+    assert pending["json_path"] == "/tmp/rebase.json"
+    assert pending["markdown_path"] == "/tmp/rebase.md"
+    assert pending["created_at"].endswith("Z")
+
+
+def test_apply_pending_native_new_rebase_context_prepends_and_consumes():
+    runner = _runner()
+    event = _event("continue")
+    event.channel_context = "existing context"
+    session_key = build_session_key(event.source)
+    runner._pending_same_thread_rebase_context[session_key] = {
+        "handoff_context": "[Hermes same-thread session rebase capsule]\nkeep going",
+        "old_session_id": "old-session-id",
+        "json_path": "/tmp/rebase.json",
+    }
+
+    applied = runner._apply_pending_native_new_rebase_context(event, session_key)
+
+    assert applied is True
+    assert event.channel_context == (
+        "[Hermes same-thread session rebase capsule]\nkeep going\n\nexisting context"
+    )
+    assert session_key not in runner._pending_same_thread_rebase_context
+
+
+def test_apply_pending_native_new_rebase_context_is_one_shot():
+    runner = _runner()
+    event = _event("continue")
+    session_key = build_session_key(event.source)
+    runner._pending_same_thread_rebase_context[session_key] = {
+        "handoff_context": "capsule",
+    }
+
+    assert runner._apply_pending_native_new_rebase_context(event, session_key) is True
+    second_event = _event("again")
+    assert runner._apply_pending_native_new_rebase_context(second_event, session_key) is False
+    assert getattr(second_event, "channel_context", None) in (None, "")
+
+
+def test_remember_native_new_rebase_handoff_is_fail_soft(monkeypatch):
+    runner = _runner()
+    event = _event()
+    session_key = build_session_key(event.source)
+
+    def _boom():
+        raise RuntimeError("helper unavailable")
+
+    monkeypatch.setattr(runner, "_load_same_thread_rebase_module", _boom)
+
+    runner._remember_native_new_rebase_handoff(
+        event=event,
+        session_key=session_key,
+        old_session_id="old-session-id",
+    )
+
+    assert runner._pending_same_thread_rebase_context == {}

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -2127,6 +2127,40 @@ def test_chat_messages_to_responses_input_reasoning_only_has_following_item(monk
     assert following.get("role") == "assistant"
 
 
+def test_chat_messages_to_responses_input_sanitizes_reasoning_summary(monkeypatch):
+    """Reasoning summary_text is output-only, but the summary field is required.
+
+    Worker profile request dumps from the native-profile recovery swarm showed
+    HTTP 400 ``Unsupported content type`` when replayed reasoning items carried
+    ``summary: [{type: 'summary_text', ...}]``.  The encrypted_content blob is
+    the replay payload; summary_text is provider output metadata.  A later
+    ChatGPT Codex verifier run showed ``input[].summary`` is still required, so
+    replay uses an empty summary list.
+    """
+    agent = _build_agent(monkeypatch)
+    messages = [
+        {"role": "user", "content": "continue"},
+        {
+            "role": "assistant",
+            "content": "",
+            "finish_reason": "incomplete",
+            "codex_reasoning_items": [
+                {
+                    "type": "reasoning",
+                    "id": "rs_with_summary",
+                    "encrypted_content": "enc_abc",
+                    "summary": [{"type": "summary_text", "text": "Thinking..."}],
+                },
+            ],
+        },
+    ]
+    from agent.codex_responses_adapter import _chat_messages_to_responses_input
+    items = _chat_messages_to_responses_input(messages)
+
+    reasoning_item = next(item for item in items if item.get("type") == "reasoning")
+    assert reasoning_item == {"type": "reasoning", "encrypted_content": "enc_abc", "summary": []}
+
+
 def test_codex_message_item_status_survives_conversion_and_preflight(monkeypatch):
     """Stored Codex assistant message statuses must survive replay normalization."""
     agent = _build_agent(monkeypatch)
@@ -2330,6 +2364,30 @@ def test_preflight_codex_input_deduplicates_reasoning_ids(monkeypatch):
     # IDs must be stripped — with store=False the API 404s on id lookups.
     for it in reasoning_items:
         assert "id" not in it
+
+
+def test_preflight_codex_input_sanitizes_reasoning_summary(monkeypatch):
+    """Preflight must also sanitize reasoning summary_text metadata."""
+    agent = _build_agent(monkeypatch)
+    raw_input = [
+        {"role": "user", "content": "hello"},
+        {
+            "type": "reasoning",
+            "id": "rs_summary",
+            "encrypted_content": "enc_summary",
+            "summary": [{"type": "summary_text", "text": "Thinking..."}],
+        },
+        {"role": "assistant", "content": ""},
+    ]
+    from agent.codex_responses_adapter import _preflight_codex_input_items
+    normalized = _preflight_codex_input_items(raw_input)
+
+    reasoning_item = next(item for item in normalized if item.get("type") == "reasoning")
+    assert reasoning_item == {
+        "type": "reasoning",
+        "encrypted_content": "enc_summary",
+        "summary": [],
+    }
 
 
 def test_run_conversation_codex_disables_reasoning_replay_after_invalid_encrypted_content(monkeypatch):

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -397,78 +397,165 @@ def test_complete_with_result_only(worker_env):
     assert d["ok"] is True
 
 
-def test_complete_with_artifacts_lands_in_event_payload(worker_env):
-    """``artifacts=[...]`` rides into the completed event payload so the
-    gateway notifier can upload them as native attachments. See the
-    kanban notifier in gateway/run.py for the consumer side."""
+def test_complete_with_artifacts_lands_in_event_payload(worker_env, tmp_path):
+    """``artifacts=[...]`` are copied into durable board attachments before
+    completion, then durable paths ride into the completed event payload so
+    the gateway notifier never depends on a cleaned scratch workspace."""
+    from pathlib import Path
     from hermes_cli import kanban_db as kb
     from tools import kanban_tools as kt
 
+    chart = tmp_path / "q3-revenue.png"
+    report = tmp_path / "q3-report.pdf"
+    chart.write_bytes(b"png")
+    report.write_bytes(b"pdf")
+
     out = kt._handle_complete({
         "summary": "rendered the chart",
-        "artifacts": ["/tmp/q3-revenue.png", "/tmp/q3-report.pdf"],
+        "artifacts": [str(chart), str(report)],
     })
     assert json.loads(out)["ok"] is True
 
     conn = kb.connect()
     try:
         events = kb.list_events(conn, worker_env)
-        # Find the completion event
         completed = [e for e in events if e.kind == "completed"]
         assert len(completed) == 1
         payload = completed[0].payload or {}
-        assert payload.get("artifacts") == [
-            "/tmp/q3-revenue.png",
-            "/tmp/q3-report.pdf",
-        ]
-        # And the artifacts also live on metadata for downstream workers
+        payload_artifacts = payload.get("artifacts")
+        assert len(payload_artifacts) == 2
+        assert all(Path(p).is_file() for p in payload_artifacts)
+        assert all("/attachments/" in p for p in payload_artifacts)
+
         run = kb.latest_run(conn, worker_env)
-        assert run.metadata.get("artifacts") == [
-            "/tmp/q3-revenue.png",
-            "/tmp/q3-report.pdf",
-        ]
+        assert run.metadata.get("artifacts") == payload_artifacts
+
+        attachments = kb.list_attachments(conn, worker_env)
+        assert [a.filename for a in attachments] == ["q3-revenue.png", "q3-report.pdf"]
+        assert [a.stored_path for a in attachments] == payload_artifacts
     finally:
         conn.close()
 
 
-def test_complete_artifacts_accepts_single_string(worker_env):
+def test_complete_artifacts_accepts_single_string(worker_env, tmp_path):
     """A bare string is auto-promoted to a single-element list for convenience."""
+    from pathlib import Path
     from hermes_cli import kanban_db as kb
     from tools import kanban_tools as kt
 
+    chart = tmp_path / "chart.png"
+    chart.write_bytes(b"chart")
     out = kt._handle_complete({
         "summary": "one chart",
-        "artifacts": "/tmp/chart.png",
+        "artifacts": str(chart),
     })
     assert json.loads(out)["ok"] is True
 
     conn = kb.connect()
     try:
         run = kb.latest_run(conn, worker_env)
-        assert run.metadata.get("artifacts") == ["/tmp/chart.png"]
+        artifacts = run.metadata.get("artifacts")
+        assert len(artifacts) == 1
+        assert Path(artifacts[0]).is_file()
+        assert artifacts[0].endswith("chart.png")
     finally:
         conn.close()
 
 
-def test_complete_artifacts_merges_with_explicit_metadata_field(worker_env):
+def test_complete_artifacts_merges_with_explicit_metadata_field(worker_env, tmp_path):
     """If the worker passes metadata.artifacts AND the top-level artifacts
-    param, merge the two without duplicates."""
+    param, merge and persist durable attachment paths without duplicates."""
+    from pathlib import Path
     from hermes_cli import kanban_db as kb
     from tools import kanban_tools as kt
 
+    a = tmp_path / "a.png"
+    b = tmp_path / "b.pdf"
+    a.write_bytes(b"a")
+    b.write_bytes(b"b")
     out = kt._handle_complete({
         "summary": "merged",
-        "metadata": {"artifacts": ["/tmp/a.png"], "other": "fact"},
-        "artifacts": ["/tmp/b.pdf", "/tmp/a.png"],
+        "metadata": {"artifacts": [str(a)], "other": "fact"},
+        "artifacts": [str(b), str(a)],
     })
     assert json.loads(out)["ok"] is True
 
     conn = kb.connect()
     try:
         run = kb.latest_run(conn, worker_env)
-        # Order: existing entries first, then new ones, deduplicated.
-        assert run.metadata.get("artifacts") == ["/tmp/a.png", "/tmp/b.pdf"]
+        artifacts = run.metadata.get("artifacts")
+        assert len(artifacts) == 2
+        assert all(Path(p).is_file() for p in artifacts)
+        assert [Path(p).name for p in artifacts] == ["a.png", "b.pdf"]
         assert run.metadata.get("other") == "fact"
+    finally:
+        conn.close()
+
+
+def test_complete_rejects_missing_artifact_without_completing(worker_env, tmp_path):
+    """Missing artifact paths must block completion instead of producing an
+    unverifiable done handoff that points at a cleaned/nonexistent path."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    missing = tmp_path / "missing.md"
+    out = kt._handle_complete({
+        "summary": "claimed missing artifact",
+        "artifacts": [str(missing)],
+    })
+    err = json.loads(out).get("error", "")
+    assert "artifact path does not exist" in err
+    assert "still in-flight" in err
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, worker_env)
+        assert task.status == "running"
+        assert not kb.list_attachments(conn, worker_env)
+        assert not [e for e in kb.list_events(conn, worker_env) if e.kind == "completed"]
+    finally:
+        conn.close()
+
+
+def test_complete_preserves_artifact_from_cleaned_scratch_workspace(worker_env):
+    """Regression for synth handoffs: complete_task removes scratch
+    workspaces, so artifact paths in run/event metadata must point at durable
+    attachment copies, not the soon-to-be-cleaned workspace file."""
+    from pathlib import Path
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        workspace = kb.workspaces_root() / worker_env
+        workspace.mkdir(parents=True)
+        artifact = workspace / "handoff.md"
+        artifact.write_text("durable handoff\n", encoding="utf-8")
+        conn.execute(
+            "UPDATE tasks SET workspace_path = ? WHERE id = ?",
+            (str(workspace), worker_env),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    out = kt._handle_complete({
+        "summary": "handoff ready",
+        "artifacts": [str(artifact)],
+    })
+    assert json.loads(out)["ok"] is True
+    assert not workspace.exists()
+
+    conn = kb.connect()
+    try:
+        run = kb.latest_run(conn, worker_env)
+        durable = Path(run.metadata["artifacts"][0])
+        assert durable.is_file()
+        assert durable.read_text(encoding="utf-8") == "durable handoff\n"
+        assert str(durable) != str(artifact)
+        assert "/attachments/" in str(durable)
+        events = [e for e in kb.list_events(conn, worker_env) if e.kind == "completed"]
+        assert events[-1].payload["artifacts"] == [str(durable)]
     finally:
         conn.close()
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -504,6 +504,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["script"] = job["script"]
     if job.get("no_agent"):
         result["no_agent"] = True
+    if job.get("background"):
+        result["background"] = True
     if job.get("enabled_toolsets"):
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
@@ -576,6 +578,7 @@ def cronjob(
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
+    background: Optional[bool] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -589,6 +592,13 @@ def cronjob(
                 return tool_error("schedule is required for create", success=False)
             canonical_skills = _canonical_skills(skill, skills)
             _no_agent = bool(no_agent)
+            _background = bool(background)
+            if _background and _no_agent:
+                return tool_error(
+                    "background=True is only valid for LLM-driven cron jobs; "
+                    "it cannot be combined with no_agent=True.",
+                    success=False,
+                )
             # Job-shape validation differs by mode:
             #   - no_agent=True → script is the job; prompt/skills are optional
             #     (and irrelevant to execution).
@@ -642,6 +652,7 @@ def cronjob(
                 enabled_toolsets=enabled_toolsets or None,
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
+                background=_background,
             )
             _notify_provider_jobs_changed_safe()
             _create_message = f"Cron job '{job['name']}' created."
@@ -811,7 +822,24 @@ def cronjob(
                             "Set `script` in the same update, or on the job first.",
                             success=False,
                         )
+                    effective_background = updates.get("background") if "background" in updates else job.get("background")
+                    if effective_background:
+                        return tool_error(
+                            "Cannot set no_agent=True on a background job. "
+                            "Disable background in the same update, or leave no_agent disabled.",
+                            success=False,
+                        )
                 updates["no_agent"] = target_no_agent
+            if background is not None:
+                target_background = bool(background)
+                effective_no_agent = updates.get("no_agent") if "no_agent" in updates else job.get("no_agent")
+                if target_background and effective_no_agent:
+                    return tool_error(
+                        "Cannot set background=True on a no_agent job. "
+                        "Disable no_agent in the same update, or leave background disabled.",
+                        success=False,
+                    )
+                updates["background"] = target_background
             if repeat is not None:
                 # Normalize: treat 0 or negative as None (infinite)
                 normalized_repeat = None if repeat <= 0 else repeat
@@ -930,6 +958,16 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                     "WHEN TO USE False (default): anything that needs reasoning — summarize a feed, draft a daily briefing, pick interesting items, rephrase data for a human, follow conditional logic based on content."
                 ),
             },
+            "background": {
+                "type": "boolean",
+                "default": False,
+                "description": (
+                    "Default: False. Set True for an LLM-driven cron job that should launch through the live gateway /background-style surface instead of running as a standalone cron agent. "
+                    "This preserves a background lane for long-running recurring work and lets the gateway own the final user-facing delivery. "
+                    "Requires a running gateway with a registered background runner plus a concrete delivery target (for example origin with saved chat/thread context or platform:chat_id[:thread_id]). "
+                    "Incompatible with no_agent=True. On update, pass False to return to normal cron execution."
+                ),
+            },
             "context_from": {
                 "type": "array",
                 "items": {"type": "string"},
@@ -1007,6 +1045,7 @@ registry.register(
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
+        background=args.get("background"),
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -30,7 +30,10 @@ from __future__ import annotations
 
 import json
 import logging
+import mimetypes
 import os
+import shutil
+from pathlib import Path
 from typing import Any, Optional
 
 from agent.redact import redact_sensitive_text
@@ -129,6 +132,81 @@ def _stamp_worker_session_metadata(
     stamped = dict(metadata or {})
     stamped["worker_session_id"] = session_id
     return stamped
+
+
+def _safe_attachment_filename(path: Path, used: set[str]) -> str:
+    """Return a basename safe to store under a task attachment directory."""
+    raw = path.name.strip() or "artifact"
+    safe = "".join(
+        ch if (ch.isalnum() or ch in {".", "-", "_"}) else "_"
+        for ch in raw
+    )
+    safe = safe.strip("._") or "artifact"
+    if safe not in used:
+        used.add(safe)
+        return safe
+    stem = Path(safe).stem or "artifact"
+    suffix = Path(safe).suffix
+    i = 2
+    while True:
+        candidate = f"{stem}-{i}{suffix}"
+        if candidate not in used:
+            used.add(candidate)
+            return candidate
+        i += 1
+
+
+def _materialize_completion_artifacts(
+    kb: Any,
+    conn: Any,
+    task_id: str,
+    artifacts: list[str],
+    *,
+    board: Optional[str],
+) -> list[str] | str:
+    """Validate and copy completion artifacts into durable task attachments.
+
+    Worker scratch workspaces are cleaned after completion, so accepting paths
+    under that workspace into run metadata creates unverifiable handoffs. Fail
+    closed on missing/non-file artifacts and rewrite valid artifact references
+    to board attachment paths that survive workspace cleanup.
+    """
+    stored: list[str] = []
+    used: set[str] = set()
+    dest_dir = kb.task_attachments_dir(task_id, board=board)
+    try:
+        dest_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        return f"could not create artifact attachment directory {dest_dir}: {exc}"
+
+    for raw in artifacts:
+        src = Path(os.path.expanduser(str(raw))).resolve()
+        if not src.is_file():
+            return f"artifact path does not exist or is not a file: {raw}"
+        filename = _safe_attachment_filename(src, used)
+        dest = dest_dir / filename
+        try:
+            shutil.copy2(src, dest)
+        except OSError as exc:
+            return f"could not copy artifact {raw} to durable attachment storage: {exc}"
+        try:
+            kb.add_attachment(
+                conn,
+                task_id,
+                filename=filename,
+                stored_path=str(dest),
+                content_type=mimetypes.guess_type(filename)[0],
+                size=dest.stat().st_size,
+                uploaded_by=os.environ.get("HERMES_PROFILE"),
+            )
+        except Exception as exc:
+            try:
+                dest.unlink(missing_ok=True)
+            except OSError:
+                pass
+            return f"could not record artifact attachment {filename}: {exc}"
+        stored.append(str(dest))
+    return stored
 
 
 def _enforce_worker_task_ownership(tid: str) -> Optional[str]:
@@ -566,6 +644,26 @@ def _handle_complete(args: dict, **kw) -> str:
     try:
         kb, conn = _connect(board=board)
         try:
+            artifact_paths = []
+            if isinstance(metadata, dict):
+                raw_artifacts = metadata.get("artifacts")
+                if isinstance(raw_artifacts, (list, tuple)):
+                    artifact_paths = [
+                        str(p).strip() for p in raw_artifacts if str(p).strip()
+                    ]
+            if artifact_paths:
+                materialized = _materialize_completion_artifacts(
+                    kb, conn, tid, artifact_paths, board=board
+                )
+                if isinstance(materialized, str):
+                    return tool_error(
+                        "kanban_complete blocked: "
+                        f"{materialized}. Your task is still in-flight "
+                        "(no completion state change)."
+                    )
+                metadata = dict(metadata or {})
+                metadata["artifacts"] = materialized
+
             try:
                 ok = kb.complete_task(
                     conn, tid,


### PR DESCRIPTION
## Summary
- harden Discord same-thread `/new` recovery/capsule handling and gateway status de-dupe paths
- add cron background-mode plumbing plus shared scheduler safety fixes found by the broader cron suite
- preserve Kanban artifact paths and sanitize Codex reasoning replay summaries that can trigger Responses 400s
- add regression coverage for native `/new`, gateway status de-dupe, cron background/no-agent behavior, and Kanban artifacts

## Local verification
- `python3 -m pytest tests/cron -o 'addopts=' -q` → 526 passed, 8 warnings
- `python3 -m pytest tests/run_agent/test_run_agent_codex_responses.py tests/agent/test_context_compressor_summary_continuity.py tests/cron/test_run_one_job.py tests/cron/test_cron_workdir.py tests/gateway/test_busy_session_ack.py tests/gateway/test_discord_connect.py tests/gateway/test_native_new_rebase.py tests/gateway/test_gateway_status_dedupe.py tests/tools/test_kanban_tools.py -o 'addopts=' -q` → 259 passed, 7 warnings

## Boundaries
- No merge approval implied.
- No deploy, gateway restart, live config/provider change, credential change, destructive cleanup, or paid/heavy benchmark was performed.
- Live Discord multi-thread concurrency/cap smoke remains manual/outside this PR.

## Provenance
- Clean worktree branch from fetched `origin/main` `0957d77187805f5c488d1fcbd8fa1c365ef695f6`.
- Commit: `d8f0c8d1c83d3372970d79f886f19300e331c87a`.