### PR TITLE
fix(desktop): disable GPU acceleration on WSL to prevent Wayland/DRM renderer crash

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -151,6 +151,7 @@ function hiddenWindowsChildOptions(options = {}) {
 // switches only apply pre-launch. Override with HERMES_DESKTOP_DISABLE_GPU
 // (1/true → always disable, 0/false → keep GPU on).
 const REMOTE_DISPLAY_REASON = detectRemoteDisplay()
+let GPU_DISABLE_REASON = REMOTE_DISPLAY_REASON
 if (REMOTE_DISPLAY_REASON) {
   app.disableHardwareAcceleration()
   // Belt-and-suspenders for X11/VNC, where the Viz compositor can still glitch
@@ -161,7 +162,28 @@ if (REMOTE_DISPLAY_REASON) {
   )
 }
 
-ipcMain.handle('hermes:get-remote-display-reason', () => REMOTE_DISPLAY_REASON)
+// WSLg Wayland: CHROMIUM's DRM device probe fails in WSL when no native GPU
+// passthrough is available (common in VMs, older hardware, or certain WSLg
+// configurations). Without a DRM node the GPU process silently fails to
+// initialize, the renderer process never starts, and the window never appears.
+// Software rendering is stable on WSLg and the CPU cost is negligible.
+// User can override with HERMES_DESKTOP_DISABLE_GPU=0 to force GPU on.
+if (!REMOTE_DISPLAY_REASON && IS_WSL) {
+  // Check if HERMES_DESKTOP_DISABLE_GPU explicitly wants GPU on
+  const override = (process.env.HERMES_DESKTOP_DISABLE_GPU || '').trim().toLowerCase()
+  const gpuOverrideOn = new Set(['1', 'true', 'yes', 'on'])
+  const gpuOverrideOff = new Set(['0', 'false', 'no', 'off'])
+  if (!gpuOverrideOff.has(override)) {
+    GPU_DISABLE_REASON = 'wslg (no DRM node available)'
+    app.disableHardwareAcceleration()
+    app.commandLine.appendSwitch('disable-gpu-compositing')
+    console.log(
+      '[hermes] WSL environment detected; disabling GPU hardware acceleration to prevent Wayland/DRM renderer crash'
+    )
+  }
+}
+
+ipcMain.handle('hermes:get-remote-display-reason', () => GPU_DISABLE_REASON)
 
 // Keep the renderer running at full speed while the window is in the background
 // or occluded. The chat transcript streams to screen through a


### PR DESCRIPTION
## Problem

The Hermes Desktop Electron app crashes silently on WSL/WSLg. Chromium's DRM device probe fails because WSLg doesn't expose native DRM nodes — GPU process silently fails, renderer never starts, no window appears. The user sees only non-fatal stderr noise (`drmGetDevices2`, `systemd`, `fs.Stats`) with no visible window.

## Root cause

`detectRemoteDisplay()` in `bootstrap-platform.cjs` deliberately skips WSLg per its design comment at line 68-69:

> "WSLg deliberately isn't treated as remote — it reports GPU-accelerated vGPU surfaces locally and doesn't show the flicker."

This assumption holds when WSLg has working GPU passthrough, but breaks on configurations without it — common in VMs, older hardware, and many default WSLg installations.

## Fix

Add a WSL-specific GPU disable block in `main.cjs` that runs after the existing remote-display check (before `app.ready()`):

- Detects WSL via the already-imported `isWslEnvironment()`
- Disables `HardwareAcceleration` and adds `disable-gpu-compositing` switch
- Respects `HERMES_DESKTOP_DISABLE_GPU` env override (both 0 and 1)
- Exposes the reason string through `hermes:get-remote-display-reason` IPC handler

~20 lines added. Follows the exact same pattern as the remote-display block.

## Testing

Confirmed on WSLg/Wayland:
1. Before: `hermes desktop` -> Electron main process starts, DRM errors, no renderer process, no window
2. After: Window appears with software rendering, errors gone

Override still works: `HERMES_DESKTOP_DISABLE_GPU=0 hermes desktop` keeps GPU on when the user has working GPU passthrough.

## Related

- `HERMES_DESKTOP_DISABLE_GPU` env var documented in code comment at line 151
- `isWslEnvironment()` already used elsewhere in the codebase (`const IS_WSL = isWslEnvironment()` at line 134)
