### PR TITLE
fix(matrix): check PairingStore in reaction auth for exec approval and model picker

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -3155,16 +3155,30 @@ class MatrixAdapter(BasePlatformAdapter):
         if not allow_all and not (
             self._allowed_user_ids and sender in self._allowed_user_ids
         ):
-            logger.info(
-                "Matrix: ignoring %s reaction from unauthorized user %s on %s",
-                prompt_label, sender, target_event_id,
-            )
-            await self._send_invalid_reaction_feedback(
-                room_id,
-                target_event_id,
-                "Only an authorized Matrix user can use these controls.",
-            )
-            return False
+            # Check pairing store — mirrors authz_mixin._check_authorization
+            # so users approved via ``hermes pairing approve`` can interact
+            # with reaction-based controls (exec approval, model picker) even
+            # without MATRIX_ALLOWED_USERS set.
+            paired = False
+            if sender:
+                try:
+                    from gateway.pairing import PairingStore
+                    store = PairingStore()
+                    if store.is_approved("matrix", sender):
+                        paired = True
+                except Exception:
+                    pass
+            if not paired:
+                logger.info(
+                    "Matrix: ignoring %s reaction from unauthorized user %s on %s",
+                    prompt_label, sender, target_event_id,
+                )
+                await self._send_invalid_reaction_feedback(
+                    room_id,
+                    target_event_id,
+                    "Only an authorized Matrix user can use these controls.",
+                )
+                return False
 
         requester = getattr(prompt, "requester_user_id", None)
         approval_require_sender = getattr(self, "_approval_require_sender", True)

--- a/tests/gateway/test_matrix_approval_reaction_fail_closed.py
+++ b/tests/gateway/test_matrix_approval_reaction_fail_closed.py
@@ -153,3 +153,27 @@ class TestApprovalReactionFailClosed:
         adapter = _make_adapter(allowed_user_ids=["@alice:matrix.org"])
         event = _make_event("@mallory:matrix.org", "$prompt-event-1")
         assert _run(adapter, event) is False
+
+    def test_pairing_approved_user_permits(self, monkeypatch):
+        """User approved via ``hermes pairing approve`` → allow."""
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        adapter = _make_adapter(allowed_user_ids=None)
+        event = _make_event("@paired:matrix.org", "$prompt-event-1")
+
+        mock_store = SimpleNamespace(
+            is_approved=lambda platform, uid: platform == "matrix" and uid == "@paired:matrix.org",
+        )
+        with patch("gateway.pairing.PairingStore", return_value=mock_store):
+            assert _run(adapter, event) is True
+
+    def test_pairing_unapproved_user_denies(self, monkeypatch):
+        """User NOT in pairing store and no allowlist → deny."""
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        adapter = _make_adapter(allowed_user_ids=None)
+        event = _make_event("@stranger:matrix.org", "$prompt-event-1")
+
+        mock_store = SimpleNamespace(
+            is_approved=lambda platform, uid: False,
+        )
+        with patch("gateway.pairing.PairingStore", return_value=mock_store):
+            assert _run(adapter, event) is False


### PR DESCRIPTION
## Summary

- `_validate_matrix_prompt_reactor` only checked env-var allowlists (`GATEWAY_ALLOW_ALL_USERS`, `MATRIX_ALLOWED_USERS`) — users approved via `hermes pairing approve` could send messages but their exec approval and model picker reactions were silently rejected
- Add `PairingStore.is_approved("matrix", sender)` fallback, mirroring the Discord fix in PR #51730
- Fail-closed behavior preserved: non-paired, non-allowed users are still denied
- Telegram and Slack unaffected — their callback auth already delegates to `_is_user_authorized` which includes PairingStore

Sibling of #50627 (Discord pairing auth for component buttons).

## Changes

- **`plugins/platforms/matrix/adapter.py`**: add PairingStore check in `_validate_matrix_prompt_reactor` after env-var allowlist miss
- **`tests/gateway/test_matrix_approval_reaction_fail_closed.py`**: 2 new tests — pairing-approved user permits, pairing-unapproved user denies

## Test plan

- [x] New tests cover pairing-approved and pairing-unapproved scenarios
- [x] Fix logic verified in isolation (6 scenarios: pairing approve, pairing deny, allowlist, allow_all, no store, empty sender)
- [ ] Existing matrix approval reaction tests unaffected