### PR TITLE
fix(desktop): let the session watchdog heal a stuck "looping" turn

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -9,6 +9,7 @@ import {
   $busy,
   $messages,
   noteSessionActivity,
+  onSessionWatchdogClear,
   setCurrentFastMode,
   setCurrentModel,
   setCurrentPersonality,
@@ -274,6 +275,31 @@ export function useSessionStateCache({
       return next
     },
     [ensureSessionState, syncSessionStateToView]
+  )
+
+  // When the store watchdog force-clears a stuck session (8 min of stream
+  // silence — a hung or looping turn that never delivered its terminal event),
+  // also drop that session's busy/awaiting flags here. Clearing the sidebar dot
+  // alone leaves the composer wedged on "Thinking"/Stop; updateSessionState
+  // re-syncs `$busy` when the healed session is the one on screen.
+  useEffect(
+    () =>
+      onSessionWatchdogClear(storedSessionId => {
+        const runtimeId = runtimeIdByStoredSessionIdRef.current.get(storedSessionId)
+        const state = runtimeId ? sessionStateByRuntimeIdRef.current.get(runtimeId) : undefined
+
+        if (!runtimeId || !state?.busy) {
+          return
+        }
+
+        updateSessionState(runtimeId, current => ({
+          ...current,
+          awaitingResponse: false,
+          busy: false,
+          needsInput: false
+        }))
+      }),
+    [updateSessionState]
   )
 
   return {

--- a/apps/desktop/src/store/session-watchdog.test.ts
+++ b/apps/desktop/src/store/session-watchdog.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $workingSessionIds, onSessionWatchdogClear, setSessionWorking, setWorkingSessionIds } from './session'
+
+const WATCHDOG_MS = 8 * 60 * 1000
+
+describe('session watchdog', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    setWorkingSessionIds(() => [])
+  })
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+  })
+
+  it('drops a stuck session and notifies listeners once the silence window elapses', () => {
+    const cleared: string[] = []
+    const off = onSessionWatchdogClear(id => cleared.push(id))
+
+    setSessionWorking('s1', true)
+    expect($workingSessionIds.get()).toContain('s1')
+
+    vi.advanceTimersByTime(WATCHDOG_MS)
+
+    // Both the sidebar dot AND the busy-clearing signal fire — the contract
+    // that lets the composer recover from a hung/looping turn, not just the dot.
+    expect($workingSessionIds.get()).not.toContain('s1')
+    expect(cleared).toEqual(['s1'])
+
+    off()
+  })
+
+  it('never fires for a session that settles before the window', () => {
+    const cleared: string[] = []
+    const off = onSessionWatchdogClear(id => cleared.push(id))
+
+    setSessionWorking('s2', true)
+    setSessionWorking('s2', false)
+
+    vi.advanceTimersByTime(WATCHDOG_MS)
+
+    expect(cleared).toEqual([])
+
+    off()
+  })
+
+  it('stops notifying after unsubscribe', () => {
+    const cleared: string[] = []
+    const off = onSessionWatchdogClear(id => cleared.push(id))
+    off()
+
+    setSessionWorking('s3', true)
+    vi.advanceTimersByTime(WATCHDOG_MS)
+
+    expect(cleared).toEqual([])
+  })
+})

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -342,6 +342,20 @@ export const setSessionPickerOpen = (next: Updater<boolean>) => updateAtom($sess
 const SESSION_WATCHDOG_TIMEOUT_MS = 8 * 60 * 1000
 const sessionWatchdogTimers = new Map<string, ReturnType<typeof setTimeout>>()
 
+// Notified (with the stored session id) whenever the watchdog force-clears a
+// stuck session. The session-state cache subscribes to also drop that session's
+// busy/awaiting flags — clearing `$workingSessionIds` alone only removes the
+// sidebar dot, leaving the composer stuck on "Thinking"/Stop for a hung or
+// looping turn that never streamed its terminal event.
+type SessionWatchdogListener = (storedSessionId: string) => void
+const sessionWatchdogListeners = new Set<SessionWatchdogListener>()
+
+export function onSessionWatchdogClear(listener: SessionWatchdogListener): () => void {
+  sessionWatchdogListeners.add(listener)
+
+  return () => void sessionWatchdogListeners.delete(listener)
+}
+
 function armSessionWatchdog(sessionId: string) {
   const existing = sessionWatchdogTimers.get(sessionId)
 
@@ -356,6 +370,10 @@ function armSessionWatchdog(sessionId: string) {
     // away or the session genuinely finished, the timer is a no-op.
     if ($workingSessionIds.get().includes(sessionId)) {
       setWorkingSessionIds(current => current.filter(id => id !== sessionId))
+    }
+
+    for (const listener of sessionWatchdogListeners) {
+      listener(sessionId)
     }
   }, SESSION_WATCHDOG_TIMEOUT_MS)
 


### PR DESCRIPTION
## Summary

"Some session from days ago was stuck looping."

The desktop's 8-minute stream-silence watchdog (`session.ts`) only removed a stuck session from `$workingSessionIds` — the **sidebar dot**. The composer's busy state lives in the **session-state cache** (`$busy` is synced from it), and the watchdog never touched it. So a hung/looping turn that never streamed its terminal event — including an **old session re-opened while the backend still reports it `running`** — stayed wedged on "Thinking" / Stop indefinitely (the watchdog cleared the dot but the composer kept spinning).

## Fix

- `session.ts`: the watchdog now notifies subscribers (`onSessionWatchdogClear`) when it force-clears a session.
- `use-session-state-cache.ts`: subscribes and drops that session's `busy` / `awaitingResponse` / `needsInput` flags. `updateSessionState` re-syncs `$busy` when the healed session is the one on screen, so the composer recovers instead of spinning forever.

Frontend-only safety net — it doesn't touch the turn lifecycle or alter caching.

## Scope / follow-up

This heals the **UI** symptom. The deeper root for the "for days, survives restart" case is backend: a stale in-memory `session["running"]` left by a turn thread that died without running its `finally` keeps re-arming busy on every `session.resume`. That reconciliation is a separate gateway-side change.

## Test plan

- [x] `vitest run --environment jsdom apps/desktop/src/store/session-watchdog.test.ts` (new) — fires + clears after the window, never fires for a settled session, stops after unsubscribe.
- [x] `tsc -p apps/desktop --noEmit`; `eslint` (no new issues).
- [ ] Manual: open a session the backend still reports running with no live stream → after the watchdog window the composer drops "Thinking" and becomes usable.