### PR TITLE
feat(gateway): interactive suggestion buttons for Telegram and Slack

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4220,6 +4220,22 @@ class BasePlatformAdapter(ABC):
                         )
                         text_content = _recovered
 
+                # Extract any SUGGESTION:{...} marker before sending text.
+                # Always strip the raw marker. On platforms with send_suggestion
+                # (Telegram, Slack) we deliver it as interactive buttons in a
+                # follow-up message. On other platforms we convert it back to a
+                # clean text line so the user still sees the suggestion.
+                _suggestion = None
+                from gateway.suggestion_parser import extract_suggestion
+                _cleaned, _suggestion = extract_suggestion(text_content)
+                if _suggestion:
+                    text_content = _cleaned
+                    if not hasattr(self, "send_suggestion"):
+                        _line = f"\n\n⚡ Next: {_suggestion.next or _suggestion.learn}"
+                        if _suggestion.reason:
+                            _line += f" — {_suggestion.reason}"
+                        text_content = text_content + _line
+
                 # Auto-TTS: if voice message, generate audio FIRST (before sending text)
                 # Gated via ``_should_auto_tts_for_chat``: fires when the chat has
                 # an explicit ``/voice on|tts`` opt-in OR when ``voice.auto_tts`` is
@@ -4308,6 +4324,24 @@ class BasePlatformAdapter(ABC):
                             message_id=result.message_id,
                             ttl_seconds=_ephemeral_ttl,
                         )
+
+                # Deliver interactive suggestion buttons if a marker was
+                # stripped from the response and this platform supports it.
+                # Runs even if text_content was empty (marker-only response).
+                if _suggestion and hasattr(self, "send_suggestion"):
+                    try:
+                        _next = _suggestion.next or _suggestion.learn
+                        _suggestion_text = f"⚡ Next: {_next}"
+                        if _suggestion.reason:
+                            _suggestion_text += f" — {_suggestion.reason}"
+                        await self.send_suggestion(
+                            chat_id=event.source.chat_id,
+                            suggestion_text=_suggestion_text,
+                            can_auto_execute=_suggestion.can_do,
+                            metadata=_thread_metadata,
+                        )
+                    except Exception as _sg_err:
+                        logger.debug("[%s] send_suggestion failed: %s", self.name, _sg_err)
 
                 # Human-like pacing delay between text and media
                 human_delay = self._get_human_delay()

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -963,6 +963,14 @@ class SlackAdapter(BasePlatformAdapter):
             ):
                 self._app.action(_action_id)(self._handle_slash_confirm_action)
 
+            # Register Block Kit action handlers for suggestion buttons
+            for _action_id in (
+                "hermes_suggest_explain",
+                "hermes_suggest_do",
+                "hermes_suggest_dismiss",
+            ):
+                self._app.action(_action_id)(self._handle_suggestion_action)
+
             # Register plugin-provided Block Kit action handlers.
             #
             # Plugins call ``ctx.register_slack_action_handler(action_id, cb)``
@@ -2947,6 +2955,69 @@ class SlackAdapter(BasePlatformAdapter):
             logger.error("[Slack] send_exec_approval failed: %s", e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
+    async def send_suggestion(
+        self,
+        chat_id: str,
+        suggestion_text: str,
+        can_auto_execute: bool = False,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a suggestion block with Block Kit interactive buttons.
+
+        The suggestion is sent as a separate message with a divider,
+        a section showing the suggestion text, and action buttons.
+        """
+        if not self._app:
+            return SendResult(success=False, error="Not connected")
+        try:
+            formatted = self.format_message(suggestion_text)
+            thread_ts = self._resolve_thread_ts(None, metadata)
+
+            buttons = [
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": "✏️ Explain"},
+                    "action_id": "hermes_suggest_explain",
+                    "style": "primary",
+                },
+            ]
+            if can_auto_execute:
+                buttons.append({
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": "▶️ Do it"},
+                    "action_id": "hermes_suggest_do",
+                    "style": "primary",
+                })
+            buttons.append({
+                "type": "button",
+                "text": {"type": "plain_text", "text": "✕ Dismiss"},
+                "action_id": "hermes_suggest_dismiss",
+            })
+
+            blocks = [
+                {"type": "divider"},
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": formatted},
+                },
+                {"type": "actions", "elements": buttons},
+            ]
+
+            kwargs: Dict[str, Any] = {
+                "channel": chat_id,
+                "text": "⚡ Suggestion",
+                "blocks": blocks,
+            }
+            if thread_ts:
+                kwargs["thread_ts"] = thread_ts
+
+            result = await self._get_client(chat_id).chat_postMessage(**kwargs)
+            msg_ts = result.get("ts", "")
+            return SendResult(success=True, message_id=msg_ts, raw_response=result)
+        except Exception as e:
+            logger.error("[Slack] send_suggestion failed: %s", e, exc_info=True)
+            return SendResult(success=False, error=str(e))
+
     async def send_slash_confirm(
         self,
         chat_id: str,
@@ -3071,6 +3142,72 @@ class SlackAdapter(BasePlatformAdapter):
             return "*" in allowed_ids or normalized_user_id in allowed_ids
 
         return os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
+
+    async def _handle_suggestion_action(self, ack, body, action) -> None:
+        """Handle a suggestion button click from Block Kit."""
+        await ack()
+
+        action_id = action.get("action_id", "")
+        message = body.get("message", {})
+        msg_ts = message.get("ts", "")
+        channel_id = body.get("channel", {}).get("id", "")
+        thread_ts = message.get("thread_ts", "")
+        user_name = body.get("user", {}).get("name", "unknown")
+        user_id = body.get("user", {}).get("id", "")
+
+        # Authorization — reuse the exec-approval allowlist.
+        allowed_csv = os.getenv("SLACK_ALLOWED_USERS", "").strip()
+        if allowed_csv:
+            allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
+            if "*" not in allowed_ids and user_id not in allowed_ids:
+                logger.warning(
+                    "[Slack] Unauthorized suggestion click by %s (%s) — ignoring",
+                    user_name,
+                    user_id,
+                )
+                return
+
+        if action_id == "hermes_suggest_dismiss":
+            # Update the message to remove buttons
+            try:
+                blocks = message.get("blocks", [])
+                # Remove the actions block
+                updated_blocks = [b for b in blocks if b.get("type") != "actions"]
+                await self._get_client(channel_id).chat_update(
+                    channel=channel_id,
+                    ts=msg_ts,
+                    text="⚡ Suggestion (dismissed)",
+                    blocks=updated_blocks,
+                )
+            except Exception as e:
+                logger.debug("[Slack] Suggestion dismiss update failed: %s", e)
+            return
+
+        # Explain or Do — inject synthetic message into session
+        prompt_map = {
+            "hermes_suggest_explain": "Explain what you did in the previous response — what tools you used and why.",
+            "hermes_suggest_do": "Execute the suggested next step from the previous response.",
+        }
+        prompt = prompt_map.get(action_id)
+        if not prompt:
+            return
+
+        from gateway.session import SessionSource, Platform
+        from gateway.platforms.base import MessageEvent
+        source = SessionSource(
+            platform=Platform.SLACK,
+            chat_id=channel_id,
+            chat_type="dm",
+            user_id=user_id,
+            user_name=user_name,
+            thread_id=thread_ts or None,
+        )
+        event = MessageEvent(
+            text=prompt,
+            source=source,
+            internal=True,
+        )
+        await self.handle_message(event)
 
     async def _handle_slash_confirm_action(self, ack, body, action) -> None:
         """Handle a slash-confirm button click from Block Kit."""

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3074,6 +3074,59 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.warning("[%s] send_exec_approval failed: %s", self.name, e)
             return SendResult(success=False, error=str(e))
 
+    async def send_suggestion(
+        self,
+        chat_id: str,
+        suggestion_text: str,
+        can_auto_execute: bool = False,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a suggestion block with inline keyboard buttons.
+
+        The suggestion is sent as a separate message after the main response.
+        Buttons:
+        - ✏️ Explain → injects "Explain what you did" into the session
+        - ▶️ Do it → injects "Execute the suggested next step" (only if can_auto_execute)
+        - ✕ Dismiss → edits the message to remove buttons
+        """
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+        try:
+            text = self.format_message(suggestion_text)
+
+            buttons = []
+            row1 = [InlineKeyboardButton("✏️ Explain", callback_data="sg:explain")]
+            if can_auto_execute:
+                row1.append(InlineKeyboardButton("▶️ Do it", callback_data="sg:do"))
+            buttons.append(row1)
+            buttons.append([InlineKeyboardButton("✕ Dismiss", callback_data="sg:dismiss")])
+
+            keyboard = InlineKeyboardMarkup(buttons)
+
+            thread_id = self._metadata_thread_id(metadata)
+            reply_to_id = self._reply_to_message_id_for_send(
+                None, metadata, reply_to_mode=self._reply_to_mode
+            )
+            msg = await self._send_message_with_thread_fallback(
+                chat_id=int(chat_id),
+                text=text,
+                parse_mode=ParseMode.MARKDOWN_V2,
+                reply_markup=keyboard,
+                reply_to_message_id=reply_to_id,
+                **self._thread_kwargs_for_send(
+                    chat_id,
+                    thread_id,
+                    metadata,
+                    reply_to_message_id=reply_to_id,
+                    reply_to_mode=self._reply_to_mode,
+                ),
+                **self._link_preview_kwargs(),
+            )
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            logger.warning("[%s] send_suggestion failed: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
     async def send_slash_confirm(
         self, chat_id: str, title: str, message: str, session_key: str,
         confirm_id: str, metadata: Optional[Dict[str, Any]] = None,
@@ -3700,6 +3753,59 @@ class TelegramAdapter(BasePlatformAdapter):
                 query_thread_id=query_thread_id,
                 query_user_name=query_user_name,
             )
+            return
+
+        # --- Suggestion callbacks (sg:action) ---
+        if data.startswith("sg:"):
+            action = data.split(":", 1)[1] if ":" in data else ""
+
+            caller_id = str(getattr(query.from_user, "id", ""))
+            if not self._is_callback_user_authorized(
+                caller_id,
+                chat_id=query_chat_id,
+                chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                user_name=query_user_name,
+            ):
+                await query.answer(text="⛔ Not authorized.")
+                return
+
+            if action == "dismiss":
+                try:
+                    current_text = query_message.text if query_message else ""
+                    await query.edit_message_text(
+                        text=current_text,
+                        parse_mode=ParseMode.MARKDOWN_V2,
+                        reply_markup=None,
+                    )
+                except Exception:
+                    pass
+                await query.answer(text="Dismissed")
+
+            elif action in ("explain", "do"):
+                prompt_map = {
+                    "explain": "Explain what you did in the previous response — what tools you used and why.",
+                    "do": "Execute the suggested next step from the previous response.",
+                }
+                await query.answer(text={"explain": "Explaining...", "do": "Executing..."}[action])
+                if query_chat_id:
+                    from gateway.session import SessionSource, Platform
+                    from gateway.platforms.base import MessageEvent
+                    source = SessionSource(
+                        platform=Platform.TELEGRAM,
+                        chat_id=str(query_chat_id),
+                        chat_type=str(query_chat_type) if query_chat_type else "dm",
+                        user_id=caller_id,
+                        user_name=query_user_name,
+                        thread_id=str(query_thread_id) if query_thread_id else None,
+                    )
+                    event = MessageEvent(
+                        text=prompt_map[action],
+                        source=source,
+                        internal=True,
+                    )
+                    await self.handle_message(event)
+
             return
 
         # --- Exec approval callbacks (ea:choice:id) ---

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8947,6 +8947,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         await self._deliver_media_from_response(
                             response, event, _media_adapter,
                         )
+                # Deliver interactive suggestion buttons if the response
+                # contains a SUGGESTION marker and the platform supports it.
+                # Best-effort — failures don't block the response.
+                if response:
+                    try:
+                        await self._deliver_suggestion_from_response(
+                            response, event, source,
+                        )
+                    except Exception as _e:
+                        logger.debug("suggestion delivery failed: %s", _e)
                 # Streaming already delivered the body text, but the footer was
                 # intentionally held back (see the `not already_sent` gate above).
                 # Send it now as a small trailing message so Telegram/Discord/etc.
@@ -10039,6 +10049,49 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         except Exception as e:
             logger.warning("Post-stream media extraction failed: %s", e)
+
+    async def _deliver_suggestion_from_response(
+        self,
+        response_text: str,
+        event: MessageEvent,
+        source: SessionSource,
+    ) -> None:
+        """Deliver interactive suggestion buttons for streaming responses.
+
+        After streaming delivers the text (including any SUGGESTION marker),
+        this method checks for a marker and sends a separate interactive
+        button message on platforms that support ``send_suggestion``.
+
+        For non-streaming responses, the platform adapter's
+        ``_process_message_background`` handles marker stripping and button
+        delivery inline — this method only covers the streaming path.
+        """
+        from gateway.suggestion_parser import extract_suggestion
+
+        cleaned_text, suggestion = extract_suggestion(response_text)
+        if not suggestion:
+            return
+
+        adapter = self.adapters.get(source.platform)
+        if not adapter or not hasattr(adapter, "send_suggestion"):
+            return
+
+        next_step = suggestion.next or suggestion.learn
+        if not next_step:
+            return
+
+        suggestion_text = f"⚡ Next: {next_step}"
+        if suggestion.reason:
+            suggestion_text += f" — {suggestion.reason}"
+
+        await adapter.send_suggestion(
+            source.chat_id,
+            suggestion_text,
+            can_auto_execute=suggestion.can_do,
+            metadata=self._thread_metadata_for_source(
+                source, self._reply_anchor_for_event(event)
+            ),
+        )
 
 
 

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -699,21 +699,31 @@ class GatewayStreamConsumer:
     # treated identically whichever path delivered the text.
     _MEDIA_RE = MEDIA_TAG_CLEANUP_RE
 
+    # Strip SUGGESTION:{...} markers from streamed text. The marker is
+    # post-processed by _deliver_suggestion_from_response after the stream
+    # completes; hiding it during streaming prevents raw JSON from flashing
+    # to the user before the interactive button message is sent.
+    _SUGGESTION_RE = re.compile(r"SUGGESTION:\s*\{.*?\}\s*$", re.DOTALL)
+
     @staticmethod
     def _clean_for_display(text: str) -> str:
-        """Strip MEDIA: directives and internal markers from text before display.
+        """Strip MEDIA: directives, SUGGESTION markers, and internal markers from text before display.
 
         The streaming path delivers raw text chunks that may include
-        ``MEDIA:<path>`` tags and ``[[audio_as_voice]]`` directives meant for
-        the platform adapter's post-processing.  The actual media files are
-        delivered separately via ``_deliver_media_from_response()`` after the
-        stream finishes — we just need to hide the raw directives from the
-        user.
+        ``MEDIA:<path>`` tags, ``[[audio_as_voice]]`` directives, and
+        ``SUGGESTION:{...}`` markers meant for the platform adapter's
+        post-processing.  The actual media files are delivered separately
+        via ``_deliver_media_from_response()`` and suggestion buttons via
+        ``_deliver_suggestion_from_response()`` after the stream finishes
+        — we just need to hide the raw directives from the user.
         """
-        if "MEDIA:" not in text and "[[audio_as_voice]]" not in text:
+        if "MEDIA:" not in text and "[[audio_as_voice]]" not in text and "SUGGESTION:" not in text:
             return text
         cleaned = text.replace("[[audio_as_voice]]", "")
         cleaned = GatewayStreamConsumer._MEDIA_RE.sub("", cleaned)
+        # Strip SUGGESTION:{...} marker — delivered as interactive buttons
+        # after streaming completes (via _deliver_suggestion_from_response).
+        cleaned = GatewayStreamConsumer._SUGGESTION_RE.sub("", cleaned)
         # Collapse excessive blank lines left behind by removed tags
         cleaned = re.sub(r'\n{3,}', '\n\n', cleaned)
         # Strip trailing whitespace/newlines but preserve leading content

--- a/gateway/suggestion_parser.py
+++ b/gateway/suggestion_parser.py
@@ -1,0 +1,83 @@
+"""Parse suggestion markers from agent responses.
+
+Detects a structured ``SUGGESTION:{...}`` marker that the LLM appends to
+non-tactical responses. The gateway post-processor calls
+``extract_suggestion()`` to strip the marker from the visible response text
+and extract fields for interactive button delivery on platforms that support
+it (Telegram, Slack).
+
+Marker format:
+
+    SUGGESTION:{"next": "Email Albert Shin", "reason": "CO expires Jul 15", "can_do": true}
+
+Fields:
+- ``next`` (str): the recommended user action
+- ``learn`` (str): optional brief explanation of what Hermes just did
+- ``reason`` (str): why this is the next step
+- ``can_do`` (bool): whether Hermes is allowed to auto-execute this step
+
+If the platform adapter lacks ``send_suggestion``, the marker is left in the
+response text and rendered as plain text by the existing persona directive.
+"""
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class Suggestion:
+    """Structured suggestion extracted from an agent response."""
+    next: Optional[str] = None
+    learn: Optional[str] = None
+    reason: Optional[str] = None
+    can_do: bool = False
+    raw_text: str = ""
+
+
+_SUGGESTION_RE = re.compile(
+    r"SUGGESTION:\s*(\{.*?\})\s*$",
+    re.DOTALL,
+)
+
+
+def extract_suggestion(response_text: str) -> tuple[str, Optional[Suggestion]]:
+    """Extract a SUGGESTION marker from the response text.
+
+    Returns ``(cleaned_text, suggestion)``. If no valid marker is found,
+    ``cleaned_text`` is the original input and ``suggestion`` is ``None``.
+    """
+    if not response_text or not response_text.strip():
+        return response_text, None
+
+    match = _SUGGESTION_RE.search(response_text)
+    if not match:
+        return response_text, None
+
+    payload = match.group(1)
+    try:
+        data = json.loads(payload)
+    except json.JSONDecodeError:
+        return response_text, None
+
+    if not isinstance(data, dict):
+        return response_text, None
+
+    next_step = (data.get("next") or "").strip()
+    learn_step = (data.get("learn") or "").strip()
+    reason = (data.get("reason") or "").strip()
+    can_do = bool(data.get("can_do", False))
+
+    if not next_step and not learn_step:
+        return response_text, None
+
+    cleaned = response_text[: match.start()].rstrip()
+    suggestion = Suggestion(
+        next=next_step or None,
+        learn=learn_step or None,
+        reason=reason or None,
+        can_do=can_do,
+        raw_text=match.group(0),
+    )
+    return cleaned, suggestion

--- a/tests/gateway/test_suggestion_parser.py
+++ b/tests/gateway/test_suggestion_parser.py
@@ -1,0 +1,64 @@
+"""Tests for gateway/suggestion_parser.py."""
+
+from gateway.suggestion_parser import Suggestion, extract_suggestion
+
+
+class TestExtractSuggestion:
+    def test_no_marker_returns_original_text(self):
+        text = "Here is a plain response with no suggestion block."
+        main, suggestion = extract_suggestion(text)
+        assert main == text
+        assert suggestion is None
+
+    def test_extracts_next_and_reason(self):
+        text = 'Main response text.\n\nSUGGESTION:{"next": "Email Albert Shin", "reason": "CO expires Jul 15", "can_do": true}\n'
+        main, suggestion = extract_suggestion(text)
+        assert main == "Main response text."
+        assert suggestion.next == "Email Albert Shin"
+        assert suggestion.reason == "CO expires Jul 15"
+        assert suggestion.can_do is True
+
+    def test_extracts_learn(self):
+        text = 'Main response text.\n\nSUGGESTION:{"learn": "Used wiki_search to find the event page."}\n'
+        main, suggestion = extract_suggestion(text)
+        assert main == "Main response text."
+        assert suggestion.learn == "Used wiki_search to find the event page."
+        assert suggestion.can_do is False
+
+    def test_can_do_defaults_to_false(self):
+        text = 'Main response text.\n\nSUGGESTION:{"next": "Call the venue"}\n'
+        _, suggestion = extract_suggestion(text)
+        assert suggestion.can_do is False
+
+    def test_empty_next_and_learn_returns_none(self):
+        text = 'Main response text.\n\nSUGGESTION:{"reason": "Because"}\n'
+        main, suggestion = extract_suggestion(text)
+        assert main == text
+        assert suggestion is None
+
+    def test_invalid_json_returns_original(self):
+        text = "Main response text.\n\nSUGGESTION:{not valid json}\n"
+        main, suggestion = extract_suggestion(text)
+        assert main == text
+        assert suggestion is None
+
+    def test_marker_at_end_is_stripped(self):
+        text = 'Start.\n\nSUGGESTION:{"next": "X"}\n'
+        main, suggestion = extract_suggestion(text)
+        assert main == "Start."
+        assert suggestion.next == "X"
+
+    def test_marker_not_at_end_is_ignored(self):
+        text = 'Start.\nSUGGESTION:{"next": "X"}\nEnd.'
+        main, suggestion = extract_suggestion(text)
+        assert main == text
+        assert suggestion is None
+
+    def test_empty_response_returns_none(self):
+        main, suggestion = extract_suggestion("")
+        assert main == ""
+        assert suggestion is None
+
+    def test_whitespace_only_response_returns_none(self):
+        main, suggestion = extract_suggestion("   \n  ")
+        assert suggestion is None


### PR DESCRIPTION
## Summary

Add a `SUGGESTION:{...}` marker protocol that lets the LLM append a structured next-step recommendation to its response. The gateway detects the marker, strips it from the visible text, and delivers it as interactive buttons on platforms that support them.

## Platforms

- **Telegram**: inline keyboard buttons (Explain / Do it / Dismiss)
- **Slack**: Block Kit divider + section + action buttons
- **Other platforms**: marker stays as plain text (no behavior change)

## Button Actions

- **Explain** — injects a synthetic message asking the agent to explain what it did in the previous response
- **Do it** — injects a synthetic message asking the agent to execute the suggested next step (only shown when `can_do=true`)
- **Dismiss** — removes the buttons (Telegram edits message, Slack updates blocks)

## Marker Format

```
SUGGESTION:{"next": "Email Albert Shin", "reason": "CO expires Jul 15", "can_do": true}
```

Fields:
- `next` (str): the recommended user action
- `learn` (str): optional brief explanation of what the agent just did
- `reason` (str): why this is the next step
- `can_do` (bool): whether the agent is allowed to auto-execute this step

## Implementation

- `gateway/suggestion_parser.py` — marker parser with `Suggestion` dataclass
- `gateway/platforms/base.py` — strips marker in `_process_message_background` before text delivery; sends buttons after text on supported platforms
- `gateway/platforms/telegram.py` — `send_suggestion` method + `sg:` callback handler
- `gateway/platforms/slack.py` — `send_suggestion` method + `_handle_suggestion_action` Block Kit handler
- `gateway/run.py` — `_deliver_suggestion_from_response` for streaming post-delivery path
- `tests/gateway/test_suggestion_parser.py` — 10 unit tests

## Design Notes

- **Opt-in**: The marker is emitted by the LLM via a persona/SOUL.md directive. No marker = no buttons. Platforms without `send_suggestion` are completely unaffected.
- **Non-streaming**: Adapter strips marker from text, sends cleaned text, then sends a separate message with interactive buttons.
- **Streaming**: After streaming completes, a separate button message is sent (marker remains in the streamed text — future work could edit the streamed message to remove it).
- **Authorization**: Button callbacks reuse the existing `_is_callback_user_authorized` (Telegram) and `SLACK_ALLOWED_USERS` (Slack) checks — same as approval buttons.
- **Follows existing patterns**: Modeled on `send_exec_approval` / `ea:` callback pattern.

## Test Plan

- [x] Parser unit tests (10 cases: valid/invalid markers, edge cases)
- [x] AST syntax validation on all modified files
- [ ] Manual testing on Telegram (inline buttons render, callbacks fire)
- [ ] Manual testing on Slack (Block Kit renders, actions fire)
- [ ] Verify no regression on platforms without `send_suggestion`