### PR TITLE
feat: support anthropic_messages transport for custom providers

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2532,6 +2532,16 @@ def build_anthropic_kwargs(
                 kwargs["temperature"] = 1
                 kwargs["max_tokens"] = max(effective_max_tokens, budget + 4096)
 
+        # Third-party providers: disable thinking by default
+        # Non-Anthropic models (deepseek, qwen, glm, etc.) exposed through
+        # Anthropic-compatible endpoints may route ALL output into thinking
+        # blocks when no thinking config is provided (e.g. deepseek-v4-flash
+        # on api.openmodel.ai). Disable thinking for these models unless the
+        # caller has explicitly set a reasoning_config.
+        _is_native_anthro = model.lower().startswith("claude-")
+        if not reasoning_config and not _is_native_anthro and not _is_kimi_coding:
+            kwargs["thinking"] = {"type": "disabled"}
+
     # ── Strip sampling params on 4.7+ ─────────────────────────────────
     # Opus 4.7 rejects any non-default temperature/top_p/top_k with a 400.
     # Callers (auxiliary_client, etc.) may set these for older models;

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -112,6 +112,11 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
         return "anthropic_messages"
     if hostname == "api.kimi.com" and "/coding" in normalized:
         return "anthropic_messages"
+    if hostname == "api.openmodel.ai":
+        # OpenModel API exposes Anthropic Messages protocol via /v1/messages
+        # (same shape as api.anthropic.com); the /v1/chat/completions route
+        # returns 404 when models list show supported_protocols: ["messages"]
+        return "anthropic_messages"
     return None
 
 


### PR DESCRIPTION
## Summary

Two changes to make custom providers work with the Anthropic Messages protocol (used by api.openmodel.ai and other third-party API gateways).

### 1. Auto-detect api.openmodel.ai as anthropic_messages

`runtime_provider.py`: Added `api.openmodel.ai` to the URL auto-detection list. The `/v1/models` endpoint reports `supported_protocols: ["messages"]` and `/v1/chat/completions` returns 404. Users no longer need to manually set `api_mode: anthropic_messages` in config.

### 2. Disable thinking for non-Anthropic models

`anthropic_adapter.py`: When no `reasoning_config` is set, non-Claude models (deepseek, qwen, glm) default to `thinking: disabled`. Without this, some providers route ALL output into thinking blocks — users see empty responses. Known-good providers (Kimi Coding) are excluded.

## Related issue

- Fixes #52013

## Files changed

| File | Changes |
|------|---------|
| `hermes_cli/runtime_provider.py` | +5 lines |
| `agent/anthropic_adapter.py` | +10 lines |
