### PR TITLE
fix(desktop): stop the update overlay looking frozen while it works

### DIFF
--- a/apps/desktop/src/components/desktop-install-overlay.tsx
+++ b/apps/desktop/src/components/desktop-install-overlay.tsx
@@ -407,7 +407,11 @@ export function DesktopInstallOverlay({ enabled = true }: DesktopInstallOverlayP
 
   const totalCount = stages.length
   const failed = Boolean(state.error)
-  const progressPct = totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0
+  // Count the running stage as half-done so the bar advances *during* a long
+  // stage instead of sitting frozen at the last completed step while its logs
+  // stream (e.g. "0 of 2" pinned at 0% for the whole first stage).
+  const progressUnits = completedCount + (!failed && currentStage ? 0.5 : 0)
+  const progressPct = totalCount > 0 ? Math.round((progressUnits / totalCount) * 100) : 0
   const currentStartedAt = currentStage ? state.stages[currentStage]?.startedAt : null
   const currentElapsed = typeof currentStartedAt === 'number' ? formatElapsed(now - currentStartedAt) : ''
 

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -531,7 +531,9 @@ function ingestProgress(payload: DesktopUpdateProgress): void {
     applying: !terminal,
     stage: payload.stage,
     message: payload.message,
-    percent: payload.percent,
+    // Streamed log lines carry percent: null; keep the last milestone percent
+    // (10/60/…) instead of resetting the bar to indeterminate on every line.
+    percent: payload.percent ?? current.percent,
     error: payload.error,
     // 'manual' carries the command to run in its message field.
     command: payload.stage === 'manual' ? payload.message : current.command,


### PR DESCRIPTION
## Summary

The desktop update overlay looked stuck ("0/2 steps", frozen bar) even though logs kept streaming. Two independent causes:

### 1. In-app overlay bar went indeterminate (macOS/Linux)
`runStreamedUpdate` forwards every stdout line as a progress event with `percent: null`, and `ingestProgress` wrote it straight through — overwriting the milestone percents (10%, 60%) so the `UpdatesOverlay` bar reset to indeterminate on every log line. Now it keeps the last known percent when a line carries `null`.

### 2. Staged-overlay bar frozen at "0 of N" / 0%
`progressPct = completedCount / totalCount` counts only **finished** stages, so a long first stage (git pull, pip/uv, rebuild — minutes) pinned the bar at 0% while its logs streamed. Now the **running** stage counts as half a unit, so the bar advances through the stage (the per-stage row already shows a spinner for the live step). The "N of M steps" label stays accurate.

Both are display-only — no stage/event semantics touched.

## Relationship to the other update PRs
- This is the **overlay state** fix; #44540 (drain announce) only stops the backend stdout going *silent*. Complementary.

## Test plan
- [x] `tsc -p apps/desktop --noEmit`; `eslint` (no new issues).
- [ ] Manual: run an update → the bar advances during stage 1 (not pinned at 0/2 0%), and the in-app overlay bar tracks the milestone percents instead of flickering to indeterminate.

> Follow-up (out of scope, separate app): `apps/bootstrap-installer` (Windows `hermes-setup --update`) uses the same "count only completed stages" logic and would benefit from the same running-stage treatment.