### PR TITLE
feat(sms): support channel_prompts with wildcard fallback

### DIFF
--- a/plugins/platforms/sms/adapter.py
+++ b/plugins/platforms/sms/adapter.py
@@ -359,12 +359,20 @@ class SmsAdapter(BasePlatformAdapter):
             user_id=from_number,
             user_name=from_number,
         )
+
+        # Resolve per-channel prompt (supports "*" wildcard as default for all SMS).
+        from gateway.platforms.base import resolve_channel_prompt
+        _channel_prompt = resolve_channel_prompt(self.config.extra, from_number)
+        if _channel_prompt is None:
+            _channel_prompt = resolve_channel_prompt(self.config.extra, "*")
+
         event = MessageEvent(
             text=text,
             message_type=MessageType.TEXT,
             source=source,
             raw_message=form,
             message_id=message_sid,
+            channel_prompt=_channel_prompt,
         )
 
         # Non-blocking: Twilio expects a fast response


### PR DESCRIPTION
## Summary

The SMS adapter is the only major platform adapter that does not resolve per-channel prompts. Telegram and Slack both call `resolve_channel_prompt()` to inject ephemeral system prompts (e.g. persona/role instructions) into sessions. SMS sessions currently have no way to receive a channel prompt.

This PR adds the same `resolve_channel_prompt()` call used by Telegram, with a `"*"` wildcard fallback so a default prompt can be applied to all SMS sessions without pre-registering every phone number.

## Use case

Multi-tenant SMS workflows (e.g. a community calendar where bar owners text events to a Twilio number). Each phone number gets its own session, but they all share a common persona/instruction prompt. Without this patch, there is no mechanism to inject a system prompt into SMS sessions — `channel_prompts` in config.yaml is silently ignored for SMS.

## Changes

- `plugins/platforms/sms/adapter.py`: resolve `channel_prompt` via `resolve_channel_prompt()` with `"*"` wildcard fallback before constructing the `MessageEvent`

## Config example

```yaml
sms:
  channel_prompts:
    "*": "You are Annika, responding via SMS for the Space Coast Kava Calendar..."
```

## Behavior

- The prompt is ephemeral (injected at API call time, never persisted to transcript history), matching the behavior on Telegram and Slack.
- Per-number prompts take precedence (exact match on `channel_id` = phone number), with `"*"` as the default.
- No breaking changes — if no `channel_prompts` are configured, behavior is unchanged (`resolve_channel_prompt` returns `None`).

## Pattern

Follows the exact pattern already in `gateway/platforms/telegram.py`:

```python
from gateway.platforms.base import resolve_channel_prompt
_channel_prompt = resolve_channel_prompt(self.config.extra, chat_id_str)
```

The only addition is the `"*"` wildcard fallback, which SMS needs because phone numbers are not known in advance.