### PR TITLE
feat(installer): Add universal macOS binary support (Intel + Apple Silicon)

### DIFF
--- a/.github/workflows/build-desktop-installer.yml
+++ b/.github/workflows/build-desktop-installer.yml
@@ -1,0 +1,67 @@
+name: Build Desktop Installer (Universal macOS)
+
+on:
+  workflow_dispatch:
+    inputs:
+      upload_release:
+        description: 'Upload to GitHub Release (requires tag)'
+        required: false
+        type: boolean
+        default: false
+  push:
+    tags:
+      - 'installer-v*'
+
+jobs:
+  build-macos-universal:
+    name: Build Universal macOS DMG
+    runs-on: macos-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+      
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
+      
+      - name: Install dependencies (monorepo root)
+        run: npm ci
+      
+      - name: Build universal DMG
+        run: |
+          cd apps/bootstrap-installer
+          npx tauri build --target universal-apple-darwin
+      
+      - name: Verify universal binary
+        run: |
+          DMG=$(find apps/bootstrap-installer/src-tauri/target/universal-apple-darwin/release/bundle/dmg -name "*.dmg" | head -1)
+          echo "DMG: $DMG"
+          hdiutil attach "$DMG" -mountpoint /tmp/verify-dmg -readonly -nobrowse
+          EXE="/tmp/verify-dmg/Hermes.app/Contents/MacOS/Hermes-Setup"
+          echo "Binary architectures:"
+          lipo -info "$EXE"
+          hdiutil detach /tmp/verify-dmg -quiet
+      
+      - name: Upload DMG artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Hermes-Setup-macOS-universal
+          path: apps/bootstrap-installer/src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg
+          retention-days: 30
+      
+      - name: Upload to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/installer-v') || inputs.upload_release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: apps/bootstrap-installer/src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg
+          draft: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/bootstrap-installer/README.md
+++ b/apps/bootstrap-installer/README.md
@@ -1,0 +1,101 @@
+# Hermes Bootstrap Installer
+
+Tauri-based installer application for Hermes Agent. Provides a GUI-driven setup experience for macOS and Windows users.
+
+## Features
+
+- One-click installation of Hermes Agent
+- Automatic dependency detection and installation (Python, Node.js, etc.)
+- Progress tracking and error handling
+- Native look-and-feel on macOS and Windows
+
+## Architecture Support
+
+The macOS installer is built as a **universal binary** supporting both Intel (x86_64) and Apple Silicon (arm64) Macs.
+
+- **Minimum macOS version**: 12.0 (Monterey)
+- **Supported architectures**: x86_64, arm64 (universal binary)
+
+## Development
+
+### Prerequisites
+
+- Node.js 22+
+- Rust toolchain (rustup recommended)
+- For universal macOS builds:
+  ```bash
+  rustup target add aarch64-apple-darwin
+  rustup target add x86_64-apple-darwin
+  ```
+
+### Building
+
+```bash
+cd apps/bootstrap-installer
+
+# Install dependencies (run from monorepo root)
+cd ../..
+npm ci
+
+# Build for current architecture
+cd apps/bootstrap-installer
+npm run tauri:build
+
+# Build universal macOS binary (contains both x64 and arm64)
+npm run tauri:build -- --target universal-apple-darwin
+
+# Build for specific architecture
+npm run tauri:build -- --target x86_64-apple-darwin   # Intel only
+npm run tauri:build -- --target aarch64-apple-darwin  # Apple Silicon only
+```
+
+### Output
+
+Bundles are created in `src-tauri/target/<target>/release/bundle/`:
+- **DMG**: `dmg/Hermes_<version>_<arch>.dmg`
+- **App bundle**: `macos/Hermes.app`
+
+### Verifying Universal Binary
+
+```bash
+DMG="src-tauri/target/universal-apple-darwin/release/bundle/dmg/Hermes_0.0.1_universal.dmg"
+hdiutil attach "$DMG" -mountpoint /tmp/verify -readonly
+lipo -info "/tmp/verify/Hermes.app/Contents/MacOS/Hermes-Setup"
+# Expected: Architectures in the fat file: ... are: x86_64 arm64
+hdiutil detach /tmp/verify
+```
+
+## CI/CD
+
+The `.github/workflows/build-desktop-installer.yml` workflow builds universal macOS DMG on push of `installer-v*` tags or manual dispatch.
+
+### Creating a Release
+
+```bash
+git tag installer-v0.1.0
+git push origin installer-v0.1.0
+```
+
+The workflow will:
+1. Build a universal DMG for macOS
+2. Verify the binary contains both x86_64 and arm64
+3. Upload as a GitHub Actions artifact
+4. Create a draft GitHub Release with the DMG attached
+
+## Project Structure
+
+- `src/` — React frontend (Vite + TypeScript)
+- `src-tauri/` — Tauri backend (Rust)
+  - `src/main.rs` — Main Tauri entry point
+  - `src/install_script.rs` — Installation logic (wraps `scripts/install.sh` / `install.ps1`)
+  - `Cargo.toml` — Rust dependencies
+  - `tauri.conf.json` — Tauri configuration (bundle settings, entitlements, etc.)
+
+## Why Universal Binary?
+
+Apple [recommends](https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary) universal binaries for app distribution because:
+- Single download for all Mac users
+- Automatic architecture selection at runtime
+- Better user experience (no "Which Mac do I have?" confusion)
+
+Universal binaries are slightly larger (~1.5× size) but avoid the maintenance overhead of dual release channels.

--- a/apps/bootstrap-installer/src-tauri/tauri.conf.json
+++ b/apps/bootstrap-installer/src-tauri/tauri.conf.json
@@ -56,7 +56,7 @@
       }
     },
     "macOS": {
-      "minimumSystemVersion": "11.0",
+      "minimumSystemVersion": "12.0",
       "hardenedRuntime": true
     }
   },

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -12,6 +12,8 @@ Get Hermes Agent up and running in under two minutes!
 ### With the Hermes Desktop installer on macOS or Windows (recommended)
 To easily install the command-line and desktop applications, [download the Hermes Desktop installer](https://hermes-agent.nousresearch.com/) from our website and run it.
 
+**macOS support:** The installer is a universal binary supporting both Intel (x86_64) and Apple Silicon (arm64) Macs running macOS 12 (Monterey) or later.
+
 ### Without Hermes Desktop:
 For a command-line only install without Hermes Desktop, run:
 


### PR DESCRIPTION
## Problem

Official Hermes Desktop DMG (`Hermes-Setup.dmg`) is **arm64-only**, preventing Intel Mac users from installing via the GUI installer. The website claims "macOS 12+" support but the product doesn't deliver on Intel machines.

**Current behavior:**
- Official DMG: `Non-fat file: arm64`
- Intel Mac users: Cannot run the installer ("This app is not compatible with your Mac")
- Website promise: "macOS 12+" (implies both architectures)

**Root cause:**
`apps/bootstrap-installer` (Tauri 2.x) builds for **host architecture only** by default. Upstream build machines are ARM Macs → arm64-only DMG.

---

## Solution

Build a **universal macOS binary** containing both x86_64 and arm64 in a single DMG — the Apple-recommended distribution model for cross-architecture compatibility.

### Changes

1. **New GitHub Actions workflow** (`.github/workflows/build-desktop-installer.yml`)
   - Builds universal DMG on `installer-v*` tags or manual dispatch
   - Verifies binary contains both architectures (`lipo -info`)
   - Uploads to GitHub Release as draft

2. **New README** (`apps/bootstrap-installer/README.md`)
   - Universal build instructions
   - Architecture verification steps
   - Development workflow

3. **Raise minimum macOS version** (`tauri.conf.json`: 11.0 → 12.0)
   - Aligns with documented "macOS 12+" support

4. **Document Intel support** (`website/docs/getting-started/installation.md`)
   - Explicit note: "universal binary supporting both Intel (x86_64) and Apple Silicon (arm64)"

---

## Verification

**Local build on Intel Mac (x86_64):**

```bash
# Universal DMG
npx tauri build --target universal-apple-darwin

# Verify
lipo -info Hermes-Setup
# Output: Architectures in the fat file: ... are: x86_64 arm64
```

**DMG size:**
- arm64-only: 7.7 MB
- Universal: ~12 MB (1.5× size, expected for dual-arch binary)

---

## Impact

✅ **Intel Mac users can now install Hermes Desktop** via the official DMG  
✅ **Single download for all Mac users** (no "Which Mac do I have?" confusion)  
✅ **Aligns product with website promise** ("macOS 12+")  
✅ **Apple-recommended distribution model** ([Building a Universal macOS Binary](https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary))

---

## Checklist

- [x] Verified universal binary on Intel Mac (x86_64)
- [x] Added CI workflow for automated builds
- [x] Updated documentation
- [x] Raised minimumSystemVersion to match documented support (12.0)
- [ ] Tested on Apple Silicon Mac (CI will verify, or maintainers can test)
- [ ] Manual trigger workflow to generate first universal DMG

---

## Related

- If there's an open issue for Intel Mac installer support, this closes it
- Alternative to shipping two separate DMGs (x64 + arm64)