### PR TITLE
fix(telegram): fall through to overflow split when rich finalize fails for oversized content (#51961)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2972,7 +2972,20 @@ class TelegramAdapter(BasePlatformAdapter):
         if finalize and self._rich_eligible(content):
             rich_result = await self._try_edit_rich(chat_id, message_id, content)
             if rich_result is not None:
-                return rich_result
+                if rich_result.success:
+                    return rich_result
+                # Rich edit failed — if content exceeds the legacy limit, fall
+                # through to _edit_overflow_split for reliable delivery.  The
+                # rich API call is atomic (either succeeds or raises), so the
+                # message was NOT edited and we can safely split via the legacy
+                # path.  (#51961)
+                if utf16_len(content) <= self.MAX_MESSAGE_LENGTH:
+                    return rich_result
+                logger.debug(
+                    "[%s] Rich finalize failed for oversized content (%d UTF-16), "
+                    "falling through to legacy overflow split",
+                    self.name, utf16_len(content),
+                )
 
         # Pre-flight: if content already exceeds the limit, split-and-deliver
         # without round-tripping a doomed edit.  During streaming

--- a/tests/gateway/test_telegram_rich_fallback_overflow.py
+++ b/tests/gateway/test_telegram_rich_fallback_overflow.py
@@ -1,0 +1,113 @@
+"""Regression tests for Telegram streaming overflow + rich fallback.  (#51961)"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import SendResult
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+def _msg(message_id: int | str) -> SimpleNamespace:
+    return SimpleNamespace(message_id=message_id)
+
+
+@pytest.fixture
+def adapter() -> TelegramAdapter:
+    a = TelegramAdapter(PlatformConfig(enabled=True, token="fake-token"))
+    a._bot = MagicMock()
+    a._bot.do_api_request = AsyncMock()  # makes _bot_supports_rich() True
+    return a
+
+
+@pytest.mark.asyncio
+async def test_finalize_rich_failure_falls_through_to_overflow_split(adapter):
+    """When _try_edit_rich fails for oversized content, edit_message must
+    fall through to _edit_overflow_split instead of returning the failure.
+
+    Before the fix, the rich failure was returned directly, leaving the user
+    with a truncated 4096-char preview and no continuation messages.  (#51961)
+    """
+    oversized = "x" * 6000
+    # _rich_eligible needs _needs_rich_rendering → True.  Patch it.
+    with patch.object(adapter, "_rich_eligible", return_value=True):
+        # _try_edit_rich returns a transient failure (non-None, success=False)
+        with patch.object(
+            adapter,
+            "_try_edit_rich",
+            return_value=SendResult(success=False, error="timed out", retryable=True),
+        ):
+            # _edit_overflow_split should be called — mock it to track the call.
+            with patch.object(
+                adapter,
+                "_edit_overflow_split",
+                new_callable=AsyncMock,
+                return_value=SendResult(
+                    success=True,
+                    message_id="456",
+                    continuation_message_ids=("457",),
+                ),
+            ) as mock_split:
+                result = await adapter.edit_message(
+                    "123", "456", oversized, finalize=True,
+                )
+
+    # The overflow split must have been called with the full oversized content.
+    mock_split.assert_awaited_once()
+    call_kwargs = mock_split.call_args
+    assert call_kwargs[0][2] == oversized  # content arg
+    assert call_kwargs[1]["finalize"] is True
+
+    # The overall result must be success (from the split, not the rich failure).
+    assert result.success is True
+    assert result.message_id == "456"
+
+
+@pytest.mark.asyncio
+async def test_finalize_rich_failure_returns_directly_when_content_within_limit(adapter):
+    """When _try_edit_rich fails for content within the legacy limit,
+    the failure must be returned directly (no overflow split needed)."""
+    short_content = "hello world"
+    with patch.object(adapter, "_rich_eligible", return_value=True):
+        with patch.object(
+            adapter,
+            "_try_edit_rich",
+            return_value=SendResult(success=False, error="timed out", retryable=True),
+        ):
+            with patch.object(
+                adapter, "_edit_overflow_split", new_callable=AsyncMock,
+            ) as mock_split:
+                result = await adapter.edit_message(
+                    "123", "456", short_content, finalize=True,
+                )
+
+    # No overflow split — content fits in one message.
+    mock_split.assert_not_awaited()
+    assert result.success is False
+    assert result.retryable is True
+
+
+@pytest.mark.asyncio
+async def test_finalize_rich_success_returns_immediately(adapter):
+    """When _try_edit_rich succeeds, the result must be returned directly
+    without reaching the overflow check (existing behavior, regression guard)."""
+    content = "x" * 6000
+    with patch.object(adapter, "_rich_eligible", return_value=True):
+        with patch.object(
+            adapter,
+            "_try_edit_rich",
+            return_value=SendResult(success=True, message_id="456"),
+        ):
+            with patch.object(
+                adapter, "_edit_overflow_split", new_callable=AsyncMock,
+            ) as mock_split:
+                result = await adapter.edit_message(
+                    "123", "456", content, finalize=True,
+                )
+
+    # Rich succeeded — no overflow split needed.
+    mock_split.assert_not_awaited()
+    assert result.success is True
+    assert result.message_id == "456"


### PR DESCRIPTION
## What does this PR do?

When `_try_edit_rich` returns a transient failure for content exceeding `MAX_MESSAGE_LENGTH` (4096 UTF-16 code units), the adapter now falls through to the legacy `_edit_overflow_split` path instead of returning the rich failure directly. This ensures the full response is delivered via split continuation messages when the rich finalize path fails for oversized content.

## Related Issue

Fixes #51961

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/telegram/adapter.py`: When `_try_edit_rich` returns a non-None failure result and content exceeds `MAX_MESSAGE_LENGTH`, fall through to `_edit_overflow_split` instead of returning the failure. Adds a debug log for the fallback path.
- `tests/gateway/test_telegram_rich_fallback_overflow.py`: 3 regression tests covering: (1) rich failure + oversized → overflow split, (2) rich failure + short content → return failure directly, (3) rich success → return immediately (regression guard).

## How to Test

1. Enable Telegram streaming: `runtime.platforms.telegram.streaming: true`
2. Configure a Telegram bot with rich message support (Bot API 10.1+)
3. Ask the agent a question requiring a response >4096 chars with Markdown tables or math
4. Simulate a transient rich API failure (e.g., network timeout during `editMessageText` with `rich_message` param)
5. Verify: the full response is delivered via split continuation messages, not clipped at 4096 chars
6. Run `pytest tests/gateway/test_telegram_rich_fallback_overflow.py tests/gateway/test_telegram_overflow_partial.py tests/gateway/test_telegram_format.py -v` — all tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `plugins/platforms/telegram/adapter.py:edit_message` (callers: 2 via stream_consumer._edit_message)
- Blast radius: LOW — only affects the rich finalize → legacy fallback path for oversized content
- Related patterns: `_edit_overflow_split` (continuation message delivery), `_truncate_stream_overflow_preview` (mid-stream truncation for #48648), `_try_edit_rich` (Bot API 10.1 rich edit)
