### PR TITLE
docs: add progress-aware iteration planning docs

### DIFF
--- a/docs/plans/2026-06-25-progress-aware-tool-call-limit-plan.md
+++ b/docs/plans/2026-06-25-progress-aware-tool-call-limit-plan.md
@@ -1,0 +1,218 @@
+---
+title: "plan: Progress-aware agent iteration policy for perceived tool-call limits"
+status: review-ready
+date: 2026-06-25
+type: plan
+target_repo: hermes-agent
+source_artifact: /Users/cube-mac/dreampia-mvp-evidence/latest/hermes-progress-aware-tool-call-limit-plan-2026-06-25.md
+related_work_order: ../work-orders/2026-06-25-progress-aware-tool-call-limit-work-order.md
+related_review: ../reviews/2026-06-25-progress-aware-tool-call-limit-plan-review.md
+---
+
+# plan: Progress-aware agent iteration policy for perceived tool-call limits
+
+## Summary
+
+Hermes currently has a user-visible failure mode where a long but productive task can appear to stop because the foreground agent loop reaches its configured iteration/turn threshold. Users experience this as a “tool-call limit,” but the root control surface is broader than individual tool calls: the agent loop counts LLM/API iterations, which may include tool-call rounds, tool results, retries, and finalization attempts.
+
+This plan proposes a progress-aware iteration policy that keeps the existing safety cap but changes the normal stop condition from “fixed count reached” to “fixed soft threshold reached with no recent progress.” Productive work should continue; repeated non-progress loops should stop with an explicit reason.
+
+## Problem
+
+The existing loop policy can stop normal work when the model is still making measurable progress, especially during long coding, verification, PR/CI, or multi-artifact tasks. Raising `agent.max_turns` alone is only a temporary workaround: it increases room for legitimate work but also increases room for broken loops.
+
+The desired behavior is:
+
+- normal progress continues past the soft threshold;
+- repeated identical failures stop quickly;
+- a large hard cap remains as a final safety boundary;
+- the final user-facing message explains why the turn stopped;
+- gateway, cron, delegation, and worker contexts can apply different policy profiles.
+
+## Goals
+
+- Treat `agent.max_turns` / `agent.max_iterations` as a soft threshold when progress-aware mode is enabled.
+- Add a separate hard maximum iteration cap as a fail-safe.
+- Detect recent progress using bounded signals from tool results, file state, process state, validation output, artifacts, and lifecycle state.
+- Detect repeated no-progress loops, including identical tool failures and idempotent no-op calls.
+- Preserve legacy behavior by default until the new policy is proven safe.
+- Make stop reasons explicit for logs, observability, and final responses.
+
+## Non-goals
+
+- Do not remove hard limits entirely.
+- Do not make Telegram/gateway delivery timeouts unbounded.
+- Do not let cron or delegated subagents inherit unrestricted interactive-session limits.
+- Do not introduce a new model-facing core tool.
+- Do not rely on model self-reporting as the only progress signal.
+- Do not mutate conversation history or break message role alternation to extend a turn.
+
+## Design principles
+
+1. **Progress beats raw count, but only inside a hard cap.** A soft limit can be crossed only when recent objective progress exists.
+2. **No-progress loops fail closed.** Repeated same-tool/same-args/same-result failures should stop before consuming a large budget.
+3. **Provider/model independence.** The policy should sit around the agent loop and tool dispatch results, not depend on provider-specific messages.
+4. **Prompt-cache safety.** The policy must not rebuild the system prompt or mutate prior conversation content mid-turn.
+5. **Profile-specific limits.** Interactive chat can be more permissive than cron/subagent/gateway contexts.
+6. **Evidence-first finalization.** A stop reason should be stored and surfaced in a useful, non-ambiguous user message.
+
+## Proposed architecture
+
+Introduce two small internal modules:
+
+- `agent/progress_tracker.py` — records bounded progress/no-progress signals and fingerprints recent tool/API outcomes.
+- `agent/iteration_policy.py` — decides whether the loop should continue, warn, gracefully stop, or hard-stop based on config, iteration count, progress window, and guardrail state.
+
+The conversation loop should ask the policy for a decision at a stable point in each iteration. The policy returns a structured decision with a reason such as `below_soft_limit`, `soft_limit_reached_but_progress_detected`, `soft_limit_reached_no_progress`, `guardrail_exact_failure`, or `hard_max_iterations_reached`.
+
+## Current implementation reconnaissance
+
+Implementation must be based on these existing seams, not on a fresh loop abstraction:
+
+- Main per-turn loop: `agent/conversation_loop.py` currently gates the loop with `api_call_count < agent.max_iterations` and `agent.iteration_budget.remaining > 0`, plus the existing `_budget_grace_call` escape hatch.
+- Budget object: `agent/iteration_budget.py` is a thread-safe consume/refund counter. `execute_code`-only tool rounds are currently refunded, so progress-aware mode must preserve that behavior.
+- Turn setup: `agent/turn_context.py` resets `agent.iteration_budget = IterationBudget(agent.max_iterations)` per turn. A progress-aware hard cap cannot be added only by changing `agent.max_iterations`, because `agent.max_iterations` is also used for legacy reporting and finalization semantics.
+- Finalization: `agent/turn_finalizer.py` currently treats `api_call_count >= agent.max_iterations` or `iteration_budget.remaining <= 0` as budget exhaustion and asks the model for a toolless summary through `_handle_max_iterations()`.
+- Tool execution: actual tool observations are emitted from `agent/tool_executor.py`, in both sequential and concurrent paths, after the underlying tool call returns and before the tool result is appended to `messages`.
+- Existing loop guardrails: `agent/tool_guardrails.py` already computes canonical tool-call signatures, repeated exact-failure counts, same-tool failure counts, and idempotent no-progress counts. The new policy should reuse or consume these decisions rather than duplicating a second fingerprinting implementation.
+- Existing guardrail halt path: `conversation_loop.py` already maps `_tool_guardrail_halt_decision` to `_turn_exit_reason = "guardrail_halt"` and a controlled final response. Progress-aware policy must not regress this behavior.
+- Config/default source: default CLI config is currently in `cli.py`; runtime entrypoints pass `max_iterations` into `AIAgent`. A user-facing config addition must update the authoritative default/config display path and the AIAgent runtime resolution path.
+
+## Implementation constraints created by current code
+
+- Legacy mode must leave the current `max_iterations` hard-stop behavior unchanged, including the existing one extra toolless summary attempt on exhaustion.
+- Progress-aware mode needs two limits: existing `agent.max_turns` / `max_iterations` as the soft threshold, and a separate effective hard budget for the per-turn loop.
+- The loop condition, `IterationBudget` initialization, and `turn_finalizer` exhaustion check must change together. Changing only one of them will either preserve the old premature stop or accidentally turn the soft threshold into a hard cap again.
+- Success/failure finalization must change with the loop: a progress-aware turn that crosses the soft threshold and later produces a valid final response should not be marked incomplete merely because `api_call_count >= agent.max_iterations`.
+- Existing near-limit error guards that compare against `agent.max_iterations - 1` must be re-anchored to the effective hard budget or a policy decision; otherwise they silently preserve the old hard-stop behavior.
+- Code paths that bypass the normal tool-calling loop, such as app-server or provider-specific runtimes, must be explicitly out of scope or given their own policy adapter.
+- Progress tracking should be event-fed from `tool_executor` and existing guardrail observations; it should not scan or mutate the conversation transcript after the fact.
+- Progress signals must remain bounded and secret-safe: store event kind, tool name, hashed args/result summaries, status, and small metadata only; never store raw large tool outputs or secrets.
+
+## Configuration strategy
+
+Add an opt-in policy under `agent.iteration_policy` and keep legacy semantics as the default initial rollout.
+
+Recommended initial shape:
+
+```yaml
+agent:
+  iteration_policy:
+    mode: legacy                # legacy | progress_aware
+    soft_max_iterations: null   # null means use existing agent.max_turns / max_iterations
+    hard_max_iterations: 300
+    progress_window: 12
+    require_progress_after_soft_limit: true
+```
+
+Guardrail thresholds should remain separate from policy mode but feed into the policy decision where available. Config rollout must update both current default/config surfaces (`cli.py` and `hermes_cli/config.py`) or route through one authoritative resolver, and nested `agent.iteration_policy` values must be deep-merged so partial user config does not erase defaults.
+
+Validation rules should reject or safely fall back on invalid modes, non-positive limits, `hard_max_iterations <= soft_max_iterations` in progress-aware mode, and context profiles that would give cron/delegation an unbounded interactive policy.
+
+For user-facing docs, `turns` can be described as the historical CLI term, but the internal policy should prefer `iterations` because the counted unit is an LLM/API loop iteration, not an individual tool call.
+
+## Progress signal strategy
+
+Progress should be recognized from objective bounded state changes, for example:
+
+- a file write/patch result changed repository or filesystem state;
+- test/validation output changed in a way that provides new information;
+- a background process produced new output or changed state;
+- git/PR/CI lifecycle state changed;
+- a new evidence artifact was created;
+- todo/progress state changed;
+- a user steer changed the active path;
+- tool args/result fingerprints changed in a meaningful way.
+
+A signal should not be considered progress merely because a model says it is making progress.
+
+The initial implementation should prioritize signals already observable without broad tool rewrites:
+
+1. existing `ToolCallGuardrailDecision` values from `agent/tool_guardrails.py`;
+2. tool completion events from `agent/tool_executor.py` with tool name, args hash, result hash/status, duration, and blocked/error flags;
+3. file mutation verifier outcomes already recorded by `_record_file_mutation_result()`;
+4. `todo` state changes and explicit user steer events;
+5. lifecycle state changes from git/PR/CI/process tools when visible in structured or hashed tool results.
+
+Signals that require tool-specific semantic parsing beyond these should be deferred until after the core policy is safe.
+
+Fingerprinting must be secret-safe. Raw args/results should be redacted or summarized before fingerprinting, low-entropy secret-looking values should not be logged even as plain hashes, and any persisted/observable fingerprint should be bounded to a turn/session scope where practical rather than becoming a durable correlation oracle.
+
+Concurrent tool execution should feed progress observations deterministically after result collection, or the tracker must be explicitly thread-safe. Cancelled, interrupted, or skipped tool calls are not progress and must not extend the turn after a soft limit.
+
+## No-progress and loop guard strategy
+
+The policy should classify the following as no-progress risks:
+
+- identical tool + identical args + identical failure repeated;
+- identical shell command returning identical exit/output repeatedly;
+- identical failed `patch` old_string search repeated;
+- same content written repeatedly;
+- invalid tool-call shape repeated;
+- read/search loops that do not change the task state after the soft threshold.
+
+These should produce warning or stop decisions depending on configured thresholds.
+
+The current `ToolCallGuardrailController` already covers the first three classes for many tools. The policy should treat an existing hard guardrail decision as an immediate stop and should treat repeated guardrail warnings as strong no-progress evidence after the soft threshold.
+
+The policy should also distinguish:
+
+- **same failing call**: same tool + same canonical args + failed result;
+- **same idempotent no-op**: same read/search call + same successful result;
+- **same tool failure path**: same tool failing with varying args;
+- **productive mutation**: a mutating tool reports a landed change or creates new evidence;
+- **informational novelty**: a read/search/test command returns a new result fingerprint that changes the known state.
+
+## Context-specific policy profiles
+
+| Context | Policy direction |
+|---|---|
+| CLI/local interactive chat | progress-aware opt-in, existing `agent.max_turns` as soft threshold, separate bounded hard cap candidate such as 300 |
+| Telegram/gateway | progress-aware opt-in only after the main `gateway/run.py` agent creation path and API-server env path both resolve bounded policy; platform delivery/inactivity timeout remains authoritative |
+| Cron | conservative by default; no progress extension beyond a small hard cap unless a job explicitly opts into a bounded profile |
+| delegate_task | child hard cap must be bounded by delegation config and must not exceed the parent/session hard-budget policy by accident |
+| Kanban/worker | integrate with task timeout/claim timeout and failure accounting; avoid infinite worker claims |
+
+## Rollout plan
+
+1. Add isolated tests around the new progress tracker and iteration policy.
+2. Wire policy into the conversation loop behind `mode: legacy` default.
+3. Add focused integration tests proving legacy mode is unchanged.
+4. Add progress-aware tests for productive soft-limit crossing and no-progress stopping.
+5. Add docs for config behavior and stop reasons.
+6. Enable opt-in locally for validation before considering default changes.
+
+## Acceptance criteria
+
+- Legacy mode preserves the current hard-count behavior.
+- Progress-aware mode allows productive work past the soft threshold until the hard cap.
+- Progress-aware mode stops repeated identical failures before the hard cap.
+- Stop reasons are explicit and test-covered.
+- A productive progress-aware turn that crosses the soft threshold and then returns a final answer is recorded as successful where appropriate, not as legacy max-iteration exhaustion.
+- Interactive/gateway/cron/delegation profiles do not accidentally share one unbounded behavior.
+- Gateway, cron, delegation, worker, and API-server entrypoints all use bounded policy resolution or explicitly remain in legacy mode.
+- Existing prompt caching and message role alternation invariants are preserved.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Infinite loop because weak signals count as progress | Require bounded objective signals and keep hard cap |
+| Legitimate long read/search phase misclassified as no progress | Use a progress window and allow new result fingerprints/new evidence to count |
+| Cron jobs run too long | Keep cron policy conservative regardless of interactive defaults |
+| Gateway user sees silence for too long | Keep gateway delivery/task timeout independent from iteration policy |
+| Config confusion between `max_turns`, `max_iterations`, and policy fields | Document terminology and preserve legacy default |
+| Prompt-cache breakage | Policy must not mutate prior messages/system prompt mid-conversation |
+
+## Open questions
+
+- Should `soft_max_iterations: null` always mean reuse the existing `agent.max_turns` value, or should context profiles be allowed to override the soft threshold independently?
+- What exact conservative hard-cap values should gateway, cron, delegation, API-server, and worker contexts use during the first opt-in rollout?
+- Should the existing guardrail controller expose a public observation/metadata API for policy consumption, or should `tool_executor` feed both guardrail and progress tracker from the same bounded event object?
+- Should stop decisions be exposed only in logs/final response, or also in structured observability hooks such as gateway run events, cron logs, delegation summaries, and activity metadata?
+
+## Links
+
+- Work order: `../work-orders/2026-06-25-progress-aware-tool-call-limit-work-order.md`
+- Review: `../reviews/2026-06-25-progress-aware-tool-call-limit-plan-review.md`
+- Source mixed artifact: `/Users/cube-mac/dreampia-mvp-evidence/latest/hermes-progress-aware-tool-call-limit-plan-2026-06-25.md`

--- a/docs/reviews/2026-06-25-progress-aware-tool-call-limit-plan-review.md
+++ b/docs/reviews/2026-06-25-progress-aware-tool-call-limit-plan-review.md
@@ -1,0 +1,196 @@
+---
+title: "review: Progress-aware tool-call limit plan separation"
+status: passed-after-deep-review-closure
+date: 2026-06-25
+type: review
+target_repo: hermes-agent
+reviewed_plan: ../plans/2026-06-25-progress-aware-tool-call-limit-plan.md
+reviewed_work_order: ../work-orders/2026-06-25-progress-aware-tool-call-limit-work-order.md
+reviewed_step_breakdown: ../work-orders/2026-06-25-progress-aware-tool-call-limit-step-breakdown.md
+source_artifact: /Users/cube-mac/dreampia-mvp-evidence/latest/hermes-progress-aware-tool-call-limit-plan-2026-06-25.md
+---
+
+# review: Progress-aware tool-call limit plan separation
+
+## Verdict
+
+PASS with notes. The original mixed artifact has been split into a pure strategic plan and a separate execution work order. The new plan is review-ready for implementation planning, while the work order carries W-unit execution detail, RED/GREEN expectations, commands, evidence packet shape, and exit criteria.
+
+## Reviewed files
+
+| File | Class | Verdict |
+|---|---|---|
+| `../plans/2026-06-25-progress-aware-tool-call-limit-plan.md` | Plan | PASS |
+| `../work-orders/2026-06-25-progress-aware-tool-call-limit-work-order.md` | Work Order | PASS |
+| `/Users/cube-mac/dreampia-mvp-evidence/latest/hermes-progress-aware-tool-call-limit-plan-2026-06-25.md` | Source artifact | Superseded notice added |
+
+## Plan purity review
+
+The plan now owns:
+
+- problem statement;
+- goals and non-goals;
+- design principles;
+- architecture direction;
+- configuration strategy;
+- progress/no-progress strategy;
+- context-specific policy direction;
+- rollout strategy;
+- acceptance criteria;
+- risks and open questions.
+
+The plan no longer owns:
+
+- W-unit implementation bodies;
+- RED/GREEN execution detail;
+- exact test command matrix;
+- per-slice file-edit instructions;
+- PR evidence packet body.
+
+## Work order review
+
+The work order now owns:
+
+- W0-W9 execution slices;
+- likely file targets;
+- RED/GREEN and evidence expectations;
+- test commands;
+- verification packet shape;
+- implementation-specific constraints.
+
+This is the correct place for the material that had been mixed into the original plan sections 8-12.
+
+## Technical review notes
+
+### N1 — Terminology clarified
+
+The plan correctly distinguishes the user-visible “tool-call limit” from the implementation-level agent iteration/API-loop limit. This matters because fixing a perceived tool-call cap by adding a model-facing tool or simply increasing max turns would address the symptom poorly.
+
+### N2 — Legacy default is correct
+
+The plan keeps `legacy` as the default rollout mode. This is important for Hermes Agent because agent-loop changes can affect CLI, gateway, cron, delegation, and workers at once.
+
+### N3 — Hard cap retained
+
+The plan does not remove hard caps. This preserves a fail-safe for broken loops and is safer than unbounded progress-aware continuation.
+
+### N4 — Context profiles need implementation attention
+
+The work order correctly separates interactive, gateway, cron, delegation, and worker contexts. During implementation, this should be treated as a real acceptance gate, not a docs-only note.
+
+### N5 — Prompt-cache and role alternation invariants included
+
+The plan explicitly protects prompt caching and message role alternation. This aligns with Hermes Agent `AGENTS.md` guidance.
+
+## Blockers
+
+None remaining after the 2026-06-25 code-recon and deep-review closure patches below. Before those patches, the plan was directionally correct but not sufficiently implementation-ready because it did not identify several existing Hermes loop/tool seams and post-soft-limit finalization/context-profile pitfalls.
+
+## Implementation sufficiency audit — 2026-06-25
+
+### Question
+
+Can an implementer build the requested progress-aware tool-call/iteration policy from the plan as written?
+
+### Pre-patch verdict
+
+**Not safely enough.** The original split plan had the right product intent, but it was missing concrete current-code anchors. An implementer could have duplicated existing guardrail logic, patched only the loop condition, or accidentally broken finalization semantics.
+
+### Code facts checked
+
+| Area | Current code fact | Implementation impact |
+|---|---|---|
+| Main loop | `agent/conversation_loop.py` gates on `api_call_count < agent.max_iterations` plus `agent.iteration_budget.remaining > 0` | Soft/hard limit split must change loop condition and budget together |
+| Turn budget | `agent/turn_context.py` resets `IterationBudget(agent.max_iterations)` per turn | A hard cap cannot be introduced by only changing config docs |
+| Finalization | `agent/turn_finalizer.py` treats `api_call_count >= agent.max_iterations` as exhaustion and calls `_handle_max_iterations()` | Soft-limit continuation requires finalizer-aware stop reasons |
+| Tool results | `agent/tool_executor.py` has separate sequential/concurrent post-call paths | Progress observations must be wired in both paths |
+| Guardrails | `agent/tool_guardrails.py` already owns canonical args/result hashes and repeated failure/no-progress counts | New tracker/policy should reuse existing decisions rather than duplicate fingerprinting |
+| Existing halt | `conversation_loop.py` already turns `_tool_guardrail_halt_decision` into `guardrail_halt` and a controlled response | Progress policy must not regress current guardrail halt behavior |
+| Config | default CLI config lives in `cli.py`; entrypoints pass `max_iterations` into `AIAgent` | Config work must cover default display/resolution and runtime init |
+| Contexts | cron/gateway/TUI/delegation construct agents through separate surfaces | Context profile work is a real implementation gate, not a doc-only note |
+
+### Gaps found and closed in docs
+
+- Added current implementation reconnaissance to the plan.
+- Added implementation constraints for `conversation_loop.py`, `turn_context.py`, `turn_finalizer.py`, `IterationBudget`, `tool_executor.py`, and `tool_guardrails.py`.
+- Replaced ambiguous turns-based internal policy names with `soft_max_iterations` / `hard_max_iterations`, while preserving user-facing explanation of historical `turns` terminology.
+- Added explicit requirement to reuse existing `ToolCallGuardrailController` fingerprint/failure/no-progress data.
+- Expanded work-order file targets to include `agent/tool_executor.py`, `agent/tool_guardrails.py`, `agent/agent_init.py`, `agent/turn_context.py`, `cli.py`, cron/gateway/TUI/delegation surfaces, and existing tests.
+- Strengthened W0/W1/W2/W4/W5/W6 so implementation starts from evidence, preserves legacy behavior, and covers both sequential/concurrent tool paths.
+
+### Post-patch verdict
+
+**Sufficient for W0/W1 implementation planning.** The plan/work-order now identify the critical seams and the failure modes that could make a naive implementation unsafe. Full implementation should still proceed W-unit by W-unit, beginning with W0 evidence and RED tests; do not jump directly to broad loop rewrites.
+
+## Deep-review closure — 2026-06-25
+
+### Review method
+
+The augmented docs were re-reviewed from three angles:
+
+1. architecture/current-code alignment;
+2. document separation, plan purity, and implementation handoff quality;
+3. operational/test/safety risk across CLI, gateway, cron, delegation, workers, and API-server surfaces.
+
+### Findings and closure ledger
+
+| Severity | Finding | Closure applied |
+|---|---|---|
+| P1 | Soft-limit continuation could still be marked incomplete because `turn_finalizer` currently requires `api_call_count < agent.max_iterations` for `completed`. | Plan acceptance and Work Order W6 now require successful post-soft-limit finalization and caller behavior evidence. |
+| P1 | Main `gateway/run.py` AIAgent creation/cache path was missing from file targets/context-profile gates. | Work Order file targets, anchors, W7 profile rules, and W9 matrix now include `gateway/run.py` plus API-server behavior. |
+| P1 | Existing guardrail data is not directly consumable because `_append_guardrail_observation()` returns only a string. | Plan open question and Work Order W2 now require a public observation/decision API or shared bounded event object. |
+| P1 | Post-error near-limit guard still compares against `agent.max_iterations - 1`. | Plan constraints and Work Order W0/W4 now require measuring and re-anchoring this guard. |
+| P1 | Provider/runtime paths that bypass the normal loop, such as app-server runtimes, were not classified. | Plan constraints and Work Order W0/W4 now require explicit exclusion or adapter coverage. |
+| P1 | Nested config rollout could diverge across `cli.py`, `hermes_cli/config.py`, gateway, cron, API-server, and delegation surfaces. | Plan config strategy and Work Order W3/W7 now require authoritative/deep-merged config resolution and validation. |
+| P1 | Context profile defaults were direction-only. | Plan context table and Work Order W7 now define initial resolution rules and evidence requirements. |
+| P1 | Source artifact notice pointed at a stale checkout path. | Work Order W8 and evidence packet now require source-artifact notice verification; the notice was patched to the active isolated worktree paths. |
+| P2 | `turns`/`iterations` reason naming was inconsistent. | Plan and Work Order now standardize on `hard_max_iterations_reached` internally. |
+| P2 | Tracker secret-safety was too weak if implemented as plain hashes of raw args/results. | Plan progress strategy and Work Order W2 now require redacted/keyed bounded fingerprints and no durable hash of low-entropy secret-looking values. |
+| P2 | Concurrent tool observation order/thread-safety was not explicit. | Plan and Work Order W2/W5 now require deterministic post-collection observation or thread-safe/order-aware tracker behavior. |
+| P2 | Interrupted/cancelled/skipped tools could be misread as progress. | Plan and Work Order W2/W5 now state they are non-progress and interrupt wins over policy. |
+| P2 | W9 verification matrix was narrower than touched surfaces. | Work Order W9 now includes guardrail runtime, turn completion explainer, iteration budget race, TUI/delegation conditional checks, context evidence, and soft-limit completion evidence. |
+
+### Post-deep-review verdict
+
+**No remaining document-level P0/P1 blockers for W0/W1 implementation planning.** The docs are still not a license for a broad one-shot loop rewrite; they are ready for the W0 evidence slice followed by W1 pure policy modeling.
+
+## Follow-up before implementation
+
+- Re-establish current code path in `agent/conversation_loop.py` and `agent/turn_finalizer.py` before editing.
+- Confirm whether an existing guardrail/fingerprint helper already exists to avoid duplicate infrastructure.
+- Keep W0 as a read/test reproduction slice before adding policy modules.
+- Do not touch unrelated desktop/i18n dirty files in the current checkout.
+
+## Step-breakdown independent review — 2026-06-25
+
+### Reviewed step-breakdown file
+
+- `../work-orders/2026-06-25-progress-aware-tool-call-limit-step-breakdown.md`
+
+### Independent review verdict
+
+**GO for W0/W1 implementation planning.** The step breakdown decomposes parent W0-W9 into contiguous `Wn.Sm` handoff steps, keeps W0 evidence-first, keeps W1 pure/import-light, and does not authorize broad conversation-loop rewrites before W0/W1 gates are complete.
+
+### Step-breakdown P2 closure ledger
+
+| Severity | Finding | Closure applied |
+|---|---|---|
+| P2 | W0.S2 mixed baseline-pinning language with RED wording, which could make implementers confuse current-behavior pinning with future desired progress-aware REDs. | W0.S2 now explicitly says the baseline-pinning test should pass once current behavior is encoded, and future progress-aware RED belongs to W5. |
+| P2 | W2/W5 responsibility boundary around `tool_executor` wiring could be read as ambiguous. | W2.S7 now states W2 owns tracker schema/classification/fingerprints/public guardrail metadata seam, while runtime sequential/concurrent `tool_executor` observation wiring is owned by W5.S3/W5.S4. |
+| P2 | W8.S4 did not repeat the concrete superseded source artifact path for handoff convenience. | W8.S4 now references the `source_artifact` path from the parent plan/review front matter and spells out the current artifact path. |
+
+### Post-step-breakdown verdict
+
+**No remaining document-level P0/P1 blockers for W0/W1 implementation planning.** Remaining caution: proceed W-unit by W-unit; do not treat this as approval for a broad one-shot loop rewrite.
+
+## Closure evidence
+
+This review should be paired with a structural validation run that checks:
+
+- plan links to work order and review;
+- work order links back to plan and review;
+- work order links to the step breakdown;
+- step breakdown links back to plan, work order, and review;
+- plan has no W-unit/RED/GREEN/command bodies;
+- superseded mixed artifact points to active split docs;
+- new docs are present at the expected paths.

--- a/docs/work-orders/2026-06-25-progress-aware-tool-call-limit-step-breakdown.md
+++ b/docs/work-orders/2026-06-25-progress-aware-tool-call-limit-step-breakdown.md
@@ -1,0 +1,512 @@
+---
+title: "step-breakdown: Progress-aware agent iteration policy for perceived tool-call limits"
+status: review-ready
+date: 2026-06-25
+type: step-breakdown
+target_repo: hermes-agent
+parent_plan: ../plans/2026-06-25-progress-aware-tool-call-limit-plan.md
+parent_work_order: ./2026-06-25-progress-aware-tool-call-limit-work-order.md
+related_review: ../reviews/2026-06-25-progress-aware-tool-call-limit-plan-review.md
+---
+
+# step-breakdown: Progress-aware agent iteration policy for perceived tool-call limits
+
+## Purpose
+
+This document decomposes the parent work order into handoff-sized implementation steps. It does **not** replace the parent work order. The parent work order remains the source for W-unit scope, RED/GREEN requirements, likely files, and final evidence packet shape.
+
+Parent plan: `../plans/2026-06-25-progress-aware-tool-call-limit-plan.md`
+
+Parent work order: `./2026-06-25-progress-aware-tool-call-limit-work-order.md`
+
+Related review: `../reviews/2026-06-25-progress-aware-tool-call-limit-plan-review.md`
+
+## Execution rules
+
+- Execute W-units in order unless a blocker requires returning to a prior W-unit.
+- Each step should be small enough to hand off to a fresh agent with no hidden context.
+- Follow RED → GREEN → verify for code-producing steps.
+- Preserve legacy runtime behavior unless `agent.iteration_policy.mode: progress_aware` is explicitly enabled.
+- Do not perform broad conversation-loop rewrites before W0 evidence and W1 pure policy tests exist.
+- Do not store raw tool outputs, secrets, credentials, or durable unsalted secret-like fingerprints in progress-tracking artifacts.
+- Treat interrupted, cancelled, and skipped tool calls as non-progress.
+- Verification wording pins: Delegation, Kanban/worker, Soft-limit success/completed evidence, redacted/keyed, and "cancelled, interrupted, and skipped tool calls are non-progress" are required coverage terms for automated review.
+- If a step touches runtime behavior, run focused tests before moving to broader gates.
+
+## Recommended first slice
+
+Start with **W0.S1 → W0.S7** only. W0 is an evidence/RED slice: it should make the current behavior measurable without changing production behavior. Do not begin W1 policy code until W0 has captured legacy loop, guardrail, finalizer, near-limit, and bypass-path facts.
+
+---
+
+## W0 — Re-establish current behavior and terminology
+
+Goal: Confirm the current limit surface and reproduce the user-visible failure class without changing production behavior.
+
+### W0.S1 — Inventory current loop and budget seams
+
+- Inspect `agent/conversation_loop.py`, `agent/turn_context.py`, `agent/turn_finalizer.py`, and `agent/iteration_budget.py`.
+- Record the exact loop condition, `IterationBudget(agent.max_iterations)` initialization, consume/refund behavior, and finalizer budget-exhaustion predicate.
+- Evidence: note line references and the observed relationship between `agent.max_turns`, `agent.max_iterations`, and `IterationBudget.max_total`.
+- Exit gate: current loop/budget/finalizer facts are written to the W0 evidence packet.
+
+### W0.S2 — Pin legacy max-iteration stop behavior
+
+- Add or identify a focused baseline-pinning test proving legacy mode stops on the fixed limit even when later progress would be possible.
+- The test should run in default/legacy behavior, should not require new policy modules, and should pass against the current implementation once the observed legacy behavior is correctly encoded.
+- If no such test exists, first add the missing baseline-pinning test; the future progress-aware behavior RED belongs to W5, not W0.
+- Exit gate: test either exists with evidence or a new baseline-pinning test demonstrates the current stop behavior.
+
+### W0.S3 — Pin existing guardrail halt behavior
+
+- Inspect `agent/tool_guardrails.py`, `run_agent.py`, and `agent/tool_executor.py` guardrail seams.
+- Prove repeated exact failure/no-progress behavior still maps to the current controlled halt flow when hard-stop guardrails are enabled.
+- Include evidence for `_tool_guardrail_halt_decision`, `_toolguard_controlled_halt_response()`, and `guardrail_halt` turn reason.
+- Exit gate: current guardrail halt behavior is documented and covered by an existing or new focused test.
+
+### W0.S4 — Capture `_budget_grace_call` and toolless-summary behavior
+
+- Inspect how `_budget_grace_call`, `_handle_max_iterations()`, and the finalizer interact.
+- Record whether the extra toolless summary attempt mutates messages and how role alternation is preserved.
+- Evidence should include `_format_turn_completion_explanation()` behavior for budget exhaustion.
+- Exit gate: legacy finalization semantics are documented before any policy change.
+
+### W0.S5 — Capture `execute_code` refund behavior
+
+- Inspect the tool-call branch where `execute_code`-only iterations refund `IterationBudget`.
+- Add or identify a focused test that proves the refund behavior remains intact.
+- Exit gate: refund behavior is pinned so W4/W5 cannot accidentally consume budget for programmatic tool-calling rounds.
+
+### W0.S6 — Capture near-limit error guard behavior
+
+- Inspect the post-error branch in `agent/conversation_loop.py` that compares `api_call_count` with `agent.max_iterations - 1`.
+- Add or identify a focused test or evidence note showing how it behaves today.
+- Exit gate: future W4 can re-anchor this hidden hard-stop behavior to the effective hard budget or policy decision.
+
+### W0.S7 — Classify loop-bypass runtime paths
+
+- Inspect app-server/provider-specific paths that can return before the normal tool-calling loop.
+- Decide whether each path is out of scope for progress-aware policy or requires an adapter.
+- Minimum surfaces: `conversation_loop.py` app-server path, provider-specific runtimes, and any path that bypasses `agent._execute_tool_calls()`.
+- Exit gate: bypass paths are explicitly listed in the W0 evidence packet.
+
+### W0 exit gate
+
+- Current behavior is measurable and documented.
+- No production behavior changed except intentional RED tests/evidence files.
+- W0 evidence references exact code paths and test commands.
+
+---
+
+## W1 — Add policy data model and pure decision tests
+
+Goal: Create a pure, import-light iteration policy that can decide continue/stop without touching provider code.
+
+### W1.S1 — Define policy vocabulary and reason constants in tests first
+
+- Write tests for the policy reason names before implementing the module.
+- Required names include `below_soft_limit`, `soft_limit_reached_but_progress_detected`, `soft_limit_reached_no_progress`, `guardrail_exact_failure`, and `hard_max_iterations_reached`.
+- Ensure no turns-based reason variant appears in active tests.
+- Exit gate: RED test fails because `agent/iteration_policy.py` does not exist or lacks the reason model.
+
+### W1.S2 — Add the minimal policy dataclasses/enums
+
+- Create `agent/iteration_policy.py` with a small decision object and config object.
+- Keep imports minimal and avoid provider, CLI, gateway, or tool executor imports.
+- Include `mode`, `soft_max_iterations`, `hard_max_iterations`, `progress_window`, and `require_progress_after_soft_limit`.
+- Exit gate: policy object can be imported in isolation.
+
+### W1.S3 — Implement below-soft-limit and hard-cap decisions
+
+- Implement pure decisions for below soft threshold and hard max reached.
+- Do not inspect messages or tool outputs.
+- Exit gate: tests for below soft limit and hard max pass.
+
+### W1.S4 — Implement soft-limit progress/no-progress decisions
+
+- Add tests for soft threshold + recent progress → continue.
+- Add tests for soft threshold + no recent progress → graceful stop.
+- Use a compact progress-window summary input, not raw tool result text.
+- Exit gate: soft-limit decisions pass without loop integration.
+
+### W1.S5 — Implement guardrail decision override
+
+- Add tests proving guardrail hard stop wins over progress.
+- Use a minimal guardrail decision input shape or adapter protocol rather than importing runtime-heavy objects.
+- Exit gate: guardrail stop test passes and policy remains pure/import-light.
+
+### W1.S6 — Verify W1 isolation
+
+- Run focused policy tests.
+- Confirm `conversation_loop.py`, `turn_context.py`, `turn_finalizer.py`, and `tool_executor.py` are unchanged in this slice.
+- Exit gate: W1 creates only pure policy code/tests and does not change runtime behavior.
+
+---
+
+## W2 — Add progress tracker and fingerprint tests
+
+Goal: Track bounded recent progress/no-progress signals without relying on model self-reporting.
+
+### W2.S1 — Define tracker event schema tests
+
+- Write RED tests for a bounded event schema: event kind, tool name, status/error flags, duration bucket, and small labels.
+- Include tests rejecting raw large output storage.
+- Exit gate: tests fail before tracker implementation.
+
+### W2.S2 — Define secret-safe fingerprint behavior
+
+- Write tests proving args/results are redacted or summarized before fingerprinting.
+- Require keyed or per-turn/session-bounded fingerprints where persisted or observable.
+- Add adversarial inputs with API-key-like strings, tokens, passwords, and low-entropy values.
+- Exit gate: tests fail until tracker avoids raw/durable secret-like fingerprints.
+
+### W2.S3 — Reuse or expose guardrail observation metadata
+
+- Inspect whether `ToolCallGuardrailController` exposes enough metadata for policy/tracker consumption.
+- If not, add a public observation/decision API or shared bounded event object.
+- Do not read private controller dictionaries from outside the controller.
+- Exit gate: tracker can consume guardrail-relevant metadata through a public seam.
+
+### W2.S4 — Implement bounded progress tracker window
+
+- Create `agent/progress_tracker.py` or extend an existing minimal helper.
+- Implement bounded window behavior and event summary production.
+- Do not scan or mutate conversation history.
+- Exit gate: bounded-window tests pass.
+
+### W2.S5 — Implement progress/no-progress classification basics
+
+- Add classification for landed mutations, new evidence artifacts, changed test output, lifecycle state changes, and new informational fingerprints.
+- Add no-progress classification for identical failed calls and repeated idempotent no-op reads/searches.
+- Exit gate: classification tests pass for positive and negative cases.
+
+### W2.S6 — Handle concurrency and cancellation semantics
+
+- Add tests for deterministic concurrent result observation or explicit thread-safe/order-aware tracker updates.
+- Add tests proving interrupted, cancelled, and skipped tool calls are non-progress.
+- Exit gate: tracker cannot extend a turn because a cancellation produced a new result string.
+
+### W2.S7 — Verify W2 no-runtime-integration boundary
+
+- Run tracker and guardrail-focused tests.
+- Confirm full loop behavior is still unchanged unless the chosen public guardrail API requires small pure changes.
+- Keep W2 responsible for tracker-level schema, classification, fingerprinting, bounded window behavior, and the public guardrail metadata seam only.
+- Keep runtime `tool_executor` sequential/concurrent observation wiring owned by W5.S3/W5.S4.
+- Exit gate: tracker is ready for W5 wiring but not yet wired into the loop.
+
+---
+
+## W3 — Wire legacy-compatible config defaults
+
+Goal: Expose policy config without changing default runtime behavior.
+
+### W3.S1 — Inventory config/default surfaces
+
+- Inspect `cli.py`, `hermes_cli/config.py`, AIAgent initialization, gateway runtime env bridging, cron config reads, API server env handling, and delegation config.
+- Record current precedence and merge behavior.
+- Exit gate: config surface map exists in the W3 evidence packet.
+
+### W3.S2 — Add config tests for legacy default
+
+- Add tests proving missing `agent.iteration_policy` resolves to `legacy` mode.
+- Prove existing `agent.max_turns` behavior remains unchanged in legacy mode.
+- Exit gate: RED tests capture default compatibility expectations.
+
+### W3.S3 — Add nested config defaults with deep merge
+
+- Add `agent.iteration_policy` defaults in all authoritative default/config surfaces or route them through one shared resolver.
+- Ensure partial user config does not erase sibling defaults.
+- Exit gate: config tests show deep-merged defaults.
+
+### W3.S4 — Add config validation tests
+
+- Test invalid mode, non-positive limits, hard cap less than or equal to soft threshold, and missing/unsafe context profile values.
+- Define whether invalid values fail closed, warn and fall back, or refuse startup.
+- Exit gate: invalid config behavior is deterministic and documented.
+
+### W3.S5 — Add AIAgent runtime resolver seam
+
+- Add a minimal resolver or initialization field for iteration policy while preserving constructor/backcompat behavior.
+- Do not yet alter the main loop stop behavior.
+- Exit gate: an agent can report resolved legacy policy without runtime behavior changes.
+
+### W3.S6 — Verify config display/check/migration behavior
+
+- Run focused `tests/hermes_cli` checks if config surfaces changed.
+- Verify `hermes config`/config display paths expose or preserve new defaults as intended.
+- Exit gate: config UX does not regress and legacy users see no behavior change.
+
+---
+
+## W4 — Integrate policy with conversation loop behind legacy mode
+
+Goal: Replace raw fixed-count loop control with policy decisions while preserving legacy semantics by default.
+
+### W4.S1 — Add loop-level legacy equivalence tests
+
+- Add tests proving `legacy` mode behaves like the old fixed-count loop.
+- Include `_budget_grace_call`, `_handle_max_iterations()`, and `execute_code` refund cases from W0 evidence.
+- Exit gate: RED tests define exact compatibility before integration.
+
+### W4.S2 — Introduce effective hard-budget computation
+
+- Add a small helper or resolver that separates soft threshold from effective hard budget in progress-aware mode.
+- Preserve `agent.max_iterations` as legacy/reporting soft threshold where appropriate.
+- Exit gate: helper tests pass without changing loop behavior yet.
+
+### W4.S3 — Update per-turn `IterationBudget` initialization
+
+- Adjust `turn_context.py` initialization only as needed so progress-aware mode can use an effective hard budget.
+- Keep legacy initialization equivalent to `IterationBudget(agent.max_iterations)`.
+- Exit gate: legacy budget tests remain green; progress-aware budget uses the hard cap.
+
+### W4.S4 — Insert policy decision point in loop
+
+- Ask the policy for a decision at stable iteration boundaries.
+- Preserve interrupt-first behavior and role alternation.
+- Exit gate: legacy loop tests pass after integration.
+
+### W4.S5 — Re-anchor near-limit error guard
+
+- Replace the old `agent.max_iterations - 1` near-limit check with effective hard-budget/policy-aware logic.
+- Add tests for both legacy and progress-aware modes.
+- Exit gate: hidden hard-stop behavior no longer defeats soft-limit continuation.
+
+### W4.S6 — Classify or adapt loop-bypass runtimes
+
+- For each W0 bypass path, either document out-of-scope behavior in code/tests or add an adapter that preserves safety.
+- Do not silently let bypass paths inherit inconsistent semantics.
+- Exit gate: bypass behavior is explicit and test-covered or intentionally deferred.
+
+### W4.S7 — Verify W4 compatibility
+
+- Run focused run-agent loop tests and existing budget/guardrail tests.
+- Exit gate: legacy mode is behavior-neutral and progress-aware mode can be wired in W5.
+
+---
+
+## W5 — Enable progress-aware mode in loop-level tests
+
+Goal: Prove productive work can pass the soft threshold and no-progress loops stop.
+
+### W5.S1 — Add productive soft-limit crossing RED test
+
+- Build a loop-level test where recent objective progress inside the window permits another iteration after the soft threshold.
+- Do not rely on model self-reporting as progress.
+- Exit gate: RED test fails before tracker wiring.
+
+### W5.S2 — Add repeated no-progress stop RED test
+
+- Add a loop-level test where repeated identical failure or idempotent no-progress stops before the hard cap.
+- Include a guardrail-derived signal where possible.
+- Exit gate: RED test proves no-progress stop is required.
+
+### W5.S3 — Wire tracker events from sequential tool execution
+
+- Feed bounded progress observations after sequential tool results are classified and before final loop decision consumes the summary.
+- Preserve existing tool result appending and budget enforcement order.
+- Exit gate: sequential progress-aware tests pass.
+
+### W5.S4 — Wire tracker events from concurrent tool execution
+
+- Feed observations after deterministic concurrent result collection or through a thread-safe/order-aware tracker.
+- Prove mixed success/failure batches produce equivalent classifications to sequential execution.
+- Exit gate: concurrent mixed-result test passes.
+
+### W5.S5 — Preserve guardrail halt semantics
+
+- Treat `_tool_guardrail_halt_decision` as terminal policy input.
+- Prove controlled guardrail halt response remains unchanged where expected.
+- Exit gate: guardrail runtime tests pass.
+
+### W5.S6 — Preserve interrupt priority
+
+- Add or run tests showing user interrupt wins over policy continuation.
+- Ensure interrupted, cancelled, and skipped tool outputs do not count as progress.
+- Exit gate: interrupt tests pass and no cancellation extends the turn.
+
+### W5.S7 — Verify W5 behavior matrix
+
+- Run progress-aware loop tests, guardrail runtime tests, and focused interrupt/budget tests.
+- Exit gate: productive progress crosses soft threshold, no-progress stops, hard cap always stops.
+
+---
+
+## W6 — Finalization and user-visible stop reason
+
+Goal: Make graceful/hard stop reasons explicit in final responses and logs without fabricating completion.
+
+### W6.S1 — Add finalizer tests for policy stop reasons
+
+- Add tests for `policy_soft_no_progress_stop` and `policy_hard_max_iterations_reached` finalization.
+- Ensure no-progress stop does not claim task success.
+- Exit gate: RED tests fail before finalizer changes.
+
+### W6.S2 — Add soft-limit success completion test
+
+- Add a test where progress-aware mode crosses the soft threshold, remains below hard cap, and returns a valid final response.
+- Prove the result is treated as complete where callers should consider the turn successful.
+- Exit gate: current `api_call_count < agent.max_iterations` completion predicate fails this RED case.
+
+### W6.S3 — Update finalizer completion semantics
+
+- Modify `agent/turn_finalizer.py` or its caller contract so policy-aware completion uses the correct soft/hard distinction.
+- Preserve legacy completion behavior in legacy mode.
+- Exit gate: soft-limit success test passes without breaking legacy budget exhaustion tests.
+
+### W6.S4 — Add user-visible stop messages
+
+- Map structured policy reasons to concise final responses and logs.
+- Distinguish no-progress guardrail stop, hard cap, and user interrupt.
+- Exit gate: `test_turn_completion_explainer.py` or equivalent focused tests pass.
+
+### W6.S5 — Verify caller semantics for cron/delegation/gateway/worker
+
+- Add focused tests or evidence showing productive soft-limit crossing is not treated as legacy budget exhaustion by cron, delegation, gateway, or worker callers.
+- Exit gate: caller-facing result metadata is unambiguous.
+
+### W6.S6 — Verify role alternation and session persistence
+
+- Confirm policy stop and controlled final responses do not create same-role adjacency or invalid resume history.
+- Exit gate: message-sequence/role alternation tests pass.
+
+---
+
+## W7 — Context profiles for gateway/cron/delegation/worker
+
+Goal: Prevent one permissive interactive policy from leaking into contexts that need stronger caps.
+
+### W7.S1 — Add context profile resolver tests
+
+- Add tests for CLI/local, gateway, API-server, cron, delegation, and worker profile resolution.
+- Include partial config and invalid config cases.
+- Exit gate: RED tests define context precedence before implementation.
+
+### W7.S2 — Implement CLI/local profile resolution
+
+- Resolve soft threshold from existing `agent.max_turns` by default.
+- Resolve a separate bounded hard cap only in progress-aware mode.
+- Exit gate: CLI/local resolver tests pass and legacy mode remains unchanged.
+
+### W7.S3 — Implement gateway profile resolution
+
+- Cover both `gateway/run.py` and `gateway/platforms/api_server.py`.
+- Ensure platform delivery/inactivity timeout remains authoritative.
+- Exit gate: gateway profile tests pass and API-server env/backcompat behavior is explicit.
+
+### W7.S4 — Implement cron conservative profile
+
+- Keep cron conservative by default and avoid unbounded progress extension.
+- Integrate policy stops with cron failure/timeout accounting as appropriate.
+- Exit gate: cron tests prove conservative hard cap behavior.
+
+### W7.S5 — Implement delegation profile resolution
+
+- Bound child hard cap by delegation config and parent/session hard-budget policy.
+- Cover sync, batch, and background delegation where relevant.
+- Exit gate: delegation tests prove children cannot silently exceed intended bounds.
+
+### W7.S6 — Implement worker/Kanban profile behavior
+
+- Integrate policy stop with task failure accounting and claim timeout behavior.
+- Ensure no infinite worker claim/retry loop is introduced.
+- Exit gate: worker/Kanban tests or explicit evidence cover policy stop behavior.
+
+### W7.S7 — Verify context matrix
+
+- Run gateway, cron, delegation, and worker-focused checks touched by this slice.
+- Exit gate: context-specific profile evidence is ready for W9 packet.
+
+---
+
+## W8 — Documentation and migration notes
+
+Goal: Document the distinction between perceived tool-call limit and agent iteration policy.
+
+### W8.S1 — Update user-facing configuration docs
+
+- Explain `agent.max_turns` / `max_iterations` terminology.
+- Explain `legacy` vs `progress_aware` mode and soft threshold vs hard cap.
+- Exit gate: config example is valid YAML and links resolve.
+
+### W8.S2 — Update developer loop/policy docs
+
+- Document where the policy sits relative to conversation loop, tool executor, finalizer, and guardrails.
+- Include invariants: prompt-cache safety, role alternation, interrupt priority, secret-safe progress events.
+- Exit gate: developer docs match implemented code paths.
+
+### W8.S3 — Add troubleshooting copy for policy stops
+
+- Document what users should do when the agent stops due to no progress.
+- Keep copy concise and avoid exposing raw internal reason strings as product language.
+- Exit gate: stop-reason copy is user-safe and test-covered where applicable.
+
+### W8.S4 — Update superseded source artifact notice
+
+- Use the `source_artifact` path from the parent plan/review front matter: `/Users/cube-mac/dreampia-mvp-evidence/latest/hermes-progress-aware-tool-call-limit-plan-2026-06-25.md`.
+- Verify the mixed source artifact points to the active split docs in the current repo/worktree or repository-relative paths.
+- Remove stale checkout-specific active-doc paths.
+- Exit gate: stale-path search returns zero hits.
+
+### W8.S5 — Verify docs and links
+
+- Run link/path structural checks for plan, work order, step breakdown, review, and source artifact notice.
+- Exit gate: docs validation passes and no plan/work-order boundary regression is introduced.
+
+---
+
+## W9 — Review, verification, and PR packet
+
+Goal: Close the work with evidence, independent review, and a clean PR lifecycle.
+
+### W9.S1 — Assemble W-unit evidence packets
+
+- For each implemented W-unit, collect touched files, focused tests, broader tests, stop-reason evidence, legacy compatibility evidence, soft-limit success/completed evidence, context profile evidence, and deferred checks.
+- Exit gate: evidence packet is complete for every implemented W-unit.
+
+### W9.S2 — Run focused policy/tracker gates
+
+- Run policy and tracker tests.
+- Include secret-safety, bounded-window, and no-progress cases.
+- Exit gate: focused policy/tracker gates pass.
+
+### W9.S3 — Run loop/finalizer/guardrail gates
+
+- Run run-agent, guardrail runtime, turn completion explainer, and iteration budget race tests.
+- Exit gate: loop/finalizer/guardrail gates pass with no new failures.
+
+### W9.S4 — Run context surface gates
+
+- Run relevant config, gateway, cron, API-server, TUI, delegation, and worker tests depending on touched surfaces.
+- Record any deferred checks and why.
+- Exit gate: context profile evidence is complete or deferrals are explicit and justified.
+
+### W9.S5 — Run static hygiene checks
+
+- Run `git diff --check` and any project lint/static gates relevant to touched files.
+- Check for hardcoded secrets or unsafe logging of raw tool outputs/fingerprints.
+- Exit gate: no formatting/security hygiene failures.
+
+### W9.S6 — Independent review
+
+- Send the final diff and evidence packet to an independent reviewer.
+- Require Critical 0 / High 0 equivalent before merge lifecycle.
+- Exit gate: independent review has no blocking findings, or findings are fixed and re-reviewed.
+
+### W9.S7 — PR lifecycle if approved
+
+- If the user approves lifecycle, push branch, open PR, observe CI, merge only after checks pass, then observe main CI.
+- Exit gate: branch/PR/main status is reported with concrete URLs/IDs and CI status.
+
+---
+
+## Step-breakdown verification checklist
+
+- Parent work order links to this step-breakdown file.
+- This file links back to the parent plan, parent work order, and related review.
+- W-unit IDs match the parent exactly: W0 through W9, in order.
+- Every W-unit has at least one `Wn.Sm` step.
+- W0 remains an evidence/RED-first slice and is the recommended first slice.
+- No production code changes are implied before W0 evidence is complete.
+- Context profiles include CLI/local, gateway, API-server, cron, delegation, and worker/Kanban surfaces.
+- Verification coverage includes focused policy/tracker, loop/finalizer/guardrail, config, context, hygiene, and independent review gates.

--- a/docs/work-orders/2026-06-25-progress-aware-tool-call-limit-work-order.md
+++ b/docs/work-orders/2026-06-25-progress-aware-tool-call-limit-work-order.md
@@ -1,0 +1,396 @@
+---
+title: "work-order: Progress-aware agent iteration policy for perceived tool-call limits"
+status: draft
+date: 2026-06-25
+type: work-order
+target_repo: hermes-agent
+parent_plan: ../plans/2026-06-25-progress-aware-tool-call-limit-plan.md
+related_review: ../reviews/2026-06-25-progress-aware-tool-call-limit-plan-review.md
+related_step_breakdown: ./2026-06-25-progress-aware-tool-call-limit-step-breakdown.md
+---
+
+# work-order: Progress-aware agent iteration policy for perceived tool-call limits
+
+## Scope
+
+Implement the parent plan in small TDD slices. This work order owns execution detail: W-units, RED/GREEN expectations, file targets, commands, evidence, and exit criteria.
+
+Parent plan: `../plans/2026-06-25-progress-aware-tool-call-limit-plan.md`
+
+Step breakdown: `./2026-06-25-progress-aware-tool-call-limit-step-breakdown.md`
+
+## Global constraints
+
+- Preserve legacy behavior unless `agent.iteration_policy.mode: progress_aware` is enabled.
+- Preserve prompt-cache invariants and message role alternation.
+- Do not introduce a new model-facing core tool.
+- Do not change unrelated desktop/i18n files already dirty in the local checkout.
+- Keep stop reasons structured enough for logs/tests and concise enough for user-facing finalization.
+- Run focused tests before broader tests.
+
+## Likely file targets
+
+```text
+agent/conversation_loop.py                 # loop condition, policy decision point, stop reason
+agent/turn_finalizer.py                    # budget exhaustion vs policy stop finalization
+agent/turn_context.py                      # per-turn IterationBudget initialization
+agent/iteration_budget.py                  # inspect; preserve consume/refund semantics
+agent/tool_executor.py                     # sequential/concurrent tool result observation seam
+agent/tool_guardrails.py                   # reuse existing signatures/repeated-failure/no-progress state
+agent/iteration_policy.py                  # new candidate: pure decision model
+agent/progress_tracker.py                  # new candidate: bounded event window, no raw large outputs
+agent/agent_init.py                        # runtime policy/config initialization
+agent/chat_completion_helpers.py           # inspect only unless completion path requires it
+cli.py                                     # current DEFAULT_CONFIG and CLI max_turns resolution
+hermes_cli/config.py                       # authoritative load_config/cfg_get behavior if config defaults move
+cron/scheduler.py                          # cron-specific conservative policy resolution
+gateway/run.py                             # main messaging gateway AIAgent creation/cache path
+gateway/platforms/api_server.py            # env-driven max_iterations surface
+tui_gateway/server.py                      # TUI/gateway AIAgent creation surface
+tools/delegate_tool.py                     # child-agent max_iterations/profile resolution
+tests/agent/test_iteration_policy.py       # new candidate
+tests/agent/test_progress_tracker.py       # new candidate
+tests/agent/test_tool_guardrails.py        # existing guardrail reuse/regression
+tests/run_agent/test_tool_call_guardrail_runtime.py
+tests/run_agent/test_turn_completion_explainer.py
+tests/run_agent/test_iteration_budget_race.py
+website/docs/user-guide/configuration.md   # docs slice if config is user-facing
+website/docs/developer-guide/prompt-assembly.md or new developer doc if loop docs fit there
+```
+
+## Current code anchors
+
+Use these anchors before making production edits:
+
+- `agent/conversation_loop.py`: current loop condition is `(api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call`; any progress-aware change must preserve legacy mode exactly.
+- `agent/turn_context.py`: resets `agent.iteration_budget = IterationBudget(agent.max_iterations)` for each turn.
+- `agent/turn_finalizer.py`: calls `_handle_max_iterations()` when `final_response is None` and either `api_call_count >= agent.max_iterations` or `iteration_budget.remaining <= 0`.
+- `agent/tool_executor.py`: both sequential and concurrent paths call `_append_guardrail_observation()` after a tool returns and before appending the tool result to the message list.
+- `agent/tool_guardrails.py`: already owns canonical args hashing, result hashing, exact failure counts, same-tool failure counts, and idempotent no-progress counts.
+- `run_agent.py`: `_toolguard_controlled_halt_response()`, `_append_guardrail_observation()`, `_guardrail_block_result()`, and `_format_turn_completion_explanation()` are existing final-response/explainer seams.
+- `run_agent.py`: `_append_guardrail_observation()` currently returns only the possibly augmented tool-result string; policy/tracker consumption needs either a public guardrail observation API or a shared bounded event object.
+- `agent/conversation_loop.py`: the near-limit error guard at the post-error path compares against `agent.max_iterations - 1`; progress-aware mode must re-anchor it to the effective hard budget or policy decision.
+- `agent/turn_finalizer.py`: `completed` currently requires `api_call_count < agent.max_iterations`; progress-aware success after the soft threshold must not be recorded as a failed/incomplete turn.
+- `agent/conversation_loop.py`: provider/runtime paths that return before the normal loop, such as app-server runtimes, need explicit out-of-scope documentation or a separate policy adapter.
+- `cli.py`: current default config contains `agent.max_turns`; config display and CLI resolution already use this name.
+- `cli.py` and `hermes_cli/config.py`: both contain default/config loading surfaces; nested `agent.iteration_policy` must deep-merge rather than replace sibling defaults.
+- `cron/scheduler.py`, `gateway/run.py`, `gateway/platforms/api_server.py`, `tui_gateway/server.py`, and `tools/delegate_tool.py`: separate AIAgent creation surfaces must not accidentally inherit an unbounded interactive policy.
+
+## W0 — Re-establish current behavior and terminology
+
+### Goal
+
+Confirm the current limit surface and reproduce the user-visible failure class without changing production behavior.
+
+### RED / evidence
+
+- Inspect current loop and max iteration handling at `conversation_loop.py`, `turn_context.py`, `turn_finalizer.py`, and `iteration_budget.py`.
+- Add or identify a focused test that proves legacy behavior stops on the fixed limit even when later progress would be possible.
+- Add or identify a test for repeated identical failure/no-progress behavior through existing `ToolCallGuardrailController` and runtime halt wiring.
+- Record how `_budget_grace_call`, `_handle_max_iterations()`, `completed`, and `_format_turn_completion_explanation()` behave today before changing policy code.
+- Record how the near-limit error guard behaves today when `api_call_count >= agent.max_iterations - 1`.
+- Record whether provider/runtime paths bypass the normal conversation loop and whether they are in scope for this feature.
+- Confirm `execute_code`-only tool rounds still refund the iteration budget.
+
+### Commands
+
+```bash
+python -m pytest tests/run_agent/test_run_agent.py -q -o 'addopts='
+python -m pytest tests/agent -q -o 'addopts='
+```
+
+### Exit criteria
+
+- Current behavior is documented in test output or review notes.
+- The code path for `agent.max_turns` / `max_iterations` is identified.
+- No production behavior changed unless a failing RED test was intentionally added in a branch/slice.
+
+## W1 — Add policy data model and pure decision tests
+
+### Goal
+
+Create a pure, import-light iteration policy that can decide continue/stop without touching provider code.
+
+### RED
+
+Add tests for:
+
+- below soft limit → continue;
+- hard max reached → hard stop;
+- soft limit reached + recent progress → continue;
+- soft limit reached + no progress → graceful stop;
+- guardrail hard stop → stop regardless of progress;
+- policy reason names consistently use `iterations`, e.g. `hard_max_iterations_reached`, not the old turns-based variant.
+
+### GREEN
+
+Add `agent/iteration_policy.py` with a small decision object and policy function/class. The model must include at least:
+
+- mode: `legacy` or `progress_aware`;
+- `soft_max_iterations` and `hard_max_iterations`;
+- progress-window summary input, not raw tool output;
+- guardrail decision input;
+- structured reason codes that can be mapped by `turn_finalizer` / `_format_turn_completion_explanation()`.
+
+Do not wire it into `conversation_loop.py` in this slice.
+
+### Exit criteria
+
+- Pure policy tests pass.
+- No conversation loop integration yet.
+
+## W2 — Add progress tracker and fingerprint tests
+
+### Goal
+
+Track bounded recent progress/no-progress signals without relying on model self-reporting.
+
+### RED
+
+Add tests for:
+
+- distinct tool result fingerprints;
+- identical tool/args/failure repeat counting;
+- file/artifact/test/git/process/todo event kinds recorded as progress;
+- bounded window behavior.
+
+### GREEN
+
+Add `agent/progress_tracker.py` or extend the smallest existing helper if an equivalent structure already exists.
+
+Implementation direction:
+
+- Reuse `ToolCallSignature`, canonical args hashing, and result hashing behavior from `agent/tool_guardrails.py` where possible.
+- If existing guardrail internals do not expose the required metadata, add a public observation/decision API or shared bounded event object instead of reading private dictionaries from outside the controller.
+- Feed observations from `agent/tool_executor.py` in both sequential and concurrent paths after `_append_guardrail_observation()` has classified failures/no-progress.
+- Store bounded metadata only: event kind, tool name, redacted/keyed args fingerprint, redacted/keyed result fingerprint/status, duration bucket, blocked/error flags, and small evidence labels.
+- Do not store raw large tool output, raw secrets, full command output, or durable unsalted fingerprints of low-entropy secret-looking values in the tracker.
+- In the concurrent tool path, update the tracker only after deterministic result collection or make the tracker explicitly thread-safe and order-aware.
+- Treat cancelled, interrupted, or skipped tool calls as non-progress.
+
+### Exit criteria
+
+- Tracker tests pass.
+- Tracker does not store large raw tool outputs unbounded.
+
+## W3 — Wire legacy-compatible config defaults
+
+### Goal
+
+Expose policy config without changing default runtime behavior.
+
+### RED
+
+Add config/default tests proving missing config resolves to `legacy` mode and existing `max_turns` behavior remains unchanged.
+
+### GREEN
+
+Add config defaults/schema parsing for:
+
+```yaml
+agent:
+  iteration_policy:
+    mode: legacy
+    soft_max_iterations: null
+    hard_max_iterations: 300
+    progress_window: 12
+    require_progress_after_soft_limit: true
+```
+
+Adjust field names if current config style requires a user-facing `turns` alias, but keep the internal policy terminology on `iterations`. Update `cli.py`, `hermes_cli/config.py`, config display/check/migration behavior, and the AIAgent init-time resolver together.
+
+Config validation must cover invalid modes, non-positive numbers, `hard_max_iterations <= soft_max_iterations`, missing nested defaults after partial user config, and context profiles that would make cron/delegation/gateway unbounded.
+
+### Exit criteria
+
+- Existing config tests pass.
+- New defaults appear in `hermes config` output or the relevant default config source.
+
+## W4 — Integrate policy with conversation loop behind legacy mode
+
+### Goal
+
+Replace raw fixed-count loop control with policy decisions while preserving legacy semantics by default.
+
+### RED
+
+Add a loop-level test proving legacy mode behaves exactly like the old fixed count.
+
+### GREEN
+
+Modify the loop control so it asks the policy for a decision at stable iteration boundaries.
+
+Implementation requirements:
+
+- In `legacy` mode, keep the current `while` condition and finalizer behavior functionally identical.
+- In `progress_aware` mode, do not let `agent.max_iterations` alone remain the loop hard stop; introduce a separate effective hard budget while preserving `agent.max_iterations` as the soft threshold/reporting value.
+- Update `turn_context.py` / `IterationBudget` initialization and `turn_finalizer.py` together so soft-limit continuation is not immediately converted back into `max_iterations_reached(...)`.
+- Update post-error near-limit handling so `api_call_count >= agent.max_iterations - 1` does not remain an implicit hard stop in progress-aware mode.
+- Explicitly exclude or adapt runtime paths that bypass the normal tool loop.
+- Preserve `_budget_grace_call` and `execute_code` refund semantics.
+
+### Exit criteria
+
+- Legacy loop tests pass.
+- Existing run-agent tests do not regress.
+- Stop reason is available to finalization code.
+
+## W5 — Enable progress-aware mode in loop-level tests
+
+### Goal
+
+Prove productive work can pass the soft threshold and no-progress loops stop.
+
+### RED
+
+Add loop-level tests for:
+
+- progress event inside window permits another iteration after soft limit;
+- repeated identical tool failure stops before hard cap;
+- hard max always stops;
+- user interrupt remains immediate.
+
+### GREEN
+
+Connect tracker events from tool results, validation/finalization points, or existing guardrail state.
+
+Implementation requirements:
+
+- Wire both `execute_tool_calls_sequential()` and `execute_tool_calls_concurrent()`; they must produce equivalent tracker observations for the same tool outcome.
+- Treat `_tool_guardrail_halt_decision` as a terminal policy input, not as ordinary progress.
+- Count a new result fingerprint from read/search/test commands as possible informational progress, but count repeated identical idempotent results as no-progress after the soft threshold.
+- Count landed file mutations/evidence artifacts as strong progress, but repeated identical writes or failed patches as no-progress/failure.
+- Do not count interrupted/cancelled/skipped tool results as progress, and always let user interrupt win over policy continuation.
+- Include a concurrent mixed-result test proving deterministic observation order and equivalent classification to the sequential path.
+
+### Exit criteria
+
+- Progress-aware loop tests pass.
+- Guardrail stops remain observable and user-safe.
+
+## W6 — Finalization and user-visible stop reason
+
+### Goal
+
+Make graceful/hard stop reasons explicit in final responses and logs without fabricating completion.
+
+### RED
+
+Add tests that a policy stop produces the expected finalization path and does not claim task success.
+
+Cover:
+
+- `policy_soft_no_progress_stop` maps to an explicit non-success response;
+- `policy_hard_max_iterations_reached` differs from legacy `max_iterations_reached(...)` where appropriate;
+- progress-aware mode with `api_call_count >= soft_max_iterations` but below the hard cap and a valid final response records successful completion where the caller should treat the turn as complete;
+- existing `guardrail_halt` remains handled by its current controlled halt response;
+- `interrupted_by_user` remains immediate and is not rewritten as a policy stop.
+
+### GREEN
+
+Update `agent/turn_finalizer.py` or the loop finalization seam to map structured reasons to user-visible messages.
+
+### Exit criteria
+
+- Stop messages distinguish no-progress guardrail, hard cap, and user interrupt.
+- Cron, delegation, gateway, and worker callers do not treat a productive soft-limit crossing as legacy budget exhaustion.
+- No same-role message alternation regression.
+
+## W7 — Context profiles for gateway/cron/delegation/worker
+
+### Goal
+
+Prevent one permissive interactive policy from leaking into contexts that need stronger caps.
+
+### RED
+
+Add focused tests or config resolution tests for context-specific policy selection.
+
+### GREEN
+
+Resolve context-specific defaults from existing runtime context/config seams.
+
+Initial resolution rules to test before changing defaults:
+
+- CLI/local interactive: soft threshold defaults to existing `agent.max_turns`; hard cap is separately bounded.
+- Gateway: both `gateway/run.py` and API-server paths must use bounded policy resolution or explicitly remain legacy; platform delivery and inactivity timeouts still win.
+- Cron: conservative hard cap and no unbounded progress extension by default.
+- Delegation: child hard cap is bounded by delegation config and must not silently exceed the parent/session hard-budget policy.
+- Kanban/worker: policy stop integrates with task failure accounting and claim timeout behavior.
+
+### Exit criteria
+
+- Cron remains conservative.
+- Delegation hard cap is lower than or bounded by parent policy.
+- Gateway retains delivery timeout boundaries.
+- API-server env/backcompat behavior remains explicit.
+
+## W8 — Documentation and migration notes
+
+### Goal
+
+Document the distinction between perceived tool-call limit and agent iteration policy.
+
+### RED / review
+
+Docs must explain:
+
+- `agent.max_turns` / `max_iterations` terminology;
+- `legacy` vs `progress_aware`;
+- hard cap vs soft threshold;
+- context-specific behavior;
+- troubleshooting steps when the agent stops due to no progress.
+
+### GREEN
+
+Patch user/developer docs in the smallest appropriate locations.
+
+Also update the superseded source artifact notice so it points to the active split documents in the current repository/worktree, not to a stale checkout path.
+
+### Exit criteria
+
+- Docs links resolve.
+- Config example is valid YAML.
+
+## W9 — Review, verification, and PR packet
+
+### Goal
+
+Close the work with evidence, independent review, and a clean PR lifecycle.
+
+### Required checks
+
+```bash
+python -m pytest tests/agent/test_iteration_policy.py tests/agent/test_progress_tracker.py -q -o 'addopts='
+python -m pytest tests/run_agent/test_run_agent.py -q -o 'addopts='
+python -m pytest tests/run_agent/test_tool_call_guardrail_runtime.py tests/run_agent/test_turn_completion_explainer.py tests/run_agent/test_iteration_budget_race.py -q -o 'addopts='
+python -m pytest tests/hermes_cli -q -o 'addopts='   # if config defaults changed
+python -m pytest tests/gateway tests/cron -q -o 'addopts='  # if context profiles touch those surfaces
+python -m pytest tests/tui_gateway tests/tools/test_delegate_tool.py -q -o 'addopts='  # if TUI/delegation surfaces touched and tests exist
+git diff --check
+```
+
+### Evidence packet
+
+```text
+W-unit:
+Gate profile:
+Touched files:
+Focused tests:
+Broader tests:
+Stop-reason behavior evidence:
+Legacy compatibility evidence:
+Soft-limit success/completed evidence:
+Context profile evidence:
+Superseded source-artifact notice evidence:
+Deferred checks and reason:
+Independent review verdict:
+```
+
+### Exit criteria
+
+- Focused tests pass.
+- No new failures versus baseline.
+- Independent review has Critical 0 / High 0 equivalent finding level.
+- Branch is clean after commit.
+- If user approves lifecycle: push → PR → CI observe → merge → main CI observe.


### PR DESCRIPTION
## Summary

- Add pure Plan / Work Order / Review docs for progress-aware agent iteration policy.
- Add companion step-breakdown document decomposing W0-W9 into 65 contiguous `Wn.Sm` implementation steps.
- Record independent step-breakdown review findings and P2 closure ledger in the review doc.

## Scope

Documentation-only baseline for Hermes Agent core-loop/tool-call-limit planning. No production code changes.

## Verification

- Structural validation: `CHECKS 73 PASS 73 FAIL 0`
- Step coverage: `STEP_COUNT 65`
- Parent/step W-unit match: `W0,W1,W2,W3,W4,W5,W6,W7,W8,W9`
- Whitespace check: `PASS`
- Secret scan over added docs: `SECRET_SCAN_FINDINGS 0`
- Staged diff check: `git diff --cached --check` PASS

## Implementation guidance captured

- W0 remains evidence/baseline-pinning first.
- W1 remains pure/import-light policy modeling.
- Runtime `tool_executor` wiring is deferred to W5.
- Broad conversation-loop rewrite is explicitly not authorized by these docs.
