### PR TITLE
fix(compressor): count reasoning_content in tail-budget walk

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -258,9 +258,22 @@ def _estimate_msg_budget_tokens(msg: dict) -> int:
     4-tool-call turn measures ~73 vs ~1,090 real tokens), so the protected
     tail overshot ``tail_token_budget`` and compression became ineffective.
     See issue #28053.
+
+    Also counts ``reasoning_content`` (and legacy ``reasoning``) metadata
+    that reasoning-capable providers persist on assistant messages.  Without
+    this, the budget walk underestimates the provider-facing request size
+    by the reasoning payload, causing near-no-op compaction on sessions
+    with large reasoning traces.  See issue #51800.
     """
     content_len = _content_length_for_budget(msg.get("content") or "")
     tokens = content_len // _CHARS_PER_TOKEN + 10  # +10 for role/key overhead
+    # Reasoning content: some providers (DeepSeek, Moonshot, Novita, …)
+    # persist reasoning_content on assistant messages.  The request
+    # estimator counts these via the full dict serialisation, so the
+    # budget walk must too.
+    reasoning = msg.get("reasoning_content") or msg.get("reasoning") or ""
+    if reasoning:
+        tokens += len(reasoning) // _CHARS_PER_TOKEN
     for tc in msg.get("tool_calls") or []:
         if isinstance(tc, dict):
             tokens += len(str(tc)) // _CHARS_PER_TOKEN

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2420,6 +2420,74 @@ class TestTokenBudgetTailProtection:
             "not a minimum floor"
         )
 
+    def test_reasoning_content_counted_in_budget_walk(self, budget_compressor):
+        """Messages with reasoning_content must inflate the budget estimate.
+
+        Regression for #51800: reasoning-capable providers (DeepSeek, Moonshot,
+        Novita, …) persist ``reasoning_content`` on assistant messages.  The
+        budget walk must count this field or it underestimates the tail by the
+        reasoning payload, causing near-no-op compaction.
+        """
+        from agent.context_compressor import _estimate_msg_budget_tokens
+
+        small_msg = {"role": "user", "content": "hello"}
+        reasoning_msg = {
+            "role": "assistant",
+            "content": "answer",
+            "reasoning_content": "x" * 2000,  # ~500 extra tokens
+        }
+        small_estimate = _estimate_msg_budget_tokens(small_msg)
+        reasoning_estimate = _estimate_msg_budget_tokens(reasoning_msg)
+        # The reasoning message should be significantly larger
+        assert reasoning_estimate > small_estimate + 400, (
+            f"reasoning_content not counted: small={small_estimate}, "
+            f"reasoning={reasoning_estimate}"
+        )
+
+    def test_legacy_reasoning_field_also_counted(self, budget_compressor):
+        """The legacy ``reasoning`` key (without ``_content`` suffix) is also counted."""
+        from agent.context_compressor import _estimate_msg_budget_tokens
+
+        msg_with_reasoning = {
+            "role": "assistant",
+            "content": "answer",
+            "reasoning": "y" * 2000,
+        }
+        msg_without = {"role": "assistant", "content": "answer"}
+        assert _estimate_msg_budget_tokens(msg_with_reasoning) > (
+            _estimate_msg_budget_tokens(msg_without) + 400
+        )
+
+    def test_reasoning_tail_budget_triggers_compaction(self, budget_compressor):
+        """A tail with large reasoning_content must exceed the budget and
+        trigger a smaller tail, not protect the entire transcript.
+
+        This is the exact scenario from #51800: 20 messages with reasoning
+        traces that fit in budget without counting, but overflow with it.
+        """
+        c = budget_compressor
+        c.tail_token_budget = 500  # small budget
+        messages = [
+            {"role": "user", "content": "head1"},
+            {"role": "user", "content": "head2"},
+        ]
+        # 10 assistant turns with large reasoning_content (~500 tokens each)
+        for i in range(10):
+            messages.append({
+                "role": "assistant",
+                "content": f"answer {i}",
+                "reasoning_content": "d" * 2000,  # ~500 tokens
+            })
+            messages.append({"role": "user", "content": f"follow-up {i}"})
+        head_end = 2
+        cut = c._find_tail_cut_by_tokens(messages, head_end)
+        tail_size = len(messages) - cut
+        # With reasoning counted, the tail should be much smaller than the full transcript
+        assert tail_size < len(messages) - 2, (
+            f"Reasoning content not counted in budget: tail={tail_size} "
+            f"of {len(messages)} messages — compaction is near-no-op"
+        )
+
 
 class TestUpdateModelBudgets:
     """Regression: update_model() must recalculate token budgets."""


### PR DESCRIPTION
## What does this PR do?

Fixes the context compressor's tail-budget walk to count `reasoning_content` (and legacy `reasoning`) metadata on assistant messages. Without this, reasoning-capable providers (DeepSeek, Moonshot, Novita, …) cause the budget walk to underestimate the provider-facing request size by 2-3×, resulting in near-no-op compaction that keeps nearly the entire transcript.

## Related Issue

Fixes #51800

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/context_compressor.py`: Count `reasoning_content` / `reasoning` fields in `_estimate_msg_budget_tokens()` using the same chars-per-token formula as message content. This aligns the budget walk with `estimate_request_tokens_rough()` which already counted these fields via full-dict serialisation.
- `tests/agent/test_context_compressor.py`: Three regression tests — unit test for `_estimate_msg_budget_tokens` with reasoning_content, unit test for legacy `reasoning` key, and integration test verifying that large reasoning traces trigger compaction instead of near-no-op.

## How to Test

1. Run `python -m pytest tests/agent/test_context_compressor.py::TestTokenBudgetTailProtection -xvs` — all 16 tests pass (13 existing + 3 new).
2. The new `test_reasoning_tail_budget_triggers_compaction` reproduces the exact scenario: 20 messages with 2000-char reasoning traces, budget=500. Without the fix, the tail would be the entire transcript (near-no-op). With the fix, compaction triggers normally.
3. Existing tests confirm no regression on plain content, multimodal, tool-call, and image-only messages.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/context_compressor.py:_estimate_msg_budget_tokens` (callers: `_find_tail_cut_by_tokens`, `_prune_old_tool_results`)
- Blast radius: LOW — isolated token-counting function, no external API changes
- Related patterns: `estimate_request_tokens_rough()` in `agent/model_metadata.py` already counts reasoning_content via full-dict serialisation; this fix aligns the budget walk with that behaviour
