### PR TITLE
fix(skills): catch PermissionError on read-only skill deletion

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -428,6 +428,30 @@ class TestDeleteSkill:
         assert result["success"] is True
         assert "absorbed into" not in result["message"]
 
+    def test_delete_readonly_skill_returns_clear_error(self, tmp_path):
+        """Deleting a read-only (bundled) skill returns a clear, non-retryable
+        error instead of crashing with PermissionError (#50938)."""
+        with _skill_dir(tmp_path):
+            _create_skill("bundled-skill", VALID_SKILL_CONTENT)
+            skill_path = tmp_path / "bundled-skill"
+            # Make the skill directory read-only (simulates a bundled install
+            # with dr-xr-xr-x permissions).
+            import stat
+            for item in skill_path.rglob("*"):
+                if item.is_file():
+                    item.chmod(item.stat().st_mode & ~stat.S_IWRITE)
+            skill_path.chmod(skill_path.stat().st_mode & ~stat.S_IWRITE)
+            result = _delete_skill("bundled-skill")
+        assert result["success"] is False
+        assert "not writable" in result["error"] or "Permission denied" in result["error"]
+        # Skill should still exist
+        assert skill_path.exists()
+        # Restore permissions so tmp_path cleanup works
+        skill_path.chmod(skill_path.stat().st_mode | stat.S_IWRITE)
+        for item in skill_path.rglob("*"):
+            if item.is_file():
+                item.chmod(item.stat().st_mode | stat.S_IWRITE)
+
     def test_delete_without_absorbed_into_backward_compat(self, tmp_path):
         # Legacy callers that don't pass the arg still work — the curator
         # reconciler falls back to its heuristic+YAML logic for such deletes.

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -814,7 +814,18 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
     if unsafe:
         return {"success": False, "error": unsafe}
 
-    shutil.rmtree(skill_dir)
+    try:
+        shutil.rmtree(skill_dir)
+    except PermissionError as exc:
+        return {
+            "success": False,
+            "error": (
+                f"Cannot delete skill '{name}': the skill directory is not "
+                f"writable (read-only/bundled install). Permission denied: "
+                f"{exc}. Remove the skill manually or reinstall the skills "
+                f"bundle without the read-only flag."
+            ),
+        }
 
     # Clean up empty category directories (don't remove the skills root itself)
     parent = skill_dir.parent


### PR DESCRIPTION
## Summary

- `_delete_skill` called `shutil.rmtree()` without catching `PermissionError`. When a bundled skill is installed with read-only permissions (`dr-xr-xr-x`), the delete crashed with `PermissionError`, causing the agent to retry indefinitely in a tool loop.
- The fix catches `PermissionError` and returns a clear, non-retryable error message explaining the skill directory is not writable, so the agent stops retrying instead of burning tool calls.

Fixes #50938

#### Test plan

- [x] `uv run ruff check tools/skill_manager_tool.py tests/tools/test_skill_manager_tool.py` — clean
- [x] `uv run ty check` — 0 new diagnostics (47 pre-existing, unchanged)
- [x] `uv lock --check` — clean
- [x] `bash scripts/run_tests.sh tests/tools/test_skill_manager_tool.py` — 95/95 pass
- [x] New test `test_delete_readonly_skill_returns_clear_error` fails before fix (`PermissionError`), passes after