### PR TITLE
fix(gateway): resolve rich-sent index path via canonical get_hermes_home

### DIFF
--- a/gateway/rich_sent_store.py
+++ b/gateway/rich_sent_store.py
@@ -20,13 +20,17 @@ import os
 import time
 from typing import Optional
 
+from hermes_constants import get_hermes_home
+
 _MAX_ENTRIES = 1000
 _MAX_TEXT_CHARS = 2000
 
 
 def _store_path() -> str:
-    home = os.environ.get("HERMES_HOME") or os.path.expanduser("~/.hermes")
-    return os.path.join(home, "state", "rich_sent_index.json")
+    # Route through the canonical resolver so the index follows the active
+    # profile (context-local override) and lands in the platform-native home
+    # (``%LOCALAPPDATA%\hermes`` on Windows), not a hand-rolled ``~/.hermes``.
+    return str(get_hermes_home() / "state" / "rich_sent_index.json")
 
 
 def _key(chat_id, message_id) -> str:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1686,6 +1686,7 @@ AUTHOR_MAP = {
     "qs2816661685@gmail.com": "qingshan89",  # PR #46895 co-author (desktop remote artifact download)
     "yspdev@gmail.com": "AJ",  # PR #44510 co-author (desktop named-profile boot loop)
     "steveonjava@gmail.com": "steveonjava",  # PR #29669 (redact secrets in kanban tool payloads)
+    "drexux0@gmail.com": "Drexuxux",  # rich_sent_store canonical HERMES_HOME resolution fix
 }
 
 

--- a/tests/gateway/test_rich_sent_store.py
+++ b/tests/gateway/test_rich_sent_store.py
@@ -1,0 +1,67 @@
+"""Tests for the Telegram rich-reply index store (``gateway.rich_sent_store``).
+
+The store must resolve its on-disk path through the canonical
+``get_hermes_home()`` so the index follows the active profile and lands in the
+platform-native Hermes home — not a hand-rolled ``os.environ`` read that
+ignores the context-local override and hardcodes ``~/.hermes`` on Windows.
+"""
+
+from hermes_constants import (
+    get_hermes_home,
+    reset_hermes_home_override,
+    set_hermes_home_override,
+)
+
+from gateway import rich_sent_store
+
+
+def _expected(home) -> str:
+    return str(home / "state" / "rich_sent_index.json")
+
+
+def test_store_path_tracks_canonical_home_from_env(monkeypatch, tmp_path):
+    """With HERMES_HOME set, the store path matches the canonical resolver."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    assert rich_sent_store._store_path() == _expected(get_hermes_home())
+
+
+def test_store_path_uses_canonical_home_when_env_unset(monkeypatch):
+    """No HERMES_HOME: the store must still defer to the platform-native home
+    (``%LOCALAPPDATA%\\hermes`` on Windows), not a hardcoded ``~/.hermes``."""
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    assert rich_sent_store._store_path() == _expected(get_hermes_home())
+
+
+def test_store_path_honors_context_override(monkeypatch, tmp_path):
+    """A context-local profile override must redirect the index path.
+
+    ``set_hermes_home_override`` scopes the home per task WITHOUT touching
+    ``os.environ`` (env is shared across threads). The old hand-rolled
+    ``os.environ.get("HERMES_HOME")`` read could never see this, so it wrote
+    the index into the wrong profile. This is the cross-platform regression
+    guard for that bug.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "env_home"))
+    override_home = tmp_path / "profile_home"
+    token = set_hermes_home_override(override_home)
+    try:
+        assert rich_sent_store._store_path() == _expected(override_home)
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_record_and_lookup_roundtrip_under_override(monkeypatch, tmp_path):
+    """record() then lookup() round-trips, and the file lands under the
+    override home — not the env home."""
+    env_home = tmp_path / "env_home"
+    override_home = tmp_path / "profile_home"
+    monkeypatch.setenv("HERMES_HOME", str(env_home))
+    token = set_hermes_home_override(override_home)
+    try:
+        rich_sent_store.record("12345", "678", "Your morning briefing.")
+        assert rich_sent_store.lookup("12345", "678") == "Your morning briefing."
+        # The index landed in the active profile, not the stale env home.
+        assert (override_home / "state" / "rich_sent_index.json").exists()
+        assert not (env_home / "state" / "rich_sent_index.json").exists()
+    finally:
+        reset_hermes_home_override(token)


### PR DESCRIPTION
## What does this PR do?

`gateway/rich_sent_store.py` computed its store path by hand instead of the
canonical `get_hermes_home()`. That ignored the context-local profile override
(`set_hermes_home_override`, which intentionally does not touch `os.environ`)
and the platform-native home, so the Telegram rich-reply index was written to
and read from the wrong location — breaking reply-context recovery under
non-default profiles. `_store_path()` now routes through `get_hermes_home()`,
matching every other `gateway/` module.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/rich_sent_store.py` — `_store_path()` uses canonical `get_hermes_home()`.
- `tests/gateway/test_rich_sent_store.py` — regression tests (profile override, default home, record/lookup roundtrip).
- `scripts/release.py` — add contributor to `AUTHOR_MAP`.

## How to Test

\`\`\`
python -m pytest tests/gateway/test_rich_sent_store.py tests/gateway/test_telegram_rich_messages.py -q
\`\`\`

Result: **68 passed** (4 new + 64 existing). The override regression test fails
on the old code and passes with the fix.