### PR TITLE
fix(skills): harden oversized skill guidance

### DIFF
--- a/tests/tools/test_skill_size_limits.py
+++ b/tests/tools/test_skill_size_limits.py
@@ -51,8 +51,15 @@ class TestValidateContentSize:
     def test_over_limit(self):
         err = _validate_content_size("a" * (MAX_SKILL_CONTENT_CHARS + 1))
         assert err is not None
+        assert "REFUSED" in err
         assert "100,001" in err
         assert "100,000" in err
+        assert "DO NOT retry" in err
+        assert "references/" in err
+        assert "templates/" in err
+        assert "scripts/" in err
+        assert "assets/" in err
+        assert "Consider splitting" not in err
 
     def test_custom_label(self):
         err = _validate_content_size("a" * (MAX_SKILL_CONTENT_CHARS + 1), label="references/api.md")

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -334,10 +334,12 @@ def _validate_content_size(content: str, label: str = "SKILL.md") -> Optional[st
     """
     if len(content) > MAX_SKILL_CONTENT_CHARS:
         return (
-            f"{label} content is {len(content):,} characters "
+            f"REFUSED: {label} content is {len(content):,} characters "
             f"(limit: {MAX_SKILL_CONTENT_CHARS:,}). "
-            f"Consider splitting into a smaller SKILL.md with supporting files "
-            f"in references/ or templates/."
+            f"DO NOT retry by submitting marginally smaller content. "
+            f"Structurally split the skill instead: keep SKILL.md concise and "
+            f"move supporting material into references/, templates/, scripts/, "
+            f"or assets/."
         )
     return None
 


### PR DESCRIPTION
Fixes #51470.

## Summary
- make the oversize SKILL.md validation message an explicit refusal
- tell agents not to retry with marginally smaller content
- point oversized skill authors toward references/, templates/, scripts/, and assets/
- add a regression assertion for the refusal wording

## Tests
- .\venv\Scripts\python.exe -m pytest tests\tools\test_skill_size_limits.py -q
- .\venv\Scripts\python.exe -m py_compile tools\skill_manager_tool.py
- .\venv\Scripts\python.exe scripts\check-windows-footguns.py --all