### PR TITLE
Log full traceback on non-retryable client API errors

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3374,6 +3374,13 @@ def run_conversation(
                             f"{agent.log_prefix}        hermes fallback add   (interactive picker — same as `hermes model`)",
                             force=True,
                         )
+                    logger.warning(
+                        "%sNon-retryable client error traceback (HTTP %s): %s",
+                        agent.log_prefix,
+                        status_code,
+                        api_error,
+                        exc_info=True,
+                    )
                     logger.error(f"{agent.log_prefix}Non-retryable client error: {api_error}")
                     # Skip session persistence when the error is likely
                     # context-overflow related (status 400 + large session).


### PR DESCRIPTION
### What
Emit the stack trace (`exc_info=True`) when a non-retryable client API error (4xx) is logged in the conversation loop.

### Why
These errors were logged as a one-line warning with no traceback, so the failing call site / cause was hard to locate from logs alone. Adding the traceback makes root-causing straightforward without reproducing.

### Changes
- One `logger.warning(..., exc_info=True)` at the non-retryable-error branch in `agent/conversation_loop.py`.
