### PR TITLE
fix: sync web personality prompt

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4062,12 +4062,56 @@ def _denormalize_config_from_web(config: Dict[str, Any]) -> Dict[str, Any]:
     return config
 
 
+def _render_personality_prompt_for_web(value: Any) -> str:
+    if isinstance(value, dict):
+        parts = [value.get("system_prompt", "")]
+        if value.get("tone"):
+            parts.append(f'Tone: {value["tone"]}')
+        if value.get("style"):
+            parts.append(f'Style: {value["style"]}')
+        return "\n".join(p for p in parts if p)
+    return str(value)
+
+
+def _sync_personality_prompt_for_web_config(config: Dict[str, Any]) -> Dict[str, Any]:
+    display = config.get("display")
+    if not isinstance(display, dict) or "personality" not in display:
+        return config
+
+    raw = str(display.get("personality") or "").strip()
+    name = raw.lower()
+
+    agent = config.get("agent")
+    if not isinstance(agent, dict):
+        agent = {}
+        config["agent"] = agent
+
+    if not name or name in {"none", "default", "neutral"}:
+        display["personality"] = ""
+        agent["system_prompt"] = ""
+        return config
+
+    personalities = agent.get("personalities")
+    if not isinstance(personalities, dict):
+        personalities = {}
+
+    if name not in personalities:
+        raise ValueError(f"Unknown personality: `{raw}`.")
+
+    display["personality"] = name
+    agent["system_prompt"] = _render_personality_prompt_for_web(personalities[name])
+    return config
+
+
 @app.put("/api/config")
 async def update_config(body: ConfigUpdate, profile: Optional[str] = None):
     try:
         with _profile_scope(body.profile or profile):
-            save_config(_denormalize_config_from_web(body.config))
+            config = _denormalize_config_from_web(body.config)
+            save_config(_sync_personality_prompt_for_web_config(config))
         return {"ok": True}
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     except HTTPException:
         raise
     except Exception:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -364,6 +364,55 @@ class TestWebServerEndpoints:
 
         assert resp.status_code == 404
 
+    def test_put_config_personality_syncs_agent_system_prompt(self):
+        from hermes_cli.config import load_config
+
+        resp = self.client.put(
+            "/api/config",
+            json={
+                "config": {
+                    "display": {"personality": "Helpful"},
+                    "agent": {
+                        "personalities": {
+                            "helpful": {
+                                "system_prompt": "You are helpful.",
+                                "tone": "clear",
+                                "style": "concise",
+                            }
+                        }
+                    },
+                }
+            },
+        )
+
+        assert resp.status_code == 200
+        config = load_config()
+        assert config["display"]["personality"] == "helpful"
+        assert config["agent"]["system_prompt"] == (
+            "You are helpful.\nTone: clear\nStyle: concise"
+        )
+
+    def test_put_config_personality_none_clears_agent_system_prompt(self):
+        from hermes_cli.config import load_config
+
+        resp = self.client.put(
+            "/api/config",
+            json={
+                "config": {
+                    "display": {"personality": "none"},
+                    "agent": {
+                        "system_prompt": "You are helpful.",
+                        "personalities": {"helpful": "You are helpful."},
+                    },
+                }
+            },
+        )
+
+        assert resp.status_code == 200
+        config = load_config()
+        assert config["display"]["personality"] == ""
+        assert config["agent"]["system_prompt"] == ""
+
     def test_get_unknown_memory_provider_returns_empty_schema(self):
         resp = self.client.get("/api/memory/providers/builtin/config")
 


### PR DESCRIPTION
## What does this PR do?

Fixes the Desktop/Web config save path so selecting a personality through settings updates both `display.personality` and the runtime `agent.system_prompt`.

Previously, `PUT /api/config` persisted only the display value, so the UI showed the selected personality but new sessions did not receive the resolved persona prompt. This mirrors the existing `config.set personality` behavior for the full config-save path.

## Related Issue

Fixes #51882

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `hermes_cli/web_server.py` to resolve `display.personality` into `agent.system_prompt` when saving config through `PUT /api/config`.
- Added regression tests in `tests/hermes_cli/test_web_server.py` for setting and clearing personality through the web config endpoint.

## How to Test

1. Reproduce on main by calling `PUT /api/config` with `display.personality=helpful` and `agent.personalities.helpful`; `agent.system_prompt` remains empty.
2. Apply this fix and repeat the same request; `agent.system_prompt` is saved with the resolved personality prompt.
3. Run:
   `uv run --python python3.13 --extra dev scripts/run_tests.sh tests/hermes_cli/test_web_server.py`
   `uv run --python python3.13 --extra dev ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_server.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
Discovered 1 test files (317 tests) under ['tests/hermes_cli/test_web_server.py']; running with -j 16
317 tests passed

ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_server.py
All checks passed
```