### PR TITLE
fix(agent): dispatch stale-stream pool cleanup by api_mode (#51844)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2609,8 +2609,14 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 pass
             # Rebuild the primary client too — its connection pool
             # may hold dead sockets from the same provider outage.
+            # Dispatch on the active API mode the same way the interrupt
+            # and non-streaming stale paths do: the OpenAI rebuild needs an
+            # api_key and fails for native/OAuth Anthropic providers (#51844).
             try:
-                agent._replace_primary_openai_client(reason="stale_stream_pool_cleanup")
+                if agent.api_mode == "anthropic_messages":
+                    agent._rebuild_anthropic_client()
+                else:
+                    agent._replace_primary_openai_client(reason="stale_stream_pool_cleanup")
             except Exception:
                 pass
             # Reset the timer so we don't kill repeatedly while


### PR DESCRIPTION
## Summary

Fixes #51844.

The SSE stale-stream handler in `agent/chat_completion_helpers.py` unconditionally called `_replace_primary_openai_client()`, which builds an **OpenAI** SDK client requiring an `api_key`. For native Anthropic providers on subscription **OAuth** (no `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`), that rebuild raised `api_key must be set` and was swallowed by `try/except: pass` — so the primary connection pool was never actually refreshed where the cleanup mattered.

## Fix

Branch on `agent.api_mode` exactly the way the interrupt and non-streaming stale paths in the same file already do:

```python
if agent.api_mode == "anthropic_messages":
    agent._rebuild_anthropic_client()
else:
    agent._replace_primary_openai_client(reason="stale_stream_pool_cleanup")
```

`_rebuild_anthropic_client()` already handles direct Anthropic, Bedrock, and the OAuth 1M-context-beta toggle. Using `api_mode` (rather than a `provider` check) keeps all three recovery branches consistent.

## Impact

Restores stale-stream pool cleanup for every Claude subscription/OAuth user on a native Anthropic provider — the exact case where it was silently failing.