### PR TITLE
fix(dashboard): prevent React from dropping first keystroke during IME composition

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -529,6 +529,30 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
 
     term.open(host);
 
+    // IME composition guard (fixes #52111).
+    //
+    // React 18's root-level event delegation intercepts keydown events with
+    // keyCode 229 (the "composition in progress" signal sent by the browser
+    // during non-Latin IME input) and synthesises an onCompositionStart
+    // event.  That synthetic path sets internal composing state that
+    // interferes with xterm.js's own IME handling on its hidden textarea,
+    // causing the first keystroke of each composition chunk to be silently
+    // dropped — most visible with Cyrillic (Ukrainian/Russian) on
+    // Firefox-based browsers, but affects any locale that uses composition
+    // events (CJK, Arabic, Hebrew).
+    //
+    // xterm.js relies on native compositionstart/compositionend on its
+    // internal textarea, not on keydown, so blocking the keyCode-229
+    // keydown from reaching React's delegation layer is safe.  The listener
+    // sits in the *capture* phase on the terminal host so it fires before
+    // the event bubbles up to the React root.
+    const _imeCompositionGuard = (e: KeyboardEvent) => {
+      if (e.keyCode === 229 || e.key === "Process") {
+        e.stopPropagation();
+      }
+    };
+    host.addEventListener("keydown", _imeCompositionGuard, true);
+
     // WebGL draws from a texture atlas sized with device pixels. On phones and
     // in DevTools device mode that often produces *visually* much larger cells
     // than `fontSize` suggests — users see "huge" text even at 7–9px settings.
@@ -813,6 +837,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // the ticket fetch resolves and ``wsRef.current`` was never assigned.
       wsRef.current?.close();
       wsRef.current = null;
+      host.removeEventListener("keydown", _imeCompositionGuard, true);
       term.dispose();
       termRef.current = null;
       fitRef.current = null;


### PR DESCRIPTION
## What does this PR do?

Adds a capture-phase keydown listener on the dashboard terminal host div that stops propagation of `keyCode === 229` (IME composition in progress) events, preventing React 18's root-level event delegation from synthesising an `onCompositionStart` that interferes with xterm.js's native IME handling. Fixes dropped first keystrokes for Cyrillic, CJK, Arabic, Hebrew, and other composition-based input methods.

## Related Issue

Fixes #52111

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `web/src/pages/ChatPage.tsx`: Added a capture-phase `keydown` listener on the terminal host element that calls `stopPropagation()` for events with `keyCode === 229` or `key === "Process"`, and removes it on cleanup. The guard prevents React's synthetic composition event path from interfering with xterm.js's own compositionstart/compositionend handling on its internal textarea.

## How to Test

1. `cd web && npx tsc -p . --noEmit` — TypeScript compiles cleanly
2. Open the Hermes Web Dashboard in Firefox: `hermes dashboard --host 0.0.0.0 --port 9119`
3. Switch keyboard layout to Ukrainian (or any Cyrillic / CJK / IME-based layout)
4. Click into the chat input (xterm.js terminal)
5. Type a Cyrillic word, e.g. "Привіт" — every character should appear on the first keystroke
6. Verify that English/Latin input still works normally
7. Verify copy/paste (Cmd+C / Cmd+Shift+V) still works
8. Existing tests pass: `cd web && npx vitest run`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `cd web && npx vitest run` and all tests pass
- [x] I've added tests for my changes — or N/A (DOM event guard; manual IME testing required; existing test suite covers unrelated utilities)
- [x] I've tested on my platform: macOS (TypeScript compiles, tests pass; IME reproduction requires Firefox + Cyrillic layout per issue reporter's environment)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (capture-phase keydown guard is standard DOM, platform-independent)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `web/src/pages/ChatPage.tsx` — terminal setup effect (term.open → cleanup)
- Blast radius: LOW — scoped to terminal host element, only intercepts keyCode 229 / key "Process"
- Related patterns: React 18 event delegation + xterm.js IME composition; `apps/desktop/src/app/chat/composer/ime-composition-dom-repro.test.tsx` has a related composition test for the desktop contentEditable composer
