### PR TITLE
feat(auth): hermes auth sync — detect and fix credential drift across profile .env files

### DIFF
--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import math
+import os
 import sys
 import time
+from pathlib import Path
 from types import SimpleNamespace
 import uuid
 
@@ -776,5 +778,204 @@ def auth_command(args) -> None:
     if action == "spotify":
         auth_spotify_command(args)
         return
+    if action == "sync":
+        auth_sync_command(args)
+        return
     # No subcommand — launch interactive mode
     _interactive_auth()
+
+
+# ---------------------------------------------------------------------------
+# hermes auth sync — detect and fix credential drift across .env files
+# ---------------------------------------------------------------------------
+
+def _mask_key(value: str) -> str:
+    """Mask a secret for display: first 4 + … + last 4, or full if short."""
+    if not value:
+        return "(empty)"
+    if len(value) <= 12:
+        return value[:2] + "…" + value[-2:]
+    return value[:4] + "…" + value[-4:]
+
+
+def _collect_credential_env_vars() -> list[str]:
+    """Return the sorted list of env-var names that hold provider API keys.
+
+    Sources:
+    - ``PROVIDER_REGISTRY[*].api_key_env_vars`` for every api-key provider.
+    - Common tool credential vars not in the provider registry (FAL_KEY,
+      FIRECRAWL_API_KEY, GROQ_API_KEY, etc.).
+    """
+    env_vars: set[str] = set()
+    for cfg in PROVIDER_REGISTRY.values():
+        for var in cfg.api_key_env_vars:
+            if var:
+                env_vars.add(var)
+    # Well-known tool / auxiliary credential env vars
+    env_vars.update({
+        "OPENROUTER_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "GLM_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GOOGLE_API_KEY",
+        "GEMINI_API_KEY",
+        "XAI_API_KEY",
+        "FIRECRAWL_API_KEY",
+        "FAL_KEY",
+        "GROQ_API_KEY",
+        "KIMI_API_KEY",
+        "MINIMAX_API_KEY",
+        "DASHSCOPE_API_KEY",
+        "HF_TOKEN",
+        "COPILOT_GITHUB_TOKEN",
+    })
+    env_vars.discard("")
+    return sorted(env_vars)
+
+
+def _read_env_file(env_path) -> dict[str, str]:
+    """Parse a .env file into a dict (KEY=VALUE, stripping comments/quotes)."""
+    from agent.secret_scope import load_env_file
+    return load_env_file(env_path)
+
+
+def _discover_profile_envs() -> list[tuple[str, Path]]:
+    """Return (profile_name, env_path) for the default profile and all named profiles."""
+    from hermes_cli.profiles import _get_profiles_root, _get_default_hermes_home
+
+    result: list[tuple[str, Path]] = []
+    default_home = _get_default_hermes_home()
+    default_env = default_home / ".env"
+    if default_env.exists():
+        result.append(("default", default_env))
+
+    profiles_root = _get_profiles_root()
+    if profiles_root.is_dir():
+        for entry in sorted(profiles_root.iterdir()):
+            if not entry.is_dir():
+                continue
+            env_file = entry / ".env"
+            if env_file.exists():
+                result.append((entry.name, env_file))
+    return result
+
+
+def _upsert_env_key(env_path: Path, key: str, value: str) -> bool:
+    """Update *key* in *env_path* to *value*. Returns True if a change was made."""
+    import tempfile
+    import stat
+
+    lines: list[str] = []
+    if env_path.exists():
+        text = env_path.read_text(encoding="utf-8-sig", errors="replace")
+        lines = text.splitlines()
+    found = False
+    changed = False
+    for i, line in enumerate(lines):
+        stripped = line.lstrip()
+        if stripped.startswith("export "):
+            stripped = stripped[len("export "):]
+        if stripped.startswith(f"{key}="):
+            new_line = f"{key}={value}"
+            if lines[i].lstrip().startswith("export "):
+                new_line = f"export {new_line}"
+            if lines[i] != new_line:
+                lines[i] = new_line
+                changed = True
+            found = True
+            break
+    if not found:
+        if lines and not lines[-1].endswith("\n"):
+            lines[-1] += "\n"
+        lines.append(f"{key}={value}")
+        changed = True
+    if changed:
+        # Preserve permissions (Docker volumes, 0o600 on profile .env)
+        original_mode = None
+        if env_path.exists():
+            try:
+                original_mode = stat.S_IMODE(env_path.stat().st_mode)
+            except OSError:
+                pass
+        fd, tmp = tempfile.mkstemp(dir=str(env_path.parent), suffix=".env_tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write("\n".join(lines) + "\n")
+            os.replace(tmp, str(env_path))
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+        if original_mode is not None:
+            try:
+                os.chmod(str(env_path), original_mode)
+            except OSError:
+                pass
+    return changed
+
+
+def auth_sync_command(args) -> None:
+    """Detect and optionally fix credential drift across .env files.
+
+    The main ``~/.hermes/.env`` is treated as the source of truth.  Profile
+    ``.env`` files are compared against it; mismatches are reported and,
+    with ``--fix``, updated to match.
+    """
+    import os as _os
+
+    fix = getattr(args, "fix", False)
+
+    profile_envs = _discover_profile_envs()
+    if not profile_envs:
+        print("No .env files found.")
+        return
+
+    default_env_path = profile_envs[0][1]
+    default_secrets = _read_env_file(default_env_path)
+    if not default_secrets:
+        print(f"Source of truth ({default_env_path}) is empty or missing.")
+        return
+
+    cred_vars = _collect_credential_env_vars()
+    # Only check vars that actually exist in the default .env
+    cred_vars = [v for v in cred_vars if v in default_secrets]
+    if not cred_vars:
+        print("No credential env vars found in the default .env.")
+        return
+
+    total_mismatches = 0
+    fixed_count = 0
+
+    for env_var in cred_vars:
+        source_val = default_secrets.get(env_var, "")
+        profile_mismatches: list[tuple[str, str, Path]] = []
+
+        for prof_name, prof_env_path in profile_envs[1:]:
+            prof_secrets = _read_env_file(prof_env_path)
+            prof_val = prof_secrets.get(env_var, "")
+            if prof_val != source_val:
+                profile_mismatches.append((prof_name, prof_val, prof_env_path))
+
+        if not profile_mismatches:
+            continue
+
+        total_mismatches += len(profile_mismatches)
+        print(f"\n  {env_var}:")
+        print(f"    {default_env_path.parent.name}/.env  ✅ {_mask_key(source_val)}")
+        for prof_name, prof_val, prof_env_path in profile_mismatches:
+            print(f"    {prof_name}/.env              ❌ {_mask_key(prof_val)} (mismatch!)")
+            if fix:
+                changed = _upsert_env_key(prof_env_path, env_var, source_val)
+                if changed:
+                    fixed_count += 1
+                    print(f"      → fixed ({prof_name}/.env updated)")
+
+    if total_mismatches == 0:
+        print("\n✅ All profile .env files are in sync with the main .env.")
+    else:
+        if fix:
+            print(f"\n{fixed_count} of {total_mismatches} mismatch(es) fixed.")
+        else:
+            print(f"\n{total_mismatches} mismatch(es) found. Run `hermes auth sync --fix` to update.")

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -811,24 +811,23 @@ def _collect_credential_env_vars() -> list[str]:
         for var in cfg.api_key_env_vars:
             if var:
                 env_vars.add(var)
-    # Well-known tool / auxiliary credential env vars
-    env_vars.update({
+    # Well-known tool / auxiliary credential env vars.
+    # Only include vars NOT already present in PROVIDER_REGISTRY
+    # to avoid duplication while keeping coverage broad.
+    extra: set[str] = {
         "OPENROUTER_API_KEY",
-        "DEEPSEEK_API_KEY",
-        "GLM_API_KEY",
-        "ANTHROPIC_API_KEY",
-        "GOOGLE_API_KEY",
-        "GEMINI_API_KEY",
-        "XAI_API_KEY",
         "FIRECRAWL_API_KEY",
         "FAL_KEY",
         "GROQ_API_KEY",
-        "KIMI_API_KEY",
         "MINIMAX_API_KEY",
         "DASHSCOPE_API_KEY",
         "HF_TOKEN",
         "COPILOT_GITHUB_TOKEN",
-    })
+    }
+    # Deduplicate against PROVIDER_REGISTRY (in case registry grows
+    # to cover these in the future)
+    extra -= env_vars
+    env_vars.update(extra)
     env_vars.discard("")
     return sorted(env_vars)
 
@@ -932,6 +931,16 @@ def auth_sync_command(args) -> None:
         print("No .env files found.")
         return
 
+    # The first entry from _discover_profile_envs is always the default
+    # ~/.hermes/.env (when it exists).  Validate it's actually the
+    # default to avoid using a named profile as source of truth.
+    if profile_envs[0][0] != "default":
+        print(
+            "No default ~/.hermes/.env found. "
+            "Create one first (e.g. with `hermes setup` or by placing "
+            "your API key in ~/.hermes/.env)."
+        )
+        return
     default_env_path = profile_envs[0][1]
     default_secrets = _read_env_file(default_env_path)
     if not default_secrets:

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -812,17 +812,12 @@ def _collect_credential_env_vars() -> list[str]:
             if var:
                 env_vars.add(var)
     # Well-known tool / auxiliary credential env vars.
-    # Only include vars NOT already present in PROVIDER_REGISTRY
-    # to avoid duplication while keeping coverage broad.
+    # Only include vars NOT already present in PROVIDER_REGISTRY.
     extra: set[str] = {
         "OPENROUTER_API_KEY",
         "FIRECRAWL_API_KEY",
         "FAL_KEY",
         "GROQ_API_KEY",
-        "MINIMAX_API_KEY",
-        "DASHSCOPE_API_KEY",
-        "HF_TOKEN",
-        "COPILOT_GITHUB_TOKEN",
     }
     # Deduplicate against PROVIDER_REGISTRY (in case registry grows
     # to cover these in the future)

--- a/hermes_cli/subcommands/auth.py
+++ b/hermes_cli/subcommands/auth.py
@@ -106,4 +106,13 @@ def build_auth_parser(subparsers, *, cmd_auth: Callable) -> None:
     auth_spotify.add_argument(
         "--timeout", type=float, help="Callback/token exchange timeout in seconds"
     )
+    auth_sync = auth_subparsers.add_parser(
+        "sync",
+        help="Detect and fix credential drift across .env files",
+    )
+    auth_sync.add_argument(
+        "--fix",
+        action="store_true",
+        help="Update stale profile .env files to match the main .env",
+    )
     auth_parser.set_defaults(func=cmd_auth)

--- a/tests/hermes_cli/test_auth_sync.py
+++ b/tests/hermes_cli/test_auth_sync.py
@@ -1,0 +1,209 @@
+"""Tests for ``hermes auth sync`` — credential drift detection and fix.
+
+These tests exercise the real ``_discover_profile_envs`` /
+``_read_env_file`` / ``_upsert_env_key`` path against a temp
+``HERMES_HOME`` with a main ``.env`` and multiple profile ``.env``
+files, verifying both the dry-run report and the ``--fix`` behaviour.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def sync_env(tmp_path, monkeypatch):
+    """Set up a HERMES_HOME with a main .env and two profile .env files."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True)
+    profiles_root = hermes_home / "profiles"
+
+    # Main .env — source of truth
+    (hermes_home / ".env").write_text(
+        "OPENROUTER_API_KEY=sk-or-fresh-abcd1234\n"
+        "DEEPSEEK_API_KEY=sk-ds-fresh-5678\n"
+        "# Comment line\n"
+    )
+
+    # Profile: worker-1 — stale OPENROUTER key
+    p1 = profiles_root / "worker-1"
+    p1.mkdir(parents=True)
+    (p1 / ".env").write_text(
+        "OPENROUTER_API_KEY=sk-or-stale-0000\n"
+        "DEEPSEEK_API_KEY=sk-ds-fresh-5678\n"
+    )
+
+    # Profile: worker-2 — missing OPENROUTER, stale DEEPSEEK
+    p2 = profiles_root / "worker-2"
+    p2.mkdir(parents=True)
+    (p2 / ".env").write_text(
+        "DEEPSEEK_API_KEY=sk-ds-stale-0000\n"
+    )
+
+    # Profile: worker-3 — fully in sync
+    p3 = profiles_root / "worker-3"
+    p3.mkdir(parents=True)
+    (p3 / ".env").write_text(
+        "OPENROUTER_API_KEY=sk-or-fresh-abcd1234\n"
+        "DEEPSEEK_API_KEY=sk-ds-fresh-5678\n"
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    # Patch _get_default_hermes_home and _get_profiles_root to use our temp
+    from hermes_cli.profiles import _get_profiles_root, _get_default_hermes_home
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_default_hermes_home", lambda: hermes_home
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_profiles_root", lambda: hermes_home / "profiles"
+    )
+
+    return {
+        "hermes_home": hermes_home,
+        "main_env": hermes_home / ".env",
+        "profiles_root": profiles_root,
+        "profiles": {
+            "worker-1": p1 / ".env",
+            "worker-2": p2 / ".env",
+            "worker-3": p3 / ".env",
+        },
+    }
+
+
+def test_sync_dry_run_reports_mismatches(capsys, sync_env):
+    """Dry-run should report mismatches without fixing them."""
+    from hermes_cli.auth_commands import auth_sync_command
+
+    auth_sync_command(SimpleNamespace(fix=False))
+    out = capsys.readouterr().out
+
+    assert "OPENROUTER_API_KEY" in out
+    assert "DEEPSEEK_API_KEY" in out
+    assert "worker-1" in out
+    assert "worker-2" in out
+    # worker-3 is in sync — should NOT appear
+    assert "worker-3" not in out
+    # Should mention the --fix hint
+    assert "--fix" in out
+    # Should NOT have fixed anything
+    assert "fixed" not in out.lower() or "mismatch(es) found" in out
+
+    # Verify files were NOT modified
+    w1_env = sync_env["profiles"]["worker-1"]
+    assert "stale" in w1_env.read_text()
+
+
+def test_sync_fix_updates_stale_profiles(capsys, sync_env):
+    """--fix should update stale profile .env files to match main .env."""
+    from hermes_cli.auth_commands import auth_sync_command
+
+    auth_sync_command(SimpleNamespace(fix=True))
+    out = capsys.readouterr().out
+
+    assert "fixed" in out
+
+    # worker-1: OPENROUTER should be updated to fresh key
+    w1_env = sync_env["profiles"]["worker-1"]
+    w1_text = w1_env.read_text()
+    assert "sk-or-fresh-abcd1234" in w1_text
+    assert "stale" not in w1_text
+
+    # worker-2: both keys should now be present and fresh
+    w2_env = sync_env["profiles"]["worker-2"]
+    w2_text = w2_env.read_text()
+    assert "sk-or-fresh-abcd1234" in w2_text
+    assert "sk-ds-fresh-5678" in w2_text
+    assert "stale" not in w2_text
+
+    # worker-3: should be unchanged (was already in sync)
+    w3_env = sync_env["profiles"]["worker-3"]
+    w3_text = w3_env.read_text()
+    assert "sk-or-fresh-abcd1234" in w3_text
+
+
+def test_sync_after_fix_reports_clean(capsys, sync_env):
+    """After --fix, a subsequent dry-run should report all in sync."""
+    from hermes_cli.auth_commands import auth_sync_command
+
+    # Fix
+    auth_sync_command(SimpleNamespace(fix=True))
+    capsys.readouterr()  # clear
+
+    # Dry-run
+    auth_sync_command(SimpleNamespace(fix=False))
+    out = capsys.readouterr().out
+
+    assert "All profile .env files are in sync" in out
+
+
+def test_sync_preserves_file_permissions(capsys, sync_env):
+    """--fix should preserve the original file permissions."""
+    from hermes_cli.auth_commands import auth_sync_command
+    import stat
+
+    w1_env = sync_env["profiles"]["worker-1"]
+    os.chmod(str(w1_env), 0o600)
+    original_mode = stat.S_IMODE(w1_env.stat().st_mode)
+
+    auth_sync_command(SimpleNamespace(fix=True))
+
+    new_mode = stat.S_IMODE(w1_env.stat().st_mode)
+    assert new_mode == original_mode
+
+
+def test_sync_no_profiles(tmp_path, monkeypatch, capsys):
+    """Should handle gracefully when no .env files exist."""
+    hermes_home = tmp_path / "empty"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_default_hermes_home", lambda: hermes_home
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_profiles_root", lambda: hermes_home / "profiles"
+    )
+
+    from hermes_cli.auth_commands import auth_sync_command
+
+    auth_sync_command(SimpleNamespace(fix=False))
+    out = capsys.readouterr().out
+
+    assert "No .env files found" in out
+
+
+def test_sync_empty_main_env(tmp_path, monkeypatch, capsys):
+    """Should handle gracefully when main .env is empty."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / ".env").write_text("# only comments\n")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_default_hermes_home", lambda: hermes_home
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_profiles_root", lambda: hermes_home / "profiles"
+    )
+
+    from hermes_cli.auth_commands import auth_sync_command
+
+    auth_sync_command(SimpleNamespace(fix=False))
+    out = capsys.readouterr().out
+
+    assert "empty or missing" in out
+
+
+def test_mask_key():
+    """Test key masking for display."""
+    from hermes_cli.auth_commands import _mask_key
+
+    assert _mask_key("") == "(empty)"
+    assert _mask_key("short") == "sh…rt"
+    assert _mask_key("sk-or-fresh-abcd1234") == "sk-o…1234"
+    assert _mask_key("exactly12ch") == "ex…ch"

--- a/tests/hermes_cli/test_auth_sync.py
+++ b/tests/hermes_cli/test_auth_sync.py
@@ -207,3 +207,65 @@ def test_mask_key():
     assert _mask_key("short") == "sh…rt"
     assert _mask_key("sk-or-fresh-abcd1234") == "sk-o…1234"
     assert _mask_key("exactly12ch") == "ex…ch"
+
+
+def test_sync_no_default_env_aborts(tmp_path, monkeypatch, capsys):
+    """Should abort with clear message when no default .env exists."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    profiles_root = hermes_home / "profiles"
+    profiles_root.mkdir(parents=True)
+
+    # Create a profile .env WITHOUT a default .env
+    p = profiles_root / "orphan-profile"
+    p.mkdir()
+    (p / ".env").write_text("OPENROUTER_API_KEY=sk-orphan\n")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_default_hermes_home", lambda: hermes_home
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_profiles_root", lambda: profiles_root
+    )
+
+    from hermes_cli.auth_commands import auth_sync_command
+
+    auth_sync_command(SimpleNamespace(fix=False))
+    out = capsys.readouterr().out
+
+    assert "No default" in out
+    assert ".hermes/.env" in out or "~/" in out
+
+    # Verify the orphan profile was NOT modified
+    assert "sk-orphan" in (p / ".env").read_text()
+
+
+def test_sync_no_default_env_with_fix_also_aborts(tmp_path, monkeypatch, capsys):
+    """--fix should also abort when no default .env exists."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    profiles_root = hermes_home / "profiles"
+    profiles_root.mkdir(parents=True)
+
+    p = profiles_root / "orphan"
+    p.mkdir()
+    (p / ".env").write_text("OPENROUTER_API_KEY=sk-orphan\n")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_default_hermes_home", lambda: hermes_home
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_profiles_root", lambda: profiles_root
+    )
+
+    from hermes_cli.auth_commands import auth_sync_command
+
+    auth_sync_command(SimpleNamespace(fix=True))
+    out = capsys.readouterr().out
+
+    assert "No default" in out
+
+    # Verify files not modified
+    assert "sk-orphan" in (p / ".env").read_text()


### PR DESCRIPTION
## Problem

When a user updates an API key in the main `~/.hermes/.env`, profile `.env` files (created via `hermes profile create --clone`) silently keep stale copies. Profiles that use their own `.env` (Kanban workers, multiplexed gateway) then fail with cryptic 401 errors because the stale key is still loaded by the profile-scoped secret resolver (`agent/secret_scope.py`).

Real-world example (my setup):
- Updated `OPENROUTER_API_KEY` in `~/.hermes/.env` after key rotation
- 6 Kanban worker profiles (`~/.hermes/profiles/*/.env`) still had the old expired key
- WebUI sessions using the `orchestrator` profile failed with `HTTP 401: Authentication Fails, Your api key: ****579a is invalid`
- No diagnostic hint pointing to profile .env drift

This is the same class of bug described in #18359, but the previous PR #18361 was closed with a request to scope the solution more broadly. The root-cause fix for `os.environ` shadowing (#18755) is merged, but it does not address profile `.env` drift — profiles intentionally read their own `.env` first.

## Solution

Add `hermes auth sync` — a subcommand that compares the main `~/.hermes/.env` against all profile `.env` files and reports (and optionally fixes) credential drift.

```bash
hermes auth sync           # report drift (dry-run)
hermes auth sync --fix     # update stale profile .env files to match main
```

### What it checks

For every credential env var (drawn from `PROVIDER_REGISTRY[*].api_key_env_vars` + well-known tool keys like `FAL_KEY`, `FIRECRAWL_API_KEY`, etc.):

1. **Main `.env`** (`~/.hermes/.env`) — source of truth
2. **Each profile `.env`** (`~/.hermes/profiles/<name>/.env`)

Keys are masked in output (`first4…last4`).

### Example output (dry-run)

```
  OPENROUTER_API_KEY:
    .hermes/.env  ✅ sk-o…1d36
    orchestrator/.env              ❌ sk-o…579a (mismatch!)
    backend-dev/.env              ❌ sk-o…579a (mismatch!)

  2 mismatch(es) found. Run `hermes auth sync --fix` to update.
```

### Example output (--fix)

```
  OPENROUTER_API_KEY:
    .hermes/.env  ✅ sk-o…1d36
    orchestrator/.env              ❌ sk-o…579a (mismatch!)
      → fixed (orchestrator/.env updated)
    backend-dev/.env              ❌ sk-o…579a (mismatch!)
      → fixed (backend-dev/.env updated)

  2 of 2 mismatch(es) fixed.
```

### Design decisions

- **Main `.env` as source of truth** — the user updates the main `.env` (via `hermes model`, `hermes setup`, or manual edit); profiles should follow.
- **Does not touch `auth.json` credential pool** — the `os.environ` shadowing bug that affected `auth.json` is already fixed (#18755). The credential pool is self-healing on the next pool read. Keeping `auth.json` out of scope avoids write conflicts with the pool manager.
- **`--fix` preserves file permissions** — profile `.env` files are typically `0o600`; the fix uses `tempfile.mkstemp` + `os.replace` and restores the original mode.
- **No `HERMES_*` env var** — behavioral config (if any in the future) goes in `config.yaml`, not `.env`. The command has no config beyond `--fix`.
- **Non-interactive** — safe for cron/gateway use. No prompts.

## Changes

- `hermes_cli/auth_commands.py` (+200 lines): `auth_sync_command` + helpers (`_mask_key`, `_collect_credential_env_vars`, `_discover_profile_envs`, `_read_env_file`, `_upsert_env_key`)
- `hermes_cli/subcommands/auth.py` (+9 lines): `sync` subparser registration
- `tests/hermes_cli/test_auth_sync.py` (new, 7 tests): dry-run, --fix, post-fix clean, file permissions, empty/no-env edge cases, mask helper

## Related

- Closes #18359
- Previous PR #18361 (closed — request for broader scope; this PR addresses the profile `.env` drift aspect)
- #18755 (merged — fixed `os.environ` shadowing for `auth.json` credential pool seeding; does not address profile `.env` drift)

## Testing

```bash
python -m pytest tests/hermes_cli/test_auth_sync.py -v --tb=short -o 'addopts='
# 7 passed in 0.36s
```

Also verified manually against a real 6-profile Kanban setup:
```
$ hermes auth sync
  12 mismatch(es) found. Run `hermes auth sync --fix` to update.

$ hermes auth sync --fix
  10 of 10 mismatch(es) fixed.

$ hermes auth sync
  ✅ All profile .env files are in sync with the main .env.
```