### PR TITLE
fix(dashboard): default invalid MiniMax OAuth intervals

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -20,6 +20,7 @@ import hmac
 import importlib.util
 import json
 import logging
+import math
 import mimetypes
 import os
 import re
@@ -6499,9 +6500,15 @@ async def _start_device_code_flow(
         # `interval` field is in milliseconds (defensive default 2000ms
         # in _minimax_poll_token).
         interval_raw = device_data.get("interval")
-        sess["interval_ms"] = (
-            int(interval_raw) if interval_raw is not None else None
-        )
+        interval_ms = None
+        if interval_raw is not None:
+            try:
+                parsed_interval = float(interval_raw)
+                if math.isfinite(parsed_interval) and parsed_interval > 0:
+                    interval_ms = int(parsed_interval)
+            except (TypeError, ValueError, OverflowError):
+                interval_ms = None
+        sess["interval_ms"] = interval_ms
         sess["user_code"] = str(device_data["user_code"])
         sess["code_verifier"] = verifier
         sess["state"] = state

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -107,6 +107,44 @@ def test_minimax_login_does_not_launch_anthropic_flow():
     assert body["expires_in"] == 600
 
 
+def test_minimax_login_defaults_when_interval_is_malformed():
+    """MiniMax's optional interval field must not block dashboard login."""
+    from hermes_cli import web_server as ws
+
+    fake_user_code_resp = {
+        "user_code": "ABCD-1234",
+        "verification_uri": "https://api.minimax.io/oauth/verify",
+        "expired_in": 600,
+        "interval": "fast",
+        "state": "stub-state",
+    }
+    with patch(
+        "hermes_cli.auth._minimax_request_user_code",
+        return_value=fake_user_code_resp,
+    ), patch(
+        "hermes_cli.auth._minimax_pkce_pair",
+        return_value=("verifier-stub", "challenge-stub", "stub-state"),
+    ), patch(
+        "hermes_cli.web_server._minimax_poller",
+        return_value=None,
+    ):
+        resp = client.post(
+            "/api/providers/oauth/minimax-oauth/start",
+            headers=HEADERS,
+        )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    session_id = body["session_id"]
+    try:
+        assert body["flow"] == "device_code"
+        assert body["user_code"] == "ABCD-1234"
+        assert body["poll_interval"] == 2
+        assert ws._oauth_sessions[session_id]["interval_ms"] is None
+    finally:
+        ws._oauth_sessions.pop(session_id, None)
+
+
 def test_nous_dashboard_device_flow_ignores_legacy_scope_override(monkeypatch):
     from hermes_cli import auth as auth_mod
     from hermes_cli import web_server as ws


### PR DESCRIPTION
## Summary
- tolerate malformed optional MiniMax OAuth `interval` values in the dashboard login flow
- fall back to the existing 2000ms polling default instead of returning a 500 from `/api/providers/oauth/minimax-oauth/start`
- keep required `expired_in` validation unchanged

## Why
The MiniMax device-code helper treats `interval` as optional, but the dashboard branch parsed it with `int(...)` whenever present. A malformed provider value such as `"fast"` made the OAuth start endpoint fail with a raw `ValueError`, even though the poller already has a safe default interval.

## Tests
- `python -m pytest tests/hermes_cli/test_web_oauth_dispatch.py::test_minimax_login_defaults_when_interval_is_malformed -q`
- `python -m pytest tests/hermes_cli/test_web_oauth_dispatch.py -q`
- `python -m pytest tests/hermes_cli/test_api_key_providers.py::TestMinimaxOAuthProvider -q`
- `python -m py_compile hermes_cli/web_server.py`
- `python scripts/check-windows-footguns.py --all`