### PR TITLE
fix(agent): close tool-tail in _persist_session for early-return interrupt paths

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1515,6 +1515,18 @@ class AIAgent:
         Ensures conversations are never lost, even on errors or early returns.
         """
         self._drop_trailing_empty_response_scaffolding(messages)
+        # Close any trailing tool-result sequence so the persisted transcript
+        # never ends at role="tool".  Without this, resuming the session
+        # creates a tool → user alternation that strict providers (Gemini,
+        # Claude) reject (#48879).  finalize_turn already handles this for
+        # the normal exit path; this guard catches the ~28 early-return
+        # paths in conversation_loop.py that call _persist_session directly.
+        if (
+            messages
+            and isinstance(messages[-1], dict)
+            and messages[-1].get("role") == "tool"
+        ):
+            messages.append({"role": "assistant", "content": "Operation interrupted."})
         self._apply_persist_user_message_override(messages)
         self._session_messages = messages
         self._save_session_log(messages)

--- a/tests/run_agent/test_persist_session_tool_tail.py
+++ b/tests/run_agent/test_persist_session_tool_tail.py
@@ -1,0 +1,110 @@
+"""_persist_session must close a trailing tool-result sequence.
+
+Early-return paths in conversation_loop.py call _persist_session directly
+without going through finalize_turn, which is the only place that
+previously closed trailing tool results.  If the session is persisted
+with messages[-1]["role"] == "tool", resuming it later creates a
+tool → user alternation that strict providers (Gemini, Claude) reject
+(#48879).
+
+This test pins the contract: _persist_session always appends a synthetic
+assistant message when the transcript ends at role="tool", regardless of
+whether finalize_turn ran.
+"""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _make_agent():
+    hermes_home = Path(tempfile.mkdtemp(prefix="hermes-test-persist-"))
+    (hermes_home / "logs").mkdir(parents=True, exist_ok=True)
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("run_agent._hermes_home", hermes_home),
+        patch("agent.model_metadata.fetch_model_metadata", return_value={}),
+    ):
+        agent = AIAgent(model="test-model")
+    agent._save_session_log = MagicMock()
+    agent._flush_messages_to_session_db = MagicMock()
+    return agent
+
+
+class TestPersistSessionToolTail:
+
+    def test_tool_tail_gets_assistant_closure(self):
+        """Messages ending at role=tool get a synthetic assistant appended."""
+        agent = _make_agent()
+        messages = [
+            {"role": "user", "content": "run the tool"},
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "tc1", "type": "function", "function": {"name": "web_search", "arguments": "{}"}}
+            ]},
+            {"role": "tool", "tool_call_id": "tc1", "content": "search results"},
+        ]
+
+        agent._persist_session(messages)
+
+        assert messages[-1]["role"] == "assistant"
+        assert messages[-1]["content"] == "Operation interrupted."
+
+    def test_assistant_tail_unchanged(self):
+        """Messages already ending at role=assistant are not modified."""
+        agent = _make_agent()
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi there"},
+        ]
+        original_len = len(messages)
+
+        agent._persist_session(messages)
+
+        assert len(messages) == original_len
+        assert messages[-1]["role"] == "assistant"
+        assert messages[-1]["content"] == "hi there"
+
+    def test_user_tail_unchanged(self):
+        """Messages ending at role=user are not modified."""
+        agent = _make_agent()
+        messages = [
+            {"role": "user", "content": "hello"},
+        ]
+        original_len = len(messages)
+
+        agent._persist_session(messages)
+
+        assert len(messages) == original_len
+        assert messages[-1]["role"] == "user"
+
+    def test_empty_messages_unchanged(self):
+        """Empty message list does not crash."""
+        agent = _make_agent()
+        messages = []
+
+        agent._persist_session(messages)
+
+        assert len(messages) == 0
+
+    def test_multiple_tool_results_get_single_closure(self):
+        """Only one assistant closure appended even with multiple trailing tools."""
+        agent = _make_agent()
+        messages = [
+            {"role": "user", "content": "run tools"},
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "tc1", "type": "function", "function": {"name": "a", "arguments": "{}"}},
+                {"id": "tc2", "type": "function", "function": {"name": "b", "arguments": "{}"}},
+            ]},
+            {"role": "tool", "tool_call_id": "tc1", "content": "result a"},
+            {"role": "tool", "tool_call_id": "tc2", "content": "result b"},
+        ]
+
+        agent._persist_session(messages)
+
+        assert messages[-1]["role"] == "assistant"
+        assert messages[-1]["content"] == "Operation interrupted."
+        assert messages[-2]["role"] == "tool"


### PR DESCRIPTION
## Summary

- PR #51727 fixed role-alternation violations on interrupt by closing trailing tool-result sequences in `finalize_turn` before persisting — but ~28 early-return paths in `conversation_loop.py` call `_persist_session` directly without going through `finalize_turn`
- When an interrupt fires during API retry backoff, error handling, or other wait loops after a tool has executed, the session persists with `messages[-1]["role"] == "tool"` — resuming later creates a `tool → user` alternation that strict providers (Gemini, Claude) reject
- Add the same tool-tail closure guard to `_persist_session` itself, after `_drop_trailing_empty_response_scaffolding`
- Safe alongside the existing `finalize_turn` guard: `finalize_turn` appends the assistant message before calling `_persist_session`, so the new guard is a no-op on that path

Sibling of #48879 (role alternation violation on interrupt).

## Changes

- **`run_agent.py`**: add tool-tail closure in `_persist_session` after scaffolding cleanup
- **`tests/run_agent/test_persist_session_tool_tail.py`**: 5 tests covering tool tail closure, assistant/user/empty tail no-ops, and multiple tool results

## Test plan

- [x] Tool tail → synthetic assistant appended
- [x] Assistant tail → unchanged (no double closure when finalize_turn already ran)
- [x] User tail → unchanged
- [x] Empty messages → no crash
- [x] Multiple trailing tool results → single closure appended
- [ ] Existing agent/persist tests unaffected