### PR TITLE
fix(curator): prevent permanent skill deletion in LLM consolidation pass

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -381,9 +381,10 @@ CURATOR_REVIEW_PROMPT = (
     "(`skills.external_dirs`). The candidate list below is already filtered "
     "to local curator-managed skills only; external skills are externally "
     "owned and read-only to this background curator.\n"
-    "2. DO NOT delete any skill. Archiving (moving the skill's directory "
-    "into ~/.hermes/skills/.archive/) is the maximum destructive action. "
-    "Archives are recoverable; deletion is not.\n"
+    "2. DO NOT delete any skill. Use skill_manage action=archive (which "
+    "moves the skill's directory into ~/.hermes/skills/.archive/). "
+    "skill_manage action=delete is permanently blocked during curator "
+    "review. Archives are recoverable; deletion is not.\n"
     "3. DO NOT touch skills shown as pinned=yes. Skip them entirely.\n"
     "3b. DO NOT archive, delete, consolidate, move, or otherwise modify any "
     "skill named in the protected built-ins list (currently: plan). These "
@@ -466,7 +467,7 @@ CURATOR_REVIEW_PROMPT = (
     "  - skill_manage action=write_file — add a references/, templates/, "
     "or scripts/ file under an existing skill (the skill must already "
     "exist)\n"
-    "  - skill_manage action=delete     — archive a skill. MUST pass "
+    "  - skill_manage action=archive    — archive a skill. MUST pass "
     "`absorbed_into=<umbrella>` when you've merged its content into another "
     "skill, or `absorbed_into=\"\"` when you're truly pruning with no "
     "forwarding target. This drives cron-job skill-reference migration — "
@@ -790,7 +791,7 @@ def _extract_absorbed_into_declarations(
                 continue
         if not isinstance(args, dict):
             continue
-        if args.get("action") != "delete":
+        if args.get("action") not in ("delete", "archive"):
             continue
         name = args.get("name")
         if not isinstance(name, str) or not name.strip():
@@ -862,7 +863,7 @@ def _reconcile_classification(
                 entry: Dict[str, Any] = {
                     "name": name,
                     "into": into_claim,
-                    "source": "absorbed_into (model-declared at delete)",
+                    "source": "absorbed_into (model-declared at archive/delete)",
                     "reason": (mc.get("reason") or "") if mc else "",
                 }
                 if hc and hc.get("evidence"):
@@ -1860,10 +1861,19 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         # terminal. The background-thread runner also hides it; this
         # belt-and-suspenders path matters when a caller invokes
         # run_curator_review(synchronous=True) from the CLI.
-        with open(os.devnull, "w", encoding="utf-8") as _devnull, \
-             contextlib.redirect_stdout(_devnull), \
-             contextlib.redirect_stderr(_devnull):
-            conv_result = review_agent.run_conversation(user_message=prompt)
+        #
+        # Set the curator-review ContextVar so skill_manage knows to refuse
+        # action='delete' (permanent loss) and require action='archive'
+        # (recoverable move to .archive/) during this pass.
+        from tools import skill_provenance as _prov
+        _cur_token = _prov.mark_curator_review()
+        try:
+            with open(os.devnull, "w", encoding="utf-8") as _devnull, \
+                 contextlib.redirect_stdout(_devnull), \
+                 contextlib.redirect_stderr(_devnull):
+                conv_result = review_agent.run_conversation(user_message=prompt)
+        finally:
+            _prov.clear_curator_review(_cur_token)
 
         final = ""
         if isinstance(conv_result, dict):

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -7,8 +7,10 @@ tests run fully offline and the curator module doesn't need real credentials.
 from __future__ import annotations
 
 import importlib
+import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -1170,3 +1172,155 @@ def test_review_fork_runs_under_background_review_origin(curator_env, monkeypatc
         "'background_review' — the skill_manage background-review write "
         "guard would not fire (GH-47688 regression)"
     )
+# ---------------------------------------------------------------------------
+# _extract_absorbed_into_declarations — archive action parity
+# ---------------------------------------------------------------------------
+
+
+def test_extract_absorbed_into_from_archive_action():
+    """_extract_absorbed_into_declarations picks up action='archive' the same
+    as action='delete' — both carry absorbed_into for consolidation/prune
+    classification."""
+    from agent.curator import _extract_absorbed_into_declarations
+
+    calls = [
+        {"name": "skill_manage", "arguments": json.dumps({
+            "action": "archive", "name": "narrow", "absorbed_into": "umbrella",
+        })},
+        {"name": "skill_manage", "arguments": json.dumps({
+            "action": "archive", "name": "stale", "absorbed_into": "",
+        })},
+    ]
+    out = _extract_absorbed_into_declarations(calls)
+    assert out["narrow"]["into"] == "umbrella"
+    assert out["narrow"]["declared"] is True
+    assert out["stale"]["into"] == ""
+    assert out["stale"]["declared"] is True
+
+
+def test_extract_absorbed_into_from_delete_action_still_works():
+    """Legacy action='delete' calls with absorbed_into are still recognized."""
+    from agent.curator import _extract_absorbed_into_declarations
+
+    calls = [
+        {"name": "skill_manage", "arguments": json.dumps({
+            "action": "delete", "name": "narrow", "absorbed_into": "umbrella",
+        })},
+    ]
+    out = _extract_absorbed_into_declarations(calls)
+    assert out["narrow"]["into"] == "umbrella"
+
+
+def test_extract_absorbed_into_ignores_other_actions():
+    """Only archive/delete actions are inspected — create/patch/etc. are skipped."""
+    from agent.curator import _extract_absorbed_into_declarations
+
+    calls = [
+        {"name": "skill_manage", "arguments": json.dumps({
+            "action": "create", "name": "narrow", "absorbed_into": "umbrella",
+        })},
+        {"name": "skill_manage", "arguments": json.dumps({
+            "action": "patch", "name": "narrow", "absorbed_into": "umbrella",
+        })},
+    ]
+    out = _extract_absorbed_into_declarations(calls)
+    assert out == {}
+
+
+# ---------------------------------------------------------------------------
+# curator review ContextVar — delete blocked during curator LLM pass
+# ---------------------------------------------------------------------------
+
+
+def test_run_llm_review_sets_curator_review_context():
+    """_run_llm_review must set the curator-review ContextVar so skill_manage
+    refuses action='delete' during the curator's LLM consolidation pass."""
+    from agent import curator as c
+    from tools.skill_provenance import is_curator_review
+
+    # Use a shallow stub that captures whether the ContextVar was set while
+    # the simulated agent runs.
+    review_captured = {}
+
+    class _FakeAgent:
+        def run_conversation(self, user_message):
+            review_captured["curator_review_set"] = is_curator_review()
+            return {"final_response": "ok"}
+
+        def close(self):
+            pass
+
+    def _fake_agent(*args, **kwargs):
+        return _FakeAgent()
+
+    with patch("run_agent.AIAgent", _fake_agent), \
+         patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={}), \
+         patch("hermes_cli.config.load_config", return_value={"model": {"provider": "test", "default": "m"}}):
+        c._run_llm_review("test prompt")
+
+    assert review_captured.get("curator_review_set") is True, (
+        "curator-review ContextVar must be True while the review agent runs"
+    )
+
+    # ContextVar must reset after _run_llm_review returns
+    assert is_curator_review() is False, (
+        "curator-review ContextVar must be False after _run_llm_review returns"
+    )
+
+
+def test_run_llm_review_clears_curator_review_on_error():
+    """ContextVar must be cleared even when the agent raises."""
+    from agent import curator as c
+    from tools.skill_provenance import is_curator_review
+
+    class _CrashingAgent:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def run_conversation(self, user_message):
+            raise RuntimeError("simulated crash")
+
+        def close(self):
+            pass
+
+    def _fake_agent(*args, **kwargs):
+        return _CrashingAgent()
+
+    with patch("run_agent.AIAgent", _fake_agent), \
+         patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={}), \
+         patch("hermes_cli.config.load_config", return_value={"model": {"provider": "test", "default": "m"}}):
+        result = c._run_llm_review("test prompt")
+
+    assert result["error"] is not None
+    # ContextVar must still be cleared after the error
+    assert is_curator_review() is False, (
+        "curator-review ContextVar must be False after _run_llm_review "
+        "even when the agent crashes"
+    )
+
+
+def test_curator_review_prompt_references_archive_action():
+    """The curator prompt must tell the LLM to use action=archive (not delete)."""
+    from agent.curator import CURATOR_REVIEW_PROMPT
+    assert "action=archive" in CURATOR_REVIEW_PROMPT, (
+        "curator prompt must tell the LLM to use action=archive"
+    )
+    # The toolset section must offer action=archive as the archival primitive,
+    # not action=delete. "action=delete" may still appear in prohibition rules
+    # (e.g. "skill_manage action=delete is permanently blocked"), but it must
+    # NOT appear as "skill_manage action=delete" in the toolset listing.
+    # Check that the line specifically offering the archive tool uses archive:
+    lines = CURATOR_REVIEW_PROMPT.split("\n")
+    tool_lines = [l.strip() for l in lines if "skill_manage action=" in l]
+    # At least one tool line must reference archive
+    archive_lines = [l for l in tool_lines if "action=archive" in l]
+    assert len(archive_lines) >= 1, (
+        "curator prompt must list skill_manage action=archive in the toolset"
+    )
+    # No tool line should reference delete as a positive instruction
+    for line in tool_lines:
+        if "action=delete" in line:
+            # Only allowed if it appears in a prohibition context
+            assert "blocked" in line.lower() or "do not" in line.lower(), (
+                f"curator prompt must not offer action=delete as a usable tool: {line}"
+            )

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -1,6 +1,7 @@
 """Tests for tools/skill_manager_tool.py — skill creation, editing, and deletion."""
 
 import json
+import os
 from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
@@ -16,6 +17,7 @@ from tools.skill_manager_tool import (
     _edit_skill,
     _patch_skill,
     _delete_skill,
+    _archive_skill,
     _write_file,
     _remove_file,
     skill_manage,
@@ -387,8 +389,8 @@ class TestDeleteSkill:
 
     def test_delete_with_absorbed_into_valid_target(self, tmp_path):
         with _skill_dir(tmp_path):
-            _create_skill("umbrella", VALID_SKILL_CONTENT)
-            _create_skill("narrow", VALID_SKILL_CONTENT)
+            _create_skill("umbrella", _content_for("umbrella"))
+            _create_skill("narrow", _content_for("narrow"))
             result = _delete_skill("narrow", absorbed_into="umbrella")
         assert result["success"] is True
         assert "absorbed into 'umbrella'" in result["message"]
@@ -397,7 +399,7 @@ class TestDeleteSkill:
 
     def test_delete_with_absorbed_into_empty_string_means_pruned(self, tmp_path):
         with _skill_dir(tmp_path):
-            _create_skill("stale-skill", VALID_SKILL_CONTENT)
+            _create_skill("stale-skill", _content_for("stale-skill"))
             result = _delete_skill("stale-skill", absorbed_into="")
         assert result["success"] is True
         # Empty absorbed_into is explicit prune — no "absorbed into" suffix in message
@@ -1091,3 +1093,240 @@ class TestDeleteSkillRmtreeGuard:
         assert result["success"] is False
         assert "skills root" in result["error"].lower()
         assert outside.exists()
+
+
+# ---------------------------------------------------------------------------
+# archive skill — recoverable move to .archive/ (curator safety)
+# ---------------------------------------------------------------------------
+
+
+def _content_for(name: str) -> str:
+    """Generate VALID_SKILL_CONTENT with the correct frontmatter `name:`."""
+    return VALID_SKILL_CONTENT.replace("name: test-skill", f"name: {name}")
+
+
+@contextmanager
+def _archive_env(tmp_path):
+    """Patch BOTH SKILLS_DIR (for _find_skill) AND get_hermes_home (for archive_skill).
+
+    archive_skill() in skill_usage locates skills via get_hermes_home()/skills/,
+    not via SKILLS_DIR. Both must point to the same temp tree.
+    """
+    home = tmp_path / ".hermes"
+    skills = home / "skills"
+    skills.mkdir(parents=True)
+
+    # Patch get_hermes_home at the source (hermes_constants) so every
+    # module that calls it — including skill_usage after reload — sees
+    # the temp path. Also patch SKILLS_DIR for _find_skill.
+    with patch("hermes_constants.get_hermes_home", return_value=home), \
+         patch("tools.skill_manager_tool.SKILLS_DIR", skills), \
+         patch("agent.skill_utils.get_all_skills_dirs", return_value=[skills]), \
+         patch.dict(os.environ, {"HERMES_HOME": str(home)}):
+        yield {"home": home, "skills": skills}
+
+
+class TestArchiveSkill:
+    def test_archive_moves_to_archive_dir(self, tmp_path):
+        with _archive_env(tmp_path) as env:
+            _create_skill("my-skill", _content_for("my-skill"))
+            result = _archive_skill("my-skill")
+            assert result["success"] is True, result
+            assert "archived" in result["message"].lower()
+            # Skill dir moved to .archive/
+            assert not (env["skills"] / "my-skill").exists()
+            assert (env["skills"] / ".archive" / "my-skill" / "SKILL.md").exists()
+            # .usage.json state set to "archived"
+            from tools import skill_usage
+            rec = skill_usage.get_record("my-skill")
+            assert rec["state"] == "archived"
+
+    def test_archive_nonexistent_skill(self, tmp_path):
+        with _archive_env(tmp_path):
+            result = _archive_skill("nonexistent")
+        assert result["success"] is False
+        assert "not found" in result["error"]
+
+    def test_archive_refuses_pinned(self, tmp_path):
+        from tools import skill_usage
+        with _archive_env(tmp_path) as env:
+            _create_skill("my-skill", _content_for("my-skill"))
+            data = skill_usage.load_usage()
+            data["my-skill"] = skill_usage._empty_record()
+            data["my-skill"]["pinned"] = True
+            skill_usage.save_usage(data)
+            result = _archive_skill("my-skill")
+        assert result["success"] is False
+        assert "pinned" in result["error"].lower()
+        assert "cannot be deleted" in result["error"]
+        # Skill still in place
+        assert (env["skills"] / "my-skill" / "SKILL.md").exists()
+
+    def test_archive_with_absorbed_into_valid_target(self, tmp_path):
+        with _archive_env(tmp_path) as env:
+            _create_skill("umbrella", _content_for("umbrella"))
+            _create_skill("narrow", _content_for("narrow"))
+            result = _archive_skill("narrow", absorbed_into="umbrella")
+        assert result["success"] is True, result
+        assert "absorbed into 'umbrella'" in result["message"]
+        assert not (env["skills"] / "narrow").exists()
+        assert (env["skills"] / "umbrella").exists()
+
+    def test_archive_with_absorbed_into_empty_string_means_pruned(self, tmp_path):
+        with _archive_env(tmp_path) as env:
+            _create_skill("stale-skill", _content_for("stale-skill"))
+            result = _archive_skill("stale-skill", absorbed_into="")
+        assert result["success"] is True, result
+        assert "absorbed into" not in result["message"]
+
+    def test_archive_with_absorbed_into_nonexistent_target_rejected(self, tmp_path):
+        with _archive_env(tmp_path) as env:
+            _create_skill("narrow", _content_for("narrow"))
+            result = _archive_skill("narrow", absorbed_into="ghost-umbrella")
+        assert result["success"] is False
+        assert "does not exist" in result["error"]
+        assert (env["skills"] / "narrow").exists()
+
+    def test_archive_with_absorbed_into_equals_self_rejected(self, tmp_path):
+        with _archive_env(tmp_path) as env:
+            _create_skill("narrow", _content_for("narrow"))
+            result = _archive_skill("narrow", absorbed_into="narrow")
+        assert result["success"] is False
+        assert "cannot equal" in result["error"]
+        assert (env["skills"] / "narrow").exists()
+
+    def test_archive_via_dispatcher(self, tmp_path):
+        with _archive_env(tmp_path) as env:
+            skill_manage(action="create", name="my-skill", content=_content_for("my-skill"))
+            raw = skill_manage(action="archive", name="my-skill", absorbed_into="")
+        result = json.loads(raw)
+        assert result["success"] is True, result
+        assert "archived" in result["message"].lower()
+        assert not (env["skills"] / "my-skill").exists()
+        assert (env["skills"] / ".archive" / "my-skill").exists()
+
+    def test_archive_refuses_bundled_when_prune_builtins_off(self, tmp_path):
+        """Proves _archive_skill reuses archive_skill() rather than a parallel
+        mover — archive_skill() refuses bundled skills when prune_builtins is off."""
+        with _archive_env(tmp_path) as env:
+            _create_skill("bundled-skill", _content_for("bundled-skill"))
+            (env["skills"] / ".bundled_manifest").write_text(
+                "bundled-skill:abc\n", encoding="utf-8"
+            )
+            # archive_skill() calls _prune_builtins_enabled() which defaults
+            # to True. Patch it to False so bundled skills are refused.
+            with patch("tools.skill_usage._prune_builtins_enabled", return_value=False):
+                result = _archive_skill("bundled-skill")
+        assert result["success"] is False
+        assert "bundled" in result["error"].lower()
+        assert (env["skills"] / "bundled-skill").exists()
+
+    def test_archive_refuses_protected_builtin(self, tmp_path):
+        """Protected built-ins (e.g. plan) are never archivable."""
+        from tools.skill_usage import PROTECTED_BUILTIN_SKILLS
+        name = next(iter(PROTECTED_BUILTIN_SKILLS))
+        with _archive_env(tmp_path) as env:
+            _create_skill(name, _content_for(name))
+            (env["skills"] / ".bundled_manifest").write_text(
+                f"{name}:abc\n", encoding="utf-8"
+            )
+            result = _archive_skill(name)
+        assert result["success"] is False
+        assert "protected" in result["error"].lower()
+        assert (env["skills"] / name).exists()
+
+    def test_archive_preserves_usage_record(self, tmp_path):
+        """archive_skill updates state to 'archived' — it does NOT drop the record.
+
+        Uses skill_manage(action='archive') through the dispatcher to exercise the
+        full path. The state update happens inside archive_skill() in skill_usage."""
+        with _archive_env(tmp_path) as env:
+            # Create via dispatcher so the skill is properly written
+            skill_manage(action="create", name="my-skill", content=_content_for("my-skill"))
+            # Set up usage manually
+            import tools.skill_usage as su
+            data = su.load_usage()
+            data["my-skill"] = su._empty_record()
+            data["my-skill"]["created_by"] = "agent"
+            data["my-skill"]["use_count"] = 5
+            su.save_usage(data)
+
+            raw = skill_manage(action="archive", name="my-skill", absorbed_into="")
+            result = json.loads(raw)
+            assert result["success"] is True, result
+            rec = su.get_record("my-skill")
+            assert rec["state"] == "archived"
+            assert rec["created_by"] == "agent"
+            assert rec["use_count"] == 5
+            assert rec["archived_at"] is not None
+            # forget() was NOT called — record exists with preserved fields
+            assert "my-skill" in su.load_usage()
+
+
+# ---------------------------------------------------------------------------
+# Curator review gate — skill_manage(action='delete') refused during curator pass
+# ---------------------------------------------------------------------------
+
+
+class TestCuratorReviewDeleteGate:
+    def test_delete_blocked_during_curator_review(self, tmp_path):
+        """action='delete' must be rejected when is_curator_review() is True."""
+        from tools.skill_provenance import mark_curator_review, clear_curator_review
+
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", _content_for("my-skill"))
+            token = mark_curator_review()
+            try:
+                raw = skill_manage(action="delete", name="my-skill")
+            finally:
+                clear_curator_review(token)
+
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "not available during curator review" in result["error"]
+        assert "action='archive'" in result["error"]
+        # Skill must NOT have been deleted
+        assert (tmp_path / "my-skill" / "SKILL.md").exists()
+
+    def test_archive_allowed_during_curator_review(self, tmp_path):
+        """action='archive' must succeed when is_curator_review() is True."""
+        from tools.skill_provenance import mark_curator_review, clear_curator_review
+
+        with _archive_env(tmp_path) as env:
+            _create_skill("my-skill", _content_for("my-skill"))
+            token = mark_curator_review()
+            try:
+                raw = skill_manage(action="archive", name="my-skill", absorbed_into="")
+            finally:
+                clear_curator_review(token)
+
+        result = json.loads(raw)
+        assert result["success"] is True, result
+        assert "archived" in result["message"].lower()
+        assert not (env["skills"] / "my-skill").exists()
+
+    def test_delete_allowed_outside_curator_review(self, tmp_path):
+        """action='delete' must still work when NOT in curator review."""
+        from tools.skill_provenance import is_curator_review
+        # Default is False — no token set
+        assert is_curator_review() is False
+
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", _content_for("my-skill"))
+            raw = skill_manage(action="delete", name="my-skill")
+        result = json.loads(raw)
+        assert result["success"] is True, result
+        assert not (tmp_path / "my-skill").exists()
+
+    def test_clear_curator_review_restores_default(self):
+        """After clear_curator_review, is_curator_review returns False."""
+        from tools.skill_provenance import (
+            mark_curator_review, clear_curator_review, is_curator_review,
+        )
+        assert is_curator_review() is False
+        token = mark_curator_review()
+        try:
+            assert is_curator_review() is True
+        finally:
+            clear_curator_review(token)
+        assert is_curator_review() is False

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -147,24 +147,25 @@ def _is_path_redirect(path: Path) -> bool:
         return False
 
 
-def _validate_delete_target(skill_dir: Path) -> Optional[str]:
-    """Last-line guard before ``shutil.rmtree(skill_dir)`` in ``_delete_skill``.
+def _validate_removal_target(skill_dir: Path) -> Optional[str]:
+    """Last-line guard before removing ``skill_dir`` — ``shutil.rmtree`` in
+    ``_delete_skill`` or ``shutil.move`` in ``_archive_skill``.
 
     ``_find_skill`` already restricts ``skill_dir`` to a real ``SKILL.md``
     parent discovered by walking the skills roots, so the agent cannot inject
     an arbitrary path the way Kilo Code's HTTP endpoint could (their issue
     #11227: a built-in-skill sentinel resolved to the server cwd and a
     recursive delete wiped the user's entire working directory). This is the
-    matching defense-in-depth for our agent-facing ``skill_manage`` delete
-    path: even if discovery or a poisoned tree hands us a bad directory, never
-    recursively delete
+    matching defense-in-depth for our agent-facing ``skill_manage``
+    delete/archive path: even if discovery or a poisoned tree hands us a bad
+    directory, never remove or move
 
       1. a path that is not strictly *inside* one of the known skills roots,
       2. a skills root itself (would wipe every installed skill), or
-      3. a directory reached via a symlink / junction (``rmtree`` would follow
-         it into content outside the skills tree).
+      3. a directory reached via a symlink / junction (``rmtree``/``move``
+         would follow it into content outside the skills tree).
 
-    Returns an error string to refuse on, or ``None`` when the delete is safe.
+    Returns an error string to refuse on, or ``None`` when the removal is safe.
     """
     from agent.skill_utils import get_all_skills_dirs
 
@@ -892,7 +893,7 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
     skills_root = _containing_skills_root(skill_dir)
 
     # Defense-in-depth before the recursive delete (port of Kilo Code #11240).
-    unsafe = _validate_delete_target(skill_dir)
+    unsafe = _validate_removal_target(skill_dir)
     if unsafe:
         return {"success": False, "error": unsafe}
 
@@ -911,6 +912,69 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
         "success": True,
         "message": message,
     }
+
+
+def _archive_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, Any]:
+    """Archive a skill — move to .archive/ (recoverable), never delete.
+
+    Mirrors the validation prologue of ``_delete_skill`` (pinned guard,
+    path-safety, absorbed_into checks) but calls
+    ``skill_usage.archive_skill()`` for the recoverable move + state update
+    instead of ``shutil.rmtree``. ``archive_skill()`` already enforces
+    curation-eligibility (refuses hub skills, bundled when prune_builtins is
+    off, protected built-ins), does the ``shutil.move`` to
+    ``~/.hermes/skills/.archive/``, and updates ``.usage.json`` state to
+    ``archived``.
+
+    ``absorbed_into`` works the same as in ``_delete_skill``: pass an
+    umbrella name when consolidating, empty string when truly pruning.
+    """
+    existing = _find_skill(name)
+    if not existing:
+        return {"success": False, "error": _skill_not_found_error(name)}
+
+    pinned_err = _pinned_guard(name)
+    if pinned_err:
+        return {"success": False, "error": pinned_err}
+
+    # Validate absorbed_into target when declared non-empty
+    if absorbed_into is not None and isinstance(absorbed_into, str) and absorbed_into.strip():
+        target_name = absorbed_into.strip()
+        if target_name == name:
+            return {
+                "success": False,
+                "error": f"absorbed_into='{target_name}' cannot equal the skill being archived.",
+            }
+        target = _find_skill(target_name)
+        if not target:
+            return {
+                "success": False,
+                "error": (
+                    f"absorbed_into='{target_name}' does not exist. "
+                    f"Create or patch the umbrella skill first, then retry the archive."
+                ),
+            }
+
+    skill_dir = existing["path"]
+    # Defense-in-depth before the move (same guard as delete, but archive
+    # moves rather than rmtree so the symlink/junction and out-of-tree
+    # guards are still load-bearing — a poisoned skill path that redirects
+    # outside the tree must not be fed to shutil.move either).
+    unsafe = _validate_removal_target(skill_dir)
+    if unsafe:
+        return {"success": False, "error": unsafe}
+
+    from tools.skill_usage import archive_skill
+    ok, msg = archive_skill(name)
+    if not ok:
+        return {"success": False, "error": msg}
+
+    # archive_skill returns "archived to <resolved dest>" — surface that real,
+    # profile-aware path rather than a hardcoded ~/.hermes/skills/.archive/.
+    message = f"Skill '{name}' {msg}."
+    if absorbed_into is not None and isinstance(absorbed_into, str) and absorbed_into.strip():
+        message += f" Content absorbed into '{absorbed_into.strip()}'."
+    return {"success": True, "message": message}
 
 
 def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
@@ -1031,7 +1095,7 @@ def _apply_skill_write_gate(action, name, **payload_kwargs):
     write should NOT proceed (blocked or staged), or None to perform the real
     write. Bypassed during approved-pending replay.
     """
-    if action not in {"create", "edit", "patch", "delete", "write_file", "remove_file"}:
+    if action not in {"create", "edit", "patch", "archive", "delete", "write_file", "remove_file"}:
         return None
     if _skill_gate_bypass.get():
         return None
@@ -1138,7 +1202,19 @@ def skill_manage(
             return tool_error("new_string is required for 'patch'. Use empty string to delete matched text.", success=False)
         result = _patch_skill(name, old_string, new_string, file_path, replace_all)
 
+    elif action == "archive":
+        result = _archive_skill(name, absorbed_into=absorbed_into)
+
     elif action == "delete":
+        from tools.skill_provenance import is_curator_review
+        if is_curator_review():
+            return tool_error(
+                "skill_manage(action='delete') is not available during curator review. "
+                "Use action='archive' instead to move the skill to "
+                "~/.hermes/skills/.archive/ where it remains recoverable. "
+                "Restore it later with `hermes curator restore <name>`.",
+                success=False,
+            )
         result = _delete_skill(name, absorbed_into=absorbed_into)
 
     elif action == "write_file":
@@ -1154,7 +1230,7 @@ def skill_manage(
         result = _remove_file(name, file_path)
 
     else:
-        result = {"success": False, "error": f"Unknown action '{action}'. Use: create, edit, patch, delete, write_file, remove_file"}
+        result = {"success": False, "error": f"Unknown action '{action}'. Use: create, edit, patch, archive, delete, write_file, remove_file"}
 
     if result.get("success"):
         try:
@@ -1191,20 +1267,21 @@ def skill_manage(
 SKILL_MANAGE_SCHEMA = {
     "name": "skill_manage",
     "description": (
-        "Manage skills (create, update, delete). Skills are your procedural "
+        "Manage skills (create, update, archive, delete). Skills are your procedural "
         "memory — reusable approaches for recurring task types. "
         f"New skills go to {display_hermes_home()}/skills/; existing skills can be modified wherever they live.\n\n"
         "Actions: create (full SKILL.md + optional category), "
         "patch (old_string/new_string — preferred for fixes), "
         "edit (full SKILL.md rewrite — major overhauls only), "
-        "delete, write_file, remove_file.\n\n"
-        "On delete, pass `absorbed_into=<umbrella>` when you're merging this "
+        "archive (recoverable move to .archive/), "
+        "delete (permanent removal), write_file, remove_file.\n\n"
+        "On archive or delete, pass `absorbed_into=<umbrella>` when you're merging this "
         "skill's content into another one, or `absorbed_into=\"\"` when you're "
         "pruning it with no forwarding target. This lets the curator tell "
         "consolidation from pruning without guessing, so downstream consumers "
         "(cron jobs that reference the old skill name, etc.) get updated "
         "correctly. The target you name in `absorbed_into` must already "
-        "exist — create/patch the umbrella first, then delete.\n\n"
+        "exist — create/patch the umbrella first, then archive or delete.\n\n"
         "Create when: complex task succeeded (5+ calls), errors overcome, "
         "user-corrected approach worked, non-trivial workflow discovered, "
         "or user asks you to remember a procedure.\n"
@@ -1215,7 +1292,8 @@ SKILL_MANAGE_SCHEMA = {
         "Skip for simple one-offs. Confirm with user before creating/deleting.\n\n"
         "Good skills: trigger conditions, numbered steps with exact commands, "
         "pitfalls section, verification steps. Use skill_view() to see format examples.\n\n"
-        "Pinned skills are protected from deletion only — skill_manage(action='delete') "
+        "Pinned skills are protected from deletion and archival — skill_manage(action='archive') "
+        "and skill_manage(action='delete') "
         "will refuse with a message pointing the user to `hermes curator unpin <name>`. "
         "Patches and edits go through on pinned skills so you can still improve them as "
         "pitfalls come up; pin only guards against irrecoverable loss."
@@ -1225,14 +1303,14 @@ SKILL_MANAGE_SCHEMA = {
         "properties": {
             "action": {
                 "type": "string",
-                "enum": ["create", "patch", "edit", "delete", "write_file", "remove_file"],
-                "description": "The action to perform."
+                "enum": ["create", "patch", "edit", "archive", "delete", "write_file", "remove_file"],
+                "description": "The action to perform. Prefer 'archive' over 'delete' — archive is recoverable."
             },
             "name": {
                 "type": "string",
                 "description": (
                     "Skill name (lowercase, hyphens/underscores, max 64 chars). "
-                    "Must match an existing skill for patch/edit/delete/write_file/remove_file."
+                    "Must match an existing skill for patch/edit/archive/delete/write_file/remove_file."
                 )
             },
             "content": {
@@ -1286,7 +1364,7 @@ SKILL_MANAGE_SCHEMA = {
             "absorbed_into": {
                 "type": "string",
                 "description": (
-                    "For 'delete' only — declares intent so the curator can "
+                    "For 'archive' and 'delete' — declares intent so the curator can "
                     "tell consolidation from pruning without guessing. "
                     "Pass the umbrella skill name when this skill's content "
                     "was merged into another (the target must already exist). "

--- a/tools/skill_provenance.py
+++ b/tools/skill_provenance.py
@@ -76,3 +76,36 @@ def is_background_review() -> bool:
     """Convenience: True iff the current write origin is the background
     review fork."""
     return get_current_write_origin() == BACKGROUND_REVIEW
+
+
+# ---------------------------------------------------------------------------
+# Curator-review guard — prevents permanent delete during curator LLM pass
+# ---------------------------------------------------------------------------
+
+_curator_review: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "curator_review", default=False
+)
+
+
+def mark_curator_review() -> contextvars.Token[bool]:
+    """Signal that the current context is a curator review fork.
+
+    Returns a Token the caller must pass to ``clear_curator_review``
+    in a ``finally`` block.
+    """
+    return _curator_review.set(True)
+
+
+def clear_curator_review(token: contextvars.Token[bool]) -> None:
+    """Restore the prior curator-review context."""
+    _curator_review.reset(token)
+
+
+def is_curator_review() -> bool:
+    """True when the current call originates from a curator review fork.
+
+    Used by ``skill_manage`` to refuse ``action='delete'`` (permanent loss)
+    during curator review passes — the curator must use ``action='archive'``
+    (recoverable move to ``.archive/``) instead.
+    """
+    return _curator_review.get()


### PR DESCRIPTION
## What does this PR do?

Fixes #26655 and supersedes #26688.

The curator's LLM consolidation pass is documented to never permanently delete skills. Archival into `~/.hermes/skills/.archive/` is supposed to be the maximum destructive action, and run reports plus `hermes curator restore` promise recoverability.

Before this PR, the forked curator review agent could still call `skill_manage(action="delete")`, which permanently removes the skill directory with `shutil.rmtree`. The prompt said not to delete skills, but the tool surface still made deletion available, so an LLM mistake could make an intended archive unrecoverable and leave `.usage.json` / run-report state stale.

This PR gives the curator review path a real recoverable archive primitive and blocks permanent delete while the curator LLM pass is active.

## Related Issue

Fixes #26655.

Supersedes #26688. That PR is prompt-only; this PR enforces the invariant in code and provides the archive action the curator should use.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/skill_manager_tool.py`
  - Adds `skill_manage(action="archive")`.
  - Routes archive through the existing `tools/skill_usage.py::archive_skill()` primitive.
  - Refuses `action="delete"` while running inside a curator review context, and points the agent to `action="archive"` instead.
  - Keeps permanent delete available for non-curator/operator use.

- `tools/skill_provenance.py`
  - Adds a curator-review `ContextVar` helper so the tool layer can distinguish curator LLM review calls from ordinary operator calls.

- `agent/curator.py`
  - Sets and resets the curator-review context around `_run_llm_review`.
  - Updates `CURATOR_REVIEW_PROMPT` to instruct `skill_manage(action="archive")` instead of `delete`.
  - Extends report classification so `action="archive"` declarations participate in consolidation-vs-pruning extraction.

- `tests/tools/test_skill_manager_tool.py`
  - Adds coverage for archive moving the full skill package to `.archive/`.
  - Adds coverage that archive updates state to `archived` and preserves the usage record.
  - Adds coverage that archive refuses pinned skills, protected built-ins, and bundled skills when built-in pruning is disabled.
  - Adds coverage that delete is blocked during curator review but remains allowed outside it.

- `tests/agent/test_curator.py`
  - Adds coverage that `_run_llm_review` sets the curator-review context and clears it on both success and error.
  - Adds coverage that archive actions are recognized by report extraction.
  - Keeps the existing background-review origin guard on the curator fork.

## How to Test

1. Run the targeted curator and skill-manager tests:

   ```bash
   scripts/run_tests.sh tests/tools/test_skill_manager_tool.py tests/agent/test_curator.py
   ```

   Result:

   ```text
   179 passed
   ```

2. Verify syntax, whitespace, and Windows/path footguns:

   ```bash
   python -m py_compile agent/curator.py tests/agent/test_curator.py tools/skill_manager_tool.py tools/skill_provenance.py
   git diff --check
   git diff --cached --check
   python scripts/check-windows-footguns.py agent/curator.py tests/agent/test_curator.py tests/tools/test_skill_manager_tool.py tools/skill_manager_tool.py tools/skill_provenance.py
   ```

   Result:

   ```text
   ✓ No Windows footguns found (5 file(s) scanned).
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 7.0.6-2-pve with Python 3.11 via the Hermes-managed venv

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
scripts/run_tests.sh tests/tools/test_skill_manager_tool.py tests/agent/test_curator.py
# 179 passed

python -m py_compile agent/curator.py tests/agent/test_curator.py tools/skill_manager_tool.py tools/skill_provenance.py
# passed

git diff --check && git diff --cached --check
# passed

python scripts/check-windows-footguns.py agent/curator.py tests/agent/test_curator.py tests/tools/test_skill_manager_tool.py tools/skill_manager_tool.py tools/skill_provenance.py
# ✓ No Windows footguns found (5 file(s) scanned).
```
