### PR TITLE
fix(desktop): stop refText crash on undefined composer attachment holes

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -554,7 +554,14 @@ export function usePromptActions({
     async (rawText: string, options?: SubmitTextOptions) => {
       const visibleText = rawText.trim()
       const usingComposerAttachments = !options?.attachments
-      const attachments = options?.attachments ?? $composerAttachments.get()
+      // Drop undefined/null holes a session switch or draft restore can leave in
+      // the attachments array (same bug class as AttachmentList #49624). Without
+      // this, the sibling iterations below (a.kind / a.label / a.refText, and the
+      // sync step) throw "Cannot read properties of undefined (reading 'refText')"
+      // and break the chat surface.
+      const attachments = (options?.attachments ?? $composerAttachments.get()).filter(
+        (a): a is ComposerAttachment => Boolean(a)
+      )
 
       const terminalContextBlocks = terminalContextBlocksFromDraft(rawText).join('\n\n')
       const hasImage = attachments.some(a => a.kind === 'image')
@@ -567,14 +574,17 @@ export function usePromptActions({
       let attachmentRefs = attachments.map(optimisticAttachmentRef).filter((r): r is string => Boolean(r))
 
       const buildContextText = (atts: ComposerAttachment[]): string => {
-        const contextRefs = atts
+        // atts may be the post-sync array, which can reintroduce holes; filter
+        // before touching a.refText / a.kind.
+        const present = atts.filter((a): a is ComposerAttachment => Boolean(a))
+        const contextRefs = present
           .map(a => a.refText)
           .filter(Boolean)
           .join('\n')
 
         return (
           [contextRefs, terminalContextBlocks, visibleText].filter(Boolean).join('\n\n') ||
-          (atts.some(a => a.kind === 'image') ? 'What do you see in this image?' : '')
+          (present.some(a => a.kind === 'image') ? 'What do you see in this image?' : '')
         )
       }
 

--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { ComposerAttachment } from '@/store/composer'
 
-import { coerceThinkingText, optimisticAttachmentRef, parseCommandDispatch } from './chat-runtime'
+import { attachmentDisplayText, coerceThinkingText, optimisticAttachmentRef, parseCommandDispatch } from './chat-runtime'
 
 const DATA_URL = 'data:image/png;base64,iVBORw0KGgoAAAANS'
 
@@ -35,6 +35,32 @@ describe('optimisticAttachmentRef', () => {
     expect(optimisticAttachmentRef(attachment({ kind: 'file', refText: '@file:src/a.ts', previewUrl: DATA_URL }))).toBe(
       '@file:src/a.ts'
     )
+  })
+
+  // Session switches / draft restores can leave undefined|null holes in the
+  // composer attachments array. AttachmentList already filters them (#49624),
+  // but the submit path maps the same array through these helpers — an unguarded
+  // hole threw "Cannot read properties of undefined (reading 'refText')",
+  // crashing the chat surface (blank pane). The helpers must no-op on holes.
+  it('returns null for an undefined attachment instead of throwing', () => {
+    expect(() => optimisticAttachmentRef(undefined as unknown as ComposerAttachment)).not.toThrow()
+    expect(optimisticAttachmentRef(undefined as unknown as ComposerAttachment)).toBeNull()
+  })
+
+  it('returns null for a null attachment instead of throwing', () => {
+    expect(optimisticAttachmentRef(null as unknown as ComposerAttachment)).toBeNull()
+  })
+})
+
+describe('attachmentDisplayText', () => {
+  it('returns null for undefined|null instead of reading .kind/.refText on a hole', () => {
+    expect(() => attachmentDisplayText(undefined as unknown as ComposerAttachment)).not.toThrow()
+    expect(attachmentDisplayText(undefined as unknown as ComposerAttachment)).toBeNull()
+    expect(attachmentDisplayText(null as unknown as ComposerAttachment)).toBeNull()
+  })
+
+  it('still resolves a normal file ref', () => {
+    expect(attachmentDisplayText(attachment({ kind: 'file', refText: '@file:src/a.ts' }))).toBe('@file:src/a.ts')
   })
 })
 

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -155,6 +155,13 @@ export function pathLabel(path: string): string {
 }
 
 export function attachmentDisplayText(attachment: ComposerAttachment): string | null {
+  // Session switches / draft restores can leave undefined holes in the
+  // composer attachments array (see AttachmentList's filter(Boolean) + #49624).
+  // Every consumer funnels through here, so guard the chokepoint too.
+  if (!attachment) {
+    return null
+  }
+
   if (attachment.kind === 'terminal' && attachment.detail) {
     return `\`\`\`terminal\n${attachment.detail.trim()}\n\`\`\``
   }
@@ -188,6 +195,10 @@ export function attachmentDisplayText(attachment: ComposerAttachment): string | 
  * through to `attachmentDisplayText`.
  */
 export function optimisticAttachmentRef(attachment: ComposerAttachment): string | null {
+  if (!attachment) {
+    return null
+  }
+
   if (attachment.kind === 'image' && attachment.previewUrl?.startsWith('data:')) {
     return attachment.previewUrl
   }


### PR DESCRIPTION
## Problem

The desktop app intermittently goes blank ("Desktop app link offline" with an empty chat pane). The renderer log shows the same error firing hundreds of times:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'refText')
```

This is the **same bug class** as #49624 (undefined/null holes left in the composer attachments array by a session switch or draft restore), but that PR only guarded `AttachmentList`'s render. The **sibling submit path was left unguarded**, so the crash persists on current `main` even after updating.

`submitPromptText` maps the same attachments array through `attachmentDisplayText` / `optimisticAttachmentRef` and `buildContextText` (reading `a.kind` / `a.label` / `a.refText`). A hole there throws the uncaught `reading 'refText'` error, which blanks the chat surface.

## Fix

Close the whole bug class:

- `attachmentDisplayText` / `optimisticAttachmentRef` no-op (return `null`) on a falsy attachment — the shared chokepoint every consumer funnels through (also protects the `thread.tsx` drop handler).
- `submitPromptText` filters falsy entries from the source array, and `buildContextText` filters its (possibly post-sync) input before reading fields.

## Test

`apps/desktop/src/lib/chat-runtime.test.ts` — asserts both helpers return `null` instead of throwing when handed `undefined`/`null` holes, so the submit path can't reproduce the crash.

```
npm run test:ui -- src/lib/chat-runtime.test.ts   # 14 passed
```

`tsc --noEmit` clean.