### PR TITLE
fix(gateway): recover WeCom sends after lost subscription

### DIFF
--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -764,6 +764,10 @@ class WeComAdapter(BasePlatformAdapter):
                     logger.warning("[%s] Rejected non-image bytes: %s", self.name, exc)
                     return None
 
+            cached_image = self._try_cache_image_bytes(raw)
+            if cached_image:
+                return cached_image
+
             filename = str(media.get("filename") or media.get("name") or "wecom_file")
             return cache_document_from_bytes(raw, filename), mimetypes.guess_type(filename)[0] or "application/octet-stream"
 
@@ -794,6 +798,10 @@ class WeComAdapter(BasePlatformAdapter):
                 logger.warning("[%s] Rejected non-image bytes from %s: %s", self.name, url, exc)
                 return None
 
+        cached_image = self._try_cache_image_bytes(raw)
+        if cached_image:
+            return cached_image
+
         filename = self._guess_filename(url, headers.get("content-disposition"), content_type)
         return cache_document_from_bytes(raw, filename), content_type
 
@@ -817,6 +825,14 @@ class WeComAdapter(BasePlatformAdapter):
     @staticmethod
     def _mime_for_ext(ext: str, fallback: str = "application/octet-stream") -> str:
         return mimetypes.types_map.get(ext.lower(), fallback)
+
+    def _try_cache_image_bytes(self, data: bytes) -> Optional[Tuple[str, str]]:
+        """Cache bytes as an image when WeCom wrapped image content as a file."""
+        ext = self._detect_image_ext(data)
+        try:
+            return cache_image_from_bytes(data, ext), self._mime_for_ext(ext, fallback="image/jpeg")
+        except ValueError:
+            return None
 
     @staticmethod
     def _guess_extension(url: str, content_type: str, fallback: str) -> str:
@@ -1030,11 +1046,28 @@ class WeComAdapter(BasePlatformAdapter):
         errmsg = str(response.get("errmsg") or "unknown error")
         return f"WeCom errcode {errcode}: {errmsg}"
 
+    @staticmethod
+    def _is_lost_subscription_error(error: str) -> bool:
+        lowered = str(error or "").lower()
+        return "846609" in lowered or "not subscribed" in lowered
+
     @classmethod
     def _raise_for_wecom_error(cls, response: Dict[str, Any], operation: str) -> None:
         error = cls._response_error(response)
         if error:
             raise RuntimeError(f"{operation} failed: {error}")
+
+    async def _recover_lost_subscription(self, reason: str) -> bool:
+        logger.warning(
+            "[%s] WeCom send lost websocket subscription; reconnecting: %s",
+            self.name,
+            reason,
+        )
+        try:
+            await self.disconnect()
+        except Exception as exc:
+            logger.debug("[%s] Error while disconnecting stale WeCom websocket: %s", self.name, exc)
+        return await self.connect()
 
     @staticmethod
     def _decrypt_file_bytes(encrypted_data: bytes, aes_key: str) -> bytes:
@@ -1372,31 +1405,63 @@ class WeComAdapter(BasePlatformAdapter):
         if not chat_id:
             return SendResult(success=False, error="chat_id is required")
 
-        try:
+        async def _send_once() -> Dict[str, Any]:
             reply_req_id = self._reply_req_id_for_message(reply_to)
 
             if not reply_req_id and chat_id in self._last_chat_req_ids:
                 reply_req_id = self._last_chat_req_ids[chat_id]
 
             if reply_req_id:
-                response = await self._send_reply_markdown(reply_req_id, content)
-            else:
-                response = await self._send_request(
-                    APP_CMD_SEND,
-                    {
-                        "chatid": chat_id,
-                        "msgtype": "markdown",
-                        "markdown": {"content": content[:self.MAX_MESSAGE_LENGTH]},
-                    },
-                )
+                return await self._send_reply_markdown(reply_req_id, content)
+
+            return await self._send_request(
+                APP_CMD_SEND,
+                {
+                    "chatid": chat_id,
+                    "msgtype": "markdown",
+                    "markdown": {"content": content[:self.MAX_MESSAGE_LENGTH]},
+                },
+            )
+
+        try:
+            response = await _send_once()
         except asyncio.TimeoutError:
             return SendResult(success=False, error="Timeout sending message to WeCom")
         except Exception as exc:
-            logger.error("[%s] Send failed: %s", self.name, exc)
-            return SendResult(success=False, error=str(exc))
+            if self._is_lost_subscription_error(str(exc)):
+                try:
+                    if not await self._recover_lost_subscription(str(exc)):
+                        return SendResult(
+                            success=False,
+                            error=f"WeCom reconnect failed after send error: {exc}",
+                        )
+                    response = await _send_once()
+                except asyncio.TimeoutError:
+                    return SendResult(success=False, error="Timeout sending message to WeCom")
+                except Exception as retry_exc:
+                    logger.error("[%s] Send retry failed: %s", self.name, retry_exc)
+                    return SendResult(success=False, error=str(retry_exc))
+            else:
+                logger.error("[%s] Send failed: %s", self.name, exc)
+                return SendResult(success=False, error=str(exc))
 
         error = self._response_error(response)
+        if error and self._is_lost_subscription_error(error):
+            try:
+                if not await self._recover_lost_subscription(error):
+                    return SendResult(
+                        success=False,
+                        error=f"WeCom reconnect failed after send error: {error}",
+                    )
+                response = await _send_once()
+            except asyncio.TimeoutError:
+                return SendResult(success=False, error="Timeout sending message to WeCom")
+            except Exception as exc:
+                logger.error("[%s] Send retry failed: %s", self.name, exc)
+                return SendResult(success=False, error=str(exc))
+            error = self._response_error(response)
         if error:
+            logger.error("[%s] Send failed: %s", self.name, error)
             return SendResult(success=False, error=error)
 
         return SendResult(

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -503,6 +503,51 @@ class TestMediaUpload:
         assert Path(cached_path).read_bytes() == plaintext
         assert content_type == "application/octet-stream"
 
+    @pytest.mark.asyncio
+    async def test_cache_media_treats_base64_file_image_bytes_as_image(self):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+
+        cached = await adapter._cache_media(
+            "file",
+            {
+                "base64": base64.b64encode(png_bytes).decode("ascii"),
+                "filename": "quote.bin",
+            },
+        )
+
+        assert cached is not None
+        cached_path, content_type = cached
+        assert Path(cached_path).suffix == ".png"
+        assert Path(cached_path).read_bytes() == png_bytes
+        assert content_type == "image/png"
+
+    @pytest.mark.asyncio
+    async def test_cache_media_treats_downloaded_file_image_bytes_as_image(self):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+        adapter._download_remote_bytes = AsyncMock(
+            return_value=(
+                png_bytes,
+                {
+                    "content-type": "application/octet-stream",
+                    "content-disposition": 'attachment; filename="quote.bin"',
+                },
+            )
+        )
+
+        cached = await adapter._cache_media("file", {"url": "https://example.com/quote.bin"})
+
+        assert cached is not None
+        cached_path, content_type = cached
+        assert Path(cached_path).suffix == ".png"
+        assert Path(cached_path).read_bytes() == png_bytes
+        assert content_type == "image/png"
+
 
 class TestSend:
     @pytest.mark.asyncio
@@ -535,6 +580,60 @@ class TestSend:
 
         assert result.success is False
         assert "40001" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_send_reconnects_and_retries_lost_subscription_response(self):
+        from plugins.platforms.wecom.adapter import APP_CMD_SEND, WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter.disconnect = AsyncMock()
+        adapter.connect = AsyncMock(return_value=True)
+        calls = []
+
+        async def fake_send_request(cmd, body):
+            calls.append((cmd, body))
+            if len(calls) == 1:
+                return {
+                    "errcode": 846609,
+                    "errmsg": "aibot websocket not subscribed",
+                }
+            return {"headers": {"req_id": "req-2"}, "errcode": 0}
+
+        adapter._send_request = fake_send_request
+
+        result = await adapter.send("chat-123", "Hello WeCom")
+
+        assert result.success is True
+        assert result.message_id == "req-2"
+        adapter.disconnect.assert_awaited_once()
+        adapter.connect.assert_awaited_once()
+        assert [cmd for cmd, _body in calls] == [APP_CMD_SEND, APP_CMD_SEND]
+
+    @pytest.mark.asyncio
+    async def test_send_reconnects_and_retries_lost_subscription_exception(self):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._reply_req_ids["msg-1"] = "req-1"
+        adapter.disconnect = AsyncMock()
+        adapter.connect = AsyncMock(return_value=True)
+        adapter._send_reply_markdown = AsyncMock(
+            side_effect=[
+                RuntimeError(
+                    "send reply markdown failed: WeCom errcode 846609: "
+                    "aibot websocket not subscribed"
+                ),
+                {"headers": {"req_id": "req-2"}, "errcode": 0},
+            ]
+        )
+
+        result = await adapter.send("chat-123", "Hello WeCom", reply_to="msg-1")
+
+        assert result.success is True
+        assert result.message_id == "req-2"
+        adapter.disconnect.assert_awaited_once()
+        adapter.connect.assert_awaited_once()
+        assert adapter._send_reply_markdown.await_count == 2
 
     @pytest.mark.asyncio
     async def test_send_image_falls_back_to_text_for_remote_url(self):


### PR DESCRIPTION
## Summary
- reconnect and retry once when WeCom sends hit errcode 846609 / not subscribed
- cache inbound file-wrapped image bytes as images so quoted .bin images remain visible to the agent
- add WeCom regression tests for lost-subscription retry and file-wrapped image caching

## Testing
- python3 -m compileall plugins/platforms/wecom/adapter.py tests/gateway/test_wecom.py
- manual async smoke test for the new WeCom retry and image-cache paths

Note: full pytest was not run locally because pytest was not installed in the local Python environment.