### PR TITLE
fix: replace 6 assert statements with explicit guards (batch 3)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4637,7 +4637,8 @@ def _run_with_idle_timeout(
 
     def _reader() -> None:
         nonlocal last_output_ts
-        assert proc.stdout is not None
+        if proc.stdout is None:
+                    raise RuntimeError("subprocess stdout not captured")
         for line in proc.stdout:
             try:
                 print(f"{indent}{line.rstrip()}", flush=True)

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -218,7 +218,8 @@ def run_oneshot(
         real_stderr.flush()
         return 1
 
-    assert response is not None  # narrowed by the empty-response guard above
+    if response is None:
+            raise RuntimeError("empty response after guard")
     real_stdout.write(response)
     if not response.endswith("\n"):
         real_stdout.write("\n")

--- a/plugins/google_meet/realtime/openai_client.py
+++ b/plugins/google_meet/realtime/openai_client.py
@@ -221,12 +221,14 @@ class RealtimeSession:
             return False
 
     def _send_json(self, payload: dict) -> None:
-        assert self._ws is not None
+        if self._ws is None:
+                raise RuntimeError("WebSocket not connected")
         with self._send_lock:
             self._ws.send(json.dumps(payload))
 
     def _recv(self, timeout: Optional[float] = None):
-        assert self._ws is not None
+        if self._ws is None:
+                raise RuntimeError("WebSocket not connected")
         try:
             if timeout is None:
                 return self._ws.recv()

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -107,7 +107,8 @@ async def _cdp_call(
     works for ``Target.*``, ``Browser.*``, ``Storage.*`` and a few other
     globally-scoped domains.
     """
-    assert websockets is not None  # guarded by _WS_AVAILABLE at call-site
+    if websockets is None:
+            raise RuntimeError("websockets not available")
 
     async with websockets.connect(
         ws_url,

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -944,7 +944,8 @@ class DockerEnvironment(BaseEnvironment):
                   timeout: int = 120,
                   stdin_data: str | None = None) -> subprocess.Popen:
         """Spawn a bash process inside the Docker container."""
-        assert self._container_id, "Container not started"
+        if not self._container_id:
+            raise RuntimeError("Container not started")
         cmd = [self._docker_exe, "exec"]
         if stdin_data is not None:
             cmd.append("-i")


### PR DESCRIPTION
## What

Replace 6 remaining `assert` statements with proper error handling.

## Changes (5 files, 12 insertions, 6 deletions)

| File | Replacement |
|------|-------------|
| `hermes_cli/main.py` | `assert proc.stdout` → `RuntimeError` |
| `hermes_cli/oneshot.py` | `assert response` → `RuntimeError` |
| `tools/browser_cdp_tool.py` | `assert websockets` → `RuntimeError` |
| `tools/environments/docker.py` | `assert container_id` → `RuntimeError` |
| `plugins/google_meet/realtime/openai_client.py` | 2× `assert ws` → `RuntimeError` |

Note: `plugins/security-guidance/patterns.py:353` assert is intentionally kept — it validates data integrity at module load time, not a runtime guard.

Complements PR #51720 (batch 1) and #51779 (batch 2).