### PR TITLE
fix(session): auto-archive subagent + compressed-parent sessions (#51855)

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -639,6 +639,16 @@ def compress_context(
                     agent._session_db_created = True
                     raise
                 agent._session_db_created = True
+                # Retire the superseded parent from the active list. Rotation
+                # leaves the parent ended (end_reason='compression') but still
+                # archived=0, so it lingers as a finished conversation cluttering
+                # the sidebar / session_search (#51855). Archive only the parent
+                # row — the live child is the continuation. Best-effort: a failure
+                # here must never regress the (already committed) rotation.
+                try:
+                    agent._session_db.archive_session(old_session_id)
+                except Exception as _ar_err:
+                    logger.debug("Could not archive compression parent: %s", _ar_err)
                 # Carry a persistent /goal onto the continuation session.
                 # Compression mints a fresh child id; load_goal does a flat
                 # per-session lookup with no parent walk, so without this an

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1389,10 +1389,17 @@ class SessionDB:
         desynced CLI session_id after ``/resume`` or ``/branch``) targets them
         with a different reason. Use ``reopen_session()`` first if you
         intentionally need to re-end a closed session with a new reason.
+
+        Subagent sessions (``source = 'subagent'``, spawned by ``delegate_task``)
+        are auto-archived as they end: they carry no independent value once their
+        delegated task returns, so they would otherwise accumulate as sidebar /
+        ``session_search`` noise. The soft archive keeps their transcripts on disk
+        for debugging while hiding them from the default list (#51855).
         """
         def _do(conn):
             conn.execute(
-                "UPDATE sessions SET ended_at = ?, end_reason = ? "
+                "UPDATE sessions SET ended_at = ?, end_reason = ?, "
+                "archived = CASE WHEN source = 'subagent' THEN 1 ELSE archived END "
                 "WHERE id = ? AND ended_at IS NULL",
                 (time.time(), end_reason, session_id),
             )
@@ -1992,6 +1999,23 @@ class SessionDB:
             return rowcount
         rowcount = self._execute_write(_do)
         return rowcount > 0
+
+    def archive_session(self, session_id: str) -> None:
+        """Archive exactly one session row — no compression-lineage walk.
+
+        Unlike :meth:`set_session_archived`, this touches only ``session_id``
+        and never its parents/children. Compression rotation uses it to retire
+        a *superseded* parent without archiving the live continuation child:
+        at the moment we archive the parent, that child already exists with
+        ``parent_session_id = <parent>`` and ``started_at >= parent.ended_at``,
+        so the lineage walk in ``set_session_archived`` would sweep it up and
+        hide the conversation the user is actively continuing (#51855).
+        """
+        def _do(conn):
+            conn.execute(
+                "UPDATE sessions SET archived = 1 WHERE id = ?", (session_id,)
+            )
+        self._execute_write(_do)
 
     def get_session_by_title(self, title: str) -> Optional[Dict[str, Any]]:
         """Look up a session by exact title. Returns session dict or None."""

--- a/tests/agent/test_compression_rotation_state.py
+++ b/tests/agent/test_compression_rotation_state.py
@@ -111,6 +111,43 @@ class TestOrphanRollbackOnCreateFailure:
         _ = real_create  # silence unused
 
 
+class TestParentArchivedOnRotation:
+    def test_superseded_parent_is_archived_child_stays_active(self, tmp_path: Path):
+        """After a successful rotation the ended parent is retired from the
+        active list (archived=1) while the live continuation child stays
+        visible (archived=0) — #51855."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        parent = "PARENT_ARCHIVE_ROT"
+        db.create_session(parent, source="cli")
+        agent = _build_agent_with_db(db, parent)
+
+        agent._compress_context(_msgs(), "sys", approx_tokens=120_000)
+        child = agent.session_id
+        assert child != parent  # rotation happened
+
+        assert db.get_session(parent)["archived"] == 1
+        assert db.get_session(parent)["end_reason"] == "compression"
+        assert db.get_session(child)["archived"] == 0
+
+    def test_parent_not_archived_when_child_create_fails(self, tmp_path: Path):
+        """Archiving happens only after the child row is committed, so an
+        orphan-rollback leaves the (reopened) parent active — it is once again
+        the live session, not a superseded one."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        parent = "PARENT_NOARCHIVE_ROT"
+        db.create_session(parent, source="cli")
+        agent = _build_agent_with_db(db, parent)
+
+        def _boom(*a, **k):
+            raise RuntimeError("FOREIGN KEY constraint failed")
+
+        with patch.object(db, "create_session", side_effect=_boom):
+            agent._compress_context(_msgs(), "sys", approx_tokens=120_000)
+
+        assert agent.session_id == parent
+        assert db.get_session(parent)["archived"] == 0
+
+
 class TestPlatformForwardedAtBoundary:
     def test_on_session_start_receives_platform(self, tmp_path: Path):
         db = SessionDB(db_path=tmp_path / "state.db")

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -104,6 +104,41 @@ class TestSessionLifecycle:
         assert isinstance(session["ended_at"], float)
         assert session["end_reason"] == "user_exit"
 
+    def test_end_session_auto_archives_subagent(self, db):
+        """Subagent sessions (source='subagent', spawned by delegate_task) carry
+        no independent value once their task returns, so end_session() soft-archives
+        them to keep them out of the default list / session_search (#51855)."""
+        db.create_session(session_id="sub", source="subagent")
+        assert db.get_session("sub")["archived"] == 0
+
+        db.end_session("sub", end_reason="task_complete")
+
+        session = db.get_session("sub")
+        assert session["archived"] == 1
+        # Transcript is preserved — soft hide, not a delete.
+        assert session["end_reason"] == "task_complete"
+
+    def test_end_session_does_not_archive_non_subagent(self, db):
+        """Only subagent sessions are auto-archived on end — a normal CLI session
+        stays visible after it ends."""
+        db.create_session(session_id="s1", source="cli")
+        db.end_session("s1", end_reason="user_exit")
+        assert db.get_session("s1")["archived"] == 0
+
+    def test_archive_session_single_row_only(self, db):
+        """archive_session() archives exactly one row and never walks the
+        compression lineage — the live continuation child must stay active."""
+        db.create_session(session_id="parent", source="cli")
+        db.end_session("parent", end_reason="compression")
+        db.create_session(
+            session_id="child", source="cli", parent_session_id="parent"
+        )
+
+        db.archive_session("parent")
+
+        assert db.get_session("parent")["archived"] == 1
+        assert db.get_session("child")["archived"] == 0
+
     def test_end_session_preserves_original_end_reason(self, db):
         """The first end_reason wins — compression splits must not be
         overwritten when a later stale ``end_session()`` call lands on the


### PR DESCRIPTION
Closes part of #51855 — the two backend root-cause fixes (P1, P2).

## What this does

These two patches stop *finished* sessions from accumulating in the desktop sidebar and polluting `session_search` — the root cause of problems #1 and #2 in the issue. They fix the data layer so the noise never enters the list in the first place.

### P1 — auto-archive subagents on end (`hermes_state.py`)
`delegate_task` spawns sessions with `source='subagent'`. Once their delegated task returns they carry no independent value, yet they linger as active rows (37/66 active sessions in the reporter's debug report were subagent noise). `end_session()` now soft-archives them via `archived = CASE WHEN source='subagent' THEN 1 ELSE archived END`. Soft hide, not delete — transcripts stay on disk for debugging/search.

### P2 — auto-archive the superseded parent on compression rotation (`conversation_compression.py`)
A successful rotation leaves the parent ended (`end_reason='compression'`) but still `archived=0`, so finished conversations linger (10 such parents, 5,572 messages in the report). After the continuation child is committed, the parent row is archived.

A new `archive_session()` helper touches **only that one row**. The existing `set_session_archived()` walks the whole compression lineage and would sweep up the live continuation child. Archiving runs only *after* the child `create_session` succeeds, so an orphan-rollback (existing #33906/#33907 path) leaves the reopened parent active.

## Tests
- `tests/test_hermes_state.py`: subagent end auto-archives; non-subagent end does not; `archive_session()` is single-row (child stays active).
- `tests/agent/test_compression_rotation_state.py`: rotation archives the parent and keeps the child active; child-create failure leaves the parent active.

All 295 state/hygiene tests + 5 rotation tests pass.

## Not included here (frontend follow-ups)
Patches P3–P7 from the issue are a connected React/Electron change (React Query polling hook, multi-select BatchBar, archived-row styling, inline search, reconnect banner) addressing problems #3 and #4. They sit on top of these backend fixes and are best reviewed/verified as a separate desktop PR since they require running the Electron app to validate.