### PR TITLE
Implement clean exit for Ctrl+D in CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3825,6 +3825,73 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             renderer.reset(leave_alternate_screen=False)
         except Exception:
             pass
+        def _request_clean_tui_exit(self, app, *, reason: str = "user_exit") -> None:
+        """Exit prompt_toolkit cleanly without leaving dead TUI chrome behind."""
+        self._should_exit = True
+
+        # Release any modal prompt that may be waiting on a queue.
+        try:
+            if self._secret_state:
+                self._cancel_secret_capture()
+
+            if self._sudo_state:
+                self._sudo_state["response_queue"].put("")
+                self._sudo_state = None
+
+            if self._approval_state:
+                self._approval_state["response_queue"].put("deny")
+                self._approval_state = None
+
+            if self._slash_confirm_state:
+                self._submit_slash_confirm_response("cancel")
+
+            if self._model_picker_state:
+                self._close_model_picker()
+
+            if self._clarify_state:
+                self._clarify_state["response_queue"].put(
+                    "The user exited the CLI. Stop waiting for clarification."
+                )
+                self._clarify_state = None
+                self._clarify_freetext = False
+
+        except Exception:
+            pass
+
+        # If the agent is mid-response, interrupt it before tearing down the UI.
+        try:
+            if self.agent and getattr(self, "_agent_running", False):
+                self.agent.interrupt(f"received {reason}")
+        except TypeError:
+            try:
+                self.agent.interrupt()
+            except Exception:
+                pass
+        except Exception:
+            pass
+
+        # Clear input and attachments so nothing is left in a half-dead state.
+        try:
+            app.current_buffer.reset()
+        except Exception:
+            pass
+
+        try:
+            self._attached_images.clear()
+        except Exception:
+            pass
+
+        # Clear prompt_toolkit's visible UI before exiting.
+        try:
+            self._clear_prompt_toolkit_screen(app)
+        except Exception:
+            pass
+
+        # Exit the prompt_toolkit application.
+        try:
+            app.exit()
+        except Exception:
+            pass
 
     def _recover_after_resize(self, app, original_on_resize) -> None:
         """Recover a resized classic CLI without desynchronizing cursor state.
@@ -12670,28 +12737,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             else:
                 self._should_exit = True
                 event.app.exit()
-
-        @kb.add('c-d')
+        @kb.add('c-d', eager=True)
         def handle_ctrl_d(event):
-            """Ctrl+D: delete char under cursor (standard readline behaviour).
-            Only exit when the input is empty — same as bash/zsh. Pending
-            attached images count as input and block the EOF-exit so the
-            user doesn't lose them silently.
-            """
-            buf = event.app.current_buffer
-            if buf.text:
-                buf.delete()
-            elif self._attached_images:
-                # Empty text but pending attachments — no-op, don't exit.
-                return
-            else:
-                self._should_exit = True
-                event.app.exit()
-
-        _modal_prompt_active = Condition(
-            lambda: bool(self._secret_state or self._sudo_state or self._slash_confirm_state)
-        )
-
+            """Ctrl+D: cleanly close the Hermes CLI instead of leaving a dead TUI."""
+            self._request_clean_tui_exit(event.app, reason="Ctrl+D")
         @kb.add('escape', filter=_modal_prompt_active, eager=True)
         def handle_escape_modal(event):
             """ESC cancels active secret/sudo prompts."""


### PR DESCRIPTION
While using the Hermes chat window, pressing `Ctrl+D` caused the prompt UI to close incorrectly. Instead of cleanly terminating the Hermes CLI session, the visible chat window sometimes remained on screen but stopped accepting input or responding normally.

This created a confusing dead window state: Hermes still appeared to be open, but the active prompt was no longer functional. The user then had to manually close or recover the terminal session.

The issue happened because `Ctrl+D` was handled as a basic EOF-style exit from the prompt input layer. That exited the `prompt_toolkit` application directly without performing a full cleanup of the active UI state, pending prompt states, running agent state, or visible terminal layout.

Technical summary:
`Ctrl+D` triggered a direct `event.app.exit()` call, which could tear down the prompt-toolkit event loop without safely clearing the TUI state. This caused the Hermes CLI to appear suspended or visually present while being non-interactive.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

