### PR TITLE
fix(agent): remove max_tokens from context overflow error patterns

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -216,7 +216,6 @@ _CONTEXT_OVERFLOW_PATTERNS = [
     "context window",
     "prompt is too long",
     "prompt exceeds max length",
-    "max_tokens",
     "maximum number of tokens",
     # vLLM / local inference server patterns
     "exceeds the max_model_len",


### PR DESCRIPTION
## What

Remove the broad `"max_tokens"` substring from `_CONTEXT_OVERFLOW_PATTERNS` in `agent/error_classifier.py`.

## Why

The `"max_tokens"` pattern matches **any** error containing that string, including parameter-validation errors like:

```
The parameter `max_tokens` specified in the request are not valid:
integer above maximum value, expected a value <= 32768, but got 65536
```

This is a **parameter rejection**, not a context overflow. But the classifier mislabels it as `context_overflow`, triggering the compression loop. The compression call succeeds (it drops `max_tokens`), then the retry re-sends the same too-large `max_tokens=65536` → 400 again → infinite loop. The session is bricked from message #1.

## What still catches real context overflow

Other patterns already cover actual context-window errors:
- `"context length"`, `"context window"`, `"context size"`
- `"token limit"`, `"too many tokens"`, `"maximum number of tokens"`
- `"prompt is too long"`, `"prompt exceeds max length"`
- Provider-specific: `"max_model_len"`, `"slot context"`, `"n_ctx_slot"`

## Changes

- `agent/error_classifier.py`: 1 file, 1 line removed

Closes #51773