### PR TITLE
fix(agent): include rate-limit errors in auxiliary capacity-error gate

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5667,7 +5667,7 @@ def call_llm(
         is_auto = resolved_provider in {"auto", "", None}
         # Capacity errors bypass the explicit-provider gate: the provider
         # literally cannot serve this request regardless of user intent.
-        is_capacity_error = _is_payment_error(first_err) or _is_connection_error(first_err)
+        is_capacity_error = _is_payment_error(first_err) or _is_connection_error(first_err) or _is_rate_limit_error(first_err)
         if should_fallback and (is_auto or is_capacity_error):
             if _is_payment_error(first_err):
                 reason = "payment error"
@@ -6114,7 +6114,7 @@ async def async_call_llm(
         # gate — the provider cannot serve the request regardless of user intent.
         # See #26803: daily token quota must fall back like a 402 credit error.
         is_auto = resolved_provider in {"auto", "", None}
-        is_capacity_error = _is_payment_error(first_err) or _is_connection_error(first_err)
+        is_capacity_error = _is_payment_error(first_err) or _is_connection_error(first_err) or _is_rate_limit_error(first_err)
         if should_fallback and (is_auto or is_capacity_error):
             if _is_payment_error(first_err):
                 reason = "payment error"


### PR DESCRIPTION
## Problem

When an auxiliary task uses an **explicit** provider (e.g. `openai-codex` / `gpt-5.5`) and that provider returns a 429 rate-limit error, the fallback chain is **never triggered**. The agent silently fails instead of falling back to an alternative provider.

**Root cause:** The `is_capacity_error` gate only checks for payment and connection errors — not rate limits:

```python
# Current — rate limits missing
is_capacity_error = _is_payment_error(first_err) or _is_connection_error(first_err)

# Fixed — rate limits included
is_capacity_error = _is_payment_error(first_err) or _is_connection_error(first_err) or _is_rate_limit_error(first_err)
```

`should_fallback` correctly includes `_is_rate_limit_error`, but the gate condition `should_fallback and (is_auto or is_capacity_error)` evaluates to `False` for explicit providers hitting rate limits because `is_auto=False` and `is_capacity_error=False`.

## Impact

All auxiliary tasks (`kanban_decomposer`, `vision`, `web_extract`, `approval`, `profile_describer`, `curator`, etc.) using an explicit provider have zero resilience to rate limits.

## Files changed

| File | Change |
|------|--------|
| `agent/auxiliary_client.py` | Add `_is_rate_limit_error` to `is_capacity_error` in both sync and async fallback paths (lines 5670, 6117) |

Fixes #52228