### PR TITLE
fix(tui): correct macOS hotkey help text to reflect actual TUI behavior

### DIFF
--- a/ui-tui/src/content/hotkeys.ts
+++ b/ui-tui/src/content/hotkeys.ts
@@ -5,8 +5,8 @@ const paste = isMac ? 'Cmd' : 'Alt'
 
 const copyHotkeys: [string, string][] = isMac
   ? [
-      ['Cmd+C', 'copy selection'],
-      ['Ctrl+C', 'interrupt / clear draft / exit']
+      ['Ctrl+C', 'interrupt / clear draft / exit'],
+      ['Cmd+C', 'copy selection (when forwarded by terminal)']
     ]
   : isRemoteShell()
     ? [


### PR DESCRIPTION
## Problem

On macOS, the TUI /help panel shows **Cmd+C** as the copy shortcut. In practice Cmd+C in the TUI produces a beep and does nothing; the actual interrupt/exit shortcut is **Ctrl+C**.

This confuses macOS users who expect Cmd+C to work as documented.

## Fix

Swap the order and clarify the description in `ui-tui/src/content/hotkeys.ts` so macOS users see:
- **Ctrl+C** — interrupt / clear draft / exit  
- **Cmd+C** — copy selection (when forwarded by terminal)

This matches the real TUI behavior where Ctrl+C is the reliable shortcut and Cmd+C only works when the terminal explicitly forwards it (e.g., VS Code/Cursor terminal with kitty keyboard protocol).

## Verification

- [x] Change is minimal (2 lines)
- [x] No functional code changes — only help text
- [x] Existing tests pass (`constants.test.ts`, `platform.test.ts`)
- [x] Fixes #21564

## Files changed

- `ui-tui/src/content/hotkeys.ts` — macOS copy/interrupt hotkey descriptions