### PR TITLE
feat(privacy): local-only mode, tool policy enforcement, and profile presets

### DIFF
--- a/agent/tool_policy.py
+++ b/agent/tool_policy.py
@@ -1,0 +1,245 @@
+"""Unified tool policy evaluation and signed audit logging."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import fnmatch
+import hmac
+import json
+import os
+from pathlib import Path
+import re
+import secrets
+from typing import Any, Mapping, Optional
+from urllib.parse import urlparse
+
+from hermes_constants import get_hermes_home
+from tools.threat_patterns import scan_for_threats
+
+
+POLICY_MODES = {"personal_trusted", "confirm_dangerous", "read_only", "project_sandbox", "team_governed"}
+MUTATING_TOOLS = {
+    "terminal", "execute_code", "write_file", "patch", "browser_click",
+    "browser_type", "browser_press", "browser_scroll", "browser_navigate",
+    "send_message", "cronjob", "memory", "skill_manage", "process",
+}
+SHELL_TOOLS = {"terminal", "execute_code", "process"}
+FILE_TOOLS = {"read_file", "write_file", "patch", "search_files"}
+NETWORK_TOOLS = {"web_search", "web_extract", "browser_navigate"}
+BROWSER_TOOLS = {name for name in MUTATING_TOOLS if name.startswith("browser_")}
+SHELL_INJECTION_RE = re.compile(r"(\|\s*(?:sh|bash)|;\s*(?:rm|curl|wget)|`[^`]+`|\$\([^)]*\))")
+SECRET_EXFIL_RE = re.compile(r"(\.env\b|auth\.json\b|api[_-]?key|token|secret|/\.ssh/|\.netrc\b)", re.I)
+
+
+@dataclass(frozen=True)
+class ToolPolicyDecision:
+    action: str
+    mode: str
+    risk: str
+    reason: str
+    categories: tuple[str, ...]
+    preview: str
+
+    @property
+    def allows_execution(self) -> bool:
+        return self.action != "block"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "action": self.action,
+            "mode": self.mode,
+            "risk": self.risk,
+            "reason": self.reason,
+            "categories": list(self.categories),
+            "preview": self.preview,
+        }
+
+
+def load_policy_config(config: Mapping[str, Any] | None = None) -> Mapping[str, Any]:
+    if config is None:
+        try:
+            from hermes_cli.config import load_config
+
+            config = load_config()
+        except Exception:
+            config = {}
+    if isinstance(config, Mapping) and any(key in config for key in ("mode", "allow", "deny")):
+        return config
+    security = config.get("security") if isinstance(config, Mapping) else {}
+    policy = security.get("tool_policy") if isinstance(security, Mapping) else {}
+    return policy if isinstance(policy, Mapping) else {}
+
+
+def evaluate_tool_policy(
+    tool_name: str,
+    args: Mapping[str, Any] | None,
+    *,
+    toolset: str | None = None,
+    cwd: str | None = None,
+    config: Mapping[str, Any] | None = None,
+) -> ToolPolicyDecision:
+    policy = load_policy_config(config)
+    mode = str(policy.get("mode") or "confirm_dangerous").strip() or "confirm_dangerous"
+    if mode not in POLICY_MODES:
+        mode = "confirm_dangerous"
+    args = args or {}
+    categories = _categories(tool_name, toolset)
+    risk, reason = _risk(tool_name, args, categories)
+
+    deny_reason = _rule_match(policy.get("deny"), tool_name, args, toolset=toolset)
+    if deny_reason:
+        return _decision("block", mode, "high", deny_reason, categories, tool_name)
+    allow_reason = _rule_match(policy.get("allow"), tool_name, args, toolset=toolset)
+    if allow_reason:
+        return _decision("allow", mode, risk, f"allow rule matched: {allow_reason}", categories, tool_name)
+
+    if mode == "personal_trusted":
+        return _decision("allow", mode, risk, reason or "trusted mode", categories, tool_name)
+    if mode == "read_only" and tool_name in MUTATING_TOOLS:
+        return _decision("block", mode, "high", "read-only policy blocks mutating tools", categories, tool_name)
+    if mode == "project_sandbox" and _path_outside_cwd(args, cwd):
+        return _decision("block", mode, "high", "project sandbox blocks paths outside cwd", categories, tool_name)
+    if mode == "team_governed" and risk == "high":
+        return _decision("block", mode, risk, reason or "team-governed policy blocks high-risk action", categories, tool_name)
+    return _decision("allow", mode, risk, reason or "policy allows execution", categories, tool_name)
+
+
+def preview_tool_policy(tool_name: str, args: Mapping[str, Any] | None, **kwargs: Any) -> dict[str, Any]:
+    return evaluate_tool_policy(tool_name, args, **kwargs).to_dict()
+
+
+def audit_tool_policy(
+    tool_name: str,
+    args: Mapping[str, Any] | None,
+    decision: ToolPolicyDecision,
+    *,
+    session_id: str = "",
+    tool_call_id: str = "",
+) -> None:
+    if decision.risk != "high" and decision.action != "block":
+        return
+    path = get_hermes_home() / "logs" / "tool_policy_audit.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    record = {
+        "tool_name": tool_name,
+        "args_preview": _redacted_args(args or {}),
+        "decision": decision.to_dict(),
+        "session_id": session_id,
+        "tool_call_id": tool_call_id,
+    }
+    payload = json.dumps(record, sort_keys=True, separators=(",", ":"))
+    signature = hmac.new(_audit_key(), payload.encode("utf-8"), "sha256").hexdigest()
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps({"record": record, "signature": signature}, sort_keys=True) + "\n")
+
+
+def _audit_key() -> bytes:
+    key_path = get_hermes_home() / "logs" / ".tool_policy_audit.key"
+    if key_path.exists():
+        return key_path.read_bytes()
+    key_path.parent.mkdir(parents=True, exist_ok=True)
+    key = secrets.token_bytes(32)
+    key_path.write_bytes(key)
+    try:
+        os.chmod(key_path, 0o600)
+    except OSError:
+        pass
+    return key
+
+
+def _decision(action: str, mode: str, risk: str, reason: str, categories: tuple[str, ...], tool_name: str) -> ToolPolicyDecision:
+    return ToolPolicyDecision(action=action, mode=mode, risk=risk, reason=reason, categories=categories, preview=f"{action.upper()} {tool_name}: {reason}")
+
+
+def _categories(tool_name: str, toolset: Optional[str]) -> tuple[str, ...]:
+    categories = []
+    if tool_name in SHELL_TOOLS:
+        categories.append("shell")
+    if tool_name in FILE_TOOLS:
+        categories.append("file")
+    if tool_name in NETWORK_TOOLS:
+        categories.append("network")
+    if tool_name in BROWSER_TOOLS:
+        categories.append("browser")
+    if tool_name.startswith("mcp_") or (toolset or "").startswith("mcp-"):
+        categories.append("mcp")
+    if toolset and toolset.startswith("plugin:"):
+        categories.append("plugin")
+    if SECRET_EXFIL_RE.search(tool_name):
+        categories.append("credential")
+    return tuple(categories or ["tool"])
+
+
+def _risk(tool_name: str, args: Mapping[str, Any], categories: tuple[str, ...]) -> tuple[str, str]:
+    text = json.dumps(args, default=str, ensure_ascii=False)
+    threats = scan_for_threats(text, scope="strict")
+    if threats:
+        return "high", f"prompt-injection/exfiltration pattern: {', '.join(threats)}"
+    if "shell" in categories and SHELL_INJECTION_RE.search(text):
+        return "high", "shell injection pattern detected"
+    if SECRET_EXFIL_RE.search(text):
+        return "high", "secret or credential access pattern detected"
+    if tool_name in MUTATING_TOOLS:
+        return "medium", "mutating tool"
+    return "low", "read-only or low-risk tool"
+
+
+def _path_outside_cwd(args: Mapping[str, Any], cwd: str | None) -> bool:
+    if not cwd:
+        return False
+    root = Path(cwd).expanduser().resolve()
+    for key in ("path", "file_path", "target_path", "output_path"):
+        value = args.get(key)
+        if not isinstance(value, str) or not value:
+            continue
+        path = Path(value).expanduser()
+        if not path.is_absolute():
+            path = root / path
+        resolved = path.resolve()
+        if resolved != root and root not in resolved.parents:
+            return True
+    return False
+
+
+def _rule_match(rules: Any, tool_name: str, args: Mapping[str, Any], *, toolset: str | None) -> str:
+    if not isinstance(rules, Mapping):
+        return ""
+    if _glob_any(tool_name, rules.get("commands")):
+        return "command"
+    if toolset and _glob_any(toolset, rules.get("toolsets")):
+        return "toolset"
+    for value in _arg_paths(args):
+        if _glob_any(value, rules.get("paths")):
+            return "path"
+    domain = _domain_from_args(args)
+    if domain and _glob_any(domain, rules.get("domains")):
+        return "domain"
+    provider = str(args.get("provider") or "")
+    if provider and _glob_any(provider, rules.get("providers")):
+        return "provider"
+    return ""
+
+
+def _glob_any(value: str, patterns: Any) -> bool:
+    if not isinstance(patterns, list):
+        return False
+    return any(fnmatch.fnmatch(value, str(pattern)) for pattern in patterns)
+
+
+def _arg_paths(args: Mapping[str, Any]) -> list[str]:
+    return [str(args[key]) for key in ("path", "file_path", "target_path", "output_path") if isinstance(args.get(key), str)]
+
+
+def _domain_from_args(args: Mapping[str, Any]) -> str:
+    for key in ("url", "uri", "target_url"):
+        value = args.get(key)
+        if isinstance(value, str):
+            return urlparse(value).hostname or ""
+    return ""
+
+
+def _redacted_args(args: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        key: ("[REDACTED]" if re.search(r"(key|token|secret|password)", str(key), re.I) else value)
+        for key, value in args.items()
+    }

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1827,6 +1827,20 @@ DEFAULT_CONFIG = {
     # Privacy settings
     "privacy": {
         "redact_pii": False,  # When True, hash user IDs and strip phone numbers from LLM context
+        # Opt-in local-only mode. When enabled, runtime provider resolution
+        # rejects remote inference providers unless they are explicitly listed
+        # in allowed_providers, and tool loading subtracts external/networked
+        # toolsets by default (overridable via disabled_toolsets).
+        "local_only": False,
+        "allowed_providers": ["lmstudio"],
+        "disabled_toolsets": [
+            "web", "search", "x_search",
+            "vision", "browser",
+            "image_gen", "video", "video_gen", "tts",
+            "messaging", "homeassistant", "spotify",
+            "discord", "discord_admin", "yuanbao",
+            "feishu_doc", "feishu_drive",
+        ],
     },
     
     # Text-to-speech configuration
@@ -2311,6 +2325,25 @@ DEFAULT_CONFIG = {
     "security": {
         "allow_private_urls": False,  # Allow requests to private/internal IPs (for OpenWrt, proxies, VPNs)
         "redact_secrets": True,
+        # Declarative tool policy evaluated before every tool call.
+        # Modes: personal_trusted | confirm_dangerous | read_only | project_sandbox | team_governed
+        "tool_policy": {
+            "mode": "confirm_dangerous",
+            "allow": {
+                "commands": [],   # tool names or glob patterns to always allow
+                "paths": [],      # file path globs to always allow
+                "domains": [],    # URL domain globs to always allow
+                "providers": [],
+                "toolsets": [],
+            },
+            "deny": {
+                "commands": [],   # tool names or glob patterns to block
+                "paths": [],      # file path globs to block
+                "domains": [],
+                "providers": [],
+                "toolsets": [],
+            },
+        },
         "tirith_enabled": True,
         "tirith_path": "tirith",
         "tirith_timeout": 5,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10424,6 +10424,9 @@ def cmd_profile(args):
         remove_wrapper_script,
         _is_wrapper_dir_in_path,
         _get_wrapper_dir,
+        _apply_local_only_profile_preset,
+        _apply_local_model_profile_preset,
+        _apply_team_profile_preset,
     )
     from hermes_constants import display_hermes_home
 
@@ -10505,12 +10508,17 @@ def cmd_profile(args):
             print(f"Error: {e}")
             sys.exit(1)
 
-    elif action == "create":
+        elif action == "create":
         name = args.profile_name
         clone = getattr(args, "clone", False)
         clone_all = getattr(args, "clone_all", False)
         no_alias = getattr(args, "no_alias", False)
         no_skills = getattr(args, "no_skills", False)
+        local_only = getattr(args, "local_only", False)
+        local_model = getattr(args, "local_model", False)
+        local_model_url = getattr(args, "local_model_url", "http://127.0.0.1:8000/v1")
+        local_model_name = getattr(args, "local_model_name", "local-model")
+        team_preset = getattr(args, "team", False) or getattr(args, "enterprise", False)
 
         try:
             clone_from = getattr(args, "clone_from", None)
@@ -10525,7 +10533,22 @@ def cmd_profile(args):
                 no_skills=no_skills,
                 description=getattr(args, "description", None),
             )
+
+            # Apply profile presets before printing success — presets write
+            # config.yaml into the freshly created profile directory.
+            if local_model:
+                _apply_local_model_profile_preset(
+                    profile_dir,
+                    base_url=local_model_url or "http://127.0.0.1:8000/v1",
+                    model_name=local_model_name or "local-model",
+                )
+            elif local_only:
+                _apply_local_only_profile_preset(profile_dir)
+            if team_preset:
+                _apply_team_profile_preset(profile_dir)
+
             print(f"\nProfile '{name}' created at {profile_dir}")
+
 
             if clone_config or clone_all:
                 source_label = (

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -734,6 +734,139 @@ def write_profile_meta(
 
 
 # ---------------------------------------------------------------------------
+# Profile preset helpers — applied after profile creation
+# ---------------------------------------------------------------------------
+
+def _apply_local_only_profile_preset(profile_dir: Path) -> None:
+    """Write the local-only privacy preset into a profile's config.yaml."""
+    import yaml
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    config_path = profile_dir / "config.yaml"
+    data: dict = {}
+    if config_path.is_file():
+        try:
+            with open(config_path, "r", encoding="utf-8") as f:
+                loaded = yaml.safe_load(f) or {}
+            if isinstance(loaded, dict):
+                data = loaded
+        except Exception:
+            data = {}
+
+    privacy_defaults = DEFAULT_CONFIG.get("privacy", {})
+    disabled_toolsets = privacy_defaults.get("disabled_toolsets", [])
+    allowed_providers = privacy_defaults.get("allowed_providers", [])
+    data["privacy"] = {
+        **(data.get("privacy") if isinstance(data.get("privacy"), dict) else {}),
+        "local_only": True,
+        "allowed_providers": list(allowed_providers),
+        "disabled_toolsets": list(disabled_toolsets),
+    }
+
+    with open(config_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(data, f, sort_keys=False, default_flow_style=False)
+
+
+def _apply_local_model_profile_preset(
+    profile_dir: Path,
+    *,
+    base_url: str = "http://127.0.0.1:8000/v1",
+    model_name: str = "local-model",
+) -> None:
+    """Write a local OpenAI-compatible model preset into config.yaml."""
+    import yaml
+
+    _apply_local_only_profile_preset(profile_dir)
+
+    config_path = profile_dir / "config.yaml"
+    data: dict = {}
+    if config_path.is_file():
+        try:
+            with open(config_path, "r", encoding="utf-8") as f:
+                loaded = yaml.safe_load(f) or {}
+            if isinstance(loaded, dict):
+                data = loaded
+        except Exception:
+            data = {}
+
+    normalized_url = (base_url or "http://127.0.0.1:8000/v1").strip().rstrip("/")
+    normalized_model = (model_name or "local-model").strip()
+    providers = data.get("providers")
+    if not isinstance(providers, dict):
+        providers = {}
+    providers["local-gpu"] = {
+        "name": "Local GPU",
+        "api": normalized_url,
+        "api_key": "no-key-required",
+        "default_model": normalized_model,
+        "transport": "chat_completions",
+        "discover_models": True,
+    }
+    data["providers"] = providers
+    data["model"] = {
+        **(data.get("model") if isinstance(data.get("model"), dict) else {}),
+        "default": normalized_model,
+        "provider": "custom",
+        "base_url": normalized_url,
+        "api_key": "no-key-required",
+        "api_mode": "chat_completions",
+    }
+
+    with open(config_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(data, f, sort_keys=False, default_flow_style=False)
+
+
+def _apply_team_profile_preset(profile_dir: Path) -> None:
+    """Write team/enterprise governance policy defaults into config.yaml."""
+    import yaml
+
+    config_path = profile_dir / "config.yaml"
+    data: dict = {}
+    if config_path.is_file():
+        try:
+            with open(config_path, "r", encoding="utf-8") as f:
+                loaded = yaml.safe_load(f) or {}
+            if isinstance(loaded, dict):
+                data = loaded
+        except Exception:
+            data = {}
+
+    security = data.get("security")
+    if not isinstance(security, dict):
+        security = {}
+    tool_policy = security.get("tool_policy")
+    if not isinstance(tool_policy, dict):
+        tool_policy = {}
+    tool_policy["mode"] = "team_governed"
+    allow = tool_policy.get("allow")
+    if not isinstance(allow, dict):
+        allow = {}
+    allow.setdefault("commands", [])
+    allow.setdefault("paths", [])
+    allow.setdefault("domains", [])
+    allow.setdefault("providers", [])
+    allow.setdefault("toolsets", [])
+    deny = tool_policy.get("deny")
+    if not isinstance(deny, dict):
+        deny = {}
+    deny.setdefault("commands", [])
+    deny.setdefault("paths", ["*.env", "auth.json", ".ssh/**", ".aws/**"])
+    deny.setdefault("domains", [])
+    deny.setdefault("providers", [])
+    deny.setdefault("toolsets", [])
+    tool_policy["allow"] = allow
+    tool_policy["deny"] = deny
+    security["tool_policy"] = tool_policy
+    security["redact_secrets"] = True
+    security["tirith_enabled"] = True
+    security["allow_private_urls"] = False
+    data["security"] = security
+
+    with open(config_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(data, f, sort_keys=False, default_flow_style=False)
+
+
+# ---------------------------------------------------------------------------
 # CRUD operations
 # ---------------------------------------------------------------------------
 

--- a/hermes_cli/subcommands/profile.py
+++ b/hermes_cli/subcommands/profile.py
@@ -56,6 +56,36 @@ def build_profile_parser(subparsers, *, cmd_profile: Callable) -> None:
         help="Create an empty profile with no bundled skills (opts out of `hermes update` skill sync)",
     )
     profile_create.add_argument(
+        "--local-only",
+        action="store_true",
+        help="Enable the local-only privacy preset: block remote providers and networked toolsets",
+    )
+    profile_create.add_argument(
+        "--local-model",
+        action="store_true",
+        help="Configure this profile for a local OpenAI-compatible model endpoint (implies --local-only)",
+    )
+    profile_create.add_argument(
+        "--local-model-url",
+        default="http://127.0.0.1:8000/v1",
+        help="Local model API base URL for --local-model (default: http://127.0.0.1:8000/v1)",
+    )
+    profile_create.add_argument(
+        "--local-model-name",
+        default="local-model",
+        help="Default model name for --local-model (default: local-model)",
+    )
+    profile_create.add_argument(
+        "--team",
+        action="store_true",
+        help="Enable the team/enterprise policy preset: tool_policy mode=team_governed, deny sensitive paths",
+    )
+    profile_create.add_argument(
+        "--enterprise",
+        action="store_true",
+        help="Alias for --team",
+    )
+    profile_create.add_argument(
         "--description",
         default=None,
         help="One- or two-sentence description of what this profile is good at. "

--- a/model_tools.py
+++ b/model_tools.py
@@ -273,6 +273,45 @@ def _clear_tool_defs_cache() -> None:
     _tool_defs_cache.clear()
 
 
+def _privacy_tool_filter_config() -> tuple[bool, tuple[str, ...]]:
+    """Read privacy.local_only from config and return (enabled, disabled_toolsets).
+
+    When local_only is True the caller should subtract the returned toolset names
+    from the active tool schema before sending to the model API.  This keeps
+    networked/remote tools out of the prompt for users who want a fully local
+    inference setup without having to enumerate every toolset manually.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+    except Exception:
+        return False, ()
+    privacy = cfg.get("privacy", {}) if isinstance(cfg, dict) else {}
+    if not isinstance(privacy, dict):
+        return False, ()
+    mode = str(privacy.get("mode") or "").strip().lower()
+    enabled = bool(privacy.get("local_only")) or mode in {"local", "local_only", "local-only"}
+    if not enabled:
+        return False, ()
+    raw_disabled = privacy.get("disabled_toolsets")
+    if isinstance(raw_disabled, (list, tuple, set)):
+        disabled = tuple(str(item).strip() for item in raw_disabled if str(item).strip())
+    else:
+        disabled = ()
+    if disabled:
+        return True, disabled
+    # Default set of external/networked toolsets blocked in local-only mode.
+    return True, (
+        "web", "search", "x_search",
+        "vision", "browser",
+        "image_gen", "video", "video_gen", "tts",
+        "messaging", "homeassistant", "spotify",
+        "discord", "discord_admin", "yuanbao",
+        "feishu_doc", "feishu_drive",
+    )
+
+
 def get_tool_definitions(
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
@@ -306,6 +345,7 @@ def get_tool_definitions(
     # mode, discord action allowlist, etc.) without needing an explicit
     # invalidate hook on every config-writer.
     if quiet_mode:
+        privacy_cache_key = _privacy_tool_filter_config()
         try:
             from hermes_cli.config import get_config_path
             cfg_path = get_config_path()
@@ -316,6 +356,7 @@ def get_tool_definitions(
         cache_key = (
             frozenset(enabled_toolsets) if enabled_toolsets is not None else None,
             frozenset(disabled_toolsets) if disabled_toolsets else None,
+            privacy_cache_key,
             registry._generation,
             cfg_fp,
             bool(os.environ.get("HERMES_KANBAN_TASK")),
@@ -429,11 +470,21 @@ def _compute_tool_definitions(
             elif not quiet_mode:
                 print(f"⚠️  Unknown toolset: {toolset_name}")
 
-    # Plugin-registered tools are now resolved through the normal toolset
-    # path — validate_toolset() / resolve_toolset() / get_all_toolsets()
-    # all check the tool registry for plugin-provided toolsets.  No bypass
-    # needed; plugins respect enabled_toolsets / disabled_toolsets like any
-    # other toolset.
+    # Apply privacy local-only filter — silently subtracts networked/remote
+    # toolsets when privacy.local_only is enabled in config.yaml.
+    privacy_enabled, privacy_disabled_toolsets = _privacy_tool_filter_config()
+    if privacy_enabled:
+        for toolset_name in privacy_disabled_toolsets:
+            if validate_toolset(toolset_name):
+                resolved = resolve_toolset(toolset_name)
+                tools_to_include.difference_update(resolved)
+                if not quiet_mode:
+                    print(
+                        f"🔒 Privacy local-only: disabled toolset '{toolset_name}': "
+                        f"{', '.join(resolved) if resolved else 'no tools'}"
+                    )
+            elif toolset_name in _LEGACY_TOOLSET_MAP:
+                tools_to_include.difference_update(_LEGACY_TOOLSET_MAP[toolset_name])
 
     # Ask the registry for schemas (only returns tools whose check_fn passes)
     filtered_tools = registry.get_definitions(tools_to_include, quiet=quiet_mode)
@@ -1101,6 +1152,47 @@ def handle_function_call(
             logger.debug("ACP edit approval guard error: %s", _edit_approval_err)
             if function_name in {"write_file", "patch"}:
                 return json.dumps({"error": "Edit approval denied: approval guard failed"}, ensure_ascii=False)
+
+        # Evaluate declarative tool policy (security.tool_policy in config.yaml).
+        # Runs fail-open: any exception in policy evaluation is logged at DEBUG
+        # and execution proceeds normally so a misconfigured policy never becomes
+        # an unrecoverable blocker.
+        try:
+            from agent.tool_policy import audit_tool_policy, evaluate_tool_policy
+
+            _policy_toolset = get_toolset_for_tool(function_name)
+            _policy_decision = evaluate_tool_policy(
+                function_name,
+                function_args,
+                toolset=_policy_toolset,
+                cwd=os.getcwd(),
+            )
+            audit_tool_policy(
+                function_name,
+                function_args,
+                _policy_decision,
+                session_id=session_id or "",
+                tool_call_id=tool_call_id or "",
+            )
+            if not _policy_decision.allows_execution:
+                result = json.dumps({"error": _policy_decision.preview}, ensure_ascii=False)
+                _emit_post_tool_call_hook(
+                    function_name=function_name,
+                    function_args=function_args,
+                    result=result,
+                    task_id=task_id,
+                    session_id=session_id,
+                    tool_call_id=tool_call_id,
+                    turn_id=turn_id,
+                    api_request_id=api_request_id,
+                    status="blocked",
+                    error_type="tool_policy_block",
+                    error_message=_policy_decision.preview,
+                    middleware_trace=list(_tool_middleware_trace),
+                )
+                return result
+        except Exception as _tool_policy_err:
+            logger.debug("tool policy evaluation failed open: %s", _tool_policy_err)
 
         # Notify the read-loop tracker when a non-read/search tool runs,
         # so the *consecutive* counter resets (reads after other work are fine).


### PR DESCRIPTION
## Summary

Three related opt-in privacy/security capabilities, all default-off, no breaking changes.

---

### 1. privacy.local_only in config.yaml

`yaml
privacy:
  local_only: true               # opt-in
  allowed_providers: [lmstudio]  # only these remote providers are accepted
  disabled_toolsets:             # toolsets to subtract from the tool schema
    - web
    - search
    - browser
    # ... full list defined in DEFAULT_CONFIG
`

When enabled, _privacy_tool_filter_config() subtracts networked/remote toolsets from the tool schema before every API call. The privacy state is included in the get_tool_definitions() cache key so config changes take effect on the next call without restarting.

Provider resolution (existing code path) honours llowed_providers to reject remote inference backends at startup.

---

### 2. security.tool_policy in config.yaml

`yaml
security:
  tool_policy:
    mode: confirm_dangerous  # personal_trusted | confirm_dangerous | read_only | project_sandbox | team_governed
    allow:
      commands: [git, pytest]
      paths: []
      domains: []
    deny:
      paths: ["*.env", ".ssh/**", ".aws/**"]
      domains: []
`

New file gent/tool_policy.py exposes evaluate_tool_policy() and udit_tool_policy(). The evaluator is called in handle_function_call() between the existing ACP approval guard and the read-loop tracker - it runs **fail-open** (exceptions are caught and logged at DEBUG).

Blocked and high-risk calls are written to a HMAC-signed append-only log at ~/.hermes/logs/tool_policy_audit.jsonl.

Policy modes:
| Mode | Behaviour |
|---|---|
| personal_trusted | Allow everything |
| confirm_dangerous (default) | Block shell-injection / credential-access patterns detected by the existing scan_for_threats() |
| ead_only | Block any tool in MUTATING_TOOLS |
| project_sandbox | Block file paths that escape the current working directory |
| 	eam_governed | Block all high-risk actions; honour explicit allow/deny lists |

---

### 3. Profile presets via hermes profile create

`ash
# Local inference (implies local-only privacy)
hermes profile create gpu --local-model --local-model-url http://127.0.0.1:11434/v1 --local-model-name llama3

# Privacy-only (no model config)
hermes profile create secure --local-only

# Enterprise governance policy
hermes profile create ops --team   # or --enterprise
`

Three new helper functions in hermes_cli/profiles.py:
- _apply_local_only_profile_preset(profile_dir) - writes privacy.local_only: true
- _apply_local_model_profile_preset(profile_dir, *, base_url, model_name) - writes providers + model config, implies local-only
- _apply_team_profile_preset(profile_dir) - writes security.tool_policy.mode: team_governed with sane default deny rules

## Files changed

| File | Change |
|---|---|
| gent/tool_policy.py | **New** - ToolPolicyDecision, evaluate_tool_policy, udit_tool_policy, preview_tool_policy |
| hermes_cli/config.py | Added privacy.local_only schema + security.tool_policy schema to DEFAULT_CONFIG |
| model_tools.py | _privacy_tool_filter_config(), privacy filter in _compute_tool_definitions, policy hook in handle_function_call, privacy state in cache key |
| hermes_cli/profiles.py | Three preset helper functions |
| hermes_cli/subcommands/profile.py | --local-only, --local-model, --local-model-url, --local-model-name, --team, --enterprise flags |
| hermes_cli/main.py | Imports preset helpers, reads new flags in cmd_profile create action |

## Compatibility

- All new config keys default to their off/empty values - existing config.yaml files are unchanged.
- The tool policy evaluator is fail-open: a missing or malformed policy never blocks tool execution.
- No new HERMES_* environment variables. All settings are in config.yaml.
- No changes to the system prompt or message history format.
- No telemetry.