### PR TITLE
fix(desktop): Surface skill slash commands in catalog

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4100,6 +4100,46 @@ def test_commands_catalog_surfaces_quick_commands(monkeypatch):
     assert resp["result"]["canon"]["/notes"] == "/notes"
 
 
+def test_commands_catalog_surfaces_skill_commands_in_categories(monkeypatch):
+    import agent.skill_commands as skill_commands
+
+    long_description = "x" * 121
+    truncated_description = ("x" * 120) + "…"
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    monkeypatch.setattr(
+        skill_commands,
+        "scan_skill_commands",
+        lambda: {
+            "/gif-search": {
+                "name": "gif-search",
+                "description": "Search for animated GIFs",
+            },
+            "/long-skill": {
+                "name": "long-skill",
+                "description": long_description,
+            },
+        },
+    )
+
+    resp = server.handle_request(
+        {"id": "1", "method": "commands.catalog", "params": {}}
+    )
+
+    pairs = dict(resp["result"]["pairs"])
+    assert pairs["/gif-search"] == "Search for animated GIFs"
+    assert pairs["/long-skill"] == truncated_description
+    assert resp["result"]["skill_count"] == 2
+
+    skills_cat = next(
+        c for c in resp["result"]["categories"] if c["name"] == "Skills"
+    )
+    skill_pairs = dict(skills_cat["pairs"])
+    assert skill_pairs == {
+        "/gif-search": "Search for animated GIFs",
+        "/long-skill": truncated_description,
+    }
+
+
 def test_commands_catalog_includes_tui_mouse_command():
     resp = server.handle_request(
         {"id": "1", "method": "commands.catalog", "params": {}}

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9368,10 +9368,20 @@ def _(rid, params: dict) -> dict:
         try:
             from agent.skill_commands import scan_skill_commands
 
+            skill_pairs: list[list[str]] = []
             for k, info in sorted(scan_skill_commands().items()):
                 d = str(info.get("description", "Skill"))
-                all_pairs.append([k, d[:120] + ("…" if len(d) > 120 else "")])
+                desc = d[:120] + ("…" if len(d) > 120 else "")
+                all_pairs.append([k, desc])
+                skill_pairs.append([k, desc])
                 skill_count += 1
+
+            if skill_pairs:
+                bucket = "Skills"
+                if bucket not in cat_map:
+                    cat_map[bucket] = []
+                    cat_order.append(bucket)
+                cat_map[bucket].extend(skill_pairs)
         except Exception as e:
             warning = f"skill discovery unavailable: {e}"
 


### PR DESCRIPTION
Surface desktop skill slash commands in the categorized catalog.

The desktop slash popover prefers commands.catalog.categories for empty-query rendering and only falls back to flat pairs when categories are absent. Skill commands were added only to flat pairs, which left them executable when typed but invisible in the palette.

This adds a Skills category only when scan_skill_commands() returns commands, while preserving the existing flat pairs, skill_count, warning, canon, UI, and dispatch behavior.