### PR TITLE
fix(desktop): route gateway restart / status / update to the active profile

### DIFF
--- a/apps/desktop/src/hermes-profile-scope.test.ts
+++ b/apps/desktop/src/hermes-profile-scope.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  checkHermesUpdate,
+  getActionStatus,
+  getStatus,
+  restartGateway,
+  setApiRequestProfile,
+  updateHermes
+} from './hermes'
+
+// Contract: every backend-targeted action helper must carry the active gateway
+// profile, so a multi-profile / global-remote user's restart, status poll, and
+// update hit the backend they're actually on — not the primary/default. The
+// System-panel "restart does nothing" bug was these helpers dropping it.
+describe('backend action helpers are profile-scoped', () => {
+  const api = vi.fn(async (_req: { path: string; profile?: string }) => ({}) as never)
+
+  beforeEach(() => {
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = { api }
+    api.mockClear()
+  })
+
+  afterEach(() => {
+    setApiRequestProfile(null)
+    delete (window as { hermesDesktop?: unknown }).hermesDesktop
+  })
+
+  const lastProfile = () => api.mock.calls.at(-1)?.[0].profile
+
+  it('omits profile when none is active (single-profile users unaffected)', () => {
+    void getStatus()
+    expect(lastProfile()).toBeUndefined()
+  })
+
+  it('forwards the active profile to every backend action', () => {
+    setApiRequestProfile('coder')
+
+    void getStatus()
+    void restartGateway()
+    void updateHermes()
+    void checkHermesUpdate()
+    void getActionStatus('gateway-restart')
+
+    for (const call of api.mock.calls) {
+      expect(call[0].profile).toBe('coder')
+    }
+  })
+})

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -274,6 +274,7 @@ export function getGlobalModelInfo(): Promise<ModelInfoResponse> {
 
 export function getStatus(): Promise<StatusResponse> {
   return window.hermesDesktop.api<StatusResponse>({
+    ...profileScoped(),
     path: '/api/status'
   })
 }
@@ -756,6 +757,7 @@ export function setModelAssignment(body: ModelAssignmentRequest): Promise<ModelA
 
 export function restartGateway(): Promise<ActionResponse> {
   return window.hermesDesktop.api<ActionResponse>({
+    ...profileScoped(),
     path: '/api/gateway/restart',
     method: 'POST'
   })
@@ -763,6 +765,7 @@ export function restartGateway(): Promise<ActionResponse> {
 
 export function updateHermes(): Promise<ActionResponse> {
   return window.hermesDesktop.api<ActionResponse>({
+    ...profileScoped(),
     path: '/api/hermes/update',
     method: 'POST'
   })
@@ -773,12 +776,14 @@ export function updateHermes(): Promise<ActionResponse> {
  *  distinct from the Electron client clone's git state. */
 export function checkHermesUpdate(force = false): Promise<BackendUpdateCheckResponse> {
   return window.hermesDesktop.api<BackendUpdateCheckResponse>({
+    ...profileScoped(),
     path: `/api/hermes/update/check${force ? '?force=true' : ''}`
   })
 }
 
 export function getActionStatus(name: string, lines = 200): Promise<ActionStatusResponse> {
   return window.hermesDesktop.api<ActionStatusResponse>({
+    ...profileScoped(),
     path: `/api/actions/${encodeURIComponent(name)}/status?lines=${Math.max(1, lines)}`
   })
 }


### PR DESCRIPTION
## Summary

The System-panel **Restart gateway** action (and Update / status reads) could silently target the wrong backend on multi-profile / global-remote setups.

`restartGateway`, `getActionStatus`, `getStatus`, `updateHermes`, and `checkHermesUpdate` call `window.hermesDesktop.api` **without** `...profileScoped()` — unlike their siblings (`getModelInfo`, `setModelAssignment`, `grantComputerUsePermissions`). `_apiProfile` tracks the active gateway profile and the Electron proxy uses `request.profile` to pick which pooled / remote backend serves the call.

So for a user on a non-default profile (or global-remote):
- **Restart** hit the primary/default gateway, not theirs — and the status poll watched the wrong backend's action log, so it never reported completion → "restart does nothing / fails".
- Same wrong-target risk for the backend Update and status panel reads.

Single-profile users are unaffected — `profileScoped()` returns `{}` when no profile is active.

## Fix

Add `...profileScoped()` to the five backend-action helpers so they follow the active profile like the rest of the API surface. Same bug class as the prior profile-routing note (#46651).

## Test plan

- [x] `vitest run --environment jsdom apps/desktop/src/hermes-profile-scope.test.ts` (new) — invariant: each helper forwards the active profile, and omits it when none is set.
- [x] `tsc -p apps/desktop --noEmit`; `eslint` (no new issues).
- [ ] Manual (two local profiles): switch to a non-default profile → System panel → Restart gateway restarts *that* profile's gateway and the status resolves.

> Note: if a single-profile-local user still sees restart fail, that's the other branch — the spawned `gateway restart` exiting non-zero (e.g. a configured systemd/launchd service failing) — surfaced as "action failed", not a routing issue.