### PR TITLE
fix(delegate): cap child terminal runtime to timeout budget

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -545,6 +545,37 @@ class TestToolNamePreservation(unittest.TestCase):
 class TestDelegateObservability(unittest.TestCase):
     """Tests for enriched metadata returned by _run_single_child."""
 
+    def test_child_terminal_timeout_cap_is_bound_inside_delegate_thread(self):
+        """Delegated children should inherit a per-thread terminal timeout cap."""
+        from tools.terminal_tool import _get_foreground_timeout_cap
+
+        parent = _make_mock_parent(depth=0)
+
+        with patch("tools.delegate_tool._get_child_timeout", return_value=30), \
+             patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "claude-sonnet-4-6"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+
+            def _run_conversation(**kwargs):
+                cap = _get_foreground_timeout_cap()
+                return {
+                    "final_response": f"cap={cap}",
+                    "completed": True,
+                    "interrupted": False,
+                    "api_calls": 0,
+                    "messages": [],
+                }
+
+            mock_child.run_conversation.side_effect = _run_conversation
+            MockAgent.return_value = mock_child
+
+            result = json.loads(delegate_task(goal="Test timeout cap", parent_agent=parent))
+
+        self.assertIsNone(_get_foreground_timeout_cap())
+        self.assertEqual(result["results"][0]["summary"], "cap=25")
+
     def test_observability_fields_present(self):
         """Completed child should return tool_trace, tokens, model, exit_reason."""
         parent = _make_mock_parent(depth=0)

--- a/tests/tools/test_terminal_foreground_timeout_cap.py
+++ b/tests/tools/test_terminal_foreground_timeout_cap.py
@@ -116,6 +116,60 @@ class TestForegroundTimeoutCap:
         assert call_kwargs[1]["timeout"] == 300
         assert "error" not in result or result["error"] is None
 
+    def test_context_timeout_cap_clamps_default_timeout(self):
+        """Delegate-scoped timeout caps should shorten the default foreground timeout."""
+        from tools.terminal_tool import (
+            reset_foreground_timeout_cap,
+            set_foreground_timeout_cap,
+            terminal_tool,
+        )
+
+        with patch("tools.terminal_tool._get_env_config",
+                    return_value=_make_env_config(timeout=180)), \
+             patch("tools.terminal_tool._start_cleanup_thread"):
+
+            mock_env = MagicMock()
+            mock_env.execute.return_value = {"output": "done", "returncode": 0}
+            token = set_foreground_timeout_cap(25)
+            try:
+                with patch("tools.terminal_tool._active_environments", {"default": mock_env}), \
+                     patch("tools.terminal_tool._last_activity", {"default": 0}), \
+                     patch("tools.terminal_tool._check_all_guards", return_value={"approved": True}):
+                    result = json.loads(terminal_tool(command="sleep 60"))
+            finally:
+                reset_foreground_timeout_cap(token)
+
+        call_kwargs = mock_env.execute.call_args
+        assert call_kwargs[1]["timeout"] == 25
+        assert "error" not in result or result["error"] is None
+
+    def test_context_timeout_cap_clamps_explicit_timeout(self):
+        """Delegate-scoped timeout caps should also shorten explicit foreground timeouts."""
+        from tools.terminal_tool import (
+            reset_foreground_timeout_cap,
+            set_foreground_timeout_cap,
+            terminal_tool,
+        )
+
+        with patch("tools.terminal_tool._get_env_config",
+                    return_value=_make_env_config(timeout=180)), \
+             patch("tools.terminal_tool._start_cleanup_thread"):
+
+            mock_env = MagicMock()
+            mock_env.execute.return_value = {"output": "done", "returncode": 0}
+            token = set_foreground_timeout_cap(25)
+            try:
+                with patch("tools.terminal_tool._active_environments", {"default": mock_env}), \
+                     patch("tools.terminal_tool._last_activity", {"default": 0}), \
+                     patch("tools.terminal_tool._check_all_guards", return_value={"approved": True}):
+                    result = json.loads(terminal_tool(command="sleep 60", timeout=90))
+            finally:
+                reset_foreground_timeout_cap(token)
+
+        call_kwargs = mock_env.execute.call_args
+        assert call_kwargs[1]["timeout"] == 25
+        assert "error" not in result or result["error"] is None
+
     def test_config_default_above_cap_not_rejected(self):
         """When config default timeout > cap but model passes no timeout, execute normally.
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -607,6 +607,7 @@ DEFAULT_MAX_ITERATIONS = 50
 # detection lives in the heartbeat staleness monitor below. Users can opt back
 # in via delegation.child_timeout_seconds.
 DEFAULT_CHILD_TIMEOUT: Optional[float] = None
+_CHILD_TERMINAL_TIMEOUT_GRACE_SECONDS = 5
 _HEARTBEAT_INTERVAL = 30  # seconds between parent activity heartbeats during delegation
 # Stale-heartbeat thresholds. A child with no API-call progress is either:
 #   - idle between turns (no current_tool) — probably stuck on a slow API call
@@ -619,6 +620,17 @@ _HEARTBEAT_INTERVAL = 30  # seconds between parent activity heartbeats during de
 _HEARTBEAT_STALE_CYCLES_IDLE = 15  # 15 * 30s = 450s idle between turns → stale
 _HEARTBEAT_STALE_CYCLES_IN_TOOL = 40  # 40 * 30s = 1200s stuck on same tool → stale
 DEFAULT_TOOLSETS = ["terminal", "file", "web"]
+
+
+def _get_child_terminal_timeout_cap(timeout_seconds: float) -> int | None:
+    """Return a per-child terminal timeout cap slightly under the child cap."""
+    try:
+        timeout_value = int(float(timeout_seconds))
+    except (TypeError, ValueError):
+        return None
+    if timeout_value <= 0:
+        return None
+    return max(1, timeout_value - _CHILD_TERMINAL_TIMEOUT_GRACE_SECONDS)
 
 
 # ---------------------------------------------------------------------------
@@ -1667,11 +1679,24 @@ def _run_single_child(
 
         def _run_with_thread_capture():
             _worker_thread_holder["t"] = threading.current_thread()
-            return child.run_conversation(
-                user_message=goal,
-                task_id=child_task_id,
-                stream_callback=_relay_child_text,
+            from tools.terminal_tool import (
+                reset_foreground_timeout_cap,
+                set_foreground_timeout_cap,
             )
+
+            timeout_token = None
+            timeout_cap = _get_child_terminal_timeout_cap(child_timeout)
+            if timeout_cap is not None:
+                timeout_token = set_foreground_timeout_cap(timeout_cap)
+            try:
+                return child.run_conversation(
+                    user_message=goal,
+                    task_id=child_task_id,
+                    stream_callback=_relay_child_text,
+                )
+            finally:
+                if timeout_token is not None:
+                    reset_foreground_timeout_cap(timeout_token)
 
         _child_future = _timeout_executor.submit(_run_with_thread_capture)
         try:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -42,6 +42,7 @@ import threading
 import atexit
 import shutil
 import subprocess
+import contextvars
 from pathlib import Path
 from typing import Optional, Dict, Any, List
 
@@ -171,6 +172,10 @@ _sudo_password_cache_lock = threading.Lock()
 # the per-session queue in tools.approval, not through these callbacks,
 # so it's unaffected.
 _callback_tls = threading.local()
+_foreground_timeout_cap_var: contextvars.ContextVar[Optional[int]] = contextvars.ContextVar(
+    "terminal_tool_foreground_timeout_cap",
+    default=None,
+)
 
 
 def _get_sudo_password_callback():
@@ -198,6 +203,32 @@ def set_approval_callback(cb):
     GHSA-qg5c-hvr5-hjgr.
     """
     _callback_tls.approval = cb
+
+
+def set_foreground_timeout_cap(timeout_seconds: Optional[int]):
+    """Bind a per-context foreground timeout cap for terminal() calls."""
+    if timeout_seconds is None:
+        return _foreground_timeout_cap_var.set(None)
+    try:
+        value = int(timeout_seconds)
+    except (TypeError, ValueError):
+        value = None
+    if value is not None and value <= 0:
+        value = None
+    return _foreground_timeout_cap_var.set(value)
+
+
+def reset_foreground_timeout_cap(token) -> None:
+    """Restore the previous per-context foreground timeout cap."""
+    _foreground_timeout_cap_var.reset(token)
+
+
+def _get_foreground_timeout_cap() -> Optional[int]:
+    """Return the active per-context foreground timeout cap, if any."""
+    value = _foreground_timeout_cap_var.get()
+    if isinstance(value, int) and value > 0:
+        return value
+    return None
 
 
 def _get_sudo_password_cache_scope() -> str:
@@ -1927,10 +1958,18 @@ def terminal_tool(
         cwd = overrides.get("cwd") or config["cwd"]
         default_timeout = config["timeout"]
         effective_timeout = timeout or default_timeout
+        delegated_timeout_cap = _get_foreground_timeout_cap()
+        if not background and delegated_timeout_cap is not None:
+            effective_timeout = min(effective_timeout, delegated_timeout_cap)
 
         # Reject foreground commands where the model explicitly requests
         # a timeout above FOREGROUND_MAX_TIMEOUT — nudge it toward background.
-        if not background and timeout and timeout > FOREGROUND_MAX_TIMEOUT:
+        if (
+            not background
+            and timeout
+            and timeout > FOREGROUND_MAX_TIMEOUT
+            and delegated_timeout_cap is None
+        ):
             return json.dumps({
                 "error": (
                     f"Foreground timeout {timeout}s exceeds the maximum of "


### PR DESCRIPTION
## Summary
- cap delegated child foreground terminal calls slightly below `delegation.child_timeout_seconds`
- carry the cap through a ContextVar-scoped override so concurrent sessions do not share state
- cover the delegate binding and terminal timeout clamping with targeted regression tests

## Verification
- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/tools/test_terminal_foreground_timeout_cap.py`
- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/tools/test_delegate.py -k 'child_terminal_timeout_cap_is_bound_inside_delegate_thread'`
- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m py_compile tools/delegate_tool.py tools/terminal_tool.py tests/tools/test_delegate.py tests/tools/test_terminal_foreground_timeout_cap.py`
- `git diff --check`

## Risks
- delegated foreground commands now inherit the child timeout budget instead of the broader user terminal default

Closes #52185
