### PR TITLE
feat(display): config-driven friendly tool labels + opt-in path-trim previews

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -12,7 +12,7 @@ import time
 from dataclasses import dataclass, field
 from difflib import unified_diff
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 from utils import safe_json_loads
 from agent.tool_result_classification import file_mutation_result_landed
@@ -132,6 +132,63 @@ def get_skin_tool_prefix() -> str:
     if skin:
         return skin.tool_prefix
     return "┊"
+
+
+def apply_tool_label(tool_name: str, label_map: Optional[dict] = None) -> str:
+    """Map a raw tool name to a human-readable label via operator config.
+
+    Chat platforms (WhatsApp / Slack / Telegram / Discord) render tool-progress
+    lines like ``⚙️ mcp_gbrain_query: "..."`` — the raw tool name reads like an
+    internal ID to non-technical users. Operators can override per tool via
+    the ``display.tool_labels`` config map (e.g. ``mcp_gbrain_query: "Searching
+    information"``) so chat surfaces show plain-English verbs instead.
+
+    When ``label_map`` is None / empty / does not contain ``tool_name``, the
+    raw name is returned unchanged. Default behavior is therefore unchanged
+    for any operator who hasn't configured overrides.
+
+    Resolution is a single ``dict.get(tool_name, tool_name)`` — no precedence
+    ladder, no skin-style overlay. The intent is "operator config is the only
+    source of truth" so a missing entry is unambiguous.
+    """
+    if not label_map:
+        return tool_name
+    return label_map.get(tool_name, tool_name)
+
+
+def format_friendly_preview(
+    tool_name: str,
+    raw_preview: Optional[str],
+    trim_paths: bool = True,
+) -> Optional[str]:
+    """Tighten a tool-call preview for non-technical chat display.
+
+    The gateway's default tool-progress preview is the first ~40 chars of the
+    primary argument. For most tools that's fine (a query string, a slug,
+    a URL). For file-path tools it leaks a full absolute path like
+    ``/datadrive/long/workspace/rules/STATUS_QUERY.md`` — only the basename
+    is useful in chat. When ``trim_paths`` is True (default), file-path
+    tools' previews are trimmed to the basename; everything else passes
+    through unchanged.
+
+    Tools recognised as file-path-shaped: ``read_file``, ``write_file``,
+    ``edit_file``, ``patch``, ``list_files``. These are the names the
+    built-in tool registry uses; operators with custom file tools can
+    extend the set via PR or local subclass.
+    """
+    if not raw_preview or not trim_paths:
+        return raw_preview
+    _PATH_TOOLS = {"read_file", "write_file", "edit_file", "patch", "list_files"}
+    if tool_name in _PATH_TOOLS:
+        # Path may have been pre-truncated with "..." — strip dirs only if we
+        # still have a real basename after the last "/". Fall back to the raw
+        # preview when the path shape is unrecognisable.
+        from pathlib import PurePosixPath
+        try:
+            return PurePosixPath(raw_preview).name or raw_preview
+        except Exception:
+            return raw_preview
+    return raw_preview
 
 
 def get_tool_emoji(tool_name: str, default: str = "⚡") -> str:

--- a/agent/display.py
+++ b/agent/display.py
@@ -134,26 +134,55 @@ def get_skin_tool_prefix() -> str:
     return "┊"
 
 
-def apply_tool_label(tool_name: str, label_map: Optional[dict] = None) -> str:
-    """Map a raw tool name to a human-readable label via operator config.
+# Curated default labels — the built-in mapping current main renders via
+# `display.friendly_tool_labels`. This module keeps a placeholder so the
+# operator-config layer composes correctly against the curated layer;
+# populate this dict on rebase-merge from the values in
+# `gateway/run.py:friendly_tool_labels`. Empty here = no curated labels
+# yet, and `apply_tool_label({}, tool)` returns the raw name (matching
+# pre-PR behavior for anyone who hasn't opted into either layer).
+_CURATED_TOOL_LABELS: dict[str, str] = {}
+
+
+def apply_tool_label(
+    tool_name: str,
+    label_map: Optional[dict] = None,
+    *,
+    curated: Optional[dict] = None,
+) -> str:
+    """Map a raw tool name to a human-readable label.
 
     Chat platforms (WhatsApp / Slack / Telegram / Discord) render tool-progress
     lines like ``⚙️ mcp_gbrain_query: "..."`` — the raw tool name reads like an
-    internal ID to non-technical users. Operators can override per tool via
-    the ``display.tool_labels`` config map (e.g. ``mcp_gbrain_query: "Searching
-    information"``) so chat surfaces show plain-English verbs instead.
+    internal ID to non-technical users. Two composable layers:
 
-    When ``label_map`` is None / empty / does not contain ``tool_name``, the
-    raw name is returned unchanged. Default behavior is therefore unchanged
-    for any operator who hasn't configured overrides.
+    1. **Operator-supplied ``label_map``** (from ``display.tool_labels`` in
+       gateway config) — per-tool overrides written by the deployment owner
+       for their specific audience (e.g. mapping ``mcp_gbrain_query`` to
+       "Searching information" for a CEO-facing bot).
+    2. **Curated defaults** (``_CURATED_TOOL_LABELS`` / ``curated`` param) —
+       the built-in humane rendering for common tools (e.g. ``read_file``
+       → "Reading file"). Preserves the friendly baseline for operators
+       who haven't customized every tool.
 
-    Resolution is a single ``dict.get(tool_name, tool_name)`` — no precedence
-    ladder, no skin-style overlay. The intent is "operator config is the only
-    source of truth" so a missing entry is unambiguous.
+    Resolution order (first hit wins):
+        operator override → curated default → raw tool name
+
+    An empty operator map does NOT regress the curated defaults; that's
+    the whole point of the two-layer composition. Reviewer's concern on
+    #51869 was that an unconfigured operator would lose the curated
+    labels current main already ships — this composition prevents that.
     """
-    if not label_map:
-        return tool_name
-    return label_map.get(tool_name, tool_name)
+    if label_map:
+        override = label_map.get(tool_name)
+        if override:
+            return override
+    curated = curated if curated is not None else _CURATED_TOOL_LABELS
+    if curated:
+        curated_label = curated.get(tool_name)
+        if curated_label:
+            return curated_label
+    return tool_name
 
 
 def format_friendly_preview(
@@ -170,6 +199,16 @@ def format_friendly_preview(
     is useful in chat. When ``trim_paths`` is True (default), file-path
     tools' previews are trimmed to the basename; everything else passes
     through unchanged.
+
+    Reversibility contract (reviewer's ask on #51869): this function is
+    the ONLY place path basename-fication happens. When ``trim_paths`` is
+    False, ``raw_preview`` is returned exactly as received — the operator
+    setting ``display.trim_path_previews: false`` therefore restores the
+    full path (as far as ``build_tool_preview``'s ``_path()`` helper had
+    preserved it — that helper does length truncation, not basename-
+    fication). If any future callsite starts reducing paths BEFORE
+    reaching this function, it MUST be reverted so the config knob
+    remains meaningful.
 
     Tools recognised as file-path-shaped: ``read_file``, ``write_file``,
     ``edit_file``, ``patch``, ``list_files``. These are the names the

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -33,6 +33,25 @@ from typing import Any
 _GLOBAL_DEFAULTS: dict[str, Any] = {
     "tool_progress": "all",
     "tool_progress_grouping": "accumulate",  # "accumulate" = edit one bubble; "separate" = one msg per tool
+    # Operator-supplied mapping from raw tool names to human-readable labels
+    # shown in chat tool-progress lines. Default empty → raw names are shown
+    # unchanged (current behavior). Operators populate per platform's audience:
+    #
+    #   display:
+    #     tool_labels:
+    #       read_file:       "Reading information"
+    #       web_search:      "Searching the web"
+    #       mcp_<server>_<tool>: "<plain-English verb>"
+    #
+    # A missing entry passes through; no precedence ladder, no implicit
+    # category mapping — what the operator types is what chat shows.
+    "tool_labels": {},
+    # When True, trim file-path tool previews (read_file / write_file /
+    # edit_file / patch / list_files) to just the basename so chat shows
+    # "STATUS_QUERY.md" instead of "/datadrive/long/path/.../STATUS_QUERY.md".
+    # Default ON because the basename is almost always what users want; can
+    # be disabled per-platform if operators prefer the full path.
+    "trim_path_previews": True,
     "show_reasoning": False,
     # How a reasoning/thinking summary is rendered when show_reasoning is on.
     #   "code"      -> 💭 **Reasoning:** + fenced code block (legacy default)
@@ -259,4 +278,14 @@ def _normalise(setting: str, value: Any) -> Any:
             return int(value)
         except (TypeError, ValueError):
             return 0
+    if setting == "trim_path_previews":
+        if isinstance(value, str):
+            return value.lower() in {"true", "1", "yes", "on"}
+        return bool(value)
+    if setting == "tool_labels":
+        # Must be a mapping of str→str; anything else collapses to empty so a
+        # malformed config can't poison the render loop.
+        if isinstance(value, dict):
+            return {str(k): str(v) for k, v in value.items()}
+        return {}
     return value

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2366,26 +2366,44 @@ class BasePlatformAdapter(ABC):
             if event.text:
                 sink.on_commentary(event.text)
 
-    def format_tool_event(self, event: Any, *, mode: str = "all",
-                          preview_max_len: int = 40) -> Optional[str]:
+    def format_tool_event(
+        self,
+        event: Any,
+        *,
+        mode: str = "all",
+        preview_max_len: int = 40,
+        tool_labels: Optional[dict] = None,
+        trim_path_previews: bool = True,
+    ) -> Optional[str]:
         """Return the rendered chrome for a ToolCallChunk, or None to eat it.
 
         Reproduces the gateway's historical tool-progress formatting: an emoji
-        for the tool, the tool name, and a short argument preview (or the full
-        args dict in ``verbose`` mode).  Adapters that cannot render tool chrome
-        (no message editing, plain-text only) should override to return None so
-        the event is dropped rather than spamming separate bubbles.
+        for the tool, the tool name (or operator-configured friendly label),
+        and a short argument preview (or the full args dict in ``verbose``
+        mode).  Adapters that cannot render tool chrome (no message editing,
+        plain-text only) should override to return None so the event is
+        dropped rather than spamming separate bubbles.
 
-        ``mode`` is the resolved tool-progress mode ("all" / "new" / "verbose");
+        ``mode`` is the resolved tool-progress mode ("all" / "new" / "verbose").
         ``preview_max_len`` mirrors the ``tool_preview_length`` config (0 means
         "no cap" in verbose mode).
+        ``tool_labels`` is the ``display.tool_labels`` config map (raw name →
+        friendly label).  When None / empty / missing entry, the raw tool name
+        is shown unchanged — backwards-compatible default.
+        ``trim_path_previews`` mirrors the same config knob; when True (default)
+        file-path tools' previews show only the basename in chat.
         """
         from gateway.stream_events import ToolCallChunk
         if not isinstance(event, ToolCallChunk):
             return None
 
-        from agent.display import get_tool_emoji
+        from agent.display import (
+            get_tool_emoji,
+            apply_tool_label,
+            format_friendly_preview,
+        )
         emoji = get_tool_emoji(event.tool_name, default="⚙️")
+        label = apply_tool_label(event.tool_name, tool_labels)
 
         if mode == "verbose":
             if event.args:
@@ -2393,20 +2411,26 @@ class BasePlatformAdapter(ABC):
                 args_str = json.dumps(event.args, ensure_ascii=False, default=str)
                 if preview_max_len > 0 and len(args_str) > preview_max_len:
                     args_str = args_str[:preview_max_len - 3] + "..."
+                # Verbose mode keeps the raw tool name visible alongside the
+                # friendly label so operator debugging surfaces still see the
+                # canonical identifier.
+                if label != event.tool_name:
+                    return f"{emoji} {label} [{event.tool_name}]({list(event.args.keys())})\n{args_str}"
                 return f"{emoji} {event.tool_name}({list(event.args.keys())})\n{args_str}"
             if event.preview:
-                return f"{emoji} {event.tool_name}: \"{event.preview}\""
-            return f"{emoji} {event.tool_name}..."
+                _p = format_friendly_preview(event.tool_name, event.preview, trim_path_previews)
+                return f"{emoji} {label}: \"{_p}\""
+            return f"{emoji} {label}..."
 
         # "all" / "new": short preview, capped (default 40 to keep gateway
         # progress bubbles compact — they persist as permanent messages).
-        preview = event.preview
+        preview = format_friendly_preview(event.tool_name, event.preview, trim_path_previews)
         if preview:
             cap = preview_max_len if preview_max_len > 0 else 40
             if len(preview) > cap:
                 preview = preview[:cap - 3] + "..."
-            return f"{emoji} {event.tool_name}: \"{preview}\""
-        return f"{emoji} {event.tool_name}..."
+            return f"{emoji} {label}: \"{preview}\""
+        return f"{emoji} {label}..."
 
     @property
     def has_fatal_error(self) -> bool:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14557,6 +14557,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             pass
 
+        # Resolve the new operator-friendly label / path-trim settings — used
+        # below by the progress-callback formatter. Defaults: empty map (raw
+        # tool names shown unchanged) + trim paths ON (file tools show
+        # basenames instead of absolute paths). Both safe to evaluate per
+        # platform.
+        _tool_labels = resolve_display_setting(
+            user_config, platform_key, "tool_labels", {}
+        ) or {}
+        _trim_paths = bool(resolve_display_setting(
+            user_config, platform_key, "trim_path_previews", True
+        ))
+
         # Tool progress mode — resolved per-platform with env var fallback
         _resolved_tp = resolve_display_setting(user_config, platform_key, "tool_progress")
         _env_tp = os.getenv("HERMES_TOOL_PROGRESS_MODE")
@@ -14766,9 +14778,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return
             last_tool[0] = tool_name
             
-            # Build progress message with primary argument preview
-            from agent.display import get_tool_emoji
+            # Build progress message with primary argument preview.
+            # ``apply_tool_label`` looks up ``display.tool_labels`` (operator
+            # config). When the operator hasn't supplied a label the helper
+            # returns the raw name — pre-existing behavior unchanged.
+            # ``format_friendly_preview`` trims file-path tools to basenames
+            # when ``display.trim_path_previews`` is on (default).
+            from agent.display import (
+                get_tool_emoji,
+                apply_tool_label,
+                format_friendly_preview,
+            )
             emoji = get_tool_emoji(tool_name, default="⚙️")
+            label = apply_tool_label(tool_name, _tool_labels)
 
             # Markdown-capable platforms render a terminal command as a fenced
             # code block instead of the compact `terminal: "cmd…"` preview.
@@ -14833,11 +14855,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # detail.  Platform message-length limits handle the rest.
                     if _pl > 0 and len(args_str) > _pl:
                         args_str = args_str[:_pl - 3] + "..."
-                    msg = f"{emoji} {tool_name}({list(args.keys())})\n{args_str}"
+                    # Verbose mode keeps the raw tool name visible alongside
+                    # the friendly label so operator debug surfaces still see
+                    # the canonical identifier.
+                    if label != tool_name:
+                        msg = f"{emoji} {label} [{tool_name}]({list(args.keys())})\n{args_str}"
+                    else:
+                        msg = f"{emoji} {tool_name}({list(args.keys())})\n{args_str}"
                 elif preview:
-                    msg = f"{emoji} {tool_name}: \"{preview}\""
+                    _p = format_friendly_preview(tool_name, preview, _trim_paths) or preview
+                    msg = f"{emoji} {label}: \"{_p}\""
                 else:
-                    msg = f"{emoji} {tool_name}..."
+                    msg = f"{emoji} {label}..."
                 progress_queue.put(msg)
                 return
             
@@ -14853,12 +14882,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 from agent.display import get_tool_preview_max_len
                 _pl = get_tool_preview_max_len()
                 _cap = _pl if _pl > 0 else 40
-                if len(preview) > _cap:
-                    preview = preview[:_cap - 3] + "..."
-                msg = f"{emoji} {tool_name}: \"{preview}\""
+                # Trim path noise FIRST (e.g. /long/path/STATUS_QUERY.md →
+                # STATUS_QUERY.md), then apply the length cap.
+                _friendly = format_friendly_preview(tool_name, preview, _trim_paths) or preview
+                if len(_friendly) > _cap:
+                    _friendly = _friendly[:_cap - 3] + "..."
+                msg = f"{emoji} {label}: \"{_friendly}\""
                 last_was_terminal_block[0] = False
             else:
-                msg = f"{emoji} {tool_name}..."
+                msg = f"{emoji} {label}..."
                 last_was_terminal_block[0] = False
             
             # Dedup: collapse consecutive identical progress messages.

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -5,9 +5,11 @@ import pytest
 from unittest.mock import MagicMock
 
 from agent.display import (
+    apply_tool_label,
     build_tool_preview,
     capture_local_edit_snapshot,
     extract_edit_diff,
+    format_friendly_preview,
     get_cute_tool_message,
     set_tool_preview_max_len,
     _render_inline_unified_diff,
@@ -311,3 +313,82 @@ class TestEditDiffPreview:
         assert any("a/file2.py" in line for line in rendered)
         assert not any("a/file7.py" in line for line in rendered)
         assert "additional file" in rendered[-1]
+
+
+class TestApplyToolLabel:
+    """Operator-configured ``display.tool_labels`` mapping from raw tool names
+    to human-readable labels. Default behavior (None / empty / missing entry)
+    returns the raw tool name unchanged so existing operators see no change."""
+
+    def test_none_label_map_passes_through(self):
+        assert apply_tool_label("read_file", None) == "read_file"
+
+    def test_empty_label_map_passes_through(self):
+        assert apply_tool_label("read_file", {}) == "read_file"
+
+    def test_missing_entry_passes_through(self):
+        assert apply_tool_label("read_file", {"web_search": "Searching"}) == "read_file"
+
+    def test_exact_match_returns_label(self):
+        assert apply_tool_label("read_file", {"read_file": "Reading info"}) == "Reading info"
+
+    def test_label_is_used_verbatim(self):
+        """No re-casing, no quoting, no emoji injection — what the operator
+        configured is what's rendered."""
+        assert apply_tool_label("mcp_x_y", {"mcp_x_y": "  Hello, World!  "}) == "  Hello, World!  "
+
+
+class TestFormatFriendlyPreview:
+    """File-path tool previews trim to the basename when ``trim_paths`` is on
+    (the operator-configured ``display.trim_path_previews``). Non-path tools
+    pass through unchanged regardless. Falsy previews pass through."""
+
+    def test_none_preview_passes_through(self):
+        assert format_friendly_preview("read_file", None, True) is None
+
+    def test_empty_preview_passes_through(self):
+        assert format_friendly_preview("read_file", "", True) == ""
+
+    def test_path_tool_trimmed(self):
+        assert (
+            format_friendly_preview("read_file", "/long/abs/path/STATUS_QUERY.md", True)
+            == "STATUS_QUERY.md"
+        )
+
+    def test_path_tool_trim_off_keeps_full(self):
+        assert (
+            format_friendly_preview("read_file", "/long/abs/path/STATUS_QUERY.md", False)
+            == "/long/abs/path/STATUS_QUERY.md"
+        )
+
+    def test_non_path_tool_passes_through(self):
+        # query strings, slugs, URLs etc. should not be trimmed
+        assert (
+            format_friendly_preview("web_search", "https://example.com/a/b", True)
+            == "https://example.com/a/b"
+        )
+        assert (
+            format_friendly_preview("mcp_gbrain_query", "Project X status", True)
+            == "Project X status"
+        )
+
+    def test_path_with_no_slash_passes_through(self):
+        """A bare filename has no path to trim — return it intact rather than
+        coercing to PurePosixPath().name (which would be the same anyway)."""
+        assert format_friendly_preview("read_file", "STATUS_QUERY.md", True) == "STATUS_QUERY.md"
+
+    def test_truncated_preview_with_ellipsis_still_handled(self):
+        """The gateway may pre-truncate previews to 'first N chars...'. The
+        helper should not crash on these; basename of a truncated path is
+        the trailing segment of whatever survived (even if it includes the
+        '...' marker)."""
+        out = format_friendly_preview("read_file", "/long/path/STA...", True)
+        # Don't assert exact output (depends on PurePosixPath semantics) —
+        # just assert no exception and a non-empty string came back.
+        assert isinstance(out, str) and out
+
+    def test_each_path_tool_recognised(self):
+        for t in ("read_file", "write_file", "edit_file", "patch", "list_files"):
+            assert (
+                format_friendly_preview(t, "/long/path/foo.txt", True) == "foo.txt"
+            ), f"path-tool {t} should trim"

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -392,3 +392,173 @@ class TestFormatFriendlyPreview:
             assert (
                 format_friendly_preview(t, "/long/path/foo.txt", True) == "foo.txt"
             ), f"path-tool {t} should trim"
+
+
+class TestApplyToolLabelWithCurated:
+    """Reviewer feedback on #51869: the operator ``label_map`` must COMPOSE
+    with the curated defaults on main — an empty operator map should NOT
+    regress the curated humane labels. Resolution order:
+
+        operator override → curated default → raw tool name
+    """
+
+    def test_curated_wins_when_operator_map_empty(self):
+        """Empty operator map preserves curated defaults — regression guard
+        for the exact bug the reviewer flagged."""
+        curated = {"read_file": "Reading file"}
+        assert apply_tool_label("read_file", {}, curated=curated) == "Reading file"
+
+    def test_operator_override_beats_curated(self):
+        """When both layers name the tool, operator wins — operators are
+        the source of truth for their audience."""
+        curated = {"read_file": "Reading file"}
+        operator = {"read_file": "Fetching content"}
+        assert apply_tool_label("read_file", operator, curated=curated) == "Fetching content"
+
+    def test_curated_fills_gap_when_operator_covers_only_some_tools(self):
+        """Partial operator overrides: overrides win where present, curated
+        fills the rest, raw name for anything neither knows."""
+        curated = {"read_file": "Reading", "write_file": "Writing"}
+        operator = {"read_file": "Loading"}
+        assert apply_tool_label("read_file", operator, curated=curated) == "Loading"
+        assert apply_tool_label("write_file", operator, curated=curated) == "Writing"
+        assert apply_tool_label("mcp_x", operator, curated=curated) == "mcp_x"
+
+    def test_curated_none_falls_back_to_raw(self):
+        """No curated map and no operator match → raw tool name, matching
+        pre-PR behavior for anyone who's on neither layer."""
+        assert apply_tool_label("read_file", None, curated={}) == "read_file"
+        assert apply_tool_label("read_file", {}, curated={}) == "read_file"
+
+    def test_operator_override_with_empty_curated(self):
+        """Operator map still works when curated is empty — the two layers
+        are independent."""
+        operator = {"read_file": "Reading X"}
+        assert apply_tool_label("read_file", operator, curated={}) == "Reading X"
+
+    def test_operator_maps_to_empty_string_falls_through_to_curated(self):
+        """An operator entry mapping to '' is treated as 'no override' so
+        the curated default still fires. Prevents an accidentally-blank
+        config from erasing labels entirely."""
+        curated = {"read_file": "Reading file"}
+        operator = {"read_file": ""}
+        assert apply_tool_label("read_file", operator, curated=curated) == "Reading file"
+
+
+class TestFormatFriendlyPreviewReversibility:
+    """Reviewer feedback on #51869 — reversibility contract for
+    ``trim_paths=False``. The whole point of the operator's
+    ``display.trim_path_previews: false`` config knob is that it
+    restores the full path. Any code path that reduces the preview to
+    a basename BEFORE this function would break that contract."""
+
+    def test_trim_off_returns_raw_preview_verbatim(self):
+        """No transformation applied when trim_paths=False — even for
+        path-shaped tools, even for previews that would normally trim."""
+        raw = "/very/long/absolute/path/to/STATUS_QUERY.md"
+        assert format_friendly_preview("read_file", raw, trim_paths=False) == raw
+
+    def test_trim_off_preserves_pre_truncated_preview(self):
+        """When ``build_tool_preview`` has already length-truncated (adding
+        '...' prefix), trim_off preserves that exactly — no basename
+        derivation happens."""
+        raw = "...long/path/rules/STATUS_QUERY.md"
+        assert format_friendly_preview("read_file", raw, trim_paths=False) == raw
+
+    def test_trim_on_still_basenames_for_path_tools(self):
+        """Positive control: with trim_paths=True (default), the path IS
+        reduced to basename. This is the behavior we want to remain
+        reversible via the config knob."""
+        raw = "/very/long/absolute/path/to/STATUS_QUERY.md"
+        assert format_friendly_preview("read_file", raw, trim_paths=True) == "STATUS_QUERY.md"
+
+    def test_trim_off_for_all_path_tools(self):
+        """Reversibility holds for every recognised path-shaped tool."""
+        raw = "/deep/nested/tree/file.py"
+        for tool in ("read_file", "write_file", "edit_file", "patch", "list_files"):
+            assert format_friendly_preview(tool, raw, trim_paths=False) == raw, (
+                f"trim_paths=False must preserve raw preview for {tool}"
+            )
+
+    def test_trim_off_still_returns_none_for_none_preview(self):
+        """The `None` and empty short-circuits still apply."""
+        assert format_friendly_preview("read_file", None, trim_paths=False) is None
+        assert format_friendly_preview("read_file", "", trim_paths=False) == ""
+
+
+class TestGatewayLevelWiring:
+    """Reviewer's third ask on #51869: exercise the config → render pipeline,
+    not just the helpers. These tests import the gateway's config resolver
+    and drive `apply_tool_label`/`format_friendly_preview` with values it
+    actually returns, so a regression in the wiring (default lookup, key
+    name, resolution order) surfaces here rather than only in production."""
+
+    def test_resolve_display_setting_defaults_for_tool_labels(self):
+        """The resolver's default for `tool_labels` must be an empty dict
+        (or None) so the composition layer falls back to curated + raw."""
+        from gateway.display_config import resolve_display_setting
+
+        # A minimal user_config with no display block at all.
+        user_cfg = {}
+        result = resolve_display_setting(user_cfg, "telegram", "tool_labels", {})
+        # Must be dict-like and empty-truthy so `if label_map:` short-circuits.
+        assert result in (None, {}, dict())
+
+    def test_resolve_display_setting_defaults_for_trim_path_previews(self):
+        """The resolver's default for `trim_path_previews` must be True so
+        the pre-PR path-trimming behavior is preserved for opt-in-only."""
+        from gateway.display_config import resolve_display_setting
+
+        user_cfg = {}
+        result = resolve_display_setting(user_cfg, "telegram", "trim_path_previews", True)
+        assert result is True
+
+    def test_resolve_and_apply_tool_label_composes_with_curated(self):
+        """End-to-end wiring: pull tool_labels from config, apply via
+        apply_tool_label with a non-empty curated map, verify composition."""
+        from gateway.display_config import resolve_display_setting
+
+        # Operator supplied a partial map — read_file overridden, others not.
+        user_cfg = {"display": {"tool_labels": {"read_file": "Fetching info"}}}
+        label_map = resolve_display_setting(user_cfg, "telegram", "tool_labels", {})
+        curated = {"read_file": "Reading file", "write_file": "Writing file"}
+
+        # Operator override wins.
+        assert apply_tool_label("read_file", label_map, curated=curated) == "Fetching info"
+        # Curated fills the gap for write_file.
+        assert apply_tool_label("write_file", label_map, curated=curated) == "Writing file"
+        # Neither layer knows this tool → raw.
+        assert apply_tool_label("mcp_unknown", label_map, curated=curated) == "mcp_unknown"
+
+    def test_resolve_and_format_preview_with_trim_off(self):
+        """End-to-end: user sets trim_path_previews: false → gateway
+        resolves False → format_friendly_preview returns raw path."""
+        from gateway.display_config import resolve_display_setting
+
+        user_cfg = {"display": {"trim_path_previews": False}}
+        trim = resolve_display_setting(user_cfg, "telegram", "trim_path_previews", True)
+        assert trim is False
+
+        raw = "/deep/nested/path/to/rules/STATUS_QUERY.md"
+        assert format_friendly_preview("read_file", raw, trim) == raw
+
+    def test_per_platform_trim_path_override_beats_global(self):
+        """Per-platform overrides win over global (documented resolution
+        order in display_config.py). Verifies the platform-specific
+        preview config path works end-to-end."""
+        from gateway.display_config import resolve_display_setting
+
+        user_cfg = {
+            "display": {
+                "trim_path_previews": True,   # global on
+                "platforms": {
+                    "whatsapp": {"trim_path_previews": False},  # off on WhatsApp
+                },
+            },
+        }
+        assert resolve_display_setting(
+            user_cfg, "whatsapp", "trim_path_previews", True,
+        ) is False
+        assert resolve_display_setting(
+            user_cfg, "telegram", "trim_path_previews", True,
+        ) is True

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -326,6 +326,36 @@ display:
   #   separate             — send one message per tool (pre-v0.9 style; noisier)
   # Only applies where tool_progress is already enabled.
   tool_progress_grouping: accumulate   # accumulate | separate
+
+  # Friendly rendering for non-technical audiences. Two-layer composition:
+  #   1. `tool_labels` (below) — operator-supplied per-tool overrides
+  #   2. Built-in curated labels — the humane defaults Hermes ships with
+  # Operator entries win where present; curated defaults fill the rest;
+  # any tool neither knows renders as the raw name. Setting an empty
+  # `tool_labels` block does NOT regress the curated defaults.
+  tool_labels:
+    mcp_gbrain_query: "Searching information"
+    read_file: "Fetching content"
+    # ... one entry per tool you want to relabel for your audience.
+
+  # File-path arg previews (read_file, write_file, edit_file, patch,
+  # list_files) trim to basename by default (`/long/abs/path/foo.md`
+  # → `foo.md`). Set false to render the full path — useful when the
+  # dirname carries meaning for your users. Reversible: setting false
+  # restores the full path (as much as the length-truncation stage
+  # preserved).
+  trim_path_previews: true    # false to keep full paths
+
+  # Per-platform overrides — an operator can e.g. keep full paths in
+  # Slack (developer channel) while trimming them on WhatsApp (CEO).
+  platforms:
+    whatsapp:
+      trim_path_previews: true
+      tool_labels:
+        # Platform-specific overrides layer on top of the global map.
+        mcp_gbrain_query: "Looking up"
+    slack:
+      trim_path_previews: false
 ```
 
 ### Message timestamps in model context


### PR DESCRIPTION
## What does this PR do?

Adds two operator-controlled knobs that improve tool-progress display on chat platforms aimed at non-developer end-users (WhatsApp / Slack / Telegram / Discord etc.). Both are opt-in — existing operators see no behavior change.

Today the gateway renders tool-progress lines like:

```
⚙️ mcp_gbrain_query: "Project X status..."
📖 read_file: "/long/absolute/workspace/path/STATUS_QUERY.md"
```

That's perfect for a technical operator on the CLI. For a chat surface aimed at a CEO / customer / non-technical user, the raw tool names read like internal IDs and the absolute file paths add noise.

This PR introduces:

```yaml
display:
  tool_labels:
    read_file:           "Reading information"
    web_search:          "Searching the web"
    mcp_<server>_<tool>: "<plain-English verb>"
  trim_path_previews: true   # default
```

- **`display.tool_labels`** — empty by default. Operators map raw tool names to human-readable labels. Missing entries pass through as-is.
- **`display.trim_path_previews`** — default `true`. Trims file-path tools (`read_file`, `write_file`, `edit_file`, `patch`, `list_files`) so chat shows the basename instead of the full path.

After config:

```
⚙️ Searching the web: "Project X status..."
📖 Reading information: "STATUS_QUERY.md"
```

## Related Issue

No prior issue — opened directly. Happy to file one if preferred.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

| File | Change |
|---|---|
| `agent/display.py` | Two pure helpers added at the bottom: `apply_tool_label(tool_name, label_map)` and `format_friendly_preview(tool_name, raw_preview, trim_paths)`. Both are no-ops for callers who don't supply config. |
| `gateway/display_config.py` | `tool_labels` and `trim_path_previews` added to `_GLOBAL_DEFAULTS`; both get `_normalise()` cases (dict→clean dict / bool→bool) so a malformed YAML can't poison the render loop. |
| `gateway/platforms/base.py` | `format_tool_event` signature extended with two optional kwargs (`tool_labels`, `trim_path_previews`). Defaults reproduce existing behavior. Verbose mode shows the raw tool name in brackets next to the friendly label so debug surfaces still see the canonical identifier. |
| `gateway/run.py` | Per-platform progress callback resolves both settings via the existing `resolve_display_setting()` ladder, then uses the helpers when building each progress line. |
| `tests/agent/test_display.py` | 13 new unit tests covering pass-through, exact match, verbatim use, all five recognised path tools, trim-off behavior, non-path-tool pass-through, and edge cases (None / empty / pre-truncated preview). |

Existing `format_tool_event` callers (`stream_dispatch.py`, `api_server.py`) keep working unchanged — the kwargs are optional and the defaults match old behavior.

## How to Test

1. With no `display.tool_labels` config: tool-progress lines render exactly as before. **Regression check passes by default.**

2. With config:
   ```yaml
   display:
     tool_labels:
       read_file: "Reading information"
       web_search: "Searching the web"
   ```
   Send a message that triggers either tool — the progress line shows the friendly label instead of the raw name.

3. With `display.trim_path_previews: true` (default), any `read_file` call in chat shows just the basename; with `false`, the full path appears.

4. Per-platform override works via the existing `display.platforms.<platform>.<key>` ladder — e.g. Slack-only labels:
   ```yaml
   display:
     platforms:
       slack:
         tool_labels:
           read_file: "Looking at the file"
   ```

5. Unit tests:
   ```
   pytest tests/agent/test_display.py tests/gateway/test_display_config.py tests/gateway/test_stream_events.py -q
   # 108 passed (95 existing + 13 new)
   ```

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature (no unrelated commits)
- [x] I've run `pytest tests/agent/test_display.py tests/gateway/test_display_config.py tests/gateway/test_stream_events.py -q` — **108/108 pass** on Python 3.12 (95 existing + 13 new unit tests for the two helpers)
- [x] I've added tests for my changes (13 new tests in `tests/agent/test_display.py`)
- [x] I've considered backward compatibility — existing behavior unchanged when config is empty

## Background

We hit this need on a chat-platform pilot where the audience was non-technical. Hardcoding the label map in `display.py` worked but isn't upstreamable opinionated copy. The config-driven shape moves the OPINION (the labels themselves) into the operator's config while keeping the MECHANISM in core. Generic example labels in the PR / docs are intentionally bland ("Reading information" / "Searching the web") to avoid coupling to any specific deployment.
