### PR TITLE
fix(cron): point script-path error at the real HERMES_HOME/scripts dir

### DIFF
--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -581,3 +581,39 @@ class TestLocalDeliveryNotice:
         )
         assert created["deliver"] == "origin"
         assert "local-only cron job" not in created["message"]
+
+
+# =========================================================================
+# Script-path validation error message reflects HERMES_HOME (#51765)
+# =========================================================================
+
+class TestCronScriptPathErrorMessage:
+    """The rejection message must point at the real HERMES_HOME/scripts/ dir
+    (where the runtime actually loads scripts), not a hardcoded ~/.hermes."""
+
+    def test_error_uses_configured_hermes_home(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from hermes_constants import display_hermes_home
+        from tools.cronjob_tools import _validate_cron_script_path
+
+        err = _validate_cron_script_path("/etc/passwd")
+        assert err is not None
+        assert f"{display_hermes_home()}/scripts/" in err
+
+    def test_error_not_hardcoded_when_custom_home(self, monkeypatch, tmp_path):
+        custom = tmp_path / "custom_home"
+        monkeypatch.setenv("HERMES_HOME", str(custom))
+        from hermes_constants import display_hermes_home
+        from tools.cronjob_tools import _validate_cron_script_path
+
+        err = _validate_cron_script_path("~/secret")
+        assert err is not None
+        # No hardcoded default path; the message points at the configured home.
+        assert "~/.hermes/scripts/" not in err
+        assert f"{display_hermes_home()}/scripts/" in err
+
+    def test_valid_relative_path_passes(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from tools.cronjob_tools import _validate_cron_script_path
+
+        assert _validate_cron_script_path("report.sh") is None

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -451,13 +451,19 @@ def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
 
     raw = script.strip()
 
+    # Resolve the scripts directory the same way the runtime does
+    # (HERMES_HOME/scripts) so the error message matches where scripts are
+    # actually loaded — the hardcoded "~/.hermes/scripts/" was wrong whenever
+    # HERMES_HOME points elsewhere (#51765).
+    scripts_display = f"{display_hermes_home()}/scripts/"
+
     # Reject absolute paths and ~ expansion at the API boundary.
-    # Only relative paths within ~/.hermes/scripts/ are allowed.
+    # Only relative paths within HERMES_HOME/scripts/ are allowed.
     if raw.startswith(("/", "~")) or (len(raw) >= 2 and raw[1] == ":"):
         return (
-            f"Script path must be relative to ~/.hermes/scripts/. "
+            f"Script path must be relative to {scripts_display}. "
             f"Got absolute or home-relative path: {raw!r}. "
-            f"Place scripts in ~/.hermes/scripts/ and use just the filename."
+            f"Place scripts in {scripts_display} and use just the filename."
         )
 
     # Validate containment after resolution


### PR DESCRIPTION
## Summary

Fixes #51765. `_validate_cron_script_path()` rejects absolute / `~` script paths with a message that **hardcodes** `~/.hermes/scripts/`:

```
Script path must be relative to ~/.hermes/scripts/. ...
Place scripts in ~/.hermes/scripts/ and use just the filename.
```

But the runtime (`_run_job_script` in `cron/scheduler.py`) loads scripts from `get_hermes_home() / "scripts"`, which respects `HERMES_HOME`. With a custom `HERMES_HOME` (e.g. `/opt/data`) the error pointed users at the wrong directory.

(The `script` tool-parameter docstring already renders `display_hermes_home()` correctly — only this error message was stale.)

## Fix

Build the message from `display_hermes_home()` (already imported in the module), so it names the directory where scripts are actually resolved. No behavioral change — only the guidance text.

## Tests

`tests/tools/test_cronjob_tools.py::TestCronScriptPathErrorMessage`: the message reflects a custom `HERMES_HOME`, no longer contains the hardcoded `~/.hermes/scripts/`, and a valid relative path still passes.
