### PR TITLE
fix: preserve profile dirs during force install

### DIFF
--- a/hermes_cli/profile_distribution.py
+++ b/hermes_cli/profile_distribution.py
@@ -65,6 +65,8 @@ import re
 import shutil
 import subprocess
 import tempfile
+import time
+import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -446,6 +448,68 @@ def _reject_distribution_symlinks(staged: Path) -> None:
         )
 
 
+def _remove_path_with_retries(
+    path: Path,
+    *,
+    attempts: int = 5,
+    delay: float = 0.05,
+    ignore_errors: bool = False,
+) -> None:
+    """Remove a file or directory, retrying transient Windows file-lock races."""
+    last_exc: OSError | None = None
+    for attempt in range(attempts):
+        try:
+            if path.is_dir() and not path.is_symlink():
+                shutil.rmtree(path)
+            else:
+                path.unlink()
+            return
+        except FileNotFoundError:
+            return
+        except OSError as exc:
+            last_exc = exc
+            if attempt + 1 < attempts:
+                time.sleep(delay * (attempt + 1))
+
+    if not ignore_errors and last_exc is not None:
+        raise last_exc
+
+
+def _copy_dist_dir_atomic(entry: Path, dest: Path, ignore) -> None:
+    """Replace a distribution-owned directory without deleting it in place.
+
+    The old implementation did ``rmtree(dest); copytree(entry, dest)``. On
+    Windows, a transient delete/copy failure in a large ``skills/`` tree could
+    remove the working profile before the replacement was ready. Stage first,
+    then swap the staged tree into place so a failure leaves ``dest`` intact.
+    """
+    parent = dest.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    staging = parent / f".{dest.name}.hermes-dist-staging-{uuid.uuid4().hex}"
+    backup = parent / f".{dest.name}.hermes-dist-old-{uuid.uuid4().hex}"
+
+    try:
+        shutil.copytree(entry, staging, ignore=ignore)
+    except BaseException:
+        _remove_path_with_retries(staging, ignore_errors=True)
+        raise
+
+    moved_old = False
+    try:
+        if dest.exists() or dest.is_symlink():
+            dest.rename(backup)
+            moved_old = True
+        staging.rename(dest)
+    except BaseException:
+        if moved_old and backup.exists() and not dest.exists():
+            backup.rename(dest)
+        _remove_path_with_retries(staging, ignore_errors=True)
+        raise
+
+    if moved_old:
+        _remove_path_with_retries(backup, ignore_errors=True)
+
+
 # ---------------------------------------------------------------------------
 # Install
 # ---------------------------------------------------------------------------
@@ -571,10 +635,8 @@ def _copy_dist_payload(
 
         dest = target / name
         if entry.is_dir():
-            if dest.exists():
-                shutil.rmtree(dest)
             staged_resolved = staged.resolve()
-            shutil.copytree(
+            _copy_dist_dir_atomic(
                 entry,
                 dest,
                 ignore=lambda d, names: (

--- a/tests/hermes_cli/test_profile_distribution.py
+++ b/tests/hermes_cli/test_profile_distribution.py
@@ -10,6 +10,7 @@ mocking git would just test the mock.
 
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 
 import pytest
@@ -305,6 +306,50 @@ class TestInstall:
         # Install again with --force succeeds
         plan = install_distribution(str(staged), name="target", force=True)
         assert plan.target_dir.is_dir()
+
+    def test_force_install_preserves_existing_dir_when_new_copy_fails(self, profile_env, monkeypatch):
+        staged = _make_staging_dir(profile_env, "src")
+        plan = install_distribution(str(staged), name="target")
+        skill = plan.target_dir / "skills" / "demo" / "SKILL.md"
+        skill.write_text("old skill\n")
+        (staged / "skills" / "demo" / "SKILL.md").write_text("new skill\n")
+        original_copytree = shutil.copytree
+
+        def fail_skills_copy(src, dst, *args, **kwargs):
+            if Path(src).name == "skills":
+                raise OSError("[WinError 145] The directory is not empty")
+            return original_copytree(src, dst, *args, **kwargs)
+
+        monkeypatch.setattr(
+            "hermes_cli.profile_distribution.shutil.copytree",
+            fail_skills_copy,
+        )
+
+        with pytest.raises(OSError, match="WinError 145"):
+            install_distribution(str(staged), name="target", force=True)
+
+        assert skill.read_text() == "old skill\n"
+
+    def test_force_install_succeeds_when_old_dir_cleanup_fails(self, profile_env, monkeypatch):
+        staged = _make_staging_dir(profile_env, "src")
+        plan = install_distribution(str(staged), name="target")
+        (staged / "skills" / "demo" / "SKILL.md").write_text("new skill\n")
+        original_rmtree = shutil.rmtree
+
+        def fail_old_backup_cleanup(path, *args, **kwargs):
+            if "hermes-dist-old" in str(path):
+                raise OSError("[WinError 145] The directory is not empty")
+            return original_rmtree(path, *args, **kwargs)
+
+        monkeypatch.setattr(
+            "hermes_cli.profile_distribution.shutil.rmtree",
+            fail_old_backup_cleanup,
+        )
+        monkeypatch.setattr("hermes_cli.profile_distribution.time.sleep", lambda *_args: None)
+
+        plan = install_distribution(str(staged), name="target", force=True)
+
+        assert (plan.target_dir / "skills" / "demo" / "SKILL.md").read_text() == "new skill\n"
 
     def test_install_rejects_default_name(self, profile_env):
         staged = _make_staging_dir(profile_env, "src")

--- a/tests/hermes_cli/test_profile_distribution.py
+++ b/tests/hermes_cli/test_profile_distribution.py
@@ -330,6 +330,29 @@ class TestInstall:
 
         assert skill.read_text() == "old skill\n"
 
+    def test_force_install_restores_existing_dir_when_staged_swap_fails(
+        self, profile_env, monkeypatch
+    ):
+        staged = _make_staging_dir(profile_env, "src")
+        plan = install_distribution(str(staged), name="target")
+        skill = plan.target_dir / "skills" / "demo" / "SKILL.md"
+        skill.write_text("old skill\n")
+        (staged / "skills" / "demo" / "SKILL.md").write_text("new skill\n")
+        original_rename = Path.rename
+
+        def fail_staged_swap(path, target):
+            if ".skills.hermes-dist-staging-" in path.name:
+                raise OSError("staged swap failed")
+            return original_rename(path, target)
+
+        monkeypatch.setattr(Path, "rename", fail_staged_swap)
+
+        with pytest.raises(OSError, match="staged swap failed"):
+            install_distribution(str(staged), name="target", force=True)
+
+        assert skill.read_text() == "old skill\n"
+        assert not list(plan.target_dir.parent.glob(".skills.hermes-dist-*"))
+
     def test_force_install_succeeds_when_old_dir_cleanup_fails(self, profile_env, monkeypatch):
         staged = _make_staging_dir(profile_env, "src")
         plan = install_distribution(str(staged), name="target")


### PR DESCRIPTION
Summary\n- Stage distribution-owned directory copies before replacing the live profile directory.\n- Move the previous directory aside and roll back if the staged swap fails, so existing skills survive failed force installs.\n- Retry transient removal failures and treat old-directory cleanup as best effort after the new tree is active.\n- Cover both copy failure and staged rename failure after the old directory has moved to backup.\n\nValidation\n- 72 profile distribution tests\n- Ruff on the changed implementation and tests\n\nRefs #52330