### PR TITLE
test(browser-dialog): cover dialog handler and check gate for 100% coverage

### DIFF
--- a/tests/tools/test_browser_dialog_tool.py
+++ b/tests/tools/test_browser_dialog_tool.py
@@ -1,0 +1,154 @@
+"""Tests for tools/browser_dialog_tool.py.
+
+Covers the browser_dialog handler: no supervisor attached, successful
+accept/dismiss, and error response from the supervisor.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from tools.browser_dialog_tool import browser_dialog
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Clear SUPERVISOR_REGISTRY before each test."""
+    from tools.browser_supervisor import SUPERVISOR_REGISTRY
+    with SUPERVISOR_REGISTRY._lock:
+        SUPERVISOR_REGISTRY._by_task.clear()
+    yield
+    with SUPERVISOR_REGISTRY._lock:
+        SUPERVISOR_REGISTRY._by_task.clear()
+
+
+class TestBrowserDialogNoSupervisor:
+    """When no CDP supervisor is attached, return a helpful error."""
+
+    def test_no_supervisor_default_task(self):
+        result = browser_dialog(action="accept")
+        data = json.loads(result)
+        assert data["success"] is False
+        assert "No CDP supervisor" in data["error"]
+
+    def test_no_supervisor_custom_task_id(self):
+        result = browser_dialog(action="dismiss", task_id="my-task")
+        data = json.loads(result)
+        assert data["success"] is False
+        assert "No CDP supervisor" in data["error"]
+
+
+class TestBrowserDialogSuccess:
+    """When the supervisor responds with ok=True, return success JSON."""
+
+    def test_accept_success(self):
+        from tools.browser_supervisor import SUPERVISOR_REGISTRY
+
+        supervisor = SimpleNamespace(
+            respond_to_dialog=lambda action, prompt_text, dialog_id: {
+                "ok": True,
+                "dialog": {"id": "d1", "type": "alert", "message": "hello"},
+            }
+        )
+        SUPERVISOR_REGISTRY._by_task["default"] = supervisor
+
+        result = browser_dialog(action="accept")
+        data = json.loads(result)
+        assert data["success"] is True
+        assert data["action"] == "accept"
+        assert data["dialog"]["id"] == "d1"
+
+    def test_dismiss_success(self):
+        from tools.browser_supervisor import SUPERVISOR_REGISTRY
+
+        supervisor = SimpleNamespace(
+            respond_to_dialog=lambda action, prompt_text, dialog_id: {
+                "ok": True,
+                "dialog": {"id": "d2", "type": "confirm"},
+            }
+        )
+        SUPERVISOR_REGISTRY._by_task["default"] = supervisor
+
+        result = browser_dialog(action="dismiss")
+        data = json.loads(result)
+        assert data["success"] is True
+        assert data["action"] == "dismiss"
+
+    def test_prompt_text_forwarded(self):
+        from tools.browser_supervisor import SUPERVISOR_REGISTRY
+
+        captured = {}
+
+        def fake_respond(action, prompt_text, dialog_id):
+            captured["prompt_text"] = prompt_text
+            captured["dialog_id"] = dialog_id
+            return {"ok": True, "dialog": {}}
+
+        supervisor = SimpleNamespace(respond_to_dialog=fake_respond)
+        SUPERVISOR_REGISTRY._by_task["default"] = supervisor
+
+        result = browser_dialog(
+            action="accept",
+            prompt_text="my answer",
+            dialog_id="dlg-42",
+        )
+        data = json.loads(result)
+        assert data["success"] is True
+        assert captured["prompt_text"] == "my answer"
+        assert captured["dialog_id"] == "dlg-42"
+
+
+class TestBrowserDialogError:
+    """When the supervisor responds with ok=False, return error JSON."""
+
+    def test_supervisor_error(self):
+        from tools.browser_supervisor import SUPERVISOR_REGISTRY
+
+        supervisor = SimpleNamespace(
+            respond_to_dialog=lambda action, prompt_text, dialog_id: {
+                "ok": False,
+                "error": "dialog already handled",
+            }
+        )
+        SUPERVISOR_REGISTRY._by_task["default"] = supervisor
+
+        result = browser_dialog(action="accept")
+        data = json.loads(result)
+        assert data["success"] is False
+        assert data["error"] == "dialog already handled"
+
+    def test_supervisor_error_default_message(self):
+        """When ok=False but no error key, use 'unknown error'."""
+        from tools.browser_supervisor import SUPERVISOR_REGISTRY
+
+        supervisor = SimpleNamespace(
+            respond_to_dialog=lambda action, prompt_text, dialog_id: {
+                "ok": False,
+            }
+        )
+        SUPERVISOR_REGISTRY._by_task["default"] = supervisor
+
+        result = browser_dialog(action="dismiss")
+        data = json.loads(result)
+        assert data["success"] is False
+        assert data["error"] == "unknown error"
+
+
+class TestBrowserDialogCheck:
+    """Cover _browser_dialog_check gate function."""
+
+    def test_check_delegates_to_cdp_check_true(self):
+        from tools.browser_dialog_tool import _browser_dialog_check
+
+        with patch("tools.browser_cdp_tool._browser_cdp_check", return_value=True):
+            assert _browser_dialog_check() is True
+
+    def test_check_delegates_to_cdp_check_false(self):
+        from tools.browser_dialog_tool import _browser_dialog_check
+
+        with patch("tools.browser_cdp_tool._browser_cdp_check", return_value=False):
+            assert _browser_dialog_check() is False


### PR DESCRIPTION
## What does this PR do?

Creates a new test file for `tools/browser_dialog_tool.py`, covering the `browser_dialog` handler (no supervisor, success, error, prompt_text forwarding) and the `_browser_dialog_check` gate function. Module coverage was at 64%; this PR brings it to 100%, closing the coverage gap tracked in #36527.

## Related Issue

Fixes #36527

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tests/tools/test_browser_dialog_tool.py` (new file, 9 tests):
  - `TestBrowserDialogNoSupervisor` — no supervisor attached → helpful error (default and custom task_id)
  - `TestBrowserDialogSuccess` — accept success, dismiss success, prompt_text and dialog_id forwarded
  - `TestBrowserDialogError` — supervisor returns ok=False with error, default "unknown error" message
  - `TestBrowserDialogCheck` — `_browser_dialog_check` delegates to `_browser_cdp_check` (true and false)

## How to Test

1. `uv run pytest tests/tools/test_browser_dialog_tool.py -q` — 9/9 pass
2. `uv run --with pytest-cov pytest tests/tools/test_browser_dialog_tool.py --cov=tools.browser_dialog_tool --cov-report=term-missing`:

```
Name                           Stmts   Miss  Cover   Missing
------------------------------------------------------------
tools/browser_dialog_tool.py      22      0   100%
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`test(browser-dialog): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] N/A — test-only change, no documentation/config/tool-behavior updates needed

## Screenshots / Logs

```
$ uv run pytest tests/tools/test_browser_dialog_tool.py -q
.........                                                                [100%]
9 passed in 0.30s
```