### PR TITLE
fix(profiles): add allow_unicode=True to write_profile_meta yaml.safe_dump

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -730,7 +730,7 @@ def write_profile_meta(
     if description_auto is not None:
         existing["description_auto"] = bool(description_auto)
     with open(path, "w", encoding="utf-8") as f:
-        yaml.safe_dump(existing, f, sort_keys=False, default_flow_style=False)
+        yaml.safe_dump(existing, f, sort_keys=False, default_flow_style=False, allow_unicode=True)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_profile_meta_unicode.py
+++ b/tests/hermes_cli/test_profile_meta_unicode.py
@@ -1,0 +1,45 @@
+"""write_profile_meta must emit real UTF-8 for emoji descriptions.
+
+Regression sibling of GitHub #51356 / PR #51676: without
+allow_unicode=True, yaml.safe_dump escapes astral-plane characters
+as \\UXXXXXXXX sequences that break under non-PyYAML parsers and
+hand-edits.
+"""
+
+import yaml
+
+from hermes_cli.profiles import write_profile_meta, read_profile_meta
+
+
+class TestWriteProfileMetaUnicode:
+
+    def test_emoji_description_written_as_utf8(self, tmp_path):
+        profile_dir = tmp_path / "test-profile"
+        profile_dir.mkdir()
+
+        write_profile_meta(profile_dir, description="Code wizard 🧙‍♂️✨🔥")
+
+        raw = (profile_dir / "profile.yaml").read_text(encoding="utf-8")
+        assert "\\U" not in raw
+        assert "\\u" not in raw
+        assert "🧙" in raw
+        assert "🔥" in raw
+
+    def test_emoji_description_round_trips(self, tmp_path):
+        profile_dir = tmp_path / "test-profile"
+        profile_dir.mkdir()
+        desc = "AI assistant 🤖 — fast & accurate ⚡"
+
+        write_profile_meta(profile_dir, description=desc)
+        meta = read_profile_meta(profile_dir)
+
+        assert meta["description"] == desc
+
+    def test_ascii_description_unaffected(self, tmp_path):
+        profile_dir = tmp_path / "test-profile"
+        profile_dir.mkdir()
+
+        write_profile_meta(profile_dir, description="Plain text description")
+
+        meta = read_profile_meta(profile_dir)
+        assert meta["description"] == "Plain text description"


### PR DESCRIPTION
## Summary

- `write_profile_meta()` in `hermes_cli/profiles.py` calls `yaml.safe_dump` without `allow_unicode=True`, escaping emoji/astral-plane characters as fragile `\UXXXXXXXX` sequences in `profile.yaml`
- Profile descriptions are user-authored (dashboard `PUT /api/profiles/{name}/description`) or LLM-auto-generated (`POST /api/profiles/{name}/describe-auto`) and commonly contain emoji
- This is the same bug class fixed in PR #51676 for `config.yaml`, `tui_gateway/server.py`, and `telegram/adapter.py` — `write_profile_meta` was missed because it writes to `profile.yaml` rather than `config.yaml`

Sibling gap from #51356.

## Changes

- **`hermes_cli/profiles.py`**: add `allow_unicode=True` to the `yaml.safe_dump` call in `write_profile_meta()`
- **`tests/hermes_cli/test_profile_meta_unicode.py`**: regression tests verifying emoji descriptions are written as real UTF-8 and round-trip correctly

## Test plan

- [x] New tests pass: `pytest tests/hermes_cli/test_profile_meta_unicode.py`
- [x] Manually verified: without fix, emoji description `"Code wizard 🧙‍♂️✨🔥"` produces `\U0001F9D9‍♂️` escapes; with fix, real UTF-8 glyphs on disk
- [ ] Existing profile tests unaffected