### PR TITLE
fix(tui): discover profile MCP before desktop agent snapshot

### DIFF
--- a/tests/tui_gateway/test_make_agent_provider.py
+++ b/tests/tui_gateway/test_make_agent_provider.py
@@ -264,6 +264,96 @@ def test_probe_config_health_flags_null_personalities_with_active_personality():
     assert "agent.personalities" in msg
 
 
+def test_make_agent_discovers_profile_mcp_before_tool_snapshot():
+    """Dashboard profile sessions must discover that profile's MCP tools before
+    constructing AIAgent.
+
+    The dashboard process can be launched from one HERMES_HOME while the user
+    opens a Desktop chat under another profile. Startup MCP discovery only covers
+    the launch profile; without this per-session discovery, AIAgent snapshots an
+    empty/non-MCP registry for the selected profile and the model never receives
+    those MCP tool schemas.
+    """
+
+    fake_runtime = {
+        "provider": "openrouter",
+        "base_url": "https://api.synthetic.new/v1",
+        "api_key": "sk-test",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": None,
+        "credential_pool": None,
+    }
+    fake_cfg = {
+        "agent": {"system_prompt": ""},
+        "model": {"default": "glm-5"},
+        "mcp_servers": {"profile-mcp": {"enabled": True, "url": "http://localhost/mcp"}},
+    }
+
+    call_order = []
+
+    def record_discover():
+        call_order.append("discover")
+        return ["mcp_profile_mcp_ping"]
+
+    def record_agent(*args, **kwargs):
+        call_order.append("agent")
+        return MagicMock()
+
+    with (
+        patch("tui_gateway.server._load_cfg", return_value=fake_cfg),
+        patch("tui_gateway.server._get_db", return_value=MagicMock()),
+        patch("tui_gateway.server._load_reasoning_config", return_value=None),
+        patch("tui_gateway.server._load_service_tier", return_value=None),
+        patch("tui_gateway.server._load_enabled_toolsets", return_value=["profile-mcp"]),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value=fake_runtime,
+        ),
+        patch("tools.mcp_tool.discover_mcp_tools", side_effect=record_discover) as mock_discover,
+        patch("run_agent.AIAgent", side_effect=record_agent) as mock_agent,
+    ):
+        from tui_gateway.server import _make_agent
+
+        _make_agent("sid-profile-mcp", "key-profile-mcp")
+
+    mock_discover.assert_called_once()
+    assert call_order == ["discover", "agent"]
+    assert mock_agent.call_args.kwargs["enabled_toolsets"] == ["profile-mcp"]
+
+
+def test_make_agent_skips_profile_mcp_discovery_when_unconfigured():
+    fake_runtime = {
+        "provider": "openrouter",
+        "base_url": "https://api.synthetic.new/v1",
+        "api_key": "sk-test",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": None,
+        "credential_pool": None,
+    }
+    fake_cfg = {"agent": {"system_prompt": ""}, "model": {"default": "glm-5"}}
+
+    with (
+        patch("tui_gateway.server._load_cfg", return_value=fake_cfg),
+        patch("tui_gateway.server._get_db", return_value=MagicMock()),
+        patch("tui_gateway.server._load_reasoning_config", return_value=None),
+        patch("tui_gateway.server._load_service_tier", return_value=None),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value=fake_runtime,
+        ),
+        patch("tools.mcp_tool.discover_mcp_tools") as mock_discover,
+        patch("run_agent.AIAgent") as mock_agent,
+    ):
+        from tui_gateway.server import _make_agent
+
+        _make_agent("sid-no-mcp", "key-no-mcp")
+
+    mock_discover.assert_not_called()
+    assert mock_agent.called
+
+
 def test_make_agent_tolerates_null_config_sections():
     """Bare `agent:` / `display:` keys in ~/.hermes/config.yaml parse as
     None. cfg.get("agent", {}) returns None (default only fires on missing

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3853,6 +3853,27 @@ def _make_agent(
         pass
 
     cfg = _load_cfg()
+
+    # Desktop dashboard sessions can be created for a profile that is different
+    # from the dashboard process' launch HERMES_HOME. The dashboard startup MCP
+    # discovery thread only sees the launch profile, so a newly-created profile
+    # session (for example `epam`) can reach AIAgent construction before that
+    # profile's MCP servers have ever been discovered in this process. AIAgent
+    # snapshots tools once in __init__, so waiting for the launch-profile thread
+    # is not sufficient: discover the *currently bound* profile's MCP servers
+    # here, while the caller's profile HERMES_HOME override is active, before the
+    # tool snapshot is built.
+    try:
+        raw_mcp = cfg.get("mcp_servers") if isinstance(cfg, dict) else None
+        if isinstance(raw_mcp, dict) and raw_mcp:
+            from tools.mcp_tool import discover_mcp_tools
+
+            discover_mcp_tools()
+    except Exception:
+        logger.warning(
+            "Profile MCP tool discovery failed before agent snapshot",
+            exc_info=True,
+        )
     agent_cfg = cfg.get("agent") or {}
     system_prompt = _prompt_text(agent_cfg.get("system_prompt", ""))
     startup_skills = _parse_tui_skills_env()


### PR DESCRIPTION
## Summary
- Discover MCP tools for the currently bound profile inside `tui_gateway.server._make_agent` before constructing `AIAgent`.
- Preserve the no-MCP fast path by skipping discovery when the selected profile has no `mcp_servers` section.
- Add regression coverage for dashboard/Desktop sessions opened under a profile different from the dashboard process launch profile.

## Why
Desktop/dashboard sessions can be created for a profile that differs from the dashboard process' launch `HERMES_HOME`. The dashboard startup MCP discovery only covers that launch profile. When the user opens a chat under another profile, `AIAgent` snapshots its tools during construction; if that profile's MCP servers were not discovered first, the model never receives the MCP tool schemas for that session even though the profile has `mcp_servers` and matching toolsets configured.


## Prior art / duplicate check
This is intentionally a follow-up to the already-merged Desktop MCP discovery fix in #44512, not a duplicate of it.

- #44512 starts MCP discovery for the dashboard `/api/ws` backend, fixing the case where Desktop never started MCP discovery at all.
- This PR covers the remaining profile-scoped case: the dashboard process may have already discovered MCP tools for its launch profile, but a newly-created Desktop session can be bound to a different profile. `_make_agent()` must discover MCP tools while that selected profile is bound, before `AIAgent` snapshots its tools.

I also checked the related open PRs (#42703, #43189, #38301, #50615, #51322). They cover dashboard startup, websocket/API/CLI startup timing, or cold-start waits; none specifically guarantees per-selected-profile MCP discovery immediately before Desktop/TUI agent snapshot.

## Test plan
- `REPO=<path-to-hermes-agent>; cd "$REPO" && PYTHONPATH="$REPO" "$REPO/venv/bin/python" -m pytest tests/tui_gateway/test_make_agent_provider.py -q -o 'addopts='`

Result: `13 passed, 1 warning in 1.73s`.

