### PR TITLE
fix(kanban-dashboard): make parent/child dependency chips clickable links

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1050,6 +1050,7 @@
           taskId: selectedTaskId,
           boardSlug: board,
           onClose: function () { setSelectedTaskId(null); },
+          onOpen: setSelectedTaskId,
           onRefresh: loadBoard,
           renderMarkdown: renderMd,
           allTasks: boardData.columns.reduce(function (acc, c) { return acc.concat(c.tasks); }, []),
@@ -3032,6 +3033,7 @@
           allTasks: props.allTasks,
           assignees: props.assignees || [],
           boardSlug: boardSlug,
+          onOpen: props.onOpen,
           onPatch: doPatch,
           onSpecify: doSpecify,
           onDecompose: doDecompose,
@@ -3248,6 +3250,7 @@
       h(DependencyEditor, {
         task: t,
         links, allTasks: props.allTasks,
+        onOpen: props.onOpen,
         onAddParent: props.onAddParent,
         onRemoveParent: props.onRemoveParent,
         onAddChild: props.onAddChild,
@@ -3600,6 +3603,35 @@
     );
   }
 
+  function depChipLabel(allTasks, id) {
+    const tk = (allTasks || []).find(function (t) { return t.id === id; });
+    if (tk && tk.title) {
+      return `${id} — ${(tk.title || "").slice(0, 50)}`;
+    }
+    return id;
+  }
+
+  function DepChip(props) {
+    const label = depChipLabel(props.allTasks, props.id);
+    const canOpen = typeof props.onOpen === "function";
+    return h("span", { key: props.id, className: "hermes-kanban-dep-chip" },
+      canOpen
+        ? h("button", {
+            type: "button",
+            className: "hermes-kanban-dep-chip-link",
+            onClick: function () { props.onOpen(props.id); },
+            title: label,
+          }, label)
+        : label,
+      h("button", {
+        type: "button",
+        className: "hermes-kanban-dep-chip-x",
+        onClick: function () { props.onRemove(props.id); },
+        title: tx(props.t, "removeDependency", "Remove dependency"),
+      }, "×"),
+    );
+  }
+
   function DependencyEditor(props) {
     const { t } = useI18n();
     const { task, links, allTasks } = props;
@@ -3622,15 +3654,14 @@
           (links.parents || []).length === 0
             ? h("span", { className: "hermes-kanban-deps-empty" }, tx(t, "none", "none"))
             : (links.parents || []).map(function (id) {
-                return h("span", { key: id, className: "hermes-kanban-dep-chip" },
-                  id,
-                  h("button", {
-                    type: "button",
-                    className: "hermes-kanban-dep-chip-x",
-                    onClick: function () { props.onRemoveParent(id); },
-                    title: tx(t, "removeDependency", "Remove dependency"),
-                  }, "×"),
-                );
+                return h(DepChip, {
+                  key: id,
+                  id: id,
+                  allTasks: allTasks,
+                  onOpen: props.onOpen,
+                  onRemove: props.onRemoveParent,
+                  t: t,
+                });
               }),
         ),
       ),
@@ -3660,15 +3691,14 @@
           (links.children || []).length === 0
             ? h("span", { className: "hermes-kanban-deps-empty" }, tx(t, "none", "none"))
             : (links.children || []).map(function (id) {
-                return h("span", { key: id, className: "hermes-kanban-dep-chip" },
-                  id,
-                  h("button", {
-                    type: "button",
-                    className: "hermes-kanban-dep-chip-x",
-                    onClick: function () { props.onRemoveChild(id); },
-                    title: tx(t, "removeDependency", "Remove dependency"),
-                  }, "×"),
-                );
+                return h(DepChip, {
+                  key: id,
+                  id: id,
+                  allTasks: allTasks,
+                  onOpen: props.onOpen,
+                  onRemove: props.onRemoveChild,
+                  t: t,
+                });
               }),
         ),
       ),

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -684,6 +684,26 @@
   font-size: 0.68rem;
   color: var(--color-foreground);
 }
+.hermes-kanban-dep-chip-link {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: var(--color-primary, #3b82f6);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+  max-width: 16rem;
+  overflow: hidden;
+  padding: 0;
+  text-align: left;
+  text-decoration: underline;
+  text-overflow: ellipsis;
+  text-underline-offset: 2px;
+  white-space: nowrap;
+}
+.hermes-kanban-dep-chip-link:hover {
+  color: color-mix(in srgb, var(--color-primary, #3b82f6) 80%, var(--color-foreground));
+}
 .hermes-kanban-dep-chip-x {
   appearance: none;
   background: transparent;

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -2252,3 +2252,16 @@ def test_dashboard_failed_card_highlight_class_exists():
     assert "hermes-kanban-card--failed" in js
     assert "hermes-kanban-card--failed" in css
     assert "failedIds" in js
+
+
+def test_dashboard_dependency_chips_open_linked_tasks():
+    """Parent/child dependency chips must navigate to the linked task drawer."""
+    repo_root = Path(__file__).resolve().parents[2]
+    js = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+    css = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "style.css").read_text()
+
+    assert "function DepChip" in js
+    assert "hermes-kanban-dep-chip-link" in js
+    assert "onOpen: setSelectedTaskId" in js
+    assert "onOpen: props.onOpen" in js
+    assert "hermes-kanban-dep-chip-link" in css


### PR DESCRIPTION
## Summary
- Wire `onOpen` through the Kanban task drawer so parent/child dependency chips navigate to the linked task
- Show `id — title` labels (when title is known) instead of bare IDs
- Style dependency chips as underlined links and add a bundle regression test

Fixes the dashboard UX gap where dependency IDs were static labels with no navigation.

## Test plan
- [x] Bundle regression test `test_dashboard_dependency_chips_open_linked_tasks`
- [ ] Open a task with parent/child links in the Kanban dashboard drawer
- [ ] Click a dependency chip and confirm the drawer switches to that task
- [ ] Confirm the remove (×) button still unlinks without navigating
