### PR TITLE
fix(gateway): tolerate invalid no-proxy ports

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -260,7 +260,11 @@ def _split_host_port(value: str) -> tuple[str, int | None]:
         return "", None
     if "://" in raw:
         parsed = urlsplit(raw)
-        return (parsed.hostname or "").lower().rstrip("."), parsed.port
+        try:
+            port = parsed.port
+        except ValueError:
+            port = None
+        return (parsed.hostname or "").lower().rstrip("."), port
     if raw.startswith("[") and "]" in raw:
         host, _, rest = raw[1:].partition("]")
         port = None

--- a/tests/gateway/test_proxy_mode.py
+++ b/tests/gateway/test_proxy_mode.py
@@ -148,6 +148,24 @@ class TestResolveProxyUrl:
 
         assert resolve_proxy_url(target_hosts="api.telegram.org") is None
 
+    def test_no_proxy_invalid_port_does_not_crash(self, monkeypatch):
+        for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                    "https_proxy", "http_proxy", "all_proxy", "NO_PROXY", "no_proxy"):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:8080")
+        monkeypatch.setenv("NO_PROXY", "http://api.telegram.org:bad")
+
+        assert resolve_proxy_url(target_hosts="api.telegram.org") is None
+
+    def test_target_host_invalid_port_does_not_crash(self, monkeypatch):
+        for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                    "https_proxy", "http_proxy", "all_proxy", "NO_PROXY", "no_proxy"):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:8080")
+        monkeypatch.setenv("NO_PROXY", "api.telegram.org")
+
+        assert resolve_proxy_url(target_hosts="https://api.telegram.org:bad") is None
+
     def test_no_proxy_bypasses_cidr_target(self, monkeypatch):
         for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
                     "https_proxy", "http_proxy", "all_proxy", "NO_PROXY", "no_proxy"):


### PR DESCRIPTION
## Summary
- prevent malformed `NO_PROXY` entries such as `http://api.telegram.org:bad` from raising `ValueError`
- tolerate malformed ports on target host URLs as well, preserving host matching when the hostname is still parseable
- keep existing host, suffix, wildcard, IP, and CIDR matching behavior unchanged

## Testing
- `./venv/Scripts/python.exe -m pytest tests/gateway/test_proxy_mode.py::TestResolveProxyUrl -q`
- `./venv/Scripts/python.exe scripts/check-windows-footguns.py --all`

Note: full `tests/gateway/test_proxy_mode.py` requires the existing aiohttp test-stub fix from #51904 in this local `.[dev]` environment.