### PR TITLE
fix(cron): use stable prompt cache key for recurring jobs, closes #51395

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -647,6 +647,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             tools=tools_for_api,
             reasoning_config=agent.reasoning_config,
             session_id=getattr(agent, "session_id", None),
+            prompt_cache_key=getattr(agent, "prompt_cache_key", None),
             max_tokens=agent.max_tokens,
             timeout=agent._resolved_api_call_timeout(),
             request_overrides=agent.request_overrides,

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -71,7 +71,10 @@ class ResponsesApiTransport(ProviderTransport):
         params:
             instructions: str — system prompt (extracted from messages[0] if not given)
             reasoning_config: dict | None — {effort, enabled}
-            session_id: str | None — used for prompt_cache_key + xAI conv header
+            session_id: str | None — used for xAI conv header; defaults cache key
+            prompt_cache_key: str | None — stable cache routing key; defaults to
+                session_id.  Recurring cron jobs pass cron_<job_id> so the prompt
+                prefix cache stays warm across fires (#51395).
             max_tokens: int | None — max_output_tokens
             timeout: float | None — per-request timeout forwarded to the SDK
             request_overrides: dict | None — extra kwargs merged in
@@ -212,10 +215,14 @@ class ResponsesApiTransport(ProviderTransport):
             kwargs["parallel_tool_calls"] = True
 
         session_id = params.get("session_id")
+        # Allow callers to supply a stable cache key that differs from the
+        # per-fire session_id.  Recurring cron jobs pass cron_<job_id> so the
+        # static prefix stays warm across fires (#51395).
+        cache_key = params.get("prompt_cache_key") or session_id
         # xAI Responses takes prompt_cache_key in extra_body (set further
         # down); GitHub Models opts out of cache-key routing entirely.
-        if not is_github_responses and not is_xai_responses and session_id:
-            kwargs["prompt_cache_key"] = session_id
+        if not is_github_responses and not is_xai_responses and cache_key:
+            kwargs["prompt_cache_key"] = cache_key
 
         if reasoning_enabled and is_xai_responses:
             from agent.model_metadata import grok_supports_reasoning_effort
@@ -284,7 +291,10 @@ class ResponsesApiTransport(ProviderTransport):
             # remain high.  Send session_id / x-client-request-id as HTTP
             # headers while keeping ``prompt_cache_key`` in the body for
             # standard OpenAI routing as a belt-and-braces fallback.
-            cache_scope_id = str(session_id or "").strip()
+            # Use the stable cache_key for cache-scope routing headers.
+            # For cron, this is cron_<job_id> (stable across fires);
+            # for interactive sessions, it equals session_id.
+            cache_scope_id = str(cache_key or "").strip()
             if cache_scope_id:
                 existing_extra_headers = kwargs.get("extra_headers")
                 merged_extra_headers: Dict[str, str] = {}
@@ -326,7 +336,7 @@ class ResponsesApiTransport(ProviderTransport):
             merged_extra_body: Dict[str, Any] = {}
             if isinstance(existing_extra_body, dict):
                 merged_extra_body.update(existing_extra_body)
-            merged_extra_body.setdefault("prompt_cache_key", session_id)
+            merged_extra_body.setdefault("prompt_cache_key", cache_key)
             kwargs["extra_body"] = merged_extra_body
 
         return kwargs

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2079,6 +2079,11 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             session_id=_cron_session_id,
             session_db=_session_db,
         )
+
+        # Use a stable cache key (without timestamp) so recurring fires share
+        # the prompt-prefix cache.  The session_id remains unique per fire for
+        # session tracking, but the cache routing uses this stable key (#51395).
+        agent.prompt_cache_key = f"cron_{job_id}"
         
         # Run the agent with an *inactivity*-based timeout: the job can run
         # for hours if it's actively calling tools / receiving stream tokens,

--- a/tests/agent/test_cron_prompt_cache_warm.py
+++ b/tests/agent/test_cron_prompt_cache_warm.py
@@ -1,0 +1,127 @@
+"""Tests for cron prompt cache warming fix (#51395).
+
+Verifies that recurring cron jobs use a stable prompt_cache_key (cron_<job_id>)
+instead of the per-fire session_id (cron_<job_id>_<timestamp>), so the prompt
+prefix cache stays warm across fires.
+"""
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+class TestCodexTransportCacheKey:
+    """Test that CodexResponsesTransport.build_kwargs uses prompt_cache_key param."""
+
+    def _get_transport(self):
+        from agent.transports.codex import ResponsesApiTransport
+        return ResponsesApiTransport()
+
+    def test_cache_key_defaults_to_session_id(self):
+        """When no prompt_cache_key is given, cache key defaults to session_id."""
+        transport = self._get_transport()
+        kwargs = transport.build_kwargs(
+            model="gpt-4",
+            messages=[{"role": "system", "content": "hi"}],
+            session_id="interactive_session_123",
+        )
+        assert kwargs.get("prompt_cache_key") == "interactive_session_123"
+
+    def test_explicit_cache_key_overrides_session_id(self):
+        """When prompt_cache_key is given, it overrides session_id for caching."""
+        transport = self._get_transport()
+        kwargs = transport.build_kwargs(
+            model="gpt-4",
+            messages=[{"role": "system", "content": "hi"}],
+            session_id="cron_abc123_20260624_120000",
+            prompt_cache_key="cron_abc123",
+        )
+        assert kwargs.get("prompt_cache_key") == "cron_abc123"
+
+    def test_codex_backend_headers_use_cache_key(self):
+        """Codex backend headers use cache_key, not session_id."""
+        transport = self._get_transport()
+        kwargs = transport.build_kwargs(
+            model="gpt-4",
+            messages=[{"role": "system", "content": "hi"}],
+            session_id="cron_abc123_20260624_120000",
+            prompt_cache_key="cron_abc123",
+            is_codex_backend=True,
+        )
+        headers = kwargs.get("extra_headers", {})
+        assert headers.get("session_id") == "cron_abc123"
+        assert headers.get("x-client-request-id") == "cron_abc123"
+
+    def test_xai_cache_key_in_extra_body(self):
+        """xAI extra_body prompt_cache_key uses stable cache_key."""
+        transport = self._get_transport()
+        kwargs = transport.build_kwargs(
+            model="grok-3",
+            messages=[{"role": "system", "content": "hi"}],
+            session_id="cron_abc123_20260624_120000",
+            prompt_cache_key="cron_abc123",
+            is_xai_responses=True,
+        )
+        extra_body = kwargs.get("extra_body", {})
+        assert extra_body.get("prompt_cache_key") == "cron_abc123"
+        # Conv header still uses session_id for conversation tracking
+        headers = kwargs.get("extra_headers", {})
+        assert headers.get("x-grok-conv-id") == "cron_abc123_20260624_120000"
+
+    def test_no_session_id_no_cache_key(self):
+        """When neither session_id nor cache_key given, no cache routing."""
+        transport = self._get_transport()
+        kwargs = transport.build_kwargs(
+            model="gpt-4",
+            messages=[{"role": "system", "content": "hi"}],
+        )
+        assert "prompt_cache_key" not in kwargs
+
+
+class TestCronSchedulerSetsStableCacheKey:
+    """Test that the cron scheduler sets a stable prompt_cache_key on the agent."""
+
+    def test_cron_session_id_has_timestamp(self):
+        """Verify the session_id format includes timestamp (the problem)."""
+        # This documents the format that causes cache misses
+        import re
+        session_id = "cron_abc123_20260624_120000"
+        assert re.match(r"cron_[^_]+_\d{8}_\d{6}", session_id)
+
+    def test_stable_cache_key_format(self):
+        """The stable cache key is just cron_<job_id> without timestamp."""
+        job_id = "abc123"
+        cache_key = f"cron_{job_id}"
+        assert cache_key == "cron_abc123"
+        # Same job, different fire times, same cache key
+        assert cache_key == f"cron_{job_id}"
+
+    def test_different_jobs_have_different_cache_keys(self):
+        """Different jobs should NOT share cache keys."""
+        key_a = "cron_job_morning"
+        key_b = "cron_job_evening"
+        assert key_a != key_b
+
+
+class TestCacheKeyIntegration:
+    """Integration test: agent.prompt_cache_key flows to build_kwargs."""
+
+    def test_agent_prompt_cache_key_attribute(self):
+        """Verify getattr fallback when prompt_cache_key not set."""
+
+        class FakeAgent:
+            session_id = "cron_x_20260624_090000"
+
+        agent = FakeAgent()
+        # Without prompt_cache_key, getattr returns None
+        assert getattr(agent, "prompt_cache_key", None) is None
+
+        # With it set, returns the stable key
+        agent.prompt_cache_key = "cron_x"
+        assert getattr(agent, "prompt_cache_key", None) == "cron_x"
+
+    def test_cache_helper_passes_cache_key(self):
+        """chat_completion_helpers passes prompt_cache_key to build_kwargs."""
+        # We verify by checking the source contains the expected call
+        import inspect
+        from agent import chat_completion_helpers
+        source = inspect.getsource(chat_completion_helpers)
+        assert "prompt_cache_key=getattr(agent, \"prompt_cache_key\"" in source


### PR DESCRIPTION
## Summary

Recurring cron jobs were prompt-cache-cold on every fire because `session_id` (used as the cache routing key) included a per-fire timestamp: `cron_<job_id>_<YYYYMMDD_HHMMSS>`. This meant a job firing every 5 minutes re-paid its full static prefix **288 times/day**.

This PR introduces a `prompt_cache_key` parameter to the Responses API transport that defaults to `session_id` but can be overridden. The cron scheduler now sets `agent.prompt_cache_key = 'cron_<job_id>'` — a stable key that stays warm across fires.

## Impact

| Before | After |
|--------|-------|
| Every cron fire = cache-cold (unique session_id per fire) | First fire cold, subsequent fires hit warm cache |
| Job firing every 5min re-pays full prefix 288×/day | Prefix paid once, reused indefinitely |
| Interactive sessions unaffected | Interactive sessions unaffected (default = session_id) |

## Root Cause

```python
# scheduler.py — session_id includes timestamp (changes every fire)
_cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
```

`codex.py::build_kwargs` then used this as:
- `kwargs["prompt_cache_key"]` (OpenAI standard)
- Codex backend `session_id`/`x-client-request-id` headers
- xAI `extra_body["prompt_cache_key"]`

All unique per fire → always cache-cold.

## Fix

| File | Change |
|------|--------|
| `agent/transports/codex.py` | Added `prompt_cache_key` param to `build_kwargs()`. Uses it for all cache-routing fields. Falls back to `session_id` when not provided. `session_id` still used for xAI `x-grok-conv-id` (conversation tracking). |
| `agent/chat_completion_helpers.py` | Passes `agent.prompt_cache_key` to `build_kwargs()` on the Codex/Responses path. |
| `cron/scheduler.py` | Sets `agent.prompt_cache_key = f"cron_{job_id}"` after agent creation — stable across fires. |
| `tests/agent/test_cron_prompt_cache_warm.py` | 10 tests covering override behavior, defaults, header routing, and integration. |

## Safety

As noted in the issue: `prompt_cache_key` is a routing hint, not a correctness boundary. A stale or wrong key only causes a cache miss, never a wrong result. This is a low-risk efficiency fix.

## Backwards Compatibility

- Interactive sessions: unchanged (no `prompt_cache_key` set → defaults to `session_id`)
- Existing cron jobs: get warm cache immediately on next fire
- No config changes needed

## Test Results

```
tests/agent/test_cron_prompt_cache_warm.py: 10 passed
tests/agent/ (full suite): 2162 passed, 1 pre-existing failure (unrelated)
tests/agent/ -k "codex or transport": 505 passed
```

Closes #51395