### PR TITLE
fix(agent): rebuild connection pool for socket-layer transport errors (BrokenPipe, ConnectionReset, etc.)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -36,7 +36,7 @@ from agent.prompt_builder import format_steer_marker
 from agent.tool_dispatch_helpers import _trajectory_normalize_msg, make_tool_result_message
 from agent.trajectory import convert_scratchpad_to_think
 from agent.credential_pool import STATUS_EXHAUSTED
-from agent.error_classifier import FailoverReason
+from agent.error_classifier import FailoverReason, _TRANSPORT_ERROR_TYPES
 from utils import base_url_host_matches, base_url_hostname, env_var_enabled, atomic_json_write
 
 logger = logging.getLogger(__name__)
@@ -1066,11 +1066,19 @@ def restore_primary_runtime(agent) -> bool:
 
 # Which error types indicate a transient transport failure worth
 # one more attempt with a rebuilt client / connection pool.
-_TRANSIENT_TRANSPORT_ERRORS = frozenset({
-    "ReadTimeout", "ConnectTimeout", "PoolTimeout",
-    "ConnectError", "RemoteProtocolError",
-    "APIConnectionError", "APITimeoutError",
-})
+#
+# Single source of truth — re-uses the canonical set from
+# agent/error_classifier.py:_TRANSPORT_ERROR_TYPES (line 368-386).
+# The classifier already maps every type here to FailoverReason.timeout
+# via the OSError / ConnectionError isinstance catch at line 736-737;
+# the recovery gate at try_recover_primary_transport line 818 must
+# rebuild the pool for the same set, or it silently skips recovery for
+# socket-level errors like BrokenPipeError / ConnectionResetError that
+# the classifier treats as retryable.
+#
+# Fixes #52216: "BrokenPipeError skips connection-pool rebuild in
+# transport-recovery gate".
+_TRANSIENT_TRANSPORT_ERRORS = _TRANSPORT_ERROR_TYPES
 
 
 

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -12,6 +12,7 @@ Verifies that:
 import time
 from unittest.mock import MagicMock, patch
 
+import pytest
 
 from run_agent import AIAgent
 
@@ -283,6 +284,60 @@ class TestTryRecoverPrimaryTransport:
             )
 
         assert result is True
+
+    @pytest.mark.parametrize("error_type", [
+        # Socket-layer / OSError family — the error types that
+        # _TRANSPORT_ERROR_TYPES in agent/error_classifier.py:368-386
+        # added beyond the original _TRANSIENT_TRANSPORT_ERRORS set.
+        # Without the sync fix in agent/agent_runtime_helpers.py:1069,
+        # these silently skipped the recovery gate at line 818 even
+        # though the classifier treats them as retryable.
+        "ConnectionError",
+        "ConnectionResetError",
+        "ConnectionAbortedError",
+        "BrokenPipeError",
+        "TimeoutError",
+        "ReadError",
+        "ServerDisconnectedError",
+    ])
+    def test_recovers_on_socket_layer_errors(self, error_type):
+        """Regression for #52216.
+
+        Each type here is in agent/error_classifier.py:_TRANSPORT_ERROR_TYPES
+        (mapped to FailoverReason.timeout), and the recovery gate at
+        try_recover_primary_transport line 818 must rebuild the pool for
+        the same set.
+        """
+        agent = _make_agent(provider="custom")
+        error = _make_transport_error(error_type)
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()), \
+             patch("time.sleep"):
+            result = agent._try_recover_primary_transport(
+                error, retry_count=3, max_retries=3,
+            )
+
+        assert result is True, (
+            f"_try_recover_primary_transport refused recovery for "
+            f"{error_type}; the gate at agent_runtime_helpers.py:818 is "
+            f"out of sync with agent/error_classifier.py:_TRANSPORT_ERROR_TYPES"
+        )
+
+    def test_transient_sets_remain_identical(self):
+        """The two frozensets must be the same object identity after the sync fix.
+
+        Regression for #52216 — guards against future drift between
+        agent/error_classifier.py:_TRANSPORT_ERROR_TYPES and
+        agent/agent_runtime_helpers.py:_TRANSIENT_TRANSPORT_ERRORS.
+        """
+        from agent import agent_runtime_helpers as arh
+        from agent.error_classifier import _TRANSPORT_ERROR_TYPES as canonical
+
+        assert arh._TRANSIENT_TRANSPORT_ERRORS is canonical, (
+            "_TRANSIENT_TRANSPORT_ERRORS must reference the canonical set "
+            "from agent/error_classifier.py:_TRANSPORT_ERROR_TYPES "
+            "directly, not a duplicated copy that can drift."
+        )
 
     def test_skipped_when_already_on_fallback(self):
         agent = _make_agent(provider="custom")


### PR DESCRIPTION
## Summary

The transport-recovery gate at `agent/agent_runtime_helpers.py:818` consulted a stale frozenset (`_TRANSIENT_TRANSPORT_ERRORS`, only 7 type names) that missed socket-layer errors the canonical classifier at `agent/error_classifier.py:_TRANSPORT_ERROR_TYPES` already treats as retryable. Result: providers whose cloud gateway closes sockets during long thinking phases (NVIDIA Nemotron 3 Ultra on hosted NIM's ~120s upstream idle kill — first-party reproduction at NVIDIA/NemoClaw#4846 — also Anthropic Opus 4.7 thinking and OpenAI o1/o3) burned all 3 outer retries against the same dead connection pool, then surfaced `API call failed after 3 retries: [Errno 32] Broken pipe`.

One source-file line change:

```python
# agent/agent_runtime_helpers.py:1081
_TRANSIENT_TRANSPORT_ERRORS = _TRANSPORT_ERROR_TYPES
```

Single source of truth — any future addition to `_TRANSPORT_ERROR_TYPES` automatically flows through, no drift possible.

## Test Plan

- [x] `python3 -m pytest tests/run_agent/test_primary_runtime_restore.py tests/agent/test_error_classifier.py tests/run_agent/test_streaming.py -q` — **238 passed**, zero failures, zero regressions.
- [x] `ruff check agent/agent_runtime_helpers.py tests/run_agent/test_primary_runtime_restore.py` — clean.
- [x] Negative test: temporarily reverted the source change and confirmed the 8 new tests fail with the exact symptom from #52216 (`_try_recover_primary_transport refused recovery for BrokenPipeError; the gate at agent_runtime_helpers.py:818 is out of sync with agent/error_classifier.py:_TRANSPORT_ERROR_TYPES`). Then restored the fix and confirmed all 39 tests in `test_primary_runtime_restore.py` pass.
- [x] Cross-vendor dual review via `agy -p`:
  - Gemini 3.5 Flash (Medium) — `passed: true`, zero blockers/should-fix/nits.
  - GPT-OSS 120B (Medium) — `passed: true`, zero blockers/should-fix/nits.
  - Both reviewers verified: alias is a Python object reference (not a copy), no callers mutate either frozenset, no import cycle (verified `agent/error_classifier.py` has no reverse import of `agent.agent_runtime_helpers`), the parametrized test correctly mirrors the production `type(api_error).__name__` check at line 818, and the identity assertion (`is`, not `==`) catches future re-introduction of a duplicated frozenset literal.

## Notes

- **Scope is the smallest possible.** 1 source line change + 1 import extension + 8 regression tests. No new modules, no new knobs, no user-visible config additions, no timeout-default changes.
- **No regression risk on aggregator providers.** The recovery gate's existing aggregator skip at line 822 (`if agent._is_openrouter_url(): return False`) and provider skip at lines 825-826 (Nous, Nous-Research) are preserved. Aggregators that manage their own retry infra still skip the rebuild.
- **No regression risk on persistent upstream errors.** The recovery fires at most once per API call block (gated by `_retry.primary_recovery_attempted` at `agent/conversation_loop.py:3421`). For truly persistent upstream issues that the rebuild cannot fix, the next outer retry surfaces the same error and the classifier's broader signals route to fallback or abort — no recovery loop.
- **Behavioral regression risk audited.** Every type in `_TRANSPORT_ERROR_TYPES` is genuinely transient:
  - `ReadTimeout`, `ConnectTimeout`, `PoolTimeout` — explicit timeouts, transient.
  - `ConnectError`, `RemoteProtocolError`, `ConnectionError`, `ConnectionResetError`, `ConnectionAbortedError`, `BrokenPipeError`, `ServerDisconnectedError`, `ReadError` — socket-level disconnects, transient (a stale-connection-pool rebuild is exactly the right recovery).
  - `TimeoutError` — generic timeout, transient.
  - `SSLError`, `SSLZeroReturnError`, `SSLWantReadError`, `SSLWantWriteError`, `SSLEOFError`, `SSLSyscallError` — TLS handshake/record failures, transient.
  - `APIConnectionError`, `APITimeoutError` — OpenAI SDK wrappers for the above, transient.
- **Related but NOT in this PR.** Issue #52217 (sister issue filed in the same session) covers the upstream-side mitigation: a per-reasoning-model stale-timeout floor that auto-scales timeouts for known reasoning models. That requires a new module (`agent/reasoning_timeouts.py`) and integration into two stale-detector scaling blocks, and is shipped separately.

Fixes #52216.
