### PR TITLE
fix(agent): tolerate null tool-call arguments

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -143,6 +143,18 @@ def _cancelled_tool_result(reason: str = "user interrupt") -> str:
     )
 
 
+def _parse_tool_call_arguments(raw_arguments: Any) -> dict:
+    if isinstance(raw_arguments, dict):
+        return dict(raw_arguments)
+    if raw_arguments in (None, ""):
+        return {}
+    try:
+        parsed = json.loads(raw_arguments)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
 def _emit_cancelled_terminal_post_tool_call(
     agent,
     *,
@@ -320,12 +332,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         elif function_name == "skill_manage":
             agent._iters_since_skill = 0
 
-        try:
-            function_args = json.loads(tool_call.function.arguments)
-        except json.JSONDecodeError:
-            function_args = {}
-        if not isinstance(function_args, dict):
-            function_args = {}
+        function_args = _parse_tool_call_arguments(tool_call.function.arguments)
 
         # ── Tool Search unwrap ────────────────────────────────────────
         # When the model invokes the tool_call bridge, peel it open so
@@ -877,13 +884,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
 
         function_name = tool_call.function.name
 
-        try:
-            function_args = json.loads(tool_call.function.arguments)
-        except json.JSONDecodeError as e:
-            logger.warning(f"Unexpected JSON error after validation: {e}")
-            function_args = {}
-        if not isinstance(function_args, dict):
-            function_args = {}
+        function_args = _parse_tool_call_arguments(tool_call.function.arguments)
 
         # Tool Search unwrap — see execute_tool_calls_concurrent for full
         # rationale, including the scope gate (the unwrap dispatches the

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -112,6 +112,44 @@ def test_default_sequential_path_warns_repeated_exact_failure_without_blocking_e
     assert agent._tool_guardrail_halt_decision is None
 
 
+def test_sequential_tool_call_null_arguments_runs_with_empty_args():
+    agent = _make_agent("terminal")
+    tc = _mock_tool_call("terminal", None, "c-null")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+
+    with patch("run_agent.handle_function_call", return_value=json.dumps({"ok": True})) as mock_hfc:
+        agent._execute_tool_calls_sequential(msg, messages, "task-1")
+
+    mock_hfc.assert_called_once()
+    assert mock_hfc.call_args.args[:3] == ("terminal", {}, "task-1")
+    assert messages[0]["tool_call_id"] == "c-null"
+    assert json.loads(messages[0]["content"]) == {"ok": True}
+
+
+def test_concurrent_tool_call_null_arguments_runs_with_empty_args():
+    agent = _make_agent("terminal")
+    calls = [
+        _mock_tool_call("terminal", None, "c-null"),
+        _mock_tool_call("terminal", json.dumps({"command": "pwd"}), "c-ok"),
+    ]
+    msg = SimpleNamespace(content="", tool_calls=calls)
+    messages = []
+
+    def fake_handle(name, args, task_id, **kwargs):
+        return json.dumps({"args": args, "id": kwargs["tool_call_id"]})
+
+    with patch("run_agent.handle_function_call", side_effect=fake_handle):
+        agent._execute_tool_calls_concurrent(msg, messages, "task-1")
+
+    assert [m["tool_call_id"] for m in messages] == ["c-null", "c-ok"]
+    assert json.loads(messages[0]["content"]) == {"args": {}, "id": "c-null"}
+    assert json.loads(messages[1]["content"]) == {
+        "args": {"command": "pwd"},
+        "id": "c-ok",
+    }
+
+
 def test_config_enabled_hard_stop_blocks_repeated_exact_failure_before_execution():
     agent = _make_agent("web_search", config=_hard_stop_config())
     args = {"query": "same"}


### PR DESCRIPTION
## Summary
- normalize null, empty, malformed, or non-object tool-call arguments to `{}` before dispatch
- apply the same parsing path to sequential and concurrent tool execution
- add runtime regression coverage for provider SDK tool calls with `function.arguments = null`

Fixes #50892.

## Tests
- `python -m pytest tests/run_agent/test_tool_call_guardrail_runtime.py::test_sequential_tool_call_null_arguments_runs_with_empty_args tests/run_agent/test_tool_call_guardrail_runtime.py::test_concurrent_tool_call_null_arguments_runs_with_empty_args -q`
- `python -m pytest tests/run_agent/test_tool_call_guardrail_runtime.py -q`
- `python -m py_compile agent/tool_executor.py`
- `python scripts/check-windows-footguns.py --all`