### PR TITLE
fix(feishu): fall back to create when reply raises exception for withdrawn message

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4671,6 +4671,44 @@ class FeishuAdapter(BasePlatformAdapter):
                 last_error = exc
                 if msg_type == "post" and _POST_CONTENT_INVALID_RE.search(str(exc)):
                     raise
+                # When a reply target has been withdrawn/missing, the Lark SDK
+                # may raise an exception instead of returning an error response
+                # with code 230011/231003.  Fall back to creating a new message
+                # so the response is not silently dropped.
+                if active_reply_to:
+                    if (metadata or {}).get("thread_id"):
+                        logger.warning(
+                            "[Feishu] Reply to %s raised in thread %s (%s); "
+                            "skipping top-level fallback to avoid creating a new topic",
+                            active_reply_to,
+                            (metadata or {}).get("thread_id"),
+                            exc,
+                        )
+                        raise
+                    logger.warning(
+                        "[Feishu] Reply to %s raised (%s); "
+                        "falling back to new message in chat %s",
+                        active_reply_to,
+                        exc,
+                        chat_id,
+                    )
+                    active_reply_to = None
+                    try:
+                        response = await self._send_raw_message(
+                            chat_id=chat_id,
+                            msg_type=msg_type,
+                            payload=payload,
+                            reply_to=None,
+                            metadata=metadata,
+                        )
+                        return response
+                    except Exception as fallback_exc:
+                        logger.warning(
+                            "[Feishu] Fallback send also failed for chat %s: %s",
+                            chat_id,
+                            fallback_exc,
+                        )
+                        raise fallback_exc from exc
                 if attempt >= _FEISHU_SEND_ATTEMPTS - 1:
                     raise
                 wait_seconds = 2 ** attempt

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2121,6 +2121,131 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(sleeps, [])
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_send_reply_exception_falls_back_to_create(self):
+        """When reply() raises an exception (e.g. withdrawn message), fall back to create()."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {"reply_calls": 0, "create_calls": 0}
+
+        class _MessageAPI:
+            def reply(self, request):
+                captured["reply_calls"] += 1
+                raise RuntimeError("message withdrawn (code 230011)")
+
+            def create(self, request):
+                captured["create_calls"] += 1
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_fallback"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(message=_MessageAPI())
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content="hello",
+                    reply_to="om_withdrawn",
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "om_fallback")
+        self.assertEqual(captured["reply_calls"], 1)
+        self.assertEqual(captured["create_calls"], 1)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_reply_exception_in_thread_raises_without_fallback(self):
+        """In a thread context, reply exception should raise (no top-level fallback)."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {"reply_calls": 0, "create_calls": 0}
+
+        class _MessageAPI:
+            def reply(self, request):
+                captured["reply_calls"] += 1
+                raise RuntimeError("message withdrawn (code 230011)")
+
+            def create(self, request):
+                captured["create_calls"] += 1
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_fallback"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(message=_MessageAPI())
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content="hello",
+                    reply_to="om_withdrawn",
+                    metadata={"thread_id": "omt-thread"},
+                )
+            )
+
+        self.assertFalse(result.success)
+        self.assertIn("withdrawn", result.error)
+        self.assertEqual(captured["reply_calls"], 1)
+        self.assertEqual(captured["create_calls"], 0)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_reply_exception_fallback_also_raises(self):
+        """When both reply and fallback create fail, the fallback exception is raised."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        class _MessageAPI:
+            def reply(self, request):
+                raise RuntimeError("message withdrawn")
+
+            def create(self, request):
+                raise RuntimeError("chat not found")
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(message=_MessageAPI())
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content="hello",
+                    reply_to="om_withdrawn",
+                )
+            )
+
+        self.assertFalse(result.success)
+        self.assertIn("chat not found", result.error)
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_send_document_reply_uses_thread_flag(self):
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter


### PR DESCRIPTION
## What does this PR do?

Fixes silent message loss when replying to a withdrawn Feishu tool-progress bubble. The Lark SDK may raise an exception (instead of returning error code 230011) when the reply target has been withdrawn — the existing fallback only handled the error-response path, causing the agent's response to be silently dropped.

## Related Issue

Fixes #52042

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/feishu/adapter.py`: In `_feishu_send_with_retry`, catch exceptions raised during reply attempts and fall back to creating a new message (matching the existing 230011/231003 error-code fallback). In thread contexts, re-raise to avoid creating a spurious new topic.
- `tests/gateway/test_feishu.py`: Added 3 regression tests — exception fallback succeeds, thread-context re-raise, and double-failure error propagation.

## How to Test

1. Run `python -m pytest tests/gateway/test_feishu.py -k "test_send_reply_exception" -v` — all 3 new tests should pass.
2. Run `python -m pytest tests/gateway/test_feishu.py -v` — all 208 tests should pass (no regressions).
3. On a Feishu-connected instance: trigger a tool call that produces a progress bubble, have the user reply to the bubble after it's withdrawn, and verify the agent's response is delivered as a new message instead of being silently dropped.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `plugins/platforms/feishu/adapter.py` `_feishu_send_with_retry` (callers: 12 send paths, flows: reply→fallback→create)
- Blast radius: LOW — only affects Feishu reply-to-withdrawn-message error path
- Related patterns: existing 230011/231003 error-code fallback at same location
