### PR TITLE
fix: harden kanban skill loading and gateway profile disables

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -404,7 +404,7 @@ def _normalize_string_set(values) -> Set[str]:
 # which becomes the dominant cost of ``hermes`` startup when ~120 skills
 # each trigger a category lookup during banner construction (10+ seconds
 # of pure waste).
-_EXTERNAL_DIRS_CACHE: Dict[Tuple[str, int], List[Path]] = {}
+_EXTERNAL_DIRS_CACHE: Dict[Tuple[str, int, str], List[Path]] = {}
 
 
 def _external_dirs_cache_clear() -> None:
@@ -414,28 +414,46 @@ def _external_dirs_cache_clear() -> None:
 
 
 def get_external_skills_dirs() -> List[Path]:
-    """Read ``skills.external_dirs`` from config.yaml and return validated paths.
+    """Read additional skill roots and return validated paths.
+
+    Sources, in order:
+    1. ``skills.external_dirs`` from config.yaml.
+    2. Internal dispatcher-provided ``HERMES_KANBAN_SHARED_SKILLS_DIRS``.
 
     Each entry is expanded (``~`` and ``${VAR}``) and resolved to an absolute
     path.  Only directories that actually exist are returned.  Duplicates and
     paths that resolve to the local ``~/.hermes/skills/`` are silently skipped.
 
-    Cached in-process, keyed on ``config.yaml`` mtime — the function is
-    called once per skill during banner / tool-registry scans, and YAML
-    parsing a non-trivial config dominates ``hermes`` cold-start time
+    ``HERMES_KANBAN_SHARED_SKILLS_DIRS`` is intentionally not a user-facing
+    config knob.  The Kanban dispatcher sets it for worker subprocesses so a
+    profile-isolated worker can still read the board owner's shared skill
+    library at startup instead of crashing with ``Unknown skill(s)`` when a
+    task references a default-profile skill.
+
+    Cached in-process, keyed on ``config.yaml`` mtime + the internal env value
+    — the function is called once per skill during banner / tool-registry scans,
+    and YAML parsing a non-trivial config dominates ``hermes`` cold-start time
     when the cache is absent.
     """
     config_path = get_config_path()
+    shared_dirs_env = os.environ.get("HERMES_KANBAN_SHARED_SKILLS_DIRS", "")
+    cache_key: Tuple[str, int, str] | None
     if not config_path.exists():
-        return []
-
-    # Cache key: (absolute path, mtime_ns).  stat() is ~2us vs ~85ms for
-    # the full YAML parse, so the fast path is nearly free.
-    try:
-        stat = config_path.stat()
-        cache_key: Tuple[str, int] = (str(config_path), stat.st_mtime_ns)
-    except OSError:
-        cache_key = None  # type: ignore[assignment]
+        if not shared_dirs_env:
+            return []
+        cache_key = None
+    else:
+        # Cache key: (absolute path, mtime_ns, internal shared dirs env).  stat() is
+        # ~2us vs ~85ms for the full YAML parse, so the fast path is nearly free.
+        try:
+            stat = config_path.stat()
+            cache_key = (
+                str(config_path),
+                stat.st_mtime_ns,
+                shared_dirs_env,
+            )
+        except OSError:
+            cache_key = None  # type: ignore[assignment]
 
     if cache_key is not None:
         cached = _EXTERNAL_DIRS_CACHE.get(cache_key)
@@ -443,31 +461,30 @@ def get_external_skills_dirs() -> List[Path]:
             # Return a copy so callers can't mutate the cached list.
             return list(cached)
 
+    raw_dirs: List[str] = []
     parsed = _load_raw_config()
-    if not parsed:
-        return []
+    if parsed:
+        skills_cfg = parsed.get("skills")
+        if isinstance(skills_cfg, dict):
+            configured_dirs = skills_cfg.get("external_dirs")
+            if isinstance(configured_dirs, str):
+                raw_dirs.append(configured_dirs)
+            elif isinstance(configured_dirs, list):
+                raw_dirs.extend(str(item) for item in configured_dirs)
 
-    skills_cfg = parsed.get("skills")
-    if not isinstance(skills_cfg, dict):
-        return []
-
-    raw_dirs = skills_cfg.get("external_dirs")
-    if not raw_dirs:
-        result: List[Path] = []
-        if cache_key is not None:
-            _EXTERNAL_DIRS_CACHE[cache_key] = list(result)
-        return result
-    if isinstance(raw_dirs, str):
-        raw_dirs = [raw_dirs]
-    if not isinstance(raw_dirs, list):
-        return []
+    if shared_dirs_env:
+        # Dispatcher-provided value is pathsep-separated so paths containing
+        # commas remain valid on POSIX/Windows.
+        raw_dirs.extend(
+            item for item in shared_dirs_env.split(os.pathsep) if item.strip()
+        )
 
     from hermes_constants import get_hermes_home
 
     hermes_home = get_hermes_home()
     local_skills = get_skills_dir().resolve()
     seen: Set[Path] = set()
-    result = []
+    result: List[Path] = []
 
     for entry in raw_dirs:
         entry = str(entry).strip()

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1476,11 +1476,17 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if hass_token:
         if Platform.HOMEASSISTANT not in config.platforms:
             config.platforms[Platform.HOMEASSISTANT] = PlatformConfig()
-        config.platforms[Platform.HOMEASSISTANT].enabled = True
-        config.platforms[Platform.HOMEASSISTANT].token = hass_token
+        hass_config = config.platforms[Platform.HOMEASSISTANT]
+        # Respect an explicit YAML disable. This lets specialized gateway
+        # profiles inherit shared secrets without unintentionally connecting
+        # the Home Assistant adapter.
+        enabled_was_explicit = bool(hass_config.extra.get("_enabled_explicit", False))
+        if hass_config.enabled or not enabled_was_explicit:
+            hass_config.enabled = True
+        hass_config.token = hass_token
         hass_url = os.getenv("HASS_URL")
         if hass_url:
-            config.platforms[Platform.HOMEASSISTANT].extra["url"] = hass_url
+            hass_config.extra["url"] = hass_url
 
     # Email
     email_addr = os.getenv("EMAIL_ADDRESS")
@@ -1530,23 +1536,29 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if api_server_enabled or api_server_key:
         if Platform.API_SERVER not in config.platforms:
             config.platforms[Platform.API_SERVER] = PlatformConfig()
-        config.platforms[Platform.API_SERVER].enabled = True
+        api_config = config.platforms[Platform.API_SERVER]
+        # API_SERVER_KEY may come from a machine-global/shared secret source.
+        # Respect an explicit YAML disable so secondary profile gateways do not
+        # all try to bind the same local API port.
+        enabled_was_explicit = bool(api_config.extra.get("_enabled_explicit", False))
+        if api_config.enabled or not enabled_was_explicit:
+            api_config.enabled = True
         if api_server_key:
-            config.platforms[Platform.API_SERVER].extra["key"] = api_server_key
+            api_config.extra["key"] = api_server_key
         if api_server_cors_origins:
             origins = [origin.strip() for origin in api_server_cors_origins.split(",") if origin.strip()]
             if origins:
-                config.platforms[Platform.API_SERVER].extra["cors_origins"] = origins
+                api_config.extra["cors_origins"] = origins
         if api_server_port:
             try:
-                config.platforms[Platform.API_SERVER].extra["port"] = int(api_server_port)
+                api_config.extra["port"] = int(api_server_port)
             except ValueError:
                 pass
         if api_server_host:
-            config.platforms[Platform.API_SERVER].extra["host"] = api_server_host
+            api_config.extra["host"] = api_server_host
         api_server_model_name = os.getenv("API_SERVER_MODEL_NAME", "")
         if api_server_model_name:
-            config.platforms[Platform.API_SERVER].extra["model_name"] = api_server_model_name
+            api_config.extra["model_name"] = api_server_model_name
 
     # Webhook platform
     webhook_enabled = os.getenv("WEBHOOK_ENABLED", "").lower() in {"true", "1", "yes"}

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7330,6 +7330,16 @@ def _default_spawn(
         # This only happens in test fixtures where the isolated
         # HERMES_HOME never had profiles created.
         pass
+
+    # Kanban boards are shared across profiles, while skills are normally
+    # profile-local. Give worker subprocesses read-only visibility into the
+    # board owner's shared skill library so per-task skills created/curated in
+    # the default profile do not fatal-crash isolated workers with
+    # ``Unknown skill(s)``. The child still writes new skills to its own profile;
+    # this only widens the read path used by skill discovery/loading.
+    shared_skills_dir = kanban_home() / "skills"
+    if shared_skills_dir.is_dir():
+        env["HERMES_KANBAN_SHARED_SKILLS_DIRS"] = str(shared_skills_dir)
     if task.tenant:
         env["HERMES_TENANT"] = task.tenant
     env["HERMES_KANBAN_TASK"] = task.id

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -451,6 +451,36 @@ class TestBuildPreloadedSkillsPrompt:
         assert loaded == ["present-skill"]
         assert missing == ["missing-skill"]
 
+    def test_loads_kanban_shared_skill_dir_from_internal_env(self, tmp_path, monkeypatch):
+        """Kanban workers can preload skills from the board owner's skill dir.
+
+        Worker profiles have their own HERMES_HOME and local skills directory,
+        but the dispatcher injects HERMES_KANBAN_SHARED_SKILLS_DIRS so a task
+        skill created in the shared/default profile loads instead of crashing as
+        Unknown skill(s) during startup.
+        """
+        local = tmp_path / "worker" / "skills"
+        shared = tmp_path / "default" / "skills"
+        local.mkdir(parents=True)
+        shared.mkdir(parents=True)
+        _make_skill(shared, "shared-kanban-skill")
+
+        monkeypatch.setenv("HERMES_KANBAN_SHARED_SKILLS_DIRS", str(shared))
+        from agent.skill_utils import _external_dirs_cache_clear
+        _external_dirs_cache_clear()
+        try:
+            with patch("tools.skills_tool.SKILLS_DIR", local):
+                prompt, loaded, missing = build_preloaded_skills_prompt(
+                    ["shared-kanban-skill"]
+                )
+        finally:
+            monkeypatch.delenv("HERMES_KANBAN_SHARED_SKILLS_DIRS", raising=False)
+            _external_dirs_cache_clear()
+
+        assert missing == []
+        assert loaded == ["shared-kanban-skill"]
+        assert "shared-kanban-skill" in prompt
+
 
 class TestBuildSkillInvocationMessage:
     def test_loads_skill_by_stored_path_when_frontmatter_name_differs(self, tmp_path):

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -565,6 +565,46 @@ class TestLoadGatewayConfig:
         assert config.platforms[Platform.API_SERVER].enabled is False
         assert Platform.API_SERVER not in config.get_connected_platforms()
 
+    def test_explicit_api_server_disable_beats_env_key(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "platforms:\n"
+            "  api_server:\n"
+            "    enabled: false\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("API_SERVER_KEY", "test-api-key")
+        monkeypatch.setenv("API_SERVER_PORT", "8642")
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.API_SERVER].enabled is False
+        assert config.platforms[Platform.API_SERVER].extra["key"] == "test-api-key"
+        assert Platform.API_SERVER not in config.get_connected_platforms()
+
+    def test_explicit_homeassistant_disable_beats_env_token(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "platforms:\n"
+            "  homeassistant:\n"
+            "    enabled: false\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HASS_TOKEN", "test-hass-token")
+        monkeypatch.setenv("HASS_URL", "http://homeassistant.local:8123")
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.HOMEASSISTANT].enabled is False
+        assert config.platforms[Platform.HOMEASSISTANT].token == "test-hass-token"
+        assert Platform.HOMEASSISTANT not in config.get_connected_platforms()
+
     def test_bridges_nested_gateway_platforms_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2729,6 +2729,7 @@ def test_default_spawn_does_not_auto_load_any_skill(kanban_home, monkeypatch):
 
     conn = kb.connect()
     try:
+        (kb.kanban_home() / "skills").mkdir(parents=True, exist_ok=True)
         tid = kb.create_task(conn, title="skill-loading test",
                              assignee="some-profile")
         task = kb.get_task(conn, tid)
@@ -2751,6 +2752,9 @@ def test_default_spawn_does_not_auto_load_any_skill(kanban_home, monkeypatch):
     env = captured["env"]
     assert env.get("HERMES_KANBAN_TASK") == tid
     assert env.get("HERMES_PROFILE") == "some-profile"
+    assert env.get("HERMES_KANBAN_SHARED_SKILLS_DIRS") == str(
+        kb.kanban_home() / "skills"
+    )
 
 
 def test_default_spawn_raises_terminal_timeout_to_task_runtime(kanban_home, monkeypatch):


### PR DESCRIPTION
## Summary
- let Kanban workers read board-owner shared skills via an internal shared skill dirs env
- include shared skill dirs in external skill-dir resolution/cache keys
- respect explicit gateway platform disables for API server/Home Assistant even when env secrets are present

## Tests
- python -m pytest tests/agent/test_skill_commands.py tests/gateway/test_config.py tests/hermes_cli/test_kanban_core_functionality.py::test_default_spawn_does_not_auto_load_any_skill tests/hermes_cli/test_kanban_core_functionality.py::test_default_spawn_appends_per_task_skills tests/hermes_cli/test_kanban_core_functionality.py::test_default_spawn_passes_task_skills_verbatim -q
- 116 passed, 2 warnings