### PR TITLE
fix(tui): prevent spurious npm install on every launch

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1370,7 +1370,24 @@ def _print_tui_exit_summary(
     )
 
 
-_NPM_LOCK_RUNTIME_KEYS = frozenset({"ideallyInert", "peer"})
+_NPM_LOCK_RUNTIME_KEYS = frozenset(
+    {
+        "ideallyInert",
+        "peer",
+        # npm writes these boolean annotation fields non-deterministically
+        # between the declarative package-lock.json and the hidden actualized
+        # .package-lock.json.  The intersection comparison (see
+        # _tui_need_npm_install) already handles the "field present in root
+        # but absent in hidden" case for structured fields like version,
+        # dependencies, license, etc.  These boolean flags need explicit
+        # exclusion because when present in *both* lockfiles they may still
+        # differ (e.g. dev: true → stripped in hidden).
+        "dev",
+        "extraneous",
+        "hasInstallScript",
+        "optional",
+    }
+)
 """Lockfile fields npm writes non-deterministically at install time.
 
 ``ideallyInert`` is npm's runtime annotation for packages it skipped installing
@@ -1380,6 +1397,13 @@ on dev-dependencies that are *also* declared as peers — the canonical
 it.  Neither key represents a real skew between what was declared and what was
 installed, so we exclude them from the comparison in :func:`_tui_need_npm_install`
 to avoid false-positive reinstalls on every launch.
+
+``dev``, ``optional``, ``extraneous``, and ``hasInstallScript`` are boolean
+annotations that npm populates differently in the hidden lock (e.g. ``dev: true``
+from the root lock may be absent or ``false`` in the hidden actualized tree).
+They never indicate a changed dependency — the authoritative check is the
+``resolved``/``integrity`` pair, which the intersection comparison always
+catches.
 """
 
 
@@ -1459,8 +1483,13 @@ def _tui_need_npm_install(root: Path) -> bool:
     For each entry in the root lock's ``packages`` map:
       - missing from hidden lock → reinstall (unless the entry is marked
         ``optional`` or ``peer``, which npm may intentionally skip per platform)
-      - present but with differing fields (excluding npm-written runtime
-        annotations like ``ideallyInert``) → reinstall
+      - present in both → compare only the **intersection** of fields (after
+        stripping ``_NPM_LOCK_RUNTIME_KEYS``).  npm's hidden lock
+        intentionally omits many metadata fields (version, license, engines,
+        dependencies, funding, etc.) — those one-side-only fields are normal
+        npm artefacts, not real skew.  A real version/dependency change will
+        change ``resolved``/``integrity``, which are present in both locks
+        and will be caught by the intersection comparison.
 
     Extra entries that exist only in the hidden lock are ignored — stale
     transitives left over from a removed dependency don't break runtime and
@@ -1509,10 +1538,21 @@ def _tui_need_npm_install(root: Path) -> bool:
                 continue
             return True
 
-        if isinstance(installed[name], dict) and comparable(pkg) != comparable(
-            installed[name]
-        ):
-            return True
+        if isinstance(installed[name], dict):
+            w = comparable(pkg)
+            i = comparable(installed[name])
+            # Only compare keys present in *both* lockfiles.  npm's hidden
+            # .package-lock.json intentionally omits many metadata fields
+            # (version, dependencies, license, engines, dev, optional, etc.)
+            # that the root lock records.  Missing-on-one-side is a normal
+            # npm artefact, not a real skew.  The authoritative fields
+            # "resolved" and "integrity" are always present for installed
+            # packages, so a real version/dependency change will still
+            # be caught through them.
+            common = set(w) & set(i)
+            for k in common:
+                if w[k] != i[k]:
+                    return True
 
     return False
 


### PR DESCRIPTION
## Description

`_tui_need_npm_install()` compared ALL fields between `package-lock.json` and `.package-lock.json`, treating npm's intentionally-stripped metadata as real dependency skew. This caused "Installing TUI dependencies…" + esbuild rebuild on **every single launch**.

### Root Cause

npm's hidden actualized lock (`.package-lock.json`) intentionally omits many fields (version, license, engines, dependencies, funding, etc.) that the declarative root lock records. The old code did a **full-dict comparison** — missing fields were treated as `None`, so 347 entries showed false-positive mismatches.

Even worse: running `npm install` does NOT make the hidden lock match the root lock (it's designed to be a subset). So the next launch triggers the same reinstall — infinite loop.

### Fix (two changes)

1. **Intersection comparison**: For entries present in both locks, only compare keys that exist in **both** dicts. A field present only in the root lock is a normal npm artefact, not a real skew. Real version/dependency changes still change `resolved`/`integrity`, which ARE present in both locks and caught by the comparison.

2. **Extended `_NPM_LOCK_RUNTIME_KEYS`**: Added `dev`, `extraneous`, `hasInstallScript`, `optional` — boolean annotations that npm writes non-deterministically between the two locks.

### Before/After

- Before: 347 lockfile entries flagged as "differing" → triggers npm install + rebuild
- After: 0 false positives → skips directly to running the TUI

### Test Plan

All 29 existing tests in `tests/hermes_cli/test_tui_npm_install.py` pass.
Verified against real lockfiles on a macOS workspace install with 194-commit gap.

### Related

The `test_install_when_version_differs_even_with_peer_drop` test intentionally creates a real version skew (2.0.0 vs 1.0.0) and still passes — because a real skew changes `resolved`/`integrity` which remain in the intersection.