### PR TITLE
fix(agent): parse Gemini retry-in cooldowns

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -293,7 +293,7 @@ def _extract_retry_delay_seconds(message: str) -> Optional[float]:
     if delay_match:
         value = float(delay_match.group(1))
         return value / 1000.0 if delay_match.group(2).lower() == "ms" else value
-    sec_match = re.search(r"retry\s+(?:after\s+)?(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)", message, re.IGNORECASE)
+    sec_match = re.search(r"retry\s+(?:(?:after|in)\s+)?(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)", message, re.IGNORECASE)
     if sec_match:
         return float(sec_match.group(1))
     # "Resets in 4hr 5min" format used by OpenCode Go weekly usage limits

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -102,6 +102,20 @@ def test_select_clears_expired_exhaustion(tmp_path, monkeypatch):
     assert entry.last_status == "ok"
 
 
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        ("Rate limit exceeded. Please retry in 6.19s.", 6.19),
+        ("Rate limit exceeded. Please retry after 30 seconds.", 30.0),
+        ("Rate limit exceeded. retry 120s", 120.0),
+    ],
+)
+def test_extract_retry_delay_accepts_retry_seconds_messages(message, expected):
+    from agent.credential_pool import _extract_retry_delay_seconds
+
+    assert _extract_retry_delay_seconds(message) == expected
+
+
 def test_round_robin_strategy_rotates_priorities(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     _write_auth_store(


### PR DESCRIPTION
## What does this PR do?

Parses Gemini-style retry cooldown messages that say `Please retry in X.Xs` when marking credentials as exhausted.

Previously `_extract_retry_delay_seconds()` recognized `retry after 30 seconds` and `retry 120s`, but not `retry in 6.19s`. When providers returned that format, Hermes could fall back to the default exhaustion TTL instead of rotating the credential back in after the actual short retry window.

## Related Issue

Fixes #51450

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/credential_pool.py`: accept `retry in <seconds>` alongside existing `retry after <seconds>` and `retry <seconds>` cooldown messages.
- `tests/agent/test_credential_pool.py`: add regression coverage for Gemini's `Please retry in 6.19s` format while preserving existing accepted formats.

## How to Test

1. `uv run --with pytest --with pyyaml --with ruamel.yaml python -m pytest tests/agent/test_credential_pool.py::test_extract_retry_delay_accepts_retry_seconds_messages -q -o 'addopts='`
2. `uv run --with pytest --with pyyaml --with ruamel.yaml python -m pytest tests/agent/test_credential_pool.py -q -o 'addopts='`
3. `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Regression test failed before the fix:

```text
AssertionError: assert None == 6.19
```

After the fix:

```text
...                                                                      [100%]
3 passed in 0.21s
```

Full credential-pool test file:

```text
........................................................................ [ 87%]
..........                                                               [100%]
82 passed in 1.31s
```
