### PR TITLE
test(clarify-gateway): cover signature, timeout fallback, and notify paths for 100% coverage

### DIFF
--- a/tests/tools/test_clarify_gateway.py
+++ b/tests/tools/test_clarify_gateway.py
@@ -250,3 +250,82 @@ class TestGatewayTextIntercept:
         
         # Clean up
         cm.clear_session("sk-tf")
+
+
+class TestCoverageGaps:
+    """Cover remaining branches: signature(), get_entry miss, find_awaiting
+    with deleted entry, cancel with None entry, timeout exception, get_notify."""
+
+    def setup_method(self):
+        _clear_clarify_state()
+
+    def test_entry_signature(self):
+        """_ClarifyEntry.signature() returns the expected dict."""
+        from tools import clarify_gateway as cm
+
+        entry = cm.register("sig1", "sk", "Q?", ["A", "B"])
+        sig = entry.signature()
+        assert sig["clarify_id"] == "sig1"
+        assert sig["session_key"] == "sk"
+        assert sig["question"] == "Q?"
+        assert sig["choices"] == ["A", "B"]
+
+    def test_entry_signature_no_choices(self):
+        """signature() returns None for choices when open-ended."""
+        from tools import clarify_gateway as cm
+
+        entry = cm.register("sig2", "sk", "Q?", None)
+        sig = entry.signature()
+        assert sig["choices"] is None
+
+    def test_wait_for_response_unknown_id_returns_none(self):
+        """wait_for_response on a non-existent id returns None immediately."""
+        from tools import clarify_gateway as cm
+
+        assert cm.wait_for_response("nonexistent-id", timeout=0.1) is None
+
+    def test_find_awaiting_skips_deleted_entry(self):
+        """get_pending_for_session skips entries that were removed from _entries
+        but still listed in _session_index."""
+        from tools import clarify_gateway as cm
+
+        cm.register("a1", "sk", "Q?", None)
+        # Manually remove from _entries but leave in _session_index
+        with cm._lock:
+            cm._entries.pop("a1", None)
+        # No entry to find → returns None
+        assert cm.get_pending_for_session("sk") is None
+
+    def test_clear_session_skips_deleted_entry(self):
+        """clear_session skips entries that are None (already removed)."""
+        from tools import clarify_gateway as cm
+
+        cm.register("c1", "sk", "Q?", ["A"])
+        # Manually remove from _entries but leave in _session_index
+        with cm._lock:
+            cm._entries.pop("c1", None)
+        # Should return 0 cancelled (entry was already gone)
+        cancelled = cm.clear_session("sk")
+        assert cancelled == 0
+
+    def test_get_clarify_timeout_exception_returns_default(self, monkeypatch):
+        """get_clarify_timeout returns 3600 when load_config raises."""
+        from tools import clarify_gateway as cm
+
+        monkeypatch.setattr("hermes_cli.config.load_config",
+                            lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+        assert cm.get_clarify_timeout() == 3600
+
+    def test_get_notify_returns_callback(self):
+        """get_notify returns the registered callback."""
+        from tools import clarify_gateway as cm
+
+        cb = lambda entry: None
+        cm.register_notify("sk-notify", cb)
+        assert cm.get_notify("sk-notify") is cb
+
+    def test_get_notify_returns_none_when_not_registered(self):
+        """get_notify returns None for an unregistered session."""
+        from tools import clarify_gateway as cm
+
+        assert cm.get_notify("unregistered") is None


### PR DESCRIPTION
## What does this PR do?

Adds tests for the remaining uncovered branches in `tools/clarify_gateway.py`: `_ClarifyEntry.signature()` (with and without choices), `wait_for_response` on unknown ID, `get_pending_for_session` skipping deleted entries, `clear_session` skipping None entries, `get_clarify_timeout` exception fallback, and `get_notify` (registered and unregistered). Module coverage was at 93%; this PR brings it to 100%, closing the coverage gap tracked in #36531.

## Related Issue

Fixes #36531

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tests/tools/test_clarify_gateway.py`: added `TestCoverageGaps` class (8 tests):
  - `test_entry_signature` — signature() with choices
  - `test_entry_signature_no_choices` — signature() with None choices
  - `test_wait_for_response_unknown_id_returns_none` — unknown ID → None (line 116)
  - `test_find_awaiting_skips_deleted_entry` — entry removed from _entries but in _session_index (line 177)
  - `test_clear_session_skips_deleted_entry` — None entry skipped in clear_session (line 216)
  - `test_get_clarify_timeout_exception_returns_default` — load_config raises → 3600 (current exception fallback)
  - `test_get_notify_returns_callback` — get_notify returns registered cb (lines 277-278)
  - `test_get_notify_returns_none_when_not_registered` — get_notify on unregistered session

## How to Test

1. `uv run pytest tests/tools/test_clarify_gateway.py -q` — 23/23 pass (15 existing + 8 new)
2. `uv run --with pytest-cov pytest tests/tools/test_clarify_gateway.py --cov=tools.clarify_gateway --cov-report=term-missing`:

```
Name                       Stmts   Miss  Cover   Missing
--------------------------------------------------------
tools/clarify_gateway.py     112      0   100%
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`test(clarify-gateway): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] N/A — test-only change, no documentation/config/tool-behavior updates needed

## Screenshots / Logs

```
$ uv run pytest tests/tools/test_clarify_gateway.py -q
.......................                                                [100%]
23 passed in 0.96s
```

