### PR TITLE
fix(cli): use binary K (/ 1024) in _format_context_length

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -555,8 +555,8 @@ def _format_context_length(tokens: int) -> str:
         if abs(val - rounded) < 0.05:
             return f"{rounded}M"
         return f"{val:.1f}M"
-    elif tokens >= 1_000:
-        val = tokens / 1_000
+    elif tokens >= 1_024:
+        val = tokens / 1_024
         rounded = round(val)
         if abs(val - rounded) < 0.05:
             return f"{rounded}K"


### PR DESCRIPTION
## What does this PR do?

\`_format_context_length\` divided by 1,000 to format "K" labels, causing context
lengths that are powers of two (the overwhelmingly common case) to display as
non-round decimals:

| Config value | Before | After |
|---|---|---|
| 65 536  | 65.5K | 64K |
| 131 072 | 131.1K | **128K** |
| 262 144 | 262.1K | 256K |

Switching to 1,024 means every standard context size displays as a clean round
number that matches what the user typed in their config.

\`format_token_count_compact\` (used-tokens counter in \`cli.py\`) is intentionally
left unchanged — raw token counts are not powers of two, so decimal K is fine there.

## Related Issue

Fixes #52103

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- \`hermes_cli/banner.py\`: \`_format_context_length\` — threshold and divisor \`1_000\` → \`1_024\`

## How to Test

1. Set \`context_length: 131072\` in \`~/.hermes/config.yaml\`
2. Run \`hermes chat\`
3. Confirm status bar shows \`0/128K\` (was \`0/131.1K\`)
4. Test other powers of two: 65536 → \`64K\`, 262144 → \`256K\`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing issues and PRs (`gh pr list --state all --search "..."`, `gh issue list --search "..."`) — no duplicate found
- [x] My PR contains only changes related to this fix
- [x] I've run `scripts/run_tests.sh tests/hermes_cli/test_banner.py` (CI-preferred runner) — 10/10 passed; one pre-existing failure in `tests/acp/test_edit_approval.py` confirmed present on upstream `main` before this change
- [x] I've tested on my platform: macOS 15 (Apple M1 Max)

### Documentation & Housekeeping

- [x] N/A — no config keys or docs affected