### PR TITLE
fix(gateway): reject non-finite streaming config values

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -11,6 +11,7 @@ Handles loading and validating configuration for:
 import logging
 import os
 import json
+import math
 from pathlib import Path
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Any, Callable
@@ -41,9 +42,10 @@ def _coerce_float(value: Any, default: float) -> float:
     if value is None:
         return default
     try:
-        return float(value)
+        parsed = float(value)
     except (TypeError, ValueError):
         return default
+    return parsed if math.isfinite(parsed) else default
 
 
 def _coerce_int(value: Any, default: int) -> int:
@@ -51,8 +53,10 @@ def _coerce_int(value: Any, default: int) -> int:
     if value is None:
         return default
     try:
+        if isinstance(value, float) and not math.isfinite(value):
+            raise ValueError(value)
         return int(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return default
 
 

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -188,6 +188,20 @@ class TestStreamingConfig:
         assert restored.buffer_threshold == 24
         assert restored.fresh_final_after_seconds == 0.0
 
+    def test_from_dict_non_finite_numeric_values_fall_back_to_defaults(self):
+        for value in ("nan", "inf", "-inf", float("nan"), float("inf"), float("-inf")):
+            restored = StreamingConfig.from_dict(
+                {
+                    "edit_interval": value,
+                    "buffer_threshold": value,
+                    "fresh_final_after_seconds": value,
+                }
+            )
+
+            assert restored.edit_interval == 0.8
+            assert restored.buffer_threshold == 24
+            assert restored.fresh_final_after_seconds == 0.0
+
 
 class TestGatewayConfigRoundtrip:
     def test_full_roundtrip(self):


### PR DESCRIPTION
## Summary
- Treat non-finite streaming config values (`NaN`, `Infinity`, `-Infinity`) as malformed input and fall back to defaults.
- Prevent float `Infinity` values from escaping `_coerce_int` via an uncaught `OverflowError`.
- Add regression coverage for `StreamingConfig.from_dict()` across string and float non-finite values.

## Why
StreamingConfig.from_dict() already falls back for malformed numeric strings like `"oops"`, but `float("nan")` and `float("inf")` are accepted by Python. That can leak non-finite `edit_interval` / `fresh_final_after_seconds` values into runtime streaming behavior, while a YAML-decoded float infinity for `buffer_threshold` can raise instead of falling back.

## Tests
- `python -m pytest tests/gateway/test_config.py::TestStreamingConfig -q`
- `python -m pytest tests/gateway/test_config.py -q`
- `python scripts/check-windows-footguns.py --all`