### PR TITLE
fix(cron): deduplicate cross-profile jobs with default-profile priority

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7138,16 +7138,41 @@ async def list_cron_jobs(profile: str = "all"):
     if requested.lower() != "all":
         return _call_cron_for_profile(requested, "list_jobs", True)
 
-    jobs: List[Dict[str, Any]] = []
+    # Aggregating across profiles can surface the SAME job id more than
+    # once -- e.g. a job copied into a second profile's cron/jobs.json
+    # during profile creation. Deduplicate by id, deterministically
+    # preferring the default profile's copy over per-iteration order
+    # (issue #51721): collect all jobs first, then resolve duplicates by
+    # id with default-profile priority, rather than keeping whichever
+    # copy happened to be seen first during the profile loop.
+    all_jobs: List[Dict[str, Any]] = []
     for item in _cron_profile_dicts():
         name = str(item.get("name") or "")
         if not name:
             continue
         try:
-            jobs.extend(_call_cron_for_profile(name, "list_jobs", True))
+            all_jobs.extend(_call_cron_for_profile(name, "list_jobs", True))
         except Exception:
             _log.exception("Failed to list cron jobs for profile %s", name)
-    return jobs
+
+    by_id: Dict[str, Dict[str, Any]] = {}
+    unkeyed: List[Dict[str, Any]] = []
+    for job in all_jobs:
+        if not isinstance(job, dict):
+            continue
+        jid = job.get("id") or job.get("job_id")
+        if not jid:
+            # Jobs without a stable id can't be deduplicated safely --
+            # keep them all rather than risk dropping a legitimate entry.
+            unkeyed.append(job)
+            continue
+        existing = by_id.get(jid)
+        if existing is None or (
+            job.get("is_default_profile") and not existing.get("is_default_profile")
+        ):
+            by_id[jid] = job
+
+    return list(by_id.values()) + unkeyed
 
 
 @app.get("/api/cron/jobs/{job_id}")


### PR DESCRIPTION
## Problem

GET /api/cron/jobs (profile=all) aggregated jobs from every profile without deduplication. A job copied into a second profile cron/jobs.json during profile creation showed up twice (issue #51721).

## Fix (alternative to #51742)

Collect all jobs first, then resolve duplicates by id with a by_id dict -- default profile copy always preferred, deterministic regardless of profile iteration order. Falls back to first-seen when no default-profile copy exists. Jobs without a stable id are never dropped.

Note: the issues own suggested-fix snippet has a subtle bug -- when a later-seen job IS the default-profile copy, the continue is skipped but the job still gets appended without removing the earlier non-default copy, so a default-vs-non-default pair could both end up in the result. The dict-based approach here avoids that by construction.

5 scenarios verified via logic test.

Fixes #51721