### PR TITLE
fix(transport): honor reasoning_config in legacy chat_completions path

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -418,7 +418,24 @@ class ChatCompletionsTransport(ProviderTransport):
         # Reasoning. LM Studio is handled above via top-level reasoning_effort,
         # so skip emitting extra_body.reasoning for it.
         if params.get("supports_reasoning", False) and not params.get("is_lmstudio", False):
-            if is_github_models:
+            # Honor reasoning_config when present (e.g. delegation.reasoning_effort
+            # override). Without this check, the legacy path unconditionally emits
+            # reasoning: {enabled: true, effort: "medium"}, ignoring the caller's
+            # explicit disable.  See #51903.
+            if reasoning_config and isinstance(reasoning_config, dict):
+                if reasoning_config.get("enabled") is False:
+                    pass  # reasoning explicitly disabled — omit entirely
+                else:
+                    _effort = str(
+                        reasoning_config.get("effort", "medium")
+                    ).strip().lower()
+                    extra_body["reasoning"] = {
+                        "enabled": True,
+                        "effort": _effort if _effort in {
+                            "low", "medium", "high", "xhigh",
+                        } else "medium",
+                    }
+            elif is_github_models:
                 gh_reasoning = params.get("github_reasoning_extra")
                 if gh_reasoning is not None:
                     extra_body["reasoning"] = gh_reasoning

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -290,6 +290,26 @@ class TestChatCompletionsBuildKwargs:
         # Nous rejects enabled=false; reasoning omitted entirely
         assert "reasoning" not in kw.get("extra_body", {})
 
+    def test_reasoning_disabled_via_config_legacy(self, transport):
+        """Legacy path (no profile): reasoning_config disables reasoning."""
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-4o", messages=msgs,
+            supports_reasoning=True,
+            reasoning_config={"enabled": False},
+        )
+        assert "reasoning" not in kw.get("extra_body", {})
+
+    def test_reasoning_custom_effort_via_config_legacy(self, transport):
+        """Legacy path (no profile): reasoning_config overrides effort."""
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-4o", messages=msgs,
+            supports_reasoning=True,
+            reasoning_config={"enabled": True, "effort": "high"},
+        )
+        assert kw["extra_body"]["reasoning"] == {"enabled": True, "effort": "high"}
+
     def test_ollama_num_ctx(self, transport):
         from providers import get_provider_profile
         profile = get_provider_profile("custom")


### PR DESCRIPTION
## What does this PR do?

Fixes the legacy (non-profile) code path in `ChatCompletionsTransport` to honor `reasoning_config` when building API kwargs. Previously, providers without a registered profile (e.g. Groq via `delegation.provider`) would unconditionally emit `reasoning: {enabled: true, effort: "medium"}`, ignoring the caller's explicit `reasoning_config={"enabled": False}`.

## Related Issue

Fixes #51903

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/transports/chat_completions.py`: Check `reasoning_config` before emitting `extra_body["reasoning"]` in the legacy path. When `enabled=False`, omit reasoning entirely; when a specific effort is set, use it; otherwise fall through to the default.
- `tests/agent/transports/test_chat_completions.py`: Add 2 regression tests for the legacy path — disabled reasoning and custom effort override.

## How to Test

1. Set `agent.reasoning_effort: medium` in parent profile
2. Set `delegation.provider: groq` and `delegation.reasoning_effort: none` in config.yaml
3. Spawn a sub-agent via `delegate_task()` — it should no longer emit `reasoning` in the API request
4. Run `pytest tests/agent/transports/test_chat_completions.py -k reasoning -v` — all 24 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/agent/transports/test_chat_completions.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/transports/chat_completions.py` `_build_kwargs()` (callers: 1, flows: legacy provider path)
- Blast radius: LOW — only affects providers without a registered profile (custom/unregistered providers)
- Related patterns: OpenRouter profile's `build_api_kwargs_extras()` already handles `reasoning_config` correctly; this fix aligns the legacy path with the profile path behavior.
