### PR TITLE
fix: skip mountinfo container check on WSL (Docker Desktop false positive)

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -642,6 +642,20 @@ def is_container() -> bool:
                 return True
     except OSError:
         pass
+    # ── WSL + Docker Desktop false-positive guard ─────────────────
+    # Docker Desktop on Windows mounts its containerd overlay filesystems into
+    # the WSL2 kernel.  These paths contain the string "containerd" and would
+    # trigger a false positive two blocks below, even though the process is
+    # running natively on the WSL2 host (not inside a container).
+    #
+    # A *real* container running inside WSL (Docker/Podman) is caught earlier
+    # by /.dockerenv, /run/.containerenv, or /proc/1/cgroup markers, so this
+    # guard is safe — it only affects the host WSL process that Docker Desktop
+    # polluted the mount table of.
+    if is_wsl():
+        _container_detected = False
+        return False
+
     # cgroup v2: /proc/1/cgroup is just "0::/" with no marker. The container
     # runtime still shows up in the mount table (overlay rootfs, runtime mount
     # paths), so scan mountinfo as a last resort.


### PR DESCRIPTION
## Problem

Docker Desktop on Windows mounts its containerd overlay filesystems into the WSL2 kernel. When Hermes Agent runs natively on the WSL2 host (not inside any container), ``/proc/self/mountinfo`` contains::

  /var/lib/containerd/.../snapshots/...

The ``is_container()`` function scans mountinfo for ``containerd`` as a cgroup-v2 fallback. On WSL + Docker Desktop this produces a **false positive**.

Real containers inside WSL are caught earlier (``/.dockerenv``, ``KUBERNETES_SERVICE_HOST``, ``/proc/1/cgroup``), so the ``is_wsl()`` guard only affects the host process.

## Fix

Add ``is_wsl()`` early-return before the mountinfo block.

## Testing

Verified on WSL2 + Docker Desktop:
- Before: ``is_container()`` = ``True`` (false positive)
- After:  ``is_container()`` = ``False`` (correct)

Refs: NousResearch/hermes-agent#47111