### PR TITLE
fix: add exist_ok=True to Path.mkdir() calls to prevent FileExistsError

### DIFF
--- a/hermes_cli/container_boot.py
+++ b/hermes_cli/container_boot.py
@@ -384,7 +384,7 @@ def _register_service(scandir: Path, profile: str, *, start: bool) -> None:
     # Wipe any leftover tmp from a previous interrupted run.
     if tmp_dir.exists():
         shutil.rmtree(tmp_dir, ignore_errors=True)
-    tmp_dir.mkdir(parents=True)
+    tmp_dir.mkdir(parents=True, exist_ok=True)
 
     try:
         (tmp_dir / "type").write_text("longrun\n")
@@ -404,7 +404,7 @@ def _register_service(scandir: Path, profile: str, *, start: bool) -> None:
 
         # Persistent log rotation (OQ8-C).
         log_subdir = tmp_dir / "log"
-        log_subdir.mkdir()
+        log_subdir.mkdir(exist_ok=True)
         log_run = log_subdir / "run"
         log_run.write_text(S6ServiceManager._render_log_run(profile))
         log_run.chmod(0o755)

--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -970,7 +970,7 @@ class S6ServiceManager:
         tmp_dir = svc_dir.with_name(svc_dir.name + ".tmp")
         if tmp_dir.exists():
             shutil.rmtree(tmp_dir, ignore_errors=True)
-        tmp_dir.mkdir(parents=True)
+        tmp_dir.mkdir(parents=True, exist_ok=True)
 
         try:
             (tmp_dir / "type").write_text("longrun\n")
@@ -986,7 +986,7 @@ class S6ServiceManager:
 
             # Persistent log rotation (OQ8-C).
             log_subdir = tmp_dir / "log"
-            log_subdir.mkdir()
+            log_subdir.mkdir(exist_ok=True)
             log_run = log_subdir / "run"
             log_run.write_text(self._render_log_run(profile))
             log_run.chmod(0o755)

--- a/scripts/tool_search_livetest.py
+++ b/scripts/tool_search_livetest.py
@@ -256,7 +256,7 @@ def setup_isolated_home(enabled: bool) -> Path:
     """
     home_dir = Path(tempfile.mkdtemp(prefix="hermes_ts_live_"))
     hermes_home = home_dir / ".hermes"
-    hermes_home.mkdir(parents=True)
+    hermes_home.mkdir(parents=True, exist_ok=True)
 
     if ORIGINAL_AUTH.exists():
         shutil.copy(ORIGINAL_AUTH, hermes_home / "auth.json")

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3309,7 +3309,7 @@ def quarantine_bundle(bundle: SkillBundle) -> Path:
     dest = QUARANTINE_DIR / skill_name
     if dest.exists():
         shutil.rmtree(dest)
-    dest.mkdir(parents=True)
+    dest.mkdir(parents=True, exist_ok=True)
 
     for rel_path, file_content in validated_files:
         file_dest = dest.joinpath(*rel_path.split("/"))

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -1470,7 +1470,7 @@ def main(
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_input_dir = Path(temp_dir) / "input"
             temp_output_dir = Path(temp_dir) / "output"
-            temp_input_dir.mkdir()
+            temp_input_dir.mkdir(exist_ok=True)
             
             # Write entries to temp file
             temp_input_file = temp_input_dir / "trajectories.jsonl"
@@ -1516,7 +1516,7 @@ def main(
             # Create a temp directory with sampled files
             with tempfile.TemporaryDirectory() as temp_dir:
                 temp_input_dir = Path(temp_dir) / "input"
-                temp_input_dir.mkdir()
+                temp_input_dir.mkdir(exist_ok=True)
                 
                 random.seed(seed)
                 total_original = 0


### PR DESCRIPTION
## Problem

Several `Path.mkdir()` calls lack `exist_ok=True`, which raises `FileExistsError` if the directory already exists. This is especially risky in calls that follow `shutil.rmtree()` where a race condition could allow another process to recreate the directory between the `rmtree` and `mkdir` calls.

## Fix

Add `exist_ok=True` to 8 `Path.mkdir()` calls across 5 files.

```python
# Before
temp_input_dir.mkdir()
dest.mkdir(parents=True)

# After
temp_input_dir.mkdir(exist_ok=True)
dest.mkdir(parents=True, exist_ok=True)
```

## Files changed

| File | Calls | Context |
|------|-------|---------|
| `trajectory_compressor.py` | 2 | Inside TemporaryDirectory (defensive) |
| `tools/skills_hub.py` | 1 | After shutil.rmtree (race condition) |
| `hermes_cli/service_manager.py` | 2 | 1 after rmtree, 1 in fresh tmp dir |
| `hermes_cli/container_boot.py` | 2 | 1 after rmtree, 1 in fresh tmp dir |
| `scripts/tool_search_livetest.py` | 1 | In fresh tempdir (defensive) |

All changes verified with `py_compile`. No behavioral difference when directories don't exist; prevents crashes when they do.