### PR TITLE
fix(dingtalk): standalone fallback uses markdown instead of text / 钉钉 fallback 路径改为 Markdown 渲染

### DIFF
--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -1553,7 +1553,7 @@ async def _standalone_send(
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.post(
                 webhook_url,
-                json={"msgtype": "text", "text": {"content": message}},
+                json={"msgtype": "markdown", "markdown": {"title": "Hermes", "text": message}},
             )
             resp.raise_for_status()
             data = resp.json()


### PR DESCRIPTION
## What / 改动

Cron delivery falls back to standalone standalone ``_standalone_send()`` when the live adapter ``session_webhook`` is invalid. The fallback was using ``msgtype: "text"``, causing Markdown tables to render as plain pipe characters in DingTalk.

## Fix / 修复

Align standalone fallback with live adapter by using ``msgtype: "markdown"``.

## Testing / 测试

Manually triggered 雪球日报 cron job, verified DingTalk renders Markdown tables correctly.