### PR TITLE
feat: add Mailinator skill for fetching emails from public inboxes

### DIFF
--- a/optional-skills/email/mailinator/SKILL.md
+++ b/optional-skills/email/mailinator/SKILL.md
@@ -18,7 +18,6 @@ metadata:
 - None. No API key required. Agent needs access to 'curl' or similar
 - [Optional] Alternatively, install the Mailinator CLI for mcp access - npm install -g mailinator-cli
 
-
 ## Quick Start
 
 ```bash

--- a/optional-skills/email/mailinator/SKILL.md
+++ b/optional-skills/email/mailinator/SKILL.md
@@ -11,9 +11,13 @@ metadata:
     homepage: https://www.mailinator.com/
 ---
 
-# Mailinator Skill
+# Mailinator - Free, disposable email
 
-This skill provides methods to fetch and inspect emails from public Mailinator inboxes using the Mailinator HTTP API.
+## Requirements
+
+- None. No API key required. Agent needs access to 'curl' or similar
+- [Optional] Alternatively, install the Mailinator CLI for mcp access - npm install -g mailinator-cli
+
 
 ## Quick Start
 
@@ -23,6 +27,9 @@ curl -s "https://www.mailinator.com/api/v2/domains/public/inboxes/{inbox}"
 
 # Get a specific email's content (with raw body)
 curl -s "https://www.mailinator.com/api/v2/domains/public/inboxes/{inbox}/messages/{message_id}?format=raw"
+
+# Get a specific email's HTML content
+curl -s "https://www.mailinator.com/api/v2/domains/public/inboxes/{inbox}/messages/{message_id}/html"
 ```
 
 ## API Endpoints
@@ -84,6 +91,8 @@ For detailed comparison, see `references/mcp-vs-http-api.md`.
 - Public inboxes are shared - emails may be deleted by other users
 - **HTTP API v2 is recommended** - Stateless polling works reliably; see `references/mcp-vs-http-api.md` for details
 - MCP WebSocket/SSE requires persistent connections - not suitable for one-off HTTP requests
+- There is no signup, login, or API auth required to access Public inboxes and emails
+- You do not need to "create" email addresses. All possible email addresses @mailinator.com already exist. Use anything you like.
 
 ## Advanced Examples
 

--- a/optional-skills/email/mailinator/SKILL.md
+++ b/optional-skills/email/mailinator/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: mailinator
+description: "Fetch and inspect emails from public Mailinator inboxes."
+version: 1.0.0
+author: Sam Lipton
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [email, mailinator, inbox, api, testing]
+    homepage: https://www.mailinator.com/
+---
+
+# Mailinator Skill
+
+This skill provides methods to fetch and inspect emails from public Mailinator inboxes using the Mailinator HTTP API.
+
+## Quick Start
+
+```bash
+# List emails in a public inbox
+curl -s "https://www.mailinator.com/api/v2/domains/public/inboxes/{inbox}"
+
+# Get a specific email's content (with raw body)
+curl -s "https://www.mailinator.com/api/v2/domains/public/inboxes/{inbox}/messages/{message_id}?format=raw"
+```
+
+## API Endpoints
+
+### List Inbox Messages
+
+```
+GET https://www.mailinator.com/api/v2/domains/public/inboxes/{inbox}
+```
+
+Example:
+```bash
+curl -s "https://www.mailinator.com/api/v2/domains/public/inboxes/joe" | python3 -m json.tool
+```
+
+Response includes:
+- `msgs`: Array of email metadata (id, from, subject, time, seconds_ago)
+- `domain`: The domain used (public)
+- `to`: The inbox name
+
+### Get Email Content
+
+```
+GET https://www.mailinator.com/api/v2/domains/public/inboxes/{inbox}/messages/{message_id}?format=raw
+```
+
+Example:
+```bash
+curl -s "https://www.mailinator.com/api/v2/domains/public/inboxes/joe/messages/{message_id}?format=raw" | python3 -m json.tool
+```
+
+Response includes:
+- `parts`: Array of email parts (text/plain, text/html)
+- `headers`: Full email headers
+- `subject`, `from`, `to`, `id`, `time`
+
+## Public vs Private Domains
+
+- **Public domains** (e.g., mailinator.com, gmail.com): No authentication required
+- **Private domains**: Require an API token (contact Mailinator for access)
+
+## HTTP API vs MCP
+
+- **HTTP API v2**: Recommended for polling, stateless, no session management needed
+- **MCP WebSocket/SSE**: Only for real-time streaming; requires persistent connection
+
+For detailed comparison, see `references/mcp-vs-http-api.md`.
+
+## Use Cases
+
+- Receiving email in workflows (e.g. signup for some service)
+- Testing email functionality in applications
+- Verifying email delivery and content
+- Extracting verification codes from emails
+- Monitoring email-based notifications
+
+## Notes
+
+- Public inboxes are shared - emails may be deleted by other users
+- **HTTP API v2 is recommended** - Stateless polling works reliably; see `references/mcp-vs-http-api.md` for details
+- MCP WebSocket/SSE requires persistent connections - not suitable for one-off HTTP requests
+
+## Advanced Examples
+
+### Private Domain Access (with API Token)
+
+```bash
+# For private domains, include your API token
+curl -s "https://www.mailinator.com/api/v2/domains/{your-domain}/inboxes/{inbox}" \
+  -H "Authorization: Bearer YOUR_API_TOKEN"
+```
+
+### Error Handling
+
+```bash
+# Check for empty inbox
+response=$(curl -s "https://www.mailinator.com/api/v2/domains/public/inboxes/nonexistent")
+if echo "$response" | grep -q '"msgs":\[\]'; then
+  echo "Inbox is empty"
+elif echo "$response" | grep -q '"error"'; then
+  echo "Error: Inbox not found or invalid"
+fi
+
+# Handle rate limiting (429 response)
+if curl -s -o /dev/null -w "%{http_code}" "https://www.mailinator.com/api/v2/domains/public/inboxes/joe" | grep -q "429"; then
+  echo "Rate limit exceeded - wait before retrying"
+fi
+```
+
+### Integration with Hermes Agent
+
+```python
+# Add this to your Hermes skill or agent tool
+from hermes_tools import terminal
+
+def fetch_inbox(inbox_name: str) -> dict:
+    """Fetch emails from a Mailinator inbox."""
+    cmd = f'curl -s "https://www.mailinator.com/api/v2/domains/public/inboxes/{inbox_name}"'
+    result = terminal(command=cmd)
+    if result["exit_code"] == 0:
+        return json_parse(result["output"])
+    raise Exception(f"Failed to fetch inbox: {result['output']}")
+
+def fetch_email(inbox_name: str, message_id: str) -> dict:
+    """Fetch a specific email's content."""
+    cmd = f'curl -s "https://www.mailinator.com/api/v2/domains/public/inboxes/{inbox_name}/messages/{message_id}?format=raw"'
+    result = terminal(command=cmd)
+    if result["exit_code"] == 0:
+        return json_parse(result["output"])
+    raise Exception(f"Failed to fetch email: {result['output']}")
+```
+
+### Alert When New Email Arrives (Cron Job)
+
+```bash
+# Create a cron job to check for new emails every 5 minutes
+# Add to your crontab: */5 * * * * /path/to/mailinator-alert.sh
+
+#!/bin/bash
+# mailinator-alert.sh
+
+INBOX="joe"
+LAST_CHECK_FILE="/tmp/mailinator_${INBOX}_last_check"
+
+# Get current message count
+CURRENT_COUNT=$(curl -s "https://www.mailinator.com/api/v2/domains/public/inboxes/${INBOX}" | \
+  python3 -c "import sys,json; print(len(json.load(sys.stdin).get('msgs',[])))" 2>/dev/null)
+
+# Get previous count
+if [ -f "$LAST_CHECK_FILE" ]; then
+  PREVIOUS_COUNT=$(cat "$LAST_CHECK_FILE")
+else
+  PREVIOUS_COUNT=0
+fi
+
+# Save current count for next check
+echo "$CURRENT_COUNT" > "$LAST_CHECK_FILE"
+
+# Alert if new messages arrived
+if [ "$CURRENT_COUNT" -gt "$PREVIOUS_COUNT" ]; then
+  NEW_MSGS=$((CURRENT_COUNT - PREVIOUS_COUNT))
+  echo "New email alert: ${NEW_MSGS} new message(s) in ${INBOX} inbox"
+  # Add your notification logic here (Slack, email, etc.)
+fi
+```
+
+## References
+
+- [Mailinator API Docs](https://www.mailinator.com/mailinator-api/)
+- [MCP Endpoint](https://www.mailinator.com/mcp) (requires initialization)
+- [Public Inbox Demo](https://www.mailinator.com/v4/public/inboxes/show?inbox=joe)
+- [MCP vs HTTP API Comparison](references/mcp-vs-http-api.md) - Detailed comparison and when to use each

--- a/optional-skills/email/mailinator/SKILL.md
+++ b/optional-skills/email/mailinator/SKILL.md
@@ -141,17 +141,23 @@ fi
 
 ```python
 # Add this to your Hermes skill or agent tool.
-# SECURITY: never interpolate dynamic values straight into a shell string.
-# Quote every dynamic component with the supported shell_quote helper so a
-# quote, space, or command substitution ($(...), backticks) in inbox_name /
-# message_id cannot escape the URL and execute arbitrary commands.
+# TWO independent safety layers, applied per dynamic component:
+#   1. urllib.parse.quote(...) percent-encodes each value so slashes, query
+#      params, spaces, '#', '&', etc. cannot alter the URL's structure
+#      (path traversal / injected query string). safe="" encodes everything.
+#   2. shell_quote(...) then quotes the fully-built command so nothing can
+#      escape into the shell that runs curl.
+# Encode the variables INDIVIDUALLY before inserting them; never quote the
+# whole assembled URL as a substitute for encoding its parts.
+from urllib.parse import quote
 from hermes_tools import terminal, shell_quote, json_parse
 
 BASE = "https://www.mailinator.com/api/v2/domains/public/inboxes"
 
 def fetch_inbox(inbox_name: str) -> dict:
     """Fetch emails from a Mailinator inbox."""
-    url = f"{BASE}/{inbox_name}"
+    inbox = quote(inbox_name, safe="")
+    url = f"{BASE}/{inbox}"
     cmd = f"curl -s {shell_quote(url)}"
     result = terminal(command=cmd)
     if result["exit_code"] == 0:
@@ -160,7 +166,11 @@ def fetch_inbox(inbox_name: str) -> dict:
 
 def fetch_email(inbox_name: str, message_id: str) -> dict:
     """Fetch a specific email's content."""
-    url = f"{BASE}/{inbox_name}/messages/{message_id}?format=raw"
+    inbox = quote(inbox_name, safe="")
+    msg_id = quote(message_id, safe="")
+    # format=raw is a literal query param WE control, appended after the
+    # encoded path so an encoded component cannot inject its own query string.
+    url = f"{BASE}/{inbox}/messages/{msg_id}?format=raw"
     cmd = f"curl -s {shell_quote(url)}"
     result = terminal(command=cmd)
     if result["exit_code"] == 0:

--- a/optional-skills/email/mailinator/SKILL.md
+++ b/optional-skills/email/mailinator/SKILL.md
@@ -45,9 +45,17 @@ curl -s "https://www.mailinator.com/api/v2/domains/public/inboxes/joe" | python3
 ```
 
 Response includes:
-- `msgs`: Array of email metadata (id, from, subject, time, seconds_ago)
+- `msgs`: Array of email metadata (`id`, `from`, `fromfull`, `origfrom`, `subject`, `to`, `time`, `seconds_ago`, `ip`)
 - `domain`: The domain used (public)
 - `to`: The inbox name
+
+> **Endpoint status:** The `domains/public/...` path above is verified working
+> (HTTP 200 with a live `msgs` array), but Mailinator's official API overview
+> (https://www.mailinator.com/mailinator-api/) documents the token-authenticated
+> **private**-inbox workflow rather than this public path. Treat the public
+> endpoint as a convenient, verified public interface and the token/private
+> workflow (see "Public vs Private Domains" below) as the authoritative,
+> upstream-documented contract for anything beyond throwaway public inboxes.
 
 ### Get Email Content
 
@@ -67,8 +75,15 @@ Response includes:
 
 ## Public vs Private Domains
 
-- **Public domains** (e.g., mailinator.com, gmail.com): No authentication required
-- **Private domains**: Require an API token (contact Mailinator for access)
+- **Public domains** (e.g., mailinator.com): No authentication required. Verified
+  working against `https://www.mailinator.com/api/v2/domains/public/...`.
+- **Private domains**: Require an API token. Per Mailinator's API overview, you
+  (1) sign up for a plan with a private domain and (2) generate your unique API
+  token in the dashboard. Private endpoints are documented under the
+  `api.mailinator.com` host, e.g.
+  `GET https://api.mailinator.com/api/v2/domains/private/inboxes/{inbox}` and
+  message/SMS fetch + HTTP POST inject variants. See the token-authenticated
+  examples in "Advanced Examples" below.
 
 ## HTTP API vs MCP
 
@@ -98,9 +113,11 @@ For detailed comparison, see `references/mcp-vs-http-api.md`.
 ### Private Domain Access (with API Token)
 
 ```bash
-# For private domains, include your API token
-curl -s "https://www.mailinator.com/api/v2/domains/{your-domain}/inboxes/{inbox}" \
-  -H "Authorization: Bearer YOUR_API_TOKEN"
+# For private domains, use the api.mailinator.com host and pass your API token.
+# The token is documented as a bearer credential; some tooling also accepts it
+# as a ?token= query parameter.
+curl -s "https://api.mailinator.com/api/v2/domains/{your-domain}/inboxes/{inbox}" \
+  -H "Authorization: Bearer ***"
 ```
 
 ### Error Handling
@@ -123,12 +140,19 @@ fi
 ### Integration with Hermes Agent
 
 ```python
-# Add this to your Hermes skill or agent tool
-from hermes_tools import terminal
+# Add this to your Hermes skill or agent tool.
+# SECURITY: never interpolate dynamic values straight into a shell string.
+# Quote every dynamic component with the supported shell_quote helper so a
+# quote, space, or command substitution ($(...), backticks) in inbox_name /
+# message_id cannot escape the URL and execute arbitrary commands.
+from hermes_tools import terminal, shell_quote, json_parse
+
+BASE = "https://www.mailinator.com/api/v2/domains/public/inboxes"
 
 def fetch_inbox(inbox_name: str) -> dict:
     """Fetch emails from a Mailinator inbox."""
-    cmd = f'curl -s "https://www.mailinator.com/api/v2/domains/public/inboxes/{inbox_name}"'
+    url = f"{BASE}/{inbox_name}"
+    cmd = f"curl -s {shell_quote(url)}"
     result = terminal(command=cmd)
     if result["exit_code"] == 0:
         return json_parse(result["output"])
@@ -136,46 +160,37 @@ def fetch_inbox(inbox_name: str) -> dict:
 
 def fetch_email(inbox_name: str, message_id: str) -> dict:
     """Fetch a specific email's content."""
-    cmd = f'curl -s "https://www.mailinator.com/api/v2/domains/public/inboxes/{inbox_name}/messages/{message_id}?format=raw"'
+    url = f"{BASE}/{inbox_name}/messages/{message_id}?format=raw"
+    cmd = f"curl -s {shell_quote(url)}"
     result = terminal(command=cmd)
     if result["exit_code"] == 0:
         return json_parse(result["output"])
     raise Exception(f"Failed to fetch email: {result['output']}")
 ```
 
-### Alert When New Email Arrives (Cron Job)
+### Alert When New Email Arrives (Cross-Platform Hermes Cronjob)
 
-```bash
-# Create a cron job to check for new emails every 5 minutes
-# Add to your crontab: */5 * * * * /path/to/mailinator-alert.sh
+Use Hermes' built-in `cronjob` tool rather than an OS-specific `crontab`/bash
+script. This works identically on Linux, macOS, and Windows (no `crontab`,
+no `/tmp`, no shell-specific syntax), which keeps this skill honest about its
+declared `platforms: [linux, macos, windows]`.
 
-#!/bin/bash
-# mailinator-alert.sh
+Ask Hermes to create a recurring job whose prompt does the polling and
+comparison in-agent. For example:
 
-INBOX="joe"
-LAST_CHECK_FILE="/tmp/mailinator_${INBOX}_last_check"
+> "Every 5 minutes, fetch the Mailinator inbox 'joe' via
+> `https://www.mailinator.com/api/v2/domains/public/inboxes/joe`, count the
+> messages, and if the count is higher than the previous run, alert me with how
+> many new messages arrived. Remember the last count between runs."
 
-# Get current message count
-CURRENT_COUNT=$(curl -s "https://www.mailinator.com/api/v2/domains/public/inboxes/${INBOX}" | \
-  python3 -c "import sys,json; print(len(json.load(sys.stdin).get('msgs',[])))" 2>/dev/null)
+The agent persists the previous count in its own state across runs, so there is
+no temp-file bookkeeping. Delivery/notification is handled by the cronjob's
+`deliver` target (a connected messaging platform), not by a hand-rolled
+notification block.
 
-# Get previous count
-if [ -f "$LAST_CHECK_FILE" ]; then
-  PREVIOUS_COUNT=$(cat "$LAST_CHECK_FILE")
-else
-  PREVIOUS_COUNT=0
-fi
-
-# Save current count for next check
-echo "$CURRENT_COUNT" > "$LAST_CHECK_FILE"
-
-# Alert if new messages arrived
-if [ "$CURRENT_COUNT" -gt "$PREVIOUS_COUNT" ]; then
-  NEW_MSGS=$((CURRENT_COUNT - PREVIOUS_COUNT))
-  echo "New email alert: ${NEW_MSGS} new message(s) in ${INBOX} inbox"
-  # Add your notification logic here (Slack, email, etc.)
-fi
-```
+If you specifically need a raw scripted poller on a Unix-like host, the logic is
+simply: GET the inbox, `len(msgs)`, compare to the previously stored count, and
+alert on an increase — but prefer the Hermes cronjob above for portability.
 
 ## References
 

--- a/optional-skills/email/mailinator/references/mcp-vs-http-api.md
+++ b/optional-skills/email/mailinator/references/mcp-vs-http-api.md
@@ -1,0 +1,79 @@
+# Mailinator MCP vs HTTP API
+
+## MCP Endpoint Limitations
+
+The Mailinator MCP endpoint at `https://www.mailinator.com/mcp` requires a persistent WebSocket/SSE connection and cannot be used with stateless HTTP requests.
+
+### MCP Endpoint Details
+
+- **WebSocket/SSE-based**: Requires `initialize` call first, then `tools/call` with a persistent session
+- **Session not persistent**: Each HTTP request gets a new session that expires immediately
+- **Streaming support**: MCP supports Server-Sent Events (SSE) for real-time message delivery
+
+### Test Results
+
+```bash
+# MCP initialize works
+curl -X POST https://www.mailinator.com/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"initialize","params":{},"id":1}'
+
+# Response includes protocolVersion and instructions
+# But tools/call fails with "Session not initialized" or "Session not found"
+```
+
+### SSE Streaming (requires persistent connection)
+
+```bash
+# This only works with a WebSocket or SSE client
+curl --no-buffer "https://www.mailinator.com/mcp?subscribe=mailinator://joe/public"
+# Returns "Session not found or expired" on one-off HTTP requests
+```
+
+## HTTP API (Recommended for Stateless Access)
+
+The HTTP API v2 is more reliable for polling use cases:
+
+### Inbox Listing
+
+```bash
+GET https://www.mailinator.com/api/v2/domains/public/inboxes/{inbox}
+```
+
+Example:
+```bash
+curl -s "https://www.mailinator.com/api/v2/domains/public/inboxes/joe" | python3 -m json.tool
+```
+
+### Email Content
+
+```bash
+GET https://www.mailinator.com/api/v2/domains/public/inboxes/{inbox}/messages/{message_id}?format=raw
+```
+
+Example:
+```bash
+curl -s "https://www.mailinator.com/api/v2/domains/public/inboxes/joe/messages/{id}?format=raw" | python3 -m json.tool
+```
+
+## When to Use Each
+
+| Use Case | Recommended Method |
+|----------|-------------------|
+| One-off polling (cron jobs, scripts) | HTTP API v2 |
+| Real-time streaming | MCP WebSocket/SSE |
+| Public domain access | HTTP API (no auth) |
+| Private domain access | HTTP API with API token |
+| Interactive CLI tools | HTTP API |
+
+## Key Takeaways
+
+1. **Use HTTP API for polling** - It's stateless, reliable, and doesn't require session management
+2. **MCP requires persistent connection** - Only use MCP if you need real-time streaming
+3. **Public domains don't need auth** - Private domains require an API token
+4. **Format parameter** - Use `?format=raw` to get the full email body
+
+## References
+
+- Mailinator HTTP API v2: https://www.mailinator.com/mailinator-api/
+- MCP Endpoint: https://www.mailinator.com/mcp


### PR DESCRIPTION

Add Mailinator skill for fetching and inspecting emails from public Mailinator inboxes.


- Fetch inbox messages via HTTP API v2
- Get email content with raw body support
- Public domain access (no auth required)
- Private domain support with API token
- Comprehensive examples and documentation

## What does this PR do?

Allows agents to quickly and seamlessly fetch any email sent to Public @mailinator.com addresses.   Email addresses do not need to be created, all email addresses @mailinator.com already exist - use any (valid) email address @mailinator.com you wish.  This can be emails sent by the agent, or by websites (i.e. signup/click-link emails).  This provides agents with nearly infinite email addresses. No API/Auth required.


## Related Issue


Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [X ] 🎯 New skill (bundled or hub)

## Changes Made

Initial checkin
- 

## How to Test

1.  Skill works with Public Inboxes (No Auth Required) - can fetch any email in any inbox
2.  Skill includes private domain support (with API token placeholder)
3. Examples tested and working
4. Documentation complete

## Checklist

### Code

- [X] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [X] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [X] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [X] I've run `pytest tests/ -q` and all tests pass
- [X] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [X] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [N/A ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [N/A ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [X] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [X] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [X] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [X] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the Mailinator skill to list the contents of the joe inbox"`
- 
## Screenshots / Logs


