### PR TITLE
fix(cron): accept weekdays at time schedules

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -332,6 +332,33 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
             "minutes": minutes,
             "display": f"every {minutes}m"
         }
+
+    weekday_match = re.match(
+        r"^weekdays?\s+at\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?$",
+        schedule_lower,
+    )
+    if weekday_match:
+        hour = int(weekday_match.group(1))
+        minute = int(weekday_match.group(2) or "0")
+        meridiem = weekday_match.group(3)
+        if meridiem == "pm" and hour != 12:
+            hour += 12
+        elif meridiem == "am" and hour == 12:
+            hour = 0
+        if not (0 <= hour <= 23 and 0 <= minute <= 59):
+            raise ValueError(f"Invalid time in schedule '{original}'")
+        expr = f"{minute} {hour} * * 1-5"
+        if not HAS_CRONITER:
+            raise ValueError("Cron expressions require 'croniter' package. Install with: pip install croniter")
+        try:
+            croniter(expr)
+        except Exception as e:
+            raise ValueError(f"Invalid cron expression '{expr}': {e}")
+        return {
+            "kind": "cron",
+            "expr": expr,
+            "display": original,
+        }
     
     # Check for cron expression (5 or 6 space-separated fields)
     # Cron fields: minute hour day month weekday [year]

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -96,6 +96,20 @@ class TestParseSchedule:
         assert result["kind"] == "cron"
         assert result["expr"] == "0 9 * * *"
 
+    @pytest.mark.parametrize(
+        ("schedule", "expected_expr"),
+        [
+            ("weekdays at 9am", "0 9 * * 1-5"),
+            ("weekdays at 09:30", "30 9 * * 1-5"),
+        ],
+    )
+    def test_weekdays_at_time_alias(self, schedule, expected_expr):
+        pytest.importorskip("croniter")
+        result = parse_schedule(schedule)
+        assert result["kind"] == "cron"
+        assert result["expr"] == expected_expr
+        assert result["display"] == schedule
+
     def test_iso_timestamp(self):
         result = parse_schedule("2030-01-15T14:00:00")
         assert result["kind"] == "once"


### PR DESCRIPTION
## Summary
- accept the Desktop-advertised `weekdays at 9am` schedule shape in the backend parser
- convert weekday-at-time aliases to validated weekday cron expressions
- add regression coverage for 12-hour and 24-hour weekday schedule aliases

Fixes #51975.

## Tests
- `python -m pytest tests/cron/test_jobs.py::TestParseSchedule::test_weekdays_at_time_alias -q`
- `python -m pytest tests/cron/test_jobs.py::TestParseSchedule -q`
- `python -m py_compile cron/jobs.py`
- `python scripts/check-windows-footguns.py --all`