### PR TITLE
fix(redact): preserve code syntax around auth header redaction (#33801)

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -125,8 +125,15 @@ _JSON_FIELD_RE = re.compile(
 # while the header name and scheme word are preserved for debuggability. The
 # previous rule only matched ``Bearer``, so ``Basic <base64 user:pass>`` and
 # ``token <pat>`` leaked verbatim into logs/transcripts.
+# Characters valid in a credential token value.  Matches everything
+# ``\S+`` would except common code-syntax delimiters (quotes, braces,
+# brackets, parens, angle brackets, backslash, comma, semicolon) so
+# that redaction never consumes a trailing delimiter and corrupts
+# surrounding code (issue #33801).
+_TOKEN_CHARS = r"[^\s\"'<>{}\[\]()\\,;]+"
+
 _AUTH_HEADER_RE = re.compile(
-    r"((?:Proxy-)?Authorization:\s*)([A-Za-z][\w.+-]*\s+)?(\S+)",
+    r"((?:Proxy-)?Authorization:\s*)([A-Za-z][\w.+-]*\s+)?(" + _TOKEN_CHARS + r")",
     re.IGNORECASE,
 )
 
@@ -138,7 +145,7 @@ _SECRET_HEADER_NAMES = (
     r"(?:x-api-key|x-goog-api-key|api-key|apikey|x-api-token|x-auth-token|x-access-token)"
 )
 _SECRET_HEADER_RE = re.compile(
-    rf"({_SECRET_HEADER_NAMES}\s*:\s*)(\S+)",
+    rf"({_SECRET_HEADER_NAMES}\s*:\s*)(" + _TOKEN_CHARS + r")",
     re.IGNORECASE,
 )
 

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -171,6 +171,120 @@ class TestAuthHeaders:
         assert redact_sensitive_text(text) == text
 
 
+class TestAuthHeaderSyntaxSafety:
+    """Regression tests for #33801: \\S+ in _AUTH_HEADER_RE and
+    _SECRET_HEADER_RE greedily captures trailing quotes / braces / brackets,
+    corrupting code syntax in tool call arguments, execute_code, and heredocs.
+
+    Test strings are built dynamically from fragments so the redaction regex
+    doesn't fire on the test source itself.
+    """
+
+    @staticmethod
+    def _auth_str(token, scheme="Bearer", header="Authorization"):
+        """Build an 'Authorization: Bearer <token>' string without triggering
+        the redaction regex on the test source."""
+        dq = chr(34)
+        return f"{dq}{header}: {scheme} {token}{dq}"
+
+    @staticmethod
+    def _api_key_str(token, header="x-api-key"):
+        dq = chr(34)
+        return f"{dq}{header}: {token}{dq}"
+
+    # --- Layer 1-3: closing quote consumed by \S+ (short token) ---
+
+    def test_short_bearer_token_quote_preserved(self):
+        token = "abcdefghijkl"  # 12 chars — token+quote = 13 < 18 floor
+        text = self._auth_str(token)
+        result = redact_sensitive_text(text)
+        assert token not in result, "token should be redacted"
+        assert result.count(chr(34)) == text.count(chr(34)), \
+            "closing quote must be preserved"
+        assert result.endswith(chr(34)), "closing quote must survive"
+
+    def test_short_basic_auth_quote_preserved(self):
+        token = "dXNlcjpsb25n"  # 12 chars
+        text = self._auth_str(token, scheme="Basic")
+        result = redact_sensitive_text(text)
+        assert token not in result
+        assert result.count(chr(34)) == text.count(chr(34))
+
+    # --- Layer 1-3: closing quote consumed by \S+ (long token) ---
+
+    def test_long_bearer_token_quote_preserved(self):
+        token = "dGhp...mc"  # 28 chars — mask keeps head/tail
+        text = self._auth_str(token)
+        result = redact_sensitive_text(text)
+        assert token not in result
+        assert result.count(chr(34)) == text.count(chr(34))
+        assert result.endswith(chr(34))
+
+    # --- Layer 5: dict literal braces consumed by \S+ ---
+
+    def test_brace_after_token_preserved(self):
+        dq = chr(34)
+        token = "abcdefghijklmnop"  # 16 chars
+        # Build: {X: "AUTHHEADER BEARER <token>"} without triggering redactor
+        hdr = "Authorization" + chr(58) + " Bearer "
+        text = "{X: " + dq + hdr + token + dq + "}"
+        result = redact_sensitive_text(text)
+        assert token not in result
+        assert result.endswith("}"), f"expected trailing brace, got: {result!r}"
+        assert result.count("}") == text.count("}")
+
+    # --- Layer 4: API-key style headers have the same \S+ problem ---
+
+    def test_x_api_key_short_token_quote_preserved(self):
+        token = "abcdefghijkl"  # 12 chars
+        text = self._api_key_str(token)
+        result = redact_sensitive_text(text)
+        assert token not in result
+        assert result.count(chr(34)) == text.count(chr(34))
+
+    def test_api_key_long_token_quote_preserved(self):
+        token = "dGhp...mc"
+        text = self._api_key_str(token, header="api-key")
+        result = redact_sensitive_text(text)
+        assert token not in result
+        assert result.count(chr(34)) == text.count(chr(34))
+
+    # --- Redaction still works in plain log lines (no delimiters) ---
+
+    def test_log_line_still_redacts(self):
+        token = "dGhp...mc"
+        text = "Authorization: Bearer " + token
+        result = redact_sensitive_text(text)
+        assert token not in result
+        assert "Authorization: Bearer" in result
+
+    def test_api_key_log_line_still_redacts(self):
+        token = "dGhp...mc"
+        text = "x-api-key: " + token
+        result = redact_sensitive_text(text)
+        assert token not in result
+        assert "x-api-key:" in result
+
+    # --- Proxy-Authorization with trailing quote ---
+
+    def test_proxy_auth_quote_preserved(self):
+        token = "dXNlcjpsb25n"
+        text = self._auth_str(token, header="Proxy-Authorization")
+        result = redact_sensitive_text(text)
+        assert token not in result
+        assert result.count(chr(34)) == text.count(chr(34))
+
+    # --- code_file=True still needs AUTH redaction but must be syntax-safe ---
+
+    def test_code_file_mode_preserves_quotes(self):
+        token = "abcdefghijkl"
+        text = self._auth_str(token)
+        result = redact_sensitive_text(text, code_file=True)
+        assert token not in result, "AUTH redaction must still fire for code_file=True"
+        assert result.count(chr(34)) == text.count(chr(34)), \
+            "closing quote must be preserved even in code_file mode"
+
+
 class TestApiKeyHeaders:
     def test_x_api_key_header_masked(self):
         text = "x-api-key: opaque-provider-key-1234567890"


### PR DESCRIPTION
## What

The `\S+` greedy capture in `_AUTH_HEADER_RE` and `_SECRET_HEADER_RE` was consuming trailing code delimiters (quotes, braces, brackets, parens) when masking credential tokens. When `_mask_token` replaced the match, those delimiters vanished, corrupting surrounding code syntax in tool output.

## Fix

Replace `\S+` with `_TOKEN_CHARS = r"[^\s\"'<>{}\[\]()\\,;]+"` — matches everything `\S+` would except common code-syntax delimiters, so redaction stops at the delimiter and the credential is still masked.

## Layers addressed (all tested)

1. Bearer token closing-quote corruption
2. Basic auth closing-quote corruption
3. Proxy-Authorization closing-quote corruption
4. x-api-key / api-key header closing-quote corruption
5. Dict-literal brace corruption (`{X: "Authorization: Bearer <tok>"}`)
6. code_file=True mode still redacts but preserves delimiters

## Verification

- **Fail-without-fix**: 7 of 10 new tests fail on unpatched code (closing quotes consumed by `\S+`)
- **With fix**: all 92 tests pass (10 new + 82 existing)
- Redaction still works correctly in plain log lines (no surrounding delimiters)

## Competitor PRs

- #33840, #34666: pass `code_file=True` at call sites — complementary but does not fix the AUTH_HEADER_RE regex itself
- #39001: adds template-context detection for `$VAR` / `${{ secrets.X }}` — complementary, does not fix the AUTH_HEADER_RE character class

This PR fixes the root regex cause; the competitor approaches address different symptoms (ENV-assignment and JSON-field corruption).

Auto-published by Moonsong via Path B automated pipeline.
