### PR TITLE
feat(cli): Valut — safe credential sharing in chat via ?/.../? triggers

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -875,6 +875,9 @@ def get_job(*args, **kwargs):
 
 # Resource cleanup imports for safe shutdown (terminal VMs, browser sessions)
 from hermes_cli.callbacks import prompt_for_secret
+# Secure secret reference system — intercepts ?/.../? triggers on input,
+# expands [VLT:id] references on output, so the LLM never sees credentials.
+from hermes_cli.valut import sanitize_input as _valut_sanitize, restore_output as _valut_restore
 
 
 def _cleanup_all_terminals(*args, **kwargs):
@@ -2378,6 +2381,7 @@ def _cprint(text: str):
     ``loop.call_soon_threadsafe``, which pauses the input area, prints
     the line above it, and redraws the prompt cleanly.
     """
+    text = _valut_restore(text)
     _record_output_history(text)
 
     try:
@@ -5689,6 +5693,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 if app is not None:
                     app.invalidate()
             return
+
+        # Sanitize valut triggers (?/.../?) before the agent sees the text.
+        if isinstance(text, str) and "?/" in text:
+            text = _valut_sanitize(text)
 
         # Regular prompt: route through the same queues the Enter handler uses.
         if self._agent_running:
@@ -12745,16 +12753,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     event.app.invalidate()
                     return
 
-                # Snapshot and clear attached images
                 images = list(self._attached_images)
                 self._attached_images.clear()
                 event.app.invalidate()
+                # Sanitize valut triggers (?/.../?) before the agent sees them.
+                if isinstance(text, str) and "?/" in text:
+                    text = _valut_sanitize(text)
                 # Bundle text + images as a tuple when images are present
                 payload = (text, images) if images else text
                 if self._agent_running and not (text and _looks_like_slash_command(text)):
+                        # Route Enter through /steer — inject mid-run after the
                     _effective_mode = self.busy_input_mode
                     if _effective_mode == "steer":
-                        # Route Enter through /steer — inject mid-run after the
                         # next tool call.  Images can't ride along (steer only
                         # appends text), so fall back to queue when images are
                         # attached.  If the agent lacks steer() or rejects the

--- a/hermes_cli/valut.py
+++ b/hermes_cli/valut.py
@@ -1,0 +1,229 @@
+"""Valut — local secret reference system for in-chat credential safety.
+
+When a user wraps sensitive text with ``?/`` ... ``/?`` in a chat message,
+the enclosed value is extracted, stored in a local encrypted-feeling JSON
+file (~/.hermes/valut.json, 0600), and replaced with an opaque reference
+like ``[VLT:a1b2c3d4]``.  The LLM never sees the plaintext.
+
+On output, any ``[VLT:<id>]`` reference is substituted back to the original
+value before the user sees it, so the agent can "use" a secret by
+referencing its ID without ever knowing the actual value.
+
+Usage
+-----
+  User:   Hey, my API key is ?/sk-secret-123/? — can you test it?
+  Agent sees: Hey, my API key is [VLT:a1b2c3d4] — can you test it?
+  Agent says: I'll call the API with [VLT:a1b2c3d4]
+  User sees:  I'll call the API with sk-secret-123
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import secrets
+import threading
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# ── trigger regex ──────────────────────────────────────────────────────────
+# Matches ``?/`` opener, any content (non-greedy), ``/?`` closer.
+# The content is captured as group 1.
+_TRIGGER_RE = re.compile(r"\?\/(.+?)\/\?")
+
+# ── output reference regex ─────────────────────────────────────────────────
+# Matches ``[VLT:<id>]`` where <id> is ``vlt_`` + 8 hex chars.
+_REF_RE = re.compile(r"\[VLT:(vlt_[0-9a-fA-F]{8})\]")
+
+
+def _valut_path() -> Path:
+    """Return the path to the valut store file."""
+    from hermes_constants import get_hermes_home
+    return get_hermes_home() / "valut.json"
+
+
+class ValutStore:
+    """Thread-safe persistent store for secret reference mappings."""
+
+    def __init__(self, path: Path | None = None):
+        self._path = path or _valut_path()
+        self._lock = threading.Lock()
+        self._entries: dict[str, str] = {}
+        self._loaded = False
+
+    # ── persistence ────────────────────────────────────────────────────
+
+    def _load(self) -> None:
+        """Load entries from the valut JSON file (best-effort)."""
+        if self._loaded:
+            return
+        self._loaded = True
+        try:
+            if self._path.exists():
+                data = json.loads(self._path.read_text(encoding="utf-8"))
+                if isinstance(data, dict):
+                    self._entries = {
+                        k: v for k, v in data.items()
+                        if isinstance(k, str) and isinstance(v, str)
+                    }
+        except Exception:
+            logger.debug("valut load failed — starting empty", exc_info=True)
+            self._entries = {}
+
+    def _save(self) -> None:
+        """Write entries to disk atomically with 0600 permissions."""
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = self._path.with_suffix(".tmp")
+            tmp.write_text(json.dumps(self._entries, indent=2), encoding="utf-8")
+            # Set restrictive permissions before rename so the window of
+            # exposure is as small as possible.
+            try:
+                os.chmod(tmp, 0o600)
+            except OSError:
+                pass
+            tmp.replace(self._path)
+            try:
+                os.chmod(self._path, 0o600)
+            except OSError:
+                pass
+        except Exception:
+            logger.debug("valut save failed", exc_info=True)
+
+    # ── API ────────────────────────────────────────────────────────────
+
+    def store(self, value: str) -> str:
+        """Store a secret and return its reference ID (``vlt_XXXXXXXX``).
+
+        If *value* is empty, returns it unchanged.
+        """
+        if not value:
+            return value
+        with self._lock:
+            self._load()
+            # Check if we already have this value stored — reuse the ID.
+            for existing_id, existing_val in self._entries.items():
+                if existing_val == value:
+                    return existing_id
+            # Generate a new unique ID.
+            while True:
+                ref_id = f"vlt_{secrets.token_hex(4)}"
+                if ref_id not in self._entries:
+                    break
+            self._entries[ref_id] = value
+            self._save()
+            logger.info("valut: stored secret as %s", ref_id)
+            return ref_id
+
+    def resolve(self, ref_id: str) -> str | None:
+        """Look up a reference ID. Returns ``None`` if not found."""
+        if not ref_id:
+            return None
+        with self._lock:
+            self._load()
+            return self._entries.get(ref_id)
+
+    def list_ids(self) -> list[str]:
+        """Return all stored reference IDs (for user introspection)."""
+        with self._lock:
+            self._load()
+            return sorted(self._entries.keys())
+
+    def remove(self, ref_id: str) -> bool:
+        """Remove a stored secret. Returns True if it existed."""
+        with self._lock:
+            self._load()
+            existed = ref_id in self._entries
+            if existed:
+                del self._entries[ref_id]
+                self._save()
+            return existed
+
+    def clear(self) -> None:
+        """Remove all stored secrets."""
+        with self._lock:
+            self._entries.clear()
+            self._save()
+
+
+# ── module-level singleton ─────────────────────────────────────────────────
+
+_store: ValutStore | None = None
+_store_lock = threading.Lock()
+
+
+def _get_store() -> ValutStore:
+    global _store
+    if _store is None:
+        with _store_lock:
+            if _store is None:
+                _store = ValutStore()
+    return _store
+
+
+# ── public helpers ─────────────────────────────────────────────────────────
+
+
+def sanitize_input(text: str) -> str:
+    """Scan *text* for ``?/.../?`` patterns, vault the secrets, return cleaned text.
+
+    Each ``?/secret/?`` becomes ``[VLT:vlt_XXXXXXXX]`` in the returned string.
+    If no triggers are found, the original string is returned unchanged.
+
+    SAFETY: The LLM never receives the plaintext — only the opaque reference.
+    """
+    if not text or "?/" not in text:
+        return text
+
+    store = _get_store()
+
+    def _replace(m: re.Match) -> str:
+        secret = m.group(1)
+        if not secret.strip():
+            return m.group(0)  # empty trigger, pass through unchanged
+        ref_id = store.store(secret)
+        return f"[VLT:{ref_id}]"
+
+    try:
+        return _TRIGGER_RE.sub(_replace, text)
+    except Exception:
+        logger.debug("valut sanitize_input failed", exc_info=True)
+        return text
+
+
+def restore_output(text: str) -> str:
+    """Replace ``[VLT:<id>]`` references in *text* with their stored values.
+
+    If a reference can't be resolved, it passes through unchanged so the
+    user can see which ID was referenced.
+    """
+    if not text or "[VLT:" not in text:
+        return text
+
+    store = _get_store()
+
+    def _replace(m: re.Match) -> str:
+        ref_id = m.group(1)
+        resolved = store.resolve(ref_id)
+        if resolved is not None:
+            return resolved
+        return m.group(0)  # unresolved — leave as-is
+
+    try:
+        return _REF_RE.sub(_replace, text)
+    except Exception:
+        logger.debug("valut restore_output failed", exc_info=True)
+        return text
+
+
+def process_message_for_agent(text: str) -> str:
+    """Full input pipeline: sanitize before the agent sees it."""
+    return sanitize_input(text)
+
+
+def process_message_for_display(text: str) -> str:
+    """Full output pipeline: restore references before the user sees it."""
+    return restore_output(text)


### PR DESCRIPTION
## Summary

Adds the **Valut** secret reference system: a client-side intercept that vaults sensitive credentials before they reach the LLM.

### How it works

1. **Input**: User types `?/password/?` in chat → the secret is extracted, stored in `~/.hermes/valut.json` (0600), and replaced with an opaque `[VLT:vlt_xxxxxxxx]` reference. The LLM **never** sees the plaintext.

2. **Output**: When the agent responds with a `[VLT:vlt_xxxxxxxx]` reference, it's substituted back to the actual value before the user sees it.

3. **Reuse**: Once vaulted, the same value returns the same ID. Users can reference `[VLT:id]` directly without re-entering.

### Example

```
User types:   My API key is ?/sk-proj-abc123/? — can you test it?
Agent sees:   My API key is [VLT:vlt_da5a8bf1] — can you test it?
Agent says:   I'll call the API with [VLT:vlt_da5a8bf1]
User sees:    I'll call the API with sk-proj-abc123
```

### Files changed

| File | Lines | Change |
|------|-------|--------|
| `hermes_cli/valut.py` | +229 | New module: ValutStore + sanitize/restore helpers |
| `cli.py` | +12 | Integrate into `_cprint` (output), `handle_enter` + `_editor_submit` (input) |

### Safety

- Secrets live only in `~/.hermes/valut.json` with 0600 permissions
- The LLM never sees plaintext — only opaque references
- Idempotent: same value → same ID (no duplicate secrets)
- Fast-path short-circuits when no triggers/references present