### PR TITLE
fix(gateway): use is_container() in /restart to detect Kubernetes/containerd/CRI-O

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -954,22 +954,26 @@ class GatewaySlashCommandsMixin:
             logger.debug("Failed to write restart dedup marker: %s", e)
 
         active_agents = self._running_agent_count()
-        # When running under a service manager (systemd/launchd) or inside a
-        # Docker/Podman container, use the service restart path: exit with
-        # code 75 so the service manager / container restart policy restarts
-        # us.  The detached subprocess approach (setsid + bash) doesn't work
-        # under systemd (KillMode=mixed kills the cgroup) or Docker (tini
+        # When running under a service manager (systemd/launchd/s6) or inside
+        # a container, use the service restart path: exit with code 75 so the
+        # service manager / container restart policy restarts us.  The detached
+        # subprocess approach (setsid + bash) doesn't work under systemd
+        # (KillMode=mixed kills the cgroup) or containers (tini/s6-svscan
         # exits when the gateway dies, taking the detached helper with it).
         # systemd sets INVOCATION_ID; launchd sets XPC_SERVICE_NAME to the
-        # job label.  Without the launchd check, macOS /restart takes the
-        # detached path and exits 0, which KeepAlive.SuccessfulExit=false
-        # treats as a deliberate stop — the gateway stays dead until next
-        # login.  Interactive macOS shells inherit XPC_SERVICE_NAME=0, so
-        # "0" must count as not-under-launchd.
-        _under_service = bool(os.environ.get("INVOCATION_ID")) or os.environ.get(
-            "XPC_SERVICE_NAME", "0"
-        ) not in ("", "0")
-        _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
+        # job label; s6-overlay exports HERMES_S6_SUPERVISED_CHILD.  Without
+        # the launchd check, macOS /restart takes the detached path and exits
+        # 0, which KeepAlive.SuccessfulExit=false treats as a deliberate
+        # stop — the gateway stays dead until next login.  Interactive macOS
+        # shells inherit XPC_SERVICE_NAME=0, so "0" must count as
+        # not-under-launchd.
+        _under_service = (
+            bool(os.environ.get("INVOCATION_ID"))
+            or os.environ.get("XPC_SERVICE_NAME", "0") not in ("", "0")
+            or bool(os.environ.get("HERMES_S6_SUPERVISED_CHILD"))
+        )
+        from hermes_constants import is_container
+        _in_container = is_container()
         if _under_service or _in_container:
             self.request_restart(detached=False, via_service=True)
         else:

--- a/tests/gateway/test_restart_service_detection.py
+++ b/tests/gateway/test_restart_service_detection.py
@@ -1,4 +1,4 @@
-"""Tests for /restart service-manager detection (launchd vs interactive).
+"""Tests for /restart service-manager and container detection.
 
 The /restart handler routes through ``request_restart(via_service=True)``
 when a service manager supervises the gateway, so the process exits with
@@ -13,12 +13,19 @@ spawns.  Interactive macOS shells inherit ``XPC_SERVICE_NAME=0`` (a
 truthy string), so the probe must treat ``"0"`` as not-under-launchd:
 routing an unsupervised interactive gateway to the service path would
 make it exit non-zero with nothing to revive it.
+
+Container detection uses ``hermes_constants.is_container()`` which covers
+Docker, Podman, Kubernetes (containerd/CRI-O), and LXC — not just the
+``.dockerenv`` / ``.containerenv`` sentinel files.
+
+s6-overlay exports ``HERMES_S6_SUPERVISED_CHILD`` for container longruns.
 """
 from unittest.mock import MagicMock
 
 import pytest
 
 import gateway.run as gateway_run
+import hermes_constants
 from gateway.platforms.base import MessageEvent, MessageType
 from tests.gateway.restart_test_helpers import make_restart_runner, make_restart_source
 
@@ -37,6 +44,8 @@ def _make_runner_with_mock_restart(tmp_path, monkeypatch):
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.delenv("INVOCATION_ID", raising=False)
     monkeypatch.delenv("XPC_SERVICE_NAME", raising=False)
+    monkeypatch.delenv("HERMES_S6_SUPERVISED_CHILD", raising=False)
+    monkeypatch.setattr(hermes_constants, "is_container", lambda: False)
     runner, _adapter = make_restart_runner()
     runner.request_restart = MagicMock(return_value=True)
     return runner
@@ -79,6 +88,39 @@ async def test_restart_under_systemd_uses_service_path(tmp_path, monkeypatch):
     """INVOCATION_ID (systemd) still routes via the service path."""
     runner = _make_runner_with_mock_restart(tmp_path, monkeypatch)
     monkeypatch.setenv("INVOCATION_ID", "abc123")
+
+    await runner._handle_restart_command(_make_restart_event())
+
+    runner.request_restart.assert_called_once_with(detached=False, via_service=True)
+
+
+@pytest.mark.asyncio
+async def test_restart_under_s6_uses_service_path(tmp_path, monkeypatch):
+    """HERMES_S6_SUPERVISED_CHILD (s6-overlay container) routes via the service path."""
+    runner = _make_runner_with_mock_restart(tmp_path, monkeypatch)
+    monkeypatch.setenv("HERMES_S6_SUPERVISED_CHILD", "1")
+
+    await runner._handle_restart_command(_make_restart_event())
+
+    runner.request_restart.assert_called_once_with(detached=False, via_service=True)
+
+
+@pytest.mark.asyncio
+async def test_restart_inside_kubernetes_pod_uses_service_path(tmp_path, monkeypatch):
+    """Kubernetes pod (containerd/CRI-O) routes via the service path."""
+    runner = _make_runner_with_mock_restart(tmp_path, monkeypatch)
+    monkeypatch.setattr(hermes_constants, "is_container", lambda: True)
+
+    await runner._handle_restart_command(_make_restart_event())
+
+    runner.request_restart.assert_called_once_with(detached=False, via_service=True)
+
+
+@pytest.mark.asyncio
+async def test_restart_inside_docker_uses_service_path(tmp_path, monkeypatch):
+    """Docker container (is_container() True) routes via the service path."""
+    runner = _make_runner_with_mock_restart(tmp_path, monkeypatch)
+    monkeypatch.setattr(hermes_constants, "is_container", lambda: True)
 
     await runner._handle_restart_command(_make_restart_event())
 


### PR DESCRIPTION
## Summary

- `/restart` handler used inline `os.path.exists("/.dockerenv")` + `os.path.exists("/run/.containerenv")` to detect containers — misses Kubernetes pods running containerd or CRI-O (neither sentinel file exists)
- On a missed container, `/restart` takes the detached subprocess path; the container's init process (s6-svscan/tini) kills the helper on gateway exit — gateway stays dead
- Replace with `hermes_constants.is_container()` which covers Docker, Podman, Kubernetes (`KUBERNETES_SERVICE_HOST`), containerd/CRI-O (cgroup/mountinfo markers), and LXC
- Also add `HERMES_S6_SUPERVISED_CHILD` to `_under_service`, matching `_running_under_gateway_supervisor()` in `hermes_cli/gateway.py`

Sibling of #43475 (launchd detection in the same code block) and #47131 (comprehensive `is_container()` for Kubernetes).

## Changes

- **`gateway/slash_commands.py`**: replace inline Docker/Podman-only container check with `hermes_constants.is_container()`; add `HERMES_S6_SUPERVISED_CHILD` to `_under_service`
- **`tests/gateway/test_restart_service_detection.py`**: 3 new tests (s6, Kubernetes, Docker); helper cleanup for new env vars

## Test plan

- [x] New tests cover s6-overlay, Kubernetes pod, and Docker container detection
- [x] Existing launchd / systemd / interactive tests updated with proper env cleanup
- [x] Manual verification: `is_container()` returns True with `KUBERNETES_SERVICE_HOST` set, False on bare host
- [ ] Existing restart test suite passes