### PR TITLE
feat: minimise to system tray on window close

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -3,6 +3,7 @@ const {
   BrowserWindow,
   Menu,
   Notification,
+  Tray,
   clipboard,
   dialog,
   ipcMain,
@@ -701,6 +702,8 @@ function registerMediaProtocol() {
 }
 
 let mainWindow = null
+let forceQuit = false
+let tray = null
 let hermesProcess = null
 let connectionPromise = null
 // Additional per-profile backends, keyed by profile name. The PRIMARY backend
@@ -3579,11 +3582,63 @@ function getAppIconPath() {
   return APP_ICON_PATHS.find(fileExists)
 }
 
+// ── System tray (minimize-to-tray) ──────────────────────────────────────
+
+function createTray() {
+  if (tray) return
+  const iconPath = getAppIconPath()
+  const icon = iconPath ? nativeImage.createFromPath(iconPath).resize({ width: 16, height: 16 }) : nativeImage.createEmpty()
+
+  tray = new Tray(icon)
+  tray.setToolTip(app.name || 'Hermes')
+
+  const contextMenu = Menu.buildFromTemplate([
+    {
+      label: 'Show Hermes',
+      click: restoreFromTray
+    },
+    { type: 'separator' },
+    {
+      label: 'Quit',
+      click: () => {
+        forceQuit = true
+        destroyTray()
+        app.quit()
+      }
+    }
+  ])
+
+  tray.setContextMenu(contextMenu)
+
+  // Restore on double-click (Windows behaviour; no-op where unsupported)
+  tray.on('double-click', restoreFromTray)
+
+  rememberLog('[tray] tray icon created')
+}
+
+function destroyTray() {
+  if (tray) {
+    tray.destroy()
+    tray = null
+    rememberLog('[tray] tray icon destroyed')
+  }
+}
+
+function restoreFromTray() {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    if (mainWindow.isMinimized()) mainWindow.restore()
+    mainWindow.show()
+    mainWindow.focus()
+  }
+  destroyTray()
+}
+
 function sendOpenUpdatesRequested() {
   if (!mainWindow || mainWindow.isDestroyed()) return
   const { webContents } = mainWindow
   if (!webContents || webContents.isDestroyed()) return
   webContents.send('hermes:open-updates')
+  destroyTray()
   if (!mainWindow.isVisible()) mainWindow.show()
   mainWindow.focus()
 }
@@ -5583,6 +5638,18 @@ function createWindow() {
   // window-all-closed from quitting on Windows/Linux).
   mainWindow.on('closed', () => closePetOverlay())
 
+  // Minimise to system tray instead of closing, unless forceQuit is set
+  // (e.g. actual quit from tray menu, Cmd+Q, or app update).
+  mainWindow.on('close', (event) => {
+    if (forceQuit) {
+      destroyTray()
+      return
+    }
+    event.preventDefault()
+    mainWindow.hide()
+    createTray()
+  })
+
   wireCommonWindowHandlers(mainWindow)
 
   mainWindow.webContents.on('render-process-gone', (_event, details) => {
@@ -6958,6 +7025,7 @@ if (!_gotSingleInstanceLock) {
     else if (mainWindow) {
       if (mainWindow.isMinimized()) mainWindow.restore()
       mainWindow.focus()
+      destroyTray()
     }
   })
 }
@@ -6995,6 +7063,8 @@ app.whenReady().then(() => {
       createWindow()
     } else {
       focusWindow(mainWindow)
+      // Window was hidden to tray; remove the tray icon on restore
+      destroyTray()
     }
   })
 })
@@ -7023,6 +7093,8 @@ function configureSpellChecker() {
 }
 
 app.on('before-quit', () => {
+  forceQuit = true
+
   // The always-on-top overlay isn't a "real" app window; close it so a stray
   // pet can't keep the process alive or float over a quit app.
   closePetOverlay()
@@ -7056,5 +7128,8 @@ app.on('before-quit', () => {
 })
 
 app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') app.quit()
+  // On non-macOS, keep the process alive while the tray icon is shown so the
+  // user can restore the window. The tray's "Quit" action calls app.quit(),
+  // which sets forceQuit and bypasses the hide-to-tray close handler.
+  if (process.platform !== 'darwin' && !tray) app.quit()
 })


### PR DESCRIPTION
## Summary

When closing the main window (clicking × on Windows/Linux, or Cmd+W on macOS), minimise to the system tray instead of quitting the application. This allows long-running background tasks — agent responses, backend processes, file operations — to continue uninterrupted.

A tray icon appears with a context menu offering **Show Hermes** and **Quit**. Double-clicking the tray icon also restores the window.

## Changes

All changes are in `apps/desktop/electron/main.cjs`:

- **Import `Tray`** from Electron (was already available in the Electron API but not imported)
- **State variables** `forceQuit` and `tray` to track quit intent and tray lifecycle
- **`createTray()`** — creates a system tray icon with the app icon, tooltip, and context menu (Show / Quit)
- **`destroyTray()`** — tears down the tray icon
- **`restoreFromTray()`** — shows and focuses the main window, then destroys the tray
- **`mainWindow.on('close')`** interception — unless `forceQuit` is set, prevents the close and hides the window to tray
- **`before-quit` handler** — sets `forceQuit = true` so updates, Cmd+Q, and tray-menu Quit bypass the tray and close properly
- **`window-all-closed` handler** — only auto-quits on non-macOS if no tray is active
- **All restore paths** (`activate` for macOS dock click, `second-instance` for second launch, `sendOpenUpdatesRequested`) now also call `destroyTray()`

## Design Decisions

- **`forceQuit` flag** follows the standard Electron pattern: before-quit sets it before windows start closing, so the close handler knows not to intercept
- **macOS**: the `window-all-closed` guard is preserved (macOS apps stay alive after window close). The tray behaviour still works but the existing dock-activate path also destroys the tray
- **Secondary windows** (session windows) close normally — only the main window minimises to tray
- **Tray icon** reuses the existing app icon, resized to 16×16

## Testing

- [ ] Click × on Windows → window hides, tray icon appears
- [ ] Double-click tray icon → window restores, tray disappears
- [ ] Right-click tray → Show Hermes / Quit menu
- [ ] Quit from tray → app fully quits
- [ ] Cmd+Q (macOS) / Alt+F4 (Windows) → app quits normally
- [ ] macOS dock click → window restores, tray disappears
- [ ] Second instance launch → focus existing window, tray disappears
- [ ] Check for updates → window shows, tray disappears
- [ ] App update → forceQuit set, close proceeds normally