### PR TITLE
feat: add safe Telegram bot-to-bot routing

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -989,6 +989,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["group_allowed_chats"] = platform_cfg["group_allowed_chats"]
                 if plat == Platform.TELEGRAM and "allowed_topics" in platform_cfg:
                     bridged["allowed_topics"] = platform_cfg["allowed_topics"]
+                if plat == Platform.TELEGRAM and "ignored_threads" in platform_cfg:
+                    bridged["ignored_threads"] = platform_cfg["ignored_threads"]
                 if "free_response_channels" in platform_cfg:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
                 if "mention_patterns" in platform_cfg:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -16,6 +16,7 @@ import os
 import tempfile
 import html as _html
 import re
+import time
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Set, Any
 
@@ -604,6 +605,10 @@ class TelegramAdapter(BasePlatformAdapter):
         # Tracks status bubbles owned by this adapter so subsequent calls with the
         # same key edit the same message instead of appending new ones (#30045).
         self._status_message_ids: Dict[tuple, str] = {}
+        # Bot-to-bot safety state.  Keys are scoped by chat/topic/sender/target
+        # so one noisy peer cannot disable unrelated human or bot traffic.
+        self._bot_to_bot_rate_windows: Dict[tuple, List[float]] = {}
+        self._bot_to_bot_circuit_breakers: Dict[tuple, Dict[str, float]] = {}
 
     def _notification_kwargs(
         self, metadata: Optional[Dict[str, Any]]
@@ -5519,6 +5524,174 @@ class TelegramAdapter(BasePlatformAdapter):
             return bool(configured)
         return os.getenv("TELEGRAM_EXCLUSIVE_BOT_MENTIONS", "true").lower() in {"true", "1", "yes", "on"}
 
+    @staticmethod
+    def _coerce_bool_value(value: Any, default: bool = False) -> bool:
+        if value is None:
+            return default
+        if isinstance(value, str):
+            return value.strip().lower() in {"true", "1", "yes", "on"}
+        return bool(value)
+
+    @staticmethod
+    def _coerce_str_set(value: Any) -> set[str]:
+        if value is None:
+            return set()
+        if isinstance(value, (list, tuple, set)):
+            return {str(part).strip() for part in value if str(part).strip()}
+        return {part.strip() for part in str(value).split(",") if part.strip()}
+
+    def _telegram_bot_to_bot_config(self) -> dict:
+        """Return the bot-to-bot config block, accepting legacy flat keys."""
+        raw = self.config.extra.get("bot_to_bot")
+        cfg = dict(raw) if isinstance(raw, dict) else {}
+        # Back-compat / easy experimentation: allow selected flat keys in extra.
+        for key in (
+            "bot_to_bot_enabled",
+            "allowlisted_bot_ids",
+            "allowlisted_bot_usernames",
+            "enabled_chats",
+            "require_explicit_mention",
+            "exclusive_bot_mentions",
+            "max_reply_depth",
+            "trace_prefix",
+            "rate_limit",
+            "circuit_breaker",
+        ):
+            if key in self.config.extra and key not in cfg:
+                target = "enabled" if key == "bot_to_bot_enabled" else key
+                cfg[target] = self.config.extra[key]
+        return cfg
+
+    def _telegram_bot_to_bot_enabled(self) -> bool:
+        cfg = self._telegram_bot_to_bot_config()
+        return self._coerce_bool_value(cfg.get("enabled"), False)
+
+    def _telegram_bot_to_bot_enabled_chats(self):
+        return self._coerce_str_set(self._telegram_bot_to_bot_config().get("enabled_chats"))
+
+    def _telegram_bot_to_bot_sender_allowed(self, message) -> bool:
+        user = getattr(message, "from_user", None)
+        if not user or not bool(getattr(user, "is_bot", False)):
+            return False
+        cfg = self._telegram_bot_to_bot_config()
+        allowed_ids = self._coerce_str_set(cfg.get("allowlisted_bot_ids"))
+        allowed_usernames = {
+            item.lstrip("@").lower()
+            for item in self._coerce_str_set(cfg.get("allowlisted_bot_usernames"))
+        }
+        sender_id = str(getattr(user, "id", "")).strip()
+        sender_username = str(getattr(user, "username", "") or "").lstrip("@").lower()
+        if not allowed_ids and not allowed_usernames:
+            return False
+        return bool(
+            (sender_id and sender_id in allowed_ids)
+            or (sender_username and sender_username in allowed_usernames)
+        )
+
+    def _telegram_bot_to_bot_chat_enabled(self, message) -> bool:
+        enabled = self._telegram_bot_to_bot_enabled_chats()
+        if not enabled:
+            return True
+        chat_id = str(getattr(getattr(message, "chat", None), "id", ""))
+        thread_id = getattr(message, "message_thread_id", None)
+        topic_id = str(thread_id) if thread_id is not None else self._GENERAL_TOPIC_THREAD_ID
+        return chat_id in enabled or f"{chat_id}:{topic_id}" in enabled
+
+    def _bot_to_bot_guard_key(self, message) -> tuple:
+        sender = getattr(message, "from_user", None)
+        chat_id = str(getattr(getattr(message, "chat", None), "id", ""))
+        thread_id = getattr(message, "message_thread_id", None)
+        topic_id = str(thread_id) if thread_id is not None else self._GENERAL_TOPIC_THREAD_ID
+        sender_id = str(getattr(sender, "id", ""))
+        target = str(getattr(self._bot, "username", "") or "").lstrip("@").lower()
+        return (chat_id, topic_id, sender_id, target)
+
+    def _telegram_bot_to_bot_trace_depth(self, message) -> int:
+        cfg = self._telegram_bot_to_bot_config()
+        prefix = re.escape(str(cfg.get("trace_prefix") or "hms"))
+        text = "\n".join(
+            part for part in (getattr(message, "text", None), getattr(message, "caption", None)) if part
+        )
+        match = re.search(rf"\[trace:{prefix}:[^\]\s]+\s+depth=(\d+)\]", text)
+        if not match:
+            return 0
+        try:
+            return int(match.group(1))
+        except (TypeError, ValueError):
+            return 0
+
+    def _telegram_bot_to_bot_guard_allows(self, message) -> bool:
+        cfg = self._telegram_bot_to_bot_config()
+        now = time.monotonic()
+        key = self._bot_to_bot_guard_key(message)
+        breakers = getattr(self, "_bot_to_bot_circuit_breakers", {})
+        breaker = breakers.get(key)
+        raw_circuit_cfg = cfg.get("circuit_breaker")
+        circuit_cfg = raw_circuit_cfg if isinstance(raw_circuit_cfg, dict) else {}
+        cooldown = float(circuit_cfg.get("cooldown_seconds", 900))
+        if breaker and breaker.get("until", 0) > now:
+            return False
+        if breaker and breaker.get("until", 0) <= now:
+            breakers.pop(key, None)
+
+        max_depth = int(cfg.get("max_reply_depth", 3) or 3)
+        if self._telegram_bot_to_bot_trace_depth(message) >= max_depth:
+            self._record_bot_to_bot_trip(key, now)
+            return False
+
+        raw_rate_cfg = cfg.get("rate_limit")
+        rate_cfg = raw_rate_cfg if isinstance(raw_rate_cfg, dict) else {}
+        window_seconds = float(rate_cfg.get("window_seconds", 60))
+        max_messages = int(rate_cfg.get("max_messages", 10) or 10)
+        windows = getattr(self, "_bot_to_bot_rate_windows", {})
+        timestamps = [ts for ts in windows.get(key, []) if now - ts < window_seconds]
+        if len(timestamps) >= max_messages:
+            self._record_bot_to_bot_trip(key, now, cooldown=cooldown)
+            windows[key] = timestamps
+            return False
+        timestamps.append(now)
+        windows[key] = timestamps
+        self._bot_to_bot_rate_windows = windows
+        return True
+
+    def _record_bot_to_bot_trip(self, key: tuple, now: Optional[float] = None, *, cooldown: Optional[float] = None) -> None:
+        now = time.monotonic() if now is None else now
+        cfg = self._telegram_bot_to_bot_config()
+        raw_circuit_cfg = cfg.get("circuit_breaker")
+        circuit_cfg = raw_circuit_cfg if isinstance(raw_circuit_cfg, dict) else {}
+        window_seconds = float(circuit_cfg.get("window_seconds", 300))
+        max_trips = int(circuit_cfg.get("max_trips", 3) or 3)
+        cooldown_seconds = float(cooldown if cooldown is not None else circuit_cfg.get("cooldown_seconds", 900))
+        breakers = getattr(self, "_bot_to_bot_circuit_breakers", {})
+        breaker = breakers.get(key, {"trips": 0, "first": now, "until": 0})
+        if now - float(breaker.get("first", now)) > window_seconds:
+            breaker = {"trips": 0, "first": now, "until": 0}
+        breaker["trips"] = float(breaker.get("trips", 0)) + 1
+        if breaker["trips"] >= max_trips:
+            breaker["until"] = now + cooldown_seconds
+        breakers[key] = breaker
+        self._bot_to_bot_circuit_breakers = breakers
+
+    def _telegram_bot_to_bot_allows(self, message) -> bool:
+        """Return whether an incoming bot-authored group message may dispatch."""
+        user = getattr(message, "from_user", None)
+        if not bool(getattr(user, "is_bot", False)):
+            return True
+        if not self._telegram_bot_to_bot_enabled():
+            return False
+        if not self._telegram_bot_to_bot_chat_enabled(message):
+            return False
+        if not self._telegram_bot_to_bot_sender_allowed(message):
+            return False
+        cfg = self._telegram_bot_to_bot_config()
+        if self._coerce_bool_value(cfg.get("require_explicit_mention"), True):
+            if not self._message_mentions_bot(message):
+                return False
+        if self._coerce_bool_value(cfg.get("exclusive_bot_mentions"), True):
+            if self._explicit_bot_mentions_exclude_self(message):
+                return False
+        return self._telegram_bot_to_bot_guard_allows(message)
+
     def _telegram_free_response_chats(self) -> set[str]:
         raw = self.config.extra.get("free_response_chats")
         if raw is None:
@@ -5811,6 +5984,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return text
         username = re.escape(self._bot.username)
         cleaned = re.sub(rf"(?i)@{username}\b[,:\-]*\s*", "", text).strip()
+        cleaned = re.sub(r"\s*\[trace:[^\]\s]+:[^\]\s]+\s+depth=\d+\]\s*$", "", cleaned).strip()
         return cleaned or text
 
     def _should_observe_unmentioned_group_message(self, message: Message) -> bool:
@@ -6106,6 +6280,8 @@ class TelegramAdapter(BasePlatformAdapter):
         mentioning the bot (``@botname /command``), both of which are
         recognised as mentions by :meth:`_message_mentions_bot`.
         """
+        if bool(getattr(getattr(message, "from_user", None), "is_bot", False)):
+            return self._telegram_bot_to_bot_allows(message)
         if not self._is_group_chat(message):
             return True
 
@@ -7114,8 +7290,78 @@ class TelegramAdapter(BasePlatformAdapter):
 
     # ── Message reactions (processing lifecycle) ──────────────────────────
 
+    def _telegram_media_config(self) -> dict:
+        raw = self.config.extra.get("media")
+        return dict(raw) if isinstance(raw, dict) else {}
+
+    def _telegram_sticker_config(self) -> dict:
+        media = self._telegram_media_config()
+        raw = media.get("stickers")
+        return dict(raw) if isinstance(raw, dict) else {}
+
+    def _stickers_enabled(self) -> bool:
+        cfg = self._telegram_sticker_config()
+        return self._coerce_bool_value(cfg.get("enabled"), False)
+
+    def _sticker_aliases(self) -> dict:
+        cfg = self._telegram_sticker_config()
+        aliases = cfg.get("aliases")
+        return dict(aliases) if isinstance(aliases, dict) else {}
+
+    async def send_sticker_alias(
+        self,
+        chat_id: str,
+        alias: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a configured Telegram sticker alias, preserving forum topic routing."""
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+        if not self._stickers_enabled():
+            return SendResult(success=False, error="Telegram sticker aliases disabled")
+        file_id = self._sticker_aliases().get(str(alias).strip())
+        if not file_id:
+            return SendResult(success=False, error=f"Unknown Telegram sticker alias: {alias}")
+        try:
+            thread_id = self._metadata_thread_id(metadata)
+            reply_to_id = int(reply_to) if reply_to and self._should_thread_reply(reply_to, 0) else None
+            thread_kwargs = self._thread_kwargs_for_send(
+                chat_id,
+                thread_id,
+                metadata,
+                reply_to_message_id=reply_to_id,
+                reply_to_mode=self._reply_to_mode,
+            )
+            msg = await self._bot.send_sticker(
+                chat_id=int(chat_id),
+                sticker=str(file_id),
+                reply_to_message_id=reply_to_id,
+                **thread_kwargs,
+                **self._notification_kwargs(metadata),
+            )
+            return SendResult(success=True, message_id=str(getattr(msg, "message_id", "")))
+        except Exception as exc:
+            logger.debug("[%s] send_sticker_alias(%s) failed: %s", self.name, alias, exc)
+            return SendResult(success=False, error=str(exc))
+
+    def _telegram_reaction_config(self) -> dict:
+        media = self._telegram_media_config()
+        raw = media.get("reactions")
+        return dict(raw) if isinstance(raw, dict) else {}
+
+    def _telegram_reaction_emoji(self, key: str, default: str) -> str:
+        cfg = self._telegram_reaction_config()
+        return str(cfg.get(key, default) or default)
+
     def _reactions_enabled(self) -> bool:
         """Check if message reactions are enabled via config/env."""
+        cfg = self._telegram_reaction_config()
+        if "enabled" in cfg:
+            return self._coerce_bool_value(cfg.get("enabled"), False)
+        configured = self.config.extra.get("reactions")
+        if configured is not None:
+            return self._coerce_bool_value(configured, False)
         return os.getenv("TELEGRAM_REACTIONS", "false").lower() not in {"false", "0", "no"}
 
     async def _set_reaction(self, chat_id: str, message_id: str, emoji: str) -> bool:
@@ -7161,7 +7407,11 @@ class TelegramAdapter(BasePlatformAdapter):
         chat_id = getattr(event.source, "chat_id", None)
         message_id = getattr(event, "message_id", None)
         if chat_id and message_id:
-            await self._set_reaction(chat_id, message_id, "\U0001f440")
+            await self._set_reaction(
+                chat_id,
+                message_id,
+                self._telegram_reaction_emoji("on_accept", "\U0001f440"),
+            )
 
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
         """Swap the in-progress reaction for a final success/failure reaction.
@@ -7185,11 +7435,12 @@ class TelegramAdapter(BasePlatformAdapter):
         if outcome == ProcessingOutcome.CANCELLED:
             await self._clear_reactions(chat_id, message_id)
         else:
-            await self._set_reaction(
-                chat_id,
-                message_id,
-                "\U0001f44d" if outcome == ProcessingOutcome.SUCCESS else "\U0001f44e",
+            emoji = (
+                self._telegram_reaction_emoji("on_success", "\U0001f44d")
+                if outcome == ProcessingOutcome.SUCCESS
+                else self._telegram_reaction_emoji("on_error", "\U0001f44e")
             )
+            await self._set_reaction(chat_id, message_id, emoji)
 
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -7378,6 +7629,9 @@ def _apply_yaml_config(yaml_cfg: dict, telegram_cfg: dict) -> dict | None:
             group_allowed_chats = ",".join(str(v) for v in group_allowed_chats)
         os.environ["TELEGRAM_GROUP_ALLOWED_CHATS"] = str(group_allowed_chats)
     for _key in ("guest_mode", "disable_link_previews", "observe_unmentioned_group_messages"):
+        if _key in telegram_cfg:
+            extras.setdefault(_key, telegram_cfg[_key])
+    for _key in ("bot_to_bot", "rich_streaming", "media", "reactions"):
         if _key in telegram_cfg:
             extras.setdefault(_key, telegram_cfg[_key])
     # Pass through telegram-specific extra keys (e.g. base_url proxy override),

--- a/tests/gateway/test_telegram_bot_to_bot.py
+++ b/tests/gateway/test_telegram_bot_to_bot.py
@@ -1,0 +1,196 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import ProcessingOutcome
+
+
+def _make_adapter(*, bot_to_bot=None, media=None, reactions=None, bot_username="hermes_bot"):
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    extra = {
+        "allowed_chats": [],
+        "group_allowed_chats": [],
+        "allowed_topics": [],
+    }
+    if bot_to_bot is not None:
+        extra["bot_to_bot"] = bot_to_bot
+    if media is not None:
+        extra["media"] = media
+    if reactions is not None:
+        extra["reactions"] = reactions
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    adapter.config = PlatformConfig(enabled=True, token="***", extra=extra)
+    adapter._bot = SimpleNamespace(
+        id=999,
+        username=bot_username,
+        set_message_reaction=AsyncMock(),
+        send_sticker=AsyncMock(return_value=SimpleNamespace(message_id=456)),
+    )
+    adapter._reply_to_mode = "first"
+    adapter._mention_patterns = []
+    adapter._bot_to_bot_rate_windows = {}
+    adapter._bot_to_bot_circuit_breakers = {}
+    adapter._status_message_ids = {}
+    adapter._notification_kwargs = lambda metadata: {}
+    adapter._thread_kwargs_for_send = lambda *args, **kwargs: {"message_thread_id": kwargs.get("reply_to_message_id") and None}
+    adapter._metadata_thread_id = lambda metadata: (metadata or {}).get("thread_id")
+    adapter._should_thread_reply = lambda reply_to, index=0: bool(reply_to)
+    return adapter
+
+
+def _mention_entity(text, mention="@hermes_bot"):
+    return SimpleNamespace(type="mention", offset=text.index(mention), length=len(mention))
+
+
+def _group_message(
+    text="hello",
+    *,
+    chat_id=-100,
+    thread_id=903,
+    sender_id=111,
+    sender_username="peer_bot",
+    sender_is_bot=True,
+    entities=None,
+):
+    return SimpleNamespace(
+        message_id=42,
+        text=text,
+        caption=None,
+        entities=entities or [],
+        caption_entities=[],
+        message_thread_id=thread_id,
+        is_topic_message=thread_id is not None,
+        chat=SimpleNamespace(id=chat_id, type="supergroup", title="Test Group", is_forum=True),
+        from_user=SimpleNamespace(
+            id=sender_id,
+            username=sender_username,
+            is_bot=sender_is_bot,
+            full_name="Peer Bot" if sender_is_bot else "Alice Example",
+            first_name="Peer" if sender_is_bot else "Alice",
+        ),
+        reply_to_message=None,
+        date=None,
+    )
+
+
+def _enabled_config(**overrides):
+    cfg = {
+        "enabled": True,
+        "allowlisted_bot_ids": ["111"],
+        "allowlisted_bot_usernames": ["peer_bot"],
+        "require_explicit_mention": True,
+        "exclusive_bot_mentions": True,
+        "enabled_chats": ["-100:903"],
+        "max_reply_depth": 3,
+        "rate_limit": {"window_seconds": 60, "max_messages": 10},
+        "circuit_breaker": {"window_seconds": 300, "max_trips": 3, "cooldown_seconds": 900},
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+def test_bot_sender_is_ignored_by_default():
+    adapter = _make_adapter()
+    text = "@hermes_bot please review"
+    msg = _group_message(text, entities=[_mention_entity(text)])
+
+    assert adapter._should_process_message(msg) is False
+
+
+def test_allowlisted_bot_sender_with_explicit_target_is_accepted():
+    adapter = _make_adapter(bot_to_bot=_enabled_config())
+    text = "@hermes_bot please review"
+    msg = _group_message(text, entities=[_mention_entity(text)])
+
+    assert adapter._should_process_message(msg) is True
+
+
+def test_non_allowlisted_bot_sender_is_ignored_even_when_mentioned():
+    adapter = _make_adapter(bot_to_bot=_enabled_config())
+    text = "@hermes_bot please review"
+    msg = _group_message(
+        text,
+        sender_id=222,
+        sender_username="stranger_bot",
+        entities=[_mention_entity(text)],
+    )
+
+    assert adapter._should_process_message(msg) is False
+
+
+def test_bot_message_to_other_bot_is_ignored():
+    adapter = _make_adapter(bot_to_bot=_enabled_config())
+    text = "@codex_bot please review"
+    msg = _group_message(text, entities=[_mention_entity(text, "@codex_bot")])
+
+    assert adapter._should_process_message(msg) is False
+
+
+def test_bot_to_bot_topic_gate_uses_chat_colon_thread():
+    adapter = _make_adapter(bot_to_bot=_enabled_config(enabled_chats=["-100:708"]))
+    text = "@hermes_bot please review"
+    msg = _group_message(text, thread_id=903, entities=[_mention_entity(text)])
+
+    assert adapter._should_process_message(msg) is False
+
+
+def test_bot_to_bot_trace_depth_blocks_at_limit_and_strips_before_dispatch():
+    adapter = _make_adapter(bot_to_bot=_enabled_config(max_reply_depth=2))
+    text = "@hermes_bot continue [trace:hms:abc depth=2]"
+    msg = _group_message(text, entities=[_mention_entity(text)])
+
+    assert adapter._should_process_message(msg) is False
+    assert adapter._clean_bot_trigger_text(text) == "continue"
+
+
+def test_bot_to_bot_rate_limit_blocks_after_window_quota():
+    adapter = _make_adapter(
+        bot_to_bot=_enabled_config(rate_limit={"window_seconds": 60, "max_messages": 1})
+    )
+    text = "@hermes_bot one"
+    msg = _group_message(text, entities=[_mention_entity(text)])
+
+    assert adapter._should_process_message(msg) is True
+    assert adapter._should_process_message(msg) is False
+
+
+def test_reactions_use_nested_media_config_emojis():
+    async def _run():
+        adapter = _make_adapter(
+            media={
+                "reactions": {
+                    "enabled": True,
+                    "on_accept": "⏳",
+                    "on_success": "✅",
+                    "on_error": "❌",
+                }
+            }
+        )
+        event = SimpleNamespace(source=SimpleNamespace(chat_id="-100"), message_id="42")
+        await adapter.on_processing_start(event)
+        await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+        calls = adapter._bot.set_message_reaction.await_args_list
+        assert calls[0].kwargs["reaction"] == "⏳"
+        assert calls[1].kwargs["reaction"] == "✅"
+
+    asyncio.run(_run())
+
+
+def test_sticker_alias_send_preserves_thread_metadata():
+    async def _run():
+        adapter = _make_adapter(
+            media={"stickers": {"enabled": True, "aliases": {"shipit": "FILE_ID"}}}
+        )
+        result = await adapter.send_sticker_alias("-100", "shipit", metadata={"thread_id": "903"})
+
+        assert result.success is True
+        assert result.message_id == "456"
+        adapter._bot.send_sticker.assert_awaited_once()
+        assert adapter._bot.send_sticker.await_args.kwargs["sticker"] == "FILE_ID"
+
+    asyncio.run(_run())

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -654,7 +654,17 @@ def test_config_bridges_telegram_group_settings(monkeypatch, tmp_path):
         "  group_allowed_chats:\n"
         "    - \"-100\"\n"
         "  allowed_topics:\n"
-        "    - 8\n",
+        "    - 8\n"
+        "  bot_to_bot:\n"
+        "    enabled: true\n"
+        "    allowlisted_bot_ids:\n"
+        "      - \"123\"\n"
+        "    enabled_chats:\n"
+        "      - \"-100:8\"\n"
+        "  media:\n"
+        "    reactions:\n"
+        "      enabled: true\n"
+        "      on_success: \"✅\"\n",
         encoding="utf-8",
     )
 
@@ -687,6 +697,14 @@ def test_config_bridges_telegram_group_settings(monkeypatch, tmp_path):
     assert tg_cfg.extra.get("allowed_chats") == ["-100"]
     assert tg_cfg.extra.get("group_allowed_chats") == ["-100"]
     assert tg_cfg.extra.get("allowed_topics") == [8]
+    assert tg_cfg.extra.get("bot_to_bot") == {
+        "enabled": True,
+        "allowlisted_bot_ids": ["123"],
+        "enabled_chats": ["-100:8"],
+    }
+    assert tg_cfg.extra.get("media") == {
+        "reactions": {"enabled": True, "on_success": "✅"}
+    }
     assert tg_cfg.extra.get("exclusive_bot_mentions") is True
     assert tg_cfg.extra.get("observe_unmentioned_group_messages") is True
 

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -132,6 +132,65 @@ TELEGRAM_OBSERVE_UNMENTIONED_GROUP_MESSAGES=true
 
 This requires Telegram to deliver ordinary group messages to the gateway, so disable BotFather privacy mode or promote the bot to group admin as described above.
 
+### Bot-to-bot communication (advanced)
+
+Telegram can deliver messages authored by other bots when BotFather bot-to-bot mode and the client/account configuration allow it. Hermes keeps bot-authored messages **off by default** because unrestricted bot-to-bot replies can create infinite loops. Enable it only for known peer bots, and preferably only in specific forum topics:
+
+```yaml
+telegram:
+  bot_to_bot:
+    enabled: true
+    # One or both allowlists may be used. Numeric IDs are preferred.
+    allowlisted_bot_ids:
+      - "123456789"
+    allowlisted_bot_usernames:
+      - codex_bot
+    require_explicit_mention: true
+    exclusive_bot_mentions: true
+    enabled_chats:
+      - "-1001234567890:903"  # chat_id:message_thread_id
+    max_reply_depth: 3
+    rate_limit:
+      window_seconds: 60
+      max_messages: 10
+    circuit_breaker:
+      window_seconds: 300
+      max_trips: 3
+      cooldown_seconds: 900
+```
+
+Rules enforced by the adapter:
+
+- bot senders are ignored unless `bot_to_bot.enabled` is true;
+- the sender must match `allowlisted_bot_ids` or `allowlisted_bot_usernames`;
+- the message must explicitly mention this bot (for example `@my_hermes_bot`);
+- when `exclusive_bot_mentions` is true, a message aimed only at another `@...bot` is ignored;
+- optional `enabled_chats` entries may be a whole chat (`-1001234567890`) or a single forum topic (`-1001234567890:903`);
+- visible trace markers like `[trace:hms:abc depth=2]` are parsed and stripped before dispatch so loops stop at `max_reply_depth`.
+
+### Rich messages, streaming drafts, reactions, and stickers
+
+Rich Telegram rendering is opt-in. When enabled, Hermes first tries Telegram Bot API rich-message methods and falls back to legacy MarkdownV2 if the API/client rejects them:
+
+```yaml
+telegram:
+  extra:
+    rich_messages: true
+  reactions: true
+  media:
+    reactions:
+      enabled: true
+      on_accept: "👀"
+      on_success: "👍"
+      on_error: "👎"
+    stickers:
+      enabled: true
+      aliases:
+        shipit: "<telegram-sticker-file-id>"
+```
+
+Sticker aliases are intentionally file-id based in v1. Capture a sticker `file_id` from a known sticker message or from Telegram API logs, then map it to an alias. This avoids relying on global sticker search behavior that may vary by Bot API/client version.
+
 ## Step 4: Find Your User ID
 
 Hermes Agent uses numeric Telegram user IDs to control access. Your user ID is **not** your username — it's a number like `123456789`.


### PR DESCRIPTION
## Summary\n- add opt-in Telegram bot-to-bot gating with allowlists, explicit mention routing, per-topic enablement, trace-depth guard, rate limit, and circuit breaker\n- add configurable Telegram media reactions and sticker alias send helper\n- bridge new Telegram config blocks into platform extras and document bot-to-bot/rich/media setup\n- add regression tests for bot sender gating, topic scoping, loop/rate guards, reaction config, sticker aliases, and config bridging\n\n## Tests\n- python -m pytest tests/gateway/test_telegram_bot_to_bot.py tests/gateway/test_telegram_group_gating.py tests/gateway/test_telegram_reactions.py tests/gateway/test_telegram_rich_messages.py tests/gateway/test_telegram_rich_newlines.py tests/tools/test_send_message_telegram_proxy.py -q -o 'addopts='\n- python -m py_compile plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_bot_to_bot.py tests/gateway/test_telegram_group_gating.py\n- hermes config check