### PR TITLE
fix(web): keep custom-provider models on the Models page instead of forcing OpenRouter

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -866,6 +866,23 @@ def _normalize_main_model_assignment(provider: str, model: str) -> tuple[str, st
     canonical = normalize_provider(prov_in)
 
     if canonical not in _KNOWN_PROVIDER_NAMES and "/" in model_in:
+        # A configured custom provider (self-hosted OpenAI-compatible gateway,
+        # e.g. litellm / Bifrost / vLLM) may serve this vendor-prefixed model
+        # id. Prefer it over the OpenRouter fallback so the Models page does not
+        # silently re-route a user's gateway model to OpenRouter (which then
+        # fails at agent init with "No LLM provider configured" when OpenRouter
+        # is not configured).
+        try:
+            from hermes_cli.config import get_compatible_custom_providers
+            from hermes_cli.providers import custom_provider_slug
+            for _cp in get_compatible_custom_providers(load_config()) or []:
+                _served = list((_cp.get("models") or {}))
+                if _cp.get("model"):
+                    _served.append(_cp.get("model"))
+                if model_in in _served:
+                    return custom_provider_slug(_cp.get("name", "")), model_in
+        except Exception:
+            _log.debug("custom-provider model resolution failed", exc_info=True)
         # Vendor prefix posing as a provider (analytics fallback). Resolve
         # against the user's current provider when it's an aggregator that
         # serves vendor-prefixed slugs; otherwise default to openrouter.


### PR DESCRIPTION
## Problem

`_normalize_main_model_assignment()` (`hermes_cli/web_server.py`) routes any vendor-prefixed model id (e.g. `mistral/mistral-medium-2604`) to `provider=openrouter` whenever the incoming provider is not a known/aggregator provider:

```python
if canonical not in _KNOWN_PROVIDER_NAMES and "/" in model_in:
    ...
    else:
        canonical = "openrouter"
        prov_in = "openrouter"
```

For users running a self-hosted OpenAI-compatible gateway (litellm / Bifrost / vLLM) registered via `custom_providers:` — where the gateway serves vendor-prefixed ids like `mistral/...` — switching such a model on the Models page silently rewrites `model.provider` from `custom:<name>` to `openrouter` (and `_apply_main_model_assignment` then clears `base_url`). The agent subsequently fails at init with **"No LLM provider configured"** when OpenRouter has no key.

Models without a `/` (e.g. `qwen3.6-27b-nvfp4`) are unaffected, since the branch is gated on `"/" in model_in` — which is why this only bites gateway users with vendor-prefixed ids.

## Repro

1. Register a custom provider for an OpenAI-compatible gateway that serves a vendor-prefixed id:
   ```yaml
   model:
     default: mistral/mistral-medium-2604
     provider: custom:mygw
     base_url: https://gw.example/v1
   custom_providers:
     - name: mygw
       base_url: https://gw.example/v1
       api_key: "..."
       models: { mistral/mistral-medium-2604: {} }
   ```
2. On the Models page, switch to that model.
3. Config is rewritten to `provider: openrouter` + `base_url: ''` → agent init fails with "No LLM provider configured".

## Fix

Before the OpenRouter fallback, check whether a configured `custom_providers` entry serves the model id (via its `model` / `models` fields). If so, resolve to that `custom:<slug>` instead of OpenRouter. Models not served by any custom provider keep the existing behaviour. Single chokepoint, ~17 lines, no change to the known-provider path.