### PR TITLE
feat(raft): add gateway setup wizard

### DIFF
--- a/plugins/platforms/raft/adapter.py
+++ b/plugins/platforms/raft/adapter.py
@@ -754,6 +754,48 @@ def _env_enablement() -> Optional[dict]:
     return {"enabled": True}
 
 
+def interactive_setup() -> None:
+    """Interactive ``hermes gateway setup`` flow for the Raft platform.
+
+    Lazy-imports CLI helpers so the plugin stays importable in gateway runtime
+    and test contexts. The flow persists ``RAFT_PROFILE`` to the Hermes env
+    file so the Raft adapter auto-enables after a gateway restart.
+    """
+    from hermes_cli.cli_output import (
+        print_header,
+        print_info,
+        print_success,
+        print_warning,
+        prompt,
+        prompt_yes_no,
+    )
+    from hermes_cli.config import get_env_value, save_env_value
+
+    print_header("Raft")
+    existing_profile = get_env_value("RAFT_PROFILE")
+    if existing_profile:
+        print_info(f"Raft: already configured (profile: {existing_profile})")
+        if not prompt_yes_no("Reconfigure Raft?", False):
+            print_info(f"Keeping RAFT_PROFILE={existing_profile}.")
+            return
+
+    print_info("Connect Hermes to Raft as an external agent.")
+    print_info("Create the External Agent in Raft first, then run:")
+    print_info("  raft agent login --server <server-url> --agent <agent-id> --profile-slug <slug>")
+    print()
+
+    profile = prompt("Raft profile slug", default=existing_profile or "")
+    if not profile:
+        print_warning("Raft profile slug is required; skipping Raft setup")
+        return
+
+    save_env_value("RAFT_PROFILE", profile.strip())
+
+    print()
+    print_success("Raft configuration saved")
+    print_info("Restart the gateway for changes to take effect: hermes gateway restart")
+
+
 def register(ctx) -> None:
     """Plugin entry point — called by the Hermes plugin system."""
     ctx.register_platform(
@@ -764,6 +806,7 @@ def register(ctx) -> None:
         is_connected=_is_connected,
         required_env=["RAFT_PROFILE"],
         install_hint="Install the Raft CLI from https://raft.build",
+        setup_fn=interactive_setup,
         env_enablement_fn=_env_enablement,
         emoji="🔔",
         platform_hint=(

--- a/tests/gateway/test_raft_adapter.py
+++ b/tests/gateway/test_raft_adapter.py
@@ -32,6 +32,7 @@ from plugins.platforms.raft.adapter import (
     _on_session_end,
     _on_session_finalize,
     check_raft_requirements,
+    interactive_setup,
     register,
 )
 from gateway.session import build_session_key
@@ -425,6 +426,34 @@ class TestRaftConfig:
         assert _is_connected(PlatformConfig(enabled=True, extra={"enabled": True})) is True
         assert _is_connected(PlatformConfig(enabled=True, extra={})) is False
 
+    def test_interactive_setup_saves_raft_profile(self, monkeypatch, tmp_path, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("RAFT_PROFILE", raising=False)
+        monkeypatch.setattr("builtins.input", lambda _prompt: "dev-profile")
+
+        interactive_setup()
+
+        assert (tmp_path / ".env").read_text(encoding="utf-8") == "RAFT_PROFILE=dev-profile\n"
+        assert os.environ["RAFT_PROFILE"] == "dev-profile"
+        out = capsys.readouterr().out
+        assert "Raft configuration saved" in out
+        assert "hermes gateway restart" in out
+
+    def test_interactive_setup_keeps_existing_profile_when_not_reconfigured(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        env_path = tmp_path / ".env"
+        env_path.write_text("RAFT_PROFILE=existing\n", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("RAFT_PROFILE", "existing")
+        monkeypatch.setattr("builtins.input", lambda _prompt: "n")
+
+        interactive_setup()
+
+        assert env_path.read_text(encoding="utf-8") == "RAFT_PROFILE=existing\n"
+        assert os.environ["RAFT_PROFILE"] == "existing"
+        assert "Keeping RAFT_PROFILE=existing" in capsys.readouterr().out
+
     def test_register_calls_register_platform(self):
         registered = {}
         hooks = {}
@@ -441,6 +470,7 @@ class TestRaftConfig:
         assert registered["name"] == "raft"
         assert registered["label"] == "Raft"
         assert registered["emoji"] == "🔔"
+        assert registered["setup_fn"] is interactive_setup
         assert "profile show" in registered["platform_hint"]
         assert "manual get" in registered["platform_hint"]
         assert "--profile" in registered["platform_hint"]


### PR DESCRIPTION
## What does this PR do?

Add an interactive setup wizard for the Raft platform adapter so `hermes gateway setup` can configure `RAFT_PROFILE` directly instead of falling through to a generic env-var hint.

The flow matches the existing platform adapter setup pattern: lazy CLI-helper imports, Hermes `cli_output` prompt/print helpers, existing-value detection, explicit reconfigure prompt, and persistence through `save_env_value()`.

## Related Issue

N/A — feature gap found during Raft external-agent onboarding.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/raft/adapter.py`: add `interactive_setup()` for `RAFT_PROFILE` setup using `hermes_cli.cli_output` helpers.
- `plugins/platforms/raft/adapter.py`: register `setup_fn=interactive_setup` in `register()`.
- `tests/gateway/test_raft_adapter.py`: cover saving `RAFT_PROFILE`, keeping an existing profile when not reconfigured, and registering `setup_fn`.

## How to Test

1. Run `hermes gateway setup` and select `Raft`.
2. Verify it prints the Raft login prerequisite and prompts for `RAFT_PROFILE`.
3. Enter a profile slug and verify it is saved to the Hermes env file (`hermes config env-path`).
4. Run setup again with an existing value and verify the `Reconfigure Raft?` keep-existing path.
5. Start or restart the gateway and verify the Raft adapter enables with the configured profile.

Local validation run on this PR head:

- `uv run --extra dev --extra messaging python -m pytest tests/gateway/test_raft_adapter.py` — 18 passed
- `uv run --extra dev ruff check plugins/platforms/raft/adapter.py tests/gateway/test_raft_adapter.py` — passed

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing Raft setup PR/work and made this PR only contain the setup wizard delta
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/Linux x64, focused commands listed above

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no docs change needed for this adapter setup hook
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, uses existing `RAFT_PROFILE`
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A, uses existing CLI prompt/env helpers
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A — CLI setup flow only; focused test and lint output listed above.