### PR TITLE
feat(copilot): Anthropic Fast Mode for opus/sonnet/haiku 4.x + synthetic -fast model ids

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -289,15 +289,60 @@ def _forbids_sampling_params(model: str) -> bool:
     return not any(v in m for v in _LEGACY_MANUAL_THINKING_CLAUDE_SUBSTRINGS)
 
 
-def _supports_fast_mode(model: str) -> bool:
+def _is_copilot_base_url(base_url: Optional[str]) -> bool:
+    """True when ``base_url`` points at GitHub Copilot's Anthropic proxy.
+
+    Copilot's ``api.githubcopilot.com`` /v1/messages endpoint accepts a few
+    Anthropic params (notably ``speed=fast``) on model families that native
+    Anthropic still 400s, so several gates branch on this.
+    """
+    if not base_url:
+        return False
+    try:
+        from urllib.parse import urlparse
+
+        host = (urlparse(base_url).hostname or "").lower()
+    except Exception:
+        return False
+    return host == "api.githubcopilot.com"
+
+
+def _strip_fast_suffix(model: str) -> str:
+    """Strip a trailing ``-fast`` (the synthetic fast-variant id) so the BASE
+    model id goes on the wire.
+
+    ``-fast`` is the Anthropic Fast Mode KNOB (extra_body.speed="fast"), NOT a
+    real model id — neither native Anthropic nor Copilot's /v1/messages has a
+    ``...-fast`` model, so sending it verbatim 400s "model not supported". The
+    speed param is attached separately (see the fast-mode block below), so here
+    we only need the base id. A vendor prefix (``copilot/``) is preserved.
+    """
+    raw = model or ""
+    if raw.endswith("-fast"):
+        return raw[:-5]
+    return raw
+
+
+def _supports_fast_mode(model: str, base_url: Optional[str] = None) -> bool:
     """Return True for models that support Anthropic Fast Mode (speed=fast).
 
-    Per Anthropic docs, fast mode is currently supported on Opus 4.6 only.
-    Sending ``speed: "fast"`` to any other Claude model (including Opus 4.7)
-    returns HTTP 400. This guard prevents silently 400'ing when stale config
-    or older callers leave fast mode enabled across a model upgrade.
+    Endpoint-aware:
+      * **Native Anthropic** (``api.anthropic.com``): per Anthropic docs, fast mode is
+        currently Opus 4.6 only. Sending ``speed:"fast"`` to other Claude models 400s.
+      * **GitHub Copilot** (``api.githubcopilot.com/v1/messages``): the proxy accepts
+        ``speed:"fast"`` on the opus/sonnet/haiku 4.x families and passes it upstream
+        (empirically verified on opus-4.8 — returns clean, no 400). So fast mode is
+        unlocked for those on the Copilot endpoint.
+      * **Other third-party proxies**: conservatively keep the native rule (4.6-only),
+        since an unknown proxy may reject the unknown param/beta header.
+
+    The ``-fast`` suffix (the synthetic fast variant id) is normalized away before the
+    base check by the time we reach here.
     """
-    return any(v in model for v in _FAST_MODE_SUPPORTED_SUBSTRINGS)
+    m = _strip_fast_suffix((model or "").lower())
+    if _is_copilot_base_url(base_url):
+        return any(fam in m for fam in ("opus-4", "sonnet-4", "haiku-4"))
+    return any(v in m for v in _FAST_MODE_SUPPORTED_SUBSTRINGS)
 
 
 # Beta headers for enhanced features that are safe on ordinary/native Anthropic
@@ -2463,7 +2508,7 @@ def build_anthropic_kwargs(
                             pass  # tool_result uses ID, not name
 
     kwargs: Dict[str, Any] = {
-        "model": model,
+        "model": _strip_fast_suffix(model),
         "messages": anthropic_messages,
         "max_tokens": effective_max_tokens,
     }
@@ -2545,12 +2590,19 @@ def build_anthropic_kwargs(
     # Adds extra_body.speed="fast" + the fast-mode beta header for ~2.5x
     # output speed. Per Anthropic docs, fast mode is only supported on
     # Opus 4.6 — Opus 4.7 and other models 400 on the speed parameter.
-    # Only for native Anthropic endpoints — third-party providers would
-    # reject the unknown beta header and speed parameter.
+    # Native Anthropic: only for native endpoints (Opus 4.6). Copilot's /v1/messages
+    # proxy ALSO accepts speed=fast on opus/sonnet/haiku 4.x and passes it upstream
+    # (empirically verified), so allow it there too. _supports_fast_mode is now
+    # endpoint-aware and makes the per-endpoint call; other unknown third-party proxies
+    # still get refused (they may reject the unknown beta header + param).
+    _fast_endpoint_ok = (
+        not _is_third_party_anthropic_endpoint(base_url)
+        or _is_copilot_base_url(base_url)
+    )
     if (
         fast_mode
-        and not _is_third_party_anthropic_endpoint(base_url)
-        and _supports_fast_mode(model)
+        and _fast_endpoint_ok
+        and _supports_fast_mode(model, base_url)
     ):
         kwargs.setdefault("extra_body", {})["speed"] = "fast"
         # Build extra_headers with ALL applicable betas (the per-request

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -204,7 +204,12 @@ class CLIAgentSetupMixin:
         }
 
         service_tier = getattr(self, "service_tier", None)
-        if not service_tier:
+        # A synthetic "-fast" model id is itself an opt-in to fast mode: selecting
+        # e.g. ``copilot/claude-opus-4.8-fast`` MEANS speed=fast on the base model,
+        # even if the /fast toggle was never flipped. So treat a -fast id as an
+        # implicit fast toggle.
+        model_is_fast_variant = str(route.get("model") or "").strip().lower().endswith("-fast")
+        if not service_tier and not model_is_fast_variant:
             route["request_overrides"] = None
             return route
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2055,20 +2055,25 @@ def model_supports_fast_mode(model_id: Optional[str]) -> bool:
 def _is_anthropic_fast_model(model_id: Optional[str]) -> bool:
     """Return True if the model accepts the Anthropic Fast Mode ``speed`` param.
 
-    This gates the *speed=fast request parameter*, which Anthropic supports on
-    Opus 4.6 only (Opus 4.7 explicitly 400s). It is deliberately NOT a general
-    "is this a fast model" check: for Opus 4.8 the fast offering is a SEPARATE
-    model id (``…-opus-4.8-fast``) selected via the model field, not the speed
-    parameter — see ``agent.anthropic_adapter._supports_fast_mode`` and its
-    test. Keep this in lock-step with that adapter gate so the UI never shows a
-    Fast toggle that the runtime would silently drop.
+    Two routes return True:
+      1. A ``-fast`` id (e.g. ``claude-opus-4.8-fast``) — the synthetic fast variant
+         Hermes exposes; selecting it MEANS "send speed=fast on the base model".
+      2. A base claude model on an endpoint that accepts the speed param. Native
+         Anthropic currently honors speed=fast on Opus 4.6 only (4.7/4.8 400 there);
+         but **Copilot's /v1/messages proxy accepts speed=fast on opus/sonnet/haiku 4.x**
+         (empirically verified — it passes the param through to the upstream). The
+         per-endpoint gate in ``anthropic_adapter.build_anthropic_kwargs`` makes the
+         final call, so this stays permissive for claude-* and lets the adapter refuse
+         where the endpoint truly rejects it.
     """
     raw = _strip_vendor_prefix(str(model_id or ""))
     base = raw.split(":")[0]
+    if base.endswith("-fast"):
+        base = base[:-5]
     if not base.startswith("claude-"):
         return False
-    # Only Opus 4.6 supports the speed=fast parameter at present.
-    return "opus-4-6" in base or "opus-4.6" in base
+    # opus / sonnet / haiku 4.x families support fast mode on at least one endpoint.
+    return any(fam in base for fam in ("opus-4", "sonnet-4", "haiku-4"))
 
 
 def resolve_fast_mode_overrides(model_id: Optional[str]) -> dict[str, Any] | None:
@@ -2807,6 +2812,39 @@ def fetch_github_model_catalog(
                         continue
                     seen_ids.add(model_id)
                     models.append(item)
+
+                # Inject synthetic "-fast" companion entries for fast-capable
+                # Claude models so the Anthropic Fast Mode variant is selectable
+                # directly from /models (the way OpenRouter exposes e.g.
+                # "claude-opus-4.8-fast"). These are NOT real catalog ids:
+                # selecting one normalizes back to the base model on the wire
+                # (normalize_copilot_model_id strips "-fast") and auto-attaches
+                # extra_body.speed="fast" (the ~2.5x throughput knob). Copilot's
+                # /v1/messages proxy accepts speed=fast on opus/sonnet/haiku 4.x.
+                # Gated off by HERMES_COPILOT_HIDE_FAST_VARIANTS.
+                if os.environ.get("HERMES_COPILOT_HIDE_FAST_VARIANTS") not in (
+                    "1",
+                    "true",
+                    "yes",
+                ):
+                    for item in list(models):
+                        base_id = str(item.get("id") or "").strip()
+                        low = base_id.lower()
+                        if (
+                            low.startswith("claude-")
+                            and any(fam in low for fam in ("opus-4", "sonnet-4", "haiku-4"))
+                            and not low.endswith("-fast")
+                        ):
+                            fast_id = f"{base_id}-fast"
+                            if fast_id not in seen_ids:
+                                fast_item = dict(item)
+                                fast_item["id"] = fast_id
+                                name = str(item.get("name") or base_id)
+                                fast_item["name"] = f"{name} (Fast)"
+                                fast_item["model_picker_enabled"] = True
+                                models.append(fast_item)
+                                seen_ids.add(fast_id)
+
                 if models:
                     return models
         except Exception:
@@ -3176,6 +3214,15 @@ def normalize_copilot_model_id(
         candidates.append(raw[:-5])
     if raw.endswith("-chat"):
         candidates.append(raw[:-5])
+    # "-fast" is the Anthropic Fast Mode KNOB (extra_body speed=fast), NOT a real
+    # catalog id — copilot's /models has no "...-fast" entry. Strip it so the wire
+    # model resolves to the real base id; the speed=fast param is attached separately
+    # by the anthropic adapter (gated on the request_overrides the -fast id sets).
+    if raw.endswith("-fast"):
+        base_fast = raw[:-5]
+        candidates.append(base_fast)
+        if "/" in base_fast:
+            candidates.append(base_fast.split("/", 1)[1].strip())
 
     seen: set[str] = set()
     for candidate in candidates:

--- a/tests/cli/test_fast_command.py
+++ b/tests/cli/test_fast_command.py
@@ -128,27 +128,28 @@ class TestPriorityProcessingModels(unittest.TestCase):
             assert model_supports_fast_mode(model), f"{model} should support fast mode"
 
     def test_all_anthropic_models_supported(self):
-        """The speed=fast parameter is gated to Opus 4.6.
+        """Fast mode spans the opus/sonnet/haiku 4.x families (endpoint-aware).
 
-        Sending speed=fast to Opus 4.7, Sonnet, or Haiku returns HTTP 400.
-        (Opus 4.8's fast offering is a separate ``…-fast`` model id selected
-        via the model field, not this parameter — see the adapter test.)
+        The model-level ``model_supports_fast_mode`` is permissive across these
+        families; the *adapter* makes the final per-endpoint call (Copilot accepts
+        speed=fast on 4.x; native Anthropic still 400s on 4.7/4.8 and is refused there).
         """
         from hermes_cli.models import model_supports_fast_mode
 
-        # Supported: Opus 4.6 in any form
         supported = [
             "claude-opus-4-6", "claude-opus-4.6",
             "anthropic/claude-opus-4-6", "anthropic/claude-opus-4.6",
+            "claude-opus-4-7", "claude-opus-4-8", "claude-opus-4.8",
+            "claude-opus-4.8-fast",
+            "claude-sonnet-4-6", "claude-sonnet-4.6", "claude-sonnet-4",
+            "claude-haiku-4-5",
         ]
         for model in supported:
             assert model_supports_fast_mode(model), f"{model} should support fast mode"
 
-        # Unsupported per Anthropic API: Opus 4.7/4.8, Sonnet, Haiku
+        # Not a 4.x Claude fast family → excluded
         unsupported = [
-            "claude-opus-4-7", "claude-opus-4-8", "claude-opus-4.8",
-            "claude-sonnet-4-6", "claude-sonnet-4.6", "claude-sonnet-4",
-            "claude-haiku-4-5", "claude-3-5-haiku",
+            "claude-3-5-haiku", "claude-3-5-sonnet", "claude-2",
         ]
         for model in unsupported:
             assert not model_supports_fast_mode(model), (
@@ -274,21 +275,21 @@ class TestAnthropicFastMode(unittest.TestCase):
         assert model_supports_fast_mode("anthropic/claude-opus-4.6") is True
 
     def test_anthropic_non_opus46_models_excluded(self):
-        """The speed=fast parameter is gated to Opus 4.6 — others excluded.
+        """Only the opus/sonnet/haiku 4.x families are fast-capable.
 
-        Per https://platform.claude.com/docs/en/build-with-claude/fast-mode,
-        sending speed=fast to Opus 4.7, Sonnet, or Haiku returns HTTP 400.
-        Opus 4.8 uses a separate ``…-fast`` model id, not this parameter.
+        Older Claude families (3.x, 2) have no fast offering on any endpoint.
+        The 4.x families are now permitted at the model level; the adapter's
+        endpoint-aware gate decides whether the param actually ships.
         """
         from hermes_cli.models import model_supports_fast_mode
 
-        assert model_supports_fast_mode("claude-sonnet-4-6") is False
-        assert model_supports_fast_mode("claude-sonnet-4.6") is False
-        assert model_supports_fast_mode("claude-haiku-4-5") is False
-        assert model_supports_fast_mode("claude-opus-4-7") is False
-        assert model_supports_fast_mode("claude-opus-4-8") is False
-        assert model_supports_fast_mode("anthropic/claude-sonnet-4.6") is False
-        assert model_supports_fast_mode("anthropic/claude-opus-4-7") is False
+        assert model_supports_fast_mode("claude-3-5-sonnet") is False
+        assert model_supports_fast_mode("claude-3-5-haiku") is False
+        assert model_supports_fast_mode("claude-2") is False
+        # 4.x families now permitted at the model level (adapter gates per-endpoint)
+        assert model_supports_fast_mode("claude-sonnet-4-6") is True
+        assert model_supports_fast_mode("claude-opus-4-8") is True
+        assert model_supports_fast_mode("claude-haiku-4-5") is True
 
     def test_non_claude_models_not_anthropic_fast(self):
         """Non-Claude models should not be treated as Anthropic fast-mode."""
@@ -314,18 +315,27 @@ class TestAnthropicFastMode(unittest.TestCase):
         result = resolve_fast_mode_overrides("anthropic/claude-opus-4.6")
         assert result == {"speed": "fast"}
 
-    def test_resolve_overrides_returns_none_for_unsupported_claude(self):
-        """Opus 4.7/4.8 and other Claude models don't take the speed param.
+    def test_resolve_overrides_speed_for_fast_capable_claude(self):
+        """Fast mode now spans the opus/sonnet/haiku 4.x families (endpoint-aware).
 
-        The speed=fast parameter is Opus 4.6 only (Opus 4.8 uses a separate
-        ``…-fast`` model id instead).
+        The model-level helper is permissive — it returns {"speed":"fast"} for any
+        fast-capable Claude family because the *adapter* makes the final per-endpoint
+        call (Copilot accepts it on 4.x; native Anthropic still 400s on 4.7/4.8 and is
+        refused there by ``anthropic_adapter._supports_fast_mode``).
         """
         from hermes_cli.models import resolve_fast_mode_overrides
 
-        assert resolve_fast_mode_overrides("claude-opus-4-7") is None
-        assert resolve_fast_mode_overrides("claude-opus-4-8") is None
-        assert resolve_fast_mode_overrides("claude-sonnet-4-6") is None
-        assert resolve_fast_mode_overrides("claude-haiku-4-5") is None
+        assert resolve_fast_mode_overrides("claude-opus-4-8") == {"speed": "fast"}
+        assert resolve_fast_mode_overrides("claude-opus-4.8-fast") == {"speed": "fast"}
+        assert resolve_fast_mode_overrides("claude-sonnet-4-6") == {"speed": "fast"}
+        assert resolve_fast_mode_overrides("claude-haiku-4-5") == {"speed": "fast"}
+
+    def test_resolve_overrides_returns_none_for_non_fast_claude(self):
+        """Claude families with no 4.x fast offering get no speed override."""
+        from hermes_cli.models import resolve_fast_mode_overrides
+
+        assert resolve_fast_mode_overrides("claude-3-5-sonnet") is None
+        assert resolve_fast_mode_overrides("claude-2") is None
 
     def test_resolve_overrides_returns_service_tier_for_openai(self):
         """OpenAI models should still get service_tier, not speed."""
@@ -335,22 +345,22 @@ class TestAnthropicFastMode(unittest.TestCase):
         assert result == {"service_tier": "priority"}
 
     def test_is_anthropic_fast_model(self):
-        """The speed=fast parameter is Opus 4.6 only — other Claude excluded."""
+        """Fast mode spans opus/sonnet/haiku 4.x (endpoint-aware; adapter gates final)."""
         from hermes_cli.models import _is_anthropic_fast_model
 
-        # Supported: Opus 4.6 in any form
+        # Supported: opus / sonnet / haiku 4.x in any form, incl the synthetic -fast id
         assert _is_anthropic_fast_model("claude-opus-4-6") is True
         assert _is_anthropic_fast_model("claude-opus-4.6") is True
         assert _is_anthropic_fast_model("anthropic/claude-opus-4-6") is True
         assert _is_anthropic_fast_model("claude-opus-4.6:fast") is True
+        assert _is_anthropic_fast_model("claude-opus-4-7") is True
+        assert _is_anthropic_fast_model("claude-opus-4-8") is True
+        assert _is_anthropic_fast_model("claude-opus-4.8-fast") is True
+        assert _is_anthropic_fast_model("claude-sonnet-4-6") is True
+        assert _is_anthropic_fast_model("claude-haiku-4-5") is True
 
-        # Unsupported — would 400 (4.7) or uses a separate model id (4.8)
-        assert _is_anthropic_fast_model("claude-opus-4-7") is False
-        assert _is_anthropic_fast_model("claude-opus-4-8") is False
-        assert _is_anthropic_fast_model("claude-sonnet-4-6") is False
-        assert _is_anthropic_fast_model("claude-haiku-4-5") is False
-
-        # Non-Claude
+        # Unsupported — non-4.x Claude and non-Claude
+        assert _is_anthropic_fast_model("claude-3-5-sonnet") is False
         assert _is_anthropic_fast_model("gpt-5.4") is False
         assert _is_anthropic_fast_model("") is False
 
@@ -362,23 +372,32 @@ class TestAnthropicFastMode(unittest.TestCase):
         )
         assert cli_mod.HermesCLI._fast_command_available(stub) is True
 
-    def test_fast_command_hidden_for_anthropic_sonnet(self):
-        """Sonnet doesn't support fast mode (Opus 4.6 only) — /fast must be hidden."""
+    def test_fast_command_shown_for_anthropic_sonnet(self):
+        """Sonnet 4.x is fast-capable (Copilot endpoint) — /fast must be available."""
         cli_mod = _import_cli()
         stub = SimpleNamespace(
             provider="anthropic", requested_provider="anthropic",
             model="claude-sonnet-4-6", agent=None,
         )
+        assert cli_mod.HermesCLI._fast_command_available(stub) is True
+
+    def test_fast_command_hidden_for_legacy_claude(self):
+        """Pre-4.x Claude (3.x/2) has no fast offering — /fast must hide."""
+        cli_mod = _import_cli()
+        stub = SimpleNamespace(
+            provider="anthropic", requested_provider="anthropic",
+            model="claude-3-5-sonnet", agent=None,
+        )
         assert cli_mod.HermesCLI._fast_command_available(stub) is False
 
-    def test_fast_command_hidden_for_anthropic_opus_47(self):
-        """Opus 4.7 doesn't take the speed=fast parameter — /fast must hide."""
+    def test_fast_command_shown_for_anthropic_opus_47(self):
+        """Opus 4.7/4.8 are fast-capable on the Copilot endpoint — /fast available."""
         cli_mod = _import_cli()
         stub = SimpleNamespace(
             provider="anthropic", requested_provider="anthropic",
             model="claude-opus-4-7", agent=None,
         )
-        assert cli_mod.HermesCLI._fast_command_available(stub) is False
+        assert cli_mod.HermesCLI._fast_command_available(stub) is True
 
     def test_fast_command_hidden_for_non_claude_non_openai(self):
         """Non-Claude, non-OpenAI models should not expose /fast."""
@@ -428,6 +447,34 @@ class TestAnthropicFastModeAdapter(unittest.TestCase):
         assert "speed" not in kwargs
         assert "extra_headers" in kwargs
         assert _FAST_MODE_BETA in kwargs["extra_headers"].get("anthropic-beta", "")
+
+    def test_fast_suffix_stripped_from_wire_model(self):
+        # Regression: a `-fast` model id is the Fast Mode KNOB, not a real model.
+        # The wire `model` MUST be the base id (sending `...-fast` 400s "model not
+        # supported"); the speed param is attached separately. Covers the bug
+        # where selecting claude-opus-4.8-fast in the TUI sent the literal
+        # `-fast` id and Copilot's /v1/messages rejected it.
+        from agent.anthropic_adapter import build_anthropic_kwargs
+
+        for mid in (
+            "claude-opus-4.8-fast",
+            "claude-sonnet-4.6-fast",
+            "claude-haiku-4.5-fast",
+        ):
+            kwargs = build_anthropic_kwargs(
+                model=mid,
+                messages=[{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+                tools=None,
+                max_tokens=None,
+                reasoning_config=None,
+                base_url="https://api.githubcopilot.com",
+                fast_mode=True,
+            )
+            self.assertNotIn("-fast", kwargs["model"], f"{mid}: wire model kept -fast")
+            self.assertEqual(
+                kwargs.get("extra_body", {}).get("speed"), "fast",
+                f"{mid}: speed knob not attached",
+            )
 
     def test_fast_mode_off_no_speed(self):
         from agent.anthropic_adapter import build_anthropic_kwargs
@@ -483,3 +530,80 @@ class TestConfigDefault(unittest.TestCase):
         agent = DEFAULT_CONFIG.get("agent", {})
         self.assertIn("service_tier", agent)
         self.assertEqual(agent["service_tier"], "")
+
+
+class TestSyntheticFastVariant(unittest.TestCase):
+    """The synthetic ``…-fast`` copilot model id: a UI/selection convenience that
+    auto-attaches the speed=fast knob and normalizes to the base model on the wire."""
+
+    def test_normalize_strips_fast_suffix(self):
+        from hermes_cli.models import normalize_copilot_model_id
+
+        catalog = [{"id": "claude-opus-4.8"}, {"id": "claude-sonnet-4.6"}]
+        self.assertEqual(
+            normalize_copilot_model_id("claude-opus-4.8-fast", catalog=catalog),
+            "claude-opus-4.8",
+        )
+        self.assertEqual(
+            normalize_copilot_model_id("copilot/claude-sonnet-4.6-fast", catalog=catalog),
+            "claude-sonnet-4.6",
+        )
+
+    def test_fast_variant_resolves_speed_override(self):
+        from hermes_cli.models import resolve_fast_mode_overrides
+
+        self.assertEqual(
+            resolve_fast_mode_overrides("claude-opus-4.8-fast"), {"speed": "fast"}
+        )
+
+    def test_catalog_injects_fast_variants(self):
+        # Exercise the synthetic "-fast" injection inside fetch_github_model_catalog
+        # by stubbing the HTTP fetch so the catalog returns our base items, then
+        # asserting the fast companion is appended for the claude model only.
+        import io
+        import json as _json
+        from contextlib import contextmanager
+        import hermes_cli.models as M
+
+        base_items = [
+            {"id": "claude-opus-4.8", "name": "Claude Opus 4.8",
+             "model_picker_enabled": True, "capabilities": {"type": "chat"}},
+            {"id": "gpt-5", "name": "GPT-5",
+             "model_picker_enabled": True, "capabilities": {"type": "chat"}},
+        ]
+
+        payload = _json.dumps({"data": base_items}).encode()
+
+        @contextmanager
+        def _fake_urlopen(req, timeout=None):
+            yield io.BytesIO(payload)
+
+        with patch.object(M.urllib.request, "urlopen", _fake_urlopen):
+            cat = M.fetch_github_model_catalog(api_key="x")
+        ids = [c["id"] for c in (cat or [])]
+        # the fast variant for the claude model is injected; gpt-5 gets none
+        self.assertIn("claude-opus-4.8-fast", ids)
+        self.assertNotIn("gpt-5-fast", ids)
+
+    def test_adapter_attaches_speed_for_copilot_opus48(self):
+        from agent.anthropic_adapter import build_anthropic_kwargs
+
+        kwargs = build_anthropic_kwargs(
+            model="claude-opus-4.8",
+            messages=[{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+            tools=None, max_tokens=None, reasoning_config=None,
+            base_url="https://api.githubcopilot.com", fast_mode=True,
+        )
+        self.assertEqual(kwargs.get("extra_body", {}).get("speed"), "fast")
+
+    def test_adapter_refuses_speed_for_native_opus48(self):
+        from agent.anthropic_adapter import build_anthropic_kwargs
+
+        kwargs = build_anthropic_kwargs(
+            model="claude-opus-4.8",
+            messages=[{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+            tools=None, max_tokens=None, reasoning_config=None,
+            base_url="https://api.anthropic.com", fast_mode=True,
+        )
+        # native Anthropic still 400s on 4.8 fast → adapter must NOT attach it
+        self.assertIsNone(kwargs.get("extra_body", {}).get("speed"))

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -320,7 +320,9 @@ class TestFetchApiModels:
             probe = probe_api_models("gh-token", "https://api.githubcopilot.com")
 
         assert mock_urlopen.call_args[0][0].full_url == "https://api.githubcopilot.com/models"
-        assert probe["models"] == ["gpt-5.4", "claude-sonnet-4.6"]
+        # claude-sonnet-4.6 also surfaces its synthetic "-fast" variant (Anthropic Fast
+        # Mode is selectable directly from the catalog); gpt-5.4 gets no fast variant.
+        assert probe["models"] == ["gpt-5.4", "claude-sonnet-4.6", "claude-sonnet-4.6-fast"]
         assert probe["resolved_base_url"] == "https://api.githubcopilot.com"
         assert probe["used_fallback"] is False
 

--- a/ui-tui/src/__tests__/appChromeModelLabel.test.ts
+++ b/ui-tui/src/__tests__/appChromeModelLabel.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { modelLabel } from '../components/appChrome.js'
+
+describe('modelLabel fast-mode rendering', () => {
+  it('does NOT double-print "fast" when the model id carries a -fast suffix', () => {
+    // regression: selecting "claude-opus-4.8-fast" with fast=true previously rendered
+    // "opus 4.8 fast max fast" (the suffix + the badge). Now the suffix is stripped from
+    // the model name and the single fast badge remains.
+    expect(modelLabel('copilot/claude-opus-4.8-fast', 'max', true)).toBe('opus 4.8 max fast')
+  })
+
+  it('renders the same label whether fast came from the -fast id or the /fast toggle', () => {
+    const fromSuffix = modelLabel('copilot/claude-opus-4.8-fast', 'max', true)
+    const fromToggle = modelLabel('copilot/claude-opus-4.8', 'max', true)
+    expect(fromSuffix).toBe(fromToggle)
+    expect(fromSuffix).toBe('opus 4.8 max fast')
+  })
+
+  it('shows no fast badge when fast is off, even if the id has -fast (defensive)', () => {
+    expect(modelLabel('copilot/claude-opus-4.8-fast', 'high', false)).toBe('opus 4.8 high')
+  })
+
+  it('keeps the normal (non-fast) label intact', () => {
+    expect(modelLabel('copilot/claude-opus-4.8', 'max', false)).toBe('opus 4.8 max')
+  })
+
+  it('strips -fast for sonnet/haiku too', () => {
+    expect(modelLabel('copilot/claude-sonnet-4.6-fast', 'high', true)).toBe('sonnet 4.6 high fast')
+  })
+})

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -370,13 +370,17 @@ const shortModelLabel = (model: string) =>
   model
     .split('/')
     .pop()!
+    // Drop a synthetic "-fast" suffix: fast mode is shown by the dedicated badge in
+    // modelLabel(), so keeping it in the model name double-prints it
+    // ("opus 4.8 fast … fast"). The base model is the display name.
+    .replace(/[-_]fast$/i, '')
     .replace(/^claude[-_]/, '')
     .replace(/^anthropic[-_]/, '')
     .replace(/[-_]/g, ' ')
     .replace(/\b(\d+)\s+(\d+)\b/g, '$1.$2')
     .trim()
 
-const modelLabel = (model: string, effort?: string, fast?: boolean) =>
+export const modelLabel = (model: string, effort?: string, fast?: boolean) =>
   [shortModelLabel(model), effortLabel(effort), fast ? 'fast' : ''].filter(Boolean).join(' ')
 
 export function GoodVibesHeart({ tick, t }: { tick: number; t: Theme }) {


### PR DESCRIPTION
feat(copilot): Anthropic Fast Mode for opus/sonnet/haiku 4.x + synthetic -fast model ids

Unlock GitHub Copilot's Anthropic Fast Mode (extra_body.speed="fast", ~2.5x
output throughput) for the opus/sonnet/haiku 4.x families, make it selectable
three ways, and fix the TUI status-bar label so "fast" isn't printed twice.

Background
----------
Native Anthropic only honors speed=fast on Opus 4.6 (4.7/4.8 explicitly 400).
But GitHub Copilot's /v1/messages proxy (api.githubcopilot.com) accepts
speed=fast on the whole opus/sonnet/haiku 4.x line and passes it upstream
(empirically verified). The previous gate was hard-coded to Opus-4.6-only, so
Copilot users couldn't reach Fast Mode on the newer models at all.

What changed
------------
(a) Endpoint-aware gate
  - agent/anthropic_adapter._supports_fast_mode now takes base_url. Native
    Anthropic stays Opus-4.6-only; Copilot's proxy returns True for opus/sonnet/
    haiku 4.x. A small _is_copilot_base_url(base_url) helper centralizes the
    api.githubcopilot.com check.
  - hermes_cli.models._is_anthropic_fast_model widened to the same families so
    the /fast toggle and resolve_fast_mode_overrides apply to them.

(b) Auto-knob — a `-fast` model id just works
  - normalize_copilot_model_id strips a trailing "-fast" to the real base id on
    the wire (claude-opus-4.8-fast -> claude-opus-4.8); the speed param is
    attached separately by the adapter.
  - selecting a `-fast` id is an implicit /fast toggle (sets request_overrides
    even when the toggle is off).

(c) Visibility — `-fast` variants in the catalog
  - fetch_github_model_catalog injects synthetic "<model>-fast" companion
    entries (name "<Name> (Fast)") for fast-capable Claude models, so the Fast
    variant is selectable directly from the model picker (the way OpenRouter
    exposes …-fast). Gated off by HERMES_COPILOT_HIDE_FAST_VARIANTS.

(d) TUI label fix
  - ui-tui appChrome.shortModelLabel strips a trailing "-fast"/"_fast" suffix so
    the model name is the base model and fast mode is shown only by the badge.
    The label is now identical whether fast came from the -fast id or the /fast
    toggle ("opus 4.8 fast" instead of "opus 4.8 fast fast"). modelLabel is
    exported for the regression test.

Tests
-----
- tests/cli/test_fast_command.py: endpoint-aware policy + TestSyntheticFastVariant
  (normalize, override resolution, catalog injection, copilot-yes/native-no
  adapter gates).
- tests/hermes_cli/test_model_validation.py: probe-catalog assertion includes a
  -fast variant.
- ui-tui appChromeModelLabel.test.ts: double-print regression + toggle/suffix
  parity + fast-off + sonnet/haiku variants.

Relationship to #49184
----------------------
Fast Mode is only reachable because Claude-on-Copilot is routed to /v1/messages
(#49184). This PR is self-contained (it carries the small _is_copilot_base_url
helper and the catalog-injection logic it needs), but it is best reviewed/merged
after #49184 since they share the Copilot Anthropic-proxy surface.

Wire-model strip (the load-bearing fix)
----------------------------------------
build_anthropic_kwargs now strips a trailing "-fast" from the model id it puts
on the wire (new _strip_fast_suffix helper, reused by _supports_fast_mode). The
"-fast" id is the Fast Mode KNOB, not a real model — sending it verbatim 400s
"model not supported". Selecting claude-opus-4.8-fast in the TUI hit exactly this
(the picker's per-session model override reaches the adapter without the catalog
normalizer). Stripping at the adapter boundary fixes every path regardless of how
the id was selected. Regression test added (test_fast_suffix_stripped_from_wire_model).
