### PR TITLE
fix: sync terminal.* config to .env in save_config()

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -6043,6 +6043,17 @@ def save_config(config: Dict[str, Any]):
         _secure_file(config_path)
         _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(current_normalized)
 
+        # Sync terminal.* config to .env so tools that read env vars directly
+        # (terminal_tool, prompt_builder) stay consistent with config.yaml.
+        # Without this, the Dashboard API (update_config → save_config) would
+        # leave stale TERMINAL_ENV etc. in .env after the user changes the
+        # terminal backend via the Desktop GUI.
+        _terminal = normalized.get("terminal")
+        if isinstance(_terminal, dict):
+            for cfg_key, env_var in TERMINAL_CONFIG_ENV_MAP.items():
+                if cfg_key in _terminal:
+                    save_env_value(env_var, _terminal_env_value(_terminal[cfg_key]))
+
 
 def load_env() -> Dict[str, str]:
     """Load environment variables from ~/.hermes/.env.


### PR DESCRIPTION
## Problem

When the user changes the terminal backend via the Desktop GUI (Settings → Advanced → Execution Backend), the Dashboard API calls ``save_config()`` which only writes ``config.yaml``. The ``.env`` file is **not** updated, leaving a stale ``TERMINAL_ENV`` that downstream consumers (``terminal_tool``, ``prompt_builder``) still read as env vars.

By contrast, ``hermes config set terminal.backend docker`` works correctly because ``set_config_value()`` syncs both ``config.yaml`` and ``.env``.

## Fix

After writing ``config.yaml`` in ``save_config()``, iterate over ``TERMINAL_CONFIG_ENV_MAP`` and call ``save_env_value()`` for every ``terminal.*`` key present in the saved config.

## Testing

Reproduced on WSL2 where ``.env`` had ``TERMINAL_ENV=docker`` while ``config.yaml`` had ``terminal.backend=local``.
- Before fix: Dashboard API changed backend → only ``config.yaml`` updated
- After fix:  Dashboard API changes backend → both files stay in sync