### PR TITLE
fix(agent): align transport-recovery error set with error classifier

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1069,6 +1069,14 @@ def restore_primary_runtime(agent) -> bool:
 _TRANSIENT_TRANSPORT_ERRORS = frozenset({
     "ReadTimeout", "ConnectTimeout", "PoolTimeout",
     "ConnectError", "RemoteProtocolError",
+    "ConnectionError", "ConnectionResetError",
+    "ConnectionAbortedError", "BrokenPipeError",
+    "TimeoutError", "ReadError",
+    "ServerDisconnectedError",
+    # SSL/TLS transport errors — transient mid-stream failures
+    "SSLError", "SSLZeroReturnError", "SSLWantReadError",
+    "SSLWantWriteError", "SSLEOFError", "SSLSyscallError",
+    # OpenAI SDK errors
     "APIConnectionError", "APITimeoutError",
 })
 


### PR DESCRIPTION
## Problem

`_TRANSIENT_TRANSPORT_ERRORS` in `agent/agent_runtime_helpers.py` (used by the transport-recovery gate) contains only 7 error type names, while `_TRANSPORT_ERROR_TYPES` in `agent/error_classifier.py` (used by the error classifier) contains 18.

The asymmetry means `BrokenPipeError`, `ConnectionResetError`, `ConnectionAbortedError`, `TimeoutError`, and other transient transport errors are classified as retryable by the error classifier but **skip the connection-pool rebuild** in the transport-recovery gate. After retry exhaustion, the user gets `API call failed after 3 retries: [Errno 32] Broken pipe` instead of the recovery-then-retry behavior.

## Fix

Add the 11 missing error type names to `_TRANSIENT_TRANSPORT_ERRORS` to align with `_TRANSPORT_ERROR_TYPES`:

```python
# Before (7 types)
_TRANSIENT_TRANSPORT_ERRORS = frozenset({
    "ReadTimeout", "ConnectTimeout", "PoolTimeout",
    "ConnectError", "RemoteProtocolError",
    "APIConnectionError", "APITimeoutError",
})

# After (18 types — aligned with _TRANSPORT_ERROR_TYPES)
_TRANSIENT_TRANSPORT_ERRORS = frozenset({
    "ReadTimeout", "ConnectTimeout", "PoolTimeout",
    "ConnectError", "RemoteProtocolError",
    "ConnectionError", "ConnectionResetError",
    "ConnectionAbortedError", "BrokenPipeError",
    "TimeoutError", "ReadError",
    "ServerDisconnectedError",
    "SSLError", "SSLZeroReturnError", "SSLWantReadError",
    "SSLWantWriteError", "SSLEOFError", "SSLSyscallError",
    "APIConnectionError", "APITimeoutError",
})
```

## Files changed

| File | Change |
|------|--------|
| `agent/agent_runtime_helpers.py` | Add 11 missing error types to `_TRANSIENT_TRANSPORT_ERRORS` |

Fixes #52216