### PR TITLE
fix(desktop): separate reasoning effort in model dropdown

### DIFF
--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -18,12 +18,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import type { HermesGateway } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { requestModelOptions } from '@/lib/model-options'
-import {
-  currentPickerSelection,
-  displayModelName,
-  modelDisplayParts,
-  reasoningEffortLabel
-} from '@/lib/model-status-label'
+import { currentPickerSelection, displayModelName, modelDisplayParts, modelStatusBadges } from '@/lib/model-status-label'
 import { normalize } from '@/lib/text'
 import { cn } from '@/lib/utils'
 import { $modelPresets, applyModelPreset, modelPresetKey } from '@/store/model-presets'
@@ -263,12 +258,11 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
                   effFast
                 )
 
-                const meta = [
-                  fastControl.kind !== 'none' && fastControl.on ? copy.fast : null,
-                  (caps?.reasoning ?? true) ? reasoningEffortLabel(effEffort) || copy.medium : null
-                ]
-                  .filter(Boolean)
-                  .join(' ')
+                const badges = modelStatusBadges({
+                  fastMode: fastControl.kind !== 'none' && fastControl.on,
+                  reasoning: caps?.reasoning ?? true,
+                  reasoningEffort: effEffort
+                })
 
                 // Every row is a hover-Edit submenu trigger. Activating it
                 // (pointer or keyboard) switches to the family's base model and
@@ -298,9 +292,20 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
                         }
                       }}
                     >
-                      <span className="min-w-0 flex-1 truncate">
-                        {name}
-                        {meta ? <span className="text-(--ui-text-tertiary)"> {meta}</span> : null}
+                      <span className="flex min-w-0 flex-1 items-center gap-1.5">
+                        <span className="min-w-0 truncate">{name}</span>
+                        {badges.length > 0 ? (
+                          <span aria-label={badges.join(', ')} className="inline-flex shrink-0 items-center gap-1">
+                            {badges.map(badge => (
+                              <span
+                                className="rounded border border-(--ui-stroke-tertiary) bg-(--ui-bg-tertiary) px-1 py-px text-[0.625rem] leading-none text-(--ui-text-tertiary)"
+                                key={badge}
+                              >
+                                {badge}
+                              </span>
+                            ))}
+                          </span>
+                        ) : null}
                       </span>
                       {isCurrent ? <Codicon className="ml-auto text-foreground" name="check" size="0.75rem" /> : null}
                     </DropdownMenuSubTrigger>

--- a/apps/desktop/src/lib/model-status-label.test.ts
+++ b/apps/desktop/src/lib/model-status-label.test.ts
@@ -4,6 +4,7 @@ import {
   currentPickerSelection,
   displayModelName,
   formatModelStatusLabel,
+  modelStatusBadges,
   reasoningEffortLabel
 } from './model-status-label'
 
@@ -30,6 +31,12 @@ describe('model-status-label', () => {
     expect(formatModelStatusLabel('openai/gpt-5.5', { fastMode: true, reasoningEffort: 'high' })).toBe(
       'GPT-5.5 · Fast High'
     )
+  })
+
+  it('keeps model menu metadata as separate badge labels', () => {
+    expect(modelStatusBadges({ fastMode: true, reasoningEffort: 'high' })).toEqual(['Fast', 'High'])
+    expect(modelStatusBadges({ reasoningEffort: '' })).toEqual(['Med'])
+    expect(modelStatusBadges({ fastMode: true, reasoning: false, reasoningEffort: 'high' })).toEqual(['Fast'])
   })
 
   it('always surfaces the effort (default medium) so the level is visible', () => {

--- a/apps/desktop/src/lib/model-status-label.ts
+++ b/apps/desktop/src/lib/model-status-label.ts
@@ -97,6 +97,24 @@ export function displayModelName(model: string): string {
   return modelDisplayParts(model).name
 }
 
+export function modelStatusBadges(options?: {
+  fastMode?: boolean
+  reasoning?: boolean
+  reasoningEffort?: string
+}): string[] {
+  const badges: string[] = []
+
+  if (options?.fastMode) {
+    badges.push('Fast')
+  }
+
+  if (options?.reasoning ?? true) {
+    badges.push(reasoningEffortLabel(options?.reasoningEffort ?? '') || 'Med')
+  }
+
+  return badges
+}
+
 /** Status bar trigger label — model name plus the live session state (effort/fast). */
 export function formatModelStatusLabel(
   model: string,
@@ -108,17 +126,13 @@ export function formatModelStatusLabel(
     return name
   }
 
-  const parts: string[] = []
-
   // Fast is shown when the speed=fast param is on (options.fastMode) OR the
   // active model is a `…-fast` variant (fast via a separate model id).
-  if (options?.fastMode || /-fast$/i.test(modelBaseId(model))) {
-    parts.push('Fast')
-  }
+  const fastMode = options?.fastMode || /-fast$/i.test(modelBaseId(model))
 
   // Always surface the effort (empty = Hermes default of medium) so the
   // current reasoning level is visible at a glance, not just when non-default.
-  parts.push(reasoningEffortLabel(options?.reasoningEffort ?? '') || 'Med')
+  const badges = modelStatusBadges({ fastMode, reasoningEffort: options?.reasoningEffort })
 
-  return `${name} · ${parts.join(' ')}`
+  return `${name} · ${badges.join(' ')}`
 }


### PR DESCRIPTION
## Summary
- Render desktop model dropdown metadata (Fast/reasoning effort) as separate compact badges instead of appending it directly to the model name.
- Reuse a small `modelStatusBadges` helper so the dropdown and status-label formatting share the same labels/default reasoning effort behavior.
- Add coverage for separate badge labels, including default medium and non-reasoning-capable rows.

Fixes #51833

## Validation
- `npm install --workspace apps/desktop` — passed; installed 1132 packages, audited 1135 packages, 0 vulnerabilities (lockfile reverted because install rewrote metadata only).
- `npx vitest run --environment jsdom src/lib/model-status-label.test.ts` — passed; 1 file / 11 tests.
- `npm run typecheck` — passed; `tsc -p . --noEmit` completed cleanly.
- `npx eslint src/app/shell/model-menu-panel.tsx src/lib/model-status-label.ts src/lib/model-status-label.test.ts` — passed with no output.
- `git diff --check HEAD~1..HEAD` — passed with no output.

## Caveat
- `npm run lint` across all desktop sources currently fails on unrelated pre-existing lint issues outside this change (for example `electron/main.cjs` unused `net`, import ordering in composer/right-sidebar/settings files, and existing curly/padding warnings). The changed files pass targeted ESLint as noted above.

## Notes
- Checked for duplicate/open PRs before implementation. No PR references #51833 directly. #51524 is related reasoning-effort UI work for the composer pill and has broader split-pill scope; this PR intentionally keeps the change limited to the model dropdown row renderer.