### PR TITLE
feat(gateway): add /bot-ping slash command for liveness check

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14353,6 +14353,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if canonical == "whoami":
             return await self._handle_whoami_command(event)
 
+        if canonical == "bot-ping":
+            return await self._handle_bot_ping_command(event)
+
         if canonical == "status":
             return await self._handle_status_command(event)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13413,6 +13413,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "help": self._handle_help_command,
                 "commands": self._handle_commands_command,
                 "profile": self._handle_profile_command,
+                "bot-ping": self._handle_bot_ping_command,
                 "update": self._handle_update_command,
                 "version": self._handle_version_command,
             }.get(name)

--- a/gateway/run_busy.py
+++ b/gateway/run_busy.py
@@ -753,7 +753,7 @@ class GatewayBusySessionMixin:
     _PLAIN_COMMANDS = (
         "status", "context", "restart", "approve", "deny", "pause", "agents", "bg", "btw",
         "kanban", "subgoal", "heartbeat", "busy", "yolo", "verbose", "footer", "help",
-        "commands", "profile", "update", "version",
+        "commands", "profile", "update", "version", "bot-ping",
     )
     # Dispatched only on the idle path (busy dispatch has its own allowlist).
     _IDLE_COMMANDS = (

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -429,6 +429,14 @@ class GatewaySlashCommandsMixin:
             f"Slash commands you can run: {runnable_str}"
         )
 
+    async def _handle_bot_ping_command(self, event: MessageEvent) -> str:
+        """Handle /bot-ping — reply 'pong' to verify bot is alive.
+
+        Designed as a liveness check for QQBot platform, similar to OpenClaw's
+        /bot-ping command. Returns simple 'pong' text for latency measurement.
+        """
+        return "pong"
+
     async def _handle_kanban_command(self, event: MessageEvent) -> str:
         """Handle /kanban — delegate to the shared kanban CLI.
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -328,6 +328,14 @@ class GatewaySlashCommandsMixin(
         runnable_str = ", ".join(f"/{c}" for c in runnable) if runnable else "(none)"
         return head + f"Tier: user\nSlash commands you can run: {runnable_str}"
 
+    async def _handle_bot_ping_command(self, event: MessageEvent) -> str:
+        """Handle /bot-ping — reply 'pong' to verify bot is alive.
+
+        Designed as a liveness check for QQBot platform, similar to OpenClaw's
+        /bot-ping command. Returns simple 'pong' text for latency measurement.
+        """
+        return "pong"
+
     async def _handle_kanban_command(self, event: MessageEvent) -> str:
         """Handle /kanban — delegate to the shared kanban CLI (DB work in a thread pool). Allowed
         while an agent runs: the board is profile-agnostic and never touches agent state."""

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -169,6 +169,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                aliases=("ctx",), args_hint="[all]", subcommands=("all",),
                busy_policy="dispatch"),
     CommandDef("whoami", "Show your slash command access (admin / user)", "Info"),
+    CommandDef("bot-ping", "Reply with 'pong' for liveness check", "Info",
+               gateway_only=True, busy_policy="dispatch"),
     CommandDef("profile", "Show active profile name and home directory", "Info",
                busy_policy="dispatch", execute="profile"),
     CommandDef("sethome", "Set this chat as the home channel", "Session",

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -139,6 +139,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("context", "Show detailed context window view with usage gauge, category breakdown, compression stats, and throughput", "Session",
                aliases=("ctx",), args_hint="[all]", subcommands=("all",), busy_policy="dispatch"),
     CommandDef("whoami", "Show your slash command access (admin / user)", "Info"),
+    CommandDef("bot-ping", "Reply with 'pong' for liveness check", "Info",
+               gateway_only=True, busy_policy="dispatch"),
     CommandDef("profile", "Show active profile name and home directory", "Info",
                busy_policy="dispatch", execute="profile"),
     CommandDef("sethome", "Set this chat as the home channel", "Session",

--- a/hermes_cli/commands_platforms.py
+++ b/hermes_cli/commands_platforms.py
@@ -368,7 +368,7 @@ _SLACK_RESERVED_COMMANDS = frozenset({
 # parity test reads this set. Aliases are never pinned ahead of canonicals.
 _SLACK_VIA_HERMES_ONLY = frozenset({
     "topup", "moa", "debug", "egress", "init", "version", "diff", "update", "heartbeat",
-    "refine", "review", "pause", "whoami", "platform", "insights"})
+    "refine", "review", "pause", "whoami", "platform", "insights", "bot-ping"})
 
 
 def _sanitize_slack_name(raw: str) -> str:

--- a/tests/gateway/test_bot_ping_command.py
+++ b/tests/gateway/test_bot_ping_command.py
@@ -1,0 +1,97 @@
+"""Tests for gateway /bot-ping command.
+
+The /bot-ping command is a liveness check that replies with 'pong' without
+triggering LLM inference.  Inspired by OpenClaw's /bot-ping for QQBot.
+"""
+
+import asyncio
+
+import pytest
+
+from hermes_cli.commands import (
+    COMMAND_REGISTRY,
+    GATEWAY_KNOWN_COMMANDS,
+    resolve_command,
+)
+
+
+# ---------------------------------------------------------------------------
+# Registry tests
+# ---------------------------------------------------------------------------
+
+
+class TestBotPingRegistry:
+    """Verify /bot-ping is properly registered in the command registry."""
+
+    def test_bot_ping_is_registered(self):
+        cmd = resolve_command("bot-ping")
+        assert cmd is not None
+        assert cmd.name == "bot-ping"
+
+    def test_bot_ping_is_gateway_only(self):
+        cmd = resolve_command("bot-ping")
+        assert cmd.gateway_only is True
+        assert cmd.cli_only is False
+
+    def test_bot_ping_category_is_info(self):
+        cmd = resolve_command("bot-ping")
+        assert cmd.category == "Info"
+
+    def test_bot_ping_description_mentions_pong(self):
+        cmd = resolve_command("bot-ping")
+        assert "pong" in cmd.description.lower()
+
+    def test_bot_ping_in_gateway_known_commands(self):
+        assert "bot-ping" in GATEWAY_KNOWN_COMMANDS
+
+    def test_bot_ping_no_aliases(self):
+        cmd = resolve_command("bot-ping")
+        assert cmd.aliases == ()
+
+    def test_bot_ping_no_args(self):
+        cmd = resolve_command("bot-ping")
+        assert cmd.args_hint == ""
+
+
+# ---------------------------------------------------------------------------
+# Handler tests
+# ---------------------------------------------------------------------------
+
+
+class TestBotPingHandler:
+    """Verify the /bot-ping handler returns 'pong'."""
+
+    def test_handler_returns_pong(self):
+        from gateway.slash_commands import GatewaySlashCommandsMixin
+
+        result = asyncio.run(
+            GatewaySlashCommandsMixin._handle_bot_ping_command(None, None)  # type: ignore[arg-type]
+        )
+        assert result == "pong"
+
+    def test_handler_returns_string(self):
+        """Ensure handler returns a plain string, not an EphemeralReply or None."""
+        from gateway.slash_commands import GatewaySlashCommandsMixin
+
+        result = asyncio.run(
+            GatewaySlashCommandsMixin._handle_bot_ping_command(None, None)  # type: ignore[arg-type]
+        )
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch tests
+# ---------------------------------------------------------------------------
+
+
+class TestBotPingDispatch:
+    """Verify /bot-ping is routed through the gateway dispatch chain."""
+
+    def test_bot_ping_resolves_with_leading_slash(self):
+        cmd = resolve_command("/bot-ping")
+        assert cmd is not None
+        assert cmd.name == "bot-ping"
+
+    def test_bot_ping_does_not_resolve_as_unknown(self):
+        assert resolve_command("bot-ping") is not None
+        assert resolve_command("nonexistent-ping") is None

--- a/tests/gateway/test_bot_ping_command.py
+++ b/tests/gateway/test_bot_ping_command.py
@@ -5,6 +5,8 @@ triggering LLM inference.  Inspired by OpenClaw's /bot-ping for QQBot.
 """
 
 import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -12,6 +14,7 @@ from hermes_cli.commands import (
     COMMAND_REGISTRY,
     GATEWAY_KNOWN_COMMANDS,
     resolve_command,
+    should_bypass_active_session,
 )
 
 
@@ -51,6 +54,25 @@ class TestBotPingRegistry:
     def test_bot_ping_no_args(self):
         cmd = resolve_command("bot-ping")
         assert cmd.args_hint == ""
+
+
+# ---------------------------------------------------------------------------
+# Bypass-active-session tests
+# ---------------------------------------------------------------------------
+
+
+class TestBotPingActiveSessionBypass:
+    """Verify /bot-ping bypasses the active-session guard."""
+
+    def test_should_bypass_active_session(self):
+        """/bot-ping must be recognized as a bypass command."""
+        assert should_bypass_active_session("bot-ping") is True
+
+    def test_should_bypass_active_session_with_slash(self):
+        assert should_bypass_active_session("/bot-ping") is True
+
+    def test_bypass_false_for_none(self):
+        assert should_bypass_active_session(None) is False
 
 
 # ---------------------------------------------------------------------------
@@ -95,3 +117,188 @@ class TestBotPingDispatch:
     def test_bot_ping_does_not_resolve_as_unknown(self):
         assert resolve_command("bot-ping") is not None
         assert resolve_command("nonexistent-ping") is None
+
+
+# ---------------------------------------------------------------------------
+# Active-session dispatch integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestBotPingActiveSessionDispatch:
+    """Verify /bot-ping works during an active session:
+    returns 'pong', does NOT queue, does NOT interrupt, does NOT reach
+    the LLM/agent path, and still obeys slash access policy.
+    """
+
+    @staticmethod
+    def _make_source():
+        from gateway.config import Platform
+        from gateway.session import SessionSource
+
+        return SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="u1",
+            chat_id="c1",
+            user_name="tester",
+            chat_type="dm",
+        )
+
+    @staticmethod
+    def _make_event(text: str):
+        from gateway.platforms.base import MessageEvent
+
+        return MessageEvent(
+            text=text,
+            source=TestBotPingActiveSessionDispatch._make_source(),
+            message_id="m1",
+        )
+
+    def _make_runner(self):
+        """Build a bare GatewayRunner with _running_agents populated."""
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+        )
+        adapter = MagicMock()
+        adapter.send = AsyncMock()
+        runner.adapters = {Platform.TELEGRAM: adapter}
+        runner._voice_mode = {}
+        runner.hooks = SimpleNamespace(
+            emit=AsyncMock(), emit_collect=AsyncMock(return_value=[]), loaded_hooks=False
+        )
+        runner._session_model_overrides = {}
+        runner._pending_model_notes = {}
+        runner._background_tasks = set()
+        runner._running_agents = {"agent:main:telegram:dm:c1:u1": MagicMock()}
+        runner._running_agents_ts = {"agent:main:telegram:dm:c1:u1": 1000.0}
+        runner._running_agent_generations = {}
+        runner._pending_messages = {}
+        runner._pending_approvals = {}
+        runner._session_db = None
+        runner._is_user_authorized = lambda _source: True
+        runner._format_session_info = lambda: ""
+        runner._agent_cache = {}
+        runner._agent_cache_lock = None
+        runner._telegram_topic_root_sessions = set()
+        runner._active_session_leases = {}
+        runner._command_hook_results = {}
+        runner._external_drain_active = False
+        runner._draining = False
+        runner.session_store = MagicMock()
+        return runner
+
+    def _make_runner_with_slash_access(self):
+        """Build a runner with an enabled slash-access policy that restricts
+        commands to admins only, to verify bot-ping is NOT a public bypass."""
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            platforms={
+                Platform.TELEGRAM: PlatformConfig(
+                    enabled=True,
+                    token="***",
+                    extra={
+                        "allow_admin_from": ["admin1"],
+                        "user_allowed_commands": [],
+                    },
+                )
+            }
+        )
+        adapter = MagicMock()
+        adapter.send = AsyncMock()
+        runner.adapters = {Platform.TELEGRAM: adapter}
+        runner._voice_mode = {}
+        runner.hooks = SimpleNamespace(
+            emit=AsyncMock(), emit_collect=AsyncMock(return_value=[]), loaded_hooks=False
+        )
+        runner._session_model_overrides = {}
+        runner._pending_model_notes = {}
+        runner._background_tasks = set()
+        runner._running_agents = {"agent:main:telegram:dm:c1:u1": MagicMock()}
+        runner._running_agents_ts = {"agent:main:telegram:dm:c1:u1": 1000.0}
+        runner._running_agent_generations = {}
+        runner._pending_messages = {}
+        runner._pending_approvals = {}
+        runner._session_db = None
+        runner._is_user_authorized = lambda _source: True
+        runner._format_session_info = lambda: ""
+        runner._agent_cache = {}
+        runner._agent_cache_lock = None
+        runner._telegram_topic_root_sessions = set()
+        runner._active_session_leases = {}
+        runner._command_hook_results = {}
+        runner._external_drain_active = False
+        runner._draining = False
+        runner.session_store = MagicMock()
+        return runner
+
+    async def test_active_session_returns_pong(self):
+        """/bot-ping returns 'pong' while agent is running."""
+        runner = self._make_runner()
+        event = self._make_event("/bot-ping")
+        result = await runner._handle_message(event)
+        assert result == "pong"
+
+    async def test_active_session_does_not_queue_message(self):
+        """Verify bot-ping does not enqueue a pending message."""
+        runner = self._make_runner()
+        event = self._make_event("/bot-ping")
+        await runner._handle_message(event)
+        # No pending message should match our event
+        for key, pending in runner._pending_messages.items():
+            assert pending != event, f"bot-ping was queued for {key}"
+
+    async def test_active_session_does_not_interrupt_agent(self):
+        """Verify bot-ping does not call interrupt on the running agent."""
+        runner = self._make_runner()
+        event = self._make_event("/bot-ping")
+        agent_key = "agent:main:telegram:dm:c1:u1"
+        original_interrupt = runner._running_agents[agent_key].interrupt
+        await runner._handle_message(event)
+        # interrupt should NOT have been called
+        original_interrupt.assert_not_called()
+
+    async def test_active_session_does_not_trigger_llm_handler(self):
+        """bot-ping is dispatched directly, not sent as user text."""
+        runner = self._make_runner()
+        event = self._make_event("/bot-ping")
+        result = await runner._handle_message(event)
+        assert result == "pong"
+        assert event.text == "/bot-ping"
+
+    async def test_active_session_slash_access_denied(self):
+        """bot-ping respects slash access policy when active session exists."""
+        from gateway.config import Platform
+        from gateway.platforms.base import MessageEvent
+        from gateway.session import SessionSource
+
+        runner = self._make_runner_with_slash_access()
+        # Non-admin user
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="nonadmin",
+            chat_id="c1",
+            user_name="nonadmin_user",
+            chat_type="dm",
+        )
+        event = MessageEvent(text="/bot-ping", source=source, message_id="m2")
+        result = await runner._handle_message(event)
+        # Should be denied, not return pong
+        assert result != "pong"
+        assert "admin" in result.lower() or "⛔" in result or "denied" in result.lower()
+
+    async def test_active_session_cold_path_returns_pong(self):
+        """Cold path (no active agent) also returns pong."""
+        runner = self._make_runner()
+        # Remove the running agent entry to simulate cold path
+        runner._running_agents = {}
+        runner._running_agents_ts = {}
+        event = self._make_event("/bot-ping")
+        result = await runner._handle_message(event)
+        assert result == "pong"

--- a/tests/gateway/test_bot_ping_command.py
+++ b/tests/gateway/test_bot_ping_command.py
@@ -1,0 +1,353 @@
+"""Tests for gateway /bot-ping command.
+
+The /bot-ping command is a liveness check that replies with 'pong' without
+triggering LLM inference.  Inspired by OpenClaw's /bot-ping for QQBot.
+"""
+
+import asyncio
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from hermes_cli.commands import (
+    GATEWAY_KNOWN_COMMANDS,
+    resolve_command,
+    should_bypass_active_session,
+)
+
+
+# ---------------------------------------------------------------------------
+# Registry tests
+# ---------------------------------------------------------------------------
+
+
+class TestBotPingRegistry:
+    """Verify /bot-ping is properly registered in the command registry."""
+
+    def test_bot_ping_is_registered(self):
+        cmd = resolve_command("bot-ping")
+        assert cmd is not None
+        assert cmd.name == "bot-ping"
+
+    def test_bot_ping_is_gateway_only(self):
+        cmd = resolve_command("bot-ping")
+        assert cmd.gateway_only is True
+        assert cmd.cli_only is False
+
+    def test_bot_ping_category_is_info(self):
+        cmd = resolve_command("bot-ping")
+        assert cmd.category == "Info"
+
+    def test_bot_ping_description_mentions_pong(self):
+        cmd = resolve_command("bot-ping")
+        assert "pong" in cmd.description.lower()
+
+    def test_bot_ping_in_gateway_known_commands(self):
+        assert "bot-ping" in GATEWAY_KNOWN_COMMANDS
+
+    def test_bot_ping_no_aliases(self):
+        cmd = resolve_command("bot-ping")
+        assert cmd.aliases == ()
+
+    def test_bot_ping_no_args(self):
+        cmd = resolve_command("bot-ping")
+        assert cmd.args_hint == ""
+
+    def test_bot_ping_busy_policy(self):
+        cmd = resolve_command("bot-ping")
+        assert cmd.busy_policy == "dispatch"
+        assert cmd.busy_handler is None
+        assert cmd.execute is None
+
+    def test_bot_ping_in_active_session_bypass_commands(self):
+        from hermes_cli.commands import ACTIVE_SESSION_BYPASS_COMMANDS
+
+        assert "bot-ping" in ACTIVE_SESSION_BYPASS_COMMANDS
+
+
+# ---------------------------------------------------------------------------
+# Bypass-active-session tests
+# ---------------------------------------------------------------------------
+
+
+class TestBotPingActiveSessionBypass:
+    """Verify /bot-ping bypasses the active-session guard."""
+
+    def test_should_bypass_active_session(self):
+        """/bot-ping must be recognized as a bypass command."""
+        assert should_bypass_active_session("bot-ping") is True
+
+    def test_should_bypass_active_session_with_slash(self):
+        assert should_bypass_active_session("/bot-ping") is True
+
+    def test_bypass_false_for_none(self):
+        assert should_bypass_active_session(None) is False
+
+
+# ---------------------------------------------------------------------------
+# Handler tests
+# ---------------------------------------------------------------------------
+
+
+class TestBotPingHandler:
+    """Verify the /bot-ping handler returns 'pong'."""
+
+    def test_handler_returns_pong(self):
+        from gateway.slash_commands import GatewaySlashCommandsMixin
+
+        result = asyncio.run(
+            GatewaySlashCommandsMixin._handle_bot_ping_command(None, None)  # type: ignore[arg-type]
+        )
+        assert result == "pong"
+
+    def test_handler_returns_string(self):
+        """Ensure handler returns a plain string, not an EphemeralReply or None."""
+        from gateway.slash_commands import GatewaySlashCommandsMixin
+
+        result = asyncio.run(
+            GatewaySlashCommandsMixin._handle_bot_ping_command(None, None)  # type: ignore[arg-type]
+        )
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch tests
+# ---------------------------------------------------------------------------
+
+
+class TestBotPingDispatch:
+    """Verify /bot-ping is routed through the gateway dispatch chain."""
+
+    def test_bot_ping_is_in_plain_command_handler_table(self):
+        """The plain-command table (idle *and* busy dispatch) maps bot-ping to its handler."""
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        handlers = runner._gateway_plain_command_handlers()
+        assert handlers.get("bot-ping") == runner._handle_bot_ping_command
+
+    def test_bot_ping_resolves_with_leading_slash(self):
+        cmd = resolve_command("/bot-ping")
+        assert cmd is not None
+        assert cmd.name == "bot-ping"
+
+    def test_bot_ping_does_not_resolve_as_unknown(self):
+        assert resolve_command("bot-ping") is not None
+        assert resolve_command("nonexistent-ping") is None
+
+
+# ---------------------------------------------------------------------------
+# Active-session dispatch integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestBotPingActiveSessionDispatch:
+    """Verify /bot-ping works during an active session:
+    returns 'pong', does NOT queue, does NOT interrupt, does NOT reach
+    the LLM/agent path, and still obeys slash access policy.
+    """
+
+    @staticmethod
+    def _make_source(user_id="u1", chat_id="c1"):
+        from gateway.config import Platform
+        from gateway.session import SessionSource
+
+        return SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id=user_id,
+            chat_id=chat_id,
+            user_name="tester",
+            chat_type="dm",
+        )
+
+    @classmethod
+    def _session_key(cls, user_id="u1", chat_id="c1"):
+        """The real routing key for the source — must match _session_key_for_source()."""
+        from gateway.session import build_session_key
+
+        return build_session_key(cls._make_source(user_id, chat_id))
+
+    @classmethod
+    def _make_event(cls, text: str, user_id="u1"):
+        from gateway.platforms.base import MessageEvent
+
+        return MessageEvent(
+            text=text, source=cls._make_source(user_id), message_id="m1",
+        )
+
+    def _make_runner(self, *, running: bool = True, gated: bool = False, user_id="u1"):
+        """Build a bare GatewayRunner.
+
+        ``running=True`` seeds the *live* session-state slot (via the legacy
+        ``_running_agents`` view) with a fresh ``started_ts`` so the runner takes its
+        running-session fast-path; ``running=False`` leaves the session idle.
+        ``gated=True`` enables an admin-only slash-access policy.
+        """
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            platforms={
+                Platform.TELEGRAM: PlatformConfig(
+                    enabled=True,
+                    token="***",
+                    extra=(
+                        {"allow_admin_from": ["admin1"], "user_allowed_commands": []}
+                        if gated else {}
+                    ),
+                )
+            }
+        )
+        adapter = MagicMock()
+        adapter.send = AsyncMock()
+        adapter._pending_messages = {}
+        runner.adapters = {Platform.TELEGRAM: adapter}
+        runner._voice_mode = {}
+        runner.hooks = SimpleNamespace(
+            emit=AsyncMock(),
+            emit_collect=AsyncMock(return_value=[]),
+            loaded_hooks=False,
+        )
+        runner._session_model_overrides = {}
+        runner._pending_model_notes = {}
+        runner._background_tasks = set()
+        runner._pending_messages = {}
+        runner._pending_approvals = {}
+        runner._session_db = None
+        runner._is_user_authorized = lambda _source: True
+        runner._format_session_info = lambda: ""
+        runner._agent_cache = {}
+        runner._agent_cache_lock = None
+        runner._telegram_topic_root_sessions = set()
+        runner._active_session_leases = {}
+        runner._command_hook_results = {}
+        runner._external_drain_active = False
+        runner._draining = False
+        runner.session_store = MagicMock()
+        key = self._session_key(user_id)
+        if running:
+            # Fresh timestamp: the runner evicts a running-agent slot that has been idle
+            # past its timeout (a stale ts would silently demote this to the idle path).
+            runner._running_agents = {key: MagicMock()}
+            runner._running_agents_ts = {key: time.time()}
+        else:
+            runner._running_agents = {}
+            runner._running_agents_ts = {}
+        return runner
+
+    def _running_agent(self, runner, user_id="u1"):
+        """The live agent object parked in the session's running slot."""
+        return runner._session_state(self._session_key(user_id)).turn.agent
+
+    async def test_active_session_is_actually_running(self):
+        """Precondition guard: the busy-path tests below must not silently run idle."""
+        runner = self._make_runner()
+        assert runner._is_session_running(self._session_key()) is True
+        assert self._running_agent(runner) is not None
+
+    async def test_active_session_returns_pong(self):
+        """/bot-ping returns 'pong' while agent is running."""
+        runner = self._make_runner()
+        assert runner._is_session_running(self._session_key()) is True
+        event = self._make_event("/bot-ping")
+        result = await runner._handle_message(event)
+        assert result == "pong"
+
+    async def test_active_session_uses_busy_fast_path(self, monkeypatch):
+        """The reply comes from the running-session fast-path, not the idle dispatch chain."""
+        from gateway.run import GatewayRunner
+
+        calls = []
+        original = GatewayRunner._hm_busy_slash_or_photo
+
+        async def _spy(self, event, source, quick_key):
+            calls.append(quick_key)
+            return await original(self, event, source, quick_key)
+
+        monkeypatch.setattr(GatewayRunner, "_hm_busy_slash_or_photo", _spy)
+        runner = self._make_runner()
+        event = self._make_event("/bot-ping")
+        assert await runner._handle_message(event) == "pong"
+        assert calls == [self._session_key()]
+
+    async def test_active_session_does_not_queue_message(self):
+        """Verify bot-ping does not enqueue a pending message."""
+        from gateway.config import Platform
+
+        runner = self._make_runner()
+        key = self._session_key()
+        adapter = runner.adapters[Platform.TELEGRAM]
+        event = self._make_event("/bot-ping")
+        await runner._handle_message(event)
+        assert key not in adapter._pending_messages
+        assert runner._session_state(key).conversation.queued_events == []
+
+    async def test_active_session_does_not_interrupt_agent(self):
+        """Verify bot-ping does not call interrupt on the running agent."""
+        runner = self._make_runner()
+        running_agent = self._running_agent(runner)
+        event = self._make_event("/bot-ping")
+        await runner._handle_message(event)
+        running_agent.interrupt.assert_not_called()
+
+    async def test_active_session_does_not_trigger_llm_handler(self, monkeypatch):
+        """bot-ping is dispatched directly, not sent as user text through the agent path."""
+        from gateway.run import GatewayRunner
+
+        calls = []
+
+        async def _spy(self, event, source, quick_key):
+            calls.append(quick_key)
+            return None
+
+        monkeypatch.setattr(GatewayRunner, "_handle_message_with_agent", _spy)
+        runner = self._make_runner()
+        event = self._make_event("/bot-ping")
+        result = await runner._handle_message(event)
+        assert result == "pong"
+        assert calls == []  # never reached the LLM/agent processing path
+        assert event.text == "/bot-ping"
+
+    async def test_active_session_slash_access_denied(self):
+        """bot-ping respects slash access policy when active session exists."""
+        from gateway.config import Platform
+        from gateway.platforms.base import MessageEvent
+
+        runner = self._make_runner(gated=True, user_id="nonadmin")
+        event = MessageEvent(
+            text="/bot-ping", source=self._make_source("nonadmin"), message_id="m2",
+        )
+        result = await runner._handle_message(event)
+        # Should be denied, not return pong
+        assert result != "pong"
+        assert "admin" in result.lower() or "⛔" in result or "denied" in result.lower()
+
+    async def test_active_session_admin_still_gets_pong(self):
+        """An admin under the same gated policy still gets 'pong' mid-run."""
+        runner = self._make_runner(gated=True, user_id="admin1")
+        event = self._make_event("/bot-ping", user_id="admin1")
+        assert await runner._handle_message(event) == "pong"
+
+    async def test_active_session_cold_path_returns_pong(self):
+        """Cold path (no active agent) also returns pong."""
+        runner = self._make_runner(running=False)
+        assert runner._is_session_running(self._session_key()) is False
+        event = self._make_event("/bot-ping")
+        result = await runner._handle_message(event)
+        assert result == "pong"
+
+    async def test_cold_path_slash_access_denied(self):
+        """bot-ping respects slash access policy on cold path (no active session)."""
+        from gateway.platforms.base import MessageEvent
+
+        runner = self._make_runner(running=False, gated=True, user_id="nonadmin")
+        event = MessageEvent(
+            text="/bot-ping", source=self._make_source("nonadmin"), message_id="m3",
+        )
+        result = await runner._handle_message(event)
+        assert result != "pong"
+        assert "admin" in result.lower() or "⛔" in result or "denied" in result.lower()


### PR DESCRIPTION
## What does this PR do?

Add `/bot-ping` slash command to Hermes Agent — a liveness check that replies with "pong" without triggering LLM inference. Inspired by OpenClaw's `/bot-ping` command for QQBot platform.

## Related Issue

Refs #25335 (Feature Request: Custom Slash Commands / Shortcuts for Messaging Platforms)

**Clarification**: This PR implements only a single built-in liveness command (`/bot-ping`). The configurable user-defined shortcuts and broader platform-menu integration requested in #25335 are not in scope.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

| File | Δ | Purpose |
|------|---|---------|
| `hermes_cli/commands.py` | +2 | Register `bot-ping` in `COMMAND_REGISTRY` — `Info`, `gateway_only=True`, `busy_policy="dispatch"` |
| `gateway/run_busy.py` | +1/-1 | Add `bot-ping` to `_PLAIN_COMMANDS` — the plain-handler table shared by the idle path and the running-session fast-path |
| `gateway/slash_commands.py` | +8 | `_handle_bot_ping_command` returns `"pong"` |
| `hermes_cli/commands_platforms.py` | +1/-1 | Route `/bot-ping` through `/hermes bot-ping` on Slack only (rationale below) |
| `tests/gateway/test_bot_ping_command.py` | +353 | 27 tests: registry, bypass, handler, dispatch table, active-session integration |

Production change: **+12 lines across 4 files**; the rest is the test file.

### Re-derived against current `main` (dispatch architecture moved)

The original commits were written against June's `gateway/run.py`, which has since been split into mixins. Rather than merge those hunks, the behaviour was re-applied to the current code:

- Slash dispatch is now driven by the declarative `busy_policy` on the `CommandDef`, and `_gateway_plain_command_handlers()` is derived from `_PLAIN_COMMANDS` in `gateway/run_busy.py` (the old `gateway/run.py` handler dict no longer exists).
- `busy_policy="dispatch"` plus membership in `_PLAIN_COMMANDS` is what makes `/bot-ping` answer `pong` while an agent runs, instead of getting the "Agent is running — can't run mid-turn" message. This is the current-main equivalent of the dedicated active-run branch requested in review.
- **Slack:** the registry sits exactly at Slack's 50-slash cap, and `tests/hermes_cli/test_commands.py::TestSlackNativeSlashes::test_telegram_parity` fails loudly when the clamp silently drops a command (adding the command as-is drops `/usage`). `/bot-ping` is therefore demoted to `/hermes bot-ping` on Slack only, which leaves every existing Slack slash untouched; Telegram/Discord/etc. get the native `/bot-ping`.

### Design Decisions

- **Platform-agnostic**: `gateway_only=True` (not QQBot-specific), so Telegram/Discord/Slack users can also use it for liveness checks.
- **Respects existing access policy**: `/bot-ping` goes through `_check_slash_access()` like every other registered command, on the idle path *and* the mid-run path. No public-command exception was added — unauthorized users get the standard denial. Covered by tests (mid-run denial, idle denial, admin allowed).
- **Active-session safe**: mid-run, `/bot-ping` is dispatched by the running-session fast-path and returns `"pong"` without queueing, without interrupting, and without entering the LLM/agent path.
- **Instant response**: returns `"pong"` directly without entering the AI queue — zero latency, zero token cost.

## How to Test

```bash
# Run the test suite (27 tests)
python -m pytest tests/gateway/test_bot_ping_command.py -v

# Manual test on any gateway platform:
# Send /bot-ping → expect "pong" response
```

### Test coverage

| Class | Tests | Covers |
|-------|-------|--------|
| `TestBotPingRegistry` | 9 | registry entry, `gateway_only`/`cli_only`, category, description, `GATEWAY_KNOWN_COMMANDS`, aliases, args, busy policy, derived bypass set |
| `TestBotPingActiveSessionBypass` | 3 | `should_bypass_active_session()` |
| `TestBotPingHandler` | 2 | handler returns a plain `str` `"pong"` |
| `TestBotPingDispatch` | 3 | plain-handler-table mapping + resolution |
| `TestBotPingActiveSessionDispatch` | 10 | mid-run returns `pong`, busy fast-path actually taken, no queued message, no interrupt, no LLM path, slash access denied (mid-run + idle), admin still allowed, idle path returns `pong` |

**Not vacuous**: the active-session tests seed the live `SessionState` routing key (`build_session_key()` + a fresh `started_ts`) and assert `_is_session_running()` before dispatching; they also spy the running-session fast-path entry point. With a hardcoded key or a stale timestamp the runner evicts the slot and silently falls back to the idle path, which is what the earlier iteration of these tests did. Removing the `_PLAIN_COMMANDS` wiring fails 6 of these tests.

### Local evidence (Windows 10, Python 3.11)

```
tests/gateway/test_bot_ping_command.py                    27 passed
tests/hermes_cli/test_commands.py + test_busy_policy_invariants.py
  + tests/cli/test_slash_dispatch_table.py
  + tests/gateway/test_update_command.py
  + tests/gateway/test_command_bypass_active_session.py
  + tests/gateway/test_slack.py
  + tests/gateway/test_discord_slash_commands.py       362 passed, 1 failed
# the 1 failure (test_update_command.py::...::test_fallback_when_no_setsid) is a
# POSIX-only `setsid` test and fails identically on a pristine upstream/main checkout
ruff check <5 changed files>                             All checks passed
```

CI does not run automatically for fork PRs — the maintainer has to approve the workflow run.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(scope):` / `test(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_bot_ping_command.py -v` and all 27 tests pass
- [x] I've added tests for my changes

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` — or N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — or N/A
- [x] I've considered cross-platform impact — N/A (gateway-only, no platform-specific code; Slack registration handled above)
- [x] I've updated tool descriptions/schemas — or N/A (no tool changes)

## Screenshots / Logs

N/A — Simple text command implementation
