### PR TITLE
fix(auxiliary): preserve auto fallback policy for vision calls

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -7976,6 +7976,11 @@ def call_llm(
     main_runtime = _normalize_main_runtime(main_runtime)
     resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         task, provider, model, base_url, api_key)
+    fallback_policy_is_auto = resolved_provider in {"auto", "", None}
+    # Keep the user's selection policy separate from the concrete backend.
+    # Vision auto-resolution may return the main provider (e.g. openai-codex),
+    # but failures from that selected backend should still follow the auto
+    # fallback layers, including top-level fallback_providers.
     if api_mode:
         resolved_api_mode = api_mode
     effective_extra_body = _get_task_extra_body(task)
@@ -8490,7 +8495,7 @@ def call_llm(
         # connection failures are capacity problems, not request constraints.
         # See #26803: daily token quota (429 + "too many tokens per day") must
         # fall back just like a 402 credit error.
-        is_auto = resolved_provider in {"auto", "", None}
+        is_auto = fallback_policy_is_auto
         # Capacity errors bypass the explicit-provider gate: the provider
         # literally cannot serve this request regardless of user intent.
         # Rate limits are included: after retries are exhausted, a 429 means
@@ -8693,6 +8698,11 @@ async def async_call_llm(
     main_runtime = _normalize_main_runtime(main_runtime)
     resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         task, provider, model, base_url, api_key)
+    fallback_policy_is_auto = resolved_provider in {"auto", "", None}
+    # Keep the user's selection policy separate from the concrete backend.
+    # Vision auto-resolution may return the main provider (e.g. openai-codex),
+    # but failures from that selected backend should still follow the auto
+    # fallback layers, including top-level fallback_providers.
     effective_extra_body = _get_task_extra_body(task)
     effective_extra_body.update(extra_body or {})
 
@@ -9099,7 +9109,7 @@ async def async_call_llm(
         # See #26803: daily token quota must fall back like a 402 credit error.
         # Model-incompatibility 400s (route cannot run this model at all)
         # bypass the gate too — see the sync call_llm() path for rationale.
-        is_auto = resolved_provider in {"auto", "", None}
+        is_auto = fallback_policy_is_auto
         is_capacity_error = (
             _is_payment_error(first_err)
             or _is_connection_error(first_err)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6731,7 +6731,7 @@ _PreparedAuxRequest = NamedTuple("_PreparedAuxRequest", [
     ("resolved_provider", str), ("request_provider", str), ("resolved_model", Optional[str]),
     ("resolved_base_url", Optional[str]), ("resolved_api_key", Optional[str]),
     ("resolved_api_mode", Optional[str]), ("effective_timeout", float),
-    ("effective_extra_body", Dict[str, Any]), ("base_info", str)])
+    ("effective_extra_body", Dict[str, Any]), ("base_info", str), ("fallback_policy_is_auto", bool)])
 
 
 def _prepare_aux_request(
@@ -6747,6 +6747,9 @@ def _prepare_aux_request(
     back to the resolved base_url when the client exposes none."""
     resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         task, provider, model, base_url, api_key)
+    # Vision resolution replaces the policy with a concrete backend. Keep the original
+    # policy for fallback eligibility, and the concrete identity for auth and requests.
+    fallback_policy_is_auto = _normalize_aux_provider(resolved_provider) == "auto"
     if api_mode:
         resolved_api_mode = api_mode
     effective_extra_body = _get_task_extra_body(task)
@@ -6792,7 +6795,7 @@ def _prepare_aux_request(
     return _PreparedAuxRequest(
         client, final_model, kwargs, resolved_provider, request_provider, resolved_model,
         resolved_base_url, resolved_api_key, resolved_api_mode, effective_timeout,
-        effective_extra_body, base_info)
+        effective_extra_body, base_info, fallback_policy_is_auto)
 
 
 class _LadderStep(NamedTuple):
@@ -7018,7 +7021,9 @@ def _next_fallback_after_quarantine(
     return fb
 
 
-def _ladder_provider_fallback(first_err: Exception, route: _LadderRoute):
+def _ladder_provider_fallback(
+    first_err: Exception, route: _LadderRoute, *, fallback_policy_is_auto: bool,
+):
     """Last rung: other providers (per-task chain; then auto: main fallback chain + discovery
     chain, explicit: main-agent-model net). Returns the response or None.
     Capacity errors (payment/quota, connection, exhausted 429, model incompatible, malformed
@@ -7031,7 +7036,7 @@ def _ladder_provider_fallback(first_err: Exception, route: _LadderRoute):
     # (429 + "too many tokens per day") must fall back just like a 402 credit error.
     # Rate limits are included: after retries are exhausted, a 429 means the provider is at capacity. See
     # #52228. See #26803: daily token quota must fall back like a 402 credit error.
-    is_auto = resolved_provider in {"auto", "", None}
+    is_auto = fallback_policy_is_auto
     reason = next((label for predicate, label in _FALLBACK_REASONS if predicate(first_err)), None)
     is_capacity_error = any(
         predicate(first_err) for predicate, label in _FALLBACK_REASONS if label != "auth error")
@@ -7100,6 +7105,7 @@ def _aux_recovery_ladder(
     resolved_base_url: Optional[str], resolved_api_key: Optional[str],
     resolved_api_mode: Optional[str], final_model: Optional[str], max_tokens: Optional[int],
     main_runtime: Optional[Dict[str, Any]], route_info: Optional[Dict[str, str]],
+    fallback_policy_is_auto: bool,
 ):
     """Ordered recovery rungs after the primary request failed (generator): parameter
     strips → Nous heal/refresh → credential refresh/pool rotation → provider fallback.
@@ -7120,7 +7126,8 @@ def _aux_recovery_ladder(
     resp, first_err = yield from _ladder_credential_rungs(first_err, route, kwargs, client_is_nous)
     if first_err is None:
         return resp
-    resp = yield from _ladder_provider_fallback(first_err, route)
+    resp = yield from _ladder_provider_fallback(
+        first_err, route, fallback_policy_is_auto=fallback_policy_is_auto)
     if resp is not None:
         return resp
     # Connection/timeout errors poison the cached client (closed transport, half-read
@@ -7311,7 +7318,8 @@ def _start_recovery_ladder(
         resolved_model=req.resolved_model, resolved_base_url=req.resolved_base_url,
         resolved_api_key=req.resolved_api_key, resolved_api_mode=req.resolved_api_mode,
         final_model=req.final_model, max_tokens=retry_kwargs["max_tokens"],
-        main_runtime=retry_kwargs["main_runtime"], route_info=route_info)
+        main_runtime=retry_kwargs["main_runtime"], route_info=route_info,
+        fallback_policy_is_auto=req.fallback_policy_is_auto)
 
 
 def _call_llm_impl(

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1663,12 +1663,92 @@ class TestAuxiliaryFallbackLayering:
         exc.status_code = 402
         return exc
 
+    def _make_codex_usage_limit_err(self):
+        exc = Exception("Error code: 429 - {'code': 'usage_limit_reached'}")
+        setattr(exc, "status_code", 429)
+        return exc
 
+    def test_auto_vision_failure_uses_top_level_main_fallback_chain(self):
+        """Vision auto keeps the user's top-level fallback chain after main provider failure."""
+        primary_client = MagicMock()
+        primary_client.chat.completions.create.side_effect = self._make_codex_usage_limit_err()
 
+        main_chain_client = MagicMock()
+        main_chain_client.chat.completions.create.return_value = MagicMock(choices=[
+            MagicMock(message=MagicMock(content="from OpenAI API fallback"))
+        ])
 
+        with patch("agent.auxiliary_client.resolve_vision_provider_client",
+                   return_value=("openai-codex", primary_client, "gpt-5.5")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("auto", None, None, None, None)), \
+             patch("agent.auxiliary_client._recoverable_pool_provider",
+                   return_value=None), \
+             patch("agent.auxiliary_client._try_configured_fallback_chain",
+                   return_value=(None, None, "")) as mock_task_chain, \
+             patch("agent.auxiliary_client._try_main_fallback_chain",
+                   return_value=(main_chain_client, "gpt-5.5", "openai-api")) as mock_main_chain, \
+             patch("agent.auxiliary_client._try_payment_fallback") as mock_builtin_chain:
+            result = call_llm(
+                task="vision",
+                messages=[{"role": "user", "content": "hello"}],
+            )
 
+        assert result.choices[0].message.content == "from OpenAI API fallback"
+        assert main_chain_client.chat.completions.create.called
+        mock_task_chain.assert_called_once_with(
+            "vision",
+            "openai-codex",
+            reason="rate limit",
+            failed_model="gpt-5.5",
+        )
+        mock_main_chain.assert_called_once_with(
+            "vision", "openai-codex", reason="rate limit")
+        mock_builtin_chain.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_async_auto_vision_failure_uses_top_level_main_fallback_chain(self):
+        """Async vision auto uses top-level fallback_providers after main provider failure."""
+        primary_client = MagicMock()
+        primary_client.chat.completions.create = AsyncMock(
+            side_effect=self._make_codex_usage_limit_err()
+        )
 
+        sync_fallback_client = MagicMock()
+        async_fallback_client = MagicMock()
+        async_fallback_client.chat.completions.create = AsyncMock(return_value=MagicMock(choices=[
+            MagicMock(message=MagicMock(content="from async OpenAI API fallback"))
+        ]))
+
+        with patch("agent.auxiliary_client.resolve_vision_provider_client",
+                   return_value=("openai-codex", primary_client, "gpt-5.5")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("auto", None, None, None, None)), \
+             patch("agent.auxiliary_client._recoverable_pool_provider",
+                   return_value=None), \
+             patch("agent.auxiliary_client._try_configured_fallback_chain",
+                   return_value=(None, None, "")) as mock_task_chain, \
+             patch("agent.auxiliary_client._try_main_fallback_chain",
+                   return_value=(sync_fallback_client, "gpt-5.5", "openai-api")) as mock_main_chain, \
+             patch("agent.auxiliary_client._try_payment_fallback") as mock_builtin_chain, \
+             patch("agent.auxiliary_client._to_async_client",
+                   return_value=(async_fallback_client, "gpt-5.5")):
+            result = await async_call_llm(
+                task="vision",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+
+        assert result.choices[0].message.content == "from async OpenAI API fallback"
+        async_fallback_client.chat.completions.create.assert_awaited_once()
+        mock_task_chain.assert_called_once_with(
+            "vision",
+            "openai-codex",
+            reason="rate limit",
+            failed_model="gpt-5.5",
+        )
+        mock_main_chain.assert_called_once_with(
+            "vision", "openai-codex", reason="rate limit")
+        mock_builtin_chain.assert_not_called()
 
     def test_explicit_provider_rate_limit_triggers_fallback(self, monkeypatch):
         """429 rate-limit on an explicit provider must trigger fallback (not be ignored).

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1836,6 +1836,122 @@ class TestStaleFallbackCandidateSkip:
 class TestAuxiliaryFallbackLayering:
     """Explicit-provider users get layered fallback: configured_chain → main agent → warn."""
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("async_mode", [False, True], ids=["sync", "async"])
+    @pytest.mark.parametrize("policy", ["auto", "AUTO", " auto ", "explicit-argument", "explicit-config"])
+    @pytest.mark.parametrize("task_fallback", ["absent", "healthy", "stale"])
+    async def test_vision_429_preserves_fallback_policy(
+        self, monkeypatch, async_mode, policy, task_fallback,
+    ):
+        """Auto keeps the configured main chain after a concrete backend exhausts its retry."""
+        from copy import deepcopy
+
+        import httpx
+        import openai
+
+        from agent import auxiliary_client as aux
+
+        primary = {"provider": "openrouter", "model": "openai/gpt-4o"}
+        task_entry = {
+            "provider": "custom", "model": "task-vision",
+            "base_url": "https://task.example/v1", "api_key": "task-key",
+            "api_mode": "chat_completions",
+        }
+        main_entry = {
+            "provider": "custom", "model": "main-vision",
+            "base_url": "https://main.example/v1", "api_key": "main-key",
+            "api_mode": "chat_completions",
+        }
+        config = {
+            "model": {
+                "provider": primary["provider"], "default": primary["model"],
+                "supports_vision": True,
+            },
+            "auxiliary": {"vision": {
+                "provider": primary["provider"] if policy == "explicit-config" else "auto",
+                "model": primary["model"],
+                # A duplicate of the failed route must be skipped using its concrete identity.
+                "fallback_chain": [primary] + ([] if task_fallback == "absent" else [task_entry]),
+            }},
+            "fallback_providers": [primary, main_entry],
+        }
+        (aux.get_hermes_home() / "config.yaml").write_text(json.dumps(config))
+        monkeypatch.setenv("OPENROUTER_API_KEY", "primary-key")
+        messages = [{"role": "user", "content": [
+            {"type": "text", "text": "Describe this image."},
+            {"type": "image_url", "image_url": {"url": "https://image.example/photo.png"}},
+        ]}]
+        original_messages = deepcopy(messages)
+        route_info = {}
+        requests = []
+
+        def respond(request):
+            payload = json.loads(request.content)
+            requests.append((request, payload, dict(route_info)))
+            if request.url.host == "openrouter.ai":
+                return httpx.Response(429, request=request, json={"error": {
+                    "message": "Rate limit exceeded", "type": "rate_limit_error",
+                }})
+            if request.url.host == "task.example" and task_fallback == "stale":
+                return httpx.Response(401, request=request, json={"error": {
+                    "message": "Invalid API key", "type": "authentication_error",
+                }})
+            assert request.url.host in {"task.example", "main.example"}
+            return httpx.Response(200, request=request, json={
+                "id": "vision-result", "object": "chat.completion", "created": 0,
+                "model": payload["model"],
+                "choices": [{"index": 0, "message": {"role": "assistant", "content": "image described"},
+                             "finish_reason": "stop"}],
+            })
+
+        async def async_send(client, request, **kwargs):
+            return respond(request)
+
+        # Mock only HTTP I/O: config, provider routing, SDKs, retry, quarantine and both chains run.
+        monkeypatch.setattr(httpx.Client, "send", lambda client, request, **kwargs: respond(request))
+        monkeypatch.setattr(httpx.AsyncClient, "send", async_send)
+        kwargs: dict = dict(
+            task="vision", messages=messages, route_info=route_info,
+            provider=(primary["provider"] if policy == "explicit-argument" else
+                      None if policy == "explicit-config" else policy),
+            max_tokens=73, temperature=0.2, timeout=19,
+        )
+        auto_policy = policy in {"auto", "AUTO", " auto "}
+        succeeds = auto_policy or task_fallback == "healthy"
+        if succeeds:
+            result = await async_call_llm(**kwargs) if async_mode else call_llm(**kwargs)
+            assert result.choices[0].message.content == "image described"
+        else:
+            with pytest.raises(openai.RateLimitError):
+                if async_mode:
+                    await async_call_llm(**kwargs)
+                else:
+                    call_llm(**kwargs)
+
+        expected = [("openrouter.ai", primary["model"], "openrouter", "primary-key")] * 2
+        if task_fallback != "absent":
+            expected.append(("task.example", task_entry["model"], "custom", "task-key"))
+        if auto_policy and task_fallback != "healthy":
+            expected.append(("main.example", main_entry["model"], "custom", "main-key"))
+        assert len(requests) == len(expected)
+        for (request, payload, observed_route), (host, model, provider, key) in zip(requests, expected):
+            assert request.url.host == host
+            assert request.url.path.endswith("/chat/completions")
+            assert request.headers["authorization"] == f"Bearer {key}"
+            assert payload["model"] == model
+            assert payload["messages"] == original_messages
+            # Native shaping budgets OpenRouter; custom vision routes omit the cap.
+            assert payload.get("max_completion_tokens", payload.get("max_tokens")) == (
+                73 if provider == "openrouter" else None
+            )
+            assert payload["temperature"] == 0.2
+            assert observed_route == {"provider": provider, "model": model}
+        assert messages == original_messages
+        assert route_info == {"provider": expected[-1][2], "model": expected[-1][1]}
+        if task_fallback == "stale":
+            assert aux._is_provider_unhealthy("custom", task_entry["base_url"])
+            assert not aux._is_provider_unhealthy("custom", main_entry["base_url"])
+
     def _make_payment_err(self):
         exc = Exception("Payment Required: insufficient credits")
         exc.status_code = 402


### PR DESCRIPTION
Automatic vision selection replaces `auto` with a concrete backend before a request. Preserve the original normalized policy so capacity and authentication recovery can still try the task fallback, then configured main fallbacks, while retaining concrete provider identity for request shaping and credential quarantine. Explicit-provider behavior is preserved.

Sync and async HTTP-mocked regressions cover `auto`, `AUTO`, ` auto `, explicit argument/config controls, and healthy, missing, or stale task fallbacks.

Related: #22097 identified the original vision-auto failure; #24039, #15714 and #47235 cover fallback layering; #31127 covers Codex quota classification.

Validation: 241 tests passed in `tests/agent/test_auxiliary_client.py`; scoped Ruff and `git diff --check` passed.
