### PR TITLE
fix(tui): reconcile subagent completion status via delegation.status poll (#52318)

### DIFF
--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -963,6 +963,48 @@ describe('createGatewayEventHandler', () => {
     expect(getTurnState().subagents.find(s => s.id === 'sa-weird')?.status).toBe('completed')
   })
 
+  it('reconciles running subagents against delegation.status active list', async () => {
+    const appended: Msg[] = []
+    const ctx = buildCtx(appended)
+    // Make rpc return a delegation.status response with only sa-a active
+    ctx.gateway.rpc = vi.fn(async () => ({
+      active: [{ subagent_id: 'sa-a', status: 'running', goal: 'child a', task_index: 0, task_count: 2 }],
+      max_concurrent_children: 5,
+      max_spawn_depth: 3,
+      paused: false
+    }))
+    const onEvent = createGatewayEventHandler(ctx)
+
+    // Register two subagents as running
+    onEvent({
+      payload: { goal: 'child a', subagent_id: 'sa-a', task_index: 0, task_count: 2 },
+      type: 'subagent.start'
+    } as any)
+    onEvent({
+      payload: { goal: 'child b', subagent_id: 'sa-b', task_index: 1, task_count: 2 },
+      type: 'subagent.start'
+    } as any)
+
+    expect(getTurnState().subagents.find(s => s.id === 'sa-a')?.status).toBe('running')
+    expect(getTurnState().subagents.find(s => s.id === 'sa-b')?.status).toBe('running')
+
+    // Trigger refreshDelegationStatus via spawn_requested (forces a poll)
+    onEvent({
+      payload: { goal: 'child c', subagent_id: 'sa-c', task_index: 2, task_count: 3 },
+      type: 'subagent.spawn_requested'
+    } as any)
+
+    // Wait for the rpc promise to resolve
+    await vi.waitFor(() => {
+      expect(ctx.gateway.rpc).toHaveBeenCalled()
+    })
+
+    // sa-a is still in the active list → stays 'running'
+    expect(getTurnState().subagents.find(s => s.id === 'sa-a')?.status).toBe('running')
+    // sa-b is NOT in the active list → reconciled to 'completed'
+    expect(getTurnState().subagents.find(s => s.id === 'sa-b')?.status).toBe('completed')
+  })
+
   it('nudges toward /agents on the first spawn_requested of a turn', () => {
     const appended: Msg[] = []
     const onEvent = createGatewayEventHandler(buildCtx(appended))

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -232,7 +232,21 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
     lastDelegationFetchAt = now
     rpc<DelegationStatusResponse>('delegation.status', {})
-      .then(r => applyDelegationStatus(r))
+      .then(r => {
+        applyDelegationStatus(r)
+        // Reconcile: any subagent still marked 'running' in turnState but
+        // absent from the server's active set has completed (or failed).
+        // This catches cases where the subagent.complete event was lost,
+        // delayed, or processed after the turn snapshot was archived.
+        if (r?.active) {
+          const activeIds = new Set(
+            r.active
+              .map(a => a.subagent_id)
+              .filter((id): id is string => typeof id === 'string')
+          )
+          turnController.reconcileSubagentStatus(activeIds)
+        }
+      })
       .catch(() => {})
   }
 

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -1002,6 +1002,32 @@ class TurnController {
       return { ...state, subagents }
     })
   }
+
+  /**
+   * Reconcile live subagent statuses against the server's active-subagent set.
+   *
+   * When the `delegation.status` poll returns, any subagent in
+   * `turnState.subagents` that is still `'running'` but absent from the
+   * server's `active` list has completed (or failed/timed out).  Mark it
+   * `'completed'` so the /agents overlay reflects reality even if the
+   * `subagent.complete` event was lost or delayed.
+   *
+   * Safe to call with an empty set — a missing `active` field in the RPC
+   * response is treated as "no reconciliation" (caller guards with `if (r?.active)`).
+   */
+  reconcileSubagentStatus(activeServerIds: Set<string>) {
+    patchTurnState(state => {
+      let changed = false
+      const subagents = state.subagents.map(s => {
+        if (s.status === 'running' && !activeServerIds.has(s.id)) {
+          changed = true
+          return { ...s, status: 'completed' as const }
+        }
+        return s
+      })
+      return changed ? { ...state, subagents } : state
+    })
+  }
 }
 
 export const turnController = new TurnController()


### PR DESCRIPTION
## What does this PR do?

The `/agents` TUI overlay showed subagents as `running` even after they had completed and returned results to the parent session. The root cause: the TUI relied solely on event-driven `subagent.complete` events to update status, but the `delegation.status` RPC poll (which returns the server's authoritative active-subagent list) was completely ignored by `applyDelegationStatus()`. When the `subagent.complete` event was lost, delayed, or processed after the turn snapshot was archived, the status stayed stuck on `running`.

This fix adds a reconciliation step: when `refreshDelegationStatus` polls the server, any subagent still marked `running` in `turnState.subagents` but absent from the server's `active` list is promoted to `completed`.

## Related Issue

Fixes #52318

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `ui-tui/src/app/turnController.ts`: Added `reconcileSubagentStatus(activeServerIds)` method that promotes `running` subagents to `completed` when they're absent from the server's active set.
- `ui-tui/src/app/createGatewayEventHandler.ts`: Modified `refreshDelegationStatus` to extract `subagent_id` values from the `delegation.status` response's `active` field and pass them to `reconcileSubagentStatus()`.
- `ui-tui/src/__tests__/createGatewayEventHandler.test.ts`: Added test verifying that the reconciliation correctly promotes absent subagents while preserving active ones.

## How to Test

1. Run `npx vitest run ui-tui/src/__tests__/createGatewayEventHandler.test.ts -t 'reconciles'` — the new test should pass
2. Run the full test file: `npx vitest run ui-tui/src/__tests__/createGatewayEventHandler.test.ts` — all 75 tests should pass
3. Manual: `hermes --tui`, dispatch subagents via `delegate_task`, wait for completion, run `/agents` — status should show `completed` not `running`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `turnController.ts` (upsertSubagent callers: 8), `createGatewayEventHandler.ts` (refreshDelegationStatus callers: 3)
- Blast radius: LOW — additive method + poll reconciliation; existing event-driven path unchanged
- Related patterns: `delegation.status` RPC → `list_active_subagents()` in `tui_gateway/server.py`; `_unregister_subagent()` in `tools/delegate_tool.py`
