### PR TITLE
fix(tui): make websocket write timeout configurable

### DIFF
--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -126,3 +126,16 @@ def test_ws_write_loop_stall_does_not_latch_transport(monkeypatch):
         loop.call_soon_threadsafe(loop.stop)
         thread.join(timeout=2)
         loop.close()
+
+
+def test_ws_write_timeout_env_override(monkeypatch):
+    monkeypatch.setenv("HERMES_TUI_WS_WRITE_TIMEOUT_S", "30.5")
+
+    assert ws_mod._resolve_ws_write_timeout() == 30.5
+
+
+def test_ws_write_timeout_env_falls_back_for_invalid_values(monkeypatch):
+    for raw in ("", "0", "-1", "nan", "inf", "slow"):
+        monkeypatch.setenv("HERMES_TUI_WS_WRITE_TIMEOUT_S", raw)
+
+        assert ws_mod._resolve_ws_write_timeout() == 10.0

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -27,17 +27,30 @@ import asyncio
 import concurrent.futures
 import json
 import logging
+import math
 import socket
 from typing import Any
 
 from tui_gateway import server
+from utils import env_float
 
 _log = logging.getLogger(__name__)
 
 # Max seconds a pool-dispatched handler will block waiting for the event loop
 # to flush a WS frame before we mark the transport dead. Protects handler
 # threads from a wedged socket.
-_WS_WRITE_TIMEOUT_S = 10.0
+_DEFAULT_WS_WRITE_TIMEOUT_S = 10.0
+_WS_WRITE_TIMEOUT_ENV = "HERMES_TUI_WS_WRITE_TIMEOUT_S"
+
+
+def _resolve_ws_write_timeout() -> float:
+    value = env_float(_WS_WRITE_TIMEOUT_ENV, _DEFAULT_WS_WRITE_TIMEOUT_S)
+    if not math.isfinite(value) or value <= 0:
+        return _DEFAULT_WS_WRITE_TIMEOUT_S
+    return value
+
+
+_WS_WRITE_TIMEOUT_S = _resolve_ws_write_timeout()
 _WS_LOG_PAYLOAD_PREVIEW = 240
 
 # Keep starlette optional at import time; handle_ws uses the real class when


### PR DESCRIPTION
## Summary
- add `HERMES_TUI_WS_WRITE_TIMEOUT_S` support for the TUI Gateway WebSocket writer
- keep the 10s default when the env var is unset, invalid, non-positive, or non-finite
- add regression coverage for valid and invalid env values

Fixes #51288.

## Tests
- `python -m pytest tests/test_tui_gateway_ws.py -q`
- `python -m py_compile tui_gateway/ws.py`
- `python scripts/check-windows-footguns.py --all`