### PR TITLE
fix(delegate): preserve profile reasoning overrides

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -11,8 +11,10 @@ Run with:  python -m pytest tests/test_delegate.py -v
 
 import json
 import os
+import sys
 import threading
 import time
+import types
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -21,6 +23,7 @@ from tools.delegate_tool import (
     DELEGATE_TASK_SCHEMA,
     DelegateEvent,
     _get_max_concurrent_children,
+    _load_config,
     _LEGACY_EVENT_MAP,
     MAX_DEPTH,
     check_delegate_requirements,
@@ -1927,6 +1930,28 @@ class TestDelegateHeartbeat(unittest.TestCase):
 
 class TestDelegationReasoningEffort(unittest.TestCase):
     """Tests for delegation.reasoning_effort config override."""
+
+    def test_load_config_fills_missing_reasoning_effort_from_persistent_config(self):
+        """Runtime CLI defaults must not hide profile delegation.reasoning_effort."""
+        fake_cli = types.SimpleNamespace(
+            CLI_CONFIG={"delegation": {"max_iterations": 45, "model": ""}}
+        )
+
+        with patch.dict(sys.modules, {"cli": fake_cli}):
+            with patch(
+                "hermes_cli.config.load_config",
+                return_value={
+                    "delegation": {
+                        "max_iterations": 50,
+                        "reasoning_effort": "none",
+                    }
+                },
+            ):
+                cfg = _load_config()
+
+        self.assertEqual(cfg["max_iterations"], 45)
+        self.assertEqual(cfg["model"], "")
+        self.assertEqual(cfg["reasoning_effort"], "none")
 
     @patch("tools.delegate_tool._load_config")
     @patch("run_agent.AIAgent")

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2816,21 +2816,29 @@ def _load_config() -> dict:
     ``delegation.model`` / ``delegation.provider`` are picked up regardless
     of the entry point (CLI, gateway, cron).
     """
+    runtime_cfg = None
     try:
         from cli import CLI_CONFIG
 
         cfg = CLI_CONFIG.get("delegation") or {}
         if cfg:
-            return cfg
+            runtime_cfg = cfg
     except Exception:
         pass
     try:
         from hermes_cli.config import load_config
 
         full = load_config()
-        return full.get("delegation") or {}
+        persistent_cfg = full.get("delegation") or {}
     except Exception:
-        return {}
+        persistent_cfg = {}
+    if runtime_cfg:
+        merged = dict(runtime_cfg)
+        for key, value in persistent_cfg.items():
+            if key not in merged:
+                merged[key] = value
+        return merged
+    return persistent_cfg
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- merge persistent delegation config keys that are missing from runtime CLI_CONFIG
- preserve runtime delegation values when both sources define a key
- add regression coverage so profile-level `delegation.reasoning_effort: none` is not hidden by partial runtime delegation config

Fixes #51903.

## Tests
- `python -m pytest tests/tools/test_delegate.py::TestDelegationReasoningEffort -q`
- `python -m pytest tests/tools/test_delegate.py::TestDelegationReasoningEffort tests/tools/test_delegate.py::TestDelegateHeartbeat::test_heartbeat_does_not_trip_idle_stale_while_inside_tool -q`
- `python -m py_compile tools/delegate_tool.py`
- `python scripts/check-windows-footguns.py --all`