### PR TITLE
fix(cli): include cron platform in hermes tools UI

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1303,7 +1303,7 @@ def run_post_setup_command(args) -> int:
 
 def _get_enabled_platforms() -> List[str]:
     """Return platform keys that are configured (have tokens or are CLI)."""
-    enabled = ["cli"]
+    enabled = ["cli", "cron"]
     if get_env_value("TELEGRAM_BOT_TOKEN"):
         enabled.append("telegram")
     if get_env_value("DISCORD_BOT_TOKEN"):


### PR DESCRIPTION
## What

Add `cron` to the list of always-available platforms in `_get_enabled_platforms()`.

## Why

`hermes tools` curses UI did not show the `cron` platform because `_get_enabled_platforms()` only returned platforms with explicit env tokens (telegram, discord, etc.) plus `cli`. Cron is a built-in feature that's always available, so it should be included alongside `cli`.

`hermes tools list --platform cron` worked because it bypassed `_get_enabled_platforms()`, but the curses UI used this function to build the platform list.

## Changes

- `hermes_cli/tools_config.py`: 1 file, 1 line change
- `enabled = ["cli"]` → `enabled = ["cli", "cron"]`

Closes #51771