### PR TITLE
fix(gateway): scope dashboard liveness fallback to the profile (salvage #52151)

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -304,6 +304,20 @@ def _record_looks_like_gateway(record: dict[str, Any]) -> bool:
     return looks_like_gateway_runtime_command_line(cmdline)
 
 
+def _record_matches_live_gateway_pid(record: dict[str, Any], pid: int) -> bool:
+    """Return True when a live PID still identifies as this gateway record.
+
+    Prefer the live command line whenever it is readable. Runtime status files
+    can outlive the gateway process they describe; if PID reuse leaves the same
+    PID occupied by an s6 supervisor/log process, the stale record's argv should
+    not make that unrelated process count as a running gateway.
+    """
+    live_cmdline = _read_process_cmdline(pid)
+    if live_cmdline:
+        return looks_like_gateway_runtime_command_line(live_cmdline)
+    return _record_looks_like_gateway(record)
+
+
 def _build_pid_record() -> dict:
     return {
         "pid": os.getpid(),
@@ -759,7 +773,7 @@ def get_runtime_status_running_pid(
     ):
         return None
 
-    if _looks_like_gateway_process(pid) or _record_looks_like_gateway(payload):
+    if _record_matches_live_gateway_pid(payload, pid):
         return pid
     return None
 
@@ -1261,7 +1275,7 @@ def get_running_pid(
         if recorded_start is not None and current_start is not None and current_start != recorded_start:
             continue
 
-        if _looks_like_gateway_process(pid) or _record_looks_like_gateway(record):
+        if _record_matches_live_gateway_pid(record, pid):
             return pid
 
     _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -304,17 +304,85 @@ def _record_looks_like_gateway(record: dict[str, Any]) -> bool:
     return looks_like_gateway_runtime_command_line(cmdline)
 
 
-def _record_matches_live_gateway_pid(record: dict[str, Any], pid: int) -> bool:
+def _profile_name_for_home(profile_home: Path) -> Optional[str]:
+    """Return the profile id a HERMES_HOME directory represents, or None.
+
+    A named profile's home is ``<root>/profiles/<name>`` (immediate parent is
+    ``profiles``).  The root/default home (``~/.hermes`` or ``$HERMES_HOME``)
+    has no such parent, so it maps to the default profile (``None`` here, which
+    callers treat as "the bare, flag-less gateway").
+    """
+    if profile_home.parent.name == "profiles":
+        return profile_home.name
+    return None
+
+
+def _command_line_belongs_to_profile(command: str, profile_home: Path) -> bool:
+    """Return True when a gateway command line belongs to ``profile_home``.
+
+    Mirrors ``hermes_cli.gateway._matches_current_profile`` so the dashboard's
+    cross-profile liveness fallback scopes a live PID to the *right* profile.
+    In a per-profile container, one profile's stale ``gateway_state.json`` can
+    record a PID that the OS has since recycled onto a DIFFERENT profile's live
+    gateway.  That recycled PID's command line still ``looks_like_gateway`` —
+    so without a profile check the dead profile is reported running.  A named
+    profile gateway carries ``-p <name>``/``--profile <name>`` (or, rarely, an
+    explicit ``HERMES_HOME=<path>``) on its argv; the default/root gateway runs
+    bare with no profile flag.
+    """
+    command_lc = command.lower()
+    profile_name = _profile_name_for_home(profile_home)
+    home_lc = str(profile_home).lower()
+
+    if profile_name is not None and profile_name != "default":
+        profile_lc = profile_name.lower()
+        return (
+            f"--profile {profile_lc}" in command_lc
+            or f"-p {profile_lc}" in command_lc
+            or f"hermes_home={home_lc}" in command_lc
+        )
+
+    # Default/root profile: the gateway runs with no profile flag. Accept unless
+    # the command advertises *some other* profile (an explicit -p/--profile) or
+    # a non-matching explicit HERMES_HOME= on the argv. HERMES_HOME is usually
+    # passed via the environment (not visible on the command line), so its mere
+    # absence is not disqualifying — only a conflicting explicit value is.
+    if "--profile " in command_lc or " -p " in command_lc:
+        return False
+    if "hermes_home=" in command_lc and f"hermes_home={home_lc}" not in command_lc:
+        return False
+    return True
+
+
+def _record_matches_live_gateway_pid(
+    record: dict[str, Any],
+    pid: int,
+    *,
+    expected_home: Optional[Path] = None,
+) -> bool:
     """Return True when a live PID still identifies as this gateway record.
 
     Prefer the live command line whenever it is readable. Runtime status files
     can outlive the gateway process they describe; if PID reuse leaves the same
     PID occupied by an s6 supervisor/log process, the stale record's argv should
     not make that unrelated process count as a running gateway.
+
+    When ``expected_home`` is provided (the dashboard enumerating a specific
+    profile's state file), the readable live command line must additionally
+    belong to *that* profile — otherwise a PID recycled onto a different
+    profile's live gateway would make the dead profile look alive.  When the
+    live command line cannot be read (Windows/permission), fall back to the
+    persisted record so cross-platform behavior is preserved.
     """
     live_cmdline = _read_process_cmdline(pid)
     if live_cmdline:
-        return looks_like_gateway_runtime_command_line(live_cmdline)
+        if not looks_like_gateway_runtime_command_line(live_cmdline):
+            return False
+        if expected_home is not None and not _command_line_belongs_to_profile(
+            live_cmdline, expected_home
+        ):
+            return False
+        return True
     return _record_looks_like_gateway(record)
 
 
@@ -745,6 +813,8 @@ def derive_gateway_drainable(*, gateway_running: bool, gateway_state: Any) -> bo
 
 def get_runtime_status_running_pid(
     runtime: Optional[dict[str, Any]] = None,
+    *,
+    expected_home: Optional[Path] = None,
 ) -> Optional[int]:
     """Return a live gateway PID from the runtime status record, if valid.
 
@@ -753,6 +823,13 @@ def get_runtime_status_running_pid(
     a live process and a fresh ``gateway_state.json`` but no ``gateway.pid``; use
     this as a conservative fallback by checking both the persisted state and the
     OS process identity.
+
+    ``expected_home`` scopes the OS-identity check to a specific profile's
+    HERMES_HOME.  Pass it when validating *another* profile's state file (the
+    dashboard enumerating every profile): a stale record whose PID the OS has
+    recycled onto a different profile's live gateway must not be reported
+    running for the dead profile.  Omit it (the default) for the active
+    profile, where any live gateway command line is acceptable.
     """
     payload = runtime if runtime is not None else read_runtime_status()
     if not isinstance(payload, dict):
@@ -773,7 +850,7 @@ def get_runtime_status_running_pid(
     ):
         return None
 
-    if _record_matches_live_gateway_pid(payload, pid):
+    if _record_matches_live_gateway_pid(payload, pid, expected_home=expected_home):
         return pid
     return None
 

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -639,7 +639,7 @@ def _check_gateway_running(profile_dir: Path) -> bool:
             read_runtime_status,
         )
         runtime = read_runtime_status(profile_dir / "gateway_state.json")
-        return get_runtime_status_running_pid(runtime) is not None
+        return get_runtime_status_running_pid(runtime, expected_home=profile_dir) is not None
     except Exception:
         return False
 

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -397,6 +397,130 @@ class TestGatewayRuntimeStatus:
 
         assert status.get_runtime_status_running_pid(payload) == 132
 
+    def test_runtime_status_running_pid_rejects_pid_reused_by_other_profile(self, monkeypatch):
+        """Regression (user report): a stale profile's recycled PID must not be
+        reported running just because it now hosts a DIFFERENT profile's gateway.
+
+        Per-profile Docker supervision: ``coder``'s gateway died leaving a
+        ``gateway_state=running`` record at PID 139.  The OS then recycled 139
+        onto the live *default* gateway (``hermes gateway run``).  The recorded
+        ``start_time`` is absent (older state file), so the start-time PID-reuse
+        guard does not catch it.  Without the profile scope the live command
+        line still ``looks_like_gateway`` and ``coder`` is wrongly reported up.
+        """
+        payload = {
+            "pid": 139,
+            "gateway_state": "running",
+            "kind": "hermes-gateway",
+            "argv": ["hermes", "gateway", "run"],
+        }
+        coder_home = Path("/opt/data/profiles/coder")
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: None)
+        # PID 139 is now the live DEFAULT gateway (bare, no -p coder).
+        monkeypatch.setattr(
+            status, "_read_process_cmdline", lambda pid: "hermes gateway run --replace"
+        )
+
+        assert (
+            status.get_runtime_status_running_pid(payload, expected_home=coder_home)
+            is None
+        )
+
+    def test_runtime_status_running_pid_accepts_matching_profile_cmdline(self, monkeypatch):
+        """A genuinely-live named gateway carries ``-p <profile>`` / ``--profile``
+        on its command line and must be reported running for that profile."""
+        payload = {
+            "pid": 139,
+            "gateway_state": "running",
+            "kind": "hermes-gateway",
+            "argv": ["hermes", "gateway", "run"],
+            "start_time": 1000,
+        }
+        coder_home = Path("/opt/data/profiles/coder")
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 1000)
+        for cmdline in (
+            "hermes -p coder gateway run --replace",
+            "/opt/hermes/.venv/bin/hermes --profile coder gateway run --replace",
+            "hermes_home=/opt/data/profiles/coder hermes gateway run --replace",
+        ):
+            monkeypatch.setattr(status, "_read_process_cmdline", lambda pid, c=cmdline: c)
+            assert (
+                status.get_runtime_status_running_pid(payload, expected_home=coder_home)
+                == 139
+            ), cmdline
+
+    def test_runtime_status_running_pid_default_profile_rejects_named_cmdline(self, monkeypatch):
+        """The default/root profile runs a bare gateway (no profile flag).  A
+        recycled PID now hosting a *named* profile gateway must not be reported
+        running for the default profile."""
+        payload = {
+            "pid": 139,
+            "gateway_state": "running",
+            "kind": "hermes-gateway",
+            "argv": ["hermes", "gateway", "run"],
+        }
+        default_home = Path("/opt/data")
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: None)
+        monkeypatch.setattr(
+            status, "_read_process_cmdline", lambda pid: "hermes -p coder gateway run --replace"
+        )
+
+        assert (
+            status.get_runtime_status_running_pid(payload, expected_home=default_home)
+            is None
+        )
+
+    def test_runtime_status_running_pid_default_profile_accepts_bare_cmdline(self, monkeypatch):
+        """The default/root gateway (bare ``hermes gateway run``) is reported
+        running for the default profile."""
+        payload = {
+            "pid": 139,
+            "gateway_state": "running",
+            "kind": "hermes-gateway",
+            "argv": ["hermes", "gateway", "run"],
+            "start_time": 1000,
+        }
+        default_home = Path("/opt/data")
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 1000)
+        monkeypatch.setattr(
+            status, "_read_process_cmdline", lambda pid: "hermes gateway run --replace"
+        )
+
+        assert (
+            status.get_runtime_status_running_pid(payload, expected_home=default_home)
+            == 139
+        )
+
+    def test_runtime_status_running_pid_profile_scope_falls_back_when_cmdline_unreadable(self, monkeypatch):
+        """When the live command line is unreadable (Windows/permission), the
+        profile scope cannot apply — fall back to the persisted record so the
+        cross-platform behavior is preserved."""
+        payload = {
+            "pid": 139,
+            "gateway_state": "running",
+            "kind": "hermes-gateway",
+            "argv": ["hermes", "gateway", "run"],
+            "start_time": 1000,
+        }
+        coder_home = Path("/opt/data/profiles/coder")
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 1000)
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: None)
+
+        assert (
+            status.get_runtime_status_running_pid(payload, expected_home=coder_home)
+            == 139
+        )
+
     def test_write_runtime_status_records_platform_failure(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -359,6 +359,44 @@ class TestGatewayRuntimeStatus:
         assert payload["pid"] == os.getpid()
         assert payload["start_time"] == 2000
 
+    def test_runtime_status_running_pid_rejects_stale_record_for_supervisor_pid(self, monkeypatch):
+        """Regression: stale profile runtime state must not mark s6 supervisors live.
+
+        Docker per-profile supervision can leave a named profile with
+        ``gateway_state=running`` metadata while the real gateway process is gone
+        and the recorded PID now belongs to ``s6-supervise`` or ``s6-log``.  If
+        the live command line is readable, it wins over the stale record argv.
+        """
+        payload = {
+            "pid": 132,
+            "start_time": 123,
+            "gateway_state": "running",
+            "kind": "hermes-gateway",
+            "argv": ["/opt/hermes/.venv/bin/hermes", "gateway", "run", "--replace"],
+        }
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: "s6-supervise gateway-coder")
+
+        assert status.get_runtime_status_running_pid(payload) is None
+
+    def test_runtime_status_running_pid_uses_record_when_cmdline_unreadable(self, monkeypatch):
+        """Keep the cross-platform fallback for hosts where cmdline is unavailable."""
+        payload = {
+            "pid": 132,
+            "start_time": 123,
+            "gateway_state": "running",
+            "kind": "hermes-gateway",
+            "argv": ["/opt/hermes/.venv/bin/hermes", "gateway", "run", "--replace"],
+        }
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: None)
+
+        assert status.get_runtime_status_running_pid(payload) == 132
+
     def test_write_runtime_status_records_platform_failure(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -1483,8 +1483,15 @@ class TestEdgeCases:
 
         # Primary pid-file/lock check returns None (no lock held by this reader),
         # exactly as it does for a separate-process dashboard. The fallback must
-        # then read the state file and confirm the gateway is alive.
-        with patch("gateway.status.get_running_pid", return_value=None):
+        # then read the state file and confirm the gateway is alive by checking
+        # the recorded PID's live command line. In the real separate-process
+        # scenario that PID belongs to the live gateway, so mock its command
+        # line to a bare ``gateway run`` (this is the default/root home, which
+        # runs the gateway with no profile flag).
+        with patch("gateway.status.get_running_pid", return_value=None), patch(
+            "gateway.status._read_process_cmdline",
+            return_value="hermes gateway run --replace",
+        ):
             assert _check_gateway_running(default_home) is True
 
     def test_gateway_running_check_runtime_state_stopped(self, profile_env):
@@ -1510,6 +1517,77 @@ class TestEdgeCases:
 
         with patch("gateway.status.get_running_pid", return_value=None):
             assert _check_gateway_running(default_home) is False
+
+    def test_gateway_running_check_rejects_pid_reused_by_other_profile(self, profile_env):
+        """Regression (user report): the dashboard showed a NAMED profile's
+        gateway green while ``hermes -p <name> gateway status`` showed it
+        stopped.
+
+        Per-profile Docker supervision: a named profile (``coder``) left a
+        ``gateway_state=running`` record whose PID the OS later recycled onto a
+        DIFFERENT live process (here the default profile's gateway).  The
+        ``_check_gateway_running`` fallback must scope the live PID to *this*
+        profile's command line, so a recycled PID hosting another profile's
+        gateway is not reported running for ``coder``.
+        """
+        from hermes_cli.profiles import _check_gateway_running
+
+        tmp_path = profile_env
+        coder_home = tmp_path / ".hermes" / "profiles" / "coder"
+        coder_home.mkdir(parents=True, exist_ok=True)
+        (coder_home / "gateway_state.json").write_text(
+            json.dumps(
+                {
+                    "pid": 139,
+                    "kind": "hermes-gateway",
+                    "argv": ["hermes", "gateway", "run"],
+                    "gateway_state": "running",
+                    "active_agents": 0,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        # PID 139 is alive but is the DEFAULT gateway (bare, no -p coder), not
+        # coder's. start_time is absent so the PID-reuse guard cannot catch it;
+        # the profile scope must.
+        with patch("gateway.status.get_running_pid", return_value=None), patch(
+            "gateway.status._pid_exists", return_value=True
+        ), patch("gateway.status._get_process_start_time", return_value=None), patch(
+            "gateway.status._read_process_cmdline",
+            return_value="hermes gateway run --replace",
+        ):
+            assert _check_gateway_running(coder_home) is False
+
+    def test_gateway_running_check_detects_matching_named_profile(self, profile_env):
+        """A genuinely-live named gateway (``-p coder`` on its command line) is
+        still reported running for that profile."""
+        from hermes_cli.profiles import _check_gateway_running
+
+        tmp_path = profile_env
+        coder_home = tmp_path / ".hermes" / "profiles" / "coder"
+        coder_home.mkdir(parents=True, exist_ok=True)
+        (coder_home / "gateway_state.json").write_text(
+            json.dumps(
+                {
+                    "pid": 139,
+                    "kind": "hermes-gateway",
+                    "argv": ["hermes", "gateway", "run"],
+                    "start_time": 1000,
+                    "gateway_state": "running",
+                    "active_agents": 0,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch("gateway.status.get_running_pid", return_value=None), patch(
+            "gateway.status._pid_exists", return_value=True
+        ), patch("gateway.status._get_process_start_time", return_value=1000), patch(
+            "gateway.status._read_process_cmdline",
+            return_value="hermes -p coder gateway run --replace",
+        ):
+            assert _check_gateway_running(coder_home) is True
 
     def test_profile_name_boundary_single_char(self):
         """Single alphanumeric character is valid."""


### PR DESCRIPTION
## Infographic

![gateway-liveness-fix](https://v3b.fal.media/files/b/0a9fa4ae/fS-U76VLVmApFXwZNzF7K_eGeGFWWg.png)

## What does this PR do?

Salvages and completes #52151 (by @helix4u), which hardened gateway liveness so a stale `gateway_state.json` whose PID was recycled onto an `s6-supervise` process no longer counts as a running gateway. That fix is correct and preserved here (cherry-picked, authorship intact).

This PR closes the gap that made the **user-reported symptom** persist: the web dashboard showed a named profile's gateway **green** while `hermes -p <profile> gateway status` correctly showed it **stopped** (reported on the latest Docker image, default + `coder` profiles).

## Root cause

The dashboard (`hermes_cli/profiles._check_gateway_running`) and the CLI (`hermes gateway status` → `find_gateway_pids`) use **different** liveness paths:

- The **CLI scan path already scopes to the profile** via `_matches_current_profile` (matches `-p <name>` / `--profile <name>` / `HERMES_HOME=<path>` on the live command line). That is *why the CLI was right*.
- The **dashboard fallback** validated only that the recycled PID "looks like *a* gateway" — not that it's *this profile's* gateway.

In per-profile Docker supervision, one profile's stale state file can record a PID the OS later recycles onto a **different profile's** live gateway. That PID's command line still passes `looks_like_gateway_runtime_command_line`, so the dead profile was reported running. The recorded `argv` can't disambiguate — `_apply_profile_override` strips the `-p <name>` selector from `sys.argv` in-process — but the live `/proc/<pid>/cmdline` still carries it.

The existing `start_time` PID-reuse guard catches the common case; it does **not** when the recorded `start_time` is absent (older state file) or unreadable — which is exactly the slip path behind this report.

## Changes

- **`gateway/status.py`**
  - `get_runtime_status_running_pid()` gains an `expected_home` keyword. When set, the readable live command line must belong to *that* profile (new helpers `_profile_name_for_home` + `_command_line_belongs_to_profile`, mirroring `hermes_cli.gateway._matches_current_profile`).
  - `_record_matches_live_gateway_pid()` threads the profile scope through.
- **`hermes_cli/profiles.py`** — `_check_gateway_running` passes the enumerated profile dir as `expected_home`.
- Plus the original #52151 hunk (live cmdline beats stale argv).

### Why this doesn't break anything the user has

- **Active-profile path untouched.** `get_running_pid` stays unscoped — it is lock-verified and any live gateway cmdline is valid there.
- **Default/root profile** runs a bare `gateway run` (no flag); the scope accepts it and rejects only a cmdline advertising *another* profile.
- **Multiplex mode unaffected.** `gateway_state="running"` is only ever written to a gateway's own home, never a secondary served profile's state file, so a profile-scoped check can't regress a multiplexed profile.
- **Cross-platform fallback preserved.** When the live cmdline is unreadable (Windows/permission), it falls back to the persisted record as before.

### Also fixes the broken test from #52151

`test_gateway_running_check_falls_back_to_runtime_state` failed on #52151 because it used the live pytest PID with a gateway-shaped record; once the live cmdline became authoritative, that PID no longer looked like a gateway. Updated to mock the live cmdline to the real separate-process-gateway scenario it describes.

## Tests

New coverage in `tests/gateway/test_status.py` and `tests/hermes_cli/test_profiles.py`:

- cross-profile PID reuse rejected (named + default profile) — **the user's bug**
- matching profile cmdline accepted (`-p`, `--profile`, explicit `HERMES_HOME=`)
- bare default gateway accepted
- unreadable-cmdline cross-platform fallback preserved
- stale s6-supervise PID still rejected (original #52151 case)

Each new cross-profile assertion was verified to **fail without the profile scope and pass with it**. Full affected + adjacent suites green (`tests/gateway/test_status.py`, `tests/hermes_cli/test_profiles.py`, `tests/gateway/test_status_command.py`, `tests/cli/test_cli_status_bar.py` — 293 passed). `ruff check` clean.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

Co-authored-by: helix4u <4317663+helix4u@users.noreply.github.com>
