### PR TITLE
fix(compression): preserve network/auth abort flags across cooldown re-entry (#29559)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2399,8 +2399,16 @@ This compaction should PRIORITISE preserving all information related to the focu
         self._last_aux_model_failure_error = None
         self._last_aux_model_failure_model = None
         self._last_compress_aborted = False
-        self._last_summary_auth_failure = False
-        self._last_summary_network_failure = False
+        # NOTE: do NOT reset _last_summary_auth_failure or
+        # _last_summary_network_failure here.  These flags are set by
+        # _generate_summary() on a terminal failure and already cleared on
+        # success (line 1697-1698).  Resetting them eagerly defeats the
+        # cooldown protection: _generate_summary() returns None from the
+        # cooldown early-return without re-asserting these flags, so the
+        # abort guard below would see False and fall through to the
+        # destructive static-fallback — the exact data-loss that #29559
+        # describes.  Letting them persist across compress() calls is safe
+        # because a successful summary always clears both.
 
         # Manual /compress (force=True) bypasses the failure cooldown so the
         # user can retry immediately after an auto-compress abort.  Without

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2693,3 +2693,82 @@ class TestPreflightSentinelGuard:
         compressor.last_prompt_tokens = 50_000
         result = self._seed(compressor.last_prompt_tokens, 10_000)
         assert result == 50_000
+
+
+class TestCooldownReentryAbort:
+    """Regression: a second compress() call during the failure cooldown must
+    still abort when the original failure was a network/auth error.
+
+    Before the fix, compress() unconditionally reset _last_summary_network_failure
+    and _last_summary_auth_failure at the top of every call.  When
+    _generate_summary() returned None from the cooldown early-return (without
+    re-setting the flags), the abort guard saw False and fell through to the
+    destructive static-fallback path — reproducing the data-loss scenario from
+    #29559 / #25585 that PR #51881 originally fixed.
+    """
+
+    def _msgs(self, n=12):
+        return [
+            {"role": "user" if i % 2 == 0 else "assistant", "content": f"msg {i}"}
+            for i in range(n)
+        ]
+
+    def test_network_failure_cooldown_reentry_still_aborts(self):
+        """ConnectionError → first compress aborts (PR #51881).  Second
+        compress within the 30s cooldown must ALSO abort — not drop the
+        middle window via the static-fallback path."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                protect_first_n=2,
+                protect_last_n=2,
+                abort_on_summary_failure=False,
+            )
+        msgs = self._msgs(12)
+
+        with patch(
+            "agent.context_compressor.call_llm",
+            side_effect=ConnectionError("Connection error."),
+        ):
+            first = c.compress(msgs, current_tokens=999999, force=True)
+        assert first == msgs
+        assert c._last_compress_aborted is True
+        assert c._last_summary_network_failure is True
+
+        second = c.compress(msgs, current_tokens=999999)
+        assert second == msgs, (
+            "Second compress during cooldown must abort (preserve messages), "
+            "not drop the middle window via static-fallback"
+        )
+        assert c._last_compress_aborted is True
+        assert c._last_summary_fallback_used is False
+
+    def test_auth_failure_cooldown_reentry_still_aborts(self):
+        """Same re-entry hole for auth failures: a 401 sets the flag, cooldown
+        returns None, second compress must still abort."""
+        err = Exception("Error code: 401 - invalid api key")
+        err.status_code = 401
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                protect_first_n=2,
+                protect_last_n=2,
+                abort_on_summary_failure=False,
+            )
+        msgs = self._msgs(12)
+
+        with patch("agent.context_compressor.call_llm", side_effect=err):
+            first = c.compress(msgs, current_tokens=999999, force=True)
+        assert first == msgs
+        assert c._last_compress_aborted is True
+        assert c._last_summary_auth_failure is True
+
+        second = c.compress(msgs, current_tokens=999999)
+        assert second == msgs, (
+            "Second compress during cooldown must abort (preserve messages), "
+            "not drop the middle window via static-fallback"
+        )
+        assert c._last_compress_aborted is True
+        assert c._last_summary_fallback_used is False


### PR DESCRIPTION
## Summary

- PR #51881 fixed context loss on transient network failures by aborting compression instead of dropping the middle window (#29559, #25585).
- However, `compress()` unconditionally resets `_last_summary_network_failure` and `_last_summary_auth_failure` at the top of every call. When a **second** auto-compress fires during the 30-second failure cooldown, `_generate_summary()` returns `None` from the cooldown early-return **without re-asserting these flags** — so the abort guard sees `False` and falls through to the destructive static-fallback path, **dropping the middle context window**.
- Both flags are already cleared on success (`_generate_summary` lines 1697-1698), so the eager reset was redundant and harmful. This PR removes it so the flags persist during cooldown and the abort guard fires correctly on re-entry.

## Repro scenario

1. Network blip causes `ConnectionError` during auto-compress → first `compress()` correctly aborts (PR #51881) ✅
2. User sends another message (adding tokens) → second `compress()` triggers within 30s cooldown
3. `compress()` resets `_last_summary_network_failure = False` → `_generate_summary()` hits cooldown guard, returns `None` without re-setting flag → abort guard sees `False` → **middle window dropped** ❌

## Fix

Remove the eager `_last_summary_auth_failure = False` / `_last_summary_network_failure = False` reset at the top of `compress()`. The flags are already cleared on success, and persisting them during cooldown is safe and correct.

## Test plan

- [x] `TestCooldownReentryAbort::test_network_failure_cooldown_reentry_still_aborts` — ConnectionError → first compress aborts → second compress during cooldown also aborts (not fallback)
- [x] `TestCooldownReentryAbort::test_auth_failure_cooldown_reentry_still_aborts` — same for 401 auth failures
- [x] All 122 existing `test_context_compressor.py` tests pass (zero regression)

```
$ pytest tests/agent/test_context_compressor.py -q
122 passed in 7.97s
```