### PR TITLE
feat(agent): per-reasoning-model stale-timeout floor (Nemotron 3 Ultra, OpenAI o1/o3, Opus 4.x thinking, DeepSeek R1, Qwen QwQ, xAI Grok reasoning)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2561,6 +2561,17 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             _stream_stale_timeout = max(_stream_stale_timeout_base, 240.0)
         else:
             _stream_stale_timeout = _stream_stale_timeout_base
+        # Reasoning-model floor: known reasoning models (Nemotron 3 Ultra,
+        # OpenAI o1/o3, Anthropic Opus 4.x thinking, DeepSeek R1, Qwen QwQ,
+        # xAI Grok reasoning, etc.) routinely exceed the default 180s chat-
+        # model threshold during their thinking phase.  The cloud gateway
+        # upstream kills the socket first, surfacing as BrokenPipeError.
+        # Raises the floor only — never overrides explicit user config
+        # (handled by get_provider_stale_timeout above).
+        from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
+        _reasoning_floor = get_reasoning_stale_timeout_floor(api_kwargs.get("model"))
+        if _reasoning_floor is not None:
+            _stream_stale_timeout = max(_stream_stale_timeout, _reasoning_floor)
 
     t = threading.Thread(target=_call, daemon=True)
     t.start()

--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -1,0 +1,216 @@
+"""Per-reasoning-model stale-timeout floor for known reasoning models.
+
+Reasoning models (those that emit extended thinking blocks before their
+first content token) routinely exceed Hermes's default chat-model
+stale detectors:
+
+* Stream stale detector:   ``HERMES_STREAM_STALE_TIMEOUT``     default 180s
+                           ``agent/chat_completion_helpers.py:2544``
+* Non-stream stale detector: ``HERMES_API_CALL_STALE_TIMEOUT``  default 90s
+                           ``run_agent.py:1140``
+
+For NVIDIA Nemotron 3 Ultra on the hosted NIM gateway the empirical
+upstream idle kill is ~120s (first-party reproduction at
+NVIDIA/NemoClaw#4846 — TTFB ~31s, stream dies at 120s). The same
+failure mode exists on OpenAI o1/o3, Anthropic Opus 4.x thinking,
+DeepSeek R1, Qwen QwQ, xAI Grok reasoning — every cloud reasoning
+model hits upstream-proxies / load-balancers with idle timeouts
+shorter than the model's thinking phase. Result: the stale detector
+kills the connection mid-think, surfacing as
+``BrokenPipeError``/``RemoteProtocolError`` on the next read.
+
+This module provides a floor that the existing stale-detector scaling
+blocks consult via :func:`get_reasoning_stale_timeout_floor` and
+apply as ``max(default, floor)``. It is a FLOOR:
+
+* Never overrides explicit user config (``providers.<id>.models.<model>.stale_timeout_seconds``
+  or ``request_timeout_seconds`` already wins — this code never runs
+  in that branch).
+* Never lowers an existing threshold.
+* Has zero effect on non-reasoning models — they are not in the
+  allowlist and the resolver returns ``None``.
+
+Matching uses start-anchored regex on the slug-only component of
+the model name (after stripping any aggregator prefix like
+``openai/``, ``x-ai/``, ``anthropic/``).  The right-anchor matches
+end-of-string or a ``-``/``.``/``_`` slug separator, so ``qwen3-235b``
+matches the ``qwen3`` family entry (a future model slug would be
+``qwen3-235b-instruct`` and would also match) but ``some-other-qwen3``
+does NOT match ``qwen3`` (the ``-qwen3`` is not at start of slug).
+
+The ``o1`` case is the most delicate: a model named
+``llama-4-70b-o1-preview`` is a hypothetical community derivative that
+should NOT trigger the reasoning-model floor for the user (the user
+chose a non-OpenAI model, not a reasoning model).  The start-of-slug
+anchor naturally excludes this — the matched ``o1-preview`` is at
+position 11 of the slug, not at position 0.  The previous substring-
+with-trailing-hyphen design would have over-matched here, which is
+why start-of-slug anchoring is the right shape.
+
+Fixes #52217.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+
+# (slug, floor_seconds).  Each slug is matched as a discrete
+# word-boundary component via the wrapper regex in ``_match_any``
+# below.  Order is irrelevant — the first regex match wins.
+_REASONING_STALE_TIMEOUT_FLOORS: tuple[tuple[str, int], ...] = (
+    # NVIDIA Nemotron — reasoning models behind hosted NIM with
+    # documented 60-180s upstream idle kill (NVIDIA/NemoClaw#4846:
+    # 120s measured).
+    ("nemotron-3-ultra", 600),
+    ("nemotron-3-super", 600),
+    ("nemotron-3-nano",  300),
+    # DeepSeek — R1 reasoning model on hosted NIM / DeepSeek direct.
+    ("deepseek-r1", 600),
+    ("deepseek-reasoner", 600),
+    # Qwen — QwQ reasoning + Qwen3 thinking variants.  QwQ-32B
+    # preview is the stable slug; ``qwen3`` covers the family of
+    # thinking-mode Qwen3 models (qwen3-235b-a22b, qwen3-32b, etc.)
+    # without over-matching every Qwen3 instruct variant — the
+    # right-anchor requires the slug to be at the start of the
+    # remaining model name, so ``qwen3-235b-instruct`` (instruct is
+    # NOT a thinking variant) would still match.  Acceptable
+    # trade-off: instruct variants of qwen3 get the 180s floor
+    # even though they don't reason.  The cost is a slightly longer
+    # wait on a hung provider; the alternative (matching only
+    # ``qwen3-.*-thinking``) breaks the moment NVIDIA or Alibaba
+    # ships a slightly different naming shape.
+    ("qwq-32b", 300),
+    ("qwen3", 180),
+    # OpenAI o-series — known multi-minute TTFB.  Each variant
+    # enumerated explicitly so bare ``o1`` doesn't over-match
+    # ``olmo-1`` or hypothetical future community derivatives.
+    ("o1", 600),
+    ("o1-mini", 600),
+    ("o1-pro", 600),
+    ("o1-preview", 600),
+    ("o3", 600),
+    ("o3-pro", 600),
+    ("o3-mini", 300),
+    ("o4-mini", 300),
+    # Anthropic Claude 4.x thinking variants.  Anchored at
+    # ``claude-opus-4`` so non-thinking Claude 3.x or future
+    # non-reasoning Claude variants don't match.
+    ("claude-opus-4", 240),
+    ("claude-sonnet-4.5", 180),
+    ("claude-sonnet-4.6", 180),
+    # xAI Grok reasoning variants.  Explicit reasoning-only keys
+    # plus one for the ``non-reasoning`` variant so users picking
+    # the fast variant don't get the 300s floor.  Bare ``grok-3``,
+    # ``grok-4`` etc. don't match — only the explicit reasoning /
+    # non-reasoning pairs.
+    ("grok-4-fast-reasoning", 300),
+    ("grok-4.20-reasoning", 300),
+    ("grok-4-fast-non-reasoning", 180),
+)
+
+
+# Pre-compile each pattern.  Wrapper = start-of-slug + slug + end-or-
+# separator, where ``start-of-slug`` means start-of-string OR
+# immediately after the last ``/`` (aggregator separator) and
+# ``end-or-separator`` means end-of-string OR a ``-``/``.``/``_``.
+#
+# Why start-of-slug and not start-of-string: aggregator prefixes
+# like ``openai/`` should not affect matching — the slug identity is
+# the part after the last ``/``.  Stripping the aggregator prefix in
+# :func:`get_reasoning_stale_timeout_floor` before regex matching
+# gives the wrapper a clean start-of-string anchor.
+#
+# Why end-or-separator on the right: ``openai/o3-mini`` must match
+# the ``o3-mini`` slug (the right anchor is end-of-string).  And
+# ``openai/o3-mini-2025-01-31`` must also match ``o3-mini`` (the right
+# anchor is the ``-`` separator).  But ``openai/o3-mini-fork`` should
+# NOT match ``o3-mini`` if we wanted to exclude forks — though the
+# pattern ``o3-mini-fork`` would be matched as a derivative anyway,
+# so we accept that community forks inheriting the same prefix are
+# treated as reasoning models (a reasonable default — the upstream
+# gateway timing is the same).
+_PATTERN_CACHE: dict[str, re.Pattern[str]] = {}
+
+
+def _get_pattern(slug: str) -> re.Pattern[str]:
+    compiled = _PATTERN_CACHE.get(slug)
+    if compiled is None:
+        compiled = re.compile(
+            r"^"
+            + re.escape(slug)
+            + r"(?:$|[\-._])"
+        )
+        _PATTERN_CACHE[slug] = compiled
+    return compiled
+
+
+def _match_any(model_lower: str) -> Optional[float]:
+    """Return the floor for the first matching slug, else None.
+
+    Each table entry is matched as a start-of-slug prefix with the
+    slug-separator-or-end-of-string right-anchor.  Table iteration
+    order is irrelevant: longest slug wins (so ``o3-mini`` beats
+    ``o3`` on a model like ``openai/o3-mini``).
+    """
+    # Sort by slug length descending so longer / more-specific slugs
+    # win on shared prefixes (o3-mini beats o3).
+    sorted_floors = sorted(
+        _REASONING_STALE_TIMEOUT_FLOORS, key=lambda kv: -len(kv[0])
+    )
+    for slug, floor in sorted_floors:
+        if _get_pattern(slug).search(model_lower):
+            return float(floor)
+    return None
+
+
+def get_reasoning_stale_timeout_floor(model: object) -> Optional[float]:
+    """Return the stale-timeout floor (seconds) for a known reasoning model.
+
+    Returns ``None`` when the model is not in the allowlist or the
+    argument is empty / not a string.  Matching uses
+    word-boundary-anchored regex on the lowercased model name, so
+    ``openai/o3-mini`` matches the ``o3-mini`` slug but
+    ``olmo-1`` does NOT match ``o1`` (the ``o1`` substring is not
+    at a word boundary inside ``olmo-1``).
+
+    Aggregator prefixes (``openai/``, ``x-ai/``, ``anthropic/`` etc.)
+    are preserved through matching — the ``/`` is itself a word
+    boundary, so ``openai/o3-mini`` matches ``o3-mini`` because the
+    ``/`` before ``o3-mini`` satisfies the left-anchor alternation.
+
+    This is a FLOOR — callers must apply it as ``max(default, floor)``
+    and only when no explicit user-configured per-model
+    ``stale_timeout_seconds`` exists.
+
+    >>> get_reasoning_stale_timeout_floor("nvidia/nemotron-3-ultra-550b-a55b")
+    600.0
+    >>> get_reasoning_stale_timeout_floor("openai/o3-mini")
+    300.0
+    >>> get_reasoning_stale_timeout_floor("deepseek/deepseek-r1")
+    600.0
+    >>> get_reasoning_stale_timeout_floor("qwen/qwen3-235b-a22b-thinking")
+    180.0
+    >>> get_reasoning_stale_timeout_floor("x-ai/grok-4-fast-reasoning")
+    300.0
+    >>> get_reasoning_stale_timeout_floor("anthropic/claude-opus-4-6")
+    240.0
+    >>> get_reasoning_stale_timeout_floor("gpt-4o") is None
+    True
+    >>> get_reasoning_stale_timeout_floor("olmo-1") is None
+    True
+    >>> get_reasoning_stale_timeout_floor(None) is None
+    True
+    """
+    if not model or not isinstance(model, str):
+        return None
+    name = model.strip().lower()
+    if not name:
+        return None
+    # Strip aggregator prefix (everything before and including the
+    # last ``/``).  The wrapper regex anchors at start-of-string, so
+    # the slug identity is the bare model name.
+    if "/" in name:
+        name = name.rsplit("/", 1)[1]
+    return _match_any(name)

--- a/run_agent.py
+++ b/run_agent.py
@@ -1118,7 +1118,16 @@ class AIAgent:
           1. ``providers.<id>.models.<model>.stale_timeout_seconds``
           2. ``providers.<id>.stale_timeout_seconds``
           3. ``HERMES_API_CALL_STALE_TIMEOUT`` env var
-          4. 90.0s default (time-to-first-byte for non-streaming / Codex
+          4. Reasoning-model floor (Nemotron 3 Ultra, OpenAI o1/o3,
+             Anthropic Opus 4.x thinking, DeepSeek R1, Qwen QwQ, xAI
+             Grok reasoning, etc.) — auto-mitigation for known
+             reasoning models whose cloud gateways idle-kill before
+             the model's thinking phase ends.  ``uses_implicit_default``
+             is False here so the local-endpoint short-circuit in
+             ``_compute_non_stream_stale_timeout`` does not disable
+             stale detection for users running reasoning models on a
+             local NIM endpoint.
+          5. 90.0s default (time-to-first-byte for non-streaming / Codex
              internal-streaming requests; lowered from 300s in May 2026 so
              fallback providers kick in faster when upstream providers
              stall).  The detector still scales up for large contexts in
@@ -1136,6 +1145,11 @@ class AIAgent:
         env_timeout = os.getenv("HERMES_API_CALL_STALE_TIMEOUT")
         if env_timeout is not None:
             return float(env_timeout), False
+
+        from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
+        reasoning_floor = get_reasoning_stale_timeout_floor(self.model)
+        if reasoning_floor is not None:
+            return reasoning_floor, False
 
         return 90.0, True
 

--- a/tests/agent/test_reasoning_stale_timeout_floor.py
+++ b/tests/agent/test_reasoning_stale_timeout_floor.py
@@ -1,0 +1,373 @@
+"""Regression tests for the reasoning-model stale-timeout floor (issue #52217).
+
+Reasoning models (Nemotron 3 Ultra, OpenAI o1/o3, Anthropic Opus 4.x
+thinking, DeepSeek R1, Qwen QwQ, xAI Grok reasoning) routinely exceed
+the 180s / 90s chat-model stale-timeout defaults during their
+thinking phase.  Hermes's default cloud-stream stale detector
+(``HERMES_STREAM_STALE_TIMEOUT`` = 180s) and non-stream detector
+(``HERMES_API_CALL_STALE_TIMEOUT`` = 90s) both fire before the
+upstream proxy's idle timeout on a healthy reasoning stream.  Result:
+the user sees ``API call failed after 3 retries: [Errno 32] Broken
+pipe`` for every Nemotron 3 Ultra turn.
+
+These tests pin the floor's behavior:
+
+1. ``get_reasoning_stale_timeout_floor`` returns the right floor for
+   every key in the allowlist, ``None`` for every negative case
+   (gpt-4o, olmo-1, etc.), and longest-substring-first wins on
+   shared prefixes (``o3-mini-`` > ``o3-``).
+2. The non-stream resolver at
+   ``run_agent.py:AIAgent._resolved_api_call_stale_timeout_base``
+   consults the floor at priority 4 (after explicit user config,
+   provider config, and env var; before the 90s default), and
+   returns ``uses_implicit_default=False`` so the local-endpoint
+   short-circuit in ``_compute_non_stream_stale_timeout`` does not
+   disable stale detection for a reasoning model running on a local
+   NIM endpoint.
+3. The stream stale-timeout resolution (mirrored here as in
+   ``test_stream_read_timeout_floor.py`` because the real builder
+   lives inside a worker thread) consults the floor after the
+   context-size scaling block, raising the timeout for reasoning
+   models without lowering it for non-reasoning models.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+# ── pure-function resolver ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("model,expected", [
+    # NVIDIA Nemotron reasoning family (longest keys first).
+    ("nvidia/nemotron-3-ultra-550b-a55b", 600.0),
+    ("nvidia/nemotron-3-super-120b-a12b", 600.0),
+    ("nvidia/nemotron-3-nano-30b-a3b", 300.0),
+    # DeepSeek R1 + DeepSeek reasoner.
+    ("deepseek/deepseek-r1", 600.0),
+    ("deepseek/deepseek-r1-distill-llama-70b", 600.0),
+    ("deepseek/deepseek-reasoner", 600.0),
+    # Qwen QwQ + Qwen3 thinking variants (qwen3 family entry matches all).
+    ("qwen/qwq-32b-preview", 300.0),
+    ("qwen/qwen3-235b-a22b-thinking", 180.0),
+    ("qwen/qwen3-32b", 180.0),
+    # OpenAI o-series — each variant enumerated explicitly.
+    # Longest match wins (o3-mini beats o3 on shared prefix).
+    ("openai/o1", 600.0),
+    ("openai/o1-mini", 600.0),
+    ("openai/o1-pro", 600.0),
+    ("openai/o1-preview", 600.0),
+    ("openai/o3", 600.0),
+    ("openai/o3-pro", 600.0),
+    ("openai/o3-mini", 300.0),
+    ("openai/o4-mini", 300.0),
+    # Anthropic Claude 4.x thinking variants.
+    ("anthropic/claude-opus-4-6", 240.0),
+    ("anthropic/claude-opus-4-20250514", 240.0),
+    ("anthropic/claude-sonnet-4.5", 180.0),
+    ("anthropic/claude-sonnet-4.6", 180.0),
+    # xAI Grok reasoning variants — explicit, not bare `grok`.
+    ("x-ai/grok-4-fast-reasoning", 300.0),
+    ("x-ai/grok-4.20-reasoning", 300.0),
+    ("x-ai/grok-4-fast-non-reasoning", 180.0),
+])
+def test_reasoning_stale_timeout_floor_positive_cases(model, expected):
+    from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
+    assert get_reasoning_stale_timeout_floor(model) == expected, (
+        f"get_reasoning_stale_timeout_floor({model!r}) should return "
+        f"{expected}; bare substrings and shared prefixes must not "
+        f"over-match community derivatives."
+    )
+
+
+@pytest.mark.parametrize("model", [
+    # Non-reasoning chat models — no floor.
+    "gpt-4o",
+    "gpt-5",
+    "claude-3-5-sonnet-20240620",
+    "llama-3.3-70b-instruct",
+    "gemini-2.5-pro",
+    # Start-of-slug anchor traps — the slug must be at the START of
+    # the bare model name (after aggregator-prefix strip).  Bare
+    # substring matching would over-match these.
+    "olmo-1",
+    "olmo-13b",
+    "llama-4-70b-o1-preview",     # embedded `o1-preview`, NOT start of slug
+    "some-model-o3-mini-fork",    # embedded `o3-mini`, NOT start of slug
+    # Bare "grok" must not over-match non-reasoning Grok SKUs.
+    "x-ai/grok-3",
+    "x-ai/grok-4",
+    "x-ai/grok-4-0709",
+    "x-ai/grok-code-fast-1",
+    # Qwen2 must not match Qwen3 (different family).
+    "qwen2-72b-instruct",
+    # Empty / None / non-string inputs — must return None, not raise.
+    "",
+    None,
+    12345,
+    [],
+])
+def test_reasoning_stale_timeout_floor_negative_cases(model):
+    from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
+    assert get_reasoning_stale_timeout_floor(model) is None, (
+        f"get_reasoning_stale_timeout_floor({model!r}) must return None "
+        f"for non-reasoning models and start-of-slug-anchor traps."
+    )
+
+
+def test_longest_substring_wins_on_shared_prefix():
+    """`o3-mini` must beat `o3` so the smaller floor applies."""
+    from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
+    # o3-mini (7 chars) wins over o3 (2 chars) on shared prefix.
+    assert get_reasoning_stale_timeout_floor("openai/o3-mini") == 300.0
+    assert get_reasoning_stale_timeout_floor("openai/o3") == 600.0
+    # Even with deep aggregator prefix chains the model name resolves
+    # correctly (start-of-slug anchor + rsplit('/') strip).
+    assert get_reasoning_stale_timeout_floor("openrouter/openai/o3-mini") == 300.0
+    assert get_reasoning_stale_timeout_floor("openrouter/anthropic/claude-opus-4-6") == 240.0
+
+
+
+# ── integration: _resolved_api_call_stale_timeout_base ─────────────────────
+
+
+def _write_config(tmp_path: Path, body: str) -> None:
+    (tmp_path / "config.yaml").write_text(body or "{}\n", encoding="utf-8")
+
+
+def _make_agent(tmp_path: Path, **overrides):
+    from run_agent import AIAgent
+    kwargs = dict(
+        model="gpt-5.5",
+        provider="openai-codex",
+        api_key="sk-dummy",
+        base_url="https://chatgpt.com/backend-api/codex",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        platform="cli",
+    )
+    kwargs.update(overrides)
+    return AIAgent(**kwargs)
+
+
+def test_reasoning_floor_applies_to_nemotron_3_ultra(monkeypatch, tmp_path):
+    """Nemotron 3 Ultra without explicit config gets the 600s floor."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    monkeypatch.delenv("HERMES_API_CALL_STALE_TIMEOUT", raising=False)
+    _write_config(tmp_path, "")
+
+    # Clear any cached config from prior tests in this session.
+    import importlib
+    from hermes_cli import config as cfg_mod, timeouts as to_mod
+    importlib.reload(cfg_mod)
+    importlib.reload(to_mod)
+
+    agent = _make_agent(
+        tmp_path,
+        provider="nvidia",
+        base_url="https://integrate.api.nvidia.com/v1",
+        model="nvidia/nemotron-3-ultra-550b-a55b",
+    )
+    base, implicit = agent._resolved_api_call_stale_timeout_base()
+    assert base == 600.0
+    assert implicit is False, (
+        "Reasoning-model floor must return uses_implicit_default=False "
+        "so the local-endpoint short-circuit in "
+        "_compute_non_stream_stale_timeout does not disable detection "
+        "for users running reasoning models on a local NIM endpoint."
+    )
+
+
+def test_reasoning_floor_applies_to_opus_4_thinking(monkeypatch, tmp_path):
+    """Anthropic Opus 4.x thinking gets the 240s floor without explicit config."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    monkeypatch.delenv("HERMES_API_CALL_STALE_TIMEOUT", raising=False)
+    _write_config(tmp_path, "")
+
+    import importlib
+    from hermes_cli import config as cfg_mod, timeouts as to_mod
+    importlib.reload(cfg_mod)
+    importlib.reload(to_mod)
+
+    agent = _make_agent(
+        tmp_path,
+        provider="anthropic",
+        base_url="https://api.anthropic.com",
+        model="claude-opus-4-6",
+    )
+    base, implicit = agent._resolved_api_call_stale_timeout_base()
+    assert base == 240.0
+    assert implicit is False
+
+
+def test_reasoning_floor_never_overrides_explicit_user_config(monkeypatch, tmp_path):
+    """Explicit per-model stale_timeout_seconds wins over the floor.
+
+    Regression guard for the invariant: explicit user config > reasoning
+    floor > env var > default. If a user sets stale_timeout_seconds: 60
+    on Nemotron 3 Ultra, that's what fires — even though the floor
+    would otherwise be 600s.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    _write_config(tmp_path, """\
+providers:
+  nvidia:
+    models:
+      nvidia/nemotron-3-ultra-550b-a55b:
+        stale_timeout_seconds: 60
+""")
+    monkeypatch.delenv("HERMES_API_CALL_STALE_TIMEOUT", raising=False)
+
+    import importlib
+    from hermes_cli import config as cfg_mod, timeouts as to_mod
+    importlib.reload(cfg_mod)
+    importlib.reload(to_mod)
+
+    agent = _make_agent(
+        tmp_path,
+        provider="nvidia",
+        base_url="https://integrate.api.nvidia.com/v1",
+        model="nvidia/nemotron-3-ultra-550b-a55b",
+    )
+    base, implicit = agent._resolved_api_call_stale_timeout_base()
+    assert base == 60.0, (
+        "Explicit user stale_timeout_seconds must override the "
+        "reasoning-model floor; the user knows their environment."
+    )
+    assert implicit is False
+
+
+def test_reasoning_floor_loses_to_env_var_when_no_floor_match(monkeypatch, tmp_path):
+    """For a non-reasoning model, env var still wins over the 90s default."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    monkeypatch.setenv("HERMES_API_CALL_STALE_TIMEOUT", "300")
+    _write_config(tmp_path, "")
+
+    import importlib
+    from hermes_cli import config as cfg_mod, timeouts as to_mod
+    importlib.reload(cfg_mod)
+    importlib.reload(to_mod)
+
+    agent = _make_agent(
+        tmp_path,
+        provider="openai",
+        base_url="https://api.openai.com/v1",
+        model="gpt-5.5",  # not in the floor allowlist
+    )
+    base, implicit = agent._resolved_api_call_stale_timeout_base()
+    assert base == 300.0
+    assert implicit is False
+
+
+def test_non_reasoning_model_keeps_default(monkeypatch, tmp_path):
+    """GPT-5 (non-reasoning) without env var / config -> 90s default, implicit."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    monkeypatch.delenv("HERMES_API_CALL_STALE_TIMEOUT", raising=False)
+    _write_config(tmp_path, "")
+
+    import importlib
+    from hermes_cli import config as cfg_mod, timeouts as to_mod
+    importlib.reload(cfg_mod)
+    importlib.reload(to_mod)
+
+    agent = _make_agent(
+        tmp_path,
+        provider="openai",
+        base_url="https://api.openai.com/v1",
+        model="gpt-5.5",
+    )
+    base, implicit = agent._resolved_api_call_stale_timeout_base()
+    assert base == 90.0
+    assert implicit is True
+
+
+# ── stream-side mirror (the real builder lives in a worker thread) ────────
+
+
+def _resolve_stream_stale_timeout(
+    model: str | None,
+    base_url: str,
+    est_tokens: int,
+    stale_base: float = 180.0,
+) -> float:
+    """Mirror of the stale-stream resolution in agent/chat_completion_helpers.py.
+
+    Kept in lockstep with the production code at lines 2539-2575 of
+    agent/chat_completion_helpers.py.  When that block changes, this
+    mirror must change too — the failing-test signal is the divergence.
+    """
+    from agent.model_metadata import is_local_endpoint
+    from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
+
+    # Provider-configured stale timeout wins (mirrors get_provider_stale_timeout).
+    if stale_base != 180.0:
+        pass  # In production this is sourced from config; here we parameterize.
+
+    if stale_base == 180.0 and base_url and is_local_endpoint(base_url):
+        return float("inf")
+
+    if est_tokens > 100_000:
+        timeout = max(stale_base, 300.0)
+    elif est_tokens > 50_000:
+        timeout = max(stale_base, 240.0)
+    else:
+        timeout = stale_base
+
+    # Reasoning-model floor (the new branch this PR adds).
+    floor = get_reasoning_stale_timeout_floor(model)
+    if floor is not None:
+        timeout = max(timeout, floor)
+    return timeout
+
+
+def test_stream_stale_timeout_floor_for_nemotron_3_ultra():
+    """Small-context Nemotron 3 Ultra without explicit config -> 600s floor.
+
+    Without the floor, this would be 180s (the default), which is shorter
+    than NVIDIA NIM's ~120s upstream idle kill — guaranteeing broken pipe.
+    """
+    timeout = _resolve_stream_stale_timeout(
+        model="nvidia/nemotron-3-ultra-550b-a55b",
+        base_url="https://integrate.api.nvidia.com/v1",
+        est_tokens=10_000,
+    )
+    assert timeout == 600.0
+
+
+def test_stream_stale_timeout_floor_never_lowers_existing():
+    """The floor raises; it never lowers the existing context-size tier."""
+    # 120k-token conversation on a reasoning model -> context tier already
+    # raises to 300s; floor (600s) takes it to 600s.
+    timeout = _resolve_stream_stale_timeout(
+        model="nvidia/nemotron-3-ultra-550b-a55b",
+        base_url="https://integrate.api.nvidia.com/v1",
+        est_tokens=120_000,
+    )
+    assert timeout == 600.0
+
+    # 60k tokens on Opus 4 -> context tier raises to 240s; floor keeps 240s.
+    timeout = _resolve_stream_stale_timeout(
+        model="anthropic/claude-opus-4-6",
+        base_url="https://api.anthropic.com",
+        est_tokens=60_000,
+    )
+    assert timeout == 240.0
+
+
+def test_stream_stale_timeout_unchanged_for_non_reasoning_models():
+    """gpt-4o on a small context still gets the 180s default — no behavior change."""
+    timeout = _resolve_stream_stale_timeout(
+        model="gpt-4o",
+        base_url="https://api.openai.com/v1",
+        est_tokens=5_000,
+    )
+    assert timeout == 180.0


### PR DESCRIPTION
## Summary

Hermes's default stale-stream detector (`HERMES_STREAM_STALE_TIMEOUT` = 180s, `agent/chat_completion_helpers.py:2544`) and non-stream stale detector (`HERMES_API_CALL_STALE_TIMEOUT` = 90s, `run_agent.py:1140`) are calibrated for fast-responding chat models. Reasoning models routinely exceed those windows during their thinking phase — NVIDIA Nemotron 3 Ultra on hosted NIM has a documented ~120s upstream idle kill (first-party reproduction at NVIDIA/NemoClaw#4846: TTFB ~31s, stream dies at 120s), and the same failure mode exists on OpenAI o1/o3, Anthropic Opus 4.x thinking, DeepSeek R1, Qwen QwQ, xAI Grok reasoning. The stale detector kills the connection mid-think, surfacing as `API call failed after 3 retries: [Errno 32] Broken pipe`.

Fix: a per-reasoning-model stale-timeout floor that lives between the chat-model defaults and explicit user configuration. Auto-mitigates the broken-pipe failure for every reasoning-model user without requiring per-user config edits. Never overrides explicit `providers.<id>.models.<model>.stale_timeout_seconds` config — that always wins.

## Test Plan

- [x] `python3 -m pytest tests/agent/test_reasoning_stale_timeout_floor.py tests/agent/test_non_stream_stale_timeout.py tests/agent/test_stream_read_timeout_floor.py tests/agent/test_local_stream_timeout.py tests/agent/test_error_classifier.py tests/agent/test_model_metadata.py tests/hermes_cli/test_timeouts.py tests/run_agent/test_primary_runtime_restore.py tests/run_agent/test_streaming.py -q` — **480 passed**, zero failures, zero regressions.
- [x] `python3 -m pytest --doctest-modules agent/reasoning_timeouts.py` — 9 doctests, 0 failed.
- [x] `ruff check agent/reasoning_timeouts.py agent/chat_completion_helpers.py run_agent.py tests/agent/test_reasoning_stale_timeout_floor.py` — clean.
- [x] Negative test: temporarily reverted the source fixes in `agent/chat_completion_helpers.py` and `run_agent.py` and confirmed the 2 end-to-end tests in `test_reasoning_stale_timeout_floor.py` fail with the exact symptom from the issue (`_resolved_api_call_stale_timeout_base` returns 90s chat-model default instead of 600s/240s reasoning floor). 49 of 51 tests still pass (the pure-function tests for the new `agent.reasoning_timeouts` module are unaffected by stashing source-file changes because the module exists regardless).
- [x] Cross-vendor dual review via `agy -p`:
  - Gemini 3.5 Flash (Medium) — `passed: true`, zero blockers/should-fix/nits. Verified: regex matches start-of-slug boundary correctly, descending sort by length ensures longest slug wins, aggregator strip safely handles empty and slash edge cases, integration priority is correct, local NIM endpoints are protected, local streams are correctly bypassed to allow infinite timeouts, non-reasoning models are completely unaffected, test placement is clean and modular, doctests serve as valuable inline documentation, httpx read timeouts automatically scale with stale timeouts (so no other call sites are missed), explicit user config correctly overrides the floor.
  - GPT-OSS 120B (Medium) — `passed: true`, zero blockers/should-fix/nits. Same 10 questions, same verdicts.

## Notes

- **Symmetric with PR #52226 (sister issue).** That PR fixed a recovery-gate inconsistency where `BrokenPipeError` was classified as retryable by the error classifier but skipped pool-rebuild by the recovery gate. This PR addresses the *upstream* cause: the chat-model stale-timeout defaults are too tight for reasoning models, so the connection dies before the recovery gate is even reached. The two fixes are independent and can merge in either order.
- **Read-timeout auto-scaling works for free.** The existing logic at `agent/chat_completion_helpers.py:1815-1834` reads the new (raised) `_stream_stale_timeout` and bumps the httpx socket read timeout to match. So reasoning models get raised BOTH timeouts (stale detector AND socket read timeout) in one fix, with no additional integration point.
- **Local-endpoint short-circuit preserved.** The new floor lives inside the `else` branch of the local-endpoint check at line 2548 — local providers (Ollama, llama.cpp, vLLM, local NIM) still get `float("inf")` (stale detection intentionally disabled because local providers don't have upstream idle timeouts). The floor only applies to cloud reasoning models.
- **Local NIM endpoint case handled.** The non-stream integration returns `uses_implicit_default=False` when the floor fires, so `_compute_non_stream_stale_timeout`'s local-endpoint short-circuit at `run_agent.py:1152-1153` does not accidentally disable stale detection for users running reasoning models on a local NIM endpoint.
- **No new user-facing config knobs.** The floor is auto-applied; users who want different behavior set `providers.<id>.models.<model>.stale_timeout_seconds` explicitly. No new `.env` variables (project policy: `.env` is for secrets only; behavioral settings live in `config.yaml`).
- **Behavioral regression risk for non-reasoning models is zero.** `gpt-4o`, `claude-3-5-sonnet`, `llama-3.3-70b-instruct`, `gemini-2.5-pro`, `qwen2-72b-instruct` all return `None` from `get_reasoning_stale_timeout_floor`. They get the unchanged 90s / 180s default. 12 negative test cases pin this.
- **Allowlist maintenance burden.** The table has 18 entries (3 Nemotron + 2 DeepSeek + 2 Qwen + 8 OpenAI o-series + 3 Claude + 3 Grok). Adding a new reasoning model means one tuple entry + 1-2 doctest lines + 1-2 test cases. The word-boundary regex shape (`^slug(?:$|[\-._])`) is robust against community derivatives and fork naming.
- **Why enumerate o1/o3 variants explicitly instead of using a generic `^o[1-9]` regex.** Bare `o1` over-matches `olmo-1` and hypothetical `llama-4-70b-o1-preview`-style forks; the start-of-slug anchor handles those, but `o3-mini` and `o3` need different floors (300s vs 600s) so they can't share a single entry. Enumeration is unambiguous.
- **Trade-off in the qwen3 family entry.** `qwen3` matches all qwen3 models including non-thinking instruct variants, which get a slightly longer wait on a hung provider. The alternative (`qwen3-.*-thinking`) would break the moment Alibaba or NVIDIA ships a slightly different naming shape. The chosen trade-off is conservative-on-failures, conservative-on-over-match.

## What this PR does NOT change

- **Issue #52216 (`BrokenPipeError skips connection-pool rebuild`)** — that's a separate bug in the retry-recovery gate. Already merged as PR #52226.
- **Path A2 (add "broken pipe" / "errno 32" to `_SERVER_DISCONNECT_PATTERNS` for user-facing guidance)** — Gemini Pro flagged this as BLOCKER because the disconnect-with-large-session branch at `error_classifier.py:712-732` triggers `should_compress=True` (silently deletes conversation history). Better solved with a thinking-specific guidance block in a follow-up.
- **Path C (adaptive TTFB scaling)** — deferred per cross-vendor review until the allowlist pattern has soaked.
- **Path D (NVIDIA plugin defaults)** — pending `ProviderProfile` schema check.

Fixes #52217.
