### PR TITLE
fix(cron): render CJK characters as UTF-8 in jobs.json

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -458,7 +458,7 @@ def save_jobs(jobs: List[Dict[str, Any]]):
     fd, tmp_path = tempfile.mkstemp(dir=str(JOBS_FILE.parent), suffix='.tmp', prefix='.jobs_')
     try:
         with os.fdopen(fd, 'w', encoding='utf-8') as f:
-            json.dump({"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, indent=2)
+            json.dump({"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, ensure_ascii=False, indent=2)
             f.flush()
             os.fsync(f.fileno())
         atomic_replace(tmp_path, JOBS_FILE)


### PR DESCRIPTION
## Problem

`jobs.json` stores non-ASCII characters (CJK, emoji in job names/prompts) as `\uXXXX` escape sequences because `json.dump()` defaults to `ensure_ascii=True`.

This makes the file unreadable with standard CLI tools like `grep`, `jq`, `less`, or any editor that does not auto-convert Unicode escapes.

## Fix

Pass `ensure_ascii=False` to `json.dump()` so CJK characters are written as UTF-8 directly — the standard modern convention for JSON files.

## Before

```json
{"name": "\u76d8\u524d\u63a8\u8350"}
```

## After

```json
{"name": "盘前推荐"}
```

No functional impact — both forms are semantically identical JSON.