### PR TITLE
fix(security): prevent session file cleanup from escaping sessions dir

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3972,6 +3972,32 @@ class SessionDB:
         self._execute_write(_do)
 
     @staticmethod
+    def _session_id_maps_inside(sessions_dir: Path, session_id: str) -> bool:
+        """True when files named after *session_id* stay directly inside
+        *sessions_dir*.
+
+        Session IDs are DB keys and may be client-supplied — the REST API's
+        create/fork endpoints accept an arbitrary ``id`` and gateways derive
+        IDs from platform identifiers. When such an ID is reused as a
+        filename (``{id}.json`` / ``{id}.jsonl`` and the
+        ``request_dump_{id}_*`` glob), a value containing path separators or
+        ``..`` would let cleanup unlink files *outside* the sessions
+        directory, turning a routine prune/delete into data loss. Resolve the
+        candidate path and require its parent to be the sessions directory —
+        the same realpath-containment idiom used for write-path access
+        control. Resolving both sides also defeats drive-letter and symlink
+        escapes cross-platform.
+        """
+        if not session_id:
+            return False
+        try:
+            base = sessions_dir.resolve()
+            probe = (sessions_dir / f"{session_id}.jsonl").resolve()
+        except (OSError, ValueError):
+            return False
+        return probe.parent == base
+
+    @staticmethod
     def _remove_session_files(sessions_dir: Optional[Path], session_id: str) -> None:
         """Remove on-disk transcript files for a session.
 
@@ -3979,8 +4005,21 @@ class SessionDB:
         ``request_dump_{session_id}_*.json`` files left by the gateway.
         Silently skips files that don't exist and swallows OSError so a
         filesystem hiccup never blocks a DB operation.
+
+        Session IDs that don't map to a path *inside* ``sessions_dir`` (e.g. a
+        client-supplied id containing ``/`` or ``..``) are skipped with a
+        warning instead of being followed: the DB row is still removed by the
+        caller, but the on-disk sweep must never escape the sessions
+        directory.
         """
         if sessions_dir is None:
+            return
+        if not SessionDB._session_id_maps_inside(sessions_dir, session_id):
+            logger.warning(
+                "Skipping on-disk cleanup for session id %r: it does not "
+                "resolve to a file inside the sessions directory",
+                session_id,
+            )
             return
         for suffix in (".json", ".jsonl"):
             p = sessions_dir / f"{session_id}{suffix}"

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1559,6 +1559,43 @@ class TestDeleteAndExport:
     def test_delete_nonexistent(self, db):
         assert db.delete_session("nope") is False
 
+    def test_delete_session_with_traversal_id_stays_inside_sessions_dir(
+        self, db, tmp_path
+    ):
+        """A client-supplied session id containing ``..`` must not let
+        on-disk cleanup unlink files outside ``sessions_dir``. The DB row is
+        still removed; the file sweep is skipped (see ``_remove_session_files``
+        containment guard). Regression for the session-cleanup path-traversal
+        data-loss bug."""
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        # A file a sibling directory above sessions_dir — must survive.
+        victim = tmp_path / "victim.jsonl"
+        victim.write_text("precious")
+
+        # Escapes sessions_dir: sessions/../victim.jsonl -> tmp_path/victim.jsonl
+        bad_id = "../victim"
+        db.create_session(session_id=bad_id, source="cli")
+
+        assert db.delete_session(bad_id, sessions_dir=sessions_dir) is True
+        # DB row gone, but the out-of-tree file is untouched.
+        assert db.get_session(bad_id) is None
+        assert victim.exists()
+        assert victim.read_text() == "precious"
+
+    def test_delete_session_cleans_normal_id_files(self, db, tmp_path):
+        """The containment guard must not regress the happy path: a normal id
+        still has its ``.json`` / ``.jsonl`` transcripts swept."""
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        db.create_session(session_id="s1", source="cli")
+        (sessions_dir / "s1.jsonl").write_text("")
+        (sessions_dir / "s1.json").write_text("{}")
+
+        assert db.delete_session("s1", sessions_dir=sessions_dir) is True
+        assert not (sessions_dir / "s1.jsonl").exists()
+        assert not (sessions_dir / "s1.json").exists()
+
     def test_resolve_session_id_exact(self, db):
         db.create_session(session_id="20260315_092437_c9a6ff", source="cli")
         assert db.resolve_session_id("20260315_092437_c9a6ff") == "20260315_092437_c9a6ff"


### PR DESCRIPTION
## What does this PR do?

`SessionDB._remove_session_files()` derives on-disk paths directly from a
session id that can be client-controlled. The REST API's create/fork endpoints
accept an arbitrary `id` and only reject CR/LF/NUL plus over-length values, so an
id containing `/` or `..` is persisted as a normal DB row. Later, when that row
is cleaned up, the function builds `sessions_dir / f"{id}.json"` / `.jsonl` and
the `request_dump_{id}_*` glob from the raw id and calls `unlink()` on the
result. An id like `../victim` resolves **outside** the sessions directory, so a
routine `delete` / `prune` / `delete-empty` turns into data loss against
unrelated files.

This is reached by real maintenance flows that pass `sessions_dir` into deletion
(CLI session delete, TUI delete, prune, auto-prune, delegate cleanup) — every one
of them funnels through `_remove_session_files()`.

**Fix:** add a realpath-containment guard. The on-disk sweep only runs when the
derived path resolves to a **direct child** of `sessions_dir`; otherwise it is
skipped and a warning is logged. The DB row is still removed by the caller — only
the filesystem sweep is gated, so it can never escape the sessions directory.

Why hardening the sink rather than only the API input: `_remove_session_files()`
is the single chokepoint for *every* delete/prune path, so this protects all id
sources (API, gateway, CLI, migration) with **no API contract change** and zero
regression risk for existing clients. The check is pure `pathlib`; resolving both
sides also neutralizes drive-letter and symlink escapes across platforms.

## Related Issue

No existing issue located. Reported proactively as a data-loss / path-traversal
hardening in session cleanup.

Fixes #

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `hermes_state.py`: add `SessionDB._session_id_maps_inside()` (resolve-and-contain
  predicate) and gate `SessionDB._remove_session_files()` on it — unsafe ids skip
  the file sweep with a `logger.warning`; the DB row is still deleted.
- `tests/test_hermes_state.py`: add two regression tests in `TestDeleteAndExport`
  — a traversal id (`../victim`) leaves the out-of-tree file untouched while the DB
  row is removed, and a normal id still has its `.json` / `.jsonl` swept.

## How to Test

Reproduction + proof the fix works:

1. Create a session whose id escapes the sessions dir and a file just outside it:

   from hermes_state import SessionDB
   db = SessionDB(db_path=tmp / "state.db")
   sessions = tmp / "sessions"; sessions.mkdir()
   victim = tmp / "victim.jsonl"; victim.write_text("precious")
   db.create_session(session_id="../victim", source="cli")

2. Run the cleanup path used by CLI/TUI/prune:

   db.delete_session("../victim", sessions_dir=sessions)

3. Before this PR: `tmp/victim.jsonl` is deleted (data loss).
   After this PR: the DB row is gone (`db.get_session("../victim") is None`) but
   `tmp/victim.jsonl` still exists with its original contents, and a warning is
   logged.

### Test Results

    $ pytest tests/test_hermes_state.py -q
    280 passed                          # includes the 2 new regression tests

    $ pytest tests/gateway/test_session_api.py -q
    12 passed

    $ pytest tests/gateway/test_api_server.py -q
    165 passed, 1 skipped

    $ pytest tests/test_hermes_state.py tests/gateway/test_session_api.py tests/gateway/test_api_server.py -q
    457 passed, 1 skipped

    # Related cleanup paths exercised:
    $ pytest tests/gateway/test_session_store_prune.py tests/test_empty_session_hygiene.py tests/test_tui_gateway_server.py -q
    321 passed

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(security):`)
- [ ] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the relevant test suites and they pass (see Test Results)
- [x] I've added tests for my changes
- [x] I've tested on my platform

### Documentation & Housekeeping

- [x] N/A — no docs/config keys changed
- [x] N/A — no config keys added/changed
- [x] N/A — no architecture/workflow change
- [x] Considered cross-platform impact — fix is pure `pathlib` (`Path.resolve()` +
  parent comparison), no OS-specific calls, and resolves both paths so drive-letter
  and symlink escapes are handled the same everywhere
- [x] N/A — no tool behavior changed