### PR TITLE
fix(openviking): retry root tenant header errors

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -257,6 +257,8 @@ class _VikingClient:
             "Trusted mode requests must include X-OpenViking-Account" in message
             or "Trusted mode requests must include X-OpenViking-User" in message
             or "Trusted mode requests must include X-OpenViking-Account or explicit account_id" in message
+            or "ROOT requests to tenant-scoped APIs must include X-OpenViking-Account" in message
+            or "ROOT requests to tenant-scoped APIs must include X-OpenViking-User" in message
         )
 
     def _send_with_trusted_identity_retry(self, send, *, multipart: bool = False) -> dict:

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1647,6 +1647,49 @@ def test_viking_client_retries_with_tenant_headers_for_trusted_mode(monkeypatch)
     assert captured_headers[1]["X-OpenViking-User"] == "usr"
 
 
+def test_viking_client_retries_with_tenant_headers_for_root_tenant_error(monkeypatch):
+    client = _VikingClient(
+        "https://example.com",
+        api_key="test-key",
+        account="acct",
+        user="usr",
+        agent="hermes",
+    )
+    captured_headers = []
+
+    def capture_post(url, **kwargs):
+        captured_headers.append(kwargs.get("headers") or {})
+        if len(captured_headers) == 1:
+            return SimpleNamespace(
+                status_code=400,
+                text="",
+                json=lambda: {
+                    "error": {
+                        "code": "INVALID_ARGUMENT",
+                        "message": "ROOT requests to tenant-scoped APIs must include X-OpenViking-Account and X-OpenViking-User headers.",
+                    },
+                },
+                raise_for_status=lambda: None,
+            )
+        return SimpleNamespace(
+            status_code=200,
+            text="",
+            json=lambda: {"status": "ok", "result": {"total": 0}},
+            raise_for_status=lambda: None,
+        )
+
+    monkeypatch.setattr(client._httpx, "post", capture_post)
+
+    assert client.post("/api/v1/search/search", {"query": "status"}) == {
+        "status": "ok",
+        "result": {"total": 0},
+    }
+    assert "X-OpenViking-Account" not in captured_headers[0]
+    assert "X-OpenViking-User" not in captured_headers[0]
+    assert captured_headers[1]["X-OpenViking-Account"] == "acct"
+    assert captured_headers[1]["X-OpenViking-User"] == "usr"
+
+
 def test_viking_client_health_sends_auth_headers(monkeypatch):
     _clear_openviking_tenant_env(monkeypatch)
     client = _VikingClient(


### PR DESCRIPTION
## Summary
- Retry OpenViking API-key requests with tenant headers when the server returns the newer ROOT tenant-scoped API error.
- Add regression coverage for tenant-header retry on POST/search requests.

## Root Cause
OpenViking can reject root API-key calls to tenant-scoped endpoints with:

```text
ROOT requests to tenant-scoped APIs must include X-OpenViking-Account and X-OpenViking-User headers.
```

Hermes already had a retry path that adds tenant headers, but it only recognized the older `Trusted mode requests must include ...` error text. The newer ROOT error was surfaced directly, causing OpenViking-backed memory/search to fail even when `OPENVIKING_ACCOUNT` and `OPENVIKING_USER` were configured.

## Fix
Extend `_needs_trusted_identity_retry()` to treat the ROOT tenant-header error as retryable, reusing the existing second request with `X-OpenViking-Account` and `X-OpenViking-User`.

## Verification
```bash
python3 -m pytest tests/plugins/memory/test_openviking_provider.py -q -o 'addopts='
# 104 passed
```

Also verified against a live OpenViking instance that the patched client can search successfully after retrying with tenant headers.
