### PR TITLE
fix: add /learn to desktop slash command specs

### DIFF
--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -128,6 +128,7 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
   { name: '/compress', description: 'Compress this conversation context', surface: exec() },
   { name: '/debug', description: 'Create a debug report', surface: exec() },
   { name: '/goal', description: 'Manage the standing goal for this session', surface: exec() },
+  { name: '/learn', description: 'Learn a reusable skill from anything you describe', surface: exec() },
   { name: '/personality', description: 'Switch personality for this session', surface: exec(), args: true },
   { name: '/pet', description: 'Toggle or adopt a petdex mascot (/pet, /pet list, /pet boba)', surface: action('pet'), args: true },
   { name: '/queue', description: 'Queue a prompt for the next turn', aliases: ['/q'], surface: exec() },


### PR DESCRIPTION
## Problem

The `/learn` command is fully implemented in the backend:
- `hermes_cli/commands.py:184` — registered as `CommandDef(learn, ...)`
- `hermes_cli/cli_commands_mixin.py:1415` — `_handle_learn_command` handler
- `agent/learn_prompt.py` — `build_learn_prompt()` prompt builder
- `gateway/run.py:8131` — gateway slash-command path

But it was **missing from `DESKTOP_COMMAND_SPECS`** in `desktop-slash-commands.ts`. The `isDesktopSlashSuggestion()` filter checks this table, so `/learn` was silently filtered out of the desktop GUI's slash command palette — users could type it and it would work, but it never appeared in autocomplete or `/help`.

## Fix

Added one line to `DESKTOP_COMMAND_SPECS`:

```ts
{ name: '/learn', description: 'Learn a reusable skill from anything you describe', surface: exec() },
```

This makes `/learn` visible in the slash command popover and the `/help` list, matching the backend's existing registration.