### PR TITLE
fix(desktop): route /learn into the agent turn

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -1214,7 +1214,7 @@ def test_slash_exec_plugin_handler_error_returns_output(server):
     assert worker.calls == []
 
 
-@pytest.mark.parametrize("cmd", ["retry", "queue hello", "q hello", "steer fix the test", "plan"])
+@pytest.mark.parametrize("cmd", ["retry", "queue hello", "q hello", "steer fix the test", "plan", "learn create a skill from docs"])
 def test_slash_exec_routes_pending_input_commands_to_dispatch(server, cmd):
     """slash.exec must route _pending_input commands to command.dispatch
     internally instead of returning the old 4018 "use command.dispatch"
@@ -1254,6 +1254,10 @@ def test_slash_exec_routes_pending_input_commands_to_dispatch(server, cmd):
     # Internal routing must yield the same payload as command.dispatch.
     assert routed.get("result") == direct.get("result")
     assert routed.get("error") == direct.get("error")
+
+    if base == "learn":
+        assert routed["result"]["type"] == "send"
+        assert "create a skill from docs" in routed["result"]["message"]
 
 
 def test_command_dispatch_queue_sends_message(server):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9291,6 +9291,7 @@ _PENDING_INPUT_COMMANDS: frozenset[str] = frozenset(
         "plan",
         "goal",
         "undo",
+        "learn",
     }
 )
 


### PR DESCRIPTION
## What does this PR do?

Fixes the Desktop/TUI gateway path for `/learn`. Desktop could show the learning acknowledgement, but the generated learn prompt was still handled by the slash worker. That worker has its own pending-input queue, so the live desktop agent never received the prompt.

This routes `/learn` through `command.dispatch`, the same path already used for commands like `/queue` and `/retry`. The existing desktop `send` dispatch handling then submits the generated learn prompt as a normal agent turn.

## Related Issue

Fixes #51829

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `learn` to the TUI gateway pending-input command routing list.
- Extended the existing slash routing regression test to cover `/learn` and verify it returns a `send` payload containing the user request.

## How to Test

1. `/Users/blackishgreen03/workspace/hermes-agent/venv/bin/python -m pytest tests/tui_gateway/test_protocol.py -q`
2. `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, focused TUI gateway regression test

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused test output:

```text
66 passed, 14 warnings in 10.76s
```