### PR TITLE
fix(auxiliary): preserve auto-chain resolved model over main-model clobber

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3689,7 +3689,18 @@ def resolve_provider_client(
                 "Dropping OpenRouter-format model %r for non-OpenRouter "
                 "auxiliary provider (using %r instead)", model, resolved)
             model = None
-        final_model = model or resolved
+        # When the auto chain successfully resolved a real provider+model,
+        # that model's name MUST win over the pre-clobbered ``model`` value
+        # set at lines 3626-3639 above. Without this precedence, an OAuth
+        # main provider (e.g. ``minimax-oauth``) that fails its own auth
+        # path falls through to the user-configured fallback chain (e.g.
+        # ``opencode-go / deepseek-v4-flash``) — but the auxiliary client
+        # then sends the user's main model name (``MiniMax-M3``) to the
+        # fallback endpoint, which doesn't serve it and returns HTTP 401.
+        # The auto chain's resolved model is already validated against the
+        # provider's accepted-model list; the pre-clobbered ``model`` is
+        # not. Prefer ``resolved`` whenever the chain returned one.
+        final_model = resolved or model
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                 else (client, final_model))
 

--- a/tests/agent/test_auxiliary_model_clobber_oauth_fallback.py
+++ b/tests/agent/test_auxiliary_model_clobber_oauth_fallback.py
@@ -1,0 +1,184 @@
+"""Regression test: auxiliary client must not clobber the auto-chain's
+resolved model with the user's main model when the auto chain successfully
+resolves via the fallback chain to a different provider.
+
+Background
+----------
+Bug in ``resolve_provider_client()`` at line 3692:
+
+The function pre-clobbers ``model`` with ``_read_main_model()`` for any
+provider whose ``_get_aux_model_for_provider()`` returns empty (lines
+3626-3627).  When ``provider == "auto"`` and the auto chain successfully
+resolves to a fallback provider (e.g. ``opencode-go`` with
+``deepseek-v4-flash``), the returned model is ``model or resolved`` — but
+``model`` is already the user's main chat model (``MiniMax-M3``), so it
+wins and the call goes out with the wrong model name.  The fallback
+endpoint rejects it with HTTP 401.
+
+Reproduction config (per the user's actual report, 2026-06-24):
+
+    model:
+      default: MiniMax-M3
+      provider: minimax-oauth
+      base_url: https://opencode.ai/zen/go/v1
+    fallback_providers:
+      - model: deepseek-v4-flash
+        provider: opencode-go
+
+Without the fix:
+
+    resolve_provider_client("auto", None, task="title_generation")
+        → (client_for_opencode_go, "MiniMax-M3")    # WRONG — 401 from OpenCode Go
+
+With the fix:
+
+    resolve_provider_client("auto", None, task="title_generation")
+        → (client_for_opencode_go, "deepseek-v4-flash")    # CORRECT
+
+Note: a related bug exists for OAuth-gated direct provider calls
+(e.g. ``flush_memories.provider = openai-codex, model = ''`` with the
+user's main chat being a MiniMax model — Codex returns 400 because
+``MiniMax-M3`` is not in Codex's allowed-model list).  That bug class is
+NOT fixed here; it is intentionally out of scope because the fix would
+regress the behavior pinned in ``test_auxiliary_client.py`` at lines
+573-627 (the universal main-model fallback for OAuth-gated providers,
+introduced in #47235).  The two failure modes (auto-chain clobber and
+direct OAuth-gated clobber) need separate, scope-limited fixes.
+
+Reproduces the issue tracked by the operator on 2026-06-24: title
+generation fails with HTTP 401 ``Model MiniMax-M3 is not supported``
+because the auxiliary call goes to OpenCode Go with the user's main
+chat model name instead of the fallback chain's correctly-resolved
+``deepseek-v4-flash``.
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+class TestAuxiliaryModelClobber:
+    """The pre-clobber of ``model`` at lines 3626-3639 must not corrupt the
+    auto chain's resolution when the chain succeeds via fallback."""
+
+    def test_auto_chain_resolved_model_wins_over_main_model_clobber(
+        self, tmp_path, monkeypatch
+    ):
+        """Reproduces the title_generation failure: ``resolve_provider_client("auto", None)``
+        on a minimax-oauth user with ``fallback_providers[0]=opencode-go/deepseek-v4-flash``
+        must return ``deepseek-v4-flash``, not the user's main ``MiniMax-M3``.
+
+        Buggy behavior: pre-fix code returns ``MiniMax-M3`` (clobbered from main
+        runtime), causing OpenCode Go to reject the call with HTTP 401.
+        """
+        import agent.auxiliary_client as mod
+
+        # Hermetic: no aggregator creds, no stale OPENAI_BASE_URL.
+        for var in ("OPENROUTER_API_KEY", "NOUS_API_KEY", "OPENAI_API_KEY",
+                    "OPENAI_BASE_URL", "HERMES_API_KEY"):
+            monkeypatch.delenv(var, raising=False)
+
+        # Empty config — runtime globals carry the user's setup.
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("model:\n  default: ''\n  provider: ''\n")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        # User's actual config: minimax-oauth main provider (the OAuth auth_type
+        # the resolver doesn't handle → falls through to fallback chain).
+        mod.clear_runtime_main()
+        try:
+            mod.set_runtime_main(
+                "minimax-oauth", "MiniMax-M3",
+                base_url="https://opencode.ai/zen/go/v1",
+                api_key="",
+                api_mode="chat_completions",
+            )
+
+            # Patch the fallback chain to return a known-good (client, model)
+            # pair — simulating the user's fallback_providers[0].
+            fake_client = MagicMock()
+            fake_client.base_url = "https://opencode.ai/zen/go/v1"
+            with patch.object(
+                mod, "_try_main_fallback_chain",
+                return_value=(fake_client, "deepseek-v4-flash", "fallback_providers[0](opencode-go)"),
+            ):
+                # Also short-circuit the unhealthy-provider check so the chain
+                # is actually exercised.
+                with patch.object(mod, "_is_provider_unhealthy", return_value=False):
+                    client, resolved = mod.resolve_provider_client(
+                        "auto", None, task="title_generation"
+                    )
+
+            assert client is fake_client, (
+                "auto chain returned a different client than the fallback chain did"
+            )
+            assert resolved == "deepseek-v4-flash", (
+                f"resolved model was {resolved!r} — expected 'deepseek-v4-flash'. "
+                "The pre-clobber of ``model`` at lines 3626-3639 overwrote the "
+                "fallback chain's correct resolution with the user's main model."
+            )
+            # Explicit regression assertion: MiniMax-M3 must NEVER come back
+            # from the auto path when the fallback chain resolved successfully.
+            assert resolved != "MiniMax-M3", (
+                "regression: auto path returned the user's main chat model "
+                "('MiniMax-M3') instead of the fallback chain's resolved model. "
+                "This produces HTTP 401 from OpenCode Go because the endpoint "
+                "does not serve 'MiniMax-M3' (its catalog is minimax-m2.7, glm-5.1, etc)."
+            )
+        finally:
+            mod.clear_runtime_main()
+
+    def test_configured_fallback_chain_also_preserves_resolved_model(
+        self, tmp_path, monkeypatch
+    ):
+        """The auto chain has two fallback paths: the user-configured
+        ``auxiliary.<task>.fallback_chain`` (task-specific) and the top-level
+        ``fallback_providers`` (global). Both return to ``_resolve_auto`` at
+        the same place and both benefit from the fix at line 3692. This test
+        pins the configured-fallback path specifically so a future refactor
+        that splits the two paths would not silently regress one of them."""
+        import agent.auxiliary_client as mod
+
+        for var in ("OPENROUTER_API_KEY", "NOUS_API_KEY", "OPENAI_API_KEY",
+                    "OPENAI_BASE_URL", "HERMES_API_KEY"):
+            monkeypatch.delenv(var, raising=False)
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("model:\n  default: ''\n  provider: ''\n")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        mod.clear_runtime_main()
+        try:
+            mod.set_runtime_main(
+                "minimax-oauth", "MiniMax-M3",
+                base_url="https://opencode.ai/zen/go/v1",
+                api_key="",
+                api_mode="chat_completions",
+            )
+
+            fake_client = MagicMock()
+            fake_client.base_url = "https://opencode.ai/zen/go/v1"
+            with patch.object(
+                mod, "_try_configured_fallback_chain",
+                return_value=(fake_client, "kimi-k2.6", "configured_chain[0]"),
+            ) as mock_configured, patch.object(
+                mod, "_try_main_fallback_chain",
+            ) as mock_main:
+                with patch.object(mod, "_is_provider_unhealthy", return_value=False):
+                    client, resolved = mod.resolve_provider_client(
+                        "auto", None, task="title_generation"  # type: ignore[arg-type]
+                    )
+
+            assert client is fake_client, "configured chain returned a different client"
+            assert resolved == "kimi-k2.6", (
+                f"configured-chain path returned {resolved!r}; expected 'kimi-k2.6'. "
+                "The configured-fallback chain's model must win the same way the "
+                "main-fallback chain's model does."
+            )
+            assert not mock_main.called, (
+                "configured-fallback chain should have short-circuited the main "
+                "fallback chain — if main was called, the configured path was bypassed"
+            )
+        finally:
+            mod.clear_runtime_main()


### PR DESCRIPTION
## Summary

Auxiliary tasks silently fail for users whose main chat provider is OAuth-gated (e.g. `minimax-oauth`) when the auto-detection chain successfully resolves a fallback provider via the user's `fallback_providers` config. The auxiliary call goes out with the user's main chat model name (e.g. `MiniMax-M3`) instead of the fallback chain's correctly-resolved model, and the fallback endpoint returns HTTP 401 because it doesn't serve that model name.

The bug fires every turn for `title_generation` (the only auxiliary task that auto-fires), and silently for 13 others (`vision`, `web_extract`, `mcp`, `skills_hub`, `session_search`, `curator`, `monitor`, `goal_judge`, etc.) when exercised.

## Root cause

`resolve_provider_client()` pre-clobbers `model` with `_read_main_model()` at lines 3626-3627 when the caller passes an empty `model` and the provider has no catalog default. Then the auto branch at line 3692 returns `final_model = model or resolved`. The chain's resolved model is the fallback's correct choice; the pre-clobbered `model` is the user's main chat model name. Both are truthy strings, so `model or resolved` picks `model` — the wrong one.

The auto chain already validated `resolved` against the provider's accepted-model list. The pre-clobbered `model` was never validated against anything; it's just `_read_main_model()` pulled in by the universal fallback chain.

## Fix

One line at line 3692 of `agent/auxiliary_client.py`:

```diff
-        final_model = model or resolved
+        final_model = resolved or model
```

The chain's `resolved` model now wins whenever the chain returned a real provider+model. Callers who pass an explicit non-None `model` go through OTHER provider branches (openrouter/nous/codex/etc.), not the auto branch, so this swap only affects the buggy path.

## Regression tests

`tests/agent/test_auxiliary_model_clobber_oauth_fallback.py` contains two tests, both reproducing the user's exact config:

```yaml
model:
  default: MiniMax-M3
  provider: minimax-oauth
  base_url: https://opencode.ai/zen/go/v1
fallback_providers:
  - model: deepseek-v4-flash
    provider: opencode-go
```

1. **`test_auto_chain_resolved_model_wins_over_main_model_clobber`** — patches `_try_main_fallback_chain` (global `fallback_providers` path) to return `(fake_client, 'deepseek-v4-flash', label)`, asserts the auto path returns that model.
2. **`test_configured_fallback_chain_also_preserves_resolved_model`** — patches `_try_configured_fallback_chain` (per-task `auxiliary.<task>.fallback_chain` path) and asserts the same precedence rule. Catches a future refactor that splits the two fallback paths.

Both tests **FAIL on pre-fix code** with `AssertionError: resolved model was 'MiniMax-M3' — expected 'deepseek-v4-flash'`, **PASS with the fix**.

## Audit (post-fix)

Empirically verified under the audit:

| Scenario | Pre-fix | Post-fix |
| --- | --- | --- |
| `resolve_provider_client('auto', None)` with minimax-oauth main + opencode-go fallback | `MiniMax-M3` (clobber) — HTTP 401 | `deepseek-v4-flash` (chain) — HTTP 200 |
| `resolve_provider_client('auto', 'kimi-k2.6')` (caller passes explicit model) | `kimi-k2.6` | `kimi-k2.6` (no change) |
| `resolve_provider_client('auto', 'anthropic/claude-sonnet-4')` (slash-format caller) | `anthropic/claude-sonnet-4` | `anthropic/claude-sonnet-4` (no change) |
| Caller model != resolved (chain overrides caller) | Caller wins (wrong) | Resolved wins (correct) |
| Cache: 2nd call with same args | Hits cache, correct model | Hits cache, correct model |
| Cache: 2nd call after main runtime changes | Old entry preserved | New entry created, both valid |

Pre-existing tests at `tests/agent/test_auxiliary_client.py:573-627` (OAuth-gated main-model fallback for xai-oauth/openai-codex) and `tests/agent/test_set_runtime_main_custom_provider.py:180` continue to pass. The fix does NOT regress the #47235 behavior.

## Out of scope (separate bug class)

A related bug exists for direct OAuth-gated provider calls (e.g. `auxiliary.flush_memories.provider = openai-codex, model = ''` with the user's main chat being a MiniMax model — Codex returns 400 "The 'MiniMax-M3' model is not supported when using Codex with a ChatGPT account"). The fix for that would regress the behavior pinned in `test_auxiliary_client.py:573-627` (universal main-model fallback for OAuth-gated providers, #47235). Two failure modes, two scope-limited fixes; this PR covers the auto-chain clobber only.

## Related

- Test extends the partial coverage at `tests/agent/test_set_runtime_main_custom_provider.py:180` (which passes today because `model == resolved` by accident in its scenario).
- The `auxiliary_client.py:3626-3627` pre-clobber has documented intent at lines 3611-3614 that this PR does NOT change; doing so would break #47235's pinned behavior.

## Reproduction (operator report, 2026-06-24)

```
WARNING agent.title_generator: Title generation failed: Error code: 401 -
{'type': 'error', 'error': {'type': 'ModelError', 'message': 'Model MiniMax-M3 is not supported'}}
WARNING agent.auxiliary_client: resolve_provider_client: unhandled auth_type oauth_minimax for minimax-oauth
INFO agent.auxiliary_client: Auxiliary call: main provider unavailable on minimax-oauth —
     main fallback chain to fallback_providers[0](opencode-go) (deepseek-v4-flash)
INFO agent.auxiliary_client: Auxiliary title_generation: using auto (MiniMax-M3) at
     https://opencode.ai/zen/go/v1/
```

The `(MiniMax-M3)` in the last log line is the bug — the chain picked `deepseek-v4-flash` but the resolver discarded it.

## Test plan

```
cd /home/openclaw/apps/hermes-agent
pytest tests/agent/test_auxiliary_model_clobber_oauth_fallback.py -v
```