### PR TITLE
fix(packaging): ship unreal-engine MCP manifest in the wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -323,6 +323,7 @@ locales = ["locales/*.yaml"]
 # entry; tests/test_packaging_metadata.py enforces an entry per optional-mcps/<name>.
 "optional-mcps/linear" = ["optional-mcps/linear/manifest.yaml"]
 "optional-mcps/n8n" = ["optional-mcps/n8n/manifest.yaml"]
+"optional-mcps/unreal-engine" = ["optional-mcps/unreal-engine/manifest.yaml"]
 
 [tool.setuptools.package-data]
 hermes_cli = ["web_dist/**/*", "tui_dist/**/*", "scripts/install.sh", "scripts/install.ps1"]

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -265,3 +265,52 @@ def test_locale_catalogs_ship_in_both_wheel_and_sdist():
     on_disk = list((REPO_ROOT / "locales").glob("*.yaml"))
     assert on_disk, "expected locales/*.yaml catalogs on disk"
 
+
+def test_mcp_catalog_manifests_ship_in_both_wheel_and_sdist():
+    """Regression test for the MCP catalog packaging gap.
+
+    optional-mcps/ is a bare data directory (no __init__.py), so -- exactly like
+    locales/ -- its manifests reach sealed installs (pip wheel, Nix store venv)
+    only when declared as setuptools data-files. ``hermes mcp catalog`` resolves
+    the packaged dir via hermes_cli/mcp_catalog.py::_catalog_root and
+    list_catalog() simply skips any entry whose manifest.yaml didn't ship, so a
+    missing data-files line silently drops that MCP from the catalog and the
+    dashboard catalog screen on packaged installs while source checkouts still
+    show it.
+
+    data-files flattens each glob into its single target dir, so every entry
+    needs its OWN ``optional-mcps/<name>`` target (a shared ``optional-mcps/*/*``
+    glob would collapse all manifests into one colliding file). This enforces
+    one target per on-disk optional-mcps/<name>/manifest.yaml -- a new catalog
+    entry added without the matching data-files line fails here instead of in a
+    user's wheel.
+    """
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    data_files = data["tool"]["setuptools"].get("data-files", {})
+
+    on_disk = sorted(
+        m.parent.name for m in (REPO_ROOT / "optional-mcps").glob("*/manifest.yaml")
+    )
+    assert on_disk, "expected optional-mcps/<name>/manifest.yaml entries on disk"
+
+    missing = [
+        name
+        for name in on_disk
+        if data_files.get(f"optional-mcps/{name}")
+        != [f"optional-mcps/{name}/manifest.yaml"]
+    ]
+    assert not missing, (
+        "These optional-mcps/ catalog entries exist on disk but are dropped from "
+        "the wheel because [tool.setuptools.data-files] is missing a per-entry "
+        "target. Add a line per entry in pyproject.toml: "
+        + ", ".join(
+            f'"optional-mcps/{name}" = ["optional-mcps/{name}/manifest.yaml"]'
+            for name in missing
+        )
+    )
+
+    manifest = (REPO_ROOT / "MANIFEST.in").read_text(encoding="utf-8")
+    assert "graft optional-mcps" in manifest, (
+        "MANIFEST.in must `graft optional-mcps` so the sdist ships the MCP catalog"
+    )
+


### PR DESCRIPTION


### What & why
`optional-mcps/` is a bare data directory, so each entry's `manifest.yaml` reaches
wheel/sealed installs only through a per-target `[tool.setuptools.data-files]` line.
`linear` and `n8n` were declared, but `unreal-engine` was missing — so `list_catalog()`
(and therefore `hermes mcp catalog` and the dashboard catalog screen) silently dropped it
on wheel installs, while source checkouts still showed it. The comment in `pyproject.toml`
already claimed a test enforced "an entry per `optional-mcps/<name>`", but no such test existed.

### Changes
- **`pyproject.toml`**: add the missing `"optional-mcps/unreal-engine"` data-files target.
- **`tests/test_packaging_metadata.py`**: add the promised regression test — every on-disk
  `optional-mcps/<name>/manifest.yaml` must have a matching data-files entry, and `MANIFEST.in`
  must graft `optional-mcps`. A new entry added without its line now fails here instead of in a
  user's wheel.

### Tests
- `pytest tests/test_packaging_metadata.py tests/hermes_cli/test_mcp_catalog.py` → **44 passed**
  (new test + existing shipped-catalog parse test).
- Confirmed the new test is a real guard: removing the data-files line makes it fail and pinpoint
  `unreal-engine`; restored → green. `ruff` clean.
- Built the wheel and verified all three manifests ship:
  `optional-mcps/{linear,n8n,unreal-engine}/manifest.yaml` (unreal-engine was absent before the fix).