### PR TITLE
fix(account): ignore non-finite usage reset timestamps

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -57,7 +57,13 @@ def _parse_dt(value: Any) -> Optional[datetime]:
     if value in {None, ""}:
         return None
     if isinstance(value, (int, float)):
-        return datetime.fromtimestamp(float(value), tz=timezone.utc)
+        numeric = float(value)
+        if not math.isfinite(numeric):
+            return None
+        try:
+            return datetime.fromtimestamp(numeric, tz=timezone.utc)
+        except (OverflowError, OSError, ValueError):
+            return None
     if isinstance(value, str):
         text = value.strip()
         if not text:

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 from agent.account_usage import (
     AccountUsageSnapshot,
     AccountUsageWindow,
+    _parse_dt,
     fetch_account_usage,
     render_account_usage_lines,
 )
@@ -49,6 +50,12 @@ class _RoutingClient:
         return _Response(self._payloads[url])
 
 
+def test_parse_dt_rejects_non_finite_numeric_timestamps():
+    assert _parse_dt(float("nan")) is None
+    assert _parse_dt(float("inf")) is None
+    assert _parse_dt(float("-inf")) is None
+
+
 def test_fetch_account_usage_codex(monkeypatch):
     monkeypatch.setattr(
         "agent.account_usage.resolve_codex_runtime_credentials",
@@ -93,6 +100,41 @@ def test_fetch_account_usage_codex(monkeypatch):
     assert snapshot.windows[0].used_percent == 15.0
     assert snapshot.windows[0].reset_at == datetime.fromtimestamp(1_900_000_000, tz=timezone.utc)
     assert "Credits balance: $12.50" in snapshot.details
+
+
+def test_fetch_account_usage_codex_ignores_non_finite_reset(monkeypatch):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_codex_runtime_credentials",
+        lambda refresh_if_expiring=True: {
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "access-token",
+        },
+    )
+    monkeypatch.setattr(
+        "agent.account_usage._read_codex_tokens",
+        lambda: {"tokens": {"account_id": "acct_123"}},
+    )
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _Client(
+            {
+                "plan_type": "pro",
+                "rate_limit": {
+                    "primary_window": {
+                        "used_percent": 15,
+                        "reset_at": float("nan"),
+                    },
+                },
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage("openai-codex")
+
+    assert snapshot is not None
+    assert snapshot.windows[0].used_percent == 15.0
+    assert snapshot.windows[0].reset_at is None
 
 
 def test_render_account_usage_lines_includes_reset_and_provider():


### PR DESCRIPTION
## Summary
- make account-usage timestamp parsing reject `NaN`, `Infinity`, and out-of-range numeric reset values
- return `None` for invalid reset timestamps instead of letting `datetime.fromtimestamp()` raise
- add coverage for both the helper and the Codex usage fetch path

## Testing
- `./venv/Scripts/python.exe -m pytest tests/test_account_usage.py -q`
- `./venv/Scripts/python.exe scripts/check-windows-footguns.py --all`