### PR TITLE
fix(tui): route /learn through command.dispatch in Desktop GUI

### DIFF
--- a/tests/tui_gateway/test_learn_command.py
+++ b/tests/tui_gateway/test_learn_command.py
@@ -1,0 +1,113 @@
+"""Tests for /learn routing in tui_gateway.
+
+The TUI routes ``/learn`` through ``command.dispatch`` (not ``slash.exec``)
+because the CLI's ``_handle_learn_command`` queues the learn prompt onto
+``_pending_input``, which the slash-worker subprocess has no reader for.
+Instead we handle ``/learn`` directly in the server and return a
+``{"type": "send", "message": ...}`` payload the TUI client uses to submit
+the learn prompt as a normal agent turn.
+"""
+
+from __future__ import annotations
+
+import importlib
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    yield home
+
+
+@pytest.fixture()
+def server(hermes_home):
+    with patch.dict(
+        "sys.modules",
+        {
+            "hermes_cli.env_loader": MagicMock(),
+            "hermes_cli.banner": MagicMock(),
+        },
+    ):
+        mod = importlib.import_module("tui_gateway.server")
+        yield mod
+        mod._sessions.clear()
+        mod._pending.clear()
+        mod._answers.clear()
+
+
+@pytest.fixture()
+def session(server):
+    sid = "sid-test"
+    session_key = "tui-learn-session-1"
+    s = {
+        "session_key": session_key,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "attached_images": [],
+        "cols": 120,
+    }
+    server._sessions[sid] = s
+    return sid, session_key, s
+
+
+def _call(server, method, **params):
+    handler = server._methods[method]
+    return handler(1, params)
+
+
+# ── _PENDING_INPUT_COMMANDS guard ─────────────────────────────────────
+
+
+def test_learn_in_pending_input_commands(server):
+    """Guard: /learn must be in _PENDING_INPUT_COMMANDS so slash.exec routes
+    it to command.dispatch instead of the slash worker subprocess."""
+    assert "learn" in server._PENDING_INPUT_COMMANDS
+
+
+# ── command.dispatch /learn ───────────────────────────────────────────
+
+
+def test_command_dispatch_learn_returns_send(server, session):
+    """command.dispatch /learn must return a 'send' dispatch with the learn
+    prompt as the message, so the Desktop frontend submits it as a turn."""
+    sid, _, _ = session
+    r = _call(server, "command.dispatch", name="learn", arg="how to use the terminal tool", session_id=sid)
+    assert "result" in r
+    assert r["result"]["type"] == "send"
+    assert "message" in r["result"]
+    assert "learn" in r["result"]["message"].lower() or "skill" in r["result"]["message"].lower()
+
+
+def test_command_dispatch_learn_bare_uses_conversation(server, session):
+    """command.dispatch /learn with no arg should build a prompt referencing
+    the current conversation."""
+    sid, _, _ = session
+    r = _call(server, "command.dispatch", name="learn", arg="", session_id=sid)
+    assert "result" in r
+    assert r["result"]["type"] == "send"
+    assert "conversation" in r["result"]["message"].lower() or "skill" in r["result"]["message"].lower()
+
+
+# ── slash.exec /learn routing ─────────────────────────────────────────
+
+
+def test_slash_exec_routes_learn_to_command_dispatch(server, session):
+    """slash.exec must route /learn directly to command.dispatch internally
+    instead of the slash worker subprocess, so the learn prompt reaches
+    the agent as a normal turn."""
+    sid, _, _ = session
+    r = _call(server, "slash.exec", command="learn how to use read_file", session_id=sid)
+    assert "result" in r
+    assert r["result"]["type"] == "send"
+    assert "message" in r["result"]
+    assert "learn" in r["result"]["message"].lower() or "skill" in r["result"]["message"].lower()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9292,6 +9292,7 @@ _PENDING_INPUT_COMMANDS: frozenset[str] = frozenset(
         "plan",
         "goal",
         "undo",
+        "learn",
     }
 )
 


### PR DESCRIPTION
## What does this PR do?

Routes the `/learn` slash command through `command.dispatch` in the TUI gateway so the Desktop GUI correctly submits the learn prompt as a normal agent turn instead of silently losing it in the slash worker subprocess.

## Related Issue

Fixes #51829

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`: Added `"learn"` to `_PENDING_INPUT_COMMANDS` frozenset so `slash.exec` routes `/learn` to `command.dispatch` instead of the `_SlashWorker` subprocess
- `tests/tui_gateway/test_learn_command.py`: Added 4 tests — guard test for `_PENDING_INPUT_COMMANDS` membership, `command.dispatch` routing with/without arg, and `slash.exec` end-to-end routing

## How to Test

1. Open Hermes Desktop GUI
2. Type `/learn how to use the terminal tool`
3. Observe: the learn prompt should be submitted as a normal agent turn (LLM processes it, gathers sources, creates a skill)
4. Previously: only the ack message "Learning a skill from what you described…" was shown and the prompt was lost

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tui_gateway/server.py` `_PENDING_INPUT_COMMANDS`, `command.dispatch` handler (line 9557), `slash.exec` handler (line 10581)
- Blast radius: LOW — single frozenset addition, routes to existing `command.dispatch` handler
- Related patterns: Same routing pattern as `/goal` (test_goal_command.py) and `/undo` (test_undo_command.py) — all CLI commands that use `_pending_input.put()` must be in `_PENDING_INPUT_COMMANDS`
