### PR TITLE
fix(browser): default non-finite Camofox vision config

### DIFF
--- a/tests/tools/test_browser_camofox.py
+++ b/tests/tools/test_browser_camofox.py
@@ -400,6 +400,40 @@ class TestCamofoxVisionConfig:
         assert mock_llm.call_args.kwargs["temperature"] == 0.1
         assert mock_llm.call_args.kwargs["timeout"] == 120.0
 
+    @patch("tools.browser_camofox.requests.post")
+    @patch("tools.browser_camofox._get")
+    @patch("tools.browser_camofox._get_raw")
+    def test_camofox_vision_defaults_nonfinite_config(self, mock_get_raw, mock_get, mock_post, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        mock_post.return_value = _mock_response(json_data={"tabId": "tab13", "url": "https://x.com"})
+        camofox_navigate("https://x.com", task_id="t13")
+
+        raw_resp = MagicMock()
+        raw_resp.content = b"fakepng"
+        mock_get_raw.return_value = raw_resp
+        mock_get.return_value = {"snapshot": '- button "Submit"\n'}
+
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Default finite config analysis"
+        mock_response.choices = [mock_choice]
+
+        with (
+            patch("tools.browser_camofox.open", create=True) as mock_open,
+            patch("agent.auxiliary_client.call_llm", return_value=mock_response) as mock_llm,
+            patch(
+                "tools.browser_camofox.load_config",
+                return_value={"auxiliary": {"vision": {"temperature": "nan", "timeout": "inf"}}},
+            ),
+        ):
+            mock_open.return_value.__enter__.return_value.read.return_value = b"fakepng"
+            result = json.loads(camofox_vision("what is on the page?", annotate=True, task_id="t13"))
+
+        assert result["success"] is True
+        assert result["analysis"] == "Default finite config analysis"
+        assert mock_llm.call_args.kwargs["temperature"] == 0.1
+        assert mock_llm.call_args.kwargs["timeout"] == 120.0
+
 
 # ---------------------------------------------------------------------------
 # Routing integration — verify browser_tool routes to camofox

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import base64
 import json
 import logging
+import math
 import os
 import threading
 import uuid
@@ -50,6 +51,14 @@ _DEFAULT_TIMEOUT = 30  # seconds per HTTP request
 _SNAPSHOT_MAX_CHARS = 80_000  # camofox paginates at this limit
 _vnc_url: Optional[str] = None  # cached from /health response
 _vnc_url_checked = False  # only probe once per process
+
+
+def _finite_float(value: Any, default: float) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return default
+    return parsed if math.isfinite(parsed) else default
 
 
 def get_camofox_url() -> str:
@@ -736,8 +745,10 @@ def camofox_vision(question: str, annotate: bool = False,
         try:
             _cfg = load_config()
             _vision_cfg = cfg_get(_cfg, "auxiliary", "vision", default={})
-            _vision_timeout = float(_vision_cfg.get("timeout", 120))
-            _vision_temperature = float(_vision_cfg.get("temperature", 0.1))
+            _vision_timeout = _finite_float(_vision_cfg.get("timeout"), 120.0)
+            _vision_temperature = _finite_float(
+                _vision_cfg.get("temperature"), 0.1
+            )
         except Exception:
             _vision_timeout = 120.0
             _vision_temperature = 0.1


### PR DESCRIPTION
## Summary
- reject non-finite Camofox vision timeout and temperature config values
- fall back to the existing 120s / 0.1 defaults for `inf` and `nan`
- add regression coverage ensuring non-finite config is not passed to `call_llm`

## Tests
- `python -m pytest tests/tools/test_browser_camofox.py::TestCamofoxVisionConfig::test_camofox_vision_defaults_nonfinite_config -q`
- `NO_PROXY=localhost,127.0.0.1,::1 python -m pytest tests/tools/test_browser_camofox.py -q`
- `python -m py_compile tools/browser_camofox.py`
- `python scripts/check-windows-footguns.py --all`