### PR TITLE
fix(cron): warn when resuming jobs without a gateway

### DIFF
--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1409,6 +1409,9 @@ class CLICommandsMixin:
             elif action == "resume":
                 print(f"(^_^)b Resumed job: {result['job']['name']} ({job_id})")
                 print(f"  Next run: {result['job'].get('next_run_at')}")
+                from hermes_cli.cron import _warn_if_gateway_not_running
+
+                _warn_if_gateway_not_running()
             elif action == "run":
                 print(f"(^_^)b Triggered job: {result['job']['name']} ({job_id})")
                 print("  It will run on the next scheduler tick.")

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1991,6 +1991,9 @@ class CLICommandsMixin:
             elif action == "resume":
                 print(f"(^_^)b Resumed job: {result['job']['name']} ({job_id})")
                 print(f"  Next run: {result['job'].get('next_run_at')}")
+                from hermes_cli.cron import _warn_if_gateway_not_running
+
+                _warn_if_gateway_not_running()
             elif action == "run":
                 print(f"(^_^)b Triggered job: {result['job']['name']} ({job_id})")
                 print("  It will run on the next scheduler tick.")

--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -1802,6 +1802,7 @@ def _cron_resume(_engine: HermesConsoleEngine, args: list[str]) -> str:
     if len(args) != 1:
         raise ConsoleCommandError("Usage: cron resume <job>")
     from cron.jobs import AmbiguousJobReference, resume_job
+    from hermes_cli.cron import _warn_if_gateway_not_running
 
     try:
         job = resume_job(args[0])
@@ -1809,6 +1810,7 @@ def _cron_resume(_engine: HermesConsoleEngine, args: list[str]) -> str:
         raise ConsoleCommandError(str(exc)) from exc
     if not job:
         raise ConsoleCommandError(f"Job not found: {args[0]}")
+    _warn_if_gateway_not_running()
     return _format_job(job, "Resumed")
 
 

--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -1617,6 +1617,7 @@ def _cron_resume(_engine: HermesConsoleEngine, args: list[str]) -> str:
     if ns.at and ns.run_now:
         raise ConsoleCommandError("Use exactly one of --at or --run-now.")
     from cron.jobs import AmbiguousJobReference, _hermes_now, rearm_oneshot, resume_job
+    from hermes_cli.cron import _warn_if_gateway_not_running
 
     try:
         if ns.at or ns.run_now:
@@ -1629,6 +1630,7 @@ def _cron_resume(_engine: HermesConsoleEngine, args: list[str]) -> str:
         raise ConsoleCommandError(str(exc)) from exc
     if not job:
         raise ConsoleCommandError(f"Job not found: {ns.job}")
+    _warn_if_gateway_not_running()
     return _format_job(job, "Resumed")
 
 

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -70,7 +70,7 @@ def _warn_if_gateway_not_running() -> None:
     gateway/run.py); there is no standalone cron daemon. Without a running
     gateway, ``next_run_at`` passes but jobs never fire and ``last_run_at``
     stays null — the most common cron support report (#51038). Surfacing this
-    at create/list time, when the user is right there, prevents it.
+    at create/list/resume time, when the user is right there, prevents it.
 
     An external provider (e.g. Chronos) fires jobs via a NAS-mediated webhook,
     NOT the in-process ticker, so a momentarily-absent gateway process does not
@@ -413,6 +413,8 @@ def _job_action(action: str, job_id: str, success_verb: str) -> int:
             print(f"  {job['execution_skipped']}")
         else:
             print("  It will run on the next scheduler tick.")
+    if action == "resume":
+        _warn_if_gateway_not_running()
     return 0
 
 

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -107,7 +107,7 @@ def _warn_if_gateway_not_running() -> None:
     gateway/run.py); there is no standalone cron daemon. Without a running
     gateway, ``next_run_at`` passes but jobs never fire and ``last_run_at``
     stays null — the most common cron support report (#51038). Surfacing this
-    at create/list time, when the user is right there, prevents it.
+    at create/list/resume time, when the user is right there, prevents it.
 
     An external provider (e.g. Chronos) fires jobs via a NAS-mediated webhook,
     NOT the in-process ticker, so a momentarily-absent gateway process does not
@@ -705,6 +705,8 @@ def _job_action(action: str, job_id: str, success_verb: str) -> int:
             print(f"  {job['execution_skipped']}")
         else:
             print("  It will run on the next scheduler tick.")
+    if action == "resume":
+        _warn_if_gateway_not_running()
     return 0
 
 

--- a/tests/hermes_cli/test_console_engine.py
+++ b/tests/hermes_cli/test_console_engine.py
@@ -601,11 +601,16 @@ def test_sessions_list_and_stats_use_isolated_session_store(_isolate_hermes_home
     assert "Listable sessions: 1" in stats.output
 
 
-def test_cron_pause_resume_and_run_require_confirmation(_isolate_hermes_home):
+def test_cron_pause_resume_and_run_require_confirmation(_isolate_hermes_home, monkeypatch):
     from cron.jobs import create_job, get_job
 
     job = create_job(prompt="say hello", schedule="every 1h", name="alpha")
     engine = HermesConsoleEngine()
+    warnings = []
+    monkeypatch.setattr(
+        "hermes_cli.cron._warn_if_gateway_not_running",
+        lambda: warnings.append(True),
+    )
 
     pending = engine.execute(f"cron pause {job['id']}")
     assert pending.status == "confirm_required"
@@ -624,6 +629,7 @@ def test_cron_pause_resume_and_run_require_confirmation(_isolate_hermes_home):
     stored = get_job(job["id"])
     assert stored is not None
     assert stored["state"] == "scheduled"
+    assert warnings == [True]
 
     triggered = engine.execute("cron run alpha", confirmed=True)
     assert triggered.status == "ok"

--- a/tests/hermes_cli/test_console_engine.py
+++ b/tests/hermes_cli/test_console_engine.py
@@ -9,6 +9,14 @@ import pytest
 from hermes_cli.console_engine import HermesConsoleEngine, run_console_repl
 
 
+@pytest.fixture()
+def tmp_cron_store(tmp_path):
+    from cron import jobs
+
+    with jobs.use_cron_store(tmp_path):
+        yield
+
+
 EXPECTED_CONSOLE_COMMANDS = {
     ("status",),
     ("doctor",),
@@ -601,7 +609,9 @@ def test_sessions_list_and_stats_use_isolated_session_store(_isolate_hermes_home
     assert "Listable sessions: 1" in stats.output
 
 
-def test_cron_pause_resume_and_run_require_confirmation(_isolate_hermes_home, monkeypatch):
+def test_cron_pause_resume_and_run_require_confirmation(
+    _isolate_hermes_home, tmp_cron_store, monkeypatch
+):
     from cron.jobs import create_job, get_job
 
     job = create_job(prompt="say hello", schedule="every 1h", name="alpha")

--- a/tests/hermes_cli/test_console_engine.py
+++ b/tests/hermes_cli/test_console_engine.py
@@ -429,11 +429,18 @@ def test_sessions_export_zero_limit_disables_guard(
     assert output.exists()
 
 
-def test_cron_pause_resume_and_run_require_confirmation(_isolate_hermes_home):
+def test_cron_pause_resume_and_run_require_confirmation(
+    _isolate_hermes_home, monkeypatch
+):
     from cron.jobs import create_job, get_job
 
     job = create_job(prompt="say hello", schedule="every 1h", name="alpha")
     engine = HermesConsoleEngine()
+    warnings = []
+    monkeypatch.setattr(
+        "hermes_cli.cron._warn_if_gateway_not_running",
+        lambda: warnings.append(True),
+    )
 
     pending = engine.execute(f"cron pause {job['id']}")
     assert pending.status == "confirm_required"
@@ -452,6 +459,7 @@ def test_cron_pause_resume_and_run_require_confirmation(_isolate_hermes_home):
     stored = get_job(job["id"])
     assert stored is not None
     assert stored["state"] == "scheduled"
+    assert warnings == [True]
 
     triggered = engine.execute("cron run alpha", confirmed=True)
     assert triggered.status == "ok"

--- a/tests/hermes_cli/test_console_engine.py
+++ b/tests/hermes_cli/test_console_engine.py
@@ -9,6 +9,14 @@ import pytest
 from hermes_cli.console_engine import HermesConsoleEngine, run_console_repl
 
 
+@pytest.fixture()
+def tmp_cron_store(tmp_path):
+    from cron import jobs
+
+    with jobs.use_cron_store(tmp_path):
+        yield
+
+
 EXPECTED_CONSOLE_COMMANDS = {
     ("status",),
     ("doctor",),
@@ -430,7 +438,7 @@ def test_sessions_export_zero_limit_disables_guard(
 
 
 def test_cron_pause_resume_and_run_require_confirmation(
-    _isolate_hermes_home, monkeypatch
+    _isolate_hermes_home, tmp_cron_store, monkeypatch
 ):
     from cron.jobs import create_job, get_job
 

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -211,6 +211,29 @@ class TestGatewayNotRunningWarning:
         out = capsys.readouterr().out
         assert "Gateway is not running" in out
 
+    def test_resume_warns_when_gateway_absent(self, tmp_cron_dir, capsys, monkeypatch):
+        job = create_job(prompt="Daily report", schedule="0 11 * * *")
+        cron_command(Namespace(cron_command="pause", job_id=job["id"]))
+        capsys.readouterr()
+
+        monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [])
+        cron_command(Namespace(cron_command="resume", job_id=job["id"]))
+
+        out = capsys.readouterr().out
+        assert "Resumed job" in out
+        assert "Gateway is not running" in out
+
+    def test_resume_silent_when_gateway_running(self, tmp_cron_dir, capsys, monkeypatch):
+        job = create_job(prompt="Daily report", schedule="0 11 * * *")
+        cron_command(Namespace(cron_command="pause", job_id=job["id"]))
+        capsys.readouterr()
+
+        monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [4242])
+        cron_command(Namespace(cron_command="resume", job_id=job["id"]))
+
+        out = capsys.readouterr().out
+        assert "Resumed job" in out
+        assert "Gateway is not running" not in out
 
 class TestExternalCronProviderStatus:
     """With an external cron provider (e.g. Chronos), jobs fire via a

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -235,6 +235,29 @@ class TestGatewayNotRunningWarning:
         assert "Resumed job" in out
         assert "Gateway is not running" not in out
 
+    def test_interactive_cli_resume_warns_when_gateway_absent(self, capsys, monkeypatch):
+        """The interactive /cron front end must share the resume warning."""
+        from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+        monkeypatch.setattr(
+            "tools.cronjob_tools.cronjob",
+            lambda **_kwargs: (
+                '{"success": true, "job": {"name": "Daily report", '
+                '"next_run_at": "2026-07-15T11:00:00Z"}}'
+            ),
+        )
+        monkeypatch.setattr(
+            cron_cli,
+            "_warn_if_gateway_not_running",
+            lambda: print("Gateway is not running"),
+        )
+
+        CLICommandsMixin()._handle_cron_command("/cron resume job-1")
+
+        out = capsys.readouterr().out
+        assert "Resumed job" in out
+        assert "Gateway is not running" in out
+
 class TestExternalCronProviderStatus:
     """With an external cron provider (e.g. Chronos), jobs fire via a
     NAS-mediated webhook, NOT the in-process ticker. The ticker-heartbeat /

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -145,6 +145,29 @@ class TestGatewayNotRunningWarning:
         out = capsys.readouterr().out
         assert "Gateway is not running" in out
 
+    def test_resume_warns_when_gateway_absent(self, tmp_cron_dir, capsys, monkeypatch):
+        job = create_job(prompt="Daily report", schedule="0 11 * * *")
+        cron_command(Namespace(cron_command="pause", job_id=job["id"]))
+        capsys.readouterr()
+
+        monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [])
+        cron_command(Namespace(cron_command="resume", job_id=job["id"]))
+
+        out = capsys.readouterr().out
+        assert "Resumed job" in out
+        assert "Gateway is not running" in out
+
+    def test_resume_silent_when_gateway_running(self, tmp_cron_dir, capsys, monkeypatch):
+        job = create_job(prompt="Daily report", schedule="0 11 * * *")
+        cron_command(Namespace(cron_command="pause", job_id=job["id"]))
+        capsys.readouterr()
+
+        monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [4242])
+        cron_command(Namespace(cron_command="resume", job_id=job["id"]))
+
+        out = capsys.readouterr().out
+        assert "Resumed job" in out
+        assert "Gateway is not running" not in out
 
 class TestExternalCronProviderStatus:
     """With an external cron provider (e.g. Chronos), jobs fire via a

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -169,6 +169,29 @@ class TestGatewayNotRunningWarning:
         assert "Resumed job" in out
         assert "Gateway is not running" not in out
 
+    def test_interactive_cli_resume_warns_when_gateway_absent(self, capsys, monkeypatch):
+        """The interactive /cron front end must share the resume warning."""
+        from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+        monkeypatch.setattr(
+            "tools.cronjob_tools.cronjob",
+            lambda **_kwargs: (
+                '{"success": true, "job": {"name": "Daily report", '
+                '"next_run_at": "2026-07-15T11:00:00Z"}}'
+            ),
+        )
+        monkeypatch.setattr(
+            cron_cli,
+            "_warn_if_gateway_not_running",
+            lambda: print("Gateway is not running"),
+        )
+
+        CLICommandsMixin()._handle_cron_command("/cron resume job-1")
+
+        out = capsys.readouterr().out
+        assert "Resumed job" in out
+        assert "Gateway is not running" in out
+
 class TestExternalCronProviderStatus:
     """With an external cron provider (e.g. Chronos), jobs fire via a
     NAS-mediated webhook, NOT the in-process ticker. The ticker-heartbeat /


### PR DESCRIPTION
## Summary

`hermes cron resume` now shows the same gateway-not-running warning that `cron create` and `cron list` already show.

## Why

Resuming a paused cron job makes it scheduled again and prints a fresh `Next run`, but automatic cron execution still depends on the gateway ticker. When no gateway is running, that `Next run` can pass without the job firing, which is the same user-facing trap the existing create/list warning was added to prevent.

I kept this deliberately narrow:

- `cron run` is not changed, because it now executes immediately outside the scheduler tick.
- `cron edit` is not changed, because edits can be metadata-only and warning there is less obviously tied to re-arming execution.
- The change only covers the resume path, where the user is explicitly re-enabling automatic scheduling.

## Validation

- `python3 -m pytest tests/hermes_cli/test_cron.py -q`
- `git diff --check`
- `python3 scripts/check-windows-footguns.py hermes_cli/cron.py tests/hermes_cli/test_cron.py`
