### PR TITLE
fix: normalize null content on tool/user messages for strict providers

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2074,6 +2074,25 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             "Pre-call sanitizer: added %d stub tool result(s)",
             len(missing_results),
         )
+
+    # 3. Normalise null-content messages to empty string.
+    #    Several providers (Xiaomi MiMo, DeepSeek, Kimi, Qwen) reject
+    #    messages where content is null.  OpenAI silently accepts null,
+    #    but empty string is universally safe and prevents HTTP 400
+    #    "text is not set" / "Invalid assistant message" errors.
+    #    Only mutates the wire copy — session DB keeps the original.
+    for msg in messages:
+        role = msg.get("role")
+        if role == "assistant":
+            # assistant: only normalise when no tool_calls or reasoning
+            if msg.get("content") is None:
+                if not msg.get("tool_calls") and not msg.get("reasoning_content"):
+                    msg["content"] = ""
+        elif role in ("tool", "user"):
+            # tool/user: any null content -> empty string
+            if msg.get("content") is None:
+                msg["content"] = ""
+
     return messages
 
 

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -512,10 +512,22 @@ def classify_api_error(
                         pass
         if not _body_msg:
             _body_msg = str(body.get("message") or "").lower()
+    # Include the ``param`` field — some providers (Xiaomi MiMo) put the
+    # actionable error detail in ``param`` rather than ``message``:
+    #   {"message": "Param Incorrect", "param": "`text` is not set"}
+    # Without this, patterns like "text is not set" never match and the
+    # error is misclassified as a non-retryable format_error.
+    _param_msg = ""
+    if isinstance(body, dict):
+        # Strip backticks — Xiaomi wraps field names in backticks
+        # (e.g. "`text` is not set") which breaks substring matching.
+        _param_msg = str(body.get("param") or "").lower().replace("`", "")
     # Combine all message sources for pattern matching
     parts = [_raw_msg]
     if _body_msg and _body_msg not in _raw_msg:
         parts.append(_body_msg)
+    if _param_msg and _param_msg not in _raw_msg and _param_msg not in _body_msg:
+        parts.append(_param_msg)
     if _metadata_msg and _metadata_msg not in _raw_msg and _metadata_msg not in _body_msg:
         parts.append(_metadata_msg)
     error_msg = " ".join(parts)


### PR DESCRIPTION
## Problem

Xiaomi MiMo (and other strict providers like DeepSeek, Kimi, Qwen) reject messages with `content: null` and return HTTP 400 "text is not set".

The existing fix in `sanitize_api_messages()` only normalizes null content on **assistant** messages. Tool and user messages with null content still reach the API and cause crashes.

## Fix

Extend the null-content normalization in `sanitize_api_messages()` to cover all three message roles:

- **assistant**: normalize when no `tool_calls` or `reasoning_content` (existing behavior)
- **tool**: any null content -> empty string
- **user**: any null content -> empty string

Empty string is universally accepted across all providers (OpenAI, Anthropic, Xiaomi, DeepSeek, etc.).

## Reproduction

1. Use mimo-v2.5 via OpenCode Go
2. Trigger vision_analyze tool calls (returns null content in some edge cases)
3. Session grows with tool results containing null content
4. API returns HTTP 400: Param Incorrect "text is not set"

## Testing

- Verified fix normalizes null content on all message roles
- Idempotent - safe to run multiple times
- No behavior change for providers that accept null (OpenAI)
