### PR TITLE
fix(nous): ignore non-finite rate limit resets

### DIFF
--- a/agent/nous_rate_guard.py
+++ b/agent/nous_rate_guard.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import tempfile
 import time
@@ -60,7 +61,7 @@ def _parse_reset_seconds(headers: Optional[Mapping[str, str]]) -> Optional[float
         if raw is not None:
             try:
                 val = float(raw)
-                if val > 0:
+                if math.isfinite(val) and val > 0:
                     return val
             except (TypeError, ValueError):
                 pass
@@ -96,11 +97,21 @@ def record_nous_rate_limit(
     # Try error_context reset_at (from body parsing)
     if reset_at is None and isinstance(error_context, dict):
         ctx_reset = error_context.get("reset_at")
-        if isinstance(ctx_reset, (int, float)) and ctx_reset > now:
+        if (
+            isinstance(ctx_reset, (int, float))
+            and math.isfinite(float(ctx_reset))
+            and ctx_reset > now
+        ):
             reset_at = float(ctx_reset)
 
     # Default cooldown
     if reset_at is None:
+        if (
+            not isinstance(default_cooldown, (int, float))
+            or not math.isfinite(float(default_cooldown))
+            or default_cooldown <= 0
+        ):
+            default_cooldown = 300.0
         reset_at = now + default_cooldown
 
     path = _state_path()
@@ -146,7 +157,13 @@ def nous_rate_limit_remaining() -> Optional[float]:
     try:
         with open(path, encoding="utf-8") as f:
             state = json.load(f)
-        reset_at = state.get("reset_at", 0)
+        reset_at = float(state.get("reset_at", 0) or 0)
+        if not math.isfinite(reset_at):
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+            return None
         remaining = reset_at - time.time()
         if remaining > 0:
             return remaining
@@ -172,6 +189,12 @@ def clear_nous_rate_limit() -> None:
 
 def format_remaining(seconds: float) -> str:
     """Format seconds remaining into human-readable duration."""
+    try:
+        seconds = float(seconds)
+    except (TypeError, ValueError, OverflowError):
+        return "0s"
+    if not math.isfinite(seconds):
+        return "0s"
     s = max(0, int(seconds))
     if s < 60:
         return f"{s}s"
@@ -262,16 +285,20 @@ def _parse_buckets_from_headers(
         if raw is None:
             return None
         try:
-            return int(float(raw))
-        except (TypeError, ValueError):
+            parsed = float(raw)
+            if not math.isfinite(parsed):
+                return None
+            return int(parsed)
+        except (TypeError, ValueError, OverflowError):
             return None
 
     def _maybe_float(raw: Optional[str]) -> Optional[float]:
         if raw is None:
             return None
         try:
-            return float(raw)
-        except (TypeError, ValueError):
+            parsed = float(raw)
+            return parsed if math.isfinite(parsed) else None
+        except (TypeError, ValueError, OverflowError):
             return None
 
     result: dict[str, tuple[Optional[int], Optional[float]]] = {}
@@ -292,7 +319,13 @@ def _has_exhausted_bucket(
             continue
         if reset is None:
             continue
-        if reset >= _MIN_RESET_FOR_BREAKER_SECONDS:
+        try:
+            reset_value = float(reset)
+        except (TypeError, ValueError, OverflowError):
+            continue
+        if not math.isfinite(reset_value):
+            continue
+        if reset_value >= _MIN_RESET_FOR_BREAKER_SECONDS:
             return True
     return False
 
@@ -320,6 +353,12 @@ def _has_exhausted_bucket_in_object(state: Any) -> bool:
             continue
         if remaining > 0:
             continue
-        if reset >= _MIN_RESET_FOR_BREAKER_SECONDS:
+        try:
+            reset_value = float(reset)
+        except (TypeError, ValueError, OverflowError):
+            continue
+        if not math.isfinite(reset_value):
+            continue
+        if reset_value >= _MIN_RESET_FOR_BREAKER_SECONDS:
             return True
     return False

--- a/tests/agent/test_nous_rate_guard.py
+++ b/tests/agent/test_nous_rate_guard.py
@@ -1,6 +1,7 @@
 """Tests for agent/nous_rate_guard.py — cross-session Nous Portal rate limit guard."""
 
 import json
+import math
 import os
 import time
 
@@ -99,6 +100,19 @@ class TestRecordNousRateLimit:
             state = json.load(f)
         assert state["reset_seconds"] == pytest.approx(120, abs=2)
 
+    def test_non_finite_header_reset_falls_back_to_default(self, rate_guard_env):
+        from agent.nous_rate_guard import record_nous_rate_limit, _state_path
+
+        record_nous_rate_limit(
+            headers={"retry-after": "inf"},
+            default_cooldown=123.0,
+        )
+
+        with open(_state_path()) as f:
+            state = json.load(f)
+        assert math.isfinite(state["reset_at"])
+        assert state["reset_seconds"] == pytest.approx(123, abs=2)
+
     def test_creates_directory_if_missing(self, rate_guard_env):
         from agent.nous_rate_guard import record_nous_rate_limit, _state_path
 
@@ -133,6 +147,24 @@ class TestNousRateLimitRemaining:
 
         assert nous_rate_limit_remaining() is None
         # File should be cleaned up
+        assert not os.path.exists(_state_path())
+
+    def test_returns_none_and_cleans_up_non_finite_state(self, rate_guard_env):
+        from agent.nous_rate_guard import nous_rate_limit_remaining, _state_path
+
+        state_dir = os.path.dirname(_state_path())
+        os.makedirs(state_dir, exist_ok=True)
+        with open(_state_path(), "w") as f:
+            json.dump(
+                {
+                    "reset_at": float("inf"),
+                    "recorded_at": time.time(),
+                    "reset_seconds": float("inf"),
+                },
+                f,
+            )
+
+        assert nous_rate_limit_remaining() is None
         assert not os.path.exists(_state_path())
 
     def test_handles_corrupt_file(self, rate_guard_env):
@@ -194,6 +226,12 @@ class TestFormatRemaining:
 
         assert format_remaining(3720) == "1h 2m"
 
+    def test_non_finite_seconds(self):
+        from agent.nous_rate_guard import format_remaining
+
+        assert format_remaining(float("inf")) == "0s"
+        assert format_remaining(float("nan")) == "0s"
+
 
 class TestParseResetSeconds:
     """Test header parsing for reset times."""
@@ -221,6 +259,16 @@ class TestParseResetSeconds:
 
         headers = {"x-ratelimit-reset-requests-1h": "not-a-number"}
         assert _parse_reset_seconds(headers) is None
+
+    def test_ignores_non_finite_values(self):
+        from agent.nous_rate_guard import _parse_reset_seconds
+
+        headers = {
+            "x-ratelimit-reset-requests-1h": "inf",
+            "x-ratelimit-reset-requests": "nan",
+            "retry-after": "60",
+        }
+        assert _parse_reset_seconds(headers) == 60.0
 
 
 class TestAuxiliaryClientIntegration:
@@ -330,6 +378,28 @@ class TestIsGenuineNousRateLimit:
             "x-ratelimit-reset-requests": "30",
         }
         assert is_genuine_nous_rate_limit(headers=headers) is False
+
+    def test_non_finite_bucket_values_are_ignored(self):
+        from agent.nous_rate_guard import is_genuine_nous_rate_limit
+
+        assert (
+            is_genuine_nous_rate_limit(
+                headers={
+                    "x-ratelimit-remaining-requests": "inf",
+                    "x-ratelimit-reset-requests": "120",
+                }
+            )
+            is False
+        )
+        assert (
+            is_genuine_nous_rate_limit(
+                headers={
+                    "x-ratelimit-remaining-requests": "0",
+                    "x-ratelimit-reset-requests": "inf",
+                }
+            )
+            is False
+        )
 
     def test_last_known_state_with_exhausted_bucket_triggers_genuine(self):
         # Headers on the 429 lack rate-limit info, but the previous


### PR DESCRIPTION
## Summary
- reject non-finite Nous rate-limit reset values from headers and error context
- avoid persisting `Infinity` breaker state and clean up non-finite state files when read
- ignore non-finite bucket values when deciding whether a Nous 429 is a genuine account limit

## Why
Malformed or non-finite rate-limit headers such as `retry-after: inf` could be recorded as an infinite cross-session cooldown. The stored `Infinity` state then made `nous_rate_limit_remaining()` return `inf`, and `format_remaining()` or bucket parsing could raise `OverflowError` instead of falling back safely.

## Tests
- `python -m pytest tests/agent/test_nous_rate_guard.py -q`
- `python -m pytest tests/agent/test_nous_rate_guard.py tests/agent/test_rate_limit_tracker.py tests/run_agent/test_nous_429_fallback_reentry.py -q`
- `python -m py_compile agent/nous_rate_guard.py`
- `python scripts/check-windows-footguns.py --all`