### PR TITLE
fix(fallback): parse JSON-string fallback_providers written by config set

### DIFF
--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 
@@ -11,7 +12,27 @@ def _normalized_base_url(value: Any) -> str:
     return value.strip().rstrip("/")
 
 
+def _coerce_json_string(raw: Any) -> Any:
+    """Parse a JSON string into its underlying object.
+
+    ``hermes config set fallback_providers '[{...}, ...]'`` stores the value
+    as a JSON-encoded string in ``config.yaml`` (it round-trips through
+    ``json.dumps``/``yaml.safe_load``). Without this coercion, the entry
+    would be silently dropped by ``_iter_fallback_entries`` and the entire
+    fallback chain would appear empty at runtime.
+    """
+    if isinstance(raw, str):
+        stripped = raw.strip()
+        if stripped and stripped[0] in ("[", "{"):
+            try:
+                return json.loads(stripped)
+            except (ValueError, TypeError):
+                return raw
+    return raw
+
+
 def _iter_fallback_entries(raw: Any) -> list[dict[str, Any]]:
+    raw = _coerce_json_string(raw)
     if isinstance(raw, dict):
         candidates = [raw]
     elif isinstance(raw, list):

--- a/tests/hermes_cli/test_fallback_cmd.py
+++ b/tests/hermes_cli/test_fallback_cmd.py
@@ -103,6 +103,34 @@ class TestReadChain:
         result[0]["provider"] = "mutated"
         assert cfg["fallback_providers"][0]["provider"] == "nous"
 
+    def test_parses_json_string_list(self):
+        # `hermes config set fallback_providers '[{...}]'` round-trips through
+        # yaml as a JSON-encoded string. The chain reader must coerce it back
+        # to the underlying list — otherwise the entire chain silently drops.
+        from hermes_cli.fallback_cmd import _read_chain
+        cfg = {
+            "fallback_providers": '[{"provider": "anthropic", "model": "claude-sonnet-4-6"}, '
+                                   '{"provider": "gemini", "model": "gemini-2.5-pro"}]'
+        }
+        assert _read_chain(cfg) == [
+            {"provider": "anthropic", "model": "claude-sonnet-4-6"},
+            {"provider": "gemini", "model": "gemini-2.5-pro"},
+        ]
+
+    def test_parses_json_string_single_dict(self):
+        from hermes_cli.fallback_cmd import _read_chain
+        cfg = {
+            "fallback_providers": '{"provider": "anthropic", "model": "claude-sonnet-4-6"}'
+        }
+        assert _read_chain(cfg) == [
+            {"provider": "anthropic", "model": "claude-sonnet-4-6"}
+        ]
+
+    def test_invalid_json_string_falls_back_to_empty(self):
+        from hermes_cli.fallback_cmd import _read_chain
+        cfg = {"fallback_providers": "[not-valid-json"}
+        assert _read_chain(cfg) == []
+
 
 # ---------------------------------------------------------------------------
 # _extract_fallback_from_model_cfg


### PR DESCRIPTION
## Summary

`hermes config set fallback_providers '[{...}, ...]'` writes the value as a JSON-encoded string in `config.yaml` rather than a YAML list. `_iter_fallback_entries` only handled list/dict inputs and silently dropped a string, so the entire fallback chain returned `[]` at runtime. When the primary provider failed, the gateway surfaced the canned `Provider authentication failed` message instead of failing over -- silently, with no INFO-level warning.

This change coerces a JSON-encoded string back into its underlying object before iteration, while leaving plain dicts, lists, and unparseable strings (defensively returning empty) untouched.

## Root cause

```python
def _iter_fallback_entries(raw):
    if isinstance(raw, dict):
        candidates = [raw]
    elif isinstance(raw, list):
        candidates = raw
    else:
        return []          # JSON string lands here -> entire chain dropped
```

## Fix

`hermes_cli/fallback_config.py` gains a small `_coerce_json_string` helper that parses a string starting with `[` or `{` into its underlying object. `_iter_fallback_entries` calls it once at the top. Malformed JSON falls through and returns `[]` (the pre-existing behavior for unsupported input).

## Validation

- **Layer 1 (syntax)**: `python3 -m py_compile hermes_cli/fallback_config.py` -> OK
- **Layer 2 (static)**: `ruff check hermes_cli/fallback_config.py` -> all checks passed
- **Layer 3 (regression)**: 3 new tests in `tests/hermes_cli/test_fallback_cmd.py` (JSON-string list, JSON-string single dict, malformed-string fallback). Pre-fix: 2/3 FAIL. Post-fix: 3/3 PASS.
- **Layer 4 (full module)**: `pytest tests/hermes_cli/test_fallback_cmd.py` -> 35/35 PASS
- **Layer 5 (wider regression)**: `pytest tests/hermes_cli/test_*fallback*.py` -> 67/67 PASS
- **Layer 6 (import smoke)**: `python3 -c "import hermes_cli.fallback_config; import hermes_cli.fallback_cmd"` -> OK; `get_fallback_chain({...})` returns expected shapes for `[]`, `{}`, `None`, no-config.

## Diff scope

49 lines added across 2 files (1 fix + 3 tests, no behavior changes outside the targeted coercion path).

Closes #51560