### PR TITLE
fix: relax hindsight-client pin from ==0.6.1 to >=0.6.1

### DIFF
--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -118,7 +118,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
 
     # ─── Memory providers ──────────────────────────────────────────────────
     "memory.honcho": ("honcho-ai==2.0.1",),
-    "memory.hindsight": ("hindsight-client==0.6.1",),
+    "memory.hindsight": ("hindsight-client>=0.6.1",),
 
     # ─── Messaging platforms (lazy-installable on demand) ──────────────────
     "platform.telegram": ("python-telegram-bot[webhooks]==22.6",),


### PR DESCRIPTION
## Problem

The exact pin `hindsight-client==0.6.1` in `LAZY_DEPS` conflicts with the hindsight plugin's own `_MIN_CLIENT_VERSION` check (which uses `>=`).

When a user has a newer version installed (e.g. 0.8.2), `_is_satisfied()` returns False because 0.8.2 does not match `==0.6.1`, triggering a forced reinstall of 0.6.1. On systems with PEP 668 (externally-managed Python, e.g. Homebrew Python 3.14), this reinstall fails and **silently breaks all Hindsight memory operations** (retain, recall, reflect).

## Root Cause

Two version management mechanisms conflict:
- `tools/lazy_deps.py`: `("hindsight-client==0.6.1",)` — exact pin, rejects higher versions
- `plugins/memory/hindsight/__init__.py`: `_MIN_CLIENT_VERSION = "0.6.1"` with `>=` — accepts higher versions

The plugin's `initialize()` auto-upgrades from 0.6.1 to newer versions using `>=0.6.1`. Then `lazy_deps.ensure()` sees the newer version doesn't match `==0.6.1`, tries to downgrade, fails on PEP 668, and raises `FeatureUnavailable`.

## Fix

Change the pin from `==0.6.1` to `>=0.6.1`, aligning with the plugin's existing constraint.

## Reproduction

1. Install hindsight-client 0.8.2 in a Python environment with PEP 668 (e.g. `pip install --user hindsight-client`)
2. Run Hermes with `memory.provider: hindsight`
3. Any `hindsight_recall` or `hindsight_retain` call fails with:
   ```
   Feature 'memory.hindsight' unavailable: pip install failed: error: externally-managed-environment
   ```

## Impact

All Hindsight memory operations silently fail when the installed client version differs from the exact pin. This affects any environment where:
- Multiple Python versions coexist (e.g. system Python 3.14 + venv Python 3.11)
- PEP 668 is active (Homebrew Python, system Python on Debian/Ubuntu)
- The user manually upgraded hindsight-client

## Testing

- `tests/tools/test_lazy_deps.py`: 61 passed ✅