### PR TITLE
fix: replace 8 assert statements and deprecated datetime.utcnow()

### DIFF
--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -396,7 +396,8 @@ class CodexAppServerSession:
             # turn re-spawns cleanly.
             result.should_retire = True
             return result
-        assert self._client is not None and self._thread_id is not None
+        if self._client is None or self._thread_id is None:
+            raise RuntimeError("send() called before connect()")
         result.thread_id = self._thread_id
 
         self._interrupt_event.clear()

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -217,13 +217,15 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         return text
 
     async def _api_get(self, path: str) -> Dict[str, Any]:
-        assert self.client is not None
+        if self.client is None:
+                raise RuntimeError("client not connected")
         res = await self.client.get(self._api_url(path))
         res.raise_for_status()
         return res.json()
 
     async def _api_post(self, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
-        assert self.client is not None
+        if self.client is None:
+                raise RuntimeError("client not connected")
         res = await self.client.post(self._api_url(path), json=payload)
         res.raise_for_status()
         return res.json()
@@ -476,7 +478,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         payload = {
             "addresses": [address],
             "message": message,
-            "tempGuid": f"temp-{datetime.utcnow().timestamp()}",
+            "tempGuid": f"temp-{datetime.now(timezone.utc).timestamp()}",
         }
         try:
             res = await self._api_post("/api/v1/chat/new", payload)
@@ -532,7 +534,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 )
             payload: Dict[str, Any] = {
                 "chatGuid": guid,
-                "tempGuid": f"temp-{datetime.utcnow().timestamp()}",
+                "tempGuid": f"temp-{datetime.now(timezone.utc).timestamp()}",
                 "message": chunk,
             }
             if reply_to and self._private_api_enabled and self._helper_connected:

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1335,7 +1335,8 @@ class WeixinAdapter(BasePlatformAdapter):
         logger.info("[%s] Disconnected", self.name)
 
     async def _poll_loop(self) -> None:
-        assert self._poll_session is not None
+        if self._poll_session is None:
+                raise RuntimeError("poll session not initialized")
         sync_buf = _load_sync_buf(self._hermes_home, self._account_id)
         timeout_ms = LONG_POLL_TIMEOUT_MS
         consecutive_failures = 0
@@ -1401,7 +1402,8 @@ class WeixinAdapter(BasePlatformAdapter):
             logger.error("[%s] unhandled inbound error from=%s: %s", self.name, _safe_id(message.get("from_user_id")), exc, exc_info=True)
 
     async def _process_message(self, message: Dict[str, Any]) -> None:
-        assert self._poll_session is not None
+        if self._poll_session is None:
+                raise RuntimeError("poll session not initialized")
         sender_id = str(message.get("from_user_id") or "").strip()
         if not sender_id:
             return
@@ -1813,7 +1815,8 @@ class WeixinAdapter(BasePlatformAdapter):
                 )
                 if wait > 0:
                     await asyncio.sleep(wait)
-        assert last_error is not None
+        if last_error is None:
+                last_error = RuntimeError("unknown error")
         raise last_error
 
     async def send(
@@ -2068,7 +2071,8 @@ class WeixinAdapter(BasePlatformAdapter):
         if not is_safe_url(url):
             raise ValueError(f"Blocked unsafe URL (SSRF protection): {url}")
 
-        assert self._send_session is not None
+        if self._send_session is None:
+                raise RuntimeError("send session not initialized")
         # Use asyncio.wait_for() instead of aiohttp ClientTimeout to avoid
         # "Timeout context manager should be used inside a task" errors.
         async def _do_fetch():
@@ -2088,7 +2092,8 @@ class WeixinAdapter(BasePlatformAdapter):
         caption: str,
         force_file_attachment: bool = False,
     ) -> str:
-        assert self._send_session is not None and self._token is not None
+        if self._send_session is None or self._token is None:
+                raise RuntimeError("send session or token not initialized")
         plaintext = Path(path).read_bytes()
         media_type, item_builder = self._outbound_media_builder(path, force_file_attachment=force_file_attachment)
         filekey = secrets.token_hex(16)


### PR DESCRIPTION
## What

Replace 8 `assert` statements with proper error handling, and fix 2 deprecated `datetime.utcnow()` calls.

## Changes (3 files, 18 insertions, 10 deletions)

### Assert replacements

| File | Count | Replacement |
|------|------:|-------------|
| `agent/transports/codex_app_server_session.py` | 1 | `RuntimeError` |
| `gateway/platforms/weixin.py` | 5 | `RuntimeError` |
| `gateway/platforms/bluebubbles.py` | 2 | `RuntimeError` |

### Deprecated API fix

| File | Change |
|------|--------|
| `gateway/platforms/bluebubbles.py` | `datetime.utcnow()` → `datetime.now(timezone.utc)` (deprecated since Python 3.12) |

Complements PR #51720 (5 other assert replacements).