### PR TITLE
fix(gateway): reliability hardening — stall watchdog, Telegram poll heartbeat, supervised tasks, launchd respawn throttle

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -780,6 +780,7 @@ def stream_converse_with_callbacks(
     on_tool_start=None,
     on_reasoning_delta=None,
     on_interrupt_check=None,
+    on_event=None,
 ) -> SimpleNamespace:
     """Process a Bedrock ConverseStream event stream with real-time callbacks.
 
@@ -799,6 +800,11 @@ def stream_converse_with_callbacks(
             on supported models (Claude 4.6+).
         on_interrupt_check: Called on each event. Should return True if the
             agent has been interrupted and streaming should stop.
+        on_event: Called once (no args) at the top of every yielded stream
+            event, before event-type branching. Provides a true liveness
+            signal for stall watchdogs — fires on tool-input deltas and
+            post-tool text that none of the content callbacks observe. A
+            callback exception is swallowed so it can't break streaming.
 
     Returns:
         An OpenAI-compatible SimpleNamespace response, identical in shape to
@@ -814,6 +820,15 @@ def stream_converse_with_callbacks(
     usage_data: Dict[str, int] = {}
 
     for event in event_stream.get("stream", []):
+        # Liveness signal on EVERY event (incl. tool-input deltas and
+        # post-tool text that fire no content callback). Swallow callback
+        # errors so a watchdog hook can't break streaming.
+        if on_event is not None:
+            try:
+                on_event()
+            except Exception:
+                pass
+
         # Check for interrupt
         if on_interrupt_check and on_interrupt_check():
             break

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1756,7 +1756,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             _bedrock_stale_timeout = max(_bedrock_stale_base, 240.0)
         else:
             _bedrock_stale_timeout = _bedrock_stale_base
-        _BEDROCK_MAX_STALE_KILLS = int(os.getenv("HERMES_STREAM_MAX_STALE_KILLS", "3"))
+        _BEDROCK_MAX_STALE_KILLS = env_int("HERMES_STREAM_MAX_STALE_KILLS", 3)
         _bedrock_stale_kills = 0
         _bedrock_chunks_at_last_kill = 0
 
@@ -2684,7 +2684,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     # if progress resumes we reset, otherwise we give up after _MAX_STALE_KILLS.
     _stale_kills = 0
     _chunks_at_last_kill = 0
-    _MAX_STALE_KILLS = int(os.getenv("HERMES_STREAM_MAX_STALE_KILLS", "3"))
+    _MAX_STALE_KILLS = env_int("HERMES_STREAM_MAX_STALE_KILLS", 3)
     while t.is_alive():
         t.join(timeout=0.3)
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1642,6 +1642,19 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 except Exception:
                     pass
 
+        # Stale-stream watchdog state for the Bedrock path (mirrors the main
+        # streaming path's detector).  ``_bedrock_last_chunk`` is refreshed on
+        # every real callback event; ``_bedrock_chunks`` is a monotonic
+        # real-event counter the poll loop uses to bound its kill loop;
+        # ``_bedrock_gave_up`` is set once the kill ceiling is hit so the
+        # callbacks and the adapter's interrupt check both short-circuit.
+        _bedrock_last_chunk = {"t": time.time()}
+        _bedrock_chunks = {"n": 0}
+        _bedrock_gave_up = {"v": False}
+        # Capture the region with .get (not .pop) so the poll loop can invalidate
+        # the cached runtime client on stall; the worker pops it below.
+        _bedrock_region = api_kwargs.get("__bedrock_region__", "us-east-1")
+
         def _bedrock_call():
             try:
                 from agent.bedrock_adapter import (
@@ -1688,15 +1701,27 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     raise
 
                 def _on_text(text):
+                    if _bedrock_gave_up["v"]:
+                        return
+                    _bedrock_last_chunk["t"] = time.time()
+                    _bedrock_chunks["n"] += 1
                     _fire_first()
                     agent._fire_stream_delta(text)
                     deltas_were_sent["yes"] = True
 
                 def _on_tool(name):
+                    if _bedrock_gave_up["v"]:
+                        return
+                    _bedrock_last_chunk["t"] = time.time()
+                    _bedrock_chunks["n"] += 1
                     _fire_first()
                     agent._fire_tool_gen_started(name)
 
                 def _on_reasoning(text):
+                    if _bedrock_gave_up["v"]:
+                        return
+                    _bedrock_last_chunk["t"] = time.time()
+                    _bedrock_chunks["n"] += 1
                     _fire_first()
                     agent._fire_reasoning_delta(text)
 
@@ -1705,10 +1730,26 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     on_text_delta=_on_text if agent._has_stream_consumers() else None,
                     on_tool_start=_on_tool,
                     on_reasoning_delta=_on_reasoning if agent.reasoning_callback or agent.stream_delta_callback else None,
-                    on_interrupt_check=lambda: agent._interrupt_requested,
+                    on_interrupt_check=lambda: agent._interrupt_requested or _bedrock_gave_up["v"],
                 )
             except Exception as e:
                 result["error"] = e
+
+        # Compute the stale timeout the same way the main streaming path does:
+        # base from HERMES_STREAM_STALE_TIMEOUT, scaled up for large contexts
+        # so a slow first token during reasoning/prefill isn't mistaken for a
+        # wedge.
+        _bedrock_stale_base = env_float("HERMES_STREAM_STALE_TIMEOUT", 180.0)
+        _bedrock_est_tokens = estimate_request_context_tokens(api_kwargs)
+        if _bedrock_est_tokens > 100_000:
+            _bedrock_stale_timeout = max(_bedrock_stale_base, 300.0)
+        elif _bedrock_est_tokens > 50_000:
+            _bedrock_stale_timeout = max(_bedrock_stale_base, 240.0)
+        else:
+            _bedrock_stale_timeout = _bedrock_stale_base
+        _BEDROCK_MAX_STALE_KILLS = int(os.getenv("HERMES_STREAM_MAX_STALE_KILLS", "3"))
+        _bedrock_stale_kills = 0
+        _bedrock_chunks_at_last_kill = 0
 
         t = threading.Thread(target=_bedrock_call, daemon=True)
         t.start()
@@ -1716,6 +1757,43 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             t.join(timeout=0.3)
             if agent._interrupt_requested:
                 raise InterruptedError("Agent interrupted during Bedrock API call")
+
+            # If real events arrived since the last kill, the stream recovered —
+            # forget prior kills so a later, unrelated stall gets the full budget.
+            if _bedrock_stale_kills and _bedrock_chunks["n"] > _bedrock_chunks_at_last_kill:
+                _bedrock_stale_kills = 0
+            if time.time() - _bedrock_last_chunk["t"] > _bedrock_stale_timeout:
+                _bedrock_stale_kills += 1
+                _bedrock_chunks_at_last_kill = _bedrock_chunks["n"]
+                logger.warning(
+                    "Bedrock stream stale for >%.0fs (kill %d/%d, model=%s) — "
+                    "invalidating runtime client and reconnecting.",
+                    _bedrock_stale_timeout, _bedrock_stale_kills,
+                    _BEDROCK_MAX_STALE_KILLS, api_kwargs.get("model", "unknown"),
+                )
+                # invalidate_runtime_client only evicts the cached boto3 client
+                # so the OUTER retry loop builds a fresh one — it cannot abort
+                # the in-flight botocore EventStream this worker is blocked on,
+                # so the worker thread may linger until the socket times out.
+                from agent.bedrock_adapter import invalidate_runtime_client
+                try:
+                    invalidate_runtime_client(_bedrock_region)
+                except Exception as _e:
+                    logger.debug("bedrock invalidate_runtime_client failed: %s", _e)
+                _bedrock_last_chunk["t"] = time.time()
+                if _bedrock_stale_kills >= _BEDROCK_MAX_STALE_KILLS:
+                    logger.error(
+                        "Bedrock stream stalled %dx (>%.0fs each) with no forward "
+                        "progress (model=%s) — aborting instead of reconnecting.",
+                        _bedrock_stale_kills, _bedrock_stale_timeout,
+                        api_kwargs.get("model", "unknown"),
+                    )
+                    _bedrock_gave_up["v"] = True
+                    result["error"] = TimeoutError(
+                        f"Bedrock stream stalled {_bedrock_stale_kills}x "
+                        f"(>{int(_bedrock_stale_timeout)}s each); aborting."
+                    )
+                    break
         if result["error"] is not None:
             raise result["error"]
         return result["response"]
@@ -1768,6 +1846,14 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     # poll loop uses this to detect stale connections that keep receiving
     # SSE keep-alive pings but no actual data.
     last_chunk_time = {"t": time.time()}
+    # Monotonic counter of REAL streamed chunks/deltas across all attempts.
+    # Unlike ``last_chunk_time`` (which retries/pings bump) and the per-attempt
+    # ``_diag["chunks"]`` (which resets every attempt), this only advances when
+    # actual content arrives.  The stale-stream watchdog uses it to decide
+    # whether forward progress happened between kills, so it can bound the
+    # number of stale kills instead of looping forever against a wedged
+    # provider that keeps the timer fresh with SSE pings.
+    chunks_seen = {"n": 0}
     # Stale-stream patience, shared between the httpx socket read timeout
     # (built in ``_call_chat_completions`` below) and the stale-stream detector
     # (computed further down, before the worker thread starts).  Initialized
@@ -1892,6 +1978,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         usage_obj = None
         for chunk in stream:
             last_chunk_time["t"] = time.time()
+            # Real chunk arrived — advance the monotonic progress counter the
+            # stale-stream watchdog reads to bound its kill loop.
+            chunks_seen["n"] += 1
             agent._touch_activity("receiving stream response")
 
             # Update per-attempt diagnostic counters.  Best-effort —
@@ -2202,6 +2291,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 # actively arriving (the chat_completions path
                 # already does this at the top of its chunk loop).
                 last_chunk_time["t"] = time.time()
+                # Real event arrived — advance the monotonic progress counter
+                # the stale-stream watchdog reads to bound its kill loop.
+                chunks_seen["n"] += 1
                 agent._touch_activity("receiving stream response")
 
                 # Update per-attempt diagnostic counters (best-effort).
@@ -2546,8 +2638,18 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     # for prefill on large contexts.  Disable the stale detector unless
     # the user explicitly set HERMES_STREAM_STALE_TIMEOUT.
     if _stream_stale_timeout_base == 180.0 and agent.base_url and is_local_endpoint(agent.base_url):
-        _stream_stale_timeout = float("inf")
-        logger.debug("Local provider detected (%s) — stale stream timeout disabled", agent.base_url)
+        # Local providers (Ollama, oMLX, llama-cpp) can take many minutes for
+        # prefill on large contexts, so the stale detector is relaxed — but it
+        # must stay FINITE.  A truly wedged local server (hung process, deadlock)
+        # would otherwise pin the stream forever.  900s tolerates slow prefill
+        # while still eventually tripping the watchdog.
+        _stream_stale_timeout = float(
+            os.getenv("HERMES_LOCAL_STREAM_STALE_TIMEOUT", "900.0")
+        )
+        logger.debug(
+            "Local provider detected (%s) — stale stream timeout relaxed to %.0fs",
+            agent.base_url, _stream_stale_timeout,
+        )
     else:
         # Scale the stale timeout for large contexts: slow models (like Opus)
         # can legitimately think for minutes before producing the first token
@@ -2566,6 +2668,14 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     t.start()
     _last_heartbeat = time.time()
     _HEARTBEAT_INTERVAL = 30.0  # seconds between gateway activity touches
+    # Bounded stale-kill ceiling.  A provider that keeps an SSE connection
+    # alive with pings but never yields a real chunk would otherwise let the
+    # watchdog kill-and-reconnect forever (the worker never returns).  Track
+    # how many times we've killed and the real-chunk count at the last kill;
+    # if progress resumes we reset, otherwise we give up after _MAX_STALE_KILLS.
+    _stale_kills = 0
+    _chunks_at_last_kill = 0
+    _MAX_STALE_KILLS = int(os.getenv("HERMES_STREAM_MAX_STALE_KILLS", "3"))
     while t.is_alive():
         t.join(timeout=0.3)
 
@@ -2588,6 +2698,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # Detect stale streams: connections kept alive by SSE pings
         # but delivering no real chunks.  Kill the client so the
         # inner retry loop can start a fresh connection.
+        # If real chunks arrived since the last kill, the connection
+        # recovered — forget prior kills so a later, unrelated stall gets
+        # the full kill budget again.
+        if _stale_kills and chunks_seen["n"] > _chunks_at_last_kill:
+            _stale_kills = 0
         _stale_elapsed = time.time() - last_chunk_time["t"]
         if _stale_elapsed > _stream_stale_timeout:
             _est_ctx = estimate_request_context_tokens(api_kwargs)
@@ -2616,6 +2731,25 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # Reset the timer so we don't kill repeatedly while
             # the inner thread processes the closure.
             last_chunk_time["t"] = time.time()
+            # Bound the kill loop: snapshot the real-chunk count at this kill
+            # and count it.  If the provider keeps pinging without ever
+            # yielding a real chunk, chunks_seen never advances past this
+            # snapshot, so the progress-reset above never fires and we hit
+            # the ceiling — at which point we abort instead of looping forever.
+            _chunks_at_last_kill = chunks_seen["n"]
+            _stale_kills += 1
+            if _stale_kills >= _MAX_STALE_KILLS:
+                logger.error(
+                    "Stream stalled %dx (>%.0fs each) with no forward progress "
+                    "(model=%s) — aborting instead of reconnecting again.",
+                    _stale_kills, _stream_stale_timeout,
+                    api_kwargs.get("model", "unknown"),
+                )
+                result["error"] = TimeoutError(
+                    f"Stream stalled {_stale_kills}x "
+                    f"(>{int(_stream_stale_timeout)}s each); aborting."
+                )
+                break
             agent._touch_activity(
                 f"stale stream detected after {int(_stale_elapsed)}s, reconnecting"
             )

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1655,6 +1655,16 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # the cached runtime client on stall; the worker pops it below.
         _bedrock_region = api_kwargs.get("__bedrock_region__", "us-east-1")
 
+        # Liveness hook passed into the adapter; fires once per Bedrock stream
+        # event (including the tool-input streaming phase that fires no content
+        # callback). This is the canonical place the watchdog timer/counter
+        # advance — so a healthy pure-tool-call turn is never falsely killed.
+        def _bedrock_on_event():
+            if _bedrock_gave_up["v"]:
+                return
+            _bedrock_last_chunk["t"] = time.time()
+            _bedrock_chunks["n"] += 1
+
         def _bedrock_call():
             try:
                 from agent.bedrock_adapter import (
@@ -1700,11 +1710,13 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         invalidate_runtime_client(region)
                     raise
 
+                # NOTE: the watchdog timer/counter (_bedrock_last_chunk /
+                # _bedrock_chunks) are advanced by _bedrock_on_event, which the
+                # adapter fires for EVERY stream event. These content callbacks
+                # only perform their consumer-facing side effects.
                 def _on_text(text):
                     if _bedrock_gave_up["v"]:
                         return
-                    _bedrock_last_chunk["t"] = time.time()
-                    _bedrock_chunks["n"] += 1
                     _fire_first()
                     agent._fire_stream_delta(text)
                     deltas_were_sent["yes"] = True
@@ -1712,16 +1724,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 def _on_tool(name):
                     if _bedrock_gave_up["v"]:
                         return
-                    _bedrock_last_chunk["t"] = time.time()
-                    _bedrock_chunks["n"] += 1
                     _fire_first()
                     agent._fire_tool_gen_started(name)
 
                 def _on_reasoning(text):
                     if _bedrock_gave_up["v"]:
                         return
-                    _bedrock_last_chunk["t"] = time.time()
-                    _bedrock_chunks["n"] += 1
                     _fire_first()
                     agent._fire_reasoning_delta(text)
 
@@ -1731,6 +1739,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     on_tool_start=_on_tool,
                     on_reasoning_delta=_on_reasoning if agent.reasoning_callback or agent.stream_delta_callback else None,
                     on_interrupt_check=lambda: agent._interrupt_requested or _bedrock_gave_up["v"],
+                    on_event=_bedrock_on_event,
                 )
             except Exception as e:
                 result["error"] = e

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -606,9 +606,21 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             if block_result is None
         ]
         futures = []
+        # Aggregate deadline for the whole concurrent batch.  Without it, a
+        # single wedged tool (one that ignores the per-thread interrupt signal —
+        # e.g. a hung network call) would block forever: the ThreadPoolExecutor
+        # ``with`` __exit__ calls shutdown(wait=True), which never returns while
+        # that tool's worker is alive.  We manage the executor manually so we
+        # can shut down WITHOUT waiting once the batch deadline trips.
+        _batch_timeout = float(os.getenv("HERMES_TOOL_BATCH_TIMEOUT", "900.0"))
+        _batch_timed_out = False
+        # Maps each submitted future → (results[] slot index, name, args) so the
+        # deadline handler can synthesize a timeout result into the right slot.
+        _future_meta = {}
         if runnable_calls:
             max_workers = min(len(runnable_calls), _MAX_TOOL_WORKERS)
-            with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
+            try:
                 for submit_index, (i, tc, name, args) in enumerate(runnable_calls):
                     # Propagate the agent turn's ContextVars (e.g.
                     # _approval_session_key) AND thread-local approval/sudo
@@ -644,6 +656,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                                 )
                         break
                     futures.append(f)
+                    _future_meta[f] = (i, name, args)
 
                 # Wait for all to complete with periodic heartbeats so the
                 # gateway's inactivity monitor doesn't kill us during long
@@ -679,6 +692,45 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                         concurrent.futures.wait(not_done, timeout=3.0)
                         break
 
+                    # Aggregate batch deadline: if the whole batch has run
+                    # longer than _batch_timeout, give up on the still-pending
+                    # tools instead of blocking the turn forever on a wedged
+                    # one.  Cancel what we can and synthesize a timeout result
+                    # into each unfinished slot so downstream assembly has a
+                    # value.  An abandoned daemon worker may later overwrite
+                    # results[index] with its real result — that's harmless,
+                    # results are assembled downstream after this loop.
+                    if (time.time() - _conc_start) > _batch_timeout:
+                        _batch_timed_out = True
+                        logger.error(
+                            "concurrent tool batch exceeded %.0fs deadline; "
+                            "abandoning %d unfinished tool(s): %s",
+                            _batch_timeout, len(not_done),
+                            ", ".join(
+                                _future_meta.get(f, (None, "unknown", None))[1]
+                                for f in not_done
+                            ),
+                        )
+                        for f in not_done:
+                            f.cancel()
+                            _meta = _future_meta.get(f)
+                            if _meta is None:
+                                continue
+                            _idx, _name, _args = _meta
+                            if results[_idx] is None:
+                                results[_idx] = (
+                                    _name,
+                                    _args,
+                                    f"Error executing tool '{_name}': "
+                                    f"tool batch exceeded {int(_batch_timeout)}s "
+                                    "deadline and was abandoned",
+                                    float(_batch_timeout),
+                                    True,
+                                    False,
+                                    parsed_calls[_idx][3],
+                                )
+                        break
+
                     _conc_elapsed = int(time.time() - _conc_start)
                     # Heartbeat every ~30s (6 × 5s poll intervals)
                     if _conc_elapsed > 0 and _conc_elapsed % 30 < 6:
@@ -691,6 +743,15 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                             f"concurrent tools running ({_conc_elapsed}s, "
                             f"{len(not_done)} remaining: {', '.join(_still_running[:3])})"
                         )
+            finally:
+                # On a clean run, shut down WAITING so worker FDs/threads are
+                # reaped before we move on.  On a batch timeout, shut down
+                # WITHOUT waiting (and cancel queued-but-unstarted futures) —
+                # waiting would re-block on the very wedged tool we just
+                # abandoned, defeating the deadline.
+                executor.shutdown(
+                    wait=not _batch_timed_out, cancel_futures=True
+                )
     finally:
         if spinner:
             # Build a summary message for the spinner stop

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2498,6 +2498,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     _session_model_overrides: Dict[str, Dict[str, str]] = {}
     _session_reasoning_overrides: Dict[str, Dict[str, Any]] = {}
     _startup_restore_in_progress: bool = False
+    # Max times _spawn_supervised will restart a watcher that died with an
+    # exception before giving up (per spawn lineage). Caps respawn storms.
+    _MAX_SUPERVISED_RESTARTS: int = 5
 
     def __init__(self, config: Optional[GatewayConfig] = None):
         global _gateway_runner_ref
@@ -5901,7 +5904,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Process in batches of 100 with event-loop yield points to avoid
             # O(n^2) event-loop blocking when recovering thousands of watchers.
             for i, watcher in enumerate(watchers):
-                asyncio.create_task(self._run_process_watcher(watcher))
+                self._spawn_supervised(
+                    lambda w=watcher: self._run_process_watcher(w),
+                    f"process_watcher:{watcher.get('session_id')}",
+                    restart=False,
+                )
                 logger.info("Resumed watcher for recovered process %s", watcher.get("session_id"))
                 if i % 100 == 99:
                     await asyncio.sleep(0)
@@ -5909,18 +5916,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.error("Recovered watcher setup error: %s", e)
 
         # Start background session expiry watcher to finalize expired sessions
-        asyncio.create_task(self._session_expiry_watcher())
+        self._spawn_supervised(self._session_expiry_watcher, "session_expiry_watcher")
 
         # Start background kanban notifier — delivers `completed`, `blocked`,
         # `spawn_auto_blocked`, and `crashed` events to gateway subscribers
         # so human-in-the-loop workflows hear back without polling.
-        asyncio.create_task(self._kanban_notifier_watcher())
+        self._spawn_supervised(self._kanban_notifier_watcher, "kanban_notifier_watcher")
 
         # Start background kanban dispatcher — spawns workers for ready
         # tasks. Gated by `kanban.dispatch_in_gateway` (default True).
         # When false, users run `hermes kanban daemon` externally or
         # simply don't use kanban; this loop becomes a no-op.
-        asyncio.create_task(self._kanban_dispatcher_watcher())
+        self._spawn_supervised(self._kanban_dispatcher_watcher, "kanban_dispatcher_watcher")
 
         # Start background reconnection watcher for platforms that failed at startup
         if self._failed_platforms:
@@ -5929,23 +5936,78 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 len(self._failed_platforms),
                 ", ".join(p.value for p in self._failed_platforms),
             )
-        asyncio.create_task(self._platform_reconnect_watcher())
+        self._spawn_supervised(self._platform_reconnect_watcher, "platform_reconnect_watcher")
 
         # Start background handoff watcher — picks up CLI sessions marked
         # handoff_state='pending' in state.db and re-binds them to the
         # destination platform's home channel, then forges a synthetic user
         # turn so the agent kicks off the new chat.
-        asyncio.create_task(self._handoff_watcher())
+        self._spawn_supervised(self._handoff_watcher, "handoff_watcher")
 
         # Start background async-delegation watcher — drains completion events
         # from delegate_task(background=true) subagents and injects each
         # result back into its originating session as a new turn, covering the
         # idle case where the subagent finishes with no agent turn running.
-        asyncio.create_task(self._async_delegation_watcher())
+        self._spawn_supervised(self._async_delegation_watcher, "async_delegation_watcher")
 
         logger.info("Press Ctrl+C to stop")
-        
+
         return True
+
+    def _spawn_supervised(self, coro_factory, name, *, restart=True, _attempt=0):
+        """Launch a long-lived watcher coroutine with crash supervision.
+
+        The 6 long-lived gateway watchers were previously launched with bare
+        ``asyncio.create_task`` — no handle, no done-callback, no restart. A
+        raise in a watcher's OUTER ``while self._running:`` loop (e.g.
+        ``_platform_reconnect_watcher``) died silently, taking that subsystem
+        offline for the life of the process. This wrapper tracks the task,
+        logs any crash, and restarts it with bounded exponential backoff.
+
+        Critical invariant: a coroutine that returns CLEANLY (no exception) is
+        NOT respawned — a clean return means the watcher was disabled/shut down
+        on purpose, and respawning a synchronously-returning watcher would
+        busy-spin the event loop.
+        """
+        if getattr(self, "_background_tasks", None) is None:
+            self._background_tasks = set()
+
+        # Do NOT pass name= to create_task — a test mocks create_task with a
+        # signature that rejects the name kwarg.
+        task = asyncio.create_task(coro_factory())
+        self._background_tasks.add(task)
+
+        def _done(t):
+            self._background_tasks.discard(t)
+            if t.cancelled():
+                return
+            exc = t.exception()
+            if exc is None:
+                # Clean return = shutdown/disabled. Do NOT respawn.
+                return
+            logger.error("Supervised task %s died: %r", name, exc, exc_info=exc)
+            if restart and self._running:
+                if _attempt >= self._MAX_SUPERVISED_RESTARTS:
+                    logger.error(
+                        "Supervised task %s exceeded restart ceiling (%d) — giving up restarts",
+                        name, _attempt,
+                    )
+                    return
+                backoff = min(60, 2 ** min(_attempt, 6))
+
+                async def _respawn():
+                    await asyncio.sleep(backoff)
+                    if self._running:
+                        self._spawn_supervised(
+                            coro_factory, name, restart=restart, _attempt=_attempt + 1
+                        )
+
+                respawn_task = asyncio.create_task(_respawn())
+                self._background_tasks.add(respawn_task)
+                respawn_task.add_done_callback(self._background_tasks.discard)
+
+        task.add_done_callback(_done)
+        return task
 
     async def _handoff_watcher(self, interval: float = 2.0) -> None:
         """Background task that processes pending CLI→gateway session handoffs.

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -13,6 +13,7 @@ concurrently under distinct configurations).
 
 import hashlib
 import json
+import logging
 import os
 import shlex
 import signal
@@ -23,6 +24,8 @@ from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Any, NamedTuple, Optional
 from utils import atomic_json_write
+
+logger = logging.getLogger(__name__)
 
 if sys.platform == "win32":
     import msvcrt
@@ -121,7 +124,8 @@ def record_start_and_check_storm(
             backoff_s = min(backoff_cap_s, 5.0 * (2 ** exponent))
             return StormInfo(count=len(recent), window_s=window_s, backoff_s=backoff_s)
         return None
-    except Exception:
+    except Exception as _e:
+        logger.debug("respawn-storm breaker bookkeeping failed (non-fatal): %s", _e)
         return None
 
 

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -21,7 +21,7 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from hermes_constants import get_hermes_home
-from typing import Any, Optional
+from typing import Any, NamedTuple, Optional
 from utils import atomic_json_write
 
 if sys.platform == "win32":
@@ -40,6 +40,89 @@ _gateway_lock_handle = None
 # past the JSON payload so runtime status / PID readers can still read the file
 # while another process holds the mutual-exclusion lock.
 _WINDOWS_LOCK_OFFSET = 1024 * 1024
+
+
+class StormInfo(NamedTuple):
+    """Summary of a detected respawn storm.
+
+    count: number of starts observed inside the window
+    window_s: the rolling window (seconds) the count was measured over
+    backoff_s: how long the caller should sleep to break the storm
+    """
+
+    count: int
+    window_s: float
+    backoff_s: float
+
+
+def _get_starts_log_path() -> Path:
+    """Return the path to the gateway start-timestamps log, respecting HERMES_HOME."""
+    return get_hermes_home() / "gateway-starts.log"
+
+
+def record_start_and_check_storm(
+    max_starts: int = 5,
+    window_s: float = 120.0,
+    *,
+    backoff_cap_s: float = 300.0,
+) -> Optional[StormInfo]:
+    """Record this gateway start and detect a respawn storm.
+
+    Appends the current UTC timestamp to the starts-log, prunes entries older
+    than ``window_s``, and returns a :class:`StormInfo` when more than
+    ``max_starts`` starts have occurred inside the window (else ``None``).
+
+    The log is ring-buffered (kept to the last ``max(max_starts * 4, 40)``
+    lines) and written atomically (temp file + ``os.replace``) so a crash
+    mid-write can never corrupt it.
+
+    Portable: relies only on a timestamp file under HERMES_HOME, so it works
+    identically under launchd, systemd, or a bare-foreground run — independent
+    of any supervisor's own respawn governance.
+
+    Hardened to never raise: any unexpected error returns ``None`` so a
+    diagnostic-only feature can never block gateway startup.
+    """
+    try:
+        path = _get_starts_log_path()
+        now = datetime.now(timezone.utc).timestamp()
+
+        existing: list[float] = []
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except (FileNotFoundError, OSError):
+            raw = ""
+        for line in raw.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                existing.append(float(line))
+            except ValueError:
+                continue
+
+        existing.append(now)
+        cutoff = now - window_s
+        recent = [ts for ts in existing if ts >= cutoff]
+
+        # Ring-buffer the persisted log so it can't grow without bound.
+        keep = max(max_starts * 4, 40)
+        to_write = recent[-keep:] if len(recent) > keep else recent
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(
+            "\n".join(f"{ts:.6f}" for ts in to_write) + "\n", encoding="utf-8"
+        )
+        os.replace(tmp, path)
+
+        if len(recent) > max_starts:
+            exponent = min(len(recent) - max_starts, 6)
+            backoff_s = min(backoff_cap_s, 5.0 * (2 ** exponent))
+            return StormInfo(count=len(recent), window_s=window_s, backoff_s=backoff_s)
+        return None
+    except Exception:
+        return None
 
 
 def _get_pid_path() -> Path:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3570,7 +3570,17 @@ def generate_launchd_plist() -> str:
     
     <key>KeepAlive</key>
     <true/>
-    
+
+    <!-- ThrottleInterval raises launchd's default 10s respawn floor to 30s so a
+         crash-looping gateway can't hammer the system (and external APIs) with a
+         restart every 10 seconds. ExitTimeOut gives the gateway 25s of
+         graceful-drain headroom on shutdown before launchd sends SIGKILL. -->
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+
+    <key>ExitTimeOut</key>
+    <integer>25</integer>
+
     <key>StandardOutPath</key>
     <string>{log_dir}/gateway.log</string>
     
@@ -4323,6 +4333,39 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False, fo
         _exit_diag("atexit.hook", sys_exc=repr(sys.exc_info()))
 
     _atexit.register(_atexit_hook)
+
+    # Portable, app-level respawn-storm circuit breaker. Independent of any
+    # supervisor's own respawn governance (launchd ThrottleInterval, systemd
+    # StartLimit), this records each start and backs off if the gateway is
+    # (re)starting too rapidly — breaking a crash-loop that would otherwise
+    # hammer external APIs. Set HERMES_GATEWAY_MAX_STARTS<=0 to disable.
+    try:
+        import time as _time
+        from gateway.status import record_start_and_check_storm
+
+        try:
+            _max_starts = int(os.getenv("HERMES_GATEWAY_MAX_STARTS", "5"))
+        except ValueError:
+            _max_starts = 5
+        try:
+            _win = float(os.getenv("HERMES_GATEWAY_START_WINDOW_S", "120"))
+        except ValueError:
+            _win = 120.0
+        _storm = (
+            record_start_and_check_storm(max_starts=_max_starts, window_s=_win)
+            if _max_starts > 0
+            else None
+        )
+        if _storm is not None:
+            logger.warning(
+                "Gateway (re)started %d times in %.0fs — backing off %.0fs to break a respawn storm.",
+                _storm.count,
+                _storm.window_s,
+                _storm.backoff_s,
+            )
+            _time.sleep(_storm.backoff_s)
+    except Exception as _be:
+        logger.debug("respawn-storm breaker check failed (non-fatal): %s", _be)
 
     success = False
     try:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -531,6 +531,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
         self._polling_error_task: Optional[asyncio.Task] = None
+        self._polling_heartbeat_task: Optional[asyncio.Task] = None
         self._polling_conflict_count: int = 0
         self._polling_network_error_count: int = 0
         self._polling_error_callback_ref = None
@@ -1704,6 +1705,81 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             await self._handle_polling_network_error(probe_err)
 
+    async def _polling_heartbeat_loop(self) -> None:
+        """Always-on periodic liveness loop for Telegram long-poll polling.
+
+        Closes the silent-wedge gap behind the reactive recovery paths:
+        ``_polling_error_callback`` only fires on an observed network error,
+        and ``_verify_polling_after_reconnect`` runs exactly once after a
+        reconnect. A network blip that wedges PTB's Updater long-poll WITHOUT
+        firing the error callback (and without a prior reconnect) leaves
+        ``updater.running == True`` but no updates ever arrive — the bot is
+        permanently deaf while the process stays alive (the silent-wedge
+        incident). This loop independently probes ``getMe()`` on an interval
+        and re-enters the reconnect ladder whenever the Updater is stopped or
+        the probe fails, so recovery no longer depends on an error callback
+        ever firing.
+        """
+        while not self.has_fatal_error:
+            try:
+                INTERVAL = float(os.getenv("HERMES_TELEGRAM_HEARTBEAT_INTERVAL", "90"))
+            except ValueError:
+                INTERVAL = 90.0
+            PROBE_TIMEOUT = 10
+
+            try:
+                await asyncio.sleep(INTERVAL)
+            except asyncio.CancelledError:
+                return
+
+            if self.has_fatal_error:
+                return
+
+            # If a reconnect is already in flight, the existing recovery path
+            # (and its post-reconnect probe) owns liveness — don't double-drive
+            # the ladder from here.
+            if self._polling_error_task and not self._polling_error_task.done():
+                continue
+
+            updater = getattr(self._app, "updater", None) if self._app else None
+            if updater is None:
+                # _app/updater may be transiently None mid-reconnect; skip this
+                # tick rather than exiting the loop entirely.
+                continue
+
+            if not updater.running:
+                logger.warning(
+                    "[%s] Polling heartbeat: updater not running — re-entering reconnect ladder",
+                    self.name,
+                )
+                try:
+                    await self._handle_polling_network_error(
+                        RuntimeError("Updater not running (heartbeat)")
+                    )
+                except Exception as _he:
+                    logger.warning(
+                        "[%s] heartbeat recovery raised: %s", self.name, _he
+                    )
+                continue
+
+            try:
+                await asyncio.wait_for(self._app.bot.get_me(), PROBE_TIMEOUT)
+                # A successful probe means the send path is healthy again.
+                self._send_path_degraded = False
+            except asyncio.CancelledError:
+                return
+            except Exception as _e:
+                logger.warning(
+                    "[%s] Polling heartbeat probe failed: %s — re-entering reconnect ladder",
+                    self.name, _e,
+                )
+                try:
+                    await self._handle_polling_network_error(_e)
+                except Exception as _he2:
+                    logger.warning(
+                        "[%s] heartbeat recovery raised: %s", self.name, _he2
+                    )
+
     async def _handle_polling_conflict(self, error: Exception) -> None:
         if self.has_fatal_error and self.fatal_error_code == "telegram_polling_conflict":
             return
@@ -2465,6 +2541,30 @@ class TelegramAdapter(BasePlatformAdapter):
             mode = "webhook" if self._webhook_mode else "polling"
             logger.info("[%s] Connected to Telegram (%s mode)", self.name, mode)
 
+            # Always-on polling liveness heartbeat (polling mode only). Opt-out
+            # via HERMES_TELEGRAM_HEARTBEAT_INTERVAL<=0. Detects a silently
+            # wedged long-poll that never fires the error callback.
+            try:
+                _hb = float(os.getenv("HERMES_TELEGRAM_HEARTBEAT_INTERVAL", "90"))
+            except ValueError:
+                _hb = 90.0
+            if _hb > 0 and not getattr(self, "_webhook_mode", False) and not self.has_fatal_error:
+                prev_hb = getattr(self, "_polling_heartbeat_task", None)
+                if prev_hb and not prev_hb.done():
+                    prev_hb.cancel()
+                hb = asyncio.ensure_future(self._polling_heartbeat_loop())
+                self._polling_heartbeat_task = hb
+                self._background_tasks.add(hb)
+
+                def _hb_done(t: "asyncio.Task") -> None:
+                    self._background_tasks.discard(t)
+                    if not t.cancelled() and t.exception() is not None:
+                        logger.error(
+                            "[%s] polling heartbeat died: %r", self.name, t.exception()
+                        )
+
+                hb.add_done_callback(_hb_done)
+
             # Surface the gateway as "Online" in the bot's short description
             # (opt-in via extra.status_indicator). Non-fatal.
             try:
@@ -2523,6 +2623,13 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def disconnect(self) -> None:
         """Stop polling/webhook, cancel pending album flushes, and disconnect."""
+        # Stop the always-on polling heartbeat before tearing down the app so it
+        # can't re-enter the reconnect ladder against a shutting-down updater.
+        hb = getattr(self, "_polling_heartbeat_task", None)
+        if hb and not hb.done():
+            hb.cancel()
+        self._polling_heartbeat_task = None
+
         # Mark the bot "Offline" in its short description while the bot's HTTP
         # client is still alive (before app shutdown closes it). Opt-in via
         # extra.status_indicator. Non-fatal. This is the clean-shutdown path;

--- a/tests/gateway/conftest.py
+++ b/tests/gateway/conftest.py
@@ -228,6 +228,20 @@ _ensure_telegram_mock()
 _ensure_discord_mock()
 
 
+@pytest.fixture(autouse=True)
+def _disable_telegram_heartbeat_by_default(monkeypatch):
+    """Default the Telegram polling heartbeat OFF for all gateway tests.
+
+    ``TelegramAdapter.connect()`` spawns an always-on
+    ``_polling_heartbeat_loop`` (the silent-wedge fix). Left at its default
+    90s interval, any test that exercises ``connect()`` would leave a live
+    background task spinning against mock objects. Setting the interval to
+    ``"0"`` makes ``connect()`` skip the spawn entirely. Tests that exercise
+    the heartbeat explicitly override this with their own setenv.
+    """
+    monkeypatch.setenv("HERMES_TELEGRAM_HEARTBEAT_INTERVAL", "0")
+
+
 # ---------------------------------------------------------------------------
 # Plugin-adapter anti-pattern guard
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -1302,3 +1302,65 @@ class TestGatewayBusyDerivation:
             assert status.derive_gateway_drainable(
                 gateway_running=True, gateway_state=state
             ) is False, state
+
+
+class TestRespawnStormBreaker:
+    def test_no_storm_under_threshold(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        results = [
+            status.record_start_and_check_storm(max_starts=5, window_s=120.0)
+            for _ in range(5)
+        ]
+        assert all(r is None for r in results), results
+
+    def test_storm_detected_over_threshold(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        results = [
+            status.record_start_and_check_storm(max_starts=5, window_s=120.0)
+            for _ in range(7)
+        ]
+        last = results[-1]
+        assert last is not None
+        assert last.count >= 6
+        assert last.backoff_s > 0
+        assert last.window_s == 120.0
+
+    def test_old_starts_pruned_outside_window(self, tmp_path, monkeypatch):
+        import time
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        log_path = tmp_path / "gateway-starts.log"
+        old = time.time() - 10000
+        log_path.write_text(
+            "\n".join(f"{old:.6f}" for _ in range(10)) + "\n", encoding="utf-8"
+        )
+        # The 10 seeded starts are all outside the window, so a single fresh
+        # start cannot constitute a storm.
+        assert status.record_start_and_check_storm(max_starts=5, window_s=120.0) is None
+
+    def test_starts_log_written_atomically(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        for _ in range(6):
+            status.record_start_and_check_storm(max_starts=5, window_s=120.0)
+
+        # No leftover temp files from the atomic write.
+        leftovers = list(tmp_path.glob("*.tmp"))
+        assert leftovers == [], leftovers
+
+        log_path = tmp_path / "gateway-starts.log"
+        assert log_path.exists()
+        for line in log_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                float(line)  # raises if any line is not a valid float
+
+
+class TestLaunchdPlistRespawnGovernance:
+    def test_plist_has_throttle_interval(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from hermes_cli.gateway import generate_launchd_plist
+
+        plist = generate_launchd_plist()
+        assert "<key>ThrottleInterval</key>" in plist
+        assert "<key>ExitTimeOut</key>" in plist
+        assert "<key>KeepAlive</key>" in plist

--- a/tests/gateway/test_supervised_watchers.py
+++ b/tests/gateway/test_supervised_watchers.py
@@ -1,0 +1,133 @@
+"""Tests for GatewayRunner._spawn_supervised — crash supervision for the
+long-lived gateway watcher tasks.
+
+The 6 long-lived watchers (session_expiry, kanban notifier, kanban
+dispatcher, platform_reconnect, handoff, async_delegation) were previously
+launched with bare ``asyncio.create_task`` — a raise in a watcher's OUTER
+``while self._running:`` loop died silently. ``_spawn_supervised`` tracks the
+task, logs crashes, and restarts with bounded exponential backoff.
+
+Two invariants matter most:
+  * A coroutine that returns CLEANLY is NOT respawned (respawning a
+    synchronously-returning watcher would busy-spin the event loop).
+  * Restarts are bounded by ``_MAX_SUPERVISED_RESTARTS`` so a permanently
+    failing watcher can't restart-storm forever.
+"""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+import gateway.run
+from gateway.run import GatewayRunner
+
+
+def _make_runner():
+    """Minimal GatewayRunner via object.__new__ to skip __init__."""
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    runner._background_tasks = set()
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_clean_synchronous_return_is_not_respawned():
+    """A supervised coro that returns immediately must be spawned exactly once.
+
+    A clean return signals shutdown/disabled — respawning it would busy-spin.
+    """
+    runner = _make_runner()
+    calls = 0
+
+    async def quick_return():
+        nonlocal calls
+        calls += 1
+        return  # clean return, no exception
+
+    runner._spawn_supervised(quick_return, "quick")
+
+    # Let the task (and any erroneously-scheduled respawn) run.
+    await asyncio.sleep(0.05)
+
+    assert calls == 1, (
+        f"Expected a cleanly-returning watcher to run exactly once, ran {calls} times"
+    )
+
+
+@pytest.mark.asyncio
+async def test_exception_restart_bounded_by_ceiling(monkeypatch):
+    """A coro that always raises is invoked exactly _MAX_SUPERVISED_RESTARTS+1 times.
+
+    The first spawn + _MAX_SUPERVISED_RESTARTS restarts, then the supervisor
+    gives up. asyncio.sleep is monkeypatched to instant so backoff doesn't
+    slow the test.
+    """
+    runner = _make_runner()
+    calls = 0
+
+    async def always_raises():
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("boom")
+
+    # Make the supervisor's backoff sleeps instant, but still yield to the
+    # loop so respawn tasks actually run. Capture the real sleep first so the
+    # drain loop below can still hand control to the event loop (the patch
+    # below replaces the module-global asyncio.sleep everywhere).
+    real_sleep = asyncio.sleep
+
+    async def _instant_sleep(_delay):
+        # Yield once so chained respawns get scheduled, but skip the backoff.
+        await real_sleep(0)
+
+    monkeypatch.setattr(gateway.run.asyncio, "sleep", _instant_sleep)
+
+    runner._spawn_supervised(always_raises, "boomer")
+
+    # Drain the chain of respawns. Each death schedules a respawn task which
+    # spawns the next attempt; yield repeatedly until both the call count has
+    # reached the ceiling AND no supervised tasks remain pending. Keep going a
+    # few extra iterations after that to prove no over-restart occurs.
+    expected = GatewayRunner._MAX_SUPERVISED_RESTARTS + 1
+    stable = 0
+    for _ in range(500):
+        await asyncio.sleep(0)
+        pending = [t for t in runner._background_tasks if not t.done()]
+        if calls >= expected and not pending:
+            stable += 1
+            if stable >= 5:
+                break
+        else:
+            stable = 0
+
+    assert calls == expected, (
+        f"Expected exactly {expected} invocations "
+        f"(1 spawn + {GatewayRunner._MAX_SUPERVISED_RESTARTS} restarts), got {calls}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_task_called_without_name_kwarg(monkeypatch):
+    """_spawn_supervised must NOT pass name= to create_task.
+
+    A real test elsewhere mocks create_task with a signature that rejects the
+    name kwarg; guard that contract here.
+    """
+    runner = _make_runner()
+    captured = {}
+    real_create_task = asyncio.create_task
+
+    def _spy_create_task(coro, *args, **kwargs):
+        captured["kwargs"] = kwargs
+        return real_create_task(coro)
+
+    monkeypatch.setattr(gateway.run.asyncio, "create_task", _spy_create_task)
+
+    async def noop():
+        return
+
+    runner._spawn_supervised(noop, "noop")
+    await asyncio.sleep(0.01)
+
+    assert "name" not in captured.get("kwargs", {})

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -473,3 +473,107 @@ async def test_reconnect_schedules_heartbeat_probe_on_success():
             await t
         except (asyncio.CancelledError, Exception):
             pass
+
+
+# ── Always-on polling heartbeat loop ──────────────────────────────────────
+#
+# These cover _polling_heartbeat_loop — the periodic liveness loop that
+# closes the silent-wedge gap behind the reactive recovery paths. Each test
+# self-terminates by tripping a fatal error after the first iteration so the
+# `while not self.has_fatal_error:` loop exits, and runs under a tight
+# wait_for so a regression that fails to terminate fails fast instead of
+# hanging.
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_loop_recovers_wedged_updater(monkeypatch):
+    """updater.running=True but get_me() raises → recovery handler is called.
+
+    Simulates the silently-wedged long-poll: the Updater still reports
+    running, but the underlying httpx pool is dead so getMe() fails.
+    """
+    monkeypatch.setenv("HERMES_TELEGRAM_HEARTBEAT_INTERVAL", "0.01")
+    adapter = _make_adapter()
+
+    mock_updater = MagicMock()
+    mock_updater.running = True
+
+    mock_app = MagicMock()
+    mock_app.updater = mock_updater
+    mock_app.bot.get_me = AsyncMock(side_effect=ConnectionError("pool wedged"))
+    adapter._app = mock_app
+
+    async def _recover(_err):
+        # Trip fatal so the heartbeat loop terminates after one iteration.
+        adapter._set_fatal_error("telegram_network_error", "wedged", retryable=True)
+
+    handler = AsyncMock(side_effect=_recover)
+    adapter._handle_polling_network_error = handler
+
+    await asyncio.wait_for(adapter._polling_heartbeat_loop(), timeout=5)
+
+    handler.assert_awaited()
+    assert isinstance(handler.await_args.args[0], ConnectionError)
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_loop_recovers_stopped_updater(monkeypatch):
+    """updater.running=False → recovery handler is called, get_me NOT probed."""
+    monkeypatch.setenv("HERMES_TELEGRAM_HEARTBEAT_INTERVAL", "0.01")
+    adapter = _make_adapter()
+
+    mock_updater = MagicMock()
+    mock_updater.running = False
+
+    mock_app = MagicMock()
+    mock_app.updater = mock_updater
+    mock_app.bot.get_me = AsyncMock()
+    adapter._app = mock_app
+
+    async def _recover(_err):
+        adapter._set_fatal_error("telegram_network_error", "stopped", retryable=True)
+
+    handler = AsyncMock(side_effect=_recover)
+    adapter._handle_polling_network_error = handler
+
+    await asyncio.wait_for(adapter._polling_heartbeat_loop(), timeout=5)
+
+    handler.assert_awaited()
+    mock_app.bot.get_me.assert_not_called()
+    err = handler.await_args.args[0]
+    assert isinstance(err, RuntimeError)
+    assert "not running" in str(err).lower()
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_loop_no_recovery_when_healthy(monkeypatch):
+    """get_me() succeeds → recovery handler is NOT called; degraded flag cleared.
+
+    The healthy path can't trip the fatal flag itself, so we self-terminate by
+    having the probe set it on the first successful call.
+    """
+    monkeypatch.setenv("HERMES_TELEGRAM_HEARTBEAT_INTERVAL", "0.01")
+    adapter = _make_adapter()
+    adapter._send_path_degraded = True
+
+    mock_updater = MagicMock()
+    mock_updater.running = True
+
+    async def _ok():
+        # Healthy probe; trip fatal so the loop exits after this iteration.
+        adapter._set_fatal_error("telegram_test_stop", "done", retryable=True)
+        return MagicMock()
+
+    mock_app = MagicMock()
+    mock_app.updater = mock_updater
+    mock_app.bot.get_me = AsyncMock(side_effect=_ok)
+    adapter._app = mock_app
+
+    handler = AsyncMock()
+    adapter._handle_polling_network_error = handler
+
+    await asyncio.wait_for(adapter._polling_heartbeat_loop(), timeout=5)
+
+    handler.assert_not_awaited()
+    # Probe ran (degraded flag cleared) before the self-terminating fatal trip.
+    assert adapter._send_path_degraded is False

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -1657,3 +1657,132 @@ class TestBedrockIamStreamingFallback:
 
         client.converse.assert_not_called()
         assert getattr(agent, "_disable_streaming", False) is False
+
+
+# ── Test: Stale-stream watchdog kill ceiling ─────────────────────────────
+
+
+class _SleepingStream:
+    """An SSE-style stream that never yields a real chunk and never errors.
+
+    Each ``__next__`` blocks (simulating a provider that holds the connection
+    open with keep-alive pings but delivers no data), so the worker thread is
+    wedged inside ``for chunk in stream`` while the outer poll loop's
+    stale-stream watchdog runs.  Mirrors the real wedge: chunks_seen never
+    advances, so the watchdog must eventually give up rather than kill forever.
+    """
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        import time as _t
+        _t.sleep(20)  # longer than the test's stale timeout; watchdog acts first
+        raise StopIteration
+
+    # The streaming code snapshots stream.response for rate-limit/diag capture.
+    response = None
+
+
+class TestStaleStreamWatchdogCeiling:
+    """Regression: a provider that keeps the SSE connection alive with pings
+    but never yields a real chunk used to wedge the gateway — the watchdog
+    killed-and-reconnected forever because the worker never returned. The
+    bounded kill ceiling (HERMES_STREAM_MAX_STALE_KILLS) aborts with a
+    TimeoutError after N fruitless kills instead of hanging indefinitely.
+    """
+
+    @patch("run_agent.AIAgent._replace_primary_openai_client")
+    @patch("run_agent.AIAgent._abort_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    def test_streaming_watchdog_aborts_after_max_stale_kills(
+        self, mock_create, mock_close, mock_abort, mock_replace, monkeypatch,
+    ):
+        """A stream that never yields a real chunk and never errors must raise
+        TimeoutError within a few seconds — not hang forever."""
+        from run_agent import AIAgent
+
+        monkeypatch.setenv("HERMES_STREAM_STALE_TIMEOUT", "0.3")
+        monkeypatch.setenv("HERMES_STREAM_MAX_STALE_KILLS", "2")
+        # Don't let the inner retry loop turn a (hypothetical) error into more
+        # work — we're exercising the watchdog ceiling, not retries.
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = (
+            lambda *a, **kw: _SleepingStream()
+        )
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        import time as _time
+        _t0 = _time.time()
+        with pytest.raises(TimeoutError) as exc_info:
+            agent._interruptible_streaming_api_call({})
+        _elapsed = _time.time() - _t0
+
+        assert "stalled" in str(exc_info.value).lower(), (
+            f"Unexpected TimeoutError message: {exc_info.value!r}"
+        )
+        # 2 kills × 0.3s stale each, plus poll granularity — should be well
+        # under 10s.  The whole point is that it does NOT hang on the 20s sleep.
+        assert _elapsed < 10.0, (
+            f"Watchdog took {_elapsed:.1f}s to abort — expected <10s; "
+            f"the kill ceiling may not be bounding the loop."
+        )
+
+    @patch("run_agent.AIAgent._replace_primary_openai_client")
+    @patch("run_agent.AIAgent._abort_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    def test_streaming_watchdog_aborts_even_when_retries_bump_timer(
+        self, mock_create, mock_close, mock_abort, mock_replace, monkeypatch,
+    ):
+        """Even if the inner retry machinery would refresh last_chunk_time on
+        each (re)attempt, the watchdog still aborts: the ceiling keys off the
+        monotonic real-chunk counter (which never advances here), not the
+        timestamp.  With retries enabled, a no-real-chunk stream must STILL
+        terminate in TimeoutError rather than loop forever."""
+        from run_agent import AIAgent
+
+        monkeypatch.setenv("HERMES_STREAM_STALE_TIMEOUT", "0.3")
+        monkeypatch.setenv("HERMES_STREAM_MAX_STALE_KILLS", "2")
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "2")
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = (
+            lambda *a, **kw: _SleepingStream()
+        )
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        import time as _time
+        _t0 = _time.time()
+        with pytest.raises(TimeoutError):
+            agent._interruptible_streaming_api_call({})
+        _elapsed = _time.time() - _t0
+        assert _elapsed < 10.0, (
+            f"Watchdog took {_elapsed:.1f}s — retries should not let a "
+            f"no-real-chunk stream evade the kill ceiling."
+        )

--- a/tests/tools/test_interrupt.py
+++ b/tests/tools/test_interrupt.py
@@ -281,6 +281,168 @@ class TestRunToolCleanupOnBaseException:
 
 
 # ---------------------------------------------------------------------------
+# Regression: concurrent tool-batch aggregate deadline (HERMES_TOOL_BATCH_TIMEOUT)
+# ---------------------------------------------------------------------------
+
+class TestConcurrentBatchTimeout:
+    """Verify the aggregate batch-deadline escape in
+    ``execute_tool_calls_concurrent``.
+
+    When a tool ignores the per-thread interrupt and runs past
+    ``HERMES_TOOL_BATCH_TIMEOUT``, the executor must:
+
+      1. stop blocking the turn (the ThreadPoolExecutor is shut down with
+         ``wait=False`` so a wedged daemon worker can't pin the turn forever),
+      2. synthesize a timeout result into the wedged tool's still-None slot,
+         flagged ``is_error=True`` with a message naming the batch deadline.
+
+    Critically, that synthesized result tuple is hand-built positionally at
+    the deadline site, so a future change to the ``_run_tool`` results-tuple
+    shape would silently desync it.  This test pins the shape: it runs a
+    normal tool and a wedged tool in the SAME batch and asserts the
+    synthesized timeout tuple unpacks identically to a real ``_run_tool``
+    result (same 7-field arity / downstream contract).  If the tuple drifts,
+    the post-execution unpack (``... = r``) raises ValueError and this test
+    fails loudly — which is the whole point of the regression.
+    """
+
+    @pytest.mark.timeout(30, method="thread")
+    def test_wedged_tool_synthesizes_timeout_result(self, monkeypatch):
+        from unittest.mock import MagicMock
+        import types
+
+        from tools.interrupt import _interrupted_threads, _lock
+        with _lock:
+            _interrupted_threads.clear()
+
+        # Trip the aggregate deadline almost immediately.  The wait loop polls
+        # every 5s, so the deadline is observed on the first poll after the
+        # blocked tool is still running.
+        monkeypatch.setenv("HERMES_TOOL_BATCH_TIMEOUT", "0.5")
+
+        # ── Capture each result tuple as it is unpacked downstream ──────
+        # The post-execution loop unpacks every results[] slot via
+        #   function_name, function_args, function_result, tool_duration,
+        #   is_error, blocked, middleware_trace = r
+        # then calls agent._append_guardrail_observation(name, args, result,
+        # failed=is_error) for non-blocked tools.  By making that a real
+        # function we observe the unpacked fields for BOTH the fast tool and
+        # the synthesized-timeout tool — proving the synthesized tuple
+        # unpacked cleanly into the same 7-field shape.
+        observed = []  # list of (name, args, result, failed)
+
+        def _record_guardrail_observation(name, args, result, failed=False):
+            observed.append((name, args, result, failed))
+            return result
+
+        # ── Minimal mock agent ─────────────────────────────────────────
+        agent = MagicMock()
+        agent._interrupt_requested = False
+        agent._tool_worker_threads = set()
+        agent._tool_worker_threads_lock = threading.Lock()
+        agent.quiet_mode = True
+        agent.tool_progress_mode = "off"
+        agent.tool_progress_callback = None
+        agent.tool_start_callback = None
+        agent.tool_complete_callback = None
+        agent.verbose_logging = False
+        agent._should_emit_quiet_tool_messages = MagicMock(return_value=False)
+        agent._should_start_quiet_spinner = MagicMock(return_value=False)
+        agent._append_guardrail_observation = _record_guardrail_observation
+        # _tool_result_content_for_active_model passes the string through;
+        # downstream make_tool_result_message wants a real string.
+        agent._tool_result_content_for_active_model = lambda name, result: result
+        agent._set_interrupt = lambda active, tid=None: None
+        # No subdirectory hints (a truthy MagicMock would be string-concatenated
+        # onto the result and blow up the post-execution loop).
+        agent._subdirectory_hints.check_tool_call = MagicMock(return_value="")
+        agent._apply_pending_steer_to_tool_results = MagicMock()
+
+        # Guardrails must allow execution (a MagicMock decision is truthy,
+        # but be explicit so a future bool() change can't silently block).
+        agent._tool_guardrails.before_call.return_value.allows_execution = True
+
+        # ── _invoke_tool: 'wedged' blocks past the deadline ignoring the
+        # interrupt signal; 'fast' returns immediately. ────────────────
+        def _invoke_tool(function_name, function_args, *a, **k):
+            if function_name == "wedged":
+                # Block far past the 0.5s deadline, ignoring interrupts — this
+                # is the daemon worker the deadline must abandon.  Sleep well
+                # beyond the executor's 5s poll interval so the only way the
+                # turn can return is via the deadline (not natural completion).
+                time.sleep(30.0)
+                return "wedged finished (should have been abandoned)"
+            return "fast ok"
+
+        agent._invoke_tool = _invoke_tool
+
+        # Bind the real concurrent executor.
+        from run_agent import AIAgent
+        agent._execute_tool_calls_concurrent = types.MethodType(
+            AIAgent._execute_tool_calls_concurrent, agent
+        )
+
+        # ── Two tool calls in one batch: fast + wedged ─────────────────
+        tc_fast = MagicMock()
+        tc_fast.id = "tc_fast"
+        tc_fast.function.name = "fast"
+        tc_fast.function.arguments = "{}"
+
+        tc_wedged = MagicMock()
+        tc_wedged.id = "tc_wedged"
+        tc_wedged.function.name = "wedged"
+        tc_wedged.function.arguments = "{}"
+
+        assistant_msg = MagicMock()
+        assistant_msg.tool_calls = [tc_fast, tc_wedged]
+
+        messages = []
+
+        # (a) The call must RETURN (not hang), despite the wedged tool
+        # sleeping 30s.  The executor polls every 5s, so the 0.5s deadline is
+        # observed at the first poll boundary (~5s).  Anything well under the
+        # wedged tool's 30s sleep proves the deadline — not natural
+        # completion — released the turn.
+        t0 = time.time()
+        agent._execute_tool_calls_concurrent(assistant_msg, messages, "default")
+        elapsed = time.time() - t0
+
+        assert elapsed < 12.0, (
+            f"batch did not honor the deadline; took {elapsed:.2f}s "
+            "(approaching the wedged tool's 30s sleep — deadline did not fire)"
+        )
+
+        # (b) Both tools were observed downstream — i.e. both result tuples
+        # unpacked into 7 fields without a ValueError.  The fast tool and the
+        # synthesized-timeout tuple share the same shape; if the synthesized
+        # tuple's arity drifted, the unpack at the post-execution loop would
+        # raise and we'd never reach _append_guardrail_observation for it.
+        observed_by_name = {name: (name, args, result, failed) for (name, args, result, failed) in observed}
+        assert "fast" in observed_by_name, f"fast tool not observed: {observed}"
+        assert "wedged" in observed_by_name, (
+            f"wedged tool's synthesized timeout result was not unpacked "
+            f"downstream (arity drift would cause this): {observed}"
+        )
+
+        # (c) The wedged tool's synthesized slot is flagged as an error and
+        # its message names the batch deadline.
+        _wname, _wargs, _wresult, _wfailed = observed_by_name["wedged"]
+        assert _wfailed is True, "synthesized timeout result not flagged is_error=True"
+        assert "batch" in _wresult.lower() and "deadline" in _wresult.lower(), (
+            f"timeout message does not mention the batch deadline: {_wresult!r}"
+        )
+
+        # (d) A tool result message for the wedged tool reached the
+        # conversation so the model isn't left with a dangling tool_call.
+        wedged_tool_msgs = [
+            m for m in messages
+            if isinstance(m, dict) and m.get("role") == "tool"
+            and m.get("tool_call_id") == "tc_wedged"
+        ]
+        assert wedged_tool_msgs, f"no tool result message for wedged tool: {messages}"
+
+
+# ---------------------------------------------------------------------------
 # Manual smoke test checklist (not automated)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Gateway & streaming reliability hardening (rebased on v0.17.0)

Three independent fixes for "the daemon is alive but not doing its job" failure modes observed running the gateway as a long-lived launchd service. Each is small, isolated, env-gated with conservative defaults, and covered by regression tests. Re-based onto current `main` (8446c1570); supersedes the now-stale #37734. (The codex null-output `TypeError` from that earlier PR is already fixed on `main` via #33042, so it's not included here.)

### 1. Streaming stall watchdog can loop forever; gaps for local & Bedrock
`agent/chat_completion_helpers.py`, `agent/tool_executor.py`
- The stale-stream watchdog killed+rebuilt the client and reset its timer on each stall but had **no kill ceiling**. A provider holding the connection open with SSE keep-alive pings (no real content, no error) makes the worker thread never return, so the watchdog kills→rebuilds→resets indefinitely — a permanent mid-stream hang. Added `HERMES_STREAM_MAX_STALE_KILLS` (default 3), keyed on a **real monotonic chunk counter** (not the last-chunk timestamp, which pings and retries bump) so a genuine stall→recover→stall sequence isn't aborted early.
- Local providers (Ollama/oMLX/llama-cpp) were given `float("inf")` stale timeout (watchdog disabled) → a wedged local server hangs forever. Now a finite ceiling, `HERMES_LOCAL_STREAM_STALE_TIMEOUT` (default 900s).
- The Bedrock streaming branch had **no stale watchdog at all** (interrupt-only poll). Added one (per-chunk timestamp, bounded kills, a gave-up flag honored by the callbacks and the interrupt check).
- Concurrent tool batches had no aggregate deadline, and the `ThreadPoolExecutor` context-manager `__exit__` blocks forever on a tool that ignores cancellation. Switched to a manual executor with `shutdown(wait=False)` on timeout, `HERMES_TOOL_BATCH_TIMEOUT` (default 900s), and synthesized timeout tool-results so the next turn isn't left with a tool_call that has no tool_result.

### 2. Telegram polling can wedge silently; supervisor tasks die silently
`plugins/platforms/telegram/adapter.py`, `gateway/run.py`
- Telegram polling self-healing is reactive-only (PTB `error_callback`) plus a **one-shot** post-reconnect probe. A network blip that wedges the long-poll without firing a callback (and without a prior reconnect) leaves `updater.running == True` but the bot permanently deaf, process alive. Added an **always-on heartbeat** that re-enters the existing reconnect ladder when the updater isn't running or a `get_me()` probe times out. `HERMES_TELEGRAM_HEARTBEAT_INTERVAL` (default 90s, `<=0` disables).
- Six long-lived supervisor tasks (`_session_expiry_watcher`, kanban notifier/dispatcher, `_platform_reconnect_watcher`, `_handoff_watcher`, recovered process watchers) are launched with bare `asyncio.create_task` — no handle retained, no exception logging, no restart. `main` added inner-loop `try/except` (narrows the blast radius) but `_platform_reconnect_watcher`'s outer loop is still unwrapped and a death there is silent. Added a `_spawn_supervised` helper (track + log + bounded-backoff restart; no respawn on a clean return, to avoid busy-spin) and routed the watchers through it.

### 3. launchd respawn storm
`hermes_cli/gateway.py`, `gateway/status.py`
- The launchd plist uses `KeepAlive <true/>` (unconditional, since #37388) with **no `ThrottleInterval`**, so a gateway repeatedly SIGTERM'd is revived at launchd's 10s default floor with nothing to dampen the spin (a healthy process killed and respawned every ~10s; ~40 restarts in 7 min observed). Added `ThrottleInterval=30` + `ExitTimeOut=25`.
- Added `record_start_and_check_storm` — a portable, service-manager-agnostic circuit breaker that records starts (atomic write) and backs off when too many land in a short window. Env overrides `HERMES_GATEWAY_MAX_STARTS` (`<=0` disables) / `HERMES_GATEWAY_START_WINDOW_S`.

## Test plan
- `pytest tests/run_agent/test_streaming.py tests/gateway/test_telegram_network_reconnect.py tests/gateway/test_supervised_watchers.py tests/gateway/test_status.py tests/gateway/test_platform_reconnect.py` — 180 passing, including new regressions for the unbounded-watchdog abort, the Telegram heartbeat (wedged / stopped-updater / healthy-quiet), and the supervised-restart + respawn-storm breaker + plist throttle keys.
- Running live on macOS launchd for weeks across the prior revision with zero respawn storms / silent wedges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)