### PR TITLE
fix(state): detect and repair FTS write corruption (#50502)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15845,6 +15845,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 inject_timestamps=_message_timestamps_enabled(_load_gateway_config()),
             )
             
+            # FTS write corruption guard (bug #50502):
+            # When the persisted history is stale/empty (FTS write failed between
+            # turns) but the cached agent still holds the live in-memory transcript,
+            # prefer the longer transcript to prevent same-session amnesia.
+            if agent is not None and hasattr(agent, '_session_messages'):
+                live_msgs = agent._session_messages
+                if live_msgs and len(live_msgs) > len(agent_history):
+                    logger.info(
+                        "Session %s: live in-memory transcript (%d msgs) is longer "
+                        "than persisted transcript (%d msgs) - preferring live copy "
+                        "(possible FTS write corruption)",
+                        session_key, len(live_msgs), len(agent_history),
+                    )
+                    agent_history = list(live_msgs)
+
             # Collect MEDIA paths already in history so we can exclude them
             # from the current turn's extraction. This is compression-safe:
             # even if the message list shrinks, we know which paths are old.

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1202,6 +1202,32 @@ def run_doctor(args):
             count = cursor.fetchone()[0]
             conn.close()
             check_ok(f"{_DHH}/state.db exists ({count} sessions)")
+
+            # FTS write health probe - detect corrupt FTS indexes that
+            # PRAGMA integrity_check misses.
+            try:
+                from hermes_state import SessionDB
+                db = SessionDB()
+                health = db._probe_fts_write_health()
+                if health is False:
+                    check_warn(
+                        "FTS write health check FAILED - FTS indexes may be corrupt",
+                        "(run 'hermes doctor --fix' or 'hermes sessions repair')"
+                    )
+                    if should_fix:
+                        try:
+                            db.repair_fts_indexes()
+                            check_ok("FTS indexes repaired")
+                            fixed_count += 1
+                        except Exception as e:
+                            check_warn(
+                                "FTS index repair failed",
+                                f"({e})"
+                            )
+                elif health is True:
+                    check_ok("FTS write health check passed")
+            except Exception as e:
+                check_info(f"FTS health probe skipped: {e}")
         except Exception as e:
             from hermes_state import is_malformed_db_error, repair_state_db_schema
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -881,6 +881,88 @@ class SessionDB:
             "FROM messages"
         )
 
+    def _rebuild_fts_in_place(self) -> bool:
+        """Rebuild FTS5 indexes in-place using the built-in 'rebuild' command.
+
+        Unlike _rebuild_fts_indexes (DELETE + INSERT), this uses the FTS5
+        built-in 'rebuild' command which rewrites the internal b-tree segments
+        from the content table.  This is the recommended recovery strategy for
+        corrupt FTS indexes because it re-indexes all content without dropping
+        or recreating the virtual table.
+
+        Safe for add-only schema — no DDL changes.
+        Returns True if all FTS tables were rebuilt successfully.
+        """
+        all_ok = True
+        with self._lock:
+            for table_name in ("messages_fts", "messages_fts_trigram"):
+                if not self._fts_table_exists(table_name):
+                    continue
+                try:
+                    self._conn.execute(
+                        f"INSERT INTO {table_name}({table_name}) VALUES('rebuild')"
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "FTS rebuild failed for %s in %s: %s",
+                        table_name, self.db_path, exc,
+                    )
+                    all_ok = False
+        return all_ok
+
+    def repair_fts_indexes(self) -> bool:
+        """Public entry point: repair corrupt FTS indexes non-destructively.
+
+        Tries in-place rebuild first (FTS5 'rebuild' command). If that
+        doesn't work or health check still fails, falls back to the
+        DELETE + INSERT approach (_rebuild_fts_indexes).
+
+        After repair, runs _probe_fts_write_health() to confirm.
+        Returns True if the health probe passes after repair.
+        """
+        ok = self._rebuild_fts_in_place()
+        if ok:
+            health = self._probe_fts_write_health()
+            if health is True:
+                logger.info("FTS indexes rebuilt in-place for %s", self.db_path)
+                return True
+
+        try:
+            cursor = self._conn.cursor()
+            self._rebuild_fts_indexes(cursor)
+            self._conn.commit()
+        except Exception as exc:
+            logger.warning("FTS index fallback rebuild failed: %s", exc)
+
+        health = self._probe_fts_write_health()
+        if health is True:
+            logger.info("FTS indexes rebuilt via fallback for %s", self.db_path)
+            return True
+
+        # Third-tier: DROP and recreate FTS virtual tables + triggers,
+        # then rebuild from the content table. Handles cases where
+        # shadow tables are structurally corrupt (not just data-corrupt).
+        try:
+            with self._lock:
+                self._conn.execute("DROP TABLE IF EXISTS messages_fts")
+                self._conn.execute("DROP TABLE IF EXISTS messages_fts_trigram")
+                self._conn.executescript(FTS_SQL)
+                self._conn.executescript(FTS_TRIGRAM_SQL)
+                cursor = self._conn.cursor()
+                self._rebuild_fts_indexes(cursor)
+                self._conn.commit()
+        except Exception as exc:
+            logger.warning("FTS DROP+recreate failed for %s: %s", self.db_path, exc)
+            return False
+
+        health = self._probe_fts_write_health()
+        if health is True:
+            logger.info("FTS indexes rebuilt via DROP+recreate for %s", self.db_path)
+            return True
+
+        logger.warning("FTS repair completed but health check still fails for %s", self.db_path)
+        return False
+
     def _fts_table_probe(self, cursor: sqlite3.Cursor, table_name: str) -> Optional[bool]:
         try:
             cursor.execute(f"SELECT * FROM {table_name} LIMIT 0")
@@ -923,6 +1005,46 @@ class SessionDB:
                 self._warn_trigram_unavailable(exc)
             else:
                 self._warn_fts5_unavailable(exc)
+            return False
+
+    def _probe_fts_write_health(self) -> Optional[bool]:
+        """Test that an INSERT through the FTS triggers can succeed.
+
+        Opens a transaction, inserts a harmless probe row into messages,
+        then rolls back.  If the FTS triggers fail (corrupt FTS index),
+        the transaction rolls back and we return False.  Returns True if
+        the write succeeded, None if FTS5 is unavailable.
+
+        This catches the case where PRAGMA integrity_check passes but
+        message writes through FTS triggers fail because the FTS5 index
+        is corrupt.  The transaction is always rolled back so no data
+        is actually persisted.
+        """
+        if not self._fts_enabled:
+            return None
+        probe_session_id = f"_fts_health_probe_{time.time()}"
+        try:
+            with self._lock:
+                self._conn.execute("BEGIN IMMEDIATE")
+                try:
+                    self._conn.execute(
+                        "INSERT OR IGNORE INTO sessions (id, source, started_at) "
+                        "VALUES (?, '_health_probe', ?)",
+                        (probe_session_id, time.time()),
+                    )
+                    self._conn.execute(
+                        "INSERT INTO messages (session_id, role, content, timestamp) "
+                        "VALUES (?, 'user', '_fts_health_probe_message', ?)",
+                        (probe_session_id, time.time()),
+                    )
+                    self._conn.execute("ROLLBACK")
+                    return True
+                except Exception:
+                    self._conn.execute("ROLLBACK")
+                    return False
+        except sqlite3.OperationalError:
+            return False
+        except Exception:
             return False
 
     def _execute_write(self, fn: Callable[[sqlite3.Connection], T]) -> T:
@@ -1340,6 +1462,15 @@ class SessionDB:
                     )
 
         self._conn.commit()
+
+        if self._fts_enabled:
+            health = self._probe_fts_write_health()
+            if health is False:
+                logger.warning(
+                    "FTS write health probe failed for %s; FTS index may be corrupt. "
+                    "Run `hermes sessions repair` to rebuild FTS indexes.",
+                    self.db_path,
+                )
 
     # =========================================================================
     # Session lifecycle

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4416,3 +4416,41 @@ class TestListCronJobRuns:
         detail = " ".join(row[-1] for row in plan)
         assert "USING INDEX" in detail or "USING COVERING INDEX" in detail, detail
         assert "idx_sessions_source" in detail, detail
+
+
+class TestFTSWriteHealth:
+    """Regression tests for FTS write health probe and repair (bug #50502)."""
+
+    def test_fts_write_health_probe_healthy_db(self, db):
+        """Probe returns True on a healthy database with messages."""
+        db.create_session("test-fts-session", source="test")
+        db.append_message("test-fts-session", role="user", content="hello")
+        db.append_message("test-fts-session", role="assistant", content="world")
+
+        result = db._probe_fts_write_health()
+        assert result is True, f"Expected True for healthy DB, got {result}"
+
+    def test_fts_write_health_probe_detects_corrupt_index(self, db):
+        """Probe returns False when FTS shadow tables are corrupt."""
+        db.create_session("test-fts-corr", source="test")
+        db.append_message("test-fts-corr", role="user", content="hello")
+        db.append_message("test-fts-corr", role="assistant", content="world")
+
+        assert db._probe_fts_write_health() is True
+
+        try:
+            db._conn.execute("DELETE FROM messages_fts_data")
+            db._conn.execute("INSERT INTO messages_fts_data VALUES (X'DEADBEEF')")
+        except sqlite3.OperationalError:
+            pass
+        try:
+            db._conn.execute("DELETE FROM messages_fts_trigram_data")
+            db._conn.execute("INSERT INTO messages_fts_trigram_data VALUES (X'CAFEBABE')")
+        except sqlite3.OperationalError:
+            pass
+
+        result = db._probe_fts_write_health()
+        assert result is False, f"Expected False for corrupt FTS, got {result}"
+
+        assert db.repair_fts_indexes() is True
+        assert db._probe_fts_write_health() is True


### PR DESCRIPTION
## Summary

FTS write corruption silently drops gateway conversation history — when the FTS5 index is corrupt but base tables are readable, `PRAGMA integrity_check` passes, yet every `INSERT INTO messages` fails through the FTS triggers. The gateway then loads stale/empty `conversation_history` on the next turn, causing same-session amnesia.

This PR is a standalone implementation — no dependency on pre-existing `_db_opens_cleanly` or `repair_state_db_schema`.

### Changes (4 files, +210 lines)

| File | What |
|------|------|
| `hermes_state.py` | `_probe_fts_write_health()` — rolled-back INSERT probe; `_rebuild_fts_in_place()` — FTS5 rebuild command; `repair_fts_indexes()` — 3-tier repair; probe runs at `_init_schema()` |
| `hermes_cli/doctor.py` | `hermes doctor` now runs FTS write probe; `--fix` auto-repairs |
| `gateway/run.py` | Prefer live `_session_messages` when longer than DB history |
| `tests/test_hermes_state.py` | `TestFTSWriteHealth` — healthy probe + corrupt-detect+repair |

### Compared to #50504 / #50576

| | This PR | #50576 | #50504 |
|---|---|---|---|
| Repair tiers | **3** (rebuild → fallback → DROP) | 1 | 1 |
| Gateway guard | ✅ | ❌ | ✅ |
| Dependency | None (standalone) | `_db_opens_cleanly` | `_db_opens_cleanly` |
| Doctor `--fix` | ✅ | ✅ (with backup) | ❌ |

Closes #50502