### PR TITLE
fix(cli): make Windows active-session lock millisecond-responsive under contention

### DIFF
--- a/hermes_cli/active_sessions.py
+++ b/hermes_cli/active_sessions.py
@@ -90,6 +90,14 @@ def _lock_path() -> Path:
 
 
 class _FileLock:
+    # Ceiling for how long to wait for the cross-process lock before giving up,
+    # and how often to re-probe on Windows. The critical sections under this
+    # lock are tiny (a read-modify-write of a small JSON file), so real
+    # contention clears in milliseconds; the timeout only guards against a
+    # wedged peer.
+    _ACQUIRE_TIMEOUT = 10.0
+    _POLL_INTERVAL = 0.01
+
     def __init__(self, path: Path):
         self.path = path
         self._fh = None
@@ -97,26 +105,41 @@ class _FileLock:
     def __enter__(self):
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self._fh = open(self.path, "a+b")
-        if os.name == "nt":
-            try:
-                import msvcrt
-
-                self._fh.seek(0)
-                msvcrt.locking(self._fh.fileno(), msvcrt.LK_LOCK, 1)
-            except Exception as exc:
-                self._fh.close()
-                self._fh = None
-                raise RuntimeError("active session file lock unavailable") from exc
-        else:
-            try:
-                import fcntl
-
-                fcntl.flock(self._fh.fileno(), fcntl.LOCK_EX)
-            except Exception as exc:
-                self._fh.close()
-                self._fh = None
-                raise RuntimeError("active session file lock unavailable") from exc
+        try:
+            self._acquire()
+        except Exception as exc:
+            self._fh.close()
+            self._fh = None
+            raise RuntimeError("active session file lock unavailable") from exc
         return self
+
+    def _acquire(self) -> None:
+        if os.name == "nt":
+            # msvcrt's blocking LK_LOCK retries on a *one-second* granularity
+            # and raises after ten tries, so under contention acquirers are
+            # serialized seconds apart instead of immediately. That coarse
+            # latency breaks try-acquire semantics: a short-lived holder can
+            # release its slot before late acquirers even obtain the lock, so
+            # several callers each claim the "last" slot in turn (the
+            # max_concurrent_sessions cap is effectively bypassed). Poll the
+            # non-blocking LK_NBLCK mode instead so acquisition is
+            # millisecond-responsive, matching POSIX flock(LOCK_EX).
+            import msvcrt
+
+            deadline = time.monotonic() + self._ACQUIRE_TIMEOUT
+            while True:
+                try:
+                    self._fh.seek(0)
+                    msvcrt.locking(self._fh.fileno(), msvcrt.LK_NBLCK, 1)
+                    return
+                except OSError:
+                    if time.monotonic() >= deadline:
+                        raise
+                    time.sleep(self._POLL_INTERVAL)
+        else:
+            import fcntl
+
+            fcntl.flock(self._fh.fileno(), fcntl.LOCK_EX)
 
     def __exit__(self, exc_type, exc, tb):
         if self._fh is None:


### PR DESCRIPTION
## What does this PR do?

The cross-process lock that guards the active-session registry
(`max_concurrent_sessions`) acquired the lock on Windows via
`msvcrt.locking(fd, LK_LOCK, 1)`. `LK_LOCK` retries on a **one-second**
granularity and raises after ten attempts. Under contention this serializes
acquirers *seconds* apart instead of immediately, which breaks try-acquire
semantics: a short-lived slot holder can release before late acquirers even
obtain the lock, so multiple callers each claim the "last" slot in turn and the
`max_concurrent_sessions` cap is effectively bypassed.

The lock itself is sound (it does provide mutual exclusion) — the problem is the
coarse acquisition latency. The fix polls the non-blocking `LK_NBLCK` mode on a
short interval so acquisition is millisecond-responsive, matching the existing
POSIX `fcntl.flock(LOCK_EX)` behavior. A bounded timeout still guards against a
wedged peer. No new dependencies; the POSIX path is unchanged.

## Related Issue

Fixes # <!-- search open/closed issues for "max_concurrent_sessions" / "active session" and link if one exists -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/active_sessions.py` — `_FileLock` now acquires the lock through a
  new `_acquire()` helper. On the lock-contended path it polls `msvcrt.LK_NBLCK`
  with a short sleep and a bounded deadline instead of the coarse blocking
  `LK_LOCK`. POSIX (`fcntl.flock(LOCK_EX)`) is untouched.

## How to Test

1. `pytest tests/hermes_cli/test_active_sessions.py -q`
2. Specifically `test_cross_process_acquire_claims_only_one_last_slot`: 6 worker
   processes race for a single slot (`max_concurrent_sessions=1`). Before the
   fix it intermittently returned multiple "OK" (the cap was bypassed); after
   the fix exactly one worker wins.
3. Re-run the cross-process test repeatedly to confirm stability.

### Test results

- `tests/hermes_cli/test_active_sessions.py` → **9 passed** (including the
  previously-flaky `test_cross_process_acquire_claims_only_one_last_slot`)
- `test_cross_process_acquire_claims_only_one_last_slot` run **8 times
  consecutively → 8/8 stable** (it failed repeatedly before the fix)
- Session-limit integration tests
  (`tests/hermes_cli/test_cli_active_session_limit.py`,
  `tests/gateway/test_max_concurrent_sessions.py`,
  `tests/gateway/test_command_bypass_active_session.py`,
  `tests/gateway/test_active_session_text_merge.py`) + `test_active_sessions.py`
  → **70 passed**
- `scripts/check-windows-footguns.py hermes_cli/active_sessions.py` → clean

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(cli): ...`)
- [ ] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] Relevant tests pass
- [x] The fix is covered by an existing test that now passes
      (`test_cross_process_acquire_claims_only_one_last_slot`)

### Documentation & Housekeeping

- [x] No docs/config changes needed — N/A
- [x] I've considered cross-platform impact: POSIX path unchanged; the change is
      isolated to the Windows acquisition path

## Note

The same `msvcrt.locking(..., LK_LOCK, 1)` pattern exists in `cron/jobs.py` and
`plugins/memory/honcho/oauth.py` and has the identical latent issue. Their
cross-process tests are `skipif(fcntl is None)` (skipped on the affected
platform), so it is not exercised there. Kept out of this PR to stay focused;
happy to follow up.