### PR TITLE
fix(telegram): use effective_message in _handle_media_message for channel posts (#52126)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6456,11 +6456,12 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def _handle_media_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming media messages, downloading images to local cache."""
-        if not update.message:
+        msg = self._effective_update_message(update)
+        if not msg:
             return
-        if not self._should_process_message(update.message):
-            if self._should_observe_unmentioned_group_message(update.message):
-                _m = update.message
+        if not self._should_process_message(msg):
+            if self._should_observe_unmentioned_group_message(msg):
+                _m = msg
                 _observe_type = self._media_message_type(_m)
                 _event = self._build_message_event(_m, _observe_type, update_id=update.update_id)
                 if _m.caption:
@@ -6470,8 +6471,6 @@ class TelegramAdapter(BasePlatformAdapter):
                     _m, _event.message_type, update_id=update.update_id, event=_event
                 )
             return
-
-        msg = update.message
 
         msg_type = self._media_message_type(msg)
 

--- a/tests/gateway/test_telegram_channel_posts.py
+++ b/tests/gateway/test_telegram_channel_posts.py
@@ -11,7 +11,7 @@ import importlib.util
 import sys
 import types
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -179,3 +179,71 @@ async def test_command_handler_uses_effective_message_for_channel_post(telegram_
     assert event.message_type == MessageType.COMMAND
     assert event.source.chat_type == "channel"
     assert event.source.chat_id == "-1003950368353"
+
+
+@pytest.mark.asyncio
+async def test_media_handler_processes_channel_post_document(telegram_adapter_cls):
+    """Regression: channel_post documents must not be silently dropped.
+
+    _handle_media_message used ``update.message`` directly, which is None for
+    channel broadcasts (PTB puts them in ``update.channel_post``).  After the
+    fix the handler uses ``effective_message`` so documents sent to channels
+    are downloaded and cached just like DM documents.
+    """
+    from unittest.mock import AsyncMock
+
+    adapter = _make_adapter(telegram_adapter_cls)
+    adapter.handle_message = AsyncMock()
+
+    # Build a channel message carrying a document attachment
+    doc = MagicMock()
+    doc.file_name = "report.pdf"
+    doc.mime_type = "application/pdf"
+    doc.file_size = 2048
+
+    file_obj = AsyncMock()
+    file_obj.download_as_bytearray = AsyncMock(return_value=bytearray(b"%PDF-1.4"))
+    file_obj.file_path = "documents/report.pdf"
+    doc.get_file = AsyncMock(return_value=file_obj)
+
+    chat = SimpleNamespace(
+        id=-1003950368353,
+        type="channel",
+        title="wzrd",
+        full_name=None,
+        is_forum=False,
+    )
+    msg = SimpleNamespace(
+        chat=chat,
+        from_user=None,
+        text="",
+        caption="annual report",
+        entities=[],
+        caption_entities=[],
+        message_thread_id=None,
+        is_topic_message=False,
+        message_id=42,
+        reply_to_message=None,
+        quote=None,
+        date=None,
+        forum_topic_created=None,
+        document=doc,
+        photo=None,
+        video=None,
+        audio=None,
+        voice=None,
+        sticker=None,
+        media_group_id=None,
+    )
+    update = _make_channel_update(msg)
+
+    with patch("plugins.platforms.telegram.adapter.cache_document_from_bytes") as mock_cache:
+        mock_cache.return_value = "/tmp/cached/report.pdf"
+        await adapter._handle_media_message(update, MagicMock())
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "annual report"
+    assert event.source.chat_type == "channel"
+    assert event.source.chat_id == "-1003950368353"
+    assert len(event.media_urls) == 1

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -113,6 +113,7 @@ def _make_update(msg):
     """Wrap a message in a mock Update."""
     update = MagicMock()
     update.message = msg
+    update.effective_message = msg
     return update
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes silent dropping of file attachments (documents, PDFs, images, voice, etc.) sent to Telegram **channels**. The `_handle_media_message` handler used `update.message` directly, which is `None` for channel broadcasts (PTB puts them in `update.channel_post`). Switches to `_effective_update_message()` — the same pattern already used by `_handle_text_message` and `_handle_command`.

## Related Issue

Fixes #52126

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/telegram/adapter.py`: Replace `update.message` references in `_handle_media_message()` with `msg = self._effective_update_message(update)` so channel-post media (documents, photos, voice, audio, video, stickers) is properly downloaded and cached.
- `tests/gateway/test_telegram_channel_posts.py`: Add regression test `test_media_handler_processes_channel_post_document` verifying channel-post documents are processed, not silently dropped.
- `tests/gateway/test_telegram_documents.py`: Update `_make_update()` fixture to set `update.effective_message = msg` so existing document tests work with the `_effective_update_message()` code path.

## How to Test

1. Create a Telegram **channel** (not supergroup), add the bot as admin with Privacy Mode OFF
2. Configure `free_response_chats` and `allowed_chats` in config.yaml to include the channel
3. Send a file/document to the channel
4. Before fix: gateway logs show no "Cached user document" entry, file is silently dropped
5. After fix: file is cached and delivered to the agent normally
6. Run `pytest tests/gateway/test_telegram_channel_posts.py tests/gateway/test_telegram_documents.py -q` — all tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `plugins/platforms/telegram/adapter.py:_handle_media_message` (callers: 1, flows: media message dispatch)
- Blast radius: LOW — single function, same pattern as 3 sibling handlers
- Related patterns: `_handle_text_message` and `_handle_command` already use `_effective_update_message()` for the same channel-post routing
