### PR TITLE
feat(tui): make WebSocket write timeout configurable via env var

### DIFF
--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -126,3 +126,23 @@ def test_ws_write_loop_stall_does_not_latch_transport(monkeypatch):
         loop.call_soon_threadsafe(loop.stop)
         thread.join(timeout=2)
         loop.close()
+
+
+def test_ws_write_timeout_env_var_override(monkeypatch):
+    import importlib
+    import tui_gateway.ws as ws_local
+    monkeypatch.setenv("HERMES_TUI_WS_WRITE_TIMEOUT_S", "30")
+    importlib.reload(ws_local)
+    assert ws_local._WS_WRITE_TIMEOUT_S == 30.0
+    monkeypatch.delenv("HERMES_TUI_WS_WRITE_TIMEOUT_S", raising=False)
+    importlib.reload(ws_local)
+
+
+def test_ws_write_timeout_env_var_invalid_falls_back(monkeypatch):
+    import importlib
+    import tui_gateway.ws as ws_local
+    monkeypatch.setenv("HERMES_TUI_WS_WRITE_TIMEOUT_S", "not_a_number")
+    importlib.reload(ws_local)
+    assert ws_local._WS_WRITE_TIMEOUT_S == 10.0
+    monkeypatch.delenv("HERMES_TUI_WS_WRITE_TIMEOUT_S", raising=False)
+    importlib.reload(ws_local)

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -36,8 +36,13 @@ _log = logging.getLogger(__name__)
 
 # Max seconds a pool-dispatched handler will block waiting for the event loop
 # to flush a WS frame before we mark the transport dead. Protects handler
-# threads from a wedged socket.
-_WS_WRITE_TIMEOUT_S = 10.0
+# threads from a wedged socket. Configurable via HERMES_TUI_WS_WRITE_TIMEOUT_S.
+import os
+try:
+    _ws_write_timeout = float(os.environ.get("HERMES_TUI_WS_WRITE_TIMEOUT_S") or "10")
+except (ValueError, TypeError):
+    _ws_write_timeout = 10.0
+_WS_WRITE_TIMEOUT_S = max(1.0, _ws_write_timeout)
 _WS_LOG_PAYLOAD_PREVIEW = 240
 
 # Keep starlette optional at import time; handle_ws uses the real class when


### PR DESCRIPTION
## What does this PR do?
Replaces the hardcoded `_WS_WRITE_TIMEOUT_S = 10.0` in `tui_gateway/ws.py`
with an environment variable override, following the same pattern already
used by `HERMES_TUI_SLASH_TIMEOUT_S`, `HERMES_TUI_SESSION_TTL_S`, and others.

Users with slow providers (GLM, Claude with large contexts) were seeing
`ws write slow (loop stalled >10.0s)` warnings and unexpected disconnects
when a single API call exceeded 10 seconds.

## Related Issue
Closes #51288

## Type of Change
- [x] ✨ New feature
- [x] ✅ Tests

## Changes Made
- `tui_gateway/ws.py`: replace hardcoded constant with env-var reading,
  `max(1.0, value)` guard, and graceful fallback on invalid input
- `tests/test_tui_gateway_ws.py`: two new tests covering valid override
  and invalid-value fallback

## How to Test
1. `HERMES_TUI_WS_WRITE_TIMEOUT_S=30 hermes dashboard --tui` — no stall warnings
2. `HERMES_TUI_WS_WRITE_TIMEOUT_S=bad hermes dashboard --tui` — falls back to 10.0s
3. `pytest tests/test_tui_gateway_ws.py -v` — all tests pass

## Checklist
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've added tests for my changes
- [x] I've considered cross-platform impact — N/A (stdlib only)
- [x] I've updated cli-config.yaml.example — N/A