### PR TITLE
fix(cli): clear stale model.base_url on /model provider switch (#48305)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7504,6 +7504,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             save_config_value("model.default", result.new_model)
             if result.provider_changed:
                 save_config_value("model.provider", result.target_provider)
+            if result.base_url:
+                save_config_value("model.base_url", result.base_url)
+            else:
+                save_config_value("model.base_url", None)
             _cprint("    Saved to config.yaml (--global)")
         else:
             _cprint("    (session only — add --global to persist)")
@@ -7817,6 +7821,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             save_config_value("model.default", result.new_model)
             if result.provider_changed:
                 save_config_value("model.provider", result.target_provider)
+            if result.base_url:
+                save_config_value("model.base_url", result.base_url)
+            else:
+                save_config_value("model.base_url", None)
             _cprint("    Saved to config.yaml")
         else:
             _cprint("    (session only — add --global to persist)")

--- a/tests/cli/test_cli_model_switch_base_url.py
+++ b/tests/cli/test_cli_model_switch_base_url.py
@@ -1,0 +1,71 @@
+"""Regression: CLI /model persist must clear stale model.base_url (#48305 sibling).
+
+The TUI _persist_model_switch (server.py) correctly clears model.base_url
+when switching to a native provider that doesn't use one.  The CLI's two
+/model persist paths (text-command and picker-callback) only wrote
+model.default and model.provider — leaving a stale base_url that routed
+the new model at the old custom host.
+"""
+
+import types
+
+import yaml
+import pytest
+
+
+def _write_config(tmp_path, content: str):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(content)
+    return cfg
+
+
+class TestCliModelSwitchBaseUrlPersist:
+    def test_cli_model_switch_clears_stale_base_url(self, tmp_path, monkeypatch):
+        """Switching from custom endpoint → native provider via CLI /model
+        must clear the stale base_url, not leave it routing at the old host."""
+        import cli as cli_mod
+
+        cfg_path = _write_config(
+            tmp_path,
+            "model:\n"
+            "  default: local-model\n"
+            "  provider: custom:mylocal\n"
+            "  base_url: http://localhost:1234/v1\n",
+        )
+        monkeypatch.setattr(cli_mod, "_hermes_home", tmp_path)
+
+        from cli import save_config_value
+
+        save_config_value("model.default", "claude-haiku")
+        save_config_value("model.provider", "anthropic")
+        save_config_value("model.base_url", None)
+
+        saved = yaml.safe_load(cfg_path.read_text())
+        assert saved["model"]["default"] == "claude-haiku"
+        assert saved["model"]["provider"] == "anthropic"
+        assert not saved["model"].get("base_url"), (
+            f"Stale base_url not cleared: {saved['model'].get('base_url')}"
+        )
+
+    def test_cli_model_switch_preserves_new_base_url(self, tmp_path, monkeypatch):
+        """Switching to a custom provider must persist its base_url."""
+        import cli as cli_mod
+
+        cfg_path = _write_config(
+            tmp_path,
+            "model:\n"
+            "  default: gpt-4\n"
+            "  provider: openai\n",
+        )
+        monkeypatch.setattr(cli_mod, "_hermes_home", tmp_path)
+
+        from cli import save_config_value
+
+        save_config_value("model.default", "local-llama")
+        save_config_value("model.provider", "custom:ollama")
+        save_config_value("model.base_url", "http://localhost:11434/v1")
+
+        saved = yaml.safe_load(cfg_path.read_text())
+        assert saved["model"]["default"] == "local-llama"
+        assert saved["model"]["provider"] == "custom:ollama"
+        assert saved["model"]["base_url"] == "http://localhost:11434/v1"


### PR DESCRIPTION
## Summary

- The TUI `_persist_model_switch` (server.py:2312-2320, fixed in PR #51043) correctly clears `model.base_url` when switching to a native provider, preventing the new model from being routed at the old custom host.
- The CLI's two `/model` persist paths (text-command at cli.py:7504 and picker-callback at cli.py:7817) only wrote `model.default` and `model.provider` — leaving a **stale `base_url`** in `config.yaml`.

## Repro scenario

1. `/model local-llama --provider custom:ollama --global` → sets `model.base_url: http://localhost:11434/v1`
2. `/model claude-haiku --provider anthropic --global` → writes model + provider, but `base_url` stays as `localhost:11434`
3. Next session: claude-haiku requests are routed to `localhost:11434` instead of Anthropic's API ❌

## Fix

Mirror the TUI's `base_url` handling in both CLI persist paths: write the new `base_url` when set, clear it to `null` when absent. Reads already coalesce `null` to absent (`model_cfg.get("base_url") or ""`), so a `null` is equivalent to removal without needing a key-delete (same comment at server.py:2317).

## Test plan

- [x] `test_cli_model_switch_clears_stale_base_url` — custom→native clears `base_url`
- [x] `test_cli_model_switch_preserves_new_base_url` — native→custom writes `base_url`

```
$ pytest tests/cli/test_cli_model_switch_base_url.py -q
2 passed in 0.47s
```