### PR TITLE
fix(browser): bypass proxies for Camofox control API

### DIFF
--- a/tests/tools/test_browser_camofox.py
+++ b/tests/tools/test_browser_camofox.py
@@ -140,6 +140,17 @@ class TestCamofoxNavigate:
         assert result["success"] is True
         assert result["url"] == "https://example.com"
 
+    @patch("tools.browser_camofox.requests.post")
+    def test_camofox_requests_bypass_environment_proxies(self, mock_post, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        monkeypatch.setenv("HTTP_PROXY", "http://127.0.0.1:7890")
+        mock_post.return_value = _mock_response(json_data={"tabId": "tab_proxy", "url": "https://example.com"})
+
+        result = json.loads(camofox_navigate("https://example.com", task_id="t_proxy"))
+
+        assert result["success"] is True
+        assert mock_post.call_args.kwargs["proxies"] == {"http": None, "https": None}
+
     @patch("tools.browser_camofox.load_config")
     @patch("tools.browser_camofox.requests.post")
     def test_navigate_uses_rewritten_loopback_url(self, mock_post, mock_config, monkeypatch):

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -47,6 +47,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 _DEFAULT_TIMEOUT = 30  # seconds per HTTP request
+_LOCAL_SERVICE_PROXIES = {"http": None, "https": None}
 _SNAPSHOT_MAX_CHARS = 80_000  # camofox paginates at this limit
 _vnc_url: Optional[str] = None  # cached from /health response
 _vnc_url_checked = False  # only probe once per process
@@ -77,7 +78,7 @@ def check_camofox_available() -> bool:
     if not url:
         return False
     try:
-        resp = requests.get(f"{url}/health", timeout=5)
+        resp = requests.get(f"{url}/health", timeout=5, proxies=_LOCAL_SERVICE_PROXIES)
         if resp.status_code == 200 and not _vnc_url_checked:
             try:
                 data = resp.json()
@@ -349,6 +350,7 @@ def _ensure_tab(task_id: Optional[str], url: str = "about:blank") -> Dict[str, A
             "url": url,
         },
         timeout=_DEFAULT_TIMEOUT,
+        proxies=_LOCAL_SERVICE_PROXIES,
     )
     resp.raise_for_status()
     data = resp.json()
@@ -387,7 +389,7 @@ def camofox_soft_cleanup(task_id: Optional[str] = None) -> bool:
 def _post(path: str, body: dict, timeout: int = _DEFAULT_TIMEOUT) -> dict:
     """POST JSON to camofox and return parsed response."""
     url = f"{get_camofox_url()}{path}"
-    resp = requests.post(url, json=body, timeout=timeout)
+    resp = requests.post(url, json=body, timeout=timeout, proxies=_LOCAL_SERVICE_PROXIES)
     resp.raise_for_status()
     return resp.json()
 
@@ -395,7 +397,7 @@ def _post(path: str, body: dict, timeout: int = _DEFAULT_TIMEOUT) -> dict:
 def _get(path: str, params: dict = None, timeout: int = _DEFAULT_TIMEOUT) -> dict:
     """GET from camofox and return parsed response."""
     url = f"{get_camofox_url()}{path}"
-    resp = requests.get(url, params=params, timeout=timeout)
+    resp = requests.get(url, params=params, timeout=timeout, proxies=_LOCAL_SERVICE_PROXIES)
     resp.raise_for_status()
     return resp.json()
 
@@ -403,7 +405,7 @@ def _get(path: str, params: dict = None, timeout: int = _DEFAULT_TIMEOUT) -> dic
 def _get_raw(path: str, params: dict = None, timeout: int = _DEFAULT_TIMEOUT) -> requests.Response:
     """GET from camofox and return raw response (for binary data)."""
     url = f"{get_camofox_url()}{path}"
-    resp = requests.get(url, params=params, timeout=timeout)
+    resp = requests.get(url, params=params, timeout=timeout, proxies=_LOCAL_SERVICE_PROXIES)
     resp.raise_for_status()
     return resp
 
@@ -411,7 +413,7 @@ def _get_raw(path: str, params: dict = None, timeout: int = _DEFAULT_TIMEOUT) ->
 def _delete(path: str, body: dict = None, timeout: int = _DEFAULT_TIMEOUT) -> dict:
     """DELETE to camofox and return parsed response."""
     url = f"{get_camofox_url()}{path}"
-    resp = requests.delete(url, json=body, timeout=timeout)
+    resp = requests.delete(url, json=body, timeout=timeout, proxies=_LOCAL_SERVICE_PROXIES)
     resp.raise_for_status()
     return resp.json()
 


### PR DESCRIPTION
## Summary
- prevent `HTTP_PROXY`/`HTTPS_PROXY` from intercepting Hermes -> Camofox control-plane requests
- pass explicit no-proxy settings to health, tab creation, GET/POST/DELETE helper calls
- add regression coverage proving Camofox requests do not inherit environment proxies

## Testing
- `./venv/Scripts/python.exe -m pytest tests/tools/test_browser_camofox.py -q`
- `./venv/Scripts/python.exe scripts/check-windows-footguns.py --all`