### PR TITLE
fix: MCP tool results falsely flagged as errors by _detect_tool_failure

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -884,6 +884,30 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
         if err and (data.get("success") is False or "error" in data):
             return True, f" [{_trim_error(str(err))}]"
 
+    # MCP tool results wrap output in {"result": ..., "structuredContent": {...}}
+    # where "error": null / false is normal and not a real failure.  The
+    # generic string scan below would falsely match the "error" key name.
+    if isinstance(data, dict) and "structuredContent" in data:
+        sc = data["structuredContent"]
+        if isinstance(sc, dict):
+            sc_success = sc.get("success")
+            sc_error = sc.get("error")
+            if sc_success is True and (sc_error is None or sc_error is False):
+                return False, ""
+            # Some MCP servers nest status inside response
+            sc_resp = sc.get("response")
+            if isinstance(sc_resp, dict):
+                resp_success = sc_resp.get("success")
+                resp_error = sc_resp.get("error")
+                if resp_success is True and (resp_error is None or resp_error is False):
+                    return False, ""
+                # Real error in nested response — surface the message
+                if isinstance(resp_error, str) and resp_error:
+                    return True, f" [{_trim_error(resp_error)}]"
+            # Real error at structuredContent top-level
+            if isinstance(sc_error, str) and sc_error:
+                return True, f" [{_trim_error(sc_error)}]"
+
     # Generic heuristic for non-terminal tools
     # Multimodal tool results (dicts with _multimodal=True) are not strings —
     # treat them as successes since failures would be JSON-encoded strings.

--- a/tests/agent/test_display_tool_failure.py
+++ b/tests/agent/test_display_tool_failure.py
@@ -134,6 +134,52 @@ class TestDetectToolFailureStructured:
         assert is_failure is False
 
 
+class TestDetectToolFailureMCP:
+    """MCP tools: structuredContent wrappers should not be flagged as errors
+    when the contained error field is null / false."""
+
+    def _mcp_result(self, error_value=None, success=True):
+        """Build a realistic agent-browser MCP result string."""
+        return json.dumps({
+            "result": "Example Domain",
+            "structuredContent": {
+                "exitCode": 0,
+                "response": {
+                    "data": {"title": "Example Domain"},
+                    "error": error_value,
+                    "success": success,
+                },
+            },
+        })
+
+    def test_null_error_is_success(self):
+        # "error": null inside structuredContent → not a real failure.
+        result = self._mcp_result(error_value=None)
+        assert _detect_tool_failure("browser_open", result) == (False, "")
+
+    def test_false_error_is_success(self):
+        # Some MCP implementations use false instead of null.
+        result = self._mcp_result(error_value=False)
+        assert _detect_tool_failure("browser_open", result) == (False, "")
+
+    def test_string_error_is_failure(self):
+        # A real error string IS a failure and should be detected.
+        result = self._mcp_result(error_value="connection refused", success=False)
+        is_failure, suffix = _detect_tool_failure("browser_open", result)
+        assert is_failure is True
+        assert "connection refused" in suffix
+
+    def test_nested_error_null_in_response(self):
+        # error is inside structuredContent.response, not at top level.
+        result = json.dumps({
+            "result": "ok",
+            "structuredContent": {
+                "response": {"error": None, "success": True},
+            },
+        })
+        assert _detect_tool_failure("browser_screenshot", result) == (False, "")
+
+
 class TestGetCuteToolMessageFailureSuffix:
     """End-to-end: failure suffix is appended by get_cute_tool_message."""
 


### PR DESCRIPTION
## Problem

Every MCP tool call (agent-browser, etc.) is logged as a WARNING/error even when successful:

```
WARNING ... Tool mcp_agent_browser_agent_browser_open returned error (0.49s): {"result": "Example Domain"...
WARNING ... Tool mcp_agent_browser_agent_browser_screenshot returned error (0.04s): {"result": "/home/...
```

The tools work correctly — the log is wrong.

## Root Cause

In `agent/display.py:_detect_tool_failure`, the generic heuristic on line 893 does a raw string scan:

```python
lower = result[:500].lower()
if "error" in lower or "failed" in lower or result.startswith("Error"):
    return True, " [error]"
```

MCP tool results are JSON-wrapped and contain `"error": null` / `"error": false` inside their `structuredContent` block:

```json
{"result": "Example Domain", "structuredContent": {"response": {"error": null, "success": true}, ...}}
```

The literal `\"error\"` substring matches even when the value is null/false, so every MCP call is flagged as a failure. This happens because the earlier structured-error check (line 882) only looks for top-level `data.get("error")` — the MCP error is nested inside `structuredContent`.

## Fix

Added an MCP-aware guard **before** the generic string heuristic. When the parsed JSON dict contains `structuredContent`, it inspects the actual error/success state:

- `success=true` + `error=null/false` at either `structuredContent` or `structuredContent.response` → not a failure (suppresses false positive)
- Real error string → surfaced with `_trim_error` for better diagnostics
- Ambiguous (no explicit success/error) → falls through to existing heuristics

### Files changed

- `agent/display.py`: 16-line guard inserted after line 885
- `tests/agent/test_display_tool_failure.py`: 4 new test cases covering null error, false error, real error string, and nested response.error

### Test results

```
28 passed in 0.13s
```

All existing tests pass + 4 new MCP-specific tests.

## Evidence

Logs from the current session showing every MCP call incorrectly flagged:

<details>
<summary>agent.log excerpt</summary>

```
WARNING ... Tool mcp_agent_browser_agent_browser_open returned error (0.49s)
WARNING ... Tool mcp_agent_browser_agent_browser_screenshot returned error (0.04s)
WARNING ... Tool mcp_agent_browser_agent_browser_snapshot returned error (0.02s)
WARNING ... Tool mcp_agent_browser_agent_browser_eval returned error (0.02s)
WARNING ... Tool mcp_agent_browser_agent_browser_click returned error (0.02s)
WARNING ... Tool mcp_agent_browser_agent_browser_wait_for_load returned error (3.76s)
WARNING ... Tool mcp_agent_browser_agent_browser_get_url returned error (0.02s)
WARNING ... Tool mcp_agent_browser_agent_browser_get_title returned error (0.02s)
WARNING ... Tool mcp_agent_browser_agent_browser_back returned error (0.52s)
WARNING ... Tool mcp_agent_browser_agent_browser_close returned error (0.12s)
```

</details>

---

> **Disclaimer:** This PR was authored by Muninn (Hermes AI agent). I am not a professional coder. The fix is a surgical 16-line guard backed by 4 test cases and clean test suite verification. All analysis is evidence-based using actual log output and source code. Please review carefully — I will respond to any feedback and make requested changes.