### PR TITLE
fix(dashboard): default invalid Codex device intervals

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6902,6 +6902,14 @@ def _minimax_poller(session_id: str) -> None:
             sess["error_message"] = str(e)
 
 
+def _coerce_codex_device_poll_interval(value: Any) -> int:
+    try:
+        interval = int(value)
+    except (TypeError, ValueError, OverflowError):
+        interval = 5
+    return max(3, interval)
+
+
 def _codex_full_login_worker(session_id: str) -> None:
     """Run the complete OpenAI Codex device-code flow.
 
@@ -6938,7 +6946,9 @@ def _codex_full_login_worker(session_id: str) -> None:
         device_data = resp.json()
         user_code = device_data.get("user_code", "")
         device_auth_id = device_data.get("device_auth_id", "")
-        poll_interval = max(3, int(device_data.get("interval", "5")))
+        poll_interval = _coerce_codex_device_poll_interval(
+            device_data.get("interval")
+        )
         if not user_code or not device_auth_id:
             raise RuntimeError("device-code response missing user_code or device_auth_id")
         verification_url = f"{issuer}/codex/device"

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -275,6 +275,65 @@ def test_codex_dashboard_worker_persists_runtime_provider(tmp_path, monkeypatch)
         ws._oauth_sessions.pop(sid, None)
 
 
+def test_codex_dashboard_worker_defaults_malformed_interval(monkeypatch):
+    from hermes_cli import auth as auth_mod
+    from hermes_cli import web_server as ws
+
+    class _Resp:
+        def __init__(self, status_code, payload):
+            self.status_code = status_code
+            self._payload = payload
+
+        def json(self):
+            return self._payload
+
+    class _Client:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def post(self, url, **kwargs):
+            if url.endswith("/deviceauth/usercode"):
+                return _Resp(200, {
+                    "device_auth_id": "device-auth-id",
+                    "interval": "fast",
+                    "user_code": "CODEX-1234",
+                })
+            if url.endswith("/deviceauth/token"):
+                return _Resp(200, {
+                    "authorization_code": "authorization-code",
+                    "code_verifier": "code-verifier",
+                })
+            return _Resp(200, {
+                "access_token": "codex-access",
+                "refresh_token": "codex-refresh",
+            })
+
+    saved = {}
+    monkeypatch.setattr(httpx, "Client", _Client)
+    monkeypatch.setattr(ws.time, "sleep", lambda _: None)
+    monkeypatch.setattr(
+        auth_mod, "_save_codex_tokens", lambda tokens: saved.update(tokens)
+    )
+
+    sid, _ = ws._new_oauth_session("openai-codex", "device_code")
+    try:
+        ws._codex_full_login_worker(sid)
+
+        sess = ws._oauth_sessions[sid]
+        assert sess["status"] == "approved"
+        assert sess["user_code"] == "CODEX-1234"
+        assert sess["interval"] == 5
+        assert saved["access_token"] == "codex-access"
+    finally:
+        ws._oauth_sessions.pop(sid, None)
+
+
 def test_codex_dashboard_worker_persists_inside_session_profile(tmp_path, monkeypatch):
     from hermes_cli import auth as auth_mod
     from hermes_cli import web_server as ws


### PR DESCRIPTION
## Summary
- default malformed OpenAI Codex dashboard device-auth `interval` values to 5 seconds
- preserve the existing minimum 3s poll interval guard
- add regression coverage so a bad interval no longer prevents the dashboard from completing login

## Tests
- `python -m pytest tests/hermes_cli/test_web_oauth_dispatch.py::test_codex_dashboard_worker_defaults_malformed_interval -q`
- `python -m pytest tests/hermes_cli/test_web_oauth_dispatch.py -q`
- `python -m py_compile hermes_cli/web_server.py`
- `python scripts/check-windows-footguns.py --all`