### PR TITLE
fix: show cron in tools platform menu

### DIFF
--- a/hermes_cli/platforms.py
+++ b/hermes_cli/platforms.py
@@ -20,6 +20,7 @@ class PlatformInfo(NamedTuple):
 # Ordered so that TUI menus are deterministic.
 PLATFORMS: OrderedDict[str, PlatformInfo] = OrderedDict([
     ("cli",            PlatformInfo(label="🖥️  CLI",            default_toolset="hermes-cli")),
+    ("cron",           PlatformInfo(label="⏰ Cron",             default_toolset="hermes-cron")),
     ("telegram",       PlatformInfo(label="📱 Telegram",        default_toolset="hermes-telegram")),
     ("discord",        PlatformInfo(label="💬 Discord",         default_toolset="hermes-discord")),
     ("slack",          PlatformInfo(label="💼 Slack",           default_toolset="hermes-slack")),

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1302,8 +1302,8 @@ def run_post_setup_command(args) -> int:
 # ─── Platform / Toolset Helpers ───────────────────────────────────────────────
 
 def _get_enabled_platforms() -> List[str]:
-    """Return platform keys that are configured (have tokens or are CLI)."""
-    enabled = ["cli"]
+    """Return platform keys configured (always-local plus token-backed platforms)."""
+    enabled = ["cli", "cron"]
     if get_env_value("TELEGRAM_BOT_TOKEN"):
         enabled.append("telegram")
     if get_env_value("DISCORD_BOT_TOKEN"):

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -12,6 +12,7 @@ from hermes_cli.tools_config import (
     _checklist_toolset_keys,
     _configure_provider,
     _reconfigure_provider,
+    _get_enabled_platforms,
     _get_platform_tools,
     _platform_toolset_summary,
     _reconfigure_tool,
@@ -21,6 +22,7 @@ from hermes_cli.tools_config import (
     _toolset_needs_configuration_prompt,
     CONFIGURABLE_TOOLSETS,
     TOOL_CATEGORIES,
+    PLATFORMS,
     gui_toolset_label,
     _visible_providers,
     tools_command,
@@ -345,6 +347,13 @@ def test_platform_toolset_summary_uses_explicit_platform_list():
 
     assert set(summary.keys()) == {"cli"}
     assert summary["cli"] == _get_platform_tools(config, "cli")
+
+
+def test_cron_is_available_in_tools_platform_menu():
+    """`hermes tools` builds its platform menu from PLATFORMS."""
+    assert PLATFORMS["cron"]["default_toolset"] == "hermes-cron"
+    assert "cron" in _get_enabled_platforms()
+    assert "cronjob" in _get_platform_tools({}, "cron")
 
 
 def test_get_platform_tools_includes_enabled_mcp_servers_by_default():
@@ -1540,5 +1549,4 @@ def test_real_configurable_changes_still_reported_in_diff():
     # User adds 'vision' (configurable) — must still report as added.
     new_enabled2 = (current - {"kanban"}) | {"vision"}
     assert ((new_enabled2 - current) & universe) == {"vision"}
-
 


### PR DESCRIPTION
## What does PR do?

Fixes #51771.

`hermes tools` built its curses platform menu from `_get_enabled_platforms()`, which only seeded `cli` plus token-detected messaging platforms. `cron` already had a `hermes-cron` toolset and `hermes tools list --platform cron` worked, but the interactive platform picker never offered cron.

This PR:

- registers `cron` in the shared platform registry with `default_toolset="hermes-cron"`
- treats `cron` as an always-local tools platform alongside `cli`
- adds a regression test that verifies the menu source sees cron and cron resolves the `cronjob` toolset

- [x] I've updated tests or added coverage for the change — `tests/hermes_cli/test_tools_config.py`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per compatibility guide — cron is an existing local platform/toolset; this only exposes it in the existing tools UI
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Duplicate search per `CONTRIBUTING.md`:

- `gh search issues --repo NousResearch/hermes-agent "\"hermes tools\" \"cron\"" --state open/closed` -> no duplicates besides the target issue
- `gh search prs --repo NousResearch/hermes-agent "\"hermes tools\" \"cron\"" --state open/closed` -> no duplicates

Tests:

```bash
scripts/run_tests.sh tests/hermes_cli/test_tools_config.py tests/gateway/test_platform_registry.py tests/gateway/test_api_server_toolset.py -- -q
```

Result: 160 tests passed.

Direct sanity check:

```bash
.venv/bin/python - <<'PY'
from hermes_cli.tools_config import PLATFORMS, _get_enabled_platforms, _get_platform_tools
print(_get_enabled_platforms())
print(PLATFORMS['cron'])
print('cronjob' in _get_platform_tools({}, 'cron'))
PY
```

Output:

```text
['cli', 'cron']
{'label': '⏰ Cron', 'default_toolset': 'hermes-cron'}
True
```
