### PR TITLE
fix(gateway): surface retry hint instead of silently dropping turn after /stop (#31884)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2332,6 +2332,12 @@ def _normalize_empty_agent_response(
     Consolidates the existing ``failed`` handler and adds a catch-all for
     the case where the agent did work (api_calls > 0) but returned no text.
     Fix for #18765.
+
+    Also surfaces a retry hint when the agent never ran at all
+    (api_calls == 0) for a non-interrupted, non-failed turn -- this is the
+    silent-drop pattern observed after ``/stop`` where the next user
+    message hits a stale generation token and returns an empty result,
+    leaving the platform with nothing to send. (#31884)
     """
     if response:
         return response
@@ -2362,6 +2368,22 @@ def _normalize_empty_agent_response(
         return (
             "⚠️ Processing completed but no response was generated. "
             "This may be a transient error — try sending your message again."
+        )
+
+    # api_calls == 0, not failed, not interrupted: the agent never ran for
+    # this turn. This is the post-/stop generation-race pattern where the
+    # gateway would otherwise silently drop the turn (response=0 chars) and
+    # the user sees no reply at all. Surface a short retry hint so the
+    # message isn't lost in silence. (#31884)
+    if (
+        api_calls == 0
+        and not agent_result.get("interrupted")
+        and not agent_result.get("failed")
+        and not agent_result.get("partial")
+    ):
+        return (
+            "⚠️ Your message wasn't processed (the previous turn was still "
+            "being cleaned up). Please send it again."
         )
 
     return response

--- a/tests/test_lazy_session_regressions.py
+++ b/tests/test_lazy_session_regressions.py
@@ -415,6 +415,31 @@ class TestGatewaySurfacesNullResponse:
 
         assert result == "Hello!"
 
+    def test_silent_drop_after_stop_surfaces_hint(self):
+        """Regression for #31884: after /stop, the next user message hits a
+        stale generation token in _run_agent and returns with api_calls=0,
+        no failure, no interruption. Without normalization the gateway
+        silently drops the turn (response=0 chars). Surface a retry hint
+        so the user knows the message was lost."""
+        from gateway.run import _normalize_empty_agent_response
+
+        agent_result = {
+            "final_response": "",
+            "api_calls": 0,
+            "failed": False,
+            "interrupted": False,
+            "partial": False,
+        }
+
+        response = agent_result.get("final_response") or ""
+        result = _normalize_empty_agent_response(
+            agent_result, response, history_len=10,
+        )
+
+        assert result, "Silent-drop turn must surface a user-facing hint"
+        lowered = result.lower()
+        assert "send it again" in lowered or "try again" in lowered
+
 
 # ===========================================================================
 # Prune: finalize_orphaned_compression_sessions


### PR DESCRIPTION
## Summary
A Telegram user message sent right after `/stop` is no longer silently dropped — the gateway now surfaces a short retry hint instead of logging `response=0 chars` and sending nothing.

Root cause: after `/stop`, the next inbound message can hit a stale generation token and return with `api_calls=0`, not failed, not interrupted, not partial. `_normalize_empty_agent_response` had no branch for that case, so it fell through to the empty string — the gateway recorded a completed zero-length response and sent nothing to the user while internal work sometimes continued.

## Changes
- `gateway/run.py`: add the `api_calls == 0 and not failed/interrupted/partial` branch to `_normalize_empty_agent_response` (the single normalization chokepoint) returning a "please send it again" hint.
- `tests/test_lazy_session_regressions.py`: regression test asserting the hint surfaces for this shape (verified it fails without the fix).

## Validation
- New test + the full `TestGatewaySurfacesNullResponse` class pass (6/6).
- Verified load-bearing: the test fails when the new branch is removed.

Salvaged from #33851 by @sweetcornna (authorship preserved). The original was ~1400 commits behind and `_normalize_empty_agent_response` had moved, so the fix was re-applied on current `main`; the logic is unchanged.

Closes #31884.
Supersedes #32393 and #32456 (competing fixes for the same issue — #33851's was the cleanest: minimal, single-chokepoint, with a regression test, and it preserves the diagnostic `response ready` log the issue relies on).
