### PR TITLE
fix(checkpoints): ignore invalid prune timestamps

### DIFF
--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -915,6 +915,37 @@ class TestPruneCheckpointsV2:
         assert (base / "store" / "projects" / f"{fresh_hash}.json").exists()
         assert not meta_path.exists()
 
+    @pytest.mark.parametrize(
+        "last_touch",
+        ["not-a-timestamp", float("nan"), float("inf"), float("-inf")],
+    )
+    def test_invalid_last_touch_does_not_abort_prune(
+        self, tmp_path, monkeypatch, last_touch
+    ):
+        base = tmp_path / "checkpoints"
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", base)
+
+        work = tmp_path / "work"
+        work.mkdir()
+        (work / "f").write_text("content")
+
+        m = CheckpointManager(enabled=True)
+        assert m.ensure_checkpoint(str(work), "initial") is True
+
+        dir_hash = _project_hash(str(work))
+        meta_path = base / "store" / "projects" / f"{dir_hash}.json"
+        meta = json.loads(meta_path.read_text())
+        meta["last_touch"] = last_touch
+        meta_path.write_text(json.dumps(meta))
+
+        result = prune_checkpoints(
+            retention_days=30, delete_orphans=False, checkpoint_base=base,
+        )
+
+        assert result["scanned"] >= 1
+        assert result["deleted_stale"] == 0
+        assert meta_path.exists()
+
     def test_legacy_archive_dirs_also_pruned(self, tmp_path, monkeypatch):
         """legacy-<ts>/ dirs older than retention_days get wiped."""
         base = tmp_path / "checkpoints"

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -51,6 +51,7 @@ project until total store size is under ``max_total_size_mb``.
 import hashlib
 import json
 import logging
+import math
 import os
 import re
 import shutil
@@ -58,7 +59,7 @@ import subprocess
 import time
 from pathlib import Path
 from hermes_constants import get_hermes_home
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from utils import env_int
 
@@ -536,6 +537,14 @@ def _list_projects(store: Path) -> List[Dict]:
         meta["_hash"] = dir_hash
         out.append(meta)
     return out
+
+
+def _coerce_project_timestamp(value: Any) -> float:
+    try:
+        parsed = float(value or 0)
+    except (OverflowError, TypeError, ValueError):
+        return 0.0
+    return parsed if math.isfinite(parsed) else 0.0
 
 
 def _dir_file_count(path: str) -> int:
@@ -1374,7 +1383,7 @@ def prune_checkpoints(
             if delete_orphans and (not workdir or not Path(workdir).exists()):
                 reason = "orphan"
             elif retention_days > 0:
-                last_touch = float(meta.get("last_touch", 0) or 0)
+                last_touch = _coerce_project_timestamp(meta.get("last_touch"))
                 if last_touch > 0 and last_touch < cutoff:
                     reason = "stale"
             if reason is None:


### PR DESCRIPTION
## Summary
- Coerce v2 checkpoint project `last_touch` metadata before stale-prune comparisons.
- Treat malformed, NaN, and infinite timestamps as unknown instead of aborting checkpoint maintenance.
- Add regression coverage for `prune_checkpoints()` with corrupted project metadata.

## Why
`prune_checkpoints()` documents that maintenance must never raise, but a corrupted project metadata file with `last_touch: "bad"` currently raises `ValueError` during stale-prune evaluation. This can break explicit `hermes checkpoints prune` runs and the startup auto-maintenance wrapper. Invalid timestamps now skip stale deletion while preserving orphan pruning and the rest of the maintenance pass.

## Tests
- `python -m pytest tests/tools/test_checkpoint_manager.py::TestPruneCheckpointsV2::test_invalid_last_touch_does_not_abort_prune -q`
- `python -m pytest tests/tools/test_checkpoint_manager.py::TestPruneCheckpointsV2 -q`
- `python -m py_compile tools/checkpoint_manager.py`
- `python scripts/check-windows-footguns.py --all`

Note: `python -m pytest tests/tools/test_checkpoint_manager.py -q` currently has unrelated Windows-local failures in this checkout: one path-separator assertion in `TestGitEnvIsolation` and one Windows file-lock cleanup failure in `TestClearFunctions`.