### PR TITLE
fix(skills): decode inline-shell output as UTF-8 regardless of locale (#51691)

### DIFF
--- a/agent/skill_preprocessing.py
+++ b/agent/skill_preprocessing.py
@@ -72,6 +72,17 @@ def run_inline_shell(command: str, cwd: Path | None, timeout: int) -> str:
             cwd=str(cwd) if cwd else None,
             capture_output=True,
             text=True,
+            # Force UTF-8 decoding of shell output. With ``text=True`` and no
+            # explicit encoding, Python decodes via ``locale.getpreferredencoding``
+            # — cp936/gbk on a Windows non-UTF-8 (e.g. Chinese) locale — so any
+            # UTF-8 bytes in the snippet output raised UnicodeDecodeError, which
+            # escaped this handler and broke skill_view for every skill that
+            # renders inline shell (read_file was unaffected — it skips preprocess).
+            # ``errors="replace"`` additionally hardens against genuinely
+            # non-UTF-8 output so one bad byte can never crash skill rendering.
+            # See issue #51691.
+            encoding="utf-8",
+            errors="replace",
             timeout=max(1, int(timeout)),
             check=False,
             stdin=subprocess.DEVNULL,

--- a/tests/agent/test_inline_shell_utf8.py
+++ b/tests/agent/test_inline_shell_utf8.py
@@ -1,0 +1,44 @@
+"""Regression for #51691: skill inline-shell rendering must decode shell output
+as UTF-8 regardless of platform locale.
+
+With ``text=True`` and no explicit encoding, Python decodes via
+``locale.getpreferredencoding`` — cp936/gbk on a Windows non-UTF-8 (e.g.
+Chinese) locale — so UTF-8 shell output raised UnicodeDecodeError that escaped
+``run_inline_shell`` and broke ``skill_view`` for every skill that renders
+inline shell. Forcing ``encoding="utf-8", errors="replace"`` fixes it
+cross-platform.
+"""
+
+import pytest
+
+import agent.skill_preprocessing as sp
+from agent.skill_preprocessing import run_inline_shell
+
+
+def test_inline_shell_forces_utf8_decode(monkeypatch):
+    """Deterministic pin: the subprocess call must request UTF-8 decoding."""
+    captured = {}
+
+    class _Completed:
+        returncode = 0
+        stdout = "ok"
+        stderr = ""
+
+    def fake_run(*args, **kwargs):
+        captured.update(kwargs)
+        return _Completed()
+
+    monkeypatch.setattr(sp.subprocess, "run", fake_run)
+    run_inline_shell("echo hi", cwd=None, timeout=5)
+    assert captured.get("encoding") == "utf-8"   # locale-independent decode
+    assert captured.get("errors") == "replace"   # never crash on a bad byte
+
+
+def test_inline_shell_roundtrips_utf8_bytes():
+    """Behavioral: raw UTF-8 bytes from the shell come back intact (not mojibake
+    or a crash), which is exactly what failed under a cp936 locale."""
+    # printf %b expands \xHH to the UTF-8 bytes for 你好.
+    out = run_inline_shell("printf '%b' '\\xe4\\xbd\\xa0\\xe5\\xa5\\xbd'", cwd=None, timeout=10)
+    if "bash not found" in out:
+        pytest.skip("bash unavailable on this runner")
+    assert "你好" in out


### PR DESCRIPTION
Fixes #51691.

## Root cause
`run_inline_shell()` (used by `skill_view`'s preprocess / inline-shell rendering) calls `subprocess.run(..., text=True)` with **no explicit `encoding`**. With `text=True` and no encoding, Python decodes shell output via `locale.getpreferredencoding()` — which is **cp936/gbk on a Windows non-UTF-8 (e.g. Chinese) locale**, not UTF-8.

So any UTF-8 bytes in snippet output raised `UnicodeDecodeError`, which **escaped** the handler (it only caught `TimeoutExpired` / `FileNotFoundError` / `RuntimeError`) and broke `skill_view` for **every** skill that renders inline shell. `read_file()` was unaffected because it skips preprocess — matching the report.

## Fix
Force `encoding="utf-8", errors="replace"` on the call: shell output decodes consistently cross-platform, and a stray non-UTF-8 byte can never crash skill rendering.

## Tests
New `tests/agent/test_inline_shell_utf8.py` (2): a deterministic pin asserting the subprocess call requests UTF-8 decoding, and a behavioral round-trip of raw UTF-8 bytes (`你好`) — the exact case that failed under cp936.
