### PR TITLE
fix(cli): report bundle changes on reload instead of always "No changes"

### DIFF
--- a/hermes_cli/bundles.py
+++ b/hermes_cli/bundles.py
@@ -27,7 +27,6 @@ from agent.skill_bundles import (
     list_bundles,
     reload_bundles,
     save_bundle,
-    scan_bundles,
 )
 
 
@@ -214,9 +213,6 @@ def register_cli(subparser) -> None:
         "reload", help="Re-scan the bundles directory and report changes"
     )
     p_reload.set_defaults(_bundles_handler=_cmd_reload)
-
-    # Ensure a fresh scan when any bundles subcommand runs.
-    scan_bundles()
 
 
 def bundles_command(args) -> None:

--- a/tests/hermes_cli/test_bundles.py
+++ b/tests/hermes_cli/test_bundles.py
@@ -90,3 +90,21 @@ class TestBundlesCli:
         bundles_command(_parse(["reload"]))
         out = capsys.readouterr().out
         assert "No changes" in out or "0" in out
+
+    def test_reload_reports_newly_added_bundle(self, bundles_env, capsys):
+        # Establish cache state = {alpha}.
+        bundles_command(_parse(["create", "alpha", "--skill", "s1", "-d", "first"]))
+        bundles_command(_parse(["reload"]))
+        capsys.readouterr()  # clear
+        # A second bundle appears on disk after the cache was populated.
+        (bundles_env / "beta.yaml").write_text(
+            "skills:\n  - s2\ndescription: second\n",
+            encoding="utf-8",
+        )
+        bundles_command(_parse(["reload"]))
+        out = capsys.readouterr().out
+        # Before the fix: register_cli's eager scan_bundles() front-runs the
+        # diff, so reload snapshots a cache that already contains beta and
+        # prints "No changes". After the fix: the cache still holds only alpha
+        # at snapshot time, so beta is reported as added.
+        assert "beta" in out


### PR DESCRIPTION
## What does this PR do?

`hermes bundles reload` always prints "No changes" and never reports a bundle that was added, removed, or edited on disk.

Root cause: `register_cli` (in `hermes_cli/bundles.py`) is invoked at argparse-build time on **every** `hermes` invocation, and it unconditionally called `scan_bundles()`. That refreshed the module-level `_bundles_cache` in `agent/skill_bundles.py` to the current on-disk state *before* any subcommand dispatched. By the time `reload_bundles()` snapshotted its "before" state, the cache already reflected the new disk contents — so `before == after` every time and the `added`/`removed` diff was always empty.

The fix removes the eager `scan_bundles()` at registration. `list`/`show` already rescan lazily via `get_skill_bundles()` (mtime-gated), and `reload` rescans explicitly, so the eager scan was redundant for those paths and actively broke reload's diff. This also brings `bundles` to parity with the sibling `skill_commands` path, which does not scan at registration.

## Related Issue

N/A — found while reviewing the bundles CLI.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/bundles.py`: removed the eager `scan_bundles()` call (and its now-unused import) at the end of `register_cli`, so the bundles cache is no longer refreshed at argparse-build time.
- `tests/hermes_cli/test_bundles.py`: added `test_reload_reports_newly_added_bundle`, a regression test asserting that a bundle dropped on disk after the cache is populated is reported by `reload`.

## How to Test

1. `hermes bundles create alpha --skill s1 -d first`
2. `hermes bundles reload` → "No changes"
3. Drop a new `beta.yaml` into the bundles directory by hand.
4. `hermes bundles reload` → **before this PR**: still "No changes"; **after**: reports `+ beta` as added.

Regression test verified both directions: it fails on `main` (asserts `'beta' in out`, but output is `No changes. 2 bundle(s) loaded.`) and passes with this fix. Full touched-area suite green: `tests/hermes_cli/test_bundles.py`, `tests/agent/test_skill_bundles.py`, `tests/gateway/test_bundles_command.py` — 46 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A