### PR TITLE
fix(gateway): guard truncate_message against splitting MarkdownV2 inline entities (#52093)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5216,6 +5216,51 @@ class BasePlatformAdapter(ABC):
                     if safe_split > _cp_limit // 4:
                         split_at = safe_split
 
+            # Avoid splitting inside a MarkdownV2 inline-formatting entity
+            # (*bold*, _italic_, ~strike~, ||spoiler||).  The same hazard the
+            # backtick guard above prevents for code spans: if the text before
+            # split_at has an odd number of *unescaped* entity markers, the
+            # split falls inside an open entity, leaving one chunk with the
+            # opening marker and the next with the closing one.  Both chunks
+            # then have an unbalanced delimiter and Telegram rejects them with
+            # "can't parse entities", forcing a plain-text fallback that strips
+            # all formatting.  Walk the markers (longest first so "||" is tried
+            # before "|") and, when one is unbalanced, back the split up to just
+            # before its last (opening) occurrence — mirroring the backtick
+            # guard, including the _cp_limit // 4 floor so we never rewind too
+            # far.  Markers are matched only when unescaped (not preceded by an
+            # odd run of backslashes), so escaped literals produced by
+            # format_message are correctly ignored.
+            def _unescaped_marker_positions(text: str, marker: str) -> list:
+                positions = []
+                idx = 0
+                mlen = len(marker)
+                while True:
+                    found = text.find(marker, idx)
+                    if found < 0:
+                        break
+                    bs = 0
+                    k = found - 1
+                    while k >= 0 and text[k] == "\\":
+                        bs += 1
+                        k -= 1
+                    if bs % 2 == 0:
+                        positions.append(found)
+                    idx = found + mlen
+                return positions
+
+            for _marker in ("||", "*", "_", "~"):
+                _cand = remaining[:split_at]
+                _positions = _unescaped_marker_positions(_cand, _marker)
+                if len(_positions) % 2 == 1:
+                    _open_at = _positions[-1]
+                    _safe = max(
+                        _cand.rfind(" ", 0, _open_at),
+                        _cand.rfind("\n", 0, _open_at),
+                    )
+                    if _safe > _cp_limit // 4:
+                        split_at = _safe
+
             chunk_body = remaining[:split_at]
             remaining = remaining[split_at:].lstrip()
 

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1364,6 +1364,53 @@ class TestTruncateMessage:
                 f"Chunk {i} too long: {len(chunk)} > {max_len}"
             )
 
+    def test_split_does_not_break_bold_entity(self):
+        """Split must not land inside a *bold* entity."""
+        # Build a message where the split boundary falls inside **bold text**.
+        # Padding pushes the bold entity so the opening * is in chunk 0
+        # and the closing * would be in chunk 1 without the guard.
+        padding = "x" * 1900
+        content = padding + " **important bold text** " + "y" * 1900
+        chunks = BasePlatformAdapter.truncate_message(content, max_length=2000)
+        assert len(chunks) > 1
+        import re
+        for i, chunk in enumerate(chunks):
+            # Count unescaped '*' (not preceded by backslash)
+            unescaped = re.sub(r"\\.", "", chunk)
+            star_count = unescaped.count("*")
+            assert star_count % 2 == 0, (
+                f"Chunk {i} has odd ({star_count}) unescaped '*' — "
+                f"bold entity split: ...{chunk[-60:]!r}"
+            )
+
+    def test_split_does_not_break_inline_entities_sweep(self):
+        """Boundary sweep: no split position should break _italic_, ~strike~, or ||spoiler||."""
+        for marker, name in [("_", "italic"), ("~", "strike"), ("||", "spoiler")]:
+            open_m = marker
+            close_m = marker
+            entity = f"{open_m}entity{name}{close_m}"
+            # Repeat the entity enough times to exceed 200 chars
+            content = (f"word {entity} word ") * 30  # ~600 chars
+            chunks = BasePlatformAdapter.truncate_message(content, max_length=200)
+            assert len(chunks) > 1, f"Expected split for {name}"
+            import re
+            for i, chunk in enumerate(chunks):
+                stripped = re.sub(r"\\.", "", chunk)
+                # Count unescaped marker occurrences
+                mlen = len(marker)
+                count = 0
+                idx = 0
+                while True:
+                    pos = stripped.find(marker, idx)
+                    if pos < 0:
+                        break
+                    count += 1
+                    idx = pos + mlen
+                assert count % 2 == 0, (
+                    f"Chunk {i} has odd ({count}) unescaped '{marker}' — "
+                    f"{name} entity split: ...{chunk[-60:]!r}"
+                )
+
 
 # ---------------------------------------------------------------------------
 # _get_human_delay


### PR DESCRIPTION
## What does this PR do?

Guards `truncate_message()` against splitting inside MarkdownV2 inline-formatting entities (`*bold*`, `_italic_`, `~strike~`, `||spoiler||`). Without this fix, when a split boundary lands inside one of these entities, each chunk gets an unbalanced delimiter and Telegram rejects them with "can't parse entities", forcing a plain-text fallback that strips all formatting.

## Related Issue

Fixes #52093

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py`: Added inline entity balance guard after the existing backtick guard in `truncate_message()`. Counts unescaped marker occurrences (`||`, `*`, `_`, `~`) in the candidate chunk; when odd, rewinds the split to just before the last opening marker (respecting the `_cp_limit // 4` floor). The helper `_unescaped_marker_positions()` handles backslash-escaped markers correctly.
- `tests/gateway/test_platform_base.py`: Added `test_split_does_not_break_bold_entity` (bold boundary case) and `test_split_does_not_break_inline_entities_sweep` (italic/strike/spoiler boundary sweep).

## How to Test

1. Run `python -m pytest tests/gateway/test_platform_base.py::TestTruncateMessage -q` — all 10 tests pass (8 existing + 2 new)
2. Run `python -m pytest tests/gateway/test_platform_base.py -q` — 162 passed, 2 skipped, 0 regressions
3. The new tests verify that no chunk has an odd count of unescaped entity markers after splitting

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/platforms/base.py:truncate_message` (callers: all platform adapters via base class)
- Blast radius: LOW — adds a guard after existing backtick guard; only moves split earlier, never later
- Related patterns: Mirrors the existing backtick balance guard pattern at the same location
