### PR TITLE
fix(gateway): resolve channel directory paths per call for profile isolation

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -9,6 +9,7 @@ action="list" and for resolving human-friendly channel names to numeric IDs.
 import json
 import logging
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from hermes_cli.config import get_hermes_home
@@ -16,21 +17,35 @@ from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
 
-DIRECTORY_PATH = get_hermes_home() / "channel_directory.json"
+
+# Paths are resolved per call rather than cached at import time. The dashboard
+# and other multi-profile flows scope a request to another profile in-process
+# via ``set_hermes_home_override()`` (a ContextVar), which never mutates the
+# HERMES_HOME env var — so an import-time constant would stay pinned to the
+# profile that happened to be active when this module was first imported and
+# read/write the wrong profile's files. Resolving at call time keeps this in
+# step with ``_build_from_sessions()`` below, which already calls
+# ``get_hermes_home()`` per invocation.
+def _directory_path() -> Path:
+    return get_hermes_home() / "channel_directory.json"
+
+
 # User-maintained friendly-name overlay. The directory is fully regenerated
 # from live adapters + session data on a timer, so hand-edits to
 # channel_directory.json don't survive. Aliases declared here are re-applied
 # on every build AND every load, giving durable human-friendly names (and
 # letting you pre-name a chat before it has produced any traffic).
 # Format: {"<platform>": {"<chat_id>": "<friendly name>", ...}, ...}
-CHANNEL_ALIASES_PATH = get_hermes_home() / "channel_aliases.json"
+def _channel_aliases_path() -> Path:
+    return get_hermes_home() / "channel_aliases.json"
 
 
 def _load_channel_aliases() -> Dict[str, Dict[str, str]]:
-    if not CHANNEL_ALIASES_PATH.exists():
+    aliases_path = _channel_aliases_path()
+    if not aliases_path.exists():
         return {}
     try:
-        with open(CHANNEL_ALIASES_PATH, encoding="utf-8") as f:
+        with open(aliases_path, encoding="utf-8") as f:
             data = json.load(f)
         return data if isinstance(data, dict) else {}
     except Exception:
@@ -112,7 +127,8 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
     """
     Build a channel directory from connected platform adapters and session data.
 
-    Returns the directory dict and writes it to DIRECTORY_PATH.
+    Returns the directory dict and writes it to ``channel_directory.json`` under
+    the active Hermes home.
     """
     from gateway.config import Platform
 
@@ -156,7 +172,7 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
     }
 
     try:
-        atomic_json_write(DIRECTORY_PATH, directory)
+        atomic_json_write(_directory_path(), directory)
     except Exception as e:
         logger.warning("Channel directory: failed to write: %s", e)
 
@@ -304,12 +320,13 @@ def _build_from_sessions(platform_name: str) -> List[Dict[str, str]]:
 
 def load_directory() -> Dict[str, Any]:
     """Load the cached channel directory from disk."""
-    if not DIRECTORY_PATH.exists():
+    directory_path = _directory_path()
+    if not directory_path.exists():
         base = {"updated_at": None, "platforms": {}}
         _apply_channel_aliases(base["platforms"])
         return base
     try:
-        with open(DIRECTORY_PATH, encoding="utf-8") as f:
+        with open(directory_path, encoding="utf-8") as f:
             data = json.load(f)
         # Re-apply aliases on read so friendly names take effect immediately,
         # even between timed rebuilds and for brand-new alias entries.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -66,6 +66,7 @@ AUTHOR_MAP = {
     "izumi0uu@gmail.com": "izumi0uu",  # PR #49544 salvage (native rich reply echo; #49534)
     "dev@pixlmedia.no": "texhy",  # PR #27435 salvage (few-but-huge preflight compression gate; #27405)
     "w31rdm4ch1n3z@protonmail.com": "w31rdm4ch1nZ",
+    "drexux0@gmail.com": "Drexuxux",
     "xtpeeps@gmail.com": "x7peeps",
     "ahmad@madsgency.com": "ahmadashfq",
     "rratmansky@gmail.com": "rratmansky",

--- a/tests/gateway/test_channel_directory.py
+++ b/tests/gateway/test_channel_directory.py
@@ -25,10 +25,10 @@ import pytest
 def _isolate_channel_aliases(tmp_path_factory):
     """Point the alias overlay at a nonexistent path by default so a real
     ~/.hermes/channel_aliases.json never leaks into directory tests. Tests
-    that exercise aliases patch CHANNEL_ALIASES_PATH themselves inside the
+    that exercise aliases patch the alias path themselves inside the
     test body, which takes precedence over this outer patch."""
     missing = tmp_path_factory.mktemp("aliases") / "none.json"
-    with patch("gateway.channel_directory.CHANNEL_ALIASES_PATH", missing):
+    with patch("gateway.channel_directory._channel_aliases_path", return_value=missing):
         yield
 
 
@@ -42,7 +42,7 @@ def _write_directory(tmp_path, platforms):
 
 class TestLoadDirectory:
     def test_missing_file(self, tmp_path):
-        with patch("gateway.channel_directory.DIRECTORY_PATH", tmp_path / "nope.json"):
+        with patch("gateway.channel_directory._directory_path", return_value=tmp_path / "nope.json"):
             result = load_directory()
         assert result["updated_at"] is None
         assert result["platforms"] == {}
@@ -51,14 +51,14 @@ class TestLoadDirectory:
         cache_file = _write_directory(tmp_path, {
             "telegram": [{"id": "123", "name": "John", "type": "dm"}]
         })
-        with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file):
+        with patch("gateway.channel_directory._directory_path", return_value=cache_file):
             result = load_directory()
         assert result["platforms"]["telegram"][0]["name"] == "John"
 
     def test_corrupt_file(self, tmp_path):
         cache_file = tmp_path / "channel_directory.json"
         cache_file.write_text("{bad json")
-        with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file):
+        with patch("gateway.channel_directory._directory_path", return_value=cache_file):
             result = load_directory()
         assert result["updated_at"] is None
 
@@ -77,7 +77,7 @@ class TestBuildChannelDirectoryWrites:
 
         monkeypatch.setattr(json, "dump", broken_dump)
 
-        with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file):
+        with patch("gateway.channel_directory._directory_path", return_value=cache_file):
             asyncio.run(build_channel_directory({}))
             result = load_directory()
 
@@ -87,7 +87,7 @@ class TestBuildChannelDirectoryWrites:
 class TestResolveChannelName:
     def _setup(self, tmp_path, platforms):
         cache_file = _write_directory(tmp_path, platforms)
-        return patch("gateway.channel_directory.DIRECTORY_PATH", cache_file)
+        return patch("gateway.channel_directory._directory_path", return_value=cache_file)
 
     def test_exact_match(self, tmp_path):
         platforms = {
@@ -283,7 +283,7 @@ class TestBuildFromSessions:
 
 class TestFormatDirectoryForDisplay:
     def test_empty_directory(self, tmp_path):
-        with patch("gateway.channel_directory.DIRECTORY_PATH", tmp_path / "nope.json"):
+        with patch("gateway.channel_directory._directory_path", return_value=tmp_path / "nope.json"):
             result = format_directory_for_display()
         assert "No messaging platforms" in result
 
@@ -295,7 +295,7 @@ class TestFormatDirectoryForDisplay:
                 {"id": "-1001:17585", "name": "Coaching Chat / topic 17585", "type": "group"},
             ]
         })
-        with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file):
+        with patch("gateway.channel_directory._directory_path", return_value=cache_file):
             result = format_directory_for_display()
 
         assert "Telegram:" in result
@@ -311,7 +311,7 @@ class TestFormatDirectoryForDisplay:
                 {"id": "3", "name": "chat", "guild": "Server2", "type": "channel"},
             ]
         })
-        with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file):
+        with patch("gateway.channel_directory._directory_path", return_value=cache_file):
             result = format_directory_for_display()
 
         assert "Discord (Server1):" in result
@@ -322,7 +322,7 @@ class TestFormatDirectoryForDisplay:
 class TestLookupChannelType:
     def _setup(self, tmp_path, platforms):
         cache_file = _write_directory(tmp_path, platforms)
-        return patch("gateway.channel_directory.DIRECTORY_PATH", cache_file)
+        return patch("gateway.channel_directory._directory_path", return_value=cache_file)
 
     def test_forum_channel(self, tmp_path):
         platforms = {
@@ -504,13 +504,13 @@ class TestChannelAliases:
     def _setup_aliases(self, tmp_path, aliases):
         alias_file = tmp_path / "channel_aliases.json"
         alias_file.write_text(json.dumps(aliases))
-        return patch("gateway.channel_directory.CHANNEL_ALIASES_PATH", alias_file)
+        return patch("gateway.channel_directory._channel_aliases_path", return_value=alias_file)
 
     def test_alias_renames_existing_entry_on_load(self, tmp_path):
         cache_file = _write_directory(tmp_path, {
             "whatsapp": [{"id": "120363@g.us", "name": "120363", "type": "group"}]
         })
-        with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file), \
+        with patch("gateway.channel_directory._directory_path", return_value=cache_file), \
              self._setup_aliases(tmp_path, {"whatsapp": {"120363@g.us": "general"}}):
             result = load_directory()
             assert result["platforms"]["whatsapp"][0]["name"] == "general"
@@ -522,7 +522,7 @@ class TestChannelAliases:
         """A group named in the alias file but not yet seen in any session is
         still addressable by name (pre-naming before first traffic)."""
         cache_file = _write_directory(tmp_path, {"whatsapp": []})
-        with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file), \
+        with patch("gateway.channel_directory._directory_path", return_value=cache_file), \
              self._setup_aliases(tmp_path, {"whatsapp": {"999@g.us": "marketing"}}):
             assert resolve_channel_name("whatsapp", "marketing") == "999@g.us"
             entries = load_directory()["platforms"]["whatsapp"]
@@ -533,8 +533,8 @@ class TestChannelAliases:
         cache_file = _write_directory(tmp_path, {
             "whatsapp": [{"id": "120363@g.us", "name": "120363", "type": "group"}]
         })
-        with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file), \
-             patch("gateway.channel_directory.CHANNEL_ALIASES_PATH", tmp_path / "nope.json"):
+        with patch("gateway.channel_directory._directory_path", return_value=cache_file), \
+             patch("gateway.channel_directory._channel_aliases_path", return_value=tmp_path / "nope.json"):
             result = load_directory()
             assert result["platforms"]["whatsapp"][0]["name"] == "120363"
 
@@ -544,8 +544,8 @@ class TestChannelAliases:
         })
         bad = tmp_path / "channel_aliases.json"
         bad.write_text("{not json")
-        with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file), \
-             patch("gateway.channel_directory.CHANNEL_ALIASES_PATH", bad):
+        with patch("gateway.channel_directory._directory_path", return_value=cache_file), \
+             patch("gateway.channel_directory._channel_aliases_path", return_value=bad):
             result = load_directory()
             assert result["platforms"]["whatsapp"][0]["name"] == "120363"
 
@@ -557,7 +557,7 @@ class TestChannelAliases:
                             lambda plat: [{"id": "120363@g.us", "name": "120363",
                                            "type": "group", "thread_id": None}]
                             if plat == "whatsapp" else [])
-        with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file), \
+        with patch("gateway.channel_directory._directory_path", return_value=cache_file), \
              self._setup_aliases(tmp_path, {"whatsapp": {"120363@g.us": "general"}}):
             asyncio.run(build_channel_directory({}))
             on_disk = json.loads(cache_file.read_text())
@@ -576,3 +576,68 @@ class TestChannelAliases:
                    }):
             _apply_channel_aliases(platforms)  # should not raise
         assert platforms["whatsapp"][0]["name"] == "1"
+
+
+class TestHermesHomeOverrideResolution:
+    """The directory and alias paths must follow an in-process
+    ``set_hermes_home_override()`` (the dashboard / multi-profile flow),
+    not a value cached when the module was first imported.
+
+    These exercise the real bug directly: no module-level path is patched,
+    so they only pass when reads/writes resolve ``get_hermes_home()`` per
+    call. Before the fix the import-time constant stayed pinned to whichever
+    profile was active at first import, so a profile-scoped request would
+    read/write the wrong profile's files.
+    """
+
+    def test_load_and_resolve_follow_home_override(self, tmp_path):
+        from hermes_constants import (
+            set_hermes_home_override,
+            reset_hermes_home_override,
+        )
+
+        profile_a = tmp_path / "profile_a"
+        profile_b = tmp_path / "profile_b"
+        profile_a.mkdir()
+        profile_b.mkdir()
+
+        # Only profile B has a cached directory, naming a Slack channel.
+        (profile_b / "channel_directory.json").write_text(json.dumps({
+            "updated_at": "2026-01-01T00:00:00",
+            "platforms": {
+                "slack": [{"id": "C123", "name": "engineering", "type": "channel"}]
+            },
+        }))
+
+        # Scoped to A: A has no cache, so nothing resolves.
+        token = set_hermes_home_override(str(profile_a))
+        try:
+            assert load_directory()["platforms"] == {}
+            assert resolve_channel_name("slack", "engineering") is None
+        finally:
+            reset_hermes_home_override(token)
+
+        # Scoped to B: B's cache is read and the friendly name resolves.
+        token = set_hermes_home_override(str(profile_b))
+        try:
+            assert resolve_channel_name("slack", "engineering") == "C123"
+        finally:
+            reset_hermes_home_override(token)
+
+    def test_build_writes_into_overridden_home(self, tmp_path):
+        from hermes_constants import (
+            set_hermes_home_override,
+            reset_hermes_home_override,
+        )
+
+        profile_a = tmp_path / "profile_a"
+        profile_a.mkdir()
+
+        token = set_hermes_home_override(str(profile_a))
+        try:
+            asyncio.run(build_channel_directory({}))
+        finally:
+            reset_hermes_home_override(token)
+
+        # The cache lands in the scoped profile, not the import-time home.
+        assert (profile_a / "channel_directory.json").exists()

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -343,7 +343,7 @@ class TestSendMessageTool:
             },
         }))
 
-        with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file), \
+        with patch("gateway.channel_directory._directory_path", return_value=cache_file), \
              patch("gateway.config.load_gateway_config", return_value=config), \
              patch("tools.interrupt.is_interrupted", return_value=False), \
              patch("model_tools._run_async", side_effect=_run_async_immediately), \


### PR DESCRIPTION
## What does this PR do?

`gateway/channel_directory.py` bound `DIRECTORY_PATH` and `CHANNEL_ALIASES_PATH`
at import time. Multi-profile flows (e.g. the dashboard) scope a profile
in-process via `set_hermes_home_override()` — a ContextVar that never touches the
`HERMES_HOME` env var — so those import-time constants stayed pinned to whichever
profile was active at first import. The module then read/wrote the wrong
profile's `channel_directory.json` / `channel_aliases.json`, breaking profile
isolation and `send_message` target resolution. Both paths now resolve via
`get_hermes_home()` per call, matching `_build_from_sessions()` in the same file.

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `gateway/channel_directory.py`: replace import-time path constants with
  call-time `_directory_path()` / `_channel_aliases_path()` helpers; update all
  read/write sites.
- `tests/gateway/test_channel_directory.py`: patch the new helpers; add
  `TestHermesHomeOverrideResolution` regression tests.
- `tests/tools/test_send_message_tool.py`: update one patch target.
- `scripts/release.py`: add author email mapping.

## How to Test

`pytest tests/gateway/test_channel_directory.py tests/tools/test_send_message_tool.py -q`

Regression proof: temporarily restoring import-time caching makes the two new
`TestHermesHomeOverrideResolution` tests fail; the fix makes them pass.

Test results (all passing):
- `tests/gateway/test_channel_directory.py` — 41 passed (incl. 2 new regression tests)
- `tests/tools/test_send_message_tool.py` (+ target_parse) — 194 passed
- `tests/cron/test_scheduler.py` — 163 passed
- `tests/test_mcp_serve.py` — 85 passed
- `tests/gateway/test_platform_reconnect.py` — 31 passed
- `tests/tools/test_mcp_loop_profile_override.py` — 4 passed
- `tests/hermes_cli/test_web_server.py` — 298 passed, 17 skipped
- `tests/hermes_cli/test_send_cmd.py` / `test_slack_cli.py` — 21 / 7 passed
- `tests/test_tui_gateway_server.py` — 288 passed

## Checklist

- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix
- [x] All tests pass
- [x] I've added regression tests for the fix