### PR TITLE
fix(delegate): keep finished subagents visible with terminal status (#52318)

### DIFF
--- a/tests/tools/test_delegate_subagent_terminal_status.py
+++ b/tests/tools/test_delegate_subagent_terminal_status.py
@@ -1,0 +1,138 @@
+# Copyright 2024 Nous Research
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for subagent terminal-status visibility (issue #52318).
+
+The TUI /agents overlay polls ``delegation.status`` (backed by
+``list_active_subagents``) on an interval.  Before this fix, a child was
+removed from the registry the instant it finished, so the overlay never saw a
+terminal status and stayed stuck on "running".  These tests pin the registry
+contract: after ``_finalize_subagent`` a child briefly appears with its
+terminal status, and is then pruned by age and count.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tools import delegate_tool
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Isolate each test from process-global subagent registry state."""
+    with delegate_tool._active_subagents_lock:
+        delegate_tool._active_subagents.clear()
+        delegate_tool._recently_finished_subagents.clear()
+    yield
+    with delegate_tool._active_subagents_lock:
+        delegate_tool._active_subagents.clear()
+        delegate_tool._recently_finished_subagents.clear()
+
+
+def _register(sid: str, status: str = "running") -> None:
+    delegate_tool._register_subagent(
+        {
+            "subagent_id": sid,
+            "parent_id": None,
+            "depth": 0,
+            "goal": f"goal-{sid}",
+            "model": "test-model",
+            "started_at": 0.0,
+            "status": status,
+            "tool_count": 0,
+            "agent": object(),  # stand-in live handle; must never be exposed
+        }
+    )
+
+
+def test_running_subagent_is_listed_as_running():
+    _register("a")
+    active = delegate_tool.list_active_subagents()
+    assert len(active) == 1
+    assert active[0]["subagent_id"] == "a"
+    assert active[0]["status"] == "running"
+    # The live agent handle must never leak through the snapshot.
+    assert "agent" not in active[0]
+
+
+@pytest.mark.parametrize("status", ["completed", "failed", "interrupted"])
+def test_finalized_subagent_surfaces_terminal_status(status):
+    _register("a")
+    delegate_tool._finalize_subagent("a", status)
+
+    listed = delegate_tool.list_active_subagents()
+    assert len(listed) == 1
+    rec = listed[0]
+    assert rec["subagent_id"] == "a"
+    # The core regression: the overlay's next poll must see the terminal
+    # status, not the stale "running" it was registered with.
+    assert rec["status"] == status
+    assert "finished_at" in rec
+    assert "agent" not in rec
+
+    # The child must no longer be in the live set.
+    with delegate_tool._active_subagents_lock:
+        assert "a" not in delegate_tool._active_subagents
+        assert "a" in delegate_tool._recently_finished_subagents
+
+
+def test_empty_status_defaults_to_completed():
+    _register("a")
+    delegate_tool._finalize_subagent("a", "")
+    rec = delegate_tool.list_active_subagents()[0]
+    assert rec["status"] == "completed"
+
+
+def test_finished_record_is_pruned_after_ttl(monkeypatch):
+    _register("a")
+    delegate_tool._finalize_subagent("a", "completed")
+    assert len(delegate_tool.list_active_subagents()) == 1
+
+    # Advance the clock past the retention window; the next snapshot prunes it.
+    real_time = delegate_tool.time.time
+    monkeypatch.setattr(
+        delegate_tool.time,
+        "time",
+        lambda: real_time() + delegate_tool._FINISHED_SUBAGENT_TTL_SECONDS + 1.0,
+    )
+    assert delegate_tool.list_active_subagents() == []
+
+
+def test_finished_records_are_bounded_by_count(monkeypatch):
+    monkeypatch.setattr(delegate_tool, "_FINISHED_SUBAGENT_MAX", 3)
+    for i in range(6):
+        sid = f"s{i}"
+        _register(sid)
+        delegate_tool._finalize_subagent(sid, "completed")
+
+    listed = delegate_tool.list_active_subagents()
+    assert len(listed) == 3
+    # Oldest evicted first; only the most recent survive.
+    surviving = {r["subagent_id"] for r in listed}
+    assert surviving == {"s3", "s4", "s5"}
+
+
+def test_active_and_finished_coexist_in_snapshot():
+    _register("live")
+    _register("done")
+    delegate_tool._finalize_subagent("done", "completed")
+
+    listed = {r["subagent_id"]: r["status"] for r in delegate_tool.list_active_subagents()}
+    assert listed == {"live": "running", "done": "completed"}
+
+
+def test_finalize_unknown_subagent_is_noop():
+    # No registration: finalize must not raise and must not invent a record.
+    delegate_tool._finalize_subagent("ghost", "completed")
+    assert delegate_tool.list_active_subagents() == []

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 import os
 import threading
 import time
+from collections import OrderedDict
 from concurrent.futures import (
     ThreadPoolExecutor,
     TimeoutError as FuturesTimeoutError,
@@ -148,6 +149,19 @@ _active_subagents_lock = threading.Lock()
 # for the lifetime of the run; _run_single_child is the owner.
 _active_subagents: Dict[str, Dict[str, Any]] = {}
 
+# subagent_id -> record of a child that just finished.  The TUI /agents
+# overlay polls delegation.status every ~5s; if we removed finished children
+# immediately they would never appear with a terminal status and the overlay
+# would stay stuck on "running" (see issue #52318).  We keep finished records
+# here briefly so at least one poll cycle observes the terminal status, then
+# prune by age and count to avoid unbounded growth.
+_recently_finished_subagents: "OrderedDict[str, Dict[str, Any]]" = OrderedDict()
+# How long a finished record stays visible (seconds) and the hard cap on how
+# many we retain.  The TTL only needs to comfortably exceed the TUI poll
+# interval (~5s); the count cap protects against spawn storms.
+_FINISHED_SUBAGENT_TTL_SECONDS = 30.0
+_FINISHED_SUBAGENT_MAX = 64
+
 
 def set_spawn_paused(paused: bool) -> bool:
     """Globally block/unblock new delegate_task spawns.
@@ -179,6 +193,53 @@ def _unregister_subagent(subagent_id: str) -> None:
         _active_subagents.pop(subagent_id, None)
 
 
+_TERMINAL_SUBAGENT_STATUSES = ("completed", "failed", "interrupted", "error")
+
+
+def _prune_finished_subagents(now: float) -> None:
+    """Drop finished records past their TTL or beyond the count cap.
+
+    Caller must hold ``_active_subagents_lock``.
+    """
+    # Age-based pruning: records are inserted in finish order, so the oldest
+    # live at the front of the OrderedDict.
+    while _recently_finished_subagents:
+        sid, rec = next(iter(_recently_finished_subagents.items()))
+        finished_at = rec.get("finished_at") or 0.0
+        if now - finished_at < _FINISHED_SUBAGENT_TTL_SECONDS:
+            break
+        _recently_finished_subagents.pop(sid, None)
+    # Count-based cap: evict oldest beyond the hard limit.
+    while len(_recently_finished_subagents) > _FINISHED_SUBAGENT_MAX:
+        _recently_finished_subagents.popitem(last=False)
+
+
+def _finalize_subagent(subagent_id: str, status: str) -> None:
+    """Mark a subagent terminal and retain it briefly for the TUI overlay.
+
+    The /agents overlay polls ``delegation.status`` on an interval; removing a
+    child the instant it finishes means the overlay never observes a terminal
+    status and stays stuck on "running" (issue #52318).  We move the record
+    into a short-lived "recently finished" store with its terminal status so at
+    least one poll cycle surfaces it, then prune by age and count.
+    """
+    if not status:
+        status = "completed"
+    with _active_subagents_lock:
+        record = _active_subagents.pop(subagent_id, None)
+        now = time.time()
+        if record is not None:
+            # Drop the live agent handle; the snapshot never exposes it and we
+            # don't want to keep the child agent alive past its lifetime.
+            record.pop("agent", None)
+            record["status"] = status
+            record["finished_at"] = now
+            # Re-insert at the end to preserve finish-time ordering.
+            _recently_finished_subagents.pop(subagent_id, None)
+            _recently_finished_subagents[subagent_id] = record
+        _prune_finished_subagents(now)
+
+
 def interrupt_subagent(subagent_id: str) -> bool:
     """Request that a single running subagent stop at its next iteration boundary.
 
@@ -203,16 +264,26 @@ def interrupt_subagent(subagent_id: str) -> bool:
 
 
 def list_active_subagents() -> List[Dict[str, Any]]:
-    """Snapshot of the currently running subagent tree.
+    """Snapshot of the running subagent tree plus recently-finished children.
 
     Each record: {subagent_id, parent_id, depth, goal, model, started_at,
-    tool_count, status}.  Safe to call from any thread — returns a copy.
+    tool_count, status}.  Children that just finished are included for a short
+    window with their terminal status (completed/failed/interrupted) and a
+    ``finished_at`` timestamp, so the TUI /agents overlay — which polls on an
+    interval — observes the terminal transition instead of staying stuck on
+    "running" (issue #52318).  Safe to call from any thread — returns copies.
     """
     with _active_subagents_lock:
-        return [
+        _prune_finished_subagents(time.time())
+        snapshot = [
             {k: v for k, v in r.items() if k != "agent"}
             for r in _active_subagents.values()
         ]
+        snapshot.extend(
+            {k: v for k, v in r.items() if k != "agent"}
+            for r in _recently_finished_subagents.values()
+        )
+        return snapshot
 
 
 def _extract_output_tail(
@@ -2273,10 +2344,20 @@ def _run_single_child(
         if _heartbeat_thread.ident is not None:
             _heartbeat_thread.join(timeout=5)
 
-        # Drop the TUI-facing registry entry.  Safe to call even if the
-        # child was never registered (e.g. ID missing on test doubles).
+        # Move the TUI-facing registry entry to its terminal state and retain
+        # it briefly so the /agents overlay's next poll observes the final
+        # status instead of staying stuck on "running" (issue #52318).  Safe to
+        # call even if the child was never registered (e.g. ID missing on test
+        # doubles).  Resolve the status defensively: the local `status` is bound
+        # on the normal path, otherwise fall back to whatever `result` reported,
+        # then to a generic "failed" for unexpected early exits.
         if _subagent_id:
-            _unregister_subagent(_subagent_id)
+            terminal_status = locals().get("status")
+            if not terminal_status:
+                _result = locals().get("result")
+                if isinstance(_result, dict):
+                    terminal_status = _result.get("status")
+            _finalize_subagent(_subagent_id, terminal_status or "failed")
 
         if child_pool is not None and leased_cred_id is not None:
             try:


### PR DESCRIPTION
## What does this PR do?

The TUI `/agents` overlay polls `delegation.status` (backed by
`list_active_subagents`) on an interval. Previously a subagent was removed from
the registry the instant it finished, so the overlay never observed a terminal
transition and stayed stuck on `running` — even after the child returned its
result to the parent session.

This change keeps finished children visible briefly with their terminal status
so at least one poll cycle surfaces the final state.

## Related Issue

Fixes #52318

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

`tools/delegate_tool.py`:

- Added a short-lived, **bounded** `_recently_finished_subagents` store
  (`OrderedDict`), with a TTL (`_FINISHED_SUBAGENT_TTL_SECONDS = 30s`,
  comfortably above the ~5s TUI poll) and a count cap
  (`_FINISHED_SUBAGENT_MAX = 64`) to protect against spawn storms.
- `_finalize_subagent(sid, status)` moves a child from the live set into the
  finished store with its terminal status (`completed` / `failed` /
  `interrupted`) and a `finished_at` timestamp. It drops the live `agent`
  handle so finished records never keep a child agent alive or leak it through
  the snapshot.
- `list_active_subagents()` now returns active children **plus** recently
  finished ones, pruning expired/over-cap records first.
- The `_run_single_child` `finally` block now calls `_finalize_subagent` with a
  defensively-resolved status (local `status` → `result["status"]` → `failed`)
  instead of immediately dropping the record.

The previous `_unregister_subagent` helper is retained (no longer called
internally) to avoid breaking any external/test callers.

## How this composes with #23705

#23705 (Fixes #22729) hydrates the overlay when live `subagent.*` events are
**missed**, pulling from `delegation.status.active`. That addresses the
"shows nothing" case. This PR addresses the complementary "stuck on running"
case: even with hydration, the backend never reported a terminal status, so a
hydrated child would never flip to `completed`. The two changes are
complementary, not duplicates — this one is backend-only and touches no TUI
frontend files.

## Tests

New `tests/tools/test_delegate_subagent_terminal_status.py` pins the
register → finalize → list contract:

- running child lists as `running`, agent handle never exposed;
- finalized child surfaces `completed` / `failed` / `interrupted`;
- empty status defaults to `completed`;
- finished record pruned after TTL;
- finished records bounded by count (oldest evicted first);
- active + finished coexist in one snapshot;
- finalizing an unknown id is a no-op.

### Local validation

```
python -m pytest tests/tools/test_delegate_subagent_terminal_status.py -q -n 0
# 9 passed

python -m pytest tests/tools/test_delegate.py \
  tests/tools/test_delegate_subagent_timeout_diagnostic.py -q -n 0
# 149 passed
```

Scope is intentionally narrow (one backend file + one test file).
