### PR TITLE
fix(gateway): clarify self-restart recovery guidance

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -6397,6 +6397,19 @@ def _dispatch_all_via_service_manager_if_s6(action: str) -> bool:
 
 
 
+def gateway_self_lifecycle_guard_message(action: str) -> str:
+    """Return the block message for self-targeting gateway lifecycle commands."""
+    command = f"hermes gateway {action}"
+    return (
+        f"Refusing to {action} the gateway from inside the gateway process.\n"
+        "This command was blocked to prevent restart loops.\n"
+        f"Run `{command}` from a separate shell outside the running gateway.\n"
+        "If a legacy installation or an explicit `--force` launch left a duplicate "
+        "foreground gateway, stop only that conflicting process or service from another "
+        "shell; see the multi-profile gateway recovery guide for platform-specific steps."
+    )
+
+
 def gateway_command(args):
     """Handle gateway subcommands."""
     try:
@@ -6776,11 +6789,7 @@ def _gateway_command_inner(args):
         # Defense: refuse self-targeting gateway stop from inside the gateway.
         # Prevents agent-initiated kill loops when combined with supervisor KeepAlive.
         if os.getenv("_HERMES_GATEWAY") == "1":
-            print_error(
-                "Refusing to stop the gateway from inside the gateway process.\n"
-                "This command was blocked to prevent restart loops.\n"
-                "Use `hermes gateway stop` from a shell outside the running gateway."
-            )
+            print_error(gateway_self_lifecycle_guard_message("stop"))
             sys.exit(1)
 
         stop_all = getattr(args, "all", False)
@@ -6869,11 +6878,7 @@ def _gateway_command_inner(args):
         # Defense: refuse self-targeting gateway restart from inside the gateway.
         # Prevents agent-initiated kill loops when combined with supervisor KeepAlive.
         if os.getenv("_HERMES_GATEWAY") == "1":
-            print_error(
-                "Refusing to restart the gateway from inside the gateway process.\n"
-                "This command was blocked to prevent restart loops.\n"
-                "Use `hermes gateway restart` from a shell outside the running gateway."
-            )
+            print_error(gateway_self_lifecycle_guard_message("restart"))
             sys.exit(1)
 
         # Try service first, fall back to killing and restarting

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -219,21 +219,31 @@ class TestCronCreateLifecycleBlock:
 class TestGatewaySelfTargetingGuard:
     """Verify hermes gateway stop/restart refuse when _HERMES_GATEWAY=1."""
 
-    def test_stop_refuses_inside_gateway(self, monkeypatch):
+    def test_stop_refuses_inside_gateway(self, monkeypatch, capsys):
         monkeypatch.setenv("_HERMES_GATEWAY", "1")
         from hermes_cli.gateway import gateway_command
         args = Namespace(gateway_command="stop", all=False, system=False)
         with pytest.raises(SystemExit) as exc_info:
             gateway_command(args)
         assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "separate shell outside the running gateway" in out
+        assert "legacy installation or an explicit `--force` launch" in out
+        assert "platform-specific steps" in out
+        assert "systemctl" not in out
 
-    def test_restart_refuses_inside_gateway(self, monkeypatch):
+    def test_restart_refuses_inside_gateway(self, monkeypatch, capsys):
         monkeypatch.setenv("_HERMES_GATEWAY", "1")
         from hermes_cli.gateway import gateway_command
         args = Namespace(gateway_command="restart", all=False, system=False)
         with pytest.raises(SystemExit) as exc_info:
             gateway_command(args)
         assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "separate shell outside the running gateway" in out
+        assert "legacy installation or an explicit `--force` launch" in out
+        assert "platform-specific steps" in out
+        assert "systemctl" not in out
 
     def test_stop_allows_outside_gateway(self, monkeypatch):
         # With the gateway marker unset, the self-targeting guard must NOT
@@ -326,6 +336,10 @@ class TestTerminalToolGatewayLifecycleGuard:
 
         assert result["exit_code"] == 1
         assert "Blocked" in result["error"]
+        assert "separate shell outside the running gateway" in result["error"]
+        assert "legacy installation or an explicit `--force` launch" in result["error"]
+        assert "platform-specific steps" in result["error"]
+        assert "systemctl" not in result["error"]
 
     def test_force_true_cannot_bypass_block(self, monkeypatch):
         import tools.terminal_tool as tt

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2282,8 +2282,11 @@ def terminal_tool(
                         "Blocked: cannot restart or stop the gateway from inside the "
                         "gateway process. The gateway would kill this command before "
                         "it could complete (SIGTERM propagates to child processes). "
-                        "Run `hermes gateway restart` from a separate shell outside "
-                        "the running gateway."
+                        "Run gateway lifecycle commands from a separate shell outside "
+                        "the running gateway. If a legacy installation or an explicit "
+                        "`--force` launch left a duplicate foreground gateway, stop only "
+                        "that conflicting process or service from another shell; see the "
+                        "multi-profile gateway recovery guide for platform-specific steps."
                     ),
                     "status": "error",
                 }, ensure_ascii=False)

--- a/website/docs/user-guide/multi-profile-gateways.md
+++ b/website/docs/user-guide/multi-profile-gateways.md
@@ -280,6 +280,46 @@ never clash:
 The default profile keeps the historical names: `ai.hermes.gateway.plist` /
 `hermes-gateway.service`.
 
+## Recover from duplicate profile gateways
+
+Current Hermes releases refuse `hermes gateway run` and
+`hermes gateway run --replace` while the profile's LaunchAgent/systemd service
+is running. Starting a duplicate requires an explicit `--force`. The recovery
+steps below apply only if a legacy installation predating that guard, or an
+explicit `--force` launch (possibly combined with `--replace`), left an
+unmanaged foreground gateway alongside the managed service.
+
+Do not run the recovery through a gateway chat: stopping the gateway would
+kill the child command before it can complete. Open a separate terminal, SSH,
+or administrator session instead.
+
+### Linux (systemd)
+
+Diagnose the owner processes:
+
+```bash
+systemctl --user list-units 'hermes-gateway*' --all
+ps -eo pid,ppid,cmd | grep 'hermes.*gateway' | grep -v grep
+```
+
+Then stop or disable only the conflicting profile unit, terminate the unmanaged
+foreground gateway for that same profile, reset failed state, and start the
+intended dedicated profile service. Leave unrelated healthy profile services
+running.
+
+```bash
+# Example: default is not used and hari should run as its own service.
+systemctl --user disable --now hermes-gateway.service
+systemctl --user stop hermes-gateway-hari.service
+
+# Review these PIDs before killing them.
+ps -eo pid,ppid,cmd | grep -E 'hermes .*gateway run' | grep -E -- '--force|--replace' | grep -v grep
+kill <hari-or-default-foreground-gateway-pid> [...]
+
+systemctl --user reset-failed hermes-gateway.service hermes-gateway-hari.service
+systemctl --user start hermes-gateway-hari.service
+```
+
 ## Viewing logs
 
 Each profile writes to its own log files:


### PR DESCRIPTION
## Summary
- Expand the self-targeting gateway stop/restart guard message with actionable multi-profile/systemd recovery guidance.
- Mirror the same recovery hint in the terminal tool's gateway lifecycle hard-block message.
- Document how to diagnose and recover duplicate profile gateways caused by unmanaged `gateway run --replace` children fighting service-managed gateways.
- Add regression assertions so the recovery guidance stays present.

## Testing
- `python -m pytest tests/hermes_cli/test_gateway_restart_loop.py -q -o 'addopts='`
- `python -m py_compile hermes_cli/gateway.py tools/terminal_tool.py`
- `git diff --check`
- `ruff check hermes_cli/gateway.py tools/terminal_tool.py tests/hermes_cli/test_gateway_restart_loop.py`

## Platforms tested
- Linux user-systemd environment; this change is primarily messaging/docs plus regression tests.
