### PR TITLE
fix(auth): reject non-finite Nous JWT expiry

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import shutil
 import shlex
@@ -1781,7 +1782,10 @@ def _nous_invoke_jwt_status(
     exp = claims.get("exp")
     skew = max(0, int(min_ttl_seconds))
     if isinstance(exp, (int, float)):
-        if float(exp) <= (time.time() + skew):
+        exp_value = float(exp)
+        if not math.isfinite(exp_value):
+            return "invoke_jwt_expiry_unknown_or_expiring"
+        if exp_value <= (time.time() + skew):
             return "invoke_jwt_expiring"
         return None
     if _is_expiring(expires_at, skew):

--- a/tests/hermes_cli/test_auth_nous_provider.py
+++ b/tests/hermes_cli/test_auth_nous_provider.py
@@ -183,6 +183,22 @@ def _invoke_jwt(*, seconds: int = 3600, scope: object = "inference:invoke") -> s
     })
 
 
+@pytest.mark.parametrize("exp", [float("nan"), float("inf"), float("-inf")])
+def test_nous_invoke_jwt_rejects_non_finite_exp(exp):
+    import hermes_cli.auth as auth_mod
+
+    token = _jwt_with_claims({
+        "sub": "test-user",
+        "scope": auth_mod.NOUS_INFERENCE_INVOKE_SCOPE,
+        "exp": exp,
+    })
+
+    assert (
+        auth_mod._nous_invoke_jwt_status(token)
+        == "invoke_jwt_expiry_unknown_or_expiring"
+    )
+
+
 def test_resolve_nous_runtime_credentials_prefers_invoke_jwt_and_mirrors(
     tmp_path,
     monkeypatch,


### PR DESCRIPTION
## Summary
- Reject non-finite `exp` claims in Nous invoke JWT usability checks.
- Route `NaN`, `Infinity`, and `-Infinity` through the existing expiry-unknown path instead of treating them as usable.
- Add focused regression coverage for malformed decoded JWT expiry values.

## Why
Python `json.loads()` accepts non-standard `NaN` / `Infinity` numeric literals. A JWT payload with `exp: NaN` or `exp: Infinity` currently reaches `_nous_invoke_jwt_status()` as a float and passes the `exp > now + skew` check, so Hermes treats the invoke JWT as usable. Expiry must be finite; malformed expiry should refresh or require re-authentication rather than bypassing expiry checks.

## Tests
- `python -m pytest tests/hermes_cli/test_auth_nous_provider.py::test_nous_invoke_jwt_rejects_non_finite_exp -q`
- `python -m pytest tests/hermes_cli/test_auth_nous_provider.py::test_nous_invoke_jwt_rejects_non_finite_exp tests/hermes_cli/test_auth_nous_provider.py::test_resolve_nous_runtime_credentials_prefers_invoke_jwt_and_mirrors tests/hermes_cli/test_auth_nous_provider.py::test_resolve_nous_runtime_credentials_reauths_when_invoke_scope_missing tests/hermes_cli/test_auth_nous_provider.py::test_resolve_nous_runtime_credentials_trusts_invoke_jwt_exp_over_stale_metadata -q`
- `python -m py_compile hermes_cli/auth.py`
- `python scripts/check-windows-footguns.py --all`

Note: `python -m pytest tests/hermes_cli/test_auth_nous_provider.py -q` currently has two unrelated Windows-local failures in this checkout: default-locale decoding of UTF-8 config text and a platform-specific shared-store file-mode assertion.