### PR TITLE
fix(dashboard): default invalid Nous OAuth intervals

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6116,6 +6116,14 @@ _OAUTH_SESSION_TTL_SECONDS = 15 * 60
 _oauth_sessions: Dict[str, Dict[str, Any]] = {}
 _oauth_sessions_lock = threading.Lock()
 
+
+def _coerce_oauth_positive_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return default
+    return parsed if parsed > 0 else default
+
 # Import OAuth constants from canonical source instead of duplicating.
 # Guarded so hermes web still starts if anthropic_adapter is unavailable;
 # Phase 2 endpoints will return 501 in that case.
@@ -6375,6 +6383,7 @@ async def _start_device_code_flow(
     """
     if provider_id == "nous":
         from hermes_cli.auth import (
+            DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS,
             _request_device_code,
             PROVIDER_REGISTRY,
         )
@@ -6407,8 +6416,12 @@ async def _start_device_code_flow(
             None, _do_nous_device_request
         )
         sid, sess = _new_oauth_session("nous", "device_code", profile=profile)
+        poll_interval = _coerce_oauth_positive_int(
+            device_data.get("interval"),
+            DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS,
+        )
         sess["device_code"] = str(device_data["device_code"])
-        sess["interval"] = int(device_data["interval"])
+        sess["interval"] = poll_interval
         sess["expires_at"] = time.time() + int(device_data["expires_in"])
         sess["portal_base_url"] = portal_base_url
         sess["client_id"] = client_id
@@ -6422,7 +6435,7 @@ async def _start_device_code_flow(
             "user_code": str(device_data["user_code"]),
             "verification_url": str(device_data["verification_uri_complete"]),
             "expires_in": int(device_data["expires_in"]),
-            "poll_interval": int(device_data["interval"]),
+            "poll_interval": poll_interval,
         }
 
     if provider_id == "openai-codex":

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -134,6 +134,31 @@ def test_nous_dashboard_device_flow_ignores_legacy_scope_override(monkeypatch):
         ws._oauth_sessions.pop(result["session_id"], None)
 
 
+def test_nous_dashboard_device_flow_defaults_malformed_interval(monkeypatch):
+    from hermes_cli import auth as auth_mod
+    from hermes_cli import web_server as ws
+
+    def fake_request_device_code(**kwargs):
+        data = _fake_nous_device_data()
+        data["interval"] = "fast"
+        return data
+
+    monkeypatch.setattr(auth_mod, "_request_device_code", fake_request_device_code)
+    monkeypatch.setattr(ws, "_nous_poller", lambda sid: None)
+
+    result = asyncio.run(ws._start_device_code_flow("nous"))
+    try:
+        assert result["flow"] == "device_code"
+        assert result["user_code"] == "NOUS-1234"
+        assert result["poll_interval"] == auth_mod.DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS
+        assert (
+            ws._oauth_sessions[result["session_id"]]["interval"]
+            == auth_mod.DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS
+        )
+    finally:
+        ws._oauth_sessions.pop(result["session_id"], None)
+
+
 def test_oauth_provider_status_uses_profile_query(tmp_path, monkeypatch):
     from hermes_cli import web_server as ws
     from hermes_constants import get_hermes_home


### PR DESCRIPTION
## Summary
- default malformed Nous dashboard OAuth `interval` values instead of crashing start
- keep the sanitized poll interval in both the in-memory session and API response
- add regression coverage for malformed Nous device-code interval responses

## Tests
- `python -m pytest tests/hermes_cli/test_web_oauth_dispatch.py::test_nous_dashboard_device_flow_defaults_malformed_interval tests/hermes_cli/test_web_oauth_dispatch.py::test_nous_dashboard_device_flow_ignores_legacy_scope_override tests/hermes_cli/test_web_oauth_dispatch.py::test_minimax_login_does_not_launch_anthropic_flow -q`
- `python -m pytest tests/hermes_cli/test_web_oauth_dispatch.py -q`
- `python -m py_compile hermes_cli/web_server.py`
- `python scripts/check-windows-footguns.py --all`