### PR TITLE
fix(cron): list_cron_job_runs opens job's own profile state.db

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7630,6 +7630,14 @@ def _cron_profile_home(profile: Optional[str]) -> Tuple[str, Path]:
 
 def _annotate_cron_job(job: Dict[str, Any], profile: str, home: Path) -> Dict[str, Any]:
     annotated = dict(job)
+    # Preserve the scheduler_profile field from jobs.json before overwriting
+    # ``profile`` with the name of the profile that owns this jobs.json file.
+    # The scheduler stamps job["profile"] with the profile the job runs under
+    # (where its run sessions are written); _annotate_cron_job then overwrites
+    # ``profile`` with the jobs.json owner.  Keeping the original in
+    # ``scheduler_profile`` lets endpoints that need to open the correct
+    # state.db (e.g. list_cron_job_runs) do so without re-reading raw JSON.
+    annotated["scheduler_profile"] = annotated.get("profile") or profile
     annotated["profile"] = profile
     annotated["profile_name"] = profile
     annotated["hermes_home"] = str(home)
@@ -7728,17 +7736,30 @@ async def list_cron_job_runs(job_id: str, profile: Optional[str] = None, limit: 
     selected = profile or _find_cron_job_profile(job_id)
     # job_id may be a human name; resolve to the canonical id used in run-session ids.
     canonical = job_id
+    # db_profile is the profile whose state.db holds the run sessions.
+    # It may differ from `selected` when the job's jobs.json lives in one profile
+    # (e.g. "default") but the job was created with profile="gerente_agente_de_compras"
+    # — the scheduler writes runs into the job's own profile state.db, not the
+    # profile that owns the jobs.json file.  Honour job["scheduler_profile"] when
+    # present (set by _annotate_cron_job from the original job["profile"] field
+    # before annotation overwrites it) so the run-history endpoint opens the
+    # correct database.  Fall back to `selected` when the field is absent.
+    db_profile = selected
     if selected:
         job = _call_cron_for_profile(selected, "get_job", job_id)
-        if job and job.get("id"):
-            canonical = str(job["id"])
+        if isinstance(job, dict):
+            if job.get("id"):
+                canonical = str(job["id"])
+            sched_prof = job.get("scheduler_profile", "")
+            if sched_prof and sched_prof != selected:
+                db_profile = sched_prof
 
     try:
         limit_n = max(1, min(int(limit), 100))
     except (TypeError, ValueError):
         limit_n = 20
 
-    db = _open_session_db_for_profile(selected)
+    db = _open_session_db_for_profile(db_profile)
     try:
         runs = db.list_cron_job_runs(canonical, limit=limit_n, offset=0)
         now = time.time()
@@ -7748,8 +7769,8 @@ async def list_cron_job_runs(job_id: str, profile: Optional[str] = None, limit: 
                 and (now - s.get("last_active", s.get("started_at", 0))) < 300
             )
             s["archived"] = bool(s.get("archived"))
-            if selected:
-                s["profile"] = selected
+            if db_profile:
+                s["profile"] = db_profile
         return {"runs": runs, "limit": limit_n}
     finally:
         db.close()

--- a/tests/hermes_cli/test_web_server_cron_profiles.py
+++ b/tests/hermes_cli/test_web_server_cron_profiles.py
@@ -197,3 +197,68 @@ async def test_cron_profile_validation_errors(isolated_profiles):
     with pytest.raises(HTTPException) as missing:
         await web_server.list_cron_jobs(profile="missing_profile")
     assert missing.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_list_cron_job_runs_reads_job_profile_state_db(isolated_profiles, tmp_path):
+    """Regression: /api/cron/jobs/{id}/runs must open the state.db that belongs to
+    the profile stored in job["profile"], NOT the profile that owns jobs.json.
+
+    Scenario that triggered the bug:
+    - jobs.json lives in "default" profile (the scheduler's home).
+    - The job carries profile="worker_alpha" (set at create time).
+    - Cron run sessions are written into worker_alpha/state.db.
+    - The endpoint was opening default/state.db → zero runs returned.
+    """
+    import json
+    import time
+
+    from hermes_state import SessionDB
+    from hermes_cli import web_server
+
+    # Create the job in the DEFAULT profile's jobs.json but tag it as worker_alpha.
+    job = web_server._call_cron_for_profile(
+        "default",
+        "create_job",
+        prompt="cross-profile run history test",
+        schedule="every 1h",
+        name="cross-profile-job",
+    )
+    job_id = job["id"]
+
+    # Manually stamp profile="worker_alpha" onto the job in jobs.json, simulating
+    # what the scheduler does for a job that was created under worker_alpha but
+    # whose jobs.json ended up in the default cron dir.
+    jobs_file = isolated_profiles["default"] / "cron" / "jobs.json"
+    data = json.loads(jobs_file.read_text())
+    for j in (data if isinstance(data, list) else data.get("jobs", [])):
+        if j.get("id") == job_id:
+            j["profile"] = "worker_alpha"
+            break
+    jobs_file.write_text(json.dumps(data if isinstance(data, list) else data))
+
+    # Write a real cron run session into worker_alpha's state.db.
+    worker_db_path = isolated_profiles["worker_alpha"] / "state.db"
+    session_id = f"cron_{job_id}_20991231_235959"
+    db = SessionDB(db_path=worker_db_path)
+    try:
+        db.create_session(
+            session_id=session_id,
+            model="test-model",
+            system_prompt="",
+            source="cron",
+        )
+        db.set_session_title(session_id, f"cross-profile-job · Dec 31 23:59")
+        db.end_session(session_id, "cron_complete")
+    finally:
+        db.close()
+
+    # The endpoint must now return the run from worker_alpha's state.db, not zero.
+    result = await web_server.list_cron_job_runs(job_id)
+    runs = result["runs"]
+    assert len(runs) == 1, (
+        f"Expected 1 run from worker_alpha state.db; got {len(runs)}. "
+        "Likely reading the wrong profile's state.db."
+    )
+    assert runs[0]["id"] == session_id
+    assert runs[0].get("profile") == "worker_alpha"


### PR DESCRIPTION
## Problem

When a cron job's `jobs.json` lives in one profile (e.g. `default`) but the job carries `profile='gerente_agente_de_compras'`, run sessions are written into the named profile's `state.db` — not the default one.

The `GET /api/cron/jobs/{id}/runs` endpoint was always opening the **wrong** `state.db`, so the UI showed stale or empty run history even though runs existed on disk.

## Root Cause

`_annotate_cron_job()` overwrote the job's original `profile` field (which names the profile whose `state.db` holds the run sessions) with the name of the profile that **owns** `jobs.json`. The original value was permanently lost after annotation.

`list_cron_job_runs()` then called `_open_session_db_for_profile(selected)` where `selected` was the `jobs.json` owner — always the wrong DB for cross-profile jobs.

## Fix

- **`_annotate_cron_job()`** now copies the raw `profile` field from `jobs.json` into a new `scheduler_profile` key *before* overwriting `profile` with the `jobs.json`-owner name. This preserves the scheduler-stamped value without changing the existing `profile` semantics the UI relies on.

- **`list_cron_job_runs()`** reads `scheduler_profile` from the resolved job and opens that profile's `state.db` when it differs from the `jobs.json` owner, ensuring run sessions written by the scheduler are always found.

## Test

Regression test added to `tests/hermes_cli/test_web_server_cron_profiles.py`:

- Creates a job in the `default` `jobs.json` tagged with `profile='worker_alpha'`
- Writes a real run session into `worker_alpha/state.db`
- Asserts that `list_cron_job_runs()` returns that run (previously returned 0)

All 8 tests in the file pass; `test_cron.py` and `test_cron_fire_dashboard.py` (10 tests) also pass unchanged.