### PR TITLE
fix(cli): accept available_models in custom provider config

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1344,6 +1344,41 @@ def _canonical_api_mode(api_mode: str) -> str:
     return _API_MODE_ALIASES.get(cleaned.lower(), cleaned)
 
 
+def _declared_models_to_mapping(value: Any) -> Dict[str, Any]:
+    """Coerce a custom-provider model declaration into ``{id: metadata}``.
+
+    Accepts the two shapes seen in real configs: a mapping (already
+    canonical) or a list of plain ids / ``{id: ...}`` rows written by hand
+    or by older Hermes versions. Anything else yields an empty mapping so
+    the caller leaves ``models`` unset rather than writing a bad shape.
+    """
+    if isinstance(value, dict) and value:
+        # Shallow-copy: the caller's `entry` may alias a cached config
+        # sub-dict, and the normalized entry escapes into long-lived runtime
+        # state (agent._custom_providers) — don't share the cached mapping.
+        return dict(value)
+
+    if not isinstance(value, list):
+        return {}
+
+    mapping: Dict[str, Any] = {}
+    for item in value:
+        if isinstance(item, str) and item.strip():
+            mapping[item.strip()] = {}
+            continue
+        if not isinstance(item, dict):
+            continue
+        model_id = item.get("id")
+        if not isinstance(model_id, str) or not model_id.strip():
+            model_id = item.get("name")
+        if not isinstance(model_id, str) or not model_id.strip():
+            continue
+        mapping[model_id.strip()] = {
+            k: v for k, v in item.items() if k not in {"id", "name"}
+        }
+    return mapping
+
+
 def _normalize_custom_provider_entry(
     entry: Any,
     *,
@@ -1388,6 +1423,8 @@ def _normalize_custom_provider_entry(
         "key_cmd",
         "api_mode", "transport", "model", "default_model", "models",
         "models_discovered",
+        # Hand-written alias for ``models`` (gh-52266); merged in below.
+        "available_models",
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
         "discover_models", "extra_body", "extra_headers",
@@ -1516,6 +1553,18 @@ def _normalize_custom_provider_entry(
             normalized_models[model_id.strip()] = model_meta
         if normalized_models:
             normalized["models"] = normalized_models
+
+    # ``models`` is the canonical declaration key, but hand-written configs
+    # also use ``available_models`` (gh-52266). That alias previously fell
+    # through to the unknown-key warning and was dropped, leaving the
+    # provider with (0) models: the picker showed nothing and every
+    # ``/model <id>`` for that provider failed to resolve. Merge it in,
+    # with ``models`` metadata winning for ids declared in both.
+    available = _declared_models_to_mapping(entry.get("available_models"))
+    if available:
+        merged_models = dict(available)
+        merged_models.update(normalized.get("models") or {})
+        normalized["models"] = merged_models
 
     if models_discovered:
         normalized["models_discovered"] = True

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1273,6 +1273,41 @@ def _warn_once_per_provider(
     logger.warning(msg, *args)
 
 
+def _declared_models_to_mapping(value: Any) -> Dict[str, Any]:
+    """Coerce a custom-provider model declaration into ``{id: metadata}``.
+
+    Accepts the two shapes seen in real configs: a mapping (already
+    canonical) or a list of plain ids / ``{id: ...}`` rows written by hand
+    or by older Hermes versions. Anything else yields an empty mapping so
+    the caller leaves ``models`` unset rather than writing a bad shape.
+    """
+    if isinstance(value, dict) and value:
+        # Shallow-copy: the caller's `entry` may alias a cached config
+        # sub-dict, and the normalized entry escapes into long-lived runtime
+        # state (agent._custom_providers) — don't share the cached mapping.
+        return dict(value)
+
+    if not isinstance(value, list):
+        return {}
+
+    mapping: Dict[str, Any] = {}
+    for item in value:
+        if isinstance(item, str) and item.strip():
+            mapping[item.strip()] = {}
+            continue
+        if not isinstance(item, dict):
+            continue
+        model_id = item.get("id")
+        if not isinstance(model_id, str) or not model_id.strip():
+            model_id = item.get("name")
+        if not isinstance(model_id, str) or not model_id.strip():
+            continue
+        mapping[model_id.strip()] = {
+            k: v for k, v in item.items() if k not in {"id", "name"}
+        }
+    return mapping
+
+
 def _normalize_custom_provider_entry(
     entry: Any,
     *,
@@ -1315,6 +1350,8 @@ def _normalize_custom_provider_entry(
         "provider",
         "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
         "api_mode", "transport", "model", "default_model", "models",
+        # Hand-written alias for ``models`` (gh-52266); merged in below.
+        "available_models",
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
         "discover_models", "extra_body", "extra_headers",
@@ -1399,36 +1436,17 @@ def _normalize_custom_provider_entry(
     if isinstance(model_name, str) and model_name.strip():
         normalized["model"] = model_name.strip()
 
-    models = entry.get("models")
-    if isinstance(models, dict) and models:
-        # Shallow-copy: `entry` may alias a cached config sub-dict, and the
-        # normalized entry escapes into long-lived runtime state
-        # (agent._custom_providers) — don't share the cached models mapping.
-        normalized["models"] = dict(models)
-    elif isinstance(models, list) and models:
-        # Hand-edited configs (and older Hermes versions) may write
-        # ``models`` as a plain list of ids or as ``[{id: ...}]`` rows.
-        # Preserve both by converting to the dict shape downstream code
-        # expects; otherwise normalize silently drops the list and /model
-        # shows the provider with (0) models.
-        normalized_models: Dict[str, Any] = {}
-        for item in models:
-            if isinstance(item, str) and item.strip():
-                normalized_models[item.strip()] = {}
-                continue
-            if not isinstance(item, dict):
-                continue
-            model_id = item.get("id")
-            if not isinstance(model_id, str) or not model_id.strip():
-                model_id = item.get("name")
-            if not isinstance(model_id, str) or not model_id.strip():
-                continue
-            model_meta = {
-                k: v for k, v in item.items() if k not in {"id", "name"}
-            }
-            normalized_models[model_id.strip()] = model_meta
-        if normalized_models:
-            normalized["models"] = normalized_models
+    # ``models`` is the canonical declaration key, but hand-written configs
+    # also use ``available_models`` (gh-52266). That alias previously fell
+    # through to the unknown-key warning and was dropped, leaving the
+    # provider with (0) models: the picker showed nothing and every
+    # ``/model <id>`` for that provider failed to resolve. Merge both, with
+    # ``models`` metadata winning for ids declared in each.
+    merged_models: Dict[str, Any] = {}
+    for models_key in ("available_models", "models"):
+        merged_models.update(_declared_models_to_mapping(entry.get(models_key)))
+    if merged_models:
+        normalized["models"] = merged_models
 
     context_length = entry.get("context_length")
     if isinstance(context_length, int) and context_length > 0:

--- a/tests/hermes_cli/test_custom_provider_available_models.py
+++ b/tests/hermes_cli/test_custom_provider_available_models.py
@@ -1,0 +1,87 @@
+"""Regression (gh-52266): ``available_models`` must declare provider models.
+
+Hand-written custom-provider configs use ``available_models`` where Hermes'
+own writer emits ``models``. The normalizer previously knew only ``models``,
+so the alias hit the unknown-key warning and was dropped — leaving the entry
+with no ``models`` at all. Downstream that means the picker lists the
+provider with (0) models and every ``/model <id>`` against it fails to
+resolve, because the routing paths all read the normalized ``models`` key.
+"""
+
+import copy
+
+from hermes_cli.config import _normalize_custom_provider_entry
+
+# The provider config from the issue report, verbatim in shape.
+_ISSUE_ENTRY = {
+    "name": "tokenplan",
+    "api_mode": "chat_completions",
+    "base_url": "https://token-plan.example/compatible-mode/v1",
+    "model": "qwen3.7-plus",
+    "available_models": [
+        "qwen3.7-plus",
+        "qwen3.7-max",
+        "deepseek-v4-pro",
+        "deepseek-v4-flash",
+        "kimi-k2.7-code",
+        "glm-5.2",
+    ],
+}
+
+
+def test_available_models_list_declares_models():
+    out = _normalize_custom_provider_entry(_ISSUE_ENTRY, provider_key="tokenplan")
+    assert out is not None
+    assert sorted(out["models"]) == sorted(_ISSUE_ENTRY["available_models"])
+
+
+def test_available_models_accepts_id_rows():
+    entry = {
+        "name": "p",
+        "base_url": "https://x.example/v1",
+        "available_models": [{"id": "m-1", "context_length": 8}, {"name": "m-2"}],
+    }
+    out = _normalize_custom_provider_entry(entry, provider_key="p")
+    assert out is not None
+    assert out["models"] == {"m-1": {"context_length": 8}, "m-2": {}}
+
+
+def test_models_metadata_wins_over_available_models():
+    """Both keys may appear; the canonical ``models`` owns shared ids."""
+    entry = {
+        "name": "p",
+        "base_url": "https://x.example/v1",
+        "available_models": ["shared", "alias-only"],
+        "models": {"shared": {"context_length": 128}, "models-only": {}},
+    }
+    out = _normalize_custom_provider_entry(entry, provider_key="p")
+    assert out is not None
+    assert sorted(out["models"]) == ["alias-only", "models-only", "shared"]
+    assert out["models"]["shared"] == {"context_length": 128}
+
+
+def test_models_only_entry_is_unchanged():
+    entry = {
+        "name": "p",
+        "base_url": "https://x.example/v1",
+        "models": {"only": {"context_length": 4}},
+    }
+    out = _normalize_custom_provider_entry(entry, provider_key="p")
+    assert out is not None
+    assert out["models"] == {"only": {"context_length": 4}}
+
+
+def test_no_declaration_leaves_models_unset():
+    entry = {"name": "p", "base_url": "https://x.example/v1"}
+    out = _normalize_custom_provider_entry(entry, provider_key="p")
+    assert out is not None
+    assert "models" not in out
+
+
+def test_available_models_does_not_mutate_input():
+    """Entries alias the shared read-only config cache — see
+    test_custom_provider_normalize_no_mutate.py."""
+    entry = copy.deepcopy(_ISSUE_ENTRY)
+    snapshot = copy.deepcopy(entry)
+    _normalize_custom_provider_entry(entry, provider_key="tokenplan")
+    assert entry == snapshot


### PR DESCRIPTION
## What does this PR do?

Makes `available_models` a recognized model-declaration key for custom providers, so a provider that declares its models under that key is actually routable by `/model`.

**This PR has been re-scoped against current `main` — see "What changed" below.**

## Related Issue

Fixes #52266

## The bug on current `main`

`_normalize_custom_provider_entry()` (`hermes_cli/config.py`) is the single chokepoint every custom-provider path runs through. It recognized only `models`, so a hand-written entry like the one in #52266:

```yaml
custom_providers:
  - name: tokenplan
    api_mode: chat_completions
    base_url: https://token-plan.example/compatible-mode/v1
    model: qwen3.7-plus
    available_models: [qwen3.7-plus, qwen3.7-max, deepseek-v4-flash, ...]
```

normalizes to an entry with **no `models` key at all**, and emits:

```
providers.tokenplan: unknown config keys ignored: available_models
```

Every downstream consumer reads the normalized `models` key, so the provider lists **(0) models** in the picker and no `/model <id>` against it resolves.

## What changed since this PR was opened

The original version of this PR also added configured-provider colon parsing (`tokenplan:deepseek-v4-flash`, `custom:tokenplan:qwen3.7-max`). **That half is now fixed on `main`** by the "single-owner `/model` request parsing" consolidation in `model_switch.py` — all three forms from the issue parse cleanly there today, including the reported `ValueError: too many values to unpack (expected 3)`.

So this PR is re-scoped to the one thing still broken: the unrecognized declaration key. The diff is now one file plus tests, instead of the previous four-file change to `model_switch.py` and `config.py`.

Reviewers: the earlier approval predates this rework and no longer describes the current diff — fresh eyes welcome.

## Changes Made

- `hermes_cli/config.py`
  - Merge `available_models` and `models` in `_normalize_custom_provider_entry()`. Fixing it at the chokepoint means typed routing, the picker list, and validation fallback all pick it up without each learning the alias.
  - `models` metadata wins for ids declared under both keys.
  - Extract the list/mapping coercion into `_declared_models_to_mapping()` so the alias inherits the same `[{id: ...}]` row handling `models` already had, instead of duplicating it.
  - Add `available_models` to `_KNOWN_KEYS` so it no longer trips the unknown-key warning.
- `tests/hermes_cli/test_custom_provider_available_models.py` (new)
  - The issue's provider config verbatim; `[{id: ...}]` rows via the alias; `models`-wins-on-conflict; `models`-only entries unchanged; neither key leaves `models` unset; and a no-mutation check (entries alias the shared read-only config cache).

## How to Test

1. Configure a custom provider declaring models under `available_models` with hyphenated ids, as above.
2. Run `/model tokenplan:deepseek-v4-flash` (or `custom:tokenplan:qwen3.7-max`, or `/model deepseek-v4-flash --provider tokenplan`).
3. The switch resolves to `custom:tokenplan` and the requested model; the picker lists all declared models rather than (0).

Verified on this branch:

- `tests/hermes_cli/test_custom_provider_available_models.py` → **6 passed**
- `test_config_validation.py`, `test_custom_provider_normalize_no_mutate.py`, `test_custom_provider_extra_headers.py`, `test_provider_config_validation.py`, `test_runtime_provider_resolution.py`, `test_config.py` → **142 passed**
- `tests/hermes_cli/ -k "model_switch or picker or custom_provider or inventory"` → **218 passed**
- `ruff check` on both changed files → **passed**

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)
