### PR TITLE
fix(cli): dispatch /whoami and /indicator in the classic CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8427,6 +8427,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             self._handle_voice_command(cmd_original)
         elif canonical == "busy":
             self._handle_busy_command(cmd_original)
+        elif canonical == "whoami":
+            self._handle_whoami_command()
+        elif canonical == "indicator":
+            self._handle_indicator_command(cmd_original)
         else:
             # Check for user-defined quick commands (bypass agent loop, no LLM call)
             base_cmd = cmd_lower.split()[0]

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2463,6 +2463,87 @@ class CLICommandsMixin:
         else:
             _cprint(f"  {_ACCENT}✓ Busy input mode set to '{arg}' (session only){_RST}")
 
+    def _handle_whoami_command(self):
+        """Handle /whoami — show your slash command access in the CLI.
+
+        The classic CLI always runs as the local operator; the admin/user
+        tiering that ``/whoami`` reports on the messaging gateway does not
+        apply here, so every slash command is available. This mirrors the
+        gateway's "unrestricted" tier so the command is no longer advertised
+        in CLI help/autocomplete while raising "Unknown command" when typed.
+        """
+        from cli import _ACCENT, _DIM, _RST, _cprint
+
+        print()
+        _cprint(f"  {_ACCENT}You — CLI (local operator){_RST}")
+        _cprint(
+            f"  {_DIM}Tier: unrestricted — admin/user gating only applies on the "
+            f"messaging gateway.{_RST}"
+        )
+        _cprint(f"  {_DIM}Slash commands: all available (type /help to list them).{_RST}")
+        print()
+
+    def _handle_indicator_command(self, cmd: str):
+        """Handle /indicator — pick the TUI busy-indicator style.
+
+        Writes ``display.tui_status_indicator`` — the same config key the Ink
+        TUI reads for its working/"busy" spinner. The value is shared across
+        surfaces, so picking it here also drives the indicator when the Ink TUI
+        is launched.
+
+        Usage:
+            /indicator               Show the current style
+            /indicator <style>       Set the style (kaomoji, emoji, unicode, ascii)
+        """
+        from cli import _ACCENT, _DIM, _RST, _cprint, save_config_value
+
+        # Keep aligned with INDICATOR_STYLES / DEFAULT_INDICATOR_STYLE in
+        # ui-tui/src/app/interfaces.ts and _INDICATOR_STYLES / _INDICATOR_DEFAULT
+        # in tui_gateway/server.py.
+        styles = ("ascii", "emoji", "kaomoji", "unicode")
+        default = "kaomoji"
+
+        def _current() -> str:
+            cfg = getattr(self, "config", None)
+            display = cfg.get("display") if isinstance(cfg, dict) else {}
+            raw = str((display or {}).get("tui_status_indicator", "")).strip().lower()
+            return raw if raw in styles else default
+
+        parts = cmd.strip().split(maxsplit=1)
+        arg = parts[1].strip().lower() if len(parts) > 1 else ""
+
+        if arg in {"", "status", "?"}:
+            _cprint(f"  {_ACCENT}TUI busy-indicator style: {_current()}{_RST}")
+            _cprint(f"  {_DIM}Usage: /indicator [{'|'.join(styles)}]{_RST}")
+            return
+
+        if arg not in styles:
+            _cprint(f"  {_DIM}(._.) Unknown indicator: {arg}{_RST}")
+            _cprint(f"  {_DIM}Pick one of: {', '.join(styles)}{_RST}")
+            return
+
+        # Mirror the live in-memory config so a follow-up /indicator reads back
+        # the new value without a config reload.
+        cfg = getattr(self, "config", None)
+        if isinstance(cfg, dict):
+            display = cfg.get("display")
+            if not isinstance(display, dict):
+                display = {}
+                cfg["display"] = display
+            display["tui_status_indicator"] = arg
+
+        if save_config_value("display.tui_status_indicator", arg):
+            _cprint(
+                f"  {_ACCENT}✓ TUI busy-indicator style set to '{arg}' "
+                f"(saved to config){_RST}"
+            )
+            _cprint(f"  {_DIM}Applies to the Ink TUI status spinner.{_RST}")
+        else:
+            _cprint(
+                f"  {_ACCENT}✓ TUI busy-indicator style set to '{arg}' "
+                f"(session only){_RST}"
+            )
+
     def _handle_fast_command(self, cmd: str):
         """Handle /fast — toggle fast mode (OpenAI Priority Processing / Anthropic Fast Mode)."""
         from cli import _ACCENT, _DIM, _RST, _cprint, save_config_value

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -114,6 +114,7 @@ AUTHOR_MAP = {
     "804436395@qq.com": "LaPhilosophie",
     "maxmitcham@mac.home": "maxtrigify",
     "ccook@nvms.com": "ccook1963",
+    "drexux0@gmail.com": "Drexuxux",
     "libre-7@users.noreply.github.com": "libre-7",
     "kristian@agrointel.no": "kristianvast",
     "thomas.paquette@gmail.com": "RyTsYdUp",

--- a/tests/cli/test_whoami_indicator_commands.py
+++ b/tests/cli/test_whoami_indicator_commands.py
@@ -1,0 +1,150 @@
+"""Tests for the /whoami and /indicator classic-CLI commands.
+
+Both commands were defined in ``COMMAND_REGISTRY`` and surfaced in the CLI's
+``/help`` listing and autocomplete, but ``cli.py``'s ``process_command`` never
+dispatched them — so typing either one printed "Unknown command". These tests
+cover the handlers and the dispatch wiring that fixes that.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def _import_cli():
+    import hermes_cli.config as config_mod
+
+    if not hasattr(config_mod, "save_env_value_secure"):
+        config_mod.save_env_value_secure = lambda key, value: {
+            "success": True,
+            "stored_as": key,
+            "validated": False,
+        }
+
+    import cli as cli_mod
+
+    return cli_mod
+
+
+class TestHandleWhoamiCommand(unittest.TestCase):
+    def test_reports_unrestricted_local_access(self):
+        cli_mod = _import_cli()
+        stub = SimpleNamespace()
+        with patch.object(cli_mod, "_cprint") as mock_cprint:
+            cli_mod.HermesCLI._handle_whoami_command(stub)
+
+        printed = " ".join(str(c) for c in mock_cprint.call_args_list)
+        self.assertIn("unrestricted", printed.lower())
+        self.assertIn("all available", printed.lower())
+
+
+class TestHandleIndicatorCommand(unittest.TestCase):
+    def _make_cli(self, current=None):
+        display = {} if current is None else {"tui_status_indicator": current}
+        return SimpleNamespace(config={"display": display})
+
+    def test_no_args_shows_current_style(self):
+        cli_mod = _import_cli()
+        stub = self._make_cli("emoji")
+        with (
+            patch.object(cli_mod, "_cprint") as mock_cprint,
+            patch.object(cli_mod, "save_config_value") as mock_save,
+        ):
+            cli_mod.HermesCLI._handle_indicator_command(stub, "/indicator")
+
+        mock_save.assert_not_called()
+        printed = " ".join(str(c) for c in mock_cprint.call_args_list)
+        self.assertIn("emoji", printed)
+
+    def test_no_args_falls_back_to_default_when_unset(self):
+        cli_mod = _import_cli()
+        stub = self._make_cli(None)
+        with (
+            patch.object(cli_mod, "_cprint") as mock_cprint,
+            patch.object(cli_mod, "save_config_value"),
+        ):
+            cli_mod.HermesCLI._handle_indicator_command(stub, "/indicator")
+
+        printed = " ".join(str(c) for c in mock_cprint.call_args_list)
+        self.assertIn("kaomoji", printed)
+
+    def test_valid_style_sets_and_saves(self):
+        cli_mod = _import_cli()
+        stub = self._make_cli("kaomoji")
+        with (
+            patch.object(cli_mod, "_cprint"),
+            patch.object(cli_mod, "save_config_value", return_value=True) as mock_save,
+        ):
+            cli_mod.HermesCLI._handle_indicator_command(stub, "/indicator emoji")
+
+        mock_save.assert_called_once_with("display.tui_status_indicator", "emoji")
+        # In-memory config mirrors the new value for a follow-up read.
+        self.assertEqual(stub.config["display"]["tui_status_indicator"], "emoji")
+
+    def test_invalid_style_lists_choices_and_does_not_save(self):
+        cli_mod = _import_cli()
+        stub = self._make_cli("kaomoji")
+        with (
+            patch.object(cli_mod, "_cprint") as mock_cprint,
+            patch.object(cli_mod, "save_config_value") as mock_save,
+        ):
+            cli_mod.HermesCLI._handle_indicator_command(stub, "/indicator sparkles")
+
+        mock_save.assert_not_called()
+        printed = " ".join(str(c) for c in mock_cprint.call_args_list)
+        self.assertIn("Unknown indicator", printed)
+
+
+class TestSlashDispatchRegression(unittest.TestCase):
+    """The exact command token must route to its handler, never "Unknown command"."""
+
+    def test_whoami_dispatches_to_handler(self):
+        cli_mod = _import_cli()
+        calls = []
+        stub = SimpleNamespace(
+            _pending_resume_sessions=None,
+            _handle_whoami_command=lambda: calls.append("whoami"),
+        )
+        with patch.object(cli_mod, "_cprint") as mock_cprint:
+            result = cli_mod.HermesCLI.process_command(stub, "/whoami")
+
+        self.assertTrue(result)
+        self.assertEqual(calls, ["whoami"])
+        printed = " ".join(str(c) for c in mock_cprint.call_args_list)
+        self.assertNotIn("Unknown command", printed)
+
+    def test_indicator_dispatches_to_handler_with_args(self):
+        cli_mod = _import_cli()
+        calls = []
+        stub = SimpleNamespace(
+            _pending_resume_sessions=None,
+            _handle_indicator_command=lambda c: calls.append(c),
+        )
+        with patch.object(cli_mod, "_cprint") as mock_cprint:
+            result = cli_mod.HermesCLI.process_command(stub, "/indicator emoji")
+
+        self.assertTrue(result)
+        self.assertEqual(calls, ["/indicator emoji"])
+        printed = " ".join(str(c) for c in mock_cprint.call_args_list)
+        self.assertNotIn("Unknown command", printed)
+
+
+class TestRegistryWiring(unittest.TestCase):
+    def test_handlers_exist_on_cli(self):
+        cli_mod = _import_cli()
+        self.assertTrue(hasattr(cli_mod.HermesCLI, "_handle_whoami_command"))
+        self.assertTrue(hasattr(cli_mod.HermesCLI, "_handle_indicator_command"))
+
+    def test_commands_are_registered_on_cli_surface(self):
+        from hermes_cli.commands import COMMANDS, resolve_command
+
+        self.assertIsNotNone(resolve_command("whoami"))
+        self.assertIsNotNone(resolve_command("indicator"))
+        # Both are advertised on the CLI surface (not gateway_only), which is
+        # exactly why the missing dispatch produced "Unknown command".
+        self.assertIn("/whoami", COMMANDS)
+        self.assertIn("/indicator", COMMANDS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this PR do?

`/whoami` and `/indicator` are defined in `COMMAND_REGISTRY` and are shown in the
classic CLI's `/help` and autocomplete, but `process_command` had no branch for
them — so typing either one fell through to the prefix matcher and printed
`Unknown command`. They were the only two non-`gateway_only` commands missing a
handler. This wires both into the dispatcher, matching every other command.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py` — add `whoami` / `indicator` branches to `process_command`.
- `hermes_cli/cli_commands_mixin.py` — `_handle_whoami_command` (shows local-operator
  access; admin/user tiering only applies on the gateway) and
  `_handle_indicator_command` (get/set `display.tui_status_indicator`, the same
  config key and style set the Ink TUI uses).
- `tests/cli/test_whoami_indicator_commands.py` — new tests.
- `scripts/release.py` — contributor `AUTHOR_MAP` entry (required by CI).

## How to Test

1. Run `hermes`, type `/whoami` → prints your access instead of "Unknown command".
2. Type `/indicator emoji` → sets the style; `/indicator` shows the current one;
   `/indicator bogus` → lists valid styles.

**Tests run:**
- `pytest tests/cli/test_whoami_indicator_commands.py` → **9 passed**
- `pytest tests/cli/ tests/hermes_cli/test_commands.py` (CLI command + registry
  suites) → **pass**