### PR TITLE
fix(codex): default non-finite watchdog env values

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import re
 import threading
@@ -117,9 +118,10 @@ def _is_openai_codex_backend(agent) -> bool:
 
 def _env_float(name: str, default: float) -> float:
     try:
-        return float(os.getenv(name, str(default)))
+        value = float(os.getenv(name, str(default)))
     except (TypeError, ValueError):
         return default
+    return value if math.isfinite(value) else default
 
 
 def interruptible_api_call(agent, api_kwargs: dict):

--- a/tests/agent/test_codex_ttfb_watchdog.py
+++ b/tests/agent/test_codex_ttfb_watchdog.py
@@ -57,6 +57,14 @@ def _make_codex_agent(tmp_path, monkeypatch):
     return agent
 
 
+@pytest.mark.parametrize("raw_value", ["inf", "-inf", "nan"])
+def test_watchdog_env_float_rejects_non_finite_values(monkeypatch, raw_value):
+    from agent.chat_completion_helpers import _env_float
+
+    monkeypatch.setenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", raw_value)
+    assert _env_float("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", 120.0) == 120.0
+
+
 def test_ttfb_kills_when_no_stream_event(tmp_path, monkeypatch):
     """Backend accepts the connection but emits no event -> killed at the TTFB
     cutoff, well before the 60s wall-clock stale timeout, with a retryable


### PR DESCRIPTION
## Summary
- reject `inf`, `-inf`, and `nan` from the Codex watchdog float env parser
- fall back to the configured defaults for TTFB and stale-event watchdog knobs
- add regression coverage for the non-finite env parsing path

## Tests
- `python -m pytest tests/agent/test_codex_ttfb_watchdog.py::test_watchdog_env_float_rejects_non_finite_values -q`
- `python -m pytest tests/agent/test_codex_ttfb_watchdog.py -q`
- `python -m py_compile agent/chat_completion_helpers.py`
- `python scripts/check-windows-footguns.py --all`