### PR TITLE
fix(feishu): honor FEISHU_ALLOWED_USERS=* wildcard for approval card clicks

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4173,6 +4173,13 @@ class FeishuAdapter(BasePlatformAdapter):
             return True
 
         if policy == "allowlist":
+            # `*` in the allowlist means "any user" — matches the documented
+            # FEISHU_ALLOWED_USERS=* semantics and the interactive-operator
+            # gate. Without this, `*` was treated as a literal id, so wildcard
+            # allowlists rejected everyone (e.g. approval card clicks, #51684).
+            # An empty allowlist still fails closed.
+            if "*" in allowlist:
+                return True
             return bool(sender_ids and (sender_ids & allowlist))
         if policy == "blacklist":
             return bool(sender_ids and not (sender_ids & blacklist))

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -615,6 +615,31 @@ class TestCardActionCallbackResponse:
         assert response.card is None
         mock_submit.assert_not_called()
 
+    def test_wildcard_allows_approval_click_from_any_user(self, _patch_callback_card_types):
+        # FEISHU_ALLOWED_USERS=* must authorize approval clicks from any user,
+        # not just literal-id matches (#51684).
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"*"}
+        adapter._approval_state[7] = {
+            "session_key": "sess-7",
+            "message_id": "msg-7",
+            "chat_id": "oc_12345",
+        }
+        data = _make_card_action_data(
+            {"hermes_action": "approve_once", "approval_id": 7},
+            open_id="ou_random_user",
+        )
+        adapter._sender_name_cache["ou_random_user"] = ("Rando", 9999999999)
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is not None
+        assert response.card.data["header"]["template"] == "green"
+
     def test_rejects_approval_click_when_callback_chat_mismatches(self, _patch_callback_card_types):
         adapter = _make_adapter()
         adapter._loop = MagicMock()


### PR DESCRIPTION
## Summary

Fixes #51684. `FEISHU_ALLOWED_USERS=*` is documented to allow any user, and the interactive prompt gate (`_is_interactive_operator_authorized`) honors `*`. But **approval / update-prompt card clicks** authorize through `_allow_group_message`, whose `allowlist` policy did a plain set intersection:

```python
return bool(sender_ids and (sender_ids & allowlist))
```

No real user id is literally `"*"`, so a wildcard allowlist intersected to empty and every approval click was rejected as `Unauthorized approval click by ou_xxx`.

## Fix

Honor `*` in the `allowlist` policy of `_allow_group_message`:

```python
if "*" in allowlist:
    return True
return bool(sender_ids and (sender_ids & allowlist))
```

- Wildcard allowlists now authorize any user (matching the documented `FEISHU_ALLOWED_USERS=*` semantics and the interactive-operator gate).
- An empty allowlist still **fails closed** (no `*`, empty intersection → `False`).
- Literal-id allowlists are unchanged.

This is the single gate both approval and update-prompt clicks use, so both are fixed, and group-message gating now treats `*` consistently.

## Tests

Adds `test_wildcard_allows_approval_click_from_any_user` (wildcard allowlist authorizes an arbitrary user's approval click → green "Approved" card). Existing auth tests stay green, including `test_rejects_approval_click_from_unauthorized_user` (literal allowlist still rejects non-members) and `test_update_prompt_empty_allowlists_fail_closed` (empty → fail closed). Full `test_feishu_approval_buttons.py`: 39 passed.
