### PR TITLE
fix(gateway): deliver images as attachments after a queued follow-up

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17991,7 +17991,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _media_adapter = self._adapter_for_source(source)
                     if _media_adapter:
                         await self._deliver_media_from_response(
-                            response, event, _media_adapter,
+                            response,
+                            event.source,
+                            _media_adapter,
+                            self._thread_metadata_for_source(
+                                event.source, self._reply_anchor_for_event(event)
+                            ),
                         )
                 # Streaming already delivered the body text, but the footer was
                 # intentionally held back (see the `not already_sent` gate above).
@@ -19088,14 +19093,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     async def _deliver_media_from_response(
         self,
         response: str,
-        event: MessageEvent,
+        source: SessionSource,
         adapter,
+        thread_metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Extract explicit MEDIA: tags from a response and deliver them.
 
-        Called after streaming has already sent the text to the user, so the
-        text itself is already delivered — this only handles file attachments
-        that the normal _process_message_background path would have caught.
+        Called once the response text has already been delivered to the user,
+        either by streaming or by the queued-follow-up resend that flushes the
+        first response before processing a queued message. It therefore only
+        handles file attachments that the normal _process_message_background
+        path would have caught. ``thread_metadata`` is the reply/thread
+        metadata to attach to each upload.
 
         Unlike the non-streaming path in ``gateway/platforms/base.py`` (which
         also auto-detects bare local paths via ``extract_local_files``), this
@@ -19136,7 +19145,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # stale inspected content), not an attachment request.
             adapter.extract_images(cleaned)
 
-            _thread_meta = self._thread_metadata_for_source(event.source, self._reply_anchor_for_event(event))
+            _thread_meta = thread_metadata
 
             _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
             _IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
@@ -19160,7 +19169,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 try:
                     images = [(f"file://{_quote(p)}", "") for p in image_paths]
                     await adapter.send_multiple_images(
-                        chat_id=event.source.chat_id,
+                        chat_id=source.chat_id,
                         images=images,
                         metadata=_thread_meta,
                     )
@@ -19170,21 +19179,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             for media_path, is_voice in non_image_media:
                 try:
                     ext = Path(media_path).suffix.lower()
-                    if should_send_media_as_audio(event.source.platform, ext, is_voice=is_voice):
+                    if should_send_media_as_audio(source.platform, ext, is_voice=is_voice):
                         await adapter.send_voice(
-                            chat_id=event.source.chat_id,
+                            chat_id=source.chat_id,
                             audio_path=media_path,
                             metadata=_thread_meta,
                         )
                     elif ext in _VIDEO_EXTS:
                         await adapter.send_video(
-                            chat_id=event.source.chat_id,
+                            chat_id=source.chat_id,
                             video_path=media_path,
                             metadata=_thread_meta,
                         )
                     else:
                         await adapter.send_document(
-                            chat_id=event.source.chat_id,
+                            chat_id=source.chat_id,
                             file_path=media_path,
                             metadata=_thread_meta,
                         )
@@ -19194,7 +19203,48 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception as e:
             logger.warning("Post-stream media extraction failed: %s", e)
 
+    async def _send_queued_first_response(
+        self,
+        response: str,
+        source: SessionSource,
+        adapter,
+        thread_metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Deliver a queued-turn first response with normal media handling."""
+        if not response:
+            return
 
+        # Strip only the explicit MEDIA: directives. Delivery here is
+        # explicit-only (#20834), so a bare local path stays in the text: it
+        # is content the user is meant to read, and nothing else would send
+        # it.
+        text_content = response
+        try:
+            from gateway.platforms.base import _strip_media_directives
+
+            _, text_content = adapter.extract_media(text_content)
+            text_content = _strip_media_directives(text_content).strip()
+        except Exception as exc:
+            logger.warning(
+                "[%s] Queued follow-up response media cleanup failed: %s",
+                getattr(adapter, "name", "adapter"),
+                exc,
+            )
+            text_content = response
+
+        if text_content:
+            await adapter.send(
+                source.chat_id,
+                text_content,
+                metadata=thread_metadata,
+            )
+
+        await self._deliver_media_from_response(
+            response,
+            source,
+            adapter,
+            thread_metadata,
+        )
 
     async def _run_background_task(
         self,
@@ -25379,10 +25429,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 "Queued follow-up for session %s: final stream delivery not confirmed; sending first response before continuing.",
                                 session_key or "?",
                             )
-                            await adapter.send(
-                                source.chat_id,
+                            await self._send_queued_first_response(
                                 first_response,
-                                metadata=_status_thread_metadata,
+                                source,
+                                adapter,
+                                _status_thread_metadata,
                             )
                         except Exception as e:
                             logger.warning("Failed to send first response before queued message: %s", e)

--- a/tests/gateway/test_73771_media_resend_dedup.py
+++ b/tests/gateway/test_73771_media_resend_dedup.py
@@ -253,16 +253,14 @@ async def test_streamed_explicit_media_resend_is_delivered(tmp_path, monkeypatch
     accidental echo of auto-appended history)."""
     img = _allowed_file(tmp_path, monkeypatch, "flyer.png")
     adapter = _stream_adapter()
-    runner = SimpleNamespace(
-        _thread_metadata_for_source=lambda source, anchor=None: {},
-        _reply_anchor_for_event=lambda event: None,
-    )
+    runner = SimpleNamespace()
 
     await GatewayRunner._deliver_media_from_response(
         runner,
         f"Here's the flyer again.\nMEDIA:{img}",
-        _stream_event(),
+        _stream_event().source,
         adapter,
+        {},
     )
 
     adapter.send_multiple_images.assert_awaited_once()

--- a/tests/gateway/test_post_stream_media_delivery.py
+++ b/tests/gateway/test_post_stream_media_delivery.py
@@ -38,11 +38,11 @@ def _event():
     )
 
 
-def _fake_runner(thread_meta):
-    return SimpleNamespace(
-        _thread_metadata_for_source=lambda source, anchor=None: thread_meta,
-        _reply_anchor_for_event=lambda event: None,
-    )
+def _runner():
+    """Stand-in for the GatewayRunner ``self``. ``_deliver_media_from_response``
+    takes the reply/thread metadata as an argument, so the runner itself is an
+    inert placeholder."""
+    return SimpleNamespace()
 
 
 def _adapter():
@@ -79,10 +79,11 @@ async def test_bare_local_path_in_streamed_reply_is_not_uploaded(tmp_path, monke
     adapter = _adapter()
 
     await GatewayRunner._deliver_media_from_response(
-        _fake_runner({}),
+        _runner(),
         f"The design lives at {media_file} if you want to look later.",
-        _event(),
+        _event().source,
         adapter,
+        {},
     )
 
     adapter.send_multiple_images.assert_not_awaited()
@@ -99,10 +100,11 @@ async def test_explicit_media_tag_still_delivers_post_stream(tmp_path, monkeypat
     adapter = _adapter()
 
     await GatewayRunner._deliver_media_from_response(
-        _fake_runner({}),
+        _runner(),
         f"Here is the chart.\nMEDIA:{media_file}",
-        _event(),
+        _event().source,
         adapter,
+        {},
     )
 
     adapter.send_multiple_images.assert_awaited_once()

--- a/tests/gateway/test_queued_followup_media_delivery.py
+++ b/tests/gateway/test_queued_followup_media_delivery.py
@@ -1,0 +1,308 @@
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from urllib.parse import quote
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, build_session_key
+
+
+def _runner() -> GatewayRunner:
+    return object.__new__(GatewayRunner)
+
+
+def _source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="chat-1",
+        chat_type="dm",
+        user_id="user-1",
+        thread_id="topic-1",
+    )
+
+
+def _adapter():
+    return SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send=AsyncMock(return_value=SendResult(success=True, message_id="text")),
+        send_multiple_images=AsyncMock(),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+
+def _allowed_media_path(tmp_path, monkeypatch, name):
+    root = tmp_path / "media-cache"
+    media_file = root / name
+    media_file.parent.mkdir(parents=True, exist_ok=True)
+    media_file.write_bytes(b"media")
+    monkeypatch.setattr(
+        "gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS",
+        (root,),
+    )
+    return media_file.resolve()
+
+
+class _QueuedMediaAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="test"), Platform.TELEGRAM)
+        self.sent = []
+        self.documents = []
+        self.images = []
+        self.typing = []
+
+    async def connect(self):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.sent.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id=f"text-{len(self.sent)}")
+
+    async def send_document(self, chat_id, file_path, metadata=None, **kwargs):
+        self.documents.append(
+            {
+                "chat_id": chat_id,
+                "file_path": file_path,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id=f"doc-{len(self.documents)}")
+
+    async def send_multiple_images(self, chat_id, images, metadata=None):
+        self.images.append(
+            {
+                "chat_id": chat_id,
+                "images": images,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id=f"images-{len(self.images)}")
+
+    async def send_typing(self, chat_id, metadata=None):
+        self.typing.append({"chat_id": chat_id, "metadata": metadata})
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id, "type": "group"}
+
+
+class _QueuedMediaAgent:
+    calls = 0
+    media_path = ""
+
+    def __init__(self, **kwargs):
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        type(self).calls += 1
+        if type(self).calls == 1:
+            return {
+                "final_response": f"Done.\nMEDIA:{type(self).media_path}",
+                "messages": [],
+                "api_calls": 1,
+            }
+
+        return {
+            "final_response": "follow-up answer",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+def _runner_for_run_agent(adapter):
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {adapter.platform: adapter}
+    runner._voice_mode = {}
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = ""
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._session_db = None
+    runner._running_agents = {}
+    runner._session_run_generation = {}
+    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner.config = SimpleNamespace(
+        thread_sessions_per_user=False,
+        group_sessions_per_user=False,
+        stt_enabled=False,
+    )
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_queued_first_response_strips_media_tag_from_text_and_sends_document(
+    tmp_path, monkeypatch,
+):
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "quote.pdf")
+    adapter = _adapter()
+
+    await GatewayRunner._send_queued_first_response(
+        _runner(),
+        f"Done.\nMEDIA:{media_file}",
+        _source(),
+        adapter,
+        {"thread_id": "topic-1"},
+    )
+
+    adapter.send.assert_awaited_once_with(
+        "chat-1",
+        "Done.",
+        metadata={"thread_id": "topic-1"},
+    )
+    adapter.send_document.assert_awaited_once_with(
+        chat_id="chat-1",
+        file_path=str(media_file),
+        metadata={"thread_id": "topic-1"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_queued_first_response_keeps_bare_image_path_as_text(
+    tmp_path, monkeypatch,
+):
+    """A bare local path is left in the visible text and not uploaded.
+
+    Attachment delivery here is explicit-only (#20834): only a ``MEDIA:``
+    directive triggers an upload. Stripping the path without uploading it
+    would delete content the user is meant to see.
+    """
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "avatar.png")
+    adapter = _adapter()
+
+    await GatewayRunner._send_queued_first_response(
+        _runner(),
+        f"Here is the image:\n{media_file}",
+        _source(),
+        adapter,
+        {"thread_id": "topic-1"},
+    )
+
+    adapter.send.assert_awaited_once_with(
+        "chat-1",
+        f"Here is the image:\n{media_file}",
+        metadata={"thread_id": "topic-1"},
+    )
+    adapter.send_multiple_images.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_queued_first_response_with_only_media_sends_no_empty_text(
+    tmp_path, monkeypatch,
+):
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "quote.pdf")
+    adapter = _adapter()
+
+    await GatewayRunner._send_queued_first_response(
+        _runner(),
+        f"MEDIA:{media_file}",
+        _source(),
+        adapter,
+        {"thread_id": "topic-1"},
+    )
+
+    adapter.send.assert_not_awaited()
+    adapter.send_document.assert_awaited_once_with(
+        chat_id="chat-1",
+        file_path=str(media_file),
+        metadata={"thread_id": "topic-1"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_queued_first_response_keeps_remote_image_url_visible():
+    adapter = _adapter()
+    response = "Mockup: https://example.com/mockup.png"
+
+    await GatewayRunner._send_queued_first_response(
+        _runner(),
+        response,
+        _source(),
+        adapter,
+        {"thread_id": "topic-1"},
+    )
+
+    adapter.send.assert_awaited_once_with(
+        "chat-1",
+        response,
+        metadata={"thread_id": "topic-1"},
+    )
+    adapter.send_multiple_images.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_agent_queued_followup_flushes_clean_text_and_native_media(
+    tmp_path, monkeypatch,
+):
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "handoff.pdf")
+    _QueuedMediaAgent.calls = 0
+    _QueuedMediaAgent.media_path = str(media_file)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _QueuedMediaAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "test"})
+
+    adapter = _QueuedMediaAdapter()
+    runner = _runner_for_run_agent(adapter)
+    source = _source()
+    source.chat_type = "group"
+    session_key = build_session_key(source)
+    adapter._pending_messages[session_key] = MessageEvent(
+        text="queued follow-up",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="queued-1",
+    )
+
+    result = await runner._run_agent(
+        message="first prompt",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-queued-media",
+        session_key=session_key,
+    )
+
+    assert result["final_response"] == "follow-up answer"
+    assert adapter.sent == [
+        {
+            "chat_id": "chat-1",
+            "content": "Done.",
+            "reply_to": None,
+            "metadata": {"thread_id": "topic-1"},
+        }
+    ]
+    assert adapter.documents == [
+        {
+            "chat_id": "chat-1",
+            "file_path": str(media_file),
+            "metadata": {"thread_id": "topic-1"},
+        }
+    ]

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -83,14 +83,11 @@ async def test_base_adapter_routes_voice_tagged_telegram_ogg_media_tag_to_voice_
     adapter.send_document.assert_not_awaited()
 
 
-def _fake_runner(thread_meta):
-    """Build a fake GatewayRunner-like object with the helper methods needed by
-    _deliver_media_from_response."""
-    runner = SimpleNamespace(
-        _thread_metadata_for_source=lambda source, anchor=None: thread_meta,
-        _reply_anchor_for_event=lambda event: None,
-    )
-    return runner
+def _runner():
+    """Stand-in for the GatewayRunner ``self``. ``_deliver_media_from_response``
+    takes the reply/thread metadata as an argument, so the runner itself is an
+    inert placeholder."""
+    return SimpleNamespace()
 
 
 @pytest.mark.asyncio
@@ -123,10 +120,11 @@ async def test_streaming_delivery_blocks_media_path_outside_allowed_roots(tmp_pa
     )
 
     await GatewayRunner._deliver_media_from_response(
-        _fake_runner({"thread_id": "topic-1"}),
+        _runner(),
         f"MEDIA:{secret}",
-        event,
+        event.source,
         adapter,
+        {"thread_id": "topic-1"},
     )
 
     adapter.send_document.assert_not_awaited()


### PR DESCRIPTION
If you sent a follow-up message while the agent was still working on the first one, any image it generated for that first message arrived as an unclickable file path instead of a real attachment. Now those images are delivered as native attachments, the same as on the normal path.

---

When a user sends a second message while the agent is still working on the first, the gateway queues the follow-up and, once the first turn finishes, flushes that turn's response before processing the queued message. That flush went out through a bare `adapter.send()`, which only delivers the text body. Any MEDIA: tags or bare file paths the agent emitted (for example the paths returned by `image_generate`) were delivered as plain text, so generated images arrived as unclickable file paths instead of native attachments.

The normal and streaming delivery paths both run media extraction, so the bug only showed up when a turn that produced files happened to be interrupted by a queued message.

Run the same media extraction and delivery after the flush that the streaming already_sent path uses. `_deliver_media_from_response` only ever needed the source and the reply/thread metadata, not the full event, so it now takes those directly. This lets both the streaming caller and the queued-follow-up resend share it. A test pins the contract the resend relies on: a bare local image path in the response body is delivered as a native attachment rather than surviving as text.
