### PR TITLE
fix: remove redundant OSError subclasses from except tuples

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -518,7 +518,7 @@ def _try_acquire_file_lock(handle) -> bool:
         else:
             fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
         return True
-    except (BlockingIOError, OSError):
+    except OSError:
         return False
 
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -993,7 +993,7 @@ def _file_lock(
                     lock_file.seek(0)
                     msvcrt.locking(lock_file.fileno(), msvcrt.LK_NBLCK, 1)
                 break
-            except (BlockingIOError, OSError, PermissionError):
+            except OSError:
                 if time.monotonic() >= deadline:
                     raise TimeoutError(timeout_message)
                 time.sleep(0.05)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1276,7 +1276,7 @@ def _cross_process_init_lock(path: Path):
                     fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
                     acquired = True
                     break
-                except (BlockingIOError, OSError):
+                except OSError:
                     if time.monotonic() >= deadline:
                         break
                     time.sleep(_INIT_LOCK_POLL_SECONDS)

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -397,7 +397,7 @@ class EmailAdapter(BasePlatformAdapter):
 
         try:
             return _connect()
-        except (socket.timeout, TimeoutError, ConnectionError, OSError) as exc:
+        except (socket.timeout, OSError) as exc:
             if isinstance(exc, ssl.SSLError):
                 raise
             # Connection-level failure (may be unreachable IPv6).

--- a/skills/creative/comfyui/scripts/_common.py
+++ b/skills/creative/comfyui/scripts/_common.py
@@ -476,7 +476,7 @@ def http_request(
                 _sleep_backoff(attempt)
                 continue
             return resp
-        except (TimeoutError, ConnectionError, OSError) as e:
+        except OSError as e:
             last_exc = e
             if attempt + 1 < retries:
                 _sleep_backoff(attempt)

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1179,7 +1179,7 @@ class ProcessRegistry:
                     chunk = stdout.read()
                     if chunk:
                         drained = chunk if isinstance(chunk, str) else chunk.decode("utf-8", errors="replace")
-                except (BlockingIOError, OSError, ValueError):
+                except (OSError, ValueError):
                     pass
                 finally:
                     try:


### PR DESCRIPTION
## Problem

`BlockingIOError`, `ConnectionError`, `TimeoutError`, `PermissionError`, `FileNotFoundError`, etc. are all subclasses of `OSError` since Python 3.3. Listing them alongside `OSError` in except tuples is redundant.

```python
# Before — BlockingIOError is already covered by OSError
except (BlockingIOError, OSError, ValueError):

# After — cleaner, same behavior
except (OSError, ValueError):
```

## Files changed (6 fixes in 6 files)

| File | Change |
|------|--------|
| `tools/process_registry.py` | `(BlockingIOError, OSError, ValueError)` → `(OSError, ValueError)` |
| `hermes_cli/kanban_db.py` | `(BlockingIOError, OSError)` → `OSError` |
| `hermes_cli/auth.py` | `(BlockingIOError, OSError, PermissionError)` → `OSError` |
| `gateway/status.py` | `(BlockingIOError, OSError)` → `OSError` |
| `skills/creative/comfyui/scripts/_common.py` | `(TimeoutError, ConnectionError, OSError)` → `OSError` |
| `plugins/platforms/email/adapter.py` | `(socket.timeout, TimeoutError, ConnectionError, OSError)` → `(socket.timeout, OSError)` |

Note: `socket.timeout` is kept because it's `OSError` only since Python 3.3, and the code may need to support older versions. `socket.timeout` is also a distinct class from `TimeoutError` in some contexts.