### PR TITLE
Add `hermes mcp validate-schemas` diagnostic

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -294,6 +294,147 @@ def _unwrap_exception_group(exc: BaseException) -> Exception:
     return RuntimeError(str(exc))
 
 
+# ─── hermes mcp validate-schemas ────
+
+class MCPSchemaValidationError(ValueError):
+    """Raised when an MCP server exposes provider-incompatible tool schemas."""
+
+
+def _find_null_defaults(value: Any, path: str = "$") -> List[str]:
+    """Return JSON paths where a schema contains ``default: null``."""
+    hits: List[str] = []
+    if isinstance(value, dict):
+        if "default" in value and value["default"] is None:
+            hits.append(f"{path}.default")
+        for key, child in value.items():
+            hits.extend(_find_null_defaults(child, f"{path}.{key}"))
+    elif isinstance(value, list):
+        for idx, child in enumerate(value):
+            hits.extend(_find_null_defaults(child, f"{path}[{idx}]"))
+    return hits
+
+
+def _validate_mcp_tool_schemas(tools: List[Any]) -> None:
+    """Validate MCP tool schemas for provider compatibility.
+
+    Hermes eagerly registers configured MCP tool schemas at session startup,
+    so a bad schema can break unrelated requests for that profile.  Keep this
+    gate intentionally conservative: schemas must normalize to a JSON object,
+    must serialize cleanly, must be valid JSON Schema, and must not contain
+    ``default: null`` because that provider-incompatible pattern was part of
+    real-world provider incompatibilities.
+    """
+    import json as _json
+    from tools.mcp_tool import _normalize_mcp_input_schema
+
+    errors: List[str] = []
+    for tool in tools:
+        tool_name = getattr(tool, "name", "<unnamed>") or "<unnamed>"
+        raw_schema = getattr(tool, "inputSchema", None)
+        try:
+            schema = _normalize_mcp_input_schema(raw_schema)
+        except Exception as exc:
+            errors.append(f"{tool_name}: schema normalization failed: {exc}")
+            continue
+        if not isinstance(schema, dict):
+            errors.append(f"{tool_name}: normalized schema is {type(schema).__name__}, not object")
+            continue
+        try:
+            _json.dumps(schema, allow_nan=False)
+        except (TypeError, ValueError) as exc:
+            errors.append(f"{tool_name}: normalized schema is not strict JSON: {exc}")
+        try:
+            from jsonschema import Draft202012Validator
+
+            Draft202012Validator.check_schema(schema)
+        except Exception as exc:
+            errors.append(f"{tool_name}: invalid JSON Schema: {exc}")
+        null_defaults = _find_null_defaults(schema)
+        if null_defaults:
+            shown = ", ".join(null_defaults[:5])
+            suffix = "" if len(null_defaults) <= 5 else f" (+{len(null_defaults) - 5} more)"
+            errors.append(f"{tool_name}: contains default:null at {shown}{suffix}")
+    if errors:
+        joined = "; ".join(errors)
+        raise MCPSchemaValidationError(f"MCP tool schema validation failed: {joined}")
+
+
+def _probe_server_tools(
+    name: str, config: dict, connect_timeout: float = 30
+) -> List[Any]:
+    """Temporarily connect to one MCP server and return raw MCP tool objects."""
+    issues = validate_mcp_server_entry(name, config)
+    if issues:
+        raise ValueError("; ".join(issues))
+
+    from tools.mcp_tool import (
+        _ensure_mcp_loop,
+        _run_on_mcp_loop,
+        _connect_server,
+        _stop_mcp_loop_if_idle,
+    )
+
+    config = _resolve_mcp_server_config(config)
+
+    _ensure_mcp_loop()
+    tools_found: List[Any] = []
+
+    async def _probe():
+        server = await asyncio.wait_for(
+            _connect_server(name, config), timeout=connect_timeout
+        )
+        try:
+            tools_found.extend(list(server._tools or []))
+        finally:
+            await server.shutdown()
+
+    try:
+        _run_on_mcp_loop(_probe(), timeout=connect_timeout + 10)
+    except BaseException as exc:
+        raise _unwrap_exception_group(exc) from None
+    finally:
+        _stop_mcp_loop_if_idle()
+
+    return tools_found
+
+
+def cmd_mcp_validate_schemas(args):
+    """Validate configured MCP tool schemas without changing config."""
+    servers = _get_mcp_servers()
+    requested = getattr(args, "name", None)
+    if requested:
+        if requested not in servers:
+            _error(f"Server '{requested}' not found in config.")
+            if servers:
+                _info(f"Available: {', '.join(servers.keys())}")
+            return
+        items = [(requested, servers[requested])]
+    else:
+        items = list(servers.items())
+
+    if not items:
+        _info("No MCP servers configured.")
+        return
+
+    failures = 0
+    print()
+    for name, cfg in items:
+        print(color(f"  Validating schemas for '{name}'...", Colors.CYAN))
+        try:
+            tools = _probe_server_tools(name, cfg)
+            _validate_mcp_tool_schemas(tools)
+        except Exception as exc:
+            failures += 1
+            _error(f"{name}: {exc}")
+            continue
+        _success(f"{name}: {len(tools)} tool schema(s) valid")
+    if failures:
+        _error(f"Schema validation failed for {failures}/{len(items)} server(s)")
+        raise SystemExit(1)
+    else:
+        _success(f"Schema validation passed for {len(items)} server(s)")
+
+
 # ─── hermes mcp add ──────────────────────────────────────────────────────────
 
 def cmd_mcp_add(args):
@@ -885,6 +1026,7 @@ def mcp_command(args):
         "list": cmd_mcp_list,
         "ls": cmd_mcp_list,
         "test": cmd_mcp_test,
+        "validate-schemas": cmd_mcp_validate_schemas,
         "configure": cmd_mcp_configure,
         "config": cmd_mcp_configure,
         "login": cmd_mcp_login,

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -75,6 +75,16 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
     mcp_test_p = mcp_sub.add_parser("test", help="Test MCP server connection")
     mcp_test_p.add_argument("name", help="Server name to test")
 
+    mcp_validate_p = mcp_sub.add_parser(
+        "validate-schemas",
+        help="Validate configured MCP tool schemas for provider compatibility",
+    )
+    mcp_validate_p.add_argument(
+        "name",
+        nargs="?",
+        help="Server name to validate (omit to validate all configured servers)",
+    )
+
     mcp_cfg_p = mcp_sub.add_parser(
         "configure", aliases=["config"], help="Toggle tool selection"
     )

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -70,9 +70,97 @@ def _seed_config(tmp_path: Path, mcp_servers: dict):
 class FakeTool:
     """Mimics an MCP tool object returned by the SDK."""
 
-    def __init__(self, name: str, description: str = ""):
+    def __init__(self, name: str, description: str = "", inputSchema=None):
         self.name = name
         self.description = description
+        self.inputSchema = (
+            inputSchema if inputSchema is not None
+            else {"type": "object", "properties": {}}
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: MCP tool-schema validation
+# ---------------------------------------------------------------------------
+
+class TestMcpSchemaValidation:
+    def test_validate_rejects_default_null(self):
+        from hermes_cli.mcp_config import (
+            MCPSchemaValidationError,
+            _validate_mcp_tool_schemas,
+        )
+
+        tool = FakeTool(
+            "bad_tool",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "optional_text": {"type": "string", "default": None},
+                },
+            },
+        )
+
+        with pytest.raises(MCPSchemaValidationError, match="default:null"):
+            _validate_mcp_tool_schemas([tool])
+
+    def test_validate_accepts_plain_object_schema(self):
+        from hermes_cli.mcp_config import _validate_mcp_tool_schemas
+
+        tool = FakeTool(
+            "good_tool",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                },
+                "required": ["query"],
+            },
+        )
+
+        _validate_mcp_tool_schemas([tool])
+
+    def test_validate_rejects_malformed_json_schema(self):
+        from hermes_cli.mcp_config import (
+            MCPSchemaValidationError,
+            _validate_mcp_tool_schemas,
+        )
+
+        tool = FakeTool(
+            "bad_schema",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {"type": 123},
+                },
+            },
+        )
+
+        with pytest.raises(MCPSchemaValidationError, match="invalid JSON Schema"):
+            _validate_mcp_tool_schemas([tool])
+
+    def test_cmd_validate_schemas_exits_nonzero_on_failure(self, tmp_path, capsys, monkeypatch):
+        _seed_config(tmp_path, {"bad": {"command": "fake"}})
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_server_tools",
+            lambda name, cfg: [
+                FakeTool(
+                    "bad_tool",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {"optional_text": {"type": "string", "default": None}},
+                    },
+                )
+            ],
+        )
+
+        from hermes_cli.mcp_config import cmd_mcp_validate_schemas
+
+        with pytest.raises(SystemExit) as exc:
+            cmd_mcp_validate_schemas(_make_args(name="bad"))
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "Schema validation failed" in out
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### What
Adds a `hermes mcp validate-schemas [server]` CLI command that validates configured MCP servers' tool schemas for provider compatibility — read-only, without changing config or making model calls.

### Why
Some MCP servers expose tool input schemas that are valid JSON Schema but incompatible with certain LLM providers' tool-use APIs — most commonly `default: null` on a property, which several providers reject with an opaque 400 at call time. Today this only surfaces as a confusing API error mid-session; this command lets users catch it proactively.

### Changes
- `MCPSchemaValidationError`; `_find_null_defaults()` (returns JSON paths containing `default: null`); `_validate_mcp_tool_schemas()`; `_probe_server_tools()` (read-only temporary connect to fetch raw tool objects); `cmd_mcp_validate_schemas()` + the `validate-schemas` subcommand wiring.
- Tests covering null-default detection and validation.

### Testing
`pytest tests/hermes_cli/test_mcp_config.py` → 46 passed.
