### PR TITLE
fix(desktop): skip ensureBackend after profile-delete teardown to prevent respawn loop (#52279)

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -5133,19 +5133,24 @@ function profileNameFromDeleteRequest(request) {
   return name.toLowerCase()
 }
 
+// Returns the profile name whose backend was torn down, or null when the
+// request is not a profile-delete.  The caller uses this to skip ensureBackend
+// for the just-torn-down profile — otherwise ensureBackend respawns a pool
+// backend whose ensure_hermes_home() recreates the deleted profile directory.
 async function prepareProfileDeleteRequest(request) {
   const profile = profileNameFromDeleteRequest(request)
   if (!profile || profile === 'default' || !PROFILE_NAME_RE.test(profile)) {
-    return
+    return null
   }
 
   if (profile === primaryProfileKey()) {
     writeActiveDesktopProfile('default')
     await teardownPrimaryBackendAndWait()
-    return
+    return profile
   }
 
   await teardownPoolBackendAndWait(profile)
+  return profile
 }
 
 async function startHermes() {
@@ -6149,10 +6154,15 @@ ipcMain.handle('hermes:api', async (_event, request) => {
     return rerouted
   }
 
-  await prepareProfileDeleteRequest(request)
+  const tornDownProfile = await prepareProfileDeleteRequest(request)
 
   const profile = request?.profile
-  const connection = await ensureBackend(profile)
+  // After tearing down a backend for profile deletion, route to the primary
+  // backend instead of spawning a fresh pool backend.  A freshly spawned
+  // backend calls ensure_hermes_home() which recreates the profile directory,
+  // defeating the deletion and leaving a zombie process.
+  const routeProfile = tornDownProfile ? null : profile
+  const connection = await ensureBackend(routeProfile)
   const timeoutMs = resolveTimeoutMs(request?.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)
   const requestPath = pathWithGlobalRemoteProfile(request.path, profile, {
     globalRemote: globalRemoteActive(),

--- a/apps/desktop/electron/profile-delete-respawn.test.cjs
+++ b/apps/desktop/electron/profile-delete-respawn.test.cjs
@@ -1,0 +1,66 @@
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const ELECTRON_DIR = __dirname
+
+function readElectronFile(name) {
+  return fs.readFileSync(path.join(ELECTRON_DIR, name), 'utf8').replace(/\r\n/g, '\n')
+}
+
+// ---------------------------------------------------------------------------
+// prepareProfileDeleteRequest must return the torn-down profile name so the
+// caller can skip ensureBackend for that profile (issue #52279).
+// ---------------------------------------------------------------------------
+
+test('prepareProfileDeleteRequest returns the torn-down profile name', () => {
+  const source = readElectronFile('main.cjs')
+
+  // Locate the function definition and its closing brace.
+  const fnStart = source.indexOf('async function prepareProfileDeleteRequest(')
+  assert.notEqual(fnStart, -1, 'prepareProfileDeleteRequest function not found')
+
+  // The function must contain "return profile" (pool and primary paths).
+  const fnBody = source.slice(fnStart, fnStart + 800)
+  const returnProfileCount = (fnBody.match(/return profile/g) || []).length
+  assert.ok(
+    returnProfileCount >= 2,
+    `expected at least 2 "return profile" statements (primary + pool paths), found ${returnProfileCount}`
+  )
+
+  // The early-exit guard must return null (not void/undefined).
+  assert.match(
+    fnBody,
+    /return null/,
+    'early-exit guard should return null, not undefined'
+  )
+})
+
+test('hermes:api handler routes profile-delete requests to the primary backend', () => {
+  const source = readElectronFile('main.cjs')
+
+  // The handler must capture prepareProfileDeleteRequest's return value.
+  assert.match(
+    source,
+    /const tornDownProfile = await prepareProfileDeleteRequest\(request\)/,
+    'handler should capture the return value of prepareProfileDeleteRequest'
+  )
+
+  // The handler must use the return value to skip ensureBackend for the
+  // torn-down profile, routing to the primary (null) instead.
+  assert.match(
+    source,
+    /const routeProfile = tornDownProfile \? null : profile/,
+    'handler should route to primary backend when a profile was just torn down'
+  )
+
+  // ensureBackend must be called with the conditional route profile.
+  assert.match(
+    source,
+    /const connection = await ensureBackend\(routeProfile\)/,
+    'handler should pass routeProfile (not raw profile) to ensureBackend'
+  )
+})


### PR DESCRIPTION
## What does this PR do?

Fixes a respawn loop where deleting a non-default profile via the Desktop UI causes the profile directory to be recreated indefinitely, accumulating zombie backend processes.

## Related Issue

Fixes #52279

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/main.cjs`: Make `prepareProfileDeleteRequest` return the torn-down profile name. In the `hermes:api` IPC handler, use this return value to route the DELETE request to the primary backend instead of spawning a fresh pool backend for the just-deleted profile.
- `apps/desktop/electron/profile-delete-respawn.test.cjs`: Structural tests verifying `prepareProfileDeleteRequest` returns the profile name and the IPC handler uses it to skip `ensureBackend`.

## How to Test

1. Create a non-default profile via the Desktop UI or `hermes profile create test-profile`
2. Delete the profile via the Desktop UI
3. Verify the profile directory is removed and does not reappear after Desktop restart
4. Verify no zombie `hermes dashboard --profile test-profile` processes remain (`ps aux | grep "hermes.*dashboard.*profile"`)
5. Run `node --test apps/desktop/electron/profile-delete-respawn.test.cjs` — both tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `node --test apps/desktop/electron/profile-delete-respawn.test.cjs` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `apps/desktop/electron/main.cjs` (`prepareProfileDeleteRequest`, `ensureBackend`, `hermes:api` handler)
- Blast radius: LOW — affects only profile-delete IPC path in Desktop; no change to CLI, gateway, or non-desktop flows
- Related patterns: `teardownPoolBackendAndWait` lifecycle, `ensure_hermes_home()` directory creation, `backendPool` management
