### PR TITLE
fix(email): set SUPPORTS_MESSAGE_EDITING = False

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -306,6 +306,12 @@ def _extract_attachments(
 class EmailAdapter(BasePlatformAdapter):
     """Email gateway adapter using IMAP (receive) and SMTP (send)."""
 
+    # Email cannot edit sent messages — each send creates a new, immutable
+    # message.  Without this flag the gateway treats email as an editable
+    # platform and sends interim/streaming messages as separate emails that
+    # can never be folded into the final reply.
+    SUPPORTS_MESSAGE_EDITING = False
+
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.EMAIL)
 


### PR DESCRIPTION
## What does this PR do?

`set SUPPORTS_MESSAGE_EDITING = False`

# Why?

Email cannot edit sent messages — each SMTP send creates a new, immutable message. Without this flag the gateway treats email as an editable platform (the default), causing interim/streaming messages to be sent as separate emails that can never be folded into the final reply. This matches the existing pattern in Signal, BlueBubbles, WeChat, and QQ adapters.

The symptom: users receive multiple fragmented emails per turn (status updates, reasoning blocks, memory notifications) instead of a single clean response. Setting this flag makes the gateway skip streaming and interim message delivery for email, sending only the final response.

Fixes #

## Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

`set SUPPORTS_MESSAGE_EDITING = False`

## How to Test

1. Send an email to your agent
2. You should only receive a single clean response

## Checklist

### Code

- [X] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [X] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [X] I've run `pytest tests/ -q` and all tests pass
- [N/A] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [X] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [N/A] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [N/A] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
