### PR TITLE
feat(finance): provider-agnostic Plaid personal finance integration (#51697)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2855,6 +2855,31 @@ DEFAULT_CONFIG = {
         "cua_telemetry": False,
     },
 
+    # Personal finance integration (finance plugin; Plaid is the first backend).
+    # Secrets (PLAID_CLIENT_ID / PLAID_SECRET) live in .env — only non-secret
+    # behavior is configured here.
+    "finance": {
+        # Active data provider. "plaid" is the only built-in backend today;
+        # the plugin is provider-agnostic so others can be added later.
+        "provider": "plaid",
+        # Suggested refresh cadence for the optional cron sync follow-up.
+        "sync_interval": "6h",
+        # Model-facing privacy: "full" returns exact figures; "summarized"
+        # buckets values (e.g. "$2k-$5k") before they enter any tool result.
+        "privacy_mode": "full",
+        "plaid": {
+            # "sandbox" (test data) or "production". Plaid retired "development".
+            "environment": "sandbox",
+            # Optional Plaid webhook URL for transaction-update notifications.
+            "webhook_url": "",
+        },
+        "categorization": {
+            # Optional LLM fallback for otherwise-uncategorized transactions.
+            # Off by default — categorization stays rules-first and cheap.
+            "llm_fallback": False,
+        },
+    },
+
 
     # Config schema version - bump this when adding new required fields
     "_config_version": 30,
@@ -3342,6 +3367,23 @@ OPTIONAL_ENV_VARS = {
         "prompt": "Brave Search subscription token",
         "url": "https://brave.com/search/api/",
         "tools": ["web_search"],
+        "password": True,
+        "category": "tool",
+    },
+    # ── Finance (Plaid) ──
+    "PLAID_CLIENT_ID": {
+        "description": "Plaid client id for the personal finance integration",
+        "prompt": "Plaid client id",
+        "url": "https://dashboard.plaid.com/developers/keys",
+        "tools": ["finance_accounts", "finance_transactions", "finance_sync"],
+        "password": True,
+        "category": "tool",
+    },
+    "PLAID_SECRET": {
+        "description": "Plaid secret for the configured environment (sandbox/production)",
+        "prompt": "Plaid secret",
+        "url": "https://dashboard.plaid.com/developers/keys",
+        "tools": ["finance_accounts", "finance_transactions", "finance_sync"],
         "password": True,
         "category": "tool",
     },

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -75,6 +75,7 @@ CONFIGURABLE_TOOLSETS = [
     ("cronjob",         "⏰ Cron Jobs",                 "create/list/update/pause/resume/run, with optional attached skills"),
     ("homeassistant",    "🏠 Home Assistant",           "smart home device control"),
     ("spotify",          "🎵 Spotify",                  "playback, search, playlists, library"),
+    ("finance",          "💰 Personal Finance",         "balances, transactions, spending, net worth (Plaid)"),
     ("discord",         "💬 Discord (read/participate)", "fetch messages, search members, create thread"),
     ("discord_admin",   "🛡️  Discord Server Admin",    "list channels/roles, pin, assign roles"),
     ("yuanbao",          "🤖 Yuanbao",                  "group info, member queries, DM"),
@@ -111,7 +112,7 @@ def gui_toolset_label(label: str) -> str:
 # `hermes tools` → X (Twitter) Search setup walks users through credential
 # setup. The tool's check_fn means the schema still won't appear to the
 # model if the credential later goes missing or expires.
-_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search"}
+_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "finance", "discord", "discord_admin", "video", "video_gen", "x_search"}
 
 
 def _xai_credentials_present() -> bool:
@@ -512,6 +513,20 @@ TOOL_CATEGORIES = {
                 "tag": "PKCE OAuth — opens the setup wizard",
                 "env_vars": [],
                 "post_setup": "spotify",
+            },
+        ],
+    },
+    "finance": {
+        "name": "Personal Finance",
+        "icon": "💰",
+        "providers": [
+            {
+                "name": "Plaid",
+                "tag": "Bank balances & transactions — then link with `hermes finance connect`",
+                "env_vars": [
+                    {"key": "PLAID_CLIENT_ID", "prompt": "Plaid client id", "url": "https://dashboard.plaid.com/developers/keys"},
+                    {"key": "PLAID_SECRET", "prompt": "Plaid secret (matches finance.plaid.environment)", "url": "https://dashboard.plaid.com/developers/keys"},
+                ],
             },
         ],
     },

--- a/plugins/finance/__init__.py
+++ b/plugins/finance/__init__.py
@@ -1,0 +1,45 @@
+"""Finance integration plugin — bundled, auto-loaded.
+
+Provider-agnostic personal-finance integration (Plaid is the first backend).
+Registers:
+
+* a ``hermes finance`` CLI command (connect / sync / status / accounts /
+  transactions / disconnect), and
+* a gated ``finance`` toolset (``finance_*``) backed by a local SQLite cache.
+
+The model tools are service-gated via ``_check_finance_available`` — they only
+appear once the active provider's credentials are configured AND an account is
+linked, so users who don't use finance pay no prompt-cache/schema cost. User
+onboarding and provider API calls go through the CLI and the explicit
+``finance_sync`` tool; everything else reads the local cache.
+
+See ``website/docs/user-guide/features/finance.md`` for the full guide.
+"""
+
+from __future__ import annotations
+
+from plugins.finance.tools import FINANCE_TOOLS, _check_finance_available
+
+
+def register(ctx) -> None:
+    """Register the finance CLI command and gated tools (called once at load)."""
+    from plugins.finance.cli import register_cli, finance_command
+
+    ctx.register_cli_command(
+        name="finance",
+        help="Personal finance: connect accounts, sync, and query balances/transactions",
+        setup_fn=register_cli,
+        handler_fn=finance_command,
+        description="Provider-agnostic personal finance integration (Plaid).",
+    )
+
+    for name, schema, handler, emoji in FINANCE_TOOLS:
+        ctx.register_tool(
+            name=name,
+            toolset="finance",
+            schema=schema,
+            handler=handler,
+            check_fn=_check_finance_available,
+            requires_env=["PLAID_CLIENT_ID", "PLAID_SECRET"],
+            emoji=emoji,
+        )

--- a/plugins/finance/categorize.py
+++ b/plugins/finance/categorize.py
@@ -1,0 +1,181 @@
+"""Rules-first transaction categorization and spending analytics.
+
+Resolution order for a transaction's category (first match wins):
+
+1. **User override, transaction-scoped** — an explicit per-transaction label.
+2. **User override, merchant-scoped** — an explicit label for a merchant name.
+3. **Provider category** — Plaid's ``personal_finance_category`` primary.
+4. **Merchant rule** — a local ``merchant_rules`` row whose pattern matches and
+   carries a category.
+5. **LLM fallback** — optional, *off by default*; only ever runs for otherwise
+   uncategorized transactions and never on the sync hot path.
+6. ``Uncategorized``.
+
+User overrides sit above the automatic sources on purpose: an "override" that
+a provider category could outvote would not be an override. Among the
+automatic sources the order follows issue #51697 (provider category, then
+local merchant rules).
+
+All resolution is in-memory and cheap; merchant rules and overrides are loaded
+once per :class:`Categorizer` instance so a batch of transactions does not
+re-query SQLite per row.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date
+from typing import Any, Callable, Dict, List, Optional
+
+UNCATEGORIZED = "Uncategorized"
+
+# Resolved categories that represent money moving between a user's own
+# accounts rather than true spending. Excluded from spending totals by default.
+_TRANSFER_HINTS = ("transfer", "payment", "credit card payment")
+
+
+class Categorizer:
+    """Resolves categories and normalized merchant names from local rules."""
+
+    def __init__(self, store: Any, *, llm_fallback: Optional[Callable[[Dict[str, Any]], Optional[str]]] = None) -> None:
+        self._rules = store.list_merchant_rules()
+        self._overrides: Dict[str, str] = {}
+        for row in store.list_category_overrides():
+            self._overrides[f"{row['scope']}:{row['key']}"] = row["category"]
+        self._llm_fallback = llm_fallback
+
+    # -- internal helpers ------------------------------------------------
+
+    @staticmethod
+    def _haystack(txn: Dict[str, Any]) -> str:
+        return (txn.get("merchant_name") or txn.get("name") or "").lower()
+
+    def _matching_rule(self, txn: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        haystack = self._haystack(txn)
+        if not haystack:
+            return None
+        for rule in self._rules:
+            pattern = (rule.get("pattern") or "").lower()
+            if not pattern:
+                continue
+            match_type = (rule.get("match_type") or "substring").lower()
+            try:
+                if match_type == "exact" and haystack == pattern:
+                    return rule
+                if match_type == "regex" and re.search(rule["pattern"], haystack, re.IGNORECASE):
+                    return rule
+                if match_type == "substring" and pattern in haystack:
+                    return rule
+            except re.error:
+                continue
+        return None
+
+    # -- public API ------------------------------------------------------
+
+    def normalize_merchant(self, txn: Dict[str, Any]) -> str:
+        """Return a clean display name, applying a matching rule if present."""
+        rule = self._matching_rule(txn)
+        if rule and rule.get("normalized_name"):
+            return rule["normalized_name"]
+        return txn.get("merchant_name") or txn.get("name") or "Unknown"
+
+    def resolve_category(self, txn: Dict[str, Any]) -> str:
+        txn_id = (txn.get("transaction_id") or "").lower()
+        if txn_id and f"transaction:{txn_id}" in self._overrides:
+            return self._overrides[f"transaction:{txn_id}"]
+        merchant_key = (txn.get("merchant_name") or txn.get("name") or "").lower()
+        if merchant_key and f"merchant:{merchant_key}" in self._overrides:
+            return self._overrides[f"merchant:{merchant_key}"]
+        if txn.get("category_primary"):
+            return txn["category_primary"]
+        rule = self._matching_rule(txn)
+        if rule and rule.get("category"):
+            return rule["category"]
+        if self._llm_fallback is not None:
+            try:
+                guess = self._llm_fallback(txn)
+            except Exception:
+                guess = None
+            if guess:
+                return guess
+        return UNCATEGORIZED
+
+
+def _is_transfer(category: str) -> bool:
+    lowered = category.lower()
+    return any(hint in lowered for hint in _TRANSFER_HINTS)
+
+
+def _subtract_months(anchor: date, months: int) -> date:
+    month_index = anchor.year * 12 + (anchor.month - 1) - months
+    year, month = divmod(month_index, 12)
+    return date(year, month + 1, 1)
+
+
+def spending_by_category(
+    store: Any,
+    *,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    include_transfers: bool = False,
+    categorizer: Optional[Categorizer] = None,
+) -> Dict[str, Any]:
+    """Aggregate outflows by resolved category over a date range.
+
+    Outflow follows Plaid's sign convention: a positive transaction amount is
+    money leaving the account. Transfers/payments between the user's own
+    accounts are excluded unless *include_transfers* is set.
+    """
+    categorizer = categorizer or Categorizer(store)
+    txns = store.iter_transactions(start_date=start_date, end_date=end_date)
+    totals: Dict[str, float] = {}
+    transactions_counted = 0
+    for txn in txns:
+        amount = txn.get("amount")
+        if amount is None or amount <= 0:
+            continue
+        category = categorizer.resolve_category(txn)
+        if not include_transfers and _is_transfer(category):
+            continue
+        totals[category] = totals.get(category, 0.0) + float(amount)
+        transactions_counted += 1
+    categories = [
+        {"category": cat, "amount": round(total, 2)}
+        for cat, total in sorted(totals.items(), key=lambda kv: kv[1], reverse=True)
+    ]
+    return {
+        "start_date": start_date,
+        "end_date": end_date,
+        "total": round(sum(totals.values()), 2),
+        "transactions": transactions_counted,
+        "categories": categories,
+    }
+
+
+def cashflow(store: Any, *, months: int = 3) -> Dict[str, Any]:
+    """Return monthly inflow/outflow/net for the trailing *months* window."""
+    months = max(1, int(months))
+    start = _subtract_months(date.today().replace(day=1), months - 1)
+    txns = store.iter_transactions(start_date=start.isoformat())
+    buckets: Dict[str, Dict[str, float]] = {}
+    for txn in txns:
+        amount = txn.get("amount")
+        txn_date = txn.get("date")
+        if amount is None or not txn_date:
+            continue
+        month = txn_date[:7]
+        bucket = buckets.setdefault(month, {"inflow": 0.0, "outflow": 0.0})
+        if amount > 0:
+            bucket["outflow"] += float(amount)
+        else:
+            bucket["inflow"] += abs(float(amount))
+    series = []
+    for month in sorted(buckets):
+        bucket = buckets[month]
+        series.append({
+            "month": month,
+            "inflow": round(bucket["inflow"], 2),
+            "outflow": round(bucket["outflow"], 2),
+            "net": round(bucket["inflow"] - bucket["outflow"], 2),
+        })
+    return {"months": months, "series": series}

--- a/plugins/finance/cli.py
+++ b/plugins/finance/cli.py
@@ -1,0 +1,232 @@
+"""``hermes finance`` CLI: connect, sync, status, accounts, transactions, disconnect.
+
+The CLI is the trusted local owner of the data, so it prints exact figures
+(privacy buckets apply to the *model-facing* tools, not the owner's terminal).
+Onboarding opens a Plaid Hosted Link URL and polls until the user finishes in
+their browser — no local web server required.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import webbrowser
+from typing import Any, List, Optional
+
+from hermes_constants import display_hermes_home
+
+from plugins.finance import privacy, settings
+from plugins.finance.errors import FinanceConfigError, FinanceError
+from plugins.finance.provider import available_providers, get_provider
+from plugins.finance.store import FinanceStore
+
+
+def register_cli(subparser: argparse.ArgumentParser) -> None:
+    subs = subparser.add_subparsers(dest="finance_action")
+
+    connect_p = subs.add_parser("connect", help="Link a financial institution")
+    connect_p.add_argument("provider", nargs="?", default="plaid", help="Provider (default: plaid)")
+    connect_p.add_argument("--sandbox", action="store_true", help="Use the provider sandbox (test data)")
+    connect_p.add_argument("--institution-id", default="", help="Institution id (sandbox/advanced)")
+    connect_p.add_argument("--products", default="", help="Comma-separated products (default: transactions)")
+    connect_p.add_argument("--timeout", type=int, default=300, help="Seconds to wait for Link completion")
+    connect_p.add_argument("--no-sync", action="store_true", help="Skip the initial sync after linking")
+    connect_p.add_argument("--no-browser", action="store_true", help="Print the Link URL but don't open a browser")
+
+    sync_p = subs.add_parser("sync", help="Refresh data from the provider")
+    sync_p.add_argument("provider", nargs="?", default="plaid")
+    sync_p.add_argument("--item-id", default="", help="Sync only this linked item")
+
+    status_p = subs.add_parser("status", help="Show linked items and last sync")
+    status_p.add_argument("provider", nargs="?", default="plaid")
+
+    accounts_p = subs.add_parser("accounts", help="List linked accounts and balances")
+    accounts_p.add_argument("provider", nargs="?", default="plaid")
+
+    txns_p = subs.add_parser("transactions", aliases=["txns"], help="List recent transactions")
+    txns_p.add_argument("provider", nargs="?", default="plaid")
+    txns_p.add_argument("--account-id", default="")
+    txns_p.add_argument("--days", type=int, default=30)
+    txns_p.add_argument("--limit", type=int, default=25)
+    txns_p.add_argument("--search", default="")
+
+    disconnect_p = subs.add_parser("disconnect", aliases=["unlink"], help="Unlink an item")
+    disconnect_p.add_argument("provider", nargs="?", default="plaid")
+    disconnect_p.add_argument("item_id", help="Item id to disconnect (see `hermes finance status`)")
+    disconnect_p.add_argument("--purge", action="store_true", help="Also delete the item's cached data")
+
+    subparser.set_defaults(func=finance_command)
+
+
+def finance_command(args: argparse.Namespace) -> int:
+    action = getattr(args, "finance_action", None)
+    if not action:
+        print("Usage: hermes finance {connect|sync|status|accounts|transactions|disconnect}")
+        print(f"Providers: {', '.join(available_providers())}")
+        return 2
+    try:
+        if action == "connect":
+            return _cmd_connect(args)
+        if action == "sync":
+            return _cmd_sync(args)
+        if action == "status":
+            return _cmd_status(args)
+        if action == "accounts":
+            return _cmd_accounts(args)
+        if action in {"transactions", "txns"}:
+            return _cmd_transactions(args)
+        if action in {"disconnect", "unlink"}:
+            return _cmd_disconnect(args)
+        print(f"Unknown finance action: {action}")
+        return 2
+    except FinanceConfigError as exc:
+        print(str(exc))
+        _print_setup_hint(getattr(args, "provider", "plaid"))
+        return 1
+    except FinanceError as exc:
+        print(f"Finance error: {exc}")
+        return 1
+
+
+def _print_setup_hint(provider: str) -> None:
+    if provider == "plaid":
+        print()
+        print(f"  Configure Plaid by adding to {display_hermes_home()}/.env:")
+        print("    PLAID_CLIENT_ID=...")
+        print("    PLAID_SECRET=...")
+        print("  Keys: https://dashboard.plaid.com/developers/keys")
+        print("  Set the environment in config.yaml under finance.plaid.environment (sandbox|production).")
+
+
+def _parse_products(raw: str) -> Optional[List[str]]:
+    items = [p.strip() for p in (raw or "").split(",") if p.strip()]
+    return items or None
+
+
+def _money(value: Any, currency: Optional[str]) -> str:
+    return privacy.format_money(value, currency, mode=privacy.FULL)
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+def _cmd_connect(args: argparse.Namespace) -> int:
+    provider = get_provider(args.provider)
+    products = _parse_products(args.products)
+    with FinanceStore() as store:
+        if args.sandbox:
+            print(f"Linking a {args.provider} sandbox item…")
+            result = provider.connect(
+                store=store, mode="sandbox",
+                institution_id=(args.institution_id or None),
+                products=products, do_sync=not args.no_sync,
+            )
+        else:
+            def _on_url(url: str) -> None:
+                print("\nOpen this URL to connect your institution:\n")
+                print(f"  {url}\n")
+                if not args.no_browser:
+                    try:
+                        webbrowser.open(url)
+                    except Exception:
+                        pass
+                print(f"Waiting up to {args.timeout}s for you to finish in the browser…")
+
+            result = provider.connect(
+                store=store, mode="hosted", products=products,
+                timeout=args.timeout, on_link_url=_on_url, do_sync=not args.no_sync,
+            )
+        print()
+        print(json.dumps(result, indent=2, sort_keys=True))
+    if result.get("status") == "pending":
+        return 1
+    return 0
+
+
+def _cmd_sync(args: argparse.Namespace) -> int:
+    provider = get_provider(args.provider)
+    with FinanceStore() as store:
+        summary = provider.sync(store, item_id=(args.item_id or None))
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+def _cmd_status(args: argparse.Namespace) -> int:
+    provider = get_provider(args.provider)
+    with FinanceStore() as store:
+        status = provider.status(store)
+    items = status.get("items") or []
+    if not items:
+        print(f"No {args.provider} items linked. Run `hermes finance connect {args.provider}`.")
+        return 0
+    print(f"\n{len(items)} linked item(s) via {args.provider}:\n")
+    for item in items:
+        print(f"  ◆ {item.get('institution_name') or item.get('item_id')}")
+        print(f"    item_id: {item.get('item_id')}")
+        print(f"    environment: {item.get('environment')}")
+        print(f"    status: {item.get('status')}  accounts: {item.get('accounts')}")
+        if item.get("last_sync_at"):
+            print(f"    last sync: {item.get('last_sync_at')}")
+        if item.get("last_error"):
+            print(f"    last error: {item.get('last_error')}")
+        print()
+    return 0
+
+
+def _cmd_accounts(args: argparse.Namespace) -> int:
+    with FinanceStore() as store:
+        accounts = store.get_accounts()
+        net_worth = store.net_worth()
+    if not accounts:
+        print("No accounts cached yet. Run `hermes finance sync`.")
+        return 0
+    print(f"\n{len(accounts)} account(s):\n")
+    for acct in accounts:
+        currency = acct.get("currency")
+        print(f"  ◆ {acct.get('name')} (…{acct.get('mask') or '----'}) [{acct.get('type')}/{acct.get('subtype')}]")
+        print(f"    current: {_money(acct.get('current_balance'), currency)}", end="")
+        if acct.get("available_balance") is not None:
+            print(f"   available: {_money(acct.get('available_balance'), currency)}", end="")
+        print()
+    for currency, vals in net_worth.items():
+        print(
+            f"\n  Net worth ({currency}): {_money(vals['net_worth'], currency)} "
+            f"(assets {_money(vals['assets'], currency)}, liabilities {_money(vals['liabilities'], currency)})"
+        )
+    return 0
+
+
+def _cmd_transactions(args: argparse.Namespace) -> int:
+    from datetime import date, timedelta
+
+    start = (date.today() - timedelta(days=max(1, args.days))).isoformat()
+    from plugins.finance import categorize
+
+    with FinanceStore() as store:
+        txns = store.iter_transactions(
+            account_id=(args.account_id or None),
+            start_date=start,
+            search=(args.search or None),
+            limit=max(1, args.limit),
+        )
+        categorizer = categorize.Categorizer(store)
+    if not txns:
+        print("No transactions cached for that window. Run `hermes finance sync`.")
+        return 0
+    print(f"\n{len(txns)} transaction(s) since {start}:\n")
+    for txn in txns:
+        currency = txn.get("currency")
+        pending = " (pending)" if txn.get("pending") else ""
+        merchant = categorizer.normalize_merchant(txn)
+        category = categorizer.resolve_category(txn)
+        print(f"  {txn.get('date')}  {_money(txn.get('amount'), currency):>14}  {merchant} — {category}{pending}")
+    return 0
+
+
+def _cmd_disconnect(args: argparse.Namespace) -> int:
+    provider = get_provider(args.provider)
+    with FinanceStore() as store:
+        result = provider.disconnect(store, args.item_id, purge=args.purge)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0

--- a/plugins/finance/errors.py
+++ b/plugins/finance/errors.py
@@ -1,0 +1,50 @@
+"""Shared error types for the finance plugin.
+
+These are provider-agnostic so the CLI, tools, and sync engine can map any
+backend failure (Plaid today, Teller/SnapTrade/etc. later) onto a small set
+of actionable categories without importing a specific provider's module.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+class FinanceError(RuntimeError):
+    """Base error for all finance plugin failures."""
+
+
+class FinanceConfigError(FinanceError):
+    """Raised when required configuration or credentials are missing."""
+
+
+class FinanceAuthRequiredError(FinanceError):
+    """Raised when no account is linked yet (the user must connect first)."""
+
+
+class FinanceProviderError(FinanceError):
+    """Structured failure returned by a financial-data provider's API."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: Optional[int] = None,
+        error_code: Optional[str] = None,
+        error_type: Optional[str] = None,
+        request_id: Optional[str] = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.error_code = error_code
+        self.error_type = error_type
+        self.request_id = request_id
+
+
+class FinanceReauthRequiredError(FinanceProviderError):
+    """Raised when a linked item needs the user to re-authenticate.
+
+    Maps to Plaid's ``ITEM_LOGIN_REQUIRED`` and similar states where the
+    stored access token is still valid but the institution requires the
+    user to refresh their login via Link update mode.
+    """

--- a/plugins/finance/plaid/__init__.py
+++ b/plugins/finance/plaid/__init__.py
@@ -1,0 +1,6 @@
+"""Plaid backend for the finance plugin.
+
+Plaid is the reference :class:`~plugins.finance.provider.FinanceProvider`. It
+talks to the Plaid REST API directly over the core ``httpx`` dependency (no
+``plaid-python`` SDK) to keep the supply-chain footprint at zero new packages.
+"""

--- a/plugins/finance/plaid/auth.py
+++ b/plugins/finance/plaid/auth.py
@@ -1,0 +1,282 @@
+"""Plaid credential resolution, secure token storage, and Link onboarding.
+
+Per-item Plaid ``access_token``s are the crown jewels: they grant ongoing
+read access to a user's bank data. They are stored in a 0600 JSON file under
+``<HERMES_HOME>/finance/plaid_tokens.json`` — never in ``config.yaml``, never
+in ``.env``, never in the queryable SQLite DB, and never returned to the model.
+
+Onboarding uses Plaid's Hosted Link flow: create a link token with
+``hosted_link`` enabled, hand the user a URL to open, then poll
+``/link/token/get`` until a ``public_token`` appears and exchange it for an
+access token. This needs no local web server or redirect handling.
+
+References:
+* https://plaid.com/docs/link/hosted-link/
+* https://plaid.com/docs/api/link/
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from hermes_constants import get_hermes_home, secure_parent_dir
+
+from plugins.finance.errors import FinanceConfigError, FinanceError
+from plugins.finance.plaid.client import PlaidClient
+
+_TOKEN_STORE_VERSION = 1
+
+# Plaid sandbox test institution ("First Platypus Bank").
+SANDBOX_INSTITUTION_ID = "ins_109508"
+
+
+def token_store_path() -> Path:
+    return get_hermes_home() / "finance" / "plaid_tokens.json"
+
+
+def get_plaid_credentials() -> Tuple[str, str]:
+    """Return ``(client_id, secret)`` from the environment.
+
+    Raises :class:`FinanceConfigError` when either is missing so the CLI/tools
+    can print a setup hint instead of failing deep in an HTTP call.
+    """
+    client_id = (os.getenv("PLAID_CLIENT_ID") or "").strip()
+    secret = (os.getenv("PLAID_SECRET") or "").strip()
+    if not client_id or not secret:
+        raise FinanceConfigError(
+            "Plaid is not configured. Add PLAID_CLIENT_ID and PLAID_SECRET to "
+            "your .env (get them from https://dashboard.plaid.com/developers/keys)."
+        )
+    return client_id, secret
+
+
+def credentials_present() -> bool:
+    """Cheap, non-raising check used to gate tool availability."""
+    return bool((os.getenv("PLAID_CLIENT_ID") or "").strip() and (os.getenv("PLAID_SECRET") or "").strip())
+
+
+def build_client(environment: str) -> PlaidClient:
+    client_id, secret = get_plaid_credentials()
+    return PlaidClient(client_id, secret, environment=environment)
+
+
+# ---------------------------------------------------------------------------
+# Secure token storage
+# ---------------------------------------------------------------------------
+
+def _write_secure_json(path: Path, data: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    secure_parent_dir(path)
+    tmp = path.with_name(path.name + ".tmp")
+    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(data, handle, indent=2)
+            handle.flush()
+            os.fsync(handle.fileno())
+    except Exception:
+        try:
+            os.unlink(str(tmp))
+        except OSError:
+            pass
+        raise
+    os.replace(str(tmp), str(path))
+    try:
+        os.chmod(str(path), 0o600)
+    except OSError:
+        pass
+
+
+def load_token_store() -> Dict[str, Any]:
+    path = token_store_path()
+    if not path.exists():
+        return {"version": _TOKEN_STORE_VERSION, "items": {}}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {"version": _TOKEN_STORE_VERSION, "items": {}}
+    if not isinstance(data, dict) or not isinstance(data.get("items"), dict):
+        return {"version": _TOKEN_STORE_VERSION, "items": {}}
+    return data
+
+
+def save_item_token(
+    item_id: str,
+    access_token: str,
+    *,
+    institution_id: Optional[str] = None,
+    institution_name: Optional[str] = None,
+    environment: Optional[str] = None,
+) -> None:
+    store = load_token_store()
+    store.setdefault("items", {})[item_id] = {
+        "access_token": access_token,
+        "institution_id": institution_id,
+        "institution_name": institution_name,
+        "environment": environment,
+        "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+    _write_secure_json(token_store_path(), store)
+
+
+def get_access_token(item_id: str) -> Optional[str]:
+    item = load_token_store().get("items", {}).get(item_id)
+    return item.get("access_token") if isinstance(item, dict) else None
+
+
+def list_token_items() -> List[Dict[str, Any]]:
+    """Return per-item metadata WITHOUT access tokens (safe to display/log)."""
+    items = load_token_store().get("items", {})
+    safe = []
+    for item_id, meta in items.items():
+        if not isinstance(meta, dict):
+            continue
+        safe.append({
+            "item_id": item_id,
+            "institution_id": meta.get("institution_id"),
+            "institution_name": meta.get("institution_name"),
+            "environment": meta.get("environment"),
+            "created_at": meta.get("created_at"),
+        })
+    return safe
+
+
+def remove_item_token(item_id: str) -> bool:
+    store = load_token_store()
+    items = store.get("items", {})
+    if item_id in items:
+        del items[item_id]
+        _write_secure_json(token_store_path(), store)
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Hosted Link onboarding
+# ---------------------------------------------------------------------------
+
+def start_hosted_link(
+    client: PlaidClient,
+    *,
+    products: Optional[List[str]] = None,
+    webhook: Optional[str] = None,
+    user_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Create a hosted Link token and return the URL the user should open."""
+    response = client.link_token_create(
+        user_id=user_id or f"hermes-{uuid.uuid4().hex[:12]}",
+        products=products or ["transactions"],
+        hosted_link={},
+        webhook=webhook or None,
+    )
+    hosted_url = response.get("hosted_link_url")
+    if not hosted_url:
+        raise FinanceError(
+            "Plaid did not return a hosted Link URL. Ensure Hosted Link is "
+            "enabled for your Plaid client (dashboard → Link → Hosted Link)."
+        )
+    return {
+        "link_token": response.get("link_token"),
+        "hosted_link_url": hosted_url,
+        "expiration": response.get("expiration"),
+    }
+
+
+def _extract_public_token(link_get_response: Dict[str, Any]) -> Optional[str]:
+    """Pull the first completed ``public_token`` out of a /link/token/get body."""
+    for session in link_get_response.get("link_sessions") or []:
+        results = (session or {}).get("results") or {}
+        for add_result in results.get("item_add_results") or []:
+            public_token = (add_result or {}).get("public_token")
+            if public_token:
+                return public_token
+    return None
+
+
+def poll_for_public_token(
+    client: PlaidClient,
+    link_token: str,
+    *,
+    timeout: float = 300.0,
+    interval: float = 3.0,
+    sleep=time.sleep,
+) -> Optional[str]:
+    """Poll ``/link/token/get`` until the user completes Link or *timeout*."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        response = client.link_token_get(link_token)
+        public_token = _extract_public_token(response)
+        if public_token:
+            return public_token
+        sleep(interval)
+    return None
+
+
+def exchange_public_token(client: PlaidClient, public_token: str) -> Dict[str, Any]:
+    response = client.item_public_token_exchange(public_token)
+    return {"access_token": response.get("access_token"), "item_id": response.get("item_id")}
+
+
+def resolve_institution_name(client: PlaidClient, institution_id: Optional[str]) -> Optional[str]:
+    if not institution_id:
+        return None
+    try:
+        response = client.institutions_get_by_id(institution_id)
+        return ((response.get("institution") or {}).get("name"))
+    except FinanceError:
+        return None
+
+
+def complete_link(
+    client: PlaidClient,
+    public_token: str,
+    *,
+    environment: str,
+    institution_id: Optional[str] = None,
+    institution_name: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Exchange a public token, persist the access token, return item metadata."""
+    exchanged = exchange_public_token(client, public_token)
+    access_token = exchanged.get("access_token")
+    item_id = exchanged.get("item_id")
+    if not access_token or not item_id:
+        raise FinanceError("Plaid public-token exchange did not return an item.")
+    if not institution_name:
+        institution_name = resolve_institution_name(client, institution_id)
+    save_item_token(
+        item_id, access_token,
+        institution_id=institution_id, institution_name=institution_name,
+        environment=environment,
+    )
+    return {
+        "item_id": item_id,
+        "institution_id": institution_id,
+        "institution_name": institution_name,
+        "environment": environment,
+    }
+
+
+def sandbox_connect(
+    client: PlaidClient,
+    *,
+    institution_id: str = SANDBOX_INSTITUTION_ID,
+    products: Optional[List[str]] = None,
+    environment: str = "sandbox",
+) -> Dict[str, Any]:
+    """Create and link a sandbox item end-to-end (for local testing)."""
+    created = client.sandbox_public_token_create(
+        institution_id=institution_id, initial_products=products or ["transactions"]
+    )
+    public_token = created.get("public_token")
+    if not public_token:
+        raise FinanceError("Plaid sandbox did not return a public token.")
+    return complete_link(
+        client, public_token, environment=environment,
+        institution_id=institution_id,
+        institution_name="Plaid Sandbox Bank",
+    )

--- a/plugins/finance/plaid/client.py
+++ b/plugins/finance/plaid/client.py
@@ -1,0 +1,191 @@
+"""Minimal Plaid REST client built on the core ``httpx`` dependency.
+
+Only the endpoints the finance plugin needs are wrapped. Every call posts the
+``client_id``/``secret`` pair in the JSON body (Plaid's auth scheme) and maps
+Plaid's structured error envelope onto the plugin's error hierarchy so callers
+get actionable, provider-agnostic failures.
+
+Reference: https://plaid.com/docs/api/
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from plugins.finance.errors import (
+    FinanceConfigError,
+    FinanceProviderError,
+    FinanceReauthRequiredError,
+)
+
+# Plaid retired the "development" environment; sandbox and production remain.
+_ENV_BASE_URLS = {
+    "sandbox": "https://sandbox.plaid.com",
+    "production": "https://production.plaid.com",
+}
+
+# Error codes that mean "the stored access token is fine, but the user must
+# re-authenticate via Link update mode".
+_REAUTH_CODES = {"ITEM_LOGIN_REQUIRED", "PENDING_EXPIRATION", "ITEM_LOGIN_REQUIRED_UPDATE"}
+
+# Error codes that indicate the configured API credentials are wrong/missing.
+_CONFIG_CODES = {"INVALID_API_KEYS", "INVALID_CLIENT", "INVALID_SECRET", "UNAUTHORIZED_ENVIRONMENT"}
+
+DEFAULT_COUNTRY_CODES = ["US"]
+DEFAULT_LANGUAGE = "en"
+
+
+class PlaidClient:
+    """Thin synchronous wrapper around the Plaid REST API."""
+
+    def __init__(
+        self,
+        client_id: str,
+        secret: str,
+        environment: str = "sandbox",
+        *,
+        base_url: Optional[str] = None,
+        timeout: float = 30.0,
+    ) -> None:
+        if not client_id or not secret:
+            raise FinanceConfigError(
+                "Plaid credentials are not configured. Set PLAID_CLIENT_ID and "
+                "PLAID_SECRET in your .env."
+            )
+        self.client_id = client_id
+        self.secret = secret
+        self.environment = (environment or "sandbox").strip().lower()
+        self.base_url = (base_url or _ENV_BASE_URLS.get(self.environment, _ENV_BASE_URLS["sandbox"])).rstrip("/")
+        self.timeout = timeout
+
+    # ------------------------------------------------------------------
+    # Transport
+    # ------------------------------------------------------------------
+
+    def _post(self, path: str, payload: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        url = f"{self.base_url}{path}"
+        body = {"client_id": self.client_id, "secret": self.secret}
+        if payload:
+            body.update(payload)
+        try:
+            response = httpx.post(url, json=body, timeout=self.timeout)
+        except httpx.HTTPError as exc:
+            raise FinanceProviderError(f"Plaid request to {path} failed: {exc}") from exc
+
+        try:
+            data = response.json()
+        except ValueError:
+            data = {}
+
+        if response.status_code >= 400 or (isinstance(data, dict) and data.get("error_code")):
+            self._raise_for_error(path, response.status_code, data if isinstance(data, dict) else {})
+        return data if isinstance(data, dict) else {}
+
+    @staticmethod
+    def _raise_for_error(path: str, status_code: int, data: Dict[str, Any]) -> None:
+        error_code = data.get("error_code")
+        error_type = data.get("error_type")
+        message = (
+            data.get("error_message")
+            or data.get("display_message")
+            or f"Plaid request to {path} failed with HTTP {status_code}"
+        )
+        request_id = data.get("request_id")
+        if error_code in _REAUTH_CODES:
+            raise FinanceReauthRequiredError(
+                message, status_code=status_code, error_code=error_code,
+                error_type=error_type, request_id=request_id,
+            )
+        if error_code in _CONFIG_CODES:
+            raise FinanceConfigError(message)
+        raise FinanceProviderError(
+            message, status_code=status_code, error_code=error_code,
+            error_type=error_type, request_id=request_id,
+        )
+
+    # ------------------------------------------------------------------
+    # Link / onboarding
+    # ------------------------------------------------------------------
+
+    def link_token_create(
+        self,
+        *,
+        user_id: str,
+        client_name: str = "Hermes",
+        products: Optional[List[str]] = None,
+        country_codes: Optional[List[str]] = None,
+        language: str = DEFAULT_LANGUAGE,
+        hosted_link: Optional[Dict[str, Any]] = None,
+        webhook: Optional[str] = None,
+        redirect_uri: Optional[str] = None,
+        access_token: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "user": {"client_user_id": user_id},
+            "client_name": client_name,
+            "country_codes": country_codes or DEFAULT_COUNTRY_CODES,
+            "language": language,
+        }
+        # Update mode (re-auth) omits products and passes the existing token.
+        if access_token:
+            payload["access_token"] = access_token
+        else:
+            payload["products"] = products or ["transactions"]
+        if hosted_link is not None:
+            payload["hosted_link"] = hosted_link
+        if webhook:
+            payload["webhook"] = webhook
+        if redirect_uri:
+            payload["redirect_uri"] = redirect_uri
+        return self._post("/link/token/create", payload)
+
+    def link_token_get(self, link_token: str) -> Dict[str, Any]:
+        return self._post("/link/token/get", {"link_token": link_token})
+
+    def item_public_token_exchange(self, public_token: str) -> Dict[str, Any]:
+        return self._post("/item/public_token/exchange", {"public_token": public_token})
+
+    def sandbox_public_token_create(
+        self, *, institution_id: str, initial_products: Optional[List[str]] = None
+    ) -> Dict[str, Any]:
+        return self._post(
+            "/sandbox/public_token/create",
+            {"institution_id": institution_id, "initial_products": initial_products or ["transactions"]},
+        )
+
+    # ------------------------------------------------------------------
+    # Data
+    # ------------------------------------------------------------------
+
+    def accounts_balance_get(self, access_token: str) -> Dict[str, Any]:
+        return self._post("/accounts/balance/get", {"access_token": access_token})
+
+    def transactions_sync(
+        self, access_token: str, *, cursor: Optional[str] = None, count: int = 500
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {"access_token": access_token, "count": count}
+        if cursor:
+            payload["cursor"] = cursor
+        return self._post("/transactions/sync", payload)
+
+    def investments_holdings_get(self, access_token: str) -> Dict[str, Any]:
+        return self._post("/investments/holdings/get", {"access_token": access_token})
+
+    def liabilities_get(self, access_token: str) -> Dict[str, Any]:
+        return self._post("/liabilities/get", {"access_token": access_token})
+
+    def item_get(self, access_token: str) -> Dict[str, Any]:
+        return self._post("/item/get", {"access_token": access_token})
+
+    def item_remove(self, access_token: str) -> Dict[str, Any]:
+        return self._post("/item/remove", {"access_token": access_token})
+
+    def institutions_get_by_id(
+        self, institution_id: str, *, country_codes: Optional[List[str]] = None
+    ) -> Dict[str, Any]:
+        return self._post(
+            "/institutions/get_by_id",
+            {"institution_id": institution_id, "country_codes": country_codes or DEFAULT_COUNTRY_CODES},
+        )

--- a/plugins/finance/plaid/provider.py
+++ b/plugins/finance/plaid/provider.py
@@ -1,0 +1,397 @@
+"""Plaid implementation of :class:`~plugins.finance.provider.FinanceProvider`.
+
+Owns the incremental sync engine: balances via ``/accounts/balance/get`` and
+transactions via the cursor-based ``/transactions/sync`` loop, with
+investments and liabilities pulled best-effort (they require the matching
+products to be enabled on the item). Transactions are only persisted after the
+final page so a mid-pagination mutation cannot leave a partial write; on
+``TRANSACTIONS_SYNC_MUTATION_DURING_PAGINATION`` the loop restarts from the
+cursor it began with.
+
+Reference: https://plaid.com/docs/api/products/transactions/#transactionssync
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Optional
+
+from plugins.finance import settings
+from plugins.finance.errors import FinanceProviderError
+from plugins.finance.plaid import auth
+from plugins.finance.plaid.client import PlaidClient
+from plugins.finance.provider import FinanceProvider
+from plugins.finance.store import FinanceStore
+
+logger = logging.getLogger(__name__)
+
+PROVIDER_NAME = "plaid"
+
+# Provider error codes for optional products that simply aren't enabled on an
+# item — treated as "no data", not a failure.
+_OPTIONAL_PRODUCT_CODES = {
+    "PRODUCTS_NOT_SUPPORTED", "PRODUCT_NOT_READY", "NO_INVESTMENT_ACCOUNTS",
+    "NO_LIABILITY_ACCOUNTS", "NO_ACCOUNTS",
+}
+
+_MAX_SYNC_RESTARTS = 5
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _balance(account: Dict[str, Any], field: str) -> Any:
+    return (account.get("balances") or {}).get(field)
+
+
+def _account_currency(account: Dict[str, Any]) -> Optional[str]:
+    balances = account.get("balances") or {}
+    return balances.get("iso_currency_code") or balances.get("unofficial_currency_code")
+
+
+def _normalize_account(account: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "account_id": account.get("account_id"),
+        "name": account.get("name"),
+        "official_name": account.get("official_name"),
+        "mask": account.get("mask"),
+        "type": account.get("type"),
+        "subtype": account.get("subtype"),
+        "currency": _account_currency(account),
+        "current_balance": _balance(account, "current"),
+        "available_balance": _balance(account, "available"),
+        "credit_limit": _balance(account, "limit"),
+    }
+
+
+def _normalize_transaction(txn: Dict[str, Any]) -> Dict[str, Any]:
+    pfc = txn.get("personal_finance_category") or {}
+    category_list = txn.get("category") or []
+    category_primary = pfc.get("primary") or (category_list[0] if category_list else None)
+    category_detailed = pfc.get("detailed") or (" > ".join(category_list) if category_list else None)
+    return {
+        "transaction_id": txn.get("transaction_id"),
+        "account_id": txn.get("account_id"),
+        "amount": txn.get("amount"),
+        "currency": txn.get("iso_currency_code") or txn.get("unofficial_currency_code"),
+        "date": txn.get("date"),
+        "datetime": txn.get("datetime"),
+        "name": txn.get("name"),
+        "merchant_name": txn.get("merchant_name"),
+        "category_primary": category_primary,
+        "category_detailed": category_detailed,
+        "pending": txn.get("pending"),
+        "payment_channel": txn.get("payment_channel"),
+        "raw": txn,
+    }
+
+
+def _normalize_holdings(response: Dict[str, Any]) -> List[Dict[str, Any]]:
+    return [
+        {
+            "account_id": holding.get("account_id"),
+            "security_id": holding.get("security_id"),
+            "quantity": holding.get("quantity"),
+            "cost_basis": holding.get("cost_basis"),
+            "institution_price": holding.get("institution_price"),
+            "institution_value": holding.get("institution_value"),
+            "currency": holding.get("iso_currency_code") or holding.get("unofficial_currency_code"),
+        }
+        for holding in response.get("holdings") or []
+    ]
+
+
+def _normalize_securities(response: Dict[str, Any]) -> List[Dict[str, Any]]:
+    return [
+        {
+            "security_id": sec.get("security_id"),
+            "name": sec.get("name"),
+            "ticker_symbol": sec.get("ticker_symbol"),
+            "type": sec.get("type"),
+            "close_price": sec.get("close_price"),
+            "currency": sec.get("iso_currency_code") or sec.get("unofficial_currency_code"),
+        }
+        for sec in response.get("securities") or []
+    ]
+
+
+def _first_apr(detail: Dict[str, Any]) -> Optional[float]:
+    aprs = detail.get("aprs") or []
+    if aprs and isinstance(aprs[0], dict):
+        return aprs[0].get("apr_percentage")
+    return None
+
+
+def _normalize_liabilities(response: Dict[str, Any]) -> List[Dict[str, Any]]:
+    liabilities = response.get("liabilities") or {}
+    rows: List[Dict[str, Any]] = []
+    for kind in ("credit", "student", "mortgage"):
+        for detail in liabilities.get(kind) or []:
+            rows.append({
+                "account_id": detail.get("account_id"),
+                "kind": kind,
+                "last_payment_amount": detail.get("last_payment_amount"),
+                "last_payment_date": detail.get("last_payment_date"),
+                "next_payment_due_date": (
+                    detail.get("next_payment_due_date") or detail.get("next_monthly_payment")
+                ),
+                "minimum_payment_amount": detail.get("minimum_payment_amount"),
+                "outstanding_balance": (
+                    detail.get("last_statement_balance") or detail.get("outstanding_interest_amount")
+                ),
+                "apr": _first_apr(detail),
+                "detail": detail,
+            })
+    return rows
+
+
+class PlaidProvider(FinanceProvider):
+    name = PROVIDER_NAME
+
+    def __init__(self, environment: Optional[str] = None) -> None:
+        self._environment = environment
+
+    def _resolve_environment(self) -> str:
+        return (self._environment or settings.get_plaid_environment() or "sandbox").strip().lower()
+
+    def _client(self, client: Optional[PlaidClient] = None) -> PlaidClient:
+        return client or auth.build_client(self._resolve_environment())
+
+    # ------------------------------------------------------------------
+    # Connect
+    # ------------------------------------------------------------------
+
+    def connect(self, **kwargs: Any) -> Dict[str, Any]:
+        store: Optional[FinanceStore] = kwargs.get("store")
+        mode = (kwargs.get("mode") or "hosted").strip().lower()
+        products: Optional[List[str]] = kwargs.get("products")
+        client = self._client(kwargs.get("client"))
+        environment = self._resolve_environment()
+        do_sync = kwargs.get("do_sync", True)
+
+        if mode == "sandbox":
+            linked = auth.sandbox_connect(
+                client,
+                institution_id=kwargs.get("institution_id") or auth.SANDBOX_INSTITUTION_ID,
+                products=products,
+                environment=environment,
+            )
+            return self._finalize_link(store, client, linked, do_sync=do_sync)
+
+        started = auth.start_hosted_link(
+            client, products=products, webhook=settings.get_plaid_webhook_url() or None,
+            user_id=kwargs.get("user_id"),
+        )
+        on_link_url: Optional[Callable[[str], None]] = kwargs.get("on_link_url")
+        if on_link_url:
+            on_link_url(started["hosted_link_url"])
+
+        public_token = auth.poll_for_public_token(
+            client, started["link_token"],
+            timeout=float(kwargs.get("timeout", 300.0)),
+            interval=float(kwargs.get("poll_interval", 3.0)),
+        )
+        if not public_token:
+            return {
+                "status": "pending",
+                "provider": self.name,
+                "hosted_link_url": started["hosted_link_url"],
+                "link_token": started["link_token"],
+                "message": "Link not completed before timeout. Reopen the URL and rerun connect.",
+            }
+        linked = auth.complete_link(
+            client, public_token, environment=environment,
+            institution_id=kwargs.get("institution_id"),
+        )
+        return self._finalize_link(store, client, linked, do_sync=do_sync)
+
+    def _finalize_link(
+        self,
+        store: Optional[FinanceStore],
+        client: PlaidClient,
+        linked: Dict[str, Any],
+        *,
+        do_sync: bool,
+    ) -> Dict[str, Any]:
+        result = {"status": "linked", "provider": self.name, **linked}
+        if store is not None:
+            store.upsert_item(
+                linked["item_id"], provider=self.name,
+                institution_id=linked.get("institution_id"),
+                institution_name=linked.get("institution_name"),
+                environment=linked.get("environment"),
+            )
+            if do_sync:
+                result["sync"] = self.sync(store, item_id=linked["item_id"], client=client)
+        return result
+
+    # ------------------------------------------------------------------
+    # Sync
+    # ------------------------------------------------------------------
+
+    def sync(self, store: FinanceStore, *, item_id: Optional[str] = None, **kwargs: Any) -> Dict[str, Any]:
+        client = self._client(kwargs.get("client"))
+        items = [item_id] if item_id else [it["item_id"] for it in auth.list_token_items()]
+        per_item = []
+        totals = {"accounts": 0, "added": 0, "modified": 0, "removed": 0}
+        for current_item in items:
+            summary = self._sync_item(store, client, current_item)
+            per_item.append(summary)
+            for key in totals:
+                totals[key] += summary.get(key, 0) or 0
+        return {"provider": self.name, "items_synced": len(items), "totals": totals, "items": per_item}
+
+    def _sync_item(self, store: FinanceStore, client: PlaidClient, item_id: str) -> Dict[str, Any]:
+        started_at = _utcnow()
+        access_token = auth.get_access_token(item_id)
+        if not access_token:
+            error = "no stored access token"
+            store.record_sync_run(
+                item_id=item_id, provider=self.name, started_at=started_at,
+                finished_at=_utcnow(), status="error", error=error,
+            )
+            return {"item_id": item_id, "status": "error", "error": error}
+
+        # Ensure the item row exists before writing FK-bound rows (accounts,
+        # transactions). A direct `finance sync` — token restored from backup,
+        # or a sync that didn't run through connect() — must still self-heal
+        # the local item record from the token metadata.
+        token_meta = next(
+            (it for it in auth.list_token_items() if it.get("item_id") == item_id), {}
+        )
+        store.upsert_item(
+            item_id, provider=self.name,
+            institution_id=token_meta.get("institution_id"),
+            institution_name=token_meta.get("institution_name"),
+            environment=token_meta.get("environment"),
+        )
+
+        summary: Dict[str, Any] = {"item_id": item_id, "status": "ok"}
+        try:
+            balance_response = client.accounts_balance_get(access_token)
+            accounts = [_normalize_account(a) for a in balance_response.get("accounts") or []]
+            summary["accounts"] = store.upsert_accounts(item_id, self.name, accounts)
+
+            txn_counts = self._sync_transactions(store, client, item_id, access_token)
+            summary.update(txn_counts)
+
+            summary["holdings"] = self._sync_holdings(store, client, item_id, access_token)
+            summary["liabilities"] = self._sync_liabilities(store, client, item_id, access_token)
+
+            store.mark_item_synced(item_id, error=None)
+            store.record_sync_run(
+                item_id=item_id, provider=self.name, started_at=started_at,
+                finished_at=_utcnow(), status="ok",
+                added=txn_counts.get("added", 0), modified=txn_counts.get("modified", 0),
+                removed=txn_counts.get("removed", 0),
+            )
+        except FinanceProviderError as exc:
+            store.mark_item_synced(item_id, error=str(exc))
+            store.record_sync_run(
+                item_id=item_id, provider=self.name, started_at=started_at,
+                finished_at=_utcnow(), status="error", error=str(exc),
+            )
+            summary["status"] = "error"
+            summary["error"] = str(exc)
+        return summary
+
+    def _sync_transactions(
+        self, store: FinanceStore, client: PlaidClient, item_id: str, access_token: str
+    ) -> Dict[str, int]:
+        original_cursor = store.get_item_cursor(item_id)
+        cursor = original_cursor
+        added: List[Dict[str, Any]] = []
+        modified: List[Dict[str, Any]] = []
+        removed: List[str] = []
+        restarts = 0
+        while True:
+            try:
+                response = client.transactions_sync(access_token, cursor=cursor)
+            except FinanceProviderError as exc:
+                if exc.error_code == "TRANSACTIONS_SYNC_MUTATION_DURING_PAGINATION" and restarts < _MAX_SYNC_RESTARTS:
+                    restarts += 1
+                    cursor = original_cursor
+                    added, modified, removed = [], [], []
+                    continue
+                raise
+            added.extend(_normalize_transaction(t) for t in response.get("added") or [])
+            modified.extend(_normalize_transaction(t) for t in response.get("modified") or [])
+            removed.extend(
+                r.get("transaction_id") for r in response.get("removed") or [] if r.get("transaction_id")
+            )
+            cursor = response.get("next_cursor")
+            if not response.get("has_more"):
+                break
+        # Only persist after the final page so a mutation cannot leave a partial write.
+        counts = store.apply_transactions(
+            item_id, self.name, added=added, modified=modified, removed=removed
+        )
+        store.set_item_cursor(item_id, cursor)
+        return counts
+
+    def _sync_holdings(
+        self, store: FinanceStore, client: PlaidClient, item_id: str, access_token: str
+    ) -> int:
+        try:
+            response = client.investments_holdings_get(access_token)
+        except FinanceProviderError as exc:
+            if exc.error_code in _OPTIONAL_PRODUCT_CODES:
+                return 0
+            logger.debug("Plaid holdings sync skipped for %s: %s", item_id, exc)
+            return 0
+        store.upsert_securities(_normalize_securities(response))
+        return store.upsert_holdings(item_id, self.name, _normalize_holdings(response))
+
+    def _sync_liabilities(
+        self, store: FinanceStore, client: PlaidClient, item_id: str, access_token: str
+    ) -> int:
+        try:
+            response = client.liabilities_get(access_token)
+        except FinanceProviderError as exc:
+            if exc.error_code in _OPTIONAL_PRODUCT_CODES:
+                return 0
+            logger.debug("Plaid liabilities sync skipped for %s: %s", item_id, exc)
+            return 0
+        return store.upsert_liabilities(item_id, self.name, _normalize_liabilities(response))
+
+    # ------------------------------------------------------------------
+    # Status + disconnect
+    # ------------------------------------------------------------------
+
+    def status(self, store: FinanceStore) -> Dict[str, Any]:
+        token_items = {it["item_id"]: it for it in auth.list_token_items()}
+        items = []
+        for item in store.list_items(provider=self.name, include_removed=True):
+            item_id = item["item_id"]
+            accounts = store.get_accounts()
+            account_count = sum(1 for a in accounts if a.get("item_id") == item_id)
+            token_meta = token_items.get(item_id, {})
+            items.append({
+                "item_id": item_id,
+                "institution_name": item.get("institution_name") or token_meta.get("institution_name"),
+                "environment": item.get("environment") or token_meta.get("environment"),
+                "status": item.get("status"),
+                "last_sync_at": item.get("last_sync_at"),
+                "last_error": item.get("last_error"),
+                "accounts": account_count,
+                "credential_present": item_id in token_items,
+            })
+        return {"provider": self.name, "items": items, "last_sync": store.last_sync_run()}
+
+    def disconnect(self, store: FinanceStore, item_id: str, *, purge: bool = False) -> Dict[str, Any]:
+        access_token = auth.get_access_token(item_id)
+        revoked = False
+        if access_token:
+            try:
+                self._client().item_remove(access_token)
+                revoked = True
+            except FinanceProviderError as exc:
+                logger.debug("Plaid item_remove failed for %s: %s", item_id, exc)
+        auth.remove_item_token(item_id)
+        if purge:
+            store.delete_item(item_id)
+        else:
+            store.set_item_status(item_id, "disconnected")
+        return {"item_id": item_id, "revoked": revoked, "purged": purge, "provider": self.name}

--- a/plugins/finance/plugin.yaml
+++ b/plugins/finance/plugin.yaml
@@ -1,0 +1,13 @@
+name: finance
+version: 1.0.0
+description: "Provider-agnostic personal finance integration (Plaid first). Adds a `hermes finance` CLI (connect/sync/status/accounts/transactions/disconnect) and a gated `finance` toolset over a local SQLite cache. Secrets: PLAID_CLIENT_ID/PLAID_SECRET in .env; settings under `finance` in config.yaml."
+author: NousResearch
+kind: backend
+provides_tools:
+  - finance_accounts
+  - finance_transactions
+  - finance_spending
+  - finance_net_worth
+  - finance_cashflow
+  - finance_holdings
+  - finance_sync

--- a/plugins/finance/privacy.py
+++ b/plugins/finance/privacy.py
@@ -1,0 +1,76 @@
+"""Privacy formatting for finance tool output.
+
+Two modes, selected by ``finance.privacy_mode`` in config.yaml:
+
+* ``full`` — exact figures (e.g. ``$2,431.18``).
+* ``summarized`` — values are bucketed into ranges (e.g. ``$2k-$5k``) *before*
+  they ever enter a prompt or tool result, so the model can reason about
+  magnitude and trends without ingesting exact balances.
+
+Access tokens and account/routing numbers are never formatted here because
+they are never loaded into tool output in the first place.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+FULL = "full"
+SUMMARIZED = "summarized"
+
+# (upper_bound_exclusive, label) for the absolute magnitude of a value.
+_BUCKETS = [
+    (100, "<{sym}100"),
+    (500, "{sym}100-{sym}500"),
+    (1_000, "{sym}500-{sym}1k"),
+    (2_000, "{sym}1k-{sym}2k"),
+    (5_000, "{sym}2k-{sym}5k"),
+    (10_000, "{sym}5k-{sym}10k"),
+    (25_000, "{sym}10k-{sym}25k"),
+    (50_000, "{sym}25k-{sym}50k"),
+    (100_000, "{sym}50k-{sym}100k"),
+    (250_000, "{sym}100k-{sym}250k"),
+    (500_000, "{sym}250k-{sym}500k"),
+    (1_000_000, "{sym}500k-{sym}1M"),
+]
+_OVER_CAP = "{sym}1M+"
+
+
+def normalize_mode(mode: Optional[str]) -> str:
+    """Coerce a config value to a known privacy mode (defaults to ``full``)."""
+    value = (mode or "").strip().lower()
+    return SUMMARIZED if value in {SUMMARIZED, "summary", "bucketed", "redacted"} else FULL
+
+
+def _symbol(currency: Optional[str]) -> str:
+    code = (currency or "USD").upper()
+    return "$" if code == "USD" else f"{code} "
+
+
+def bucket_amount(value: Optional[float], currency: Optional[str] = None) -> str:
+    """Return a coarse range label for *value* (sign preserved)."""
+    if value is None:
+        return "n/a"
+    sym = _symbol(currency)
+    magnitude = abs(float(value))
+    sign = "-" if value < 0 else ""
+    if magnitude == 0:
+        return f"{sym}0"
+    for upper, label in _BUCKETS:
+        if magnitude < upper:
+            return sign + label.format(sym=sym)
+    return sign + _OVER_CAP.format(sym=sym)
+
+
+def format_money(value: Optional[float], currency: Optional[str] = None, *, mode: str = FULL) -> str:
+    """Format a monetary *value* per the active privacy *mode*."""
+    if value is None:
+        return "n/a"
+    if normalize_mode(mode) == SUMMARIZED:
+        return bucket_amount(value, currency)
+    sym = _symbol(currency)
+    return f"{sym}{float(value):,.2f}"
+
+
+def is_summarized(mode: Optional[str]) -> bool:
+    return normalize_mode(mode) == SUMMARIZED

--- a/plugins/finance/provider.py
+++ b/plugins/finance/provider.py
@@ -1,0 +1,106 @@
+"""Provider abstraction for the finance plugin.
+
+A :class:`FinanceProvider` is the seam that keeps the finance feature
+provider-agnostic. Plaid is the only concrete implementation today, but the
+issue (#51697) explicitly calls for additional connectors (Teller, SnapTrade,
+Salt Edge, TrueLayer, crypto exchanges) without redesigning the storage,
+sync, or tool layers. Everything above this seam talks to accounts,
+transactions, holdings, and liabilities in the local store; everything below
+it talks to a specific aggregator's API.
+
+Providers are resolved lazily by name so importing this module never pulls in
+a backend's HTTP client (or its optional deps) until it is actually used.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
+
+from plugins.finance.errors import FinanceConfigError
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from plugins.finance.store import FinanceStore
+
+
+class FinanceProvider(ABC):
+    """Abstract financial-data provider.
+
+    Concrete providers wrap a single aggregator. The contract is intentionally
+    small: link/unlink an institution, pull fresh data into the store, and
+    report status. All money/data persistence happens through the passed-in
+    :class:`~plugins.finance.store.FinanceStore`; providers never own storage.
+    """
+
+    #: Stable, lowercase identifier used in config and the CLI (e.g. "plaid").
+    name: str = ""
+
+    @abstractmethod
+    def connect(self, **kwargs: Any) -> Dict[str, Any]:
+        """Begin or complete linking an institution.
+
+        Returns a JSON-serializable dict describing the next step (e.g. a
+        hosted-link URL to open) or the completed link (item id + institution).
+        """
+
+    @abstractmethod
+    def sync(self, store: "FinanceStore", *, item_id: Optional[str] = None) -> Dict[str, Any]:
+        """Pull fresh balances/transactions/holdings/liabilities into *store*.
+
+        When *item_id* is given, only that item is refreshed; otherwise every
+        linked item for this provider is synced. Returns a summary dict.
+        """
+
+    @abstractmethod
+    def status(self, store: "FinanceStore") -> Dict[str, Any]:
+        """Return linked-item + last-sync status for this provider."""
+
+    @abstractmethod
+    def disconnect(self, store: "FinanceStore", item_id: str, *, purge: bool = False) -> Dict[str, Any]:
+        """Unlink an item, revoking its credential. Optionally purge its data."""
+
+
+# ---------------------------------------------------------------------------
+# Lazy provider registry
+# ---------------------------------------------------------------------------
+
+# Maps provider name -> zero-arg factory. Factories import their backend module
+# only when invoked, so the default import path stays light and a provider's
+# optional deps are never required unless the user selected it.
+_PROVIDER_FACTORIES: Dict[str, Callable[[], FinanceProvider]] = {}
+
+
+def register_provider(name: str, factory: Callable[[], FinanceProvider]) -> None:
+    """Register a provider factory under *name* (last writer wins)."""
+    _PROVIDER_FACTORIES[name.strip().lower()] = factory
+
+
+def _default_plaid_factory() -> FinanceProvider:
+    from plugins.finance.plaid.provider import PlaidProvider
+
+    return PlaidProvider()
+
+
+# Built-in providers. Plaid is the reference implementation.
+register_provider("plaid", _default_plaid_factory)
+
+
+def available_providers() -> List[str]:
+    """Return the sorted names of all registered providers."""
+    return sorted(_PROVIDER_FACTORIES)
+
+
+def get_provider(name: str) -> FinanceProvider:
+    """Instantiate a registered provider by name.
+
+    Raises :class:`FinanceConfigError` for an unknown provider so the CLI and
+    tools surface an actionable message instead of a raw KeyError.
+    """
+    key = (name or "").strip().lower()
+    factory = _PROVIDER_FACTORIES.get(key)
+    if factory is None:
+        known = ", ".join(available_providers()) or "(none)"
+        raise FinanceConfigError(
+            f"Unknown finance provider '{name}'. Known providers: {known}."
+        )
+    return factory()

--- a/plugins/finance/settings.py
+++ b/plugins/finance/settings.py
@@ -1,0 +1,66 @@
+"""Config access for the finance plugin.
+
+Non-secret settings live in ``config.yaml`` under the ``finance:`` section
+(provider, sync interval, privacy mode, Plaid environment). Secrets
+(``PLAID_CLIENT_ID`` / ``PLAID_SECRET``) live in ``.env`` and are read straight
+from the environment — never from here.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Dict
+
+# Mirrors the ``finance`` block added to DEFAULT_CONFIG; used as a fallback when
+# the config file cannot be loaded (e.g. minimal test environments).
+_DEFAULTS: Dict[str, Any] = {
+    "provider": "plaid",
+    "sync_interval": "6h",
+    "privacy_mode": "full",
+    "plaid": {"environment": "sandbox", "webhook_url": ""},
+    "categorization": {"llm_fallback": False},
+}
+
+
+def load_finance_settings() -> Dict[str, Any]:
+    """Return the merged ``finance`` config section (defaults + user config)."""
+    merged = copy.deepcopy(_DEFAULTS)
+    try:
+        from hermes_cli.config import load_config
+
+        finance = (load_config() or {}).get("finance") or {}
+    except Exception:
+        finance = {}
+    _deep_merge(merged, finance)
+    return merged
+
+
+def _deep_merge(base: Dict[str, Any], overrides: Dict[str, Any]) -> None:
+    for key, value in overrides.items():
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            _deep_merge(base[key], value)
+        else:
+            base[key] = value
+
+
+def get_provider_name() -> str:
+    return str(load_finance_settings().get("provider") or "plaid").strip().lower()
+
+
+def get_privacy_mode() -> str:
+    return str(load_finance_settings().get("privacy_mode") or "full").strip().lower()
+
+
+def get_plaid_environment() -> str:
+    plaid = load_finance_settings().get("plaid") or {}
+    return str(plaid.get("environment") or "sandbox").strip().lower()
+
+
+def get_plaid_webhook_url() -> str:
+    plaid = load_finance_settings().get("plaid") or {}
+    return str(plaid.get("webhook_url") or "").strip()
+
+
+def llm_fallback_enabled() -> bool:
+    cat = load_finance_settings().get("categorization") or {}
+    return bool(cat.get("llm_fallback"))

--- a/plugins/finance/store.py
+++ b/plugins/finance/store.py
@@ -1,0 +1,848 @@
+"""Local SQLite store for the finance plugin.
+
+Everything Hermes knows about a user's finances lives here, on disk, under the
+profile-scoped Hermes home — never in a remote service and never alongside the
+provider access tokens (those live in a 0600 file; see ``plaid/auth.py``).
+
+Design notes:
+
+* **Append-only transactions.** Plaid's ``/transactions/sync`` can mark a
+  transaction ``removed``; we never hard-delete it. Removed rows are
+  tombstoned (``removed=1`` + ``removed_at``) so history and prior agent
+  answers stay reproducible. Queries exclude tombstones by default.
+* **Profile-safe path.** The DB path derives from ``get_hermes_home()`` so each
+  profile gets its own ``finance/finance.db``.
+* **Money is stored as Plaid reports it.** Amounts follow Plaid's sign
+  convention: a *positive* transaction amount is money leaving the account
+  (a debit/outflow); a *negative* amount is money coming in (a credit/inflow).
+  Aggregations document where they flip the sign for human-friendly output.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from hermes_constants import get_hermes_home, secure_parent_dir
+
+# Account types treated as assets vs liabilities for net-worth math.
+_LIABILITY_TYPES = {"credit", "loan"}
+
+
+def default_db_path() -> Path:
+    """Return the profile-scoped path to ``finance.db``."""
+    return get_hermes_home() / "finance" / "finance.db"
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _to_float(value: Any) -> Optional[float]:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS items (
+    item_id TEXT PRIMARY KEY,
+    provider TEXT NOT NULL,
+    institution_id TEXT,
+    institution_name TEXT,
+    environment TEXT,
+    status TEXT NOT NULL DEFAULT 'active',
+    transactions_cursor TEXT,
+    last_sync_at TEXT,
+    last_error TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS accounts (
+    account_id TEXT PRIMARY KEY,
+    item_id TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    name TEXT,
+    official_name TEXT,
+    mask TEXT,
+    type TEXT,
+    subtype TEXT,
+    currency TEXT,
+    current_balance REAL,
+    available_balance REAL,
+    credit_limit REAL,
+    removed INTEGER NOT NULL DEFAULT 0,
+    last_synced_at TEXT,
+    FOREIGN KEY (item_id) REFERENCES items(item_id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_accounts_item ON accounts(item_id);
+
+CREATE TABLE IF NOT EXISTS transactions (
+    transaction_id TEXT PRIMARY KEY,
+    account_id TEXT NOT NULL,
+    item_id TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    amount REAL,
+    currency TEXT,
+    date TEXT,
+    datetime TEXT,
+    name TEXT,
+    merchant_name TEXT,
+    category_primary TEXT,
+    category_detailed TEXT,
+    pending INTEGER NOT NULL DEFAULT 0,
+    payment_channel TEXT,
+    removed INTEGER NOT NULL DEFAULT 0,
+    removed_at TEXT,
+    raw TEXT,
+    first_seen_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (item_id) REFERENCES items(item_id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_txn_account ON transactions(account_id);
+CREATE INDEX IF NOT EXISTS idx_txn_item ON transactions(item_id);
+CREATE INDEX IF NOT EXISTS idx_txn_date ON transactions(date);
+
+CREATE TABLE IF NOT EXISTS securities (
+    security_id TEXT PRIMARY KEY,
+    name TEXT,
+    ticker_symbol TEXT,
+    type TEXT,
+    close_price REAL,
+    currency TEXT,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS holdings (
+    account_id TEXT NOT NULL,
+    security_id TEXT NOT NULL,
+    item_id TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    quantity REAL,
+    cost_basis REAL,
+    institution_price REAL,
+    institution_value REAL,
+    currency TEXT,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (account_id, security_id),
+    FOREIGN KEY (item_id) REFERENCES items(item_id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_holdings_item ON holdings(item_id);
+
+CREATE TABLE IF NOT EXISTS liabilities (
+    account_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    item_id TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    last_payment_amount REAL,
+    last_payment_date TEXT,
+    next_payment_due_date TEXT,
+    minimum_payment_amount REAL,
+    outstanding_balance REAL,
+    apr REAL,
+    detail TEXT,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (account_id, kind),
+    FOREIGN KEY (item_id) REFERENCES items(item_id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_liabilities_item ON liabilities(item_id);
+
+CREATE TABLE IF NOT EXISTS balance_snapshots (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    account_id TEXT NOT NULL,
+    item_id TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    current_balance REAL,
+    available_balance REAL,
+    currency TEXT,
+    captured_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_balsnap_account ON balance_snapshots(account_id);
+CREATE INDEX IF NOT EXISTS idx_balsnap_captured ON balance_snapshots(captured_at);
+
+CREATE TABLE IF NOT EXISTS sync_runs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    item_id TEXT,
+    provider TEXT,
+    started_at TEXT,
+    finished_at TEXT,
+    status TEXT,
+    added INTEGER NOT NULL DEFAULT 0,
+    modified INTEGER NOT NULL DEFAULT 0,
+    removed INTEGER NOT NULL DEFAULT 0,
+    error TEXT
+);
+
+CREATE TABLE IF NOT EXISTS merchant_rules (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    match_type TEXT NOT NULL DEFAULT 'substring',
+    pattern TEXT NOT NULL,
+    normalized_name TEXT,
+    category TEXT,
+    priority INTEGER NOT NULL DEFAULT 100,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS category_overrides (
+    scope TEXT NOT NULL,
+    key TEXT NOT NULL,
+    category TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (scope, key)
+);
+"""
+
+
+class FinanceStore:
+    """Thread-safe handle to the local finance SQLite database."""
+
+    def __init__(self, db_path: Optional[Path] = None) -> None:
+        self.path = Path(db_path) if db_path else default_db_path()
+        self._lock = threading.RLock()
+        self._conn: Optional[sqlite3.Connection] = None
+
+    # ------------------------------------------------------------------
+    # Connection lifecycle
+    # ------------------------------------------------------------------
+
+    def _connection(self) -> sqlite3.Connection:
+        with self._lock:
+            if self._conn is None:
+                self.path.parent.mkdir(parents=True, exist_ok=True)
+                # Lock down the finance/ directory (also holds the token file).
+                secure_parent_dir(self.path)
+                conn = sqlite3.connect(str(self.path), check_same_thread=False)
+                conn.row_factory = sqlite3.Row
+                self._apply_pragmas(conn)
+                conn.executescript(SCHEMA_SQL)
+                self._conn = conn
+            return self._conn
+
+    @staticmethod
+    def _apply_pragmas(conn: sqlite3.Connection) -> None:
+        try:
+            from hermes_state import apply_wal_with_fallback
+
+            apply_wal_with_fallback(conn, db_label="finance.db")
+        except Exception:
+            # Network filesystems and minimal test envs may reject WAL; the
+            # default rollback journal is correct, just slower.
+            try:
+                conn.execute("PRAGMA journal_mode=WAL")
+            except sqlite3.DatabaseError:
+                pass
+        conn.execute("PRAGMA synchronous=NORMAL")
+        conn.execute("PRAGMA foreign_keys=ON")
+
+    def close(self) -> None:
+        with self._lock:
+            if self._conn is not None:
+                try:
+                    self._conn.close()
+                finally:
+                    self._conn = None
+
+    def __enter__(self) -> "FinanceStore":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()
+
+    # ------------------------------------------------------------------
+    # Items
+    # ------------------------------------------------------------------
+
+    def upsert_item(
+        self,
+        item_id: str,
+        *,
+        provider: str,
+        institution_id: Optional[str] = None,
+        institution_name: Optional[str] = None,
+        environment: Optional[str] = None,
+        status: str = "active",
+    ) -> None:
+        now = _utcnow()
+        conn = self._connection()
+        with self._lock, conn:
+            conn.execute(
+                """
+                INSERT INTO items (item_id, provider, institution_id, institution_name,
+                                   environment, status, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(item_id) DO UPDATE SET
+                    provider=excluded.provider,
+                    institution_id=COALESCE(excluded.institution_id, items.institution_id),
+                    institution_name=COALESCE(excluded.institution_name, items.institution_name),
+                    environment=COALESCE(excluded.environment, items.environment),
+                    status=excluded.status,
+                    updated_at=excluded.updated_at
+                """,
+                (item_id, provider, institution_id, institution_name,
+                 environment, status, now, now),
+            )
+
+    def get_item(self, item_id: str) -> Optional[Dict[str, Any]]:
+        conn = self._connection()
+        with self._lock:
+            row = conn.execute("SELECT * FROM items WHERE item_id=?", (item_id,)).fetchone()
+        return dict(row) if row else None
+
+    def list_items(self, provider: Optional[str] = None, *, include_removed: bool = False) -> List[Dict[str, Any]]:
+        conn = self._connection()
+        clauses, params = [], []
+        if provider:
+            clauses.append("provider=?")
+            params.append(provider)
+        if not include_removed:
+            clauses.append("status != 'disconnected'")
+        where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+        with self._lock:
+            rows = conn.execute(f"SELECT * FROM items{where} ORDER BY created_at", params).fetchall()
+        return [dict(r) for r in rows]
+
+    def set_item_cursor(self, item_id: str, cursor: Optional[str]) -> None:
+        conn = self._connection()
+        with self._lock, conn:
+            conn.execute(
+                "UPDATE items SET transactions_cursor=?, updated_at=? WHERE item_id=?",
+                (cursor, _utcnow(), item_id),
+            )
+
+    def get_item_cursor(self, item_id: str) -> Optional[str]:
+        item = self.get_item(item_id)
+        return item.get("transactions_cursor") if item else None
+
+    def mark_item_synced(self, item_id: str, *, error: Optional[str] = None) -> None:
+        conn = self._connection()
+        now = _utcnow()
+        with self._lock, conn:
+            conn.execute(
+                "UPDATE items SET last_sync_at=?, last_error=?, updated_at=? WHERE item_id=?",
+                (now, error, now, item_id),
+            )
+
+    def set_item_status(self, item_id: str, status: str) -> None:
+        conn = self._connection()
+        with self._lock, conn:
+            conn.execute(
+                "UPDATE items SET status=?, updated_at=? WHERE item_id=?",
+                (status, _utcnow(), item_id),
+            )
+
+    def delete_item(self, item_id: str) -> None:
+        """Hard-delete an item and all of its data (used by ``--purge``)."""
+        conn = self._connection()
+        with self._lock, conn:
+            conn.execute("DELETE FROM items WHERE item_id=?", (item_id,))
+
+    # ------------------------------------------------------------------
+    # Accounts + balances
+    # ------------------------------------------------------------------
+
+    def upsert_accounts(self, item_id: str, provider: str, accounts: Iterable[Dict[str, Any]]) -> int:
+        now = _utcnow()
+        conn = self._connection()
+        count = 0
+        with self._lock, conn:
+            for acct in accounts:
+                account_id = acct.get("account_id")
+                if not account_id:
+                    continue
+                conn.execute(
+                    """
+                    INSERT INTO accounts (account_id, item_id, provider, name, official_name,
+                                          mask, type, subtype, currency, current_balance,
+                                          available_balance, credit_limit, removed, last_synced_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?)
+                    ON CONFLICT(account_id) DO UPDATE SET
+                        item_id=excluded.item_id,
+                        provider=excluded.provider,
+                        name=excluded.name,
+                        official_name=excluded.official_name,
+                        mask=excluded.mask,
+                        type=excluded.type,
+                        subtype=excluded.subtype,
+                        currency=excluded.currency,
+                        current_balance=excluded.current_balance,
+                        available_balance=excluded.available_balance,
+                        credit_limit=excluded.credit_limit,
+                        removed=0,
+                        last_synced_at=excluded.last_synced_at
+                    """,
+                    (
+                        account_id, item_id, provider, acct.get("name"),
+                        acct.get("official_name"), acct.get("mask"), acct.get("type"),
+                        acct.get("subtype"), acct.get("currency"),
+                        _to_float(acct.get("current_balance")),
+                        _to_float(acct.get("available_balance")),
+                        _to_float(acct.get("credit_limit")), now,
+                    ),
+                )
+                conn.execute(
+                    """
+                    INSERT INTO balance_snapshots (account_id, item_id, provider,
+                                                   current_balance, available_balance,
+                                                   currency, captured_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        account_id, item_id, provider,
+                        _to_float(acct.get("current_balance")),
+                        _to_float(acct.get("available_balance")),
+                        acct.get("currency"), now,
+                    ),
+                )
+                count += 1
+        return count
+
+    def get_accounts(self, *, provider: Optional[str] = None, include_removed: bool = False) -> List[Dict[str, Any]]:
+        conn = self._connection()
+        clauses, params = [], []
+        if provider:
+            clauses.append("provider=?")
+            params.append(provider)
+        if not include_removed:
+            clauses.append("removed=0")
+        where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+        with self._lock:
+            rows = conn.execute(f"SELECT * FROM accounts{where} ORDER BY name", params).fetchall()
+        return [dict(r) for r in rows]
+
+    def net_worth(self) -> Dict[str, Any]:
+        """Return assets, liabilities, and net worth grouped by currency.
+
+        Liability-type accounts (credit, loan) carry a positive ``current``
+        balance representing what is owed, so they subtract from net worth.
+        """
+        accounts = self.get_accounts()
+        by_currency: Dict[str, Dict[str, float]] = {}
+        for acct in accounts:
+            currency = (acct.get("currency") or "USD").upper()
+            bucket = by_currency.setdefault(currency, {"assets": 0.0, "liabilities": 0.0})
+            balance = acct.get("current_balance")
+            if balance is None:
+                continue
+            if (acct.get("type") or "").lower() in _LIABILITY_TYPES:
+                bucket["liabilities"] += abs(balance)
+            else:
+                bucket["assets"] += balance
+        result = {}
+        for currency, bucket in by_currency.items():
+            net = round(bucket["assets"] - bucket["liabilities"], 2)
+            result[currency] = {
+                "assets": round(bucket["assets"], 2),
+                "liabilities": round(bucket["liabilities"], 2),
+                "net_worth": net,
+            }
+        return result
+
+    def net_worth_history(self, *, limit_days: int = 90) -> List[Dict[str, Any]]:
+        """Return per-day net-worth points from balance snapshots.
+
+        Uses the last snapshot per account per day so a day with multiple
+        syncs counts each account once.
+        """
+        conn = self._connection()
+        with self._lock:
+            rows = conn.execute(
+                """
+                SELECT a.type AS type, a.currency AS currency,
+                       substr(b.captured_at, 1, 10) AS day,
+                       b.current_balance AS current_balance,
+                       b.captured_at AS captured_at,
+                       b.account_id AS account_id
+                FROM balance_snapshots b
+                JOIN accounts a ON a.account_id = b.account_id
+                ORDER BY b.captured_at
+                """
+            ).fetchall()
+        # Keep the latest snapshot per (day, account).
+        latest: Dict[tuple, sqlite3.Row] = {}
+        for row in rows:
+            latest[(row["day"], row["account_id"])] = row
+        per_day: Dict[str, float] = {}
+        for (day, _account), row in latest.items():
+            balance = row["current_balance"]
+            if balance is None:
+                continue
+            signed = -abs(balance) if (row["type"] or "").lower() in _LIABILITY_TYPES else balance
+            per_day[day] = per_day.get(day, 0.0) + signed
+        points = [{"date": day, "net_worth": round(val, 2)} for day, val in sorted(per_day.items())]
+        return points[-limit_days:] if limit_days else points
+
+    # ------------------------------------------------------------------
+    # Transactions
+    # ------------------------------------------------------------------
+
+    def apply_transactions(
+        self,
+        item_id: str,
+        provider: str,
+        *,
+        added: Iterable[Dict[str, Any]] = (),
+        modified: Iterable[Dict[str, Any]] = (),
+        removed: Iterable[str] = (),
+    ) -> Dict[str, int]:
+        now = _utcnow()
+        conn = self._connection()
+        counts = {"added": 0, "modified": 0, "removed": 0}
+        with self._lock, conn:
+            for txn in added:
+                self._upsert_transaction(conn, item_id, provider, txn, now)
+                counts["added"] += 1
+            for txn in modified:
+                self._upsert_transaction(conn, item_id, provider, txn, now)
+                counts["modified"] += 1
+            for txn_id in removed:
+                if not txn_id:
+                    continue
+                conn.execute(
+                    "UPDATE transactions SET removed=1, removed_at=?, updated_at=? WHERE transaction_id=?",
+                    (now, now, txn_id),
+                )
+                counts["removed"] += 1
+        return counts
+
+    @staticmethod
+    def _upsert_transaction(
+        conn: sqlite3.Connection, item_id: str, provider: str, txn: Dict[str, Any], now: str
+    ) -> None:
+        transaction_id = txn.get("transaction_id")
+        if not transaction_id:
+            return
+        raw = txn.get("raw")
+        raw_json = json.dumps(raw, ensure_ascii=False) if raw is not None else None
+        conn.execute(
+            """
+            INSERT INTO transactions (transaction_id, account_id, item_id, provider, amount,
+                                      currency, date, datetime, name, merchant_name,
+                                      category_primary, category_detailed, pending,
+                                      payment_channel, removed, removed_at, raw,
+                                      first_seen_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL, ?, ?, ?)
+            ON CONFLICT(transaction_id) DO UPDATE SET
+                account_id=excluded.account_id,
+                amount=excluded.amount,
+                currency=excluded.currency,
+                date=excluded.date,
+                datetime=excluded.datetime,
+                name=excluded.name,
+                merchant_name=excluded.merchant_name,
+                category_primary=excluded.category_primary,
+                category_detailed=excluded.category_detailed,
+                pending=excluded.pending,
+                payment_channel=excluded.payment_channel,
+                removed=0,
+                removed_at=NULL,
+                raw=excluded.raw,
+                updated_at=excluded.updated_at
+            """,
+            (
+                transaction_id, txn.get("account_id"), item_id, provider,
+                _to_float(txn.get("amount")), txn.get("currency"), txn.get("date"),
+                txn.get("datetime"), txn.get("name"), txn.get("merchant_name"),
+                txn.get("category_primary"), txn.get("category_detailed"),
+                1 if txn.get("pending") else 0, txn.get("payment_channel"),
+                raw_json, now, now,
+            ),
+        )
+
+    def iter_transactions(
+        self,
+        *,
+        account_id: Optional[str] = None,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        search: Optional[str] = None,
+        include_pending: bool = True,
+        include_removed: bool = False,
+        limit: Optional[int] = None,
+        order: str = "date_desc",
+    ) -> List[Dict[str, Any]]:
+        conn = self._connection()
+        clauses, params = [], []
+        if not include_removed:
+            clauses.append("removed=0")
+        if account_id:
+            clauses.append("account_id=?")
+            params.append(account_id)
+        if start_date:
+            clauses.append("date >= ?")
+            params.append(start_date)
+        if end_date:
+            clauses.append("date <= ?")
+            params.append(end_date)
+        if not include_pending:
+            clauses.append("pending=0")
+        if search:
+            clauses.append("(LOWER(name) LIKE ? OR LOWER(merchant_name) LIKE ?)")
+            needle = f"%{search.lower()}%"
+            params.extend([needle, needle])
+        where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+        order_sql = {
+            "date_desc": "date DESC, datetime DESC",
+            "date_asc": "date ASC, datetime ASC",
+            "amount_desc": "ABS(amount) DESC",
+        }.get(order, "date DESC")
+        sql = f"SELECT * FROM transactions{where} ORDER BY {order_sql}"
+        if limit:
+            sql += " LIMIT ?"
+            params.append(int(limit))
+        with self._lock:
+            rows = conn.execute(sql, params).fetchall()
+        return [dict(r) for r in rows]
+
+    # ------------------------------------------------------------------
+    # Investments + liabilities
+    # ------------------------------------------------------------------
+
+    def upsert_securities(self, securities: Iterable[Dict[str, Any]]) -> int:
+        now = _utcnow()
+        conn = self._connection()
+        count = 0
+        with self._lock, conn:
+            for sec in securities:
+                security_id = sec.get("security_id")
+                if not security_id:
+                    continue
+                conn.execute(
+                    """
+                    INSERT INTO securities (security_id, name, ticker_symbol, type,
+                                            close_price, currency, updated_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(security_id) DO UPDATE SET
+                        name=excluded.name,
+                        ticker_symbol=excluded.ticker_symbol,
+                        type=excluded.type,
+                        close_price=excluded.close_price,
+                        currency=excluded.currency,
+                        updated_at=excluded.updated_at
+                    """,
+                    (
+                        security_id, sec.get("name"), sec.get("ticker_symbol"),
+                        sec.get("type"), _to_float(sec.get("close_price")),
+                        sec.get("currency"), now,
+                    ),
+                )
+                count += 1
+        return count
+
+    def upsert_holdings(self, item_id: str, provider: str, holdings: Iterable[Dict[str, Any]]) -> int:
+        now = _utcnow()
+        conn = self._connection()
+        count = 0
+        with self._lock, conn:
+            for holding in holdings:
+                account_id = holding.get("account_id")
+                security_id = holding.get("security_id")
+                if not account_id or not security_id:
+                    continue
+                conn.execute(
+                    """
+                    INSERT INTO holdings (account_id, security_id, item_id, provider, quantity,
+                                          cost_basis, institution_price, institution_value,
+                                          currency, updated_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(account_id, security_id) DO UPDATE SET
+                        item_id=excluded.item_id,
+                        provider=excluded.provider,
+                        quantity=excluded.quantity,
+                        cost_basis=excluded.cost_basis,
+                        institution_price=excluded.institution_price,
+                        institution_value=excluded.institution_value,
+                        currency=excluded.currency,
+                        updated_at=excluded.updated_at
+                    """,
+                    (
+                        account_id, security_id, item_id, provider,
+                        _to_float(holding.get("quantity")), _to_float(holding.get("cost_basis")),
+                        _to_float(holding.get("institution_price")),
+                        _to_float(holding.get("institution_value")),
+                        holding.get("currency"), now,
+                    ),
+                )
+                count += 1
+        return count
+
+    def get_holdings(self) -> List[Dict[str, Any]]:
+        conn = self._connection()
+        with self._lock:
+            rows = conn.execute(
+                """
+                SELECT h.*, s.name AS security_name, s.ticker_symbol AS ticker_symbol,
+                       s.type AS security_type, a.name AS account_name
+                FROM holdings h
+                LEFT JOIN securities s ON s.security_id = h.security_id
+                LEFT JOIN accounts a ON a.account_id = h.account_id
+                ORDER BY h.institution_value DESC
+                """
+            ).fetchall()
+        return [dict(r) for r in rows]
+
+    def upsert_liabilities(self, item_id: str, provider: str, liabilities: Iterable[Dict[str, Any]]) -> int:
+        now = _utcnow()
+        conn = self._connection()
+        count = 0
+        with self._lock, conn:
+            for liability in liabilities:
+                account_id = liability.get("account_id")
+                kind = liability.get("kind")
+                if not account_id or not kind:
+                    continue
+                detail = liability.get("detail")
+                detail_json = json.dumps(detail, ensure_ascii=False) if detail is not None else None
+                conn.execute(
+                    """
+                    INSERT INTO liabilities (account_id, kind, item_id, provider,
+                                             last_payment_amount, last_payment_date,
+                                             next_payment_due_date, minimum_payment_amount,
+                                             outstanding_balance, apr, detail, updated_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(account_id, kind) DO UPDATE SET
+                        item_id=excluded.item_id,
+                        provider=excluded.provider,
+                        last_payment_amount=excluded.last_payment_amount,
+                        last_payment_date=excluded.last_payment_date,
+                        next_payment_due_date=excluded.next_payment_due_date,
+                        minimum_payment_amount=excluded.minimum_payment_amount,
+                        outstanding_balance=excluded.outstanding_balance,
+                        apr=excluded.apr,
+                        detail=excluded.detail,
+                        updated_at=excluded.updated_at
+                    """,
+                    (
+                        account_id, kind, item_id, provider,
+                        _to_float(liability.get("last_payment_amount")),
+                        liability.get("last_payment_date"),
+                        liability.get("next_payment_due_date"),
+                        _to_float(liability.get("minimum_payment_amount")),
+                        _to_float(liability.get("outstanding_balance")),
+                        _to_float(liability.get("apr")), detail_json, now,
+                    ),
+                )
+                count += 1
+        return count
+
+    def get_liabilities(self) -> List[Dict[str, Any]]:
+        conn = self._connection()
+        with self._lock:
+            rows = conn.execute(
+                """
+                SELECT l.*, a.name AS account_name
+                FROM liabilities l
+                LEFT JOIN accounts a ON a.account_id = l.account_id
+                ORDER BY l.next_payment_due_date
+                """
+            ).fetchall()
+        result = []
+        for row in rows:
+            record = dict(row)
+            if record.get("detail"):
+                try:
+                    record["detail"] = json.loads(record["detail"])
+                except (TypeError, ValueError):
+                    pass
+            result.append(record)
+        return result
+
+    # ------------------------------------------------------------------
+    # Sync history
+    # ------------------------------------------------------------------
+
+    def record_sync_run(
+        self,
+        *,
+        item_id: Optional[str],
+        provider: str,
+        started_at: str,
+        finished_at: str,
+        status: str,
+        added: int = 0,
+        modified: int = 0,
+        removed: int = 0,
+        error: Optional[str] = None,
+    ) -> None:
+        conn = self._connection()
+        with self._lock, conn:
+            conn.execute(
+                """
+                INSERT INTO sync_runs (item_id, provider, started_at, finished_at, status,
+                                       added, modified, removed, error)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (item_id, provider, started_at, finished_at, status, added, modified, removed, error),
+            )
+
+    def last_sync_run(self) -> Optional[Dict[str, Any]]:
+        conn = self._connection()
+        with self._lock:
+            row = conn.execute(
+                "SELECT * FROM sync_runs ORDER BY id DESC LIMIT 1"
+            ).fetchone()
+        return dict(row) if row else None
+
+    # ------------------------------------------------------------------
+    # Merchant rules + category overrides
+    # ------------------------------------------------------------------
+
+    def add_merchant_rule(
+        self,
+        *,
+        pattern: str,
+        match_type: str = "substring",
+        normalized_name: Optional[str] = None,
+        category: Optional[str] = None,
+        priority: int = 100,
+    ) -> int:
+        conn = self._connection()
+        with self._lock, conn:
+            cur = conn.execute(
+                """
+                INSERT INTO merchant_rules (match_type, pattern, normalized_name, category,
+                                            priority, created_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (match_type, pattern, normalized_name, category, priority, _utcnow()),
+            )
+            return int(cur.lastrowid)
+
+    def list_merchant_rules(self) -> List[Dict[str, Any]]:
+        conn = self._connection()
+        with self._lock:
+            rows = conn.execute(
+                "SELECT * FROM merchant_rules ORDER BY priority, id"
+            ).fetchall()
+        return [dict(r) for r in rows]
+
+    def delete_merchant_rule(self, rule_id: int) -> bool:
+        conn = self._connection()
+        with self._lock, conn:
+            cur = conn.execute("DELETE FROM merchant_rules WHERE id=?", (rule_id,))
+            return cur.rowcount > 0
+
+    def set_category_override(self, *, scope: str, key: str, category: str) -> None:
+        conn = self._connection()
+        with self._lock, conn:
+            conn.execute(
+                """
+                INSERT INTO category_overrides (scope, key, category, created_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(scope, key) DO UPDATE SET category=excluded.category
+                """,
+                (scope, key.lower(), category, _utcnow()),
+            )
+
+    def list_category_overrides(self) -> List[Dict[str, Any]]:
+        conn = self._connection()
+        with self._lock:
+            rows = conn.execute("SELECT * FROM category_overrides").fetchall()
+        return [dict(r) for r in rows]

--- a/plugins/finance/tools.py
+++ b/plugins/finance/tools.py
@@ -1,0 +1,389 @@
+"""Gated, read-mostly ``finance_*`` model tools backed by the local store.
+
+All query tools read the local SQLite cache only — they never call a provider
+API, so the model can ask about balances, spending, net worth, cashflow, and
+holdings cheaply and offline. The single exception is ``finance_sync``, which
+explicitly refreshes data from the configured provider.
+
+The whole toolset is service-gated: it is only exposed when the active
+provider's credentials are configured AND at least one account is linked, so
+users who don't use finance pay zero schema/prompt-cache cost. Amounts honor
+``finance.privacy_mode`` — in ``summarized`` mode exact figures are bucketed
+before they ever reach the model. Access tokens are never loaded here.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Any, Dict, List, Optional
+
+from tools.registry import tool_error, tool_result
+
+from plugins.finance import categorize, privacy, settings
+from plugins.finance.errors import FinanceError
+from plugins.finance.provider import get_provider
+from plugins.finance.store import FinanceStore, default_db_path
+
+_TXN_DEFAULT_LIMIT = 50
+_TXN_MAX_LIMIT = 500
+
+
+# ---------------------------------------------------------------------------
+# Availability gate
+# ---------------------------------------------------------------------------
+
+def _check_finance_available() -> bool:
+    """True when the active provider is configured AND an account is linked.
+
+    Deliberately avoids creating ``finance.db`` as a side effect: if the file
+    doesn't exist there can be no linked items, so the tools stay hidden.
+    """
+    try:
+        if settings.get_provider_name() == "plaid":
+            from plugins.finance.plaid import auth
+
+            if not auth.credentials_present():
+                return False
+        path = default_db_path()
+        if not path.exists():
+            return False
+        store = FinanceStore(path)
+        try:
+            return bool(store.list_items())
+        finally:
+            store.close()
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mode() -> str:
+    return settings.get_privacy_mode()
+
+
+def _amt(value: Optional[float], currency: Optional[str], mode: str) -> Any:
+    """Return a numeric amount (full mode) or a bucket label (summarized)."""
+    if value is None:
+        return None
+    if privacy.is_summarized(mode):
+        return privacy.bucket_amount(value, currency)
+    return round(float(value), 2)
+
+
+def _resolve_range(args: Dict[str, Any], *, default_days: int) -> Dict[str, Optional[str]]:
+    start = (args.get("start_date") or "").strip() or None
+    end = (args.get("end_date") or "").strip() or None
+    if not start:
+        days = args.get("days")
+        days = int(days) if isinstance(days, (int, float, str)) and str(days).strip() else default_days
+        start = (date.today() - timedelta(days=max(1, days))).isoformat()
+    return {"start_date": start, "end_date": end}
+
+
+def _open_store() -> FinanceStore:
+    return FinanceStore()
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+def handle_finance_accounts(args: Dict[str, Any], **_kw: Any) -> str:
+    mode = _mode()
+    account_type = (args.get("account_type") or "").strip().lower()
+    store = _open_store()
+    try:
+        accounts = store.get_accounts()
+        net_worth = store.net_worth()
+    finally:
+        store.close()
+    rows = []
+    for acct in accounts:
+        if account_type and (acct.get("type") or "").lower() != account_type:
+            continue
+        currency = acct.get("currency")
+        rows.append({
+            "name": acct.get("name"),
+            "official_name": acct.get("official_name"),
+            "mask": acct.get("mask"),
+            "type": acct.get("type"),
+            "subtype": acct.get("subtype"),
+            "currency": currency,
+            "current_balance": _amt(acct.get("current_balance"), currency, mode),
+            "available_balance": _amt(acct.get("available_balance"), currency, mode),
+        })
+    net_view = {
+        cur: {k: _amt(v, cur, mode) for k, v in vals.items()}
+        for cur, vals in net_worth.items()
+    }
+    return tool_result({
+        "privacy_mode": mode,
+        "account_count": len(rows),
+        "accounts": rows,
+        "net_worth": net_view,
+    })
+
+
+def handle_finance_transactions(args: Dict[str, Any], **_kw: Any) -> str:
+    mode = _mode()
+    limit = args.get("limit")
+    try:
+        limit = int(limit) if limit else _TXN_DEFAULT_LIMIT
+    except (TypeError, ValueError):
+        limit = _TXN_DEFAULT_LIMIT
+    limit = max(1, min(limit, _TXN_MAX_LIMIT))
+    order = "amount_desc" if (args.get("sort") or "").strip().lower() in {"amount", "largest"} else "date_desc"
+    store = _open_store()
+    try:
+        txns = store.iter_transactions(
+            account_id=(args.get("account_id") or "").strip() or None,
+            start_date=(args.get("start_date") or "").strip() or None,
+            end_date=(args.get("end_date") or "").strip() or None,
+            search=(args.get("search") or "").strip() or None,
+            include_pending=bool(args.get("include_pending", True)),
+            limit=limit,
+            order=order,
+        )
+        categorizer = categorize.Categorizer(store)
+    finally:
+        store.close()
+    rows = []
+    for txn in txns:
+        currency = txn.get("currency")
+        rows.append({
+            "date": txn.get("date"),
+            "merchant": categorizer.normalize_merchant(txn),
+            "name": txn.get("name"),
+            "amount": _amt(txn.get("amount"), currency, mode),
+            "currency": currency,
+            "category": categorizer.resolve_category(txn),
+            "pending": bool(txn.get("pending")),
+        })
+    return tool_result({"privacy_mode": mode, "count": len(rows), "transactions": rows})
+
+
+def handle_finance_spending(args: Dict[str, Any], **_kw: Any) -> str:
+    mode = _mode()
+    date_range = _resolve_range(args, default_days=30)
+    include_transfers = bool(args.get("include_transfers", False))
+    store = _open_store()
+    try:
+        summary = categorize.spending_by_category(
+            store,
+            start_date=date_range["start_date"],
+            end_date=date_range["end_date"],
+            include_transfers=include_transfers,
+        )
+    finally:
+        store.close()
+    categories = [
+        {"category": row["category"], "amount": _amt(row["amount"], None, mode)}
+        for row in summary["categories"]
+    ]
+    return tool_result({
+        "privacy_mode": mode,
+        "start_date": summary["start_date"],
+        "end_date": summary["end_date"],
+        "transactions": summary["transactions"],
+        "total": _amt(summary["total"], None, mode),
+        "categories": categories,
+    })
+
+
+def handle_finance_net_worth(args: Dict[str, Any], **_kw: Any) -> str:
+    mode = _mode()
+    include_history = bool(args.get("include_history", False))
+    store = _open_store()
+    try:
+        net_worth = store.net_worth()
+        history = store.net_worth_history() if include_history else []
+    finally:
+        store.close()
+    net_view = {
+        cur: {k: _amt(v, cur, mode) for k, v in vals.items()}
+        for cur, vals in net_worth.items()
+    }
+    payload: Dict[str, Any] = {"privacy_mode": mode, "net_worth": net_view}
+    if include_history:
+        payload["history"] = [
+            {"date": point["date"], "net_worth": _amt(point["net_worth"], None, mode)}
+            for point in history
+        ]
+    return tool_result(payload)
+
+
+def handle_finance_cashflow(args: Dict[str, Any], **_kw: Any) -> str:
+    mode = _mode()
+    months = args.get("months")
+    try:
+        months = int(months) if months else 3
+    except (TypeError, ValueError):
+        months = 3
+    store = _open_store()
+    try:
+        result = categorize.cashflow(store, months=months)
+    finally:
+        store.close()
+    series = [
+        {
+            "month": row["month"],
+            "inflow": _amt(row["inflow"], None, mode),
+            "outflow": _amt(row["outflow"], None, mode),
+            "net": _amt(row["net"], None, mode),
+        }
+        for row in result["series"]
+    ]
+    return tool_result({"privacy_mode": mode, "months": result["months"], "series": series})
+
+
+def handle_finance_holdings(args: Dict[str, Any], **_kw: Any) -> str:
+    mode = _mode()
+    store = _open_store()
+    try:
+        holdings = store.get_holdings()
+    finally:
+        store.close()
+    rows = []
+    for holding in holdings:
+        currency = holding.get("currency")
+        rows.append({
+            "account": holding.get("account_name"),
+            "security": holding.get("security_name"),
+            "ticker": holding.get("ticker_symbol"),
+            "type": holding.get("security_type"),
+            "quantity": holding.get("quantity"),
+            "price": _amt(holding.get("institution_price"), currency, mode),
+            "value": _amt(holding.get("institution_value"), currency, mode),
+            "cost_basis": _amt(holding.get("cost_basis"), currency, mode),
+            "currency": currency,
+        })
+    return tool_result({"privacy_mode": mode, "count": len(rows), "holdings": rows})
+
+
+def handle_finance_sync(args: Dict[str, Any], **_kw: Any) -> str:
+    item_id = (args.get("item_id") or "").strip() or None
+    store = _open_store()
+    try:
+        provider = get_provider(settings.get_provider_name())
+        summary = provider.sync(store, item_id=item_id)
+    except FinanceError as exc:
+        store.close()
+        return tool_error(str(exc))
+    finally:
+        store.close()
+    return tool_result({"success": True, **summary})
+
+
+# ---------------------------------------------------------------------------
+# Schemas + registration table
+# ---------------------------------------------------------------------------
+
+FINANCE_ACCOUNTS_SCHEMA = {
+    "name": "finance_accounts",
+    "description": (
+        "List the user's linked financial accounts with their balances and a "
+        "net-worth summary, read from the local finance cache."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "account_type": {
+                "type": "string",
+                "description": "Optional filter: depository, credit, loan, investment, brokerage, other.",
+            },
+        },
+    },
+}
+
+FINANCE_TRANSACTIONS_SCHEMA = {
+    "name": "finance_transactions",
+    "description": (
+        "Query recent transactions from the local finance cache. Filter by "
+        "account, date range, or text search; sort by date or largest amount."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "account_id": {"type": "string", "description": "Restrict to one account id."},
+            "start_date": {"type": "string", "description": "ISO date (YYYY-MM-DD) lower bound."},
+            "end_date": {"type": "string", "description": "ISO date (YYYY-MM-DD) upper bound."},
+            "search": {"type": "string", "description": "Match merchant or description text."},
+            "include_pending": {"type": "boolean", "description": "Include pending transactions (default true)."},
+            "sort": {"type": "string", "enum": ["date", "amount"], "description": "Sort order (default date)."},
+            "limit": {"type": "integer", "description": f"Max rows (default {_TXN_DEFAULT_LIMIT}, max {_TXN_MAX_LIMIT})."},
+        },
+    },
+}
+
+FINANCE_SPENDING_SCHEMA = {
+    "name": "finance_spending",
+    "description": (
+        "Summarize spending by category over a date range (defaults to the "
+        "last 30 days). Transfers between the user's own accounts are excluded."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "days": {"type": "integer", "description": "Trailing window in days when no start_date is given."},
+            "start_date": {"type": "string", "description": "ISO date (YYYY-MM-DD) lower bound."},
+            "end_date": {"type": "string", "description": "ISO date (YYYY-MM-DD) upper bound."},
+            "include_transfers": {"type": "boolean", "description": "Include transfer/payment categories (default false)."},
+        },
+    },
+}
+
+FINANCE_NET_WORTH_SCHEMA = {
+    "name": "finance_net_worth",
+    "description": "Report total assets, liabilities, and net worth by currency, optionally with a daily trend.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "include_history": {"type": "boolean", "description": "Include the daily net-worth trend (default false)."},
+        },
+    },
+}
+
+FINANCE_CASHFLOW_SCHEMA = {
+    "name": "finance_cashflow",
+    "description": "Report monthly inflow, outflow, and net cashflow for the trailing months.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "months": {"type": "integer", "description": "Number of trailing months (default 3)."},
+        },
+    },
+}
+
+FINANCE_HOLDINGS_SCHEMA = {
+    "name": "finance_holdings",
+    "description": "List investment holdings (securities, quantities, and values) from linked investment accounts.",
+    "parameters": {"type": "object", "properties": {}},
+}
+
+FINANCE_SYNC_SCHEMA = {
+    "name": "finance_sync",
+    "description": (
+        "Refresh financial data from the configured provider into the local "
+        "cache. This is the only finance tool that contacts the provider."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "item_id": {"type": "string", "description": "Optional: sync only this linked item."},
+        },
+    },
+}
+
+# (tool_name, schema, handler, emoji)
+FINANCE_TOOLS = [
+    ("finance_accounts", FINANCE_ACCOUNTS_SCHEMA, handle_finance_accounts, "🏦"),
+    ("finance_transactions", FINANCE_TRANSACTIONS_SCHEMA, handle_finance_transactions, "🧾"),
+    ("finance_spending", FINANCE_SPENDING_SCHEMA, handle_finance_spending, "💸"),
+    ("finance_net_worth", FINANCE_NET_WORTH_SCHEMA, handle_finance_net_worth, "📈"),
+    ("finance_cashflow", FINANCE_CASHFLOW_SCHEMA, handle_finance_cashflow, "💵"),
+    ("finance_holdings", FINANCE_HOLDINGS_SCHEMA, handle_finance_holdings, "📊"),
+    ("finance_sync", FINANCE_SYNC_SCHEMA, handle_finance_sync, "🔄"),
+]

--- a/tests/plugins/test_finance_plugin.py
+++ b/tests/plugins/test_finance_plugin.py
@@ -1,0 +1,770 @@
+"""Tests for the bundled finance plugin (``plugins/finance/``).
+
+Covers the local SQLite store, privacy formatting, rules-first categorization,
+the Plaid REST client error mapping, secure token storage + Hosted Link
+onboarding, the cursor-based incremental sync engine (including the
+mid-pagination mutation restart), the gated ``finance_*`` tools, the
+``hermes finance`` CLI dispatch, and plugin registration.
+
+Everything is mocked — no live network, no real Plaid credentials.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import stat
+from unittest import mock
+
+import pytest
+
+from plugins.finance import categorize, privacy, settings
+from plugins.finance.errors import (
+    FinanceConfigError,
+    FinanceProviderError,
+    FinanceReauthRequiredError,
+)
+from plugins.finance.store import FinanceStore, default_db_path
+
+
+@pytest.fixture(autouse=True)
+def _finance_home(tmp_path, monkeypatch):
+    """Predictable, isolated HERMES_HOME for every finance test."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+def _store(tmp_path):
+    return FinanceStore(tmp_path / "finance.db")
+
+
+# ===========================================================================
+# Store
+# ===========================================================================
+
+def test_store_initializes_schema(tmp_path):
+    store = _store(tmp_path)
+    # No items / accounts in a fresh DB; queries return empty, not errors.
+    assert store.list_items() == []
+    assert store.get_accounts() == []
+    assert store.net_worth() == {}
+    store.close()
+
+
+def test_net_worth_assets_minus_liabilities(tmp_path):
+    store = _store(tmp_path)
+    store.upsert_item("i1", provider="plaid")
+    store.upsert_accounts("i1", "plaid", [
+        {"account_id": "a", "name": "Checking", "type": "depository", "currency": "USD", "current_balance": 5000.0},
+        {"account_id": "b", "name": "Card", "type": "credit", "currency": "USD", "current_balance": 1200.0},
+    ])
+    nw = store.net_worth()["USD"]
+    assert nw["assets"] == 5000.0
+    assert nw["liabilities"] == 1200.0
+    assert nw["net_worth"] == 3800.0
+    store.close()
+
+
+def test_transactions_append_only_tombstone(tmp_path):
+    store = _store(tmp_path)
+    store.upsert_item("i1", provider="plaid")
+    store.apply_transactions("i1", "plaid", added=[
+        {"transaction_id": "t1", "account_id": "a", "amount": 10.0, "date": "2026-06-01", "name": "Shop"},
+    ])
+    assert len(store.iter_transactions()) == 1
+    # Removing tombstones (does not hard-delete): excluded by default, visible
+    # when include_removed=True.
+    store.apply_transactions("i1", "plaid", removed=["t1"])
+    assert store.iter_transactions() == []
+    all_rows = store.iter_transactions(include_removed=True)
+    assert len(all_rows) == 1
+    assert all_rows[0]["removed"] == 1
+    assert all_rows[0]["removed_at"] is not None
+    store.close()
+
+
+def test_transactions_upsert_is_idempotent(tmp_path):
+    store = _store(tmp_path)
+    store.upsert_item("i1", provider="plaid")
+    txn = {"transaction_id": "t1", "account_id": "a", "amount": 10.0, "date": "2026-06-01", "name": "Shop"}
+    store.apply_transactions("i1", "plaid", added=[txn])
+    store.apply_transactions("i1", "plaid", modified=[{**txn, "amount": 12.5, "name": "Shop B"}])
+    rows = store.iter_transactions()
+    assert len(rows) == 1
+    assert rows[0]["amount"] == 12.5
+    assert rows[0]["name"] == "Shop B"
+    store.close()
+
+
+def test_balance_snapshots_feed_net_worth_history(tmp_path):
+    store = _store(tmp_path)
+    store.upsert_item("i1", provider="plaid")
+    store.upsert_accounts("i1", "plaid", [
+        {"account_id": "a", "name": "Checking", "type": "depository", "currency": "USD", "current_balance": 100.0},
+    ])
+    history = store.net_worth_history()
+    assert history and history[-1]["net_worth"] == 100.0
+    store.close()
+
+
+def test_holdings_and_liabilities_roundtrip(tmp_path):
+    store = _store(tmp_path)
+    store.upsert_item("i1", provider="plaid")
+    store.upsert_securities([{"security_id": "s1", "name": "ACME", "ticker_symbol": "ACME", "type": "equity"}])
+    store.upsert_holdings("i1", "plaid", [
+        {"account_id": "inv", "security_id": "s1", "quantity": 10, "institution_value": 1000.0, "institution_price": 100.0},
+    ])
+    holdings = store.get_holdings()
+    assert holdings[0]["security_name"] == "ACME"
+    assert holdings[0]["institution_value"] == 1000.0
+
+    store.upsert_liabilities("i1", "plaid", [
+        {"account_id": "c1", "kind": "credit", "minimum_payment_amount": 35.0,
+         "next_payment_due_date": "2026-07-01", "apr": 19.99, "detail": {"is_overdue": False}},
+    ])
+    liabilities = store.get_liabilities()
+    assert liabilities[0]["kind"] == "credit"
+    assert liabilities[0]["apr"] == 19.99
+    assert liabilities[0]["detail"] == {"is_overdue": False}
+    store.close()
+
+
+def test_merchant_rules_and_overrides_crud(tmp_path):
+    store = _store(tmp_path)
+    rule_id = store.add_merchant_rule(pattern="sbux", normalized_name="Starbucks", category="Coffee")
+    assert any(r["id"] == rule_id for r in store.list_merchant_rules())
+    store.set_category_override(scope="merchant", key="Starbucks", category="Treats")
+    overrides = {o["key"]: o["category"] for o in store.list_category_overrides()}
+    assert overrides["starbucks"] == "Treats"
+    assert store.delete_merchant_rule(rule_id) is True
+    store.close()
+
+
+# ===========================================================================
+# Privacy
+# ===========================================================================
+
+@pytest.mark.parametrize("value,expected", [
+    (0, "$0"),
+    (42, "<$100"),
+    (250, "$100-$500"),
+    (2500, "$2k-$5k"),
+    (1_500_000, "$1M+"),
+    (-2500, "-$2k-$5k"),
+])
+def test_bucket_amount(value, expected):
+    assert privacy.bucket_amount(value, "USD") == expected
+
+
+def test_format_money_modes():
+    assert privacy.format_money(2500.5, "USD", mode="full") == "$2,500.50"
+    assert privacy.format_money(2500.5, "USD", mode="summarized") == "$2k-$5k"
+    assert privacy.format_money(None, "USD") == "n/a"
+
+
+def test_non_usd_symbol():
+    assert privacy.bucket_amount(2500, "EUR") == "EUR 2k-EUR 5k"
+
+
+def test_normalize_mode():
+    assert privacy.normalize_mode("summary") == privacy.SUMMARIZED
+    assert privacy.normalize_mode("") == privacy.FULL
+    assert privacy.is_summarized("summarized") is True
+
+
+# ===========================================================================
+# Categorization
+# ===========================================================================
+
+def test_resolve_category_priority(tmp_path):
+    store = _store(tmp_path)
+    # Merchant rule + a Plaid category present.
+    store.add_merchant_rule(pattern="starbucks", category="Coffee")
+    txn = {"transaction_id": "t1", "merchant_name": "Starbucks", "category_primary": "FOOD_AND_DRINK"}
+    cat = categorize.Categorizer(store)
+    # Plaid category outranks the merchant rule (issue order).
+    assert cat.resolve_category(txn) == "FOOD_AND_DRINK"
+
+    # A user override outranks everything.
+    store.set_category_override(scope="merchant", key="Starbucks", category="Treats")
+    cat = categorize.Categorizer(store)
+    assert cat.resolve_category(txn) == "Treats"
+    store.close()
+
+
+def test_resolve_category_falls_back_to_rule_then_uncategorized(tmp_path):
+    store = _store(tmp_path)
+    store.add_merchant_rule(pattern="acme", category="Shopping")
+    cat = categorize.Categorizer(store)
+    assert cat.resolve_category({"transaction_id": "t", "name": "ACME STORE"}) == "Shopping"
+    assert cat.resolve_category({"transaction_id": "u", "name": "Mystery"}) == categorize.UNCATEGORIZED
+    store.close()
+
+
+def test_normalize_merchant_uses_rule(tmp_path):
+    store = _store(tmp_path)
+    store.add_merchant_rule(pattern="sq *coffee", normalized_name="Corner Coffee")
+    cat = categorize.Categorizer(store)
+    assert cat.normalize_merchant({"name": "SQ *COFFEE 123"}) == "Corner Coffee"
+    store.close()
+
+
+def test_spending_excludes_transfers(tmp_path):
+    store = _store(tmp_path)
+    store.upsert_item("i1", provider="plaid")
+    store.apply_transactions("i1", "plaid", added=[
+        {"transaction_id": "t1", "account_id": "a", "amount": 30.0, "date": "2026-06-01", "name": "Lunch", "category_primary": "FOOD_AND_DRINK"},
+        {"transaction_id": "t2", "account_id": "a", "amount": 100.0, "date": "2026-06-02", "name": "Move", "category_primary": "TRANSFER_OUT"},
+        {"transaction_id": "t3", "account_id": "a", "amount": -500.0, "date": "2026-06-03", "name": "Paycheck", "category_primary": "INCOME"},
+    ])
+    summary = categorize.spending_by_category(store, start_date="2026-05-01")
+    cats = {c["category"]: c["amount"] for c in summary["categories"]}
+    assert cats == {"FOOD_AND_DRINK": 30.0}  # transfer + income (negative) excluded
+    assert summary["total"] == 30.0
+
+    summary_inc = categorize.spending_by_category(store, start_date="2026-05-01", include_transfers=True)
+    assert "TRANSFER_OUT" in {c["category"] for c in summary_inc["categories"]}
+    store.close()
+
+
+def test_cashflow_buckets_by_month(tmp_path):
+    store = _store(tmp_path)
+    store.upsert_item("i1", provider="plaid")
+    store.apply_transactions("i1", "plaid", added=[
+        {"transaction_id": "t1", "account_id": "a", "amount": -2000.0, "date": "2026-06-01", "name": "Pay"},
+        {"transaction_id": "t2", "account_id": "a", "amount": 500.0, "date": "2026-06-15", "name": "Rent"},
+    ])
+    result = categorize.cashflow(store, months=12)
+    june = next(row for row in result["series"] if row["month"] == "2026-06")
+    assert june["inflow"] == 2000.0
+    assert june["outflow"] == 500.0
+    assert june["net"] == 1500.0
+    store.close()
+
+
+# ===========================================================================
+# Plaid client (error mapping)
+# ===========================================================================
+
+class _FakeResp:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def _client():
+    from plugins.finance.plaid.client import PlaidClient
+
+    return PlaidClient("cid", "secret", environment="sandbox")
+
+
+def test_client_requires_credentials():
+    from plugins.finance.plaid.client import PlaidClient
+
+    with pytest.raises(FinanceConfigError):
+        PlaidClient("", "", environment="sandbox")
+
+
+def test_client_base_url_by_environment():
+    from plugins.finance.plaid.client import PlaidClient
+
+    assert PlaidClient("c", "s", environment="sandbox").base_url.endswith("sandbox.plaid.com")
+    assert PlaidClient("c", "s", environment="production").base_url.endswith("production.plaid.com")
+
+
+def test_client_success():
+    with mock.patch("plugins.finance.plaid.client.httpx.post", return_value=_FakeResp(200, {"ok": True})):
+        assert _client()._post("/x", {"a": 1}) == {"ok": True}
+
+
+def test_client_maps_reauth_error():
+    payload = {"error_code": "ITEM_LOGIN_REQUIRED", "error_message": "login"}
+    with mock.patch("plugins.finance.plaid.client.httpx.post", return_value=_FakeResp(400, payload)):
+        with pytest.raises(FinanceReauthRequiredError):
+            _client()._post("/x")
+
+
+def test_client_maps_config_error():
+    payload = {"error_code": "INVALID_API_KEYS", "error_message": "bad keys"}
+    with mock.patch("plugins.finance.plaid.client.httpx.post", return_value=_FakeResp(400, payload)):
+        with pytest.raises(FinanceConfigError):
+            _client()._post("/x")
+
+
+def test_client_maps_generic_error_with_code():
+    payload = {"error_code": "RATE_LIMIT_EXCEEDED", "error_message": "slow down", "request_id": "r1"}
+    with mock.patch("plugins.finance.plaid.client.httpx.post", return_value=_FakeResp(429, payload)):
+        with pytest.raises(FinanceProviderError) as exc:
+            _client()._post("/x")
+    assert exc.value.error_code == "RATE_LIMIT_EXCEEDED"
+    assert exc.value.request_id == "r1"
+
+
+# ===========================================================================
+# Plaid auth (token storage + onboarding)
+# ===========================================================================
+
+def test_token_storage_roundtrip_and_perms():
+    from plugins.finance.plaid import auth
+
+    auth.save_item_token("itm1", "access-secret", institution_name="Bank", environment="sandbox")
+    assert auth.get_access_token("itm1") == "access-secret"
+
+    # Metadata listing must NOT leak the access token.
+    items = auth.list_token_items()
+    assert items[0]["item_id"] == "itm1"
+    assert "access_token" not in items[0]
+
+    # File is 0600.
+    if os.name == "posix":
+        mode = stat.S_IMODE(os.stat(auth.token_store_path()).st_mode)
+        assert mode == 0o600
+
+    assert auth.remove_item_token("itm1") is True
+    assert auth.get_access_token("itm1") is None
+
+
+def test_credentials_present(monkeypatch):
+    from plugins.finance.plaid import auth
+
+    monkeypatch.delenv("PLAID_CLIENT_ID", raising=False)
+    monkeypatch.delenv("PLAID_SECRET", raising=False)
+    assert auth.credentials_present() is False
+    monkeypatch.setenv("PLAID_CLIENT_ID", "cid")
+    monkeypatch.setenv("PLAID_SECRET", "secret")
+    assert auth.credentials_present() is True
+    assert auth.get_plaid_credentials() == ("cid", "secret")
+
+
+def test_extract_and_poll_public_token():
+    from plugins.finance.plaid import auth
+
+    completed = {"link_sessions": [{"results": {"item_add_results": [{"public_token": "pub-123"}]}}]}
+    assert auth._extract_public_token(completed) == "pub-123"
+    assert auth._extract_public_token({"link_sessions": []}) is None
+
+    class _LinkClient:
+        def __init__(self):
+            self.calls = 0
+
+        def link_token_get(self, link_token):
+            self.calls += 1
+            return completed if self.calls >= 2 else {"link_sessions": []}
+
+    client = _LinkClient()
+    token = auth.poll_for_public_token(client, "lt", timeout=10, interval=0, sleep=lambda *_: None)
+    assert token == "pub-123"
+
+
+# ===========================================================================
+# Plaid provider (sync engine)
+# ===========================================================================
+
+class FakePlaidClient:
+    """Cursor-keyed fake of the Plaid REST client for sync tests."""
+
+    def __init__(self, *, pages, balance, holdings=None, liabilities=None,
+                 holdings_error=None, liabilities_error=None, mutation_cursors=()):
+        self.pages = pages  # {cursor_or_None: response_dict}
+        self.balance = balance
+        self.holdings = holdings or {"holdings": [], "securities": []}
+        self.liabilities = liabilities or {"liabilities": {}}
+        self.holdings_error = holdings_error
+        self.liabilities_error = liabilities_error
+        self._mutation_cursors = set(mutation_cursors)
+        self.removed_called = False
+
+    def accounts_balance_get(self, access_token):
+        return self.balance
+
+    def transactions_sync(self, access_token, *, cursor=None, count=500):
+        if cursor in self._mutation_cursors:
+            self._mutation_cursors.discard(cursor)
+            raise FinanceProviderError(
+                "mutation", error_code="TRANSACTIONS_SYNC_MUTATION_DURING_PAGINATION"
+            )
+        return self.pages[cursor]
+
+    def investments_holdings_get(self, access_token):
+        if self.holdings_error:
+            raise self.holdings_error
+        return self.holdings
+
+    def liabilities_get(self, access_token):
+        if self.liabilities_error:
+            raise self.liabilities_error
+        return self.liabilities
+
+    def item_remove(self, access_token):
+        self.removed_called = True
+        return {}
+
+
+def _balance_payload():
+    return {"accounts": [
+        {"account_id": "a1", "name": "Checking", "type": "depository", "subtype": "checking",
+         "balances": {"current": 2500.0, "available": 2400.0, "iso_currency_code": "USD"}},
+    ]}
+
+
+def _txn(tid, amount=10.0):
+    return {"transaction_id": tid, "account_id": "a1", "amount": amount, "date": "2026-06-01",
+            "name": f"txn-{tid}", "personal_finance_category": {"primary": "GENERAL_MERCHANDISE"}}
+
+
+def test_provider_sync_paginates_and_persists(tmp_path):
+    from plugins.finance.plaid import auth
+    from plugins.finance.plaid.provider import PlaidProvider
+
+    auth.save_item_token("item1", "tok", environment="sandbox")
+    pages = {
+        None: {"added": [_txn("A")], "modified": [], "removed": [], "next_cursor": "c1", "has_more": True},
+        "c1": {"added": [_txn("B")], "modified": [], "removed": [], "next_cursor": "c2", "has_more": False},
+    }
+    fake = FakePlaidClient(pages=pages, balance=_balance_payload())
+    store = _store(tmp_path)
+    provider = PlaidProvider(environment="sandbox")
+    summary = provider.sync(store, item_id="item1", client=fake)
+
+    assert summary["totals"]["added"] == 2
+    assert summary["totals"]["accounts"] == 1
+    assert store.get_item_cursor("item1") == "c2"
+    assert {t["transaction_id"] for t in store.iter_transactions()} == {"A", "B"}
+    store.close()
+
+
+def test_provider_sync_restarts_on_mutation(tmp_path):
+    from plugins.finance.plaid import auth
+    from plugins.finance.plaid.provider import PlaidProvider
+
+    auth.save_item_token("item1", "tok", environment="sandbox")
+    pages = {
+        None: {"added": [_txn("A")], "modified": [], "removed": [], "next_cursor": "c1", "has_more": True},
+        "c1": {"added": [_txn("B")], "modified": [], "removed": [], "next_cursor": "c2", "has_more": False},
+    }
+    # Raise a mutation error the first time we request cursor c1; the loop must
+    # restart from the original cursor and not double-count "A".
+    fake = FakePlaidClient(pages=pages, balance=_balance_payload(), mutation_cursors={"c1"})
+    store = _store(tmp_path)
+    provider = PlaidProvider(environment="sandbox")
+    summary = provider.sync(store, item_id="item1", client=fake)
+
+    assert summary["totals"]["added"] == 2
+    assert {t["transaction_id"] for t in store.iter_transactions()} == {"A", "B"}
+    store.close()
+
+
+def test_provider_sync_optional_products_are_best_effort(tmp_path):
+    from plugins.finance.plaid import auth
+    from plugins.finance.plaid.provider import PlaidProvider
+
+    auth.save_item_token("item1", "tok", environment="sandbox")
+    pages = {None: {"added": [], "modified": [], "removed": [], "next_cursor": "c1", "has_more": False}}
+    fake = FakePlaidClient(
+        pages=pages, balance=_balance_payload(),
+        holdings_error=FinanceProviderError("no inv", error_code="NO_INVESTMENT_ACCOUNTS"),
+        liabilities_error=FinanceProviderError("no liab", error_code="PRODUCTS_NOT_SUPPORTED"),
+    )
+    store = _store(tmp_path)
+    provider = PlaidProvider(environment="sandbox")
+    summary = provider.sync(store, item_id="item1", client=fake)
+    item_summary = summary["items"][0]
+    assert item_summary["status"] == "ok"
+    assert item_summary["holdings"] == 0
+    assert item_summary["liabilities"] == 0
+    store.close()
+
+
+def test_provider_sync_records_error_when_no_token(tmp_path):
+    from plugins.finance.plaid.provider import PlaidProvider
+
+    store = _store(tmp_path)
+    provider = PlaidProvider(environment="sandbox")
+    # No saved token for this item id.
+    summary = provider.sync(store, item_id="ghost", client=FakePlaidClient(pages={}, balance={}))
+    assert summary["items"][0]["status"] == "error"
+    assert store.last_sync_run()["status"] == "error"
+    store.close()
+
+
+def test_provider_disconnect_revokes_and_marks(tmp_path, monkeypatch):
+    from plugins.finance.plaid import auth
+    from plugins.finance.plaid import provider as provider_mod
+    from plugins.finance.plaid.provider import PlaidProvider
+
+    auth.save_item_token("item1", "tok", environment="sandbox")
+    store = _store(tmp_path)
+    store.upsert_item("item1", provider="plaid")
+    fake = FakePlaidClient(pages={}, balance={})
+    monkeypatch.setattr(provider_mod.auth, "build_client", lambda env: fake)
+
+    result = PlaidProvider(environment="sandbox").disconnect(store, "item1")
+    assert result["revoked"] is True
+    assert fake.removed_called is True
+    assert auth.get_access_token("item1") is None
+    assert store.get_item("item1")["status"] == "disconnected"
+    store.close()
+
+
+def test_provider_status_reports_items(tmp_path):
+    from plugins.finance.plaid import auth
+    from plugins.finance.plaid.provider import PlaidProvider
+
+    auth.save_item_token("item1", "tok", institution_name="Bank", environment="sandbox")
+    store = _store(tmp_path)
+    store.upsert_item("item1", provider="plaid", institution_name="Bank", environment="sandbox")
+    status = PlaidProvider(environment="sandbox").status(store)
+    assert status["items"][0]["item_id"] == "item1"
+    assert status["items"][0]["credential_present"] is True
+    store.close()
+
+
+# ===========================================================================
+# Tools (gating + privacy)
+# ===========================================================================
+
+def _seed_default_store():
+    store = FinanceStore()  # default (isolated HERMES_HOME) path
+    store.upsert_item("item1", provider="plaid", institution_name="Bank", environment="sandbox")
+    store.upsert_accounts("item1", "plaid", [
+        {"account_id": "a1", "name": "Checking", "type": "depository", "currency": "USD", "current_balance": 2500.0, "available_balance": 2400.0},
+        {"account_id": "c1", "name": "Card", "type": "credit", "currency": "USD", "current_balance": 800.0},
+    ])
+    store.apply_transactions("item1", "plaid", added=[
+        {"transaction_id": "t1", "account_id": "a1", "amount": 54.2, "date": "2026-06-01", "name": "Coffee", "merchant_name": "Starbucks", "category_primary": "FOOD_AND_DRINK"},
+        {"transaction_id": "t2", "account_id": "a1", "amount": -2000.0, "date": "2026-06-02", "name": "Payroll", "category_primary": "INCOME"},
+    ])
+    store.close()
+
+
+def test_tool_gate_requires_creds_and_items(monkeypatch):
+    from plugins.finance import tools
+
+    monkeypatch.delenv("PLAID_CLIENT_ID", raising=False)
+    monkeypatch.delenv("PLAID_SECRET", raising=False)
+    # No creds, no db.
+    assert tools._check_finance_available() is False
+
+    monkeypatch.setenv("PLAID_CLIENT_ID", "cid")
+    monkeypatch.setenv("PLAID_SECRET", "sec")
+    # Creds present but no linked items yet -> still hidden.
+    assert tools._check_finance_available() is False
+
+    _seed_default_store()
+    assert tools._check_finance_available() is True
+
+
+def test_tool_accounts_full_and_summarized(monkeypatch):
+    from plugins.finance import tools
+
+    _seed_default_store()
+    payload = json.loads(tools.handle_finance_accounts({}))
+    assert payload["account_count"] == 2
+    assert payload["net_worth"]["USD"]["net_worth"] == 1700.0  # 2500 - 800
+
+    monkeypatch.setattr(settings, "get_privacy_mode", lambda: "summarized")
+    summarized = json.loads(tools.handle_finance_accounts({}))
+    assert summarized["privacy_mode"] == "summarized"
+    assert summarized["net_worth"]["USD"]["net_worth"] == "$1k-$2k"
+    # No raw float leaks in summarized mode.
+    assert isinstance(summarized["accounts"][0]["current_balance"], str)
+
+
+def test_tool_transactions_and_spending(monkeypatch):
+    from plugins.finance import tools
+
+    _seed_default_store()
+    txns = json.loads(tools.handle_finance_transactions({"limit": 10}))
+    assert txns["count"] == 2
+    assert txns["transactions"][0]["category"] in {"FOOD_AND_DRINK", "INCOME"}
+
+    spending = json.loads(tools.handle_finance_spending({"start_date": "2026-05-01"}))
+    cats = {c["category"]: c["amount"] for c in spending["categories"]}
+    assert cats == {"FOOD_AND_DRINK": 54.2}  # income (negative) + no transfers
+
+
+def test_tool_cashflow_and_net_worth_history():
+    from plugins.finance import tools
+
+    _seed_default_store()
+    cashflow = json.loads(tools.handle_finance_cashflow({"months": 12}))
+    assert any(row["month"] == "2026-06" for row in cashflow["series"])
+
+    nw = json.loads(tools.handle_finance_net_worth({"include_history": True}))
+    assert nw["net_worth"]["USD"]["net_worth"] == 1700.0
+    assert isinstance(nw["history"], list)
+
+
+def test_tool_sync_invokes_provider(monkeypatch):
+    from plugins.finance import tools
+
+    _seed_default_store()
+
+    class _FakeProvider:
+        def sync(self, store, *, item_id=None, **kw):
+            return {"provider": "plaid", "items_synced": 1, "totals": {"added": 3}}
+
+    monkeypatch.setattr(tools, "get_provider", lambda name: _FakeProvider())
+    result = json.loads(tools.handle_finance_sync({}))
+    assert result["success"] is True
+    assert result["items_synced"] == 1
+
+
+def test_tool_sync_surfaces_finance_error(monkeypatch):
+    from plugins.finance import tools
+
+    _seed_default_store()
+
+    class _BadProvider:
+        def sync(self, store, *, item_id=None, **kw):
+            raise FinanceConfigError("not configured")
+
+    monkeypatch.setattr(tools, "get_provider", lambda name: _BadProvider())
+    result = json.loads(tools.handle_finance_sync({}))
+    assert "error" in result
+
+
+# ===========================================================================
+# CLI dispatch
+# ===========================================================================
+
+def _finance_parser():
+    from plugins.finance.cli import register_cli
+
+    parser = argparse.ArgumentParser()
+    subs = parser.add_subparsers(dest="cmd")
+    finance = subs.add_parser("finance")
+    register_cli(finance)
+    return parser
+
+
+def test_cli_disconnect_positional_parsing():
+    parser = _finance_parser()
+    args = parser.parse_args(["finance", "disconnect", "plaid", "item-9", "--purge"])
+    assert args.provider == "plaid"
+    assert args.item_id == "item-9"
+    assert args.purge is True
+    # Provider defaults to plaid when only the item id is supplied.
+    args2 = parser.parse_args(["finance", "disconnect", "item-9"])
+    assert args2.provider == "plaid"
+    assert args2.item_id == "item-9"
+
+
+def test_cli_status_dispatch(monkeypatch, capsys):
+    from plugins.finance import cli
+
+    class _FakeProvider:
+        def status(self, store):
+            return {"items": [{"item_id": "i1", "institution_name": "Bank", "environment": "sandbox", "status": "active", "accounts": 2}]}
+
+    monkeypatch.setattr(cli, "get_provider", lambda name: _FakeProvider())
+    parser = _finance_parser()
+    args = parser.parse_args(["finance", "status", "plaid"])
+    assert args.func(args) == 0
+    assert "Bank" in capsys.readouterr().out
+
+
+def test_cli_accounts_reads_store(capsys):
+    from plugins.finance import cli
+
+    _seed_default_store()
+    parser = _finance_parser()
+    args = parser.parse_args(["finance", "accounts"])
+    assert args.func(args) == 0
+    out = capsys.readouterr().out
+    assert "Checking" in out
+    assert "Net worth" in out
+
+
+def test_cli_connect_sandbox(monkeypatch, capsys):
+    from plugins.finance import cli
+
+    class _FakeProvider:
+        def connect(self, **kwargs):
+            return {"status": "linked", "provider": "plaid", "item_id": "i1"}
+
+    monkeypatch.setattr(cli, "get_provider", lambda name: _FakeProvider())
+    parser = _finance_parser()
+    args = parser.parse_args(["finance", "connect", "plaid", "--sandbox", "--no-sync"])
+    assert args.func(args) == 0
+    assert "linked" in capsys.readouterr().out
+
+
+def test_cli_missing_credentials_prints_hint(monkeypatch, capsys):
+    from plugins.finance import cli
+
+    def _raise(name):
+        raise FinanceConfigError("Plaid is not configured.")
+
+    monkeypatch.setattr(cli, "get_provider", _raise)
+    parser = _finance_parser()
+    args = parser.parse_args(["finance", "sync", "plaid"])
+    assert args.func(args) == 1
+    out = capsys.readouterr().out
+    assert "PLAID_CLIENT_ID" in out
+
+
+# ===========================================================================
+# Plugin registration
+# ===========================================================================
+
+def test_register_wires_cli_and_tools():
+    import plugins.finance as finance_plugin
+
+    class _Ctx:
+        def __init__(self):
+            self.tools = []
+            self.cli_command = None
+
+        def register_tool(self, **kwargs):
+            self.tools.append(kwargs["name"])
+
+        def register_cli_command(self, **kwargs):
+            self.cli_command = kwargs["name"]
+
+    ctx = _Ctx()
+    finance_plugin.register(ctx)
+    assert ctx.cli_command == "finance"
+    assert set(ctx.tools) == {
+        "finance_accounts", "finance_transactions", "finance_spending",
+        "finance_net_worth", "finance_cashflow", "finance_holdings", "finance_sync",
+    }
+
+
+def test_config_defaults_have_finance_section():
+    from hermes_cli.config import DEFAULT_CONFIG, OPTIONAL_ENV_VARS
+
+    finance = DEFAULT_CONFIG["finance"]
+    assert finance["provider"] == "plaid"
+    assert finance["plaid"]["environment"] == "sandbox"
+    assert finance["privacy_mode"] == "full"
+    assert "PLAID_CLIENT_ID" in OPTIONAL_ENV_VARS
+    assert "PLAID_SECRET" in OPTIONAL_ENV_VARS
+
+
+def test_finance_is_configurable_and_default_off():
+    from hermes_cli.tools_config import CONFIGURABLE_TOOLSETS, _DEFAULT_OFF_TOOLSETS
+
+    keys = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS}
+    assert "finance" in keys
+    assert "finance" in _DEFAULT_OFF_TOOLSETS
+
+
+def test_finance_setup_category_prompts_for_plaid_keys():
+    """Enabling finance in `hermes tools` must surface the Plaid credential
+    prompts, like spotify/homeassistant — not silently toggle on with no setup."""
+    from hermes_cli.tools_config import TOOL_CATEGORIES
+
+    entry = TOOL_CATEGORIES["finance"]
+    prompted = {
+        ev["key"]
+        for provider in entry["providers"]
+        for ev in provider.get("env_vars", [])
+    }
+    assert {"PLAID_CLIENT_ID", "PLAID_SECRET"} <= prompted

--- a/toolsets.py
+++ b/toolsets.py
@@ -317,6 +317,21 @@ TOOLSETS = {
         "includes": []
     },
 
+    "finance": {
+        "description": (
+            "Personal finance (Plaid): query account balances, transactions, "
+            "spending by category, net worth, cashflow, and holdings from a "
+            "local cache, plus an explicit refresh. Off by default; enable in "
+            "`hermes tools` once Plaid is configured and an account is linked."
+        ),
+        "tools": [
+            "finance_accounts", "finance_transactions", "finance_spending",
+            "finance_net_worth", "finance_cashflow", "finance_holdings",
+            "finance_sync",
+        ],
+        "includes": []
+    },
+
 
     # Scenario-specific toolsets
     

--- a/website/docs/user-guide/features/built-in-plugins.md
+++ b/website/docs/user-guide/features/built-in-plugins.md
@@ -61,6 +61,7 @@ The repo ships these bundled plugins under `plugins/`. All are opt-in — enable
 | `observability/nemo_relay` | hooks | Relay observability events (turns / LLM calls / tools) to an NVIDIA NeMo endpoint |
 | `teams_pipeline` | standalone | Microsoft Teams meeting pipeline — Graph-backed, transcript-first meeting summaries |
 | `spotify` | backend (7 tools) | Native Spotify playback, queue, search, playlists, albums, library |
+| `finance` | backend (7 tools) | Provider-agnostic personal finance (Plaid) — balances, transactions, spending, net worth, cashflow, holdings over a local SQLite cache. See [Personal Finance](./finance.md). |
 | `google_meet` | standalone | Join Meet calls, live-caption transcription, optional realtime duplex audio |
 | `image_gen/openai` | image backend | OpenAI `gpt-image-2` image generation backend (alternative to FAL) |
 | `image_gen/openai-codex` | image backend | OpenAI image generation via Codex OAuth |

--- a/website/docs/user-guide/features/finance.md
+++ b/website/docs/user-guide/features/finance.md
@@ -1,0 +1,187 @@
+# Personal Finance (Plaid)
+
+Hermes can read your real financial accounts — balances, transactions, spending by category, net worth, cashflow, and investment holdings — through [Plaid](https://plaid.com). Everything is stored **locally** in a SQLite database under your Hermes home; nothing about your finances leaves your machine unless you explicitly ask the agent to send it somewhere.
+
+The integration is provider-agnostic by design (Plaid is the first backend), exposed two ways:
+
+- A `hermes finance` CLI for connecting institutions and refreshing data.
+- A gated `finance` toolset (`finance_*`) the agent uses to answer questions from the local cache.
+
+The model tools are **off by default** and only appear once Plaid is configured and at least one account is linked — so users who don't use finance never ship finance tool schemas on every API call.
+
+## Prerequisites
+
+- A **Plaid account** with a client id and a secret. Sign up at [plaid.com](https://plaid.com); the free Sandbox tier is enough to try everything end-to-end with fake banks.
+- Hermes Agent installed and running.
+- For real bank data: a Plaid environment that allows production access. Plaid ships two environments — `sandbox` (fake test data) and `production` (your real banks). Start in sandbox.
+
+## Setup
+
+### 1. Add your Plaid keys (secrets)
+
+Plaid credentials are secrets, so they live in `~/.hermes/.env`:
+
+```
+PLAID_CLIENT_ID=...
+PLAID_SECRET=...
+```
+
+Get both from the [Plaid dashboard → Keys](https://dashboard.plaid.com/developers/keys). The secret is environment-specific — use your **sandbox** secret while testing.
+
+### 2. Choose the environment (non-secret)
+
+Everything that isn't a secret lives in `config.yaml` under `finance`:
+
+```yaml
+finance:
+  provider: plaid
+  privacy_mode: full        # full | summarized
+  sync_interval: 6h
+  plaid:
+    environment: sandbox    # sandbox | production
+    webhook_url: ""         # optional
+  categorization:
+    llm_fallback: false
+```
+
+### 3. Enable the toolset
+
+```bash
+hermes tools
+```
+
+Scroll to `💰 Personal Finance`, press space to toggle it on, then `s` to save. The finance tools stay opt-in; this is what surfaces them to the agent.
+
+## Connecting an account
+
+Hermes uses Plaid's [Hosted Link](https://plaid.com/docs/link/hosted-link/) flow: it creates a link token, hands you a URL to open in your browser, and polls until you finish — no local web server or redirect handling required.
+
+```bash
+hermes finance connect plaid
+```
+
+Hermes prints (and opens) a Plaid Link URL. Pick your institution and sign in there; when you finish, Hermes exchanges the result for an access token, stores it securely, and runs an initial sync.
+
+### Try it with fake data first
+
+The sandbox connects instantly with a test bank — no real credentials, no browser:
+
+```bash
+hermes finance connect plaid --sandbox
+```
+
+This links Plaid's "First Platypus Bank" test institution and syncs sample accounts and transactions so you can explore the tools immediately.
+
+### Useful flags
+
+| Flag | Purpose |
+|------|---------|
+| `--sandbox` | Link an instant test item (sandbox data). |
+| `--products a,b` | Comma-separated Plaid products (default: `transactions`). Add `liabilities`, `investments`, etc. |
+| `--timeout N` | Seconds to wait for you to finish Link (default 300). |
+| `--no-sync` | Skip the initial sync after linking. |
+| `--no-browser` | Print the Link URL but don't auto-open a browser (SSH/headless). |
+
+## Privacy
+
+Local by default — the SQLite cache lives under your Hermes home and access tokens are stored separately in a `0600` file (`finance/plaid_tokens.json`), never in the database, never in `.env`, and **never returned to the model**.
+
+`privacy_mode` controls what the agent's tools can see:
+
+- `full` (default) — exact figures (`$2,431.18`).
+- `summarized` — values are bucketed into ranges (`$2k-$5k`) *before* they ever enter a tool result, so the agent can reason about magnitude and trends without ingesting exact balances.
+
+The `hermes finance` CLI always shows exact figures — it's you looking at your own data on your own terminal. Privacy buckets apply only to the model-facing tools.
+
+## Using it
+
+Once an account is linked, talk to the agent naturally — it picks the right tool:
+
+```
+> what's my current net worth
+> how much did I spend on restaurants last month
+> show my five largest transactions this week
+> what's my monthly cashflow over the last 3 months
+> list my investment holdings
+> refresh my accounts
+```
+
+### Tool reference
+
+All query tools read the **local cache only** — they never call Plaid. The one exception is `finance_sync`.
+
+| Tool | Purpose |
+|------|---------|
+| `finance_accounts` | List linked accounts with balances and a net-worth summary. |
+| `finance_transactions` | Query transactions (filter by account, date range, text search; sort by date or largest). |
+| `finance_spending` | Spending by category over a window (default 30 days); excludes transfers. |
+| `finance_net_worth` | Total assets, liabilities, and net worth by currency, optionally with a daily trend. |
+| `finance_cashflow` | Monthly inflow / outflow / net for the trailing months. |
+| `finance_holdings` | Investment positions (security, quantity, value). |
+| `finance_sync` | Refresh data from the provider into the local cache (the only tool that contacts Plaid). |
+
+## Categorization (rules-first)
+
+Each transaction's category is resolved cheaply, with no LLM on the hot path, in this order:
+
+1. **Your override** for that transaction or merchant (an override always wins).
+2. **Plaid's category**.
+3. **A local merchant rule** (substring / exact / regex match → category and/or a normalized display name).
+4. **Optional LLM fallback** — off by default; only ever runs for otherwise-uncategorized transactions.
+5. `Uncategorized`.
+
+## CLI reference
+
+```bash
+hermes finance connect [plaid] [--sandbox] [--products ...] [--timeout N] [--no-sync] [--no-browser]
+hermes finance sync [plaid] [--item-id ID]
+hermes finance status [plaid]
+hermes finance accounts [plaid]
+hermes finance transactions [plaid] [--days N] [--limit N] [--account-id ID] [--search TEXT]
+hermes finance disconnect [plaid] <item_id> [--purge]
+```
+
+`disconnect` revokes the item with Plaid and removes its access token. Cached data is kept for history unless you pass `--purge`.
+
+## Incremental sync
+
+Transactions use Plaid's cursor-based [`/transactions/sync`](https://plaid.com/docs/api/products/transactions/#transactionssync): the first sync pulls everything, later syncs pull only the delta. Hermes paginates fully and only writes after the final page, so a mid-pagination data mutation can't leave a partial write — on `TRANSACTIONS_SYNC_MUTATION_DURING_PAGINATION` the sync restarts from the cursor it began with. Removed transactions are **tombstoned**, never hard-deleted, so history and prior answers stay reproducible.
+
+## Scheduling: finance + cron
+
+Because `hermes finance sync` is a plain command, you can keep the cache fresh on a schedule:
+
+```bash
+hermes cron add --name "finance-refresh" "0 */6 * * *" \
+  --script "hermes finance sync" --no-agent
+```
+
+Or let an agent session do it and summarize:
+
+```bash
+hermes cron add --name "weekly-finance" "0 8 * * 1" \
+  "Sync my finances, then summarize last week's spending by category and flag anything unusual."
+```
+
+## Troubleshooting
+
+**Tools don't appear to the agent** — finance is opt-in. Enable `💰 Personal Finance` in `hermes tools`, and make sure `PLAID_CLIENT_ID` / `PLAID_SECRET` are set and at least one account is linked (`hermes finance status`).
+
+**`Plaid is not configured`** — add `PLAID_CLIENT_ID` and `PLAID_SECRET` to `~/.hermes/.env`. The secret must match the configured `finance.plaid.environment`.
+
+**Link didn't return a hosted URL** — enable Hosted Link for your Plaid client (dashboard → Link → Hosted Link).
+
+**An item needs re-authentication** — banks occasionally require you to log in again. Re-run `hermes finance connect plaid`; Plaid's update mode refreshes the existing item.
+
+**No holdings or liabilities** — those products must be enabled for the item. Re-connect with `--products transactions,investments,liabilities`. Hermes treats missing products as "no data," not an error.
+
+## Where things live
+
+| Path | Contents |
+|------|----------|
+| `~/.hermes/finance/finance.db` | Accounts, transactions, holdings, liabilities, balance snapshots, sync state, merchant rules (SQLite). |
+| `~/.hermes/finance/plaid_tokens.json` | Per-item Plaid access tokens (`0600`, never sent to the model). |
+| `~/.hermes/.env` | `PLAID_CLIENT_ID`, `PLAID_SECRET`. |
+| `~/.hermes/config.yaml` → `finance` | Provider, privacy mode, environment, categorization settings. |
+
+(Paths are profile-aware — each Hermes profile gets its own finance database and tokens.)


### PR DESCRIPTION
## Summary

The beginning of the Plaid personal finance integration from #51697 (child of #12324): a **local-first, provider-agnostic** finance backend shipped as a gated, default-off plugin, with Plaid as the first provider.

- `hermes finance` CLI: `connect` (Hosted Link + instant `--sandbox`), `sync`, `status`, `accounts`, `transactions`, `disconnect`.
- Gated `finance_*` toolset (7 tools): accounts, transactions, spending, net worth, cashflow, holdings, and an explicit `finance_sync`. Off by default; surfaces only once Plaid is configured.
- Profile-safe SQLite cache (`HERMES_HOME/finance/finance.db`): accounts, append-only transactions (tombstoned on removal), holdings/securities, liabilities, balance snapshots, sync cursors, merchant rules + category overrides.
- Incremental `/transactions/sync` with cursor + restart-on-`TRANSACTIONS_SYNC_MUTATION_DURING_PAGINATION`.
- `privacy_mode: full | summarized` — buckets figures (e.g. `$2k–$5k`) before they reach any tool result.
- Rules-first categorization (txn/merchant override → Plaid → merchant rule → optional LLM fallback, off by default).

## Footprint (per the contribution rubric)

- Ships as a **plugin** (`plugins/finance/`), not a core tool — zero permanent model-tool schema cost; the 7 tools are service-gated (`check_fn`) and default-off, so prompt caching is unaffected for users who don't enable it.
- **No new dependencies** — Plaid REST over the existing `httpx`.
- No changes to the core agent loop (`run_agent.py` / `cli.py` / `gateway/run.py` / `main.py`). The only core touches are the sanctioned plugin-integration surfaces, mirroring `spotify`: a `finance` toolset in `toolsets.py`, a configurable default-off entry + `hermes tools` setup prompt in `tools_config.py`, and a `finance:` config section + `PLAID_CLIENT_ID`/`PLAID_SECRET` secrets in `config.py`.

## Security / privacy

- Plaid `access_token`s live in a `0600` file (`finance/plaid_tokens.json`), never in the DB, never in `.env`, and **never returned to the model**.
- Local by default — nothing about finances leaves the machine unless the user explicitly asks the agent to send it somewhere.

## Design note

The `FinanceProvider` ABC has a single consumer (Plaid) today. That is intentional, not speculative infra: #51697 explicitly requires the design be "extensible to future providers (Teller/SnapTrade/…) without redesign." Plaid is wrapped as the first concrete provider behind that boundary.

## Test plan

- `scripts/run_tests.sh tests/plugins/test_finance_plugin.py` — 51 mocked tests (store, client error-mapping, auth/token storage, sync cursor + mutation restart, tool gating + privacy, CLI dispatch, plugin registration, config/setup wiring). No live network.
- Regressions: `tests/test_toolsets.py`, `tests/hermes_cli/test_tools_config.py`, `tests/hermes_cli/test_config.py`, `tests/hermes_cli/test_plugins.py` — all green.
- Manual: `hermes finance connect plaid --sandbox` → `hermes finance accounts` / `transactions` against sandbox data.

## Docs

`website/docs/user-guide/features/finance.md` + a row in `built-in-plugins.md`.

## Follow-ups (out of scope here)

- Optional cron auto-refresh keyed off `finance.sync_interval`.
- Additional providers behind the same ABC.

Made with [Cursor](https://cursor.com)