### PR TITLE
fix(desktop): surface update progress lines

### DIFF
--- a/apps/desktop/src/app/updates-overlay.tsx
+++ b/apps/desktop/src/app/updates-overlay.tsx
@@ -382,6 +382,8 @@ function ApplyingView({ apply, isBackend }: { apply: UpdateApplyState; isBackend
   const u = t.updates
   const label = u.stages[apply.stage as DesktopUpdateStage] ?? u.stages.idle
   const body = isBackend ? u.applyingBodyBackend : u.applyingBody
+  const currentMessage = apply.message.trim()
+  const recentLog = apply.log.slice(-4)
 
   const percent =
     typeof apply.percent === 'number' && Number.isFinite(apply.percent)
@@ -397,6 +399,12 @@ function ApplyingView({ apply, isBackend }: { apply: UpdateApplyState; isBackend
         <DialogDescription className="text-center text-sm">
           {body}
         </DialogDescription>
+
+        {currentMessage ? (
+          <p className="max-w-lg break-words text-center text-xs leading-5 text-muted-foreground">
+            {currentMessage}
+          </p>
+        ) : null}
       </div>
 
       <div className="h-2 overflow-hidden rounded-full bg-muted">
@@ -408,6 +416,16 @@ function ApplyingView({ apply, isBackend }: { apply: UpdateApplyState; isBackend
           style={percent !== null ? { width: `${percent}%` } : undefined}
         />
       </div>
+
+      {recentLog.length > 1 ? (
+        <div className="max-h-24 overflow-hidden rounded-md border border-border/70 bg-muted/35 px-3 py-2 text-left font-mono text-[11px] leading-4 text-muted-foreground">
+          {recentLog.map((entry, index) => (
+            <div className="truncate" key={`${entry.at}-${index}`}>
+              {entry.message}
+            </div>
+          ))}
+        </div>
+      ) : null}
 
       <p className="text-center text-xs text-muted-foreground">{u.applyingClose}</p>
     </div>

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -370,6 +370,40 @@ describe('applyBackendUpdate recovery', () => {
     expect($backendUpdateApply.get().applying).toBe(false)
   })
 
+  it('surfaces backend update action log lines while the action is running', async () => {
+    updateHermesSpy.mockResolvedValue({ ok: true, name: 'update', pid: 1 })
+    getActionStatusSpy
+      .mockResolvedValueOnce({
+        exit_code: null,
+        lines: ['Pulling updates...', 'Installing dependencies...'],
+        name: 'update',
+        pid: 1,
+        running: true
+      })
+      .mockRejectedValueOnce(new Error('ECONNREFUSED'))
+    checkHermesUpdateSpy.mockResolvedValue({
+      install_method: 'git',
+      current_version: '0.16.0',
+      behind: 0,
+      update_available: false,
+      can_apply: true,
+      update_command: 'hermes update',
+      message: null
+    })
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(1500)
+
+    expect($backendUpdateApply.get().message).toBe('Installing dependencies...')
+    expect($backendUpdateApply.get().log.map(entry => entry.message)).toEqual([
+      'Pulling updates...',
+      'Installing dependencies...'
+    ])
+
+    await vi.advanceTimersByTimeAsync(5000)
+    await promise
+  })
+
   it('surfaces an error when the backend never comes back after the restart', async () => {
     updateHermesSpy.mockResolvedValue({ ok: true, name: 'update', pid: 1 })
     getActionStatusSpy.mockRejectedValue(new Error('ECONNREFUSED'))
@@ -383,4 +417,3 @@ describe('applyBackendUpdate recovery', () => {
     expect($backendUpdateApply.get().stage).toBe('error')
   })
 })
-

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -455,6 +455,25 @@ function finishBackendApply(returned: boolean): DesktopUpdateApplyResult {
   return { ok: false, error: 'apply-failed', message: 'Backend did not come back online.' }
 }
 
+function ingestBackendActionStatus(status: Awaited<ReturnType<typeof getActionStatus>>): void {
+  const current = $backendUpdateApply.get()
+  const log = status.lines
+    .filter(line => line.trim().length > 0)
+    .map(line => ({ at: Date.now(), message: line, stage: current.stage }))
+    .slice(-50)
+  const latest = log.at(-1)?.message
+
+  if (log.length === 0 && !latest) {
+    return
+  }
+
+  $backendUpdateApply.set({
+    ...current,
+    log,
+    message: latest ?? current.message
+  })
+}
+
 export async function applyBackendUpdate(): Promise<DesktopUpdateApplyResult> {
   dismissNotification(UPDATE_TOAST_ID)
   $backendUpdateApply.set({ ...IDLE, applying: true, stage: 'prepare', message: translateNow('updates.applyStatus.preparing') })
@@ -477,6 +496,7 @@ export async function applyBackendUpdate(): Promise<DesktopUpdateApplyResult> {
       await new Promise(resolve => globalThis.setTimeout(resolve, 1500))
       try {
         last = await getActionStatus(started.name, 200)
+        ingestBackendActionStatus(last)
       } catch {
         // The dashboard restarts mid-update, dropping this connection — expected, not a failure.
         $backendUpdateApply.set({


### PR DESCRIPTION
## What does this PR do?

Makes the Desktop update apply screen show live update progress instead of only the static stage copy.

Root cause:

- Local Desktop updates already stream progress into `$updateApply.message` and `$updateApply.log`, but `ApplyingView` never rendered either value.
- Backend/remote updates poll `/api/actions/{name}/status`, which returns tailed action `lines`, but the frontend ignored those lines while the update was running.

This keeps the update overlay moving by rendering the latest progress line plus a compact recent tail, and by feeding backend action log lines into `$backendUpdateApply` during polling.

Related: #52203 covers a CLI-side silence source during gateway drain waits. This PR covers the Desktop frontend visibility path.

## Related Issue

Related: #52203

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/updates-overlay.tsx`: render the current apply message and a compact recent progress tail during updates.
- `apps/desktop/src/store/updates.ts`: ingest backend action-status log lines into the backend update apply state.
- `apps/desktop/src/store/updates.test.ts`: add coverage for backend update log-line ingestion while the action is still running.

## How to Test

1. Run `npm --prefix apps/desktop run test:ui -- src/store/updates.test.ts`.
2. Run `npm --prefix apps/desktop run typecheck`.
3. Start a Desktop update and confirm the apply overlay shows live progress lines instead of only static stage text.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL/Linux desktop test environment

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

N/A