### PR TITLE
fix(desktop): guard second-instance focus against destroyed window

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -6955,9 +6955,8 @@ if (!_gotSingleInstanceLock) {
   app.on('second-instance', (_event, argv) => {
     const url = _extractDeepLink(argv)
     if (url) handleDeepLink(url)
-    else if (mainWindow) {
-      if (mainWindow.isMinimized()) mainWindow.restore()
-      mainWindow.focus()
+    else if (mainWindow && !mainWindow.isDestroyed()) {
+      focusWindow(mainWindow)
     }
   })
 }


### PR DESCRIPTION
Uncaught exception when a second app launch (or second `hermes://` deep link) is routed into the running instance:

```
Uncaught Exception:
TypeError: Object has been destroyed
    at EventEmitter.<anonymous> (.../app.asar/electron/main.cjs:6959:22)
    at EventEmitter.emit (node:events:509:28)
```

## Root cause

The `second-instance` handler in `apps/desktop/electron/main.cjs` checks only that `mainWindow` is truthy before calling `mainWindow.isMinimized()`:

```js
app.on("second-instance", (_event, argv) => {
  const url = _extractDeepLink(argv)
  if (url) handleDeepLink(url)
  else if (mainWindow) {
    if (mainWindow.isMinimized()) mainWindow.restore()  // throws
    mainWindow.focus()
  }
})
```

`mainWindow` keeps a non-null JS reference after its native window is destroyed, so once the window has been closed, the `isMinimized()` call on the dead native object throws `TypeError: Object has been destroyed`. There is no try/catch around it, so it surfaces as an uncaught exception and takes down the main process.

This is a missing sibling guard: every other `mainWindow.isMinimized()` call site already guards `isDestroyed()` (the `handleDeepLink` path at ~6905 and the pet-overlay control path at ~5785 both early-return on `isDestroyed()`), and there is an existing `focusWindow()` helper that does exactly this — it is already used by the `activate` handler.

## Fix

Reuse `focusWindow()` (which guards `isDestroyed()`, restores if minimized, shows if hidden, then focuses) and add the matching `!isDestroyed()` check:

```js
else if (mainWindow && !mainWindow.isDestroyed()) {
  focusWindow(mainWindow)
}
```

## Testing

- `node --check apps/desktop/electron/main.cjs` passes.
- Verified the crashing line in the packaged `app.asar` matched the unguarded source, repacked with the fix locally, and the app no longer throws on second-instance with a previously-closed main window.