### PR TITLE
fix(computer-use): replace nonexistent 'screenshot' tool call with get_window_state(capture_mode='vision')

### DIFF
--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -497,10 +497,16 @@ class CuaDriverBackend(ComputerUseBackend):
         window_title = ""
 
         if mode == "vision":
-            # screenshot tool: just the PNG, no AX walk.
+            # `get_window_state` with capture_mode="vision" returns the PNG
+            # (no AX walk). The previous implementation called a non-existent
+            # `screenshot` tool, which always returned "Unknown tool".
             sc_out = self._session.call_tool(
-                "screenshot",
-                {"window_id": self._active_window_id, "format": "jpeg", "quality": 85},
+                "get_window_state",
+                {
+                    "pid": self._active_pid,
+                    "window_id": self._active_window_id,
+                    "capture_mode": "vision",
+                },
             )
             if sc_out["images"]:
                 png_b64 = sc_out["images"][0]

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 # Version pinning
 # ---------------------------------------------------------------------------
 
-PINNED_CUA_DRIVER_VERSION = os.environ.get("HERMES_CUA_DRIVER_VERSION", "0.5.0")
+PINNED_CUA_DRIVER_VERSION = os.environ.get("HERMES_CUA_DRIVER_VERSION", "0.6.7")
 
 _CUA_DRIVER_CMD = os.environ.get("HERMES_CUA_DRIVER_CMD", "cua-driver")
 _CUA_DRIVER_ARGS = ["mcp"]  # stdio MCP transport


### PR DESCRIPTION
## Summary

Two fixes for the Hermes `computer_use` wrapper on macOS:

1. **Wrapper bug**: vision mode called a tool named `screenshot`, which does not exist in the cua-driver MCP tool list. The call returned `isError: True, "Unknown tool: screenshot"` and the wrapper silently produced 0x0 captures.

2. **Pinned version bump**: 0.5.0 → 0.6.7. The 0.6.x line adds a `health_report` tool that gives structured diagnostics on TCC + bundle identity + ScreenCaptureKit reachability, and the recommended launch path (`open -n -g -a CuaDriver --args serve`) gives the daemon a proper CFBundleIdentifier so the TCC grants apply.

## Repro of bug 1

```bash
$ cua-driver call list-tools | grep -i screenshot
# (no output — screenshot is not a real tool)

# computer_use capture mode=vision always returned 0x0 even when SOM mode
# on the same window returned 1846 elements
```

## Fix

```diff
-            # screenshot tool: just the PNG, no AX walk.
+            # `get_window_state` with capture_mode="vision" returns the PNG
+            # (no AX walk). The previous implementation called a non-existent
+            # `screenshot` tool, which always returned "Unknown tool".
             sc_out = self._session.call_tool(
-                "screenshot",
-                {"window_id": self._active_window_id, "format": "jpeg", "quality": 85},
+                "get_window_state",
+                {
+                    "pid": self._active_pid,
+                    "window_id": self._active_window_id,
+                    "capture_mode": "vision",
+                },
             )
```

```diff
-PINNED_CUA_DRIVER_VERSION = os.environ.get("HERMES_CUA_DRIVER_VERSION", "0.5.0")
+PINNED_CUA_DRIVER_VERSION = os.environ.get("HERMES_CUA_DRIVER_VERSION", "0.6.7")
```

## Why the version bump matters for the bug

In 0.5.x, the only diagnostic for a broken capture was a silent 0x0 return. In 0.6.x, `cua-driver call health_report` returns structured pass/fail checks for bundle identity, TCC grants, AX capability, and ScreenCaptureKit shareable display count — which makes it obvious which layer is broken and where to look. Even when capture is still broken at the OS level, the new diagnostics tell you it's the macOS framebuffer and not the daemon.

## Verification

- End-to-end against running cua-driver 0.6.7 on macOS 26.5.1
- `computer_use capture mode=som app="Google Chrome"` → 1846 AX elements parsed
- `computer_use capture mode=vision app="Google Chrome"` → wrapper now calls the correct tool and returns image content when the framebuffer is alive
- `cua-driver call health_report` → all checks pass; bundle ID = com.trycua.driver; ScreenCaptureKit reachable, 0 displays shareable
- 135/135 `tests/tools/test_computer_use*` + `tests/hermes_cli/test_install_cua_driver.py` pass

## Note

This PR makes the wrapper work correctly on any Mac with a functional framebuffer. On macOS 26.2+ physical hardware, the Core Graphics screencapture subsystem may still return black PNGs even with this fix in place — that's the separate trycua/cua#870 "no backing store" regression (`health_report` surfaces it as `0 display(s) shareable`) and requires a macOS or display-driver fix.