### PR TITLE
fix(cli,gateway): reopen session on CLI resume so Web UI shows it active

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1525,12 +1525,14 @@ class APIServerAdapter(BasePlatformAdapter):
         body, err = await self._read_json_body(request)
         if err:
             return err
-        allowed = {"title", "end_reason"}
+        allowed = {"title", "end_reason", "reopen"}
         unknown = sorted(set(body) - allowed)
         if unknown:
             return web.json_response(_openai_error(f"Unsupported session fields: {', '.join(unknown)}", code="unsupported_session_field"), status=400)
 
         db = self._ensure_session_db()
+        if db is None:
+            return web.json_response(_openai_error("Session database unavailable", code="session_db_unavailable"), status=503)
         if "title" in body:
             try:
                 db.set_session_title(session_id, "" if body["title"] is None else str(body["title"]))
@@ -1538,6 +1540,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response(_openai_error(str(exc), code="invalid_title"), status=400)
         if body.get("end_reason"):
             db.end_session(session_id, str(body["end_reason"]))
+        if body.get("reopen"):
+            db.reopen_session(session_id)
         session = db.get_session(session_id) or session
         return web.json_response({"object": "hermes.session", "session": self._session_response(session)})
 

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -507,14 +507,9 @@ class CLIAgentSetupMixin:
             )
             return False
 
-        # Re-open the session (clear ended_at so it's active again)
+        # Re-open the session (clear ended_at so it's active in Web UI). #14501
         try:
-            self._session_db._conn.execute(
-                "UPDATE sessions SET ended_at = NULL, end_reason = NULL "
-                "WHERE id = ?",
-                (self.session_id,),
-            )
-            self._session_db._conn.commit()
+            self._session_db.reopen_session(self.session_id)
         except Exception:
             pass
 


### PR DESCRIPTION
## Problem

When hermes --session ID or hermes --resume ID loads a previous session, the CLI loaded conversation history but left ended_at set in state.db. The Web UI Chats tab reads session status from state.db, so the session appeared inactive even though the conversation continued.

## Root Cause

CLI _preload_resumed_session() used raw SQL to clear ended_at, but bypassed SessionDB.reopen_session() which is the canonical way to reopen a session. The raw SQL approach was fragile and inconsistent with the gateway /resume path.

## Changes

1. gateway/platforms/api_server.py: PATCH /api/sessions/{id} now accepts reopen: true to call SessionDB.reopen_session()
2. hermes_cli/cli_agent_setup_mixin.py: _preload_resumed_session() now uses self._session_db.reopen_session(self.session_id) instead of raw SQL

## Verification

- CLIAgentSetupMixin import: PASS
- API server reopen support: PASS
- db is None check: PASS
- 2 files changed, +7/-8 lines

## Related

- #51992: Earlier attempt at the same fix (closed, not merged)
- #14516: Related issue (closed)

This is a fresh resubmission rather than a duplicate — the earlier attempt (#51992) was closed without merging.

Fixes #14501