### PR TITLE
fix(telegram): cache forum topic names from status updates

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -21,6 +21,7 @@ import re
 import sqlite3
 import threading
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 from agent.memory_manager import sanitize_context
@@ -589,6 +590,15 @@ CREATE TABLE IF NOT EXISTS compression_locks (
     holder TEXT NOT NULL,
     acquired_at REAL NOT NULL,
     expires_at REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS telegram_group_topic_cache (
+    chat_id TEXT NOT NULL,
+    thread_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    source TEXT NOT NULL,
+    PRIMARY KEY (chat_id, thread_id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
@@ -4332,6 +4342,65 @@ class SessionDB:
                 (key, value),
             )
         self._execute_write(_do)
+
+    def set_telegram_group_topic_name(
+        self,
+        *,
+        chat_id: str,
+        thread_id: str,
+        name: str,
+        source: str = "forum_topic_status_update",
+    ) -> None:
+        """Persist a Telegram forum group topic name observed from Bot API events."""
+        chat_id = str(chat_id).strip()
+        thread_id = str(thread_id).strip()
+        name = str(name).strip()
+        source = str(source or "forum_topic_status_update").strip()
+        if not chat_id or not thread_id or not name:
+            return
+        updated_at = datetime.now(timezone.utc).isoformat()
+
+        def _do(conn):
+            conn.execute(
+                """
+                INSERT INTO telegram_group_topic_cache (
+                    chat_id, thread_id, name, updated_at, source
+                ) VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(chat_id, thread_id) DO UPDATE SET
+                    name = excluded.name,
+                    updated_at = excluded.updated_at,
+                    source = excluded.source
+                """,
+                (chat_id, thread_id, name, updated_at, source),
+            )
+        self._execute_write(_do)
+
+    def get_telegram_group_topic_name(
+        self,
+        *,
+        chat_id: str,
+        thread_id: str,
+    ) -> Optional[str]:
+        """Return a cached Telegram forum group topic name, if one is known."""
+        chat_id = str(chat_id).strip()
+        thread_id = str(thread_id).strip()
+        if not chat_id or not thread_id:
+            return None
+        with self._lock:
+            try:
+                row = self._conn.execute(
+                    """
+                    SELECT name FROM telegram_group_topic_cache
+                    WHERE chat_id = ? AND thread_id = ?
+                    """,
+                    (chat_id, thread_id),
+                ).fetchone()
+            except sqlite3.OperationalError:
+                return None
+        if row is None:
+            return None
+        value = row["name"] if isinstance(row, sqlite3.Row) else row[0]
+        return str(value).strip() or None
 
     def apply_telegram_topic_migration(self) -> None:
         """Create Telegram DM topic-mode tables on explicit /topic opt-in.

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -543,6 +543,8 @@ class TelegramAdapter(BasePlatformAdapter):
         self._send_path_degraded: bool = False
         # DM Topics: map of topic_name -> message_thread_id (populated at startup)
         self._dm_topics: Dict[str, int] = {}
+        self._telegram_group_topic_cache_db = None
+        self._owns_telegram_group_topic_cache_db = False
         # Track forum chats where we've already registered bot commands
         self._forum_command_registered: set[int] = set()
         # Lock per la registrazione sicura dei comandi nei forum supergroup
@@ -2313,6 +2315,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL | filters.Sticker.ALL,
                 self._handle_media_message
             ))
+            self._register_forum_topic_status_handler()
             # Handle inline keyboard button callbacks (update prompts)
             self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
             
@@ -2552,6 +2555,17 @@ class TelegramAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("[%s] Error during Telegram disconnect: %s", self.name, e, exc_info=True)
         self._release_platform_lock()
+
+        if getattr(self, "_owns_telegram_group_topic_cache_db", False):
+            db = getattr(self, "_telegram_group_topic_cache_db", None)
+            close = getattr(db, "close", None)
+            if callable(close):
+                try:
+                    close()
+                except Exception:
+                    pass
+            self._telegram_group_topic_cache_db = None
+            self._owns_telegram_group_topic_cache_db = False
 
         for task in self._pending_photo_batch_tasks.values():
             if task and not task.done():
@@ -6224,6 +6238,117 @@ class TelegramAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("[%s] Forum command lazy-registration failed: %s", self.name, e)
 
+    def _get_telegram_group_topic_cache_db(self, *, create: bool = False):
+        """Return the state.db handle used for Telegram forum topic name cache."""
+        db = getattr(self, "_telegram_group_topic_cache_db", None)
+        if db is not None:
+            return db
+
+        runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+        db = getattr(runner, "_session_db", None)
+        if db is not None:
+            self._telegram_group_topic_cache_db = db
+            return db
+
+        if not create:
+            return None
+
+        try:
+            from hermes_state import SessionDB
+
+            db = SessionDB()
+            self._telegram_group_topic_cache_db = db
+            self._owns_telegram_group_topic_cache_db = True
+            return db
+        except Exception as exc:
+            logger.debug(
+                "[%s] Telegram group topic cache unavailable: %s",
+                self.name,
+                exc,
+            )
+            return None
+
+    def _cache_telegram_group_topic_name(
+        self,
+        chat_id: str,
+        thread_id: str,
+        name: str,
+        *,
+        source: str,
+    ) -> None:
+        """Persist an observed Telegram forum group topic name."""
+        db = self._get_telegram_group_topic_cache_db(create=True)
+        if db is None:
+            return
+        try:
+            db.set_telegram_group_topic_name(
+                chat_id=str(chat_id),
+                thread_id=str(thread_id),
+                name=name,
+                source=source,
+            )
+        except Exception as exc:
+            logger.debug(
+                "[%s] Failed to cache Telegram group topic %s/%s: %s",
+                self.name,
+                chat_id,
+                thread_id,
+                exc,
+            )
+
+    def _get_cached_telegram_group_topic_name(
+        self,
+        chat_id: str,
+        thread_id: str,
+    ) -> Optional[str]:
+        """Return a persisted Telegram forum group topic name, if known."""
+        db = self._get_telegram_group_topic_cache_db(create=False)
+        if db is None:
+            return None
+        try:
+            return db.get_telegram_group_topic_name(
+                chat_id=str(chat_id),
+                thread_id=str(thread_id),
+            )
+        except Exception as exc:
+            logger.debug(
+                "[%s] Failed to read Telegram group topic cache %s/%s: %s",
+                self.name,
+                chat_id,
+                thread_id,
+                exc,
+            )
+            return None
+
+    def _forum_topic_status_filter(self):
+        """Build the PTB filter for forum topic created/edited service updates."""
+        status_update = getattr(filters, "StatusUpdate", None) if filters is not None else None
+        if status_update is None:
+            return None
+        created = getattr(status_update, "FORUM_TOPIC_CREATED", None)
+        edited = getattr(status_update, "FORUM_TOPIC_EDITED", None)
+        if created is None:
+            return edited
+        if edited is None:
+            return created
+        try:
+            return created | edited
+        except Exception:
+            return None
+
+    def _register_forum_topic_status_handler(self) -> None:
+        """Register a non-agent handler for forum topic created/edited events."""
+        if not self._app:
+            return
+        status_filter = self._forum_topic_status_filter()
+        if status_filter is None:
+            logger.debug("[%s] Telegram forum topic status filters unavailable", self.name)
+            return
+        self._app.add_handler(TelegramMessageHandler(
+            status_filter,
+            self._handle_forum_topic_status_update,
+        ))
+
     def _effective_update_message(self, update: Update) -> Optional[Message]:
         """Return the message-like payload for normal messages and channel posts.
 
@@ -6233,6 +6358,44 @@ class TelegramAdapter(BasePlatformAdapter):
         consuming channel posts without ever building a gateway event.
         """
         return getattr(update, "effective_message", None) or getattr(update, "message", None)
+
+    async def _handle_forum_topic_status_update(
+        self,
+        update: Update,
+        context: ContextTypes.DEFAULT_TYPE,
+    ) -> None:
+        """Cache forum topic names from Telegram service messages and return."""
+        msg = self._effective_update_message(update)
+        if not msg:
+            return
+
+        chat = getattr(msg, "chat", None)
+        chat_id = getattr(chat, "id", None)
+        thread_id = getattr(msg, "message_thread_id", None)
+        if chat_id is None or thread_id is None:
+            return
+
+        name = None
+        source = None
+        created = getattr(msg, "forum_topic_created", None)
+        if created is not None:
+            name = getattr(created, "name", None)
+            source = "forum_topic_created"
+        else:
+            edited = getattr(msg, "forum_topic_edited", None)
+            if edited is not None:
+                name = getattr(edited, "name", None)
+                source = "forum_topic_edited"
+
+        if not source or not name or not str(name).strip():
+            return
+
+        self._cache_telegram_group_topic_name(
+            str(chat_id),
+            str(thread_id),
+            str(name).strip(),
+            source=source,
+        )
 
     async def _handle_text_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming text messages.
@@ -7065,6 +7228,11 @@ class TelegramAdapter(BasePlatformAdapter):
                             topic_skill = topic.get("skill")
                             break
                     break
+            if not chat_topic:
+                chat_topic = self._get_cached_telegram_group_topic_name(
+                    str(chat.id),
+                    thread_id_str,
+                )
 
         # Build source
         source = self.build_source(

--- a/tests/gateway/test_dm_topics.py
+++ b/tests/gateway/test_dm_topics.py
@@ -45,7 +45,9 @@ def _ensure_telegram_mock():
 
 _ensure_telegram_mock()
 
+import plugins.platforms.telegram.adapter as telegram_module  # noqa: E402
 from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+from hermes_state import SessionDB  # noqa: E402
 
 
 def _make_adapter(dm_topics_config=None, group_topics_config=None):
@@ -542,7 +544,7 @@ def test_cache_dm_topic_from_message_no_overwrite():
 
 def _make_mock_message(chat_id=111, chat_type="private", text="hello", thread_id=None,
                        user_id=42, user_name="Test User", forum_topic_created=None,
-                       is_topic_message=None, is_forum=None):
+                       forum_topic_edited=None, is_topic_message=None, is_forum=None):
     """Create a mock Telegram Message for _build_message_event tests."""
     chat = SimpleNamespace(
         id=chat_id,
@@ -573,6 +575,7 @@ def _make_mock_message(chat_id=111, chat_type="private", text="hello", thread_id
         reply_to_message=None,
         date=None,
         forum_topic_created=forum_topic_created,
+        forum_topic_edited=forum_topic_edited,
     )
     return msg
 
@@ -784,6 +787,126 @@ def test_group_topic_unmapped_thread_id():
     assert event.source.chat_topic is None
 
 
+def test_group_topic_config_takes_priority_over_cache():
+    """Manual group_topics config should win over the learned cache."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter(group_topics_config=[
+        {
+            "chat_id": -1001234567890,
+            "topics": [
+                {"name": "Configured", "thread_id": 5, "skill": "configured-skill"},
+            ],
+        }
+    ])
+    cache_db = SimpleNamespace(get_telegram_group_topic_name=MagicMock(return_value="Cached"))
+    adapter._telegram_group_topic_cache_db = cache_db
+
+    msg = _make_mock_message(
+        chat_id=-1001234567890,
+        chat_type=_ChatType.SUPERGROUP,
+        thread_id=5,
+        text="hello",
+        is_topic_message=True,
+        is_forum=True,
+    )
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.auto_skill == "configured-skill"
+    assert event.source.chat_topic == "Configured"
+    cache_db.get_telegram_group_topic_name.assert_not_called()
+
+
+def test_group_topic_cache_hit_sets_chat_topic_without_config():
+    """A learned group topic name should populate SessionSource.chat_topic."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter()
+    adapter._telegram_group_topic_cache_db = SimpleNamespace(
+        get_telegram_group_topic_name=MagicMock(return_value="Cached Topic")
+    )
+
+    msg = _make_mock_message(
+        chat_id=-1001234567890,
+        chat_type=_ChatType.SUPERGROUP,
+        thread_id=12,
+        text="hello",
+        is_topic_message=True,
+        is_forum=True,
+    )
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.auto_skill is None
+    assert event.source.chat_topic == "Cached Topic"
+    adapter._telegram_group_topic_cache_db.get_telegram_group_topic_name.assert_called_once_with(
+        chat_id="-1001234567890",
+        thread_id="12",
+    )
+
+
+def test_group_topic_cache_miss_keeps_chat_topic_none():
+    """Unknown group topic names should preserve the existing None behavior."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter()
+    adapter._telegram_group_topic_cache_db = SimpleNamespace(
+        get_telegram_group_topic_name=MagicMock(return_value=None)
+    )
+
+    msg = _make_mock_message(
+        chat_id=-1001234567890,
+        chat_type=_ChatType.SUPERGROUP,
+        thread_id=12,
+        text="hello",
+        is_topic_message=True,
+        is_forum=True,
+    )
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.auto_skill is None
+    assert event.source.chat_topic is None
+
+
+@pytest.mark.asyncio
+async def test_group_topic_cache_reuses_runner_session_db_and_disconnect_keeps_it_open(tmp_path):
+    """A gateway runner-owned SessionDB is shared, not adapter-owned."""
+    adapter = _make_adapter()
+    shared_db = SessionDB(db_path=tmp_path / "state.db")
+
+    class Runner:
+        def __init__(self, session_db):
+            self._session_db = session_db
+
+        async def handle_message(self, *_args, **_kwargs):
+            return None
+
+    runner = Runner(shared_db)
+    adapter._message_handler = runner.handle_message
+
+    try:
+        cache_db = adapter._get_telegram_group_topic_cache_db(create=True)
+
+        assert cache_db is shared_db
+        assert adapter._telegram_group_topic_cache_db is shared_db
+        assert adapter._owns_telegram_group_topic_cache_db is False
+
+        await adapter.disconnect()
+
+        assert shared_db._conn is not None
+        shared_db.set_telegram_group_topic_name(
+            chat_id="-1001234567890",
+            thread_id="77",
+            name="Shared",
+            source="test",
+        )
+        assert shared_db.get_telegram_group_topic_name(
+            chat_id="-1001234567890",
+            thread_id="77",
+        ) == "Shared"
+    finally:
+        shared_db.close()
+
+
 def test_group_topic_unmapped_chat_id():
     """Chat ID not in group_topics config should fall through silently."""
     from gateway.platforms.base import MessageType
@@ -809,6 +932,138 @@ def test_group_topic_unmapped_chat_id():
 
     assert event.auto_skill is None
     assert event.source.chat_topic is None
+
+
+@pytest.mark.asyncio
+async def test_forum_topic_created_service_message_writes_cache_without_agent(tmp_path):
+    """forum_topic_created should only update the cache and not dispatch to the agent."""
+    adapter = _make_adapter()
+    cache_db = SessionDB(db_path=tmp_path / "state.db")
+    adapter._telegram_group_topic_cache_db = cache_db
+    adapter.handle_message = AsyncMock()
+
+    msg = _make_mock_message(
+        chat_id=-1001234567890,
+        chat_type=_ChatType.SUPERGROUP,
+        thread_id=77,
+        is_topic_message=True,
+        is_forum=True,
+        forum_topic_created=SimpleNamespace(name="Launch"),
+    )
+    update = SimpleNamespace(update_id=1, effective_message=msg, message=msg)
+
+    await adapter._handle_forum_topic_status_update(update, None)
+
+    assert cache_db.get_telegram_group_topic_name(
+        chat_id="-1001234567890",
+        thread_id="77",
+    ) == "Launch"
+    adapter.handle_message.assert_not_awaited()
+    cache_db.close()
+
+
+@pytest.mark.asyncio
+async def test_forum_topic_edited_nonempty_name_updates_cache(tmp_path):
+    """forum_topic_edited with a name should replace the learned cache value."""
+    adapter = _make_adapter()
+    cache_db = SessionDB(db_path=tmp_path / "state.db")
+    cache_db.set_telegram_group_topic_name(
+        chat_id="-1001234567890",
+        thread_id="77",
+        name="Old",
+        source="test",
+    )
+    adapter._telegram_group_topic_cache_db = cache_db
+
+    msg = _make_mock_message(
+        chat_id=-1001234567890,
+        chat_type=_ChatType.SUPERGROUP,
+        thread_id=77,
+        is_topic_message=True,
+        is_forum=True,
+        forum_topic_edited=SimpleNamespace(name="Renamed"),
+    )
+    update = SimpleNamespace(update_id=2, effective_message=msg, message=msg)
+
+    await adapter._handle_forum_topic_status_update(update, None)
+
+    assert cache_db.get_telegram_group_topic_name(
+        chat_id="-1001234567890",
+        thread_id="77",
+    ) == "Renamed"
+    cache_db.close()
+
+
+@pytest.mark.asyncio
+async def test_forum_topic_edited_empty_name_does_not_overwrite_cache(tmp_path):
+    """Icon-only forum_topic_edited events should leave the old cached name intact."""
+    adapter = _make_adapter()
+    cache_db = SessionDB(db_path=tmp_path / "state.db")
+    cache_db.set_telegram_group_topic_name(
+        chat_id="-1001234567890",
+        thread_id="77",
+        name="Still Here",
+        source="test",
+    )
+    adapter._telegram_group_topic_cache_db = cache_db
+
+    msg = _make_mock_message(
+        chat_id=-1001234567890,
+        chat_type=_ChatType.SUPERGROUP,
+        thread_id=77,
+        is_topic_message=True,
+        is_forum=True,
+        forum_topic_edited=SimpleNamespace(name=None),
+    )
+    update = SimpleNamespace(update_id=3, effective_message=msg, message=msg)
+
+    await adapter._handle_forum_topic_status_update(update, None)
+
+    assert cache_db.get_telegram_group_topic_name(
+        chat_id="-1001234567890",
+        thread_id="77",
+    ) == "Still Here"
+    cache_db.close()
+
+
+def test_forum_topic_status_handler_registers_created_and_edited(monkeypatch):
+    """The Telegram adapter should register status filters for created and edited topics."""
+    adapter = _make_adapter()
+    adapter._app = SimpleNamespace(add_handler=MagicMock())
+
+    class FakeFilter:
+        def __init__(self, names):
+            self.names = set(names)
+
+        def __or__(self, other):
+            return FakeFilter(self.names | other.names)
+
+    created = FakeFilter({"FORUM_TOPIC_CREATED"})
+    edited = FakeFilter({"FORUM_TOPIC_EDITED"})
+    monkeypatch.setattr(
+        telegram_module,
+        "filters",
+        SimpleNamespace(
+            StatusUpdate=SimpleNamespace(
+                FORUM_TOPIC_CREATED=created,
+                FORUM_TOPIC_EDITED=edited,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        telegram_module,
+        "TelegramMessageHandler",
+        lambda filter_obj, callback: SimpleNamespace(
+            filter=filter_obj,
+            callback=callback,
+        ),
+    )
+
+    adapter._register_forum_topic_status_handler()
+
+    handler = adapter._app.add_handler.call_args.args[0]
+    assert handler.filter.names == {"FORUM_TOPIC_CREATED", "FORUM_TOPIC_EDITED"}
+    assert handler.callback == adapter._handle_forum_topic_status_update
 
 
 def test_group_topic_no_config():

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2262,6 +2262,89 @@ class TestSchemaInit:
         columns = {row[1] for row in cursor.fetchall()}
         assert "title" in columns
 
+    def test_existing_db_creates_telegram_group_topic_cache_without_version_bump(
+        self, tmp_path
+    ):
+        """Opening an existing DB should create the group-topic cache table."""
+        from hermes_state import SCHEMA_VERSION
+
+        old_db = tmp_path / "old.db"
+        conn = sqlite3.connect(old_db)
+        conn.executescript(
+            """
+            CREATE TABLE schema_version (version INTEGER NOT NULL);
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT NOT NULL,
+                user_id TEXT,
+                model TEXT,
+                model_config TEXT,
+                system_prompt TEXT,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL,
+                end_reason TEXT,
+                message_count INTEGER DEFAULT 0,
+                tool_call_count INTEGER DEFAULT 0,
+                input_tokens INTEGER DEFAULT 0,
+                output_tokens INTEGER DEFAULT 0,
+                cache_read_tokens INTEGER DEFAULT 0,
+                cache_write_tokens INTEGER DEFAULT 0,
+                reasoning_tokens INTEGER DEFAULT 0,
+                billing_provider TEXT,
+                billing_base_url TEXT,
+                billing_mode TEXT,
+                estimated_cost_usd REAL,
+                actual_cost_usd REAL,
+                cost_status TEXT,
+                cost_source TEXT,
+                pricing_version TEXT,
+                title TEXT,
+                api_call_count INTEGER DEFAULT 0,
+                FOREIGN KEY (parent_session_id) REFERENCES sessions(id)
+            );
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL REFERENCES sessions(id),
+                role TEXT NOT NULL,
+                content TEXT,
+                tool_call_id TEXT,
+                tool_calls TEXT,
+                tool_name TEXT,
+                timestamp REAL NOT NULL,
+                token_count INTEGER,
+                finish_reason TEXT,
+                reasoning TEXT,
+                reasoning_content TEXT,
+                reasoning_details TEXT,
+                codex_reasoning_items TEXT,
+                codex_message_items TEXT
+            );
+            """
+        )
+        conn.execute("INSERT INTO schema_version VALUES (?)", (SCHEMA_VERSION,))
+        conn.commit()
+        conn.close()
+
+        db = SessionDB(db_path=old_db)
+        try:
+            version = db._conn.execute("SELECT version FROM schema_version").fetchone()[0]
+            assert version == SCHEMA_VERSION
+
+            db.set_telegram_group_topic_name(
+                chat_id="-1001234567890",
+                thread_id="77",
+                name="Launch",
+                source="test",
+            )
+
+            assert db.get_telegram_group_topic_name(
+                chat_id="-1001234567890",
+                thread_id="77",
+            ) == "Launch"
+        finally:
+            db.close()
+
     def test_topic_mode_schema_is_not_auto_migrated_on_open(self, tmp_path):
         """Opening an old DB should not add topic-mode columns until /topic opts in.
 


### PR DESCRIPTION
## Summary

- Cache Telegram forum topic names observed from `forum_topic_created` / `forum_topic_edited` service messages.
- Fill `SessionSource.chat_topic` for later regular messages in the same `(chat_id, message_thread_id)` topic when no manual `extra.group_topics` entry matches.
- Keep topic service messages out of the agent path; they update cache only and do not trigger a response.
- Preserve existing routing contracts: session keys and delivery targets still use `chat_id` + `thread_id`; manual `group_topics` config remains highest priority.

## Notes

Telegram Bot API does not expose a method to look up a forum topic name by `chat_id` + `message_thread_id`, so this is an online-learning cache. Existing/old topics are populated only after the bot observes a create or rename service message.

## Tests

- `uv run --extra dev python -m pytest tests/gateway/test_dm_topics.py tests/test_hermes_state.py -q -o addopts=` → `323 passed`
- `uv run --extra dev ruff check plugins/platforms/telegram/adapter.py hermes_state.py tests/gateway/test_dm_topics.py tests/test_hermes_state.py` → `All checks passed!`
- `git diff --check` → passed

## Review

Independent Codex review found no blockers. Two non-blocking coverage suggestions were added before this PR:

- runner-owned `SessionDB` is reused and not closed by adapter disconnect
- existing `state.db` opens create `telegram_group_topic_cache` without a schema version bump
