### PR TITLE
test(clarify): cover _flatten_choice list/tuple branch for 100% coverage

### DIFF
--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -200,6 +200,18 @@ class TestClarifyDictChoices:
         assert _flatten_choice(7) == "7"
         assert _flatten_choice(None) == ""
 
+    def test_flatten_joins_list_of_strings(self):
+        """A list choice is flattened by joining its elements with spaces."""
+        assert _flatten_choice(["alpha", "beta"]) == "alpha beta"
+
+    def test_flatten_joins_tuple_of_strings(self):
+        """A tuple choice is flattened by joining its elements with spaces."""
+        assert _flatten_choice(("alpha", "beta")) == "alpha beta"
+
+    def test_flatten_joins_nested_dicts_in_list(self):
+        """List elements are recursively flattened before joining."""
+        assert _flatten_choice([{"label": "alpha"}, {"label": "beta"}]) == "alpha beta"
+
     def test_dict_choices_reach_callback_as_clean_text(self):
         """The whole point: the UI callback never sees a dict repr."""
         seen = []

--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -111,6 +111,18 @@ class TestClarifyDictChoices:
         assert _flatten_choice({"label": "Short", "description": "Long"}) == "Short"
 
 
+    def test_flatten_joins_list_of_strings(self):
+        """A list choice is flattened by joining its elements with spaces."""
+        assert _flatten_choice(["alpha", "beta"]) == "alpha beta"
+
+    def test_flatten_joins_tuple_of_strings(self):
+        """A tuple choice is flattened by joining its elements with spaces."""
+        assert _flatten_choice(("alpha", "beta")) == "alpha beta"
+
+    def test_flatten_joins_nested_dicts_in_list(self):
+        """List elements are recursively flattened before joining."""
+        assert _flatten_choice([{"label": "alpha"}, {"label": "beta"}]) == "alpha beta"
+
     def test_dict_choices_reach_callback_as_clean_text(self):
         """The whole point: the UI callback never sees a dict repr."""
         seen = []


### PR DESCRIPTION
## What does this PR do?

Adds tests for the list/tuple branch of `_flatten_choice()` in `tools/clarify_tool.py` (line 52). The function flattens LLM-emitted choices into user-facing text, but the branch handling list/tuple-shaped choices (`return " ".join(_flatten_choice(x) for x in c).strip()`) was previously untested, leaving module coverage at 98%. This PR brings it to 100% and closes the coverage gap tracked in #36532.

## Related Issue

Fixes #36532

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tests/tools/test_clarify_tool.py`: added 3 tests in `TestClarifyDictChoices`:
  - `test_flatten_joins_list_of_strings` — verifies `["alpha", "beta"]` → `"alpha beta"`
  - `test_flatten_joins_tuple_of_strings` — verifies `("alpha", "beta")` → `"alpha beta"`
  - `test_flatten_joins_nested_dicts_in_list` — verifies recursive flattening of dicts inside a list

## How to Test

1. `uv run pytest tests/tools/test_clarify_tool.py -q` — 31/31 pass (28 existing + 3 new)
2. `uv run --with pytest-cov pytest tests/tools/test_clarify_tool.py --cov=tools.clarify_tool --cov-report=term-missing` — `tools/clarify_tool.py` shows 100% coverage (was 98%, missing line 52)

```
Name                    Stmts   Miss  Cover   Missing
-----------------------------------------------------
tools/clarify_tool.py      41      0   100%
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`test(clarify): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] N/A — test-only change, no documentation/config/tool-behavior updates needed

## Screenshots / Logs

```
$ uv run pytest tests/tools/test_clarify_tool.py -q
...............................                                          [100%]
31 passed in 0.45s
```