### PR TITLE
[codex] Fix custom relay startup routing

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3567,8 +3567,16 @@ def resolve_provider_client(
     if provider == "custom":
         if explicit_base_url:
             custom_base = _to_openai_base_url(explicit_base_url).strip()
+            limen_relay_key = ""
+            try:
+                relay_base = (os.getenv("LIMEN_RELAY_BASE_URL", "") or "").strip().rstrip("/")
+                if relay_base and custom_base.rstrip("/") == relay_base:
+                    limen_relay_key = (os.getenv("LIMEN_RELAY_API_KEY", "") or "").strip()
+            except Exception:
+                limen_relay_key = ""
             custom_key = (
                 (explicit_api_key or "").strip()
+                or limen_relay_key
                 or os.getenv("OPENAI_API_KEY", "").strip()
                 or "no-key-required"  # local servers don't need auth
             )

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -157,6 +157,16 @@ def _host_derived_api_key(base_url: str) -> str:
     return (os.getenv(env_name, "") or "").strip()
 
 
+def _limen_relay_api_key_for_base_url(base_url: str) -> str:
+    """Return the LIMEN employee relay key only for the exact LIMEN relay URL."""
+    key = (os.getenv("LIMEN_RELAY_API_KEY", "") or "").strip()
+    relay_base_url = (os.getenv("LIMEN_RELAY_BASE_URL", "") or "").strip().rstrip("/")
+    candidate = (base_url or "").strip().rstrip("/")
+    if key and relay_base_url and candidate == relay_base_url:
+        return key
+    return ""
+
+
 def _auto_detect_local_model(base_url: str) -> str:
     """Query a local server for its model name when only one model is loaded."""
     if not base_url:
@@ -677,6 +687,7 @@ def _resolve_named_custom_runtime(
         _da_is_openrouter   = base_url_host_matches(base_url, "openrouter.ai")
         api_key_candidates = [
             (explicit_api_key or "").strip(),
+            _limen_relay_api_key_for_base_url(base_url),
             # Gate env key fallbacks on authoritative hosts (#28660)
             (os.getenv("OPENAI_API_KEY", "").strip()     if _da_is_openai_url else ""),
             (os.getenv("OPENROUTER_API_KEY", "").strip() if _da_is_openrouter  else ""),
@@ -733,6 +744,7 @@ def _resolve_named_custom_runtime(
         (explicit_api_key or "").strip(),
         str(custom_provider.get("api_key", "") or "").strip(),
         os.getenv(str(custom_provider.get("key_env", "") or "").strip(), "").strip(),
+        _limen_relay_api_key_for_base_url(base_url),
         # Gate provider env keys on their authoritative hosts — sending
         # OPENAI_API_KEY to a local-llm endpoint leaks credentials (#28660).
         (os.getenv("OPENAI_API_KEY", "").strip()     if _cp_is_openai_url  else ""),
@@ -857,6 +869,7 @@ def _resolve_openrouter_runtime(
         api_key_candidates = [
             explicit_api_key,
             (cfg_api_key if use_config_base_url else ""),
+            _limen_relay_api_key_for_base_url(base_url),
             (os.getenv("OLLAMA_API_KEY")     if _is_ollama_url                       else ""),
             (os.getenv("OPENAI_API_KEY")     if (_is_openai_url or _is_openai_azure) else ""),
             (os.getenv("OPENROUTER_API_KEY") if _is_openrouter_url                   else ""),

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -2508,6 +2508,48 @@ def test_openai_key_only_sent_to_openai_host(monkeypatch):
     assert resolved["api_key"] == "no-key-required"
 
 
+def test_limen_relay_key_reaches_matching_limen_relay_url(monkeypatch):
+    """LIMEN's scoped LiteLLM virtual key is allowed only for its relay URL."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "custom",
+            "base_url": "https://tokenhub.limenlab.ai/v1",
+        },
+    )
+    monkeypatch.setenv("LIMEN_RELAY_BASE_URL", "https://tokenhub.limenlab.ai/v1")
+    monkeypatch.setenv("LIMEN_RELAY_API_KEY", "sk-limen-employee")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-should-not-be-used")
+
+    resolved = rp.resolve_runtime_provider(requested="custom")
+
+    assert resolved["base_url"] == "https://tokenhub.limenlab.ai/v1"
+    assert resolved["api_key"] == "sk-limen-employee"
+
+
+def test_limen_relay_key_not_sent_to_non_matching_custom_url(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "custom",
+            "base_url": "https://api.deepseek.com/v1",
+        },
+    )
+    monkeypatch.setenv("LIMEN_RELAY_BASE_URL", "https://tokenhub.limenlab.ai/v1")
+    monkeypatch.setenv("LIMEN_RELAY_API_KEY", "sk-limen-employee")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-should-not-be-used")
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="custom")
+
+    assert resolved["base_url"] == "https://api.deepseek.com/v1"
+    assert resolved["api_key"] == "no-key-required"
+
+
 def test_openai_key_reaches_openai_host(monkeypatch):
     """OPENAI_API_KEY must be forwarded when the base_url is api.openai.com."""
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")

--- a/tests/tui_gateway/test_make_agent_provider.py
+++ b/tests/tui_gateway/test_make_agent_provider.py
@@ -60,6 +60,61 @@ def test_make_agent_passes_resolved_provider():
         assert call_kwargs.kwargs["api_mode"] == "anthropic_messages"
 
 
+def test_resolve_startup_runtime_keeps_custom_relay_for_vendor_named_model(monkeypatch):
+    """A custom relay model can look like a vendor model name.
+
+    LIMEN receives tenant-scoped LiteLLM virtual keys and exposes vendor-named
+    model aliases through a custom OpenAI-compatible endpoint. If HERMES_MODEL
+    is set to ``deepseek-v4-pro``, startup must not infer the native DeepSeek
+    provider and bypass the relay.
+    """
+
+    fake_cfg = {
+        "model": {
+            "default": "deepseek-v4-pro",
+            "provider": "custom",
+            "base_url": "https://relay.example.test/v1",
+        }
+    }
+
+    monkeypatch.setenv("HERMES_MODEL", "deepseek-v4-pro")
+    monkeypatch.delenv("HERMES_TUI_PROVIDER", raising=False)
+    monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+
+    with patch("tui_gateway.server._load_cfg", return_value=fake_cfg):
+        from tui_gateway.server import _resolve_startup_runtime
+
+        model, provider = _resolve_startup_runtime()
+
+    assert model == "deepseek-v4-pro"
+    assert provider is None
+
+
+def test_git_branch_for_cwd_does_not_spawn_git_for_non_repo_workspace(tmp_path):
+    """Session info must not block on Git for LIMEN employee workspaces."""
+
+    class GitWasCalled(BaseException):
+        pass
+
+    from tui_gateway.server import _git_branch_for_cwd
+
+    with patch("tui_gateway.server.subprocess.run", side_effect=GitWasCalled):
+        assert _git_branch_for_cwd(str(tmp_path)) == ""
+
+
+def test_git_branch_for_cwd_reads_head_without_subprocess(tmp_path):
+    git_dir = tmp_path / ".git"
+    git_dir.mkdir()
+    (git_dir / "HEAD").write_text(
+        "ref: refs/heads/feature/qwen-relay\n",
+        encoding="utf-8",
+    )
+
+    from tui_gateway.server import _git_branch_for_cwd
+
+    assert _git_branch_for_cwd(str(tmp_path)) == "feature/qwen-relay"
+
+
 def test_make_agent_ignores_display_personality_without_system_prompt():
     """The TUI matches the classic CLI: personality only becomes active once
     it has been saved to agent.system_prompt."""

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -839,25 +839,32 @@ def _terminal_task_cwd(session: dict | None) -> str:
 
 def _git_branch_for_cwd(cwd: str) -> str:
     try:
-        result = subprocess.run(
-            ["git", "-C", cwd, "branch", "--show-current"],
-            capture_output=True,
-            text=True,
-            timeout=1.5,
-            check=False,
-        )
-        if result.returncode == 0:
-            branch = result.stdout.strip()
-            if branch:
-                return branch
-        head = subprocess.run(
-            ["git", "-C", cwd, "rev-parse", "--short", "HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=1.5,
-            check=False,
-        )
-        return head.stdout.strip() if head.returncode == 0 else ""
+        path = Path(cwd).absolute()
+        if path.is_file():
+            path = path.parent
+
+        git_dir: Path | None = None
+        for candidate in (path, *path.parents):
+            marker = candidate / ".git"
+            if marker.is_dir():
+                git_dir = marker
+                break
+            if marker.is_file():
+                text = marker.read_text(encoding="utf-8", errors="ignore").strip()
+                if text.lower().startswith("gitdir:"):
+                    raw = text.split(":", 1)[1].strip()
+                    resolved = Path(raw)
+                    git_dir = resolved if resolved.is_absolute() else (candidate / resolved).absolute()
+                    break
+        if git_dir is None:
+            return ""
+
+        head = (git_dir / "HEAD").read_text(encoding="utf-8", errors="ignore").strip()
+        if head.startswith("ref:"):
+            ref = head.split(":", 1)[1].strip()
+            prefix = "refs/heads/"
+            return ref[len(prefix):] if ref.startswith(prefix) else Path(ref).name
+        return head[:7] if head else ""
     except Exception:
         return ""
 
@@ -1163,6 +1170,8 @@ def _resolve_startup_runtime() -> tuple[str, str | None]:
             or os.environ.get("HERMES_INFERENCE_PROVIDER", "").strip().lower()
             or "auto"
         )
+        if current_provider == "custom" or current_provider.startswith("custom:"):
+            return model, None
         detected = detect_static_provider_for_model(explicit_model, current_provider)
         if detected:
             provider, detected_model = detected


### PR DESCRIPTION
## Summary
- keep custom relay provider selection for vendor-named models instead of static provider inference
- pass LIMEN relay virtual keys only to the exact configured relay URL
- avoid spawning git while composing TUI session info so non-repo employee workspaces cannot block startup

## Validation
- python -m pytest -o addopts= tests/hermes_cli/test_runtime_provider_resolution.py tests/tui_gateway/test_make_agent_provider.py
- rebuilt Windows unsigned/manual LIMEN 0.9.2 package with CLOUD_API_URL=https://console.limenlab.ai