### PR TITLE
fix(prompt): report Windows 11 host builds

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -7,6 +7,7 @@ assemble pieces, then combines them with memory and ephemeral prompts.
 import json
 import logging
 import os
+import re
 import threading
 import contextvars
 from collections import OrderedDict
@@ -884,6 +885,7 @@ _BACKEND_FALLBACK_DESCRIPTIONS: dict[str, str] = {
 # disk) because the probe captures live backend state that may change
 # across Hermes restarts.
 _BACKEND_PROBE_CACHE: dict[tuple[str, str], str] = {}
+_WINDOWS_11_MIN_BUILD = 22000
 
 
 _WINDOWS_BASH_SHELL_HINT = (
@@ -895,6 +897,22 @@ _WINDOWS_BASH_SHELL_HINT = (
     "(`Get-ChildItem`, `$env:FOO`, `Select-String`) will NOT work — use their "
     "POSIX equivalents (`ls`, `$FOO`, `grep`)."
 )
+
+
+def _windows_release_label(release: str, version: str, platform_label: str) -> str:
+    """Return the user-facing Windows release, correcting Windows 11 builds."""
+    if release != "10":
+        return release
+    for value in (version or "", platform_label or ""):
+        match = re.search(r"(?:^|[^\d])10\.0\.(\d{5,})(?:[^\d]|$)", value)
+        if not match:
+            continue
+        try:
+            if int(match.group(1)) >= _WINDOWS_11_MIN_BUILD:
+                return "11"
+        except ValueError:
+            continue
+    return release
 
 
 def _probe_remote_backend(env_type: str) -> str | None:
@@ -1008,7 +1026,10 @@ def build_environment_hints() -> str:
         if is_wsl():
             host_lines.append("Host: WSL (Windows Subsystem for Linux)")
         elif sys.platform == "win32":
-            host_lines.append(f"Host: Windows ({platform.release()})")
+            host_lines.append(
+                "Host: Windows "
+                f"({_windows_release_label(platform.release(), platform.version(), platform.platform())})"
+            )
         elif sys.platform == "darwin":
             mac_ver = platform.mac_ver()[0]
             host_lines.append(f"Host: macOS ({mac_ver or platform.release()})")

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1136,6 +1136,22 @@ class TestEnvironmentHints:
         assert "bash" in result
         assert "PowerShell" in result
 
+    def test_build_environment_hints_reports_windows_11_by_build(self, monkeypatch):
+        import agent.prompt_builder as _pb
+        import sys, platform
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(platform, "release", lambda: "10")
+        monkeypatch.setattr(platform, "version", lambda: "10.0.26200")
+        monkeypatch.setattr(platform, "platform", lambda: "Windows-10-10.0.26200-SP0")
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        _pb._clear_backend_probe_cache()
+
+        result = _pb.build_environment_hints()
+
+        assert "Host: Windows (11)" in result
+        assert "Host: Windows (10)" not in result
+
     def test_build_environment_hints_on_macos_local(self, monkeypatch):
         import agent.prompt_builder as _pb
         import sys


### PR DESCRIPTION
## Summary
- detect Windows 11 from NT 10.0 build numbers in the system prompt environment hint
- keep Windows 10 builds labeled as Windows 10
- add regression coverage for Windows 11 build 26200

Fixes #51755.

## Tests
- `python -m pytest tests/agent/test_prompt_builder.py::TestEnvironmentHints::test_build_environment_hints_reports_windows_11_by_build tests/agent/test_prompt_builder.py::TestEnvironmentHints::test_build_environment_hints_on_windows_local -q`
- `python -m pytest tests/agent/test_prompt_builder.py -q`
- `python -m py_compile agent/prompt_builder.py`
- `python scripts/check-windows-footguns.py --all`