### PR TITLE
fix: remove redundant exception types from except tuples

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -653,7 +653,7 @@ def compress_context(
                     try:
                         new_title = agent._session_db.get_next_title_in_lineage(old_title)
                         agent._session_db.set_session_title(agent.session_id, new_title)
-                    except (ValueError, Exception) as e:
+                    except Exception as e:
                         logger.debug("Could not propagate title on compression: %s", e)
 
             # Shared post-write steps (both modes target agent.session_id, which

--- a/cli.py
+++ b/cli.py
@@ -9140,7 +9140,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         fetch_account_usage, provider,
                         base_url=base_url, api_key=api_key,
                     ).result(timeout=10.0)
-                except (concurrent.futures.TimeoutError, Exception):
+                except Exception:
                     account_snapshot = None
         account_lines = [f"  {line}" for line in render_account_usage_lines(account_snapshot)]
         if account_lines:

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -433,7 +433,7 @@ class CLIAgentSetupMixin:
                         _cprint(f"  Session title applied: {self._pending_title}")
                         self._pending_title = None
                     # else: row creation failed transiently — keep _pending_title for retry
-                except (ValueError, Exception) as e:
+                except Exception as e:
                     _cprint(f"  Could not apply pending title: {e}")
                     # Keep _pending_title so it can be retried after row creation succeeds
             return True

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1897,7 +1897,7 @@ class CLICommandsMixin:
                     s.connect(("127.0.0.1", _port))
                     s.close()
                     print("   Status: ✓ reachable")
-                except (OSError, Exception):
+                except Exception:
                     print("   Status: ⚠ not reachable (browser may not be running)")
             else:
                 try:

--- a/hermes_time.py
+++ b/hermes_time.py
@@ -74,7 +74,7 @@ def _get_zoneinfo(name: str) -> Optional[ZoneInfo]:
         return None
     try:
         return ZoneInfo(name)
-    except (KeyError, Exception) as exc:
+    except Exception as exc:
         logger.warning(
             "Invalid timezone '%s': %s. Falling back to server local time.",
             name, exc,

--- a/scripts/discord-voice-doctor.py
+++ b/scripts/discord-voice-doctor.py
@@ -80,7 +80,7 @@ def check_packages():
             import nacl.secret
             nacl.secret.Aead(bytes(32))
             check("PyNaCl", True, f"v{ver}")
-        except (AttributeError, Exception):
+        except Exception:
             check("PyNaCl (Aead)", False, f"v{ver} — need >=1.5.0")
             ok = False
     except ImportError:

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -502,7 +502,7 @@ def _is_satisfied(spec: str) -> bool:
 
     try:
         return Version(installed) in SpecifierSet(spec_tail)
-    except (InvalidSpecifier, InvalidVersion, Exception):
+    except Exception:
         # Malformed spec or installed version we can't parse — don't churn.
         return True
 
@@ -898,7 +898,7 @@ def ensure_and_bind(
     """
     try:
         ensure(feature, prompt=prompt)
-    except (FeatureUnavailable, Exception):
+    except Exception:
         return False
 
     try:

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -138,7 +138,7 @@ def _load_web_config() -> dict:
     try:
         from hermes_cli.config import load_config
         return load_config().get("web", {})
-    except (ImportError, Exception):
+    except Exception:
         return {}
 
 def _get_backend() -> str:


### PR DESCRIPTION
## Problem

When `Exception` is in an except tuple, all its subclasses are already covered. Listing them explicitly is redundant and confusing.

```python
# Before — ValueError is already covered by Exception
except (ValueError, Exception) as e:

# After — cleaner, same behavior
except Exception as e:
```

## Files changed (9 fixes in 8 files)

| File | Redundant type removed |
|------|----------------------|
| `agent/conversation_compression.py` | ValueError |
| `tools/lazy_deps.py` | InvalidSpecifier, InvalidVersion, FeatureUnavailable |
| `tools/web_tools.py` | ImportError |
| `hermes_cli/cli_commands_mixin.py` | OSError |
| `hermes_cli/cli_agent_setup_mixin.py` | ValueError |
| `hermes_time.py` | KeyError |
| `scripts/discord-voice-doctor.py` | AttributeError |
| `cli.py` | concurrent.futures.TimeoutError |

Note: Cases with `asyncio.CancelledError` (e.g. `except (CancelledError, Exception)`) are NOT redundant — `CancelledError` inherits from `BaseException`, not `Exception`.