### PR TITLE
fix(desktop): stop restoring popped-out composer

### DIFF
--- a/apps/desktop/src/store/composer-popout.test.ts
+++ b/apps/desktop/src/store/composer-popout.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const POPOUT_ENABLED_STORAGE_KEY = 'hermes.desktop.composerPopout.enabled'
+
+function installLocalStorage() {
+  const entries = new Map<string, string>()
+  const storage: Storage = {
+    get length() {
+      return entries.size
+    },
+    clear: () => entries.clear(),
+    getItem: key => (entries.has(key) ? entries.get(key)! : null),
+    key: index => Array.from(entries.keys())[index] ?? null,
+    removeItem: key => entries.delete(key),
+    setItem: (key, value) => entries.set(key, String(value))
+  }
+
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: storage
+  })
+}
+
+describe('composer popout store', () => {
+  beforeEach(() => {
+    installLocalStorage()
+  })
+
+  afterEach(() => {
+    window.localStorage.removeItem(POPOUT_ENABLED_STORAGE_KEY)
+    vi.resetModules()
+  })
+
+  it('ignores a stale persisted enabled flag on module import', async () => {
+    window.localStorage.setItem(POPOUT_ENABLED_STORAGE_KEY, 'true')
+    vi.resetModules()
+
+    const { $composerPoppedOut } = await import('./composer-popout')
+
+    expect($composerPoppedOut.get()).toBe(false)
+    expect(window.localStorage.getItem(POPOUT_ENABLED_STORAGE_KEY)).toBe('true')
+  })
+
+  it('does not persist the enabled flag when toggled', async () => {
+    window.localStorage.removeItem(POPOUT_ENABLED_STORAGE_KEY)
+    vi.resetModules()
+
+    const { $composerPoppedOut, setComposerPoppedOut } = await import('./composer-popout')
+
+    setComposerPoppedOut(true)
+
+    expect($composerPoppedOut.get()).toBe(true)
+    expect(window.localStorage.getItem(POPOUT_ENABLED_STORAGE_KEY)).toBeNull()
+
+    setComposerPoppedOut(false)
+
+    expect($composerPoppedOut.get()).toBe(false)
+    expect(window.localStorage.getItem(POPOUT_ENABLED_STORAGE_KEY)).toBeNull()
+  })
+})

--- a/apps/desktop/src/store/composer-popout.ts
+++ b/apps/desktop/src/store/composer-popout.ts
@@ -1,8 +1,7 @@
 import { atom } from 'nanostores'
 
-import { persistBoolean, persistString, storedBoolean, storedString } from '@/lib/storage'
+import { persistString, storedString } from '@/lib/storage'
 
-const POPOUT_ENABLED_STORAGE_KEY = 'hermes.desktop.composerPopout.enabled'
 const POPOUT_POSITION_STORAGE_KEY = 'hermes.desktop.composerPopout.position'
 
 /** Where the floating composer's bottom-right corner sits, measured as an inset
@@ -110,12 +109,11 @@ function clampPosition({ bottom, right }: PopoutPosition, size?: PopoutSize, are
   }
 }
 
-export const $composerPoppedOut = atom(storedBoolean(POPOUT_ENABLED_STORAGE_KEY, false))
+export const $composerPoppedOut = atom(false)
 export const $composerPopoutPosition = atom<PopoutPosition>(readPosition())
 
 export function setComposerPoppedOut(value: boolean) {
   $composerPoppedOut.set(value)
-  persistBoolean(POPOUT_ENABLED_STORAGE_KEY, value)
 }
 
 /** Move the box (state only by default). Used per-frame during a drag — no IO


### PR DESCRIPTION
## Summary
- starts the Desktop composer docked on every fresh renderer launch
- stops persisting the popped-out enabled flag while keeping popout position persistence
- adds a regression test for stale localStorage from older builds

## Validation
- `npm --workspace apps/desktop run test:ui -- src/store/composer-popout.test.ts`
- `npm --workspace apps/desktop run typecheck`
- `npm --workspace apps/desktop run build`

## Duplicate / related checks
- No open PR found for `popped out composer`, `desktop input field`, `localStorage composer`, or `floating composer`.
- Related but non-duplicate: #49610 / #49588 fixes the docked composer drag affordance; this PR fixes persisted restoration of an accidental popped-out state across restarts.
