### PR TITLE
test(debug-helpers): cover save() error path for 100% module coverage

### DIFF
--- a/tests/tools/test_debug_helpers.py
+++ b/tests/tools/test_debug_helpers.py
@@ -115,3 +115,15 @@ class TestDebugSessionEnabled:
         data = json.loads(files[0].read_text())
         assert data["total_calls"] == 0
         assert data["tool_calls"] == []
+
+    def test_save_handles_error_gracefully(self, tmp_path, caplog):
+        """save() must not raise when the log file cannot be written."""
+        ds = self._make_enabled(tmp_path)
+        # Point log_dir at a file (not a directory) so open() fails.
+        blocker = tmp_path / "blocker"
+        blocker.write_text("not a dir")
+        ds.log_dir = blocker
+        ds.log_call("search", {"query": "x"})
+        with caplog.at_level("ERROR", logger="tools.debug_helpers"):
+            ds.save()  # must not raise
+        assert any("Error saving" in r.message for r in caplog.records)

--- a/tests/tools/test_debug_helpers.py
+++ b/tests/tools/test_debug_helpers.py
@@ -52,3 +52,15 @@ class TestDebugSessionEnabled:
         data = json.loads(files[0].read_text())
         assert data["total_calls"] == 0
         assert data["tool_calls"] == []
+
+    def test_save_handles_error_gracefully(self, tmp_path, caplog):
+        """save() must not raise when the log file cannot be written."""
+        ds = self._make_enabled(tmp_path)
+        # Point log_dir at a file (not a directory) so open() fails.
+        blocker = tmp_path / "blocker"
+        blocker.write_text("not a dir")
+        ds.log_dir = blocker
+        ds.log_call("search", {"query": "x"})
+        with caplog.at_level("ERROR", logger="tools.debug_helpers"):
+            ds.save()  # must not raise
+        assert any("Error saving" in r.message for r in caplog.records)


### PR DESCRIPTION
## What does this PR do?

Adds a test for the error-handling path in `DebugSession.save()` (`tools/debug_helpers.py`). The `save()` method wraps its file-write in a `try/except` that logs an error and swallows the exception — but that `except` branch (lines 88–89) was previously untested, leaving module coverage at 95%. This PR brings it to 100% and closes the coverage gap tracked in #36539.

## Related Issue

Fixes #36539

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tests/tools/test_debug_helpers.py`: added `test_save_handles_error_gracefully` — points `log_dir` at a regular file (not a directory) so `open()` raises `NotADirectoryError`, then asserts `save()` does not propagate the exception and that the ERROR-level log message is emitted.

## How to Test

1. `uv run pytest tests/tools/test_debug_helpers.py -q` — 14/14 pass (13 existing + 1 new)
2. `uv run --with pytest-cov pytest tests/tools/test_debug_helpers.py --cov=tools.debug_helpers --cov-report=term-missing` — `tools/debug_helpers.py` shows 100% coverage (was 95%, missing lines 88–89)

```
Name                     Stmts   Miss  Cover   Missing
------------------------------------------------------
tools/debug_helpers.py      42      0   100%
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`test(debug-helpers): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] N/A — test-only change, no documentation/config/tool-behavior updates needed

## Screenshots / Logs

```
$ uv run pytest tests/tools/test_debug_helpers.py -q
..............                                                           [100%]
14 passed in 0.36s
```