### PR TITLE
fix(cli): honor non-interactive context in prompt_yes_no (desktop gateway restart hang)

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -272,8 +272,35 @@ def prompt_choice(question: str, choices: list, default: int = 0, description: s
             sys.exit(1)
 
 
+def is_noninteractive() -> bool:
+    """True when no human is available to answer a prompt.
+
+    The dashboard/desktop spawn CLI actions with ``stdin=DEVNULL`` and
+    ``HERMES_NONINTERACTIVE=1`` (see ``hermes_cli/web_server.py``). In that
+    context an ``input()`` raises ``EOFError`` immediately, so a prompt that
+    aborts on EOF kills the spawned action — this is what made the desktop
+    "restart gateway" fail when the Windows gateway service was not yet
+    installed (the start path asks "Install it now?" with no one to answer).
+    Honour the explicit env flag here so callers fall back to their default.
+    """
+    return os.environ.get("HERMES_NONINTERACTIVE", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
 def prompt_yes_no(question: str, default: bool = True) -> bool:
-    """Prompt for yes/no. Ctrl+C exits, empty input returns default."""
+    """Prompt for yes/no. Ctrl+C exits, empty input returns default.
+
+    Non-interactive callers (``HERMES_NONINTERACTIVE=1`` or a closed/redirected
+    stdin) have no one to answer, so fall back to ``default`` instead of
+    aborting the whole process.
+    """
+    if is_noninteractive():
+        return default
+
     default_str = "Y/n" if default else "y/N"
 
     while True:
@@ -283,9 +310,15 @@ def prompt_yes_no(question: str, default: bool = True) -> bool:
                 .strip()
                 .lower()
             )
-        except (KeyboardInterrupt, EOFError):
+        except KeyboardInterrupt:
             print()
             sys.exit(1)
+        except EOFError:
+            # No stdin to read (closed/redirected, e.g. a spawned action with
+            # stdin=DEVNULL). Accept the default rather than exit so the caller
+            # can proceed unattended instead of failing the whole command.
+            print()
+            return default
 
         if not value:
             return default

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -494,3 +494,49 @@ def test_modal_setup_persists_direct_mode_when_user_chooses_their_own_account(tm
 # test_setup_slack_* moved to tests/gateway/test_slack_plugin_setup.py — the
 # _setup_slack wizard migrated to the slack plugin's interactive_setup (#41112).
 
+
+def test_prompt_yes_no_returns_default_when_noninteractive_env_set(monkeypatch):
+    """HERMES_NONINTERACTIVE=1 (set by dashboard/desktop spawns) must make
+    prompt_yes_no fall back to its default instead of reading stdin."""
+    monkeypatch.setenv("HERMES_NONINTERACTIVE", "1")
+
+    def _boom(*_a, **_k):
+        raise AssertionError("input() must not be called in non-interactive mode")
+
+    monkeypatch.setattr("builtins.input", _boom)
+
+    assert setup_mod.prompt_yes_no("Install it now?", True) is True
+    assert setup_mod.prompt_yes_no("Install it now?", False) is False
+
+
+def test_prompt_yes_no_eof_returns_default_instead_of_exiting(monkeypatch):
+    """A closed/redirected stdin (EOFError) must yield the default, not abort.
+
+    Regression: the Windows gateway start path asks "Install it now?" when the
+    service is not installed; spawned from the desktop app (stdin=DEVNULL) the
+    EOFError used to sys.exit(1), killing every desktop-triggered restart."""
+    monkeypatch.delenv("HERMES_NONINTERACTIVE", raising=False)
+
+    def _eof(*_a, **_k):
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", _eof)
+
+    assert setup_mod.prompt_yes_no("Install it now?", True) is True
+    assert setup_mod.prompt_yes_no("Install it now?", False) is False
+
+
+def test_prompt_yes_no_keyboard_interrupt_still_exits(monkeypatch):
+    """Ctrl+C is an explicit user abort and must keep exiting."""
+    monkeypatch.delenv("HERMES_NONINTERACTIVE", raising=False)
+
+    def _interrupt(*_a, **_k):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr("builtins.input", _interrupt)
+
+    import pytest
+
+    with pytest.raises(SystemExit):
+        setup_mod.prompt_yes_no("Install it now?", True)
+


### PR DESCRIPTION
## Summary

Desktop / dashboard "restart gateway" silently fails on Windows when the
gateway service (scheduled task / startup entry) is not yet installed. The
gateway never starts and the user is stuck on `✗ Gateway service is not installed`.

Root cause: the dashboard/desktop spawn gateway actions **non-interactively**
— `hermes_cli/web_server.py` launches them with `stdin=subprocess.DEVNULL` and
`HERMES_NONINTERACTIVE=1`. But `prompt_yes_no()` never honored that contract
(`HERMES_NONINTERACTIVE` is set but read nowhere), and it called
`sys.exit(1)` on the `EOFError` that an empty stdin produces.

On Windows, `gateway start` asks `Install it now so the gateway starts on
login? [Y/n]` when nothing is installed. Spawned from the desktop app there is
no stdin to answer it, so the child exits 1 at the prompt and every
desktop-triggered restart aborts. The attached user log shows dozens of restart
attempts, each ending exactly at that `[Y/n]:` line.

## Fix

`prompt_yes_no()` now falls back to its `default` instead of aborting when:
- `HERMES_NONINTERACTIVE` is set (the contract the desktop/dashboard already declares), or
- `input()` raises `EOFError` (closed/redirected stdin).

`KeyboardInterrupt` (Ctrl+C) still exits. Interactive TTY behavior is unchanged.

With this, the Windows start path proceeds unattended: the UAC sub-prompt
(default `No`) falls back to the Startup-folder install, then `start()`
direct-spawns the gateway — no terminal required.

## Test plan

- [x] `prompt_yes_no` returns the default when `HERMES_NONINTERACTIVE=1` (input not called)
- [x] `prompt_yes_no` returns the default on `EOFError` instead of exiting
- [x] `KeyboardInterrupt` still raises `SystemExit`
- [x] `scripts/run_tests.sh tests/hermes_cli/test_setup.py` — 18 passed