### PR TITLE
fix(memory): gate auto-injection prompt on auto_recall in Hindsight system_prompt_block

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1442,11 +1442,17 @@ class HindsightMemoryProvider(MemoryProvider):
             t.start()
 
     def system_prompt_block(self) -> str:
+        auto_inject = self._auto_recall and self._memory_mode != "tools"
         if self._memory_mode == "context":
+            inject_msg = (
+                "Relevant memories are automatically injected into context."
+                if auto_inject
+                else "Auto-injection is disabled. Use hindsight_recall to search."
+            )
             return (
                 f"# Hindsight Memory\n"
                 f"Active (context mode). Bank: {self._bank_id}, budget: {self._budget}.\n"
-                f"Relevant memories are automatically injected into context."
+                f"{inject_msg}"
             )
         if self._memory_mode == "tools":
             return (
@@ -1455,10 +1461,15 @@ class HindsightMemoryProvider(MemoryProvider):
                 f"Use hindsight_recall to search, hindsight_reflect for synthesis, "
                 f"hindsight_retain to store facts."
             )
+        inject_msg = (
+            "Relevant memories are automatically injected into context. "
+            if auto_inject
+            else "Auto-injection is disabled. "
+        )
         return (
             f"# Hindsight Memory\n"
             f"Active. Bank: {self._bank_id}, budget: {self._budget}.\n"
-            f"Relevant memories are automatically injected into context. "
+            f"{inject_msg}"
             f"Use hindsight_recall to search, hindsight_reflect for synthesis, "
             f"hindsight_retain to store facts."
         )

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1460,6 +1460,34 @@ class TestSystemPrompt:
         assert "tools mode" in block
         assert "hindsight_recall" in block
 
+    def test_context_mode_auto_recall_disabled(self, provider_with_config):
+        p = provider_with_config(memory_mode="context", auto_recall=False)
+        block = p.system_prompt_block()
+        assert "context mode" in block
+        assert "automatically injected" not in block
+        assert "Auto-injection is disabled" in block
+        assert "hindsight_recall" in block
+
+    def test_hybrid_mode_auto_recall_disabled(self, provider_with_config):
+        p = provider_with_config(memory_mode="hybrid", auto_recall=False)
+        block = p.system_prompt_block()
+        assert "automatically injected" not in block
+        assert "Auto-injection is disabled" in block
+        assert "hindsight_recall" in block
+
+    def test_context_mode_auto_recall_enabled(self, provider_with_config):
+        p = provider_with_config(memory_mode="context", auto_recall=True)
+        block = p.system_prompt_block()
+        assert "automatically injected" in block
+        assert "hindsight_recall" not in block
+
+    def test_tools_mode_ignores_auto_recall(self, provider_with_config):
+        """tools mode never claims auto-injection regardless of auto_recall."""
+        p = provider_with_config(memory_mode="tools", auto_recall=True)
+        block = p.system_prompt_block()
+        assert "automatically injected" not in block
+        assert "hindsight_recall" in block
+
 
 # ---------------------------------------------------------------------------
 # Config schema tests


### PR DESCRIPTION
## What does this PR do?

Gates the "automatically injected" prompt line in `HindsightProvider.system_prompt_block()` on `auto_recall=True` and `memory_mode != "tools"`. When auto-injection is disabled, the prompt now correctly tells the model to use `hindsight_recall` instead of claiming memories are auto-injected.

## Related Issue

Fixes #52153

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/hindsight/__init__.py`: Gate "automatically injected" message on `self._auto_recall and self._memory_mode != "tools"`. In context mode with auto_recall disabled, show "Auto-injection is disabled. Use hindsight_recall to search." In hybrid mode with auto_recall disabled, replace "automatically injected" with "Auto-injection is disabled."
- `tests/plugins/memory/test_hindsight_provider.py`: Add 4 tests covering auto_recall=False in context/hybrid modes, auto_recall=True in context mode, and tools mode ignoring auto_recall.

## How to Test

1. Configure Hindsight with `"auto_recall": false` in `~/.hermes/hindsight/config.json`
2. Start a Hermes session and inspect the system prompt
3. Verify it says "Auto-injection is disabled" instead of "automatically injected"
4. Run `python -m pytest tests/plugins/memory/test_hindsight_provider.py::TestSystemPrompt -q` — all 7 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/plugins/memory/test_hindsight_provider.py -q` and all 120 tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `HindsightProvider.system_prompt_block()` (3 return branches, 2 new conditional paths)
- Blast radius: LOW — only affects system prompt text, no behavioral change
- Related patterns: `queue_prefetch()` already gates on `self._auto_recall` (line 1488); this fix aligns the prompt with the actual prefetch behavior
