### PR TITLE
feat(cron): add no_header option for clean delivery output

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -242,6 +242,7 @@ def _normalize_job_record(job: Dict[str, Any]) -> Dict[str, Any]:
         name = label_source[:50].strip() or "cron job"
     normalized["name"] = name
     normalized["schedule_display"] = _schedule_display_for_job(normalized)
+    normalized["no_header"] = normalized.get("no_header") is True
 
     state = _coerce_job_text(normalized.get("state")).strip()
     if not state:
@@ -789,6 +790,7 @@ def create_job(
     workdir: Optional[str] = None,
     no_agent: bool = False,
     attach_to_session: Optional[bool] = None,
+    no_header: bool = False,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -833,6 +835,8 @@ def create_job(
                 and deliver its stdout directly. Empty stdout = silent (no
                 delivery). Requires ``script`` to be set. Ideal for classic
                 watchdogs and periodic alerts that don't need LLM reasoning.
+        no_header: When True, deliver successful cron output without the
+                automatic "Cronjob Response" wrapper. Defaults to False.
 
     Returns:
         The created job dict
@@ -868,6 +872,7 @@ def create_job(
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
+    normalized_no_header = no_header is True
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -945,6 +950,7 @@ def create_job(
         "base_url": normalized_base_url,
         "script": normalized_script,
         "no_agent": normalized_no_agent,
+        "no_header": normalized_no_header,
         "context_from": context_from,
         "schedule": parsed_schedule,
         "schedule_display": parsed_schedule.get("display", schedule),

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1060,7 +1060,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     except Exception:
         pass
 
-    if wrap_response:
+    if wrap_response and job.get("no_header") is not True:
         task_name = job.get("name", job["id"])
         job_id = job.get("id", "")
         delivery_content = (

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -98,6 +98,28 @@ def test_update_job_roundtrips_no_agent_flag(hermes_env):
 # ---------------------------------------------------------------------------
 
 
+def test_cronjob_tool_create_and_update_no_header(hermes_env):
+    from tools.cronjob_tools import cronjob
+
+    created = json.loads(
+        cronjob(
+            action="create",
+            schedule="every 5m",
+            prompt="report",
+            deliver="local",
+            no_header=True,
+        )
+    )
+    assert created["success"] is True
+    assert created["job"]["no_header"] is True
+
+    updated = json.loads(
+        cronjob(action="update", job_id=created["job_id"], no_header=False)
+    )
+    assert updated["success"] is True
+    assert "no_header" not in updated["job"]
+
+
 def test_cronjob_tool_create_no_agent_without_script_errors(hermes_env):
     from tools.cronjob_tools import cronjob
 

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -319,6 +319,28 @@ class TestJobCRUD:
         job = create_job(prompt="Test", schedule="30m")
         assert job["deliver"] == "local"
 
+    def test_create_defaults_no_header_false(self, tmp_cron_dir):
+        job = create_job(prompt="Test", schedule="30m")
+        assert job["no_header"] is False
+
+    def test_create_accepts_no_header_true(self, tmp_cron_dir):
+        job = create_job(prompt="Test", schedule="30m", no_header=True)
+        assert job["no_header"] is True
+        assert get_job(job["id"])["no_header"] is True
+
+    def test_legacy_record_missing_no_header_normalizes_false(self, tmp_cron_dir):
+        save_jobs([
+            {
+                "id": "abc123deadbe",
+                "name": "legacy",
+                "prompt": "Test",
+                "schedule": {"kind": "interval", "minutes": 60, "display": "every 60m"},
+                "enabled": True,
+            }
+        ])
+
+        assert list_jobs()[0]["no_header"] is False
+
 
 class TestUpdateJob:
     def test_update_name(self, tmp_cron_dir):
@@ -360,6 +382,14 @@ class TestUpdateJob:
         assert updated["enabled"] is False
         fetched = get_job(job["id"])
         assert fetched["enabled"] is False
+
+    def test_update_no_header(self, tmp_cron_dir):
+        job = create_job(prompt="Report", schedule="every 1h")
+
+        updated = update_job(job["id"], {"no_header": True})
+
+        assert updated["no_header"] is True
+        assert get_job(job["id"])["no_header"] is True
 
     def test_update_nonexistent_returns_none(self, tmp_cron_dir):
         result = update_job("nonexistent_id", {"name": "X"})

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -613,6 +613,55 @@ class TestDeliverResultWrapping:
         sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
         assert "Cronjob Response: abc-123" in sent_content
 
+    def test_delivery_no_header_job_option_sends_body_as_is(self):
+        """Per-job no_header should skip the cron delivery wrapper."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock:
+            job = {
+                "id": "test-job",
+                "name": "daily-report",
+                "deliver": "origin",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+                "no_header": True,
+            }
+            _deliver_result(job, "Clean output only.")
+
+        send_mock.assert_called_once()
+        sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
+        assert sent_content == "Clean output only."
+        assert "Cronjob Response" not in sent_content
+        assert "To stop or manage this job" not in sent_content
+
+    def test_delivery_missing_no_header_keeps_default_wrapper(self):
+        """Legacy job records without no_header should keep existing wrapping."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock:
+            job = {
+                "id": "legacy-job",
+                "name": "legacy-report",
+                "deliver": "origin",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+            }
+            _deliver_result(job, "Legacy output.")
+
+        sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
+        assert "Cronjob Response: legacy-report" in sent_content
+        assert "Legacy output." in sent_content
+
     def test_delivery_skips_wrapping_when_config_disabled(self):
         """When cron.wrap_response is false, deliver raw content without header/footer."""
         from gateway.config import Platform

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -510,6 +510,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["script"] = job["script"]
     if job.get("no_agent"):
         result["no_agent"] = True
+    if job.get("no_header") is True:
+        result["no_header"] = True
     if job.get("enabled_toolsets"):
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
@@ -583,6 +585,7 @@ def cronjob(
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
     attach_to_session: Optional[bool] = None,
+    no_header: Optional[bool] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -650,6 +653,7 @@ def cronjob(
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
                 attach_to_session=attach_to_session,
+                no_header=no_header is True,
             )
             _notify_provider_jobs_changed_safe()
             _create_message = f"Cron job '{job['name']}' created."
@@ -822,6 +826,8 @@ def cronjob(
                             success=False,
                         )
                 updates["no_agent"] = target_no_agent
+            if no_header is not None:
+                updates["no_header"] = no_header is True
             if repeat is not None:
                 # Normalize: treat 0 or negative as None (infinite)
                 normalized_repeat = None if repeat <= 0 else repeat
@@ -940,6 +946,16 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                     "WHEN TO USE False (default): anything that needs reasoning — summarize a feed, draft a daily briefing, pick interesting items, rephrase data for a human, follow conditional logic based on content."
                 ),
             },
+            "no_header": {
+                "type": "boolean",
+                "default": False,
+                "description": (
+                    "Default: False. Set True to deliver successful cron output "
+                    "without the automatic 'Cronjob Response: <job name>' header "
+                    "and management footer. This only changes delivery formatting; "
+                    "it does not change agent reasoning or no_agent execution."
+                ),
+            },
             "context_from": {
                 "type": "array",
                 "items": {"type": "string"},
@@ -1021,6 +1037,7 @@ registry.register(
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
+        no_header=args.get("no_header"),
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -290,7 +290,16 @@ Cronjob Response: Morning feeds
 Note: The agent cannot see this message, and therefore cannot respond to it.
 ```
 
-To deliver the raw agent output without the wrapper, set `cron.wrap_response` to `false`:
+For a single job, set `no_header=True` when creating or updating it to deliver that job's output exactly as produced while leaving other cron jobs unchanged.
+
+```yaml
+deliver: origin
+no_header: true
+```
+
+When omitted or false, Hermes keeps the existing Cronjob Response wrapper. When true, Hermes delivers only the job output body.
+
+To deliver the raw agent output without the wrapper for all jobs, set `cron.wrap_response` to `false`:
 
 ```yaml
 # ~/.hermes/config.yaml


### PR DESCRIPTION
## Summary

Adds a backward-compatible per-cron-job `no_header` option that suppresses the automatic cron delivery wrapper when explicitly enabled.

By default, cron delivery behavior is unchanged. Jobs only deliver the raw response body when created or updated with `no_header: true`.

## Why

Some cron jobs already generate self-contained formatted output for Telegram, monitoring, or daily report delivery. The current mandatory `Cronjob Response: ...` wrapper can make those messages noisy or redundant.

## Changes

- Adds normalized `no_header` job config with default `false`
- Skips the cron wrapper only when `job.get("no_header") is True`
- Exposes `no_header` in cronjob tool create/update path
- Documents the option in cron user docs
- Adds regression coverage for default wrapping and explicit raw-body delivery

## Example

```yaml
deliver: origin
no_header: true
```

When omitted or false, Hermes keeps the existing cron response wrapper. When true, Hermes delivers only the job output body.

## Tests

```bash
pytest tests/cron/test_scheduler.py::TestDeliverResultWrapping -q
pytest tests/cron/test_cron_no_agent.py::test_cronjob_tool_create_and_update_no_header -q
pytest tests/cron/test_cronjob_schema.py -q
pytest tests/cron/test_jobs.py::TestJobCRUD tests/cron/test_jobs.py::TestUpdateJob -q
pytest tests/cron -q
```

Results:

```text
12 passed
1 passed
3 passed
19 passed
544 passed
```

## Related issue

Closes #24020
