### PR TITLE
fix(telegram): gate rich draft previews separately

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -741,6 +741,7 @@ platform_toolsets:
 #     extra:
 #       disable_link_previews: false  # Set true to suppress Telegram URL previews in bot messages
 #       rich_messages: false          # Bot API 10.1 rich messages (tables/task lists/details/math); default false for copyable legacy MarkdownV2, set true to opt in
+#       rich_drafts: false            # Experimental rich draft previews during Telegram DM streaming; default false because Telegram Desktop/macOS can visually overlay draft frames
 #       command_menu:
 #         # Telegram allows up to 100 BotCommands; Hermes defaults to 60 so
 #         # all built-in commands plus common skill commands stay visible

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2218,6 +2218,7 @@ DEFAULT_CONFIG = {
         "allowed_chats": "",           # If set, bot ONLY responds in these group/supergroup chat IDs (whitelist)
         "extra": {
             "rich_messages": False,     # Bot API 10.1 rich messages (tables/task lists/details/math) render natively; set True to opt in. Default stays legacy MarkdownV2 because rich messages can be hard to copy as plain text in Telegram clients.
+            "rich_drafts": False,       # Experimental Bot API 10.1 rich draft previews during Telegram DM streaming. Default off because Telegram Desktop/macOS can visually overlay rich draft frames until the chat redraws.
         },
     },
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -497,6 +497,10 @@ class TelegramAdapter(BasePlatformAdapter):
         # as plain text, which is worse than degraded table/task-list rendering
         # for command snippets and mobile handoffs.
         self._rich_messages_enabled: bool = self._coerce_bool_extra("rich_messages", False)
+        # Rich draft previews use a separate opt-in. Telegram macOS / Desktop
+        # can leave Bot API 10.1 rich draft frames visually overlaid until the
+        # chat is redrawn, while final rich messages remain useful.
+        self._rich_drafts_enabled: bool = self._coerce_bool_extra("rich_drafts", False)
         # Latched off after a capability failure on sendRichMessage /
         # sendRichMessageDraft (e.g. older python-telegram-bot without the
         # endpoint) so later sends skip the doomed rich attempt entirely.
@@ -1485,6 +1489,7 @@ class TelegramAdapter(BasePlatformAdapter):
     def _should_attempt_rich_draft(self, content: str) -> bool:
         return bool(
             getattr(self, "_rich_messages_enabled", True)
+            and getattr(self, "_rich_drafts_enabled", False)
             and not getattr(self, "_rich_send_disabled", False)
             and not getattr(self, "_rich_draft_disabled", False)
             and content

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -900,6 +900,25 @@ class TestLoadGatewayConfig:
 
         assert config.platforms[Platform.TELEGRAM].extra["rich_messages"] is False
 
+    def test_loads_telegram_rich_drafts_from_gateway_platform_extra(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "gateway:\n"
+            "  platforms:\n"
+            "    telegram:\n"
+            "      extra:\n"
+            "        rich_drafts: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.TELEGRAM].extra["rich_drafts"] is True
+
     def test_load_config_default_keeps_telegram_rich_messages_opt_in(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
@@ -911,6 +930,7 @@ class TestLoadGatewayConfig:
         config = load_config()
 
         assert config["telegram"]["extra"]["rich_messages"] is False
+        assert config["telegram"]["extra"]["rich_drafts"] is False
 
     def test_bridges_telegram_extra_base_url_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -547,7 +547,7 @@ async def test_rich_gate_tolerates_minimal_bot_without_raw_endpoint():
 
 @pytest.mark.asyncio
 async def test_details_with_math_skips_rich_draft_to_avoid_tdesktop_crash():
-    adapter = _make_adapter()
+    adapter = _make_adapter(extra={"rich_drafts": True})
     bot = adapter._bot
     assert bot is not None
     bot.do_api_request = AsyncMock(return_value=True)
@@ -560,8 +560,20 @@ async def test_details_with_math_skips_rich_draft_to_avoid_tdesktop_crash():
 
 
 @pytest.mark.asyncio
-async def test_rich_draft_happy_path_sends_raw_markdown():
+async def test_rich_draft_default_uses_legacy_to_avoid_tdesktop_reflow_glitches():
     adapter = _make_adapter()
+    adapter._bot.do_api_request = AsyncMock(return_value=True)
+
+    result = await adapter.send_draft("12345", draft_id=7, content=RICH_CONTENT)
+
+    assert result.success is True
+    adapter._bot.do_api_request.assert_not_called()
+    adapter._bot.send_message_draft.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_rich_draft_opt_in_sends_raw_markdown():
+    adapter = _make_adapter(extra={"rich_drafts": True})
     adapter._bot.do_api_request = AsyncMock(return_value=True)
 
     result = await adapter.send_draft("12345", draft_id=7, content=RICH_CONTENT)
@@ -579,7 +591,7 @@ async def test_rich_draft_happy_path_sends_raw_markdown():
 
 @pytest.mark.asyncio
 async def test_cjk_rich_content_skips_rich_draft_to_avoid_tdesktop_garble():
-    adapter = _make_adapter()
+    adapter = _make_adapter(extra={"rich_drafts": True})
     adapter._bot.do_api_request = AsyncMock(return_value=True)
 
     result = await adapter.send_draft("12345", draft_id=7, content=CJK_RICH_CONTENT)
@@ -591,7 +603,7 @@ async def test_cjk_rich_content_skips_rich_draft_to_avoid_tdesktop_garble():
 
 @pytest.mark.asyncio
 async def test_rich_draft_capability_failure_falls_back_and_latches_off():
-    adapter = _make_adapter()
+    adapter = _make_adapter(extra={"rich_drafts": True})
     adapter._bot.do_api_request = AsyncMock(side_effect=BadRequest("Method not found"))
 
     result = await adapter.send_draft("12345", draft_id=7, content=RICH_CONTENT)
@@ -611,7 +623,7 @@ async def test_rich_draft_capability_failure_falls_back_and_latches_off():
 
 @pytest.mark.asyncio
 async def test_rich_draft_transient_failure_does_not_latch_off():
-    adapter = _make_adapter()
+    adapter = _make_adapter(extra={"rich_drafts": True})
     adapter._bot.do_api_request = AsyncMock(side_effect=TimedOut("timed out"))
 
     result = await adapter.send_draft("12345", draft_id=7, content=RICH_CONTENT)
@@ -624,7 +636,7 @@ async def test_rich_draft_transient_failure_does_not_latch_off():
 
 @pytest.mark.asyncio
 async def test_rich_draft_oversized_uses_legacy():
-    adapter = _make_adapter()
+    adapter = _make_adapter(extra={"rich_drafts": True})
     oversized = "a" * 40000
 
     result = await adapter.send_draft("12345", draft_id=7, content=oversized)

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -973,9 +973,10 @@ gateway:
     telegram:
       extra:
         rich_messages: true
+        rich_drafts: false
 ```
 
-This setting is for client-rendering/copy compatibility; Hermes already falls back automatically when Telegram rejects the rich API call. If you only want the legacy "always code-block" table behavior while keeping rich messages enabled, disable table normalization by setting `telegram.pretty_tables: false` in `config.yaml` (default: `true`).
+This setting is for client-rendering/copy compatibility; Hermes already falls back automatically when Telegram rejects the rich API call. `rich_drafts` controls the experimental rich draft preview path during Telegram DM streaming and stays off by default because Telegram Desktop/macOS can visually overlay rich draft frames until the chat redraws. If you only want the legacy "always code-block" table behavior while keeping rich messages enabled, disable table normalization by setting `telegram.pretty_tables: false` in `config.yaml` (default: `true`).
 
 **Link previews.** Telegram auto-generates link previews for URLs in bot messages. If you'd rather suppress those (long `/tools` output, agent reply that mentions ten links, etc.):
 


### PR DESCRIPTION
## What does this PR do?

Decouples Telegram Bot API 10.1 final rich messages from rich draft previews during streaming.

`telegram.extra.rich_messages: true` still enables final rich rendering for tables/task lists/details/math, but `sendRichMessageDraft` now requires a separate `telegram.extra.rich_drafts: true` opt-in. The new `rich_drafts` default is `false` because Telegram Desktop/macOS can visually overlay rich draft frames until the chat redraws.

## Related Issue

No linked issue; this came from support reports of Telegram Desktop/macOS rich draft previews visually overlapping during streaming.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `telegram.extra.rich_drafts` with a default of `false`.
- Gate Telegram `sendRichMessageDraft` behind `rich_drafts` instead of enabling it automatically with `rich_messages`.
- Preserve final rich message behavior for users who opt into `rich_messages`.
- Add config and Telegram rich-message tests for the new default and explicit opt-in path.
- Update Telegram docs and `cli-config.yaml.example` for the new setting.

## How to Test

1. Enable `gateway.platforms.telegram.extra.rich_messages: true` and leave `rich_drafts` unset/false.
2. Send a streamed Telegram DM with table/task-list style output. Draft previews use the legacy `sendMessageDraft` path; the final message can still use rich rendering.
3. Set `gateway.platforms.telegram.extra.rich_drafts: true` to opt back into `sendRichMessageDraft`.

Local checks run:

- `git diff --check -- plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_rich_messages.py tests/gateway/test_config.py hermes_cli/config.py cli-config.yaml.example website/docs/user-guide/messaging/telegram.md`
- `python -m py_compile plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_rich_messages.py tests/gateway/test_config.py hermes_cli/config.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Support reports showed Telegram Desktop/macOS visually overlaying rich draft/streaming frames until the chat redraws. This PR keeps final rich messages available while making the rich draft preview path separately opt-in.



## Infographic

![nous-mission-patch](https://v3b.fal.media/files/b/0a9fa67b/Bht03asC-5JPm-1Fjzj2g_kFUf4GEc.png)
