### PR TITLE
fix(agent): trigger preflight compression on few-but-huge sessions (#27405)

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -34,6 +34,29 @@ from agent.model_metadata import estimate_request_tokens_rough
 logger = logging.getLogger(__name__)
 
 
+def _should_run_preflight_estimate(
+    messages: List[Dict[str, Any]],
+    protect_first_n: int,
+    protect_last_n: int,
+    threshold_tokens: int,
+) -> bool:
+    """Cheap gate for the (expensive) full preflight token estimate.
+
+    Returns True when either:
+      (a) message count exceeds the protected ranges (the historical gate), or
+      (b) a char-based estimate already crosses the configured threshold —
+          the few-but-huge case from issue #27405 that the count-only gate
+          would silently skip.
+
+    The downstream estimator remains authoritative; this is just a hint.
+    """
+    if len(messages) > protect_first_n + protect_last_n + 1:
+        return True
+    approx_chars = sum(len(str(m.get("content", "") or "")) for m in messages)
+    approx_tokens = approx_chars // 4
+    return approx_tokens >= threshold_tokens
+
+
 def _compression_made_progress(
     orig_len: int, new_len: int, orig_tokens: int, new_tokens: int
 ) -> bool:
@@ -289,10 +312,14 @@ def build_turn_context(
         )
 
     # ── Preflight context compression ──
-    if (
-        agent.compression_enabled
-        and len(messages) > agent.context_compressor.protect_first_n
-                            + agent.context_compressor.protect_last_n + 1
+    # Gate the (expensive) full token estimate behind a cheap pre-check.
+    # See _should_run_preflight_estimate for the OR semantics that fix
+    # #27405 (few-but-huge messages slipping past the count-only gate).
+    if agent.compression_enabled and _should_run_preflight_estimate(
+        messages,
+        agent.context_compressor.protect_first_n,
+        agent.context_compressor.protect_last_n,
+        agent.context_compressor.threshold_tokens,
     ):
         _preflight_tokens = estimate_request_tokens_rough(
             messages,

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1616,6 +1616,7 @@ AUTHOR_MAP = {
     "claw@openclaw.ai": "wanwan2qq",  # PR #10215 (strip brackets/quotes from /resume; gateway session-ID lookup)
     "simo.kiihamaki@gmail.com": "SimoKiihamaki",  # PR #30773 (Windows /reset+/new freeze; stdin fallback for modal)
     "66773372+Tranquil-Flow@users.noreply.github.com": "Tranquil-Flow",  # PR #27518 (bracketed-paste timeout)
+    "dev@pixlmedia.no": "texhy",  # PR #27435 salvage (preflight compression token gate, #27405)
     "8bit64k@pm.me": "8bit64k",  # PR #14681 (TUI /q alias from quit to queue)
     "chenglunhu@gmail.com": "hclsys",  # PR #31985 (TUI /q alias regression test)
     "dearmayo@localhost": "ffr31mr",  # PR #32103 (SubdirectoryHintTracker workspace boundary)

--- a/tests/agent/test_preflight_compression_gate.py
+++ b/tests/agent/test_preflight_compression_gate.py
@@ -1,0 +1,87 @@
+"""Regression tests for issue #27405.
+
+The preflight compression gate must trigger when *either* the message
+count exceeds the protected ranges OR the cheap char-based token
+estimate already crosses the configured threshold. Pre-fix, only the
+message-count condition was checked, so a session with a small number
+of huge messages would silently skip compression and eventually hit a
+hard context-overflow error.
+"""
+
+from agent.turn_context import _should_run_preflight_estimate
+
+
+# Compressor defaults mirrored in the tests so we don't depend on
+# MINIMUM_CONTEXT_LENGTH / model metadata.
+PROTECT_FIRST_N = 3
+PROTECT_LAST_N = 20
+THRESHOLD_TOKENS = 64_000  # matches the production floor
+
+
+def _msg(content: str) -> dict:
+    return {"role": "user", "content": content}
+
+
+def test_few_messages_huge_content_triggers_gate():
+    """The bug from #27405: 8 messages with one massive content blob."""
+    # ~280K chars in one message ≈ 70K tokens at 4 chars/token.
+    big = "x" * 280_000
+    messages = [_msg("hi")] * 7 + [_msg(big)]
+    assert len(messages) <= PROTECT_FIRST_N + PROTECT_LAST_N + 1  # would fail old gate
+    assert _should_run_preflight_estimate(
+        messages, PROTECT_FIRST_N, PROTECT_LAST_N, THRESHOLD_TOKENS
+    ) is True
+
+
+def test_few_messages_small_content_does_not_trigger():
+    """Regression guard: tiny sessions should not pay the estimator cost."""
+    messages = [_msg("hello world")] * 8
+    assert _should_run_preflight_estimate(
+        messages, PROTECT_FIRST_N, PROTECT_LAST_N, THRESHOLD_TOKENS
+    ) is False
+
+
+def test_many_small_messages_still_triggers_via_count():
+    """The historical path: > protect_first + protect_last + 1 messages."""
+    messages = [_msg("ok")] * (PROTECT_FIRST_N + PROTECT_LAST_N + 2)  # 25
+    assert _should_run_preflight_estimate(
+        messages, PROTECT_FIRST_N, PROTECT_LAST_N, THRESHOLD_TOKENS
+    ) is True
+
+
+def test_content_exactly_at_threshold_triggers():
+    """Boundary: approx_tokens >= threshold should trigger (inclusive)."""
+    # 4 chars per token, so threshold * 4 chars produces exactly threshold tokens.
+    messages = [_msg("x" * (THRESHOLD_TOKENS * 4))]
+    assert _should_run_preflight_estimate(
+        messages, PROTECT_FIRST_N, PROTECT_LAST_N, THRESHOLD_TOKENS
+    ) is True
+
+
+def test_content_just_below_threshold_does_not_trigger():
+    """Boundary: one token below threshold and few messages must not trigger."""
+    messages = [_msg("x" * ((THRESHOLD_TOKENS - 1) * 4))]
+    assert _should_run_preflight_estimate(
+        messages, PROTECT_FIRST_N, PROTECT_LAST_N, THRESHOLD_TOKENS
+    ) is False
+
+
+def test_message_with_none_content_is_treated_as_empty():
+    """Assistant turns mid-tool-call carry content=None — must not crash."""
+    messages = [{"role": "assistant", "content": None}] * 5
+    assert _should_run_preflight_estimate(
+        messages, PROTECT_FIRST_N, PROTECT_LAST_N, THRESHOLD_TOKENS
+    ) is False
+
+
+def test_message_with_list_content_uses_repr_length():
+    """Multimodal content lists are handled by str(); approximate is fine.
+
+    The downstream real estimator is authoritative; the gate just needs to
+    not crash and to err on the side of admitting suspicious payloads.
+    """
+    parts = [{"type": "text", "text": "x" * 300_000}]
+    messages = [{"role": "user", "content": parts}]
+    assert _should_run_preflight_estimate(
+        messages, PROTECT_FIRST_N, PROTECT_LAST_N, THRESHOLD_TOKENS
+    ) is True


### PR DESCRIPTION
## Summary
Preflight compression now triggers when either message count OR a cheap char-based token estimate crosses the threshold, fixing silent context overflow on sessions with few but very large messages.

## Changes
- `agent/turn_context.py`: add `_should_run_preflight_estimate()` — returns True on either (a) message count > protect_first_n + protect_last_n + 1 (historical gate), or (b) cheap char//4 estimate >= threshold_tokens. The downstream `estimate_request_tokens_rough` + `should_compress` check remains authoritative.
- `tests/agent/test_preflight_compression_gate.py`: 7 regression tests (few-but-huge, few-and-small, many-small, boundary cases, None content, list content)

## Validation
| | Before | After |
|---|---|---|
| 5 messages, 500K tokens | preflight skipped (count < 24) | preflight fires (char estimate >> threshold) |
| 25 messages, 1K tokens | preflight fires (count > 24) | unchanged |
| 5 messages, 1K tokens | preflight skipped | unchanged |

- 7 new tests pass
- All existing threshold/floor tests pass

Salvaged from #27435 by @texhy (devatpixl). Adapted from `conversation_loop.py` to `turn_context.py` where the preflight gate moved in the turn-context extraction refactor.

Closes #27405