### PR TITLE
fix: add error handling for subprocess and shutil.rmtree calls

### DIFF
--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -814,7 +814,10 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
     if unsafe:
         return {"success": False, "error": unsafe}
 
-    shutil.rmtree(skill_dir)
+    try:
+        shutil.rmtree(skill_dir)
+    except OSError as exc:
+        return {"success": False, "error": f"Failed to delete skill directory: {exc}"}
 
     # Clean up empty category directories (don't remove the skills root itself)
     parent = skill_dir.parent

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3308,7 +3308,10 @@ def quarantine_bundle(bundle: SkillBundle) -> Path:
 
     dest = QUARANTINE_DIR / skill_name
     if dest.exists():
-        shutil.rmtree(dest)
+        try:
+            shutil.rmtree(dest)
+        except OSError as exc:
+            raise RuntimeError(f"Failed to clean quarantine dir {dest}: {exc}") from exc
     dest.mkdir(parents=True)
 
     for rel_path, file_content in validated_files:
@@ -3348,7 +3351,10 @@ def install_from_quarantine(
     install_dir = _resolve_lock_install_path(install_rel_path, safe_skill_name)
 
     if install_dir.exists():
-        shutil.rmtree(install_dir)
+        try:
+            shutil.rmtree(install_dir)
+        except OSError as exc:
+            raise RuntimeError(f"Failed to remove install dir {install_dir}: {exc}") from exc
 
     # Warn (but don't block) if SKILL.md is very large
     skill_md = quarantine_path / "SKILL.md"
@@ -3429,7 +3435,10 @@ def uninstall_skill(skill_name: str) -> Tuple[bool, str]:
         return False, f"Refusing to uninstall '{skill_name}': {exc}"
 
     if install_path.exists():
-        shutil.rmtree(install_path)
+        try:
+            shutil.rmtree(install_path)
+        except OSError as exc:
+            return False, f"Failed to remove skill directory {install_path}: {exc}"
 
     lock.record_uninstall(skill_name)
     append_audit_log("UNINSTALL", skill_name, entry["source"], entry["trust_level"], "n/a", "user_request")

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1871,8 +1871,17 @@ def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) ->
         ffmpeg = shutil.which("ffmpeg")
         if ffmpeg:
             conv_cmd = [ffmpeg, "-i", wav_path, "-y", "-loglevel", "error", output_path]
-            subprocess.run(conv_cmd, check=True, timeout=30, stdin=subprocess.DEVNULL)
-            os.remove(wav_path)
+            try:
+                subprocess.run(conv_cmd, check=True, timeout=30, stdin=subprocess.DEVNULL)
+            except subprocess.CalledProcessError as exc:
+                raise RuntimeError(
+                    f"ffmpeg conversion failed (exit {exc.returncode}): {exc.stderr or 'no stderr'}"
+                ) from exc
+            finally:
+                try:
+                    os.remove(wav_path)
+                except OSError:
+                    pass
         else:
             # No ffmpeg — just rename the WAV to the expected path
             os.rename(wav_path, output_path)
@@ -2050,11 +2059,17 @@ def _generate_piper_tts(text: str, output_path: str, tts_config: Dict[str, Any])
         ffmpeg = shutil.which("ffmpeg")
         if ffmpeg:
             conv_cmd = [ffmpeg, "-i", wav_path, "-y", "-loglevel", "error", output_path]
-            subprocess.run(conv_cmd, check=True, timeout=30, stdin=subprocess.DEVNULL)
             try:
-                os.remove(wav_path)
-            except OSError:
-                pass
+                subprocess.run(conv_cmd, check=True, timeout=30, stdin=subprocess.DEVNULL)
+            except subprocess.CalledProcessError as exc:
+                raise RuntimeError(
+                    f"ffmpeg conversion failed (exit {exc.returncode}): {exc.stderr or 'no stderr'}"
+                ) from exc
+            finally:
+                try:
+                    os.remove(wav_path)
+                except OSError:
+                    pass
         else:
             # No ffmpeg — keep WAV and return that path
             os.rename(wav_path, output_path)
@@ -2116,8 +2131,17 @@ def _generate_kittentts(text: str, output_path: str, tts_config: Dict[str, Any])
         ffmpeg = shutil.which("ffmpeg")
         if ffmpeg:
             conv_cmd = [ffmpeg, "-i", wav_path, "-y", "-loglevel", "error", output_path]
-            subprocess.run(conv_cmd, check=True, timeout=30, stdin=subprocess.DEVNULL)
-            os.remove(wav_path)
+            try:
+                subprocess.run(conv_cmd, check=True, timeout=30, stdin=subprocess.DEVNULL)
+            except subprocess.CalledProcessError as exc:
+                raise RuntimeError(
+                    f"ffmpeg conversion failed (exit {exc.returncode}): {exc.stderr or 'no stderr'}"
+                ) from exc
+            finally:
+                try:
+                    os.remove(wav_path)
+                except OSError:
+                    pass
         else:
             # No ffmpeg — rename the WAV to the expected path
             os.rename(wav_path, output_path)


### PR DESCRIPTION
## Summary

Three tools had bare `subprocess.run(check=True)` or `shutil.rmtree()` calls that would propagate unhandled exceptions on failure, leaving temp files behind and crashing the tool call with unhelpful tracebacks.

## Changes

### tools/tts_tool.py (3 call-sites)

`subprocess.run(conv_cmd, check=True)` for ffmpeg conversion would raise bare `CalledProcessError` on failure, leaking the temp WAV file.

**Fix:** Wrap in `try/except CalledProcessError`, re-raise as `RuntimeError` with stderr details, clean up temp WAV in `finally` block.

### tools/skill_manager_tool.py

`shutil.rmtree(skill_dir)` had no error handling — permission errors or locked files would crash the delete operation.

**Fix:** Wrap in `try/except OSError`, return `{"success": False, "error": ...}` dict.

### tools/skills_hub.py (3 call-sites)

- `install_from_quarantine`: quarantine dir cleanup — raises `RuntimeError` on failure
- `install_from_quarantine`: install dir cleanup — raises `RuntimeError` on failure  
- `uninstall_skill`: skill dir cleanup — returns `(False, error_msg)` tuple on failure

## Testing

- All modified files parse cleanly with `ast.parse()`
- No new lint/type errors introduced