### PR TITLE
Daytona: set auto-archive interval on sandbox create (quota safety)

### DIFF
--- a/tests/tools/test_daytona_environment.py
+++ b/tests/tools/test_daytona_environment.py
@@ -186,6 +186,31 @@ class TestPersistence:
 
 
 # ---------------------------------------------------------------------------
+# Auto-archive quota safety
+# ---------------------------------------------------------------------------
+
+class TestAutoArchive:
+    def test_create_passes_default_auto_archive_interval(self, make_env, daytona_sdk):
+        # Capture the params object so we can inspect the create kwargs.
+        capture = MagicMock(name="CreateSandboxFromImageParams")
+        daytona_sdk.CreateSandboxFromImageParams = capture
+        make_env(persistent=False)
+        capture.assert_called_once()
+        kwargs = capture.call_args.kwargs
+        # A stopped sandbox keeps counting against the org disk quota; only an
+        # archived one stops counting. The create call must pass an archive
+        # interval so crashed or interrupted runs do not leak quota.
+        assert kwargs["auto_archive_interval"] == 60
+
+    def test_create_honors_custom_auto_archive_interval(self, make_env, daytona_sdk):
+        capture = MagicMock(name="CreateSandboxFromImageParams")
+        daytona_sdk.CreateSandboxFromImageParams = capture
+        make_env(persistent=False, auto_archive_interval=15)
+        kwargs = capture.call_args.kwargs
+        assert kwargs["auto_archive_interval"] == 15
+
+
+# ---------------------------------------------------------------------------
 # Cleanup
 # ---------------------------------------------------------------------------
 

--- a/tools/environments/daytona.py
+++ b/tools/environments/daytona.py
@@ -47,6 +47,7 @@ class DaytonaEnvironment(BaseEnvironment):
         disk: int = 10240,
         persistent_filesystem: bool = True,
         task_id: str = "default",
+        auto_archive_interval: int = 60,
     ):
         requested_cwd = cwd
         super().__init__(cwd=cwd, timeout=timeout)
@@ -123,6 +124,14 @@ class DaytonaEnvironment(BaseEnvironment):
                     name=sandbox_name,
                     labels=labels,
                     auto_stop_interval=0,
+                    # Quota safety: a stopped Daytona sandbox still counts against
+                    # the org disk quota; only an archived one stops counting.
+                    # Without an archive interval, a crashed or interrupted run can
+                    # leak sandboxes at a few GiB each until the quota fills and
+                    # blocks all workers. Resume already handles ARCHIVED state in
+                    # _ensure_sandbox_ready, so archiving is transparent here.
+                    # See paperclipai/paperclip#8561.
+                    auto_archive_interval=auto_archive_interval,
                     resources=resources,
                 )
             )


### PR DESCRIPTION
## Source signal (primary-source verified)

Paperclip commit `b3209486ca2238a07d9e3091d729643eea42eeeb`, "fix: default Daytona sandboxes to auto-archive so they leave the disk quota (#8561)." Verified via `gh api repos/paperclipai/paperclip/commits/b3209486...`.

https://github.com/paperclipai/paperclip/commit/b3209486ca2238a07d9e3091d729643eea42eeeb

Key claim from the commit body: Daytona bills storage against an org-wide disk quota; a stopped sandbox still counts against the quota, only an archived sandbox stops counting. Creating sandboxes without an auto-archive interval means Daytona falls back to its default (archive after 7 days). When in-product cleanup fails or never runs (crashed runs, failed lease destroys, orphaned probes), stopped sandboxes sit for a week at a few GiB each until the org storage quota fills and blocks all workers.

## Baseline (read on origin/main)

`tools/environments/daytona.py` create call on `origin/main`:

```python
self._sandbox = self._daytona.create(
    CreateSandboxFromImageParams(
        image=image,
        name=sandbox_name,
        labels=labels,
        auto_stop_interval=0,
        resources=resources,
    )
)
```

No `auto_archive_interval` was passed, so Daytona used its 7-day default. The same silent quota-leak pattern Paperclip just fixed.

The pinned SDK (`daytona==0.155.0` in `pyproject.toml`) accepts `auto_archive_interval` on `CreateSandboxFromImageParams` ("Interval in minutes after which a continuously stopped Sandbox will automatically archive"), so no version bump is needed.

## What changed

- Add an `auto_archive_interval` parameter to `DaytonaEnvironment.__init__` (default 60 minutes, overridable) and forward it to the `CreateSandboxFromImageParams` create call.
- Add two unit tests asserting the default and a custom interval reach the create call.

Auto-delete is deliberately left untouched, so persistent-filesystem semantics are unchanged and there is no data-loss risk.

## Test evidence

`bash scripts/run_tests.sh tests/tools/test_daytona_environment.py` -> 28 passed, 0 failed (26 baseline + 2 new).

## Review verdict

requesting-code-review gate: passed. Static security scan clean (no secrets, no shell/SQL injection, no eval/exec/pickle). No logic errors: the new param has a safe default, changes no control flow, and the resume path (`_ensure_sandbox_ready`) already restarts ARCHIVED sandboxes, so archiving is transparent.

## Why this is safe to merge

- Additive: one optional, default-safe parameter on an existing create call. No behavior change for the resume path (already handles ARCHIVED).
- Reversible: revert the one call site.
- Scoped: one file plus one test file.
- Not a refactor: a direct fix for a verified quota-leak pattern.
- Pinned SDK confirmed to accept the param; no dependency change.

Draft proposal: `working/draft-proposals/2026-06-24-daytona-auto-archive-quota-safe.md` (Argus).
