### PR TITLE
fix(execute_code): preserve session id for nested tools

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -38,6 +38,7 @@ from unittest.mock import patch, MagicMock
 
 from tools.code_execution_tool import (
     SANDBOX_ALLOWED_TOOLS,
+    SANDBOX_AVAILABLE,
     execute_code,
     generate_hermes_tools_module,
     check_sandbox_requirements,
@@ -713,6 +714,48 @@ class TestBuildExecuteCodeSchema(unittest.TestCase):
         schema_none = build_execute_code_schema(None)
         schema_all = build_execute_code_schema(SANDBOX_ALLOWED_TOOLS)
         self.assertEqual(schema_none["description"], schema_all["description"])
+
+
+@unittest.skipUnless(SANDBOX_AVAILABLE, "execute_code sandbox unavailable")
+class TestNestedToolSessionContext(unittest.TestCase):
+    def test_registry_execute_code_forwards_session_id_to_nested_tools(self):
+        captured = []
+
+        def fake_handle_function_call(function_name, function_args, **kwargs):
+            captured.append({
+                "name": function_name,
+                "args": function_args,
+                "kwargs": kwargs,
+            })
+            return json.dumps({"content": "ok"})
+
+        code = (
+            "from hermes_tools import read_file\n"
+            "print(read_file('README.md'))\n"
+        )
+
+        from tools.registry import registry
+
+        with patch("model_tools.handle_function_call",
+                   side_effect=fake_handle_function_call), \
+             patch("tools.code_execution_tool._load_config",
+                   return_value={"timeout": 10, "max_tool_calls": 50}):
+            raw = registry.dispatch(
+                "execute_code",
+                {"code": code},
+                task_id="task-nested-session",
+                session_id="sess-nested-session",
+                enabled_tools=["read_file"],
+            )
+
+        result = json.loads(raw)
+        self.assertEqual(result["status"], "success", result)
+        self.assertEqual(result["tool_calls_made"], 1)
+        self.assertEqual(captured[0]["name"], "read_file")
+        self.assertEqual(
+            captured[0]["kwargs"].get("session_id"),
+            "sess-nested-session",
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -468,6 +468,7 @@ _TERMINAL_BLOCKED_PARAMS = {"background", "pty", "notify_on_complete", "watch_pa
 def _rpc_server_loop(
     server_sock: socket.socket,
     task_id: str,
+    session_id: Optional[str],
     tool_call_log: list,
     tool_call_counter: list,   # mutable [int] so the thread can increment
     max_tool_calls: int,
@@ -559,7 +560,8 @@ def _rpc_server_loop(
                         sys.stdout = devnull
                         sys.stderr = devnull
                         result = handle_function_call(
-                            tool_name, tool_args, task_id=task_id
+                            tool_name, tool_args, task_id=task_id,
+                            session_id=session_id,
                         )
                     finally:
                         sys.stdout, sys.stderr = _real_stdout, _real_stderr
@@ -736,6 +738,7 @@ def _rpc_poll_loop(
     env,
     rpc_dir: str,
     task_id: str,
+    session_id: Optional[str],
     tool_call_log: list,
     tool_call_counter: list,
     max_tool_calls: int,
@@ -832,7 +835,8 @@ def _rpc_poll_loop(
                             sys.stdout = devnull
                             sys.stderr = devnull
                             tool_result = handle_function_call(
-                                tool_name, tool_args, task_id=task_id
+                                tool_name, tool_args, task_id=task_id,
+                                session_id=session_id,
                             )
                         finally:
                             sys.stdout, sys.stderr = _real_stdout, _real_stderr
@@ -878,6 +882,7 @@ def _execute_remote(
     code: str,
     task_id: Optional[str],
     enabled_tools: Optional[List[str]],
+    session_id: Optional[str],
 ) -> str:
     """Run a script on the remote terminal backend via file-based RPC.
 
@@ -947,6 +952,7 @@ def _execute_remote(
             target=propagate_context_to_thread(_rpc_poll_loop),
             args=(
                 env, f"{sandbox_dir}/rpc", effective_task_id,
+                session_id,
                 tool_call_log, tool_call_counter, max_tool_calls,
                 sandbox_tools, stop_event,
             ),
@@ -1075,6 +1081,7 @@ def execute_code(
     code: str,
     task_id: Optional[str] = None,
     enabled_tools: Optional[List[str]] = None,
+    session_id: Optional[str] = None,
 ) -> str:
     """
     Run a Python script in a sandboxed child process with RPC access
@@ -1088,6 +1095,8 @@ def execute_code(
         task_id:       Session task ID for tool isolation (terminal env, etc.).
         enabled_tools: Tool names enabled in the current session. The sandbox
                        gets the intersection with SANDBOX_ALLOWED_TOOLS.
+        session_id:    Current Hermes session ID propagated to nested tool
+                       hooks invoked from hermes_tools.
 
     Returns:
         JSON string with execution results.
@@ -1120,7 +1129,7 @@ def execute_code(
         }, ensure_ascii=False)
 
     if env_type != "local":
-        return _execute_remote(code, task_id, enabled_tools)
+        return _execute_remote(code, task_id, enabled_tools, session_id)
 
     # --- Local execution path (UDS) --- below this line is unchanged ---
 
@@ -1212,7 +1221,8 @@ def execute_code(
         rpc_thread = threading.Thread(
             target=propagate_context_to_thread(_rpc_server_loop),
             args=(
-                server_sock, task_id, tool_call_log,
+                server_sock, task_id, session_id,
+                tool_call_log,
                 tool_call_counter, max_tool_calls, sandbox_tools, stop_event,
             ),
             daemon=True,
@@ -1841,7 +1851,8 @@ registry.register(
     handler=lambda args, **kw: execute_code(
         code=args.get("code", ""),
         task_id=kw.get("task_id"),
-        enabled_tools=kw.get("enabled_tools")),
+        enabled_tools=kw.get("enabled_tools"),
+        session_id=kw.get("session_id")),
     check_fn=check_sandbox_requirements,
     emoji="🐍",
     max_result_size_chars=100_000,


### PR DESCRIPTION
## What does this PR do?

Preserves the current Hermes `session_id` when sandboxed `execute_code` scripts call nested tools through `hermes_tools`.

The top-level dispatcher already forwards `session_id` into `registry.dispatch`, but the `execute_code` registry handler did not pass it into `execute_code`. As a result, the local socket RPC path and remote file RPC path could only call nested tools with `task_id`, so `pre_tool_call` / `post_tool_call` hooks saw an empty `session_id` for nested tool calls.

This keeps the change narrow: nested tools inherit the session identifier, while synthetic nested calls still do not reuse the parent model tool call id.

## Related Issue

Fixes #51931

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `tools/code_execution_tool.py`: threads the optional `session_id` from the registry handler into `execute_code`, `_execute_remote`, `_rpc_server_loop`, and `_rpc_poll_loop`.
- `tests/tools/test_code_execution.py`: adds a regression test that calls `execute_code` through the real registry, invokes `hermes_tools.read_file` from the sandbox, and verifies the nested dispatcher receives the same `session_id`.

## How to Test

1. Reproduce the bug by dispatching `execute_code` through the registry with `session_id="sess-repro"` and having sandbox code call `hermes_tools.read_file`; before this patch, the nested dispatcher kwargs only included `task_id`.
2. Run the targeted regression test:
   - `.\.venv\Scripts\python.exe -m pytest tests/tools/test_code_execution.py::TestNestedToolSessionContext::test_registry_execute_code_forwards_session_id_to_nested_tools -q`
3. Run the existing related dispatch coverage:
   - `.\.venv\Scripts\python.exe -m pytest tests/test_dispatch_session_id.py tests/tools/test_code_execution.py::TestNestedToolSessionContext -q`
4. Run adjacent execute_code coverage:
   - `.\.venv\Scripts\python.exe -m pytest tests/tools/test_code_execution.py::TestSandboxRequirements tests/tools/test_code_execution.py::TestHermesToolsGeneration tests/tools/test_code_execution.py::TestNestedToolSessionContext tests/tools/test_code_execution.py::TestExecuteCodeEdgeCases -q`
5. Run lint on touched files:
   - `.\.venv\Scripts\python.exe -m ruff check tools/code_execution_tool.py tests/tools/test_code_execution.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / PowerShell

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

Validation performed:

```text
.                                                                        [100%]
1 passed in 2.04s

.....                                                                    [100%]
5 passed in 2.12s

............sss..                                                        [100%]
14 passed, 3 skipped in 2.46s

All checks passed!
```

Also attempted the repository script:

```text
bash scripts/run_tests.sh tests/test_dispatch_session_id.py tests/tools/test_code_execution.py::TestNestedToolSessionContext -q
error: no virtualenv found in /c/Users/Administrator/OneDrive/.../hermes-agent/.venv or /c/Users/Administrator/OneDrive/.../hermes-agent/venv
```

That appears to be a Windows/Git-Bash virtualenv path issue in this local checkout; the equivalent tests above were run with the checked-out `.venv\Scripts\python.exe`.