### PR TITLE
fix(vision): let Kimi auto routing use model capabilities

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -363,21 +363,6 @@ _PROVIDER_VISION_MODELS: Dict[str, str] = {
     "zai": "glm-5v-turbo",
 }
 
-# Providers whose endpoint does not accept image input, even though the
-# provider's broader ecosystem has vision models available elsewhere.  When
-# `auxiliary.vision.provider: auto` sees one of these as the main provider,
-# it must skip straight to the aggregator chain instead of returning a client
-# that will 404 on every vision request.
-#
-# kimi-coding / kimi-coding-cn: the Kimi Coding Plan routes through
-# api.kimi.com/coding (Anthropic Messages wire) which Kimi's own docs
-# describe as having no image_in capability. Vision lives on the separate
-# Kimi Platform (api.moonshot.ai, OpenAI-wire, pay-as-you-go).  See #17076.
-_PROVIDERS_WITHOUT_VISION: frozenset = frozenset({
-    "kimi-coding",
-    "kimi-coding-cn",
-})
-
 # OpenRouter app attribution headers (base — always sent).
 # `X-Title` is the canonical attribution header OpenRouter's dashboard
 # reads; the previous `X-OpenRouter-Title` label was not recognized there.
@@ -4409,19 +4394,6 @@ def resolve_vision_provider_client(
                         main_provider, default_model or resolved_model or main_model,
                     )
                     return _finalize(main_provider, sync_client, default_model)
-            elif main_provider in _PROVIDERS_WITHOUT_VISION:
-                # Kimi Coding Plan's /coding endpoint (Anthropic Messages wire)
-                # does not accept image input — Kimi's own docs say "Current
-                # model does not support image input, switch to a model with
-                # image_in capability" and vision lives on the separate Kimi
-                # Platform (api.moonshot.ai). Skip the main provider and fall
-                # through to the aggregator chain instead of returning a
-                # client that will 404 on every vision request (#17076).
-                logger.debug(
-                    "Vision auto-detect: skipping main provider %s (no "
-                    "vision support) — falling through to aggregator chain",
-                    main_provider,
-                )
             elif not _main_model_supports_vision(main_provider, vision_model):
                 # The main model is known to be text-only (e.g. DeepSeek V4,
                 # gpt-oss-120b without vision). Building a client and sending
@@ -4429,9 +4401,8 @@ def resolve_vision_provider_client(
                 # ``unknown variant `image_url`, expected `text``` (#31179).
                 # Fall through to the aggregator chain instead.
                 #
-                # Only log the provider name (not the model) — mirrors the
-                # sibling _PROVIDERS_WITHOUT_VISION branch above, and avoids
-                # CodeQL py/clear-text-logging-sensitive-data heuristic false
+                # Only log the provider name (not the model) — avoids CodeQL
+                # py/clear-text-logging-sensitive-data heuristic false
                 # positives on multi-value interpolations.
                 logger.debug(
                     "Vision auto-detect: skipping main provider %s "

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3008,31 +3008,62 @@ class TestCodexAdapterReasoningTranslation:
         assert captured.get("include") == ["reasoning.encrypted_content"]
 
 
-class TestVisionAutoSkipsKimiCoding:
-    """_resolve_auto vision branch skips providers that have no vision on
-    their main endpoint (e.g. Kimi Coding Plan /coding) and falls through
-    to the aggregator chain instead of handing back a client that will 404
-    on every request (#17076).
-    """
+class TestVisionAutoKimiCoding:
+    """Kimi Coding Plan participates in normal vision capability routing."""
 
-    def test_kimi_coding_skipped_falls_through_to_openrouter(self, monkeypatch):
-        """kimi-coding as main + vision auto → OpenRouter (not kimi)."""
+    def test_kimi_coding_auto_tries_main_provider_when_capability_allows(self, monkeypatch):
+        """kimi-coding as main + vision auto tries Kimi before aggregators."""
+        fake_kimi_client = MagicMock(name="kimi_client")
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._read_main_provider", lambda: "kimi-coding",
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._read_main_model", lambda: "kimi-k2.6",
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._main_model_supports_vision",
+            lambda provider, model: True,
+        )
+        rpc_mock = MagicMock(return_value=(fake_kimi_client, "kimi-k2.6"))
+        monkeypatch.setattr(
+            "agent.auxiliary_client.resolve_provider_client", rpc_mock,
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._resolve_strict_vision_backend",
+            MagicMock(side_effect=AssertionError(
+                "aggregator fallback should not run when kimi-coding resolves")),
+        )
+
+        provider, client, model = resolve_vision_provider_client()
+        assert provider == "kimi-coding"
+        assert client is fake_kimi_client
+        assert model == "kimi-k2.6"
+        rpc_mock.assert_called_once_with(
+            "kimi-coding",
+            "kimi-k2.6",
+            api_mode=None,
+            is_vision=True,
+        )
+
+    def test_kimi_coding_text_only_capability_still_falls_through(self, monkeypatch):
+        """A confirmed text-only Kimi model still falls through to OpenRouter."""
         fake_or_client = MagicMock(name="openrouter_client")
 
         monkeypatch.setattr(
             "agent.auxiliary_client._read_main_provider", lambda: "kimi-coding",
         )
         monkeypatch.setattr(
-            "agent.auxiliary_client._read_main_model", lambda: "kimi-code",
+            "agent.auxiliary_client._read_main_model", lambda: "kimi-for-coding",
         )
-        # Guard: if the skip doesn't fire, _resolve_strict_vision_backend
-        # and resolve_provider_client both would try kimi-coding — detect
-        # either via the main-provider call and fail loud.
-        rpc_mock = MagicMock(side_effect=AssertionError(
-            "resolve_provider_client should NOT be called for kimi-coding "
-            "on the vision auto path"))
         monkeypatch.setattr(
-            "agent.auxiliary_client.resolve_provider_client", rpc_mock,
+            "agent.auxiliary_client._main_model_supports_vision",
+            lambda provider, model: False,
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client.resolve_provider_client",
+            MagicMock(side_effect=AssertionError(
+                "text-only kimi-coding should not be called for vision auto")),
         )
 
         def fake_strict(provider, model=None):
@@ -3040,10 +3071,8 @@ class TestVisionAutoSkipsKimiCoding:
                 return fake_or_client, "google/gemini-3-flash-preview"
             if provider == "nous":
                 return None, None
-            raise AssertionError(
-                f"strict vision backend should not be called for {provider!r} "
-                "when main provider is kimi-coding"
-            )
+            raise AssertionError(f"unexpected strict provider {provider!r}")
+
         monkeypatch.setattr(
             "agent.auxiliary_client._resolve_strict_vision_backend",
             fake_strict,
@@ -3054,37 +3083,36 @@ class TestVisionAutoSkipsKimiCoding:
         assert client is fake_or_client
         assert model == "google/gemini-3-flash-preview"
 
-    def test_kimi_coding_cn_skipped_too(self, monkeypatch):
-        """Same skip applies to the CN variant."""
-        fake_or_client = MagicMock(name="openrouter_client")
+    def test_kimi_coding_cn_auto_tries_main_provider_too(self, monkeypatch):
+        """The CN Kimi provider follows the same main-first path."""
+        fake_kimi_client = MagicMock(name="kimi_cn_client")
 
         monkeypatch.setattr(
             "agent.auxiliary_client._read_main_provider", lambda: "kimi-coding-cn",
         )
         monkeypatch.setattr(
-            "agent.auxiliary_client._read_main_model", lambda: "kimi-code",
+            "agent.auxiliary_client._read_main_model", lambda: "kimi-k2.6",
         )
-        rpc_mock = MagicMock(side_effect=AssertionError(
-            "resolve_provider_client should NOT be called for kimi-coding-cn"))
+        monkeypatch.setattr(
+            "agent.auxiliary_client._main_model_supports_vision",
+            lambda provider, model: True,
+        )
+        rpc_mock = MagicMock(return_value=(fake_kimi_client, "kimi-k2.6"))
         monkeypatch.setattr(
             "agent.auxiliary_client.resolve_provider_client", rpc_mock,
         )
-        monkeypatch.setattr(
-            "agent.auxiliary_client._resolve_strict_vision_backend",
-            lambda p, m=None: (fake_or_client, "gemini")
-            if p == "openrouter"
-            else (None, None),
-        )
 
-        provider, client, _ = resolve_vision_provider_client()
-        assert provider == "openrouter"
-        assert client is fake_or_client
+        provider, client, model = resolve_vision_provider_client()
+        assert provider == "kimi-coding-cn"
+        assert client is fake_kimi_client
+        assert model == "kimi-k2.6"
+        assert rpc_mock.call_args.kwargs.get("is_vision") is True
 
     def test_explicit_override_to_kimi_coding_still_honored(self, monkeypatch):
         """When a user *explicitly* requests kimi-coding for vision (e.g.
         they know what they're doing, or are running a future build that
         adds image_in capability to Kimi Code), the explicit path still
-        routes to kimi-coding — only the auto branch applies the skip.
+        routes to kimi-coding.
         """
         monkeypatch.setattr(
             "agent.auxiliary_client._read_main_provider", lambda: "openrouter",
@@ -3101,14 +3129,6 @@ class TestVisionAutoSkipsKimiCoding:
         assert provider == "kimi-coding"
         assert client is fake_kimi_client
         gcc_mock.assert_called_once()
-
-    def test_skip_set_covers_exactly_known_entries(self):
-        """Guard against accidental widening of the skip list."""
-        from agent.auxiliary_client import _PROVIDERS_WITHOUT_VISION
-        assert _PROVIDERS_WITHOUT_VISION == frozenset({
-            "kimi-coding",
-            "kimi-coding-cn",
-        })
 
 
 class TestCodexAuxiliaryAdapterTimeout:


### PR DESCRIPTION
Fixes #51996.

## Summary
- remove the hard-coded Kimi Coding Plan no-vision skip from vision auto-routing
- let the existing model capability guard decide whether Kimi should be tried or skipped
- keep fallback behavior for models explicitly known to be text-only
- update regression coverage for Kimi main-first routing and text-only fallback

## Tests
- .\venv\Scripts\python.exe -m pytest tests\agent\test_auxiliary_client.py tests\agent\test_auxiliary_main_first.py -q
- .\venv\Scripts\python.exe -m py_compile agent\auxiliary_client.py
- .\venv\Scripts\python.exe scripts\check-windows-footguns.py --all