### PR TITLE
fix(agent): classify provider memory-ceiling 400s as overloaded, not context_overflow

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -339,6 +339,84 @@ _REQUEST_VALIDATION_PATTERNS = [
     "unsupported_parameter",
 ]
 
+# Local-inference memory/resource-ceiling rejections (oMLX / MLX memory guard,
+# llama.cpp/vLLM OOM, Metal/CUDA allocation ceilings).  The server aborts on a
+# GPU/unified-memory PREFILL peak — NOT a context-window limit — yet the
+# rejection text often suggests "reduce context length" / "reduce context size"
+# as a remediation hint, which collides with _CONTEXT_OVERFLOW_PATTERNS.
+# Compressing conversation history cannot lower a prefill memory peak (the
+# conversation is typically far below the window), so routing these into the
+# compress-and-shrink loop burns max_compression_attempts, re-hits the wedged
+# server with each compression call, and ends in "Cannot compress further" →
+# destructive session reset.  These tokens reference memory/allocation/ceiling/
+# guard wording exclusively (never a token or window count), so they are
+# disjoint from genuine context-window-overflow language.  Must be checked
+# BEFORE context_overflow at every classification site.  See issue #52261.
+_MEMORY_CEILING_PATTERNS = [
+    "memory guard",                      # "prefill memory guard rejected"
+    "memory limit exceeded",             # "process memory limit exceeded"
+    "memory_guard_tier",                 # "lower memory_guard_tier"
+    "dynamic ceiling",                   # "dynamic ceiling is 13.50 GB"
+    "memory ceiling",
+    "available memory",                  # "too large for available memory"
+    "out of memory",
+    "insufficient memory",
+    "prefill would require",             # "Prefill would require ~13.87 GB peak"
+]
+
+# Structured error codes that unambiguously identify a local-inference memory/
+# resource-ceiling rejection at the source — before an OpenAI-compatible proxy
+# (LiteLLM) flattens the body and drops the code, and independent of message
+# wording (which can be reworded by the provider or the proxy).  oMLX returns
+# ``code: "prefill_memory_exceeded"`` (mirrored in ``omlx_code``) with
+# ``limit_bytes`` in *bytes* — definitively memory, not a token/window count.
+# Deliberately NARROW: only memory-prefill codes, never ``resource_exhausted``
+# (already mapped to rate_limit) or generic ``invalid_request_error``.
+# See issue #52261.
+_MEMORY_CEILING_ERROR_CODES = frozenset({
+    "prefill_memory_exceeded",
+    "omlx_prefill_memory_exceeded",
+    "memory_limit_exceeded",
+})
+
+
+def _is_memory_ceiling(error_msg: str, error_code: str = "") -> bool:
+    """True when the body identifies a local-inference memory/resource ceiling.
+
+    Single detection predicate for every classification site (400, 500/502,
+    503/529, structured code, status-less message).  The structured code is
+    matched in ADDITION to the message patterns so a direct (non-proxied)
+    connection whose body carries ``code: "prefill_memory_exceeded"`` is caught
+    even when the message has been reworded and contains no memory substring;
+    a LiteLLM proxy strips the code, so the message patterns remain the
+    fallback there.  See issue #52261.
+    """
+    return (
+        (error_code or "").lower() in _MEMORY_CEILING_ERROR_CODES
+        or any(p in error_msg for p in _MEMORY_CEILING_PATTERNS)
+    )
+
+
+def _memory_ceiling_result(result_fn) -> ClassifiedError:
+    """The single recovery contract for a memory-ceiling rejection.
+
+    Transient server-side capacity condition: retry with backoff, NO
+    compression (it cannot relieve a prefill memory peak), NO session reset.
+    ``should_fallback`` is set because a local-inference memory wall stays
+    wedged until the server is restarted, so the durable recovery is failing
+    over to a roomier provider once the primary's retries are exhausted.
+
+    Centralised so the annotation cannot drift between detection routes — the
+    same rejection must classify identically whether it arrives as a 400, as a
+    5xx, as a structured code, or as a status-less streaming message.
+    """
+    return result_fn(
+        FailoverReason.overloaded,
+        retryable=True,
+        should_fallback=True,
+    )
+
+
 # OpenRouter aggregator policy-block patterns.
 #
 # When a user's OpenRouter account privacy setting (or a per-request
@@ -1089,6 +1167,13 @@ def _classify_by_status(
                 retryable=False,
                 should_fallback=True,
             )
+        # Memory-ceiling rejection surfaced as a 5xx: the same local-inference
+        # servers that report overflow-as-500 below also report OOM/prefill
+        # aborts as 500/502, and their bodies carry the same "reduce context
+        # length" remediation hint.  Must precede the overflow check for the
+        # reason documented at _MEMORY_CEILING_PATTERNS.  See issue #52261.
+        if _is_memory_ceiling(error_msg, error_code):
+            return _memory_ceiling_result(result_fn)
         # Some local inference servers (notably llama.cpp / llama-server)
         # report context overflow with an HTTP 500 instead of the standard
         # 400/413. The request-validation guard above already ran, so any
@@ -1112,6 +1197,13 @@ def _classify_by_status(
         return result_fn(FailoverReason.server_error, retryable=True)
 
     if status_code in {503, 529}:
+        # Memory-ceiling guard, same as the 500/502 branch above.  This status
+        # pair is the likeliest 5xx home for a memory abort — the overflow
+        # comment below already names "model-load OOM" as a source — and the
+        # bare `overloaded` fallthrough would otherwise be reached only when
+        # the body happens to omit context wording.  See issue #52261.
+        if _is_memory_ceiling(error_msg, error_code):
+            return _memory_ceiling_result(result_fn)
         # Same overflow-as-5xx variant (server busy / model-load OOM, or a
         # Cloudflare/Tailscale hop relabeling the status). Route explicit
         # overflow bodies into compression; otherwise treat as transient
@@ -1281,6 +1373,16 @@ def _classify_400(
             should_compress=False,
         )
 
+    # Local-inference memory/resource-ceiling rejection (oMLX/MLX memory guard,
+    # OOM).  Checked BEFORE context_overflow: the prompt is often tiny and the
+    # remediation hint ("reduce context length"/"reduce context size") collides
+    # with the overflow patterns, but compressing history cannot relieve a
+    # prefill memory peak — routing it into compression wedges the session into
+    # a "Cannot compress further" reset loop.  Without overflow wording it would
+    # instead fall through to a non-retryable ``format_error``.  See #52261.
+    if _is_memory_ceiling(error_msg, error_code_lower):
+        return _memory_ceiling_result(result_fn)
+
     # Context overflow from 400
     if any(p in error_msg for p in _CONTEXT_OVERFLOW_PATTERNS):
         return result_fn(
@@ -1361,6 +1463,15 @@ def _classify_by_error_code(
     """Classify by structured error codes from the response body."""
     code_lower = error_code.lower()
 
+    # Local-inference memory-ceiling code (oMLX ``prefill_memory_exceeded`` and
+    # kin).  The structured code survives provider message rewording and is the
+    # only signal on a direct (non-proxied) connection whose message carries no
+    # memory substring.  Routed through the shared contract so a status-less
+    # code-only rejection is annotated exactly like the 400/5xx/message paths.
+    # See issue #52261.
+    if code_lower in _MEMORY_CEILING_ERROR_CODES:
+        return _memory_ceiling_result(result_fn)
+
     if code_lower in {"resource_exhausted", "throttled", "rate_limit_exceeded"}:
         return result_fn(
             FailoverReason.rate_limit,
@@ -1433,6 +1544,21 @@ def _classify_by_message(
             FailoverReason.image_too_large,
             retryable=True,
         )
+
+    # Local-inference memory/resource-ceiling rejection without an HTTP status
+    # (streaming / no-status APIError, e.g. "process memory limit exceeded" or
+    # "Prefill context too large for available memory").  Checked BEFORE the
+    # usage-limit/billing/rate-limit patterns below — NOT just before
+    # context_overflow — because oMLX's streaming memory abort
+    # ("Request aborted: process memory limit exceeded …") contains the
+    # substring "limit exceeded", which is a _USAGE_LIMIT_PATTERN.  With no
+    # transient signal it would disambiguate to billing (non-retryable, rotate
+    # credential) below — a different wrong bucket than context_overflow — so
+    # the memory guard must run first.  Compressing or rotating credentials
+    # cannot relieve a prefill memory peak; the correct recovery is the
+    # transient ``overloaded`` path (retry, no compression).  See issue #52261.
+    if _is_memory_ceiling(error_msg):
+        return _memory_ceiling_result(result_fn)
 
     # Usage-limit patterns need the same disambiguation as 402: some providers
     # surface "usage limit" errors without an HTTP status code.  A transient

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -510,6 +510,82 @@ def _is_server_injected_param_rejection(error_msg: str, provider: str) -> bool:
             return False
         return True
     return False
+# Local-inference memory/resource-ceiling rejections (oMLX / MLX memory guard,
+# llama.cpp/vLLM OOM, Metal/CUDA allocation ceilings).  The server aborts on a
+# GPU/unified-memory PREFILL peak — NOT a context-window limit — yet the
+# rejection text often suggests "reduce context length" / "reduce context size"
+# as a remediation hint, which collides with _CONTEXT_OVERFLOW_PATTERNS.
+# Compressing conversation history cannot lower a prefill memory peak (the
+# conversation is typically far below the window), so routing these into the
+# compress-and-shrink loop burns max_compression_attempts, re-hits the wedged
+# server with each compression call, and ends in "Cannot compress further" →
+# destructive session reset.  These tokens reference memory/allocation/ceiling/
+# guard wording exclusively (never a token or window count), so they are
+# disjoint from genuine context-window-overflow language.  Must be checked
+# BEFORE context_overflow at every classification site.  See issue #52261.
+_MEMORY_CEILING_PATTERNS = [
+    "memory guard",                      # "prefill memory guard rejected"
+    "memory limit exceeded",             # "process memory limit exceeded"
+    "memory_guard_tier",                 # "lower memory_guard_tier"
+    "dynamic ceiling",                   # "dynamic ceiling is 13.50 GB"
+    "memory ceiling",
+    "available memory",                  # "too large for available memory"
+    "out of memory",
+    "insufficient memory",
+    "prefill would require",             # "Prefill would require ~13.87 GB peak"
+]
+
+# Structured error codes that unambiguously identify a local-inference memory/
+# resource-ceiling rejection at the source — before an OpenAI-compatible proxy
+# (LiteLLM) flattens the body and drops the code, and independent of message
+# wording (which can be reworded by the provider or the proxy).  oMLX returns
+# ``code: "prefill_memory_exceeded"`` (mirrored in ``omlx_code``) with
+# ``limit_bytes`` in *bytes* — definitively memory, not a token/window count.
+# Deliberately NARROW: only memory-prefill codes, never ``resource_exhausted``
+# (already mapped to rate_limit) or generic ``invalid_request_error``.
+# See issue #52261.
+_MEMORY_CEILING_ERROR_CODES = frozenset({
+    "prefill_memory_exceeded",
+    "omlx_prefill_memory_exceeded",
+    "memory_limit_exceeded",
+})
+
+
+def _is_memory_ceiling(error_msg: str, error_code: str = "") -> bool:
+    """True when the body identifies a local-inference memory/resource ceiling.
+
+    Single detection predicate for every classification site (400, 500/502,
+    503/529, structured code, status-less message).  The structured code is
+    matched in ADDITION to the message patterns so a direct (non-proxied)
+    connection whose body carries ``code: "prefill_memory_exceeded"`` is caught
+    even when the message has been reworded and contains no memory substring;
+    a LiteLLM proxy strips the code, so the message patterns remain the
+    fallback there.  See issue #52261.
+    """
+    return (
+        (error_code or "").lower() in _MEMORY_CEILING_ERROR_CODES
+        or any(p in error_msg for p in _MEMORY_CEILING_PATTERNS)
+    )
+
+
+def _memory_ceiling_result(result_fn) -> ClassifiedError:
+    """The single recovery contract for a memory-ceiling rejection.
+
+    Transient server-side capacity condition: retry with backoff, NO
+    compression (it cannot relieve a prefill memory peak), NO session reset.
+    ``should_fallback`` is set because a local-inference memory wall stays
+    wedged until the server is restarted, so the durable recovery is failing
+    over to a roomier provider once the primary's retries are exhausted.
+
+    Centralised so the annotation cannot drift between detection routes — the
+    same rejection must classify identically whether it arrives as a 400, as a
+    5xx, as a structured code, or as a status-less streaming message.
+    """
+    return result_fn(
+        FailoverReason.overloaded,
+        retryable=True,
+        should_fallback=True,
+    )
 
 
 # OpenRouter aggregator policy-block patterns.
@@ -1378,6 +1454,13 @@ def _classify_by_status(
                 retryable=False,
                 should_fallback=True,
             )
+        # Memory-ceiling rejection surfaced as a 5xx: the same local-inference
+        # servers that report overflow-as-500 below also report OOM/prefill
+        # aborts as 500/502, and their bodies carry the same "reduce context
+        # length" remediation hint.  Must precede the overflow check for the
+        # reason documented at _MEMORY_CEILING_PATTERNS.  See issue #52261.
+        if _is_memory_ceiling(error_msg, error_code):
+            return _memory_ceiling_result(result_fn)
         # Some local inference servers (notably llama.cpp / llama-server)
         # report context overflow with an HTTP 500 instead of the standard
         # 400/413. The request-validation guard above already ran, so any
@@ -1401,6 +1484,13 @@ def _classify_by_status(
         return result_fn(FailoverReason.server_error, retryable=True)
 
     if status_code in {503, 529}:
+        # Memory-ceiling guard, same as the 500/502 branch above.  This status
+        # pair is the likeliest 5xx home for a memory abort — the overflow
+        # comment below already names "model-load OOM" as a source — and the
+        # bare `overloaded` fallthrough would otherwise be reached only when
+        # the body happens to omit context wording.  See issue #52261.
+        if _is_memory_ceiling(error_msg, error_code):
+            return _memory_ceiling_result(result_fn)
         # Same overflow-as-5xx variant (server busy / model-load OOM, or a
         # Cloudflare/Tailscale hop relabeling the status). Route explicit
         # overflow bodies into compression; otherwise treat as transient
@@ -1616,6 +1706,16 @@ def _classify_400(
             should_compress=False,
         )
 
+    # Local-inference memory/resource-ceiling rejection (oMLX/MLX memory guard,
+    # OOM).  Checked BEFORE context_overflow: the prompt is often tiny and the
+    # remediation hint ("reduce context length"/"reduce context size") collides
+    # with the overflow patterns, but compressing history cannot relieve a
+    # prefill memory peak — routing it into compression wedges the session into
+    # a "Cannot compress further" reset loop.  Without overflow wording it would
+    # instead fall through to a non-retryable ``format_error``.  See #52261.
+    if _is_memory_ceiling(error_msg, error_code_lower):
+        return _memory_ceiling_result(result_fn)
+
     # Context overflow from 400
     if any(p in error_msg for p in _CONTEXT_OVERFLOW_PATTERNS):
         return result_fn(
@@ -1726,6 +1826,15 @@ def _classify_by_error_code(
             should_fallback=True,
         )
 
+    # Local-inference memory-ceiling code (oMLX ``prefill_memory_exceeded`` and
+    # kin).  The structured code survives provider message rewording and is the
+    # only signal on a direct (non-proxied) connection whose message carries no
+    # memory substring.  Routed through the shared contract so a status-less
+    # code-only rejection is annotated exactly like the 400/5xx/message paths.
+    # See issue #52261.
+    if code_lower in _MEMORY_CEILING_ERROR_CODES:
+        return _memory_ceiling_result(result_fn)
+
     if code_lower in {"resource_exhausted", "throttled", "rate_limit_exceeded"}:
         return result_fn(
             FailoverReason.rate_limit,
@@ -1798,6 +1907,21 @@ def _classify_by_message(
             FailoverReason.image_too_large,
             retryable=True,
         )
+
+    # Local-inference memory/resource-ceiling rejection without an HTTP status
+    # (streaming / no-status APIError, e.g. "process memory limit exceeded" or
+    # "Prefill context too large for available memory").  Checked BEFORE the
+    # usage-limit/billing/rate-limit patterns below — NOT just before
+    # context_overflow — because oMLX's streaming memory abort
+    # ("Request aborted: process memory limit exceeded …") contains the
+    # substring "limit exceeded", which is a _USAGE_LIMIT_PATTERN.  With no
+    # transient signal it would disambiguate to billing (non-retryable, rotate
+    # credential) below — a different wrong bucket than context_overflow — so
+    # the memory guard must run first.  Compressing or rotating credentials
+    # cannot relieve a prefill memory peak; the correct recovery is the
+    # transient ``overloaded`` path (retry, no compression).  See issue #52261.
+    if _is_memory_ceiling(error_msg):
+        return _memory_ceiling_result(result_fn)
 
     # Usage-limit patterns need the same disambiguation as 402: some providers
     # surface "usage limit" errors without an HTTP status code.  A transient

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -526,6 +526,17 @@ def _is_server_injected_param_rejection(error_msg: str, provider: str) -> bool:
 _MEMORY_CEILING_PATTERNS = [
     "memory guard",                      # "prefill memory guard rejected"
     "memory limit exceeded",             # "process memory limit exceeded"
+    # Neither of the next two is load-bearing, and the list must not be pruned
+    # down to them.  oMLX builds the remediation tail from
+    # ``describe_ceiling_binding()``, whose branches vary BOTH: the noun before
+    # "ceiling" is "ceiling" / "static ceiling" / "dynamic ceiling" /
+    # "metal_cap ceiling" depending on which cap binds (and ties slash-join, so
+    # "static/metal_cap ceiling" is reachable), and "memory_guard_tier" is named
+    # in only some branches — the dynamic+custom branch says "Raise
+    # custom_ceiling_bytes in admin Memory settings" and the metal_cap branch
+    # says "Raise kernel iogpu.wired_limit_mb in Terminal" instead.  Nothing is
+    # left unguarded, because "memory limit exceeded" sits in the message PREFIX
+    # and survives every branch; these two just widen the net.
     "memory_guard_tier",                 # "lower memory_guard_tier"
     "dynamic ceiling",                   # "dynamic ceiling is 13.50 GB"
     "memory ceiling",
@@ -556,16 +567,27 @@ _MEMORY_CEILING_PATTERNS = [
 # ``limit_bytes`` in *bytes* — definitively memory, not a token/window count.
 # Deliberately NARROW: only memory-prefill codes, never ``resource_exhausted``
 # (already mapped to rate_limit) or generic ``invalid_request_error``.
-# See issue #52261.
+#
 # ``prefill_memory_aborted`` is the SIBLING of ``prefill_memory_exceeded``:
 # oMLX's prefill-memory body builder picks between the two by exception type
 # (``PrefillMemoryAbortedError`` vs the rejection), so "exceeded" is the prompt
 # turned away at admission and "aborted" is the prompt admitted and then killed
-# mid-prefill.  Same guard, same wall, same recovery — but only one of them was
-# in this set.  Today's aborted body still says "memory guard" and "available
-# memory", so it classifies correctly through the message patterns; the code
-# layer is the one that would not hold, which is the layer that exists
-# precisely for a reworded or proxy-stripped body.
+# mid-prefill.  Same guard, same wall, same recovery.  Today's aborted body
+# still says "memory guard" and "available memory", so it classifies correctly
+# through the message patterns; the code layer is the one that would not hold,
+# which is the layer that exists precisely for a reworded or proxy-stripped
+# body.
+#
+# ``omlx_prefill_memory_exceeded`` has NO KNOWN PRODUCER.  ``omlx_code`` is a
+# mirror of ``code`` rather than a prefixed variant, so the engine emits the
+# unprefixed spelling in both fields (the captured bodies in the tests show
+# exactly that), and this entry has never matched anything observed.  It is
+# retained rather than dropped because it cannot false-positive — no other
+# vendor will emit a string this specific — and because a namespacing proxy or
+# a later engine release is the obvious way it would start appearing.  Do not
+# read it as evidence that such a body exists.
+#
+# See issue #52261.
 _MEMORY_CEILING_ERROR_CODES = frozenset({
     "prefill_memory_exceeded",
     "prefill_memory_aborted",

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -557,8 +557,18 @@ _MEMORY_CEILING_PATTERNS = [
 # Deliberately NARROW: only memory-prefill codes, never ``resource_exhausted``
 # (already mapped to rate_limit) or generic ``invalid_request_error``.
 # See issue #52261.
+# ``prefill_memory_aborted`` is the SIBLING of ``prefill_memory_exceeded``:
+# oMLX's prefill-memory body builder picks between the two by exception type
+# (``PrefillMemoryAbortedError`` vs the rejection), so "exceeded" is the prompt
+# turned away at admission and "aborted" is the prompt admitted and then killed
+# mid-prefill.  Same guard, same wall, same recovery — but only one of them was
+# in this set.  Today's aborted body still says "memory guard" and "available
+# memory", so it classifies correctly through the message patterns; the code
+# layer is the one that would not hold, which is the layer that exists
+# precisely for a reworded or proxy-stripped body.
 _MEMORY_CEILING_ERROR_CODES = frozenset({
     "prefill_memory_exceeded",
+    "prefill_memory_aborted",
     "omlx_prefill_memory_exceeded",
     "memory_limit_exceeded",
 })

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1522,6 +1522,25 @@ def _classify_by_status(
             )
         return result_fn(FailoverReason.overloaded, retryable=True)
 
+    # 507 Insufficient Storage — the local-inference model-LOAD path, which is
+    # a different guard from the prefill path above and does not arrive as a
+    # 400 or as a 500/503.  oMLX maps both ``ModelTooLargeError`` and
+    # ``InsufficientMemoryError`` to 507, and ``/v1/chat/completions``,
+    # ``/v1/completions`` and ``/v1/messages`` all reach them through
+    # ``get_engine_for_model`` → ``get_engine``, so an ordinary chat call can
+    # come back as "Model 'X' (33.95GB) does not fit under the dynamic memory
+    # ceiling (25.22GB) … raise memory_guard_tier".  Without this check the
+    # body falls to the generic "other 5xx" bucket below, which does retry but
+    # leaves ``should_fallback`` unset — and a model that does not fit under
+    # the host's memory ceiling does not start fitting within the retry
+    # budget, so the turn is stranded on the wedged host instead of failing
+    # over to a roomier provider.  That gap is exactly what
+    # _memory_ceiling_result exists to close.  Gated on the shared predicate,
+    # so a 507 with no memory wording (a real disk/storage exhaustion) keeps
+    # the generic 5xx treatment.  See issue #52261.
+    if status_code == 507 and _is_memory_ceiling(error_msg, error_code):
+        return _memory_ceiling_result(result_fn)
+
     # 408 Request Timeout — a transient timing failure the server itself flags
     # as safe to retry (RFC 9110 §15.5.9), not a malformed request. Commonly
     # emitted by reverse proxies sitting in front of self-hosted backends

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -532,7 +532,20 @@ _MEMORY_CEILING_PATTERNS = [
     "available memory",                  # "too large for available memory"
     "out of memory",
     "insufficient memory",
+    # Memory-accounting wording.  "prefill would require" was written against
+    # the oMLX build that reports "Prefill would require ~13.87 GB peak"; 0.5.7
+    # reworded the same sentence to "predicted peak would require ~78.57 GB"
+    # (pre-stream) and "predicted peak would exceed prefill safety cap 77.8GB"
+    # (mid-stream), so that entry silently stopped covering the release it was
+    # written for.  Both entries are kept — the older wording is still in the
+    # field — and the cap names below are added because they survive the verb
+    # change and appear in both 0.5.7 exits.  All of these name an allocation
+    # ceiling in BYTES, never a token or window count, so they remain disjoint
+    # from _CONTEXT_OVERFLOW_PATTERNS.
     "prefill would require",             # "Prefill would require ~13.87 GB peak"
+    "predicted peak would",              # "predicted peak would require/exceed"
+    "prefill safety cap",                # "prefill safety cap is 77.76 GB"
+    "metal_cap",                         # "90% of metal_cap ceiling 86.40 GB"
 ]
 
 # Structured error codes that unambiguously identify a local-inference memory/

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1562,6 +1562,25 @@ def _classify_by_status(
     if status_code == 408:
         return result_fn(FailoverReason.timeout, retryable=True)
 
+    # 409 Conflict carrying memory-ceiling wording.  oMLX raises
+    # ``ModelLoadingError`` with "Model 'X' load aborted: process memory limit
+    # exceeded" and ``server.py`` maps it to 409, which reaches the generic
+    # "other 4xx" bucket below and is reported as ``format_error``,
+    # retryable=False — a transient memory abort called a malformed request.
+    # ``should_fallback`` is already set there so the turn is not stranded, but
+    # it is never retried against the primary either, even though the abort
+    # clears as soon as the host reclaims memory.
+    #
+    # UNLIKE the 507 branch above, this one is read from the engine's source,
+    # not from a captured response: no reporter has produced a 409 body.  It is
+    # included because it is the same guard and the same wall as the shapes
+    # that ARE captured, and because the predicate gate makes it inert
+    # otherwise — a 409 without memory wording (a genuine state conflict, e.g.
+    # a model swap already in progress) keeps the existing 4xx treatment.
+    # See issue #52261.
+    if status_code == 409 and _is_memory_ceiling(error_msg, error_code):
+        return _memory_ceiling_result(result_fn)
+
     # Other 4xx — non-retryable
     if 400 <= status_code < 500:
         return result_fn(

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -771,6 +771,276 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.format_error
         assert result.should_compress is False
 
+    # ── Local-inference memory/resource-ceiling 400s (issue #52261) ──
+    # A provider memory-guard / OOM rejection often suggests "reduce context
+    # length", colliding with the context-overflow patterns.  Compressing
+    # history cannot relieve a prefill memory peak, so these must classify as
+    # transient ``overloaded`` (retry, no compression) — NOT context_overflow.
+
+    def test_400_omlx_prefill_memory_guard_is_overloaded_not_context_overflow(self):
+        # Verbatim oMLX memory-guard rejection on a TINY (~5.7k-token) prompt.
+        e = MockAPIError(
+            "oMLX prefill memory guard rejected this prompt: Prefill would "
+            "require ~13.87 GB peak (current 13.46 GB + KV+SDPA 419.28 MB) but "
+            "dynamic ceiling is 13.50 GB. ... or reduce context length.",
+            status_code=400,
+        )
+        result = classify_api_error(
+            e, provider="custom", model="omlx-chat",
+            approx_tokens=5700, context_length=64000,
+        )
+        assert result.reason == FailoverReason.overloaded
+        # Must NOT enter the compress-and-shrink loop.
+        assert result.should_compress is False
+
+    def test_400_process_memory_limit_exceeded_is_overloaded(self):
+        e = MockAPIError(
+            "Request aborted: process memory limit exceeded (usage 13.7 GB, "
+            "ceiling 13.5 GB). Reduce context size or lower memory_guard_tier.",
+            status_code=400,
+        )
+        result = classify_api_error(
+            e, provider="custom", model="omlx-chat",
+            approx_tokens=5745, context_length=64000,
+        )
+        assert result.reason == FailoverReason.overloaded
+        assert result.should_compress is False
+
+    def test_no_status_prefill_too_large_for_available_memory_is_overloaded(self):
+        # Streaming / no-status path: APIError text, no HTTP code.
+        e = Exception("Prefill context too large for available memory")
+        result = classify_api_error(
+            e, provider="custom", model="omlx-chat",
+            approx_tokens=15000, context_length=64000,
+        )
+        assert result.reason == FailoverReason.overloaded
+        assert result.should_compress is False
+
+    def test_400_genuine_context_window_overflow_still_compresses(self):
+        # NEGATIVE/invariant guard: a real window overflow must STILL route to
+        # context_overflow + compression (proves the memory guard is precise
+        # and does not swallow genuine "reduce the length" overflows).
+        e = MockAPIError(
+            "This model's maximum context length is 8192 tokens; "
+            "reduce the length of the messages.",
+            status_code=400,
+        )
+        result = classify_api_error(
+            e, provider="custom", model="x",
+            approx_tokens=9000, context_length=8192,
+        )
+        assert result.reason == FailoverReason.context_overflow
+        assert result.should_compress is True
+
+    def test_streaming_process_memory_limit_exceeded_is_overloaded_not_billing(self):
+        # Status-LESS streaming abort (oMLX emits this on the streaming path
+        # under memory pressure).  "process memory limit exceeded" contains the
+        # substring "limit exceeded", a _USAGE_LIMIT_PATTERN — so before the
+        # memory guard was moved ahead of the billing/usage checks in
+        # _classify_by_message, this misclassified as BILLING (retryable=False,
+        # rotate-credential), a different wrong bucket than context_overflow.
+        e = Exception(
+            "Request aborted: process memory limit exceeded (usage 13.7 GB, "
+            "ceiling 13.5 GB). Reduce context size or lower memory_guard_tier."
+        )
+        result = classify_api_error(
+            e, provider="custom", model="omlx-chat",
+            approx_tokens=5745, context_length=64000,
+        )
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+        assert result.should_compress is False
+        # Must NOT be routed into credential rotation like a billing error.
+        assert result.should_rotate_credential is False
+        # Failover-eligible: a wedged local memory wall recovers via a roomier
+        # provider once retries are exhausted, not by hammering the same server.
+        assert result.should_fallback is True
+
+    def test_400_prefill_memory_code_reworded_message_is_overloaded(self):
+        # Direct (non-proxied) connection: the message is reworded with NO
+        # memory substring, but the structured body carries the unambiguous
+        # ``code: "prefill_memory_exceeded"`` (+ limit_bytes in *bytes*).
+        # Without the error-code guard this fell through to a non-retryable
+        # ``format_error`` (no overflow wording to catch it either).
+        body = {"error": {
+            "message": "Prompt rejected by the prefill guard. Try a smaller request.",
+            "type": "invalid_request_error",
+            "code": "prefill_memory_exceeded",
+            "omlx_code": "prefill_memory_exceeded",
+            "limit_bytes": 14495514624,
+        }, "type": "error"}
+        e = MockAPIError(
+            "Prompt rejected by the prefill guard. Try a smaller request.",
+            status_code=400, body=body,
+        )
+        result = classify_api_error(
+            e, provider="custom", model="omlx-chat",
+            approx_tokens=5700, context_length=64000,
+        )
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+        assert result.should_compress is False
+        assert result.should_fallback is True
+
+    def test_no_status_prefill_memory_code_is_overloaded(self):
+        # Streaming / no-status path carrying only the structured code (message
+        # fully reworded).  Previously fell to the retryable ``unknown`` bucket;
+        # the _classify_by_error_code memory-code guard now catches it.
+        body = {"error": {
+            "message": "Prompt rejected by the prefill guard. Try a smaller request.",
+            "code": "prefill_memory_exceeded",
+            "limit_bytes": 14495514624,
+        }, "type": "error"}
+        e = MockAPIError(
+            "Prompt rejected by the prefill guard. Try a smaller request.",
+            status_code=None, body=body,
+        )
+        result = classify_api_error(
+            e, provider="custom", model="omlx-chat",
+            approx_tokens=5700, context_length=64000,
+        )
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+        assert result.should_compress is False
+        # Same rejection, detected via the structured code instead of the
+        # message: the recovery annotation must be identical to the 400 and
+        # message-pattern paths, not silently weaker.  Guards the shared
+        # _memory_ceiling_result contract against per-route drift.
+        assert result.should_fallback is True
+
+    def test_400_litellm_proxy_flattened_memory_guard_is_overloaded(self):
+        # Proxy-flattened transport shape (real oMLX-behind-LiteLLM capture from
+        # issue #52261): LiteLLM collapses the structured body into a single
+        # "OpenAIException - <message>" string and DROPS the ``code``, so the
+        # error-code guard cannot fire — only the message substring survives.
+        # On clean main this 400 matched the bare "reduce context length"
+        # overflow pattern and misclassified as context_overflow (→ compress →
+        # wedge-loop reset).  The message-pattern memory guard ("memory guard",
+        # "dynamic ceiling", "prefill would require") must catch it even with no
+        # status code or structured code to lean on.
+        e = MockAPIError(
+            "litellm.BadRequestError: OpenAIException - oMLX prefill memory "
+            "guard rejected this prompt: Prefill would require ~13.87 GB peak "
+            "(current 13.46 GB + KV+SDPA 419.28 MB) but dynamic ceiling is "
+            "13.50 GB. Raise custom_ceiling_bytes in admin Memory settings, or "
+            "reduce context length.",
+            status_code=400,
+        )
+        result = classify_api_error(
+            e, provider="custom", model="omlx-chat",
+            approx_tokens=5700, context_length=64000,
+        )
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+        # Must NOT enter the compress-and-shrink loop a context_overflow would.
+        assert result.should_compress is False
+        assert result.should_fallback is True
+
+    # ── Memory-ceiling rejections surfaced as 5xx (issue #52261) ──
+    # main routes explicit context-overflow wording in a 500/502/503/529 body
+    # into compression (llama.cpp/vLLM report overflow-as-5xx).  A memory abort
+    # from those same servers carries the same "reduce context length" hint, so
+    # without a guard it reaches the identical wedge-loop these tests exist to
+    # prevent — the 400 fix alone does not cover it.
+
+    @pytest.mark.parametrize("status_code", [500, 502, 503, 529])
+    def test_5xx_memory_guard_is_overloaded_not_context_overflow(self, status_code):
+        # Body carries BOTH memory wording and the colliding "reduce context
+        # length" hint.  Fails before the 5xx guard: matches
+        # _CONTEXT_OVERFLOW_PATTERNS → context_overflow + should_compress=True.
+        e = MockAPIError(
+            "oMLX prefill memory guard rejected this prompt: Prefill would "
+            "require ~13.87 GB peak but dynamic ceiling is 13.50 GB. Raise "
+            "custom_ceiling_bytes in admin Memory settings, or reduce "
+            "context length.",
+            status_code=status_code,
+        )
+        result = classify_api_error(
+            e, provider="custom", model="omlx-chat",
+            approx_tokens=5700, context_length=64000,
+        )
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+        # The whole point: compressing history cannot lower a prefill peak.
+        assert result.should_compress is False
+        # Same contract as the 400 / code / message routes.
+        assert result.should_fallback is True
+
+    @pytest.mark.parametrize("status_code", [500, 502, 503, 529])
+    def test_5xx_memory_code_reworded_message_is_overloaded(self, status_code):
+        # Direct (non-proxied) 5xx whose message was reworded to carry no memory
+        # substring — only the structured code identifies it.
+        body = {"error": {
+            "message": "Prompt rejected by the prefill guard.",
+            "code": "prefill_memory_exceeded",
+            "limit_bytes": 14495514624,
+        }, "type": "error"}
+        e = MockAPIError(
+            "Prompt rejected by the prefill guard.",
+            status_code=status_code, body=body,
+        )
+        result = classify_api_error(
+            e, provider="custom", model="omlx-chat",
+            approx_tokens=5700, context_length=64000,
+        )
+        assert result.reason == FailoverReason.overloaded
+        assert result.should_compress is False
+        assert result.should_fallback is True
+
+    @pytest.mark.parametrize("status_code", [500, 502, 503, 529])
+    def test_5xx_genuine_context_overflow_still_compresses(self, status_code):
+        # CONTROL for the guard above: a real overflow body (no memory wording)
+        # must STILL take the compression path main added.  Proves the memory
+        # guard is narrow and did not disable overflow-as-5xx handling.
+        e = MockAPIError(
+            "the request exceeds the available context size. try increasing "
+            "the context size or enable context shift",
+            status_code=status_code,
+        )
+        result = classify_api_error(
+            e, provider="custom", model="local-llama",
+            approx_tokens=150000, context_length=64000,
+        )
+        assert result.reason == FailoverReason.context_overflow
+        assert result.retryable is True
+        assert result.should_compress is True
+
+    def test_503_generic_overload_unaffected_by_memory_guard(self):
+        # CONTROL: a plain transient 503 with neither memory nor overflow
+        # wording keeps its existing bare-``overloaded`` classification.
+        e = MockAPIError("Service temporarily unavailable, please retry.",
+                         status_code=503)
+        result = classify_api_error(
+            e, provider="custom", model="x",
+            approx_tokens=5000, context_length=64000,
+        )
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+        assert result.should_compress is False
+
+    def test_500_generic_server_error_unaffected_by_memory_guard(self):
+        # CONTROL: a plain 500 with no memory/overflow wording must still be a
+        # generic server_error, not swept into the memory bucket.
+        e = MockAPIError("Internal server error", status_code=500)
+        result = classify_api_error(
+            e, provider="custom", model="x",
+            approx_tokens=5000, context_length=64000,
+        )
+        assert result.reason == FailoverReason.server_error
+        assert result.retryable is True
+
+    def test_genuine_billing_credit_limit_still_billing(self):
+        # NEGATIVE/invariant guard: a real billing exhaustion message must STILL
+        # classify as billing — proves the memory-guard reorder in
+        # _classify_by_message did not swallow legitimate billing errors.
+        e = Exception("Your account has insufficient credits to complete this request.")
+        result = classify_api_error(
+            e, provider="openrouter", model="x",
+            approx_tokens=5000, context_length=64000,
+        )
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+
     # ── Server disconnect + large session ──
 
     def test_disconnect_large_session_context_overflow(self):

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -280,11 +280,25 @@ _SYNTHETIC_PREFILL_400_NO_OVERFLOW_TOKEN = (
 # guard has to sit ahead of the overflow branch rather than beside it, and
 # ahead of the usage-limit branch too.
 #
-# The separator between the tier names is a "→" in the reporter's transcript.
-# Whether the engine emits U+2192 or ASCII "->" has not been established from
-# the raw log, so both forms are pinned below and asserted to classify
-# identically.  None of the matching keys ("memory limit exceeded",
-# "memory_guard_tier", "context length") involve the separator.
+# SEPARATOR: SETTLED — it is U+2192, and this fixture already carried the right
+# one.  An earlier revision of this comment said the spelling "has not been
+# established from the raw log"; it has been since.  ``grep`` over the raw logs
+# returns twelve occurrences in ``agent.log`` and twelve in ``errors.log``,
+# every one of them the bytes ``e2 86 92``, with zero occurrences of the ASCII
+# "safe -> balanced" in either; and the engine holds the ladder in a single
+# module-level constant, ``MEMORY_GUARD_TIER_LADDER = "safe → balanced →
+# aggressive"``, with no ASCII sibling in the bundle.  Strictly the grep proves
+# the decoded string rather than the wire encoding, and the constant settles the
+# rest.
+#
+# The ASCII form below is therefore CONSTRUCTED, not captured — the same status
+# as _SYNTHETIC_PREFILL_400_NO_OVERFLOW_TOKEN above, and it is labelled here so
+# nobody reads it as a second real spelling.  It is kept because its job is a
+# lower bound, not a claim: none of the matching keys ("memory limit exceeded",
+# "memory_guard_tier", "context length") involve the separator, and the test
+# below pins that, so a future transcoding hop — a proxy, a log shipper, a
+# terminal — cannot quietly become load-bearing.  Do not add an ASCII spelling
+# to any production pattern list.
 _OMLX_057_PROCESS_MEMORY_ABORT = (
     "Request aborted: process memory limit exceeded (usage 49.8 GB, abort "
     "threshold (hard watermark) 49.2 GB, ceiling 51.8 GB). Reduce context "
@@ -1214,10 +1228,11 @@ class TestClassifyApiError:
         assert result.should_fallback is True
 
     def test_omlx_057_process_memory_abort_does_not_rest_on_the_arrow(self):
-        # The tier separator is the one byte in this capture that could not be
-        # confirmed against the raw log, so nothing is allowed to depend on it:
-        # the two spellings must be indistinguishable to the classifier, and
-        # every matching token must live outside the separator.
+        # The tier separator is settled as U+2192 (see the fixture comment), so
+        # this is no longer a test about an open question — it is a lower bound.
+        # Nothing is allowed to depend on the separator surviving a transcoding
+        # hop: the two spellings must be indistinguishable to the classifier,
+        # and every matching token must live outside the separator.
         for message in (
             _OMLX_057_PROCESS_MEMORY_ABORT,
             _OMLX_057_PROCESS_MEMORY_ABORT_ASCII_ARROW,

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -201,6 +201,33 @@ _OMLX_057_STREAM_ABORT = (
     "reduce context length."
 )
 
+# oMLX 0.5.7, PRE-STREAM 400 — the same guard rejecting before the stream
+# opens.  Here the prefill-aware body builder runs, so the wrapper prefix and
+# the structured ``code``/``omlx_code`` survive.  Captured alongside the
+# stream abort above (same reporter, same engine build), which is what makes
+# the pair useful: it isolates the streaming exit as the only thing that
+# strips the structure.  Trailing "..." is the reporter's own elision of the
+# remediation sentence and is kept, so this fixture deliberately carries NO
+# context-overflow token at all.
+_OMLX_057_PREFILL_400_MESSAGE = (
+    "oMLX prefill memory guard rejected this prompt: Prefill context too "
+    "large for available memory (preflight safety guard, kv_len=51311, "
+    "min_chunk=32): predicted peak would require ~78.57 GB (current 71.22 GB "
+    "+ KV 3.28 GB + min-chunk transient 4.08 GB) but prefill safety cap is "
+    "77.76 GB (90% of metal_cap ceiling 86.40 GB). ..."
+)
+
+_OMLX_057_PREFILL_400_BODY = {
+    "error": {
+        "message": _OMLX_057_PREFILL_400_MESSAGE,
+        "type": "invalid_request_error",
+        "param": None,
+        "code": "prefill_memory_exceeded",
+        "omlx_code": "prefill_memory_exceeded",
+        "estimated_bytes": 84368206439,
+    }
+}
+
 
 # ── Test: Full classification pipeline ─────────────────────────────────
 
@@ -846,6 +873,35 @@ class TestClassifyApiError:
         # Nor is it a credential problem.
         assert result.should_rotate_credential is False
         # A wedged local memory wall recovers via a roomier provider.
+        assert result.should_fallback is True
+
+    def test_400_omlx_057_prefill_memory_exceeded_is_overloaded(self):
+        # Verbatim pre-stream capture (issue #52261), paired with the streaming
+        # abort above from the same engine build.  ``str(error)`` is the OpenAI
+        # SDK's rendering of an ``openai.BadRequestError``, i.e. the whole body
+        # repr — which embeds ``'type': 'invalid_request_error'``.  That literal
+        # is why _REQUEST_VALIDATION_PATTERNS excludes it from its own match;
+        # without that exclusion this 400 would be a non-retryable format_error
+        # before any memory or overflow check ran.
+        #
+        # This body carries NO context-overflow token (the reporter elided the
+        # remediation sentence), so on an unguarded classifier it does not even
+        # reach the overflow branch — it falls all the way through 400 handling
+        # to the non-retryable format_error default.  Wrong in a different
+        # direction from the streaming shape, and from the same rejection.
+        e = MockAPIError(
+            "Error code: 400 - " + repr(_OMLX_057_PREFILL_400_BODY),
+            status_code=400,
+            body=_OMLX_057_PREFILL_400_BODY,
+        )
+        result = classify_api_error(
+            e, provider="custom", model="qw36-27b-8bit-mtp:agent",
+            approx_tokens=63337, context_length=256000,
+        )
+        assert result.reason == FailoverReason.overloaded
+        # A memory wall is transient; a format_error would strand the turn.
+        assert result.retryable is True
+        assert result.should_compress is False
         assert result.should_fallback is True
 
     # ── Server disconnect + large session ──

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -208,15 +208,30 @@ _OMLX_057_STREAM_ABORT = (
 # the structured ``code``/``omlx_code`` survive.  Captured alongside the
 # stream abort above (same reporter, same engine build), which is what makes
 # the pair useful: it isolates the streaming exit as the only thing that
-# strips the structure.  Trailing "..." is the reporter's own elision of the
-# remediation sentence and is kept, so this fixture deliberately carries NO
-# context-overflow token at all.
+# strips the structure.
+#
+# COMPLETE capture.  An earlier revision of this fixture ended at "metal_cap
+# ceiling 86.40 GB). ..." because the report it was transcribed from elided
+# the remediation sentence; ``limit_bytes`` and the outer ``"type": "error"``
+# sat behind a second elision.  All three are on the wire, and the first of
+# them carries "context length", so this shape DOES reach the overflow branch
+# — see the docstring on the 400 test below, which the elision had made
+# wrong.  ``error.message`` is 562 characters.
+#
+# This is the 13 Aug 14:11 firing (``kv_len=83168``): the one that goes with
+# the ``approx_tokens=63337`` the test below passes, and with the 174 -> 9
+# message collapse the report is built on.  A 12 Aug 16:37 firing
+# (``kv_len=51311``, ``estimated_bytes`` 84368206439, 560 characters) is
+# equally real and identically worded — only the accounting numbers differ —
+# so the self-consistent pairing is the one pinned here.
 _OMLX_057_PREFILL_400_MESSAGE = (
-    "oMLX prefill memory guard rejected this prompt: Prefill context too "
-    "large for available memory (preflight safety guard, kv_len=51311, "
-    "min_chunk=32): predicted peak would require ~78.57 GB (current 71.22 GB "
-    "+ KV 3.28 GB + min-chunk transient 4.08 GB) but prefill safety cap is "
-    "77.76 GB (90% of metal_cap ceiling 86.40 GB). ..."
+    "oMLX prefill memory guard rejected this prompt: Prefill context too large for "
+    "available memory (preflight safety guard, kv_len=83168, min_chunk=32): predicted "
+    "peak would require ~78.31 GB (current 72.33 GB + KV 5.22 GB + min-chunk transient "
+    "772.56 MB) but prefill safety cap is 77.76 GB (90% of metal_cap ceiling 86.40 GB). "
+    "Raise kernel iogpu.wired_limit_mb in Terminal (currently caps Metal at 86.40 GB), "
+    "or reduce context length. To continue, set Memory Guard to aggressive, raise the "
+    "custom memory guard ceiling, free system memory, or compact/reduce context."
 )
 
 _OMLX_057_PREFILL_400_BODY = {
@@ -226,9 +241,27 @@ _OMLX_057_PREFILL_400_BODY = {
         "param": None,
         "code": "prefill_memory_exceeded",
         "omlx_code": "prefill_memory_exceeded",
-        "estimated_bytes": 84368206439,
-    }
+        "estimated_bytes": 84082063701,
+        "limit_bytes": 83493598003,
+    },
+    "type": "error",
 }
+
+# CONSTRUCTED — NOT a capture.  This is the truncated form the fixture above
+# used to carry, kept deliberately because no real oMLX body omits the
+# remediation sentence: the reporter went looking for a token-less capture and
+# there is not one.  Its only job is to pin the LOWER BOUND — that the guard
+# rests on the memory wording and the structured code, not on the presence of
+# "context length" — so that a future engine copy-edit which drops the
+# remediation hint cannot silently reopen this bug.  Do not describe it as
+# captured output anywhere.
+_SYNTHETIC_PREFILL_400_NO_OVERFLOW_TOKEN = (
+    "oMLX prefill memory guard rejected this prompt: Prefill context too "
+    "large for available memory (preflight safety guard, kv_len=51311, "
+    "min_chunk=32): predicted peak would require ~78.57 GB (current 71.22 GB "
+    "+ KV 3.28 GB + min-chunk transient 4.08 GB) but prefill safety cap is "
+    "77.76 GB (90% of metal_cap ceiling 86.40 GB). ..."
+)
 
 
 # ── Test: Full classification pipeline ─────────────────────────────────
@@ -905,6 +938,46 @@ class TestClassifyApiError:
         assert result.retryable is True
         assert result.should_compress is False
         assert result.should_fallback is True
+
+    def test_400_prefill_memory_code_without_overflow_token_is_overloaded(self):
+        # LOWER BOUND, on a CONSTRUCTED body — see the fixture comment.  Every
+        # real oMLX rejection ends with a "reduce context length" hint, so the
+        # guard is never actually asked to work without one.  This pins that it
+        # could: strip the remediation sentence and classification still rests
+        # on the memory wording plus ``code: prefill_memory_exceeded``, so an
+        # engine copy-edit that drops the hint cannot silently reopen #52261.
+        #
+        # This is also the one shape whose unguarded failure mode is
+        # format_error rather than context_overflow: with no overflow token the
+        # 400 falls past every check to the non-retryable default.
+        body = {
+            "error": {
+                "message": _SYNTHETIC_PREFILL_400_NO_OVERFLOW_TOKEN,
+                "type": "invalid_request_error",
+                "param": None,
+                "code": "prefill_memory_exceeded",
+                "omlx_code": "prefill_memory_exceeded",
+                "estimated_bytes": 84368206439,
+                "limit_bytes": 83493598003,
+            },
+            "type": "error",
+        }
+        e = MockAPIError(
+            "Error code: 400 - " + repr(body), status_code=400, body=body,
+        )
+        result = classify_api_error(
+            e, provider="custom", model="qw36-27b-8bit-mtp:agent",
+            approx_tokens=63337, context_length=256000,
+        )
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+        assert result.should_compress is False
+        assert result.should_fallback is True
+        # The premise of this fixture: no overflow token is present at all.
+        assert not any(
+            p in _SYNTHETIC_PREFILL_400_NO_OVERFLOW_TOKEN.lower()
+            for p in _CONTEXT_OVERFLOW_PATTERNS
+        )
 
     @pytest.mark.parametrize("shape,message", [
         ("mid-stream", _OMLX_057_STREAM_ABORT),

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -819,6 +819,48 @@ class TestClassifyApiError:
         # _memory_ceiling_result contract against per-route drift.
         assert result.should_fallback is True
 
+    @pytest.mark.parametrize("status_code", [400, None])
+    def test_prefill_memory_aborted_code_is_overloaded(self, status_code):
+        # The SIBLING code.  oMLX's prefill-memory body builder picks between
+        # ``prefill_memory_exceeded`` and ``prefill_memory_aborted`` by
+        # exception type (``PrefillMemoryAbortedError``): "exceeded" is the
+        # prompt turned away at admission, "aborted" is the prompt admitted and
+        # then killed mid-prefill.  Same guard, same wall, same recovery — but
+        # only "exceeded" was in _MEMORY_CEILING_ERROR_CODES, so with the
+        # message stripped of memory wording (the scenario the code layer
+        # exists for) the two diverged: exceeded -> overloaded/retryable,
+        # aborted -> format_error/not-retryable on the 400 path and the
+        # retryable ``unknown`` bucket on the status-less one.
+        #
+        # NOT a capture: the reporter's logs carry only
+        # ``prefill_memory_exceeded``.  The code pairing is read from the
+        # engine's body builder, and the reworded-message premise is the one
+        # already established by the 0.5.6 -> 0.5.7 rewording documented below.
+        body = {"error": {
+            "message": "Prompt aborted by the prefill guard. Try a smaller request.",
+            "type": "invalid_request_error",
+            "code": "prefill_memory_aborted",
+            "omlx_code": "prefill_memory_aborted",
+            "limit_bytes": 14495514624,
+        }, "type": "error"}
+        e = MockAPIError(
+            "Prompt aborted by the prefill guard. Try a smaller request.",
+            status_code=status_code, body=body,
+        )
+        result = classify_api_error(
+            e, provider="custom", model="omlx-chat",
+            approx_tokens=5700, context_length=64000,
+        )
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+        assert result.should_compress is False
+        assert result.should_fallback is True
+        # The premise of this test: nothing in the message could have carried
+        # the classification.
+        assert not any(
+            p in body["error"]["message"].lower() for p in _MEMORY_CEILING_PATTERNS
+        )
+
     def test_400_litellm_proxy_flattened_memory_guard_is_overloaded(self):
         # Proxy-flattened transport shape (real oMLX-behind-LiteLLM capture from
         # issue #52261): LiteLLM collapses the structured body into a single

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -296,6 +296,44 @@ _OMLX_057_PROCESS_MEMORY_ABORT_ASCII_ARROW = (
     _OMLX_057_PROCESS_MEMORY_ABORT.replace("→", "->")
 )
 
+# oMLX 0.5.7, FOURTH shape — the model LOAD guard, reached before any prefill
+# happens at all, and the only one of the four that arrives as HTTP 507.
+# ``omlx/server.py`` maps both ``ModelTooLargeError`` and
+# ``InsufficientMemoryError`` to 507, and ``/v1/chat/completions``,
+# ``/v1/completions`` and ``/v1/messages`` all reach them through
+# ``get_engine_for_model`` -> ``get_engine``, so an ordinary chat call against a
+# model the host cannot seat comes back on a status the classifier had no
+# branch for.
+#
+# CAPTURED: verbatim from a reporter's log, 11 Aug 04:03:30, a plain
+# ``/v1/chat/completions`` call surfaced by the OpenAI SDK as
+# ``openai.InternalServerError: Error code: 507``.  ``code`` is null in the
+# body — the wrapper that carries the structured ``prefill_memory_*`` codes is
+# on the prefill path, not this one — so classification rests entirely on the
+# message, which carries "memory ceiling" and "memory_guard_tier".
+#
+# Unguarded, this lands in the generic "other 5xx" bucket: retryable=True but
+# should_fallback=False.  ``should_fallback`` is the bit that matters here,
+# because a model that does not fit under the ceiling does not begin to fit
+# within the retry budget.  The ``InsufficientMemoryError`` sibling is not
+# pinned: it is documented as sharing the 507 mapping, but no body for it has
+# been captured, so there is nothing to assert against.
+_OMLX_057_MODEL_LOAD_507 = (
+    "Model 'Qwen3.6-27B-MLX-8bit' (33.95GB) does not fit under the dynamic "
+    "memory ceiling (25.22GB). Close other apps to free RAM (static cap is "
+    "90.00GB but only 7.15GB is reclaimable right now), raise memory_guard_tier "
+    "(safe → balanced → aggressive), or use a smaller model."
+)
+
+_OMLX_057_MODEL_LOAD_507_BODY = {
+    "error": {
+        "message": _OMLX_057_MODEL_LOAD_507,
+        "type": "server_error",
+        "param": None,
+        "code": None,
+    },
+}
+
 
 # ── Test: Full classification pipeline ─────────────────────────────────
 
@@ -901,6 +939,49 @@ class TestClassifyApiError:
         )
         assert result.reason == FailoverReason.server_error
         assert result.retryable is True
+
+    # ── Memory-ceiling rejections surfaced as 507 (issue #52261) ──
+    #
+    # The model-LOAD guard, which is not the prefill guard and does not come
+    # back as a 400.  See the _OMLX_057_MODEL_LOAD_507 fixture.
+
+    def test_507_omlx_model_load_ceiling_is_overloaded_with_fallback(self):
+        # Verbatim 507 capture.  Before the 507 branch this fell through to the
+        # generic "other 5xx" rule: server_error, retryable=True, but
+        # should_fallback=False — so once the retries were spent the turn died
+        # on a host whose memory wall had not moved, with no failover to a
+        # roomier provider.  Every other memory-ceiling route already sets
+        # should_fallback; this one has to match them.
+        e = MockAPIError(
+            "Error code: 507 - " + repr(_OMLX_057_MODEL_LOAD_507_BODY),
+            status_code=507,
+            body=_OMLX_057_MODEL_LOAD_507_BODY,
+        )
+        result = classify_api_error(
+            e, provider="custom", model="qwen3.6-27b-mlx-8bit",
+            approx_tokens=63337, context_length=256000,
+        )
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+        # Nothing to compress: the model does not fit before a single token of
+        # the conversation is read.
+        assert result.should_compress is False
+        # The regression this test exists for.
+        assert result.should_fallback is True
+        assert result.should_rotate_credential is False
+
+    def test_507_without_memory_wording_is_generic_server_error(self):
+        # CONTROL: 507 Insufficient Storage also has its literal meaning.  A
+        # body with no memory wording must keep the generic 5xx treatment, so
+        # the new branch cannot claim the whole status code.
+        e = MockAPIError("Insufficient storage on device.", status_code=507)
+        result = classify_api_error(
+            e, provider="custom", model="x",
+            approx_tokens=5000, context_length=64000,
+        )
+        assert result.reason == FailoverReason.server_error
+        assert result.retryable is True
+        assert result.should_compress is False
 
     def test_genuine_billing_credit_limit_still_billing(self):
         # NEGATIVE/invariant guard: a real billing exhaustion message must STILL

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -177,6 +177,31 @@ class TestClassify402:
 
 
 
+# ── Captured oMLX prefill-memory-guard rejections (issue #52261) ───────
+#
+# Verbatim provider text from field reports on the issue thread, kept as
+# module constants so every assertion below runs against exactly the same
+# bytes the reporter captured.  Do not reflow or "tidy" these strings — the
+# classifier matches substrings, so a reflow silently changes what is tested.
+
+# oMLX 0.5.7, MID-STREAM abort.  Raised as a base ``openai.APIError`` from
+# ``openai/_streaming.py:95``: that class carries no ``status_code`` at all,
+# and the chat streaming generator's own ``except Exception`` handler builds
+# ``{"error": {"message": str(e), "type": "server_error"}}`` without the
+# ``isinstance(e, PrefillMemoryExceededError)`` discrimination the pre-stream
+# path uses, so the structured ``prefill_memory_exceeded`` code is dropped
+# too.  Classification therefore rests entirely on this message text.
+# Reported by tkaufmann; the first code-less capture from a reporter other
+# than the original 13.5 GB build, which is why it is pinned separately.
+_OMLX_057_STREAM_ABORT = (
+    "Prefill context too large for available memory (pre-chunk guard at 192 "
+    "tokens, kv_len=37056): predicted peak would exceed prefill safety cap "
+    "77.8GB (90% of metal_cap ceiling 86.4GB). Raise kernel "
+    "iogpu.wired_limit_mb in Terminal (currently caps Metal at 86.40 GB), or "
+    "reduce context length."
+)
+
+
 # ── Test: Full classification pipeline ─────────────────────────────────
 
 class TestClassifyApiError:
@@ -793,6 +818,35 @@ class TestClassifyApiError:
         )
         assert result.reason == FailoverReason.billing
         assert result.retryable is False
+
+    def test_streaming_omlx_057_prefill_abort_without_status_or_code(self):
+        # Verbatim mid-stream capture (issue #52261): base ``openai.APIError``
+        # with NO http status and NO structured code, so neither the 400 route
+        # nor the error-code route can fire — only _classify_by_message can.
+        # The single overflow token in the text is "context length", from the
+        # trailing remediation hint, so unguarded main reads a memory rejection
+        # as a window overflow, compresses, and reports the session
+        # uncompressible at 37,629 tokens two minutes later.
+        #
+        # The window figures are the reporter's corrected ones: the model's own
+        # window is 262,144, but Hermes could not read it (the value is nested
+        # under ``text_config`` in config.json) and fell back to 256,000, which
+        # is the number the compression decision was actually taken against.
+        # Either way 37,629 tokens is nowhere near the ceiling — the request was
+        # rejected on a GPU memory peak, not on context.
+        e = Exception(_OMLX_057_STREAM_ABORT)
+        result = classify_api_error(
+            e, provider="custom", model="qw36-27b-8bit-mtp:agent",
+            approx_tokens=37629, context_length=256000,
+        )
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+        # The whole point: compression cannot lower a prefill memory peak.
+        assert result.should_compress is False
+        # Nor is it a credential problem.
+        assert result.should_rotate_credential is False
+        # A wedged local memory wall recovers via a roomier provider.
+        assert result.should_fallback is True
 
     # ── Server disconnect + large session ──
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -310,6 +310,31 @@ _OMLX_057_PROCESS_MEMORY_ABORT_ASCII_ARROW = (
     _OMLX_057_PROCESS_MEMORY_ABORT.replace("→", "->")
 )
 
+# The SAME shape, CAPTURED AGAIN nine days later on a different host, with the
+# remediation tail reworded.  Both halves are captures: 2 Aug above, 11 Aug
+# here.
+#
+# Not a host difference.  engine_core.py on the first host carries an mtime one
+# day after its own 2 Aug capture, and the tail now comes from
+# describe_ceiling_binding(), which emits neither "loosen" nor "free system
+# memory" in any branch — so that host cannot reproduce its own earlier wording
+# today.  The engine reworded it.
+#
+# This is the same drift the memory-accounting entries in
+# _MEMORY_CEILING_PATTERNS were added for, caught a second time on a different
+# sentence: "loosen memory_guard_tier ... free system memory" became "Close
+# other apps to free RAM ... raise memory_guard_tier", and the bound cap moved
+# from a bare "ceiling" to a "dynamic ceiling" with the static cap reported
+# alongside it.  Pinned so the pair is on the record rather than only the
+# earlier half, and so a third copy-edit has something to fail against.
+_OMLX_057_PROCESS_MEMORY_ABORT_REWORDED = (
+    "Request aborted: process memory limit exceeded (usage 53.3 GB, abort "
+    "threshold (hard watermark) 57.4 GB, dynamic ceiling 60.4 GB). Close other "
+    "apps to free RAM (static cap is 90.00 GB but only 7.15 GB is reclaimable "
+    "right now), raise memory_guard_tier (safe → balanced → aggressive), or "
+    "reduce context length."
+)
+
 # oMLX 0.5.7, FOURTH shape — the model LOAD guard, reached before any prefill
 # happens at all, and the only one of the four that arrives as HTTP 507.
 # ``omlx/server.py`` maps both ``ModelTooLargeError`` and
@@ -1226,6 +1251,42 @@ class TestClassifyApiError:
         # Emphatically not a credential or billing problem.
         assert result.should_rotate_credential is False
         assert result.should_fallback is True
+
+    def test_omlx_057_process_memory_abort_reworded_tail_is_overloaded(self):
+        # The 11 Aug capture of the same guard, with the remediation tail
+        # reworded by the engine (see fixture).  This one already classified
+        # correctly before it was pinned — that is the point: it is a
+        # characterisation test, not a regression test, and it exists because
+        # the previous copy-edit to this engine's wording broke a pattern
+        # silently and nothing failed.
+        e = Exception(_OMLX_057_PROCESS_MEMORY_ABORT_REWORDED)
+        result = classify_api_error(
+            e, provider="custom", model="qw36-27b-8bit-mtp:agent",
+            approx_tokens=63337, context_length=256000,
+        )
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+        assert result.should_compress is False
+        assert result.should_rotate_credential is False
+        assert result.should_fallback is True
+
+    def test_omlx_057_process_memory_abort_wordings_actually_differ(self):
+        # Guards the premise of the fixture pair: if a later tidy-up collapses
+        # the two captures into one string, the drift they document disappears
+        # and the test above becomes a duplicate.  The 2 Aug tail says "loosen"
+        # and "free system memory"; the 11 Aug tail says neither.
+        earlier = _OMLX_057_PROCESS_MEMORY_ABORT.lower()
+        later = _OMLX_057_PROCESS_MEMORY_ABORT_REWORDED.lower()
+        for token in ("loosen", "free system memory"):
+            assert token in earlier
+            assert token not in later
+        # And both must still rest on more than one memory token, for the
+        # reason spelled out in the 0.5.6 -> 0.5.7 rewording test below.
+        for message in (earlier, later):
+            matched = [p for p in _MEMORY_CEILING_PATTERNS if p in message]
+            assert len(matched) >= 2, (
+                f"process-memory shape rests on a single memory token {matched!r}"
+            )
 
     def test_omlx_057_process_memory_abort_does_not_rest_on_the_arrow(self):
         # The tier separator is settled as U+2192 (see the fixture comment), so

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -263,6 +263,39 @@ _SYNTHETIC_PREFILL_400_NO_OVERFLOW_TOKEN = (
     "77.76 GB (90% of metal_cap ceiling 86.40 GB). ..."
 )
 
+# oMLX 0.5.7, THIRD shape — a different guard from the two above.  The prefill
+# guard rejects a prompt before admitting it; this is the PROCESS MEMORY
+# ENFORCER aborting a request already in flight because resident usage crossed
+# a watermark.  Different guard, different trigger, same engine, and the same
+# closing advice to reduce context length.
+#
+# Pinned because its unguarded failure mode is the worst of the three and is
+# NOT the overflow misroute the other two suffer: "process memory limit
+# exceeded" contains "limit exceeded", which is a _USAGE_LIMIT_PATTERNS entry
+# checked ahead of the overflow branch, and the body carries none of the
+# transient signals ("try again", "retry", "wait", …) that disambiguate a
+# usage limit toward rate_limit.  So an unguarded classifier calls a local
+# Metal watermark abort a BILLING failure — non-retryable, and reported to the
+# user as an account problem.  Three shapes, two guards, one engine; a memory
+# guard has to sit ahead of the overflow branch rather than beside it, and
+# ahead of the usage-limit branch too.
+#
+# The separator between the tier names is a "→" in the reporter's transcript.
+# Whether the engine emits U+2192 or ASCII "->" has not been established from
+# the raw log, so both forms are pinned below and asserted to classify
+# identically.  None of the matching keys ("memory limit exceeded",
+# "memory_guard_tier", "context length") involve the separator.
+_OMLX_057_PROCESS_MEMORY_ABORT = (
+    "Request aborted: process memory limit exceeded (usage 49.8 GB, abort "
+    "threshold (hard watermark) 49.2 GB, ceiling 51.8 GB). Reduce context "
+    "length, free system memory, or loosen memory_guard_tier "
+    "(safe → balanced → aggressive)."
+)
+
+_OMLX_057_PROCESS_MEMORY_ABORT_ASCII_ARROW = (
+    _OMLX_057_PROCESS_MEMORY_ABORT.replace("→", "->")
+)
+
 
 # ── Test: Full classification pipeline ─────────────────────────────────
 
@@ -989,6 +1022,46 @@ class TestClassifyApiError:
             p in _SYNTHETIC_PREFILL_400_NO_OVERFLOW_TOKEN.lower()
             for p in _CONTEXT_OVERFLOW_PATTERNS
         )
+
+    @pytest.mark.parametrize("arrow,message", [
+        ("unicode", _OMLX_057_PROCESS_MEMORY_ABORT),
+        ("ascii", _OMLX_057_PROCESS_MEMORY_ABORT_ASCII_ARROW),
+    ])
+    def test_omlx_057_process_memory_abort_is_overloaded(self, arrow, message):
+        # The third shape (see fixture): the process memory enforcer, not the
+        # prefill guard.  Arrives message-only, like the mid-stream abort.
+        #
+        # Unguarded, this is the worst-classified of the three — "limit
+        # exceeded" routes it to billing, non-retryable, before the overflow
+        # branch is ever reached — so a local Metal watermark abort surfaces as
+        # an account problem and strands the turn outright.
+        e = Exception(message)
+        result = classify_api_error(
+            e, provider="custom", model="qw36-27b-8bit-mtp:agent",
+            approx_tokens=63337, context_length=256000,
+        )
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+        # Compression cannot lower resident process memory either.
+        assert result.should_compress is False
+        # Emphatically not a credential or billing problem.
+        assert result.should_rotate_credential is False
+        assert result.should_fallback is True
+
+    def test_omlx_057_process_memory_abort_does_not_rest_on_the_arrow(self):
+        # The tier separator is the one byte in this capture that could not be
+        # confirmed against the raw log, so nothing is allowed to depend on it:
+        # the two spellings must be indistinguishable to the classifier, and
+        # every matching token must live outside the separator.
+        for message in (
+            _OMLX_057_PROCESS_MEMORY_ABORT,
+            _OMLX_057_PROCESS_MEMORY_ABORT_ASCII_ARROW,
+        ):
+            matched = [p for p in _MEMORY_CEILING_PATTERNS if p in message.lower()]
+            assert len(matched) >= 2, (
+                f"process-memory shape rests on a single memory token {matched!r}"
+            )
+            assert all("→" not in p and "->" not in p for p in matched)
 
     @pytest.mark.parametrize("shape,message", [
         ("mid-stream", _OMLX_057_STREAM_ABORT),

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -890,12 +890,17 @@ class TestClassifyApiError:
         # as a window overflow, compresses, and reports the session
         # uncompressible at 37,629 tokens two minutes later.
         #
-        # The window figures are the reporter's corrected ones: the model's own
-        # window is 262,144, but Hermes could not read it (the value is nested
-        # under ``text_config`` in config.json) and fell back to 256,000, which
-        # is the number the compression decision was actually taken against.
-        # Either way 37,629 tokens is nowhere near the ceiling — the request was
-        # rejected on a GPU memory peak, not on context.
+        # ``context_length`` here only has to be a plausible window well above
+        # 37,629; it is not a claim about what the compressor resolved.  (An
+        # earlier revision of this comment asserted that Hermes could not read
+        # the model's window because it was nested under ``text_config``, and
+        # that 256,000 was therefore the number compression ran against.  Both
+        # were wrong: oMLX reports ``{"max_model_len": 262144}`` on /v1/models,
+        # which model_metadata already parses, and 256,000 is a dashboard
+        # display value from a different code path.)  What the assertions below
+        # rest on is only this: 37,629 tokens is nowhere near any plausible
+        # ceiling, so the request was rejected on a GPU memory peak, not on
+        # context.
         e = Exception(_OMLX_057_STREAM_ABORT)
         result = classify_api_error(
             e, provider="custom", model="qw36-27b-8bit-mtp:agent",
@@ -919,11 +924,17 @@ class TestClassifyApiError:
         # without that exclusion this 400 would be a non-retryable format_error
         # before any memory or overflow check ran.
         #
-        # This body carries NO context-overflow token (the reporter elided the
-        # remediation sentence), so on an unguarded classifier it does not even
-        # reach the overflow branch — it falls all the way through 400 handling
-        # to the non-retryable format_error default.  Wrong in a different
-        # direction from the streaming shape, and from the same rejection.
+        # On an unguarded classifier this body is read as context_overflow with
+        # should_compress=True — the SAME failure direction as the mid-stream
+        # shape above, from the same rejection: its remediation sentence ends
+        # "or reduce context length", which is the single overflow token.
+        #
+        # (An earlier revision of this comment said the opposite — that the body
+        # carried no overflow token and fell through to a non-retryable
+        # format_error.  That described the elided transcription this fixture
+        # used to carry, not oMLX; see the fixture comment.  The same claim is
+        # in the message of commit 4db5a59, which is pushed and cannot be
+        # amended, so it is corrected here instead.)
         e = MockAPIError(
             "Error code: 400 - " + repr(_OMLX_057_PREFILL_400_BODY),
             status_code=400,

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -5,6 +5,8 @@ from agent.error_classifier import (
     ClassifiedError,
     FailoverReason,
     PROVIDER_STREAM_NON_JSON_ERROR_CODE,
+    _CONTEXT_OVERFLOW_PATTERNS,
+    _MEMORY_CEILING_PATTERNS,
     classify_api_error,
     _extract_status_code,
     _extract_error_body,
@@ -903,6 +905,42 @@ class TestClassifyApiError:
         assert result.retryable is True
         assert result.should_compress is False
         assert result.should_fallback is True
+
+    @pytest.mark.parametrize("shape,message", [
+        ("mid-stream", _OMLX_057_STREAM_ABORT),
+        ("pre-stream 400", _OMLX_057_PREFILL_400_MESSAGE),
+    ])
+    def test_omlx_057_wording_matches_more_than_one_memory_token(self, shape, message):
+        # The oMLX 0.5.6 → 0.5.7 rewording is the evidence for this assertion,
+        # not a hypothetical: "Prefill would require ~13.87 GB peak" became
+        # "predicted peak would require ~78.57 GB", and the pattern written
+        # against the first wording stopped matching the engine it was written
+        # for without anything failing.  Before the memory-accounting entries
+        # were added, the mid-stream shape matched exactly ONE token
+        # ("available memory") while _CONTEXT_OVERFLOW_PATTERNS matched exactly
+        # one of its own ("context length", from the remediation hint) — so a
+        # single further copy-edit on either side flips the classification.
+        #
+        # Scoped to the two 0.5.7 captures because those are the shapes we have
+        # two releases of wording for; it is not asserted as a property of every
+        # message in the list.
+        matched = [p for p in _MEMORY_CEILING_PATTERNS if p in message.lower()]
+        assert len(matched) >= 2, (
+            f"{shape} shape rests on a single memory token {matched!r}; "
+            "one provider copy-edit would reclassify it"
+        )
+
+    def test_memory_ceiling_tokens_stay_disjoint_from_overflow_tokens(self):
+        # The list's stated invariant: every memory-ceiling token names an
+        # allocation ceiling, never a token or window count.  Guards the entries
+        # added for the 0.5.7 wording against drifting into overflow language,
+        # which would silently divert genuine window overflows out of
+        # compression — the failure the whole guard exists to avoid causing.
+        for mem in _MEMORY_CEILING_PATTERNS:
+            for ovf in _CONTEXT_OVERFLOW_PATTERNS:
+                assert mem not in ovf and ovf not in mem, (
+                    f"memory token {mem!r} overlaps overflow token {ovf!r}"
+                )
 
     # ── Server disconnect + large session ──
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1012,6 +1012,48 @@ class TestClassifyApiError:
         assert result.should_fallback is True
         assert result.should_rotate_credential is False
 
+    # ── Memory-ceiling rejections surfaced as 409 (issue #52261) ──
+    #
+    # NOT CAPTURED.  Read from the engine's source: oMLX's ``ModelLoadingError``
+    # carries "Model 'X' load aborted: process memory limit exceeded" and
+    # ``server.py`` maps it to 409.  No reporter has produced a 409 body, so
+    # this fixture is constructed from that message, and the test is pinned as
+    # a code reading rather than as evidence.
+
+    def test_409_memory_abort_is_overloaded_not_format_error(self):
+        # Before the 409 branch this reached the generic "other 4xx" bucket and
+        # was reported as format_error / retryable=False: a transient memory
+        # abort called a malformed request.  should_fallback was already set,
+        # so the turn was not stranded — but it was never retried against the
+        # primary either, even though the abort clears the moment the host
+        # reclaims memory.
+        e = MockAPIError(
+            "Model 'Qwen3.6-27B-MLX-8bit' load aborted: process memory limit "
+            "exceeded",
+            status_code=409,
+        )
+        result = classify_api_error(
+            e, provider="custom", model="qwen3.6-27b-mlx-8bit",
+            approx_tokens=63337, context_length=256000,
+        )
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+        assert result.should_compress is False
+        assert result.should_fallback is True
+
+    def test_409_without_memory_wording_is_still_format_error(self):
+        # CONTROL: 409 Conflict has ordinary uses (a model swap already in
+        # flight, a duplicate request id).  Those must keep the existing 4xx
+        # treatment, so the new branch cannot claim the whole status code.
+        e = MockAPIError("A model swap is already in progress.", status_code=409)
+        result = classify_api_error(
+            e, provider="custom", model="x",
+            approx_tokens=5000, context_length=64000,
+        )
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+        assert result.should_fallback is True
+
     def test_507_without_memory_wording_is_generic_server_error(self):
         # CONTROL: 507 Insufficient Storage also has its literal meaning.  A
         # body with no memory wording must keep the generic 5xx treatment, so

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -524,6 +524,276 @@ class TestClassifyApiError:
 
 
 
+    # ── Local-inference memory/resource-ceiling 400s (issue #52261) ──
+    # A provider memory-guard / OOM rejection often suggests "reduce context
+    # length", colliding with the context-overflow patterns.  Compressing
+    # history cannot relieve a prefill memory peak, so these must classify as
+    # transient ``overloaded`` (retry, no compression) — NOT context_overflow.
+
+    def test_400_omlx_prefill_memory_guard_is_overloaded_not_context_overflow(self):
+        # Verbatim oMLX memory-guard rejection on a TINY (~5.7k-token) prompt.
+        e = MockAPIError(
+            "oMLX prefill memory guard rejected this prompt: Prefill would "
+            "require ~13.87 GB peak (current 13.46 GB + KV+SDPA 419.28 MB) but "
+            "dynamic ceiling is 13.50 GB. ... or reduce context length.",
+            status_code=400,
+        )
+        result = classify_api_error(
+            e, provider="custom", model="omlx-chat",
+            approx_tokens=5700, context_length=64000,
+        )
+        assert result.reason == FailoverReason.overloaded
+        # Must NOT enter the compress-and-shrink loop.
+        assert result.should_compress is False
+
+    def test_400_process_memory_limit_exceeded_is_overloaded(self):
+        e = MockAPIError(
+            "Request aborted: process memory limit exceeded (usage 13.7 GB, "
+            "ceiling 13.5 GB). Reduce context size or lower memory_guard_tier.",
+            status_code=400,
+        )
+        result = classify_api_error(
+            e, provider="custom", model="omlx-chat",
+            approx_tokens=5745, context_length=64000,
+        )
+        assert result.reason == FailoverReason.overloaded
+        assert result.should_compress is False
+
+    def test_no_status_prefill_too_large_for_available_memory_is_overloaded(self):
+        # Streaming / no-status path: APIError text, no HTTP code.
+        e = Exception("Prefill context too large for available memory")
+        result = classify_api_error(
+            e, provider="custom", model="omlx-chat",
+            approx_tokens=15000, context_length=64000,
+        )
+        assert result.reason == FailoverReason.overloaded
+        assert result.should_compress is False
+
+    def test_400_genuine_context_window_overflow_still_compresses(self):
+        # NEGATIVE/invariant guard: a real window overflow must STILL route to
+        # context_overflow + compression (proves the memory guard is precise
+        # and does not swallow genuine "reduce the length" overflows).
+        e = MockAPIError(
+            "This model's maximum context length is 8192 tokens; "
+            "reduce the length of the messages.",
+            status_code=400,
+        )
+        result = classify_api_error(
+            e, provider="custom", model="x",
+            approx_tokens=9000, context_length=8192,
+        )
+        assert result.reason == FailoverReason.context_overflow
+        assert result.should_compress is True
+
+    def test_streaming_process_memory_limit_exceeded_is_overloaded_not_billing(self):
+        # Status-LESS streaming abort (oMLX emits this on the streaming path
+        # under memory pressure).  "process memory limit exceeded" contains the
+        # substring "limit exceeded", a _USAGE_LIMIT_PATTERN — so before the
+        # memory guard was moved ahead of the billing/usage checks in
+        # _classify_by_message, this misclassified as BILLING (retryable=False,
+        # rotate-credential), a different wrong bucket than context_overflow.
+        e = Exception(
+            "Request aborted: process memory limit exceeded (usage 13.7 GB, "
+            "ceiling 13.5 GB). Reduce context size or lower memory_guard_tier."
+        )
+        result = classify_api_error(
+            e, provider="custom", model="omlx-chat",
+            approx_tokens=5745, context_length=64000,
+        )
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+        assert result.should_compress is False
+        # Must NOT be routed into credential rotation like a billing error.
+        assert result.should_rotate_credential is False
+        # Failover-eligible: a wedged local memory wall recovers via a roomier
+        # provider once retries are exhausted, not by hammering the same server.
+        assert result.should_fallback is True
+
+    def test_400_prefill_memory_code_reworded_message_is_overloaded(self):
+        # Direct (non-proxied) connection: the message is reworded with NO
+        # memory substring, but the structured body carries the unambiguous
+        # ``code: "prefill_memory_exceeded"`` (+ limit_bytes in *bytes*).
+        # Without the error-code guard this fell through to a non-retryable
+        # ``format_error`` (no overflow wording to catch it either).
+        body = {"error": {
+            "message": "Prompt rejected by the prefill guard. Try a smaller request.",
+            "type": "invalid_request_error",
+            "code": "prefill_memory_exceeded",
+            "omlx_code": "prefill_memory_exceeded",
+            "limit_bytes": 14495514624,
+        }, "type": "error"}
+        e = MockAPIError(
+            "Prompt rejected by the prefill guard. Try a smaller request.",
+            status_code=400, body=body,
+        )
+        result = classify_api_error(
+            e, provider="custom", model="omlx-chat",
+            approx_tokens=5700, context_length=64000,
+        )
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+        assert result.should_compress is False
+        assert result.should_fallback is True
+
+    def test_no_status_prefill_memory_code_is_overloaded(self):
+        # Streaming / no-status path carrying only the structured code (message
+        # fully reworded).  Previously fell to the retryable ``unknown`` bucket;
+        # the _classify_by_error_code memory-code guard now catches it.
+        body = {"error": {
+            "message": "Prompt rejected by the prefill guard. Try a smaller request.",
+            "code": "prefill_memory_exceeded",
+            "limit_bytes": 14495514624,
+        }, "type": "error"}
+        e = MockAPIError(
+            "Prompt rejected by the prefill guard. Try a smaller request.",
+            status_code=None, body=body,
+        )
+        result = classify_api_error(
+            e, provider="custom", model="omlx-chat",
+            approx_tokens=5700, context_length=64000,
+        )
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+        assert result.should_compress is False
+        # Same rejection, detected via the structured code instead of the
+        # message: the recovery annotation must be identical to the 400 and
+        # message-pattern paths, not silently weaker.  Guards the shared
+        # _memory_ceiling_result contract against per-route drift.
+        assert result.should_fallback is True
+
+    def test_400_litellm_proxy_flattened_memory_guard_is_overloaded(self):
+        # Proxy-flattened transport shape (real oMLX-behind-LiteLLM capture from
+        # issue #52261): LiteLLM collapses the structured body into a single
+        # "OpenAIException - <message>" string and DROPS the ``code``, so the
+        # error-code guard cannot fire — only the message substring survives.
+        # On clean main this 400 matched the bare "reduce context length"
+        # overflow pattern and misclassified as context_overflow (→ compress →
+        # wedge-loop reset).  The message-pattern memory guard ("memory guard",
+        # "dynamic ceiling", "prefill would require") must catch it even with no
+        # status code or structured code to lean on.
+        e = MockAPIError(
+            "litellm.BadRequestError: OpenAIException - oMLX prefill memory "
+            "guard rejected this prompt: Prefill would require ~13.87 GB peak "
+            "(current 13.46 GB + KV+SDPA 419.28 MB) but dynamic ceiling is "
+            "13.50 GB. Raise custom_ceiling_bytes in admin Memory settings, or "
+            "reduce context length.",
+            status_code=400,
+        )
+        result = classify_api_error(
+            e, provider="custom", model="omlx-chat",
+            approx_tokens=5700, context_length=64000,
+        )
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+        # Must NOT enter the compress-and-shrink loop a context_overflow would.
+        assert result.should_compress is False
+        assert result.should_fallback is True
+
+    # ── Memory-ceiling rejections surfaced as 5xx (issue #52261) ──
+    # main routes explicit context-overflow wording in a 500/502/503/529 body
+    # into compression (llama.cpp/vLLM report overflow-as-5xx).  A memory abort
+    # from those same servers carries the same "reduce context length" hint, so
+    # without a guard it reaches the identical wedge-loop these tests exist to
+    # prevent — the 400 fix alone does not cover it.
+
+    @pytest.mark.parametrize("status_code", [500, 502, 503, 529])
+    def test_5xx_memory_guard_is_overloaded_not_context_overflow(self, status_code):
+        # Body carries BOTH memory wording and the colliding "reduce context
+        # length" hint.  Fails before the 5xx guard: matches
+        # _CONTEXT_OVERFLOW_PATTERNS → context_overflow + should_compress=True.
+        e = MockAPIError(
+            "oMLX prefill memory guard rejected this prompt: Prefill would "
+            "require ~13.87 GB peak but dynamic ceiling is 13.50 GB. Raise "
+            "custom_ceiling_bytes in admin Memory settings, or reduce "
+            "context length.",
+            status_code=status_code,
+        )
+        result = classify_api_error(
+            e, provider="custom", model="omlx-chat",
+            approx_tokens=5700, context_length=64000,
+        )
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+        # The whole point: compressing history cannot lower a prefill peak.
+        assert result.should_compress is False
+        # Same contract as the 400 / code / message routes.
+        assert result.should_fallback is True
+
+    @pytest.mark.parametrize("status_code", [500, 502, 503, 529])
+    def test_5xx_memory_code_reworded_message_is_overloaded(self, status_code):
+        # Direct (non-proxied) 5xx whose message was reworded to carry no memory
+        # substring — only the structured code identifies it.
+        body = {"error": {
+            "message": "Prompt rejected by the prefill guard.",
+            "code": "prefill_memory_exceeded",
+            "limit_bytes": 14495514624,
+        }, "type": "error"}
+        e = MockAPIError(
+            "Prompt rejected by the prefill guard.",
+            status_code=status_code, body=body,
+        )
+        result = classify_api_error(
+            e, provider="custom", model="omlx-chat",
+            approx_tokens=5700, context_length=64000,
+        )
+        assert result.reason == FailoverReason.overloaded
+        assert result.should_compress is False
+        assert result.should_fallback is True
+
+    @pytest.mark.parametrize("status_code", [500, 502, 503, 529])
+    def test_5xx_genuine_context_overflow_still_compresses(self, status_code):
+        # CONTROL for the guard above: a real overflow body (no memory wording)
+        # must STILL take the compression path main added.  Proves the memory
+        # guard is narrow and did not disable overflow-as-5xx handling.
+        e = MockAPIError(
+            "the request exceeds the available context size. try increasing "
+            "the context size or enable context shift",
+            status_code=status_code,
+        )
+        result = classify_api_error(
+            e, provider="custom", model="local-llama",
+            approx_tokens=150000, context_length=64000,
+        )
+        assert result.reason == FailoverReason.context_overflow
+        assert result.retryable is True
+        assert result.should_compress is True
+
+    def test_503_generic_overload_unaffected_by_memory_guard(self):
+        # CONTROL: a plain transient 503 with neither memory nor overflow
+        # wording keeps its existing bare-``overloaded`` classification.
+        e = MockAPIError("Service temporarily unavailable, please retry.",
+                         status_code=503)
+        result = classify_api_error(
+            e, provider="custom", model="x",
+            approx_tokens=5000, context_length=64000,
+        )
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+        assert result.should_compress is False
+
+    def test_500_generic_server_error_unaffected_by_memory_guard(self):
+        # CONTROL: a plain 500 with no memory/overflow wording must still be a
+        # generic server_error, not swept into the memory bucket.
+        e = MockAPIError("Internal server error", status_code=500)
+        result = classify_api_error(
+            e, provider="custom", model="x",
+            approx_tokens=5000, context_length=64000,
+        )
+        assert result.reason == FailoverReason.server_error
+        assert result.retryable is True
+
+    def test_genuine_billing_credit_limit_still_billing(self):
+        # NEGATIVE/invariant guard: a real billing exhaustion message must STILL
+        # classify as billing — proves the memory-guard reorder in
+        # _classify_by_message did not swallow legitimate billing errors.
+        e = Exception("Your account has insufficient credits to complete this request.")
+        result = classify_api_error(
+            e, provider="openrouter", model="x",
+            approx_tokens=5000, context_length=64000,
+        )
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+
     # ── Server disconnect + large session ──
 
 


### PR DESCRIPTION
## What does this PR do?

Local-inference providers (oMLX / MLX with a memory guard, and similar
Metal/CUDA setups) abort a request when the **prefill memory peak** exceeds a
GPU/unified-memory ceiling. Their rejection text often suggests "reduce context
length" / "reduce context size", which collides with the context-overflow
patterns — so Hermes classifies a *memory-ceiling* 400 as `context_overflow`
and routes it into the compress → shrink-context → retry loop. Compression
cannot lower a prefill memory peak (the conversation is tiny — ~5.7k tokens in
the report), so it exhausts `max_compression_attempts`, the compression call
itself re-hits the wedged server, and the loop ends in "Cannot compress
further" → destructive session reset.

This PR adds a `_MEMORY_CEILING_PATTERNS` check that runs **before** the
context-overflow check at every classification site, classifying these as
`FailoverReason.overloaded` (transient, retry-with-backoff, no compression, no
reset) — the same "checked BEFORE context_overflow" guard pattern already used
for multimodal / image-too-large / request-validation 400s. `overloaded`
mirrors the existing 503/529 recovery: `retryable=True`, `should_compress`
defaults to `False`, and it is in the retryable set so the loop never enters the
client-error abort/reset path.

**The same wall reaches the classifier on five different routes**, and all five
now share one predicate (`_is_memory_ceiling`) and one recovery annotation
(`_memory_ceiling_result`), so the treatment cannot drift between them:

| route | before | after |
|---|---|---|
| HTTP 400 (prefill guard, pre-stream) | `context_overflow` → compress → reset | `overloaded`, retryable, fallback |
| no status (mid-stream `APIError`) | `context_overflow` / `billing` | `overloaded`, retryable, fallback |
| HTTP 500/502/503/529 | `context_overflow` / bare `overloaded` | `overloaded`, retryable, fallback |
| **HTTP 507** (model-load guard) | `server_error`, retryable, **`should_fallback=False`** | `overloaded`, retryable, fallback |
| **HTTP 409** (`ModelLoadingError`) | `format_error`, **`retryable=False`** | `overloaded`, retryable, fallback |
| structured `code` (proxy-stripped message) | `format_error` / `unknown` | `overloaded`, retryable, fallback |

The 507 and 409 routes and the `prefill_memory_aborted` code were found by
@tkaufmann against this branch's head. **Evidence grades are recorded per
commit and per code comment and are not flattened:** the 507 gap and both
process-abort wordings are captured bodies from his own hosts; the 409 mapping
and the `prefill_memory_aborted` code pairing are read from the engine's source
and are labelled as code readings, not as evidence.

## Related Issue

Fixes #52261

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/error_classifier.py`:
  - `_MEMORY_CEILING_PATTERNS` + `_MEMORY_CEILING_ERROR_CODES`, consumed
    through the single `_is_memory_ceiling` predicate and the single
    `_memory_ceiling_result` recovery contract.
  - Guard placed before the context-overflow check at `_classify_400`, the
    500/502 and 503/529 branches, `_classify_by_error_code`, and the no-status
    `_classify_by_message` streaming path.
  - New `507` branch (local-inference model-**load** guard: oMLX maps both
    `ModelTooLargeError` and `InsufficientMemoryError` here, reachable from
    `/v1/chat/completions`, `/v1/completions` and `/v1/messages`). Previously
    fell to generic "other 5xx": retryable, but `should_fallback=False`.
  - New `409` branch (`ModelLoadingError`, "load aborted: process memory limit
    exceeded"). Previously fell to generic "other 4xx": `format_error`,
    `retryable=False`.
  - `prefill_memory_aborted` added to `_MEMORY_CEILING_ERROR_CODES` — the
    admitted-then-killed sibling of `prefill_memory_exceeded`, selected by
    exception type in the engine's body builder.
  - Both new branches are gated on the shared predicate, so a 507 in its
    literal Insufficient Storage sense and an ordinary 409 conflict keep their
    existing treatment.
- `tests/agent/test_error_classifier.py`: captured provider wordings pinned as
  module constants across the 400 / no-status / 5xx / 507 / 409 / structured-code
  paths, each with a control proving the guard is narrow, plus invariant tests
  that a genuine context-window overflow still compresses and a genuine billing
  exhaustion is still billing.

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/agent/test_error_classifier.py -v`
2. Regression guard (fail-before / pass-after), verified per commit by
   restoring the pre-change blob of `agent/error_classifier.py` and re-running:
   - `test_507_omlx_model_load_ceiling_is_overloaded_with_fallback` → red as
     `server_error` / `should_fallback=False`
   - `test_prefill_memory_aborted_code_is_overloaded[400]` / `[None]` → red as
     `format_error` / `unknown`
   - `test_409_memory_abort_is_overloaded_not_format_error` → red as
     `format_error` / `retryable=False`
   - every control test passes in both states, proving the guards are narrow.
3. Full file: 115 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — for this update: `tests/agent/` (the suite covering the only production file touched). 155 failures, and the failing set is **byte-identical to clean `origin/main` (c896c09c429)**, which fails the same 155. Zero of them are in `test_error_classifier.py`, which is 115/115 green.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (pure string-classification logic — platform-independent)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Contract Protected

**Invariant:** a provider **memory/resource-ceiling** rejection never enters the
compress-and-shrink-context path and is never reported as a client error,
regardless of which route it arrives on — HTTP 400, 409, 500/502, 503/529, 507,
a structured error code, or a no-status streaming `APIError`.

- **Known-bad inputs (now covered), captured:** the oMLX/MLX wordings — "oMLX
  prefill memory guard rejected … dynamic ceiling is 13.50 GB … reduce context
  length"; "process memory limit exceeded … loosen memory_guard_tier" and its
  reworded 11 Aug sibling "… dynamic ceiling 60.4 GB. Close other apps to free
  RAM … raise memory_guard_tier"; the no-status "Prefill context too large for
  available memory"; and the 507 "Model 'X' (33.95GB) does not fit under the
  dynamic memory ceiling (25.22GB)".
- **Known-bad inputs, read from engine source (labelled as such, not claimed as
  captures):** the 409 "Model 'X' load aborted: process memory limit exceeded",
  and the `prefill_memory_aborted` structured code.
- **Future-input coverage:** `_MEMORY_CEILING_PATTERNS` keys on
  memory/allocation/ceiling/guard wording (OOM, llama.cpp/vLLM, Metal/CUDA),
  disjoint from token/window-count language; `_MEMORY_CEILING_ERROR_CODES`
  covers the reworded/proxy-stripped case where no memory substring survives.
  Two captured wordings of the same shape, nine days apart, are pinned against
  each other so a third engine copy-edit fails loudly instead of silently.
- **Negative cases:** a genuine `maximum context length … reduce the length` 400
  still routes to `context_overflow` + compression; a genuine billing
  exhaustion is still `billing`; a plain 500/503 is untouched; a 507 with no
  memory wording stays a generic `server_error`; an ordinary 409 conflict stays
  a `format_error`.

> Sibling follow-up (intentionally out of scope to keep the diff coherent): a
> dedicated `FailoverReason.resource_exhausted` reason — instead of reusing
> `overloaded` — would let callers surface a clearer "free memory / raise the
> guard ceiling" message. Happy to widen if preferred.
