### PR TITLE
fix(gateway): allow tool progress on non-edit platforms with separate grouping

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14939,7 +14939,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Skip tool progress for platforms that don't support message
             # editing (e.g. iMessage/BlueBubbles) — each progress update
             # would become a separate message bubble, which is noisy.
-            if type(adapter).edit_message is BasePlatformAdapter.edit_message:
+            # When grouping is "separate", each update is a new message
+            # (no editing needed), so only bail out in accumulate mode.
+            _no_edit_support = type(adapter).edit_message is BasePlatformAdapter.edit_message
+            can_edit = progress_grouping != "separate"  # "separate" = one message per tool (pre-v0.9 behavior)
+            if _no_edit_support and can_edit:
                 while not progress_queue.empty():
                     try:
                         progress_queue.get_nowait()
@@ -14949,7 +14953,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             progress_lines = []      # Accumulated tool lines for the CURRENT editable bubble
             progress_msg_id = None   # ID of the current progress message to edit
-            can_edit = progress_grouping != "separate"  # "separate" = one message per tool (pre-v0.9 behavior)
             _last_edit_ts = 0.0      # Throttle edits to avoid Telegram flood control
             _PROGRESS_EDIT_INTERVAL = 1.5  # Minimum seconds between edits
 


### PR DESCRIPTION
## Problem

Non-edit platforms (QQ Bot, WeChat, Signal, BlueBubbles, DingTalk, etc.) silently drop ALL tool progress messages even when `tool_progress_grouping: separate` is configured.

**Root cause:** In `gateway/run.py` `send_progress_messages()`, the `edit_message` guard fires BEFORE `can_edit` is evaluated:

```python
# Current code — guard fires first (line 14942)
if type(adapter).edit_message is BasePlatformAdapter.edit_message:
    # drain queue and return — ALL progress discarded
    ...

# can_edit computed AFTER the guard — non-edit platforms never reach here
can_edit = progress_grouping != "separate"  # line 14952
```

When `tool_progress_grouping: separate`, each progress update is a NEW message (no editing needed), but the guard doesn't check this because `can_edit` hasn't been computed yet.

## Fix

Move `can_edit` evaluation before the guard, and only bail out when the platform lacks edit support AND the grouping mode requires editing:

```python
_no_edit_support = type(adapter).edit_message is BasePlatformAdapter.edit_message
can_edit = progress_grouping != "separate"
if _no_edit_support and can_edit:
    # Only discard progress when editing is needed but not supported
    ...
```

## Files changed

| File | Change |
|------|--------|
| `gateway/run.py` | Move `can_edit` before guard, add `_no_edit_support` check |

Fixes #52212