### PR TITLE
fix(feishu): restore adapter methods and enable v2 interactive cards for markdown tables

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4377,10 +4377,10 @@ class FeishuAdapter(BasePlatformAdapter):
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
         # Feishu post-type 'md' elements do not render markdown tables; sending
         # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
+        # Force v2 interactive card for anything that looks like a markdown table.
         if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
+            card = _markdown_to_v2_card(content)
+            return "interactive", json.dumps(card, ensure_ascii=False)
         if _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}
@@ -4881,6 +4881,72 @@ class FeishuAdapter(BasePlatformAdapter):
         return _FEISHU_FILE_UPLOAD_TYPE, "file"
 
 
+def _markdown_to_v2_card(content: str) -> dict:
+    """Convert markdown (with tables) to Feishu v2 interactive card.
+
+    Feishu's post-type 'md' elements cannot render markdown tables, so when
+    Sihao sends markdown containing a pipe table we promote the whole reply
+    to a v2 interactive card with native table components (data_type:
+    lark_md, flat {col_N: ...} rows) — exactly the structure that
+    feishu-card-table skill v3.1.0 v2 white-list prescribes.
+    """
+    table_pattern = re.compile(
+        r'(?:^\|.+\|\r?\n)+^\|[-: |]+\|.*\r?\n(?:^\|.+\|\r?\n?)+',
+        re.MULTILINE,
+    )
+    elements: List[Dict[str, Any]] = []
+    last_end = 0
+    for m in table_pattern.finditer(content):
+        before = content[last_end:m.start()].rstrip()
+        if before:
+            elements.append({"tag": "div", "text": {"tag": "lark_md", "content": before}})
+        table_text = m.group(0).strip()
+        rows_raw = [r for r in table_text.split("\n") if r.strip().startswith("|")]
+        if len(rows_raw) < 3:
+            last_end = m.end()
+            continue
+        header = [c.strip() for c in rows_raw[0].strip("|").split("|")]
+        data_rows = []
+        for r in rows_raw[2:]:
+            cells = [c.strip() for c in r.strip("|").split("|")]
+            data_rows.append(cells)
+        n_cols = len(header)
+        columns = [
+            {
+                "name": f"col_{i}",
+                "display_name": header[i] if i < len(header) else f"C{i}",
+                "data_type": "lark_md",
+            }
+            for i in range(n_cols)
+        ]
+        card_rows: List[Dict[str, str]] = []
+        for row in data_rows:
+            card_row = {f"col_{i}": row[i] if i < len(row) else "" for i in range(n_cols)}
+            for k, v in card_row.items():
+                if not v:
+                    card_row[k] = "—"
+            card_rows.append(card_row)
+        elements.append({"tag": "table", "columns": columns, "rows": card_rows})
+        last_end = m.end()
+    after = content[last_end:].strip()
+    if after:
+        elements.append({"tag": "div", "text": {"tag": "lark_md", "content": after}})
+    if not elements:
+        elements = [{"tag": "div", "text": {"tag": "lark_md", "content": content}}]
+    # cap at 5 tables per card (Feishu v2 limit, code 230099 otherwise)
+    table_count = sum(1 for e in elements if e.get("tag") == "table")
+    if table_count > 5:
+        # truncate to 5 tables; trailing content still gets a div
+        kept: List[Dict[str, Any]] = []
+        seen = 0
+        for e in elements:
+            if e.get("tag") == "table":
+                seen += 1
+                if seen > 5:
+                    continue
+            kept.append(e)
+        elements = kept
+    return {"schema": "2.0", "config": {"wide_screen_mode": True}, "body": {"elements": elements}}
 # =============================================================================
 # QR scan-to-create onboarding
 #


### PR DESCRIPTION
## Summary

Fixes a structural indentation bug in the Feishu adapter that broke gateway startup and Feishu JSON 2.0 card sending.

## Problem

A previous edit added `_markdown_to_v2_card` inside the `FeishuAdapter` class body but misplaced its closing, causing a large block of adapter methods to be parsed as local functions inside it. Affected methods included `_release_app_lock`, `_build_outbound_payload`, `_send_raw_message`, `_feishu_send_with_retry`, and all Lark API request builders.

This produced the runtime error seen when starting `hermes gateway`:

```
'FeishuAdapter' object has no attribute '_release_app_lock'
```

It also prevented outbound JSON 2.0 interactive cards from being sent, because `_build_outbound_payload` was no longer a real class method.

## Changes

- Move `_markdown_to_v2_card` to module level (where `_build_outbound_payload` can call it).
- Restore the trapped methods to the `FeishuAdapter` class body.
- Keep the v2 card conversion in `_build_outbound_payload`: markdown tables are now sent as Feishu schema-2.0 interactive cards instead of falling back to plain text.

## Verification

- `python -m py_compile plugins/platforms/feishu/adapter.py` passes.
- AST check confirms `FeishuAdapter` again contains `_release_app_lock`, `_build_outbound_payload`, `_send_raw_message`, and `_feishu_send_with_retry`.
- Direct invocation confirms markdown tables produce `msg_type="interactive"` with `schema: "2.0"`, and `_release_app_lock()` executes without error.
- Running the full `tests/gateway/test_feishu.py` suite is blocked on this Windows/uv Python install by an unrelated `ssl.SSLError: [SSL] unknown error` during `aiohttp` import; the same failure occurs on a clean checkout of `main`.