### PR TITLE
fix(tui): add /learn to _PENDING_INPUT_COMMANDS so Desktop GUI submits the learn prompt

### DIFF
--- a/tests/tui_gateway/test_learn_command.py
+++ b/tests/tui_gateway/test_learn_command.py
@@ -1,0 +1,49 @@
+"""Tests for the ``/learn`` slash command in the TUI gateway.
+
+``/learn`` must be listed in ``_PENDING_INPUT_COMMANDS`` because the CLI
+handler (``_handle_learn_command``) queues the learn prompt on
+``_pending_input`` — a queue that the slash-worker subprocess does **not**
+consume.  Routing through ``command.dispatch`` returns ``{"type": "send",
+"message": …}`` so the frontend can submit the prompt directly.
+"""
+
+import importlib
+
+import pytest
+
+server = importlib.import_module("tui_gateway.server")
+
+
+def test_learn_in_pending_input_commands():
+    """Registry sanity: /learn must be in _PENDING_INPUT_COMMANDS so
+    slash.exec routes it to command.dispatch instead of the worker."""
+    assert "learn" in server._PENDING_INPUT_COMMANDS
+
+
+def test_command_dispatch_learn_returns_send_type():
+    """command.dispatch for /learn returns a ``send`` payload with a message
+    that the frontend can submit as a user prompt."""
+    resp = server._methods["command.dispatch"](
+        "test-rid",
+        {"name": "learn", "arg": "create a skill from https://example.com", "session_id": ""},
+    )
+    assert "result" in resp, f"Expected JSON-RPC result, got: {resp}"
+    payload = resp["result"]
+    assert payload["type"] == "send"
+    assert isinstance(payload["message"], str)
+    assert len(payload["message"]) > 0
+    assert "skill" in payload["message"].lower() or "learn" in payload["message"].lower()
+
+
+def test_command_dispatch_learn_no_arg():
+    """command.dispatch for /learn with no argument still returns a valid
+    send payload (the prompt describes learning from the current conversation)."""
+    resp = server._methods["command.dispatch"](
+        "test-rid",
+        {"name": "learn", "arg": "", "session_id": ""},
+    )
+    assert "result" in resp, f"Expected JSON-RPC result, got: {resp}"
+    payload = resp["result"]
+    assert payload["type"] == "send"
+    assert isinstance(payload["message"], str)
+    assert len(payload["message"]) > 0

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9289,6 +9289,7 @@ _PENDING_INPUT_COMMANDS: frozenset[str] = frozenset(
         "plan",
         "goal",
         "undo",
+        "learn",
     }
 )
 


### PR DESCRIPTION
## What does this PR do?

Adds `/learn` to `_PENDING_INPUT_COMMANDS` in the TUI gateway so the Desktop GUI correctly submits the learn prompt to the agent instead of only showing the ack message.

## Related Issue

Fixes #51829

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`: Added `"learn"` to `_PENDING_INPUT_COMMANDS` frozenset so `slash.exec` routes to `command.dispatch` (which returns `{type: "send", message: …}`) instead of the slash worker subprocess (where `_pending_input` has no consumer).
- `tests/tui_gateway/test_learn_command.py`: Added 3 regression tests — registry sanity check, send-type response with arg, and send-type response without arg.

## How to Test

1. Open Hermes Desktop GUI
2. Type `/learn create a skill from https://example.com/docs`
3. Verify: the learn prompt is submitted to the agent (LLM request fires, no longer just "⚡ Learning a skill..." ack with no follow-up)
4. Run `python -m pytest tests/tui_gateway/test_learn_command.py -v` — all 3 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tui_gateway/server.py:_PENDING_INPUT_COMMANDS` (callers: `slash.exec` dispatch gate)
- Blast radius: LOW — only affects the `/learn` command routing in TUI/Desktop; CLI and gateway paths are unchanged
- Related patterns: Same fix pattern as #48848 which added `goal`/`plan`/`steer` to `_PENDING_INPUT_COMMANDS`
