### PR TITLE
fix(gateway): move cross-process cache invalidation cleanup outside lock (#52197)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13849,6 +13849,53 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if release_running_state:
             self._release_running_agent_state(session_key)
 
+    def _evict_stale_cross_process_agent(
+        self,
+        session_key: str,
+        current_msg_count: Optional[int],
+        *,
+        sig: Optional[str] = None,
+    ) -> Optional[Any]:
+        """Check cross-process coherence and evict a stale cached agent.
+
+        The cross-process guard (#45966) compares the session's on-disk
+        ``message_count`` against the count snapshotted when the agent was
+        cached.  On mismatch, the cached agent is popped so a fresh one
+        rebuilds from the DB transcript.
+
+        When *sig* is given, the cache entry's signature must also match
+        (a changed sig means the config changed, handled by the normal
+        rebuild path — not a cross-process issue).
+
+        Returns the evicted agent (caller must clean up *outside* the lock)
+        or ``None`` when the cache is current or absent.
+        """
+        _cache_lock = getattr(self, "_agent_cache_lock", None)
+        _cache = getattr(self, "_agent_cache", None)
+        if not _cache_lock or _cache is None:
+            return None
+        with _cache_lock:
+            cached = _cache.get(session_key)
+            if not cached or len(cached) < 3:
+                return None
+            if sig is not None and cached[1] != sig:
+                return None
+            _cached_mc = cached[2]
+            if (
+                _cached_mc is not None
+                and current_msg_count is not None
+                and current_msg_count != _cached_mc
+            ):
+                logger.info(
+                    "Agent cache invalidated for session %s: "
+                    "message_count changed (%s -> %s), "
+                    "possible cross-process write",
+                    session_key, _cached_mc, current_msg_count,
+                )
+                evicted = _cache.pop(session_key, None)
+                return evicted[0] if isinstance(evicted, tuple) and evicted else None
+        return None
+
     def _refresh_agent_cache_message_count(
         self, session_key: str, session_id: Optional[str]
     ) -> None:
@@ -15555,29 +15602,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     pass
 
             if _cache_lock and _cache is not None:
-                _ev_agent = None
-                with _cache_lock:
-                    cached = _cache.get(session_key)
-                    if cached and cached[1] == _sig:
-                        # cached[2] is the message_count at cache time;
-                        # stale when a second process appended rows.
-                        _cached_mc = cached[2] if len(cached) > 2 else None
-                        if (
-                            _cached_mc is not None
-                            and _current_msg_count is not None
-                            and _current_msg_count != _cached_mc
-                        ):
-                            # Cross-process write detected — discard stale
-                            # agent so it rebuilds from fresh DB transcript.
-                            logger.info(
-                                "Agent cache invalidated for session %s: "
-                                "message_count changed (%s -> %s), "
-                                "possible cross-process write",
-                                session_key, _cached_mc, _current_msg_count,
-                            )
-                            evicted = self._agent_cache.pop(session_key, None)
-                            _ev_agent = evicted[0] if isinstance(evicted, tuple) and evicted else None
-                        else:
+                _ev_agent = self._evict_stale_cross_process_agent(
+                    session_key, _current_msg_count, sig=_sig,
+                )
+                if _ev_agent is None:
+                    # Cache is current — try to reuse the agent.
+                    with _cache_lock:
+                        cached = _cache.get(session_key)
+                        if cached and cached[1] == _sig:
                             agent = cached[0]
                             # Refresh LRU order so the cap enforcement evicts
                             # truly-oldest entries, not the one we just used.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15555,6 +15555,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     pass
 
             if _cache_lock and _cache is not None:
+                _ev_agent = None
                 with _cache_lock:
                     cached = _cache.get(session_key)
                     if cached and cached[1] == _sig:
@@ -15576,8 +15577,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             )
                             evicted = self._agent_cache.pop(session_key, None)
                             _ev_agent = evicted[0] if isinstance(evicted, tuple) and evicted else None
-                            if _ev_agent and _ev_agent is not _AGENT_PENDING_SENTINEL:
-                                self._cleanup_agent_resources(_ev_agent)
                         else:
                             agent = cached[0]
                             # Refresh LRU order so the cap enforcement evicts
@@ -15592,6 +15591,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             # (cached agent may have been created with old config)
                             agent.max_iterations = max_iterations
                             logger.debug("Reusing cached agent for session %s", session_key)
+
+                # Cleanup outside the lock — _cleanup_agent_resources can be
+                # slow (shutdown_memory_provider, close async clients) and
+                # must not stall the event loop while _agent_cache_lock is
+                # held.  Matches the discipline in _evict_cached_agent() and
+                # _sweep_idle_cached_agents().  (#52197)
+                if _ev_agent and _ev_agent is not _AGENT_PENDING_SENTINEL:
+                    try:
+                        self._cleanup_agent_resources(_ev_agent)
+                    except Exception:
+                        pass
 
             if agent is None:
                 # Config changed or first message — create fresh agent

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -1706,3 +1706,82 @@ class TestAgentCacheMessageCountRebaseline:
         runner._refresh_agent_cache_message_count("telegram:s1", "s1")
         with runner._agent_cache_lock:
             assert runner._agent_cache["telegram:s1"][2] == 5
+
+
+class TestCrossProcessInvalidationLockDiscipline:
+    """Cross-process cache invalidation must NOT call _cleanup_agent_resources
+    while holding _agent_cache_lock (#52197).
+
+    Other eviction paths (_evict_cached_agent, _sweep_idle_cached_agents)
+    already pop under the lock and clean up outside it.  The cross-process
+    coherence guard (#45966) was the only path that still did cleanup inside
+    the lock, which stalls the event loop when cleanup is slow (memory
+    provider shutdown, async client teardown).
+    """
+
+    def test_cleanup_called_outside_lock(self, tmp_path):
+        """_cleanup_agent_resources must NOT be called while the lock is held."""
+        from hermes_state import SessionDB
+        from gateway.run import _AGENT_PENDING_SENTINEL
+
+        db = SessionDB(db_path=tmp_path / "sessions.db")
+        db.create_session("s1", source="telegram")
+        db.append_message("s1", role="user", content="hi")
+        runner = _make_runner()
+        runner._session_db = db
+
+        # Build a cached agent with a stale message_count.
+        _row = db.get_session("s1")
+        stale_count = _row.get("message_count", 0) if _row else 0
+        fake_agent = MagicMock()
+        with runner._agent_cache_lock:
+            runner._agent_cache["telegram:s1"] = (fake_agent, "sig", stale_count)
+
+        # Simulate a cross-process write: another process appends a turn.
+        db.append_message("s1", role="user", content="from dashboard")
+        db.append_message("s1", role="assistant", content="reply")
+
+        # Track whether the lock is held when cleanup runs.
+        lock_held_during_cleanup = threading.Event()
+
+        original_cleanup = runner._cleanup_agent_resources
+
+        def spy_cleanup(agent):
+            if runner._agent_cache_lock.locked():
+                lock_held_during_cleanup.set()
+            original_cleanup(agent)
+
+        runner._cleanup_agent_resources = spy_cleanup
+
+        # Now exercise the cross-process invalidation path.
+        # We need to simulate the production code path that checks
+        # message_count and invalidates.  The production code is inside
+        # _handle_message_with_agent which is too complex to call directly,
+        # so we replicate the exact guard logic:
+        _current_msg_count = db.get_session("s1").get("message_count", 0)
+        _cache = runner._agent_cache
+        _cache_lock = runner._agent_cache_lock
+        _ev_agent = None
+
+        with _cache_lock:
+            cached = _cache.get("telegram:s1")
+            if cached and cached[1] == "sig":
+                _cached_mc = cached[2] if len(cached) > 2 else None
+                if (
+                    _cached_mc is not None
+                    and _current_msg_count is not None
+                    and _current_msg_count != _cached_mc
+                ):
+                    evicted = _cache.pop("telegram:s1", None)
+                    _ev_agent = evicted[0] if isinstance(evicted, tuple) and evicted else None
+
+        # Cleanup OUTSIDE the lock — this is the fix.
+        if _ev_agent and _ev_agent is not _AGENT_PENDING_SENTINEL:
+            runner._cleanup_agent_resources(_ev_agent)
+
+        # The agent must have been evicted.
+        assert "telegram:s1" not in runner._agent_cache
+        # The lock must NOT have been held during cleanup.
+        assert not lock_held_during_cleanup.is_set(), (
+            "_cleanup_agent_resources was called while _agent_cache_lock was held"
+        )

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -1719,6 +1719,78 @@ class TestCrossProcessInvalidationLockDiscipline:
     provider shutdown, async client teardown).
     """
 
+    def test_evict_stale_returns_agent_when_stale(self, tmp_path):
+        """_evict_stale_cross_process_agent returns the agent on count mismatch."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "sessions.db")
+        db.create_session("s1", source="telegram")
+        db.append_message("s1", role="user", content="hi")
+        runner = _make_runner()
+        runner._session_db = db
+
+        _row = db.get_session("s1")
+        stale_count = _row.get("message_count", 0) if _row else 0
+        fake_agent = MagicMock()
+        with runner._agent_cache_lock:
+            runner._agent_cache["telegram:s1"] = (fake_agent, "sig", stale_count)
+
+        # Simulate a cross-process write.
+        db.append_message("s1", role="user", content="from dashboard")
+        db.append_message("s1", role="assistant", content="reply")
+
+        _current = db.get_session("s1").get("message_count", 0)
+        evicted = runner._evict_stale_cross_process_agent(
+            "telegram:s1", _current, sig="sig",
+        )
+        assert evicted is fake_agent
+        assert "telegram:s1" not in runner._agent_cache
+
+    def test_evict_stale_returns_none_when_current(self, tmp_path):
+        """_evict_stale_cross_process_agent returns None when counts match."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "sessions.db")
+        db.create_session("s1", source="telegram")
+        db.append_message("s1", role="user", content="hi")
+        runner = _make_runner()
+        runner._session_db = db
+
+        _row = db.get_session("s1")
+        count = _row.get("message_count", 0) if _row else 0
+        fake_agent = MagicMock()
+        with runner._agent_cache_lock:
+            runner._agent_cache["telegram:s1"] = (fake_agent, "sig", count)
+
+        evicted = runner._evict_stale_cross_process_agent(
+            "telegram:s1", count, sig="sig",
+        )
+        assert evicted is None
+        assert "telegram:s1" in runner._agent_cache
+
+    def test_evict_stale_returns_none_on_sig_mismatch(self, tmp_path):
+        """When sig doesn't match, the helper skips (config-change path)."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "sessions.db")
+        db.create_session("s1", source="telegram")
+        db.append_message("s1", role="user", content="hi")
+        runner = _make_runner()
+        runner._session_db = db
+
+        _row = db.get_session("s1")
+        count = _row.get("message_count", 0) if _row else 0
+        fake_agent = MagicMock()
+        with runner._agent_cache_lock:
+            runner._agent_cache["telegram:s1"] = (fake_agent, "old-sig", count)
+
+        db.append_message("s1", role="user", content="from dashboard")
+        _current = db.get_session("s1").get("message_count", 0)
+        evicted = runner._evict_stale_cross_process_agent(
+            "telegram:s1", _current, sig="new-sig",
+        )
+        assert evicted is None
+
     def test_cleanup_called_outside_lock(self, tmp_path):
         """_cleanup_agent_resources must NOT be called while the lock is held."""
         from hermes_state import SessionDB
@@ -1753,27 +1825,11 @@ class TestCrossProcessInvalidationLockDiscipline:
 
         runner._cleanup_agent_resources = spy_cleanup
 
-        # Now exercise the cross-process invalidation path.
-        # We need to simulate the production code path that checks
-        # message_count and invalidates.  The production code is inside
-        # _handle_message_with_agent which is too complex to call directly,
-        # so we replicate the exact guard logic:
+        # Exercise the production helper directly.
         _current_msg_count = db.get_session("s1").get("message_count", 0)
-        _cache = runner._agent_cache
-        _cache_lock = runner._agent_cache_lock
-        _ev_agent = None
-
-        with _cache_lock:
-            cached = _cache.get("telegram:s1")
-            if cached and cached[1] == "sig":
-                _cached_mc = cached[2] if len(cached) > 2 else None
-                if (
-                    _cached_mc is not None
-                    and _current_msg_count is not None
-                    and _current_msg_count != _cached_mc
-                ):
-                    evicted = _cache.pop("telegram:s1", None)
-                    _ev_agent = evicted[0] if isinstance(evicted, tuple) and evicted else None
+        _ev_agent = runner._evict_stale_cross_process_agent(
+            "telegram:s1", _current_msg_count, sig="sig",
+        )
 
         # Cleanup OUTSIDE the lock — this is the fix.
         if _ev_agent and _ev_agent is not _AGENT_PENDING_SENTINEL:


### PR DESCRIPTION
## What does this PR do?

Moves the `_cleanup_agent_resources` call in the cross-process agent-cache invalidation path outside the `_agent_cache_lock`, preventing event-loop stalls that block Discord heartbeats for minutes.

## Related Issue

Fixes #52197

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: Extract stale agent reference inside the lock, perform cleanup outside it — matching the existing discipline in `_evict_cached_agent()` and `_sweep_idle_cached_agents()`
- `tests/gateway/test_agent_cache.py`: Add `TestCrossProcessInvalidationLockDiscipline` verifying cleanup is not called while lock is held

## How to Test

1. Run `python -m pytest tests/gateway/test_agent_cache.py -x -q` — all 69 tests pass
2. The new test `test_cleanup_called_outside_lock` sets up a cached agent with a stale message_count, simulates a cross-process write, triggers the invalidation path, and asserts that `_cleanup_agent_resources` was NOT called while `_agent_cache_lock` was held
3. For manual verification: run a Discord gateway with cross-process session sharing (e.g., dashboard backend appending to the same session), trigger a message after an external write, and confirm no "heartbeat blocked" warnings appear

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_agent_cache.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/run.py` L15557-15605 (cross-process invalidation path, callers: `_handle_message_with_agent`)
- Blast radius: LOW — single code path, matches existing pattern in two sibling functions
- Related patterns: `_evict_cached_agent()` (L13903), `_sweep_idle_cached_agents()` (L14095) — both already pop-under-lock + cleanup-outside-lock
