### PR TITLE
fix(matrix): classify DMs from m.direct account data

### DIFF
--- a/contributors/emails/iain@orangesquash.org.uk
+++ b/contributors/emails/iain@orangesquash.org.uk
@@ -1,0 +1,1 @@
+iainlane

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -4508,10 +4508,12 @@ class MatrixAdapter(BasePlatformAdapter):
         *,
         force_refresh: bool = False,
     ) -> MatrixRoomIdentity:
-        """Resolve Matrix room identity without member-count DM heuristics.
+        """Resolve Matrix room identity.
 
-        Matrix ``m.direct`` account data is the authoritative DM signal, but
-        explicitly named rooms win over stale/conflicting DM account data.
+        ``m.direct`` account data is the authoritative DM signal, matching how
+        matrix-js-sdk and Element classify (their ``DMRoomMap`` is built from
+        ``m.direct``). An explicit room name does not demote a DM, and member
+        count does not promote a non-DM room.
         """
         cached = self._room_identities.get(room_id)
         cached_at = self._room_identity_cached_at.get(room_id, 0.0)
@@ -4528,23 +4530,18 @@ class MatrixAdapter(BasePlatformAdapter):
         member_count = await self._get_room_member_count(room_id)
         has_explicit_name = bool(room_name)
         is_direct = bool(self._dm_rooms.get(room_id, False))
-        # member_count is the primary DM signal: <=2 members means this is
-        # necessarily a 1:1 conversation (or self-DM), regardless of m.direct
-        # or room name. Most Matrix clients auto-name DM rooms (e.g.
-        # "Alice & Bot"), so the old `not has_explicit_name` check
-        # misclassified virtually all client-created DMs as rooms. Falls back
-        # to the m.direct + name heuristic when the count is unavailable (e.g.
-        # state_store and API query both fail). A room that grew to 3+ members
-        # but is still in stale m.direct is correctly classified as a room.
-        is_likely_dm = (member_count is not None and member_count <= 2) or (
-            is_direct and not has_explicit_name
-        )
-        conflict = bool(
-            is_direct
-            and has_explicit_name
-            and (member_count is None or member_count > 2)
-        )
-        chat_type = "dm" if is_likely_dm else "room"
+        # m.direct is the authoritative DM signal, matching matrix-js-sdk and
+        # Element: Element's DMRoomMap is built from m.direct account data, with
+        # the invite `is_direct` flag as the only fallback (both fold into
+        # `_dm_rooms`). Member count never promotes a room to a DM — a joined
+        # room with <=2 members is not a DM unless m.direct says so — and an
+        # explicit room name never demotes one, since clients routinely
+        # auto-name DMs (e.g. "Alice & Bot").
+        chat_type = "dm" if is_direct else "room"
+        # A room still in m.direct but grown past two members is most likely a
+        # group left behind by a stale m.direct entry; surface that for
+        # diagnostics without overriding the m.direct classification.
+        conflict = bool(is_direct and member_count is not None and member_count > 2)
         display_name = room_name or canonical_alias or room_id
 
         identity = MatrixRoomIdentity(

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2927,6 +2927,11 @@ class MatrixAdapter(BasePlatformAdapter):
                         self._room_identities.clear()
                         self._room_identity_cached_at.clear()
 
+                    # Apply live m.direct changes (e.g. Element marking or
+                    # unmarking a DM) before dispatching events, so messages
+                    # in the same sync batch see the new classification.
+                    self._update_dm_rooms_from_sync(sync_data)
+
                     # Advance the sync token so the next request is
                     # incremental instead of a full initial sync.
                     nb = sync_data.get("next_batch")
@@ -4583,6 +4588,10 @@ class MatrixAdapter(BasePlatformAdapter):
         if dm_data is None:
             return
 
+        self._apply_m_direct_content(dm_data)
+
+    def _apply_m_direct_content(self, dm_data: Dict) -> None:
+        """Rebuild the DM room cache from m.direct content."""
         dm_room_ids: Set[str] = set()
         for user_id, rooms in dm_data.items():
             if isinstance(rooms, list):
@@ -4632,6 +4641,31 @@ class MatrixAdapter(BasePlatformAdapter):
         self._dm_rooms[room_id] = True
         self._room_identities.pop(room_id, None)
         self._room_identity_cached_at.pop(room_id, None)
+
+    def _update_dm_rooms_from_sync(self, sync_data: Dict[str, Any]) -> None:
+        """Apply live m.direct updates delivered in a sync response.
+
+        Element edits m.direct account data when the user marks or unmarks a
+        room as a DM; the change arrives as a top-level account_data event on
+        the next sync, so the DM cache must not wait for a reconnect.
+        """
+        account_data = sync_data.get("account_data")
+        if not isinstance(account_data, dict):
+            return
+
+        events = account_data.get("events")
+        if not isinstance(events, list):
+            return
+
+        for raw_event in events:
+            if not isinstance(raw_event, dict):
+                continue
+            if raw_event.get("type") != "m.direct":
+                continue
+
+            content = raw_event.get("content")
+            if isinstance(content, dict):
+                self._apply_m_direct_content(content)
 
     # ------------------------------------------------------------------
     # Mention detection helpers

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -4758,10 +4758,12 @@ class MatrixAdapter(BasePlatformAdapter):
         *,
         force_refresh: bool = False,
     ) -> MatrixRoomIdentity:
-        """Resolve Matrix room identity without member-count DM heuristics.
+        """Resolve Matrix room identity.
 
-        Matrix ``m.direct`` account data is the authoritative DM signal, but
-        explicitly named rooms win over stale/conflicting DM account data.
+        ``m.direct`` account data is the authoritative DM signal, matching how
+        matrix-js-sdk and Element classify (their ``DMRoomMap`` is built from
+        ``m.direct``). An explicit room name does not demote a DM, and member
+        count does not promote a non-DM room.
         """
         cached = self._room_identities.get(room_id)
         cached_at = self._room_identity_cached_at.get(room_id, 0.0)
@@ -4778,23 +4780,18 @@ class MatrixAdapter(BasePlatformAdapter):
         member_count = await self._get_room_member_count(room_id)
         has_explicit_name = bool(room_name)
         is_direct = bool(self._dm_rooms.get(room_id, False))
-        # member_count is the primary DM signal: <=2 members means this is
-        # necessarily a 1:1 conversation (or self-DM), regardless of m.direct
-        # or room name. Most Matrix clients auto-name DM rooms (e.g.
-        # "Alice & Bot"), so the old `not has_explicit_name` check
-        # misclassified virtually all client-created DMs as rooms. Falls back
-        # to the m.direct + name heuristic when the count is unavailable (e.g.
-        # state_store and API query both fail). A room that grew to 3+ members
-        # but is still in stale m.direct is correctly classified as a room.
-        is_likely_dm = (member_count is not None and member_count <= 2) or (
-            is_direct and not has_explicit_name
-        )
-        conflict = bool(
-            is_direct
-            and has_explicit_name
-            and (member_count is None or member_count > 2)
-        )
-        chat_type = "dm" if is_likely_dm else "room"
+        # m.direct is the authoritative DM signal, matching matrix-js-sdk and
+        # Element: Element's DMRoomMap is built from m.direct account data, with
+        # the invite `is_direct` flag as the only fallback (both fold into
+        # `_dm_rooms`). Member count never promotes a room to a DM — a joined
+        # room with <=2 members is not a DM unless m.direct says so — and an
+        # explicit room name never demotes one, since clients routinely
+        # auto-name DMs (e.g. "Alice & Bot").
+        chat_type = "dm" if is_direct else "room"
+        # A room still in m.direct but grown past two members is most likely a
+        # group left behind by a stale m.direct entry; surface that for
+        # diagnostics without overriding the m.direct classification.
+        conflict = bool(is_direct and member_count is not None and member_count > 2)
         display_name = room_name or canonical_alias or room_id
 
         identity = MatrixRoomIdentity(

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2114,8 +2114,12 @@ class MatrixAdapter(BasePlatformAdapter):
                     "Matrix: initial sync complete, joined %d rooms",
                     len(self._joined_rooms),
                 )
-                # Build DM room cache from m.direct account data.
-                await self._refresh_dm_cache()
+                # Build the DM room cache before dispatching messages from the
+                # same sync response. Older homeservers may omit account data
+                # here, so retain the separate account-data request as a
+                # fallback.
+                if not self._update_dm_rooms_from_sync(sync_data):
+                    await self._refresh_dm_cache()
 
                 # Dispatch events from the initial sync so the OlmMachine
                 # receives to-device key shares queued while we were offline.
@@ -4892,7 +4896,7 @@ class MatrixAdapter(BasePlatformAdapter):
         self._room_identities.pop(room_id, None)
         self._room_identity_cached_at.pop(room_id, None)
 
-    def _update_dm_rooms_from_sync(self, sync_data: Dict[str, Any]) -> None:
+    def _update_dm_rooms_from_sync(self, sync_data: Dict[str, Any]) -> bool:
         """Apply live m.direct updates delivered in a sync response.
 
         Element edits m.direct account data when the user marks or unmarks a
@@ -4901,11 +4905,11 @@ class MatrixAdapter(BasePlatformAdapter):
         """
         account_data = sync_data.get("account_data")
         if not isinstance(account_data, dict):
-            return
+            return False
 
         events = account_data.get("events")
         if not isinstance(events, list):
-            return
+            return False
 
         for raw_event in events:
             if not isinstance(raw_event, dict):
@@ -4916,6 +4920,9 @@ class MatrixAdapter(BasePlatformAdapter):
             content = raw_event.get("content")
             if isinstance(content, dict):
                 self._apply_m_direct_content(content)
+                return True
+
+        return False
 
     # ------------------------------------------------------------------
     # Mention detection helpers

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -3058,6 +3058,11 @@ class MatrixAdapter(BasePlatformAdapter):
                         self._room_identities.clear()
                         self._room_identity_cached_at.clear()
 
+                    # Apply live m.direct changes (e.g. Element marking or
+                    # unmarking a DM) before dispatching events, so messages
+                    # in the same sync batch see the new classification.
+                    self._update_dm_rooms_from_sync(sync_data)
+
                     # Advance the sync token so the next request is
                     # incremental instead of a full initial sync.
                     nb = sync_data.get("next_batch")
@@ -4833,6 +4838,10 @@ class MatrixAdapter(BasePlatformAdapter):
         if dm_data is None:
             return
 
+        self._apply_m_direct_content(dm_data)
+
+    def _apply_m_direct_content(self, dm_data: Dict) -> None:
+        """Rebuild the DM room cache from m.direct content."""
         dm_room_ids: Set[str] = set()
         for user_id, rooms in dm_data.items():
             if isinstance(rooms, list):
@@ -4882,6 +4891,31 @@ class MatrixAdapter(BasePlatformAdapter):
         self._dm_rooms[room_id] = True
         self._room_identities.pop(room_id, None)
         self._room_identity_cached_at.pop(room_id, None)
+
+    def _update_dm_rooms_from_sync(self, sync_data: Dict[str, Any]) -> None:
+        """Apply live m.direct updates delivered in a sync response.
+
+        Element edits m.direct account data when the user marks or unmarks a
+        room as a DM; the change arrives as a top-level account_data event on
+        the next sync, so the DM cache must not wait for a reconnect.
+        """
+        account_data = sync_data.get("account_data")
+        if not isinstance(account_data, dict):
+            return
+
+        events = account_data.get("events")
+        if not isinstance(events, list):
+            return
+
+        for raw_event in events:
+            if not isinstance(raw_event, dict):
+                continue
+            if raw_event.get("type") != "m.direct":
+                continue
+
+            content = raw_event.get("content")
+            if isinstance(content, dict):
+                self._apply_m_direct_content(content)
 
     # ------------------------------------------------------------------
     # Mention detection helpers

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -3790,14 +3790,7 @@ class MatrixAdapter(BasePlatformAdapter):
         # federated Matrix user could invite the bot into arbitrary rooms,
         # exposing its presence and metadata. Mirrors the allow-list gate
         # used on the message/reaction paths.
-        allow_all = os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {
-            "true",
-            "1",
-            "yes",
-        }
-        if not allow_all and not (
-            self._allowed_user_ids and inviter in self._allowed_user_ids
-        ):
+        if not self._is_authorized_inviter(inviter):
             logger.warning(
                 "Matrix: rejecting invite to %s from unauthorized user %s",
                 room_id,
@@ -3819,6 +3812,22 @@ class MatrixAdapter(BasePlatformAdapter):
             is_direct=is_direct and bool(inviter),
             inviter=inviter,
         )
+
+    def _is_authorized_inviter(self, inviter: str) -> bool:
+        """Whether an invite from this user may be auto-joined.
+
+        Fails closed: an unknown (empty) inviter or an empty allowlist
+        rejects the invite, unless GATEWAY_ALLOW_ALL_USERS opts out of
+        gating entirely.
+        """
+        allow_all = os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {
+            "true",
+            "1",
+            "yes",
+        }
+        if allow_all:
+            return True
+        return bool(self._allowed_user_ids and inviter in self._allowed_user_ids)
 
     async def _join_room_by_id(self, room_id: str) -> bool:
         """Join a room by ID and refresh local caches on success."""
@@ -3896,6 +3905,25 @@ class MatrixAdapter(BasePlatformAdapter):
             # direct invite joined via reconciliation is never recorded in
             # m.direct and gets misclassified as a group.
             is_direct, inviter = self._extract_invite_dm_signal(invited_room)
+            # The inviter allowlist gate from _on_invite applies here too.
+            # Without it, an invite from an arbitrary federated user that
+            # arrives while the gateway is down would be auto-joined on
+            # restart, bypassing the gate. An inviter missing from the
+            # stripped invite state fails closed, like an empty sender in
+            # _on_invite.
+            if not self._is_authorized_inviter(inviter):
+                logger.warning(
+                    "Matrix: rejecting invite to %s from unauthorized user %s",
+                    room_id,
+                    inviter,
+                )
+                continue
+            if is_direct and not inviter:
+                logger.warning(
+                    "Matrix: joining direct invite to %s without recording it "
+                    "in m.direct because the invite state has no inviter",
+                    room_id,
+                )
             logger.info(
                 "Matrix: reconciling pending invite for %s (is_direct=%s)",
                 room_id,
@@ -3914,6 +3942,9 @@ class MatrixAdapter(BasePlatformAdapter):
         ``is_direct`` flag from the original invite; its sender is the
         inviter. Returns ``(False, "")`` when the signal is absent.
         """
+        if not self._user_id:
+            return False, ""
+
         if not isinstance(invited_room, dict):
             return False, ""
 

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -3887,11 +3887,61 @@ class MatrixAdapter(BasePlatformAdapter):
         invites = rooms.get("invite", {})
         if not isinstance(invites, dict):
             return
-        for room_id in invites:
+        for room_id, invited_room in invites.items():
             if room_id in self._joined_rooms:
                 continue
-            logger.info("Matrix: reconciling pending invite for %s", room_id)
-            self._schedule_invite_join(str(room_id))
+            # A pending invite reconciled here (e.g. after a gateway
+            # restart) never fires _on_invite, so the DM signal must be
+            # read from the stripped invite state instead. Without it, a
+            # direct invite joined via reconciliation is never recorded in
+            # m.direct and gets misclassified as a group.
+            is_direct, inviter = self._extract_invite_dm_signal(invited_room)
+            logger.info(
+                "Matrix: reconciling pending invite for %s (is_direct=%s)",
+                room_id,
+                is_direct,
+            )
+            self._schedule_invite_join(
+                str(room_id),
+                is_direct=is_direct and bool(inviter),
+                inviter=inviter,
+            )
+
+    def _extract_invite_dm_signal(self, invited_room: Any) -> tuple[bool, str]:
+        """Read the is_direct flag and inviter from a room's invite_state.
+
+        The stripped ``m.room.member`` event for our own user carries the
+        ``is_direct`` flag from the original invite; its sender is the
+        inviter. Returns ``(False, "")`` when the signal is absent.
+        """
+        if not isinstance(invited_room, dict):
+            return False, ""
+
+        invite_state = invited_room.get("invite_state", {})
+        if not isinstance(invite_state, dict):
+            return False, ""
+
+        events = invite_state.get("events", [])
+        if not isinstance(events, list):
+            return False, ""
+
+        for event in events:
+            if not isinstance(event, dict):
+                continue
+            if event.get("type") != "m.room.member":
+                continue
+            if self._user_id and event.get("state_key") != self._user_id:
+                continue
+
+            content = event.get("content", {})
+            if not isinstance(content, dict):
+                continue
+            if content.get("membership") != "invite":
+                continue
+
+            return bool(content.get("is_direct")), str(event.get("sender", ""))
+
+        return False, ""
 
     # ------------------------------------------------------------------
     # Reactions (send, receive, processing lifecycle)

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -541,6 +541,81 @@ class TestMatrixDmDetection:
             "!room_b:ex.org": False,
         }
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("initial_dm", "new_m_direct", "expected_dm"),
+        [
+            pytest.param(
+                False,
+                {"@alice:ex.org": ["!chat:ex.org"]},
+                True,
+                id="marked-as-dm",
+            ),
+            pytest.param(
+                True,
+                {},
+                False,
+                id="unmarked-as-dm",
+            ),
+        ],
+    )
+    async def test_live_m_direct_update_reclassifies_without_reconnect(
+        self, initial_dm, new_m_direct, expected_dm
+    ):
+        """An m.direct account-data event delivered in a sync response takes
+        effect immediately, without a reconnect or an account-data fetch."""
+        self.adapter._joined_rooms = {"!chat:ex.org"}
+        self.adapter._dm_rooms = {"!chat:ex.org": initial_dm}
+        self.adapter._client = MagicMock()
+        self.adapter._client.get_account_data = AsyncMock()
+        self.adapter._client.get_state_event = AsyncMock(side_effect=Exception("no state"))
+        self.adapter._client.state_store = MagicMock()
+        self.adapter._client.state_store.get_members = AsyncMock(
+            return_value=["@bot:ex.org", "@alice:ex.org"]
+        )
+
+        assert await self.adapter._is_dm_room("!chat:ex.org") is initial_dm
+
+        self.adapter._update_dm_rooms_from_sync(
+            {
+                "account_data": {
+                    "events": [{"type": "m.direct", "content": new_m_direct}]
+                },
+                "next_batch": "s2",
+            }
+        )
+
+        assert await self.adapter._is_dm_room("!chat:ex.org") is expected_dm
+        self.adapter._client.get_account_data.assert_not_awaited()
+
+    @pytest.mark.parametrize(
+        "sync_data",
+        [
+            pytest.param({}, id="no-account-data"),
+            pytest.param({"account_data": None}, id="account-data-not-dict"),
+            pytest.param({"account_data": {"events": None}}, id="events-not-list"),
+            pytest.param(
+                {
+                    "account_data": {
+                        "events": [
+                            "bogus",
+                            {"type": "m.push_rules", "content": {}},
+                            {"type": "m.direct", "content": None},
+                        ]
+                    }
+                },
+                id="irrelevant-or-malformed-events",
+            ),
+        ],
+    )
+    def test_update_dm_rooms_from_sync_ignores_irrelevant_payloads(self, sync_data):
+        self.adapter._joined_rooms = {"!dm:ex.org"}
+        self.adapter._dm_rooms = {"!dm:ex.org": True}
+
+        self.adapter._update_dm_rooms_from_sync(sync_data)
+
+        assert self.adapter._dm_rooms == {"!dm:ex.org": True}
+
 
 # ---------------------------------------------------------------------------
 # Reply fallback stripping
@@ -1550,6 +1625,53 @@ class TestMatrixSyncLoop:
         assert captured[0].source.chat_type == "dm"
 
         await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_sync_loop_applies_live_m_direct_reclassification(self):
+        """An Element-side DM reclassification arriving via sync account_data
+        takes effect without a reconnect or an account-data fetch."""
+        adapter = _make_adapter()
+        adapter._closing = False
+        adapter._joined_rooms = {"!chat:example.org"}
+        adapter._dm_rooms = {"!chat:example.org": False}
+
+        async def _sync_once(**kwargs):
+            adapter._closing = True
+            return {
+                "account_data": {
+                    "events": [
+                        {
+                            "type": "m.direct",
+                            "content": {"@alice:example.org": ["!chat:example.org"]},
+                        }
+                    ]
+                },
+                "rooms": {"join": {"!chat:example.org": {}}},
+                "next_batch": "s2",
+            }
+
+        mock_sync_store = MagicMock()
+        mock_sync_store.get_next_batch = AsyncMock(return_value=None)
+        mock_sync_store.put_next_batch = AsyncMock()
+
+        fake_client = MagicMock()
+        fake_client.sync = AsyncMock(side_effect=_sync_once)
+        fake_client.sync_store = mock_sync_store
+        fake_client.handle_sync = MagicMock(return_value=[])
+        fake_client.get_account_data = AsyncMock()
+        fake_client.get_state_event = AsyncMock(side_effect=Exception("no state"))
+        fake_client.state_store = MagicMock()
+        fake_client.state_store.get_members = AsyncMock(
+            return_value=["@bot:example.org", "@alice:example.org"]
+        )
+        adapter._client = fake_client
+
+        assert await adapter._is_dm_room("!chat:example.org") is False
+
+        await adapter._sync_loop()
+
+        assert await adapter._is_dm_room("!chat:example.org") is True
+        fake_client.get_account_data.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_room_message_after_invite_join_is_received(self):

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -384,6 +384,66 @@ class TestMatrixDmDetection:
         self.adapter._dm_rooms = {}
         assert self.adapter._dm_rooms.get("!unknown:ex.org") is None
 
+    @pytest.mark.asyncio
+    async def test_refresh_dm_cache_with_m_direct(self):
+        """_refresh_dm_cache should populate _dm_rooms from m.direct data."""
+        self.adapter._joined_rooms = {"!room_a:ex.org", "!room_b:ex.org", "!room_c:ex.org"}
+
+        mock_client = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.content = {
+            "@alice:ex.org": ["!room_a:ex.org"],
+            "@bob:ex.org": ["!room_b:ex.org"],
+        }
+        mock_client.get_account_data = AsyncMock(return_value=mock_resp)
+        self.adapter._client = mock_client
+
+        await self.adapter._refresh_dm_cache()
+
+        assert self.adapter._dm_rooms["!room_a:ex.org"] is True
+        assert self.adapter._dm_rooms["!room_b:ex.org"] is True
+        assert self.adapter._dm_rooms["!room_c:ex.org"] is False
+
+    @pytest.mark.asyncio
+    async def test_m_direct_room_is_dm(self):
+        """m.direct account data is the authoritative DM signal."""
+        self.adapter._joined_rooms = {"!dm_room:ex.org"}
+        self.adapter._dm_rooms = {"!dm_room:ex.org": True}
+        self.adapter._client = MagicMock()
+        self.adapter._client.get_state_event = AsyncMock(side_effect=Exception("no state"))
+        self.adapter._client.state_store = MagicMock()
+        self.adapter._client.state_store.get_members = AsyncMock(return_value=["@bot:ex.org", "@alice:ex.org"])
+
+        assert await self.adapter._is_dm_room("!dm_room:ex.org") is True
+
+    @pytest.mark.asyncio
+    async def test_two_member_room_not_in_m_direct_is_room(self):
+        """A two-member room NOT in m.direct is a room, not a DM.
+
+        Member count never promotes a room to a DM: matrix-js-sdk and Element
+        classify purely from m.direct (their DMRoomMap is built from it), so a
+        small room the user never marked direct stays a room.
+        """
+        self.adapter._joined_rooms = {"!project:ex.org"}
+        self.adapter._dm_rooms = {}
+        self.adapter._client = MagicMock()
+        self.adapter._client.get_state_event = AsyncMock(
+            side_effect=lambda room_id, event_type: {"name": "Project Room"}
+            if event_type == "m.room.name"
+            else (_ for _ in ()).throw(Exception("no alias"))
+        )
+        self.adapter._client.state_store = MagicMock()
+        self.adapter._client.state_store.get_members = AsyncMock(
+            return_value=["@bot:ex.org", "@alice:ex.org"]
+        )
+
+        identity = await self.adapter._resolve_room_identity("!project:ex.org")
+
+        assert identity.chat_type == "room"
+        assert identity.conflict is False
+        assert identity.display_name == "Project Room"
+        assert identity.joined_member_count == 2
+        assert await self.adapter._is_dm_room("!project:ex.org") is False
 
     @pytest.mark.asyncio
     async def test_named_two_member_dm_is_dm(self):
@@ -411,6 +471,75 @@ class TestMatrixDmDetection:
         assert identity.conflict is False
         assert identity.joined_member_count == 2
         assert await self.adapter._is_dm_room("!named_dm:ex.org") is True
+
+    @pytest.mark.asyncio
+    async def test_m_direct_room_grown_past_two_stays_dm_flags_conflict(self):
+        """m.direct stays authoritative even once a DM grows past two members.
+
+        Element keeps a room mapped as a DM until m.direct itself is updated,
+        so we do too. The grown-past-two case is surfaced via `conflict` for
+        diagnostics rather than silently reclassified.
+        """
+        self.adapter._joined_rooms = {"!grown:ex.org"}
+        self.adapter._dm_rooms = {"!grown:ex.org": True}
+        self.adapter._client = MagicMock()
+        self.adapter._client.get_state_event = AsyncMock(
+            side_effect=lambda room_id, event_type: {"content": {"name": "Ops Room"}}
+            if event_type == "m.room.name"
+            else (_ for _ in ()).throw(Exception("no alias"))
+        )
+        self.adapter._client.state_store = MagicMock()
+        self.adapter._client.state_store.get_members = AsyncMock(
+            return_value=["@bot:ex.org", "@alice:ex.org", "@bob:ex.org"]
+        )
+
+        identity = await self.adapter._resolve_room_identity("!grown:ex.org")
+
+        assert identity.chat_type == "dm"
+        assert identity.conflict is True
+        assert identity.joined_member_count == 3
+        assert await self.adapter._is_dm_room("!grown:ex.org") is True
+
+    @pytest.mark.asyncio
+    async def test_canonical_alias_used_when_name_missing(self):
+        self.adapter._joined_rooms = {"!alias:ex.org"}
+        self.adapter._dm_rooms = {}
+        self.adapter._client = MagicMock()
+
+        async def get_state_event(room_id, event_type):
+            if event_type == "m.room.name":
+                raise Exception("no name")
+            if event_type == "m.room.canonical_alias":
+                return {"content": {"alias": "#hermes:ex.org"}}
+            raise Exception("unknown")
+
+        self.adapter._client.get_state_event = AsyncMock(side_effect=get_state_event)
+        self.adapter._client.state_store = MagicMock()
+        self.adapter._client.state_store.get_members = AsyncMock(return_value=None)
+
+        identity = await self.adapter._resolve_room_identity("!alias:ex.org")
+
+        assert identity.display_name == "#hermes:ex.org"
+        assert identity.chat_type == "room"
+
+    @pytest.mark.asyncio
+    async def test_non_string_m_direct_entries_ignored(self):
+        self.adapter._joined_rooms = {"!room_a:ex.org", "!room_b:ex.org"}
+
+        mock_client = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.content = {
+            "@alice:ex.org": ["!room_a:ex.org", 42, None],
+        }
+        mock_client.get_account_data = AsyncMock(return_value=mock_resp)
+        self.adapter._client = mock_client
+
+        await self.adapter._refresh_dm_cache()
+
+        assert self.adapter._dm_rooms == {
+            "!room_a:ex.org": True,
+            "!room_b:ex.org": False,
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -1421,6 +1550,116 @@ class TestMatrixSyncLoop:
         assert captured[0].source.chat_type == "dm"
 
         await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_room_message_after_invite_join_is_received(self):
+        """After invite reconciliation joins a room, later room messages dispatch."""
+        adapter = _make_adapter()
+        adapter._closing = False
+        adapter._user_id = "@bot:example.org"
+        adapter._startup_ts = time.time() - 10
+        adapter._require_mention = True
+        adapter._text_batch_delay_seconds = 0
+        adapter._background_read_receipt = MagicMock()
+
+        captured = []
+
+        async def capture(event):
+            captured.append(event)
+
+        adapter.handle_message = capture
+
+        sync_count = 0
+
+        async def _sync(**kwargs):
+            nonlocal sync_count
+            sync_count += 1
+            if sync_count == 1:
+                return {
+                    "rooms": {"invite": {"!room:example.org": {}}},
+                    "next_batch": "s1",
+                }
+            adapter._closing = True
+            return {
+                "rooms": {"join": {"!room:example.org": {}}},
+                "next_batch": "s2",
+            }
+
+        event = types.SimpleNamespace(
+            sender="@alice:example.org",
+            event_id="$room1",
+            room_id="!room:example.org",
+            timestamp=int(time.time() * 1000),
+            content={
+                "msgtype": "m.text",
+                "body": "@bot:example.org hello room",
+                "m.mentions": {"user_ids": ["@bot:example.org"]},
+            },
+        )
+
+        mock_sync_store = MagicMock()
+        mock_sync_store.get_next_batch = AsyncMock(return_value=None)
+        mock_sync_store.put_next_batch = AsyncMock()
+
+        fake_client = MagicMock()
+        fake_client.sync = AsyncMock(side_effect=_sync)
+        fake_client.join_room = AsyncMock()
+        fake_client.sync_store = mock_sync_store
+        fake_client.get_account_data = AsyncMock(return_value=MagicMock(content={}))
+        fake_client.get_state_event = AsyncMock(side_effect=Exception("no state"))
+        fake_client.state_store = MagicMock()
+        fake_client.state_store.get_members = AsyncMock(return_value=["@bot:example.org", "@alice:example.org"])
+        fake_client.state_store.get_member = AsyncMock(return_value=None)
+
+        def handle_sync(sync_data):
+            if sync_data["next_batch"] == "s2":
+                return [asyncio.create_task(adapter._on_room_message(event))]
+            return []
+
+        fake_client.handle_sync = MagicMock(side_effect=handle_sync)
+        adapter._client = fake_client
+
+        await adapter._sync_loop()
+
+        fake_client.join_room.assert_awaited_once()
+        assert "!room:example.org" in adapter._joined_rooms
+        assert len(captured) == 1
+        # The invite carries no is_direct flag and the room is not in m.direct,
+        # so it is a group; the @mention is what gets the message dispatched.
+        assert captured[0].source.chat_type == "group"
+
+    @pytest.mark.asyncio
+    async def test_seconds_timestamp_is_not_treated_as_milliseconds(self):
+        adapter = _make_adapter()
+        adapter._user_id = "@bot:example.org"
+        adapter._startup_ts = time.time() - 10
+        adapter._dm_rooms = {"!dm:example.org": True}
+        adapter._text_batch_delay_seconds = 0
+        adapter._background_read_receipt = MagicMock()
+        adapter._client = MagicMock()
+        adapter._client.get_state_event = AsyncMock(side_effect=Exception("no state"))
+        adapter._client.state_store = MagicMock()
+        adapter._client.state_store.get_members = AsyncMock(return_value=["@bot:example.org", "@alice:example.org"])
+        adapter._client.state_store.get_member = AsyncMock(return_value=None)
+
+        captured = []
+
+        async def capture(event):
+            captured.append(event)
+
+        adapter.handle_message = capture
+
+        event = types.SimpleNamespace(
+            sender="@alice:example.org",
+            event_id="$seconds",
+            room_id="!dm:example.org",
+            timestamp=time.time(),
+            content={"msgtype": "m.text", "body": "seconds ts"},
+        )
+
+        await adapter._on_room_message(event)
+
+        assert len(captured) == 1
 
 
 class TestMatrixUploadAndSend:

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1689,6 +1689,7 @@ class TestMatrixSyncLoop:
         adapter._require_mention = True
         adapter._text_batch_delay_seconds = 0
         adapter._background_read_receipt = MagicMock()
+        adapter._allowed_user_ids = {"@alice:example.org"}
 
         captured = []
 
@@ -1704,7 +1705,22 @@ class TestMatrixSyncLoop:
             sync_count += 1
             if sync_count == 1:
                 return {
-                    "rooms": {"invite": {"!room:example.org": {}}},
+                    "rooms": {
+                        "invite": {
+                            "!room:example.org": {
+                                "invite_state": {
+                                    "events": [
+                                        {
+                                            "type": "m.room.member",
+                                            "state_key": "@bot:example.org",
+                                            "sender": "@alice:example.org",
+                                            "content": {"membership": "invite"},
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
                     "next_batch": "s1",
                 }
             adapter._closing = True

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1545,8 +1545,8 @@ class TestMatrixSyncLoop:
         assert captured[0].source.chat_type == "dm"
 
     @pytest.mark.asyncio
-    async def test_connect_receives_dm_from_initial_sync_dispatch(self):
-        """A DM delivered by initial sync should reach the message handler after connect."""
+    async def test_connect_applies_m_direct_before_initial_sync_dispatch(self):
+        """Initial sync account data classifies messages in the same response."""
         from plugins.platforms.matrix.adapter import MatrixAdapter
 
         adapter = MatrixAdapter(
@@ -1584,11 +1584,17 @@ class TestMatrixSyncLoop:
         mock_client.whoami = AsyncMock(return_value=MagicMock(user_id="@bot:example.org", device_id="DEV123"))
         mock_client.sync = AsyncMock(return_value={
             "rooms": {"join": {"!dm:example.org": {}}},
+            "account_data": {
+                "events": [
+                    {
+                        "type": "m.direct",
+                        "content": {"@alice:example.org": ["!dm:example.org"]},
+                    }
+                ]
+            },
             "next_batch": "s1",
         })
-        mock_client.get_account_data = AsyncMock(
-            return_value=MagicMock(content={"@alice:example.org": ["!dm:example.org"]})
-        )
+        mock_client.get_account_data = AsyncMock(side_effect=Exception("unavailable"))
         mock_client.get_state_event = AsyncMock(side_effect=Exception("no state"))
         mock_client.state_store = MagicMock()
         mock_client.state_store.get_members = AsyncMock(return_value=["@bot:example.org", "@alice:example.org"])

--- a/tests/gateway/test_matrix_dm_invite_recording.py
+++ b/tests/gateway/test_matrix_dm_invite_recording.py
@@ -183,34 +183,20 @@ class TestPendingInviteReconciliationRecordsDM:
         )
         assert adapter._dm_rooms.get("!dm_room:example.org") is True
 
-    @pytest.mark.parametrize(
-        "invite_state",
-        [
-            pytest.param(None, id="no-invite-state"),
-            pytest.param({"events": []}, id="empty-events"),
-            pytest.param(
-                {"events": [_member_invite_event(is_direct=False)]},
-                id="not-direct",
-            ),
-            pytest.param(
-                {"events": [_member_invite_event(state_key="@other:example.org")]},
-                id="member-event-for-other-user",
-            ),
-            pytest.param(
-                {"events": [_member_invite_event(sender="")]},
-                id="missing-inviter",
-            ),
-        ],
-    )
     @pytest.mark.asyncio
-    async def test_reconciled_invite_without_dm_signal_does_not_record(
-        self, invite_state
-    ):
+    async def test_reconciled_non_direct_invite_does_not_record(self):
+        """A pending invite without the is_direct flag joins (the inviter
+        is allow-listed) but records nothing in m.direct. Invites whose
+        inviter cannot be read from the stripped state at all are covered
+        by test_matrix_pending_invite_auth.py: they are rejected outright
+        by the inviter allowlist gate, so no join happens either."""
         adapter = _make_adapter()
         adapter._join_room_by_id = AsyncMock(return_value=True)
         adapter._record_dm_room = AsyncMock()
 
-        sync_data = _invite_sync_data(invite_state=invite_state)
+        sync_data = _invite_sync_data(
+            invite_state={"events": [_member_invite_event(is_direct=False)]}
+        )
         adapter._schedule_pending_invite_joins(sync_data)
         await self._drain_invite_tasks(adapter)
 

--- a/tests/gateway/test_matrix_dm_invite_recording.py
+++ b/tests/gateway/test_matrix_dm_invite_recording.py
@@ -102,6 +102,123 @@ class TestOnInviteRecordsDM:
 
 
 # ---------------------------------------------------------------------------
+# _schedule_pending_invite_joins DM recording
+# ---------------------------------------------------------------------------
+
+
+def _member_invite_event(
+    state_key="@hermes:example.org",
+    sender="@alice:example.org",
+    is_direct=True,
+    membership="invite",
+):
+    """Create a stripped m.room.member event as found in invite_state."""
+    return {
+        "type": "m.room.member",
+        "state_key": state_key,
+        "sender": sender,
+        "content": {"membership": membership, "is_direct": is_direct},
+    }
+
+
+def _invite_sync_data(room_id="!dm_room:example.org", invite_state=None):
+    """Create a sync payload with one pending invite room."""
+    room = {} if invite_state is None else {"invite_state": invite_state}
+    return {"rooms": {"invite": {room_id: room}}, "next_batch": "s1"}
+
+
+class TestPendingInviteReconciliationRecordsDM:
+    """_schedule_pending_invite_joins threads the DM signal from invite_state.
+
+    After a gateway restart a direct invite is reconciled from sync's
+    ``rooms.invite`` rather than a live invite event. The stripped
+    ``m.room.member`` event in ``invite_state`` still carries ``is_direct``
+    and the inviter; without threading them through, the room is never
+    recorded in ``m.direct`` and is misclassified as a group (surfaced by
+    the triage of #62493).
+    """
+
+    @staticmethod
+    async def _drain_invite_tasks(adapter):
+        """Await any tasks _schedule_invite_join spawned."""
+        for task in list(adapter._invite_join_tasks.values()):
+            await task
+
+    @pytest.mark.asyncio
+    async def test_reconciled_direct_invite_records_dm(self):
+        adapter = _make_adapter()
+        adapter._join_room_by_id = AsyncMock(return_value=True)
+        adapter._record_dm_room = AsyncMock()
+
+        sync_data = _invite_sync_data(
+            invite_state={"events": [_member_invite_event(is_direct=True)]}
+        )
+        adapter._schedule_pending_invite_joins(sync_data)
+        await self._drain_invite_tasks(adapter)
+
+        adapter._join_room_by_id.assert_awaited_once_with("!dm_room:example.org")
+        adapter._record_dm_room.assert_awaited_once_with(
+            "!dm_room:example.org", "@alice:example.org"
+        )
+
+    @pytest.mark.asyncio
+    async def test_reconciled_direct_invite_ends_up_classified_as_dm(self):
+        """End to end: the reconciled room lands in _dm_rooms as a DM."""
+        adapter = _make_adapter()
+        adapter._join_room_by_id = AsyncMock(return_value=True)
+        adapter._client = MagicMock()
+        adapter._client.get_account_data = AsyncMock(
+            side_effect=Exception("M_NOT_FOUND")
+        )
+        adapter._client.set_account_data = AsyncMock()
+
+        sync_data = _invite_sync_data(
+            invite_state={"events": [_member_invite_event(is_direct=True)]}
+        )
+        adapter._schedule_pending_invite_joins(sync_data)
+        await self._drain_invite_tasks(adapter)
+
+        adapter._client.set_account_data.assert_awaited_once_with(
+            "m.direct", {"@alice:example.org": ["!dm_room:example.org"]}
+        )
+        assert adapter._dm_rooms.get("!dm_room:example.org") is True
+
+    @pytest.mark.parametrize(
+        "invite_state",
+        [
+            pytest.param(None, id="no-invite-state"),
+            pytest.param({"events": []}, id="empty-events"),
+            pytest.param(
+                {"events": [_member_invite_event(is_direct=False)]},
+                id="not-direct",
+            ),
+            pytest.param(
+                {"events": [_member_invite_event(state_key="@other:example.org")]},
+                id="member-event-for-other-user",
+            ),
+            pytest.param(
+                {"events": [_member_invite_event(sender="")]},
+                id="missing-inviter",
+            ),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_reconciled_invite_without_dm_signal_does_not_record(
+        self, invite_state
+    ):
+        adapter = _make_adapter()
+        adapter._join_room_by_id = AsyncMock(return_value=True)
+        adapter._record_dm_room = AsyncMock()
+
+        sync_data = _invite_sync_data(invite_state=invite_state)
+        adapter._schedule_pending_invite_joins(sync_data)
+        await self._drain_invite_tasks(adapter)
+
+        adapter._join_room_by_id.assert_awaited_once_with("!dm_room:example.org")
+        adapter._record_dm_room.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
 # _record_dm_room
 # ---------------------------------------------------------------------------
 

--- a/tests/gateway/test_matrix_pending_invite_auth.py
+++ b/tests/gateway/test_matrix_pending_invite_auth.py
@@ -1,0 +1,190 @@
+"""Tests for the inviter allowlist gate on pending-invite reconciliation.
+
+``_on_invite`` only auto-joins when the inviter is allow-listed, but a
+pending invite reconciled from sync's ``rooms.invite`` after a gateway
+restart never fires ``_on_invite``. ``_schedule_pending_invite_joins``
+must apply the same gate, reading the inviter from the stripped invite
+state, or an invite from an arbitrary federated user that arrives while
+the gateway is down gets auto-joined on restart.
+"""
+
+import logging
+import time
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _make_adapter():
+    """Create a MatrixAdapter with mocked config and a one-user allowlist."""
+    from plugins.platforms.matrix.adapter import MatrixAdapter
+
+    config = PlatformConfig(
+        enabled=True,
+        token="syt_test_token",
+        extra={
+            "homeserver": "https://matrix.example.org",
+            "user_id": "@hermes:example.org",
+        },
+    )
+    adapter = MatrixAdapter(config)
+    adapter._text_batch_delay_seconds = 0
+    adapter.handle_message = AsyncMock()
+    adapter._startup_ts = time.time() - 10
+    adapter._allowed_user_ids = {"@alice:example.org"}
+    adapter._join_room_by_id = AsyncMock(return_value=True)
+    adapter._record_dm_room = AsyncMock()
+    return adapter
+
+
+def _member_invite_event(
+    state_key="@hermes:example.org",
+    sender="@alice:example.org",
+    is_direct=True,
+    membership="invite",
+):
+    """Create a stripped m.room.member event as found in invite_state."""
+    return {
+        "type": "m.room.member",
+        "state_key": state_key,
+        "sender": sender,
+        "content": {"membership": membership, "is_direct": is_direct},
+    }
+
+
+def _invite_sync_data(room_id="!pending_room:example.org", invite_state=None):
+    """Create a sync payload with one pending invite room."""
+    room = {} if invite_state is None else {"invite_state": invite_state}
+    return {"rooms": {"invite": {room_id: room}}, "next_batch": "s1"}
+
+
+async def _drain_invite_tasks(adapter):
+    """Await any tasks _schedule_invite_join spawned."""
+    for task in list(adapter._invite_join_tasks.values()):
+        await task
+
+
+class TestPendingInviteAuthorization:
+    """_schedule_pending_invite_joins applies _on_invite's inviter gate.
+
+    Rejection mirrors _on_invite exactly: no join is scheduled (so no
+    entry lands in _invite_join_tasks), nothing is recorded in m.direct,
+    and the pending invite is otherwise left untouched.
+    """
+
+    @pytest.mark.asyncio
+    async def test_allowed_inviter_is_joined(self):
+        adapter = _make_adapter()
+
+        sync_data = _invite_sync_data(invite_state={"events": [_member_invite_event()]})
+        adapter._schedule_pending_invite_joins(sync_data)
+        await _drain_invite_tasks(adapter)
+
+        adapter._join_room_by_id.assert_awaited_once_with("!pending_room:example.org")
+        adapter._record_dm_room.assert_awaited_once_with(
+            "!pending_room:example.org", "@alice:example.org"
+        )
+
+    @pytest.mark.asyncio
+    async def test_unknown_bot_user_id_fails_closed(self):
+        adapter = _make_adapter()
+        adapter._user_id = ""
+
+        sync_data = _invite_sync_data(invite_state={"events": [_member_invite_event()]})
+        adapter._schedule_pending_invite_joins(sync_data)
+        await _drain_invite_tasks(adapter)
+
+        adapter._join_room_by_id.assert_not_awaited()
+        adapter._record_dm_room.assert_not_awaited()
+        assert adapter._invite_join_tasks == {}
+
+    @pytest.mark.parametrize(
+        "invite_state",
+        [
+            pytest.param(
+                {"events": [_member_invite_event(sender="@mallory:evil.example")]},
+                id="non-allowed-inviter",
+            ),
+            pytest.param(None, id="no-invite-state"),
+            pytest.param({"events": []}, id="empty-events"),
+            pytest.param(
+                {"events": [_member_invite_event(state_key="@other:example.org")]},
+                id="member-event-for-other-user",
+            ),
+            pytest.param(
+                {"events": [_member_invite_event(sender="")]},
+                id="missing-inviter",
+            ),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_unauthorized_or_unknown_inviter_is_not_joined(self, invite_state):
+        """An inviter outside the allowlist, or one that cannot be read
+        from the stripped invite state at all, fails closed like
+        _on_invite: no join is scheduled and nothing is recorded."""
+        adapter = _make_adapter()
+
+        sync_data = _invite_sync_data(invite_state=invite_state)
+        adapter._schedule_pending_invite_joins(sync_data)
+        await _drain_invite_tasks(adapter)
+
+        adapter._join_room_by_id.assert_not_awaited()
+        adapter._record_dm_room.assert_not_awaited()
+        assert adapter._invite_join_tasks == {}
+
+    @pytest.mark.asyncio
+    async def test_empty_allowlist_fails_closed(self):
+        """With no allowlist configured, _on_invite rejects every invite;
+        reconciliation must do the same."""
+        adapter = _make_adapter()
+        adapter._allowed_user_ids = set()
+
+        sync_data = _invite_sync_data(invite_state={"events": [_member_invite_event()]})
+        adapter._schedule_pending_invite_joins(sync_data)
+        await _drain_invite_tasks(adapter)
+
+        adapter._join_room_by_id.assert_not_awaited()
+        adapter._record_dm_room.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_allow_all_env_bypasses_gate(self, monkeypatch):
+        """GATEWAY_ALLOW_ALL_USERS disables the gate, exactly as it does
+        for _on_invite, even when the inviter is unknown."""
+        monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+        adapter = _make_adapter()
+        adapter._allowed_user_ids = set()
+
+        sync_data = _invite_sync_data(invite_state=None)
+        adapter._schedule_pending_invite_joins(sync_data)
+        await _drain_invite_tasks(adapter)
+
+        adapter._join_room_by_id.assert_awaited_once_with("!pending_room:example.org")
+        adapter._record_dm_room.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_allow_all_logs_direct_invite_without_inviter(
+        self, monkeypatch, caplog
+    ):
+        monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+        adapter = _make_adapter()
+        adapter._allowed_user_ids = set()
+
+        sync_data = _invite_sync_data(
+            invite_state={"events": [_member_invite_event(sender="")]}
+        )
+        with caplog.at_level(
+            logging.WARNING,
+            logger="plugins.platforms.matrix.adapter",
+        ):
+            adapter._schedule_pending_invite_joins(sync_data)
+            await _drain_invite_tasks(adapter)
+
+        adapter._join_room_by_id.assert_awaited_once_with("!pending_room:example.org")
+        adapter._record_dm_room.assert_not_awaited()
+        assert [record.getMessage() for record in caplog.records] == [
+            "Matrix: joining direct invite to !pending_room:example.org "
+            "without recording it in m.direct because the invite state "
+            "has no inviter"
+        ]


### PR DESCRIPTION
## What does this PR do?

DM classification on main misfires in both directions; this PR classifies
from `m.direct` alone and makes that signal trustworthy.

### What is broken

The original report, [#48551], was about false negatives: most Matrix
clients auto-name a DM when creating it (for example "Alice & Bot"), so
the old `is_direct and not has_explicit_name` heuristic classified
virtually every client-created DM as a room and forced `require_mention`
gating inside legitimate one-on-one chats.

The salvage that fixed it, commit [`4aa79334`] (from #48554), replaced
the name check with a member count: any room with two or fewer members
is a DM, full stop. That trades one set of misclassifications for
another:

- False positives: every two-member room becomes a DM, including rooms
  the user never marked as direct. A small private project room, or a
  room where everyone else has left, silently gains DM semantics and
  loses mention gating.
- False negatives: a genuine DM that grows past two members (or whose
  member list is temporarily incomplete) is demoted to a room, even
  while the user's own client still shows it as a DM. The fallback path
  for when the count is unavailable also reinstates the old
  `not has_explicit_name` check, so named DMs are misclassified again
  exactly when the member cache is cold.

## Why the heuristic cannot be fixed incrementally

Member count is not a signal of DM-ness; it is a coincidence of one.
Any tweak that keeps it primary keeps both failure modes: there is no
threshold at which "small room" implies "direct chat", and no way to
recover the user's intent from a count.

The heuristic's own commit message concedes the real issue it was
routing around, stale `m.direct` data:

> A room that grew to 3+ members but is still in stale m.direct is
> still classified as a room (conflict flag set).

That is, `4aa79334` distrusted `m.direct` because our copy of it could
be stale. The right fix for stale data is to stop letting it go stale,
not to switch to a proxy signal that is wrong for rooms the user never
marked and for DMs that grew.

## Why m.direct-only is safe now

`m.direct` is how the ecosystem defines a DM: Element and matrix-js-sdk
classify purely from it, with the `is_direct` invite flag as the only
fallback ([`getUserIdForRoomId`], [`Room.getDMInviter`]). Their
two-member checks only narrow rooms that are already in `m.direct`;
they never promote a room into being a DM.

Main has already been investing in making the bot's `m.direct`
accurate, and this PR completes that line rather than reverting it:

- Commit [`14baeefe`] (salvaged in #54129, fixing #44679) records DM
  rooms into `m.direct` when a direct invite arrives, so fresh bot
  accounts with no DM history classify correctly.
- This PR's second commit refreshes `_dm_rooms` live from `m.direct`
  account-data events in the sync loop, so an Element-side mark or
  unmark takes effect without a reconnect. This removes the staleness
  window that `4aa79334`'s commit message accepted as a trade-off, and
  it addresses the sweeper's finding about a stale cache.
- This PR's third commit closes the remaining write-side gap surfaced
  by the triage of #62493: a direct invite reconciled from `rooms.invite`
  after a gateway restart never fired `_on_invite`, so its `is_direct`
  flag was dropped and the room was never recorded into `m.direct`. The
  reconciliation path now reads the DM signal from the stripped invite
  state and records it after the join, the same as the live path.

## What the PR does

- Classifies a room as a DM if and only if it is in `m.direct`
  (tracked by the `_dm_rooms` cache). Member count no longer promotes a
  room and an explicit name no longer demotes one, which is what fixes
  the original #48551 symptom: a named DM in `m.direct` is still a DM.
- Keeps the existing `conflict` diagnostic flag for rooms whose member
  count disagrees with `m.direct`.
- Rebuilds the DM cache from live `m.direct` account-data sync events.
- Records reconciled direct invites into `m.direct` after restart.
- Adds tests for classification, live refresh (promotion, demotion,
  malformed payloads, end-to-end through the sync loop), and
  restart-time invite reconciliation.

## Remaining trade-offs

A client or bridge that never writes `m.direct` and never sets
`is_direct` on the invite gets no signal at all, and such rooms
classify as groups until the user marks them as DMs. That matches
Element's behaviour for the same rooms, and misclassifying towards
"group" is the safe direction: it gates responses behind mentions
rather than removing the gate. The member-count heuristic had the same
blind spot while also misfiring on rooms with good data.

Fixes #48551.
## Related Issue

Fixes #48551.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/matrix/adapter.py`: classify a room as a DM if and
  only if it is in `m.direct` (`_dm_rooms`); rebuild the cache from live
  `m.direct` account-data sync events; record restart-reconciled direct
  invites into `m.direct` (`_extract_invite_dm_signal`).
- `tests/gateway/test_matrix.py`, `tests/gateway/test_matrix_dm_invite_recording.py`:
  classification, live-refresh (promotion, demotion, malformed payloads,
  end-to-end sync-loop pass), and reconciliation coverage.

## How to Test

1. `pytest tests/gateway/test_matrix.py tests/gateway/test_matrix_dm_invite_recording.py -q`
   (138 tests).
2. Manually: mark or unmark a room as a DM in Element while the bot is
   connected; classification follows without a reconnect.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (targeted suites
  locally: 138 across the two Matrix DM test files; the full suite runs
  in CI)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

[#48551]: https://github.com/NousResearch/hermes-agent/issues/48551
[`4aa79334`]: https://github.com/NousResearch/hermes-agent/commit/4aa793345ec9b19cdfe6856cdc9da84c53abe406
[`getUserIdForRoomId`]: https://github.com/element-hq/element-web/blob/29b9c04d2096bef568558d44bd72d0a13ab56183/apps/web/src/utils/DMRoomMap.ts#L172-L191
[`Room.getDMInviter`]: https://github.com/matrix-org/matrix-js-sdk/blob/25c6171cb6a88ec7450472f8cf1a2d98823f2211/src/models/room.ts#L887-L900
[`14baeefe`]: https://github.com/NousResearch/hermes-agent/commit/14baeefe1d0b80e67429ffb47934acc4cd399fd1

## Review follow-up (2026-08-16)

This branch has been rebuilt on #87258, so reconciled pending invites cannot bypass inviter authorisation. Initial sync now applies an `m.direct` event from the sync response before dispatch and uses the separate account-data request only as a fallback. A failed secondary request therefore cannot misclassify messages in the same initial response.

The initial-sync regression failed before the fix. Validation: 144 Matrix tests passed.

Matrix merge order: **#87258 → #51802 → #51804 → #62088**.
