### PR TITLE
fix: reject BMP for native vision embedding

### DIFF
--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -13,6 +13,7 @@ from tools.vision_tools import (
     _validate_image_url,
     _handle_vision_analyze,
     _determine_mime_type,
+    _detect_image_mime_type,
     _image_to_base64_data_url,
     _resize_image_for_vision,
     _image_exceeds_dimension,
@@ -141,6 +142,19 @@ class TestDetermineMimeType:
 
     def test_unknown_extension_defaults_to_jpeg(self):
         assert _determine_mime_type(Path("file.xyz")) == "image/jpeg"
+
+
+# ---------------------------------------------------------------------------
+# _detect_image_mime_type
+# ---------------------------------------------------------------------------
+
+
+class TestDetectImageMimeType:
+    def test_bmp_header_is_unsupported_for_native_embedding(self, tmp_path):
+        img = tmp_path / "sample.bmp"
+        img.write_bytes(b"BM" + b"\x00" * 62)
+
+        assert _detect_image_mime_type(img) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -117,8 +117,13 @@ def _detect_image_mime_type(image_path: Path) -> Optional[str]:
         return "image/jpeg"
     if header.startswith((b"GIF87a", b"GIF89a")):
         return "image/gif"
+    # The native multimodal path sends this MIME directly to model APIs.
+    # OpenAI/Codex currently accepts jpeg/png/gif/webp only; returning BMP
+    # here wedges sessions with HTTP 400 once the tool output is embedded.
+    # Treat BMP as unsupported unless/until we add conversion to a supported
+    # format before constructing the data URL.
     if header.startswith(b"BM"):
-        return "image/bmp"
+        return None
     if len(header) >= 12 and header[:4] == b"RIFF" and header[8:12] == b"WEBP":
         return "image/webp"
     if image_path.suffix.lower() == ".svg":


### PR DESCRIPTION
## Summary
- Treat BMP files as unsupported in native vision MIME sniffing instead of embedding them as image/bmp data URLs.
- Add regression coverage for BMP headers returning None.

## Rationale
OpenAI/Codex native multimodal inputs currently accept jpeg/png/gif/webp, but not BMP. Returning image/bmp can wedge sessions with HTTP 400 once the tool output is embedded. Until conversion is added before data URL construction, BMP should be rejected by the native embedding path.

## Test
- venv/bin/python -m pytest tests/tools/test_vision_tools.py -q -o 'addopts='