### PR TITLE
fix(compression): count reasoning fields in tail-budget token walk (#51800)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -264,6 +264,16 @@ def _estimate_msg_budget_tokens(msg: dict) -> int:
     for tc in msg.get("tool_calls") or []:
         if isinstance(tc, dict):
             tokens += len(str(tc)) // _CHARS_PER_TOKEN
+    # Provider-visible reasoning persists on the message and is re-sent on every
+    # request, so the tail-protection walk must count it too. Omitting it let
+    # reasoning-heavy turns (e.g. DeepSeek reasoning models) undercount by the
+    # entire reasoning payload, so an oversized recent tail appeared to fit
+    # inside the budget and compaction became a near no-op. Same failure class
+    # as the tool-call envelope undercount above. See issue #51800 (#28053).
+    for key in ("reasoning_content", "reasoning_details", "reasoning"):
+        val = msg.get(key)
+        if val:
+            tokens += len(val if isinstance(val, str) else str(val)) // _CHARS_PER_TOKEN
     return tokens
 
 

--- a/tests/agent/test_estimate_msg_budget_reasoning.py
+++ b/tests/agent/test_estimate_msg_budget_reasoning.py
@@ -1,0 +1,52 @@
+"""Regression for #51800: the tail-protection budget walk must count
+provider-visible reasoning fields (reasoning_content / reasoning_details /
+reasoning), not only content + tool-call envelopes.
+
+Persisted reasoning is re-sent on every request, so omitting it let
+reasoning-heavy turns (e.g. DeepSeek reasoning models) undercount by the entire
+reasoning payload — an oversized recent tail then appeared to fit inside the
+budget and compaction summarized almost nothing.
+"""
+
+from agent.context_compressor import _CHARS_PER_TOKEN, _estimate_msg_budget_tokens
+
+_BIG = "z" * 4000  # ~1000 tokens at _CHARS_PER_TOKEN
+
+
+def _base():
+    return _estimate_msg_budget_tokens({"role": "assistant", "content": "hi"})
+
+
+def test_reasoning_content_counted():
+    got = _estimate_msg_budget_tokens(
+        {"role": "assistant", "content": "hi", "reasoning_content": _BIG}
+    )
+    assert got >= _base() + (len(_BIG) // _CHARS_PER_TOKEN)
+
+
+def test_reasoning_details_and_reasoning_counted():
+    for key in ("reasoning_details", "reasoning"):
+        got = _estimate_msg_budget_tokens(
+            {"role": "assistant", "content": "hi", key: _BIG}
+        )
+        assert got >= _base() + (len(_BIG) // _CHARS_PER_TOKEN), key
+
+
+def test_non_string_reasoning_counted_without_crashing():
+    # reasoning_details frequently arrives as a list/dict, not a str.
+    msg = {
+        "role": "assistant",
+        "content": "hi",
+        "reasoning_details": [{"type": "reasoning.text", "text": "z" * 2000}],
+    }
+    assert _estimate_msg_budget_tokens(msg) > _base()
+
+
+def test_absent_or_empty_reasoning_adds_nothing():
+    base_msg = {"role": "user", "content": "hello world"}
+    assert _estimate_msg_budget_tokens({**base_msg, "reasoning_content": ""}) == (
+        _estimate_msg_budget_tokens(base_msg)
+    )
+    assert _estimate_msg_budget_tokens({**base_msg, "reasoning_content": None}) == (
+        _estimate_msg_budget_tokens(base_msg)
+    )


### PR DESCRIPTION
Fixes #51800.

## Root cause
`_estimate_msg_budget_tokens()` (the per-message estimator used by the tail-protection budget walks) counts message `content` and the full tool-call envelope, but **not** provider-visible reasoning fields (`reasoning_content`, `reasoning_details`, `reasoning`).

That reasoning persists on the message and is re-sent on every request. So on reasoning-heavy turns (e.g. DeepSeek reasoning models) the walk undercounted by the **entire reasoning payload** — an oversized recent tail appeared to fit inside `tail_token_budget * 1.5`, compaction summarized ~one message, and the request could even grow. The reporter measured a tail walk estimating ~74,847 tokens for a list the shared request estimator put at ~151,280.

This is the same failure class as the tool-call envelope undercount fixed in #28053.

## Fix
Count the reasoning fields in `_estimate_msg_budget_tokens` alongside content + tool-calls (string or stringified non-string payloads), using the existing `_CHARS_PER_TOKEN` heuristic.

## Tests
New `tests/agent/test_estimate_msg_budget_reasoning.py` (4): `reasoning_content` counted, `reasoning_details`/`reasoning` counted, non-string reasoning counted without crashing, absent/empty adds nothing. Existing `test_context_compressor.py` (118) green.
