### PR TITLE
feat(skills): add Ponytail simplification skills

### DIFF
--- a/skills/software-development/ponytail-audit/SKILL.md
+++ b/skills/software-development/ponytail-audit/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: ponytail-audit
+description: Audit a codebase for removable complexity.
+version: 1.0.0
+author: SeoYeonKim (@westkite1201), Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [audit, code-review, simplification, yagni, dependencies, refactor]
+    related_skills: [ponytail, ponytail-review, simplify-code]
+---
+
+# Ponytail Audit Skill
+
+Ponytail Audit extends the over-engineering review from one diff to a whole
+repository or named subsystem. It produces a ranked, read-only report of likely
+deletions and simplifications; it does not apply them by default.
+
+## When to Use
+
+Use this skill when the user asks for a repository-wide or subsystem-wide
+over-engineering audit, a ranked list of bloat, what can be deleted, or where
+dependencies, abstractions, wrappers, and configuration exceed current needs.
+
+Do not use it as a correctness or security audit. If the request names a
+subsystem, keep the audit there instead of expanding to the whole repository.
+
+## Prerequisites
+
+- A local repository and a user-approved repository or subsystem scope.
+- Repository instructions, branch/status context, and the relevant base branch.
+- Access to manifests, callers, configuration, and extension-point docs needed
+  to distinguish dead flexibility from public API.
+- Use `terminal` for version-control context, `search_files` for candidates and
+  callers, and `read_file` for evidence.
+
+This workflow is report-only. Editing files, removing dependencies, committing,
+pushing, or changing external review state requires a follow-up request.
+
+## How to Run
+
+Start with the narrowest context that matches the request. Use `terminal` to
+inspect repository status and branch scope before searching implementation:
+
+```bash
+git status --short --branch
+git diff --stat origin/main...HEAD
+```
+
+Then inspect likely complexity centers without dumping the entire tree:
+
+- dependency manifests
+- directories or symbols named helpers, services, managers, adapters,
+  providers, factories, interfaces, or registries
+- configuration values and feature flags
+- wrappers that only delegate
+- files, components, or classes with one caller
+- hand-rolled parsing, validation, formatting, retry, debounce, caching, or
+  date logic
+
+## Quick Reference
+
+Rank findings by likely removable maintenance burden, not by cosmetic line
+count. Use these tags:
+
+| Tag | Candidate | Replacement |
+|---|---|---|
+| `delete:` | Dead code, stale flags, unused config. | Nothing. |
+| `reuse:` | Duplicate repository behavior. | Existing named helper. |
+| `stdlib:` | Hand-rolled library behavior. | Named standard-library API. |
+| `native:` | Custom platform/framework behavior. | Named native feature. |
+| `yagni:` | One-use flexibility. | Inline now; extract on a real second use. |
+| `shrink:` | Equivalent but verbose code. | Clear smaller form. |
+
+Use `verify:` whenever a candidate might be public API, a plugin or extension
+surface, a compatibility contract, or an externally consumed configuration.
+Do not present uncertain removal as safe.
+
+Never recommend removing these merely to reduce size:
+
+- trust-boundary validation, auth, permissions, or secret handling
+- data-loss prevention and corrupt-state recovery
+- migrations and backward compatibility for existing users/data
+- accessibility basics
+- focused tests for non-trivial behavior
+- production observability that operators rely on
+- extension points with real external consumers
+
+## Procedure
+
+1. **Confirm scope.** Record repository status, branch/base, and the exact
+   subsystem requested. Completion: the audit boundary is explicit.
+2. **Map candidates.** Inspect manifests, abstraction-heavy directories,
+   wrappers, configuration, flags, and hand-rolled utilities. Completion: the
+   candidate list covers the requested scope without a blind full-tree dump.
+3. **Trace use.** Search callers, imports, configuration reads, documentation,
+   and plugin/extension contracts. Completion: every finding distinguishes
+   unused code from an external surface.
+4. **Protect invariants.** Exclude security, data protection, compatibility,
+   accessibility, necessary observability, focused tests, and proven extension
+   consumers. Completion: no recommendation weakens those boundaries.
+5. **Rank by impact.** Put the largest likely maintenance/dependency cut first.
+   Completion: ordering reflects value, not arbitrary discovery order.
+6. **Write the report.** Use this form:
+
+   ```text
+   1. <tag> <what to cut>. <replacement>. [path:line or path + symbol]
+   2. <tag> <what to cut>. <replacement>. [path:line or path + symbol]
+   net: roughly -<N> lines, -<M> deps possible.
+   ```
+
+   Add a `verify:` clause before uncertain public or extension-surface cuts.
+   If nothing meaningful is removable, report:
+
+   ```text
+   No meaningful over-engineering findings in this scoped audit.
+   ```
+7. **Separate other defects.** Label incidental correctness, security, or
+   performance concerns `normal-review:` and recommend the appropriate review.
+   Completion: the Ponytail ranking remains complexity-only.
+
+Do not implement the findings unless the user explicitly asks for a separate
+cleanup pass.
+
+## Pitfalls
+
+1. **Auditing beyond the request.** A subsystem request is not permission for a
+   repository-wide cleanup.
+2. **Fake precision.** Estimate conservatively and use ranges when the change
+   has not been implemented.
+3. **Ignoring external consumers.** Public APIs, plugin hooks, CLI contracts,
+   and compatibility settings need `verify:` unless non-use is proven.
+4. **Calling safety code bloat.** Security, data safety, accessibility,
+   migration, observability, and focused tests are protected boundaries.
+5. **Ranking by line count alone.** Prefer maintenance and dependency impact.
+6. **Applying fixes during the audit.** The default output is a report.
+
+## Verification
+
+- [ ] Repository status, branch/base, and requested scope were confirmed.
+- [ ] Candidates were traced to callers and configuration reads.
+- [ ] Existing helpers were verified before `reuse:` findings.
+- [ ] Public APIs and extension surfaces use `verify:` when uncertain.
+- [ ] Safety, compatibility, accessibility, observability, and tests remain.
+- [ ] Findings are ranked by likely impact and cite evidence.
+- [ ] Estimates are conservative rather than exact guesses.
+- [ ] No implementation or external mutation occurred without explicit approval.
+
+## Attribution
+
+Adapted from [DietrichGebert/ponytail](https://github.com/DietrichGebert/ponytail)
+under the MIT License.
+
+```text
+MIT License
+
+Copyright (c) 2026 DietrichGebert
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/skills/software-development/ponytail-review/SKILL.md
+++ b/skills/software-development/ponytail-review/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: ponytail-review
+description: Review a diff only for removable complexity.
+version: 1.0.0
+author: SeoYeonKim (@westkite1201), Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [code-review, simplification, yagni, dependencies, refactor]
+    related_skills: [ponytail, simplify-code, requesting-code-review]
+---
+
+# Ponytail Review Skill
+
+Ponytail Review performs a narrow, read-only review of a concrete diff for
+unnecessary complexity. It reports what can safely be deleted, reused, or
+replaced, but it is not a correctness, security, or performance review.
+
+## When to Use
+
+Use this skill when the user asks for an over-engineering-only review, a YAGNI
+review, what can be deleted from a diff, or whether a change is overbuilt. It
+is especially useful when a diff adds dependencies, wrappers, abstractions,
+configuration, factories, custom parsers, or duplicate helpers.
+
+Do not use it as the only pre-merge review for risky changes. Pair it with the
+normal code-review or security-review workflow when those concerns matter.
+
+## Prerequisites
+
+- A concrete diff, commit, pull request patch, or file scope.
+- The repository's base branch and local instructions.
+- Access to nearby code so `reuse:` findings can name a real existing helper.
+- Use `terminal` to obtain the diff, `search_files` to find callers/helpers,
+  and `read_file` to inspect evidence.
+
+This workflow is report-only. Editing, committing, pushing, replying to a pull
+request, or resolving a review thread requires a separate explicit request.
+
+## How to Run
+
+Choose the smallest diff source that answers the request. For example, use
+`terminal` to inspect uncommitted work, staged work, a branch against its base,
+or one named file:
+
+```bash
+git diff
+git diff --staged
+git diff origin/main...HEAD
+git diff -- path/to/file
+```
+
+If the diff spans unrelated subsystems, review each subsystem separately so
+every finding remains evidence-backed.
+
+## Quick Reference
+
+Use one tag per finding:
+
+| Tag | Use for | Required replacement |
+|---|---|---|
+| `delete:` | Dead or speculative code. | Nothing. |
+| `reuse:` | Code duplicated from this repository. | Name the existing helper. |
+| `stdlib:` | Hand-rolled standard-library behavior. | Name the built-in. |
+| `native:` | Custom code replacing platform behavior. | Name the native feature. |
+| `yagni:` | Flexibility with no concrete second use. | Inline or defer it. |
+| `shrink:` | Equivalent behavior in clearer, fewer code. | Show the smaller form. |
+
+Never flag these merely because they add lines:
+
+- trust-boundary validation, auth, permissions, or secret handling
+- data-loss prevention and corrupt-state recovery
+- migrations or compatibility paths for existing users/data
+- accessibility basics
+- a focused behavior test for non-trivial logic
+- production observability required by operators
+
+## Procedure
+
+1. **Set scope.** Identify the exact diff and base. Completion: no file outside
+   the requested scope can produce a finding.
+2. **Read intent.** Inspect the request, changed behavior, and nearby callers.
+   Completion: each candidate can be judged without guessing its purpose.
+3. **Search before labeling.** Find existing helpers before `reuse:` and confirm
+   caller counts before `yagni:`. Completion: every claim names evidence.
+4. **Apply the safety boundary.** Exclude security, data protection,
+   compatibility, accessibility, necessary observability, and focused tests.
+   Completion: no finding weakens one of those invariants.
+5. **Write only actionable findings.** Use one line per item:
+
+   ```text
+   <file>:L<line>: <tag> <what to cut>. <replacement>.
+   ```
+
+   Completion: every line has a location, tag, cut, and replacement.
+6. **Separate other defects.** If a correctness, security, or performance issue
+   is noticed, label it `normal-review:` so it is not mistaken for the
+   Ponytail score. Completion: scope boundaries are explicit.
+7. **Estimate impact.** End with a conservative line/dependency reduction:
+
+   ```text
+   net: roughly -<N> lines possible, -<M> deps possible.
+   ```
+
+   If there is nothing meaningful to cut, return exactly the useful outcome:
+
+   ```text
+   No over-engineering findings in this scope. Run normal verification before shipping.
+   ```
+
+Do not apply any suggested change unless the user explicitly asks for a
+follow-up implementation.
+
+## Pitfalls
+
+1. **Vague advice.** A question like "could this be simpler?" is not a finding;
+   cite the line and the concrete replacement.
+2. **Deleting verification.** A focused behavior check is usually the minimum,
+   not bloat.
+3. **Unverified reuse.** Search and name the existing helper before using the
+   `reuse:` tag.
+4. **Style disguised as simplification.** Naming and formatting preferences do
+   not count unless they remove real complexity.
+5. **Scope drift.** Keep correctness and security observations under
+   `normal-review:` and recommend the appropriate follow-up review.
+6. **Applying fixes during review.** The default deliverable is a report, not a
+   modified working tree.
+
+## Verification
+
+- [ ] The review used a concrete, user-requested diff scope.
+- [ ] Existing helpers and callers were searched before making claims.
+- [ ] Findings cover removable complexity only.
+- [ ] Safety, compatibility, accessibility, observability, and tests remain.
+- [ ] Each finding has one location, one tag, and one replacement.
+- [ ] Non-Ponytail defects are labeled `normal-review:`.
+- [ ] The result ends with conservative net impact or the no-findings message.
+- [ ] No files or external review state were changed without explicit approval.
+
+## Attribution
+
+Adapted from [DietrichGebert/ponytail](https://github.com/DietrichGebert/ponytail)
+under the MIT License.
+
+```text
+MIT License
+
+Copyright (c) 2026 DietrichGebert
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/skills/software-development/ponytail/SKILL.md
+++ b/skills/software-development/ponytail/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: ponytail
+description: Choose the smallest safe implementation that works.
+version: 1.0.0
+author: SeoYeonKim (@westkite1201), Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [coding, simplification, yagni, minimalism, refactor]
+    related_skills: [simplify-code, requesting-code-review, test-driven-development]
+---
+
+# Ponytail Skill
+
+Ponytail is an opt-in coding discipline for finding the smallest safe solution.
+It removes speculative complexity without removing correctness, security, data
+safety, accessibility, verification, or an explicit user requirement.
+
+## When to Use
+
+Use this skill only when the user explicitly asks for Ponytail, YAGNI, a
+minimal solution, the shortest safe path, or an aggressive simplification.
+It also fits a requested implementation that specifically calls out avoiding
+dependencies, wrappers, factories, configuration, or future-proofing.
+
+Do not auto-run Ponytail for every coding task. Do not use it to skip reading
+the relevant code or diagnosing a bug's root cause.
+
+## Prerequisites
+
+- Access to the task, nearby code, and the repository's own instructions.
+- A clear statement of the behavior that must remain true.
+- For a bug, a confirmed root cause. Use `systematic-debugging` or the
+  repository's normal debugging workflow before simplifying the fix.
+- Use `search_files` to look for existing helpers and `read_file` to inspect
+  the actual call path before proposing new code.
+
+No external service or dependency is required.
+
+## How to Run
+
+State the requested intensity when useful:
+
+- **lite** — implement the request normally and name a simpler alternative.
+- **full** — default; enforce the ladder for the current task.
+- **ultra** — challenge unneeded requirements and prefer deletion when the
+  user explicitly asks for aggressive YAGNI.
+
+The skill is task-scoped. Never claim that Ponytail remains enabled for future
+sessions.
+
+## Quick Reference
+
+Stop at the first rung that fully satisfies the requested behavior:
+
+| Rung | Question | Preferred result |
+|---|---|---|
+| 1 | Does this need to exist? | Skip speculative work. |
+| 2 | Does the codebase already solve it? | Reuse the existing path. |
+| 3 | Does the standard library solve it? | Use the built-in. |
+| 4 | Does the platform or framework solve it? | Use native behavior. |
+| 5 | Does an installed dependency solve it? | Reuse it without adding one. |
+| 6 | Can clear local code solve it? | Write the fewest readable lines. |
+
+Complexity is justified when it protects a concrete requirement. In
+particular, do not simplify away:
+
+- trust-boundary validation, authentication, authorization, or secret handling
+- error handling that prevents corrupt state or data loss
+- accessibility basics in user-facing interfaces
+- migrations and compatibility paths that protect existing users or data
+- operational observability that production support depends on
+- tests for non-trivial, security-sensitive, monetary, parsing, or concurrent
+  behavior
+- calibration, tolerances, or safety margins for physical systems
+
+## Procedure
+
+1. **Fix the boundary.** Restate the required behavior and explicit constraints.
+   Completion: every proposed deletion can be checked against that boundary.
+2. **Read the path.** Inspect the relevant implementation and callers before
+   editing. Completion: the real shared change point or root cause is known.
+3. **Climb the ladder.** Check existing code, standard library, native features,
+   and installed dependencies in order. Completion: the highest viable rung is
+   selected with evidence.
+4. **Make the smallest safe change.** Prefer one shared-path fix, deletion over
+   addition, and direct local code over a one-use abstraction. Completion: no
+   requested behavior or safety invariant was removed.
+5. **Verify narrowly.** Run the repository's smallest relevant test, lint,
+   type, or build command. Add one focused regression test for non-trivial
+   behavior when a test suite exists. Completion: the changed behavior is
+   exercised, not merely imported.
+6. **Report the tradeoff.** State what changed, what complexity was skipped,
+   and the concrete trigger for adding it later. Completion: the user can tell
+   when the minimal design would stop being sufficient.
+
+Suggested response shape:
+
+```text
+changed: <smallest working fix>
+skipped: <dependency, abstraction, or config not added>
+add when: <specific future condition that justifies it>
+```
+
+If the user explicitly chooses a fuller version after seeing the simpler path,
+implement the requested version without repeatedly arguing against it.
+
+## Pitfalls
+
+1. **Small diff, wrong path.** Minimalism starts after comprehension; patch the
+   shared cause rather than several symptoms.
+2. **Safety labeled as bloat.** Validation, auth, data protection,
+   accessibility, and meaningful tests are constraints, not ornament.
+3. **One-use architecture.** Wait for a second concrete implementation before
+   adding an interface, factory, registry, or configuration layer.
+4. **A new dependency for a tiny helper.** Prefer existing dependencies,
+   standard library, or a few clear local lines.
+5. **Clever compression.** Fewer lines are not better when the result is harder
+   to read, debug, or operate.
+6. **No verification.** A minimal implementation still needs the smallest
+   check that proves its behavior.
+
+## Verification
+
+- [ ] The user explicitly requested the minimal/YAGNI mode.
+- [ ] The relevant code path or bug root cause was inspected first.
+- [ ] Existing code, standard library, and native features were checked.
+- [ ] No safety, compatibility, accessibility, or data invariant was removed.
+- [ ] No speculative dependency or abstraction was introduced.
+- [ ] The smallest relevant runnable verification passed.
+- [ ] Skipped complexity has a concrete future trigger.
+
+## Attribution
+
+Adapted from [DietrichGebert/ponytail](https://github.com/DietrichGebert/ponytail)
+under the MIT License.
+
+```text
+MIT License
+
+Copyright (c) 2026 DietrichGebert
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/tests/skills/test_ponytail_audit_skill.py
+++ b/tests/skills/test_ponytail_audit_skill.py
@@ -1,0 +1,62 @@
+"""Contract tests for the Ponytail Audit skill."""
+
+import re
+from pathlib import Path
+
+
+SKILL_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "skills"
+    / "software-development"
+    / "ponytail-audit"
+    / "SKILL.md"
+)
+CONTENT = SKILL_PATH.read_text(encoding="utf-8")
+
+
+def _frontmatter_field(name: str) -> str:
+    match = re.search(rf"^{name}: (.+)$", CONTENT, re.MULTILINE)
+    assert match, f"missing {name} frontmatter"
+    return match.group(1)
+
+
+def test_frontmatter_is_listing_safe_and_credits_human_first():
+    description = _frontmatter_field("description")
+    assert len(description) <= 60
+    assert description.endswith(".")
+    assert _frontmatter_field("author").startswith("SeoYeonKim (@westkite1201)")
+
+
+def test_sections_follow_modern_skill_order():
+    sections = [
+        "# Ponytail Audit Skill",
+        "## When to Use",
+        "## Prerequisites",
+        "## How to Run",
+        "## Quick Reference",
+        "## Procedure",
+        "## Pitfalls",
+        "## Verification",
+    ]
+    positions = [CONTENT.index(section) for section in sections]
+    assert positions == sorted(positions)
+
+
+def test_audit_is_scoped_and_report_only():
+    assert "keep the audit there instead of expanding" in CONTENT
+    assert "This workflow is report-only" in CONTENT
+    assert "Do not implement the findings unless the user explicitly asks" in CONTENT
+
+
+def test_uncertain_external_surfaces_require_verification():
+    assert "Use `verify:` whenever a candidate might be public API" in CONTENT
+    assert "Do not present uncertain removal as safe" in CONTENT
+    assert "extension points with real external consumers" in CONTENT
+
+
+def test_audit_preserves_safety_and_ranks_evidence_backed_impact():
+    for boundary in ("trust-boundary validation", "data-loss prevention", "accessibility"):
+        assert boundary in CONTENT
+    assert "Rank findings by likely removable maintenance burden" in CONTENT
+    assert "Findings are ranked by likely impact and cite evidence" in CONTENT
+

--- a/tests/skills/test_ponytail_review_skill.py
+++ b/tests/skills/test_ponytail_review_skill.py
@@ -1,0 +1,62 @@
+"""Contract tests for the Ponytail Review skill."""
+
+import re
+from pathlib import Path
+
+
+SKILL_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "skills"
+    / "software-development"
+    / "ponytail-review"
+    / "SKILL.md"
+)
+CONTENT = SKILL_PATH.read_text(encoding="utf-8")
+
+
+def _frontmatter_field(name: str) -> str:
+    match = re.search(rf"^{name}: (.+)$", CONTENT, re.MULTILINE)
+    assert match, f"missing {name} frontmatter"
+    return match.group(1)
+
+
+def test_frontmatter_is_listing_safe_and_credits_human_first():
+    description = _frontmatter_field("description")
+    assert len(description) <= 60
+    assert description.endswith(".")
+    assert _frontmatter_field("author").startswith("SeoYeonKim (@westkite1201)")
+
+
+def test_sections_follow_modern_skill_order():
+    sections = [
+        "# Ponytail Review Skill",
+        "## When to Use",
+        "## Prerequisites",
+        "## How to Run",
+        "## Quick Reference",
+        "## Procedure",
+        "## Pitfalls",
+        "## Verification",
+    ]
+    positions = [CONTENT.index(section) for section in sections]
+    assert positions == sorted(positions)
+
+
+def test_review_is_read_only_and_requires_separate_change_authority():
+    assert "This workflow is report-only" in CONTENT
+    assert "requires a separate explicit request" in CONTENT
+    assert "Do not apply any suggested change unless the user explicitly asks" in CONTENT
+
+
+def test_review_stays_complexity_only_and_preserves_safety_controls():
+    assert "not a correctness, security, or performance review" in CONTENT
+    assert "label it `normal-review:`" in CONTENT
+    for boundary in ("trust-boundary validation", "data-loss prevention", "accessibility"):
+        assert boundary in CONTENT
+
+
+def test_findings_require_location_tag_cut_and_replacement():
+    assert "<file>:L<line>: <tag> <what to cut>. <replacement>." in CONTENT
+    assert "one location, one tag, and one replacement" in CONTENT
+    assert "No over-engineering findings in this scope" in CONTENT
+

--- a/tests/skills/test_ponytail_skill.py
+++ b/tests/skills/test_ponytail_skill.py
@@ -1,0 +1,65 @@
+"""Contract tests for the Ponytail skill."""
+
+import re
+from pathlib import Path
+
+
+SKILL_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "skills"
+    / "software-development"
+    / "ponytail"
+    / "SKILL.md"
+)
+CONTENT = SKILL_PATH.read_text(encoding="utf-8")
+
+
+def _frontmatter_field(name: str) -> str:
+    match = re.search(rf"^{name}: (.+)$", CONTENT, re.MULTILINE)
+    assert match, f"missing {name} frontmatter"
+    return match.group(1)
+
+
+def test_frontmatter_is_listing_safe_and_credits_human_first():
+    description = _frontmatter_field("description")
+    assert len(description) <= 60
+    assert description.endswith(".")
+    assert "\n" not in description
+    assert _frontmatter_field("author").startswith("SeoYeonKim (@westkite1201)")
+
+
+def test_sections_follow_modern_skill_order():
+    sections = [
+        "# Ponytail Skill",
+        "## When to Use",
+        "## Prerequisites",
+        "## How to Run",
+        "## Quick Reference",
+        "## Procedure",
+        "## Pitfalls",
+        "## Verification",
+    ]
+    positions = [CONTENT.index(section) for section in sections]
+    assert positions == sorted(positions)
+
+
+def test_minimalism_is_explicit_opt_in_not_a_debugging_shortcut():
+    assert "only when the user explicitly asks" in CONTENT
+    assert "Do not auto-run Ponytail" in CONTENT
+    assert "Do not use it to skip reading" in CONTENT
+    assert "confirmed root cause" in CONTENT
+
+
+def test_safety_and_verification_are_protected_from_simplification():
+    protected = (
+        "trust-boundary validation",
+        "authentication",
+        "data loss",
+        "accessibility",
+        "migrations",
+        "tests for non-trivial",
+    )
+    for boundary in protected:
+        assert boundary in CONTENT
+    assert "Run the repository's smallest relevant test" in CONTENT
+


### PR DESCRIPTION
## Summary

Adds three Ponytail-inspired software-development skills:

- `ponytail`: task-scoped minimal-code implementation discipline
- `ponytail-review`: diff-focused, read-only over-engineering review
- `ponytail-audit`: repo/subsystem read-only over-engineering audit

These are pure `SKILL.md` additions: no runtime code, no new tools, and no dependencies.

The skills are adapted from [DietrichGebert/ponytail](https://github.com/DietrichGebert/ponytail) under the MIT License. Each skill preserves the upstream MIT copyright and permission/warranty notice.

## Relationship to existing skills

- `simplify-code` is a broader multi-reviewer cleanup workflow that may apply changes.
- These skills are narrower, task-scoped/read-only where applicable, and focus specifically on avoiding unnecessary dependencies, abstractions, wrappers, and custom code.
- `ponytail` explicitly defers bug investigation/test-first workflow to `systematic-debugging` and `test-driven-development`.

## Test Plan

- [x] Parsed all new `SKILL.md` frontmatter with PyYAML
- [x] Checked description length and skill size limits
- [x] Verified full upstream MIT notice is present in all three files
- [x] Verified `Lean already. Ship.` was removed from narrow review/audit outputs
- [x] `git diff --check`
- [x] Searched added diff for hardcoded secret / eval / exec / shell-injection patterns
- [x] `python -m pytest tests/tools/test_skill_manager_tool.py tests/tools/test_skill_size_limits.py tests/agent/test_skill_bundles.py -q -o 'addopts='`
