### PR TITLE
security(agent): strip Hermes secrets from codex/copilot subprocess env

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -108,6 +108,14 @@ def _build_subprocess_env() -> dict[str, str]:
     env["HOME"] = home
     from hermes_constants import apply_subprocess_home_env
     apply_subprocess_home_env(env)
+    # `copilot --acp` is a model-driven coding agent that executes tool calls;
+    # strip Hermes-managed secrets (provider keys, gateway/session tokens,
+    # GH/Modal/Daytona creds) so model-controlled actions can't read or
+    # exfiltrate them. Copilot authenticates via its own CLI login state under
+    # HOME (preserved here, not blocklisted), so this does not affect its auth.
+    from tools.environments.local import _sanitize_subprocess_env
+
+    env = _sanitize_subprocess_env(env)
     return env
 
 

--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -114,6 +114,18 @@ class CodexAppServerClient:
         # Codex emits tracing to stderr; default WARN keeps it quiet for users.
         spawn_env.setdefault("RUST_LOG", "warn")
 
+        # codex app-server runs a model-driven agent that executes tool calls;
+        # strip Hermes-managed secrets (provider keys, gateway/session tokens,
+        # GH/Modal/Daytona creds) so model-controlled actions can't read or
+        # exfiltrate them. Codex authenticates via CODEX_HOME, not Hermes
+        # provider env, and the non-secret vars it needs (CODEX_HOME, RUST_LOG,
+        # PATH, HOME, HERMES_HOME, HERMES_KANBAN_*) survive sanitization. This
+        # mirrors the sanitizer already applied at the cron, gateway,
+        # process_registry, and computer-use spawn sites.
+        from tools.environments.local import _sanitize_subprocess_env
+
+        spawn_env = _sanitize_subprocess_env(spawn_env)
+
         self._proc = subprocess.Popen(
             cmd,
             stdin=subprocess.PIPE,


### PR DESCRIPTION
The codex app-server and copilot ACP transports spawn model-driven coding
agents (they execute model-chosen tool calls) but build the child env from a
bare os.environ.copy(), bypassing the standard _sanitize_subprocess_env
scrubber used at the other six spawn sites. The child therefore inherits every
Hermes-managed secret: provider API keys/OAuth, HERMES_DASHBOARD_SESSION_TOKEN,
GATEWAY_ALLOWED_USERS, GH_TOKEN, GITHUB_APP_PRIVATE_KEY_PATH, MODAL/DAYTONA
tokens. A model-controlled action can read and exfiltrate them.

Route both transports' env through _sanitize_subprocess_env right before Popen.
The non-secret vars each child needs (CODEX_HOME, RUST_LOG, PATH, HOME,
HERMES_HOME, HERMES_KANBAN_*) survive sanitization; codex auths via CODEX_HOME
and copilot via its CLI login state under HOME, so auth is unaffected.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
