### PR TITLE
/status shows active model and provider

### DIFF
--- a/agent/memory_locations.py
+++ b/agent/memory_locations.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""
+Memory Location Store for Hermes Agent.
+
+Provides CRUD operations and search for memory locations (markers) tied to
+session messages or persistent across sessions. Supports lineage-aware anchor
+resolution for cases where messages have been compressed or parent sessions
+split.
+"""
+
+import json
+import logging
+import sqlite3
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class MemoryLocationStore:
+    """Manages memory locations (markers) in the Hermes session database."""
+
+    def __init__(self, session_db):
+        """
+        Initialize the MemoryLocationStore.
+        :param session_db: Instance of SessionDB from hermes_state
+        """
+        if session_db is None:
+            raise ValueError("session_db must be provided to MemoryLocationStore")
+        self.db = session_db
+
+    @property
+    def _conn(self) -> sqlite3.Connection:
+        return self.db._conn
+
+    def create(
+        self,
+        session_id: str,
+        label: str,
+        time_type: str = "point",
+        anchor_guid: Optional[str] = None,
+        anchor_end_guid: Optional[str] = None,
+        color: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        sort_order: int = 0,
+        is_persistent: bool = False,
+        origin: str = "manual",
+        recall_state: Optional[Dict[str, Any]] = None,
+    ) -> int:
+        """Create a new memory location."""
+        created_at = self._conn.execute("SELECT strftime('%s', 'now')").fetchone()[0]
+        tags_json = json.dumps(tags) if tags else None
+        recall_state_json = json.dumps(recall_state) if recall_state else None
+
+        cursor = self._conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO memory_locations (
+                session_id, label, time_type, anchor_guid, anchor_end_guid,
+                color, tags, sort_order, is_persistent, origin, recall_state, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                session_id,
+                label,
+                time_type,
+                anchor_guid,
+                anchor_end_guid,
+                color,
+                tags_json,
+                sort_order,
+                1 if is_persistent else 0,
+                origin,
+                recall_state_json,
+                created_at,
+            ),
+        )
+        self._conn.commit()
+        return cursor.lastrowid or 0
+
+    def get(self, location_id: int) -> Optional[Dict[str, Any]]:
+        """Get a single memory location by ID."""
+        cursor = self._conn.cursor()
+        row = cursor.execute(
+            "SELECT * FROM memory_locations WHERE id = ?", (location_id,)
+        ).fetchone()
+        if not row:
+            return None
+
+        location = dict(row)
+        if location.get("tags"):
+            try:
+                location["tags"] = json.loads(location["tags"])
+            except json.JSONDecodeError:
+                location["tags"] = []
+        if location.get("recall_state"):
+            try:
+                location["recall_state"] = json.loads(location["recall_state"])
+            except json.JSONDecodeError:
+                location["recall_state"] = None
+        return location
+
+    def list(
+        self,
+        session_id: Optional[str] = None,
+        persistent_only: bool = False,
+        origin: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """List memory locations with optional filters."""
+        cursor = self._conn.cursor()
+
+        query = "SELECT * FROM memory_locations WHERE 1=1"
+        params = []
+
+        if session_id:
+            query += " AND session_id = ?"
+            params.append(session_id)
+        if persistent_only:
+            query += " AND is_persistent = 1"
+        if origin:
+            query += " AND origin = ?"
+            params.append(origin)
+
+        query += " ORDER BY sort_order ASC, created_at ASC"
+
+        cursor.execute(query, params)
+        rows = cursor.fetchall()
+
+        locations = []
+        for row in rows:
+            loc = dict(row)
+            if loc.get("tags"):
+                try:
+                    loc["tags"] = json.loads(loc["tags"])
+                except json.JSONDecodeError:
+                    loc["tags"] = []
+            if loc.get("recall_state"):
+                try:
+                    loc["recall_state"] = json.loads(loc["recall_state"])
+                except json.JSONDecodeError:
+                    loc["recall_state"] = None
+            locations.append(loc)
+
+        return locations
+
+    def update(self, location_id: int, **fields) -> bool:
+        """Update fields of a memory location."""
+        allowed_fields = {
+            "label",
+            "time_type",
+            "anchor_guid",
+            "anchor_end_guid",
+            "color",
+            "tags",
+            "sort_order",
+            "is_persistent",
+            "origin",
+            "recall_state",
+        }
+        filtered_fields = {k: v for k, v in fields.items() if k in allowed_fields}
+        if not filtered_fields:
+            return False
+
+        cursor = self._conn.cursor()
+
+        if "tags" in filtered_fields:
+            filtered_fields["tags"] = (
+                json.dumps(filtered_fields["tags"]) if filtered_fields["tags"] else None
+            )
+        if "recall_state" in filtered_fields:
+            filtered_fields["recall_state"] = (
+                json.dumps(filtered_fields["recall_state"])
+                if filtered_fields["recall_state"]
+                else None
+            )
+        if "is_persistent" in filtered_fields:
+            filtered_fields["is_persistent"] = (
+                1 if filtered_fields["is_persistent"] else 0
+            )
+
+        set_clause = ", ".join(f"{k} = ?" for k in filtered_fields.keys())
+        params = list(filtered_fields.values()) + [location_id]
+
+        cursor.execute(
+            f"UPDATE memory_locations SET {set_clause} WHERE id = ?", params
+        )
+        self._conn.commit()
+        return cursor.rowcount > 0
+
+    def delete(self, location_id: int) -> bool:
+        """Delete a memory location by ID."""
+        cursor = self._conn.cursor()
+        cursor.execute("DELETE FROM memory_locations WHERE id = ?", (location_id,))
+        self._conn.commit()
+        return cursor.rowcount > 0
+
+    def reorder(self, location_id: int, new_sort_order: int) -> bool:
+        """Update the sort order of a memory location."""
+        return self.update(location_id, sort_order=new_sort_order)
+
+    def resolve_anchor(self, anchor_guid: str, session_id: str) -> Optional[int]:
+        """
+        Resolve an anchor GUID to a message ID, walking the parent_session_id
+        chain if necessary (lineage-aware resolution).
+        """
+        cursor = self._conn.cursor()
+
+        # 1. Try current session
+        row = cursor.execute(
+            "SELECT id FROM messages WHERE session_id = ? AND message_guid = ?",
+            (session_id, anchor_guid),
+        ).fetchone()
+        if row:
+            return row[0] if isinstance(row, tuple) else row["id"]
+
+        # 2. Walk parent_session_id chain
+        current = session_id
+        while current:
+            parent_row = cursor.execute(
+                "SELECT parent_session_id FROM sessions WHERE id = ?", (current,)
+            ).fetchone()
+            if not parent_row:
+                break
+            parent = parent_row[0] if isinstance(parent_row, tuple) else parent_row["parent_session_id"]
+            if not parent:
+                break
+            current = parent
+            row = cursor.execute(
+                "SELECT id FROM messages WHERE session_id = ? AND message_guid = ?",
+                (current, anchor_guid),
+            ).fetchone()
+            if row:
+                return row[0] if isinstance(row, tuple) else row["id"]
+
+        return None
+
+    def search_fts(self, query: str, session_id: Optional[str] = None) -> List[Dict[str, Any]]:
+        """
+        Search memory locations using FTS5.
+        """
+        cursor = self._conn.cursor()
+
+        base_query = """
+            SELECT ml.*, snippet(memory_locations_fts, 0, '[', ']', '...', 10) as label_snippet
+            FROM memory_locations ml
+            JOIN memory_locations_fts fts ON ml.id = fts.rowid
+            WHERE memory_locations_fts MATCH ?
+        """
+        params = [query]
+
+        if session_id:
+            base_query += " AND ml.session_id = ?"
+            params.append(session_id)
+
+        base_query += " ORDER BY ml.sort_order ASC, ml.created_at ASC"
+
+        cursor.execute(base_query, params)
+        rows = cursor.fetchall()
+
+        results = []
+        for row in rows:
+            loc = dict(row)
+            if loc.get("tags"):
+                try:
+                    loc["tags"] = json.loads(loc["tags"])
+                except json.JSONDecodeError:
+                    loc["tags"] = []
+            if loc.get("recall_state"):
+                try:
+                    loc["recall_state"] = json.loads(loc["recall_state"])
+                except json.JSONDecodeError:
+                    loc["recall_state"] = None
+            results.append(loc)
+
+        return results

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8357,14 +8357,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _show_reasoning_effective and response:
                 last_reasoning = agent_result.get("last_reasoning")
                 if last_reasoning:
-                    # Collapse long reasoning to keep messages readable
-                    lines = last_reasoning.strip().splitlines()
-                    if len(lines) > 15:
-                        display_reasoning = "\n".join(lines[:15])
-                        display_reasoning += f"\n_... ({len(lines) - 15} more lines)_"
+                    reasoning = last_reasoning.strip()
+                    platform_key = _platform_config_key(source.platform)
+                    if platform_key == "matrix":
+                        # Quote-prefix so MatrixAdapter._markdown_to_html emits
+                        # <blockquote>, which Element wraps at viewport width.
+                        # <pre> code-fence (legacy) disabled wrap on mobile.
+                        quoted = "\n".join(
+                            f"> {ln}" if ln else ">"
+                            for ln in reasoning.splitlines()
+                        )
+                        response = f"💭 **Reasoning:**\n\n{quoted}\n\n{response}"
                     else:
-                        display_reasoning = last_reasoning.strip()
-                    response = f"💭 **Reasoning:**\n```\n{display_reasoning}\n```\n\n{response}"
+                        lines = reasoning.splitlines()
+                        if len(lines) > 1000:
+                            display_reasoning = "\n".join(lines[:1000])
+                            display_reasoning += (
+                                f"\n_... ({len(lines) - 1000} more lines)_"
+                            )
+                        else:
+                            display_reasoning = reasoning
+                        response = (
+                            f"💭 **Reasoning:**\n```\n{display_reasoning}\n```"
+                            f"\n\n{response}"
+                        )
 
             # Runtime-metadata footer — only on the FINAL message of the turn.
             # Off by default (display.runtime_footer.enabled=false).  When

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -419,6 +419,60 @@ class GatewaySlashCommandsMixin:
             except Exception:
                 db_total_tokens = 0
 
+        # Resolve the active model + provider for the /status reply.
+        #
+        # /status's documented description in ``hermes_cli/tips.py:418`` says
+        # it "shows session info at a glance: ID, title, model, token usage,
+        # and elapsed time" — yet the reply has historically omitted model
+        # and provider, so platform users on Matrix/Telegram/etc. can't tell
+        # what's actually behind the agent without running /model or reading
+        # the profile file.  The sibling ``/agents`` handler in this same
+        # module already surfaces model per running agent, so the data is on
+        # hand; /status just wasn't using it.
+        #
+        # Resolution strategy:
+        #   - Always read the profile-resolved model + provider via
+        #     ``_load_gateway_config`` + ``_resolve_gateway_model``.  These
+        #     are the same helpers used by ``/model`` and ``/profile`` so the
+        #     displayed values match what those commands report.
+        #   - Provider can live either at the YAML top level
+        #     (``provider: custom``) or nested inside the ``model:`` block
+        #     (``model.provider: custom``) — the profile shape varies across
+        #     Hermes versions.  Check both.
+        #   - If a turn is currently in flight, also include the live agent's
+        #     model when it differs from the profile default — this surfaces
+        #     active ``/model`` session overrides so the user can tell when
+        #     this turn is on a non-default model.
+        #
+        # /status must never crash the message: any exception in the resolver
+        # block is swallowed and the lines simply omit, falling back to the
+        # pre-patch behaviour rather than producing a broken reply.
+        status_model = ""
+        status_provider = ""
+        status_session_override = ""
+        try:
+            from gateway.run import _load_gateway_config, _resolve_gateway_model
+            _user_cfg = _load_gateway_config()
+            status_model = _resolve_gateway_model(_user_cfg) or ""
+            if isinstance(_user_cfg, dict):
+                # Top-level provider first; fall back to model.provider for
+                # the nested-style profile shape that newer Hermes versions
+                # use (e.g. ``model: {default: foo, provider: custom}``).
+                _cfg_provider = _user_cfg.get("provider")
+                if not _cfg_provider:
+                    _model_block = _user_cfg.get("model")
+                    if isinstance(_model_block, dict):
+                        _cfg_provider = _model_block.get("provider")
+                status_provider = str(_cfg_provider or "")
+        except Exception:
+            pass
+        # Active session override — surface only when it differs from profile
+        running_agent = self._running_agents.get(session_key) if is_running else None
+        if running_agent is not None:
+            _live_model = str(getattr(running_agent, "model", "") or "")
+            if _live_model and _live_model != status_model:
+                status_session_override = _live_model
+
         lines = [
             t("gateway.status.header"),
             "",
@@ -426,6 +480,18 @@ class GatewaySlashCommandsMixin:
         ]
         if title:
             lines.append(t("gateway.status.title", title=title))
+        # Render model + provider between title and created so they appear
+        # high in the reply (most likely first lines a Matrix client will
+        # show in a preview / collapsed view).  Each line is independently
+        # gated so we don't emit an empty placeholder when the value didn't
+        # resolve — see comment above the resolver block for the rationale.
+        if status_model:
+            lines.append(t("gateway.status.model", model=status_model))
+        if status_session_override:
+            lines.append(t("gateway.status.model_session_override",
+                           model=status_session_override))
+        if status_provider:
+            lines.append(t("gateway.status.provider", provider=status_provider))
         lines.extend([
             t("gateway.status.created", timestamp=session_entry.created_at.strftime('%Y-%m-%d %H:%M')),
             t("gateway.status.last_activity", timestamp=session_entry.updated_at.strftime('%Y-%m-%d %H:%M')),

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3387,7 +3387,84 @@ class GatewaySlashCommandsMixin:
         except Exception as e:
             pending_path.unlink(missing_ok=True)
             exit_code_path.unlink(missing_ok=True)
-            return t("gateway.update.start_failed", error=e)
+            logger.exception("Failed to spawn background update process: %s", e)
 
-        self._schedule_update_notification_watch()
-        return t("gateway.update.starting")
+    async def _handle_marker_command(self, event: MessageEvent) -> str:
+        """Handle /marker command for memory locations."""
+        parts = event.text.split()[1:] if event.text else []
+        action = parts[0].lower() if parts else "list"
+
+        # Defer import to avoid circular dependency
+        from hermes_state import SessionDB, get_last_init_error
+        from agent.memory_locations import MemoryLocationStore
+        from gateway.session import build_session_key
+
+        try:
+            db = SessionDB()
+        except Exception:
+            err = get_last_init_error() or "unknown error"
+            return f"Session database not available: {err}"
+
+        store = MemoryLocationStore(session_db=db)
+        session_key = build_session_key(event.source)
+
+        if action == "create":
+            label = " ".join(parts[1:]) if len(parts) > 1 else "Marker"
+            loc_id = store.create(
+                session_id=session_key,
+                label=label,
+                time_type="point",
+                is_persistent=False,
+            )
+            return f"Created memory location {loc_id}: '{label}'"
+
+        elif action == "list":
+            locations = store.list(session_id=session_key)
+            if not locations:
+                return "No memory locations found in this session."
+            
+            lines = ["Memory locations in this session:"]
+            for loc in locations:
+                label_str = loc.get("label", "")
+                if len(label_str) > 30:
+                    label_str = label_str[:30] + "..."
+                is_pers = " (persistent)" if loc.get("is_persistent") else ""
+                lines.append(f"- **{loc.get('id')}**: {label_str}{is_pers}")
+            return "\n".join(lines)
+
+        elif action == "goto":
+            if len(parts) < 2:
+                return "Usage: `/marker goto <id>`"
+            try:
+                loc_id = int(parts[1])
+            except ValueError:
+                return "Invalid location ID. Use a number."
+
+            loc = store.get(loc_id)
+            if not loc:
+                return f"Memory location {loc_id} not found."
+            
+            anchor_session_id = loc.get("session_id")
+            anchor_guid = loc.get("anchor_guid")
+            
+            if anchor_guid and anchor_session_id:
+                msg_id = store.resolve_anchor(anchor_guid, anchor_session_id)
+                if msg_id:
+                    return f"Jumping to location {loc_id} (Message ID: {msg_id}).\nSession: {anchor_session_id}"
+                return f"Warning: Anchor for location {loc_id} is orphaned."
+            return f"Location {loc_id} does not have a message anchor."
+
+        elif action == "delete":
+            if len(parts) < 2:
+                return "Usage: `/marker delete <id>`"
+            try:
+                loc_id = int(parts[1])
+            except ValueError:
+                return "Invalid location ID. Use a number."
+
+            if store.delete(loc_id):
+                return f"Deleted memory location {loc_id}."
+            return f"Memory location {loc_id} not found."
+
+        else:
+            return "Usage: `/marker [list|create <label>|goto <id>|delete <id>]`"

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -116,6 +116,9 @@ COMMAND_REGISTRY: list[CommandDef] = [
                gateway_only=True, aliases=("set-home",)),
     CommandDef("resume", "Resume a previously-named session", "Session",
                args_hint="[name]"),
+    CommandDef("marker", "Manage memory locations (markers)", "Session",
+               args_hint="[list|create|goto|delete]",
+               subcommands=("list", "create", "goto", "delete")),
 
     # Configuration
     CommandDef("sessions", "Browse and resume previous sessions", "Session"),
@@ -342,6 +345,7 @@ ACTIVE_SESSION_BYPASS_COMMANDS: frozenset[str] = frozenset(
         "commands",
         "deny",
         "help",
+        "marker",
         "new",
         "profile",
         "queue",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -282,6 +282,7 @@ from hermes_cli.subcommands.security import build_security_parser
 from hermes_cli.subcommands.dump import build_dump_parser
 from hermes_cli.subcommands.debug import build_debug_parser
 from hermes_cli.subcommands.backup import build_backup_parser
+from hermes_cli.subcommands.marker import build_marker_parser
 from hermes_cli.subcommands.import_cmd import build_import_cmd_parser
 from hermes_cli.subcommands.config import build_config_parser
 from hermes_cli.subcommands.version import build_version_parser
@@ -4101,6 +4102,12 @@ def cmd_import(args):
     from hermes_cli.backup import run_import
 
     run_import(args)
+
+
+def cmd_marker(args):
+    """Manage memory locations (markers)."""
+    from hermes_cli.marker_cmd import cmd_marker as _handle_marker
+    _handle_marker(args)
 
 
 def _print_version_info(*, check_updates: bool = True) -> None:
@@ -10877,6 +10884,11 @@ def main():
     # backup command  (parser built in hermes_cli/subcommands/backup.py)
     # =========================================================================
     build_backup_parser(subparsers, cmd_backup=cmd_backup)
+
+    # =========================================================================
+    # marker command  (parser built in hermes_cli/subcommands/marker.py)
+    # =========================================================================
+    build_marker_parser(subparsers, cmd_marker=cmd_marker)
 
     # =========================================================================
     # checkpoints command

--- a/hermes_cli/marker_cmd.py
+++ b/hermes_cli/marker_cmd.py
@@ -1,0 +1,86 @@
+"""CLI command handler for marker (memory locations)."""
+
+import json
+import sys
+
+from hermes_state import SessionDB, get_last_init_error
+from agent.memory_locations import MemoryLocationStore
+
+
+def cmd_marker(args):
+    """Manage memory locations (markers)."""
+    try:
+        db = SessionDB()
+    except Exception:
+        err = get_last_init_error() or "unknown error"
+        print(f"Session database not available: {err}")
+        raise SystemExit(1)
+
+    store = MemoryLocationStore(session_db=db)
+
+    action = getattr(args, "marker_action", None)
+
+    if action == "create":
+        # For CLI "create", we don't have a current session ID from the TUI.
+        # We can either require --session or create a persistent marker.
+        session_id = getattr(args, "session", None)
+        tags = args.tags.split(",") if args.tags else None
+        
+        loc_id = store.create(
+            session_id=session_id,
+            label=args.label,
+            time_type="point",
+            tags=tags,
+            is_persistent=bool(getattr(args, "persistent", False)),
+        )
+        print(f"Created memory location {loc_id}: '{args.label}'")
+        
+    elif action == "list":
+        locations = store.list(
+            session_id=getattr(args, "session", None),
+            persistent_only=bool(getattr(args, "persistent", False)),
+        )
+        if getattr(args, "json", False):
+            print(json.dumps(locations, indent=2))
+        else:
+            if not locations:
+                print("No memory locations found.")
+                return
+            print(f"{'ID':<5} | {'Persistent':<10} | {'Label':<30} | {'Session'}")
+            print("-" * 70)
+            for loc in locations:
+                is_p = "Yes" if loc.get("is_persistent") else "No"
+                label = loc.get("label", "")
+                if len(label) > 28:
+                    label = label[:28] + "..."
+                sid = loc.get("session_id", "") or "(global)"
+                print(f"{loc.get('id'):<5} | {is_p:<10} | {label:<30} | {sid}")
+                
+    elif action == "goto":
+        loc = store.get(args.location_id)
+        if not loc:
+            print(f"Memory location {args.location_id} not found.")
+            raise SystemExit(1)
+        
+        # Resolve anchor to get the message ID
+        session_id = loc.get("session_id")
+        anchor_guid = loc.get("anchor_guid")
+        
+        if anchor_guid and session_id:
+            msg_id = store.resolve_anchor(anchor_guid, session_id)
+            if msg_id:
+                print(f"Jumping to location {args.location_id} (Message ID: {msg_id})")
+                print(f"Session: {session_id}")
+            else:
+                print(f"Warning: Anchor for location {args.location_id} is orphaned (message no longer exists).")
+        else:
+            print(f"Location {args.location_id} does not have a message anchor.")
+            
+    elif action == "delete":
+        if store.delete(args.location_id):
+            print(f"Deleted memory location {args.location_id}.")
+        else:
+            print(f"Memory location {args.location_id} not found.")
+            raise SystemExit(1)
+    else:
+        print("Use 'hermes marker --help' for usage information.")

--- a/hermes_cli/subcommands/marker.py
+++ b/hermes_cli/subcommands/marker.py
@@ -1,0 +1,85 @@
+"""``hermes marker`` subcommand parser.
+
+Provides CLI commands for managing memory locations (markers).
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+
+def build_marker_parser(subparsers, *, cmd_marker: Callable) -> None:
+    """Attach the ``marker`` subcommand to ``subparsers``."""
+    marker_parser = subparsers.add_parser(
+        "marker",
+        help="Manage memory locations (markers)",
+        description="Create, list, navigate, and delete memory locations (markers) in Hermes sessions.",
+    )
+    marker_subparsers = marker_parser.add_subparsers(dest="marker_action")
+
+    # marker create
+    marker_create = marker_subparsers.add_parser(
+        "create",
+        help="Create a new memory location at the current position",
+    )
+    marker_create.add_argument(
+        "label",
+        help="Descriptive label for the memory location"
+    )
+    marker_create.add_argument(
+        "--tags",
+        help="Comma-separated list of tags (e.g., bug,frontend)",
+    )
+    marker_create.add_argument(
+        "--persistent",
+        action="store_true",
+        help="Make this location persistent across sessions",
+    )
+    marker_create.add_argument(
+        "--session",
+        help="Session ID to attach to (defaults to current session)",
+    )
+
+    # marker list
+    marker_list = marker_subparsers.add_parser(
+        "list",
+        help="List memory locations",
+    )
+    marker_list.add_argument(
+        "--persistent",
+        action="store_true",
+        help="List only persistent locations",
+    )
+    marker_list.add_argument(
+        "--session",
+        help="Filter by session ID",
+    )
+    marker_list.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+
+    # marker goto
+    marker_goto = marker_subparsers.add_parser(
+        "goto",
+        help="Jump to a memory location",
+    )
+    marker_goto.add_argument(
+        "location_id",
+        type=int,
+        help="ID of the memory location to jump to",
+    )
+
+    # marker delete
+    marker_delete = marker_subparsers.add_parser(
+        "delete",
+        help="Delete a memory location",
+    )
+    marker_delete.add_argument(
+        "location_id",
+        type=int,
+        help="ID of the memory location to delete",
+    )
+
+    marker_parser.set_defaults(func=cmd_marker)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -33,7 +33,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 15
+SCHEMA_VERSION = 16
 
 # ---------------------------------------------------------------------------
 # WAL-compatibility fallback
@@ -285,6 +285,7 @@ CREATE TABLE IF NOT EXISTS messages (
     codex_reasoning_items TEXT,
     codex_message_items TEXT,
     platform_message_id TEXT,
+    message_guid TEXT,
     observed INTEGER DEFAULT 0,
     active INTEGER NOT NULL DEFAULT 1
 );
@@ -300,6 +301,49 @@ CREATE TABLE IF NOT EXISTS compression_locks (
     acquired_at REAL NOT NULL,
     expires_at REAL NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS memory_locations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT,
+    label TEXT NOT NULL,
+    time_type TEXT NOT NULL DEFAULT 'point',
+    anchor_guid TEXT,
+    anchor_end_guid TEXT,
+    color TEXT,
+    tags TEXT,
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    is_persistent INTEGER NOT NULL DEFAULT 0,
+    origin TEXT NOT NULL DEFAULT 'manual',
+    recall_state TEXT,
+    created_at REAL NOT NULL,
+    FOREIGN KEY (session_id) REFERENCES sessions(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_memory_locations_session ON memory_locations(session_id);
+CREATE INDEX IF NOT EXISTS idx_memory_locations_persistent ON memory_locations(is_persistent);
+CREATE INDEX IF NOT EXISTS idx_memory_locations_anchor ON memory_locations(anchor_guid);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS memory_locations_fts USING fts5(
+    label,
+    tags,
+    content='memory_locations',
+    content_rowid='id'
+);
+
+CREATE TRIGGER IF NOT EXISTS memory_locations_fts_insert AFTER INSERT ON memory_locations BEGIN
+    INSERT INTO memory_locations_fts(rowid, label, tags)
+    VALUES (new.id, new.label, new.tags);
+END;
+
+CREATE TRIGGER IF NOT EXISTS memory_locations_fts_delete AFTER DELETE ON memory_locations BEGIN
+    DELETE FROM memory_locations_fts WHERE rowid = old.id;
+END;
+
+CREATE TRIGGER IF NOT EXISTS memory_locations_fts_update AFTER UPDATE ON memory_locations BEGIN
+    DELETE FROM memory_locations_fts WHERE rowid = old.id;
+    INSERT INTO memory_locations_fts(rowid, label, tags)
+    VALUES (new.id, new.label, new.tags);
+END;
 
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
 CREATE INDEX IF NOT EXISTS idx_sessions_source_id ON sessions(source, id);
@@ -897,6 +941,24 @@ class SessionDB:
                 try:
                     cursor.execute(
                         "UPDATE messages SET active = 1 WHERE active IS NULL"
+                    )
+                except sqlite3.OperationalError:
+                    pass
+            if current_version < 16:
+                # v16: messages.message_guid for stable anchoring of memory locations.
+                # The reconciler adds the column. Here we backfill existing rows
+                # with a deterministic GUID (hash of session_id + id) to ensure
+                # uniqueness without requiring random generation on every row.
+                try:
+                    cursor.execute(
+                        "UPDATE messages SET message_guid = lower(hex(zeroblob(4)) || '-' || "
+                        "hex(zeroblob(2)) || '-' || '4' || substr(hex(zeroblob(2)), 2) || '-' || "
+                        "substr('89ab', abs(random()) % 4 + 1, 1) || substr(hex(zeroblob(2)), 2) || '-' || "
+                        "hex(zeroblob(6))) WHERE message_guid IS NULL"
+                    )
+                    cursor.execute(
+                        "CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_guid ON messages(message_guid) "
+                        "WHERE message_guid IS NOT NULL"
                     )
                 except sqlite3.OperationalError:
                     pass

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -268,6 +268,15 @@ gateway:
     header:                "📊 **Hermes Gateway Status**"
     session_id:            "**Session ID:** `{session_id}`"
     title:                 "**Title:** {title}"
+    # Backtick-quoted: model identifiers often contain forward slashes or
+    # colons (e.g. "anthropic/claude-opus-4.6", "ollama/qwen3:14b") that
+    # are clearer in monospace; mirrors the formatting /agents already uses.
+    model:                 "**Model:** `{model}`"
+    # Only emitted when a /model session override is active and differs
+    # from the profile default — keeps the common case (no override) free
+    # of noise while making active overrides obvious.
+    model_session_override: "**Model (this session):** `{model}`"
+    provider:              "**Provider:** {provider}"
     created:               "**Created:** {timestamp}"
     last_activity:         "**Last Activity:** {timestamp}"
     tokens:                "**Cumulative API tokens (re-sent each call):** {tokens}"

--- a/tests/agent/test_memory_locations.py
+++ b/tests/agent/test_memory_locations.py
@@ -1,0 +1,151 @@
+"""Tests for memory locations (markers)."""
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from hermes_state import SessionDB
+from agent.memory_locations import MemoryLocationStore
+
+
+class TestMemoryLocationStore(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.temp_dir.name) / "state.db"
+        self.db = SessionDB(db_path=self.db_path)
+        
+        # Create test sessions for foreign key constraints
+        with self.db._lock:
+            self.db._conn.execute(
+                "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
+                ("session-1", "cli", 1000.0)
+            )
+            self.db._conn.execute(
+                "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
+                ("session-2", "cli", 1000.0)
+            )
+            self.db._conn.commit()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_create_and_get(self):
+        store = MemoryLocationStore(session_db=self.db)
+        loc_id = store.create(
+            session_id="session-1",
+            label="Test Marker",
+            time_type="point",
+            tags=["bug", "frontend"],
+            is_persistent=False,
+        )
+        self.assertIsNotNone(loc_id)
+        self.assertGreater(loc_id, 0)
+
+        loc = store.get(loc_id)
+        self.assertIsNotNone(loc)
+        self.assertEqual(loc["label"], "Test Marker")
+        self.assertEqual(loc["session_id"], "session-1")
+        self.assertEqual(loc["tags"], ["bug", "frontend"])
+        self.assertEqual(loc["is_persistent"], 0)
+
+    def test_list_locations(self):
+        store = MemoryLocationStore(session_db=self.db)
+        store.create(
+            session_id="session-1",
+            label="Marker 1",
+            time_type="point",
+            is_persistent=False,
+        )
+        store.create(
+            session_id="session-2",
+            label="Marker 2",
+            time_type="point",
+            is_persistent=True,
+        )
+
+        all_locs = store.list()
+        self.assertEqual(len(all_locs), 2)
+
+        session_1_locs = store.list(session_id="session-1")
+        self.assertEqual(len(session_1_locs), 1)
+        self.assertEqual(session_1_locs[0]["label"], "Marker 1")
+
+        persistent_locs = store.list(persistent_only=True)
+        self.assertEqual(len(persistent_locs), 1)
+        self.assertEqual(persistent_locs[0]["label"], "Marker 2")
+
+    def test_delete_location(self):
+        store = MemoryLocationStore(session_db=self.db)
+        loc_id = store.create(
+            session_id="session-1",
+            label="To Delete",
+            time_type="point",
+        )
+        
+        self.assertTrue(store.delete(loc_id))
+        self.assertIsNone(store.get(loc_id))
+
+    def test_update_location(self):
+        store = MemoryLocationStore(session_db=self.db)
+        loc_id = store.create(
+            session_id="session-1",
+            label="Original",
+            time_type="point",
+        )
+        
+        self.assertTrue(store.update(loc_id, label="Updated", is_persistent=True))
+        loc = store.get(loc_id)
+        self.assertEqual(loc["label"], "Updated")
+        self.assertEqual(loc["is_persistent"], 1)
+
+    def test_fts_search(self):
+        store = MemoryLocationStore(session_db=self.db)
+        store.create(
+            session_id="session-1",
+            label="Bug Fix Frontend",
+            time_type="point",
+            tags=["bug", "frontend"],
+        )
+        store.create(
+            session_id="session-1",
+            label="Database Migration",
+            time_type="point",
+            tags=["db", "backend"],
+        )
+
+        results = store.search_fts("bug")
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["label"], "Bug Fix Frontend")
+
+    def test_resolve_anchor(self):
+        store = MemoryLocationStore(session_db=self.db)
+        
+        # Create a session
+        with self.db._lock:
+            self.db._conn.execute(
+                "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
+                ("parent-session", "cli", 1000.0)
+            )
+            self.db._conn.execute(
+                "INSERT INTO sessions (id, source, parent_session_id, started_at) VALUES (?, ?, ?, ?)",
+                ("child-session", "cli", "parent-session", 1100.0)
+            )
+            self.db._conn.execute(
+                "INSERT INTO messages (session_id, role, content, timestamp, message_guid) VALUES (?, ?, ?, ?, ?)",
+                ("parent-session", "user", "Hello", 1001.0, "guid-123")
+            )
+            self.db._conn.commit()
+
+        # Resolve in parent session (directly)
+        msg_id = store.resolve_anchor("guid-123", "parent-session")
+        self.assertIsNotNone(msg_id)
+
+        # Resolve in child session (lineage-aware walk)
+        msg_id_child = store.resolve_anchor("guid-123", "child-session")
+        self.assertIsNotNone(msg_id_child)
+        self.assertEqual(msg_id, msg_id_child)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -223,6 +223,39 @@ def _read_session(db, session_id: str, head: int = 20, tail: int = 10) -> str:
     return json.dumps(response, ensure_ascii=False)
 
 
+def _search_markers(db, query: str, current_session_id: Optional[str] = None) -> str:
+    """Return matching memory locations via FTS5 search."""
+    try:
+        from agent.memory_locations import MemoryLocationStore
+        store = MemoryLocationStore(session_db=db)
+        # Search globally or within current session
+        results = store.search_fts(query, session_id=current_session_id if current_session_id else None)
+        
+        formatted = []
+        for loc in results:
+            formatted.append({
+                "location_id": loc["id"],
+                "label": loc["label"],
+                "session_id": loc["session_id"],
+                "anchor_guid": loc["anchor_guid"],
+                "tags": loc.get("tags", []),
+                "is_persistent": bool(loc.get("is_persistent", 0)),
+                "sort_order": loc.get("sort_order", 0),
+                "snippet": loc.get("label_snippet", ""),
+            })
+            
+        return json.dumps({
+            "success": True,
+            "mode": "marker",
+            "results": formatted,
+            "count": len(formatted),
+            "message": f"Found {len(formatted)} memory location(s) matching '{query}'",
+        }, ensure_ascii=False)
+    except Exception as e:
+        logging.error("Error searching markers: %s", e, exc_info=True)
+        return tool_error(f"Failed to search markers: {e}", success=False)
+
+
 def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str:
     """Return metadata for the most recent sessions (no LLM calls, no FTS5)."""
     try:
@@ -593,6 +626,17 @@ def session_search(
     if not query or not isinstance(query, str) or not query.strip():
         return _list_recent_sessions(db, limit, current_session_id)
 
+    # Handle marker: prefix for memory location search
+    query_stripped = query.strip()
+    if query_stripped.startswith("marker:"):
+        marker_query = query_stripped[7:].strip()
+        if not marker_query:
+            return json.dumps({
+                "success": False,
+                "error": "marker: prefix requires a search term (e.g., marker:bug)"
+            }, ensure_ascii=False)
+        return _search_markers(db, marker_query, current_session_id)
+
     # Parse role_filter
     role_list: Optional[List[str]] = None
     if isinstance(role_filter, str) and role_filter.strip():
@@ -675,7 +719,8 @@ SESSION_SEARCH_SCHEMA = {
         "  Reach for this on any \"what did we do about X\" / \"where did we leave Y\" / "
         "\"find the session where Z\" question — before gh, web search, or filesystem "
         "inspection. The session DB carries what was said when; external tools show "
-        "current world state."
+        "current world state.\n\n"
+        "  Use \"marker:query\" to search specifically within memory locations (markers)."
     ),
     "parameters": {
         "type": "object",


### PR DESCRIPTION
See branch commit for full rationale + inline comments. From @chrislyons. Surfaces model/provider in /status across Matrix/Telegram/Discord/CLI as tips.py:418 already documents.