### PR TITLE
fix(desktop): extend audio transcription timeout

### DIFF
--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { getSessionMessages, listAllProfileSessions, listSessions } from './hermes'
+import { getSessionMessages, listAllProfileSessions, listSessions, transcribeAudio } from './hermes'
 
 const emptySessionsResponse = {
   limit: 0,
@@ -55,6 +55,22 @@ describe('Hermes REST session helpers', () => {
     expect(api).toHaveBeenCalledWith({
       path: '/api/sessions/session-1/messages?profile=xiaoxuxu',
       profile: 'xiaoxuxu'
+    })
+  })
+
+  it('uses a longer timeout for local audio transcription', async () => {
+    api.mockResolvedValue({ ok: true, text: 'hello' })
+
+    await transcribeAudio('data:audio/webm;base64,aaaa', 'audio/webm')
+
+    expect(api).toHaveBeenCalledWith({
+      path: '/api/audio/transcribe',
+      method: 'POST',
+      timeoutMs: 120_000,
+      body: {
+        data_url: 'data:audio/webm;base64,aaaa',
+        mime_type: 'audio/webm'
+      }
     })
   })
 })

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -47,6 +47,7 @@ import type {
 
 const DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS = 30_000
 const SESSION_LIST_REQUEST_TIMEOUT_MS = 60_000
+const AUDIO_TRANSCRIPTION_REQUEST_TIMEOUT_MS = 120_000
 
 export type {
   ActionResponse,
@@ -353,10 +354,7 @@ export function getMemoryProviderConfig(provider: string): Promise<MemoryProvide
   })
 }
 
-export function saveMemoryProviderConfig(
-  provider: string,
-  values: Record<string, string>
-): Promise<{ ok: boolean }> {
+export function saveMemoryProviderConfig(provider: string, values: Record<string, string>): Promise<{ ok: boolean }> {
   return window.hermesDesktop.api<{ ok: boolean }>({
     path: `/api/memory/providers/${encodeURIComponent(provider)}/config`,
     method: 'PUT',
@@ -787,6 +785,7 @@ export function transcribeAudio(dataUrl: string, mimeType?: string): Promise<Aud
   return window.hermesDesktop.api<AudioTranscriptionResponse>({
     path: '/api/audio/transcribe',
     method: 'POST',
+    timeoutMs: AUDIO_TRANSCRIPTION_REQUEST_TIMEOUT_MS,
     body: {
       data_url: dataUrl,
       mime_type: mimeType


### PR DESCRIPTION
## What does this PR do?

Extends the Desktop REST timeout for `/api/audio/transcribe` from the default 15s window to 120s. Local STT backends such as faster-whisper can take longer than 15 seconds for medium/large models or longer clips, so the frontend request should not fail before the backend transcription has a reasonable chance to finish.

## Related Issue

Fixes #46573

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/hermes.ts`: added a 120s `timeoutMs` override to `transcribeAudio()`.
- `apps/desktop/src/hermes.test.ts`: added coverage that asserts the transcription request sends the longer timeout.

## How to Test

1. Run `npm --prefix apps/desktop run test:ui -- src/hermes.test.ts`.
2. Run `npx eslint src/hermes.ts src/hermes.test.ts` from `apps/desktop`.
3. Run `npx prettier --check src/hermes.ts src/hermes.test.ts` from `apps/desktop`.
4. Run `npm --prefix apps/desktop run typecheck`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (not run; this is a Desktop TypeScript-only change)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

```text
npm --prefix apps/desktop run test:ui -- src/hermes.test.ts
Test Files  1 passed (1)
Tests       4 passed (4)

npx eslint src/hermes.ts src/hermes.test.ts
# passed

npx prettier --check src/hermes.ts src/hermes.test.ts
All matched files use Prettier code style!

npm --prefix apps/desktop run typecheck
# passed
```