### PR TITLE
fix: enable Opus voice output for Feishu and Lark platforms

### DIFF
--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2177,7 +2177,7 @@ def text_to_speech_tool(
     # and needs ffmpeg for conversion.
     from gateway.session_context import get_session_env
     platform = get_session_env("HERMES_SESSION_PLATFORM", "").lower()
-    want_opus = (platform == "telegram")
+    want_opus = (platform in {"telegram", "feishu", "lark"})
 
     # Determine output path
     if output_path:


### PR DESCRIPTION
## Problem

TTS voice messages on Feishu/Lark are sent as file attachments instead of playable voice bubbles.

## Root Cause

In `tools/tts_tool.py`, `want_opus` (which triggers ffmpeg conversion from MP3 to Opus and marks the output as `voice_compatible`) only checked for `platform == "telegram"`. Feishu and Lark were excluded.

Meanwhile, the Feishu adapter only uploads `.ogg`/`.opus` files with the native "audio" message type (`_FEISHU_OPUS_UPLOAD_EXTENSIONS = {".ogg", ".opus"}`). MP3 files fall through to generic file attachment delivery.

## Fix

One-line change: extend the `want_opus` condition to include `feishu` and `lark`:

```python
- want_opus = (platform == "telegram")
+ want_opus = (platform in {"telegram", "feishu", "lark"})
```

This triggers:
1. ffmpeg MP3→Opus conversion for Edge TTS on Feishu/Lark
2. `voice_compatible = True` → `[[audio_as_voice]]` marker prepended
3. Opus file recognized by Feishu adapter → sent as native audio message

## Testing

Tested on Feishu with Edge TTS: voice messages now arrive as playable audio bubbles instead of file attachments.