### PR TITLE
fix: add error handling to os.remove/os.unlink calls

### DIFF
--- a/hermes_cli/voice.py
+++ b/hermes_cli/voice.py
@@ -504,8 +504,11 @@ def stop_continuous(force_transcribe: bool = False) -> None:
                                 if text and not is_whisper_hallucination(text):
                                     transcript = text
                         finally:
-                            if os.path.isfile(wav_path):
-                                os.unlink(wav_path)
+                            try:
+                                if os.path.isfile(wav_path):
+                                    os.unlink(wav_path)
+                            except OSError:
+                                pass
                 except Exception as e:
                     logger.warning("failed to stop/transcribe recorder: %s", e)
                 finally:

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -922,7 +922,7 @@ class SimplexAdapter(BasePlatformAdapter):
                         "data:image/jpg;base64," + base64.b64encode(f.read()).decode()
                     )
                 os.remove(tmp_path)
-            except (FileNotFoundError, subprocess.SubprocessError) as exc:
+            except (OSError, subprocess.SubprocessError) as exc:
                 logger.warning("SimpleX: image conversion unavailable: %s", exc)
 
         return png_path, thumb_uri

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1872,7 +1872,10 @@ def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) ->
         if ffmpeg:
             conv_cmd = [ffmpeg, "-i", wav_path, "-y", "-loglevel", "error", output_path]
             subprocess.run(conv_cmd, check=True, timeout=30, stdin=subprocess.DEVNULL)
-            os.remove(wav_path)
+            try:
+                os.remove(wav_path)
+            except OSError:
+                pass
         else:
             # No ffmpeg — just rename the WAV to the expected path
             os.rename(wav_path, output_path)
@@ -2117,7 +2120,10 @@ def _generate_kittentts(text: str, output_path: str, tts_config: Dict[str, Any])
         if ffmpeg:
             conv_cmd = [ffmpeg, "-i", wav_path, "-y", "-loglevel", "error", output_path]
             subprocess.run(conv_cmd, check=True, timeout=30, stdin=subprocess.DEVNULL)
-            os.remove(wav_path)
+            try:
+                os.remove(wav_path)
+            except OSError:
+                pass
         else:
             # No ffmpeg — rename the WAV to the expected path
             os.rename(wav_path, output_path)


### PR DESCRIPTION
## What

Wrap `os.remove()` and `os.unlink()` calls in `try/except OSError` to handle cases where the file is already deleted, locked, or inaccessible.

## Why

Without error handling, these calls crash with `FileNotFoundError` or `PermissionError` if the file is deleted between the existence check and the removal, or if the file is locked by another process.

## Changes (3 files, 14 insertions, 5 deletions)

| File | Change |
|------|--------|
| `hermes_cli/voice.py` | Wrap `os.unlink(wav_path)` in finally block with try/except |
| `tools/tts_tool.py` | Wrap 2× `os.remove(wav_path)` after ffmpeg conversion |
| `plugins/platforms/simplex/adapter.py` | Broaden `except FileNotFoundError` to `except OSError` (parent class) |