### PR TITLE
fix(anthropic): prepend user turn when compaction leaves a leading assistant message

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2259,6 +2259,12 @@ def _evict_old_screenshots(result: List[Dict[str, Any]]) -> None:
                 ]
 
 
+def _ensure_leading_user_turn(result: List[Dict[str, Any]], system: Any) -> None:
+    """Anthropic requires messages[0] to be user when system is extracted."""
+    if system is not None and result and result[0].get("role") != "user":
+        result.insert(0, {"role": "user", "content": [{"type": "text", "text": " "}]})
+
+
 def convert_messages_to_anthropic(
     messages: List[Dict],
     base_url: str | None = None,
@@ -2317,6 +2323,7 @@ def convert_messages_to_anthropic(
 
     _strip_orphaned_tool_blocks(result)
     result = _merge_consecutive_roles(result)
+    _ensure_leading_user_turn(result, system)
     _manage_thinking_signatures(result, base_url, model)
     _evict_old_screenshots(result)
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -996,7 +996,8 @@ class TestConvertMessages:
         ])
 
         _, result = convert_messages_to_anthropic(messages)
-        assistant_blocks = result[0]["content"]
+        assistant_msg = next(m for m in result if m["role"] == "assistant")
+        assistant_blocks = assistant_msg["content"]
 
         assert assistant_blocks[0]["type"] == "text"
         assert assistant_blocks[0]["text"] == "Hello from assistant"
@@ -1016,7 +1017,12 @@ class TestConvertMessages:
         ], native_anthropic=True)
 
         _, result = convert_messages_to_anthropic(messages)
-        user_msg = [m for m in result if m["role"] == "user"][0]
+        user_msg = next(
+            m for m in result
+            if m["role"] == "user"
+            and isinstance(m["content"], list)
+            and any(b.get("type") == "tool_result" for b in m["content"])
+        )
         tool_block = user_msg["content"][0]
 
         assert tool_block["type"] == "tool_result"
@@ -1164,6 +1170,69 @@ class TestConvertMessages:
         assert result[0]["role"] == "user"
         assert isinstance(result[0]["content"], list)
         assert result[0]["content"] == [{"type": "text", "text": "(empty message)"}]
+
+    def test_leading_assistant_after_compaction_gets_user_turn_prepended(self):
+        """The adapter backstops compactors that emit a leading assistant summary."""
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "assistant", "content": "[Context compaction summary] earlier work…"},
+            {"role": "user", "content": "continue"},
+        ]
+
+        system, result = convert_messages_to_anthropic(messages)
+
+        assert system == "You are helpful."
+        assert result[0]["role"] == "user"
+        assert result[0]["content"] == [{"type": "text", "text": " "}]
+        assert result[1]["role"] == "assistant"
+        assert any(
+            m["role"] == "assistant" and "Context compaction summary" in str(m["content"])
+            for m in result
+        )
+
+    def test_leading_user_message_is_not_modified(self):
+        """A normal transcript that already starts with user must be untouched."""
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+
+        _, result = convert_messages_to_anthropic(messages)
+
+        assert len(result) == 2
+        assert result[0]["role"] == "user"
+        assert result[0]["content"] == "hello"
+
+    def test_leading_assistant_with_tool_use_after_compaction_is_repaired(self):
+        """Repair the leading role without disturbing adjacent tool pairs."""
+        messages = [
+            {"role": "system", "content": "sys"},
+            {
+                "role": "assistant",
+                "content": "running it",
+                "tool_calls": [
+                    {"id": "toolu_1", "function": {"name": "terminal", "arguments": "{}"}},
+                ],
+            },
+            {"role": "tool", "tool_call_id": "toolu_1", "content": "ok"},
+            {"role": "user", "content": "next"},
+        ]
+
+        _, result = convert_messages_to_anthropic(messages)
+
+        assert result[0]["role"] == "user"
+        asst_idx = next(
+            i for i, m in enumerate(result)
+            if m["role"] == "assistant"
+            and any(b.get("type") == "tool_use" for b in m["content"] if isinstance(b, dict))
+        )
+        nxt = result[asst_idx + 1]
+        assert nxt["role"] == "user"
+        assert any(
+            isinstance(b, dict) and b.get("type") == "tool_result" and b.get("tool_use_id") == "toolu_1"
+            for b in nxt["content"]
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes a non-retryable Anthropic HTTP 400 when a compacted transcript reaches the native Anthropic adapter with `messages[0].role == "assistant"` after the system prompt has been extracted into the separate `system` field.

The observed provider error is misleadingly worded as a `tool_use` / `tool_result` adjacency failure. A saved failing request from a real `claude-opus-4-8` session showed the opposite:

```text
total messages  : 58
msg[0].role     : assistant      # blocks: [text, text, tool_use]
msg[1].role     : user           # blocks: [text, tool_result] -> matches msg[0]
orphaned pairs  : 0              # every tool_use has its immediately-following tool_result
```

So the failing invariant is the leading assistant role, not tool pairing.

This patch adds a small adapter-boundary guard in `convert_messages_to_anthropic`: when a `system` prompt is extracted and the first remaining message is not `user`, prepend a blank user turn before sending the payload. This mirrors the existing Bedrock Converse behavior (`convert_messages_to_converse` already inserts a leading user turn) and keeps the fix below any single context engine.

## Relationship to #52167

Complements #52167 rather than competing with it.

- #52167 fixes one producer: the built-in `ContextCompressor` summary-role choice.
- This PR fixes the lower Anthropic serialization surface: any producer of a leading-assistant transcript is normalized before the API call.
- That includes the built-in compressor, DAG/LCM context engines, session truncation/rebuild paths, or any future compactor that hands the Anthropic adapter a leading assistant turn.

## Related Issue

Fixes #52160

## Type of Change

- [x] Bug fix (non-breaking change)

## Changes Made

- `agent/anthropic_adapter.py`: add `_ensure_leading_user_turn(result, system)` after role merging and before thinking-signature management.
- `tests/agent/test_anthropic_adapter.py`: add regression coverage for:
  - leading assistant compaction summary gets a prepended user turn,
  - normal leading-user transcripts are unchanged,
  - leading assistant + adjacent `tool_use`/`tool_result` keeps the tool pair adjacent after repair.
- Update two cache-control assertions to target the role/block they care about instead of assuming `result[0]` remains the original message.

## How to Test

Targeted regression tests:

```bash
python -m pytest tests/agent/test_anthropic_adapter.py \
  -q -o 'addopts=' \
  -k 'leading_assistant_after_compaction_gets_user_turn_prepended or leading_user_message_is_not_modified or leading_assistant_with_tool_use_after_compaction_is_repaired or assistant_cache_control_blocks_are_preserved or tool_cache_control_is_preserved_on_tool_result_block'
# 5 passed, 164 deselected
```

End-to-end payload shape check through `build_anthropic_kwargs`:

```text
system= sys
roles= ['user', 'assistant', 'user']
first_content= [{'type': 'text', 'text': ' '}]
E2E payload shape OK
```

`git diff --check` is clean.

Note: the full `tests/agent/test_anthropic_adapter.py` file has unrelated local failures on this macOS/Python 3.13 machine in Claude Code credential/keychain tests; the same failures reproduce on current `origin/main`, so they are not introduced by this PR.

## Checklist

- [x] Commit message follows the repo's Conventional Commit style.
- [x] PR is limited to the Anthropic adapter fix and tests.
- [x] The branch is rebased onto latest `main`.
- [x] Regression tests and E2E payload-shape check pass locally.
