### PR TITLE
Fix gateway restart for sentinel-managed containers

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5821,11 +5821,42 @@ def _dispatch_via_service_manager_if_s6(
         else:
             return False
     except GatewayNotRegisteredError as exc:
+        if action == "restart" and _request_restart_via_sentinel_if_configured(profile):
+            return True
         print(f"✗ {exc}")
         sys.exit(1)
     except S6CommandError as exc:
         print(f"✗ {exc}")
         sys.exit(1)
+    return True
+
+
+def _request_restart_via_sentinel_if_configured(profile: str) -> bool:
+    """Request an unsupervised container gateway restart via sentinel.
+
+    Some container deployments run the gateway as the container's main
+    process instead of registering a dynamic ``gateway-<profile>`` s6 slot.
+    In that mode ``hermes gateway restart`` can be wired through a wrapper
+    that watches ``HERMES_GATEWAY_RESTART_SENTINEL``.  Only use the sentinel
+    for the active profile; an explicit ``-p other`` must still fail instead
+    of restarting the wrong gateway.
+    """
+    sentinel = os.environ.get("HERMES_GATEWAY_RESTART_SENTINEL")
+    if not sentinel:
+        return False
+
+    active_profile = _profile_suffix() or "default"
+    if profile != active_profile:
+        return False
+
+    sentinel_path = Path(sentinel)
+    try:
+        sentinel_path.touch()
+    except OSError as exc:
+        print(f"✗ Could not request gateway restart via {sentinel_path}: {exc}")
+        sys.exit(1)
+
+    print(f"✓ Requested gateway restart via {sentinel_path}")
     return True
 
 

--- a/tests/hermes_cli/test_gateway_s6_dispatch.py
+++ b/tests/hermes_cli/test_gateway_s6_dispatch.py
@@ -116,6 +116,69 @@ def test_dispatch_defaults_profile_to_default(
     assert rec.calls == [("start", "gateway-default")]
 
 
+def test_dispatch_restart_uses_configured_sentinel_when_gateway_slot_missing(
+    tmp_path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+) -> None:
+    """Unsupervised container gateways can expose a restart sentinel instead
+    of a dynamic gateway-default s6 slot."""
+    from hermes_cli import gateway as gw
+    from hermes_cli.service_manager import GatewayNotRegisteredError
+
+    sentinel = tmp_path / "gateway-restart-requested"
+
+    class _MissingDefault(_CallRecorder):
+        def restart(self, name: str) -> None:
+            self.calls.append(("restart", name))
+            raise GatewayNotRegisteredError("default")
+
+    rec = _MissingDefault()
+    monkeypatch.setattr(
+        "hermes_cli.service_manager.detect_service_manager", lambda: "s6",
+    )
+    monkeypatch.setattr(
+        "hermes_cli.service_manager.get_service_manager", lambda: rec,
+    )
+    monkeypatch.setattr("hermes_cli.gateway._profile_suffix", lambda: "")
+    monkeypatch.setenv("HERMES_GATEWAY_RESTART_SENTINEL", str(sentinel))
+
+    assert gw._dispatch_via_service_manager_if_s6("restart") is True
+    assert rec.calls == [("restart", "gateway-default")]
+    assert sentinel.exists()
+    out = capsys.readouterr().out
+    assert "Requested gateway restart via" in out
+
+
+def test_dispatch_restart_does_not_use_sentinel_for_other_profile(
+    tmp_path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A sentinel restart targets the active container gateway only."""
+    from hermes_cli import gateway as gw
+    from hermes_cli.service_manager import GatewayNotRegisteredError
+
+    sentinel = tmp_path / "gateway-restart-requested"
+
+    class _MissingCoder(_CallRecorder):
+        def restart(self, name: str) -> None:
+            self.calls.append(("restart", name))
+            raise GatewayNotRegisteredError("coder")
+
+    rec = _MissingCoder()
+    monkeypatch.setattr(
+        "hermes_cli.service_manager.detect_service_manager", lambda: "s6",
+    )
+    monkeypatch.setattr(
+        "hermes_cli.service_manager.get_service_manager", lambda: rec,
+    )
+    monkeypatch.setattr("hermes_cli.gateway._profile_suffix", lambda: "")
+    monkeypatch.setenv("HERMES_GATEWAY_RESTART_SENTINEL", str(sentinel))
+
+    with pytest.raises(SystemExit) as excinfo:
+        gw._dispatch_via_service_manager_if_s6("restart", profile="coder")
+    assert excinfo.value.code == 1
+    assert rec.calls == [("restart", "gateway-coder")]
+    assert not sentinel.exists()
+
+
 # ---------------------------------------------------------------------------
 # _dispatch_all_via_service_manager_if_s6 — --all under s6
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix `hermes gateway restart` in container deployments where the active gateway is managed by a wrapper/sentinel instead of a dynamic `gateway-<profile>` s6 service directory.

In that runtime, `hermes gateway restart` currently resolves the default profile to `gateway-default`, asks the s6 service manager to restart it, and fails with:

```text
no such gateway 'default': register it with `hermes profile create default` first, or pass an existing profile name via `-p <name>`
```

However, the gateway is actually running and receiving Telegram messages. The restart path is targeting a registry entry that does not exist in this deployment mode.

## Observed Runtime

On Olares, the gateway container exposes:

```text
HERMES_GATEWAY_NO_SUPERVISE=1
HERMES_GATEWAY_RESTART_SENTINEL=/opt/data/.gateway-restart-requested
HERMES_GATEWAY_RESTART_DELAY_SECONDS=30
HERMES_GATEWAY_SENTINEL_POLL_SECONDS=2
HERMES_GATEWAY_SENTINEL_RESTART_DELAY_SECONDS=3
```

The s6 service directories include static services such as:

```text
/run/s6/db/servicedirs/dashboard
/run/s6/db/servicedirs/main-hermes
```

But no dynamic `gateway-default` service is registered, so both the dashboard "Restart Gateway" button and `hermes gateway restart` fail even while the real gateway process is healthy.

## Change

When the s6 dispatch path receives `GatewayNotRegisteredError` for a `restart`, this patch checks whether `HERMES_GATEWAY_RESTART_SENTINEL` is configured for the active profile.

If it is, Hermes touches that sentinel file and exits successfully:

```text
✓ Requested gateway restart via /opt/data/.gateway-restart-requested
```

The fallback is intentionally narrow:

- only applies to `restart`
- only applies when `HERMES_GATEWAY_RESTART_SENTINEL` is explicitly configured
- only applies to the active profile, so `hermes -p other gateway restart` does not accidentally restart the wrong gateway
- preserves the existing `no such gateway` error when the sentinel is absent

## Tests

Added regression coverage in `tests/hermes_cli/test_gateway_s6_dispatch.py`:

- missing `gateway-default` + configured sentinel requests restart via sentinel
- explicit different profile does not use the sentinel fallback

Local verification:

```text
PYTHONPYCACHEPREFIX=/private/tmp/hermes-pycache python3 -m py_compile hermes_cli/gateway.py tests/hermes_cli/test_gateway_s6_dispatch.py
```

`pytest` was not available in the local macOS system Python used to prepare this patch, so the targeted pytest command still needs to run in CI or a Hermes dev environment:

```text
python -m pytest tests/hermes_cli/test_gateway_s6_dispatch.py -q
```
