### PR TITLE
fix(safety): casefold credential path guards

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
 from typing import Optional
 
@@ -23,6 +24,28 @@ def _hermes_root_path() -> Path:
         return get_default_hermes_root()
     except Exception:
         return Path(os.path.expanduser("~/.hermes"))
+
+
+def _paths_case_insensitive() -> bool:
+    return os.name == "nt" or sys.platform == "darwin"
+
+
+def _path_compare_key(path: str | Path) -> str:
+    key = os.path.normpath(os.fspath(path))
+    if _paths_case_insensitive():
+        key = os.path.normcase(key).casefold()
+    return key
+
+
+def _same_path(left: str | Path, right: str | Path) -> bool:
+    return _path_compare_key(left) == _path_compare_key(right)
+
+
+def _path_under_or_equal(path: str | Path, root: str | Path) -> bool:
+    path_key = _path_compare_key(path)
+    root_key = _path_compare_key(root)
+    root_prefix = root_key.rstrip("/\\") or root_key
+    return path_key == root_prefix or path_key.startswith(root_prefix + os.sep)
 
 
 def build_write_denied_paths(home: str) -> set[str]:
@@ -92,11 +115,12 @@ def is_write_denied(path: str) -> bool:
     """Return True if path is blocked by the write denylist or safe root."""
     home = os.path.realpath(os.path.expanduser("~"))
     resolved = os.path.realpath(os.path.expanduser(str(path)))
+    resolved_key = _path_compare_key(resolved)
 
-    if resolved in build_write_denied_paths(home):
+    if resolved_key in {_path_compare_key(p) for p in build_write_denied_paths(home)}:
         return True
     for prefix in build_write_denied_prefixes(home):
-        if resolved.startswith(prefix):
+        if _path_under_or_equal(resolved, prefix):
             return True
 
     mcp_tokens_dir_name = "mcp-tokens"
@@ -113,19 +137,19 @@ def is_write_denied(path: str) -> bool:
     for base_real in hermes_dirs:
         try:
             mcp_real = os.path.realpath(os.path.join(base_real, mcp_tokens_dir_name))
-            if resolved == mcp_real or resolved.startswith(mcp_real + os.sep):
+            if _path_under_or_equal(resolved, mcp_real):
                 return True
         except Exception:
             pass
         try:
             pairing_real = os.path.realpath(os.path.join(base_real, "pairing"))
-            if resolved == pairing_real or resolved.startswith(pairing_real + os.sep):
+            if _path_under_or_equal(resolved, pairing_real):
                 return True
         except Exception:
             pass
 
     safe_root = get_safe_write_root()
-    if safe_root and not (resolved == safe_root or resolved.startswith(safe_root + os.sep)):
+    if safe_root and not _path_under_or_equal(resolved, safe_root):
         return True
 
     return False
@@ -213,9 +237,7 @@ def get_read_block_error(path: str) -> Optional[str]:
             hd / "skills" / ".hub",
         ]
         for blocked in blocked_dirs:
-            try:
-                resolved.relative_to(blocked)
-            except ValueError:
+            if not _path_under_or_equal(resolved, blocked):
                 continue
             return (
                 f"Access denied: {path} is an internal Hermes cache file "
@@ -243,7 +265,7 @@ def get_read_block_error(path: str) -> Optional[str]:
                 blocked = (hd / name).resolve()
             except Exception:
                 continue
-            if resolved == blocked:
+            if _same_path(resolved, blocked):
                 return (
                     f"Access denied: {path} is a Hermes credential store "
                     "and cannot be read directly. Provider tools consume "
@@ -259,15 +281,13 @@ def get_read_block_error(path: str) -> Optional[str]:
             mcp_tokens = (hd / "mcp-tokens").resolve()
         except Exception:
             continue
-        if resolved == mcp_tokens:
+        if _same_path(resolved, mcp_tokens):
             return (
                 f"Access denied: {path} is the Hermes MCP token directory "
                 "and cannot be read directly. (Defense-in-depth — not a "
                 "security boundary; the terminal tool can still bypass.)"
             )
-        try:
-            resolved.relative_to(mcp_tokens)
-        except ValueError:
+        if not _path_under_or_equal(resolved, mcp_tokens):
             continue
         return (
             f"Access denied: {path} is a Hermes MCP token file "
@@ -280,7 +300,8 @@ def get_read_block_error(path: str) -> Optional[str]:
     # .env contents — .env.example is the documented-shape substitute. The
     # terminal tool can still ``cat .env``; this is defense-in-depth, not a
     # boundary (see module docstring).
-    if resolved.name in _BLOCKED_PROJECT_ENV_BASENAMES:
+    basename = resolved.name.casefold() if _paths_case_insensitive() else resolved.name
+    if basename in _BLOCKED_PROJECT_ENV_BASENAMES:
         return (
             f"Access denied: {path} is a secret-bearing environment file "
             "and cannot be read to prevent credential leakage. "

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -18,6 +18,7 @@ import sys
 import time
 import uuid
 from abc import ABC, abstractmethod
+from pathlib import Path
 from urllib.parse import urlsplit
 
 from utils import normalize_proxy_url
@@ -50,6 +51,28 @@ def _float_env(name: str, default: float) -> float:
         return float(raw)
     except (TypeError, ValueError):
         return default
+
+
+def _paths_case_insensitive() -> bool:
+    return os.name == "nt" or sys.platform == "darwin"
+
+
+def _path_compare_key(path: str | Path) -> str:
+    key = os.path.normpath(os.fspath(path))
+    if _paths_case_insensitive():
+        key = os.path.normcase(key).casefold()
+    return key
+
+
+def _same_path(left: str | Path, right: str | Path) -> bool:
+    return _path_compare_key(left) == _path_compare_key(right)
+
+
+def _path_under_or_equal(path: str | Path, root: str | Path) -> bool:
+    path_key = _path_compare_key(path)
+    root_key = _path_compare_key(root)
+    root_prefix = root_key.rstrip("/\\") or root_key
+    return path_key == root_prefix or path_key.startswith(root_prefix + os.sep)
 
 
 def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) -> dict | None:
@@ -483,7 +506,6 @@ def is_host_excluded_by_no_proxy(hostname: str, no_proxy_value: str | None = Non
 import dataclasses
 from dataclasses import dataclass, field
 from datetime import datetime
-from pathlib import Path
 from typing import Dict, List, Optional, Any, Callable, Awaitable, Tuple, Union
 from enum import Enum
 
@@ -1134,11 +1156,11 @@ def _path_under_denied_prefix(resolved: Path) -> bool:
             resolved_denied = denied.expanduser().resolve(strict=False)
         except (OSError, RuntimeError, ValueError):
             continue
-        if not (_path_is_within(resolved, resolved_denied) or resolved == resolved_denied):
+        if not _path_under_or_equal(resolved, resolved_denied):
             continue
         # Allow the running user's own home tree; its credential sub-dirs are
         # caught by their own (more-specific) denylist entries above.
-        if home is not None and resolved_denied == home:
+        if home is not None and _same_path(resolved_denied, home):
             continue
         return True
     return False

--- a/tests/agent/test_file_safety_credentials.py
+++ b/tests/agent/test_file_safety_credentials.py
@@ -48,6 +48,19 @@ def test_auth_json_blocked(fake_home):
     assert "auth.json" in err
 
 
+def test_auth_json_case_variant_blocked_on_case_insensitive_fs(
+    fake_home, monkeypatch
+):
+    import agent.file_safety as fs
+    from agent.file_safety import get_read_block_error
+
+    monkeypatch.setattr(fs, "_paths_case_insensitive", lambda: True)
+
+    err = get_read_block_error(str(fake_home / "AUTH.JSON"))
+    assert err is not None
+    assert "credential store" in err
+
+
 def test_auth_lock_blocked(fake_home):
     from agent.file_safety import get_read_block_error
 
@@ -203,6 +216,17 @@ def test_dotenv_blocked(fake_home):
     err = get_read_block_error(str(env))
     assert err is not None
     assert "credential store" in err
+
+
+def test_project_env_case_variant_blocked_on_case_insensitive_fs(monkeypatch):
+    import agent.file_safety as fs
+    from agent.file_safety import get_read_block_error
+
+    monkeypatch.setattr(fs, "_paths_case_insensitive", lambda: True)
+
+    err = get_read_block_error("/tmp/project/.ENV")
+    assert err is not None
+    assert "environment file" in err
 
 
 def test_webhook_subscriptions_blocked(fake_home):

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -792,6 +792,7 @@ class TestMediaDeliveryPathValidation:
         secret = ssh_dir / "id_rsa.txt"
         secret.write_bytes(b"-----BEGIN ...")  # mtime = now
         monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setenv("USERPROFILE", str(fake_home))
 
         assert BasePlatformAdapter.validate_media_delivery_path(str(secret)) is None
 
@@ -886,6 +887,7 @@ class TestMediaDeliveryDefaultMode:
         secret = ssh_dir / "id_rsa"
         secret.write_bytes(b"-----BEGIN ...")
         monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setenv("USERPROFILE", str(fake_home))
 
         assert BasePlatformAdapter.validate_media_delivery_path(str(secret)) is None
 
@@ -1122,6 +1124,7 @@ class TestMediaDeliveryDefaultMode:
         doc = workdir / "proposal.docx"
         doc.write_bytes(b"PK\x03\x04")
         monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setenv("USERPROFILE", str(fake_home))
         # $HOME is itself on the denied-prefix list, mirroring /root.
         monkeypatch.setattr(
             "gateway.platforms.base._MEDIA_DELIVERY_DENIED_PREFIXES",
@@ -1151,6 +1154,25 @@ class TestMediaDeliveryDefaultMode:
             "gateway.platforms.base._MEDIA_DELIVERY_DENIED_PREFIXES",
             (str(fake_home),),
         )
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(key)) is None
+
+    def test_case_variant_ssh_key_blocked_on_case_insensitive_fs(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_MEDIA_DELIVERY_STRICT", "0")
+        monkeypatch.setattr(
+            "gateway.platforms.base._paths_case_insensitive",
+            lambda: True,
+        )
+
+        fake_home = tmp_path / "home"
+        ssh_dir = fake_home / ".SSH"
+        ssh_dir.mkdir(parents=True)
+        key = ssh_dir / "id_rsa"
+        key.write_bytes(b"-----BEGIN OPENSSH PRIVATE KEY-----")
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setenv("USERPROFILE", str(fake_home))
 
         assert BasePlatformAdapter.validate_media_delivery_path(str(key)) is None
 

--- a/tests/tools/test_write_deny.py
+++ b/tests/tools/test_write_deny.py
@@ -80,8 +80,24 @@ class TestWriteDenyPrefixes:
         path = os.path.join(str(Path.home()), ".ssh", "some_key")
         assert _is_write_denied(path) is True
 
+    def test_case_variant_ssh_prefix_denied_on_case_insensitive_fs(self, monkeypatch):
+        import agent.file_safety as fs
+
+        monkeypatch.setattr(fs, "_paths_case_insensitive", lambda: True)
+        path = os.path.join(str(Path.home()), ".SSH", "some_key")
+
+        assert _is_write_denied(path) is True
+
     def test_aws_prefix(self):
         path = os.path.join(str(Path.home()), ".aws", "credentials")
+        assert _is_write_denied(path) is True
+
+    def test_case_variant_aws_prefix_denied_on_case_insensitive_fs(self, monkeypatch):
+        import agent.file_safety as fs
+
+        monkeypatch.setattr(fs, "_paths_case_insensitive", lambda: True)
+        path = os.path.join(str(Path.home()), ".AWS", "credentials")
+
         assert _is_write_denied(path) is True
 
     def test_gnupg_prefix(self):


### PR DESCRIPTION
## Summary
- compare credential deny paths case-insensitively on Windows and macOS while keeping Linux case-sensitive
- apply the same comparison to write guards, read guards, and media-delivery deny checks
- add regression coverage for `.SSH`, `.AWS`, `AUTH.JSON`, `.ENV`, and media delivery of case-variant SSH keys

Fixes #51474.

## Tests
- `python -m pytest tests/tools/test_write_deny.py tests/agent/test_file_safety_credentials.py tests/agent/test_file_safety.py tests/gateway/test_platform_base.py::TestMediaDeliveryDefaultMode tests/gateway/test_platform_base.py::TestMediaDeliveryPathValidation -q`
- `python -m py_compile agent/file_safety.py gateway/platforms/base.py`
- `python scripts/check-windows-footguns.py --all`