### PR TITLE
fix: add explicit encoding="utf-8" to text-mode file opens

### DIFF
--- a/agent/nous_rate_guard.py
+++ b/agent/nous_rate_guard.py
@@ -117,7 +117,7 @@ def record_nous_rate_limit(
         # Atomic write: write to temp file + rename
         fd, tmp_path = tempfile.mkstemp(dir=state_dir, suffix=".tmp")
         try:
-            with os.fdopen(fd, "w") as f:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
                 json.dump(state, f)
             atomic_replace(tmp_path, path)
         except Exception:

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -627,7 +627,7 @@ def save_allowlist(data: Dict[str, Any]) -> None:
             prefix=f"{p.name}.", suffix=".tmp", dir=str(p.parent),
         )
         try:
-            with os.fdopen(fd, "w") as fh:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
                 fh.write(json.dumps(data, indent=2, sort_keys=True))
             atomic_replace(tmp_path, p)
         except Exception:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4034,7 +4034,7 @@ class GatewaySlashCommandsMixin:
                     with open(output_path, "wb") as f:
                         proc = subprocess.Popen(cmd, stdout=f, stderr=subprocess.STDOUT, env=env)
                         rc = proc.wait(timeout=3600)
-                    with open(exit_code_path, "w") as f:
+                    with open(exit_code_path, "w", encoding="utf-8") as f:
                         f.write(str(rc))
                     """
                 ).strip()


### PR DESCRIPTION
## Summary

Three file-write call-sites use `open()` / `os.fdopen()` in text mode without specifying `encoding=`. On systems where the locale default is not UTF-8 (e.g. `C`/`POSIX` locale on Linux servers, minimal Docker base images, some CI environments), non-ASCII characters in JSON payloads or values would either raise `UnicodeEncodeError` or silently produce mojibake.

## Changes

| File | Line | Issue |
|------|------|-------|
| `agent/nous_rate_guard.py` | L120 | `os.fdopen(fd, "w")` — writes JSON state with `json.dump()` |
| `agent/shell_hooks.py` | L630 | `os.fdopen(fd, "w")` — writes JSON data with `json.dumps()` |
| `gateway/slash_commands.py` | L4037 | `open(exit_code_path, "w")` — writes exit code integer |

**Fix:** Add `encoding="utf-8"` to each call-site.

## Context

All sibling call-sites in the repo already pass `encoding="utf-8"`:
- `hermes_cli/config.py` uses `write_kw = {"encoding": "utf-8"}` for all `os.fdopen` calls
- `utils.py` atomic helpers use `encoding="utf-8"`
- Various other modules follow the same pattern

These three are the only remaining gaps.

## Testing

- Verified with `python -c "import ast; ast.parse(open(\"f\").read())"` on each modified file
- No new lint/type errors introduced