### PR TITLE
fix(cli): hide Windows dashboard reexec console

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11345,7 +11345,12 @@ def cmd_dashboard(args):
         # re-executing the dashboard for a non-default profile.  Use
         # subprocess.Popen + sys.exit() on Windows to avoid the crash.
         if sys.platform == "win32":
-            proc = subprocess.Popen(reexec_argv, env=env)
+            create_no_window = getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)
+            proc = subprocess.Popen(
+                reexec_argv,
+                env=env,
+                creationflags=create_no_window,
+            )
             sys.exit(proc.wait())
         else:
             os.execvpe(sys.executable, reexec_argv, env)

--- a/tests/hermes_cli/test_dashboard_unified_launch.py
+++ b/tests/hermes_cli/test_dashboard_unified_launch.py
@@ -87,6 +87,37 @@ class TestUnifiedDashboardRouting:
         from hermes_constants import get_default_hermes_root
         assert env.get("HERMES_HOME") == str(get_default_hermes_root())
 
+    def test_windows_reexec_uses_no_window_flag(self, main_mod, monkeypatch):
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name", lambda: "worker_x"
+        )
+        monkeypatch.setattr(main_mod, "_dashboard_listening", lambda host, port: False)
+        monkeypatch.setattr(main_mod.sys, "platform", "win32")
+
+        popen_calls = []
+
+        class FakeProc:
+            def wait(self):
+                return 0
+
+        def fake_popen(*args, **kwargs):
+            popen_calls.append((args, kwargs))
+            return FakeProc()
+
+        monkeypatch.setattr(
+            main_mod.subprocess, "CREATE_NO_WINDOW", 0x08000000, raising=False
+        )
+        monkeypatch.setattr(main_mod.subprocess, "Popen", fake_popen)
+
+        with pytest.raises(SystemExit) as exc:
+            main_mod.cmd_dashboard(_args())
+
+        assert exc.value.code == 0
+        assert len(popen_calls) == 1
+        _args_used, kwargs = popen_calls[0]
+        assert kwargs["creationflags"] & 0x08000000
+
     def test_reexec_pins_docker_machine_root(self, main_mod, monkeypatch):
         """In the Docker layout (HERMES_HOME=/opt/data, profiles under
         /opt/data/profiles/<name>) the reroute must pin the child to the


### PR DESCRIPTION
## What does PR do?

Prevents the Windows dashboard profile reroute from opening a visible empty console window. The reroute path already uses `subprocess.Popen(...)` on Windows to avoid the `os.execvpe(...)` crash; this adds the Windows `CREATE_NO_WINDOW` creation flag to that same narrow path.

## Related Issue

Fixes #51759

## Type Change

- [x] 🐛 Bug fix (non-breaking change fixes issue)
- [ ] ✨ New feature (non-breaking change adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled hub)

## Changes Made

- `hermes_cli/main.py`: pass `creationflags=CREATE_NO_WINDOW` for the Windows-only dashboard re-exec `subprocess.Popen(...)` path.
- `tests/hermes_cli/test_dashboard_unified_launch.py`: add a regression test that patches the reroute path to `win32` and asserts `CREATE_NO_WINDOW` is passed to `Popen`.

## How Test

1. Reproduced the reported code path: non-default profile dashboard launch reroutes through the Windows-only `subprocess.Popen(reexec_argv, env=env)` branch.
2. Added a regression test that exercises that branch and captures the `Popen` kwargs.
3. Ran `scripts/run_tests.sh tests/hermes_cli/test_dashboard_unified_launch.py` (10 tests passed).

## Checklist

### Code

- [x] I've read [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) make sure isn't duplicate
- [x] My PR contains **only** changes related fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` all tests pass
- [x] I've added tests changes (required bug fixes, strongly encouraged features)
- [x] I've tested on my platform: macOS with focused regression test simulating `sys.platform == "win32"`

### Documentation & Housekeeping

- [x] I've considered cross-platform impact (Windows, macOS) per [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
scripts/run_tests.sh tests/hermes_cli/test_dashboard_unified_launch.py

=== Summary: 1 files, 10 tests passed, 0 failed (100% complete) in 2.1s ===
```
