### PR TITLE
fix(tool-results): handle missing content during budget enforcement

### DIFF
--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -584,3 +584,105 @@ class TestPerToolThresholds:
             assert val == 100_000
         except ImportError:
             pytest.skip("file_tools not importable in test env")
+
+
+# ── _resolve_storage_dir edge cases ───────────────────────────────────
+
+class TestResolveStorageDirEdgeCases:
+    def test_env_get_temp_dir_raises(self):
+        """When env.get_temp_dir() raises, falls back to STORAGE_DIR."""
+        env = MagicMock()
+        env.get_temp_dir.side_effect = OSError("permission denied")
+        assert _resolve_storage_dir(env) == STORAGE_DIR
+
+    def test_env_get_temp_dir_returns_empty(self):
+        """When env.get_temp_dir() returns empty string, falls back to STORAGE_DIR."""
+        env = MagicMock()
+        env.get_temp_dir.return_value = ""
+        assert _resolve_storage_dir(env) == STORAGE_DIR
+
+    def test_env_get_temp_dir_returns_none(self):
+        """When env.get_temp_dir() returns None, falls back to STORAGE_DIR."""
+        env = MagicMock()
+        env.get_temp_dir.return_value = None
+        assert _resolve_storage_dir(env) == STORAGE_DIR
+
+    def test_env_has_no_get_temp_dir(self):
+        """When env has no get_temp_dir attribute, falls back to STORAGE_DIR."""
+        env = MagicMock()
+        del env.get_temp_dir
+        assert _resolve_storage_dir(env) == STORAGE_DIR
+
+    def test_env_temp_dir_trailing_slash_stripped(self):
+        """Trailing slashes are stripped from the temp dir."""
+        env = MagicMock()
+        env.get_temp_dir.return_value = "/var/tmp///"
+        result = _resolve_storage_dir(env)
+        assert result == "/var/tmp/hermes-results"
+
+    def test_env_temp_dir_root_only(self):
+        """When temp dir is just '/', the rstrip-or-slash fallback yields
+        a double-slash path — cosmetic, not a bug."""
+        env = MagicMock()
+        env.get_temp_dir.return_value = "/"
+        result = _resolve_storage_dir(env)
+        assert result.endswith("/hermes-results")
+
+
+# ── enforce_turn_budget edge cases ─────────────────────────────────────
+
+class TestEnforceTurnBudgetEdgeCases:
+    def test_missing_tool_call_id_uses_budget_prefix(self):
+        """Messages without tool_call_id get a budget_ prefix."""
+        env = MagicMock()
+        env.execute.return_value = {"output": "", "returncode": 0}
+        msgs = [
+            {"role": "tool", "content": "x" * 250_000},
+        ]
+        enforce_turn_budget(msgs, env=env, config=BudgetConfig(turn_budget=200_000))
+        # Should be persisted with a budget_ prefix filename
+        assert PERSISTED_OUTPUT_TAG in msgs[0]["content"]
+        assert "budget_0" in msgs[0]["content"]
+
+    def test_no_content_key_uses_empty_string(self):
+        """Missing content remains safe when another result exceeds the budget."""
+        persisted = (
+            f"{PERSISTED_OUTPUT_TAG}\n{'x' * 200}\n{PERSISTED_OUTPUT_CLOSING_TAG}"
+        )
+        msgs = [
+            {"role": "tool", "tool_call_id": "t1"},
+            {"role": "tool", "tool_call_id": "t2", "content": persisted},
+        ]
+        result = enforce_turn_budget(
+            msgs, env=None, config=BudgetConfig(turn_budget=100)
+        )
+        assert result is msgs
+        assert "content" not in result[0]
+        assert result[1]["content"] == persisted
+
+    def test_all_already_persisted(self):
+        """Over-budget persisted results are not persisted a second time."""
+        persisted = (
+            f"{PERSISTED_OUTPUT_TAG}\n{'x' * 200}\n{PERSISTED_OUTPUT_CLOSING_TAG}"
+        )
+        msgs = [
+            {"role": "tool", "tool_call_id": "t1", "content": persisted},
+        ]
+        result = enforce_turn_budget(msgs, env=None, config=BudgetConfig(turn_budget=100))
+        assert result is msgs
+        assert result[0]["content"] == persisted
+
+    def test_budget_enforcement_logs_persisted(self):
+        """Verify the logging path for budget enforcement is exercised."""
+        env = MagicMock()
+        env.execute.return_value = {"output": "", "returncode": 0}
+        msgs = [
+            {"role": "tool", "tool_call_id": "t1", "content": "x" * 250_000},
+        ]
+        with patch("tools.tool_result_storage.logger") as mock_logger:
+            enforce_turn_budget(msgs, env=env, config=BudgetConfig(turn_budget=200_000))
+            mock_logger.info.assert_any_call(
+                "Budget enforcement: persisted tool result %s (%d chars)",
+                "t1",
+                250_000,
+            )

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -231,7 +231,7 @@ def enforce_turn_budget(
         if total_size <= config.turn_budget:
             break
         msg = tool_messages[idx]
-        content = msg["content"]
+        content = msg.get("content", "")
         tool_use_id = msg.get("tool_call_id", f"budget_{idx}")
 
         replacement = maybe_persist_tool_result(


### PR DESCRIPTION
## What does this PR do?

Harden turn-budget enforcement for tool messages without a `content` key and add focused storage/budget edge-case coverage. The missing-content regression exposed a real `KeyError` on current main when another persisted result pushed the turn over budget.

## Related Issue

Refs #36595

The original coverage threshold is already satisfied on main; this
PR covers the remaining missing-content defect and incremental edge cases.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tools/tool_result_storage.py` handles missing `content` consistently during candidate discovery and budget enforcement.
- `tests/tools/test_tool_result_storage.py` adds regressions for storage-directory fallbacks, missing content, persisted results, and exact budget logging. The all-persisted fixture explicitly exceeds the budget and verifies that already stored content remains unchanged.
- Preserved current-main host-side spillover coverage while carrying the PR's storage and budget edge cases through the conflict.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_tool_result_storage.py -q` → 44 passed.
2. The missing-content regression fails on the exact base with `KeyError: 'content'` and passes on this branch.

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run the focused test suite and all tests pass
- [x] I've added tests for the bug fix
- [x] I've tested on macOS arm64
- [x] I've considered cross-platform impact or N/A

## Screenshots / Logs

Not applicable.
