### PR TITLE
fix(tui): ignore invalid skills browse pagination

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -1318,6 +1318,43 @@ def test_skills_manage_search_uses_tools_hub_sources(server):
     search.assert_called_once_with("showroom", ["source"], source_filter="all", limit=20)
 
 
+def test_skills_manage_browse_ignores_invalid_pagination(server):
+    browse = MagicMock(
+        side_effect=[
+            {"items": [], "page": 3, "total_pages": 1, "total": 0},
+            {"items": [], "page": 1, "total_pages": 1, "total": 0},
+        ]
+    )
+    fake_hub = types.SimpleNamespace(browse_skills=browse)
+
+    with patch.dict(sys.modules, {"hermes_cli.skills_hub": fake_hub}):
+        resp_with_query_page = server.handle_request({
+            "id": "skills-browse-query-page",
+            "method": "skills.manage",
+            "params": {
+                "action": "browse",
+                "query": "3",
+                "page": "not-int",
+                "page_size": "wide",
+            },
+        })
+        resp_with_bad_query = server.handle_request({
+            "id": "skills-browse-bad-query",
+            "method": "skills.manage",
+            "params": {
+                "action": "browse",
+                "query": 7,
+                "page": float("inf"),
+                "page_size": None,
+            },
+        })
+
+    assert "error" not in resp_with_query_page
+    assert "error" not in resp_with_bad_query
+    assert browse.call_args_list[0].kwargs == {"page": 3, "page_size": 20}
+    assert browse.call_args_list[1].kwargs == {"page": 1, "page_size": 20}
+
+
 def test_command_dispatch_steer_fallback_sends_message(server):
     """command.dispatch /steer with no active agent falls back to send."""
     sid = "test-session"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11581,6 +11581,13 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 5023, str(e))
 
 
+def _coerce_skills_browse_int(value: object, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError, OverflowError):
+        return default
+
+
 @method("skills.manage")
 def _(rid, params: dict) -> dict:
     action, query = params.get("action", "list"), params.get("query", "")
@@ -11625,11 +11632,19 @@ def _(rid, params: dict) -> dict:
         if action == "browse":
             from hermes_cli.skills_hub import browse_skills
 
-            pg = int(params.get("page", 0) or 0) or (
-                int(query) if query.isdigit() else 1
+            pg = _coerce_skills_browse_int(params.get("page", 0) or 0, 0)
+            if not pg:
+                pg = (
+                    _coerce_skills_browse_int(query, 1)
+                    if isinstance(query, str) and query.isdigit()
+                    else 1
+                )
+            page_size = _coerce_skills_browse_int(
+                params.get("page_size", 20) or 20,
+                20,
             )
             return _ok(
-                rid, browse_skills(page=pg, page_size=int(params.get("page_size", 20)))
+                rid, browse_skills(page=pg, page_size=page_size)
             )
         if action == "inspect":
             from hermes_cli.skills_hub import inspect_skill


### PR DESCRIPTION
## Summary
- tolerate malformed `skills.manage` browse pagination inputs in the TUI gateway
- fall back to query-derived page or page 1 when `page` is invalid
- fall back to the default page size when `page_size` is invalid, while preserving `browse_skills` range clamping

## Tests
- `python -m pytest tests/tui_gateway/test_protocol.py::test_skills_manage_browse_ignores_invalid_pagination -q`
- `python -m pytest tests/tui_gateway/test_protocol.py::test_skills_manage_search_uses_tools_hub_sources tests/tui_gateway/test_protocol.py::test_skills_manage_browse_ignores_invalid_pagination -q`
- `python -m pytest tests/tui_gateway/test_protocol.py -q`
- `python -m py_compile tui_gateway/server.py`
- `python scripts/check-windows-footguns.py --all`