### PR TITLE
fix(auth): treat fallback chain providers as explicitly configured

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1383,6 +1383,17 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
     except Exception:
         pass
 
+    # 2b. Check fallback_providers — if the user explicitly listed a provider
+    # in their fallback chain, that's an intentional configuration choice.
+    try:
+        from hermes_cli.config import load_config as _load_cfg
+        from hermes_cli.fallback_config import get_fallback_chain
+        for entry in get_fallback_chain(_load_cfg()):
+            if (entry.get("provider") or "").strip().lower() == normalized:
+                return True
+    except Exception:
+        pass
+
     # 3. Check provider-specific env vars
     # Exclude CLAUDE_CODE_OAUTH_TOKEN — it's set by Claude Code itself,
     # not by the user explicitly configuring anthropic in Hermes.


### PR DESCRIPTION
## What changed and why

`is_provider_explicitly_configured()` determines whether a provider counts as "user-configured" to suppress the "not configured" warning. Providers explicitly listed in the user's `fallback_providers` chain are an intentional configuration choice, but the check did not consider them — so Hermes would warn about an unconfigured provider even when the user deliberately added it to their fallback chain.

This PR adds a check (position 2b in the existing priority chain) that loads the user's `config.yaml`, resolves the current fallback chain via `get_fallback_chain()`, and returns `True` if the provider appears in any fallback entry.

## How to test

```python
from hermes_cli.auth import is_provider_explicitly_configured
import inspect
assert "fallback_providers" in inspect.getsource(is_provider_explicitly_configured)
```

With a config that has a fallback chain including e.g. `opencode-go`:
```yaml
fallback_providers:
  - provider: opencode-go
    model: deepseek-v4-pro
```
Then `is_provider_explicitly_configured("opencode-go")` returns `True`.

## Platforms tested

Linux (Proxmox LXC, Python 3.11)

## Model Used

- Provider: Anthropic (Claude Max)
- Model: Claude Sonnet 4.6