### PR TITLE
test(mcp-oauth-manager): cover handle_401 dedup, disk-watch edges, and async_auth_flow bridge for 75% coverage

### DIFF
--- a/tests/tools/test_mcp_oauth_manager.py
+++ b/tests/tools/test_mcp_oauth_manager.py
@@ -4,10 +4,11 @@ The manager consolidates the eight scattered MCP-OAuth call sites into a
 single object with disk-mtime watch, dedup'd 401 handling, and a provider
 cache. See `tools/mcp_oauth_manager.py` for design rationale.
 """
+
 import json
 import os
 import time
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -26,6 +27,7 @@ def _set_interactive_stdin(monkeypatch, *, is_tty: bool = True) -> None:
 def test_manager_is_singleton():
     """get_manager() returns the same instance across calls."""
     from tools.mcp_oauth_manager import get_manager, reset_manager_for_tests
+
     reset_manager_for_tests()
     m1 = get_manager()
     m2 = get_manager()
@@ -65,10 +67,12 @@ def test_manager_remove_evicts_cache(tmp_path, monkeypatch):
     # Pre-seed tokens on disk
     token_dir = tmp_path / "mcp-tokens"
     token_dir.mkdir(parents=True)
-    (token_dir / "srv.json").write_text(json.dumps({
-        "access_token": "TOK",
-        "token_type": "Bearer",
-    }))
+    (token_dir / "srv.json").write_text(
+        json.dumps({
+            "access_token": "TOK",
+            "token_type": "Bearer",
+        })
+    )
 
     mgr = MCPOAuthManager()
     p1 = mgr.get_or_build_provider("srv", "https://example.com/mcp", None)
@@ -107,10 +111,12 @@ async def test_disk_watch_invalidates_on_mtime_change(tmp_path, monkeypatch):
     token_dir = tmp_path / "mcp-tokens"
     token_dir.mkdir(parents=True)
     tokens_file = token_dir / "srv.json"
-    tokens_file.write_text(json.dumps({
-        "access_token": "OLD",
-        "token_type": "Bearer",
-    }))
+    tokens_file.write_text(
+        json.dumps({
+            "access_token": "OLD",
+            "token_type": "Bearer",
+        })
+    )
 
     mgr = MCPOAuthManager()
     provider = mgr.get_or_build_provider("srv", "https://example.com/mcp", None)
@@ -137,8 +143,11 @@ async def test_disk_watch_invalidates_on_mtime_change(tmp_path, monkeypatch):
 def test_manager_builds_hermes_provider_subclass(tmp_path, monkeypatch):
     """get_or_build_provider returns HermesMCPOAuthProvider, not plain OAuthClientProvider."""
     from tools.mcp_oauth_manager import (
-        MCPOAuthManager, _HERMES_PROVIDER_CLS, reset_manager_for_tests,
+        MCPOAuthManager,
+        _HERMES_PROVIDER_CLS,
+        reset_manager_for_tests,
     )
+
     reset_manager_for_tests()
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     _set_interactive_stdin(monkeypatch)
@@ -357,3 +366,617 @@ def test_bridge_forwards_requests_and_poisons_on_token_endpoint_400(
     assert not (d / "srv.client.json").exists()
     assert provider._initialized is False
     assert provider.context.client_info is None
+
+
+# invalidate_if_disk_changed — edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalidate_returns_false_for_unknown_server(tmp_path, monkeypatch):
+    """No entry for the server → returns False."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    mgr = MCPOAuthManager()
+    result = await mgr.invalidate_if_disk_changed("nonexistent")
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_invalidate_returns_false_when_provider_is_none(tmp_path, monkeypatch):
+    """Entry exists but provider is None (build failed) → returns False."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch, is_tty=False)
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    mgr = MCPOAuthManager()
+    # Trigger a failed build (non-interactive, no cached tokens)
+    with pytest.raises(Exception):
+        mgr.get_or_build_provider("srv", "https://example.com/mcp", None)
+    # Entry exists but provider is None
+    assert mgr._entries["srv"].provider is None
+    result = await mgr.invalidate_if_disk_changed("srv")
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_invalidate_returns_false_on_file_not_found(tmp_path, monkeypatch):
+    """Tokens file deleted from disk → returns False (no crash)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    token_dir = tmp_path / "mcp-tokens"
+    token_dir.mkdir(parents=True)
+    (token_dir / "srv.json").write_text(
+        json.dumps({
+            "access_token": "TOK",
+            "token_type": "Bearer",
+        })
+    )
+
+    mgr = MCPOAuthManager()
+    mgr.get_or_build_provider("srv", "https://example.com/mcp", None)
+
+    # Delete the tokens file
+    (token_dir / "srv.json").unlink()
+
+    result = await mgr.invalidate_if_disk_changed("srv")
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# handle_401 — thundering-herd deduplication
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_401_returns_false_for_unknown_server(tmp_path, monkeypatch):
+    """No entry for the server → returns False."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    mgr = MCPOAuthManager()
+    result = await mgr.handle_401("nonexistent")
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_handle_401_returns_false_when_provider_is_none(tmp_path, monkeypatch):
+    """Entry exists but provider is None → returns False."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch, is_tty=False)
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    mgr = MCPOAuthManager()
+    with pytest.raises(Exception):
+        mgr.get_or_build_provider("srv", "https://example.com/mcp", None)
+    result = await mgr.handle_401("srv")
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_handle_401_disk_changed_returns_true(tmp_path, monkeypatch):
+    """When disk changed (external refresh), handle_401 returns True."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    token_dir = tmp_path / "mcp-tokens"
+    token_dir.mkdir(parents=True)
+    tokens_file = token_dir / "srv.json"
+    tokens_file.write_text(
+        json.dumps({
+            "access_token": "OLD",
+            "token_type": "Bearer",
+        })
+    )
+
+    mgr = MCPOAuthManager()
+    mgr.get_or_build_provider("srv", "https://example.com/mcp", None)
+
+    # First invalidate records the mtime
+    await mgr.invalidate_if_disk_changed("srv")
+
+    # Touch the file to simulate external refresh
+    future_mtime = time.time() + 10
+    os.utime(tokens_file, (future_mtime, future_mtime))
+
+    result = await mgr.handle_401("srv", failed_access_token="OLD")
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_handle_401_no_disk_change_checks_can_refresh(tmp_path, monkeypatch):
+    """No disk change → falls back to provider.context.can_refresh_token()."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    token_dir = tmp_path / "mcp-tokens"
+    token_dir.mkdir(parents=True)
+    (token_dir / "srv.json").write_text(
+        json.dumps({
+            "access_token": "TOK",
+            "token_type": "Bearer",
+        })
+    )
+
+    mgr = MCPOAuthManager()
+    provider = mgr.get_or_build_provider("srv", "https://example.com/mcp", None)
+    assert provider is not None
+
+    # Record mtime so disk won't appear changed
+    await mgr.invalidate_if_disk_changed("srv")
+
+    # Mock can_refresh_token on the provider's context
+    ctx = MagicMock()
+    ctx.can_refresh_token = MagicMock(return_value=True)
+    provider.context = ctx
+
+    result = await mgr.handle_401("srv", failed_access_token="TOK")
+    assert result is True
+    ctx.can_refresh_token.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_401_can_refresh_false_returns_false(tmp_path, monkeypatch):
+    """No disk change + can_refresh_token()=False → returns False."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    token_dir = tmp_path / "mcp-tokens"
+    token_dir.mkdir(parents=True)
+    (token_dir / "srv.json").write_text(
+        json.dumps({
+            "access_token": "TOK",
+            "token_type": "Bearer",
+        })
+    )
+
+    mgr = MCPOAuthManager()
+    provider = mgr.get_or_build_provider("srv", "https://example.com/mcp", None)
+    assert provider is not None
+    await mgr.invalidate_if_disk_changed("srv")
+
+    ctx = MagicMock()
+    ctx.can_refresh_token = MagicMock(return_value=False)
+    provider.context = ctx
+
+    result = await mgr.handle_401("srv", failed_access_token="TOK")
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_handle_401_no_context_returns_false(tmp_path, monkeypatch):
+    """No context on provider → can_refresh defaults to False → returns False."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    token_dir = tmp_path / "mcp-tokens"
+    token_dir.mkdir(parents=True)
+    (token_dir / "srv.json").write_text(
+        json.dumps({
+            "access_token": "TOK",
+            "token_type": "Bearer",
+        })
+    )
+
+    mgr = MCPOAuthManager()
+    provider = mgr.get_or_build_provider("srv", "https://example.com/mcp", None)
+    assert provider is not None
+    await mgr.invalidate_if_disk_changed("srv")
+
+    # Remove context attribute
+    provider.context = None
+
+    result = await mgr.handle_401("srv", failed_access_token="TOK")
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_handle_401_can_refresh_raises_returns_false(tmp_path, monkeypatch):
+    """can_refresh_token() raises → caught, can_refresh stays False."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    token_dir = tmp_path / "mcp-tokens"
+    token_dir.mkdir(parents=True)
+    (token_dir / "srv.json").write_text(
+        json.dumps({
+            "access_token": "TOK",
+            "token_type": "Bearer",
+        })
+    )
+
+    mgr = MCPOAuthManager()
+    provider = mgr.get_or_build_provider("srv", "https://example.com/mcp", None)
+    assert provider is not None
+    await mgr.invalidate_if_disk_changed("srv")
+
+    ctx = MagicMock()
+    ctx.can_refresh_token = MagicMock(side_effect=RuntimeError("boom"))
+    provider.context = ctx
+
+    result = await mgr.handle_401("srv", failed_access_token="TOK")
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_handle_401_deduplicates_concurrent_calls(tmp_path, monkeypatch):
+    """Two concurrent handle_401 with same token → only one recovery attempt."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    token_dir = tmp_path / "mcp-tokens"
+    token_dir.mkdir(parents=True)
+    (token_dir / "srv.json").write_text(
+        json.dumps({
+            "access_token": "TOK",
+            "token_type": "Bearer",
+        })
+    )
+
+    mgr = MCPOAuthManager()
+    provider = mgr.get_or_build_provider("srv", "https://example.com/mcp", None)
+    assert provider is not None
+    await mgr.invalidate_if_disk_changed("srv")
+
+    ctx = MagicMock()
+    ctx.can_refresh_token = MagicMock(return_value=True)
+    provider.context = ctx
+
+    # Launch two concurrent handle_401 calls with the same failed token
+    import asyncio
+
+    results = await asyncio.gather(
+        mgr.handle_401("srv", failed_access_token="TOK"),
+        mgr.handle_401("srv", failed_access_token="TOK"),
+    )
+    # Both should return True (same future)
+    assert all(r is True for r in results)
+    # can_refresh_token should only be called once (dedup'd)
+    assert ctx.can_refresh_token.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_handle_401_default_key_when_no_token(tmp_path, monkeypatch):
+    """failed_access_token=None → uses '<unknown>' as dedup key."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    token_dir = tmp_path / "mcp-tokens"
+    token_dir.mkdir(parents=True)
+    (token_dir / "srv.json").write_text(
+        json.dumps({
+            "access_token": "TOK",
+            "token_type": "Bearer",
+        })
+    )
+
+    mgr = MCPOAuthManager()
+    provider = mgr.get_or_build_provider("srv", "https://example.com/mcp", None)
+    assert provider is not None
+    await mgr.invalidate_if_disk_changed("srv")
+
+    ctx = MagicMock()
+    ctx.can_refresh_token = MagicMock(return_value=False)
+    provider.context = ctx
+
+    result = await mgr.handle_401("srv")  # no failed_access_token
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# _build_provider — SDK unavailable paths
+# ---------------------------------------------------------------------------
+
+
+def test_build_provider_returns_none_when_cls_is_none(tmp_path, monkeypatch):
+    """When _HERMES_PROVIDER_CLS is None (SDK missing), returns None."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools.mcp_oauth_manager import MCPOAuthManager
+    import tools.mcp_oauth_manager as mod
+
+    mgr = MCPOAuthManager()
+    entry = mod._ProviderEntry(server_url="https://example.com/mcp", oauth_config=None)
+
+    with patch.object(mod, "_HERMES_PROVIDER_CLS", None):
+        result = mgr._build_provider("srv", entry)
+    assert result is None
+
+
+def test_build_provider_returns_none_when_oauth_not_available(tmp_path, monkeypatch):
+    """When _OAUTH_AVAILABLE is False, returns None."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+    from tools.mcp_oauth_manager import MCPOAuthManager
+    import tools.mcp_oauth_manager as mod
+    import tools.mcp_oauth as oauth_mod
+
+    mgr = MCPOAuthManager()
+    entry = mod._ProviderEntry(server_url="https://example.com/mcp", oauth_config=None)
+
+    with patch.object(oauth_mod, "_OAUTH_AVAILABLE", False):
+        result = mgr._build_provider("srv", entry)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# remove — edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_remove_unknown_server_is_noop(tmp_path, monkeypatch):
+    """remove() on a server that was never registered → no crash."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    mgr = MCPOAuthManager()
+    mgr.remove("never-registered")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# _persist_oauth_metadata_if_changed
+# ---------------------------------------------------------------------------
+
+
+def test_persist_metadata_no_metadata_is_noop(tmp_path, monkeypatch):
+    """When oauth_metadata is None, _persist is a no-op."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    token_dir = tmp_path / "mcp-tokens"
+    token_dir.mkdir(parents=True)
+    (token_dir / "srv.json").write_text(
+        json.dumps({
+            "access_token": "TOK",
+            "token_type": "Bearer",
+        })
+    )
+
+    mgr = MCPOAuthManager()
+    provider = mgr.get_or_build_provider("srv", "https://example.com/mcp", None)
+    assert provider is not None
+
+    # Set context.oauth_metadata to None
+    ctx = MagicMock()
+    ctx.oauth_metadata = None
+    provider.context = ctx
+
+    # Must not raise
+    provider._persist_oauth_metadata_if_changed()
+
+
+def test_persist_metadata_non_hermes_storage_is_noop(tmp_path, monkeypatch):
+    """When storage is not HermesTokenStorage, _persist is a no-op."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    token_dir = tmp_path / "mcp-tokens"
+    token_dir.mkdir(parents=True)
+    (token_dir / "srv.json").write_text(
+        json.dumps({
+            "access_token": "TOK",
+            "token_type": "Bearer",
+        })
+    )
+
+    mgr = MCPOAuthManager()
+    provider = mgr.get_or_build_provider("srv", "https://example.com/mcp", None)
+    assert provider is not None
+
+    # Set context with metadata but non-HermesTokenStorage
+    ctx = MagicMock()
+    ctx.oauth_metadata = MagicMock(token_endpoint="https://as.example.com/token")
+    ctx.storage = MagicMock()  # not HermesTokenStorage
+    provider.context = ctx
+
+    # Must not raise — isinstance check fails, so no save attempted
+    provider._persist_oauth_metadata_if_changed()
+
+
+def test_persist_metadata_saves_when_token_endpoint_differs(tmp_path, monkeypatch):
+    """When token_endpoint differs from existing, metadata is saved."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+    from tools.mcp_oauth_manager import MCPOAuthManager
+    from tools.mcp_oauth import HermesTokenStorage
+
+    token_dir = tmp_path / "mcp-tokens"
+    token_dir.mkdir(parents=True)
+    (token_dir / "srv.json").write_text(
+        json.dumps({
+            "access_token": "TOK",
+            "token_type": "Bearer",
+        })
+    )
+
+    mgr = MCPOAuthManager()
+    provider = mgr.get_or_build_provider("srv", "https://example.com/mcp", None)
+    assert provider is not None
+
+    storage = HermesTokenStorage("srv")
+    meta = MagicMock(token_endpoint="https://as.example.com/token")
+    ctx = MagicMock()
+    ctx.oauth_metadata = meta
+    ctx.storage = storage
+    provider.context = ctx
+
+    # load_oauth_metadata returns None (no existing) → should save
+    with patch.object(storage, "load_oauth_metadata", return_value=None):
+        with patch.object(storage, "save_oauth_metadata") as save_mock:
+            provider._persist_oauth_metadata_if_changed()
+            save_mock.assert_called_once_with(meta)
+
+
+def test_persist_metadata_skips_when_token_endpoint_same(tmp_path, monkeypatch):
+    """When token_endpoint matches existing, no save."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+    from tools.mcp_oauth_manager import MCPOAuthManager
+    from tools.mcp_oauth import HermesTokenStorage
+
+    token_dir = tmp_path / "mcp-tokens"
+    token_dir.mkdir(parents=True)
+    (token_dir / "srv.json").write_text(
+        json.dumps({
+            "access_token": "TOK",
+            "token_type": "Bearer",
+        })
+    )
+
+    mgr = MCPOAuthManager()
+    provider = mgr.get_or_build_provider("srv", "https://example.com/mcp", None)
+    assert provider is not None
+
+    storage = HermesTokenStorage("srv")
+    meta = MagicMock(token_endpoint="https://as.example.com/token")
+    existing = MagicMock(token_endpoint="https://as.example.com/token")
+    ctx = MagicMock()
+    ctx.oauth_metadata = meta
+    ctx.storage = storage
+    provider.context = ctx
+
+    with patch.object(storage, "load_oauth_metadata", return_value=existing):
+        with patch.object(storage, "save_oauth_metadata") as save_mock:
+            provider._persist_oauth_metadata_if_changed()
+            save_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# async_auth_flow — bidirectional generator bridge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_auth_flow_bridges_bidirectional_generator(tmp_path, monkeypatch):
+    """async_auth_flow forwards .asend() values into the inner generator."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+    from tools.mcp_oauth_manager import (
+        MCPOAuthManager,
+        get_manager,
+        reset_manager_for_tests,
+    )
+
+    reset_manager_for_tests()
+
+    token_dir = tmp_path / "mcp-tokens"
+    token_dir.mkdir(parents=True)
+    (token_dir / "srv.json").write_text(
+        json.dumps({
+            "access_token": "TOK",
+            "token_type": "Bearer",
+        })
+    )
+
+    mgr = get_manager()
+    provider = mgr.get_or_build_provider("srv", "https://example.com/mcp", None)
+    assert provider is not None
+
+    # Mock super().async_auth_flow to return a simple bidirectional generator
+    # that yields a request and expects a response via .asend()
+    sent_responses = []
+
+    async def fake_super_flow(self, request):
+        response = yield "REQUEST_1"
+        sent_responses.append(response)
+        yield "REQUEST_2"
+        # StopAsyncIteration ends the flow
+
+    # Patch OAuthClientProvider.async_auth_flow (the base class method)
+    from mcp.client.auth.oauth2 import OAuthClientProvider
+
+    with patch.object(OAuthClientProvider, "async_auth_flow", fake_super_flow):
+        # Set context to None so _persist_oauth_metadata_if_changed is a no-op
+        provider.context = MagicMock()
+        provider.context.oauth_metadata = None
+
+        gen = provider.async_auth_flow("fake-request")
+
+        # First yield: get the outgoing request
+        outgoing1 = await gen.__anext__()
+        assert outgoing1 == "REQUEST_1"
+
+        # Send a response back via .asend()
+        outgoing2 = await gen.asend("RESPONSE_1")
+        assert outgoing2 == "REQUEST_2"
+
+        # End the flow (StopAsyncIteration)
+        try:
+            await gen.__anext__()
+            assert False, "should have raised StopAsyncIteration"
+        except StopAsyncIteration:
+            pass
+
+    assert sent_responses == ["RESPONSE_1"]
+    reset_manager_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_async_auth_flow_persists_metadata_on_completion(tmp_path, monkeypatch):
+    """async_auth_flow calls _persist_oauth_metadata_if_changed on StopAsyncIteration."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+    from tools.mcp_oauth_manager import (
+        MCPOAuthManager,
+        get_manager,
+        reset_manager_for_tests,
+    )
+
+    reset_manager_for_tests()
+
+    token_dir = tmp_path / "mcp-tokens"
+    token_dir.mkdir(parents=True)
+    (token_dir / "srv.json").write_text(
+        json.dumps({
+            "access_token": "TOK",
+            "token_type": "Bearer",
+        })
+    )
+
+    mgr = get_manager()
+    provider = mgr.get_or_build_provider("srv", "https://example.com/mcp", None)
+    assert provider is not None
+
+    # Mock super().async_auth_flow to immediately stop (empty generator)
+    async def empty_flow(self, request):
+        return
+        yield  # make it an async generator
+
+    from mcp.client.auth.oauth2 import OAuthClientProvider
+
+    # Set up context with metadata so _persist is called
+    from tools.mcp_oauth import HermesTokenStorage
+
+    storage = HermesTokenStorage("srv")
+    meta = MagicMock(token_endpoint="https://as.example.com/token")
+    ctx = MagicMock()
+    ctx.oauth_metadata = meta
+    ctx.storage = storage
+    provider.context = ctx
+
+    persist_called = []
+    with patch.object(OAuthClientProvider, "async_auth_flow", empty_flow):
+        with patch.object(
+            provider,
+            "_persist_oauth_metadata_if_changed",
+            lambda: persist_called.append(True),
+        ):
+            gen = provider.async_auth_flow("fake-request")
+            try:
+                await gen.__anext__()
+            except StopAsyncIteration:
+                pass
+
+    assert persist_called == [True]
+    reset_manager_for_tests()


### PR DESCRIPTION
## What does this PR do?

Adds comprehensive unit tests for the MCP OAuth manager (`tools/mcp_oauth_manager.py`), bringing module coverage from 45% to 75%. The existing `tests/tools/test_mcp_oauth_manager.py` covered the basic provider caching, URL-change rebuild, disk-watch happy path, and non-interactive fail-fast — but the entire `handle_401` thundering-herd deduplication path, `_persist_oauth_metadata_if_changed`, `async_auth_flow` bidirectional generator bridge, and several edge cases had zero coverage.

## Related Issue

Fixes #36568

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- **Extended file:** `tests/tools/test_mcp_oauth_manager.py` (+634 lines, 21 new tests)

### New test groups:

- **`invalidate_if_disk_changed` edge cases** (3 tests) — unknown server returns False, provider-is-None returns False, file-not-found returns False (no crash)
- **`handle_401` thundering-herd deduplication** (9 tests) — unknown server returns False, provider-is-None returns False, disk-changed returns True, no-disk-change checks `can_refresh_token()`, can_refresh=False returns False, no-context returns False, can_refresh raises returns False, concurrent calls deduplicated (single recovery attempt), default key when no failed token
- **`_build_provider` SDK-unavailable paths** (2 tests) — `_HERMES_PROVIDER_CLS is None` returns None, `_OAUTH_AVAILABLE is False` returns None
- **`remove` edge case** (1 test) — remove on never-registered server is a no-op
- **`_persist_oauth_metadata_if_changed`** (4 tests) — no metadata is no-op, non-HermesTokenStorage is no-op, saves when token_endpoint differs, skips when token_endpoint matches
- **`async_auth_flow` bidirectional generator bridge** (2 tests) — forwards `.asend()` values into inner generator (preserving bidirectional contract), persists metadata on StopAsyncIteration

## How to Test

```bash
# Run the test suite
uv run pytest tests/tools/test_mcp_oauth_manager.py -v

# Verify coverage
uv run --with pytest-cov pytest tests/tools/test_mcp_oauth_manager.py \
  --cov=tools.mcp_oauth_manager --cov-report=term-missing
# Expected: 75% coverage (49 missing — _initialize + _prefetch_oauth_metadata
# deeply tied to MCP SDK internals, not unit-testable without full SDK mock)
```

## Checklist

- [x] Tests pass locally (`29/29 passed`)
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `ty check` no-regression (1=1, pre-existing `_hermes_server_name` on Optional[Any])
- [x] `uv lock --check` passes
- [x] No competing PR (dedupe verified: `gh search prs --state open "36568"` → empty)
- [x] Test-only change — no source modifications
- [x] All network/SDK interactions mocked — runs on any host with MCP SDK installed
