### PR TITLE
fix(browser): default non-finite vision config

### DIFF
--- a/tests/tools/test_browser_console.py
+++ b/tests/tools/test_browser_console.py
@@ -250,6 +250,40 @@ class TestBrowserVisionConfig:
         assert mock_llm.call_args.kwargs["temperature"] == 0.1
         assert mock_llm.call_args.kwargs["timeout"] == 120.0
 
+    def test_browser_vision_defaults_nonfinite_config(self, tmp_path):
+        from tools.browser_tool import browser_vision
+
+        shots_dir, screenshot = self._setup_screenshot(tmp_path)
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Default finite screenshot analysis"
+        mock_response.choices = [mock_choice]
+
+        with (
+            patch("hermes_constants.get_hermes_dir", return_value=shots_dir),
+            patch("tools.browser_tool._cleanup_old_screenshots"),
+            patch(
+                "tools.browser_tool._run_browser_command",
+                return_value={"success": True, "data": {"path": str(screenshot)}},
+            ),
+            patch("tools.browser_tool._get_vision_model", return_value="test-model"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={
+                    "auxiliary": {
+                        "vision": {"temperature": "nan", "timeout": "inf"}
+                    }
+                },
+            ),
+            patch("tools.browser_tool.call_llm", return_value=mock_response) as mock_llm,
+        ):
+            result = json.loads(browser_vision("what is on the page?", task_id="test"))
+
+        assert result["success"] is True
+        assert result["analysis"] == "Default finite screenshot analysis"
+        assert mock_llm.call_args.kwargs["temperature"] == 0.1
+        assert mock_llm.call_args.kwargs["timeout"] == 120.0
+
     def test_browser_vision_native_fast_path_returns_multimodal(self, tmp_path):
         """supports_vision override → screenshot attached natively, no aux call."""
         from agent.auxiliary_client import clear_runtime_main, set_runtime_main

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -53,6 +53,7 @@ import atexit
 import functools
 import json
 import logging
+import math
 import os
 import re
 import subprocess
@@ -112,6 +113,15 @@ except ImportError:
     _is_camofox_mode = lambda: False  # noqa: E731
 
 logger = logging.getLogger(__name__)
+
+
+def _finite_float(value: Any, default: float) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return default
+    return parsed if math.isfinite(parsed) else default
+
 
 # Standard PATH entries for environments with minimal PATH (e.g. systemd services).
 # Includes Android/Termux and macOS Homebrew locations needed for agent-browser,
@@ -3401,10 +3411,10 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
             _vision_cfg = cfg_get(_cfg, "auxiliary", "vision", default={})
             _vt = _vision_cfg.get("timeout")
             if _vt is not None:
-                vision_timeout = float(_vt)
+                vision_timeout = _finite_float(_vt, 120.0)
             _vtemp = _vision_cfg.get("temperature")
             if _vtemp is not None:
-                vision_temperature = float(_vtemp)
+                vision_temperature = _finite_float(_vtemp, 0.1)
         except Exception:
             pass
 


### PR DESCRIPTION
## Summary
- reject non-finite browser vision timeout and temperature config values
- fall back to the existing 120s / 0.1 defaults for `inf` and `nan`
- add regression coverage for the regular browser vision path

## Tests
- `python -m pytest tests/tools/test_browser_console.py::TestBrowserVisionConfig::test_browser_vision_defaults_nonfinite_config -q`
- `python -m pytest tests/tools/test_browser_console.py::TestBrowserVisionConfig -q`
- `python -m pytest tests/tools/test_browser_console.py -q` *(fails on Windows due existing default-encoding reads of SKILL.md in TestDogfoodSkill; targeted browser vision tests pass)*
- `python -m py_compile tools/browser_tool.py`
- `python scripts/check-windows-footguns.py --all`