### PR TITLE
fix(credential-pool): parse 'retry in N seconds' preposition from Gemini API

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -293,7 +293,7 @@ def _extract_retry_delay_seconds(message: str) -> Optional[float]:
     if delay_match:
         value = float(delay_match.group(1))
         return value / 1000.0 if delay_match.group(2).lower() == "ms" else value
-    sec_match = re.search(r"retry\s+(?:after\s+)?(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)", message, re.IGNORECASE)
+    sec_match = re.search(r"retry\s+(?:in\s+|after\s+)?(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)", message, re.IGNORECASE)
     if sec_match:
         return float(sec_match.group(1))
     # "Resets in 4hr 5min" format used by OpenCode Go weekly usage limits

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -3045,3 +3045,31 @@ def test_codex_oauth_nonterminal_refresh_does_not_quarantine(tmp_path, monkeypat
     tokens = auth_payload["providers"]["openai-codex"].get("tokens", {})
     assert tokens.get("access_token") == "old-access-token"
     assert tokens.get("refresh_token") == "old-refresh-token"
+
+
+# ---------------------------------------------------------------------------
+# _extract_retry_delay_seconds — regex coverage
+# ---------------------------------------------------------------------------
+
+class TestExtractRetryDelaySeconds:
+    def _f(self):
+        from agent.credential_pool import _extract_retry_delay_seconds
+        return _extract_retry_delay_seconds
+
+    def test_gemini_please_retry_in_seconds(self):
+        # Gemini API format: "Please retry in 6.19s"
+        # Pre-fix this returned None and the credential pool defaulted to a
+        # 1-hour block, artificially exhausting the pool under load.
+        assert self._f()("Please retry in 6.19s") == pytest.approx(6.19)
+
+    def test_retry_after_seconds_still_parsed(self):
+        assert self._f()("rate limit hit, retry after 30 seconds") == pytest.approx(30.0)
+
+    def test_retry_in_seconds_without_s_prefix(self):
+        assert self._f()("retry in 5s") == pytest.approx(5.0)
+
+    def test_retry_bare_number(self):
+        assert self._f()("retry 45 sec") == pytest.approx(45.0)
+
+    def test_returns_none_for_unparseable(self):
+        assert self._f()("unrelated error message") is None


### PR DESCRIPTION
## Summary

The Gemini API frequently returns rate-limit messages in the form `Please retry in 6.19s`. The pre-fix regex in `_extract_retry_delay_seconds` only matched the preposition `after` (and a bare `retry N s`), so the `Please retry in N seconds` format was unparsed. The function returned `None` and the credential pool defaulted to a 1-hour block, artificially exhausting the entire pool under high-load Gemini usage.

This change adds `in` to the optional preposition group in the retry regex while preserving every previously-matched format (`retry after`, `retry`, `retry N sec`).

## Root cause

```python
sec_match = re.search(r"retry\s+(?:after\s+)?(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)", message, re.IGNORECASE)
#                                 ^^^^^^^^^ only "after" matched; "in" silently fell through
```

When the match fails the function falls through to the `resets in Xhr Ymin` / `resets in Xhr` / `resets in Xmin` regexes (which don't fit either) and ultimately returns `None`, causing the caller to apply a 1-hour cooldown instead of the actual retry delay.

## Fix

Single-token addition in `agent/credential_pool.py`: `(?:after\s+)?` -> `(?:in\s+|after\s+)?`. Malformed/unrelated messages continue to return `None` (no behavior change outside the targeted preposition).

## Validation

- **Layer 1 (syntax)**: `python3 -m py_compile agent/credential_pool.py` -> OK
- **Layer 2 (static)**: `ruff check agent/credential_pool.py` -> all checks passed
- **Layer 3 (regression)**: 5 new tests in `tests/agent/test_credential_pool.py` (Gemini format, retry-after, retry-in, bare retry, unparseable). Pre-fix: `test_gemini_please_retry_in_seconds` FAIL. Post-fix: 5/5 PASS.
- **Layer 4 (full module)**: `pytest tests/agent/test_credential_pool.py` -> 84/84 PASS
- **Layer 5 (smoke)**: live imports confirmed the function returns the expected numeric value for the issue's reported message.

## Diff scope

29 insertions, 1 deletion across 2 files. No behavior change for any previously-matched format.

Closes #51450