### PR TITLE
fix: add encoding='utf-8' to os.fdopen() and open() text-mode calls

### DIFF
--- a/agent/nous_rate_guard.py
+++ b/agent/nous_rate_guard.py
@@ -117,7 +117,7 @@ def record_nous_rate_limit(
         # Atomic write: write to temp file + rename
         fd, tmp_path = tempfile.mkstemp(dir=state_dir, suffix=".tmp")
         try:
-            with os.fdopen(fd, "w") as f:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
                 json.dump(state, f)
             atomic_replace(tmp_path, path)
         except Exception:

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -627,7 +627,7 @@ def save_allowlist(data: Dict[str, Any]) -> None:
             prefix=f"{p.name}.", suffix=".tmp", dir=str(p.parent),
         )
         try:
-            with os.fdopen(fd, "w") as fh:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
                 fh.write(json.dumps(data, indent=2, sort_keys=True))
             atomic_replace(tmp_path, p)
         except Exception:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4034,7 +4034,7 @@ class GatewaySlashCommandsMixin:
                     with open(output_path, "wb") as f:
                         proc = subprocess.Popen(cmd, stdout=f, stderr=subprocess.STDOUT, env=env)
                         rc = proc.wait(timeout=3600)
-                    with open(exit_code_path, "w") as f:
+                    with open(exit_code_path, "w", encoding="utf-8") as f:
                         f.write(str(rc))
                     """
                 ).strip()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -6211,7 +6211,7 @@ def sanitize_env_file() -> int:
 
     fd, tmp_path = tempfile.mkstemp(dir=str(env_path.parent), suffix=".tmp", prefix=".env_")
     try:
-        with os.fdopen(fd, "w", **write_kw) as f:
+        with os.fdopen(fd, "w", encoding="utf-8", **write_kw) as f:
             f.writelines(sanitized)
             f.flush()
             os.fsync(f.fileno())
@@ -6329,7 +6329,7 @@ def save_env_value(key: str, value: str):
         except OSError:
             pass
     try:
-        with os.fdopen(fd, 'w', **write_kw) as f:
+        with os.fdopen(fd, 'w', encoding='utf-8', **write_kw) as f:
             f.writelines(lines)
             f.flush()
             os.fsync(f.fileno())
@@ -6400,7 +6400,7 @@ def remove_env_value(key: str) -> bool:
         except OSError:
             pass
         try:
-            with os.fdopen(fd, 'w', **write_kw) as f:
+            with os.fdopen(fd, 'w', encoding='utf-8', **write_kw) as f:
                 f.writelines(new_lines)
                 f.flush()
                 os.fsync(f.fileno())


### PR DESCRIPTION
## What

Add `encoding='utf-8'` to `os.fdopen()` and `open()` calls in text mode that omitted it.

## Why

On Windows with non-UTF-8 locale, the default encoding is the system locale. Writing UTF-8 content without explicit encoding causes `UnicodeEncodeError`.

Complements PR #51748/#51752/#51761 (read_text/write_text) and #51406 (initial fdopen batch).

## Changes (4 files, 6 lines)

| File | Change |
|------|--------|
| `agent/nous_rate_guard.py` | `os.fdopen(fd, 'w')` → add encoding |
| `agent/shell_hooks.py` | `os.fdopen(fd, 'w')` → add encoding |
| `gateway/slash_commands.py` | `open(exit_code_path, 'w')` → add encoding |
| `hermes_cli/config.py` | 3× `os.fdopen(fd, 'w', **write_kw)` → add encoding |