### PR TITLE
fix(cli): show /learn progress steps

### DIFF
--- a/agent/learn_prompt.py
+++ b/agent/learn_prompt.py
@@ -69,6 +69,23 @@ Quality bar:
   inlined for the agent to re-type every run."""
 
 
+_LEARN_PROGRESS_STEPS = (
+    "1/3 gather source material",
+    "2/3 write and save the skill",
+    "3/3 report the skill name and category",
+)
+
+
+def build_learn_progress_message(user_request: str) -> str:
+    """Build the user-facing progress hint shown when ``/learn`` starts."""
+    req = (user_request or "").strip()
+    source = "what you described" if req else "this conversation"
+    lines = [f"Learning a skill from {source}..."]
+    lines.extend(f"  {step}" for step in _LEARN_PROGRESS_STEPS)
+    lines.append("I will include the new skill name when it finishes.")
+    return "\n".join(lines)
+
+
 def build_learn_prompt(user_request: str) -> str:
     """Build the agent prompt for an open-ended ``/learn`` request.
 
@@ -102,7 +119,10 @@ def build_learn_prompt(user_request: str) -> str:
         "2. Author ONE SKILL.md and save it with the `skill_manage` tool "
         "(action=\"create\"). Pick a sensible category. If the procedure needs "
         "a non-trivial script, add it under the skill's `scripts/` with "
-        "`skill_manage` write_file and reference it by relative path.\n\n"
+        "`skill_manage` write_file and reference it by relative path.\n"
+        "3. Keep progress visible where the surface supports it: first gather "
+        "source material, then write and save the skill, then report the "
+        "created skill name and category.\n\n"
         f"{_AUTHORING_STANDARDS}\n\n"
         "When done, tell the user the skill name, its category, and a "
         "one-line summary of what it captured."

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8157,14 +8157,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # web_extract, this conversation, pasted text) and authors the skill
             # via skill_manage. Mirrors the /blueprint fall-through so role
             # alternation is preserved. No engine, works on any backend.
-            from agent.learn_prompt import build_learn_prompt
+            from agent.learn_prompt import (
+                build_learn_progress_message,
+                build_learn_prompt,
+            )
 
             _learn_req = event.get_command_args().strip()
-            _ack = (
-                "Learning a skill from what you described…"
-                if _learn_req
-                else "Learning a skill from this conversation…"
-            )
+            _ack = build_learn_progress_message(_learn_req)
             try:
                 adapter = self.adapters.get(source.platform)
                 if adapter:

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1422,17 +1422,17 @@ class CLICommandsMixin:
         authors the skill via ``skill_manage``. No engine, no model-tool
         footprint, works on any terminal backend.
         """
-        from agent.learn_prompt import build_learn_prompt
+        from agent.learn_prompt import (
+            build_learn_progress_message,
+            build_learn_prompt,
+        )
 
         # Everything after the command word is the open-ended request.
         parts = cmd.strip().split(None, 1)
         user_request = parts[1].strip() if len(parts) > 1 else ""
 
         msg = build_learn_prompt(user_request)
-        if user_request:
-            print("\n⚡ Learning a skill from what you described...")
-        else:
-            print("\n⚡ Learning a skill from this conversation...")
+        print(f"\n⚡ {build_learn_progress_message(user_request)}")
         if hasattr(self, "_pending_input"):
             self._pending_input.put(msg)
         else:  # pragma: no cover - defensive (no live input loop)

--- a/tests/agent/test_learn_prompt.py
+++ b/tests/agent/test_learn_prompt.py
@@ -6,7 +6,11 @@ builds a standards-guided prompt that the live agent runs as a normal turn, so
 these are the load-bearing behavior contracts.
 """
 
-from agent.learn_prompt import build_learn_prompt, _AUTHORING_STANDARDS
+from agent.learn_prompt import (
+    _AUTHORING_STANDARDS,
+    build_learn_progress_message,
+    build_learn_prompt,
+)
 
 
 class TestBuildLearnPrompt:
@@ -45,6 +49,26 @@ class TestBuildLearnPrompt:
     def test_description_length_rule_is_in_the_standards(self):
         # The single most-violated rule must be explicit in the prompt.
         assert "60" in _AUTHORING_STANDARDS
+
+
+    def test_prompt_instructs_visible_progress_and_final_skill_name(self):
+        prompt = build_learn_prompt("our release checklist")
+        assert "Keep progress visible" in prompt
+        assert "created skill name and category" in prompt
+
+
+class TestBuildLearnProgressMessage:
+    def test_progress_message_shows_phases_for_described_source(self):
+        message = build_learn_progress_message("the deploy script")
+        assert "what you described" in message
+        assert "1/3 gather source material" in message
+        assert "2/3 write and save the skill" in message
+        assert "3/3 report the skill name and category" in message
+
+    def test_progress_message_names_conversation_source_for_bare_learn(self):
+        message = build_learn_progress_message("")
+        assert "this conversation" in message
+        assert "new skill name" in message
 
 
 class TestLearnRegistryWiring:

--- a/tests/cli/test_cli_learn.py
+++ b/tests/cli/test_cli_learn.py
@@ -1,0 +1,44 @@
+"""Regression tests for CLI /learn progress messaging."""
+
+from tests.cli.test_cli_init import _make_cli
+
+
+def test_process_command_learn_prints_progress_and_queues_prompt(capsys):
+    cli = _make_cli()
+    queued = []
+
+    class _Queue:
+        def put(self, value):
+            queued.append(value)
+
+    cli._pending_input = _Queue()
+
+    cli.process_command("/learn the deploy workflow")
+
+    out = capsys.readouterr().out
+    assert "Learning a skill from what you described" in out
+    assert "1/3 gather source material" in out
+    assert "2/3 write and save the skill" in out
+    assert "3/3 report the skill name and category" in out
+    assert "new skill name" in out
+    assert len(queued) == 1
+    assert "the deploy workflow" in queued[0]
+    assert "Keep progress visible" in queued[0]
+
+
+def test_process_command_bare_learn_names_conversation_source(capsys):
+    cli = _make_cli()
+    queued = []
+
+    class _Queue:
+        def put(self, value):
+            queued.append(value)
+
+    cli._pending_input = _Queue()
+
+    cli.process_command("/learn")
+
+    out = capsys.readouterr().out
+    assert "Learning a skill from this conversation" in out
+    assert len(queued) == 1
+    assert "workflow we just went through" in queued[0]


### PR DESCRIPTION
## Summary
- Show /learn progress steps on CLI and gateway surfaces

## Test Plan
- scripts/run_tests.sh tests/cli/test_cli_learn.py tests/agent/test_learn_prompt.py -- -q