### PR TITLE
feat(compression): flip in_place default to True (#38763) [2/2]

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9357,7 +9357,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                     _hyg_new_sid = _hyg_agent.session_id
                                     _hyg_rotated = _hyg_new_sid != session_entry.session_id
                                     _hyg_in_place = bool(
-                                        getattr(_hyg_agent, "compression_in_place", False)
+                                        getattr(_hyg_agent, "_last_compaction_in_place", False)
                                     )
                                     if _hyg_rotated:
                                         session_entry.session_id = _hyg_new_sid

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2817,7 +2817,7 @@ class GatewaySlashCommandsMixin:
                 # transcript replaced with the compacted set).
                 new_session_id = tmp_agent.session_id
                 rotated = new_session_id != session_entry.session_id
-                _in_place = bool(getattr(tmp_agent, "compression_in_place", False))
+                _in_place = bool(getattr(tmp_agent, "_last_compaction_in_place", False))
                 if rotated:
                     session_entry.session_id = new_session_id
                     self.session_store._save()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1293,7 +1293,7 @@ DEFAULT_CONFIG = {
                                       # exact route is affected — gpt-5.5 on OpenAI's
                                       # direct API, OpenRouter, and Copilot keep the
                                       # global threshold regardless.
-        "in_place": False,            # When True, compaction rewrites the message
+        "in_place": True,             # When True, compaction rewrites the message
                                       # list and rebuilds the system prompt WITHOUT
                                       # rotating the session id — the conversation
                                       # keeps one durable id for its whole life

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -74,6 +74,7 @@ AUTHOR_MAP = {
     "87440198+JoaoMarcos44@users.noreply.github.com": "JoaoMarcos44",
     "joaomarcosdias444@gmail.com": "JoaoMarcos44",
     "286497132+srojk34@users.noreply.github.com": "srojk34",
+    "srojk34@users.noreply.github.com": "srojk34",  # legacy prefix-less noreply (PR #50098 salvage; #38763)
     "59806492+sitkarev@users.noreply.github.com": "sitkarev",
     "zheng@omegasys.eu": "omegazheng",
     "220877172+james47kjv@users.noreply.github.com": "james47kjv",

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -77,6 +77,10 @@ def _build_agent_with_db(db: SessionDB, session_id: str):
     compressor._last_aux_model_failure_model = None
     compressor._last_aux_model_failure_error = None
     agent.context_compressor = compressor
+    # These tests cover the ROTATION fallback path (forking, child sessions,
+    # lock contention) — pin in_place=False so they keep exercising it
+    # regardless of the global default (which flipped to True in #38763).
+    agent.compression_in_place = False
     return agent
 
 

--- a/tests/agent/test_compression_logging_session_context.py
+++ b/tests/agent/test_compression_logging_session_context.py
@@ -50,6 +50,10 @@ def _build_agent_with_db(db: SessionDB, session_id: str):
     compressor._last_aux_model_failure_model = None
     compressor._last_aux_model_failure_error = None
     agent.context_compressor = compressor
+    # This test covers the ROTATION fallback (logging session-context follows
+    # the id rotation) — pin in_place=False so it keeps exercising rotation
+    # regardless of the global default (flipped to True in #38763).
+    agent.compression_in_place = False
     return agent
 
 

--- a/tests/agent/test_compression_rotation_state.py
+++ b/tests/agent/test_compression_rotation_state.py
@@ -54,6 +54,9 @@ def _build_agent_with_db(db: SessionDB, session_id: str, platform: str = "telegr
     compressor._last_aux_model_failure_model = None
     compressor._last_aux_model_failure_error = None
     agent.context_compressor = compressor
+    # ROTATION fallback path — pin in_place=False so these keep covering fork
+    # rotation regardless of the global default (flipped to True in #38763).
+    agent.compression_in_place = False
     return agent
 
 

--- a/tests/gateway/test_compression_concurrent_sessions.py
+++ b/tests/gateway/test_compression_concurrent_sessions.py
@@ -71,6 +71,10 @@ def _build_agent_with_db(db: SessionDB, session_id: str):
     compressor._last_aux_model_failure_model = None
     compressor._last_aux_model_failure_error = None
     agent.context_compressor = compressor
+    # ROTATION fallback path — pin in_place=False so these keep covering the
+    # concurrent-rotation lock contract regardless of the global default
+    # (flipped to True in #38763).
+    agent.compression_in_place = False
     return agent
 
 

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -495,6 +495,105 @@ async def test_session_hygiene_preserves_transcript_when_no_rotation(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_session_hygiene_preserves_transcript_when_in_place_configured_but_no_db(monkeypatch, tmp_path):
+    """Regression: when compression.in_place is True but the hygiene agent has
+    no session_db, archive_and_compact cannot run — _last_compaction_in_place
+    stays False.  The guard must read the *result* flag, not the *config* flag,
+    otherwise the transcript is unconditionally rewritten with only the summary
+    (permanent data loss identical to #21301)."""
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    class InPlaceConfiguredAgent:
+        last_instance = None
+
+        def __init__(self, **kwargs):
+            self.model = kwargs.get("model")
+            self.session_id = kwargs.get("session_id", "fake-session")
+            self.compression_in_place = True
+            self._last_compaction_in_place = False
+            self._print_fn = None
+            self.shutdown_memory_provider = MagicMock()
+            self.close = MagicMock()
+            type(self).last_instance = self
+
+        def _compress_context(self, messages, *_args, **_kwargs):
+            return ([{"role": "assistant", "content": "summary only"}], None)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = InPlaceConfiguredAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+
+    adapter = HygieneCaptureAdapter()
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake-token")}
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key="agent:main:telegram:group:-1001:17585",
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+    )
+    runner.session_store.load_transcript.return_value = _make_history(6, content_size=400)
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.append_to_transcript = MagicMock()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100,
+    )
+    monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "795544298")
+
+    event = MessageEvent(
+        text="hello",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1001",
+            chat_type="group",
+            thread_id="17585",
+            user_id="12345",
+        ),
+        message_id="1",
+    )
+
+    result = await runner._handle_message(event)
+
+    assert result == "ok"
+    # The config says in_place=True, but the DB write failed (no session_db)
+    # so _last_compaction_in_place is False. Transcript must NOT be rewritten.
+    runner.session_store.rewrite_transcript.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_session_hygiene_warns_user_when_compression_aborts(monkeypatch, tmp_path):
     """When auxiliary compression's summary LLM call fails, the compressor
     ABORTS — returns messages unchanged, sets _last_compress_aborted=True,

--- a/tests/run_agent/test_compression_boundary_hook.py
+++ b/tests/run_agent/test_compression_boundary_hook.py
@@ -22,7 +22,7 @@ class TestCompressionBoundaryHook:
     def _make_agent(self, session_db):
         with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
             from run_agent import AIAgent
-            return AIAgent(
+            agent = AIAgent(
                 api_key="test-key",
                 base_url="https://openrouter.ai/api/v1",
                 model="test/model",
@@ -32,6 +32,9 @@ class TestCompressionBoundaryHook:
                 skip_context_files=True,
                 skip_memory=True,
             )
+            # ROTATION fallback — pin in_place=False regardless of default (#38763).
+            agent.compression_in_place = False
+            return agent
 
     def test_on_session_start_called_with_compression_boundary(self):
         from hermes_state import SessionDB
@@ -167,7 +170,7 @@ class TestSessionCompressEvent:
     def _make_agent(self, session_db, event_callback=None):
         with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
             from run_agent import AIAgent
-            return AIAgent(
+            agent = AIAgent(
                 api_key="test-key",
                 base_url="https://openrouter.ai/api/v1",
                 model="test/model",
@@ -178,6 +181,9 @@ class TestSessionCompressEvent:
                 skip_memory=True,
                 event_callback=event_callback,
             )
+            # ROTATION fallback — pin in_place=False regardless of default (#38763).
+            agent.compression_in_place = False
+            return agent
 
     def _stub_compressor(self):
         compressor = MagicMock()

--- a/tests/run_agent/test_in_place_compaction.py
+++ b/tests/run_agent/test_in_place_compaction.py
@@ -184,9 +184,11 @@ class TestInPlaceCompaction:
             assert calls["n"] == 1
 
 
-class TestRotationStillDefault:
+class TestRotationFallbackWhenFlagOff:
     def test_rotation_when_flag_off(self):
-        """Regression guard: flag off => legacy rotation is unchanged."""
+        """Rotation is now the OPT-OUT fallback (default flipped to in-place in
+        #38763). With in_place=False explicitly set, legacy rotation is
+        unchanged — forks a renamed continuation session."""
         from hermes_state import SessionDB
         from agent.conversation_compression import compress_context
 
@@ -247,10 +249,12 @@ class TestInPlaceSignalForGateway:
 
 
 class TestInPlaceConfigDefault:
-    def test_flag_defaults_off(self):
+    def test_flag_defaults_on(self):
+        """In-place is the default as of #38763 (rotation is now opt-out via
+        compression.in_place: false)."""
         from hermes_cli.config import DEFAULT_CONFIG
 
-        assert DEFAULT_CONFIG["compression"].get("in_place") is False
+        assert DEFAULT_CONFIG["compression"].get("in_place") is True
 
 
 class TestCompactedTurnsStaySearchable:


### PR DESCRIPTION
Salvage of #50098 by @srojk34 (cherry-picked, authorship preserved) + the default flip.

## Summary
Second of two staged PRs for the session-rotation bug cluster (#38763). Flips `compression.in_place` default **False → True** — in-place compaction (single durable session id, non-destructive soft-archive from #49739) becomes the default. Rotation is now the **opt-out fallback** via `compression.in_place: false`.

## Commit stack
1. **fix(gateway): read compaction result flag not config flag in hygiene guard (#50098)** — salvage of #50098 by @srojk34. The hygiene auto-compress guard and `/compress` both read `compression_in_place` (config flag — is in-place *enabled*?) instead of `_last_compaction_in_place` (result flag — did in-place *succeed*?). Both agents are built without a `session_db`, so `archive_and_compact` always fails silently and `_last_compaction_in_place` stays `False`. Reading the config flag makes the guard think in-place succeeded → `rewrite_transcript()` replaces the original messages with only the summary → permanent data loss. **This must land before the flip** — without it, flipping the default causes data loss on every gateway hygiene-compress + `/compress` when no `session_db` is available. Includes the regression test `test_session_hygiene_preserves_transcript_when_in_place_configured_but_no_db`.
2. **feat(compression): flip in_place default to True** — the one-line config change.
3. **test(compression): pin rotation-fallback tests to in_place=False** — 7 rotation-asserting test sites pinned explicitly so they keep covering the retained rotation fallback regardless of the global default.

## Why staged (not folded into #49739)
#49739 shipped default-off precisely so in-place soaks before becoming everyone's default. This PR is the flip AFTER that soak. Folding it into #49739 would have collapsed the staging and removed the validation gate.

## Blast radius (empirically measured on current main)
Flipping the default breaks exactly **7 rotation-asserting tests** that build agents without setting the flag and assert rotation behavior. Each is pinned to `in_place=False` (NOT deleted — rotation stays a working fallback and deserves coverage):
- `test_compression_concurrent_fork._build_agent_with_db` (fork + lock contention)
- `test_compression_logging_session_context._build_agent_with_db` (logging follows id rotation)
- `test_compression_rotation_state._build_agent_with_db` (goal migration, platform forward, orphan rollback)
- `test_compression_boundary_hook._make_agent` ×2 (CompressionBoundaryHook + SessionCompressEvent)
- `test_compression_concurrent_sessions._build_agent_with_db` (concurrent-rotation lock contract)

The `test_in_place_compaction.py` default assertion flipped from `test_flag_defaults_off` → `test_flag_defaults_on`, and `TestRotationStillDefault` → `TestRotationFallbackWhenFlagOff`.

## What is NOT in this PR (per plan)
- **Deletion of rotation machinery: DEFERRED.** PR1 shipped as non-destructive soft-archive, so rotation is now a *working* fallback (not dead code). Deleting it removes an escape hatch if in-place hits a production edge case. Optional standalone PR later, only if we decide to drop the fallback after in-place soaks as the default.
- **Legacy-chain read shim: DROPPED.** Old rotated conversations (`parent_session_id` chains, `#N` titles) already display + resume via existing lineage-aware reads. No shim needed.
- **Band-aid triage: separate follow-up.** See the issue triage below — not coupled to this flip.

## Validation (verified against current main)
- Full compression suite green: 175 agent/run_agent + 40 gateway + 355 state + 36 CLI tests pass.
- The #50098 regression test passes (and fails without the fix).
- ruff clean.
- `test_concurrent_compression_does_not_fork_session` has a pre-existing thread-timing flake (flakes ~1/5 on clean main too — confirmed before the flip); passes reliably in isolation.

## P1 issue triage — what this flip fixes/supersedes

The session_id rotation that in-place eliminates was the root cause of a whole cluster of P1 bugs. Full triage of every open P1 tagged `comp/agent` or compression-related, evaluated against what this flip actually changes:

### Directly superseded (root cause = session_id rotation; in-place removes the rotation)

| Issue | P | Title | Why in-place fixes it |
|-------|---|-------|----------------------|
| #14238 | P1 | Pending response lost when session split occurs at response boundary | Split at response boundary → response persisted to child id, gateway delivers to old id. In-place: no split → response stays on the same id the gateway routes to. |
| #13840 | P1 | Compression-ended parent sessions excluded from search results — memory black hole | `session_search` excludes all sessions in the lineage root, including compression-ended parents. In-place: no parents, no lineage exclusion; archived turns (`active=0`) stay on the same id and remain FTS-searchable. |
| #36777 | P2 | TUI: session.info event does not update ctx.sid after compression fork | TUI doesn't update ctx.sid after fork. In-place: no fork → ctx.sid never goes stale. |
| #42228 | P3 | Desktop/TUI compressed sessions move into No workspace because continuation cwd is null | Continuation session has null cwd. In-place: no continuation → same cwd. |

### Already closed — were rotation band-aids (now vestigial under in-place)

| Issue | P | Title | Note |
|-------|---|-------|------|
| #34089 | P1 | Conversation compression desynchronizes session ID between agent and gateway | The canonical P1 of the cluster. Closed by logging/contextvar re-sync band-aid. Under in-place the re-sync code is dead (rotation branch never runs) — harmless but vestigial. |
| #25921 | P1 | Gateway can reuse parent-sized history after split → infinite preflight compression | Closed (implemented-on-main). In-place eliminates the parent/child history confusion entirely. |
| #20293 | P1 | Compressed summary injected as valid history into new session | Closed. New session got summary + originals as valid history. In-place: no new session → summary stays on the same id as archived context. |
| #33618 | P2 | Persistent /goal lost after compression rotates session_id | Closed. Goal stored under old id, not migrated. In-place: id doesn't rotate → goal stays. |
| #33907 | P2 | Orphan sessions missing from state.db | Closed (duplicate). New session JSON created but no state.db row. In-place: no new session → no orphan. |

### Partially addressed (rotation was a contributing factor; has an orthogonal component)

| Issue | P | Title | Why partial |
|-------|---|-------|------------|
| #29522 | P1 | Automatic compaction can hide or drop just-completed assistant response | In-place keeps the response on the same id (no routing loss). But the Workspace UI may still hide it if archived at `active=0` — `protect_last_n` should keep it active. Needs verification against Workspace UI behavior. |
| #28093 | P1 | Context compaction drops user messages that arrive during active processing | PR1's flush-before-rewrite fix (#47202) applies to in-place. But the root cause is a message-arrival race (message B arrives during the turn, not in the list when compaction runs). Flush helps; the race may not be fully closed. |
| #9096 | P1 | Context compression causes historical conversations to be inserted into current conversation | Symptom (history appended not replaced) matches the gateway-store divergence the #50098 fix + in-place address. Issue is old (2026-04-25); needs repro on current main with `in_place=true`. |
| #19434 | P1 | session_search recall failures: cron drowns + JSON/SQLite split-brain + child sessions hidden | One of 4 sub-bugs ("child sessions hidden") is superseded. The other 3 (JSON/SQLite split-brain, cron drowning, FTS issues) are orthogonal and NOT fixed. |

### Not fixed (orthogonal — compression mechanics, error handling, thresholds)

| Issue | P | Title | Why not fixed |
|-------|---|-------|---------------|
| #25242 | P1 | Auto-continue note persisted/amplified by preflight compression | Interrupt/tool-tail replay, not rotation. |
| #27405 | P1 | Preflight compression guard uses message-count not token-count | Threshold logic, not rotation. |
| #24098 | P1 | Compression failure hangs response loop on HTTP 400 | Error handling/retry, not rotation. |
| #31600 | P1 | Hardcoded MINIMUM_CONTEXT_LENGTH=64K deadlocks compression | Threshold, not rotation. |
| #11585 | P1 | context_compressor drops messages when summarization fails | Abort path, not rotation. |
| #20250 | P1 | VS Code ACP prompt in-flight after compression timeout | ACP lifecycle, not rotation. |

### Follow-up plan (post-merge)
- Close the 4 directly-superseded issues (#14238, #13840, #36777, #42228) with a crediting redirect to #38763 + this PR.
- Verify the 4 partially-addressed issues (#29522, #28093, #9096, #19434) on merged main with `in_place=true` before closing — do NOT close without confirming the in-place path resolves the symptom.
- Leave the 6 orthogonal issues open.

Closes #50098.
Plan: `.hermes/plans/in-place-compaction-38763.md`
