### PR TITLE
feat(upload): make file size caps configurable

### DIFF
--- a/apps/desktop/electron/hardening.cjs
+++ b/apps/desktop/electron/hardening.cjs
@@ -4,7 +4,11 @@ const path = require('node:path')
 const { fileURLToPath } = require('node:url')
 
 const DEFAULT_FETCH_TIMEOUT_MS = 15_000
-const DATA_URL_READ_MAX_BYTES = 16 * 1024 * 1024
+const DEFAULT_DATA_URL_READ_MAX_BYTES = 16 * 1024 * 1024
+const DATA_URL_READ_MAX_BYTES = resolvePositiveIntegerEnv(
+  'HERMES_DATA_URL_READ_MAX_BYTES',
+  DEFAULT_DATA_URL_READ_MAX_BYTES
+)
 const TEXT_PREVIEW_SOURCE_MAX_BYTES = 64 * 1024 * 1024
 
 const SAFE_ENV_SUFFIXES = new Set(['dist', 'example', 'sample', 'template'])
@@ -17,6 +21,16 @@ function resolveTimeoutMs(timeoutMs, fallbackMs = DEFAULT_FETCH_TIMEOUT_MS) {
 
   if (Number.isFinite(parsed) && parsed > 0) {
     return Math.round(parsed)
+  }
+
+  return fallback
+}
+
+function resolvePositiveIntegerEnv(name, fallback) {
+  const parsed = Number(process.env[name] || '')
+
+  if (Number.isSafeInteger(parsed) && parsed > 0) {
+    return parsed
   }
 
   return fallback
@@ -267,6 +281,7 @@ async function resolveReadableFileForIpc(filePath, options = {}) {
 
 module.exports = {
   DATA_URL_READ_MAX_BYTES,
+  DEFAULT_DATA_URL_READ_MAX_BYTES,
   DEFAULT_FETCH_TIMEOUT_MS,
   TEXT_PREVIEW_SOURCE_MAX_BYTES,
   encryptDesktopSecret,
@@ -274,6 +289,7 @@ module.exports = {
   resolveDirectoryForIpc,
   resolveReadableFileForIpc,
   resolveRequestedPathForIpc,
+  resolvePositiveIntegerEnv,
   resolveTimeoutMs,
   sensitiveFileBlockReason
 }

--- a/apps/desktop/electron/hardening.test.cjs
+++ b/apps/desktop/electron/hardening.test.cjs
@@ -7,10 +7,12 @@ const { pathToFileURL } = require('node:url')
 
 const {
   DEFAULT_FETCH_TIMEOUT_MS,
+  DEFAULT_DATA_URL_READ_MAX_BYTES,
   encryptDesktopSecret,
   resolveDirectoryForIpc,
   resolveReadableFileForIpc,
   resolveRequestedPathForIpc,
+  resolvePositiveIntegerEnv,
   resolveTimeoutMs,
   sensitiveFileBlockReason
 } = require('./hardening.cjs')
@@ -27,6 +29,28 @@ test('resolveTimeoutMs falls back to defaults and accepts overrides', () => {
   assert.equal(resolveTimeoutMs(0), DEFAULT_FETCH_TIMEOUT_MS)
   assert.equal(resolveTimeoutMs(-25), DEFAULT_FETCH_TIMEOUT_MS)
   assert.equal(resolveTimeoutMs('2750'), 2750)
+})
+
+test('resolvePositiveIntegerEnv accepts positive values and falls back', () => {
+  const previous = process.env.HERMES_DATA_URL_READ_MAX_BYTES
+  try {
+    process.env.HERMES_DATA_URL_READ_MAX_BYTES = '33554432'
+    assert.equal(resolvePositiveIntegerEnv('HERMES_DATA_URL_READ_MAX_BYTES', DEFAULT_DATA_URL_READ_MAX_BYTES), 33554432)
+
+    for (const raw of ['', '0', '-1', 'NaN', '12.5', 'large']) {
+      process.env.HERMES_DATA_URL_READ_MAX_BYTES = raw
+      assert.equal(
+        resolvePositiveIntegerEnv('HERMES_DATA_URL_READ_MAX_BYTES', DEFAULT_DATA_URL_READ_MAX_BYTES),
+        DEFAULT_DATA_URL_READ_MAX_BYTES
+      )
+    }
+  } finally {
+    if (previous === undefined) {
+      delete process.env.HERMES_DATA_URL_READ_MAX_BYTES
+    } else {
+      process.env.HERMES_DATA_URL_READ_MAX_BYTES = previous
+    }
+  }
 })
 
 test('encryptDesktopSecret requires available secure storage', () => {

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -642,8 +642,9 @@ app.setAboutPanelOptions({
 
 // Custom scheme for streaming local media (video/audio) into the renderer.
 // Reading large media through `readFileDataUrl` failed: it base64-loads the
-// whole file into memory and is hard-capped at DATA_URL_READ_MAX_BYTES (16 MB),
-// so any non-trivial video silently refused to load. Streaming via a protocol
+// whole file into memory and is capped by DATA_URL_READ_MAX_BYTES (16 MB by
+// default, configurable via HERMES_DATA_URL_READ_MAX_BYTES), so any non-trivial
+// video silently refused to load. Streaming via a protocol
 // handler removes the size cap and gives the <video> element seekable,
 // range-aware playback. Must be registered before the app is ready.
 const MEDIA_PROTOCOL = 'hermes-media'

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -193,9 +193,9 @@ async function readFileDataUrlForAttach(filePath: string): Promise<string | null
 }
 
 // The readFileDataUrl IPC base64-loads the whole file into memory and is
-// hard-capped (DATA_URL_READ_MAX_BYTES, 16 MB) in electron/hardening.cjs, which
-// rejects with a raw "file is too large (N bytes; limit M bytes)" string. In
-// remote mode every attachment's bytes go through that read, so a big file
+// capped by DATA_URL_READ_MAX_BYTES in electron/hardening.cjs (16 MB by default,
+// configurable via HERMES_DATA_URL_READ_MAX_BYTES), which rejects with a raw
+// "file is too large (N bytes; limit M bytes)" string. In remote mode every attachment's bytes go through that read, so a big file
 // surfaces that internal message verbatim in the failure toast. Translate it
 // into a friendly "too large to upload to the remote gateway" line, parsing the
 // limit out of the message so it tracks the real cap. Non-cap errors pass

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -58,6 +58,7 @@ from gateway.platforms.base import (
     SendResult,
     is_network_accessible,
 )
+from utils import env_positive_int
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +89,14 @@ def _hermes_version() -> str:
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8642
 MAX_STORED_RESPONSES = 100
-MAX_REQUEST_BYTES = 10_000_000  # 10 MB — accommodates long agent conversations with tool calls
+DEFAULT_MAX_REQUEST_BYTES = 10_000_000
+
+
+def _resolve_max_request_bytes() -> int:
+    return env_positive_int("API_SERVER_MAX_REQUEST_BYTES", DEFAULT_MAX_REQUEST_BYTES)
+
+
+MAX_REQUEST_BYTES = _resolve_max_request_bytes()
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -77,7 +77,7 @@ from gateway.status import (
     parse_active_agents,
     read_runtime_status,
 )
-from utils import env_var_enabled
+from utils import env_positive_int, env_var_enabled
 
 try:
     from fastapi import (
@@ -1054,7 +1054,25 @@ _FS_READDIR_HIDDEN = {
     "target",
     "venv",
 }
-_FS_DATA_URL_MAX_BYTES = 16 * 1024 * 1024
+_DEFAULT_DASHBOARD_WS_MAX_SIZE_BYTES = 16 * 1024 * 1024
+_DEFAULT_FS_DATA_URL_MAX_BYTES = 16 * 1024 * 1024
+
+
+def _resolve_fs_data_url_max_bytes() -> int:
+    return env_positive_int(
+        "HERMES_FS_DATA_URL_MAX_BYTES",
+        _DEFAULT_FS_DATA_URL_MAX_BYTES,
+    )
+
+
+def _resolve_dashboard_ws_max_size_bytes() -> int:
+    return env_positive_int(
+        "HERMES_DASHBOARD_WS_MAX_SIZE_BYTES",
+        _DEFAULT_DASHBOARD_WS_MAX_SIZE_BYTES,
+    )
+
+
+_FS_DATA_URL_MAX_BYTES = _resolve_fs_data_url_max_bytes()
 _FS_TEXT_SOURCE_MAX_BYTES = 64 * 1024 * 1024
 _FS_TEXT_PREVIEW_MAX_BYTES = 512 * 1024
 _FS_PREVIEW_LANGUAGE_BY_EXT = {
@@ -13028,6 +13046,7 @@ def start_server(
         # timeout, keeping it warm.
         ws_ping_interval=20.0,
         ws_ping_timeout=20.0,
+        ws_max_size=_resolve_dashboard_ws_max_size_bytes(),
     )
     server = uvicorn.Server(config)
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -50,6 +50,20 @@ class TestCheckRequirements:
         assert check_api_server_requirements() is False
 
 
+def test_max_request_bytes_env_override(monkeypatch):
+    from gateway.platforms.api_server import (
+        DEFAULT_MAX_REQUEST_BYTES,
+        _resolve_max_request_bytes,
+    )
+
+    monkeypatch.setenv("API_SERVER_MAX_REQUEST_BYTES", "25000000")
+    assert _resolve_max_request_bytes() == 25_000_000
+
+    for raw in ("", "0", "-5", "not-bytes"):
+        monkeypatch.setenv("API_SERVER_MAX_REQUEST_BYTES", raw)
+        assert _resolve_max_request_bytes() == DEFAULT_MAX_REQUEST_BYTES
+
+
 # ---------------------------------------------------------------------------
 # ResponseStore
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_web_server_fs.py
+++ b/tests/hermes_cli/test_web_server_fs.py
@@ -128,6 +128,18 @@ def test_fs_read_data_url_rejects_over_cap(client, tmp_path, monkeypatch):
     assert response.status_code == 413
 
 
+def test_fs_data_url_max_bytes_env_override(monkeypatch):
+    monkeypatch.setenv("HERMES_FS_DATA_URL_MAX_BYTES", "24000000")
+    assert web_server._resolve_fs_data_url_max_bytes() == 24_000_000
+
+    for raw in ("", "0", "-2", "not-bytes"):
+        monkeypatch.setenv("HERMES_FS_DATA_URL_MAX_BYTES", raw)
+        assert (
+            web_server._resolve_fs_data_url_max_bytes()
+            == web_server._DEFAULT_FS_DATA_URL_MAX_BYTES
+        )
+
+
 def test_fs_git_root_for_nested_file(client, tmp_path):
     (tmp_path / ".git").mkdir()
     nested = tmp_path / "pkg" / "mod"

--- a/tests/test_utils_truthy_values.py
+++ b/tests/test_utils_truthy_values.py
@@ -1,6 +1,6 @@
-"""Tests for shared truthy-value helpers."""
+"""Tests for shared environment-value helpers."""
 
-from utils import env_var_enabled, is_truthy_value
+from utils import env_positive_int, env_var_enabled, is_truthy_value
 
 
 def test_is_truthy_value_accepts_common_truthy_strings():
@@ -27,3 +27,12 @@ def test_env_var_enabled_uses_shared_truthy_rules(monkeypatch):
 
     monkeypatch.setenv("HERMES_TEST_BOOL", "no")
     assert env_var_enabled("HERMES_TEST_BOOL") is False
+
+
+def test_env_positive_int_accepts_positive_values_and_falls_back(monkeypatch):
+    monkeypatch.setenv("HERMES_TEST_INT", "4096")
+    assert env_positive_int("HERMES_TEST_INT", 16) == 4096
+
+    for raw in ("", "0", "-1", "nan", "12.5", "large"):
+        monkeypatch.setenv("HERMES_TEST_INT", raw)
+        assert env_positive_int("HERMES_TEST_INT", 16) == 16

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -81,6 +81,15 @@ def test_start_server_enables_ws_ping_for_half_open_detection(monkeypatch):
     assert captured["ws_ping_timeout"] == 20.0
 
 
+def test_start_server_configures_ws_max_size_from_env(monkeypatch):
+    captured = _stub_uvicorn(monkeypatch)
+    monkeypatch.setenv("HERMES_DASHBOARD_WS_MAX_SIZE_BYTES", "33554432")
+
+    web_server.start_server(host="127.0.0.1", port=0, open_browser=False)
+
+    assert captured["ws_max_size"] == 33_554_432
+
+
 def test_start_server_runs_on_uvicorns_loop_factory(monkeypatch):
     """The dashboard/desktop backend must serve uvicorn on the loop *uvicorn*
     selects, not the interpreter default.

--- a/utils.py
+++ b/utils.py
@@ -336,6 +336,18 @@ def env_int(key: str, default: int = 0) -> int:
         return default
 
 
+def env_positive_int(key: str, default: int) -> int:
+    """Read an environment variable as a positive integer, with fallback."""
+    raw = os.getenv(key, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except (ValueError, TypeError):
+        return default
+    return value if value > 0 else default
+
+
 def env_float(key: str, default: float = 0.0) -> float:
     """Read an environment variable as a float, with fallback."""
     raw = os.getenv(key, "").strip()

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -447,6 +447,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `API_SERVER_PORT` | Port for the API server (default: `8642`) |
 | `API_SERVER_HOST` | Host/bind address for the API server (default: `127.0.0.1`). `API_SERVER_KEY` is still required on loopback; use a narrow `API_SERVER_CORS_ORIGINS` allowlist for browser access. |
 | `API_SERVER_MODEL_NAME` | Model name advertised on `/v1/models`. Defaults to the profile name (or `hermes-agent` for the default profile). Useful for multi-user setups where frontends like Open WebUI need distinct model names per connection. |
+| `API_SERVER_MAX_REQUEST_BYTES` | Maximum API server HTTP request body size in bytes (default: `10000000`). Raise this for large file/data uploads through OpenAI-compatible frontends. |
 | `GATEWAY_PROXY_URL` | URL of a remote Hermes API server to forward messages to ([proxy mode](/user-guide/messaging/matrix#proxy-mode-e2ee-on-macos)). When set, the gateway handles platform I/O only — all agent work is delegated to the remote server. Also configurable via `gateway.proxy_url` in `config.yaml`. |
 | `GATEWAY_PROXY_KEY` | Bearer token for authenticating with the remote API server in proxy mode. Must match `API_SERVER_KEY` on the remote host. |
 | `MESSAGING_CWD` | Deprecated compatibility fallback for gateway working directory. Prefer `terminal.cwd` in `config.yaml`. |
@@ -471,6 +472,9 @@ Three dashboard-auth providers ship in the box. For a remote Hermes Desktop conn
 | `HERMES_DASHBOARD_OIDC_ISSUER` | OIDC issuer URL for the bundled self-hosted OIDC provider (`plugins/dashboard_auth/self_hosted`). Required to activate it. Overrides `dashboard.oauth.self_hosted.issuer`. |
 | `HERMES_DASHBOARD_OIDC_CLIENT_ID` | Public OIDC client id (authorization-code + PKCE) for the self-hosted OIDC provider. Required to activate it. Overrides `dashboard.oauth.self_hosted.client_id`. |
 | `HERMES_DASHBOARD_OIDC_SCOPES` | Requested OIDC scopes for the self-hosted OIDC provider (default `openid profile email`). Overrides `dashboard.oauth.self_hosted.scopes`. |
+| `HERMES_FS_DATA_URL_MAX_BYTES` | Maximum file size read by `/api/fs/read-data-url` before base64 encoding for desktop/remote uploads (default: `16777216`). |
+| `HERMES_DASHBOARD_WS_MAX_SIZE_BYTES` | Uvicorn WebSocket frame cap for dashboard/desktop messages (default: `16777216`). Raise alongside file upload limits because base64 expands binary data. |
+| `HERMES_DATA_URL_READ_MAX_BYTES` | (Desktop side) Maximum local file size Electron reads into a data URL for remote-gateway upload (default: `16777216`). |
 | `HERMES_DESKTOP_REMOTE_URL` | (Desktop side) Base URL of the remote backend, e.g. `http://host:9119`. When set, overrides the in-app Gateway URL; you still sign in from the Gateway settings panel (OAuth redirect or username/password, whichever the backend advertises). |
 | `HERMES_DESKTOP_HERMES` | Desktop backend command override. Used by packagers/Nix or troubleshooting to point Electron at a specific `hermes` executable after backend probing. |
 | `HERMES_DESKTOP_HERMES_ROOT` | Desktop source-checkout override used by `hermes desktop --hermes-root`; checked before the packaged first-launch install or an existing `hermes` on `PATH`. |


### PR DESCRIPTION
## Summary
- make API server request body, dashboard data URL, dashboard websocket frame, and Electron data URL file caps configurable via env vars
- keep existing defaults and fall back on empty, invalid, or non-positive values
- document the new upload-related environment variables

Fixes #51355.

## Tests
- `python -m pytest tests/test_utils_truthy_values.py tests/gateway/test_api_server.py::test_max_request_bytes_env_override tests/hermes_cli/test_web_server_fs.py::test_fs_data_url_max_bytes_env_override tests/test_web_server.py::test_start_server_configures_ws_max_size_from_env -q`
- `node --test electron/hardening.test.cjs` (from `apps/desktop`)
- `python -m py_compile utils.py gateway/platforms/api_server.py hermes_cli/web_server.py`
- `python scripts/check-windows-footguns.py --all`