### PR TITLE
fix(gateway): resolve google_chat bot-id cache path via profile-aware HERMES_HOME

### DIFF
--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -695,8 +695,12 @@ class GoogleChatAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
     def _bot_id_cache_path(self) -> _Path:
         """Location where the resolved bot user_id is cached across restarts."""
-        base = os.getenv("HERMES_HOME", str(_Path.home() / ".hermes"))
-        return _Path(base) / "google_chat_bot_id.json"
+        try:
+            from hermes_constants import get_hermes_home as _get_hermes_home
+            base = _get_hermes_home()
+        except (ModuleNotFoundError, ImportError):
+            base = _Path.home() / ".hermes"
+        return base / "google_chat_bot_id.json"
 
     def _load_cached_bot_id(self) -> Optional[str]:
         path = self._bot_id_cache_path()

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -351,6 +351,47 @@ class TestGoogleOwnedHost:
         assert _is_google_owned_host(url) is False
 
 
+class TestBotIdCachePath:
+    """``_bot_id_cache_path`` must resolve through the profile-aware
+    HERMES_HOME helper (``hermes_constants.get_hermes_home``), not a raw
+    ``os.getenv`` read. A raw read ignores the context-local override, so the
+    bot-id cache lands in the default profile while the rest of the adapter's
+    state (e.g. the thread-count store) follows the active profile.
+    """
+
+    def test_honors_hermes_home_env(self, tmp_path, monkeypatch):
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        # Clear any sticky context-local override so the env var decides.
+        token = set_hermes_home_override(None)
+        try:
+            monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+            a = GoogleChatAdapter(_base_config())
+            assert a._bot_id_cache_path() == tmp_path / "google_chat_bot_id.json"
+        finally:
+            reset_hermes_home_override(token)
+
+    def test_honors_context_local_profile_override(self, tmp_path, monkeypatch):
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        # The regression: HERMES_HOME is unset in the environment but a
+        # per-task profile override is active. The cache path must follow it.
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        profile = tmp_path / "profiles" / "profileA"
+        token = set_hermes_home_override(profile)
+        try:
+            a = GoogleChatAdapter(_base_config())
+            assert a._bot_id_cache_path() == profile / "google_chat_bot_id.json"
+        finally:
+            reset_hermes_home_override(token)
+
+
 # ===========================================================================
 # Config validation (inside connect())
 # ===========================================================================


### PR DESCRIPTION
## What does this PR do?

The Google Chat adapter resolved `HERMES_HOME` two different ways. The
thread-count store uses `hermes_constants.get_hermes_home()`, but
`_bot_id_cache_path()` used a raw `os.getenv("HERMES_HOME", str(Path.home() /
".hermes"))`. `get_hermes_home()` honors a context-local profile override
(`set_hermes_home_override`) and the platform-native default; the raw read
honors neither.

As a result, when `HERMES_HOME` is unset or a per-task profile override is
active, the bot-id cache lands in a different home than the rest of the
adapter's state. The cache then misses on every gateway restart, triggering
redundant `members.list` lookups and leaving self-filtering on the weaker
"bot_user_id not yet resolved" fallback.

The fix routes `_bot_id_cache_path()` through `get_hermes_home()` using the
same import fallback already used by the thread-count store
(`adapter.py:525`). All persistence paths in the plugin now share a single
`HERMES_HOME`, and profile overrides are honored. Behavior is unchanged when
`HERMES_HOME` is set explicitly.

## Related Issue

Aligns with the broader effort to route HERMES_HOME callsites through
`get_hermes_home()`. No separate tracking issue.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/google_chat/adapter.py` — `_bot_id_cache_path()` now
  resolves the base directory via `hermes_constants.get_hermes_home()` (with a
  `ModuleNotFoundError`/`ImportError` fallback to `~/.hermes`), replacing the
  raw `os.getenv("HERMES_HOME", ...)` read that ignored context-local profile
  overrides.
- `tests/gateway/test_google_chat.py` — added `TestBotIdCachePath` with two
  cases: `HERMES_HOME` env resolution, and the context-local profile override
  (the regression case, which fails against the pre-fix code).

## How to Test

1. With a context-local profile override active and `HERMES_HOME` unset, call
   `GoogleChatAdapter._bot_id_cache_path()` — pre-fix it returned the default
   `~/.hermes/...`; post-fix it returns `<profile>/google_chat_bot_id.json`,
   matching the thread-count store.
2. Run the adapter test suite:

   ~~~
   python -m pytest tests/gateway/test_google_chat.py -q
   # 162 passed

   python -m pytest tests/gateway/test_google_chat.py::TestBotIdCachePath -v
   # test_honors_hermes_home_env ............................ PASSED
   # test_honors_context_local_profile_override ............. PASSED
   ~~~
3. Cross-platform footgun check on the diff:

   ~~~
   python scripts/check-windows-footguns.py plugins/platforms/google_chat/adapter.py tests/gateway/test_google_chat.py
   # No Windows footguns found
   ~~~

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(gateway): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] Ran `pytest tests/gateway/test_google_chat.py -q` (the affected suite) → 162 passed
- [x] I've added tests for my changes (`TestBotIdCachePath`)
- [x] I've tested this change locally

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no doc/behavior surface change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact (the fix uses the platform-native `get_hermes_home()` default, an improvement over the hardcoded `~/.hermes`)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

~~~
$ python -m pytest tests/gateway/test_google_chat.py -q
162 passed, 6 warnings in ~13s

$ python -m pytest tests/gateway/test_google_chat.py::TestBotIdCachePath -v
tests/gateway/test_google_chat.py::TestBotIdCachePath::test_honors_hermes_home_env PASSED
tests/gateway/test_google_chat.py::TestBotIdCachePath::test_honors_context_local_profile_override PASSED
2 passed

$ python scripts/check-windows-footguns.py plugins/platforms/google_chat/adapter.py tests/gateway/test_google_chat.py
No Windows footguns found (2 file(s) scanned).
~~~