### PR TITLE
fix(desktop): handle notification action indexes

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -68,6 +68,7 @@ import { readDirForIpc } from './fs-read-dir'
 import { resolvePickerDefaultPath } from './wsl-path-bridge'
 import { probeGatewayWebSocket } from './gateway-ws-probe'
 import { scanGitRepos } from './git-repo-scan'
+import { resolveNotificationAction } from './notification-actions'
 import {
   fileDiffVsHead,
   repoStatus,
@@ -7891,7 +7892,7 @@ ipcMain.handle('hermes:notify', (_event, payload) => {
 
   // Action buttons render only on signed macOS builds; elsewhere they're dropped
   // and the body click still works.
-  const actions = Array.isArray(payload?.actions) ? payload.actions : []
+  const actions: { id?: string; text?: unknown }[] = Array.isArray(payload?.actions) ? payload.actions : []
 
   const notification = new Notification({
     title: payload?.title || 'Hermes',
@@ -7911,12 +7912,12 @@ ipcMain.handle('hermes:notify', (_event, payload) => {
       mainWindow.webContents.send('hermes:focus-session', payload.sessionId)
     }
   })
-  notification.on('action', (_actionEvent, index) => {
+  notification.on('action', (actionEvent, index) => {
     if (!mainWindow || mainWindow.isDestroyed()) {
       return
     }
 
-    const action = actions[index]
+    const action = resolveNotificationAction(actions, actionEvent, index)
 
     if (action?.id) {
       mainWindow.webContents.send('hermes:notification-action', { sessionId: payload?.sessionId, actionId: action.id })

--- a/apps/desktop/electron/notification-actions.test.ts
+++ b/apps/desktop/electron/notification-actions.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { resolveNotificationAction } from './notification-actions'
+
+const actions = [
+  { id: 'approve', text: 'Approve' },
+  { id: 'reject', text: 'Reject' }
+]
+
+test('resolves an action from Electron 40 event details', () => {
+  assert.deepEqual(resolveNotificationAction(actions, { actionIndex: 1 }, undefined), actions[1])
+})
+
+test('falls back to the legacy positional action index', () => {
+  assert.deepEqual(resolveNotificationAction(actions, {}, 0), actions[0])
+})
+
+test('prefers Electron event details over the legacy positional index', () => {
+  assert.deepEqual(resolveNotificationAction(actions, { actionIndex: 1 }, 0), actions[1])
+})
+
+test('ignores missing and out-of-range action indexes', () => {
+  assert.equal(resolveNotificationAction(actions, {}, undefined), null)
+  assert.equal(resolveNotificationAction(actions, { actionIndex: -1 }, undefined), null)
+  assert.equal(resolveNotificationAction(actions, { actionIndex: 2 }, undefined), null)
+})

--- a/apps/desktop/electron/notification-actions.ts
+++ b/apps/desktop/electron/notification-actions.ts
@@ -1,0 +1,29 @@
+function isActionIndex(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value)
+}
+
+function notificationActionIndex(actionEvent: unknown, legacyIndex: unknown): number | null {
+  if (actionEvent && typeof actionEvent === 'object' && 'actionIndex' in actionEvent) {
+    const { actionIndex } = actionEvent as { actionIndex?: unknown }
+
+    if (isActionIndex(actionIndex)) {
+      return actionIndex
+    }
+  }
+
+  return isActionIndex(legacyIndex) ? legacyIndex : null
+}
+
+export function resolveNotificationAction<T>(
+  actions: readonly T[],
+  actionEvent: unknown,
+  legacyIndex: unknown
+): T | null {
+  const index = notificationActionIndex(actionEvent, legacyIndex)
+
+  if (index === null || index < 0 || index >= actions.length) {
+    return null
+  }
+
+  return actions[index] ?? null
+}


### PR DESCRIPTION
## What does this PR do?

Fixes desktop native notification approval actions on Electron 40. Electron now exposes the selected action through `details.actionIndex`, while the main process previously read only the deprecated positional index. This could leave the action unresolved and prevent `hermes:notification-action` from reaching the renderer.

## Related Issue

Fixes #51444

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Added `apps/desktop/electron/notification-actions.ts` to resolve Electron 40 event details first, with the legacy positional-index fallback retained.
- Updated `apps/desktop/electron/main.ts` to use the resolver before forwarding `hermes:notification-action`.
- Added `apps/desktop/electron/notification-actions.test.ts` covering Electron 40 details, legacy fallback, precedence, and invalid indexes.

## How to Test

1. Trigger a desktop approval notification on Electron 40.
2. Click Approve or Reject in the native notification.
3. The main process resolves `actionEvent.actionIndex` and forwards the matching action to the renderer.

Checks run locally:

- [x] `npm run test:desktop:platforms -- electron/notification-actions.test.ts` (4 tests passed)
- [x] Lint for `notification-actions.ts` and `notification-actions.test.ts`
- [x] Standalone TypeScript check for `notification-actions.ts`

`npm run typecheck` was attempted in a temporary sparse worktree but did not complete reliably because of its reused dependency setup; CI remains the project-level validation source.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 development workspace

### Documentation & Housekeeping

- [x] Documentation update N/A
- [x] `cli-config.yaml.example` update N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update N/A
- [x] Cross-platform impact considered: Electron 40 details are preferred while older positional callbacks retain their behavior
- [x] Tool descriptions/schemas update N/A

## Screenshots / Logs

N/A - main-process notification event handling fix covered by Electron tests.
