### PR TITLE
fix(update): announce gateway drain waits so desktop updates don't look hung

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3891,6 +3891,16 @@ def launchd_restart():
             print("✓ Service restart requested")
             return
         if pid is not None:
+            # Announce the drain BEFORE waiting on it. This wait can run for
+            # the full drain budget (180s by default) while the old gateway
+            # finishes in-flight agent runs, and it streams into surfaces with
+            # no other feedback — the desktop updater's live output most of
+            # all, where a silent stop here reads as "update stuck" (#44515).
+            # Mirrors the systemd branch's "draining (up to Ns)..." line.
+            print(
+                f"→ Stopping gateway (PID {pid}) — draining in-flight runs "
+                f"(up to {drain_timeout:.0f}s)..."
+            )
             try:
                 terminate_pid(pid, force=False)
             except (ProcessLookupError, PermissionError, OSError):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10178,6 +10178,14 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 # gateway doesn't support SIGUSR1 or doesn't exit within
                 # the drain budget, fall back to SIGTERM — the watcher
                 # still sees the exit and relaunches either way.
+                # Announce the drain first: this wait can hold for the full
+                # budget per gateway with no other output, and on surfaces
+                # that stream update progress (the desktop updater most of
+                # all) the silence reads as a hung update (#44515).
+                print(
+                    f"  → {proc.profile}: draining gateway PID {pid} "
+                    f"(up to {int(_drain_budget)}s)..."
+                )
                 drained = _graceful_restart_via_sigusr1(
                     pid,
                     drain_timeout=_drain_budget,

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -774,7 +774,7 @@ class TestLaunchdServiceRecovery:
             ["launchctl", "kickstart", target],
         ]
 
-    def test_launchd_restart_drains_running_gateway_before_kickstart(self, monkeypatch):
+    def test_launchd_restart_drains_running_gateway_before_kickstart(self, monkeypatch, capsys):
         calls = []
         target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
 
@@ -799,6 +799,12 @@ class TestLaunchdServiceRecovery:
             ("term", 321, False),
             ["launchctl", "kickstart", "-k", target],
         ]
+        # The drain can silently hold for the full budget (180s default); the
+        # desktop updater streams this output as its only progress feedback,
+        # so the stop must be announced BEFORE the wait (#44515).
+        out = capsys.readouterr().out
+        assert "draining in-flight runs" in out
+        assert "up to 12s" in out
 
     def test_launchd_restart_self_requests_graceful_restart_without_kickstart(self, monkeypatch, capsys):
         calls = []


### PR DESCRIPTION
Salvages **#44540** by @AIalliAI onto a `bb/` branch (cherry-picked, authorship preserved); applies cleanly to current `main`.

## What

The desktop updater streams stage-1's stdout as its only progress feedback. On macOS, stage 1 ends in the gateway-restart phase **after** `✓ Update complete!`: `launchd_restart()` SIGTERMs the gateway and waits up to `agent.restart_drain_timeout` (default 180s) to drain in-flight runs — printing **nothing**. The manual profile-gateway loop in `_cmd_update_impl` does the same. So the window sits silent on step 1 for minutes (#44515), making force-kills *appear* required. The systemd branch already announces its drain; launchd + the manual loop were the silent outliers.

Output-only — prints `→ … draining … (up to Ns)` before the wait. No signal/timeout semantics touched.

## Verified on current main

- `pytest tests/hermes_cli/test_gateway_service.py -k launchd` → 32 passed (incl. the extended announce assertion).

## Scope note

This fixes the **silence** during drain. The separate "update overlay shows 0/2 and stays stale" report is a frontend counter-semantics bug (the step counter only counts *finished* stages) — addressed in its own PR, not here.

Supersedes #44540. Fixes #44515.