### PR TITLE
fix(agent): preserve required arrays in outbound tool schemas

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -15,6 +15,7 @@ sites unchanged.  Symbols that tests patch on ``run_agent`` (e.g.
 
 from __future__ import annotations
 
+import copy as _copy
 import json
 import logging
 import os
@@ -48,6 +49,81 @@ def _ra():
     """
     import run_agent
     return run_agent
+
+
+
+def _ensure_required_arrays_in_schema(schema: Any) -> Any:
+    """Ensure outbound JSON Schema object nodes carry array-valued required.
+
+    Some OpenAI-compatible-to-Bedrock proxies translate a missing JSON Schema
+    ``required`` key to ``null``. Bedrock rejects ``inputSchema.required=null``.
+    Keep this as an outbound compatibility pass only; do not mutate agent.tools.
+    """
+    if not isinstance(schema, dict):
+        return schema
+
+    if schema.get("type") == "object" or "properties" in schema:
+        props = schema.get("properties")
+        if not isinstance(props, dict):
+            props = {}
+            schema["properties"] = props
+
+        required = schema.get("required")
+        if isinstance(required, list):
+            schema["required"] = [
+                item for item in required
+                if isinstance(item, str) and item in props
+            ]
+        else:
+            schema["required"] = []
+
+    for key in ("properties", "$defs", "definitions"):
+        value = schema.get(key)
+        if isinstance(value, dict):
+            for child_key, child_schema in list(value.items()):
+                if isinstance(child_schema, dict):
+                    value[child_key] = _ensure_required_arrays_in_schema(child_schema)
+
+    for key in ("items", "additionalProperties"):
+        value = schema.get(key)
+        if isinstance(value, dict):
+            schema[key] = _ensure_required_arrays_in_schema(value)
+
+    for key in ("anyOf", "oneOf", "allOf"):
+        value = schema.get(key)
+        if isinstance(value, list):
+            schema[key] = [
+                _ensure_required_arrays_in_schema(item) if isinstance(item, dict) else item
+                for item in value
+            ]
+
+    return schema
+
+
+def _ensure_required_arrays_for_openai_tools(tools: Any) -> Any:
+    """Normalize a copied outbound tools payload for strict schema translators."""
+    if not isinstance(tools, list):
+        return tools
+
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+
+        function = tool.get("function")
+        if isinstance(function, dict):
+            parameters = function.get("parameters")
+            if isinstance(parameters, dict):
+                function["parameters"] = _ensure_required_arrays_in_schema(parameters)
+
+        input_schema = tool.get("input_schema")
+        if isinstance(input_schema, dict):
+            tool["input_schema"] = _ensure_required_arrays_in_schema(input_schema)
+
+        input_schema_camel = tool.get("inputSchema")
+        if isinstance(input_schema_camel, dict):
+            tool["inputSchema"] = _ensure_required_arrays_in_schema(input_schema_camel)
+
+    return tools
 
 
 def estimate_request_context_tokens(api_payload: Any) -> int:
@@ -554,7 +630,8 @@ def interruptible_api_call(agent, api_kwargs: dict):
 
 def build_api_kwargs(agent, api_messages: list) -> dict:
     """Build the keyword arguments dict for the active API mode."""
-    tools_for_api = agent.tools
+    tools_for_api = _copy.deepcopy(agent.tools) if agent.tools else None
+    tools_for_api = _ensure_required_arrays_for_openai_tools(tools_for_api)
 
     if agent.api_mode == "anthropic_messages":
         _transport = agent._get_transport()
@@ -627,7 +704,6 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         # main-model swap) sees the already-stripped schema.  See #27907.
         if is_xai_responses:
             try:
-                import copy as _copy
                 from tools.schema_sanitizer import (
                     strip_pattern_and_format,
                     strip_slash_enum,
@@ -635,6 +711,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
                 tools_for_api = _copy.deepcopy(tools_for_api)
                 tools_for_api, _ = strip_pattern_and_format(tools_for_api)
                 tools_for_api, _ = strip_slash_enum(tools_for_api)
+                tools_for_api = _ensure_required_arrays_for_openai_tools(tools_for_api)
             except Exception as exc:
                 logger.warning(
                     "%s⚠️ Failed to sanitize tool schemas for xAI: %s",

--- a/tests/agent/test_outbound_tool_required_arrays.py
+++ b/tests/agent/test_outbound_tool_required_arrays.py
@@ -1,0 +1,149 @@
+import copy
+
+from agent.chat_completion_helpers import _ensure_required_arrays_for_openai_tools
+
+
+def _normalize_one(parameters):
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "test_tool",
+                "parameters": parameters,
+            },
+        }
+    ]
+    return _ensure_required_arrays_for_openai_tools(copy.deepcopy(tools))[0]["function"]["parameters"]
+
+
+def test_missing_required_becomes_empty_array():
+    params = _normalize_one(
+        {
+            "type": "object",
+            "properties": {},
+        }
+    )
+
+    assert params["required"] == []
+
+
+def test_required_none_becomes_empty_array():
+    params = _normalize_one(
+        {
+            "type": "object",
+            "properties": {},
+            "required": None,
+        }
+    )
+
+    assert params["required"] == []
+
+
+def test_required_non_list_becomes_empty_array():
+    params = _normalize_one(
+        {
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": "query",
+        }
+    )
+
+    assert params["required"] == []
+
+
+def test_valid_required_is_preserved():
+    params = _normalize_one(
+        {
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+        }
+    )
+
+    assert params["required"] == ["query"]
+
+
+def test_invalid_required_entries_are_filtered_but_key_is_kept():
+    params = _normalize_one(
+        {
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query", "missing"],
+        }
+    )
+
+    assert params["required"] == ["query"]
+
+
+def test_all_invalid_required_entries_become_empty_array():
+    params = _normalize_one(
+        {
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["missing"],
+        }
+    )
+
+    assert params["required"] == []
+
+
+def test_nested_object_required_is_added():
+    params = _normalize_one(
+        {
+            "type": "object",
+            "properties": {
+                "payload": {
+                    "type": "object",
+                    "properties": {},
+                }
+            },
+        }
+    )
+
+    assert params["required"] == []
+    assert params["properties"]["payload"]["required"] == []
+
+
+def test_normalizer_does_not_mutate_original_tools():
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "test_tool",
+                "parameters": {
+                    "type": "object",
+                    "properties": {},
+                },
+            },
+        }
+    ]
+    before = copy.deepcopy(tools)
+
+    normalized = _ensure_required_arrays_for_openai_tools(copy.deepcopy(tools))
+
+    assert tools == before
+    assert normalized[0]["function"]["parameters"]["required"] == []
+
+
+def test_input_schema_variants_are_normalized_defensively():
+    tools = [
+        {
+            "name": "anthropic_style",
+            "input_schema": {
+                "type": "object",
+                "properties": {},
+            },
+        },
+        {
+            "name": "bedrock_style",
+            "inputSchema": {
+                "type": "object",
+                "properties": {},
+            },
+        },
+    ]
+
+    normalized = _ensure_required_arrays_for_openai_tools(copy.deepcopy(tools))
+
+    assert normalized[0]["input_schema"]["required"] == []
+    assert normalized[1]["inputSchema"]["required"] == []


### PR DESCRIPTION
## Summary

- Normalize the deep-copied outbound Chat Completions tool payload so JSON Schema object nodes always carry array-valued `required` fields.
- Preserve existing valid `required` entries and filter invalid entries instead of deleting the `required` key.
- Avoid changing global schema sanitizer behavior or mutating `agent.tools`.

## Why

Some OpenAI-compatible proxies that translate requests to AWS Bedrock Converse may convert a missing JSON Schema `required` key into `null`.

Bedrock rejects `inputSchema.required = null` with `TOOL_SCHEMA_INVALID` because `required` must be an array. Sending explicit `required: []` for object schemas is valid JSON Schema and avoids this class of proxy-side conversion failure.

## Tests

- `python -m py_compile agent/chat_completion_helpers.py tests/agent/test_outbound_tool_required_arrays.py`
- `python -m pytest -q tests/agent/test_outbound_tool_required_arrays.py`
- `build_api_kwargs` smoke test confirming outbound tools are normalized without mutating `agent.tools`
