### PR TITLE
fix(agent): capture DeepSeek v4 token usage from stream + normalize cache fields

### DIFF
--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -362,6 +362,49 @@ class TestStreamingAccumulator:
         assert response.choices[0].message.content == "Let me check"
         assert len(response.choices[0].message.tool_calls) == 1
 
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_usage_captured_from_content_chunk(self, mock_close, mock_create):
+        """Usage from a content-bearing chunk (DeepSeek v4 pattern) is captured.
+
+        Regression guard: some providers (DeepSeek v4, Kilocode) send usage
+        in a chunk that ALSO has content/choices populated, rather than in a
+        dedicated trailing empty-choices chunk. The usage capture must not be
+        gated on empty choices.
+        """
+        from run_agent import AIAgent
+
+        chunks = [
+            _make_stream_chunk(content="Hello"),  # no usage
+            _make_stream_chunk(
+                content=" world",
+                usage=SimpleNamespace(prompt_tokens=12, completion_tokens=2, total_tokens=14),
+            ),  # content + usage in same chunk (DeepSeek pattern)
+            _make_stream_chunk(content="!", finish_reason="stop", model="test-model"),
+        ]
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter(chunks)
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://api.deepseek.com/v1",
+            model="deepseek-v4-flash",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.usage is not None
+        assert response.usage.prompt_tokens == 12
+        assert response.usage.completion_tokens == 2
+        assert response.usage.total_tokens == 14
+
 
 # ── Test: Streaming Callbacks ────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Two-part fix for the inline token counter showing dashes (`⏱[↑—↑/↓—↓]`) with DeepSeek v4 models (and compatible proxies like Kilocode).

### Part 1 — Streaming usage capture (agent/chat_completion_helpers.py)

Moved the `usage_obj = chunk.usage` capture outside the `if not chunk.choices:` guard to catch usage data from any stream chunk. Standard OpenAI sends usage in a dedicated trailing chunk with empty choices, but some providers and proxies — including DeepSeek v4 and Kilocode — may include usage in a chunk that also has content/choices populated. The old check silently dropped usage in this case, leaving `session_input_tokens`/`session_output_tokens` at 0.

### Part 2 — Cache token normalization (agent/usage_pricing.py)

DeepSeek v4 reports cache tokens at the usage-object top level as `prompt_cache_hit_tokens` / `prompt_cache_miss_tokens` rather than nesting them inside OpenAI-standard `prompt_tokens_details` or using Anthropic-style `cache_read_input_tokens`. Added `prompt_cache_hit_tokens` as a third fallback for `cache_read_tokens` in the chat-completions branch of `normalize_usage()`.

## Testing

- Added `test_normalize_usage_deepseek_v4_cache_hit_fallback` covering `prompt_cache_hit_tokens` → `cache_read_tokens` mapping and correct `input_tokens` derivation
- All 16 existing tests in `tests/agent/test_usage_pricing.py` continue to pass

## Notes

The `prompt_cache_miss_tokens` field is deliberately NOT referenced as a separate bucket — DeepSeek's schema defines `prompt_tokens = prompt_cache_hit_tokens + prompt_cache_miss_tokens`, so the existing total/subtraction arithmetic already accounts for both through `prompt_tokens`. Only the hit-tokens field is needed to break out the cache-read portion.

## Related

Fixes #51982