### PR TITLE
fix: add 'from e' to ImportError re-raises to preserve exception chain

### DIFF
--- a/tools/environments/daytona.py
+++ b/tools/environments/daytona.py
@@ -57,7 +57,7 @@ class DaytonaEnvironment(BaseEnvironment):
         except ImportError:
             pass
         except Exception as e:
-            raise ImportError(str(e))
+            raise ImportError(str(e)) from e
         from daytona import (
             Daytona,
             CreateSandboxFromImageParams,

--- a/tools/environments/modal.py
+++ b/tools/environments/modal.py
@@ -88,7 +88,7 @@ def _ensure_modal_sdk() -> None:
     except ImportError:
         pass
     except Exception as e:
-        raise ImportError(str(e))
+        raise ImportError(str(e)) from e
 
 
 def _resolve_modal_image(image_spec: Any) -> Any:

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -90,7 +90,7 @@ def _import_edge_tts():
     except ImportError:
         pass
     except Exception as e:
-        raise ImportError(str(e))
+        raise ImportError(str(e)) from e
     import edge_tts
     return edge_tts
 
@@ -111,7 +111,7 @@ def _import_elevenlabs():
         # so older code paths still get a clean ImportError.
         pass
     except Exception as e:  # FeatureUnavailable or any unexpected error
-        raise ImportError(str(e))
+        raise ImportError(str(e)) from e
     from elevenlabs.client import ElevenLabs
     return ElevenLabs
 
@@ -134,7 +134,7 @@ def _import_mistral_client():
     except ImportError:
         pass
     except Exception as e:  # FeatureUnavailable or any unexpected error
-        raise ImportError(str(e))
+        raise ImportError(str(e)) from e
     from mistralai.client import Mistral
     return Mistral
 


### PR DESCRIPTION
## Problem

Several places catch `Exception` and re-raise as `ImportError` without `from e`, which loses the original traceback. When a dependency fails to import due to a configuration error, version mismatch, or other non-`ImportError` exception, the user sees a bare `ImportError` with no indication of the root cause.

```python
# Current — original traceback lost
except Exception as e:
    raise ImportError(str(e))

# Fixed — original exception preserved in chain
except Exception as e:
    raise ImportError(str(e)) from e
```

## Files changed

| File | Lines | Context |
|------|-------|---------|
| `tools/tts_tool.py` | 93, 114, 137 | edge_tts, elevenlabs, mistralai imports |
| `tools/environments/daytona.py` | 60 | Daytona SDK import |
| `tools/environments/modal.py` | 91 | Modal SDK import |

All changes verified with `py_compile`.