### PR TITLE
fix(codex-runtime): resolve FileNotFoundError on Windows for npm-installed .cmd CLIs

### DIFF
--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -20,6 +20,7 @@ import json
 import os
 import queue
 import subprocess
+import sys
 import threading
 import time
 from dataclasses import dataclass, field
@@ -121,6 +122,7 @@ class CodexAppServerClient:
             stderr=subprocess.PIPE,
             bufsize=0,
             env=spawn_env,
+            shell=(sys.platform == "win32"),
         )
         self._next_id = 1
         self._pending: dict[int, _Pending] = {}
@@ -373,12 +375,16 @@ def check_codex_binary(
 
     Returns (ok, message). Used by setup wizard and runtime startup."""
     try:
+        # On Windows, npm-installed CLIs are .cmd files; subprocess with a
+        # list arg doesn't find them unless shell=True is used.
+        use_shell = sys.platform == "win32"
         proc = subprocess.run(
             [codex_bin, "--version"],
             capture_output=True,
             text=True,
             timeout=10,
             stdin=subprocess.DEVNULL,
+            shell=use_shell,
         )
     except FileNotFoundError:
         return False, (


### PR DESCRIPTION
## Problem

On Windows, `/codex-runtime on` fails with:

```
Cannot enable codex_app_server runtime: codex CLI not found at 'codex'. Install with: npm i -g @openai/codex
```

Even though `codex --version` works fine in the terminal.

**Root cause**: npm-installed global CLIs on Windows are `.cmd` wrapper scripts (e.g. `codex.cmd`). Python's `subprocess.run([codex, ...])` with a list argument does **not** resolve `.cmd` extensions, even when the directory is in `PATH`. This is a well-known Windows-specific behavior where only `cmd.exe` (shell) resolves `.cmd`/`.bat` extensions.

```python
# Fails on Windows:
subprocess.run([codex, --version])        # FileNotFoundError

# Works:
subprocess.run([codex, --version], shell=True)  # OK (uses cmd.exe)
subprocess.run([codex.cmd, --version])    # OK (explicit extension)
```

## Fix

Add `shell=True` on Windows (`sys.platform == win32`) for both subprocess calls:

1. **`check_codex_binary()`** — version validation during `/codex-runtime on`
2. **`CodexAppServerClient.Popen()`** — actual `codex app-server` spawn

The `shell=True` is safe here because:
- The commands are hardcoded (`[codex, --version]` and `[codex, app-server, ...]`)
- No user-controlled input is interpolated into the shell command
- Only activated on Windows

## Testing

Verified on Windows 10 + Python 3.14 + codex-cli 0.141.0:
- `check_codex_binary()` returns `True` after fix (was `False`)
- `/codex-runtime on` succeeds, migrates MCP servers, and registers Hermes tool callback

## Related

- Windows subprocess + `.cmd` behavior: https://bugs.python.org/issue8557
- npm global installs on Windows create `.cmd` shims by default