### PR TITLE
fix(feishu): preserve markdown around tables

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -155,8 +155,11 @@ _MARKDOWN_HINT_RE = re.compile(
     re.MULTILINE,
 )
 # Detect markdown tables: a line starting with | followed by a separator line.
-# Feishu post-type 'md' elements do not render tables, so we force text mode.
+# Feishu post-type 'md' elements do not render tables directly.
 _MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
+_MARKDOWN_TABLE_SEPARATOR_LINE_RE = re.compile(
+    r"^\s*\|\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)+\|?\s*$"
+)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
 _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
@@ -558,6 +561,73 @@ def _build_markdown_post_payload(content: str) -> str:
         },
         ensure_ascii=False,
     )
+
+
+def _is_markdown_table_row(line: str) -> bool:
+    stripped = line.strip()
+    return (
+        stripped.startswith("|")
+        and stripped.endswith("|")
+        and stripped.count("|") >= 2
+    )
+
+
+def _is_markdown_table_separator(line: str) -> bool:
+    return bool(_MARKDOWN_TABLE_SEPARATOR_LINE_RE.match(line))
+
+
+def _protect_markdown_tables_for_post(content: str) -> tuple[str, str, bool]:
+    """Wrap markdown table blocks in code fences before sending a post payload.
+
+    Feishu's post ``md`` renderer cannot render tables, but a table inside a
+    fenced code block remains visible. The returned non-table content lets the
+    caller decide whether there is any other markdown worth preserving.
+    """
+    lines = content.splitlines()
+    protected: List[str] = []
+    non_table: List[str] = []
+    found_table = False
+    in_code_block = False
+    i = 0
+
+    while i < len(lines):
+        raw_line = lines[i]
+        stripped_line = raw_line.strip()
+        is_fence = bool(
+            _MARKDOWN_FENCE_CLOSE_RE.match(stripped_line)
+            if in_code_block
+            else _MARKDOWN_FENCE_OPEN_RE.match(stripped_line)
+        )
+        if is_fence:
+            protected.append(raw_line)
+            non_table.append(raw_line)
+            in_code_block = not in_code_block
+            i += 1
+            continue
+
+        if (
+            not in_code_block
+            and i + 1 < len(lines)
+            and _is_markdown_table_row(raw_line)
+            and _is_markdown_table_separator(lines[i + 1])
+        ):
+            table_lines: List[str] = []
+            while i < len(lines) and _is_markdown_table_row(lines[i]):
+                table_lines.append(lines[i])
+                i += 1
+            protected.append("```")
+            protected.extend(table_lines)
+            protected.append("```")
+            found_table = True
+            continue
+
+        protected.append(raw_line)
+        non_table.append(raw_line)
+        i += 1
+
+    if not found_table:
+        return content, content, False
+    return "\n".join(protected), "\n".join(non_table), True
 
 
 def _build_markdown_post_rows(content: str) -> List[List[Dict[str, str]]]:
@@ -4377,8 +4447,14 @@ class FeishuAdapter(BasePlatformAdapter):
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
         # Feishu post-type 'md' elements do not render markdown tables; sending
         # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
+        # Keep pure table payloads as plain text, but preserve surrounding
+        # markdown by fencing only the table block when a response mixes both.
         if _MARKDOWN_TABLE_RE.search(content):
+            protected_content, non_table_content, found_table = (
+                _protect_markdown_tables_for_post(content)
+            )
+            if found_table and _MARKDOWN_HINT_RE.search(non_table_content):
+                return "post", _build_markdown_post_payload(protected_content)
             text_payload = {"text": content}
             return "text", json.dumps(text_payload, ensure_ascii=False)
         if _MARKDOWN_HINT_RE.search(content):

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -154,11 +154,15 @@ _MARKDOWN_HINT_RE = re.compile(
     r"(^#{1,6}\s)|(^\s*[-*]\s)|(^\s*\d+\.\s)|(^\s*---+\s*$)|(```)|(`[^`\n]+`)|(\*\*[^*\n].+?\*\*)|(~~[^~\n].+?~~)|(<u>.+?</u>)|(\*[^*\n]+\*)|(\[[^\]]+\]\([^)]+\))|(^>\s)",
     re.MULTILINE,
 )
-# Detect markdown tables: a line starting with | followed by a separator line.
+# Detect markdown tables with or without optional outer pipes.
 # Feishu post-type 'md' elements do not render tables directly.
-_MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
+_MARKDOWN_TABLE_RE = re.compile(
+    r"^\s*\|?[^\n|]+\|[^\n|]+(?:\|[^\n|]+)*\|?\s*\n"
+    r"\s*\|?\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)+\|?\s*$",
+    re.MULTILINE,
+)
 _MARKDOWN_TABLE_SEPARATOR_LINE_RE = re.compile(
-    r"^\s*\|\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)+\|?\s*$"
+    r"^\s*\|?\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)+\|?\s*$"
 )
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
@@ -565,11 +569,7 @@ def _build_markdown_post_payload(content: str) -> str:
 
 def _is_markdown_table_row(line: str) -> bool:
     stripped = line.strip()
-    return (
-        stripped.startswith("|")
-        and stripped.endswith("|")
-        and stripped.count("|") >= 2
-    )
+    return stripped.count("|") >= 1 and bool(stripped.strip("|").strip())
 
 
 def _is_markdown_table_separator(line: str) -> bool:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2539,6 +2539,43 @@ class TestAdapterBehavior(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_build_outbound_payload_keeps_plain_table_as_text(self):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter.__new__(FeishuAdapter)
+        content = "| Name | Value |\n| --- | --- |\n| ok | yes |"
+
+        msg_type, payload = adapter._build_outbound_payload(content)
+
+        self.assertEqual(msg_type, "text")
+        self.assertEqual(json.loads(payload), {"text": content})
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_build_outbound_payload_preserves_markdown_around_table(self):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter.__new__(FeishuAdapter)
+        content = (
+            "**Summary**\n\n"
+            "| Name | Value |\n"
+            "| --- | --- |\n"
+            "| ok | yes |\n\n"
+            "- next step"
+        )
+
+        msg_type, payload = adapter._build_outbound_payload(content)
+
+        self.assertEqual(msg_type, "post")
+        rows = json.loads(payload)["zh_cn"]["content"]
+        row_texts = [row[0]["text"] for row in rows]
+        self.assertIn("**Summary**", row_texts[0])
+        self.assertEqual(
+            row_texts[1],
+            "```\n| Name | Value |\n| --- | --- |\n| ok | yes |\n```",
+        )
+        self.assertIn("- next step", row_texts[2])
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_send_uses_post_for_inline_markdown(self):
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2576,6 +2576,31 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertIn("- next step", row_texts[2])
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_build_outbound_payload_preserves_markdown_around_bare_pipe_table(self):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter.__new__(FeishuAdapter)
+        content = (
+            "**Summary**\n\n"
+            "Name | Value\n"
+            "--- | ---\n"
+            "ok | yes\n\n"
+            "- next step"
+        )
+
+        msg_type, payload = adapter._build_outbound_payload(content)
+
+        self.assertEqual(msg_type, "post")
+        rows = json.loads(payload)["zh_cn"]["content"]
+        row_texts = [row[0]["text"] for row in rows]
+        self.assertIn("**Summary**", row_texts[0])
+        self.assertEqual(
+            row_texts[1],
+            "```\nName | Value\n--- | ---\nok | yes\n```",
+        )
+        self.assertIn("- next step", row_texts[2])
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_send_uses_post_for_inline_markdown(self):
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter


### PR DESCRIPTION
Fixes #52046.

## Summary
- keep pure markdown-table messages on Feishu's plain text fallback
- preserve surrounding markdown for mixed table/prose responses by fencing only table blocks before building a post payload
- add regression coverage for pure-table text fallback and mixed markdown/table post payloads

## Tests
- .\venv\Scripts\python.exe -m pytest tests\gateway\test_feishu.py::TestAdapterBehavior::test_build_outbound_payload_keeps_plain_table_as_text tests\gateway\test_feishu.py::TestAdapterBehavior::test_build_outbound_payload_preserves_markdown_around_table -q
- .\venv\Scripts\python.exe -m py_compile plugins\platforms\feishu\adapter.py
- .\venv\Scripts\python.exe scripts\check-windows-footguns.py --all

Note: running the broader markdown subset on Windows currently trips pre-existing tests that clear HOME/USERPROFILE before constructing FeishuAdapter; the two new regression tests avoid adapter initialization and pass directly.