### PR TITLE
fix(billing): reject non-finite money values

### DIFF
--- a/agent/billing_view.py
+++ b/agent/billing_view.py
@@ -38,9 +38,10 @@ def parse_money(value: Any) -> Optional[Decimal]:
         return None
     try:
         # Decimal(str(...)) avoids binary-float artifacts if a float ever sneaks in.
-        return Decimal(str(value).strip())
+        parsed = Decimal(str(value).strip())
     except (InvalidOperation, ValueError, TypeError):
         return None
+    return parsed if parsed.is_finite() else None
 
 
 def format_money(value: Optional[Decimal]) -> str:
@@ -51,6 +52,8 @@ def format_money(value: Optional[Decimal]) -> str:
     ``Decimal("0.01")`` → ``"$0.01"``.
     """
     if value is None:
+        return "—"
+    if not value.is_finite():
         return "—"
     if value == value.to_integral_value():
         # Whole dollars — no decimal point. format(..., "f") avoids 1E+3 for 1000.

--- a/tests/agent/test_billing_view.py
+++ b/tests/agent/test_billing_view.py
@@ -62,7 +62,10 @@ def test_parse_money_valid(raw, expected):
     assert parse_money(raw) == expected
 
 
-@pytest.mark.parametrize("raw", [None, "", "abc", "1.2.3", "$5", {}])
+@pytest.mark.parametrize(
+    "raw",
+    [None, "", "abc", "1.2.3", "$5", {}, "NaN", "Infinity", "-Infinity", float("nan"), float("inf")],
+)
 def test_parse_money_invalid_returns_none(raw):
     assert parse_money(raw) is None
 
@@ -79,6 +82,8 @@ def test_parse_money_never_uses_binary_float():
         (Decimal("100"), "$100"),
         (Decimal("0.01"), "$0.01"),
         (Decimal("1000"), "$1000"),
+        (Decimal("NaN"), "—"),
+        (Decimal("Infinity"), "—"),
         (None, "—"),
     ],
 )


### PR DESCRIPTION
## Summary
- make billing money parsing reject `NaN`, `Infinity`, and `-Infinity`
- prevent `format_money()` from rendering non-finite `Decimal` values as `$NaN` or `$Infinity`
- extend billing view tests for non-finite parser and formatter inputs

## Testing
- `./venv/Scripts/python.exe -m pytest tests/agent/test_billing_view.py -q`
- `./venv/Scripts/python.exe scripts/check-windows-footguns.py --all`