### PR TITLE
fix(browser): ignore invalid Camofox loopback ports

### DIFF
--- a/tests/tools/test_browser_camofox.py
+++ b/tests/tools/test_browser_camofox.py
@@ -114,6 +114,16 @@ class TestCamofoxLoopbackRewrite:
         assert metadata is None
 
     @patch("tools.browser_camofox.load_config")
+    def test_invalid_loopback_port_fails_closed(self, mock_config, monkeypatch):
+        monkeypatch.delenv("CAMOFOX_REWRITE_LOOPBACK_URLS", raising=False)
+        mock_config.return_value = _config_with_camofox(rewrite_loopback_urls=True)
+
+        rewritten, metadata = _rewrite_loopback_url_for_camofox("http://127.0.0.1:bad/path")
+
+        assert rewritten == "http://127.0.0.1:bad/path"
+        assert metadata is None
+
+    @patch("tools.browser_camofox.load_config")
     def test_env_alias_takes_precedence(self, mock_config, monkeypatch):
         monkeypatch.setenv("CAMOFOX_REWRITE_LOOPBACK_URLS", "true")
         monkeypatch.setenv("CAMOFOX_LOOPBACK_HOST_ALIAS", "192.168.1.10")

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -234,7 +234,11 @@ def _rewrite_loopback_url_for_camofox(url: str) -> tuple[str, Optional[Dict[str,
             userinfo += f":{parsed.password}"
         userinfo += "@"
     host_part = f"[{alias}]" if ":" in alias and not alias.startswith("[") else alias
-    port_part = f":{parsed.port}" if parsed.port else ""
+    try:
+        port = parsed.port
+    except ValueError:
+        return url, None
+    port_part = f":{port}" if port else ""
     rewritten = urlunsplit(
         SplitResult(parsed.scheme, f"{userinfo}{host_part}{port_part}", parsed.path, parsed.query, parsed.fragment)
     )


### PR DESCRIPTION
## Summary
- prevent Camofox loopback URL rewriting from raising `ValueError` on malformed ports such as `http://127.0.0.1:bad/path`
- fail closed by leaving the original URL unchanged when the loopback port is not parseable
- add regression coverage with loopback rewrite enabled

## Testing
- `./venv/Scripts/python.exe -m pytest tests/tools/test_browser_camofox.py::TestCamofoxLoopbackRewrite -q`
- `./venv/Scripts/python.exe scripts/check-windows-footguns.py --all`

Note: full `tests/tools/test_browser_camofox.py` exposes an unrelated local proxy issue for `localhost:19999`, which I am handling separately.