### PR TITLE
fix(profile): auto-allocate conflict-free ports on create or clone

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -822,6 +822,128 @@ def profiles_to_serve(multiplex: bool) -> List[Tuple[str, Path]]:
     return serve
 
 
+def _read_profile_ports(profile_dir: Path) -> Tuple[int, int]:
+    """Resolve the API Server port and Webhook port for a given profile directory."""
+    api_port = 8642
+    web_port = 8644
+
+    config_path = profile_dir / "config.yaml"
+    if config_path.exists():
+        try:
+            import yaml
+            with open(config_path, "r", encoding="utf-8") as f:
+                cfg = yaml.safe_load(f) or {}
+            
+            platforms = cfg.get("platforms", {})
+            api_srv = platforms.get("api_server", {})
+            if isinstance(api_srv, dict):
+                p_port = api_srv.get("extra", {}).get("port")
+                if p_port is not None:
+                    api_port = int(p_port)
+
+            web_hk = platforms.get("webhook", {})
+            if isinstance(web_hk, dict):
+                w_port = web_hk.get("extra", {}).get("port")
+                if w_port is not None:
+                    web_port = int(w_port)
+
+            if "API_SERVER_PORT" in cfg:
+                api_port = int(cfg["API_SERVER_PORT"])
+            if "WEBHOOK_PORT" in cfg:
+                web_port = int(cfg["WEBHOOK_PORT"])
+        except Exception:
+            pass
+
+    env_path = profile_dir / ".env"
+    if env_path.exists():
+        try:
+            with open(env_path, "r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if line and not line.startswith("#") and "=" in line:
+                        k, v = line.split("=", 1)
+                        k = k.strip()
+                        v = v.strip()
+                        if k == "API_SERVER_PORT":
+                            api_port = int(v)
+                        elif k == "WEBHOOK_PORT":
+                            web_port = int(v)
+        except Exception:
+            pass
+
+    return api_port, web_port
+
+
+def _is_port_free(port: int, allocated_ports: set[int]) -> bool:
+    """Check if a port is free of configuration allocation and active system listening."""
+    if port in allocated_ports:
+        return False
+    import socket
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        try:
+            s.bind(("127.0.0.1", port))
+            return True
+        except OSError:
+            return False
+
+
+def _get_allocated_ports() -> set[int]:
+    """Collect all API server and Webhook ports allocated to existing profiles."""
+    ports = set()
+    default_home = _get_default_hermes_home()
+    if default_home.is_dir():
+        api, web = _read_profile_ports(default_home)
+        ports.add(api)
+        ports.add(web)
+        
+    profiles_root = _get_profiles_root()
+    if profiles_root.is_dir():
+        for entry in profiles_root.iterdir():
+            if entry.is_dir() and _PROFILE_ID_RE.match(entry.name) and entry.name != "default":
+                api, web = _read_profile_ports(entry)
+                ports.add(api)
+                ports.add(web)
+                
+    return ports
+
+
+def _update_env_ports(env_path: Path, api_port: int, web_port: int) -> None:
+    """Safely update or append API_SERVER_PORT and WEBHOOK_PORT in the given .env file."""
+    lines = []
+    if env_path.exists():
+        try:
+            with open(env_path, "r", encoding="utf-8") as f:
+                lines = f.readlines()
+        except OSError:
+            pass
+
+    api_found = False
+    web_found = False
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("API_SERVER_PORT="):
+            lines[i] = f"API_SERVER_PORT={api_port}\n"
+            api_found = True
+        elif stripped.startswith("WEBHOOK_PORT="):
+            lines[i] = f"WEBHOOK_PORT={web_port}\n"
+            web_found = True
+
+    if not api_found:
+        if lines and not lines[-1].endswith("\n"):
+            lines[-1] += "\n"
+        lines.append(f"API_SERVER_PORT={api_port}\n")
+    if not web_found:
+        if lines and not lines[-1].endswith("\n"):
+            lines[-1] += "\n"
+        lines.append(f"WEBHOOK_PORT={web_port}\n")
+
+    try:
+        with open(env_path, "w", encoding="utf-8") as f:
+            f.writelines(lines)
+    except OSError:
+        pass
+
+
 def create_profile(
     name: str,
     clone_from: Optional[str] = None,
@@ -870,6 +992,8 @@ def create_profile(
         raise ValueError(
             "Cannot create a profile named 'default' — it is the built-in profile (~/.hermes)."
         )
+
+    allocated_ports = _get_allocated_ports()
 
     profile_dir = get_profile_dir(canon)
     if profile_dir.exists():
@@ -1002,6 +1126,23 @@ def create_profile(
             )
         except Exception:
             pass  # non-fatal — user can describe later with `hermes profile describe`
+
+    # Resolve any potential port conflicts
+    api_port, web_port = _read_profile_ports(profile_dir)
+    if not _is_port_free(api_port, allocated_ports) or not _is_port_free(web_port, allocated_ports) or api_port == web_port:
+        new_api_port = api_port
+        while not _is_port_free(new_api_port, allocated_ports):
+            new_api_port += 1
+            
+        new_web_port = web_port
+        if new_web_port == new_api_port:
+            new_web_port += 1
+        while not _is_port_free(new_web_port, allocated_ports) or new_web_port == new_api_port:
+            new_web_port += 1
+            
+        _update_env_ports(profile_dir / ".env", new_api_port, new_web_port)
+        print(f"ℹ Port conflict detected or defaults in use. Allocated unique ports: "
+              f"API_SERVER_PORT={new_api_port}, WEBHOOK_PORT={new_web_port}")
 
     # Phase 4: when running inside a container under s6, register the
     # new profile's gateway as a runtime s6 service so

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -173,7 +173,7 @@ class TestCreateProfile:
         content = env_path.read_text(encoding="utf-8")
         # Placeholder only — no credentials leak in from anywhere.
         assert all(
-            line.startswith("#") or not line.strip()
+            line.startswith("#") or not line.strip() or "PORT=" in line
             for line in content.splitlines()
         )
         mode = stat.S_IMODE(env_path.stat().st_mode)
@@ -184,7 +184,7 @@ class TestCreateProfile:
         default_home = tmp_path / ".hermes"
         (default_home / ".env").write_text("KEY=val")
         profile_dir = create_profile("coder", clone_config=True, no_alias=True)
-        assert (profile_dir / ".env").read_text() == "KEY=val"
+        assert "KEY=val" in (profile_dir / ".env").read_text().splitlines()
 
     def test_duplicate_raises_file_exists(self, profile_env):
         create_profile("coder", no_alias=True)
@@ -212,7 +212,7 @@ class TestCreateProfile:
         cloned_config = yaml.safe_load((profile_dir / "config.yaml").read_text())
         assert cloned_config["_config_version"] == DEFAULT_CONFIG["_config_version"]
         assert cloned_config["model"] == "test"
-        assert (profile_dir / ".env").read_text().strip() == "KEY=val"
+        assert "KEY=val" in (profile_dir / ".env").read_text().splitlines()
         assert (profile_dir / "SOUL.md").read_text() == "Be helpful."
 
     def test_clone_config_migrates_legacy_config_version(self, profile_env):
@@ -336,7 +336,7 @@ class TestCreateProfile:
         # All profile data must be present
         assert (profile_dir / "skills" / "my-skill" / "SKILL.md").read_text() == "skill"
         assert (profile_dir / "config.yaml").read_text() == "model: gpt-4"
-        assert (profile_dir / ".env").read_text() == "KEY=val"
+        assert "KEY=val" in (profile_dir / ".env").read_text().splitlines()
         assert (profile_dir / "logs" / "gateway.log").read_text() == "log"
 
     def test_clone_all_excludes_history_artifacts(self, profile_env):
@@ -1475,7 +1475,7 @@ class TestEdgeCases:
         cloned_config = yaml.safe_load((target_dir / "config.yaml").read_text())
         assert cloned_config["_config_version"] == DEFAULT_CONFIG["_config_version"]
         assert cloned_config["model"] == "cloned"
-        assert (target_dir / ".env").read_text().strip() == "SECRET=yes"
+        assert "SECRET=yes" in (target_dir / ".env").read_text().splitlines()
 
     def test_delete_clears_active_profile(self, profile_env):
         """Deleting the active profile resets active to default."""
@@ -1488,6 +1488,27 @@ class TestEdgeCases:
             delete_profile("coder", yes=True)
 
         assert get_active_profile() == "default"
+
+    def test_create_profile_prevents_port_conflict(self, profile_env):
+        """Creating or cloning a profile automatically resolves port conflicts."""
+        tmp_path = profile_env
+        # 1. Create a source profile with explicit ports in its .env
+        source_dir = create_profile("source", no_alias=True)
+        (source_dir / ".env").write_text("API_SERVER_PORT=8642\nWEBHOOK_PORT=8644\n")
+
+        # 2. Create another profile cloning from source or as a clean profile
+        # Since 8642 and 8644 are already allocated to 'source', they must be conflict-resolved.
+        target_dir = create_profile(
+            "target", clone_from="source", clone_config=True, no_alias=True,
+        )
+        
+        # Read the targets' ports
+        from hermes_cli.profiles import _read_profile_ports
+        target_api, target_web = _read_profile_ports(target_dir)
+        
+        assert target_api != 8642
+        assert target_web != 8644
+        assert target_api != target_web
 
 
 class TestProfilesToServe:


### PR DESCRIPTION
This PR implements automatic, guaranteed conflict-free listening port allocation (for `API_SERVER_PORT` and `WEBHOOK_PORT`) when creating or cloning a new profile.

### Core Changes:
- Added a helper `_read_profile_ports` to resolve active ports of an existing profile.
- Added a helper `_is_port_free` to verify socket binding and check if a port is in the set of allocated ports.
- Added a helper `_get_allocated_ports` to scan all profiles and find currently configured ports.
- Automatically scan existing profiles for allocations before creating/cloning a new profile.
- Dynamically find the next available ports if a conflict with the defaults or source profile is detected.
- Updated the created profile's `.env` with the newly assigned ports.
- Updated existing tests to handle the additional `.env` port allocations dynamically.
- Added a dedicated test `test_create_profile_prevents_port_conflict` to verify correct behavior.