### PR TITLE
fix(dashboard): tolerate invalid Nous token TTLs

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6757,6 +6757,7 @@ def _add_xai_oauth_pool_entry(
 def _nous_poller(session_id: str) -> None:
     """Background poller that drives a Nous device-code flow to completion."""
     from hermes_cli.auth import (
+        _coerce_ttl_seconds,
         _poll_for_token,
         refresh_nous_oauth_from_state,
     )
@@ -6784,7 +6785,7 @@ def _nous_poller(session_id: str) -> None:
             )
         # Same post-processing as _nous_device_code_login (validate/refresh JWT)
         now = datetime.now(timezone.utc)
-        token_ttl = int(token_data.get("expires_in") or 0)
+        token_ttl = _coerce_ttl_seconds(token_data.get("expires_in"))
         auth_state = {
             "portal_base_url": portal_base_url,
             "inference_base_url": token_data.get("inference_base_url"),

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -390,6 +390,58 @@ def test_nous_dashboard_poller_preserves_effective_scope_when_token_omits_scope(
         ws._oauth_sessions.pop(session_id, None)
 
 
+def test_nous_dashboard_poller_defaults_malformed_token_ttl(monkeypatch):
+    from hermes_cli import auth as auth_mod
+    from hermes_cli import web_server as ws
+
+    session_id = "nous-malformed-token-ttl-test"
+    ws._oauth_sessions[session_id] = {
+        "session_id": session_id,
+        "provider": "nous",
+        "flow": "device_code",
+        "created_at": time.time(),
+        "status": "pending",
+        "error_message": None,
+        "portal_base_url": "https://portal.nousresearch.com",
+        "client_id": "hermes-cli",
+        "device_code": "device-code",
+        "interval": 5,
+        "expires_at": time.time() + 600,
+        "scope": auth_mod.DEFAULT_NOUS_SCOPE,
+    }
+    captured_state = {}
+
+    def fake_refresh_nous_oauth_from_state(state, **kwargs):
+        captured_state.update(state)
+        return {**state, "agent_key": "jwt-agent-key"}
+
+    monkeypatch.setattr(
+        auth_mod,
+        "_poll_for_token",
+        lambda **kwargs: {
+            "access_token": "access-token",
+            "refresh_token": "refresh-token",
+            "expires_in": "soon",
+            "token_type": "Bearer",
+        },
+    )
+    monkeypatch.setattr(
+        auth_mod,
+        "refresh_nous_oauth_from_state",
+        fake_refresh_nous_oauth_from_state,
+    )
+    monkeypatch.setattr(auth_mod, "persist_nous_credentials", lambda state: None)
+
+    try:
+        ws._nous_poller(session_id)
+        assert ws._oauth_sessions[session_id]["status"] == "approved"
+        assert captured_state["access_token"] == "access-token"
+        assert captured_state["expires_in"] == 0
+        assert captured_state["expires_at"] is None
+    finally:
+        ws._oauth_sessions.pop(session_id, None)
+
+
 def test_minimax_dashboard_poller_accepts_absolute_ms_expired_in():
     """Dashboard MiniMax completion must accept unix-ms token expiry values."""
     from hermes_cli import web_server as ws


### PR DESCRIPTION
## Summary
- use the existing Nous TTL coercion helper in the dashboard device-code poller
- avoid failing a successful token response only because `expires_in` is malformed
- add regression coverage for malformed token TTLs in the Nous dashboard poller

## Tests
- `python -m pytest tests/hermes_cli/test_web_oauth_dispatch.py::test_nous_dashboard_poller_defaults_malformed_token_ttl -q`
- `python -m pytest tests/hermes_cli/test_web_oauth_dispatch.py -q`
- `python -m py_compile hermes_cli/web_server.py`
- `python scripts/check-windows-footguns.py --all`