### PR TITLE
fix(agent): route reasoning model disconnects to timeout, not context_overflow

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -717,6 +717,27 @@ def classify_api_error(
 
     is_disconnect = any(p in error_msg for p in _SERVER_DISCONNECT_PATTERNS)
     if is_disconnect and not status_code:
+        # Reasoning models (o1/o3, DeepSeek R1, Nemotron, Grok reasoning,
+        # QwQ, etc.) can think for minutes before producing tokens.  A
+        # transport disconnect during thinking is almost always an upstream
+        # proxy idle-kill, NOT a real context overflow.  Classifying it as
+        # context_overflow triggers destructive compression on a phantom
+        # error.  Route to timeout instead so retries/fallback can handle it.
+        _model_lower = (model or "").lower()
+        _reasoning_prefixes = (
+            "o1", "o3", "o4",
+            "deepseek-r", "deepseek-reasoner",
+            "nemotron",
+            "qwq", "qwen3",
+            "grok-4",
+        )
+        _is_reasoning = any(
+            _model_lower.startswith(p) or f"/{p}" in _model_lower
+            for p in _reasoning_prefixes
+        )
+        if _is_reasoning:
+            return _result(FailoverReason.timeout, retryable=True)
+
         # Absolute token/message-count thresholds are only a proxy for smaller
         # context windows.  Large-context sessions can have hundreds of
         # messages while still being far below their actual token budget.


### PR DESCRIPTION
## Problem

When a reasoning model (o1/o3, DeepSeek R1, Nemotron, Grok reasoning, QwQ) hits a transport disconnect on a large session, the error classifier incorrectly classifies it as `context_overflow` with `should_compress=True`.

Reasoning models can think for minutes before producing tokens. A transport disconnect during thinking is almost always an upstream proxy idle-kill (NVIDIA NIM ~120s, OpenAI/Anthropic stream-idle), NOT a real context overflow. Classifying it as `context_overflow` triggers destructive compression on a phantom error, silently deleting conversation history.

## Fix

Add reasoning model detection before the `context_overflow` classification at `agent/error_classifier.py:718`. For reasoning models, route to `timeout` instead so retries/fallback can handle the disconnect properly.

```python
# Reasoning model prefixes that should skip context_overflow classification
_reasoning_prefixes = (
    "o1", "o3", "o4",
    "deepseek-r", "deepseek-reasoner",
    "nemotron", "qwq", "qwen3",
    "grok-4",
)
```

## Files changed

| File | Change |
|------|--------|
| `agent/error_classifier.py` | Add reasoning model check before context_overflow classification (+21 lines) |

Fixes #52271