### PR TITLE
fix(checkpoints): tolerate invalid timestamps

### DIFF
--- a/hermes_cli/checkpoints.py
+++ b/hermes_cli/checkpoints.py
@@ -22,6 +22,7 @@ None of these require the agent to be running.  Safe to call any time.
 from __future__ import annotations
 
 import argparse
+import math
 import time
 from datetime import datetime
 from pathlib import Path
@@ -40,18 +41,29 @@ def _fmt_bytes(n: int) -> str:
     return f"{size:.1f} TB"
 
 
-def _fmt_ts(ts: Any) -> str:
+def _coerce_timestamp(ts: Any) -> float | None:
     try:
-        return datetime.fromtimestamp(float(ts)).strftime("%Y-%m-%d %H:%M")
+        value = float(ts)
     except (TypeError, ValueError):
+        return None
+    return value if math.isfinite(value) else None
+
+
+def _fmt_ts(ts: Any) -> str:
+    value = _coerce_timestamp(ts)
+    if value is None:
+        return "—"
+    try:
+        return datetime.fromtimestamp(value).strftime("%Y-%m-%d %H:%M")
+    except (OverflowError, OSError, ValueError):
         return "—"
 
 
 def _fmt_age(ts: Any) -> str:
-    try:
-        age = time.time() - float(ts)
-    except (TypeError, ValueError):
+    value = _coerce_timestamp(ts)
+    if value is None:
         return "—"
+    age = time.time() - value
     if age < 0:
         return "now"
     if age < 60:
@@ -76,7 +88,7 @@ def cmd_status(args: argparse.Namespace) -> int:
 
     projects = sorted(
         info["projects"],
-        key=lambda p: (p.get("last_touch") or 0),
+        key=lambda p: (_coerce_timestamp(p.get("last_touch")) or 0),
         reverse=True,
     )
     if projects:

--- a/tests/hermes_cli/test_checkpoints_cli.py
+++ b/tests/hermes_cli/test_checkpoints_cli.py
@@ -1,0 +1,50 @@
+"""Tests for the `hermes checkpoints` CLI helpers."""
+
+import argparse
+
+import pytest
+
+from hermes_cli import checkpoints
+
+
+@pytest.mark.parametrize("value", [float("inf"), float("-inf"), float("nan"), "bad", None])
+def test_timestamp_formatters_hide_invalid_values(value):
+    assert checkpoints._fmt_ts(value) == "—"
+    assert checkpoints._fmt_age(value) == "—"
+
+
+def test_age_formatter_keeps_future_finite_timestamps_as_now(monkeypatch):
+    monkeypatch.setattr(checkpoints.time, "time", lambda: 1_000.0)
+
+    assert checkpoints._fmt_age(1_001.0) == "now"
+
+
+def test_status_tolerates_malformed_project_last_touch(monkeypatch, capsys):
+    from tools import checkpoint_manager
+
+    monkeypatch.setattr(
+        checkpoint_manager,
+        "store_status",
+        lambda: {
+            "base": "/tmp/checkpoints",
+            "total_size_bytes": 0,
+            "store_size_bytes": 0,
+            "legacy_size_bytes": 0,
+            "project_count": 3,
+            "projects": [
+                {"workdir": "/finite", "commits": 1, "last_touch": 900.0, "exists": True},
+                {"workdir": "/nan", "commits": 1, "last_touch": float("nan"), "exists": True},
+                {"workdir": "/string", "commits": 1, "last_touch": "bad", "exists": False},
+            ],
+            "legacy_archives": [],
+        },
+    )
+    monkeypatch.setattr(checkpoints.time, "time", lambda: 1_000.0)
+
+    assert checkpoints.cmd_status(argparse.Namespace(limit=20)) == 0
+    output = capsys.readouterr().out
+
+    assert "/finite" in output
+    assert "/nan" in output
+    assert "/string" in output
+    assert "—" in output


### PR DESCRIPTION
## Summary
- Add a checkpoint timestamp coercion helper that rejects malformed and non-finite values.
- Make `hermes checkpoints status` sorting tolerate invalid `last_touch` metadata instead of raising.
- Add focused CLI helper/status tests for invalid checkpoint timestamps.

## Why
Checkpoint project metadata is local JSON state. If `last_touch` is corrupted or hand-edited to `NaN` / `Infinity`, the current formatter can raise `OverflowError` / `ValueError`, and `Infinity` can be displayed as `now`. The status command should keep reporting the rest of the checkpoint store and display an unknown timestamp placeholder for bad values.

## Tests
- `python -m pytest tests/hermes_cli/test_checkpoints_cli.py -q`
- `python -m py_compile hermes_cli/checkpoints.py`
- `python scripts/check-windows-footguns.py --all`