### PR TITLE
fix(bedrock): pass CLI --model flag as target_model to resolve_runtime_provider

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -42,6 +42,7 @@ class CLIAgentSetupMixin:
                 requested=self.requested_provider,
                 explicit_api_key=self._explicit_api_key,
                 explicit_base_url=self._explicit_base_url,
+                target_model=self.model or None,
             )
         except Exception as exc:
             _primary_exc = exc


### PR DESCRIPTION
## Problem

PR #51724 (fixing issue #49095) corrected the Bedrock api_mode routing in `resolve_runtime_provider()` for the **delegation path**. It added `target_model` support so Claude models route through AnthropicBedrock SDK and non-Claude models route through the Converse API.

However the **CLI path** (`hermes chat --model <non-claude> --provider bedrock`) was not fixed. `CLIAgentSetupMixin.setup_provider()` calls `resolve_runtime_provider()` without passing `target_model`, so the resolver still falls back to `model_cfg.get('default')` — which is typically a Claude model — and routes non-Claude models through the wrong SDK.

## Reproducer

\```bash
# config.yaml default: global.anthropic.claude-sonnet-4-6
hermes chat --model amazon.nova-pro-v1:0 --provider bedrock -q "hello"
# Before: routes through AnthropicBedrock SDK, sends anthropic_version param, API error
# After: routes through Converse API, works correctly
\```

## Fix

One line in `CLIAgentSetupMixin.setup_provider()` — pass `self.model` as `target_model`:

```python
runtime = resolve_runtime_provider(
    requested=self.requested_provider,
    explicit_api_key=self._explicit_api_key,
    explicit_base_url=self._explicit_base_url,
+   target_model=self.model or None,
)
```

No new tests needed — same code path in `resolve_runtime_provider()` already covered by the regression suite from #51724.

## Relates to

- Issue #49095
- PR #51724 (fixed delegation path; this completes the fix for the CLI path)
