### PR TITLE
harden(pets): sanitize slug in thumbnail_png to prevent path traversal

### DIFF
--- a/agent/pet/store.py
+++ b/agent/pet/store.py
@@ -232,7 +232,7 @@ def thumbnail_png(slug: str, *, source_url: str = "", timeout: float = 30.0) -> 
     break a direct ``<img src=cdn>`` and lets the result ride the authenticated
     gateway as a same-origin data URL.
     """
-    slug = slug.strip()
+    slug = _safe_slug(slug)
     if not slug:
         return None
 

--- a/tests/agent/test_pet_engine.py
+++ b/tests/agent/test_pet_engine.py
@@ -369,3 +369,28 @@ def test_vscode_terminal_ignores_leaked_graphics_env(monkeypatch):
         monkeypatch.setenv(leaked, "1")
         assert render.detect_terminal_graphics() == "unicode"
         monkeypatch.delenv(leaked)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# thumbnail_png — slug sanitization (path-traversal guard)
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_thumbnail_png_rejects_path_traversal(tmp_path, monkeypatch):
+    """A slug containing path separators must not escape the thumbs directory."""
+    monkeypatch.setattr(store, "_thumbs_dir", lambda: tmp_path / ".thumbs")
+    (tmp_path / ".thumbs").mkdir()
+
+    result = store.thumbnail_png("../../etc/passwd")
+    assert result is None
+
+    written = list((tmp_path / ".thumbs").iterdir())
+    assert len(written) == 0
+
+
+def test_thumbnail_png_rejects_dotdot(tmp_path, monkeypatch):
+    """Bare '..' slug must be rejected."""
+    monkeypatch.setattr(store, "_thumbs_dir", lambda: tmp_path / ".thumbs")
+    (tmp_path / ".thumbs").mkdir()
+
+    result = store.thumbnail_png("..")
+    assert result is None


### PR DESCRIPTION
## Summary

- The hardening commit `6afeea2be` added `_safe_slug()` to `load_pet`, `install_pet`, and `remove_pet` — but missed `thumbnail_png()`
- `thumbnail_png()` used bare `slug.strip()`, allowing a crafted slug with path separators (e.g. `../../.config/target`) to escape the `.thumbs` cache directory
- The gateway's `pet.thumb` RPC passes the client-supplied slug directly to `thumbnail_png`, so a WebSocket client could trigger an out-of-directory file write (`.png` suffix) or read existing `.png` files at arbitrary paths
- Replace `slug.strip()` with `_safe_slug(slug)`, consistent with every other slug-consuming function in the module

## Changes

- **`agent/pet/store.py`**: replace `slug.strip()` with `_safe_slug(slug)` in `thumbnail_png()`
- **`tests/agent/test_pet_engine.py`**: 2 regression tests — path traversal slug rejected, bare `..` rejected

## Test plan

- [x] `thumbnail_png("../../etc/passwd")` returns `None`, no files written outside `.thumbs/`
- [x] `thumbnail_png("..")` returns `None`
- [x] `_safe_slug` assertions verified: traversal stripped, dotdot rejected, normal slugs pass
- [ ] Existing pet engine tests unaffected