### PR TITLE
fix(url_safety): allow NAT64 well-known prefix without fail-open SSRF (salvage of #12256 by @SergoVashakmadze)

### DIFF
--- a/contributors/emails/seraphine@Seraphines-Mac-Studio.local
+++ b/contributors/emails/seraphine@Seraphines-Mac-Studio.local
@@ -1,0 +1,2 @@
+Bartok9
+# Seraphine Mac Studio local email on Bartok9 PR tips (per-PR attribution; Teknium/Daniel 2026-08-01)

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -209,6 +209,13 @@ _MAX_SSRF_CONNECT_IPS = 8
 # VPNs, and some cloud internal networks.
 _CGNAT_NETWORK = ipaddress.ip_network("100.64.0.0/10")
 
+# 64:ff9b::/96 (NAT64 Well-Known Prefix, RFC 6052) is flagged by
+# ipaddress.is_reserved, but it carries an embedded IPv4 target in its low
+# 32 bits. We allow it ONLY after re-checking that embedded IPv4 against the
+# IPv4 SSRF policy (so public targets pass while private/metadata/loopback
+# embedded addresses stay blocked).
+_NAT64_NETWORK = ipaddress.ip_network("64:ff9b::/96")
+
 # ---------------------------------------------------------------------------
 # Global toggle: allow private/internal IP resolution
 # ---------------------------------------------------------------------------
@@ -286,16 +293,51 @@ def _reset_allow_private_cache() -> None:
     _cached_allow_private = False
 
 
+def _embedded_ipv4_is_blocked(embedded_ip: ipaddress.IPv4Address) -> bool:
+    """Apply the IPv4 SSRF policy to an IPv4 address embedded in IPv6."""
+    return (embedded_ip.is_private or embedded_ip.is_loopback or
+            embedded_ip.is_link_local or embedded_ip.is_reserved or
+            embedded_ip.is_multicast or embedded_ip.is_unspecified or
+            embedded_ip in _CGNAT_NETWORK)
+
+
+def _is_always_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Return True if ``ip`` is in the non-negotiable metadata/link-local floor.
+
+    This floor is enforced even when ``allow_private_urls`` is on — the config
+    that skips ``_is_blocked_ip()`` in ``is_safe_url()``. A NAT64 Well-Known
+    Prefix address (``64:ff9b::169.254.169.254``, RFC 6052) would otherwise slip
+    past the literal ``_ALWAYS_BLOCKED_IPS`` / ``_ALWAYS_BLOCKED_NETWORKS``
+    membership test, because those sets hold the bare IPv4 metadata endpoints,
+    not their NAT64-wrapped form. Unwrap the attacker-controllable embedded IPv4
+    from the low 32 bits and re-check it against the floor so the mandatory
+    metadata block holds in every configuration.
+    """
+    if isinstance(ip, ipaddress.IPv6Address) and ip in _NAT64_NETWORK:
+        ip = ipaddress.IPv4Address(int(ip) & 0xFFFFFFFF)
+    return ip in _ALWAYS_BLOCKED_IPS or any(
+        ip in net for net in _ALWAYS_BLOCKED_NETWORKS
+    )
+
+
 def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     """Return True if the IP should be blocked for SSRF protection."""
     # IPv4-mapped IPv6 addresses (``::ffff:x.x.x.x``) should be checked
     # by their embedded IPv4 address, not as IPv6
     if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
-        embedded_ip = ip.ipv4_mapped
-        return (embedded_ip.is_private or embedded_ip.is_loopback or
-                embedded_ip.is_link_local or embedded_ip.is_reserved or
-                embedded_ip.is_multicast or embedded_ip.is_unspecified or
-                embedded_ip in _CGNAT_NETWORK)
+        return _embedded_ipv4_is_blocked(ip.ipv4_mapped)
+
+    # NAT64 Well-Known Prefix (``64:ff9b::/96``, RFC 6052) synthesizes an
+    # IPv6 representation of a target IPv4 service reachable via an upstream
+    # NAT64 translator (common on dual-stack-lite consumer ISPs). The whole
+    # prefix is flagged by ``is_reserved``, which would be a false-positive
+    # SSRF block for public IPv4 targets. But we must NOT blanket-allow it:
+    # the low 32 bits are an attacker-controllable IPv4 address, so
+    # ``64:ff9b::169.254.169.254`` (cloud metadata) or ``64:ff9b::10.0.0.1``
+    # must still be blocked. Decide on the EMBEDDED IPv4 address.
+    if isinstance(ip, ipaddress.IPv6Address) and ip in _NAT64_NETWORK:
+        embedded_ip = ipaddress.IPv4Address(int(ip) & 0xFFFFFFFF)
+        return _embedded_ipv4_is_blocked(embedded_ip)
 
     # Standard IPv4/IPv6 address checking
     if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
@@ -358,9 +400,7 @@ def is_always_blocked_url(url: str) -> bool:
             ip = None
 
         if ip is not None:
-            if ip in _ALWAYS_BLOCKED_IPS or any(
-                ip in net for net in _ALWAYS_BLOCKED_NETWORKS
-            ):
+            if _is_always_blocked_ip(ip):
                 logger.warning(
                     "Blocked request to cloud metadata address "
                     "(always-blocked floor): %s",
@@ -387,9 +427,7 @@ def is_always_blocked_url(url: str) -> bool:
             except ValueError:
                 logger.warning("Unparseable IP address %r for hostname %s — skipping address", sockaddr[0], hostname)
                 continue
-            if resolved in _ALWAYS_BLOCKED_IPS or any(
-                resolved in net for net in _ALWAYS_BLOCKED_NETWORKS
-            ):
+            if _is_always_blocked_ip(resolved):
                 logger.warning(
                     "Blocked request to cloud metadata address "
                     "(always-blocked floor): %s -> %s",
@@ -484,8 +522,10 @@ def is_safe_url(url: str) -> bool:
                 logger.warning("Blocked request — unparseable IP address %r for hostname %s", sockaddr[0], hostname)
                 return False
 
-            # Always block cloud metadata IPs and link-local, even with toggle on
-            if ip in _ALWAYS_BLOCKED_IPS or any(ip in net for net in _ALWAYS_BLOCKED_NETWORKS):
+            # Always block cloud metadata IPs and link-local, even with toggle on.
+            # Unwraps NAT64-embedded IPv4 so 64:ff9b::169.254.169.254 can't slip
+            # past the floor when allow_private_urls skips _is_blocked_ip() below.
+            if _is_always_blocked_ip(ip):
                 logger.warning(
                     "Blocked request to cloud metadata address: %s -> %s",
                     hostname, ip_str,


### PR DESCRIPTION
## Summary

- Stops `is_safe_url()` from false-positive-blocking public hosts that resolve to NAT64 synthesized IPv6 addresses (64:ff9b::/96, RFC 6052) — common on dual-stack-lite consumer ISPs.
- Does so **without** opening an SSRF hole: the embedded IPv4 target is re-checked against the IPv4 policy, so NAT64 addresses embedding private/metadata/loopback IPv4 stay blocked.

## Motivation

Salvage of #12256 by @SergoVashakmadze, re-targeted onto current `main`.

`ipaddress.is_reserved` returns `True` for the entire NAT64 Well-Known Prefix, so any host resolving to a `64:ff9b::` address was blocked even when the embedded IPv4 target is a public service reachable via the upstream NAT64 translator.

## Differential value vs. the original #12256

The original fix returned `False` (allowed) for **the whole `64:ff9b::/96` prefix unconditionally**. That is a fail-open SSRF bypass: the low 32 bits are attacker-controllable, so `64:ff9b::169.254.169.254` (cloud metadata), `64:ff9b::10.0.0.1` (RFC1918), and `64:ff9b::127.0.0.1` (loopback) would all have been *allowed*.

This salvage instead extracts the embedded IPv4 (`int(ip) & 0xFFFFFFFF`) and runs the existing IPv4 SSRF checks on it — mirroring main's existing `ipv4_mapped` (`::ffff:x.x.x.x`) handling, via a shared `_embedded_ipv4_is_blocked()` helper. Public embedded targets pass; private/reserved/metadata embedded targets stay blocked.

## Verification

- `.venv/bin/python -m pytest tests/tools/test_url_safety.py` — **134 passed**

## Real behavior proof

- **Environment:** repo `.venv` (CPython).
- **With the fix (captured):**
  ```
  tests/tools/test_url_safety.py::TestIsBlockedIp  37 passed in 0.27s
  ```
- **Without the source fix (source reverted, tests kept — captured):**
  ```
  WARNING tools.url_safety: Blocked request to private/internal address: dns.google -> 64:ff9b::8.8.8.8
  FAILED ...test_allowed_ips[64:ff9b::2.19.248.139]
  FAILED ...test_allowed_ips[64:ff9b::8.8.8.8]
  FAILED ...test_allowed_ips[64:ff9b::1.1.1.1]
  FAILED ...test_nat64_url_allowed_end_to_end
  FAILED ...test_nat64_only_resolution_allowed
  5 failed, 10 passed
  ```
- **Regression tests:** public-NAT64 allow cases (fail without the fix); private/metadata-embedded NAT64 block cases + `test_nat64_embedding_metadata_blocked_end_to_end` (the fail-open guard — these stay blocked, proving the fix doesn't over-allow).
- **What was NOT tested:** live DNS resolution against a real NAT64 translator (mocked `socket.getaddrinfo` instead).

Salvage credit: original fix and test scaffolding by @SergoVashakmadze (#12256).
