### PR TITLE
fix: correct Xiaomi MiMo base URL from api.xiaomimimo.com to token-plan-cn.xiaomimimo.com

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -399,7 +399,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         id="xiaomi",
         name="Xiaomi MiMo",
         auth_type="api_key",
-        inference_base_url="https://api.xiaomimimo.com/v1",
+        inference_base_url="https://token-plan-cn.xiaomimimo.com/v1",
         api_key_env_vars=("XIAOMI_API_KEY",),
         base_url_env_var="XIAOMI_BASE_URL",
     ),

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3242,7 +3242,7 @@ OPTIONAL_ENV_VARS = {
         "category": "provider",
     },
     "XIAOMI_BASE_URL": {
-        "description": "Xiaomi MiMo base URL override (default: https://api.xiaomimimo.com/v1)",
+        "description": "Xiaomi MiMo base URL override (default: https://token-plan-cn.xiaomimimo.com/v1)",
         "prompt": "Xiaomi base URL (leave empty for default)",
         "url": None,
         "password": False,

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -107,7 +107,7 @@ _MATCHING_PREFIX_STRIP_PROVIDERS: frozenset[str] = frozenset({
 })
 
 # Providers whose APIs require lowercase model IDs.  Xiaomi's
-# ``api.xiaomimimo.com`` rejects mixed-case names like ``MiMo-V2.5-Pro``
+# ``token-plan-cn.xiaomimimo.com`` rejects mixed-case names like ``MiMo-V2.5-Pro``
 # that users might copy from marketing docs — it only accepts
 # ``mimo-v2.5-pro``.  After stripping a matching provider prefix, these
 # providers also get ``.lower()`` applied.


### PR DESCRIPTION
## Problem

The Xiaomi MiMo provider's default `inference_base_url` in `hermes_cli/auth.py` is hardcoded to `https://api.xiaomimimo.com/v1`, which is incorrect. The correct base URL is `https://token-plan-cn.xiaomimimo.com/v1`.

Every time a user runs `hermes model switch` to switch to the MiMo model, the wrong URL gets written into `config.yaml`, causing connection failures.

## Fix

Updated 3 files:
- **`hermes_cli/auth.py`** — `inference_base_url` in `ProviderConfig` (the core fix)
- **`hermes_cli/config.py`** — description text for `XIAOMI_BASE_URL` env var
- **`hermes_cli/model_normalize.py`** — comment referencing the domain

All changed from `api.xiaomimimo.com` → `token-plan-cn.xiaomimimo.com`.