### PR TITLE
fix(gateway): correct misleading "open access" allowlist prompts in platform setup

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -6959,6 +6959,7 @@ def interactive_setup() -> None:
         print_header,
         print_info,
         print_success,
+        print_warning,
     )
 
     print_header("Discord")
@@ -6967,7 +6968,7 @@ def interactive_setup() -> None:
         print_info("Discord: already configured")
         if not prompt_yes_no("Reconfigure Discord?", False):
             if not get_env_value("DISCORD_ALLOWED_USERS"):
-                print_info("⚠️  Discord has no user allowlist - anyone can use your bot!")
+                print_warning("⚠️  Discord has no user allowlist - unpaired users are denied by default.")
                 if prompt_yes_no("Add allowed users now?", True):
                     print_info("   To find Discord ID: Enable Developer Mode, right-click name → Copy ID")
                     allowed_users = prompt("Allowed user IDs (comma-separated)")
@@ -6993,14 +6994,15 @@ def interactive_setup() -> None:
     print_info("   You can also use Discord usernames (resolved on gateway start).")
     print()
     allowed_users = prompt(
-        "Allowed user IDs or usernames (comma-separated, leave empty for open access)"
+        "Allowed user IDs or usernames (comma-separated, leave empty to deny everyone except paired users)"
     )
     if allowed_users:
         cleaned_ids = _clean_discord_user_ids(allowed_users)
         save_env_value("DISCORD_ALLOWED_USERS", ",".join(cleaned_ids))
         print_success("Discord allowlist configured")
     else:
-        print_info("⚠️  No allowlist set - anyone in servers with your bot can use it!")
+        print_warning("⚠️  No Discord allowlist set - unpaired users will be denied by default.")
+        print_info("   Set DISCORD_ALLOW_ALL_USERS=true or GATEWAY_ALLOW_ALL_USERS=true only if you intentionally want open access.")
 
     print()
     print_info("📬 Home Channel: where Hermes delivers cron job results,")

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -4294,12 +4294,13 @@ def interactive_setup() -> None:
 
         print_info("🔒 Security: Restrict who can use your bot")
         print_info("   Matrix user IDs look like @username:server")
-        allowed_users = prompt("Allowed user IDs (comma-separated, leave empty for open access)")
+        allowed_users = prompt("Allowed user IDs (comma-separated, leave empty to deny everyone except paired users)")
         if allowed_users:
             save_env_value("MATRIX_ALLOWED_USERS", allowed_users.replace(" ", ""))
             print_success("Matrix allowlist configured")
         else:
-            print_info("⚠️  No allowlist set - anyone who can message the bot can use it!")
+            print_warning("⚠️  No Matrix allowlist set - unpaired users will be denied by default.")
+            print_info("   Set MATRIX_ALLOW_ALL_USERS=true or GATEWAY_ALLOW_ALL_USERS=true only if you intentionally want open access.")
 
         print_info("📬 Home Room: where Hermes delivers cron job results and notifications.")
         print_info("   Room IDs look like !abc123:server (shown in Element room settings)")

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -1114,6 +1114,7 @@ def interactive_setup() -> None:
         print_header,
         print_info,
         print_success,
+        print_warning,
     )
 
     print_header("Mattermost")
@@ -1141,12 +1142,13 @@ def interactive_setup() -> None:
     print_info("   To find your user ID: click your avatar → Profile")
     print_info("   or use the API: GET /api/v4/users/me")
     print()
-    allowed_users = prompt("Allowed user IDs (comma-separated, leave empty for open access)")
+    allowed_users = prompt("Allowed user IDs (comma-separated, leave empty to deny everyone except paired users)")
     if allowed_users:
         save_env_value("MATTERMOST_ALLOWED_USERS", allowed_users.replace(" ", ""))
         print_success("Mattermost allowlist configured")
     else:
-        print_info("⚠️  No allowlist set - anyone who can message the bot can use it!")
+        print_warning("⚠️  No Mattermost allowlist set - unpaired users will be denied by default.")
+        print_info("   Set MATTERMOST_ALLOW_ALL_USERS=true or GATEWAY_ALLOW_ALL_USERS=true only if you intentionally want open access.")
 
     print()
     print_info("📬 Home Channel: where Hermes delivers cron job results and notifications.")

--- a/tests/gateway/test_setup_allowlist_prompts.py
+++ b/tests/gateway/test_setup_allowlist_prompts.py
@@ -1,0 +1,108 @@
+"""Setup-wizard regression tests for the empty-allowlist messaging.
+
+The gateway is default-deny: an empty allowlist denies every sender unless the
+operator explicitly sets ``{PLATFORM}_ALLOW_ALL_USERS`` or
+``GATEWAY_ALLOW_ALL_USERS`` (``gateway/authz_mixin.py::_is_user_authorized``,
+SECURITY.md §2.6 rule 2). The Matrix / Mattermost / Discord setup wizards used
+to tell operators the opposite — "leave empty for open access" — so a user who
+left the allowlist blank expecting open access actually got default-deny and
+their own messages were rejected as unauthorized.
+
+These tests pin the corrected behavior: the empty path is described as
+default-deny, never saves an allowlist or allow-all env var on its own, and
+points the operator at the explicit opt-in. ``interactive_setup`` lazy-imports
+its helpers from ``hermes_cli.config`` (get_env_value / save_env_value) and
+``hermes_cli.cli_output`` (prompt / prompt_yes_no / print_*), so we patch those
+source modules — the same approach as ``test_slack_plugin_setup.py``.
+"""
+import importlib
+
+import pytest
+
+import hermes_cli.config as config_mod
+import hermes_cli.cli_output as cli_output_mod
+
+# (module path, env-var prefix, a representative allowlist value)
+PLATFORMS = [
+    pytest.param("plugins.platforms.matrix.adapter", "MATRIX", "@bot:server.org", id="matrix"),
+    pytest.param("plugins.platforms.mattermost.adapter", "MATTERMOST", "user123", id="mattermost"),
+    pytest.param("plugins.platforms.discord.adapter", "DISCORD", "123456789012345678", id="discord"),
+]
+
+
+def _drive_setup(monkeypatch, modpath, allowlist_input):
+    """Run a platform's interactive_setup with mocked I/O.
+
+    Returns (saved_env, prompts_shown, output_lines) where output_lines is the
+    combined text emitted via print_info and print_warning during the security
+    step.
+    """
+    saved = {}
+    prompts = []
+    output = []
+
+    def fake_prompt(message="", *_a, **_kw):
+        msg = str(message)
+        prompts.append(msg)
+        low = msg.lower()
+        if "allowed user" in low or "allowed nick" in low:
+            return allowlist_input
+        # Supply the credentials needed to reach the security/allowlist step;
+        # leave every other optional field (user id, home channel, password) blank.
+        if "access token" in low or "homeserver" in low or "server url" in low or "bot token" in low:
+            return "dummy"
+        return ""
+
+    monkeypatch.setattr(config_mod, "get_env_value", lambda key: "")
+    monkeypatch.setattr(config_mod, "save_env_value", lambda k, v: saved.__setitem__(k, v))
+    monkeypatch.setattr(cli_output_mod, "prompt", fake_prompt)
+    monkeypatch.setattr(cli_output_mod, "prompt_yes_no", lambda *_a, **_kw: False)
+    monkeypatch.setattr(cli_output_mod, "print_header", lambda *_a, **_kw: None)
+    monkeypatch.setattr(cli_output_mod, "print_success", lambda *_a, **_kw: None)
+    monkeypatch.setattr(
+        cli_output_mod,
+        "print_info",
+        lambda *a, **_kw: output.append(" ".join(str(x) for x in a)),
+    )
+    monkeypatch.setattr(
+        cli_output_mod,
+        "print_warning",
+        lambda *a, **_kw: output.append(" ".join(str(x) for x in a)),
+    )
+
+    # Matrix's wizard probes optional E2EE deps and may shell out to install
+    # them; force "nothing missing" so the test never touches the network.
+    lazy_mod = importlib.import_module("tools.lazy_deps")
+    monkeypatch.setattr(lazy_mod, "feature_missing", lambda *_a, **_kw: [])
+
+    mod = importlib.import_module(modpath)
+    mod.interactive_setup()
+    return saved, prompts, output
+
+
+@pytest.mark.parametrize("modpath,prefix,sample", PLATFORMS)
+def test_empty_allowlist_is_default_deny_not_open_access(monkeypatch, modpath, prefix, sample):
+    saved, prompts, output = _drive_setup(monkeypatch, modpath, "")
+
+    allow_prompt = next((p for p in prompts if "allowed user" in p.lower()), None)
+    assert allow_prompt is not None, "the allowlist prompt was never shown"
+    assert "open access" not in allow_prompt.lower(), (
+        f"{prefix} setup still promises 'open access' for an empty allowlist, "
+        "but the gateway is default-deny"
+    )
+
+    # Leaving it blank must not silently grant access through either env var.
+    assert f"{prefix}_ALLOWED_USERS" not in saved
+    assert f"{prefix}_ALLOW_ALL_USERS" not in saved
+
+    # The operator is told access is denied by default and how to opt into open access.
+    joined = " ".join(output)
+    assert "denied by default" in joined
+    assert f"{prefix}_ALLOW_ALL_USERS=true" in joined
+    assert "GATEWAY_ALLOW_ALL_USERS=true" in joined
+
+
+@pytest.mark.parametrize("modpath,prefix,sample", PLATFORMS)
+def test_allowlist_saved_when_provided(monkeypatch, modpath, prefix, sample):
+    saved, _, _ = _drive_setup(monkeypatch, modpath, sample)
+    assert saved.get(f"{prefix}_ALLOWED_USERS"), f"{prefix}_ALLOWED_USERS was not saved"


### PR DESCRIPTION
## What does this PR do?

The Matrix, Mattermost, and Discord gateway setup wizards told operators that leaving the allowlist empty grants **"open access"**. That is the opposite of what the gateway actually does.

`gateway/authz_mixin.py::_is_user_authorized` is **default-deny**: when an adapter has no `*_ALLOWED_USERS` allowlist and neither `*_ALLOW_ALL_USERS` nor `GATEWAY_ALLOW_ALL_USERS` is set, every sender is rejected. This is the intended, documented behavior — `SECURITY.md` §2.6 requires an allowlist for every network-exposed adapter and explicitly calls fail-open code paths bugs.

So the wizard copy produced a confusing first-run experience: an operator who follows the prompt and leaves the allowlist blank "for open access" instead gets a bot that silently denies **everyone — including themselves** — with their messages rejected as unauthorized.

This PR fixes the wizard copy only. **There is no change to authorization behavior.** The three wizards are aligned with the Slack adapter (`plugins/platforms/slack/adapter.py`), which already describes the empty path correctly and points operators at the explicit opt-in env vars.

Before / after of the empty-allowlist prompt:

- Before: `Allowed user IDs (comma-separated, leave empty for open access)` → `⚠️  No allowlist set - anyone who can message the bot can use it!`
- After: `Allowed user IDs (comma-separated, leave empty to deny everyone except paired users)` → `⚠️  No <Platform> allowlist set - unpaired users will be denied by default.` + `Set <PLATFORM>_ALLOW_ALL_USERS=true or GATEWAY_ALLOW_ALL_USERS=true only if you intentionally want open access.`

## Related Issue

No existing tracker issue. The correct behavior is specified in `SECURITY.md` §2.6 — *"An allowlist is required for every enabled network-exposed adapter… Code paths that fail open when no allowlist is configured are code bugs"* — and this PR brings the setup wizards in line with it.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/matrix/adapter.py` — allowlist prompt no longer promises "open access"; the empty path now warns that unpaired users are denied by default and points at `MATRIX_ALLOW_ALL_USERS` / `GATEWAY_ALLOW_ALL_USERS`.
- `plugins/platforms/mattermost/adapter.py` — same fix; added `print_warning` to the wizard's lazy imports.
- `plugins/platforms/discord/adapter.py` — same fix; also corrected the identical false "anyone can use your bot!" message in the reconfigure branch; added `print_warning` to the wizard's lazy imports.
- `tests/gateway/test_setup_allowlist_prompts.py` — new parametrized regression tests for all three adapters.

## How to Test

Behavior the fix relies on (unchanged): with no allowlist and no allow-all flag, `gateway/authz_mixin.py::_is_user_authorized` returns deny.

Automated:

```
pytest tests/gateway/test_setup_allowlist_prompts.py -q
```

For each adapter the test drives `interactive_setup()` with mocked I/O and asserts that, on an empty allowlist: (1) the prompt does not promise "open access", (2) neither `*_ALLOWED_USERS` nor `*_ALLOW_ALL_USERS` is saved, (3) the operator is told access is denied by default and shown the explicit opt-in env vars; and separately that a provided allowlist is still saved.

Manual: run `hermes gateway setup`, choose Matrix / Mattermost / Discord, leave the allowlist blank, and confirm the prompt now describes default-deny instead of "open access".

## Tests run & results

New regression test file — `pytest tests/gateway/test_setup_allowlist_prompts.py -v`:

```
test_empty_allowlist_is_default_deny_not_open_access[matrix] PASSED
test_empty_allowlist_is_default_deny_not_open_access[mattermost] PASSED
test_empty_allowlist_is_default_deny_not_open_access[discord] PASSED
test_allowlist_saved_when_provided[matrix] PASSED
test_allowlist_saved_when_provided[mattermost] PASSED
test_allowlist_saved_when_provided[discord] PASSED

============================== 6 passed in 0.31s ==============================
```

Wider regression across the affected adapters, the setup-wizard pattern, and the authorization logic the fix relies on:

```
pytest tests/gateway/test_setup_allowlist_prompts.py \
       tests/gateway/test_slack_plugin_setup.py \
       tests/gateway/test_config_driven_access_policy.py \
       tests/gateway/test_mattermost.py \
       tests/gateway/test_discord_imports.py \
       tests/gateway/test_discord_slash_auth.py -q

144 passed, 3 warnings in 7.46s
```

(The 3 warnings are pre-existing third-party `DeprecationWarning`s unrelated to this change.) The full hermetic suite runs in CI.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(gateway):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I ran the relevant gateway / setup-wizard / authorization suites locally (144 passed) plus the new tests; the full hermetic suite runs in CI
- [x] I've added tests for my changes
- [x] Verified via the automated tests above

### Documentation & Housekeeping

- [x] N/A — wizard copy only; the referenced env vars already exist and are documented
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow changes
- [x] N/A — pure string/copy change plus one already-exported helper import
- [x] N/A — no tool descriptions/schemas changed****