### PR TITLE
fix: add EnvironmentFile to systemd unit so .env tokens are visible

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2594,6 +2594,7 @@ Environment="LOGNAME={username}"
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"
+EnvironmentFile=-{hermes_home}/.env
 Restart=always
 RestartSec=5
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
@@ -2627,6 +2628,7 @@ WorkingDirectory={working_dir}
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"
+EnvironmentFile=-{hermes_home}/.env
 Restart=always
 RestartSec=5
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}


### PR DESCRIPTION
## Problem

The systemd unit template for both system-level and user-level gateway services only sets `Environment` for `HERMES_HOME`, `PATH`, `VIRTUAL_ENV` etc., but NOT `EnvironmentFile` for `~/.hermes/.env`.

This means tokens stored in `.env` (`TELEGRAM_BOT_TOKEN`, `DISCORD_BOT_TOKEN`, etc.) are invisible to the systemd service on startup. The gateway exits with a connection error → `Restart=always` triggers → infinite crash loop.

## Fix

Add `EnvironmentFile=-{hermes_home}/.env` after the `HERMES_HOME` `Environment` line in both templates (system-level and user-level).

The `-` prefix makes the file optional — first-time installs without a `.env` file don't error.

## Verification

- `test_gateway_service.py`: 154 passed (9 system-level root-related deselected — pre-existing environment issue)
- `test_gateway.py`: 48 passed
- `test_gateway_linger.py`: 6 passed