### PR TITLE
fix: classify max_tokens cap errors as format errors

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -270,6 +270,14 @@ _REQUEST_VALIDATION_PATTERNS = [
     "unsupported_parameter",
 ]
 
+_MAX_TOKENS_VALUE_VALIDATION_PATTERNS = [
+    "integer above maximum value",
+    "above maximum value",
+    "expected a value <=",
+    "less than or equal to",
+    "must be less than or equal",
+]
+
 # OpenRouter aggregator policy-block patterns.
 #
 # When a user's OpenRouter account privacy setting (or a per-request
@@ -984,6 +992,13 @@ def _classify_400(
             should_fallback=False,
         )
 
+    if _is_max_tokens_value_validation_error(error_msg, error_code_lower, body):
+        return result_fn(
+            FailoverReason.format_error,
+            retryable=False,
+            should_fallback=True,
+        )
+
     # Request-validation errors (unsupported / unknown parameter) MUST be
     # checked BEFORE context_overflow.  A GPT-5 model rejecting max_tokens
     # returns:
@@ -1347,6 +1362,47 @@ def _extract_error_code(body: dict) -> str:
         if text and text != "400":
             return text
     return ""
+
+
+def _extract_error_param(body: dict) -> str:
+    """Extract the provider-reported parameter name from an error body."""
+    if not body:
+        return ""
+
+    error_obj = body.get("error", {})
+    if isinstance(error_obj, dict):
+        param = error_obj.get("param") or ""
+        if isinstance(param, str) and param.strip():
+            return param.strip()
+
+    param = body.get("param") or ""
+    if isinstance(param, str):
+        return param.strip()
+    return ""
+
+
+def _is_max_tokens_value_validation_error(
+    error_msg: str,
+    error_code_lower: str,
+    body: dict,
+) -> bool:
+    """Detect output-token cap validation, not context-window overflow."""
+    if not any(p in error_msg for p in _MAX_TOKENS_VALUE_VALIDATION_PATTERNS):
+        return False
+
+    error_param = _extract_error_param(body).lower()
+    if error_param == "max_tokens":
+        return True
+
+    if "max_tokens" not in error_msg:
+        return False
+
+    return error_code_lower in {
+        "invalidparameter",
+        "invalid_parameter",
+        "badrequest",
+        "bad_request",
+    }
 
 
 def _extract_message(error: Exception, body: dict) -> str:

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1022,6 +1022,37 @@ class TestClassifyApiError:
         assert result.retryable is False
         assert result.should_compress is False
 
+    def test_400_max_tokens_above_provider_limit_not_context_overflow(self):
+        """A provider-side max_tokens value limit is request validation."""
+        msg = (
+            "The parameter max_tokens specified in the request are not valid: "
+            "integer above maximum value, expected a value <= 32768, but got "
+            "65536 instead."
+        )
+        e = MockAPIError(
+            msg,
+            status_code=400,
+            body={
+                "error": {
+                    "message": msg,
+                    "code": "InvalidParameter",
+                    "param": "max_tokens",
+                    "type": "BadRequest",
+                }
+            },
+        )
+        result = classify_api_error(
+            e,
+            provider="custom",
+            model="ep-20250610112940-c9wgb",
+            approx_tokens=1000,
+            context_length=200000,
+        )
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+        assert result.should_compress is False
+        assert result.should_fallback is True
+
     def test_400_unknown_parameter_not_context_overflow(self):
         """'Unknown parameter' 400s are deterministic request-validation
         failures, not overflows."""


### PR DESCRIPTION
## What does this PR do?

Fixes a max_tokens request-validation misclassification in the API error classifier.

Some OpenAI-compatible providers reject an output cap above their allowed maximum with a 400 response such as `InvalidParameter` / `param=max_tokens`. Because `max_tokens` is also part of the context-overflow pattern list, Hermes classified these deterministic validation errors as `context_overflow`, entered the compression path, and retried without changing the invalid parameter.

This change recognizes provider-side max_tokens value limit errors as non-retryable `format_error`s before the context-overflow match runs. Real context-window overflows still use the existing compression path.

## Related Issue

Fixes #51773

## Type of Change

- [x] ?? Bug fix (non-breaking change that fixes an issue)
- [x] ? Tests (adding or improving test coverage)

## Changes Made

- `agent/error_classifier.py`: detect max_tokens value-limit validation errors before generic context-overflow matching.
- `tests/agent/test_error_classifier.py`: add a regression test for the Volcengine Ark-style `InvalidParameter` / `param=max_tokens` error body.

## How to Test

1. `uv run --locked --extra dev python -m pytest tests\agent\test_error_classifier.py -q`
2. `uv run --locked --extra dev ruff check .`
3. `uv run --locked --extra dev python scripts\check-windows-footguns.py --all`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / PowerShell

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

```text
uv run --locked --extra dev python -m pytest tests\agent\test_error_classifier.py -q
162 passed in 6.34s

uv run --locked --extra dev ruff check .
All checks passed!

uv run --locked --extra dev python scripts\check-windows-footguns.py --all
? No Windows footguns found (687 file(s) scanned).
```