### PR TITLE
fix(agent): detect Windows 11 by build number in system prompt

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1008,7 +1008,14 @@ def build_environment_hints() -> str:
         if is_wsl():
             host_lines.append("Host: WSL (Windows Subsystem for Linux)")
         elif sys.platform == "win32":
-            host_lines.append(f"Host: Windows ({platform.release()})")
+            # platform.release() returns '10.0' for both Windows 10 and 11.
+            # Distinguish by build number: >= 22000 is Windows 11+.
+            try:
+                _build = sys.getwindowsversion().build
+                _win_ver = "11" if _build >= 22000 else "10"
+            except Exception:
+                _win_ver = platform.release()
+            host_lines.append(f"Host: Windows ({_win_ver})")
         elif sys.platform == "darwin":
             mac_ver = platform.mac_ver()[0]
             host_lines.append(f"Host: macOS ({mac_ver or platform.release()})")


### PR DESCRIPTION
## What

Fix the system prompt reporting `Host: Windows (10)` on Windows 11 machines.

## Why

`platform.release()` returns `'10.0'` for both Windows 10 and Windows 11 because they share the same NT kernel version. The system prompt incorrectly tells the LLM the host is Windows 10 even on Windows 11.

## Fix

Use `sys.getwindowsversion().build` to distinguish:
- Build >= 22000 → Windows 11 (or later)
- Build < 22000 → Windows 10

Falls back to `platform.release()` if `getwindowsversion()` fails (e.g. non-Windows).

## Changes

- `agent/prompt_builder.py`: 1 file, 8 insertions, 1 deletion

Closes #51755