### PR TITLE
fix: use time.monotonic() for duration measurement (batch 2)

### DIFF
--- a/agent/rate_limit_tracker.py
+++ b/agent/rate_limit_tracker.py
@@ -49,7 +49,7 @@ class RateLimitBucket:
     @property
     def remaining_seconds_now(self) -> float:
         """Estimated seconds remaining until reset, adjusted for elapsed time."""
-        elapsed = time.time() - self.captured_at
+        elapsed = time.monotonic() - self.captured_at
         return max(0.0, self.reset_seconds - elapsed)
 
 

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -493,7 +493,7 @@ class SignalAdapter(BasePlatformAdapter):
             if not self._running:
                 break
 
-            elapsed = time.time() - self._last_sse_activity
+            elapsed = time.monotonic() - self._last_sse_activity
             if elapsed > HEALTH_CHECK_STALE_THRESHOLD:
                 logger.warning("Signal: SSE idle for %.0fs, checking daemon health", elapsed)
                 try:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6930,12 +6930,12 @@ def _run_install_with_heartbeat(
     know ``hermes update`` is still progressing even if pip/uv itself is silent.
     """
     done = threading.Event()
-    start = _time.time()
+    start = _time.monotonic()
 
     def _heartbeat() -> None:
         # Wait first, then print, so short installs don't emit noise.
         while not done.wait(heartbeat_interval_seconds):
-            elapsed = int(_time.time() - start)
+            elapsed = int(_time.monotonic() - start)
             print(
                 f"  … still installing dependencies ({elapsed}s elapsed)"
                 " — compiling Rust/C extensions can take several minutes",

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2404,7 +2404,7 @@ class MatrixAdapter(BasePlatformAdapter):
             #    room can deliver events spanning hours/days — those skews
             #    will be all over the place and reset the counter.
             if not self._clock_skew_warned and (
-                time.time() - self._startup_ts > 30
+                time.monotonic() - self._startup_ts > 30
             ):
                 skew = self._startup_ts - event_ts
                 # Sanity bound: malformed events with negative or absurd

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -359,7 +359,7 @@ class SimplexAdapter(BasePlatformAdapter):
             await asyncio.sleep(HEALTH_CHECK_INTERVAL)
             if not self._running:
                 break
-            elapsed = time.time() - self._last_ws_activity
+            elapsed = time.monotonic() - self._last_ws_activity
             if elapsed > HEALTH_CHECK_STALE_THRESHOLD:
                 logger.debug("SimpleX: WS application-idle for %.0fs", elapsed)
 

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -240,7 +240,7 @@ def dispatch_async_delegation(
                 "summary": None,
                 "error": f"{type(exc).__name__}: {exc}",
                 "api_calls": 0,
-                "duration_seconds": round(time.time() - dispatched_at, 2),
+                "duration_seconds": round(time.monotonic() - dispatched_at, 2),
             }
             status = "error"
         finally:
@@ -425,7 +425,7 @@ def dispatch_async_delegation_batch(
             combined = {
                 "results": [],
                 "error": f"{type(exc).__name__}: {exc}",
-                "total_duration_seconds": round(time.time() - dispatched_at, 2),
+                "total_duration_seconds": round(time.monotonic() - dispatched_at, 2),
             }
             status = "error"
         finally:


### PR DESCRIPTION
## What

Replace `time.time()` with `time.monotonic()` for elapsed-time calculations in 6 more files.

## Why

`time.monotonic()` is immune to system clock adjustments (NTP, manual changes). Using `time.time()` for duration can produce wrong intervals.

## Changes (6 files, 8 lines)

| File | What was fixed |
|------|----------------|
| `agent/rate_limit_tracker.py` | Elapsed since capture |
| `gateway/platforms/signal.py` | Elapsed since last SSE activity |
| `plugins/platforms/simplex/adapter.py` | Elapsed since last WS activity |
| `plugins/platforms/matrix/adapter.py` | Elapsed since startup |
| `hermes_cli/main.py` | Update start/elapsed |
| `tools/async_delegation.py` | Delegation duration |

Complements PR #51679 (batch 1: 5 files, 36 lines).