### PR TITLE
fix(cron): enforce profile isolation for scheduled jobs, closes #51853

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -789,6 +789,7 @@ def create_job(
     workdir: Optional[str] = None,
     no_agent: bool = False,
     attach_to_session: Optional[bool] = None,
+    hermes_home: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -833,6 +834,12 @@ def create_job(
                 and deliver its stdout directly. Empty stdout = silent (no
                 delivery). Requires ``script`` to be set. Ideal for classic
                 watchdogs and periodic alerts that don't need LLM reasoning.
+        hermes_home: Optional HERMES_HOME path of the profile that created this
+                job. When set, the scheduler loads config.yaml and tool
+                restrictions from this path at execution time, ensuring
+                restricted profiles cannot escalate privileges via cron.
+                When unset, falls back to the scheduler's own HERMES_HOME
+                (legacy behavior).
 
     Returns:
         The created job dict
@@ -967,6 +974,7 @@ def create_job(
         "origin": origin,  # Tracks where job was created for "origin" delivery
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
+        "hermes_home": hermes_home or str(get_hermes_home()),
     }
     # Only persist attach_to_session when explicitly set, so existing jobs and
     # the common case stay byte-identical (absent key => fall back to the

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2173,11 +2173,13 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     try:
         # Re-read .env and config.yaml fresh every run so provider/key
         # changes take effect without a gateway restart.
+        # Use the job's stored hermes_home for profile isolation (#51853).
+        _job_home_for_env = Path(job["hermes_home"]) if job.get("hermes_home") else _get_hermes_home()
         from dotenv import load_dotenv
         try:
-            load_dotenv(str(_get_hermes_home() / ".env"), override=True, encoding="utf-8")
+            load_dotenv(str(_job_home_for_env / ".env"), override=True, encoding="utf-8")
         except UnicodeDecodeError:
-            load_dotenv(str(_get_hermes_home() / ".env"), override=True, encoding="latin-1")
+            load_dotenv(str(_job_home_for_env / ".env"), override=True, encoding="latin-1")
 
         delivery_target = _resolve_delivery_target(job)
         if delivery_target:
@@ -2197,10 +2199,15 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         model = job.get("model") or os.getenv("HERMES_MODEL") or ""
 
         # Load config.yaml for model, reasoning, prefill, toolsets, provider routing
+        # Use the job's stored hermes_home (the profile that created this job)
+        # so that tool restrictions from restricted profiles are honored at
+        # execution time.  Falls back to the scheduler's own hermes_home for
+        # legacy jobs that predate this field (#51853).
+        _job_hermes_home = Path(job["hermes_home"]) if job.get("hermes_home") else _get_hermes_home()
         _cfg = {}
         try:
             import yaml
-            _cfg_path = str(_get_hermes_home() / "config.yaml")
+            _cfg_path = str(_job_hermes_home / "config.yaml")
             if os.path.exists(_cfg_path):
                 with open(_cfg_path, encoding="utf-8") as _f:
                     _cfg = yaml.safe_load(_f) or {}
@@ -2269,7 +2276,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         if prefill_file:
             pfpath = Path(prefill_file).expanduser()
             if not pfpath.is_absolute():
-                pfpath = _get_hermes_home() / pfpath
+                pfpath = _job_hermes_home / pfpath
             if pfpath.exists():
                 try:
                     with open(pfpath, "r", encoding="utf-8") as _pf:

--- a/tests/cron/test_cron_profile_isolation.py
+++ b/tests/cron/test_cron_profile_isolation.py
@@ -1,0 +1,174 @@
+"""
+Tests for cron job profile isolation (#51853).
+
+Verifies that:
+1. Jobs store the originating profile hermes_home at creation time
+2. The scheduler loads config.yaml from the job hermes_home
+3. Tool restrictions from the originating profile are applied at execution time
+4. Legacy jobs without hermes_home fall back to the default hermes_home
+"""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+
+def _load_yaml(path):
+    """Helper to load a YAML file."""
+    with open(path) as f:
+        return yaml.safe_load(f) or {}
+
+
+@pytest.fixture
+def temp_hermes_homes(tmp_path):
+    """Create two simulated profile hermes_home directories."""
+    default_home = tmp_path / "default"
+    default_home.mkdir()
+    (default_home / "cron").mkdir()
+    (default_home / "config.yaml").write_text(
+        "agent:\n  disabled_toolsets: []\nmodel:\n  default: gpt-4\n"
+    )
+
+    restricted_home = tmp_path / "profiles" / "restricted"
+    restricted_home.mkdir(parents=True)
+    (restricted_home / "cron").mkdir()
+    (restricted_home / "config.yaml").write_text(
+        "agent:\n  disabled_toolsets:\n    - terminal\n    - file\nmodel:\n  default: gpt-3.5-turbo\n"
+    )
+
+    return {"default": default_home, "restricted": restricted_home}
+
+
+class TestJobCreationStoresHermesHome:
+    """Jobs must record the creating profile hermes_home."""
+
+    def test_create_job_stores_explicit_hermes_home(self, temp_hermes_homes):
+        """create_job() persists the hermes_home field in the job record."""
+        from cron.jobs import create_job
+
+        restricted_home = str(temp_hermes_homes["restricted"])
+
+        with patch("cron.jobs.get_hermes_home", return_value=temp_hermes_homes["default"]):
+            with patch("cron.jobs.HERMES_DIR", temp_hermes_homes["default"]):
+                with patch("cron.jobs.CRON_DIR", temp_hermes_homes["default"] / "cron"):
+                    with patch("cron.jobs.JOBS_FILE", temp_hermes_homes["default"] / "cron" / "jobs.json"):
+                        job = create_job(
+                            prompt="test prompt",
+                            schedule="every 30m",
+                            hermes_home=restricted_home,
+                        )
+
+        assert job["hermes_home"] == restricted_home
+
+    def test_create_job_defaults_to_current_hermes_home(self, temp_hermes_homes):
+        """When hermes_home is not passed, it defaults to get_hermes_home()."""
+        from cron.jobs import create_job
+
+        with patch("cron.jobs.get_hermes_home", return_value=temp_hermes_homes["default"]):
+            with patch("cron.jobs.HERMES_DIR", temp_hermes_homes["default"]):
+                with patch("cron.jobs.CRON_DIR", temp_hermes_homes["default"] / "cron"):
+                    with patch("cron.jobs.JOBS_FILE", temp_hermes_homes["default"] / "cron" / "jobs.json"):
+                        job = create_job(
+                            prompt="test prompt",
+                            schedule="every 30m",
+                        )
+
+        assert job["hermes_home"] == str(temp_hermes_homes["default"])
+
+
+class TestSchedulerUsesJobHermesHome:
+    """The scheduler must load config from the job hermes_home."""
+
+    def test_resolve_cron_disabled_toolsets_from_restricted_profile(self, temp_hermes_homes):
+        """Tool restrictions from the restricted profile config must be applied."""
+        from cron.scheduler import _resolve_cron_disabled_toolsets
+
+        cfg = _load_yaml(temp_hermes_homes["restricted"] / "config.yaml")
+        disabled = _resolve_cron_disabled_toolsets(cfg)
+
+        assert "cronjob" in disabled
+        assert "messaging" in disabled
+        assert "clarify" in disabled
+        assert "terminal" in disabled
+        assert "file" in disabled
+
+    def test_resolve_cron_disabled_toolsets_from_default_profile(self, temp_hermes_homes):
+        """Default profile should not have extra restrictions."""
+        from cron.scheduler import _resolve_cron_disabled_toolsets
+
+        cfg = _load_yaml(temp_hermes_homes["default"] / "config.yaml")
+        disabled = _resolve_cron_disabled_toolsets(cfg)
+
+        assert "cronjob" in disabled
+        assert "messaging" in disabled
+        assert "clarify" in disabled
+        assert "terminal" not in disabled
+        assert "file" not in disabled
+
+    def test_legacy_job_without_hermes_home_uses_default(self, temp_hermes_homes):
+        """Jobs without hermes_home field (pre-fix) fall back to _get_hermes_home()."""
+        legacy_job = {"id": "abc123", "name": "legacy job", "prompt": "test"}
+
+        from cron.scheduler import _get_hermes_home
+
+        job_home = (
+            Path(legacy_job["hermes_home"])
+            if legacy_job.get("hermes_home")
+            else _get_hermes_home()
+        )
+        assert job_home == _get_hermes_home()
+
+    def test_job_with_hermes_home_uses_stored_path(self, temp_hermes_homes):
+        """Jobs with hermes_home use their stored profile path."""
+        job = {
+            "id": "def456",
+            "hermes_home": str(temp_hermes_homes["restricted"]),
+        }
+        job_home = Path(job["hermes_home"]) if job.get("hermes_home") else None
+        assert job_home == temp_hermes_homes["restricted"]
+
+
+class TestToolEscalationPrevention:
+    """Verify that a restricted profile cannot escalate via cron."""
+
+    def test_restricted_profile_terminal_blocked(self, temp_hermes_homes):
+        """A job from a terminal-disabled profile must have terminal in disabled_toolsets."""
+        from cron.scheduler import _resolve_cron_disabled_toolsets
+
+        cfg = _load_yaml(Path(str(temp_hermes_homes["restricted"])) / "config.yaml")
+        disabled = _resolve_cron_disabled_toolsets(cfg)
+
+        assert "terminal" in disabled, "SECURITY: terminal must be disabled"
+        assert "file" in disabled, "SECURITY: file must be disabled"
+
+    def test_default_profile_terminal_allowed(self, temp_hermes_homes):
+        """A job from the default profile keeps terminal access."""
+        from cron.scheduler import _resolve_cron_disabled_toolsets
+
+        cfg = _load_yaml(Path(str(temp_hermes_homes["default"])) / "config.yaml")
+        disabled = _resolve_cron_disabled_toolsets(cfg)
+
+        assert "terminal" not in disabled
+        assert "file" not in disabled
+
+    def test_config_path_resolves_to_job_profile(self, temp_hermes_homes):
+        """config.yaml must be loaded from the job hermes_home."""
+        job = {"id": "cfg_test", "hermes_home": str(temp_hermes_homes["restricted"])}
+        job_hermes_home = (
+            Path(job["hermes_home"])
+            if job.get("hermes_home")
+            else temp_hermes_homes["default"]
+        )
+        cfg = _load_yaml(job_hermes_home / "config.yaml")
+
+        agent_cfg = cfg.get("agent", {})
+        assert "terminal" in agent_cfg.get("disabled_toolsets", [])
+        assert "file" in agent_cfg.get("disabled_toolsets", [])
+
+        default_cfg = _load_yaml(temp_hermes_homes["default"] / "config.yaml")
+        default_agent_cfg = default_cfg.get("agent", {})
+        assert default_agent_cfg.get("disabled_toolsets") == []

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -12,7 +12,7 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
-from hermes_constants import display_hermes_home
+from hermes_constants import display_hermes_home, get_hermes_home
 
 logger = logging.getLogger(__name__)
 
@@ -650,6 +650,7 @@ def cronjob(
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
                 attach_to_session=attach_to_session,
+                hermes_home=str(get_hermes_home()),
             )
             _notify_provider_jobs_changed_safe()
             _create_message = f"Cron job '{job['name']}' created."


### PR DESCRIPTION
## Summary

Cron jobs created from restricted profiles now store the originating `HERMES_HOME` path in the job record. At execution time, the scheduler loads `config.yaml`, `.env`, and prefill files from the stored profile path instead of always using the default profile.

This prevents a **privilege escalation** where a restricted profile (with `disabled_toolsets` like `terminal`/`file`) could bypass those restrictions by creating a cron job that would run under the default profile's unrestricted permissions.

## Root Cause

`cron/scheduler.py` always called `_get_hermes_home()` at execution time, which resolves to the running gateway's profile (typically `~/.hermes`). This means:
1. Tool restrictions (`agent.disabled_toolsets`) from the **default** profile's `config.yaml` were applied — not the originating profile's
2. `.env` (containing bot tokens) from the default profile was loaded — delivering via the wrong bot

## Changes

| File | Change |
|------|--------|
| `cron/jobs.py` | Added `hermes_home` parameter to `create_job()`; persisted in job record. Defaults to `get_hermes_home()` for backwards compatibility. |
| `cron/scheduler.py` | Load config, .env, and prefill from the job's stored `hermes_home`. Legacy jobs without the field fall back to `_get_hermes_home()`. |
| `tools/cronjob_tools.py` | Pass current `hermes_home` when creating jobs via the tool interface. |
| `tests/cron/test_cron_profile_isolation.py` | 9 tests covering profile isolation, escalation prevention, and legacy fallback. |

## Backwards Compatibility

- **Legacy jobs** (created before this fix) have no `hermes_home` field → the scheduler falls back to `_get_hermes_home()`, preserving the old behavior.
- **New jobs** automatically capture the creating profile's path.
- No migration needed.

## Test Results

```
tests/cron/test_cron_profile_isolation.py: 9 passed
tests/cron/ + tests/tools/test_cronjob_tools.py: 225 passed, 6 skipped
```

Closes #51853