### PR TITLE
fix(agent): dispatch stale-stream pool cleanup to correct client for Anthropic/Bedrock

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2392,9 +2392,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         )
                         _close_request_client_once("stream_mid_tool_retry_cleanup")
                         try:
-                            agent._replace_primary_openai_client(
-                                reason="stream_mid_tool_retry_pool_cleanup"
-                            )
+                            if agent.api_mode in ("anthropic_messages", "bedrock_converse"):
+                                agent._rebuild_anthropic_client()
+                            else:
+                                agent._replace_primary_openai_client(
+                                    reason="stream_mid_tool_retry_pool_cleanup"
+                                )
                         except Exception:
                             pass
                         continue
@@ -2445,9 +2448,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             # Also rebuild the primary client to purge
                             # any dead connections from the pool.
                             try:
-                                agent._replace_primary_openai_client(
-                                    reason="stream_retry_pool_cleanup"
-                                )
+                                if agent.api_mode in ("anthropic_messages", "bedrock_converse"):
+                                    agent._rebuild_anthropic_client()
+                                else:
+                                    agent._replace_primary_openai_client(
+                                        reason="stream_retry_pool_cleanup"
+                                    )
                             except Exception:
                                 pass
                             continue
@@ -2610,7 +2616,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # Rebuild the primary client too — its connection pool
             # may hold dead sockets from the same provider outage.
             try:
-                agent._replace_primary_openai_client(reason="stale_stream_pool_cleanup")
+                if agent.api_mode in ("anthropic_messages", "bedrock_converse"):
+                    agent._rebuild_anthropic_client()
+                else:
+                    agent._replace_primary_openai_client(reason="stale_stream_pool_cleanup")
             except Exception:
                 pass
             # Reset the timer so we don't kill repeatedly while

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -986,9 +986,10 @@ class TestAnthropicStreamCallbacks:
 
         assert touch_calls.count("receiving stream response") == len(events)
 
+    @patch("run_agent.AIAgent._rebuild_anthropic_client")
     @patch("run_agent.AIAgent._replace_primary_openai_client")
     def test_anthropic_stream_parser_valueerror_retries_before_delivery(
-        self, mock_replace, monkeypatch,
+        self, mock_replace, mock_rebuild, monkeypatch,
     ):
         """Malformed Anthropic event-stream frames retry instead of surfacing HTTP None."""
         from run_agent import AIAgent
@@ -1035,7 +1036,10 @@ class TestAnthropicStreamCallbacks:
 
         assert response is final_message
         assert agent._anthropic_client.messages.stream.call_count == 2
-        assert mock_replace.call_count == 1
+        # After the PR: anthropic_messages mode dispatches to
+        # _rebuild_anthropic_client, not _replace_primary_openai_client.
+        assert mock_rebuild.call_count == 1
+        assert mock_replace.call_count == 0
 
     @patch("run_agent.AIAgent._replace_primary_openai_client")
     def test_generic_anthropic_valueerror_still_propagates_without_stream_retry(

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -1657,3 +1657,70 @@ class TestBedrockIamStreamingFallback:
 
         client.converse.assert_not_called()
         assert getattr(agent, "_disable_streaming", False) is False
+
+
+class TestStaleStreamAnthropicRebuild:
+    """Stale-stream pool cleanup must dispatch to the correct client rebuild
+    for Anthropic/Bedrock providers, not always call the OpenAI rebuild."""
+
+    @patch("run_agent.AIAgent._rebuild_anthropic_client")
+    @patch("run_agent.AIAgent._replace_primary_openai_client")
+    def test_stale_stream_anthropic_calls_rebuild_not_openai(
+        self, mock_openai_rebuild, mock_anthropic_rebuild, monkeypatch,
+    ):
+        """When api_mode is anthropic_messages, stale-stream cleanup must
+        call _rebuild_anthropic_client(), not _replace_primary_openai_client()."""
+        from threading import Event
+
+        from run_agent import AIAgent
+
+        monkeypatch.setenv("HERMES_STREAM_STALE_TIMEOUT", "0.5")
+        monkeypatch.setenv("HERMES_STREAM_READ_TIMEOUT", "0.5")
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+
+        agent = AIAgent(
+            api_key="test-oauth-token",
+            base_url="https://api.anthropic.com",
+            provider="anthropic",
+            model="claude-sonnet-4-5",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "anthropic_messages"
+        agent._interrupt_requested = False
+
+        _hang = Event()  # never set — stream hangs indefinitely
+
+        class _HangingStream:
+            response = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def __iter__(self):
+                _hang.wait(timeout=5)
+                return iter([])
+
+            def get_final_message(self):
+                _hang.wait(timeout=5)
+                return SimpleNamespace(content=[], stop_reason="end_turn")
+
+        agent._anthropic_client = MagicMock()
+        agent._anthropic_client.messages.stream.return_value = _HangingStream()
+
+        response = agent._interruptible_streaming_api_call({})
+
+        # The stale detector should have fired and dispatched to the
+        # Anthropic rebuild, NOT the OpenAI rebuild.
+        assert mock_anthropic_rebuild.call_count >= 1, (
+            f"_rebuild_anthropic_client was not called for anthropic_messages "
+            f"stale-stream cleanup. Calls: {mock_anthropic_rebuild.call_count}"
+        )
+        assert mock_openai_rebuild.call_count == 0, (
+            f"_replace_primary_openai_client should NOT be called for "
+            f"anthropic_messages. Calls: {mock_openai_rebuild.call_count}"
+        )


### PR DESCRIPTION
## What does this PR do?

Fixes the stale-stream pool cleanup (and two stream-retry paths) to dispatch to the correct client rebuild method for Anthropic/Bedrock providers. Previously, all three sites unconditionally called `_replace_primary_openai_client()`, which fails silently for OAuth-authenticated Anthropic users (no `OPENAI_API_KEY`), leaving the connection pool unrefreshed after a stale stream.

## Related Issue

Fixes #51844

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py`: Branch on `api_mode` at three streaming pool-cleanup sites (`stale_stream_pool_cleanup`, `stream_mid_tool_retry_pool_cleanup`, `stream_retry_pool_cleanup`) to call `_rebuild_anthropic_client()` for `anthropic_messages`/`bedrock_converse` modes, matching the existing interrupt path and non-streaming stale path.
- `tests/run_agent/test_streaming.py`: Add `TestStaleStreamAnthropicRebuild` with a test that creates an Anthropic-mode agent, triggers the stale-stream detector via a hanging stream, and asserts `_rebuild_anthropic_client()` is called instead of `_replace_primary_openai_client()`.

## How to Test

1. Run `python -m pytest tests/run_agent/test_streaming.py::TestStaleStreamAnthropicRebuild -xvs` — the test should pass, confirming the Anthropic rebuild is dispatched.
2. Verify the existing streaming tests still pass: `python -m pytest tests/run_agent/test_streaming.py -x -q`.
3. Review the diff: all three changed sites use the same `if agent.api_mode in ("anthropic_messages", "bedrock_converse")` pattern already established at lines 502 and 2634.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/chat_completion_helpers.py` (3 call sites: lines 2395, 2448, 2613)
- Blast radius: LOW — only affects streaming pool-cleanup dispatch; non-streaming paths and interrupt paths already had correct branching
- Related patterns: Lines 502-506 (non-streaming stale path) and 2634-2638 (stream interrupt path) already use the same `api_mode` check
