### PR TITLE
fix: honor tui clarify timeout

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -14,6 +14,30 @@ from hermes_cli.active_sessions import active_session_registry_snapshot
 from tui_gateway import server
 
 
+def test_clarify_callback_uses_configured_timeout(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(server, "_clarify_timeout_seconds", lambda: 42)
+
+    def fake_block(event, sid, payload, timeout=300):
+        captured.update(
+            {"event": event, "sid": sid, "payload": payload, "timeout": timeout}
+        )
+        return "answer"
+
+    monkeypatch.setattr(server, "_block", fake_block)
+
+    result = server._agent_cbs("sid-1")["clarify_callback"]("Pick one", ["a", "b"])
+
+    assert result == "answer"
+    assert captured == {
+        "event": "clarify.request",
+        "sid": "sid-1",
+        "payload": {"question": "Pick one", "choices": ["a", "b"]},
+        "timeout": 42,
+    }
+
+
 def test_session_create_rejects_at_active_session_limit(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1626,6 +1626,15 @@ def _block(event: str, sid: str, payload: dict, timeout: int = 300) -> str:
         return _answers.pop(rid, "")
 
 
+def _clarify_timeout_seconds() -> int:
+    try:
+        from tools.clarify_gateway import get_clarify_timeout
+
+        return get_clarify_timeout()
+    except Exception:
+        return 600
+
+
 def _clear_pending(sid: str | None = None) -> None:
     """Release pending prompts with an empty answer.
 
@@ -3357,7 +3366,10 @@ def _agent_cbs(sid: str) -> dict:
             "notification.clear", sid, {"key": key}
         ),
         "clarify_callback": lambda q, c: _block(
-            "clarify.request", sid, {"question": q, "choices": c}
+            "clarify.request",
+            sid,
+            {"question": q, "choices": c},
+            timeout=_clarify_timeout_seconds(),
         ),
         # read_terminal tool (desktop GUI): same blocking bridge as clarify — the
         # renderer answers terminal.read.respond with the serialized buffer.


### PR DESCRIPTION
## What does this PR do?

Fixes the TUI/Desktop clarify prompt timeout path so it honors the existing `agent.clarify_timeout` config instead of always using the hardcoded `_block()` default of 300 seconds.

The messaging gateway already reads this config through `tools.clarify_gateway.get_clarify_timeout()`, so this reuses that existing helper and keeps the TUI/Desktop behavior aligned with the gateway path.

## Related Issue

Fixes #51960

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `tui_gateway/server.py` so `clarify_callback` passes a configured timeout to `_block()`.
- Added `_clarify_timeout_seconds()` to reuse `tools.clarify_gateway.get_clarify_timeout()`.
- Added a regression test in `tests/test_tui_gateway_server.py` to verify the clarify callback uses the configured timeout instead of `_block()`'s default.

## How to Test

1. On main, inspect `tui_gateway/server.py`: `clarify_callback` calls `_block(...)` without a timeout, so it uses the hardcoded 300s default.
2. With this change, `clarify_callback` passes `timeout=_clarify_timeout_seconds()`, which reads `agent.clarify_timeout`.
3. Run:
   `uv run --python python3.13 --extra dev scripts/run_tests.sh tests/test_tui_gateway_server.py -- -k test_clarify_callback_uses_configured_timeout`
   `uv run --python python3.13 --extra dev ruff check tui_gateway/server.py tests/test_tui_gateway_server.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
uv run --python python3.13 --extra dev scripts/run_tests.sh tests/test_tui_gateway_server.py -- -k test_clarify_callback_uses_configured_timeout
1 tests passed

uv run --python python3.13 --extra dev ruff check tui_gateway/server.py tests/test_tui_gateway_server.py
All checks passed
```

Note: running the full `tests/test_tui_gateway_server.py` file produced one unrelated existing failure in `test_browser_manage_connect_default_local_reports_launch_hint`; the new clarify timeout regression test passes.