### PR TITLE
fix(desktop): stop refText crash on undefined composer attachment holes

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -555,7 +555,14 @@ export function usePromptActions({
     async (rawText: string, options?: SubmitTextOptions) => {
       const visibleText = rawText.trim()
       const usingComposerAttachments = !options?.attachments
-      const attachments = options?.attachments ?? $composerAttachments.get()
+      // Drop undefined/null holes a session switch or draft restore can leave in
+      // the attachments array (same bug class as AttachmentList #49624). Without
+      // this, the sibling iterations below (a.kind / a.label / a.refText, and the
+      // sync step) throw "Cannot read properties of undefined (reading 'refText')"
+      // and break the chat surface.
+      const attachments = (options?.attachments ?? $composerAttachments.get()).filter(
+        (a): a is ComposerAttachment => Boolean(a)
+      )
 
       const terminalContextBlocks = terminalContextBlocksFromDraft(rawText).join('\n\n')
       const hasImage = attachments.some(a => a.kind === 'image')
@@ -568,14 +575,17 @@ export function usePromptActions({
       let attachmentRefs = attachments.map(optimisticAttachmentRef).filter((r): r is string => Boolean(r))
 
       const buildContextText = (atts: ComposerAttachment[]): string => {
-        const contextRefs = atts
+        // atts may be the post-sync array, which can reintroduce holes; filter
+        // before touching a.refText / a.kind.
+        const present = atts.filter((a): a is ComposerAttachment => Boolean(a))
+        const contextRefs = present
           .map(a => a.refText)
           .filter(Boolean)
           .join('\n')
 
         return (
           [contextRefs, terminalContextBlocks, visibleText].filter(Boolean).join('\n\n') ||
-          (atts.some(a => a.kind === 'image') ? 'What do you see in this image?' : '')
+          (present.some(a => a.kind === 'image') ? 'What do you see in this image?' : '')
         )
       }
 

--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { ComposerAttachment } from '@/store/composer'
 
-import { coerceThinkingText, optimisticAttachmentRef, parseCommandDispatch } from './chat-runtime'
+import { attachmentDisplayText, coerceThinkingText, optimisticAttachmentRef, parseCommandDispatch } from './chat-runtime'
 
 const DATA_URL = 'data:image/png;base64,iVBORw0KGgoAAAANS'
 
@@ -35,6 +35,32 @@ describe('optimisticAttachmentRef', () => {
     expect(optimisticAttachmentRef(attachment({ kind: 'file', refText: '@file:src/a.ts', previewUrl: DATA_URL }))).toBe(
       '@file:src/a.ts'
     )
+  })
+
+  // Session switches / draft restores can leave undefined|null holes in the
+  // composer attachments array. AttachmentList already filters them (#49624),
+  // but the submit path maps the same array through these helpers — an unguarded
+  // hole threw "Cannot read properties of undefined (reading 'refText')",
+  // crashing the chat surface (blank pane). The helpers must no-op on holes.
+  it('returns null for an undefined attachment instead of throwing', () => {
+    expect(() => optimisticAttachmentRef(undefined as unknown as ComposerAttachment)).not.toThrow()
+    expect(optimisticAttachmentRef(undefined as unknown as ComposerAttachment)).toBeNull()
+  })
+
+  it('returns null for a null attachment instead of throwing', () => {
+    expect(optimisticAttachmentRef(null as unknown as ComposerAttachment)).toBeNull()
+  })
+})
+
+describe('attachmentDisplayText', () => {
+  it('returns null for undefined|null instead of reading .kind/.refText on a hole', () => {
+    expect(() => attachmentDisplayText(undefined as unknown as ComposerAttachment)).not.toThrow()
+    expect(attachmentDisplayText(undefined as unknown as ComposerAttachment)).toBeNull()
+    expect(attachmentDisplayText(null as unknown as ComposerAttachment)).toBeNull()
+  })
+
+  it('still resolves a normal file ref', () => {
+    expect(attachmentDisplayText(attachment({ kind: 'file', refText: '@file:src/a.ts' }))).toBe('@file:src/a.ts')
   })
 })
 

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -155,6 +155,13 @@ export function pathLabel(path: string): string {
 }
 
 export function attachmentDisplayText(attachment: ComposerAttachment): string | null {
+  // Session switches / draft restores can leave undefined holes in the
+  // composer attachments array (see AttachmentList's filter(Boolean) + #49624).
+  // Every consumer funnels through here, so guard the chokepoint too.
+  if (!attachment) {
+    return null
+  }
+
   if (attachment.kind === 'terminal' && attachment.detail) {
     return `\`\`\`terminal\n${attachment.detail.trim()}\n\`\`\``
   }
@@ -188,6 +195,10 @@ export function attachmentDisplayText(attachment: ComposerAttachment): string | 
  * through to `attachmentDisplayText`.
  */
 export function optimisticAttachmentRef(attachment: ComposerAttachment): string | null {
+  if (!attachment) {
+    return null
+  }
+
   if (attachment.kind === 'image' && attachment.previewUrl?.startsWith('data:')) {
     return attachment.previewUrl
   }


### PR DESCRIPTION
## Summary
The desktop app no longer goes blank ("Desktop app link offline") when the composer attachments array has undefined/null holes. Salvages #52021 by @xxxigm onto current `main`.

Root cause: a session switch or draft restore can leave empty slots in the composer attachments array. `AttachmentList` already filtered them (#49624), but the **submit path** didn't — it mapped the same array through `a.refText` / `a.kind` / `a.label`, throwing `Cannot read properties of undefined (reading 'refText')` hundreds of times and crashing the renderer.

## Changes
- `use-prompt-actions.ts`: `.filter(Boolean)` the source attachments array before the submit/sync iterations; filter again in `buildContextText` (the post-sync array can reintroduce holes).
- `chat-runtime.ts`: guard the two chokepoint helpers `attachmentDisplayText` and `optimisticAttachmentRef` against a hole.
- `chat-runtime.test.ts`: cover undefined/null attachment cases for both helpers.

## Validation
| | Before | After |
|---|---|---|
| Hole in attachments array | `TypeError: ...reading 'refText'` → blank pane | no-op, send proceeds |
| `chat-runtime.test.ts` | — | pass |
| `use-prompt-actions.test.tsx` | — | 50/50 pass |

Confirmed live on `main`: lines 557/564/568/593 of `use-prompt-actions.ts` dereference attachment fields with no hole guard, and the `chat-runtime.ts` helpers are unguarded. Re-reported in two debug dumps (the `refText` TypeError firing repeatedly).

Salvage of #52021 — @xxxigm's commits cherry-picked, authorship preserved.

## Infographic

![desktop-reftext-crash-fixed](https://v3b.fal.media/files/b/0a9fa67f/klzB_HG_XicjKoPo4tELe_XSzxJJab.png)
