### PR TITLE
fix(approval): fall back for non-finite timeouts

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -31,6 +31,23 @@ class TestApprovalModeParsing:
             assert _get_approval_mode() == "off"
 
 
+class TestApprovalTimeoutParsing:
+    def test_cli_timeout_non_finite_values_fall_back_to_default(self):
+        for value in (float("inf"), float("-inf"), float("nan")):
+            with mock_patch(
+                "hermes_cli.config.load_config",
+                return_value={"approvals": {"timeout": value}},
+            ):
+                assert approval_module._get_approval_timeout() == 60
+
+    def test_gateway_timeout_parser_rejects_non_finite_values(self):
+        for value in (float("inf"), float("-inf"), float("nan")):
+            assert approval_module._coerce_approval_timeout(value, 300) == 300
+
+    def test_timeout_parser_preserves_valid_integer_values(self):
+        assert approval_module._coerce_approval_timeout("42", 300) == 42
+
+
 class TestSmartApproval:
     def test_smart_approval_uses_call_llm(self):
         response = SimpleNamespace(

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1066,12 +1066,17 @@ def _get_approval_mode() -> str:
     return _normalize_approval_mode(mode)
 
 
+def _coerce_approval_timeout(value, default: int) -> int:
+    """Coerce approval timeout config, falling back on malformed values."""
+    try:
+        return int(value)
+    except (OverflowError, TypeError, ValueError):
+        return default
+
+
 def _get_approval_timeout() -> int:
     """Read the approval timeout from config. Defaults to 60 seconds."""
-    try:
-        return int(_get_approval_config().get("timeout", 60))
-    except (ValueError, TypeError):
-        return 60
+    return _coerce_approval_timeout(_get_approval_config().get("timeout", 60), 60)
 
 
 def _get_cron_approval_mode() -> str:
@@ -1405,11 +1410,9 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     # slices so we can fire activity heartbeats every ~10s to the agent's
     # inactivity tracker — otherwise the gateway watchdog kills the agent
     # while the user is still responding. Mirrors _wait_for_process() cadence.
-    timeout = _get_approval_config().get("gateway_timeout", 300)
-    try:
-        timeout = int(timeout)
-    except (ValueError, TypeError):
-        timeout = 300
+    timeout = _coerce_approval_timeout(
+        _get_approval_config().get("gateway_timeout", 300), 300
+    )
 
     try:
         from tools.environments.base import touch_activity_if_due


### PR DESCRIPTION
## Summary
- Add a shared approval-timeout coercion helper that falls back on malformed numeric config.
- Cover non-finite CLI approval timeouts and gateway approval timeouts.
- Preserve existing valid integer parsing behavior.

## Why
The approval timeout readers already fall back for string/type errors, but `int(float("inf"))` raises `OverflowError`. A YAML-decoded `approvals.timeout: .inf` can crash `_get_approval_timeout()` before the dangerous-command approval prompt is shown. The gateway approval path had the same direct `int()` conversion for `gateway_timeout`.

## Tests
- `python -m pytest tests/tools/test_approval.py::TestApprovalTimeoutParsing -q`
- `python -m pytest tests/tools/test_approval.py::TestApprovalTimeoutParsing tests/tools/test_approval.py::TestApprovalTimeoutIsNotConsent -q`
- `python -m pytest tests/gateway/test_approve_deny_commands.py::TestBlockingApprovalE2E::test_blocking_approval_timeout -q`
- `python scripts/check-windows-footguns.py --all`

Note: `python -m pytest tests/tools/test_approval.py -q` currently has unrelated Windows-only absolute-home/Hermes-home path detector failures in this checkout; the timeout-focused tests above pass.