### PR TITLE
fix(desktop): set PYTHONIOENCODING=utf-8 for spawned Python backends on Windows

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -4943,6 +4943,7 @@ async function spawnPoolBackend(profile, entry) {
       cwd: hermesCwd,
       env: {
         ...process.env,
+        PYTHONIOENCODING: 'utf-8',
         HERMES_HOME,
         ...backend.env,
         // Pin the gateway's tool/terminal cwd to the same directory we chose for
@@ -5163,14 +5164,7 @@ async function startHermes() {
         cwd: hermesCwd,
         env: {
           ...process.env,
-          // Explicitly pin HERMES_HOME for the child so Python's get_hermes_home()
-          // resolves to the SAME location our resolveHermesHome() picked. Without
-          // this pin, Python falls back to ~/.hermes on every platform — fine on
-          // mac/linux (where our default matches), but on Windows our default is
-          // %LOCALAPPDATA%\hermes, which differs from C:\Users\<u>\.hermes.
-          // Mismatch would split config / sessions / .env / logs across two
-          // directories. install.ps1 sets HERMES_HOME via setx; the desktop
-          // can't reliably do that, so we set it inline for every spawn.
+          PYTHONIOENCODING: 'utf-8',
           HERMES_HOME,
           ...backend.env,
           TERMINAL_CWD: hermesCwd,

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -341,6 +341,7 @@ export class GatewayClient extends EventEmitter {
     const python = resolvePython(root)
     const cwd = process.env.HERMES_CWD || root
     const env = { ...process.env }
+    env.PYTHONIOENCODING = 'utf-8'
     const pyPath = env.PYTHONPATH?.trim()
 
     env.PYTHONPATH = pyPath ? `${root}${delimiter}${pyPath}` : root


### PR DESCRIPTION
## Summary

On Windows, Python 3 pipe stdout defaults to the system locale encoding (often cp1252), not UTF-8. When the TUI gateway writes JSON-RPC frames with Chinese characters through the pipe, non-UTF-8 encoding mangles multi-byte characters:

你好 → ä½ å¥½  (UTF-8 bytes decoded as Latin-1)

## Root Cause

Three spawn sites create Python child processes with piped stdio on Windows. None set PYTHONIOENCODING=utf-8. Python treats pipe stdout as the system locale encoding, producing mojibake for non-ASCII characters.

## Fix

Add PYTHONIOENCODING=utf-8 to the child process environment at all three spawn sites.

## Related

Fixes #52013

## Files changed

- apps/desktop/electron/main.cjs: +2 lines (two backend spawns)
- ui-tui/src/gatewayClient.ts: +1 line (gateway spawn)
