### PR TITLE
fix(prompt): report Windows 11 instead of Windows 10 in environment hints

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -978,6 +978,24 @@ def _clear_backend_probe_cache() -> None:
     _BACKEND_PROBE_CACHE.clear()
 
 
+def _windows_display_release() -> str:
+    """Return the user-facing Windows release name ('11' / '10').
+
+    ``platform.release()`` reports ``"10"`` on BOTH Windows 10 and Windows 11
+    because they share kernel version 10.0; the editions are distinguished only
+    by build number (>= 22000 is Windows 11). Without this, the system prompt
+    tells the model the host is Windows 10 on every Windows 11 machine (#51755).
+    Falls back to ``platform.release()`` if the build can't be read.
+    """
+    import sys
+    import platform
+    try:
+        build = sys.getwindowsversion().build
+    except Exception:
+        return platform.release()
+    return "11" if build >= 22000 else "10"
+
+
 def build_environment_hints() -> str:
     """Return environment-specific guidance for the system prompt.
 
@@ -1008,7 +1026,7 @@ def build_environment_hints() -> str:
         if is_wsl():
             host_lines.append("Host: WSL (Windows Subsystem for Linux)")
         elif sys.platform == "win32":
-            host_lines.append(f"Host: Windows ({platform.release()})")
+            host_lines.append(f"Host: Windows ({_windows_display_release()})")
         elif sys.platform == "darwin":
             mac_ver = platform.mac_ver()[0]
             host_lines.append(f"Host: macOS ({mac_ver or platform.release()})")

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1556,3 +1556,43 @@ class TestParallelToolCallGuidance:
 # =========================================================================
 
 
+
+
+# =========================================================================
+# Windows release detection (Windows 11 vs 10) — #51755
+# =========================================================================
+
+class TestWindowsDisplayRelease:
+    """platform.release() reports '10' on both Windows 10 and 11; the build
+    number (>= 22000 == Windows 11) is the only reliable discriminator."""
+
+    def _patch_build(self, monkeypatch, build):
+        import sys as _sys
+        from collections import namedtuple
+        WV = namedtuple("WV", ["build"])
+        monkeypatch.setattr(_sys, "getwindowsversion", lambda: WV(build=build), raising=False)
+
+    def test_windows_11_build(self, monkeypatch):
+        from agent.prompt_builder import _windows_display_release
+        self._patch_build(monkeypatch, 26200)
+        assert _windows_display_release() == "11"
+
+    def test_windows_11_threshold(self, monkeypatch):
+        from agent.prompt_builder import _windows_display_release
+        self._patch_build(monkeypatch, 22000)
+        assert _windows_display_release() == "11"
+
+    def test_windows_10_build(self, monkeypatch):
+        from agent.prompt_builder import _windows_display_release
+        self._patch_build(monkeypatch, 19045)
+        assert _windows_display_release() == "10"
+
+    def test_falls_back_when_unavailable(self, monkeypatch):
+        import sys as _sys
+        import platform as _platform
+        from agent.prompt_builder import _windows_display_release
+
+        def _boom():
+            raise OSError("not on windows")
+        monkeypatch.setattr(_sys, "getwindowsversion", _boom, raising=False)
+        assert _windows_display_release() == _platform.release()


### PR DESCRIPTION
## Summary

Fixes #51755. `build_environment_hints()` builds the `Host:` line with `platform.release()`, which returns `"10"` on **both** Windows 10 and Windows 11 — they share kernel version 10.0. So the system prompt reports `Host: Windows (10)` on every Windows 11 machine, misinforming the model about the host OS.

## Fix

Add `_windows_display_release()`, which distinguishes the editions by build number — `sys.getwindowsversion().build >= 22000` → `"11"`, else `"10"` — and falls back to `platform.release()` if the build can't be read. `build_environment_hints()` now uses it for the Windows host line.

Verified on a Windows 11 host: `platform.release()` → `"10"`, `sys.getwindowsversion().build` → `26200`, helper → `"11"`.

## Tests

`tests/agent/test_prompt_builder.py::TestWindowsDisplayRelease`: build 26200 and the 22000 threshold → `"11"`, build 19045 → `"10"`, and the fallback to `platform.release()` when `getwindowsversion()` is unavailable (non-Windows / error). The build is monkeypatched so the tests run on any platform.
