### PR TITLE
fix(gateway): reject non-finite restart drain timeouts

### DIFF
--- a/gateway/restart.py
+++ b/gateway/restart.py
@@ -1,5 +1,7 @@
 """Shared gateway restart constants and parsing helpers."""
 
+import math
+
 from hermes_cli.config import DEFAULT_CONFIG
 
 # EX_TEMPFAIL from sysexits.h — used to ask the service manager to restart
@@ -22,5 +24,7 @@ def parse_restart_drain_timeout(raw: object) -> float:
     try:
         value = float(raw) if str(raw or "").strip() else DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
     except (TypeError, ValueError):
+        return DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
+    if not math.isfinite(value):
         return DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
     return max(0.0, value)

--- a/tests/gateway/test_restart.py
+++ b/tests/gateway/test_restart.py
@@ -1,0 +1,29 @@
+"""Tests for shared gateway restart parsing helpers."""
+
+import math
+
+import pytest
+
+from gateway.restart import (
+    DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
+    parse_restart_drain_timeout,
+)
+
+
+def test_parse_restart_drain_timeout_uses_default_for_empty_or_invalid_values():
+    assert parse_restart_drain_timeout("") == DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
+    assert parse_restart_drain_timeout(None) == DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
+    assert parse_restart_drain_timeout("not-a-number") == DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
+
+
+def test_parse_restart_drain_timeout_clamps_negative_values_to_zero():
+    assert parse_restart_drain_timeout("-1") == 0.0
+    assert parse_restart_drain_timeout(-5) == 0.0
+
+
+@pytest.mark.parametrize("raw", ["inf", "Infinity", float("inf"), float("-inf"), float("nan")])
+def test_parse_restart_drain_timeout_rejects_non_finite_values(raw):
+    value = parse_restart_drain_timeout(raw)
+
+    assert value == DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
+    assert math.isfinite(value)


### PR DESCRIPTION
## Summary
- reject non-finite `restart_drain_timeout` values such as `inf`, `Infinity`, and `nan`
- fall back to the shared default timeout for invalid or non-finite values so gateway restart drains cannot wait forever
- keep the existing behavior that clamps negative finite values to `0.0`

## Testing
- `./venv/Scripts/python.exe -m pytest tests/gateway/test_restart.py -q`
- `./venv/Scripts/python.exe scripts/check-windows-footguns.py --all`

Note: I also ran `tests/gateway/test_proxy_mode.py` locally; it fails in this `.[dev]` environment because `aiohttp` is not installed, unrelated to this change.