### PR TITLE
fix(dashboard): default invalid Anthropic PKCE expiry

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6283,6 +6283,14 @@ def _start_anthropic_pkce(profile: Optional[str] = None) -> Dict[str, Any]:
     }
 
 
+def _coerce_anthropic_pkce_expires_in(value: Any) -> int:
+    try:
+        expires_in = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return 3600
+    return expires_in if expires_in > 0 else 3600
+
+
 def _submit_anthropic_pkce(
     session_id: str,
     code_input: str,
@@ -6341,7 +6349,7 @@ def _submit_anthropic_pkce(
 
     access_token = result.get("access_token", "")
     refresh_token = result.get("refresh_token", "")
-    expires_in = int(result.get("expires_in") or 3600)
+    expires_in = _coerce_anthropic_pkce_expires_in(result.get("expires_in"))
     if not access_token:
         with _oauth_sessions_lock:
             sess["status"] = "error"

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -460,6 +460,55 @@ def test_anthropic_pkce_branch_still_works():
     assert "claude.ai" in body["auth_url"]
 
 
+def test_anthropic_pkce_submit_defaults_malformed_expires_in(monkeypatch):
+    """A malformed optional token TTL must not discard a successful login."""
+    from hermes_cli import web_server as ws
+
+    class _FakeTokenResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def read(self):
+            return (
+                b'{"access_token":"anthropic-access",'
+                b'"refresh_token":"anthropic-refresh","expires_in":"soon"}'
+            )
+
+    saved = {}
+    monkeypatch.setattr(
+        ws.urllib.request, "urlopen", lambda *a, **k: _FakeTokenResponse()
+    )
+    monkeypatch.setattr(
+        ws,
+        "_save_anthropic_oauth_creds",
+        lambda access, refresh, expires_at_ms: saved.update(
+            {
+                "access": access,
+                "refresh": refresh,
+                "expires_at_ms": expires_at_ms,
+            }
+        ),
+    )
+
+    session_id, sess = ws._new_oauth_session("anthropic", "pkce")
+    sess["verifier"] = "verifier"
+    sess["state"] = "state"
+
+    try:
+        result = ws._submit_anthropic_pkce(session_id, "auth-code#state")
+        assert result == {"ok": True, "status": "approved"}
+        assert ws._oauth_sessions[session_id]["status"] == "approved"
+        assert saved["access"] == "anthropic-access"
+        assert saved["refresh"] == "anthropic-refresh"
+        ttl_ms = saved["expires_at_ms"] - int(time.time() * 1000)
+        assert 3_500_000 <= ttl_ms <= 3_700_000
+    finally:
+        ws._oauth_sessions.pop(session_id, None)
+
+
 def test_xai_oauth_listed_as_loopback_flow():
     """xAI Grok OAuth must surface in the catalog as a first-class loopback flow."""
     resp = client.get("/api/providers/oauth", headers=HEADERS)


### PR DESCRIPTION
## Summary
- default malformed Anthropic dashboard PKCE `expires_in` values to the existing 3600s fallback
- keep successful token exchanges from being discarded because an optional TTL field is malformed
- add regression coverage for malformed Anthropic PKCE expiry responses

## Tests
- `python -m pytest tests/hermes_cli/test_web_oauth_dispatch.py::test_anthropic_pkce_submit_defaults_malformed_expires_in -q`
- `python -m pytest tests/hermes_cli/test_web_oauth_dispatch.py -q`
- `python -m pytest tests/hermes_cli/test_web_server_oauth_write.py -q` *(fails on Windows: existing POSIX permission-mode assertion expects 0o600 but Windows stat reports 0o666)*
- `python -m py_compile hermes_cli/web_server.py`
- `python scripts/check-windows-footguns.py --all`