### PR TITLE
fix(api_server): mark port conflict as non-retryable to stop infinite reconnect loop

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4499,12 +4499,32 @@ class APIServerAdapter(BasePlatformAdapter):
                         self.name, self._host,
                     )
 
-            # Port conflict detection — fail fast if port is already in use
+            # Port conflict detection — fail fast if port is already in use.
+            # A port conflict is a configuration error, not a transient blip:
+            # the port will not free itself (another gateway or process holds
+            # it for the lifetime of that process).  Previously this returned
+            # ``False`` without setting a fatal error, so the reconnect watcher
+            # in ``gateway.run`` treated it as *retryable* and looped
+            # indefinitely — every 5 min at the backoff cap, forever, filling
+            # ``errors.log`` with thousands of duplicate lines and leaking 2
+            # file descriptors per retry (#37011).  Marking the error
+            # non-retryable drops the platform from the reconnect queue
+            # immediately, matching how other platforms handle config errors
+            # (e.g. ``weixin.py`` missing-token, ``whatsapp_cloud.py`` missing
+            # credentials).  The operator can recover with ``/platform resume``
+            # after changing ``API_SERVER_PORT``.
             try:
                 with _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM) as _s:
                     _s.settimeout(1)
                     _s.connect(('127.0.0.1', self._port))
-                logger.error('[%s] Port %d already in use. Set a different port in config.yaml: platforms.api_server.port', self.name, self._port)
+                self._set_fatal_error(
+                    "api_server_port_in_use",
+                    f"Port {self._port} already in use. Set API_SERVER_PORT "
+                    f"(or platforms.api_server.port in config.yaml) to a "
+                    f"different value. Use `/platform resume api_server` "
+                    f"after changing the port.",
+                    retryable=False,
+                )
                 return False
             except (ConnectionRefusedError, OSError):
                 pass  # port is free

--- a/tests/gateway/test_api_server_bind_guard.py
+++ b/tests/gateway/test_api_server_bind_guard.py
@@ -131,3 +131,39 @@ class TestConnectBindGuard:
         assert adapter._api_key == "sk-test"
         assert is_network_accessible("0.0.0.0") is True
         # Combined: the guard condition is False (key is set), so it passes
+
+    @pytest.mark.asyncio
+    async def test_port_conflict_sets_non_retryable_fatal_error(self):
+        """When the api_server port is already in use, connect() must set a
+        non-retryable fatal error so the reconnect watcher drops it from the
+        retry queue instead of looping indefinitely.
+
+        Previously connect() returned ``False`` without setting a fatal error,
+        so the reconnect watcher treated the port conflict as a transient,
+        retryable failure and retried every 5 minutes forever — filling
+        errors.log with thousands of duplicate lines and leaking 2 fds/retry.
+        """
+        # Use a key so we pass the auth guard and reach the port-conflict check.
+        # Bind a real socket on an ephemeral port to simulate the conflict.
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind(("127.0.0.1", 0))
+        sock.listen(1)
+        conflict_port = sock.getsockname()[1]
+        try:
+            adapter = APIServerAdapter(
+                PlatformConfig(
+                    enabled=True,
+                    extra={"host": "127.0.0.1", "key": "sk-test", "port": conflict_port},
+                )
+            )
+            result = await adapter.connect()
+            assert result is False
+            # The critical assertion: the error must be non-retryable so the
+            # reconnect watcher stops retrying.
+            assert adapter.has_fatal_error is True
+            assert adapter.fatal_error_retryable is False
+            assert adapter.fatal_error_code == "api_server_port_in_use"
+            assert str(conflict_port) in (adapter.fatal_error_message or "")
+        finally:
+            sock.close()
+


### PR DESCRIPTION
## Problem

When the `api_server` port is already in use — common in multi-profile gateway setups where several profiles all default to `DEFAULT_PORT = 8642` — `connect()` returns `False` **without setting a fatal error**. The reconnect watcher in `gateway/run.py` (`_platform_reconnect_watcher`) treats a bare `False` return as a *retryable* failure and retries indefinitely with exponential backoff capped at 300s.

**Observed in production** (4 gateway profiles: default, writer, seo-expert, design-agent, all with `API_SERVER_ENABLED=true`):
- **1568+ reconnect attempts** over 5 days for a single port conflict
- `errors.log` filled with thousands of duplicate `Port 8642 already in use` lines
- 2 file descriptors leaked per retry (adapter's ResponseStore SQLite connection, per #37011) — ~12 fds/hour at the 300s backoff cap

## Root Cause

`gateway/platforms/api_server.py` line ~4507:
```python
# Port conflict detection — fail fast if port is already in use
try:
    with _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM) as _s:
        _s.settimeout(1)
        _s.connect(('127.0.0.1', self._port))
    logger.error('[%s] Port %d already in use. ...', self.name, self._port)
    return False          # ← no fatal error set → treated as retryable
except (ConnectionRefusedError, OSError):
    pass  # port is free
```

The reconnect watcher (`gateway/run.py:6341`) only drops a platform from the retry queue when `adapter.has_fatal_error and not adapter.fatal_error_retryable`. A port conflict is a **configuration error** (the port won't free itself — another process holds it for its lifetime), but it was being retried as if it were a transient network blip.

## Fix

Replace the bare `return False` with `self._set_fatal_error("api_server_port_in_use", ..., retryable=False)`, matching the pattern used by other platforms for config errors:
- `weixin.py`: `_set_fatal_error("weixin_missing_token", ..., retryable=False)`
- `whatsapp_cloud.py`: `_set_fatal_error(..., ..., retryable=False)` for missing credentials
- `yuanbao.py`: `_set_fatal_error("yuanbao_missing_credentials", ..., retryable=False)`

The operator can recover with `/platform resume api_server` after changing `API_SERVER_PORT`.

## Relationship to other work

- **#51908** (`fix(profile): auto-allocate conflict-free ports on create or clone`) prevents the conflict at profile *creation* time. This PR handles the *runtime* case — already-existing profiles or manual multi-gateway setups where the conflict is detected at `connect()` time. The two are complementary.
- **#37011** (fd leak on failed reconnects) is partially mitigated by `_dispose_unused_adapter` in the reconnect watcher, but this PR eliminates the retry entirely for port conflicts, removing the fd leak at the source.

## Test

Added `test_port_conflict_sets_non_retryable_fatal_error` in `tests/gateway/test_api_server_bind_guard.py`:
- Binds a real socket on an ephemeral port to simulate the conflict
- Verifies `connect()` returns `False`
- **Critical assertion**: `adapter.has_fatal_error is True` and `adapter.fatal_error_retryable is False` and `adapter.fatal_error_code == "api_server_port_in_use"`

## Checklist

- [x] Code follows the existing pattern (`_set_fatal_error` with `retryable=False`)
- [x] Test added and covers the critical behavior (non-retryable fatal error)
- [x] No breaking changes — `connect()` still returns `False`, just also sets the fatal error
- [x] Recovery path documented (`/platform resume api_server`)