### PR TITLE
fix(auxiliary): default non-finite task timeouts

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -43,6 +43,7 @@ Payment / credit exhaustion fallback:
 import contextlib
 import json
 import logging
+import math
 import os
 import threading
 import time
@@ -5025,7 +5026,9 @@ def _get_task_timeout(task: str, default: float = _DEFAULT_AUX_TIMEOUT) -> float
     raw = task_config.get("timeout")
     if raw is not None:
         try:
-            return float(raw)
+            parsed = float(raw)
+            if math.isfinite(parsed):
+                return parsed
         except (ValueError, TypeError):
             pass
     return default

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -92,6 +92,27 @@ def codex_auth_dir(tmp_path, monkeypatch):
     return codex_dir
 
 
+class TestAuxiliaryTaskTimeout:
+    @pytest.mark.parametrize("raw", ["inf", "nan", float("inf"), float("nan")])
+    def test_nonfinite_timeout_uses_default(self, monkeypatch, raw):
+        import agent.auxiliary_client as aux
+
+        monkeypatch.setattr(
+            aux, "_get_auxiliary_task_config", lambda _task: {"timeout": raw}
+        )
+
+        assert aux._get_task_timeout("vision", default=12.5) == 12.5
+
+    def test_finite_timeout_still_applies(self, monkeypatch):
+        import agent.auxiliary_client as aux
+
+        monkeypatch.setattr(
+            aux, "_get_auxiliary_task_config", lambda _task: {"timeout": "45.5"}
+        )
+
+        assert aux._get_task_timeout("vision", default=12.5) == 45.5
+
+
 class TestAuxiliaryMaxTokensParam:
     def test_uses_max_completion_tokens_for_github_copilot_custom_base(self):
         with patch("agent.auxiliary_client._resolve_custom_runtime", return_value=("https://api.githubcopilot.com", "key", None)), \


### PR DESCRIPTION
## Summary
- reject `inf` / `nan` auxiliary task timeout values from config
- fall back to the caller-provided default instead of passing non-finite timeout values downstream
- add regression coverage while preserving finite timeout overrides

## Tests
- `python -m pytest tests/agent/test_auxiliary_client.py::TestAuxiliaryTaskTimeout -q`
- `python -m pytest tests/agent/test_auxiliary_client.py::TestAuxiliaryTaskTimeout tests/agent/test_auxiliary_client.py::TestBuildCallKwargsMaxTokens -q`
- `python -m py_compile agent/auxiliary_client.py`
- `python scripts/check-windows-footguns.py --all`