### PR TITLE
fix(gateway): honor SIGNAL_GROUP_ALLOWED_USERS at gateway authorization

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -233,19 +233,21 @@ class GatewayAuthorizationMixin:
         user_id = source.user_id
 
         # Telegram (and similar) authorize entire group/forum/channel chats
-        # by chat ID via TELEGRAM_GROUP_ALLOWED_CHATS / QQ_GROUP_ALLOWED_USERS.
-        # That allowlist is chat-scoped, so it must work even when
-        # source.user_id is None — Telegram emits anonymous-admin posts,
-        # sender_chat traffic, and channel broadcasts with no `from_user`,
+        # by chat ID via TELEGRAM_GROUP_ALLOWED_CHATS / QQ_GROUP_ALLOWED_USERS /
+        # SIGNAL_GROUP_ALLOWED_USERS. That allowlist is chat-scoped, so it must
+        # work even when source.user_id is None — Telegram emits anonymous-admin
+        # posts, sender_chat traffic, and channel broadcasts with no `from_user`,
         # and an operator who explicitly listed the chat expects those to
         # be honored. Run this check before the no-user-id guard below so
         # documented behavior matches reality
         # (website/docs/reference/environment-variables.md,
-        # website/docs/user-guide/messaging/telegram.md).
+        # website/docs/user-guide/messaging/telegram.md,
+        # website/docs/user-guide/messaging/signal.md).
         if source.chat_type in {"group", "forum", "channel"} and source.chat_id:
             chat_allowlist_env = {
                 Platform.TELEGRAM: "TELEGRAM_GROUP_ALLOWED_CHATS",
                 Platform.QQBOT: "QQ_GROUP_ALLOWED_USERS",
+                Platform.SIGNAL: "SIGNAL_GROUP_ALLOWED_USERS",
             }.get(source.platform, "")
             if chat_allowlist_env:
                 raw_chat_allowlist = os.getenv(chat_allowlist_env, "").strip()
@@ -255,7 +257,15 @@ class GatewayAuthorizationMixin:
                         for cid in raw_chat_allowlist.split(",")
                         if cid.strip()
                     }
-                    if "*" in allowed_group_ids or source.chat_id in allowed_group_ids:
+                    # Signal sets chat_id to "group:<id>" but keeps the raw
+                    # group id in chat_id_alt, and SIGNAL_GROUP_ALLOWED_USERS
+                    # lists those raw ids — so compare chat_id_alt too. Telegram
+                    # and QQBot leave chat_id_alt None, so this is a no-op for
+                    # them and their chat_id match is unchanged.
+                    candidate_chat_ids = {source.chat_id}
+                    if source.chat_id_alt:
+                        candidate_chat_ids.add(source.chat_id_alt)
+                    if "*" in allowed_group_ids or candidate_chat_ids & allowed_group_ids:
                         return True
 
         if not user_id:

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -454,8 +454,8 @@ class TestSignalPhoneRedaction:
 # ---------------------------------------------------------------------------
 
 class TestSignalAuthorization:
-    def test_signal_in_allowlist_maps(self):
-        """Signal should be in the platform auth maps."""
+    @staticmethod
+    def _make_runner():
         from gateway.run import GatewayRunner
         from gateway.config import GatewayConfig
 
@@ -463,6 +463,26 @@ class TestSignalAuthorization:
         gw.config = GatewayConfig()
         gw.pairing_store = MagicMock()
         gw.pairing_store.is_approved.return_value = False
+        return gw
+
+    @staticmethod
+    def _group_source(group_id="group123", sender="+15559999999"):
+        """Mirror the source SignalAdapter builds for a group message:
+        chat_id is prefixed ``group:<id>`` while chat_id_alt holds the raw id."""
+        from gateway.session import SessionSource
+
+        return SessionSource(
+            platform=Platform.SIGNAL,
+            chat_id=f"group:{group_id}",
+            chat_type="group",
+            user_id=sender,
+            user_name=sender,
+            chat_id_alt=group_id,
+        )
+
+    def test_signal_in_allowlist_maps(self):
+        """Signal should be in the platform auth maps."""
+        gw = self._make_runner()
 
         source = MagicMock()
         source.platform = Platform.SIGNAL
@@ -472,6 +492,38 @@ class TestSignalAuthorization:
         with patch.dict("os.environ", {}, clear=True):
             result = gw._is_user_authorized(source)
             assert result is False
+
+    def test_signal_group_authorized_by_group_allowlist(self):
+        """A group listed in SIGNAL_GROUP_ALLOWED_USERS authorizes its senders
+        even when they are not in SIGNAL_ALLOWED_USERS — parity with Telegram's
+        TELEGRAM_GROUP_ALLOWED_CHATS. The env var holds the raw group id, which
+        the adapter exposes via chat_id_alt (chat_id is ``group:<id>``)."""
+        gw = self._make_runner()
+        source = self._group_source(group_id="group123")
+
+        with patch.dict(
+            "os.environ", {"SIGNAL_GROUP_ALLOWED_USERS": "group123,group456"}, clear=True
+        ):
+            assert gw._is_user_authorized(source) is True
+
+    def test_signal_group_authorized_by_wildcard(self):
+        """SIGNAL_GROUP_ALLOWED_USERS='*' authorizes any group."""
+        gw = self._make_runner()
+        source = self._group_source(group_id="whatever-group")
+
+        with patch.dict("os.environ", {"SIGNAL_GROUP_ALLOWED_USERS": "*"}, clear=True):
+            assert gw._is_user_authorized(source) is True
+
+    def test_signal_group_not_in_allowlist_denied(self):
+        """A group absent from SIGNAL_GROUP_ALLOWED_USERS (and no other
+        allowlist) is not authorized — the fix must not fail open."""
+        gw = self._make_runner()
+        source = self._group_source(group_id="group999")
+
+        with patch.dict(
+            "os.environ", {"SIGNAL_GROUP_ALLOWED_USERS": "group123"}, clear=True
+        ):
+            assert gw._is_user_authorized(source) is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What & why
Signal group messages that passed the adapter's `SIGNAL_GROUP_ALLOWED_USERS`
filter were still rejected at the gateway as "Unauthorized user" unless the
sender was *also* in `SIGNAL_ALLOWED_USERS`. The gateway's chat-scoped
allowlist map in `_is_user_authorized` only covered Telegram and QQBot, and
Signal does not set `enforces_own_access_policy`, so an allowlisted group fell
through to default-deny. This contradicts the docs, where
`SIGNAL_GROUP_ALLOWED_USERS=groupId1,groupId2` is documented to enable those
groups.

## Fix
- Add `Platform.SIGNAL: "SIGNAL_GROUP_ALLOWED_USERS"` to the chat-scoped
  allowlist map — parity with Telegram's `TELEGRAM_GROUP_ALLOWED_CHATS`.
- Match `chat_id_alt` (the raw group id) in addition to `chat_id`, since
  Signal sets `chat_id` to `group:<id>` while the env var lists raw ids.
  Telegram/QQBot leave `chat_id_alt` None, so their behavior is unchanged.

Scope is intentionally limited to group authorization; DM pairing behavior is
untouched.

## Tests
Added to `tests/gateway/test_signal.py::TestSignalAuthorization`:
- `test_signal_group_authorized_by_group_allowlist` — group in the allowlist
  authorizes its senders even without `SIGNAL_ALLOWED_USERS`.
- `test_signal_group_authorized_by_wildcard` — `*` authorizes any group.
- `test_signal_group_not_in_allowlist_denied` — a group not listed is denied
  (no fail-open).

### Results
- New + existing Signal authz tests: **4 passed**.
- Regression check across the authorization suites (`test_signal`,
  `test_unauthorized_dm_behavior`, `test_telegram_group_gating`,
  `test_allowlist_startup_check`, `test_config_driven_access_policy`,
  `test_relay_upstream_authz`): **274 passed, 1 skipped**.