### PR TITLE
fix(desktop): make Agents indicator match the Spawn-tree panel

### DIFF
--- a/apps/desktop/src/app/agents/index.tsx
+++ b/apps/desktop/src/app/agents/index.tsx
@@ -9,9 +9,9 @@ import { type Translations, useI18n } from '@/i18n'
 import { AlertCircle, CheckCircle2, Sparkles } from '@/lib/icons'
 import { useEnterAnimation } from '@/lib/use-enter-animation'
 import { cn } from '@/lib/utils'
-import { $activeSessionId } from '@/store/session'
 import {
   $subagentsBySession,
+  allSubagents,
   buildSubagentTree,
   type SubagentNode,
   type SubagentStatus,
@@ -77,15 +77,12 @@ interface AgentsViewProps {
 
 export function AgentsView({ onClose }: AgentsViewProps) {
   const { t } = useI18n()
-  const activeSessionId = useStore($activeSessionId)
   const subagentsBySession = useStore($subagentsBySession)
 
-  const activeSubagents = useMemo(
-    () => (activeSessionId ? (subagentsBySession[activeSessionId] ?? []) : []),
-    [activeSessionId, subagentsBySession]
-  )
-
-  const tree = useMemo(() => buildSubagentTree(activeSubagents), [activeSubagents])
+  // Aggregate every session, matching the status-bar indicator — a subagent
+  // running in a background session must still be visible here, or the two
+  // desync ("Agents N running" vs an empty tree).
+  const tree = useMemo(() => buildSubagentTree(allSubagents(subagentsBySession)), [subagentsBySession])
 
   return (
     <OverlayView

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -22,8 +22,6 @@ import type { RuntimeReadinessResult } from '@/lib/runtime-readiness'
 import { contextBarLabel, LiveDuration, usageContextLabel } from '@/lib/statusbar'
 import { cn } from '@/lib/utils'
 import { setGlobalYolo, setSessionYolo } from '@/lib/yolo-session'
-import { $desktopActionTasks } from '@/store/activity'
-import { $previewServerRestartStatus } from '@/store/preview'
 import {
   $activeSessionId,
   $busy,
@@ -31,11 +29,10 @@ import {
   $currentUsage,
   $sessionStartedAt,
   $turnStartedAt,
-  $workingSessionIds,
   $yoloActive,
   setYoloActive
 } from '@/store/session'
-import { $subagentsBySession, activeSubagentCount } from '@/store/subagents'
+import { $subagentsBySession, activeSubagentCount, failedSubagentCount } from '@/store/subagents'
 import { $gatewayRestarting } from '@/store/system-actions'
 import {
   $backendUpdateApply,
@@ -90,12 +87,9 @@ export function useStatusbarItems({
   const yoloActive = useStore($yoloActive)
   const busy = useStore($busy)
   const currentUsage = useStore($currentUsage)
-  const desktopActionTasks = useStore($desktopActionTasks)
   const gatewayRestarting = useStore($gatewayRestarting)
-  const previewServerRestartStatus = useStore($previewServerRestartStatus)
   const sessionStartedAt = useStore($sessionStartedAt)
   const turnStartedAt = useStore($turnStartedAt)
-  const workingSessionIds = useStore($workingSessionIds)
   const subagentsBySession = useStore($subagentsBySession)
   const updateStatus = useStore($updateStatus)
   const updateApply = useStore($updateApply)
@@ -159,24 +153,17 @@ export function useStatusbarItems({
     [gatewayLogLines, gatewayState, inferenceStatus, openCommandCenterSection, statusSnapshot]
   )
 
-  const { bgFailed, bgRunning, subagentsRunning } = useMemo(() => {
-    const actions = Object.values(desktopActionTasks)
-    const running = actions.filter(t => t.status.running).length
-    const failed = actions.filter(t => !t.status.running && (t.status.exit_code ?? 0) !== 0).length
-    const previewRunning = previewServerRestartStatus === 'running' ? 1 : 0
-    const previewFailed = previewServerRestartStatus === 'error' ? 1 : 0
-
-    const subagentsRunning = Object.values(subagentsBySession).reduce(
-      (sum, items) => sum + activeSubagentCount(items),
-      0
-    )
+  // The indicator must speak the same scope as the Spawn-tree panel it opens:
+  // every session's subagents, never background system actions (gateway
+  // restarts, toolset installs) which surface in their own panels.
+  const { subagentsFailed, subagentsRunning } = useMemo(() => {
+    const lists = Object.values(subagentsBySession)
 
     return {
-      bgFailed: failed + previewFailed,
-      bgRunning: workingSessionIds.length + running + previewRunning,
-      subagentsRunning
+      subagentsFailed: lists.reduce((sum, items) => sum + failedSubagentCount(items), 0),
+      subagentsRunning: lists.reduce((sum, items) => sum + activeSubagentCount(items), 0)
     }
-  }, [desktopActionTasks, previewServerRestartStatus, subagentsBySession, workingSessionIds])
+  }, [subagentsBySession])
 
   const gatewayOpen = gatewayState === 'open'
   const gatewayConnecting = gatewayState === 'connecting'
@@ -321,20 +308,18 @@ export function useStatusbarItems({
       {
         className: cn(
           agentsOpen && 'bg-accent/55 text-foreground',
-          bgFailed > 0 && 'text-destructive hover:text-destructive'
+          subagentsFailed > 0 && 'text-destructive hover:text-destructive'
         ),
         detail:
           subagentsRunning > 0
             ? copy.subagents(subagentsRunning)
-            : bgFailed > 0
-              ? copy.failed(bgFailed)
-              : bgRunning > 0
-                ? copy.running(bgRunning)
-                : undefined,
+            : subagentsFailed > 0
+              ? copy.failed(subagentsFailed)
+              : undefined,
         icon:
-          bgFailed > 0 ? (
+          subagentsFailed > 0 ? (
             <AlertCircle className="size-3" />
-          ) : bgRunning > 0 || subagentsRunning > 0 ? (
+          ) : subagentsRunning > 0 ? (
             <Loader2 className="size-3 animate-spin" />
           ) : (
             <Sparkles className="size-3" />
@@ -356,8 +341,6 @@ export function useStatusbarItems({
     ],
     [
       agentsOpen,
-      bgFailed,
-      bgRunning,
       commandCenterOpen,
       copy,
       gatewayMenuContent,
@@ -367,6 +350,7 @@ export function useStatusbarItems({
       inferenceReady,
       inferenceStatus?.reason,
       openAgents,
+      subagentsFailed,
       subagentsRunning,
       toggleCommandCenter
     ]

--- a/apps/desktop/src/store/subagents.test.ts
+++ b/apps/desktop/src/store/subagents.test.ts
@@ -3,8 +3,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   $subagentsBySession,
   activeSubagentCount,
+  allSubagents,
   buildSubagentTree,
   clearSessionSubagents,
+  failedSubagentCount,
   pruneDelegateFallbackSubagents,
   upsertSubagent
 } from './subagents'
@@ -97,6 +99,27 @@ describe('subagent store', () => {
     pruneDelegateFallbackSubagents('s1')
 
     expect(listFor('s1').map(item => item.id)).toEqual(['sa-0-xyz'])
+  })
+
+  // Contract: the status-bar "Agents" indicator and the Spawn-tree panel read
+  // the same scope — every session's subagents — so a count can never point at
+  // an empty tree (the desync behind "Agents (N)" vs "No live subagents").
+  it('counts running/failed across every session, matching the aggregated tree', () => {
+    upsertSubagent('s1', { goal: 'a', status: 'running', subagent_id: 'a', task_index: 0 })
+    upsertSubagent('s1', { goal: 'b', status: 'failed', subagent_id: 'b', task_index: 1 })
+    upsertSubagent('s2', { goal: 'c', status: 'running', subagent_id: 'c', task_index: 0 })
+    upsertSubagent('s2', { goal: 'd', status: 'failed', subagent_id: 'd', task_index: 1 })
+
+    const flat = allSubagents($subagentsBySession.get())
+    const indicatorRunning = Object.values($subagentsBySession.get()).reduce((n, l) => n + activeSubagentCount(l), 0)
+    const indicatorFailed = Object.values($subagentsBySession.get()).reduce((n, l) => n + failedSubagentCount(l), 0)
+    const tree = buildSubagentTree(flat)
+
+    // The active-session-only filter would have reported 1/1 here, not 2/2.
+    expect(indicatorRunning).toBe(2)
+    expect(indicatorFailed).toBe(2)
+    expect(tree).toHaveLength(4)
+    expect(indicatorRunning + indicatorFailed).toBe(tree.length)
   })
 
   it('clears one session without touching another', () => {

--- a/apps/desktop/src/store/subagents.ts
+++ b/apps/desktop/src/store/subagents.ts
@@ -261,3 +261,10 @@ export function buildSubagentTree(items: readonly SubagentProgress[]): SubagentN
 
 export const activeSubagentCount = (items: readonly SubagentProgress[]) =>
   items.filter(item => item.status === 'queued' || item.status === 'running').length
+
+export const failedSubagentCount = (items: readonly SubagentProgress[]) =>
+  items.filter(item => item.status === 'failed' || item.status === 'interrupted').length
+
+/** Flatten every session's subagents — the scope the Spawn-tree panel and the
+ *  status-bar indicator must agree on. */
+export const allSubagents = (bySession: Record<string, SubagentProgress[]>) => Object.values(bySession).flat()


### PR DESCRIPTION
## Summary

The status-bar **Agents** item and the **Spawn tree** panel it opens read different data, so the indicator can report activity over an empty tree.

The indicator mixed three signals:
- running subagents (aggregated across all sessions),
- in-flight session turns (`$workingSessionIds`),
- failed/running **background system actions** (`$desktopActionTasks` — gateway restarts, toolset installs, computer-use grants — plus preview-server restarts).

But `AgentsView` renders **only subagents**, and only for the **active session**. Two desyncs result:
1. A failed gateway restart / toolset install shows **"Agents (1 Failed)"** while the panel shows **"No live subagents"** (the reported bug).
2. A subagent running in a background session shows **"Agents N running"** with an empty tree (#49808).

## Fix

Make both surfaces speak the same scope:
- `AgentsView` aggregates subagents across **every** session (salvages #49819's core change).
- The indicator's running/failed counts come from **subagents only**, aggregated across sessions — never background system actions, which keep their own surfaces (settings panels, command center).

Net: `Agents (N running)` / `Agents (N failed)` now always point at a populated Spawn tree. The `$desktopActionTasks` / `$workingSessionIds` / preview-restart wiring is dropped from this indicator (it was the only consumer of `buildRailTasks`-style data here; system actions remain visible where they're triggered).

New helpers `failedSubagentCount` / `allSubagents` keep the indicator and panel DRY against one source of truth.

## Why this supersedes #49819

#49819 only made `AgentsView` aggregate across sessions, which fixes case (2) but **not** the reported "(1 Failed)" case — that count never came from subagents, so it would still hover over an empty tree. This change fixes both.

## Test plan

- [x] `vitest run apps/desktop/src/store/subagents.test.ts` — added a contract test asserting indicator counts (running+failed, aggregated) equal the aggregated tree the panel builds.
- [x] `tsc -p apps/desktop --noEmit`
- [x] `eslint` on changed files
- [ ] Manual: trigger a failed gateway restart → no "Agents (1 Failed)"; run a delegating turn in a background session → indicator + Spawn tree agree.

Supersedes #49819. Fixes #49808.