### PR TITLE
feat(gateway): per-channel display overrides (display.platforms.<plat>.channels.<id>.<key>)

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -4,10 +4,24 @@ Provides ``resolve_display_setting()`` — the single entry-point for reading
 display settings with platform-specific overrides and sensible defaults.
 
 Resolution order (first non-None wins):
+    0. ``display.platforms.<platform>.channels.<channel_id>.<key>``  — explicit
+       per-channel override (only when a ``channel_id`` is passed)
     1. ``display.platforms.<platform>.<key>``  — explicit per-platform user override
     2. ``display.<key>``                       — global user setting
     3. ``_PLATFORM_DEFAULTS[<platform>][<key>]``  — built-in sensible default
     4. ``_GLOBAL_DEFAULTS[<key>]``              — built-in global default
+
+Per-channel overrides let a single noisy channel opt out of a setting (e.g.
+``interim_assistant_messages``) without changing the rest of the platform's
+channels. They sit one level deeper than the per-platform block:
+
+    display:
+      platforms:
+        slack:
+          interim_assistant_messages: true        # platform-wide
+          channels:
+            C0123456789:
+              interim_assistant_messages: false   # this channel only
 
 Exception: ``display.streaming`` is CLI-only.  Gateway streaming follows the
 top-level ``streaming`` config unless ``display.platforms.<platform>.streaming``
@@ -162,8 +176,9 @@ def resolve_display_setting(
     platform_key: str,
     setting: str,
     fallback: Any = None,
+    channel_id: str | None = None,
 ) -> Any:
-    """Resolve a display setting with per-platform override support.
+    """Resolve a display setting with per-platform (and per-channel) override support.
 
     Parameters
     ----------
@@ -176,16 +191,31 @@ def resolve_display_setting(
         Display setting name (e.g. ``"tool_progress"``, ``"show_reasoning"``).
     fallback : Any
         Fallback value when the setting isn't found anywhere.
+    channel_id : str | None
+        When given, a ``display.platforms.<platform>.channels.<channel_id>.<key>``
+        override takes priority over the per-platform value — letting a single
+        channel opt out of (or into) a setting. Ignored when ``None``.
 
     Returns
     -------
     The resolved value, or *fallback* if nothing is configured.
     """
     display_cfg = user_config.get("display") or {}
-
-    # 1. Explicit per-platform override (display.platforms.<platform>.<key>)
     platforms = display_cfg.get("platforms") or {}
     plat_overrides = platforms.get(platform_key)
+
+    # 0. Explicit per-channel override
+    #    (display.platforms.<platform>.channels.<channel_id>.<key>)
+    if channel_id and isinstance(plat_overrides, dict):
+        channels = plat_overrides.get("channels")
+        if isinstance(channels, dict):
+            chan_overrides = channels.get(channel_id)
+            if isinstance(chan_overrides, dict):
+                val = chan_overrides.get(setting)
+                if val is not None:
+                    return _normalise(setting, val)
+
+    # 1. Explicit per-platform override (display.platforms.<platform>.<key>)
     if isinstance(plat_overrides, dict):
         val = plat_overrides.get(setting)
         if val is not None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -442,8 +442,15 @@ def _resolve_progress_thread_id(platform: Any, source_thread_id: Any, event_mess
     return None
 
 
-def _has_platform_display_override(user_config: dict, platform_key: str, setting: str) -> bool:
-    """Return True when display.platforms.<platform> explicitly sets setting."""
+def _has_platform_display_override(
+    user_config: dict, platform_key: str, setting: str, channel_id: str | None = None
+) -> bool:
+    """Return True when display.platforms.<platform> explicitly sets setting.
+
+    When ``channel_id`` is given, a per-channel override
+    (display.platforms.<platform>.channels.<channel_id>.<setting>) also counts —
+    so a channel-level opt-in satisfies the platform-only gate below.
+    """
     display = user_config.get("display") if isinstance(user_config, dict) else None
     if not isinstance(display, dict):
         return False
@@ -451,7 +458,16 @@ def _has_platform_display_override(user_config: dict, platform_key: str, setting
     if not isinstance(platforms, dict):
         return False
     platform_cfg = platforms.get(platform_key)
-    return isinstance(platform_cfg, dict) and setting in platform_cfg
+    if not isinstance(platform_cfg, dict):
+        return False
+    if setting in platform_cfg:
+        return True
+    if channel_id:
+        channels = platform_cfg.get("channels")
+        chan_cfg = channels.get(channel_id) if isinstance(channels, dict) else None
+        if isinstance(chan_cfg, dict) and setting in chan_cfg:
+            return True
+    return False
 
 
 def _resolve_gateway_display_bool(
@@ -462,13 +478,18 @@ def _resolve_gateway_display_bool(
     default: bool = False,
     platform: Any = None,
     require_platform_override_for: set[Any] | None = None,
+    channel_id: str | None = None,
 ) -> bool:
     """Resolve a boolean display setting with optional platform-only opt-in.
 
     Some display features expose assistant scratch text rather than deliberate
     user-facing output.  For high-noise threaded chat surfaces such as
     Mattermost, a global opt-in is too broad: they must be enabled with an
-    explicit display.platforms.<platform>.<setting> override.
+    explicit display.platforms.<platform>.<setting> override (a per-channel
+    override under that platform also satisfies the gate).
+
+    ``channel_id`` lets a single channel override the platform value via
+    display.platforms.<platform>.channels.<channel_id>.<setting>.
     """
     current_platform = _gateway_platform_value(platform or platform_key)
     platform_only = {
@@ -477,13 +498,15 @@ def _resolve_gateway_display_bool(
     }
     if (
         current_platform in platform_only
-        and not _has_platform_display_override(user_config, platform_key, setting)
+        and not _has_platform_display_override(user_config, platform_key, setting, channel_id)
     ):
         return False
 
     from gateway.display_config import resolve_display_setting
 
-    value = resolve_display_setting(user_config, platform_key, setting, default)
+    value = resolve_display_setting(
+        user_config, platform_key, setting, default, channel_id=channel_id
+    )
     if isinstance(value, bool):
         return value
     if isinstance(value, str):
@@ -14626,6 +14649,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 default=True,
                 platform=source.platform,
                 require_platform_override_for={Platform.MATTERMOST},
+                channel_id=str(source.chat_id) if getattr(source, "chat_id", None) else None,
             )
         )
         # thinking_progress is independent — if enabled, we need the progress

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -80,6 +80,78 @@ class TestResolveDisplaySetting:
 
 
 # ---------------------------------------------------------------------------
+# Per-channel overrides: display.platforms.<platform>.channels.<channel>.<key>
+# ---------------------------------------------------------------------------
+
+class TestPerChannelOverride:
+    """resolve_display_setting() honours per-channel overrides when channel_id is given."""
+
+    def _config(self):
+        return {
+            "display": {
+                "platforms": {
+                    "slack": {
+                        "interim_assistant_messages": True,   # platform-wide ON
+                        "channels": {
+                            "C_QUIET": {"interim_assistant_messages": False},
+                        },
+                    },
+                },
+            }
+        }
+
+    def test_channel_override_wins_over_platform(self):
+        """display.platforms.<plat>.channels.<chan>.<key> beats the per-platform value."""
+        from gateway.display_config import resolve_display_setting
+
+        assert resolve_display_setting(
+            self._config(), "slack", "interim_assistant_messages",
+            channel_id="C_QUIET",
+        ) is False
+
+    def test_other_channel_falls_through_to_platform(self):
+        """A channel without an override keeps the per-platform value."""
+        from gateway.display_config import resolve_display_setting
+
+        assert resolve_display_setting(
+            self._config(), "slack", "interim_assistant_messages",
+            channel_id="C_OTHER",
+        ) is True
+
+    def test_no_channel_id_ignores_channel_block(self):
+        """Without channel_id the per-channel block is ignored (back-compat)."""
+        from gateway.display_config import resolve_display_setting
+
+        assert resolve_display_setting(
+            self._config(), "slack", "interim_assistant_messages",
+        ) is True
+
+    def test_channel_override_does_not_leak_to_other_platform(self):
+        """A slack channel override never affects another platform."""
+        from gateway.display_config import resolve_display_setting
+
+        assert resolve_display_setting(
+            self._config(), "telegram", "interim_assistant_messages",
+            channel_id="C_QUIET",
+        ) is True
+
+    def test_channel_override_normalises_yaml_off(self):
+        """Bare YAML ``off``/``on`` strings normalise to bool for the channel layer."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "platforms": {
+                    "slack": {"channels": {"C1": {"show_reasoning": "on"}}},
+                },
+            }
+        }
+        assert resolve_display_setting(
+            config, "slack", "show_reasoning", channel_id="C1",
+        ) is True
+
+
+# ---------------------------------------------------------------------------
 # Backward compatibility: tool_progress_overrides
 # ---------------------------------------------------------------------------
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1469,6 +1469,30 @@ Platforms without an override fall back to the global `tool_progress` value. Val
 
 Signal is listed as a valid platform key because the setting can be saved per platform, but the current Signal adapter cannot edit sent messages and does not render tool-progress bubbles. Keep Signal `tool_progress` set to `off`; use the CLI or an editing-capable messaging platform if you need to watch each tool call live.
 
+#### Per-channel overrides
+
+Need one noisy channel quieter (or louder) than the rest of a platform? Nest a
+`channels` map under the platform and key it by the channel/chat ID. A
+per-channel value beats the per-platform value; channels without an entry keep
+the platform setting.
+
+```yaml
+display:
+  platforms:
+    slack:
+      interim_assistant_messages: true     # platform-wide: mid-turn updates on
+      tool_progress: 'off'
+      channels:
+        C0123456789:                       # one specific channel
+          interim_assistant_messages: false  # …but stay quiet here
+```
+
+Resolution order is: per-channel → per-platform → global `display.<key>` →
+built-in default. The channel ID is the platform's native conversation ID (e.g.
+a Slack `C…`/`G…` channel ID). Per-channel overrides apply to the same keys as
+per-platform overrides (`tool_progress`, `interim_assistant_messages`,
+`show_reasoning`, `tool_preview_length`, `cleanup_progress`, …).
+
 `interim_assistant_messages` is gateway-only. When enabled, Hermes sends completed mid-turn assistant updates as separate chat messages. This is independent from `tool_progress` and does not require gateway streaming.
 
 ## Privacy


### PR DESCRIPTION
## What does this PR do?

Display settings (`tool_progress`, `interim_assistant_messages`, `show_reasoning`, …) can be tuned **globally** or **per-platform** (`display.platforms.<platform>.<key>`), but not **per-channel**. A single high-traffic channel that wants mid-turn assistant updates (`interim_assistant_messages`) off had no way to opt out without silencing the whole platform.

This adds a **per-channel override layer**, resolved with highest priority:

```
per-channel → per-platform → global display.<key> → built-in default
```

```yaml
display:
  platforms:
    slack:
      interim_assistant_messages: true        # platform-wide
      channels:
        C0123456789:
          interim_assistant_messages: false   # this channel only
```

Fully backward-compatible: `resolve_display_setting()` gains an optional `channel_id` that defaults to `None`, and the per-channel block is only consulted when a `channel_id` is passed.

## Related Issue

No existing issue found (searched open/merged PRs + issues for "per-channel display" / "interim_assistant_messages channel"). Happy to open one if preferred.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/display_config.py` — `resolve_display_setting()` gains optional `channel_id`; reads `display.platforms.<platform>.channels.<channel_id>.<key>` before the per-platform value. Docstring resolution order updated.
- `gateway/run.py` — `_resolve_gateway_display_bool()` and `_has_platform_display_override()` thread `channel_id` through (a channel-level override also satisfies the Mattermost-style platform-opt-in gate). The `interim_assistant_messages` resolution now passes the inbound channel id (`source.chat_id`).
- `tests/gateway/test_display_config.py` — `TestPerChannelOverride`: channel beats platform, falls through when unlisted, ignored without `channel_id`, no cross-platform leak, YAML `off/on` normalisation.
- `website/docs/user-guide/configuration.md` — "Per-channel overrides" section + example.

## How to Test

1. `pytest tests/gateway/test_display_config.py -q` → all pass (51, incl. 5 new per-channel cases).
2. In `~/.hermes/config.yaml` set `display.platforms.slack.interim_assistant_messages: true` and `display.platforms.slack.channels.<CHANNEL_ID>.interim_assistant_messages: false`.
3. In that channel, the bot no longer posts mid-turn assistant updates; other Slack channels still do.

> Draft for maintainer feedback on the config shape (`platforms.<plat>.channels.<id>.<key>`) before finalizing.