### PR TITLE
fix(agent): classify max_tokens ceiling errors as format errors

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -270,6 +270,38 @@ _REQUEST_VALIDATION_PATTERNS = [
     "unsupported_parameter",
 ]
 
+_MAX_TOKENS_REQUEST_VALIDATION_PATTERNS = [
+    "above maximum value",
+    "integer above maximum",
+    "expected a value <=",
+    "expected value <=",
+]
+
+
+def _is_max_tokens_request_validation(error_msg: str, error_code: str, body: dict) -> bool:
+    """Return True when max_tokens itself is invalid, not the prompt size."""
+    error_obj = body.get("error", {}) if isinstance(body, dict) else {}
+    param = ""
+    error_type = ""
+    if isinstance(error_obj, dict):
+        param = str(error_obj.get("param") or "").lower()
+        error_type = str(error_obj.get("type") or "").lower()
+
+    code_lower = (error_code or "").lower()
+    invalid_code = code_lower in {
+        "invalidparameter",
+        "invalid_parameter",
+        "invalid_request_error",
+        "badrequest",
+        "bad_request",
+    }
+    if param == "max_tokens" and (invalid_code or error_type == "badrequest"):
+        return True
+
+    return "max_tokens" in error_msg and any(
+        p in error_msg for p in _MAX_TOKENS_REQUEST_VALIDATION_PATTERNS
+    )
+
 # OpenRouter aggregator policy-block patterns.
 #
 # When a user's OpenRouter account privacy setting (or a per-request
@@ -1013,6 +1045,15 @@ def _classify_400(
         )
 
     # Context overflow from 400
+    # max_tokens ceiling validation is about the requested output cap, not
+    # input context size. Keep it out of the compression recovery path.
+    if _is_max_tokens_request_validation(error_msg, error_code, body):
+        return result_fn(
+            FailoverReason.format_error,
+            retryable=False,
+            should_fallback=True,
+        )
+
     if any(p in error_msg for p in _CONTEXT_OVERFLOW_PATTERNS):
         return result_fn(
             FailoverReason.context_overflow,

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -576,6 +576,31 @@ class TestClassifyApiError:
         result = classify_api_error(e)
         assert result.reason == FailoverReason.context_overflow
 
+    def test_400_max_tokens_above_provider_ceiling_is_format_error(self):
+        """max_tokens request validation is not input context overflow."""
+        e = MockAPIError(
+            "HTTP 400: The parameter `max_tokens` specified in the request are not "
+            "valid: integer above maximum value, expected a value <= 32768, but got "
+            "65536 instead.",
+            status_code=400,
+            body={
+                "error": {
+                    "code": "InvalidParameter",
+                    "param": "max_tokens",
+                    "type": "BadRequest",
+                    "message": (
+                        "The parameter `max_tokens` specified in the request are not "
+                        "valid: integer above maximum value, expected a value <= 32768, "
+                        "but got 65536 instead."
+                    ),
+                }
+            },
+        )
+        result = classify_api_error(e, provider="custom", model="kimi-k2.7-code")
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+        assert result.should_compress is False
+
     def test_400_generic_large_session(self):
         """Generic 400 with large session → context overflow heuristic."""
         e = MockAPIError(


### PR DESCRIPTION
## What does PR do?

Fixes a classifier false positive where OpenAI-compatible providers that reject an oversized `max_tokens` request cap were treated as context-window overflows. That sent Hermes into context compression even though the prompt was not too large, and retries kept sending the same invalid output cap.

This PR routes structured or clearly worded `max_tokens` ceiling validation failures into the existing non-retryable `format_error` bucket before the broad context-overflow substring matcher sees `max_tokens`.

## Related Issue

Fixes #51773

## Type Change

- [x] 🐛 Bug fix (non-breaking change fixes issue)
- [ ] ✨ New feature (non-breaking change adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled hub)

## Changes Made

- Added a narrow `max_tokens` request-validation classifier guard in `agent/error_classifier.py`.
- Added a regression test covering the Volcengine Ark-style `InvalidParameter` / `param=max_tokens` / `expected a value <= 32768` response.
- Preserved existing context-overflow behavior for genuine prompt/context length errors.

## How Test

1. `scripts/run_tests.sh tests/agent/test_error_classifier.py`
2. `scripts/run_tests.sh tests/test_ctx_halving_fix.py`
3. Duplicate search: `gh search prs` / `gh search issues` for `max_tokens context_overflow InvalidParameter` and `Volcengine Ark max_tokens` returned no matching PRs/issues beyond the target issue.

## Checklist

### Code

- [x] I've read [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) make sure isn't duplicate
- [x] My PR contains **only** changes related fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` all tests pass
- [x] I've added tests changes (required bug fixes, strongly encouraged features)
- [x] I've tested on my platform: macOS, focused test files via `scripts/run_tests.sh`

### Documentation & Housekeeping

- [x] I've considered cross-platform impact (Windows, macOS) per [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — classifier-only change, N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
scripts/run_tests.sh tests/agent/test_error_classifier.py
=== Summary: 1 files, 162 tests passed, 0 failed (100% complete) in 1.3s ===

scripts/run_tests.sh tests/test_ctx_halving_fix.py
=== Summary: 1 files, 27 tests passed, 0 failed (100% complete) in 1.7s ===
```
