### PR TITLE
fix(gateway): reject non-finite keepalive expiry

### DIFF
--- a/gateway/platforms/_http_client_limits.py
+++ b/gateway/platforms/_http_client_limits.py
@@ -28,6 +28,7 @@ Override via ``HERMES_GATEWAY_HTTPX_KEEPALIVE_EXPIRY`` /
 
 from __future__ import annotations
 
+import math
 import os
 
 try:
@@ -58,7 +59,7 @@ def platform_httpx_limits() -> "httpx.Limits | None":
             val = float(raw)
         except (TypeError, ValueError):
             return default
-        return val if val > 0 else default
+        return val if math.isfinite(val) and val > 0 else default
 
     def _env_int(name: str, default: int) -> int:
         raw = os.environ.get(name, "").strip()

--- a/tests/gateway/test_platform_http_client_limits.py
+++ b/tests/gateway/test_platform_http_client_limits.py
@@ -71,6 +71,18 @@ def test_env_override_rejects_garbage(monkeypatch):
     assert limits.max_keepalive_connections > 0
 
 
+@pytest.mark.parametrize("raw_value", ["inf", "nan"])
+def test_env_override_rejects_non_finite_keepalive_expiry(monkeypatch, raw_value):
+    monkeypatch.setenv("HERMES_GATEWAY_HTTPX_KEEPALIVE_EXPIRY", raw_value)
+    from gateway.platforms._http_client_limits import (
+        _DEFAULT_KEEPALIVE_EXPIRY_S,
+        platform_httpx_limits,
+    )
+
+    limits = platform_httpx_limits()
+    assert limits.keepalive_expiry == _DEFAULT_KEEPALIVE_EXPIRY_S
+
+
 def test_helper_is_importable_from_every_platform_that_uses_it():
     """Every persistent-httpx-client platform adapter imports this helper.
     If any of those modules fails to import, this test surfaces it before


### PR DESCRIPTION
## Summary
- reject `inf`/`nan` values for `HERMES_GATEWAY_HTTPX_KEEPALIVE_EXPIRY`
- fall back to the tuned gateway default instead of passing an unusable expiry into `httpx.Limits`
- add regression coverage for non-finite env overrides

## Tests
- `python -m pytest tests/gateway/test_platform_http_client_limits.py::test_env_override_rejects_non_finite_keepalive_expiry -q`
- `python -m pytest tests/gateway/test_platform_http_client_limits.py -q`
- `python -m py_compile gateway/platforms/_http_client_limits.py`
- `python scripts/check-windows-footguns.py --all`