### PR TITLE
fix(desktop): render reasoning effort as a distinct badge in the model menu (#51833)

### DIFF
--- a/apps/desktop/src/app/shell/model-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.tsx
@@ -1,10 +1,16 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { DropdownMenu, DropdownMenuContent } from '@/components/ui/dropdown-menu'
 import { $collapsedProviders, toggleCollapsedProvider } from '@/store/provider-collapse'
-import { $activeSessionId, $currentModel, $currentProvider } from '@/store/session'
+import {
+  $activeSessionId,
+  $currentFastMode,
+  $currentModel,
+  $currentProvider,
+  $currentReasoningEffort
+} from '@/store/session'
 
 import { ModelMenuPanel } from './model-menu-panel'
 
@@ -46,6 +52,10 @@ beforeEach(() => {
   $currentModel.set('')
   $currentProvider.set('')
   $collapsedProviders.set([])
+  // Reasoning/fast atoms are global; reset them so the reasoning-effort badge
+  // suite (which sets its own) can't bleed into the other suites.
+  $currentReasoningEffort.set('')
+  $currentFastMode.set(false)
   getGlobalModelOptions.mockResolvedValue({ providers: MOCK_PROVIDERS })
 })
 
@@ -270,5 +280,59 @@ describe('ModelMenuPanel provider collapse', () => {
 
     expect($collapsedProviders.get()).toContain('google')
     expect($collapsedProviders.get()).toContain('deepseek')
+  })
+})
+
+describe('ModelMenuPanel reasoning-effort badge', () => {
+  // Regression for #51833: the reasoning effort must render as its own badge,
+  // distinct from the model name, so "High" doesn't read as part of a
+  // differently-named model. Pre-session (global) selection marks the row
+  // "current" from the sticky composer stores, so the effort resolves live.
+  const setDashscopeSession = (reasoning: boolean) => {
+    $activeSessionId.set(null)
+    $currentModel.set('qwen3.7-max')
+    $currentProvider.set('dashscope')
+    $currentReasoningEffort.set('high')
+    $currentFastMode.set(false)
+    getGlobalModelOptions.mockResolvedValue({
+      model: 'qwen3.7-max',
+      provider: 'dashscope',
+      providers: [
+        {
+          name: 'DashScope',
+          slug: 'dashscope',
+          models: ['qwen3.7-max'],
+          authenticated: true,
+          capabilities: { 'qwen3.7-max': { reasoning, fast: false } }
+        }
+      ]
+    })
+  }
+
+  it('renders the reasoning effort as a separate badge, not appended to the name', async () => {
+    setDashscopeSession(true)
+    renderPanel()
+
+    const name = await screen.findByText('Qwen3.7 Max')
+    const badge = await screen.findByText('High')
+
+    // The effort lives in its own element — the name node never absorbs it.
+    expect(name).not.toBe(badge)
+    expect(name.contains(badge)).toBe(false)
+    expect(name.textContent).toBe('Qwen3.7 Max')
+
+    // …and it carries distinct badge styling (bordered chip), not plain inline
+    // tertiary text bleeding into the model name.
+    expect(badge.className).toContain('border')
+    expect(badge.className).toContain('rounded-sm')
+  })
+
+  it('drops the effort badge entirely when the model has no reasoning support', async () => {
+    setDashscopeSession(false)
+    renderPanel()
+
+    await screen.findByText('Qwen3.7 Max')
+    await waitFor(() => expect(screen.queryByText('High')).toBeNull())
+    expect(screen.queryByText('Med')).toBeNull()
   })
 })

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -296,12 +296,13 @@ export function ModelMenuPanel({ gateway, onSelectModel, profile = 'default', re
                       effFast
                     )
 
-                    const meta = [
+                    // Fast / reasoning-effort surface as discrete badges beside the
+                    // name — not appended to it — so "High" reads as the model's
+                    // reasoning setting, not part of a differently-named model. (#51833)
+                    const metaTags = [
                       fastControl.kind !== 'none' && fastControl.on ? copy.fast : null,
-                      (caps?.reasoning ?? true) ? reasoningEffortLabel(effEffort || defaultEffort) : null
-                    ]
-                      .filter(Boolean)
-                      .join(' ')
+                      (caps?.reasoning ?? true) ? reasoningEffortLabel(effEffort) || copy.medium : null
+                    ].filter((tag): tag is string => Boolean(tag))
 
                     // Every row is a hover-Edit submenu trigger. Activating it
                     // (pointer or keyboard) switches to the family's base model and
@@ -331,9 +332,16 @@ export function ModelMenuPanel({ gateway, onSelectModel, profile = 'default', re
                             }
                           }}
                         >
-                          <span className="min-w-0 flex-1 truncate">
-                            {name}
-                            {meta ? <span className="text-(--ui-text-tertiary)"> {meta}</span> : null}
+                          <span className="flex min-w-0 flex-1 items-center gap-1.5">
+                            <span className="min-w-0 truncate">{name}</span>
+                            {metaTags.map(tag => (
+                              <span
+                                className="shrink-0 rounded-sm border border-(--ui-stroke-secondary) bg-(--chrome-action-hover) px-1 py-px text-[0.625rem] font-medium uppercase leading-none tracking-wide text-(--ui-text-tertiary)"
+                                key={tag}
+                              >
+                                {tag}
+                              </span>
+                            ))}
                           </span>
                           {isCurrent ? (
                             <Codicon className="ml-auto text-foreground" name="check" size="0.75rem" />


### PR DESCRIPTION
## Summary
The desktop model dropdown no longer makes a model look duplicated when a reasoning effort is set. The effort (and "Fast") now renders as a distinct badge chip beside the model name instead of plain grey text appended to it. Fixes #51833.

**Root cause:** in `model-menu-panel.tsx` each row built a single `meta` string (`Fast High`, `Med`, …) and rendered it *inside the same truncating span as the model name*, separated only by a leading space and a `text-(--ui-text-tertiary)` color:

```tsx
<span className="min-w-0 flex-1 truncate">
  {name}
  {meta ? <span className="text-(--ui-text-tertiary)"> {meta}</span> : null}
</span>
```

With `agent.reasoning_effort: high`, a row reads `Qwen3.7 Max High` — the lighter grey isn't enough separation, so users (per the report) read it as a second, differently-named model rather than the same model carrying a "High" reasoning setting.

## Changes
- `apps/desktop/src/app/shell/model-menu-panel.tsx`: build the fast/effort meta as a `metaTags` array (instead of a joined string) and render each as a discrete bordered badge chip (`rounded-sm border` + uppercase micro-label) beside the model name. The name now lives in its own `truncate` span so a long name still clips without swallowing the badges. No change to *which* tags show or how effort/fast are computed — purely how they're presented.
- `apps/desktop/src/app/shell/model-menu-panel.test.tsx`: new regression test — the effort renders in its own bordered badge element (not concatenated into the name node), and the badge is dropped entirely for models without reasoning support.

## Validation
| | Before | After |
|---|---|---|
| `reasoning_effort: high` row | `Qwen3.7 Max High` — grey text on the name, reads as a duplicate model | `Qwen3.7 Max` + a separate `HIGH` badge chip |
| Non-reasoning model | trailing `Med` text | no badge |
| Long model name | name + meta share one truncating span | name truncates on its own; badge stays visible |

- `npx vitest run --environment jsdom src/app/shell/model-menu-panel.test.tsx`: 2/2 passed
- Related suites (`model-status-label`, `model-edit-submenu`): 13/13 passed
- `npm run typecheck` (apps/desktop): clean
- `eslint` on both changed files: clean