### PR TITLE
fix(desktop): hide platform/internal toolsets from the Skills & Tools list

### DIFF
--- a/apps/desktop/src/app/skills/index.tsx
+++ b/apps/desktop/src/app/skills/index.tsx
@@ -9,6 +9,7 @@ import { Switch } from '@/components/ui/switch'
 import { TextTab, TextTabMeta } from '@/components/ui/text-tab'
 import { getSkills, getToolsets, toggleSkill, toggleToolset } from '@/hermes'
 import { useI18n } from '@/i18n'
+import { isDesktopToolsetVisible } from '@/lib/desktop-toolsets'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
 import type { SkillInfo, ToolsetInfo } from '@/types/hermes'
@@ -52,6 +53,10 @@ function filteredToolsets(toolsets: ToolsetInfo[], query: string): ToolsetInfo[]
 
   return toolsets
     .filter(toolset => {
+      if (!isDesktopToolsetVisible(toolset.name)) {
+        return false
+      }
+
       if (!q) {
         return true
       }

--- a/apps/desktop/src/lib/desktop-toolsets.test.ts
+++ b/apps/desktop/src/lib/desktop-toolsets.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { isDesktopToolsetVisible } from './desktop-toolsets'
+
+describe('isDesktopToolsetVisible', () => {
+  it('hides platform-coupled and internal toolsets', () => {
+    for (const name of ['discord', 'discord_admin', 'yuanbao', 'context_engine', 'moa']) {
+      expect(isDesktopToolsetVisible(name)).toBe(false)
+    }
+  })
+
+  it('keeps ordinary user-facing toolsets', () => {
+    for (const name of ['web', 'browser', 'terminal', 'file', 'memory', 'vision', 'image_gen']) {
+      expect(isDesktopToolsetVisible(name)).toBe(true)
+    }
+  })
+})

--- a/apps/desktop/src/lib/desktop-toolsets.ts
+++ b/apps/desktop/src/lib/desktop-toolsets.ts
@@ -1,0 +1,24 @@
+// Curation for the desktop "Skills & Tools → Toolsets" list.
+//
+// `GET /api/tools/toolsets` returns the full CONFIGURABLE_TOOLSETS set with no
+// desktop-specific filter — so it surfaces entries that don't belong in a flat
+// per-user toggle list on the desktop: platform-coupled toolsets (which
+// `hermes tools` already platform-restricts on the CLI) and internal plumbing
+// that isn't a user-facing capability. Mirror the curation approach used for
+// slash commands (`desktop-slash-commands.ts`): one documented block-list, one
+// predicate. Hiding a toolset only removes its row — its enabled state and
+// runtime gating are untouched.
+const DESKTOP_HIDDEN_TOOLSETS = new Set([
+  // Platform-coupled — only meaningful when that platform is the active
+  // adapter; `hermes tools` restricts these off the CLI too.
+  'discord',
+  'discord_admin',
+  'yuanbao',
+  // Internal plumbing, not a user capability toggle.
+  'context_engine',
+  'moa'
+])
+
+export function isDesktopToolsetVisible(name: string): boolean {
+  return !DESKTOP_HIDDEN_TOOLSETS.has(name)
+}


### PR DESCRIPTION
## Summary

The desktop **Skills & Tools → Toolsets** list is fed by `GET /api/tools/toolsets` (the full `CONFIGURABLE_TOOLSETS` set) with **no desktop curation**, while `hermes tools` (curses) platform-restricts and trims the same data. So the desktop wrongly shows:

- **Platform-coupled:** `discord`, `discord_admin`, `yuanbao` — only meaningful when that platform is the active adapter; `hermes tools` hides them off the CLI.
- **Internal plumbing:** `context_engine` ("Context Tool"), `moa` — not user-facing capability toggles.

(`feishu_doc`/`feishu_drive`/`kanban` are already excluded server-side, so they never appeared.)

## Fix

A small documented block-list + predicate (`isDesktopToolsetVisible`) in `lib/desktop-toolsets.ts`, mirroring the `desktop-slash-commands.ts` curation pattern, applied in `filteredToolsets`. Hiding a row is cosmetic — a toolset's enabled state and runtime gating are untouched.

## Test plan

- [x] `vitest run apps/desktop/src/lib/desktop-toolsets.test.ts` — hidden set is hidden, ordinary toolsets stay visible.
- [x] `tsc -p apps/desktop --noEmit`; `eslint` (no new issues).
- [ ] Manual: Skills & Tools → Toolsets no longer lists Discord / Discord admin / Yuanbao / Context Engine / MoA.

> Follow-up (out of scope): the raw `toolsets` list field also sits in Settings → Advanced (the `hermes-cli` composite) — a separate footgun worth de-emphasizing.