### PR TITLE
fix(telegram): cache channel-post media via effective_message (#51543)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -10102,18 +10102,24 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def _handle_media_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming media messages, downloading images to local cache."""
-        if not update.message:
+        # Telegram delivers channel broadcasts as ``update.channel_post`` rather
+        # than ``update.message``. Resolve via ``_effective_update_message`` so
+        # channel file attachments are cached and delivered like DM/group media,
+        # matching ``_handle_text_message`` (which was already fixed). Guarding on
+        # ``update.message`` alone silently dropped every channel-post attachment.
+        msg = self._effective_update_message(update)
+        if not msg:
             return
-        if not self._is_user_authorized_from_message(update.message):
+        if not self._is_user_authorized_from_message(msg):
             logger.info(
                 "[Telegram] Blocked media from unauthorized user %s in chat %s",
-                getattr(getattr(update.message, "from_user", None), "id", None),
-                getattr(getattr(update.message, "chat", None), "id", None),
+                getattr(getattr(msg, "from_user", None), "id", None),
+                getattr(getattr(msg, "chat", None), "id", None),
             )
             return
-        if not self._should_process_message(update.message):
-            if self._should_observe_unmentioned_group_message(update.message):
-                _m = update.message
+        if not self._should_process_message(msg):
+            if self._should_observe_unmentioned_group_message(msg):
+                _m = msg
                 _observe_type = self._media_message_type(_m)
                 _event = self._build_message_event(_m, _observe_type, update_id=update.update_id)
                 if _m.caption:
@@ -10123,8 +10129,6 @@ class TelegramAdapter(BasePlatformAdapter):
                     _m, _event.message_type, update_id=update.update_id, event=_event
                 )
             return
-
-        msg = update.message
 
         msg_type = self._media_message_type(msg)
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9177,18 +9177,24 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def _handle_media_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming media messages, downloading images to local cache."""
-        if not update.message:
+        # Telegram delivers channel broadcasts as ``update.channel_post`` rather
+        # than ``update.message``. Resolve via ``_effective_update_message`` so
+        # channel file attachments are cached and delivered like DM/group media,
+        # matching ``_handle_text_message`` (which was already fixed). Guarding on
+        # ``update.message`` alone silently dropped every channel-post attachment.
+        msg = self._effective_update_message(update)
+        if not msg:
             return
-        if not self._is_user_authorized_from_message(update.message):
+        if not self._is_user_authorized_from_message(msg):
             logger.info(
                 "[Telegram] Blocked media from unauthorized user %s in chat %s",
-                getattr(getattr(update.message, "from_user", None), "id", None),
-                getattr(getattr(update.message, "chat", None), "id", None),
+                getattr(getattr(msg, "from_user", None), "id", None),
+                getattr(getattr(msg, "chat", None), "id", None),
             )
             return
-        if not self._should_process_message(update.message):
-            if self._should_observe_unmentioned_group_message(update.message):
-                _m = update.message
+        if not self._should_process_message(msg):
+            if self._should_observe_unmentioned_group_message(msg):
+                _m = msg
                 _observe_type = self._media_message_type(_m)
                 _event = self._build_message_event(_m, _observe_type, update_id=update.update_id)
                 if _m.caption:
@@ -9198,8 +9204,6 @@ class TelegramAdapter(BasePlatformAdapter):
                     _m, _event.message_type, update_id=update.update_id, event=_event
                 )
             return
-
-        msg = update.message
 
         msg_type = self._media_message_type(msg)
 

--- a/tests/gateway/test_telegram_channel_posts.py
+++ b/tests/gateway/test_telegram_channel_posts.py
@@ -148,3 +148,122 @@ def test_build_message_event_uses_channel_identity_for_channel_posts(telegram_ad
     assert event.platform_update_id == 12345
 
 
+def _make_channel_photo_message(caption="report @hermes_bot"):
+    """A channel broadcast carrying a photo attachment."""
+    chat = SimpleNamespace(
+        id=-1003950368353,
+        type="channel",
+        title="wzrd",
+        full_name=None,
+        is_forum=False,
+    )
+    photo = SimpleNamespace(
+        get_file=AsyncMock(
+            return_value=SimpleNamespace(
+                download_as_bytearray=AsyncMock(return_value=bytearray(b"\x89PNG")),
+                file_path="photo.png",
+            )
+        )
+    )
+    return SimpleNamespace(
+        chat=chat,
+        from_user=None,
+        text=None,
+        caption=caption,
+        entities=[],
+        caption_entities=[],
+        message_thread_id=None,
+        is_topic_message=False,
+        message_id=11,
+        reply_to_message=None,
+        quote=None,
+        date=None,
+        forum_topic_created=None,
+        photo=[photo],
+        sticker=None,
+        voice=None,
+        audio=None,
+        video=None,
+        document=None,
+        media_group_id=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_media_handler_uses_effective_message_for_channel_post(
+    telegram_adapter_cls, monkeypatch
+):
+    """Channel broadcasts deliver media as ``channel_post``, not ``message``.
+
+    Regression for #51543: ``_handle_media_message`` guarded on
+    ``update.message`` alone and silently dropped every channel-post
+    attachment.  It must resolve via ``_effective_update_message`` like the
+    text/command handlers and route the photo into the caching pipeline.
+    """
+    adapter = _make_adapter(telegram_adapter_cls)
+    msg = _make_channel_photo_message()
+    update = _make_channel_update(msg)
+
+    adapter._should_process_message = lambda m: True
+    adapter._apply_telegram_group_observe_attribution = lambda e: e
+    adapter._photo_batch_key = MagicMock(return_value="batch-key")
+    adapter._enqueue_photo_event = MagicMock()
+
+    adapter_module = sys.modules["plugins.platforms.telegram.adapter"]
+    monkeypatch.setattr(
+        adapter_module, "cache_image_from_bytes", lambda *a, **k: "/cache/photo.png"
+    )
+
+    await adapter._handle_media_message(update, MagicMock())
+
+    # The photo was routed into the caching pipeline rather than dropped.
+    adapter._enqueue_photo_event.assert_called_once()
+    event = adapter._enqueue_photo_event.call_args.args[1]
+    assert event.media_urls == ["/cache/photo.png"]
+    assert event.source.chat_type == "channel"
+    assert event.source.chat_id == "-1003950368353"
+
+
+@pytest.mark.asyncio
+async def test_media_handler_blocks_unauthorized_channel_post(
+    telegram_adapter_cls, monkeypatch
+):
+    """The auth prefilter must see the resolved channel-post message.
+
+    Companion to the positive caching test: when the broadcast's
+    ``sender_chat`` is not on the adapter allowlist, the intake prefilter
+    (#40863) must reject it BEFORE any caching or enqueueing.  Passing
+    ``update.message`` (None for channel posts) instead of the resolved
+    message would skip sender_chat authorization entirely.
+    """
+    adapter = telegram_adapter_cls(
+        PlatformConfig(
+            enabled=True,
+            token="***",
+            extra={"group_allow_from": ["424242"]},
+        )
+    )
+    msg = _make_channel_photo_message()
+    # Give the broadcast an authorizable channel identity that is NOT on the
+    # allowlist above.
+    msg.sender_chat = SimpleNamespace(id=-1003950368353, title="wzrd")
+    update = _make_channel_update(msg)
+
+    adapter._should_process_message = lambda m: True
+    adapter._apply_telegram_group_observe_attribution = lambda e: e
+    adapter._enqueue_photo_event = MagicMock()
+
+    cache_calls = []
+    adapter_module = sys.modules["plugins.platforms.telegram.adapter"]
+    monkeypatch.setattr(
+        adapter_module,
+        "cache_image_from_bytes",
+        lambda *a, **k: cache_calls.append(a) or "/cache/photo.png",
+    )
+
+    await adapter._handle_media_message(update, MagicMock())
+
+    # Rejected at intake: nothing cached, nothing enqueued.
+    assert cache_calls == []
+    adapter._enqueue_photo_event.assert_not_called()
+    msg.photo[0].get_file.assert_not_awaited()

--- a/tests/gateway/test_telegram_channel_posts.py
+++ b/tests/gateway/test_telegram_channel_posts.py
@@ -147,3 +147,122 @@ def test_build_message_event_uses_channel_identity_for_channel_posts(telegram_ad
     assert event.platform_update_id == 12345
 
 
+def _make_channel_photo_message(caption="report @hermes_bot"):
+    """A channel broadcast carrying a photo attachment."""
+    chat = SimpleNamespace(
+        id=-1003950368353,
+        type="channel",
+        title="wzrd",
+        full_name=None,
+        is_forum=False,
+    )
+    photo = SimpleNamespace(
+        get_file=AsyncMock(
+            return_value=SimpleNamespace(
+                download_as_bytearray=AsyncMock(return_value=bytearray(b"\x89PNG")),
+                file_path="photo.png",
+            )
+        )
+    )
+    return SimpleNamespace(
+        chat=chat,
+        from_user=None,
+        text=None,
+        caption=caption,
+        entities=[],
+        caption_entities=[],
+        message_thread_id=None,
+        is_topic_message=False,
+        message_id=11,
+        reply_to_message=None,
+        quote=None,
+        date=None,
+        forum_topic_created=None,
+        photo=[photo],
+        sticker=None,
+        voice=None,
+        audio=None,
+        video=None,
+        document=None,
+        media_group_id=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_media_handler_uses_effective_message_for_channel_post(
+    telegram_adapter_cls, monkeypatch
+):
+    """Channel broadcasts deliver media as ``channel_post``, not ``message``.
+
+    Regression for #51543: ``_handle_media_message`` guarded on
+    ``update.message`` alone and silently dropped every channel-post
+    attachment.  It must resolve via ``_effective_update_message`` like the
+    text/command handlers and route the photo into the caching pipeline.
+    """
+    adapter = _make_adapter(telegram_adapter_cls)
+    msg = _make_channel_photo_message()
+    update = _make_channel_update(msg)
+
+    adapter._should_process_message = lambda m: True
+    adapter._apply_telegram_group_observe_attribution = lambda e: e
+    adapter._photo_batch_key = MagicMock(return_value="batch-key")
+    adapter._enqueue_photo_event = MagicMock()
+
+    adapter_module = sys.modules["plugins.platforms.telegram.adapter"]
+    monkeypatch.setattr(
+        adapter_module, "cache_image_from_bytes", lambda *a, **k: "/cache/photo.png"
+    )
+
+    await adapter._handle_media_message(update, MagicMock())
+
+    # The photo was routed into the caching pipeline rather than dropped.
+    adapter._enqueue_photo_event.assert_called_once()
+    event = adapter._enqueue_photo_event.call_args.args[1]
+    assert event.media_urls == ["/cache/photo.png"]
+    assert event.source.chat_type == "channel"
+    assert event.source.chat_id == "-1003950368353"
+
+
+@pytest.mark.asyncio
+async def test_media_handler_blocks_unauthorized_channel_post(
+    telegram_adapter_cls, monkeypatch
+):
+    """The auth prefilter must see the resolved channel-post message.
+
+    Companion to the positive caching test: when the broadcast's
+    ``sender_chat`` is not on the adapter allowlist, the intake prefilter
+    (#40863) must reject it BEFORE any caching or enqueueing.  Passing
+    ``update.message`` (None for channel posts) instead of the resolved
+    message would skip sender_chat authorization entirely.
+    """
+    adapter = telegram_adapter_cls(
+        PlatformConfig(
+            enabled=True,
+            token="***",
+            extra={"group_allow_from": ["424242"]},
+        )
+    )
+    msg = _make_channel_photo_message()
+    # Give the broadcast an authorizable channel identity that is NOT on the
+    # allowlist above.
+    msg.sender_chat = SimpleNamespace(id=-1003950368353, title="wzrd")
+    update = _make_channel_update(msg)
+
+    adapter._should_process_message = lambda m: True
+    adapter._apply_telegram_group_observe_attribution = lambda e: e
+    adapter._enqueue_photo_event = MagicMock()
+
+    cache_calls = []
+    adapter_module = sys.modules["plugins.platforms.telegram.adapter"]
+    monkeypatch.setattr(
+        adapter_module,
+        "cache_image_from_bytes",
+        lambda *a, **k: cache_calls.append(a) or "/cache/photo.png",
+    )
+
+    await adapter._handle_media_message(update, MagicMock())
+
+    # Rejected at intake: nothing cached, nothing enqueued.
+    assert cache_calls == []
+    adapter._enqueue_photo_event.assert_not_called()
+    msg.photo[0].get_file.assert_not_awaited()

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -111,9 +111,16 @@ def _make_message(document=None, caption=None, media_group_id=None, photo=None):
 
 
 def _make_update(msg):
-    """Wrap a message in a mock Update."""
+    """Wrap a message in a mock Update.
+
+    Mirrors python-telegram-bot, where ``Update.effective_message`` resolves to
+    the underlying message for DMs/groups (and to ``channel_post`` for channel
+    broadcasts).  The media handler resolves via ``_effective_update_message``,
+    so the mock must expose ``effective_message`` like the real object does.
+    """
     update = MagicMock()
     update.message = msg
+    update.effective_message = msg
     return update
 
 

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -88,9 +88,16 @@ def _make_message(document=None, caption=None, media_group_id=None, photo=None):
 
 
 def _make_update(msg):
-    """Wrap a message in a mock Update."""
+    """Wrap a message in a mock Update.
+
+    Mirrors python-telegram-bot, where ``Update.effective_message`` resolves to
+    the underlying message for DMs/groups (and to ``channel_post`` for channel
+    broadcasts).  The media handler resolves via ``_effective_update_message``,
+    so the mock must expose ``effective_message`` like the real object does.
+    """
     update = MagicMock()
     update.message = msg
+    update.effective_message = msg
     return update
 
 


### PR DESCRIPTION
Fixes #51543

## Problem

Telegram delivers channel broadcasts as `update.channel_post`, not `update.message`. `_handle_media_message` guarded on `if not update.message:` and bailed immediately for channel posts, so **file / photo / video / voice attachments sent to a broadcast channel were silently dropped** — only the caption text reached the agent and nothing was cached at `~/.hermes/cache/`.

The sibling handlers `_handle_text_message` and `_handle_command` already resolve the payload via `_effective_update_message(update)` (which returns `effective_message → message → None`). The media handler was missed during the plugin refactor that deleted the old `gateway/platforms/telegram.py` (commit `560010547`); this ports the same fix to the new plugin location.

## Fix

- Resolve the message via `_effective_update_message(update)` and replace the five `update.message` references in the early-return block with the resolved `msg`, mirroring the text/command handlers. The rest of the method already used a local `msg`.

## Tests

- New regression test `test_media_handler_uses_effective_message_for_channel_post` in `tests/gateway/test_telegram_channel_posts.py`: sends a channel-post photo and asserts it is routed into the caching pipeline. **Verified RED on the unpatched handler** (the early `return` means `_enqueue_photo_event` is never called) and **GREEN after the fix**.
- Updated `_make_update` in `tests/gateway/test_telegram_documents.py` to expose `effective_message` alongside `message`, matching real python-telegram-bot `Update` objects (where `effective_message` always resolves the active payload). Without this the existing mock only modelled `.message`.
- Full media regression suite green: `test_telegram_channel_posts.py`, `test_telegram_documents.py`, `test_telegram_group_gating.py` → 90 passed.

---
*NL — kort voor de eigen administratie: kanaal-broadcasts kwamen binnen als `channel_post` i.p.v. `message`, waardoor de media-handler meteen afhaakte en bijlagen in kanalen nooit werden gecached. Dezelfde `effective_message`-resolutie die de tekst- en command-handlers al gebruiken nu ook in de media-handler gezet, met een regressietest die zonder de fix faalt.*