### PR TITLE
fix(chat-completions): strip non-spec timestamp from nested content parts (2026-06-23 TDM 502)

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -115,6 +115,52 @@ def _model_consumes_thought_signature(model: Any) -> bool:
     return "gemini" in m or "gemma" in m
 
 
+# Internal-only keys that are valid on a Hermes transcript message/part but are
+# NOT part of the OpenAI Chat Completions content-part schema. They must be
+# scrubbed from multimodal ``content`` list parts before the request goes
+# upstream, the same way they are from the top-level message object.
+_CONTENT_PART_INTERNAL_KEYS: frozenset[str] = frozenset({"timestamp", "observed"})
+
+
+def _content_part_has_internal_keys(part: Any) -> bool:
+    """True when a single content-list part carries an internal-only key.
+
+    Internal keys are the explicit bookkeeping fields (``timestamp``,
+    ``observed``) plus any Hermes ``_``-prefixed scaffolding marker. OpenAI's
+    content-part schema has none of these, so their presence means the part
+    needs a sanitize pass.
+    """
+    if not isinstance(part, dict):
+        return False
+    if any(k in part for k in _CONTENT_PART_INTERNAL_KEYS):
+        return True
+    return any(isinstance(k, str) and k.startswith("_") for k in part)
+
+
+def _content_parts_need_sanitize(content: Any) -> bool:
+    """True when a message ``content`` is a parts list with any internal key."""
+    if not isinstance(content, list):
+        return False
+    return any(_content_part_has_internal_keys(part) for part in content)
+
+
+def _strip_content_part_internal_keys(content: Any) -> None:
+    """Remove internal-only keys from each part of a multimodal content list.
+
+    Mutates in place (callers operate on a deepcopy). No-op when ``content``
+    is not a list (plain-string content carries no per-part metadata).
+    """
+    if not isinstance(content, list):
+        return
+    for part in content:
+        if not isinstance(part, dict):
+            continue
+        for key in _CONTENT_PART_INTERNAL_KEYS:
+            part.pop(key, None)
+        for key in [k for k in part if isinstance(k, str) and k.startswith("_")]:
+            part.pop(key, None)
+
+
 class ChatCompletionsTransport(ProviderTransport):
     """Transport for api_mode='chat_completions'.
 
@@ -179,6 +225,15 @@ class ChatCompletionsTransport(ProviderTransport):
             if any(isinstance(k, str) and k.startswith("_") for k in msg):
                 needs_sanitize = True
                 break
+            # A multimodal ``content`` list can carry the same internal-only
+            # keys on individual parts (e.g. a per-part ``timestamp`` inherited
+            # from the transcript store). The shallow top-level strip misses
+            # them, so strict providers still reject the whole request with
+            # HTTP 422 ``loc: [...,messages,N,user,timestamp]`` — the
+            # 2026-06-23 TDM 502 / timestamp incident. Detect them here too.
+            if _content_parts_need_sanitize(msg.get("content")):
+                needs_sanitize = True
+                break
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):
                 for tc in tool_calls:
@@ -208,6 +263,10 @@ class ChatCompletionsTransport(ProviderTransport):
             # is safe and future-proofs against new markers being added.
             for key in [k for k in msg if isinstance(k, str) and k.startswith("_")]:
                 msg.pop(key, None)
+            # Same scrub for multimodal content-list parts — a nested
+            # ``timestamp`` (or ``_``-prefixed marker) on a part is just as
+            # schema-foreign to strict providers as a top-level one.
+            _strip_content_part_internal_keys(msg.get("content"))
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):
                 for tc in tool_calls:

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -123,6 +123,61 @@ class TestChatCompletionsBasic:
         # Original list untouched (deepcopy-on-demand)
         assert msgs[0]["timestamp"] == 1781976577.0
 
+    def test_convert_messages_strips_timestamp_in_content_parts(self, transport):
+        """``timestamp`` (and other internal-only keys) nested inside a
+        multimodal ``content`` list part must also be stripped — not just the
+        top-level message key. A user turn whose ``content`` is a list of
+        parts can inherit a per-part ``timestamp`` from the transcript store;
+        the shallow top-level strip leaves it on the wire and strict providers
+        (Mistral, Fireworks) still reject the whole request with HTTP 422
+        ``Extra inputs are not permitted, loc: [...,messages,N,user,timestamp]``,
+        collapsing the TDM fallback chain into a 502.
+
+        Regression for the 2026-06-23 TDM 502 / timestamp incident (whole
+        bug class around #47868 — nested content-part variant).
+        """
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "hi", "timestamp": 1782267431.528704},
+                ],
+                "timestamp": 1782267431.528704,
+            },
+        ]
+        result = transport.convert_messages(msgs, model="mistral-large")
+        # No ``timestamp`` anywhere in the serialized payload — top-level or
+        # nested inside any content part.
+        import json
+        serialized = json.dumps(result)
+        assert "timestamp" not in serialized, serialized
+        assert "timestamp" not in result[0]
+        assert "timestamp" not in result[0]["content"][0]
+        # Real content survives untouched.
+        assert result[0]["content"][0]["text"] == "hi"
+        assert result[0]["content"][0]["type"] == "text"
+        assert result[0]["role"] == "user"
+        # Original list untouched (deepcopy-on-demand).
+        assert msgs[0]["content"][0]["timestamp"] == 1782267431.528704
+
+    def test_convert_messages_strips_internal_markers_in_content_parts(self, transport):
+        """Hermes-internal ``_``-prefixed scaffolding keys nested inside a
+        content-list part must also never reach the wire."""
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "run", "_thinking_prefill": True},
+                ],
+            },
+        ]
+        result = transport.convert_messages(msgs)
+        assert not any(
+            isinstance(k, str) and k.startswith("_")
+            for k in result[0]["content"][0]
+        ), result[0]["content"][0]
+        assert result[0]["content"][0]["text"] == "run"
+
     def test_convert_messages_no_copy_without_timestamp(self, transport):
         """A timestamp-free message list needs no sanitize pass and is
         returned by identity (preserves the deepcopy-on-demand contract)."""


### PR DESCRIPTION
## Summary

Stops the client from emitting a non-spec `timestamp` field nested inside multimodal `content` parts of outgoing chat `messages[]`, which schema-strict upstream providers (e.g. `mistral-large`, Fireworks) reject with HTTP 422 `extra_forbidden`, collapsing the TDM provider-fallback chain into a 502.

### Incident (2026-06-23 TDM 502 / timestamp)
A live request to a strict provider failed with:
```json
{"detail":[{"type":"extra_forbidden","loc":["body","messages",1,"user","timestamp"],"msg":"Extra inputs are not permitted","input":1782267431.528704}]}
```
The float-epoch `timestamp` originates from the transcript store (`hermes_state.get_messages` stamps every row, and gateway/run.py reconstructs API messages from those rows).

### Root cause
PR #47868 (commit `4467c22c8`, 2026-06-20) added a strip for a **top-level** per-message `timestamp` in `ChatCompletionsTransport.convert_messages`. That strip is **shallow** — a `timestamp` (or any Hermes `_`-prefixed scaffolding marker) nested inside a multimodal `content` **list part** survives and still reaches the wire. Permissive providers silently drop unknown keys; strict ones 422 the whole request.

### Fix
`agent/transports/chat_completions.py` — `ChatCompletionsTransport.convert_messages` now also scrubs internal-only keys (`timestamp`, `observed`, and `_`-prefixed markers) from each part of a `content` list, mirroring the existing top-level scrub. Three small module-level helpers (`_content_part_has_internal_keys`, `_content_parts_need_sanitize`, `_strip_content_part_internal_keys`) keep it unit-testable.

- Where in the pipeline: `build_kwargs` → `convert_messages` (the single sanitize chokepoint for the chat_completions / OpenAI-compatible path, used by both the provider-profile and legacy paths in `agent/chat_completion_helpers.py`).
- `role` / `content` / `tool_call_id` / `name` / `tool_calls` are untouched. Plain-string content and the deepcopy-on-demand identity fast-path are unchanged.
- The `timestamp` is **kept** in transcript storage — only the outgoing provider request body is cleaned.

### TDD
Failing-first tests added in `tests/agent/transports/test_chat_completions.py`:
- `test_convert_messages_strips_timestamp_in_content_parts` — asserts the serialized payload contains **no** `timestamp` key anywhere (top-level or nested in a content part).
- `test_convert_messages_strips_internal_markers_in_content_parts` — same for `_`-prefixed markers on parts.

```
$ pytest tests/agent/transports/test_chat_completions.py -q
85 passed

$ pytest tests/agent/transports/ -q
341 passed
```

Refs the 2026-06-23 TDM 502 / timestamp incident; whole-bug-class follow-up to #47868.

> Do NOT merge / deploy — review only.