### PR TITLE
fix(browser): default non-finite dialog timeouts

### DIFF
--- a/tests/tools/test_browser_hardening.py
+++ b/tests/tools/test_browser_hardening.py
@@ -147,6 +147,29 @@ class TestSessionInactivityTimeout:
             assert _get_session_inactivity_timeout() == 240
 
 
+class TestDialogPolicyConfig:
+
+    @pytest.mark.parametrize("timeout_raw", [float("inf"), float("-inf"), float("nan"), "inf", "nan"])
+    def test_non_finite_dialog_timeout_uses_default(self, timeout_raw):
+        from tools.browser_supervisor import (
+            DEFAULT_DIALOG_TIMEOUT_S,
+            DIALOG_POLICY_AUTO_DISMISS,
+        )
+        from tools.browser_tool import _get_dialog_policy_config
+
+        cfg = {
+            "browser": {
+                "dialog_policy": DIALOG_POLICY_AUTO_DISMISS,
+                "dialog_timeout_s": timeout_raw,
+            }
+        }
+        with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+            policy, timeout_s = _get_dialog_policy_config()
+
+        assert policy == DIALOG_POLICY_AUTO_DISMISS
+        assert timeout_s == DEFAULT_DIALOG_TIMEOUT_S
+
+
 # ---------------------------------------------------------------------------
 # Caching: _discover_homebrew_node_dirs
 # ---------------------------------------------------------------------------

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -335,8 +335,10 @@ def _get_dialog_policy_config() -> Tuple[str, float]:
             policy = DEFAULT_DIALOG_POLICY
         timeout_raw = browser_cfg.get("dialog_timeout_s")
         try:
+            import math
+
             timeout_s = float(timeout_raw) if timeout_raw is not None else DEFAULT_DIALOG_TIMEOUT_S
-            if timeout_s <= 0:
+            if not math.isfinite(timeout_s) or timeout_s <= 0:
                 timeout_s = DEFAULT_DIALOG_TIMEOUT_S
         except (TypeError, ValueError):
             timeout_s = DEFAULT_DIALOG_TIMEOUT_S


### PR DESCRIPTION
## Summary
- reject NaN/Infinity values from `browser.dialog_timeout_s`
- fall back to the supervisor default while preserving a valid dialog policy
- add regression coverage for numeric and string non-finite values

## Tests
- `python -m pytest tests/tools/test_browser_hardening.py::TestDialogPolicyConfig -q`
- `python -m pytest tests/tools/test_browser_hardening.py -q`
- `python -m py_compile tools/browser_tool.py`
- `python scripts/check-windows-footguns.py --all`