### PR TITLE
feat(cron): add optional profile-pinning for jobs

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -251,6 +251,46 @@ def _normalize_job_record(job: Dict[str, Any]) -> Dict[str, Any]:
     return normalized
 
 
+def _active_profile_name() -> str:
+    """Return the Hermes profile name for the current process.
+
+    Cron jobs are stored in a shared JSON database, but in multi-profile
+    deployments each gateway executes jobs with its own profile-local skills,
+    memory, config, and MCP servers. The active profile is derived from the
+    current Hermes home path so the scheduler can skip jobs pinned to a
+    different profile without touching the global tick lock behaviour.
+
+    Standard layouts:
+
+    * ``~/.hermes`` (or any non-profile Hermes home) -> ``"default"``
+    * ``~/.hermes/profiles/<name>`` -> ``"<name>"``
+
+    ``HERMES_PROFILE`` is honored when present because some launchers already
+    export it alongside ``HERMES_HOME``; otherwise ``get_hermes_home()`` remains
+    the source of truth. Path resolution is non-strict so tests and first-run
+    profiles do not need to pre-create directories.
+    """
+    explicit = os.getenv("HERMES_PROFILE", "").strip()
+    if explicit:
+        return explicit
+
+    hermes_home = get_hermes_home().expanduser().resolve()
+    if hermes_home.parent.name == "profiles" and hermes_home.name:
+        return hermes_home.name
+    return "default"
+
+
+def _job_matches_active_profile(job: Dict[str, Any], active_profile: str) -> bool:
+    """Return True when *job* may be ticked by *active_profile*.
+
+    Missing, ``None``, and empty-string profile values intentionally preserve
+    the historical race behaviour: any gateway that wins ``tick.lock`` may run
+    the job. Only a non-empty profile string pins execution to that profile.
+    """
+    pinned_profile = str(job.get("profile") or "").strip()
+    return not pinned_profile or pinned_profile == active_profile
+
+
 def _secure_dir(path: Path):
     """Set directory to owner-only access (0700). No-op on Windows."""
     try:
@@ -749,6 +789,7 @@ def create_job(
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
     no_agent: bool = False,
+    profile: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -793,6 +834,9 @@ def create_job(
                 and deliver its stdout directly. Empty stdout = silent (no
                 delivery). Requires ``script`` to be set. Ideal for classic
                 watchdogs and periodic alerts that don't need LLM reasoning.
+        profile: Optional Hermes profile pin. When set, only the gateway
+                running that profile will tick this job. ``None`` or an empty
+                string preserves the historical any-profile race behaviour.
 
     Returns:
         The created job dict
@@ -827,6 +871,8 @@ def create_job(
     normalized_toolsets = normalized_toolsets or None
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
+    normalized_profile = str(profile).strip() if isinstance(profile, str) else None
+    normalized_profile = normalized_profile or None
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -881,6 +927,8 @@ def create_job(
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
     }
+    if normalized_profile:
+        job["profile"] = normalized_profile
 
     with _jobs_lock():
         jobs = load_jobs()
@@ -970,6 +1018,11 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updates["workdir"] = None
                 else:
                     updates["workdir"] = _normalize_workdir(_wd)
+
+            if "profile" in updates:
+                _profile = updates["profile"]
+                updates["profile"] = str(_profile).strip() if isinstance(_profile, str) else None
+                updates["profile"] = updates["profile"] or None
 
             updated = _apply_skill_fields({**job, **updates})
             schedule_changed = "schedule" in updates
@@ -1269,12 +1322,16 @@ def get_due_jobs() -> List[Dict[str, Any]]:
 def _get_due_jobs_locked() -> List[Dict[str, Any]]:
     """Inner implementation of get_due_jobs(); must be called with _jobs_lock held."""
     now = _hermes_now()
+    active_profile = _active_profile_name()
     raw_jobs = load_jobs()
     jobs = [_apply_skill_fields(j) for j in copy.deepcopy(raw_jobs)]
     due = []
     needs_save = False
 
     for job in jobs:
+        if not _job_matches_active_profile(job, active_profile):
+            continue
+
         if not job.get("enabled", True):
             continue
 

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -144,6 +144,9 @@ def cron_list(show_all: bool = False):
         workdir = job.get("workdir")
         if workdir:
             print(f"    Workdir:   {workdir}")
+        profile = job.get("profile")
+        if profile:
+            print(f"    Profile:   {profile}")
 
         # Execution history
         last_status = job.get("last_status")
@@ -341,6 +344,7 @@ def cron_edit(args):
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
         no_agent=getattr(args, "no_agent", None),
+        profile=getattr(args, "profile", None),
     )
     if not result.get("success"):
         print(color(f"Failed to update job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -360,6 +364,8 @@ def cron_edit(args):
         print("  Mode: no-agent (script stdout delivered directly)")
     if updated.get("workdir"):
         print(f"  Workdir: {updated['workdir']}")
+    if updated.get("profile"):
+        print(f"  Profile: {updated['profile']}")
     return 0
 
 

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -134,6 +134,10 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         "--workdir",
         help="Absolute path for the job to run from (injects AGENTS.md etc. and sets terminal cwd). Pass empty string to clear.",
     )
+    cron_edit.add_argument(
+        "--profile",
+        help="Pin this job to a Hermes profile. Pass an empty string to clear the pin.",
+    )
 
     # lifecycle actions
     cron_pause = cron_subparsers.add_parser("pause", help="Pause a scheduled job")

--- a/tests/cron/test_profile_pinning.py
+++ b/tests/cron/test_profile_pinning.py
@@ -1,0 +1,145 @@
+"""Cron profile pinning tests.
+
+Profile-pinned jobs should only be considered due by the gateway running that
+profile. Unpinned jobs keep the historical any-profile race behaviour.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from cron.jobs import get_due_jobs, save_jobs
+
+
+@pytest.fixture()
+def cron_store(tmp_path, monkeypatch):
+    """Use one shared cron store while varying the active HERMES_HOME profile."""
+    cron_dir = tmp_path / "cron"
+    monkeypatch.setattr("cron.jobs.CRON_DIR", cron_dir)
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", cron_dir / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", cron_dir / "output")
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+    return tmp_path
+
+
+@pytest.fixture()
+def fixed_now(monkeypatch):
+    now = datetime(2026, 6, 24, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+    return now
+
+
+_UNSET = object()
+
+
+def _due_job(now: datetime, *, profile=_UNSET):
+    run_at = (now - timedelta(seconds=10)).isoformat()
+    job = {
+        "id": "job1",
+        "name": "profile pinning test",
+        "prompt": "run",
+        "skills": [],
+        "skill": None,
+        "schedule": {"kind": "once", "run_at": run_at},
+        "schedule_display": run_at,
+        "repeat": {"times": 1, "completed": 0},
+        "enabled": True,
+        "state": "scheduled",
+        "created_at": now.isoformat(),
+        "next_run_at": run_at,
+        "last_run_at": None,
+        "last_status": None,
+        "deliver": "local",
+        "origin": None,
+    }
+    if profile is not _UNSET:
+        job["profile"] = profile
+    return job
+
+
+def _due_ids():
+    return {job["id"] for job in get_due_jobs()}
+
+
+def test_no_profile_field_runs_anywhere(cron_store, fixed_now, monkeypatch):
+    save_jobs([_due_job(fixed_now)])
+
+    monkeypatch.setenv("HERMES_HOME", str(cron_store))
+    assert "job1" in _due_ids()
+
+    monkeypatch.setenv("HERMES_HOME", str(cron_store / "profiles" / "dev"))
+    assert "job1" in _due_ids()
+
+
+def test_profile_match_runs(cron_store, fixed_now, monkeypatch):
+    save_jobs([_due_job(fixed_now, profile="dev")])
+
+    monkeypatch.setenv("HERMES_HOME", str(cron_store / "profiles" / "dev"))
+
+    assert "job1" in _due_ids()
+
+
+def test_profile_mismatch_skips(cron_store, fixed_now, monkeypatch):
+    save_jobs([_due_job(fixed_now, profile="dev")])
+
+    monkeypatch.setenv("HERMES_HOME", str(cron_store))
+
+    assert "job1" not in _due_ids()
+
+
+def test_lock_still_prevents_double_fire(tmp_path, monkeypatch):
+    """A held tick.lock still makes a second scheduler tick skip immediately."""
+    hermes_home = tmp_path / "profiles" / "dev"
+    lock_dir = hermes_home / "cron"
+    lock_dir.mkdir(parents=True)
+    lock_file = lock_dir / ".tick.lock"
+
+    holder = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import fcntl, pathlib, sys, time\n"
+                f"path = pathlib.Path({str(lock_file)!r})\n"
+                "path.parent.mkdir(parents=True, exist_ok=True)\n"
+                "fd = path.open('w', encoding='utf-8')\n"
+                "fcntl.flock(fd, fcntl.LOCK_EX)\n"
+                "print('locked', flush=True)\n"
+                "time.sleep(10)\n"
+            ),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert holder.stdout is not None
+        assert holder.stdout.readline().strip() == "locked"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        import cron.scheduler as scheduler
+
+        called = False
+
+        def fail_if_called():
+            nonlocal called
+            called = True
+            raise AssertionError("get_due_jobs should not run while tick.lock is held")
+
+        monkeypatch.setattr(scheduler, "get_due_jobs", fail_if_called)
+
+        assert scheduler.tick(verbose=False, sync=True) == 0
+        assert called is False
+    finally:
+        holder.terminate()
+        try:
+            holder.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            holder.kill()
+            holder.wait(timeout=5)

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -508,6 +508,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    if job.get("profile"):
+        result["profile"] = job["profile"]
     return result
 
 
@@ -576,6 +578,7 @@ def cronjob(
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
+    profile: Optional[str] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -642,6 +645,7 @@ def cronjob(
                 enabled_toolsets=enabled_toolsets or None,
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
+                profile=_normalize_optional_job_value(profile),
             )
             _notify_provider_jobs_changed_safe()
             _create_message = f"Cron job '{job['name']}' created."
@@ -798,6 +802,9 @@ def cronjob(
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.
                 updates["workdir"] = _normalize_optional_job_value(workdir) or None
+            if profile is not None:
+                # Empty string clears the pin and restores any-profile ticking.
+                updates["profile"] = _normalize_optional_job_value(profile) or None
             if no_agent is not None:
                 # Toggling no_agent on/off at update time. If flipping to True,
                 # we need a script to already exist on the job (or be part of
@@ -952,6 +959,10 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "string",
                 "description": "Optional absolute path to run the job from. When set, AGENTS.md / CLAUDE.md / .cursorrules from that directory are injected into the system prompt, and the terminal/file/code_exec tools use it as their working directory — useful for running a job inside a specific project repo. Must be an absolute path that exists. When unset (default), preserves the original behaviour: no project context files, tools use the scheduler's cwd. On update, pass an empty string to clear. Jobs with workdir run sequentially (not parallel) to keep per-job directories isolated."
             },
+            "profile": {
+                "type": "string",
+                "description": "Pin job to a specific Hermes profile. Only the gateway running this profile will tick it. Omit or null = any profile may tick. On update, pass an empty string to clear the pin."
+            },
         },
         "required": ["action"]
     }
@@ -1007,6 +1018,7 @@ registry.register(
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
+        profile=args.get("profile"),
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -125,6 +125,31 @@ When `workdir` is set:
 Jobs with a `workdir` run sequentially on the scheduler tick, not in the parallel pool. This is deliberate: the cron worker applies the job workdir through process-global terminal state, so two workdir jobs running at the same time would corrupt each other's cwd. Workdir-less jobs still run in parallel as before.
 :::
 
+## Pinning a job to a profile
+
+In multi-profile setups, several gateways may read the same cron store and race for the shared `tick.lock`. By default that behavior is unchanged: jobs with no `profile` field (or `profile: null`) may be ticked by any gateway that wins the lock.
+
+Set `profile` when a job depends on profile-specific skills, memory, config, or MCP servers and must run in that profile's context:
+
+```python
+cronjob(
+    action="create",
+    schedule="0 9 * * *",
+    profile="dev",
+    skills=["release-checklist"],
+    prompt="Run the dev release checklist and summarize blockers.",
+)
+```
+
+Pinned jobs are only considered due by the gateway running the matching profile. For example, `profile="dev"` runs in the `dev` gateway and is skipped by the `default` gateway. Omit `profile`, set it to `null`, or clear it with an empty string to restore any-profile ticking.
+
+```bash
+hermes cron edit <job_id> --profile dev
+hermes cron edit <job_id> --profile ""   # clear the pin
+```
+
+`hermes cron list` shows a `Profile:` line only for jobs with an active pin.
+
 ## Editing jobs
 
 You do not need to delete and recreate jobs just to change them.


### PR DESCRIPTION
## Motivation

Multi-profile Hermes deployments currently have every active gateway reading the same cron store and racing for the shared `tick.lock`. Whichever gateway wins runs the job in its own profile context: skills, memory, config, and MCP servers.

That is fine for profile-agnostic jobs, but it breaks jobs that depend on profile-specific capabilities. For example, a daily operations job that relies on skills installed only in the default MeyKo profile can be fired by a dev-profile gateway that does not have those skills.

## What changed

This PR adds an optional `profile` field on cron jobs:

- `cron/jobs.py` derives the active profile from the current Hermes home (`~/.hermes` => `default`, `~/.hermes/profiles/<name>` => `<name>`) and filters due jobs before scheduling them.
- `hermes cron edit <job_id> --profile <name>` sets a pin.
- `hermes cron edit <job_id> --profile ""` clears the pin.
- `hermes cron list` shows `Profile: <name>` only for pinned jobs.
- The `cronjob` tool schema and handler accept optional `profile` for create/update.
- Cron docs describe when to use profile pinning.

## Backward compatibility

Jobs without a `profile` field, with `profile: null`, or with an empty profile string keep the historical behavior: any gateway that wins `tick.lock` may run them.

The global tick lock and job execution pipeline are otherwise unchanged.

## Test coverage

Added `tests/cron/test_profile_pinning.py` covering:

- unpinned jobs run from both default and dev profiles
- pinned `profile: dev` jobs run in the dev gateway
- pinned `profile: dev` jobs are skipped by the default gateway
- a held `tick.lock` still makes a concurrent tick skip before reading due jobs

Local test runs:

```text
python -m pytest tests/cron/test_profile_pinning.py -v
# 4 passed in 0.26s

python -m pytest tests/cron/ -q
# 527 passed in 17.10s
```
