### PR TITLE
fix(telegram): avoid resending after partial delivery

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3751,6 +3751,14 @@ class BasePlatformAdapter(ABC):
         if result.success:
             return result
 
+        raw_response = getattr(result, "raw_response", None)
+        if isinstance(raw_response, dict) and raw_response.get("partial_delivery"):
+            # The adapter already put part of a multi-message response on the
+            # platform. Retrying the full payload would duplicate the visible
+            # prefix (Telegram "(1/N)" spam). Return the partial failure to the
+            # caller and let the next user turn recover context explicitly.
+            return result
+
         error_str = result.error or ""
         is_network = result.retryable or self._is_retryable_error(error_str)
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2603,6 +2603,8 @@ class TelegramAdapter(BasePlatformAdapter):
         if not content or not content.strip():
             return SendResult(success=True, message_id=None)
         
+        message_ids = []
+        chunks = []
         try:
             # Bot API 10.1 rich fast-path: send the raw agent markdown via
             # sendRichMessage so tables/task lists/etc. render natively. Falls
@@ -2877,6 +2879,19 @@ class TelegramAdapter(BasePlatformAdapter):
             
         except Exception as e:
             logger.error("[%s] Failed to send Telegram message: %s", self.name, e, exc_info=True)
+            if message_ids:
+                return SendResult(
+                    success=False,
+                    message_id=message_ids[-1],
+                    error=str(e),
+                    retryable=False,
+                    raw_response={
+                        "partial_delivery": True,
+                        "message_ids": tuple(message_ids),
+                        "delivered_chunks": len(message_ids),
+                        "total_chunks": len(chunks) if chunks else len(message_ids),
+                    },
+                )
             err_str = str(e).lower()
             error_kind = classify_send_error(e)
             # Message too long — content exceeded 4096 chars. Return failure so
@@ -3299,7 +3314,12 @@ class TelegramAdapter(BasePlatformAdapter):
                     success=False,
                     message_id=prev_id,
                     error="overflow_continuation_failed",
-                    retryable=True,
+                    # Do NOT mark this retryable. Retrying the whole overflow
+                    # edit after chunk 1 was already delivered causes Telegram
+                    # users to see the first "(1/N)" chunk again and again
+                    # when continuation sends hit flood control. Better to
+                    # fail partial once than spam duplicates.
+                    retryable=False,
                     raw_response={
                         "partial_overflow": True,
                         "delivered_chunks": 1 + len(continuation_ids),

--- a/tests/gateway/test_telegram_overflow_partial.py
+++ b/tests/gateway/test_telegram_overflow_partial.py
@@ -84,7 +84,7 @@ async def test_edit_overflow_split_reports_partial_failure_when_continuation_fai
     )
 
     assert result.success is False
-    assert result.retryable is True
+    assert result.retryable is False
     assert result.error == "overflow_continuation_failed"
     assert result.message_id == "201"
     assert result.raw_response["partial_overflow"] is True
@@ -138,3 +138,21 @@ async def test_stream_consumer_fallback_sends_tail_after_partial_overflow():
     adapter.delete_message.assert_not_awaited()
     assert consumer.final_response_sent is True
     assert consumer.final_content_delivered is True
+
+
+@pytest.mark.asyncio
+async def test_send_with_retry_does_not_resend_full_payload_after_partial_chunk_delivery(telegram_adapter):
+    """If Telegram accepts chunk 1 then rejects chunk 2, do not resend chunk 1."""
+    object.__setattr__(telegram_adapter, "MAX_MESSAGE_LENGTH", 80)
+    content = "word " * 80
+    telegram_adapter._bot.send_message = AsyncMock(
+        side_effect=[_message(301), RuntimeError("Flood control exceeded")]
+    )
+
+    result = await telegram_adapter._send_with_retry("12345", content)
+
+    assert result.success is False
+    assert result.retryable is False
+    assert result.raw_response["partial_delivery"] is True
+    assert result.raw_response["delivered_chunks"] == 1
+    assert telegram_adapter._bot.send_message.await_count == 2


### PR DESCRIPTION
## Summary

- avoid retrying a full platform payload after an adapter reports partial delivery
- make Telegram chunk/overflow partial failures non-retryable to avoid duplicate visible chunks
- add regression coverage for chunk 1 delivered / chunk 2 failed behavior

## Why

If Telegram accepts the first chunk of a multi-message response and a later chunk fails, retrying the whole payload can duplicate the visible prefix, e.g. repeated `(1/N)` chunks. Returning the partial failure lets the next user turn recover context explicitly without spamming duplicates.

## Tests

```bash
python -m pytest tests/gateway/test_telegram_overflow_partial.py tests/gateway/test_telegram_rich_messages.py tests/gateway/test_telegram_send_path_health.py tests/gateway/test_telegram_progress_edit_transient.py -q -o 'addopts='\n```\n\nResult: `94 passed in 7.97s`.\n