### PR TITLE
fix(tui): route /learn through command.dispatch so the prompt fires (#51829)

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -1214,7 +1214,7 @@ def test_slash_exec_plugin_handler_error_returns_output(server):
     assert worker.calls == []
 
 
-@pytest.mark.parametrize("cmd", ["retry", "queue hello", "q hello", "steer fix the test", "plan"])
+@pytest.mark.parametrize("cmd", ["retry", "queue hello", "q hello", "steer fix the test", "plan", "learn create a skill from https://example.com/docs"])
 def test_slash_exec_routes_pending_input_commands_to_dispatch(server, cmd):
     """slash.exec must route _pending_input commands to command.dispatch
     internally instead of returning the old 4018 "use command.dispatch"
@@ -1286,6 +1286,38 @@ def test_command_dispatch_queue_requires_arg(server):
 
     assert "error" in resp
     assert resp["error"]["code"] == 4004
+
+
+def test_command_dispatch_learn_sends_built_prompt(server):
+    """command.dispatch /learn returns {type: 'send', message: <built prompt>}
+    so the TUI fires a real agent turn (#51829). The CLI handler queues onto
+    _pending_input — a queue the TUI slash worker has no reader for — so the
+    prompt was silently dropped after the ack. Routing through command.dispatch
+    injects the standards-guided prompt as a normal turn instead.
+    """
+    from agent.learn_prompt import build_learn_prompt
+
+    sid = "test-session"
+    server._sessions[sid] = {"session_key": sid}
+
+    arg = "create a skill from https://example.com/docs"
+    resp = server.handle_request({
+        "id": "r-learn",
+        "method": "command.dispatch",
+        "params": {"name": "learn", "arg": arg, "session_id": sid},
+    })
+
+    assert "error" not in resp
+    result = resp["result"]
+    assert result["type"] == "send"
+    assert result["message"] == build_learn_prompt(arg)
+
+
+def test_pending_input_commands_includes_learn(server):
+    """Guard: _PENDING_INPUT_COMMANDS must list 'learn' — without it slash.exec
+    routes /learn to the slash worker, which only prints the ack and drops the
+    prompt onto the dead _pending_input queue (#51829)."""
+    assert "learn" in server._PENDING_INPUT_COMMANDS
 
 
 def test_skills_manage_search_uses_tools_hub_sources(server):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9885,6 +9885,7 @@ _PENDING_INPUT_COMMANDS: frozenset[str] = frozenset(
         "plan",
         "goal",
         "undo",
+        "learn",
     }
 )
 


### PR DESCRIPTION
## Summary

Fixes #51829 — `/learn` in the Desktop GUI (TUI) shows the "Learning a skill…" ack but never triggers an LLM request or creates a skill.

## Root cause

The CLI's `_handle_learn_command` (`hermes_cli/cli_commands_mixin.py:1483`) prints the ack and puts the built prompt onto `self._pending_input` — a queue consumed by the CLI's agent loop. In the TUI, slash commands run in a **slash-worker subprocess that has no reader for `_pending_input`**, so the prompt is silently dropped. (Same class of bug already fixed for `goal`/`queue`/`steer`/`plan` in #48848.)

`tui_gateway/server.py` already has a correct `command.dispatch` handler for `learn` (returns `{"type": "send", "message": build_learn_prompt(arg)}`, which fires a real agent turn). But `learn` was **missing from `_PENDING_INPUT_COMMANDS`**, so `slash.exec` fell through to the worker subprocess instead of routing to `command.dispatch`.

## Fix

Add `"learn"` to `_PENDING_INPUT_COMMANDS`. One-line behavioral change; the dispatch handler was already in place.

## Tests

- Extended the existing `test_slash_exec_routes_pending_input_commands_to_dispatch` parametrization to cover `learn` (asserts `slash.exec` produces the exact `command.dispatch` payload).
- Added `test_command_dispatch_learn_sends_built_prompt` (verifies the built prompt is sent as a turn).
- Added `test_pending_input_commands_includes_learn` guard (mirrors the existing `goal` guard so removal re-breaks loudly).

All 8 relevant tests pass:
```
python -m pytest tests/tui_gateway/test_protocol.py -k 'learn or pending_input or routes_pending'
8 passed, 60 deselected
```

CLI and gateway paths are unaffected (both already worked, as the issue notes).