### PR TITLE
fix(slack): handle bot alert Block Kit text

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -108,21 +108,34 @@ def check_slack_requirements() -> bool:
 
 
 def _extract_text_from_slack_blocks(blocks: list) -> str:
-    """Extract readable text from Slack Block Kit blocks, including quoted/forwarded content.
+    """Extract readable text from Slack Block Kit blocks.
 
     Slack's modern WYSIWYG composer sends messages with a ``blocks`` array
     containing ``rich_text`` elements. When a user forwards or quotes another
     message, the quoted content appears as nested ``rich_text_quote`` elements
     that are *not* included in the plain ``text`` field of the event.
 
-    This helper walks the rich-text tree recursively and returns readable lines,
-    preserving quotes, list items, and preformatted blocks so the agent can see
-    forwarded/quoted content instead of only the lossy plain-text field.
+    Grafana/Alertmanager and other Slack apps often post bot messages with an
+    empty top-level ``text`` field and put the human-visible content in Block
+    Kit ``section``/``fields`` objects, sometimes nested inside an attachment.
+
+    This helper walks the Block Kit / rich-text tree and returns readable
+    lines, preserving quotes, list items, preformatted blocks, sections, fields,
+    headers, and context text so the agent sees the same useful payload that a
+    human sees in Slack instead of a lossy or empty ``text`` field.
     """
     if not blocks:
         return ""
 
     parts: list[str] = []
+
+    def _render_text_object(value: Any) -> str:
+        """Render Slack mrkdwn/plain_text objects and scalar fallbacks."""
+        if isinstance(value, dict):
+            return str(value.get("text", "") or "")
+        if isinstance(value, str):
+            return value
+        return ""
 
     def _render_inline_elements(elements: list) -> str:
         """Render inline elements (text, link, channel, user, emoji, etc.)."""
@@ -196,8 +209,32 @@ def _extract_text_from_slack_blocks(blocks: list) -> str:
                     _append_line(rendered, quote_depth=quote_depth, bullet=bullet)
 
     for block in blocks:
-        if (block or {}).get("type") == "rich_text":
+        block = block or {}
+        block_type = block.get("type")
+        if block_type == "rich_text":
             _walk_elements(block.get("elements", []))
+        elif block_type in {"section", "header"}:
+            _append_line(_render_text_object(block.get("text")))
+            for field in block.get("fields") or []:
+                _append_line(_render_text_object(field))
+        elif block_type == "context":
+            rendered = []
+            for element in block.get("elements") or []:
+                if isinstance(element, dict) and element.get("type") in {"mrkdwn", "plain_text"}:
+                    text_obj = _render_text_object(element)
+                else:
+                    text_obj = _render_inline_elements([element]) if isinstance(element, dict) else ""
+                if text_obj:
+                    rendered.append(text_obj)
+            if rendered:
+                _append_line(" ".join(rendered))
+        elif block_type in {"input", "actions"}:
+            label = _render_text_object(block.get("label"))
+            if label:
+                _append_line(label)
+            for element in block.get("elements") or []:
+                if isinstance(element, dict):
+                    _append_line(_render_text_object(element.get("text")))
 
     return "\n".join(parts)
 
@@ -2351,6 +2388,8 @@ class SlackAdapter(BasePlatformAdapter):
 
     async def _handle_slack_message(self, event: dict) -> None:
         """Handle an incoming Slack message event."""
+        channel_id_for_routing = event.get("channel", "")
+
         # Dedup: Slack Socket Mode can redeliver events after reconnects (#4777)
         event_ts = event.get("ts", "")
         if event_ts and self._dedup.is_duplicate(event_ts):
@@ -2361,21 +2400,32 @@ class SlackAdapter(BasePlatformAdapter):
         #   "mentions" — accept bot messages only when they @mention us
         #   "all"      — accept all bot messages (except our own)
         if event.get("bot_id") or event.get("subtype") == "bot_message":
-            allow_bots = self.config.extra.get("allow_bots", "")
-            if not allow_bots:
-                allow_bots = os.getenv("SLACK_ALLOW_BOTS", "none")
-            allow_bots = str(allow_bots).lower().strip()
-            if allow_bots == "none":
-                return
-            elif allow_bots == "mentions":
-                text_check = event.get("text", "")
-                if self._bot_user_id and f"<@{self._bot_user_id}>" not in text_check:
-                    return
-            # "all" falls through to process the message
-            # Always ignore our own messages to prevent echo loops
+            # Always ignore our own messages to prevent echo loops.
+            # Slack bot events normally include the bot user id in ``user``;
+            # keep this guard before any free-response/allow_bots bypass.
             msg_user = event.get("user", "")
             if msg_user and self._bot_user_id and msg_user == self._bot_user_id:
                 return
+
+            # ``free_response_channels`` is an explicit opt-in to process every
+            # message in that channel. Alerting integrations commonly post as
+            # Slack bots and do not @mention Hermes, so treating this channel
+            # allowlist as a bot-message allowlist lets on-call/alert channels
+            # trigger immediately while preserving the safe default elsewhere.
+            if channel_id_for_routing in self._slack_free_response_channels():
+                pass
+            else:
+                allow_bots = self.config.extra.get("allow_bots", "")
+                if not allow_bots:
+                    allow_bots = os.getenv("SLACK_ALLOW_BOTS", "none")
+                allow_bots = str(allow_bots).lower().strip()
+                if allow_bots == "none":
+                    return
+                elif allow_bots == "mentions":
+                    text_check = event.get("text", "")
+                    if self._bot_user_id and f"<@{self._bot_user_id}>" not in text_check:
+                        return
+                # "all" falls through to process the message
 
         # Ignore message edits and deletions
         subtype = event.get("subtype")
@@ -2447,6 +2497,20 @@ class SlackAdapter(BasePlatformAdapter):
                 att_text = att.get("text", "")
                 att_footer = att.get("footer", "")
                 att_fallback = att.get("fallback", "")
+                att_blocks_text = _extract_text_from_slack_blocks(att.get("blocks") or [])
+                att_fields: list[str] = []
+                for field in att.get("fields") or []:
+                    if not isinstance(field, dict):
+                        continue
+                    field_title = str(field.get("title", "") or "").strip()
+                    field_value = str(field.get("value", "") or "").strip()
+                    if field_title and field_value:
+                        att_fields.append(f"{field_title}: {field_value}")
+                    elif field_value:
+                        att_fields.append(field_value)
+                    elif field_title:
+                        att_fields.append(field_title)
+                att_fields_text = "\n".join(att_fields)
 
                 # Skip message-type attachments (e.g. Slack bot messages with
                 # is_msg_unfurl) to avoid echoing our own content.
@@ -2463,8 +2527,18 @@ class SlackAdapter(BasePlatformAdapter):
                 else:
                     header = None
 
-                # Prefer preview text, fall back to fallback description.
-                body = att_text or att_fallback or ""
+                # Prefer rich preview text and Block Kit/attachment fields;
+                # fall back to Slack's plain fallback when no structured body
+                # exists. Alerting apps often keep the actual payload in
+                # attachment-level blocks/fields while top-level text is empty.
+                body_parts: list[str] = []
+                for candidate in (att_text, att_blocks_text, att_fields_text):
+                    candidate = (candidate or "").strip()
+                    if candidate and candidate not in body_parts:
+                        body_parts.append(candidate)
+                if not body_parts and att_fallback:
+                    body_parts.append(att_fallback.strip())
+                body = "\n".join(body_parts)
                 if body:
                     body = body.strip()
                     if len(body) > 500:

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -4,8 +4,9 @@ Tests for Slack mention gating (require_mention / free_response_channels).
 Follows the same pattern as test_whatsapp_group_gating.py.
 """
 
+import asyncio
 import sys
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from gateway.config import Platform, PlatformConfig
 
@@ -43,7 +44,7 @@ _ensure_slack_mock()
 import plugins.platforms.slack.adapter as _slack_mod
 _slack_mod.SLACK_AVAILABLE = True
 
-from plugins.platforms.slack.adapter import SlackAdapter  # noqa: E402
+from plugins.platforms.slack.adapter import SlackAdapter, _extract_text_from_slack_blocks  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -74,6 +75,31 @@ def _make_adapter(require_mention=None, strict_mention=None, free_response_chann
     adapter.config = PlatformConfig(enabled=True, extra=extra)
     adapter._bot_user_id = BOT_USER_ID
     adapter._team_bot_user_ids = {}
+    return adapter
+
+
+def _prepare_adapter_for_handle(adapter):
+    """Populate attrs used by _handle_slack_message without opening Slack."""
+    adapter._dedup = MagicMock()
+    adapter._dedup.is_duplicate.return_value = False
+    adapter._bot_message_ts = set()
+    adapter._mentioned_threads = set()
+    adapter._MENTIONED_THREADS_MAX = 5000
+    adapter._channel_team = {}
+    adapter._assistant_thread_index = {}
+    adapter._assistant_session_index = {}
+    adapter._thread_context_cache = {}
+    adapter._reacting_message_ids = set()
+    adapter._resolve_user_name = AsyncMock(return_value="Alert Bot")
+    adapter._fetch_thread_context = AsyncMock(return_value="")
+    adapter._fetch_thread_parent_text = AsyncMock(return_value="")
+    adapter._has_active_session_for_thread = MagicMock(return_value=False)
+    adapter._captured_messages = []
+
+    async def _capture_message(msg_event):
+        adapter._captured_messages.append(msg_event)
+
+    adapter.handle_message = _capture_message
     return adapter
 
 
@@ -235,6 +261,101 @@ def test_free_response_channels_int_list():
     adapter = _make_adapter(free_response_channels=[1491973769726791812, 99999])
     result = adapter._slack_free_response_channels()
     assert result == {"1491973769726791812", "99999"}
+
+
+def test_extracts_text_from_block_kit_sections_fields_and_context():
+    blocks = [
+        {"type": "header", "text": {"type": "plain_text", "text": "FIRING alert"}},
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": "*High CPU throttling*"},
+            "fields": [
+                {"type": "mrkdwn", "text": "*namespace:* sdm-dev"},
+                {"type": "mrkdwn", "text": "*pod:* sdm-backend-abc"},
+            ],
+        },
+        {
+            "type": "context",
+            "elements": [{"type": "mrkdwn", "text": "StartsAt: 2026-06-25T00:00:00Z"}],
+        },
+    ]
+
+    rendered = _extract_text_from_slack_blocks(blocks)
+
+    assert "FIRING alert" in rendered
+    assert "High CPU throttling" in rendered
+    assert "namespace" in rendered
+    assert "sdm-backend-abc" in rendered
+    assert "StartsAt" in rendered
+
+
+def test_free_response_channel_processes_bot_message_with_empty_text_and_blocks():
+    adapter = _prepare_adapter_for_handle(
+        _make_adapter(require_mention=True, free_response_channels=[CHANNEL_ID])
+    )
+
+    event = {
+        "type": "message",
+        "subtype": "bot_message",
+        "bot_id": "B_EXTERNAL_ALERT",
+        "user": "U_EXTERNAL_BOT",
+        "channel": CHANNEL_ID,
+        "channel_type": "channel",
+        "team": "T1",
+        "ts": "1710000000.000100",
+        "text": "",
+        "blocks": [
+            {"type": "section", "text": {"type": "mrkdwn", "text": "*FIRING*: CPUThrottlingHigh"}},
+            {"type": "section", "fields": [{"type": "mrkdwn", "text": "*service_name:* sdm-backend"}]},
+        ],
+    }
+
+    asyncio.run(adapter._handle_slack_message(event))
+
+    captured = getattr(adapter, "_captured_messages")
+    assert len(captured) == 1
+    msg_event = captured[0]
+    assert "CPUThrottlingHigh" in msg_event.text
+    assert "sdm-backend" in msg_event.text
+
+
+def test_free_response_channel_processes_bot_message_with_attachment_blocks():
+    adapter = _prepare_adapter_for_handle(
+        _make_adapter(require_mention=True, free_response_channels=[CHANNEL_ID])
+    )
+
+    event = {
+        "type": "message",
+        "subtype": "bot_message",
+        "bot_id": "B_EXTERNAL_ALERT",
+        "user": "U_EXTERNAL_BOT",
+        "channel": CHANNEL_ID,
+        "channel_type": "channel",
+        "team": "T1",
+        "ts": "1710000000.000200",
+        "text": "",
+        "attachments": [
+            {
+                "color": "danger",
+                "title": "Grafana Alert",
+                "blocks": [
+                    {"type": "section", "text": {"type": "mrkdwn", "text": "*FIRING*: RedisDLQ"}},
+                    {"type": "context", "elements": [{"type": "mrkdwn", "text": "env=dev"}]},
+                ],
+                "fields": [{"title": "service", "value": "sdm-backend"}],
+            }
+        ],
+    }
+
+    asyncio.run(adapter._handle_slack_message(event))
+
+    captured = getattr(adapter, "_captured_messages")
+    assert len(captured) == 1
+    msg_event = captured[0]
+    assert "Grafana Alert" in msg_event.text
+    assert "RedisDLQ" in msg_event.text
+    assert "env=dev" in msg_event.text
+    assert "service: sdm-backend" in msg_event.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Treat `free_response_channels` as an explicit opt-in for external Slack bot/app messages so alert channels can trigger the agent without requiring a mention.
- Extract readable text from Slack Block Kit `section`, `header`, `fields`, `context`, `input`, and `actions` blocks when top-level `text` is empty.
- Include attachment-level Block Kit blocks and attachment fields in inbound Slack message text, covering Grafana/Alertmanager-style alert payloads.
- Preserve self-bot loop prevention, allowed-channel gating, mention gating outside free-response channels, and existing rich-text quote extraction.

## Why
Slack alert apps can emit `bot_message` events with empty top-level `text` while the human-visible payload is only present in `blocks` or `attachments[].blocks`. Those events were received by the Slack gateway but could be dropped before becoming inbound Hermes messages.

## Tests
- `python -m pytest tests/gateway/test_slack_mention.py` — 66 passed, 2 warnings
- `python -m pytest tests/gateway/test_slack*.py` — 335 passed, 51 warnings (existing async mock/socket watchdog warnings)
- `python -m compileall -q plugins/platforms/slack/adapter.py tests/gateway/test_slack_mention.py`
- `git diff --check`
