### PR TITLE
fix(testing): tolerate legacy console encodings

### DIFF
--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -80,6 +80,18 @@ _DEFAULT_FILE_TIMEOUT_SECONDS = 140.0 # set by observing the slowest file at com
 _DURATIONS_FILE = "test_durations.json"
 
 
+def _make_console_output_best_effort() -> None:
+    """Avoid progress-output crashes on legacy console encodings."""
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(errors="replace")
+        except (OSError, ValueError):
+            pass
+
+
 def _count_tests(
     files: List[Path], repo_root: Path, pytest_passthrough: List[str]
 ) -> dict[Path, int]:
@@ -594,6 +606,8 @@ def _slice_files(
 
 
 def main() -> int:
+    _make_console_output_best_effort()
+
     parser = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/tests/test_run_tests_parallel.py
+++ b/tests/test_run_tests_parallel.py
@@ -63,6 +63,43 @@ def _pid_alive(pid: int) -> bool:
     return True
 
 
+def test_progress_output_tolerates_legacy_stdout_encoding(tmp_path: Path) -> None:
+    """Progress glyphs must not crash the runner on non-UTF-8 consoles."""
+    repo_root = Path(__file__).resolve().parent.parent
+    runner = repo_root / "scripts" / "run_tests_parallel.py"
+
+    probe_dir = tmp_path / "probe"
+    probe_dir.mkdir()
+    probe = probe_dir / "test_probe_smoke.py"
+    probe.write_text("def test_smoke():\n    assert True\n", encoding="utf-8")
+
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "cp1252:strict"
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(runner),
+            "--paths",
+            str(probe_dir),
+            "-j",
+            "1",
+            "--file-timeout",
+            "30",
+        ],
+        cwd=repo_root,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=60,
+    )
+
+    assert proc.returncode == 0, proc.stdout
+    assert "UnicodeEncodeError" not in proc.stdout
+    assert "1 tests passed" in proc.stdout
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only probe")
 @pytest.mark.live_system_guard_bypass
 def test_grandchild_leak_is_killed_by_runner(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- prevent `scripts/run_tests_parallel.py` progress output from crashing when stdout/stderr use strict legacy encodings such as `cp1252` or Windows console code pages
- reconfigure runner output streams to replace unencodable progress glyphs instead of raising `UnicodeEncodeError`
- add a regression test that runs the runner with `PYTHONIOENCODING=cp1252:strict`

## Testing
- `./venv/Scripts/python.exe -m pytest tests/test_run_tests_parallel.py::test_progress_output_tolerates_legacy_stdout_encoding -q`
- `./venv/Scripts/python.exe -m pytest tests/test_run_tests_parallel.py -q`
- `./venv/Scripts/python.exe scripts/check-windows-footguns.py --all`