### PR TITLE
fix(cron): block gateway lifecycle commands on job update

### DIFF
--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -484,6 +484,130 @@ class TestCreateJobBlocksLifecycleCommands:
         assert "#30719" in result.get("error", "")
 
 
+class TestCronjobUpdateBlocksLifecycleCommands:
+    """The model tool must apply the shared lifecycle guard to updates too."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_cron_dir(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        scripts_dir = hermes_home / "scripts"
+        scripts_dir.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr("cron.jobs.CRON_DIR", hermes_home / "cron")
+        monkeypatch.setattr("cron.jobs.JOBS_FILE", hermes_home / "cron" / "jobs.json")
+        monkeypatch.setattr("cron.jobs.OUTPUT_DIR", hermes_home / "cron" / "output")
+        (scripts_dir / "safe.sh").write_text("printf 'ok\\n'\n", encoding="utf-8")
+
+    @pytest.mark.parametrize(
+        ("script_name", "command"),
+        [
+            (
+                "restart-launchd.sh",
+                "launchctl kickstart -k gui/501/ai.hermes.gateway\n",
+            ),
+            (
+                "restart-systemd.sh",
+                "systemctl --user restart hermes-gateway.service\n",
+            ),
+        ],
+    )
+    def test_update_rejects_lifecycle_script(self, tmp_path, script_name, command):
+        from tools.cronjob_tools import cronjob
+
+        scripts_dir = tmp_path / ".hermes" / "scripts"
+        (scripts_dir / script_name).write_text(command, encoding="utf-8")
+        created = json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            script="safe.sh",
+            no_agent=True,
+        ))
+        assert created["success"] is True
+
+        result = json.loads(cronjob(
+            action="update",
+            job_id=created["job_id"],
+            script=script_name,
+        ))
+
+        assert result["success"] is False
+        assert "#30719" in result["error"]
+
+    def test_update_rejects_lifecycle_prompt(self):
+        from tools.cronjob_tools import cronjob
+
+        created = json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="summarize gateway health",
+        ))
+        assert created["success"] is True
+
+        result = json.loads(cronjob(
+            action="update",
+            job_id=created["job_id"],
+            prompt="run hermes gateway restart after the summary",
+        ))
+
+        assert result["success"] is False
+        assert "#30719" in result["error"]
+
+    def test_unrelated_update_rejects_stored_lifecycle_script(self, tmp_path):
+        from cron.jobs import update_job
+        from tools.cronjob_tools import cronjob
+
+        scripts_dir = tmp_path / ".hermes" / "scripts"
+        (scripts_dir / "legacy-restart.sh").write_text(
+            "systemctl --user restart hermes-gateway.service\n",
+            encoding="utf-8",
+        )
+        created = json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            script="safe.sh",
+            no_agent=True,
+        ))
+        assert created["success"] is True
+        update_job(created["job_id"], {"script": "legacy-restart.sh"})
+
+        result = json.loads(cronjob(
+            action="update",
+            job_id=created["job_id"],
+            name="renamed",
+        ))
+
+        assert result["success"] is False
+        assert "#30719" in result["error"]
+
+    def test_update_can_clear_stored_lifecycle_script(self, tmp_path):
+        from cron.jobs import update_job
+        from tools.cronjob_tools import cronjob
+
+        scripts_dir = tmp_path / ".hermes" / "scripts"
+        (scripts_dir / "legacy-restart.sh").write_text(
+            "systemctl --user restart hermes-gateway.service\n",
+            encoding="utf-8",
+        )
+        created = json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            script="safe.sh",
+            no_agent=True,
+        ))
+        assert created["success"] is True
+        update_job(created["job_id"], {"script": "legacy-restart.sh"})
+
+        result = json.loads(cronjob(
+            action="update",
+            job_id=created["job_id"],
+            script="",
+            no_agent=False,
+        ))
+
+        assert result["success"] is True
+        assert result["job"].get("script") is None
+
+
 # ---------------------------------------------------------------------------
 # Defense 3: auto-resume restart-loop breaker
 # ---------------------------------------------------------------------------

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -956,6 +956,17 @@ def cronjob(
                     updates["enabled"] = True
             if not updates:
                 return tool_error("No updates provided.", success=False)
+
+            # Validate the job's final execution content, not only fields present
+            # in this partial update. Legacy/directly-written jobs may already
+            # contain a lifecycle command, while a replacement prompt or script
+            # may remediate one in the same request.
+            from cron.lifecycle_guard import check_gateway_lifecycle
+
+            effective_prompt = updates.get("prompt", job.get("prompt"))
+            effective_script = updates.get("script", job.get("script"))
+            check_gateway_lifecycle(effective_prompt, effective_script)
+
             updated = update_job(job_id, updates)
             _notify_provider_jobs_changed_safe()
             return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)


### PR DESCRIPTION
## Summary

- close the remaining `cronjob` tool update-path bypass for gateway lifecycle commands
- reuse the current shared `cron.lifecycle_guard.check_gateway_lifecycle` implementation
- validate the effective stored-plus-updated prompt and script before persisting a partial update
- preserve remediation: an update may replace or clear previously stored unsafe content
- cover launchd and systemd scripts, lifecycle prompts, stored unsafe jobs, and script clearing

## Root Cause

Current `main` already protects job creation in `cron.jobs.create_job`, but `tools.cronjob_tools.cronjob(action="update")` only validates a replacement script path before calling `update_job()`. It does not scan the script contents, and unrelated partial updates do not revalidate lifecycle content already stored on the job.

That leaves an update-only route for scheduling commands such as:

```bash
launchctl kickstart -k gui/501/ai.hermes.gateway
systemctl --user restart hermes-gateway.service
```

The fix merges the current update over the stored job for the two execution-content fields, then calls the existing shared lifecycle guard immediately before `update_job()`.

Fixes #51976

## Test Plan

```bash
python -m pytest \
  tests/hermes_cli/test_gateway_restart_loop.py \
  tests/tools/test_cronjob_tools.py \
  tests/cron/test_cron_script.py \
  tests/cron/test_cron_no_agent.py -q
```

Result on current `main`: `203 passed, 1 pre-existing deprecation warning`.
