### PR TITLE
fix(desktop): give the gateway reconnect loop an escape hatch

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -40,6 +40,13 @@ import {
 } from '@/store/session'
 import type { RpcEvent } from '@/types/hermes'
 
+// After this many consecutive failed reconnects (≈45s with the 1→15s backoff)
+// raise a recoverable boot error. Otherwise a dropped remote gateway loops the
+// backoff forever behind the fullscreen CONNECTING overlay with no way to reach
+// Settings / sign in / switch to local — the "lost connection breaks the app"
+// dead end. The next successful reconnect clears it.
+const RECONNECT_ESCALATE_AFTER = 6
+
 interface GatewayBootOptions {
   handleGatewayEvent: (event: RpcEvent) => void
   onConnectionReady: (
@@ -105,6 +112,10 @@ export function useGatewayBoot({
     // tick — a stale OAuth ticket fails every attempt and would otherwise stack
     // identical error toasts (and their haptics). Reset on the next clean open.
     let reauthNotified = false
+    // Raised once the reconnect loop crosses RECONNECT_ESCALATE_AFTER so the
+    // recovery overlay replaces the dead-end CONNECTING screen. Reset on a clean
+    // open or a manual/wake-driven reconnect.
+    let escalated = false
 
     // Wrap the live getter in a call so TS control-flow analysis doesn't narrow
     // `connectionState` to a constant across the early-return guards (the state
@@ -171,6 +182,11 @@ export function useGatewayBoot({
         reconnecting = false
 
         if (!cancelled && !gatewayOpen()) {
+          if (reconnectAttempt >= RECONNECT_ESCALATE_AFTER && !escalated) {
+            escalated = true
+            failDesktopBoot(translateNow('boot.errors.gatewayConnectionLost'))
+          }
+
           scheduleReconnect()
         }
       }
@@ -197,6 +213,7 @@ export function useGatewayBoot({
 
       clearReconnectTimer()
       reconnectAttempt = 0
+      escalated = false
       reconnectSecondaryGateways()
 
       if (!gatewayOpen()) {
@@ -230,6 +247,7 @@ export function useGatewayBoot({
       if (st === 'open') {
         reconnectAttempt = 0
         reauthNotified = false
+        escalated = false
         clearReconnectTimer()
 
         // A revalidate-driven reconnect can rebuild the backend in place when the

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -57,6 +57,7 @@ export const en: Translations = {
       backgroundExitedDuringStartup: 'Hermes background process exited during startup.',
       backendStopped: 'Backend stopped',
       desktopBootFailed: 'Desktop boot failed',
+      gatewayConnectionLost: 'Lost connection to the gateway',
       gatewaySignInRequired: 'Gateway sign-in required',
       ipcBridgeUnavailable: 'Desktop IPC bridge is unavailable.'
     },

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -57,6 +57,7 @@ export const ja = defineLocale({
       backgroundExitedDuringStartup: '起動中に Hermes バックグラウンドプロセスが終了しました。',
       backendStopped: 'バックエンドが停止しました',
       desktopBootFailed: 'デスクトップの起動に失敗しました',
+      gatewayConnectionLost: 'ゲートウェイへの接続が切断されました',
       gatewaySignInRequired: 'ゲートウェイへのサインインが必要です',
       ipcBridgeUnavailable: 'デスクトップ IPC ブリッジが利用できません。'
     },

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -72,6 +72,7 @@ export interface Translations {
       backgroundExitedDuringStartup: string
       backendStopped: string
       desktopBootFailed: string
+      gatewayConnectionLost: string
       gatewaySignInRequired: string
       ipcBridgeUnavailable: string
     }

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -57,6 +57,7 @@ export const zhHant = defineLocale({
       backgroundExitedDuringStartup: 'Hermes 背景程序在啟動期間結束。',
       backendStopped: '後端已停止',
       desktopBootFailed: '桌面啟動失敗',
+      gatewayConnectionLost: '與閘道的連線已中斷',
       gatewaySignInRequired: '需要閘道登入',
       ipcBridgeUnavailable: '桌面 IPC 橋接器不可用。'
     },

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -57,6 +57,7 @@ export const zh: Translations = {
       backgroundExitedDuringStartup: 'Hermes 后台进程在启动期间退出。',
       backendStopped: '后端已停止',
       desktopBootFailed: '桌面启动失败',
+      gatewayConnectionLost: '与网关的连接已断开',
       gatewaySignInRequired: '需要登录网关',
       ipcBridgeUnavailable: '桌面 IPC 桥不可用。'
     },


### PR DESCRIPTION
## Summary

"If you lose connection to the internet the app seems to break."

When a **remote** gateway drops after a healthy boot (internet loss, sleep/wake, VPS restart), `use-gateway-boot` retried with exponential backoff **forever** and never raised an error. The renderer stayed behind the fullscreen **CONNECTING** overlay with `gatewayState` non-open and `boot.error` null — so Settings, "sign in again", and "use local gateway" were all unreachable. The app looked bricked until a manual restart.

## Fix

Once the reconnect loop crosses `RECONNECT_ESCALATE_AFTER` (6 attempts, ≈45s), raise a recoverable boot error so the **BootFailureOverlay** (Retry / Sign in / Use local gateway) replaces the dead-end CONNECTING screen. The backoff keeps retrying underneath; a successful reconnect — or a manual/wake/online nudge — resets the counter and clears the error.

One new i18n string (`boot.errors.gatewayConnectionLost`) across all four locales.

## Why this was sitting unfixed

`apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx` already specifies this exact behavior with two `FIX:` tests — but the desktop **vitest suite isn't run in CI** (CI only typechecks + builds the renderer), so those specs were red and nobody noticed. This change makes them green.

## Scope

This addresses the remote-disconnect "stuck on CONNECTING" dead end. The related "a turn's `$busy`/working state never clears after a drop" is handled separately (session loop-guard).

## Test plan

- [x] `vitest run --environment jsdom apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx` — 4/4 pass (incl. both `FIX:` specs).
- [x] `vitest run --environment jsdom apps/desktop/src/components/gateway-connecting-overlay.test.tsx` — 3/3 pass.
- [x] `tsc -p apps/desktop --noEmit`; `eslint` (no new issues).
- [x] Manual (remote gateway): kill connectivity → after ~45s the recovery overlay appears; restore → it reconnects and dismisses.