### PR TITLE
fix(web): make plugin-provided web backends selectable

### DIFF
--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -240,6 +240,19 @@ def _is_backend_available(backend: str) -> bool:
             return has_xai_credentials()
         except Exception:
             return False
+    # Plugin-provided backends: defer to the web registry so providers
+    # registered via register_web_search_provider() (user / 3rd-party web
+    # plugins) are selectable through web.{search,extract,}_backend. Generic —
+    # no per-provider hardcoding. Discovery is triggered first because this
+    # gate can run before the dispatcher's own _ensure_web_plugins_loaded().
+    try:
+        _ensure_web_plugins_loaded()
+        from agent.web_search_registry import get_provider
+        prov = get_provider(backend)
+        if prov is not None:
+            return prov.is_available()
+    except Exception:
+        pass
     return False
 
 


### PR DESCRIPTION
## Problem

`agent/web_search_provider.py` documents a user / third-party web-provider
plugin surface: a provider subclasses `WebSearchProvider`, registers via
`PluginContext.register_web_search_provider()`, and is selected through
`web.search_backend` / `web.extract_backend` / `web.backend`.

In practice that surface is only half-wired. `tools/web_tools.py::_is_backend_available()`
gates selection on a **hardcoded allowlist**:

```python
if backend == "exa":   ...
if backend == "parallel": ...
# firecrawl / tavily / searxng / brave-free / ddgs / xai
return False
```

Any backend name not in that list returns `False`. So a plugin provider is
discovered and *dispatchable* (the registry knows it), but can never be
*selected*: `_get_capability_backend()` sees `_is_backend_available(name)` is
False and falls through to the auto-detect cascade, picking some other
backend. For an extract-only plugin this surfaces as a misleading
"search-only backend" or "no extract provider configured" error even though
the provider is installed, enabled, and reports `is_available() == True`.

## Fix

Add a generic fallback at the end of `_is_backend_available()`: when the name
isn't one of the built-ins, defer to the web registry's own provider
`is_available()`. Plugin discovery is triggered first because this gate can
run *before* the dispatcher's own `_ensure_web_plugins_loaded()` (in the
extract path, `_get_extract_backend()` is called before discovery).

```python
    try:
        _ensure_web_plugins_loaded()
        from agent.web_search_registry import get_provider
        prov = get_provider(backend)
        if prov is not None:
            return prov.is_available()
    except Exception:
        pass
    return False
```

No per-provider hardcoding — it works for any backend registered through the
documented plugin path. Built-in backends are unaffected: they return from
their existing `if backend == ...` branches before reaching the new code.

## Testing

Verified with a local Crawl4AI extract-only provider installed at
`~/.hermes/plugins/web/crawl4ai/` and enabled via `plugins.enabled`:

- Before: `web.extract_backend: crawl4ai` → `_get_extract_backend()` returned
  `searxng` (cascade fallback); `web_extract` failed.
- After: `_get_extract_backend()` returns `crawl4ai`; a live extract returns
  clean markdown. Built-in backends (firecrawl with a real key, searxng,
  ddgs) continue to resolve and run unchanged.

## Scope

One file, +13 lines, no behavior change for existing backends.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
