### PR TITLE
fix(account): harden usage percent rendering

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -102,11 +102,12 @@ def render_account_usage_lines(snapshot: Optional[AccountUsageSnapshot], *, mark
     else:
         lines.append(f"Provider: {snapshot.provider}")
     for window in snapshot.windows:
-        if window.used_percent is None:
+        used_percent = _normalized_percent(window.used_percent)
+        if used_percent is None:
             base = f"{window.label}: unavailable"
         else:
-            remaining = max(0, round(100 - float(window.used_percent)))
-            used = max(0, round(float(window.used_percent)))
+            remaining = round(100 - used_percent)
+            used = round(used_percent)
             base = f"{window.label}: {remaining}% remaining ({used}% used)"
         if window.reset_at:
             base += f" • resets {_format_reset(window.reset_at)}"
@@ -118,6 +119,18 @@ def render_account_usage_lines(snapshot: Optional[AccountUsageSnapshot], *, mark
     if snapshot.unavailable_reason:
         lines.append(f"Unavailable: {snapshot.unavailable_reason}")
     return lines
+
+
+def _normalized_percent(value: Optional[float]) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        percent = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(percent):
+        return None
+    return max(0.0, min(100.0, percent))
 
 
 def _fmt_usd(d: float) -> str:

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -118,6 +118,40 @@ def test_render_account_usage_lines_includes_reset_and_provider():
     assert "Credits balance: $9.99" in lines[3]
 
 
+def test_render_account_usage_lines_treats_non_finite_percent_as_unavailable():
+    snapshot = AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage_api",
+        fetched_at=datetime.now(timezone.utc),
+        windows=(
+            AccountUsageWindow(label="Session", used_percent=float("nan")),
+            AccountUsageWindow(label="Weekly", used_percent=float("inf")),
+        ),
+    )
+
+    lines = render_account_usage_lines(snapshot)
+
+    assert "Session: unavailable" in lines[2]
+    assert "Weekly: unavailable" in lines[3]
+
+
+def test_render_account_usage_lines_clamps_out_of_range_percentages():
+    snapshot = AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage_api",
+        fetched_at=datetime.now(timezone.utc),
+        windows=(
+            AccountUsageWindow(label="Negative", used_percent=-5),
+            AccountUsageWindow(label="Over", used_percent=150),
+        ),
+    )
+
+    lines = render_account_usage_lines(snapshot)
+
+    assert "Negative: 100% remaining (0% used)" in lines[2]
+    assert "Over: 0% remaining (100% used)" in lines[3]
+
+
 def test_fetch_account_usage_openrouter_uses_limit_remaining_and_ignores_deprecated_rate_limit(monkeypatch):
     monkeypatch.setattr(
         "agent.account_usage.resolve_runtime_provider",


### PR DESCRIPTION
## Summary
- prevent account-usage rendering from raising on non-finite `used_percent` values
- render NaN/Infinity percentages as unavailable instead of crashing
- clamp finite out-of-range percentages to 0..100 so the UI does not show impossible values like 105% remaining or 150% used

## Testing
- `./venv/Scripts/python.exe -m pytest tests/test_account_usage.py -q`
- `./venv/Scripts/python.exe scripts/check-windows-footguns.py --all`