### PR TITLE
fix(desktop): keep stream-stall timer alive across overlay routes

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -97,7 +97,7 @@ export const AssistantMessage: FC<{
       >
         {/* Todos render in the composer status stack now, not inline. */}
         <MessagePrimitive.Parts components={MESSAGE_PARTS_COMPONENTS} />
-        {isPlaceholder ? <ResponseLoadingIndicator /> : isRunning && <StreamStallIndicator />}
+        {isPlaceholder ? <ResponseLoadingIndicator /> : isRunning && <StreamStallIndicator messageId={messageId} />}
         {previewTargets.length > 0 && (
           <div className="mt-3 flex flex-wrap gap-2">
             {previewTargets.map(target => (

--- a/apps/desktop/src/components/assistant-ui/thread/status.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/status.tsx
@@ -127,7 +127,7 @@ const STREAM_STALL_S = 2
 // Subscribes to the activity signal ITSELF (rather than taking it as a prop)
 // so that per-token updates re-render only this leaf, not the whole
 // AssistantMessage subtree.
-export const StreamStallIndicator: FC = () => {
+export const StreamStallIndicator: FC<{ messageId: string }> = ({ messageId }) => {
   const activity = useAuiState(s => {
     let textLength = 0
 
@@ -144,7 +144,6 @@ export const StreamStallIndicator: FC = () => {
 
   const [stalled, setStalled] = useState(false)
   const compacting = useStore($compactionActive)
-  const turnTimerKey = useActiveTurnTimerKey()
   // A pending clarify / approval / sudo / secret means the turn is paused on the
   // user, not working — so don't resurrect the "thinking" timer while they
   // decide (matches the pet's awaitingInput pose taking priority over busy).
@@ -158,7 +157,7 @@ export const StreamStallIndicator: FC = () => {
   }, [activity])
 
   const active = (stalled || compacting) && !awaitingInput
-  const elapsed = useElapsedSeconds(active, compacting ? turnTimerKey : undefined)
+  const elapsed = useElapsedSeconds(active, `stream-stall:${messageId}`)
 
   if (!active) {
     return null

--- a/apps/desktop/src/components/chat/activity-timer.test.tsx
+++ b/apps/desktop/src/components/chat/activity-timer.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from '@testing-library/react'
+import { act, cleanup, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { __resetElapsedTimerRegistryForTests, useElapsedSeconds } from './activity-timer'
@@ -18,6 +18,7 @@ describe('useElapsedSeconds', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+    cleanup()
     __resetElapsedTimerRegistryForTests()
   })
 
@@ -39,5 +40,55 @@ describe('useElapsedSeconds', () => {
     render(<Probe active timerKey="tool:abc" />)
 
     expect(screen.getByTestId('elapsed').textContent).toBe('8')
+  })
+
+  // Regression: opening a thread-level overlay (settings / agents /
+  // command-center) navigates to a different route and unmounts the chat
+  // route entirely (see <Routes element={null} path="settings" ...> in
+  // desktop-controller). Without a timerKey the elapsed clock resets to 0
+  // on every overlay open/close. A per-message timerKey (e.g.
+  // stream-stall:{messageId}) keeps the start time in the module registry
+  // across the unmount/remount cycle — same message keeps counting,
+  // different message resets (the key changes).
+  it('simulates overlay remount keeping the clock alive for the same message key', () => {
+    const { unmount } = render(<Probe active timerKey="stream-stall:msg-1" />)
+
+    act(() => {
+      vi.advanceTimersByTime(10_000)
+    })
+
+    expect(screen.getByTestId('elapsed').textContent).toBe('10')
+
+    // User opens settings overlay → chat route unmounts.
+    unmount()
+
+    act(() => {
+      vi.advanceTimersByTime(7_000)
+    })
+
+    // User closes settings overlay → chat route remounts with the same key.
+    render(<Probe active timerKey="stream-stall:msg-1" />)
+
+    expect(screen.getByTestId('elapsed').textContent).toBe('17')
+  })
+
+  it('resets when the message key changes via rerender', () => {
+    const { rerender } = render(<Probe active timerKey="stream-stall:msg-1" />)
+
+    act(() => {
+      vi.advanceTimersByTime(10_000)
+    })
+
+    expect(screen.getByTestId('elapsed').textContent).toBe('10')
+
+    // Simulate a new turn: the same component instance receives a new
+    // key.  The old key should be deleted from the registry.
+    rerender(<Probe active timerKey="stream-stall:msg-2" />)
+
+    act(() => {
+      vi.advanceTimersByTime(3_000)
+    })
+
+    expect(screen.getByTestId('elapsed').textContent).toBe('3')
   })
 })

--- a/apps/desktop/src/components/chat/activity-timer.ts
+++ b/apps/desktop/src/components/chat/activity-timer.ts
@@ -36,6 +36,14 @@ export function useElapsedSeconds(active = true, timerKey?: string): number {
   const [elapsed, setElapsed] = useState(() => Math.max(0, Math.floor((Date.now() - start.current) / 1000)))
 
   if (lastKey.current !== timerKey) {
+    // Clean up the previous key's registry entry when a mounted hook
+    // receives a new key (e.g. a new message id in ThinkingDisclosure).
+    // Components that unmount completely (StreamStallIndicator when
+    // isRunning becomes false) do NOT hit this path.
+    if (lastKey.current !== undefined) {
+      startedAtByKey.delete(lastKey.current)
+    }
+
     start.current = startedAt(timerKey)
     lastKey.current = timerKey
   }


### PR DESCRIPTION
## What does this PR do?

When opening modal overlays (Settings / Agents) the React Router switches to a <Route element={null} /> which unmounts the entire ChatView subtree. The StreamStallIndicator under each assistant message used useElapsedSeconds() without a timerKey, so every mount seeded Date.now() as the start time — closing the overlay appeared to reset the "Hermes is thinking" timer to zero.

Fix by passing a per-message timerKey (stream-stall:{messageId}) so the module-level registry preserves the start time across the unmount/remount cycle. A new message gets a new key, so the timer resets correctly when a new turn begins.

Also clean up the old key's registry entry when the timer key changes to prevent unbounded Map growth across turns.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- apps/desktop/src/components/assistant-ui/thread.tsx: pass messageId to StreamStallIndicator and use it as timerKey
- apps/desktop/src/components/chat/activity-timer.ts: clean up stale registry entries on key change
- apps/desktop/src/components/chat/activity-timer.test.tsx: add regression tests for overlay remount and key change

## How to Test

1. Send a message to the agent
2. While the agent is responding (or stalled), open Settings or Agents
3. Close the overlay
4. Verify the "Hermes is thinking" timer continues from where it was, not from 0

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

typecheck: pass tests: 3/3 pass (1 existing + 2 new regression tests) manual: verified on dev build
