### PR TITLE
feat(tools): add read_code_structure tool

### DIFF
--- a/tests/tools/test_read_code_structure.py
+++ b/tests/tools/test_read_code_structure.py
@@ -1,0 +1,811 @@
+#!/usr/bin/env python3
+"""
+Tests for the read_code_structure tool.
+
+Covers:
+- Python AST extraction (functions, classes, methods, decorators, docstrings,
+  nested structures, async functions, syntax errors)
+- Regex-based extraction for JavaScript, TypeScript, Go, Java, C/C++, Ruby,
+  Rust, PHP, R
+- Handler-level tests (missing path, non-existent file, unsupported extension,
+  file-not-found suggestions, empty files)
+- Docstring/comment extraction for multiple languages
+
+Run with:  python -m pytest tests/tools/test_read_code_structure.py -v
+"""
+
+import json
+import os
+import shutil
+import tempfile
+import unittest
+
+from tools.read_code_structure_tool import (
+    ALL_CODE_EXTENSIONS,
+    READ_CODE_STRUCTURE_SCHEMA,
+    _extract_python_structure,
+    _extract_regex_structure,
+    _find_docstring_above_line,
+    _handle_read_code_structure,
+    check_code_structure_requirements,
+)
+from tools.registry import tool_error, tool_result
+
+
+# ---------------------------------------------------------------------------
+# Python AST extraction
+# ---------------------------------------------------------------------------
+
+class TestPythonASTExtraction(unittest.TestCase):
+    """Tests for _extract_python_structure using the ast module."""
+
+    def test_simple_function(self):
+        source = '''def hello():
+    """Say hello."""
+    print("hello")
+'''
+        entries = _extract_python_structure(source)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["name"], "hello")
+        self.assertEqual(entries[0]["type"], "function")
+        self.assertEqual(entries[0]["line"], 1)
+        self.assertEqual(entries[0]["end_line"], 3)
+        self.assertEqual(entries[0]["docstring"], "Say hello.")
+        self.assertIsNone(entries[0]["parent"])
+
+    def test_async_function(self):
+        source = '''async def fetch_data(url):
+    """Fetch data from URL."""
+    pass
+'''
+        entries = _extract_python_structure(source)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["name"], "fetch_data")
+        self.assertEqual(entries[0]["type"], "function")
+        self.assertEqual(entries[0]["docstring"], "Fetch data from URL.")
+
+    def test_class_with_methods(self):
+        source = '''class Calculator:
+    """A simple calculator."""
+
+    def add(self, a, b):
+        """Add two numbers."""
+        return a + b
+
+    def subtract(self, a, b):
+        """Subtract b from a."""
+        return a - b
+'''
+        entries = _extract_python_structure(source)
+        # 1 class + 2 methods = 3 entries
+        self.assertEqual(len(entries), 3)
+
+        # Class entry
+        cls = entries[0]
+        self.assertEqual(cls["name"], "Calculator")
+        self.assertEqual(cls["type"], "class")
+        self.assertEqual(cls["docstring"], "A simple calculator.")
+        self.assertIsNone(cls["parent"])
+
+        # Methods
+        add_method = entries[1]
+        self.assertEqual(add_method["name"], "add")
+        self.assertEqual(add_method["type"], "method")
+        self.assertEqual(add_method["parent"], "Calculator")
+        self.assertEqual(add_method["docstring"], "Add two numbers.")
+
+        sub_method = entries[2]
+        self.assertEqual(sub_method["name"], "subtract")
+        self.assertEqual(sub_method["type"], "method")
+        self.assertEqual(sub_method["parent"], "Calculator")
+
+    def test_decorators(self):
+        source = '''@staticmethod
+@cache
+def get_config():
+    """Get the config."""
+    pass
+'''
+        entries = _extract_python_structure(source)
+        self.assertEqual(len(entries), 1)
+        self.assertIn("staticmethod", entries[0]["decorators"])
+        self.assertIn("cache", entries[0]["decorators"])
+
+    def test_decorator_with_args(self):
+        source = '''@route("/api/v1/users")
+def list_users():
+    """List all users."""
+    pass
+'''
+        entries = _extract_python_structure(source)
+        self.assertEqual(len(entries), 1)
+        self.assertIn("route", entries[0]["decorators"])
+
+    def test_nested_class(self):
+        source = '''class Outer:
+    """Outer class."""
+    class Inner:
+        """Inner class."""
+        pass
+'''
+        entries = _extract_python_structure(source)
+        self.assertEqual(len(entries), 2)
+        outer = entries[0]
+        inner = entries[1]
+        self.assertEqual(outer["name"], "Outer")
+        self.assertEqual(inner["name"], "Inner")
+        self.assertEqual(inner["parent"], "Outer")
+
+    def test_function_without_docstring(self):
+        source = '''def no_doc():
+    pass
+'''
+        entries = _extract_python_structure(source)
+        self.assertEqual(len(entries), 1)
+        self.assertIsNone(entries[0]["docstring"])
+
+    def test_class_without_docstring(self):
+        source = '''class NoDoc:
+    pass
+'''
+        entries = _extract_python_structure(source)
+        self.assertEqual(len(entries), 1)
+        self.assertIsNone(entries[0]["docstring"])
+
+    def test_syntax_error_returns_empty(self):
+        source = '''def broken(
+    this is not valid python
+'''
+        entries = _extract_python_structure(source)
+        self.assertEqual(entries, [])
+
+    def test_empty_source(self):
+        entries = _extract_python_structure("")
+        self.assertEqual(entries, [])
+
+    def test_module_level_only(self):
+        source = '''import os
+
+CONSTANT = 42
+
+def foo():
+    pass
+
+x = 1
+'''
+        entries = _extract_python_structure(source)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["name"], "foo")
+
+    def test_nested_function_in_function(self):
+        source = '''def outer():
+    """Outer function."""
+    def inner():
+        """Inner function."""
+        pass
+'''
+        entries = _extract_python_structure(source)
+        self.assertEqual(len(entries), 2)
+        self.assertEqual(entries[0]["name"], "outer")
+        self.assertEqual(entries[0]["type"], "function")
+        self.assertEqual(entries[1]["name"], "inner")
+        self.assertEqual(entries[1]["type"], "function")
+        self.assertEqual(entries[1]["parent"], "outer")
+
+    def test_line_numbers_accurate(self):
+        source = '''# comment line 1
+# comment line 2
+
+def first():
+    pass
+
+class MyClass:
+    def method(self):
+        pass
+'''
+        entries = _extract_python_structure(source)
+        self.assertEqual(entries[0]["line"], 4)   # def first
+        self.assertEqual(entries[1]["line"], 7)   # class MyClass
+        self.assertEqual(entries[2]["line"], 8)   # def method
+
+    def test_multiple_classes_and_functions(self):
+        source = '''def standalone():
+    pass
+
+class A:
+    def a_method(self):
+        pass
+
+class B:
+    def b_method(self):
+        pass
+
+def another_standalone():
+    pass
+'''
+        entries = _extract_python_structure(source)
+        self.assertEqual(len(entries), 6)
+        names = [e["name"] for e in entries]
+        self.assertEqual(names, ["standalone", "A", "a_method", "B", "b_method", "another_standalone"])
+
+
+# ---------------------------------------------------------------------------
+# Regex-based extraction — JavaScript
+# ---------------------------------------------------------------------------
+
+class TestJavaScriptExtraction(unittest.TestCase):
+    def test_function_declaration(self):
+        source = '''function hello() {
+  return "hello";
+}
+'''
+        entries = _extract_regex_structure(source, ".js")
+        func_names = [e["name"] for e in entries if e["type"] == "function"]
+        self.assertIn("hello", func_names)
+
+    def test_async_function(self):
+        source = '''async function fetchData() {
+  return await fetch(url);
+}
+'''
+        entries = _extract_regex_structure(source, ".js")
+        func_names = [e["name"] for e in entries if e["type"] == "function"]
+        self.assertIn("fetchData", func_names)
+
+    def test_export_function(self):
+        source = '''export function helper() {}
+'''
+        entries = _extract_regex_structure(source, ".js")
+        func_names = [e["name"] for e in entries if e["type"] == "function"]
+        self.assertIn("helper", func_names)
+
+    def test_arrow_function(self):
+        source = '''const add = (a, b) => a + b;
+'''
+        entries = _extract_regex_structure(source, ".js")
+        func_names = [e["name"] for e in entries if e["type"] == "function"]
+        self.assertIn("add", func_names)
+
+    def test_class_declaration(self):
+        source = '''class DataProcessor {
+  process(input) {
+    return input.trim();
+  }
+}
+'''
+        entries = _extract_regex_structure(source, ".js")
+        class_names = [e["name"] for e in entries if e["type"] == "class"]
+        self.assertIn("DataProcessor", class_names)
+
+    def test_export_class(self):
+        source = '''export default class App extends React.Component {}
+'''
+        entries = _extract_regex_structure(source, ".js")
+        class_names = [e["name"] for e in entries if e["type"] == "class"]
+        self.assertIn("App", class_names)
+
+
+# ---------------------------------------------------------------------------
+# Regex-based extraction — TypeScript
+# ---------------------------------------------------------------------------
+
+class TestTypeScriptExtraction(unittest.TestCase):
+    def test_typed_function(self):
+        source = '''function greet(name: string): string {
+  return `Hello, ${name}`;
+}
+'''
+        entries = _extract_regex_structure(source, ".ts")
+        func_names = [e["name"] for e in entries if e["type"] == "function"]
+        self.assertIn("greet", func_names)
+
+    def test_generic_function(self):
+        source = '''function identity<T>(arg: T): T {
+  return arg;
+}
+'''
+        entries = _extract_regex_structure(source, ".ts")
+        func_names = [e["name"] for e in entries if e["type"] == "function"]
+        self.assertIn("identity", func_names)
+
+    def test_abstract_class(self):
+        source = '''export abstract class BaseService {
+  abstract execute(): void;
+}
+'''
+        entries = _extract_regex_structure(source, ".ts")
+        class_names = [e["name"] for e in entries if e["type"] == "class"]
+        self.assertIn("BaseService", class_names)
+
+
+# ---------------------------------------------------------------------------
+# Regex-based extraction — Go
+# ---------------------------------------------------------------------------
+
+class TestGoExtraction(unittest.TestCase):
+    def test_package_function(self):
+        source = '''package main
+
+func hello() string {
+    return "hello"
+}
+'''
+        entries = _extract_regex_structure(source, ".go")
+        func_names = [e["name"] for e in entries if e["type"] == "function"]
+        self.assertIn("hello", func_names)
+
+    def test_method_with_receiver(self):
+        source = '''func (c *Calculator) Add(a, b int) int {
+    return a + b
+}
+'''
+        entries = _extract_regex_structure(source, ".go")
+        func_names = [e["name"] for e in entries if e["type"] == "function"]
+        self.assertIn("Add", func_names)
+
+    def test_struct(self):
+        source = '''type Server struct {
+    Host string
+    Port int
+}
+'''
+        entries = _extract_regex_structure(source, ".go")
+        class_names = [e["name"] for e in entries if e["type"] == "class"]
+        self.assertIn("Server", class_names)
+
+
+# ---------------------------------------------------------------------------
+# Regex-based extraction — Java
+# ---------------------------------------------------------------------------
+
+class TestJavaExtraction(unittest.TestCase):
+    def test_class_declaration(self):
+        source = '''public class HelloWorld {
+    public static void main(String[] args) {
+        System.out.println("Hello");
+    }
+}
+'''
+        entries = _extract_regex_structure(source, ".java")
+        class_names = [e["name"] for e in entries if e["type"] == "class"]
+        self.assertIn("HelloWorld", class_names)
+
+    def test_interface(self):
+        source = '''public interface Runnable {
+    void run();
+}
+'''
+        entries = _extract_regex_structure(source, ".java")
+        class_names = [e["name"] for e in entries if e["type"] == "class"]
+        self.assertIn("Runnable", class_names)
+
+
+# ---------------------------------------------------------------------------
+# Regex-based extraction — Ruby
+# ---------------------------------------------------------------------------
+
+class TestRubyExtraction(unittest.TestCase):
+    def test_method_definition(self):
+        source = '''def greet(name)
+  puts "Hello, #{name}!"
+end
+'''
+        entries = _extract_regex_structure(source, ".rb")
+        func_names = [e["name"] for e in entries if e["type"] == "function"]
+        self.assertIn("greet", func_names)
+
+    def test_self_method(self):
+        source = '''def self.create(params)
+  new(params)
+end
+'''
+        entries = _extract_regex_structure(source, ".rb")
+        func_names = [e["name"] for e in entries if e["type"] == "function"]
+        self.assertIn("create", func_names)
+
+    def test_class(self):
+        source = '''class User
+  def initialize(name)
+    @name = name
+  end
+end
+'''
+        entries = _extract_regex_structure(source, ".rb")
+        class_names = [e["name"] for e in entries if e["type"] == "class"]
+        self.assertIn("User", class_names)
+
+    def test_module(self):
+        source = '''module Authenticatable
+  def authenticate
+    true
+  end
+end
+'''
+        entries = _extract_regex_structure(source, ".rb")
+        class_names = [e["name"] for e in entries if e["type"] == "class"]
+        self.assertIn("Authenticatable", class_names)
+
+    def test_predicate_method(self):
+        source = '''def active?
+  status == "active"
+end
+'''
+        entries = _extract_regex_structure(source, ".rb")
+        func_names = [e["name"] for e in entries if e["type"] == "function"]
+        self.assertIn("active?", func_names)
+
+    def test_bang_method(self):
+        source = '''def save!
+  raise "Invalid" unless valid?
+end
+'''
+        entries = _extract_regex_structure(source, ".rb")
+        func_names = [e["name"] for e in entries if e["type"] == "function"]
+        self.assertIn("save!", func_names)
+
+
+# ---------------------------------------------------------------------------
+# Regex-based extraction — Rust
+# ---------------------------------------------------------------------------
+
+class TestRustExtraction(unittest.TestCase):
+    def test_fn_declaration(self):
+        source = '''fn main() {
+    println!("Hello");
+}
+'''
+        entries = _extract_regex_structure(source, ".rs")
+        func_names = [e["name"] for e in entries if e["type"] == "function"]
+        self.assertIn("main", func_names)
+
+    def test_pub_fn(self):
+        source = '''pub fn new(config: Config) -> Self {
+    Self { config }
+}
+'''
+        entries = _extract_regex_structure(source, ".rs")
+        func_names = [e["name"] for e in entries if e["type"] == "function"]
+        self.assertIn("new", func_names)
+
+    def test_async_fn(self):
+        source = '''pub async fn fetch(url: &str) -> Result<String> {
+    Ok(reqwest::get(url).await?.text().await?)
+}
+'''
+        entries = _extract_regex_structure(source, ".rs")
+        func_names = [e["name"] for e in entries if e["type"] == "function"]
+        self.assertIn("fetch", func_names)
+
+    def test_struct(self):
+        source = '''pub struct Server {
+    host: String,
+    port: u16,
+}
+'''
+        entries = _extract_regex_structure(source, ".rs")
+        class_names = [e["name"] for e in entries if e["type"] == "class"]
+        self.assertIn("Server", class_names)
+
+    def test_trait(self):
+        source = '''pub trait Handler {
+    fn handle(&self, req: Request) -> Response;
+}
+'''
+        entries = _extract_regex_structure(source, ".rs")
+        class_names = [e["name"] for e in entries if e["type"] == "class"]
+        self.assertIn("Handler", class_names)
+
+    def test_enum(self):
+        source = '''pub enum Color {
+    Red,
+    Green,
+    Blue,
+}
+'''
+        entries = _extract_regex_structure(source, ".rs")
+        class_names = [e["name"] for e in entries if e["type"] == "class"]
+        self.assertIn("Color", class_names)
+
+
+# ---------------------------------------------------------------------------
+# Regex-based extraction — PHP
+# ---------------------------------------------------------------------------
+
+class TestPHPExtraction(unittest.TestCase):
+    def test_function(self):
+        source = '''<?php
+function greet($name) {
+    return "Hello, " . $name;
+}
+'''
+        entries = _extract_regex_structure(source, ".php")
+        func_names = [e["name"] for e in entries if e["type"] == "function"]
+        self.assertIn("greet", func_names)
+
+    def test_class(self):
+        source = '''<?php
+class User {
+    public function getName() {
+        return $this->name;
+    }
+}
+'''
+        entries = _extract_regex_structure(source, ".php")
+        class_names = [e["name"] for e in entries if e["type"] == "class"]
+        self.assertIn("User", class_names)
+
+
+# ---------------------------------------------------------------------------
+# Regex-based extraction — R
+# ---------------------------------------------------------------------------
+
+class TestRExtraction(unittest.TestCase):
+    def test_function_assignment(self):
+        source = '''add <- function(a, b) {
+  a + b
+}
+'''
+        entries = _extract_regex_structure(source, ".R")
+        func_names = [e["name"] for e in entries if e["type"] == "function"]
+        self.assertIn("add", func_names)
+
+
+# ---------------------------------------------------------------------------
+# Docstring / comment extraction
+# ---------------------------------------------------------------------------
+
+class TestDocstringExtraction(unittest.TestCase):
+    def test_python_docstring_via_ast(self):
+        source = '''def foo():
+    """This is a docstring."""
+    pass
+'''
+        entries = _extract_python_structure(source)
+        self.assertEqual(entries[0]["docstring"], "This is a docstring.")
+
+    def test_js_doc_comment_above_function(self):
+        source = '''/**
+ * Calculate the sum.
+ * @param a first number
+ */
+function sum(a, b) {
+  return a + b;
+}
+'''
+        doc = _find_docstring_above_line(source, 5, ".js")
+        self.assertIsNotNone(doc)
+        self.assertIn("Calculate the sum", doc)
+
+    def test_go_comment_above_func(self):
+        source = '''// Add returns the sum of a and b.
+func Add(a, b int) int {
+    return a + b
+}
+'''
+        doc = _find_docstring_above_line(source, 2, ".go")
+        self.assertIsNotNone(doc)
+        self.assertIn("Add returns the sum", doc)
+
+    def test_rust_doc_comment(self):
+        source = '''/// Fetches data from the given URL.
+/// Returns a Result on success.
+pub async fn fetch(url: &str) -> Result<String> {
+    todo!()
+}
+'''
+        doc = _find_docstring_above_line(source, 3, ".rs")
+        self.assertIsNotNone(doc)
+        self.assertIn("Fetches data", doc)
+
+    def test_no_comment_returns_none(self):
+        source = '''function noComment() {}
+'''
+        doc = _find_docstring_above_line(source, 1, ".js")
+        self.assertIsNone(doc)
+
+    def test_python_returns_none(self):
+        # Python docstrings are handled by AST, not regex
+        doc = _find_docstring_above_line("def foo():\n    pass\n", 1, ".py")
+        self.assertIsNone(doc)
+
+
+# ---------------------------------------------------------------------------
+# Handler-level tests
+# ---------------------------------------------------------------------------
+
+class TestHandler(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="rcs_test_")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _write(self, name, content):
+        path = os.path.join(self.tmp, name)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(content)
+        return path
+
+    def test_missing_path_returns_error(self):
+        result = _handle_read_code_structure({})
+        self.assertIn("error", result)
+
+    def test_empty_path_returns_error(self):
+        result = _handle_read_code_structure({"path": ""})
+        self.assertIn("error", result)
+
+    def test_nonexistent_file_returns_error(self):
+        result = _handle_read_code_structure({"path": "/nonexistent/file.py"})
+        self.assertIn("error", result)
+
+    def test_unsupported_extension_returns_error(self):
+        path = self._write("data.txt", "hello world")
+        result = _handle_read_code_structure({"path": path})
+        self.assertIn("error", result)
+        self.assertIn("Unsupported", result)
+
+    def test_python_file_returns_structure(self):
+        path = self._write("example.py", '''"""Module docstring."""
+
+def hello():
+    """Say hello."""
+    print("hello")
+
+class Greeter:
+    """A greeting class."""
+
+    def greet(self, name):
+        """Greet someone."""
+        return f"Hello, {name}"
+''')
+        result = _handle_read_code_structure({"path": path})
+        # Result should be parseable JSON
+        data = json.loads(result)
+        self.assertIn("entries", data)
+        self.assertEqual(data["language"], "py")
+        # 1 function + 1 class + 1 method = 3 entries
+        self.assertEqual(len(data["entries"]), 3)
+
+    def test_go_file_returns_structure(self):
+        path = self._write("main.go", '''package main
+
+import "fmt"
+
+// Calculator performs math
+type Calculator struct {
+    name string
+}
+
+// Add adds two numbers
+func (c *Calculator) Add(a, b int) int {
+    return a + b
+}
+
+func main() {
+    fmt.Println("hello")
+}
+''')
+        result = _handle_read_code_structure({"path": path})
+        data = json.loads(result)
+        self.assertEqual(data["language"], "go")
+        self.assertTrue(len(data["entries"]) >= 2)  # At least Add and Calculator
+
+    def test_js_file_returns_structure(self):
+        path = self._write("app.js", '''class App {
+  constructor() {
+    this.name = "app";
+  }
+}
+
+async function run() {
+  return Promise.resolve(42);
+}
+''')
+        result = _handle_read_code_structure({"path": path})
+        data = json.loads(result)
+        self.assertEqual(data["language"], "js")
+        self.assertTrue(len(data["entries"]) >= 1)
+
+    def test_file_with_no_structure(self):
+        path = self._write("empty.py", "# Just a comment\nx = 1\n")
+        result = _handle_read_code_structure({"path": path})
+        data = json.loads(result)
+        self.assertEqual(data["entries"], [])
+
+    def test_tilde_expansion(self):
+        # Write a file using ~/tmp path — only works if ~/tmp exists
+        home_tmp = os.path.expanduser("~/tmp_rcs_test")
+        try:
+            os.makedirs(home_tmp, exist_ok=True)
+            fpath = os.path.join(home_tmp, "test_tilde.py")
+            with open(fpath, "w") as f:
+                f.write("def foo(): pass\n")
+            result = _handle_read_code_structure({"path": "~/tmp_rcs_test/test_tilde.py"})
+            data = json.loads(result)
+            self.assertIn("entries", data)
+        finally:
+            shutil.rmtree(home_tmp, ignore_errors=True)
+
+    def test_file_not_found_suggests_similar(self):
+        # Create a file, then ask for a similar name
+        self._write("calculator.py", "def add(): pass\n")
+        path = os.path.join(self.tmp, "calculatr.py")
+        result = _handle_read_code_structure({"path": path})
+        # Should suggest "calculator.py"
+        self.assertIn("Did you mean", result)
+
+    def test_rust_file_returns_structure(self):
+        path = self._write("lib.rs", '''pub struct Config {
+    pub host: String,
+}
+
+pub fn load() -> Config {
+    Config { host: "localhost".into() }
+}
+''')
+        result = _handle_read_code_structure({"path": path})
+        data = json.loads(result)
+        self.assertEqual(data["language"], "rs")
+        self.assertTrue(len(data["entries"]) >= 2)
+
+
+# ---------------------------------------------------------------------------
+# Schema and registry
+# ---------------------------------------------------------------------------
+
+class TestSchemaAndRegistry(unittest.TestCase):
+    def test_schema_has_required_fields(self):
+        self.assertEqual(READ_CODE_STRUCTURE_SCHEMA["name"], "read_code_structure")
+        self.assertIn("parameters", READ_CODE_STRUCTURE_SCHEMA)
+        self.assertIn("path", READ_CODE_STRUCTURE_SCHEMA["parameters"]["properties"])
+        self.assertIn("path", READ_CODE_STRUCTURE_SCHEMA["parameters"]["required"])
+
+    def test_schema_description_mentions_languages(self):
+        desc = READ_CODE_STRUCTURE_SCHEMA["description"]
+        self.assertIn("Python", desc)
+        self.assertIn("JavaScript", desc)
+        self.assertIn("Go", desc)
+        self.assertIn("Rust", desc)
+
+    def test_all_extensions_are_covered(self):
+        expected = {".py", ".js", ".jsx", ".ts", ".tsx", ".go", ".java",
+                    ".c", ".cpp", ".h", ".hpp", ".rb", ".rs", ".php", ".r", ".R"}
+        self.assertEqual(ALL_CODE_EXTENSIONS, expected)
+
+    def test_check_requirements_always_true(self):
+        self.assertTrue(check_code_structure_requirements())
+
+
+# ---------------------------------------------------------------------------
+# Regex entry line-number accuracy
+# ---------------------------------------------------------------------------
+
+class TestRegexLineNumbers(unittest.TestCase):
+    def test_go_line_numbers(self):
+        source = '''package main
+
+func first() {}
+func second() {}
+func third() {}
+'''
+        entries = _extract_regex_structure(source, ".go")
+        func_entries = [e for e in entries if e["type"] == "function"]
+        # Sorted by line number
+        lines = [e["line"] for e in func_entries]
+        self.assertEqual(lines, sorted(lines))
+        self.assertTrue(all(l > 0 for l in lines))
+
+    def test_js_class_before_function(self):
+        source = '''class App {}
+
+function init() {}
+'''
+        entries = _extract_regex_structure(source, ".js")
+        # Class should come before function in line order
+        class_entry = next(e for e in entries if e["type"] == "class")
+        func_entry = next(e for e in entries if e["type"] == "function")
+        self.assertLess(class_entry["line"], func_entry["line"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/read_code_structure_tool.py
+++ b/tools/read_code_structure_tool.py
@@ -1,0 +1,601 @@
+#!/usr/bin/env python3
+"""
+Code Structure Reading Tool
+============================
+
+Single ``read_code_structure`` tool that parses source code files and returns
+a structured summary of function and class definitions — including their
+names, start line numbers, and docstrings — without reading the full file
+contents.
+
+Supported languages:
+- Python (.py) — full AST parsing
+- JavaScript / TypeScript (.js, .ts, .jsx, .tsx) — regex-based extraction
+- Go (.go) — regex-based extraction
+- Java (.java) — regex-based extraction
+- C / C++ (.c, .cpp, .h, .hpp) — regex-based extraction
+- Ruby (.rb) — regex-based extraction
+- Rust (.rs) — regex-based extraction
+- PHP (.php) — regex-based extraction
+- R (.r, .R) — regex-based extraction
+
+For Python, the tool uses the ``ast`` module to reliably extract:
+- Functions (including async) with their decorators
+- Classes with their decorators and base classes
+- Nested functions/classes within classes (methods)
+
+For other languages, a robust regex-based extraction is used that captures:
+- Function / method / procedure declarations
+- Class / struct / interface / trait declarations
+
+Output format
+-------------
+Each entry in the result is a dict with:
+
+- ``name``: the function/method/class name
+- ``type``: ``"function"`` or ``"class"`` (or ``"method"`` for Python class members)
+- ``line``: the 1-indexed start line number
+- ``end_line``: the 1-indexed end line number (Python only, ``null`` for regex)
+- ``docstring``: the docstring text, or ``null`` if absent
+- ``decorators``: list of decorator names (Python only)
+- ``parent``: the parent class name for methods (Python only)
+
+The tool belongs to the ``file`` toolset alongside ``read_file``,
+``write_file``, ``patch``, and ``search_files``.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from tools.registry import registry, tool_error, tool_result
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Supported extensions and their parsing strategies
+# ---------------------------------------------------------------------------
+
+_PYTHON_EXTENSIONS = {".py"}
+_REGEX_EXTENSIONS = {
+    ".js", ".jsx", ".ts", ".tsx",  # JS/TS family
+    ".go",                          # Go
+    ".java",                        # Java
+    ".c", ".cpp", ".h", ".hpp",    # C/C++
+    ".rb",                          # Ruby
+    ".rs",                          # Rust
+    ".php",                         # PHP
+    ".r", ".R",                     # R
+}
+ALL_CODE_EXTENSIONS = _PYTHON_EXTENSIONS | _REGEX_EXTENSIONS
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+READ_CODE_STRUCTURE_SCHEMA: Dict[str, Any] = {
+    "name": "read_code_structure",
+    "description": (
+        "Parse a source code file and return its function/class structure "
+        "(names, line numbers, docstrings) without reading the full file contents. "
+        "Supports Python (full AST), JavaScript/TypeScript, Go, Java, C/C++, "
+        "Ruby, Rust, PHP, and R (regex-based). "
+        "Use this when you need an overview of a code file's structure — "
+        "function names, class names, their line numbers, and docstrings — "
+        "rather than the full source. Faster and more token-efficient than "
+        "read_file for large files."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": (
+                    "Path to the source code file (absolute, relative, or "
+                    "~/path). Must be a code file with a supported extension "
+                    f"({', '.join(sorted(ALL_CODE_EXTENSIONS))})."
+                ),
+            },
+        },
+        "required": ["path"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Python AST extraction
+# ---------------------------------------------------------------------------
+
+def _extract_python_structure(source: str, filename: str = "<module>") -> List[Dict[str, Any]]:
+    """Use ``ast.parse`` to extract functions, classes, and methods."""
+
+    try:
+        tree = ast.parse(source, filename=filename)
+    except SyntaxError as exc:
+        logger.warning("Python AST parse error in %s: %s", filename, exc)
+        return []
+
+    results: List[Dict[str, Any]] = []
+
+    def _docstring(node: ast.AST) -> Optional[str]:
+        ds = ast.get_docstring(node)
+        return ds.strip() if ds else None
+
+    def _decorators(node: ast.AST) -> List[str]:
+        if not hasattr(node, "decorator_list"):
+            return []
+        decs: List[str] = []
+        for dec in node.decorator_list:
+            if isinstance(dec, ast.Name):
+                decs.append(dec.id)
+            elif isinstance(dec, ast.Attribute):
+                decs.append(ast.dump(dec))
+            elif isinstance(dec, ast.Call):
+                if isinstance(dec.func, ast.Name):
+                    decs.append(dec.func.id)
+                elif isinstance(dec.func, ast.Attribute):
+                    decs.append(ast.dump(dec.func))
+            else:
+                decs.append(ast.dump(dec))
+        return decs
+
+    def _visit_class(class_node: ast.ClassDef, parent: Optional[str] = None) -> None:
+        entry = {
+            "name": class_node.name,
+            "type": "class",
+            "line": class_node.lineno,
+            "end_line": class_node.end_lineno,
+            "docstring": _docstring(class_node),
+            "decorators": _decorators(class_node),
+            "parent": parent,
+        }
+        results.append(entry)
+        # Visit nested classes and methods
+        for node in class_node.body:
+            if isinstance(node, ast.FunctionDef) or isinstance(node, ast.AsyncFunctionDef):
+                _visit_function(node, parent=class_node.name, parent_is_class=True)
+            elif isinstance(node, ast.ClassDef):
+                _visit_class(node, parent=class_node.name)
+
+    def _visit_function(func_node, parent: Optional[str] = None, parent_is_class: bool = False) -> None:
+        is_method = parent_is_class
+        entry = {
+            "name": func_node.name,
+            "type": "method" if is_method else "function",
+            "line": func_node.lineno,
+            "end_line": func_node.end_lineno,
+            "docstring": _docstring(func_node),
+            "decorators": _decorators(func_node),
+            "parent": parent,
+        }
+        results.append(entry)
+        # Visit nested classes and functions within function body
+        for node in func_node.body:
+            if isinstance(node, ast.ClassDef):
+                _visit_class(node, parent=f"{parent}.{func_node.name}" if parent else func_node.name)
+            elif isinstance(node, ast.FunctionDef) or isinstance(node, ast.AsyncFunctionDef):
+                _visit_function(node, parent=f"{parent}.{func_node.name}" if parent else func_node.name, parent_is_class=False)
+
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef):
+            _visit_class(node)
+        elif isinstance(node, ast.FunctionDef) or isinstance(node, ast.AsyncFunctionDef):
+            _visit_function(node)
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Regex-based extraction for non-Python languages
+# ---------------------------------------------------------------------------
+
+# Language-specific regex patterns for function declarations
+_FUNCTION_PATTERNS = {
+    # JavaScript / TypeScript — function declarations and arrow functions
+    ".js": [
+        re.compile(
+            r"^\s*(?:export\s+)?(?:async\s+)?function\s+(\w+)\s*\(",
+            re.MULTILINE,
+        ),
+        re.compile(
+            r"^\s*(?:export\s+)?(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s+)?(?:\([^)]*\)\s*=>|\([^)]*\)\s*:\s*\w+\s*=>)",
+            re.MULTILINE,
+        ),
+    ],
+    ".jsx": [  # same as .js
+        re.compile(
+            r"^\s*(?:export\s+)?(?:async\s+)?function\s+(\w+)\s*\(",
+            re.MULTILINE,
+        ),
+        re.compile(
+            r"^\s*(?:export\s+)?(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s+)?(?:\([^)]*\)\s*=>|\([^)]*\)\s*:\s*\w+\s*=>)",
+            re.MULTILINE,
+        ),
+    ],
+    ".ts": [
+        re.compile(
+            r"^\s*(?:export\s+)?(?:async\s+)?function\s+(\w+)\s*[<(]",
+            re.MULTILINE,
+        ),
+        re.compile(
+            r"^\s*(?:export\s+)?(?:const|let)\s+(\w+)\s*=\s*(?:async\s+)?(?:\([^)]*\)\s*=>|\([^)]*\)\s*:\s*\w+\s*=>)",
+            re.MULTILINE,
+        ),
+    ],
+    ".tsx": [  # same as .ts
+        re.compile(
+            r"^\s*(?:export\s+)?(?:async\s+)?function\s+(\w+)\s*[<(]",
+            re.MULTILINE,
+        ),
+        re.compile(
+            r"^\s*(?:export\s+)?(?:const|let)\s+(\w+)\s*=\s*(?:async\s+)?(?:\([^)]*\)\s*=>|\([^)]*\)\s*:\s*\w+\s*=>)",
+            re.MULTILINE,
+        ),
+    ],
+    # Go — func declarations
+    ".go": [
+        re.compile(
+            r"^\s*func\s+(?:\([^)]+\)\s+)?(\w+)\s*\(",
+            re.MULTILINE,
+        ),
+    ],
+    # Java — method and class declarations
+    ".java": [
+        re.compile(
+            r"^\s*(?:public|private|protected|static|\s)*\s+(?:class|interface|enum)\s+(\w+)",
+            re.MULTILINE,
+        ),
+        re.compile(
+            r"^\s*(?:public|private|protected|static|synchronized|final|abstract|\s)+\s+(\w+)\s*\(",
+            re.MULTILINE,
+        ),
+    ],
+    # C / C++ — function declarations
+    ".c": [
+        re.compile(
+            r"^\s*(?:[\w:*<>\s]+?)\s+(\w+)\s*\([^)]*\)\s*(?:\{|;)",
+            re.MULTILINE,
+        ),
+    ],
+    ".cpp": [
+        re.compile(
+            r"^\s*(?:[\w:*<>\s]+?)\s+(\w+)\s*\([^)]*\)\s*(?:\{|;|const)",
+            re.MULTILINE,
+        ),
+    ],
+    ".h": [  # same as .c
+        re.compile(
+            r"^\s*(?:[\w:*<>\s]+?)\s+(\w+)\s*\([^)]*\)\s*(?:\{|;)",
+            re.MULTILINE,
+        ),
+    ],
+    ".hpp": [  # same as .cpp
+        re.compile(
+            r"^\s*(?:[\w:*<>\s]+?)\s+(\w+)\s*\([^)]*\)\s*(?:\{|;|const)",
+            re.MULTILINE,
+        ),
+    ],
+    # Ruby — method definitions
+    ".rb": [
+        re.compile(
+            r"^\s*def\s+(?:self\.)?(\w+[?!]?)",
+            re.MULTILINE,
+        ),
+        re.compile(
+            r"^\s*class\s+(\w+)",
+            re.MULTILINE,
+        ),
+        re.compile(
+            r"^\s*module\s+(\w+)",
+            re.MULTILINE,
+        ),
+    ],
+    # Rust — fn declarations
+    ".rs": [
+        re.compile(
+            r"^\s*(?:pub\s+)?(?:async\s+)?fn\s+(\w+)",
+            re.MULTILINE,
+        ),
+        re.compile(
+            r"^\s*(?:pub\s+)?struct\s+(\w+)",
+            re.MULTILINE,
+        ),
+        re.compile(
+            r"^\s*(?:pub\s+)?(?:trait|enum|impl)\s+(\w+)",
+            re.MULTILINE,
+        ),
+    ],
+    # PHP — function and class declarations
+    ".php": [
+        re.compile(
+            r"^\s*function\s+(\w+)\s*\(",
+            re.MULTILINE,
+        ),
+        re.compile(
+            r"^\s*(?:abstract\s+|final\s+)?class\s+(\w+)",
+            re.MULTILINE,
+        ),
+    ],
+    # R — function definitions
+    ".r": [
+        re.compile(
+            r"^\s*(\w+)\s*<-\s*function\s*\(",
+            re.MULTILINE,
+        ),
+    ],
+    ".R": [  # same as .r
+        re.compile(
+            r"^\s*(\w+)\s*<-\s*function\s*\(",
+            re.MULTILINE,
+        ),
+    ],
+}
+
+# Class/struct patterns for non-Python languages
+_CLASS_PATTERNS = {
+    ".js": [
+        re.compile(r"^\s*(?:export\s+)?(?:default\s+)?class\s+(\w+)", re.MULTILINE),
+    ],
+    ".jsx": [
+        re.compile(r"^\s*(?:export\s+)?(?:default\s+)?class\s+(\w+)", re.MULTILINE),
+    ],
+    ".ts": [
+        re.compile(r"^\s*(?:export\s+)?(?:default\s+)?(?:abstract\s+)?class\s+(\w+)", re.MULTILINE),
+    ],
+    ".tsx": [
+        re.compile(r"^\s*(?:export\s+)?(?:default\s+)?(?:abstract\s+)?class\s+(\w+)", re.MULTILINE),
+    ],
+    ".go": [
+        re.compile(r"^\s*type\s+(\w+)\s+struct\s*\{", re.MULTILINE),
+    ],
+    ".java": [
+        re.compile(r"^\s*(?:public|private|protected|static|\s)*\s+(?:class|interface|enum)\s+(\w+)", re.MULTILINE),
+    ],
+    ".c": [
+        re.compile(r"^\s*(?:typedef\s+)?struct\s+(\w+)", re.MULTILINE),
+    ],
+    ".cpp": [
+        re.compile(r"^\s*(?:typedef\s+)?struct\s+(\w+)", re.MULTILINE),
+        re.compile(r"^\s*class\s+(\w+)", re.MULTILINE),
+    ],
+    ".h": [
+        re.compile(r"^\s*(?:typedef\s+)?struct\s+(\w+)", re.MULTILINE),
+        re.compile(r"^\s*class\s+(\w+)", re.MULTILINE),
+    ],
+    ".hpp": [
+        re.compile(r"^\s*(?:typedef\s+)?struct\s+(\w+)", re.MULTILINE),
+        re.compile(r"^\s*class\s+(\w+)", re.MULTILINE),
+    ],
+    ".rb": [
+        re.compile(r"^\s*class\s+(\w+)", re.MULTILINE),
+        re.compile(r"^\s*module\s+(\w+)", re.MULTILINE),
+    ],
+    ".rs": [
+        re.compile(r"^\s*(?:pub\s+)?struct\s+(\w+)", re.MULTILINE),
+        re.compile(r"^\s*(?:pub\s+)?trait\s+(\w+)", re.MULTILINE),
+        re.compile(r"^\s*(?:pub\s+)?enum\s+(\w+)", re.MULTILINE),
+    ],
+    ".php": [
+        re.compile(r"^\s*(?:abstract\s+|final\s+)?class\s+(\w+)", re.MULTILINE),
+        re.compile(r"^\s*interface\s+(\w+)", re.MULTILINE),
+        re.compile(r"^\s*trait\s+(\w+)", re.MULTILINE),
+    ],
+    ".r": [],
+    ".R": [],
+}
+
+
+def _find_docstring_above_line(source: str, line_number: int, ext: str) -> Optional[str]:
+    """Attempt to find a docstring or comment block immediately above a line.
+
+    For multi-line block comments (e.g. JSDoc ``/** ... */``), the function
+    scans backwards from the line just above ``line_number``, detects the
+    ``*/`` closer, then continues scanning back to the ``/**`` opener, and
+    returns the whole block as a single docstring.
+
+    For single-line comment styles (``//``, ``#``, ``///``), contiguous
+    comment lines above the target are collected.
+    """
+    lines = source.splitlines()
+    if line_number < 2 or len(lines) < line_number - 1:
+        return None
+
+    # Check if the line just above the target ends a block comment (*/)
+    line_above = lines[line_number - 2].rstrip()
+
+    # --- Multi-line block comment (JSDoc / JavaDoc / Doxygen) ---
+    if line_above.endswith("*/"):
+        # Collect lines from */ back to /**
+        block_lines: List[str] = []
+        i = line_number - 2  # 0-indexed, the */ line
+        found_opener = False
+        while i >= 0:
+            l = lines[i]
+            block_lines.insert(0, l)
+            if "/**" in l or "/*" in l:
+                found_opener = True
+                break
+            i -= 1
+        if found_opener and block_lines:
+            # Strip comment markers and join
+            cleaned = []
+            for bl in block_lines:
+                bl_clean = re.sub(
+                    r"^\s*(?:/\*\*?|\*\s?|\*/)\s*", "", bl
+                ).strip()
+                # Also handle standalone * lines inside the block
+                bl_clean = re.sub(r"^\*\s?", "", bl_clean).strip()
+                if bl_clean:
+                    cleaned.append(bl_clean)
+            return " ".join(cleaned) if cleaned else None
+
+    # --- Single-line comment style ---
+    # Determine the single-line comment prefix pattern for this extension
+    _SINGLE_LINE_PREFIX: Dict[str, re.Pattern] = {
+        ".js": re.compile(r"^\s*//"),
+        ".jsx": re.compile(r"^\s*//"),
+        ".ts": re.compile(r"^\s*//"),
+        ".tsx": re.compile(r"^\s*//"),
+        ".go": re.compile(r"^\s*//"),
+        ".java": re.compile(r"^\s*//"),
+        ".c": re.compile(r"^\s*//"),
+        ".cpp": re.compile(r"^\s*//"),
+        ".h": re.compile(r"^\s*//"),
+        ".hpp": re.compile(r"^\s*//"),
+        ".rb": re.compile(r"^\s*#"),
+        ".rs": re.compile(r"^\s*///|^\s*//!"),
+        ".php": re.compile(r"^\s*//|^\s*#"),
+        ".r": re.compile(r"^\s*#"),
+        ".R": re.compile(r"^\s*#"),
+    }
+    single_pat = _SINGLE_LINE_PREFIX.get(ext)
+    if single_pat is None:
+        return None
+
+    doc_lines: List[str] = []
+    i = line_number - 2  # 0-indexed, one line above the target
+    while i >= 0:
+        line = lines[i] if i < len(lines) else ""
+        if single_pat.match(line):
+            doc_lines.insert(0, line)
+            i -= 1
+        else:
+            break
+    if not doc_lines:
+        return None
+    # Strip comment markers and join
+    cleaned = []
+    for dl in doc_lines:
+        dl_clean = re.sub(r"^\s*(?://|///|//!|#!|#)\s*", "", dl).strip()
+        if dl_clean:
+            cleaned.append(dl_clean)
+    return " ".join(cleaned) if cleaned else None
+
+
+def _extract_regex_structure(source: str, ext: str) -> List[Dict[str, Any]]:
+    """Regex-based extraction for non-Python languages."""
+    results: List[Dict[str, Any]] = []
+
+    # Extract functions
+    func_patterns = _FUNCTION_PATTERNS.get(ext, [])
+    for pat in func_patterns:
+        for match in pat.finditer(source):
+            name = match.group(1)
+            line = source[:match.start()].count("\n") + 1
+            docstring = _find_docstring_above_line(source, line, ext)
+            results.append({
+                "name": name,
+                "type": "function",
+                "line": line,
+                "end_line": None,
+                "docstring": docstring,
+                "decorators": [],
+                "parent": None,
+            })
+
+    # Extract classes / structs / interfaces / traits
+    class_patterns = _CLASS_PATTERNS.get(ext, [])
+    for pat in class_patterns:
+        for match in pat.finditer(source):
+            name = match.group(1)
+            line = source[:match.start()].count("\n") + 1
+            docstring = _find_docstring_above_line(source, line, ext)
+            results.append({
+                "name": name,
+                "type": "class",
+                "line": line,
+                "end_line": None,
+                "docstring": docstring,
+                "decorators": [],
+                "parent": None,
+            })
+
+    # Sort by line number
+    results.sort(key=lambda r: r["line"])
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Availability check
+# ---------------------------------------------------------------------------
+
+def check_code_structure_requirements() -> bool:
+    """Always available — no external dependencies needed."""
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Handler
+# ---------------------------------------------------------------------------
+
+def _handle_read_code_structure(args: Dict[str, Any], **_kw: Any) -> str:
+    path = (args.get("path") or "").strip()
+    if not path:
+        return tool_error("path is required for read_code_structure")
+
+    resolved = Path(path).expanduser()
+    if not resolved.exists():
+        # Suggest similar filenames using fuzzy matching
+        try:
+            from difflib import get_close_matches
+            parent = resolved.parent
+            if parent.exists():
+                sibling_names = [p.name for p in parent.iterdir() if p.is_file()]
+                matches = get_close_matches(resolved.name, sibling_names, n=5, cutoff=0.4)
+                if matches:
+                    suggestion = f" Did you mean: {', '.join(matches)}?"
+                else:
+                    suggestion = ""
+            else:
+                suggestion = ""
+        except Exception:
+            suggestion = ""
+        return tool_error(f"File not found: {path}.{suggestion}")
+
+    ext = resolved.suffix.lower()
+    if ext not in ALL_CODE_EXTENSIONS:
+        return tool_error(
+            f"Unsupported file type: '{ext}'. Supported extensions: "
+            f"{', '.join(sorted(ALL_CODE_EXTENSIONS))}"
+        )
+
+    try:
+        source = resolved.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        return tool_error(f"Cannot read file: {exc}")
+
+    if ext in _PYTHON_EXTENSIONS:
+        entries = _extract_python_structure(source, filename=str(resolved))
+    else:
+        entries = _extract_regex_structure(source, ext)
+
+    if not entries:
+        return tool_result({"path": str(resolved), "entries": [], "language": ext.lstrip(".")})
+
+    return tool_result({
+        "path": str(resolved),
+        "language": ext.lstrip("."),
+        "entries": entries,
+    })
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+registry.register(
+    name="read_code_structure",
+    toolset="file",
+    schema=READ_CODE_STRUCTURE_SCHEMA,
+    handler=_handle_read_code_structure,
+    check_fn=check_code_structure_requirements,
+    requires_env=[],
+    is_async=False,
+    emoji="🗂️",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -37,7 +37,7 @@ _HERMES_CORE_TOOLS = [
     # via check_fn in tools/read_terminal_tool.py — hidden outside the GUI).
     "read_terminal",
     # File manipulation
-    "read_file", "write_file", "patch", "search_files",
+    "read_file", "write_file", "patch", "search_files", "read_code_structure",
     # Vision + image generation
     "vision_analyze", "image_generate",
     # Skills


### PR DESCRIPTION
## What changed

Added a new `read_code_structure` tool that returns the structure of a code file (function names, line numbers, comments).

Only 3 files changed:
- `tools/read_code_structure_tool.py` — new tool implementation
- `toolsets.py` — register the new tool in the core toolset
- `tests/tools/test_read_code_structure.py` — unit tests

## Why

Helps LLMs quickly understand a code file's structure without reading the entire file, reducing context window usage and improving efficiency when exploring unfamiliar codebases.

## How to test

```bash
python -m pytest tests/tools/test_read_code_structure.py -v
```

## Platforms tested

macOS