### PR TITLE
feat(slack): add markdown blocks and workspace tools

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -414,6 +414,10 @@ class SlackAdapter(BasePlatformAdapter):
     """
 
     MAX_MESSAGE_LENGTH = 39000  # Slack API allows 40,000 chars; leave margin
+    # Slack markdown blocks support richer standard Markdown rendering (notably
+    # tables), but have a separate 12,000-character cumulative text limit per
+    # payload. Keep each one below the documented ceiling with some margin.
+    MARKDOWN_BLOCK_TEXT_LENGTH = 11500
     supports_code_blocks = True  # Slack mrkdwn renders fenced code blocks
     splits_long_messages = True  # send() chunks via truncate_message(MAX_MESSAGE_LENGTH)
     # Slack blocks typed native slash commands inside threads ("/approve is
@@ -1250,8 +1254,28 @@ class SlackAdapter(BasePlatformAdapter):
             # Convert standard markdown → Slack mrkdwn
             formatted = self.format_message(content)
 
-            # Split long messages, preserving code block boundaries
-            chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+            if self._markdown_blocks_enabled():
+                raw_chunks = self.truncate_message(
+                    content or "",
+                    self.MARKDOWN_BLOCK_TEXT_LENGTH,
+                )
+                send_items = [
+                    {
+                        "text": (
+                            self.truncate_message(
+                                self.format_message(raw_chunk),
+                                self.MAX_MESSAGE_LENGTH,
+                            )
+                            or [""]
+                        )[0],
+                        "blocks": [{"type": "markdown", "text": raw_chunk}],
+                    }
+                    for raw_chunk in raw_chunks
+                ] or [{"text": formatted or "", "blocks": None}]
+            else:
+                # Split long messages, preserving code block boundaries
+                chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+                send_items = [{"text": chunk, "blocks": None} for chunk in chunks]
 
             thread_ts = self._resolve_thread_ts(reply_to, metadata)
             last_result = None
@@ -1260,12 +1284,14 @@ class SlackAdapter(BasePlatformAdapter):
             # Controlled via platform config: gateway.slack.reply_broadcast
             broadcast = self.config.extra.get("reply_broadcast", False)
 
-            for i, chunk in enumerate(chunks):
+            for i, item in enumerate(send_items):
                 kwargs = {
                     "channel": chat_id,
-                    "text": chunk,
+                    "text": item["text"],
                     "mrkdwn": True,
                 }
+                if item["blocks"]:
+                    kwargs["blocks"] = item["blocks"]
                 if thread_ts:
                     kwargs["thread_ts"] = thread_ts
                     # Only broadcast the first chunk of the first reply
@@ -1779,6 +1805,18 @@ class SlackAdapter(BasePlatformAdapter):
             text = text.replace(key, placeholders[key])
 
         return text
+
+    def _markdown_blocks_enabled(self) -> bool:
+        """Return True when Slack sends final replies with markdown blocks.
+
+        Slack's normal ``text`` + ``mrkdwn`` path does not render GitHub-style
+        Markdown tables. The newer Block Kit ``markdown`` block does, so this
+        flag lets operators opt in while keeping the legacy path as the default.
+        """
+        value = self.config.extra.get("markdown_blocks")
+        if isinstance(value, bool):
+            return value
+        return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
 
     # ----- Reactions -----
 

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3267,6 +3267,48 @@ class TestMessageSplitting:
         assert kwargs.get("mrkdwn") is True
 
     @pytest.mark.asyncio
+    async def test_send_uses_markdown_block_when_enabled(self, adapter):
+        adapter.config.extra["markdown_blocks"] = True
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "msg_ts"})
+        content = (
+            "| 항목 | 상태 | 비고 |\n"
+            "| --- | --- | --- |\n"
+            "| API | 정상 | 200 OK |\n"
+            "| DB | 정상 | 지연 없음 |"
+        )
+
+        result = await adapter.send(chat_id="C123", content=content, metadata={"thread_id": "parent_ts"})
+
+        assert result.success is True
+        call_kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert call_kwargs["thread_ts"] == "parent_ts"
+        assert call_kwargs["mrkdwn"] is True
+        assert call_kwargs["text"] == content
+        assert call_kwargs["blocks"] == [{"type": "markdown", "text": content}]
+
+    @pytest.mark.asyncio
+    async def test_send_keeps_legacy_text_path_by_default(self, adapter):
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "msg_ts"})
+
+        result = await adapter.send(chat_id="C123", content="**bold**")
+
+        assert result.success is True
+        call_kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert call_kwargs["text"] == "*bold*"
+        assert "blocks" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_markdown_blocks_preserve_standard_markdown_in_block_text(self, adapter):
+        adapter.config.extra["markdown_blocks"] = True
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "msg_ts"})
+
+        await adapter.send(chat_id="C123", content="**Bold** and [link](https://example.com)")
+
+        call_kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert call_kwargs["text"] == "*Bold* and <https://example.com|link>"
+        assert call_kwargs["blocks"][0]["text"] == "**Bold** and [link](https://example.com)"
+
+    @pytest.mark.asyncio
     async def test_send_does_not_double_escape_entities(self, adapter):
         """Pre-escaped &amp; in sent messages must not become &amp;amp;."""
         adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "ts1"})

--- a/tests/tools/test_slack_usergroup_tool.py
+++ b/tests/tools/test_slack_usergroup_tool.py
@@ -1,0 +1,62 @@
+import json
+
+import pytest
+
+from tools import slack_usergroup_tool as tool
+
+
+def test_normalize_users_rejects_empty_membership():
+    with pytest.raises(ValueError, match="refusing to empty"):
+        tool._normalize_users(" , ,, ")
+
+
+def test_normalize_users_deduplicates_and_trims():
+    assert tool._normalize_users(" U1, U2, U1 ,, U3 ") == ["U1", "U2", "U3"]
+
+
+def test_update_usergroup_users_posts_complete_normalized_membership(monkeypatch):
+    calls = []
+
+    def fake_slack_api(method, params):
+        calls.append((method, params))
+        return {"ok": True, "usergroup": {"id": params["usergroup"]}}
+
+    monkeypatch.setattr(tool, "_slack_api", fake_slack_api)
+    result = json.loads(tool.slack_update_usergroup_users(" S123 ", " U1, U2, U1 "))
+
+    assert calls == [
+        ("usergroups.users.update", {"usergroup": "S123", "users": "U1,U2"})
+    ]
+    assert result["ok"] is True
+    assert result["users"] == ["U1", "U2"]
+
+
+def test_list_usergroups_maps_response(monkeypatch):
+    def fake_slack_api(method, params):
+        assert method == "usergroups.list"
+        assert params == {"include_users": "true", "include_disabled": "false"}
+        return {
+            "ok": True,
+            "usergroups": [
+                {
+                    "id": "S123",
+                    "handle": "jubeon",
+                    "name": "주번",
+                    "description": "weekly duty",
+                    "date_delete": 0,
+                    "users": ["U1"],
+                }
+            ],
+        }
+
+    monkeypatch.setattr(tool, "_slack_api", fake_slack_api)
+    result = json.loads(tool.slack_list_usergroups(include_users=True))
+
+    assert result["usergroups"][0] == {
+        "id": "S123",
+        "handle": "jubeon",
+        "name": "주번",
+        "description": "weekly duty",
+        "is_disabled": False,
+        "users": ["U1"],
+    }

--- a/tools/slack_message_tool.py
+++ b/tools/slack_message_tool.py
@@ -1,0 +1,114 @@
+"""Slack message maintenance tools for Hermes gateway/local runtime.
+
+Uses Hermes' SLACK_BOT_TOKEN. The delete helper is intended for deleting
+messages authored by the bot, usually from Slack cleanup requests where the
+caller has a message ts.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.parse
+import urllib.request
+from typing import Any, Dict
+
+from tools.registry import registry
+
+SLACK_API_BASE = "https://slack.com/api"
+
+
+def check_slack_message_requirements() -> bool:
+    return bool(os.getenv("SLACK_BOT_TOKEN", "").strip())
+
+
+def _token() -> str:
+    token = os.getenv("SLACK_BOT_TOKEN", "").strip()
+    if not token:
+        raise RuntimeError("SLACK_BOT_TOKEN is not set")
+    return token
+
+
+def _default_channel() -> str:
+    return (
+        os.getenv("SLACK_CHANNEL", "").strip()
+        or os.getenv("SLACK_HOME_CHANNEL", "").strip()
+    )
+
+
+def _slack_api(method: str, params: Dict[str, Any]) -> Dict[str, Any]:
+    body = urllib.parse.urlencode(
+        {key: value for key, value in params.items() if value is not None}
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        f"{SLACK_API_BASE}/{method}",
+        data=body,
+        headers={
+            "Authorization": f"Bearer {_token()}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def slack_delete_message(ts: str, channel: str | None = None) -> str:
+    """Delete a Slack message by timestamp from the given/default channel."""
+    ts = str(ts or "").strip()
+    resolved_channel = str(channel or "").strip() or _default_channel()
+    if not ts:
+        return json.dumps({"ok": False, "error": "missing_ts"}, ensure_ascii=False)
+    if not resolved_channel:
+        return json.dumps(
+            {
+                "ok": False,
+                "error": "missing_channel",
+                "hint": "Pass channel or set SLACK_CHANNEL/SLACK_HOME_CHANNEL.",
+            },
+            ensure_ascii=False,
+        )
+
+    data = _slack_api("chat.delete", {"channel": resolved_channel, "ts": ts})
+    return json.dumps(
+        {
+            "ok": bool(data.get("ok")),
+            "channel": data.get("channel", resolved_channel),
+            "ts": data.get("ts", ts),
+            "error": data.get("error"),
+        },
+        ensure_ascii=False,
+    )
+
+
+SLACK_DELETE_MESSAGE_SCHEMA = {
+    "name": "slack_delete_message",
+    "description": "Delete a Slack message by ts using Hermes' SLACK_BOT_TOKEN. Defaults to SLACK_CHANNEL/SLACK_HOME_CHANNEL when channel is omitted. Usually only bot-authored messages can be deleted.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "ts": {
+                "type": "string",
+                "description": "Slack message timestamp, e.g. 1781830158.966569 or the p-link timestamp converted to dotted form.",
+            },
+            "channel": {
+                "type": "string",
+                "description": "Optional Slack channel ID, e.g. C07NTPS63QE. If omitted, uses SLACK_CHANNEL then SLACK_HOME_CHANNEL.",
+            },
+        },
+        "required": ["ts"],
+    },
+}
+
+
+registry.register(
+    name="slack_delete_message",
+    toolset="slack",
+    schema=SLACK_DELETE_MESSAGE_SCHEMA,
+    handler=lambda args, **kw: slack_delete_message(
+        args.get("ts", ""), args.get("channel")
+    ),
+    check_fn=check_slack_message_requirements,
+    requires_env=["SLACK_BOT_TOKEN"],
+    emoji="🧹",
+)

--- a/tools/slack_usergroup_tool.py
+++ b/tools/slack_usergroup_tool.py
@@ -1,0 +1,198 @@
+"""Slack usergroup management tools for Hermes gateway/local runtime.
+
+Uses the same SLACK_BOT_TOKEN that the Hermes Slack gateway uses. The update
+endpoint replaces the complete usergroup membership, so helpers reject empty
+membership and expose read tools to inspect current state first.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.parse
+import urllib.request
+from typing import Any, Dict, Iterable, List
+
+from tools.registry import registry
+
+SLACK_API_BASE = "https://slack.com/api"
+
+
+def check_slack_usergroup_requirements() -> bool:
+    return bool(os.getenv("SLACK_BOT_TOKEN", "").strip())
+
+
+def _token() -> str:
+    token = os.getenv("SLACK_BOT_TOKEN", "").strip()
+    if not token:
+        raise RuntimeError("SLACK_BOT_TOKEN is not set")
+    return token
+
+
+def _normalize_users(users: Any) -> List[str]:
+    if isinstance(users, str):
+        parts = users.split(",")
+    elif isinstance(users, Iterable):
+        parts = [str(user) for user in users]
+    else:
+        parts = []
+
+    normalized: List[str] = []
+    seen = set()
+    for part in parts:
+        user_id = str(part).strip()
+        if not user_id or user_id in seen:
+            continue
+        normalized.append(user_id)
+        seen.add(user_id)
+
+    if not normalized:
+        raise ValueError("At least one Slack user ID is required; refusing to empty a usergroup")
+    return normalized
+
+
+def _slack_api(method: str, params: Dict[str, Any]) -> Dict[str, Any]:
+    body = urllib.parse.urlencode(
+        {key: value for key, value in params.items() if value is not None}
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        f"{SLACK_API_BASE}/{method}",
+        data=body,
+        headers={
+            "Authorization": f"Bearer {_token()}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        payload = json.loads(resp.read().decode("utf-8"))
+    if not payload.get("ok"):
+        raise RuntimeError(f"Slack API error on {method}: {payload.get('error', 'unknown')}")
+    return payload
+
+
+def slack_list_usergroups(include_users: bool = False, include_disabled: bool = False) -> str:
+    data = _slack_api(
+        "usergroups.list",
+        {
+            "include_users": "true" if include_users else "false",
+            "include_disabled": "true" if include_disabled else "false",
+        },
+    )
+    groups = []
+    for group in data.get("usergroups", []):
+        groups.append(
+            {
+                "id": group.get("id"),
+                "handle": group.get("handle"),
+                "name": group.get("name"),
+                "description": group.get("description"),
+                "is_disabled": group.get("date_delete") not in (None, 0),
+                "users": group.get("users") if include_users else None,
+            }
+        )
+    return json.dumps({"ok": True, "usergroups": groups}, ensure_ascii=False)
+
+
+def slack_list_usergroup_users(usergroup: str) -> str:
+    data = _slack_api("usergroups.users.list", {"usergroup": usergroup.strip()})
+    return json.dumps(
+        {"ok": True, "usergroup": usergroup.strip(), "users": data.get("users", [])},
+        ensure_ascii=False,
+    )
+
+
+def slack_update_usergroup_users(usergroup: str, users: Any) -> str:
+    usergroup = usergroup.strip()
+    normalized_users = _normalize_users(users)
+    data = _slack_api(
+        "usergroups.users.update",
+        {"usergroup": usergroup, "users": ",".join(normalized_users)},
+    )
+    return json.dumps(
+        {
+            "ok": True,
+            "usergroup": usergroup,
+            "users": normalized_users,
+            "slack_response": {"usergroup": data.get("usergroup", {})},
+        },
+        ensure_ascii=False,
+    )
+
+
+SLACK_LIST_USERGROUPS_SCHEMA = {
+    "name": "slack_list_usergroups",
+    "description": "List Slack usergroups/subteams using Hermes' SLACK_BOT_TOKEN. Use this to find a usergroup ID/handle before updating membership.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "include_users": {"type": "boolean", "default": False},
+            "include_disabled": {"type": "boolean", "default": False},
+        },
+    },
+}
+
+SLACK_LIST_USERGROUP_USERS_SCHEMA = {
+    "name": "slack_list_usergroup_users",
+    "description": "List current member user IDs of a Slack usergroup/subteam. Always call this before slack_update_usergroup_users because Slack update replaces complete membership.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "usergroup": {"type": "string", "description": "Slack usergroup ID, e.g. S0123456789"},
+        },
+        "required": ["usergroup"],
+    },
+}
+
+SLACK_UPDATE_USERGROUP_USERS_SCHEMA = {
+    "name": "slack_update_usergroup_users",
+    "description": "Replace the complete membership of a Slack usergroup/subteam using Hermes' SLACK_BOT_TOKEN. Requires usergroups:write. Provide the full final member list; empty lists are rejected.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "usergroup": {"type": "string", "description": "Slack usergroup ID, e.g. S0123456789"},
+            "users": {
+                "oneOf": [
+                    {"type": "string", "description": "Comma-separated Slack user IDs"},
+                    {"type": "array", "items": {"type": "string"}},
+                ],
+                "description": "Complete final membership as Slack user IDs. Do not pass only the delta.",
+            },
+        },
+        "required": ["usergroup", "users"],
+    },
+}
+
+registry.register(
+    name="slack_list_usergroups",
+    toolset="slack",
+    schema=SLACK_LIST_USERGROUPS_SCHEMA,
+    handler=lambda args, **kw: slack_list_usergroups(
+        bool(args.get("include_users", False)), bool(args.get("include_disabled", False))
+    ),
+    check_fn=check_slack_usergroup_requirements,
+    requires_env=["SLACK_BOT_TOKEN"],
+    emoji="💬",
+)
+
+registry.register(
+    name="slack_list_usergroup_users",
+    toolset="slack",
+    schema=SLACK_LIST_USERGROUP_USERS_SCHEMA,
+    handler=lambda args, **kw: slack_list_usergroup_users(args.get("usergroup", "")),
+    check_fn=check_slack_usergroup_requirements,
+    requires_env=["SLACK_BOT_TOKEN"],
+    emoji="💬",
+)
+
+registry.register(
+    name="slack_update_usergroup_users",
+    toolset="slack",
+    schema=SLACK_UPDATE_USERGROUP_USERS_SCHEMA,
+    handler=lambda args, **kw: slack_update_usergroup_users(
+        args.get("usergroup", ""), args.get("users", [])
+    ),
+    check_fn=check_slack_usergroup_requirements,
+    requires_env=["SLACK_BOT_TOKEN"],
+    emoji="💬",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -460,7 +460,23 @@ TOOLSETS = {
     
     "hermes-slack": {
         "description": "Slack bot toolset - full access for workspace use (terminal has safety checks)",
-        "tools": _HERMES_CORE_TOOLS,
+        "tools": _HERMES_CORE_TOOLS + [
+            "slack_delete_message",
+            "slack_list_usergroups",
+            "slack_list_usergroup_users",
+            "slack_update_usergroup_users",
+        ],
+        "includes": []
+    },
+
+    "slack": {
+        "description": "Slack workspace maintenance tools gated on SLACK_BOT_TOKEN",
+        "tools": [
+            "slack_delete_message",
+            "slack_list_usergroups",
+            "slack_list_usergroup_users",
+            "slack_update_usergroup_users",
+        ],
         "includes": []
     },
     


### PR DESCRIPTION
## Summary
- add opt-in Slack Block Kit markdown blocks for final replies so GitHub-style Markdown tables can render while preserving the legacy mrkdwn text path by default
- add Slack workspace maintenance tools for deleting bot messages and managing usergroup membership, gated on SLACK_BOT_TOKEN and scoped to the Slack toolset
- add regression coverage for markdown block sending and Slack usergroup membership normalization/update/list behavior

## Tests
- python -m pytest tests/gateway/test_slack.py tests/tools/test_slack_usergroup_tool.py -q -o 'addopts='
