### PR TITLE
fix(ci): give CPU-heavy test files a per-file timeout override

### DIFF
--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -74,6 +74,33 @@ _SKIP_PARTS = {"integration", "e2e", "docker"}
 # via --file-timeout or HERMES_TEST_FILE_TIMEOUT.
 _DEFAULT_FILE_TIMEOUT_SECONDS = 140.0 # set by observing the slowest file at commit time was ~100s in CI and adding some leeway
 
+# A small number of files do legitimately heavy CPU work and, under CI's
+# oversubscribed worker pool (more pytest workers than cores), run right up
+# against the global per-file cap. Give *those specific files* a larger budget
+# instead of raising the global default — raising the default would blunt the
+# cap's value as a hang detector for the ~1600 other files. Keyed by basename
+# so the match is independent of the discovery root the file is found under.
+_FILE_TIMEOUT_OVERRIDES: dict[str, float] = {
+    # ~30-36 real PIL atlas-composition tests; ~30s in isolation but balloons
+    # past the default cap under CI's 8-worker contention, SIGKILL'ing the file
+    # mid-run with no test actually failing. See tests/agent/test_pet_generate.py.
+    "test_pet_generate.py": 300.0,
+}
+
+
+def _file_timeout_for(file: Path, default: float) -> float:
+    """Resolve the per-file wall-clock cap for ``file``.
+
+    Returns the registered override for a known-heavy file, but only when it is
+    larger than the active ``default`` — so an explicit ``--file-timeout`` /
+    ``HERMES_TEST_FILE_TIMEOUT`` that is already more generous still wins, and an
+    override can only *extend* a file's budget, never shorten it.
+    """
+    override = _FILE_TIMEOUT_OVERRIDES.get(file.name)
+    if override is not None and override > default:
+        return override
+    return default
+
 # Duration cache: maps relative file paths to last-observed subprocess
 # wall-clock seconds. Used by ``--slice`` to distribute files across
 # CI jobs by estimated total time, so no one job gets all the slow files.
@@ -776,7 +803,11 @@ def main() -> int:
         for file in files:
             t0 = time.monotonic()
             fut = pool.submit(
-                _run_one_file, file, pytest_passthrough, repo_root, args.file_timeout
+                _run_one_file,
+                file,
+                pytest_passthrough,
+                repo_root,
+                _file_timeout_for(file, args.file_timeout),
             )
             fut.add_done_callback(lambda f, file=file, t0=t0: _on_done(file, t0, f))
             futures.append(fut)

--- a/tests/test_run_tests_parallel.py
+++ b/tests/test_run_tests_parallel.py
@@ -63,6 +63,51 @@ def _pid_alive(pid: int) -> bool:
     return True
 
 
+def _load_runner_module():
+    """Import scripts/run_tests_parallel.py as a module for in-process testing."""
+    import importlib.util
+
+    repo_root = Path(__file__).resolve().parent.parent
+    path = repo_root / "scripts" / "run_tests_parallel.py"
+    spec = importlib.util.spec_from_file_location("_rtp_under_test", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_file_timeout_override_only_extends_known_heavy_files() -> None:
+    """The per-file timeout registry must only ever *extend* a file's budget,
+    and only for files explicitly registered as heavy — everything else stays on
+    the default cap so the cap keeps working as a hang detector."""
+    rtp = _load_runner_module()
+    default = rtp._DEFAULT_FILE_TIMEOUT_SECONDS
+
+    # Contract, not a snapshot: every registered override gives MORE time than
+    # the default (otherwise the entry is pointless / would shorten the budget).
+    assert rtp._FILE_TIMEOUT_OVERRIDES, "expected at least one heavy-file override"
+    for name, secs in rtp._FILE_TIMEOUT_OVERRIDES.items():
+        assert secs > default, f"override for {name} ({secs}s) must exceed default {default}s"
+
+    # An unregistered file gets exactly the default.
+    assert rtp._file_timeout_for(Path("tests/agent/test_something_else.py"), default) == default
+
+    # A registered heavy file gets its (larger) override...
+    heavy = next(iter(rtp._FILE_TIMEOUT_OVERRIDES))
+    assert rtp._file_timeout_for(Path("tests/agent") / heavy, default) == rtp._FILE_TIMEOUT_OVERRIDES[heavy]
+
+    # ...but a more generous explicit default still wins (override never shortens).
+    bigger = max(rtp._FILE_TIMEOUT_OVERRIDES.values()) + 100.0
+    assert rtp._file_timeout_for(Path("tests/agent") / heavy, bigger) == bigger
+
+
+def test_pet_generate_is_registered_as_heavy() -> None:
+    """The pet-generation suite is CPU-heavy enough to exceed the default cap
+    under CI worker contention; it must carry a timeout override so the file is
+    not SIGKILL'd mid-run."""
+    rtp = _load_runner_module()
+    assert "test_pet_generate.py" in rtp._FILE_TIMEOUT_OVERRIDES
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only probe")
 @pytest.mark.live_system_guard_bypass
 def test_grandchild_leak_is_killed_by_runner(tmp_path: Path) -> None:


### PR DESCRIPTION
## What does this PR do?

Fixes a CI flake: `scripts/run_tests_parallel.py` SIGKILLs `tests/agent/test_pet_generate.py` once it crosses the global **140s per-file** cap. The file is ~30–36 real PIL atlas-composition tests (`hatch_pet_end_to_end`, `compose_atlas`, …) — ~30s in isolation, but it balloons past 140s under CI's 8-worker oversubscription, so the file is killed mid-run with **zero test failures** (`6494 passed, 0 failed` + `1 file where no tests ran`). Deterministic shard assignment keeps it in `tests / test (3)`, so it reliably tips that shard red — currently on `main` and several open PRs.

Adds a small basename-keyed `_FILE_TIMEOUT_OVERRIDES` registry plus a `_file_timeout_for()` resolver, and registers `test_pet_generate.py → 300s`. Every other file keeps the tight 140s cap as a hang detector; the override only ever **extends** a file's budget, and a larger explicit `--file-timeout` / `HERMES_TEST_FILE_TIMEOUT` still wins.

## Related Issue

Fixes #52332

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `scripts/run_tests_parallel.py`
  - Add `_FILE_TIMEOUT_OVERRIDES` (basename → seconds) and `_file_timeout_for(file, default)`.
  - Resolve the per-file cap at the dispatch site so heavy files get their override while everything else stays on the default.
- `tests/test_run_tests_parallel.py`
  - Contract test: every override strictly exceeds the default; unknown files get the default; a registered file gets its override; a larger explicit default still wins (override never shortens).
  - Test that `test_pet_generate.py` is registered as heavy.

## How to Test

- `scripts/run_tests.sh tests/test_run_tests_parallel.py -- -q` (new contract tests pass).
- This PR's own `tests / test (3)` shard validates the fix in the exact environment that was failing.

Local checks:
- Resolver: `pet@140 → 300`, `pet@600 → 600` (never shortens), `other@140 → 140`.
- `tests/agent/test_pet_generate.py` passes (30/30, ~27s).

## Checklist

- [x] Conventional Commit (`fix(ci): …`)
- [x] PR contains only changes related to this fix
- [x] Added tests for the change
- [x] Tested on my platform: macOS local checkout

## Why not just raise the global default?

The 140s cap doubles as a hang detector for ~1600 files; raising it globally would let real hangs run 2–3× longer everywhere. Scoping the extra budget to the one known-heavy file keeps the cap tight where it matters.

## 2026-07-11 shepherding refresh

Current `main` has implemented the underlying timeout relief more broadly. Merged PR #54143 changed `_DEFAULT_FILE_TIMEOUT_SECONDS` from 140s to 300s in `scripts/run_tests_parallel.py` (`b508d4296`), explicitly to prevent false per-file timeouts under isolated-test subprocess overhead and loaded CI runners.

That global 300s default matches this branch's proposed `test_pet_generate.py` budget, so the special-case registry no longer changes behavior for the reported failure. Issue #52332 remains open, but its original 140s premise is no longer reproducible on current `main`; this PR is therefore superseded by #54143 rather than an independent remaining fix. The branch and its historical green checks are unchanged.
