### PR TITLE
security(mcp): scrub all secret headers on cross-origin redirects

### DIFF
--- a/tests/tools/test_mcp_client_cert.py
+++ b/tests/tools/test_mcp_client_cert.py
@@ -431,8 +431,6 @@ class TestSSEClientCert:
         cross-origin redirect. The auto-seeded mcp-protocol-version header
         alone must NOT trigger this (covered by test_no_factory_when_defaults),
         and the scrubber must only strip the configured keys."""
-        import httpx
-
         from tools.mcp_tool import MCPServerTask
 
         server = MCPServerTask("sse-test")
@@ -461,29 +459,19 @@ class TestSSEClientCert:
             "expected httpx_client_factory when secret headers are configured"
         )
 
-        # The factory's client must carry a response hook that scrubs the
-        # configured secret header on a cross-origin redirect but leaves the
-        # (non-secret) seeded protocol header alone.
+        # The factory's client must carry a *request* hook that scrubs secret
+        # headers. It has to be a request hook, not a response hook: under
+        # follow_redirects=True httpx never populates response.next_request, so
+        # a response hook can't touch the request that is actually sent. The
+        # end-to-end scrubbing behaviour is exercised against httpx's real
+        # redirect machinery in TestRedirectSecretScrubber below.
         client = factory(headers=None, timeout=None, auth=None)
-        hooks = client.event_hooks.get("response") or []
-        assert hooks, "expected a redirect-scrubbing response hook"
-
-        next_request = httpx.Request(
-            "GET", "https://evil.example.net/landing",
-            headers={
-                "X-API-Key": "sekrit",
-                "mcp-protocol-version": "2025-11-25",
-            },
+        request_hooks = client.event_hooks.get("request") or []
+        assert request_hooks, "expected a redirect-scrubbing request hook"
+        assert not (client.event_hooks.get("response") or []), (
+            "scrubber must not be installed as a response hook — it would be a "
+            "no-op on followed redirects"
         )
-        redirect = httpx.Response(
-            302,
-            headers={"location": "https://evil.example.net/landing"},
-            request=httpx.Request("GET", "https://example.com/mcp/sse"),
-        )
-        redirect.next_request = next_request
-        asyncio.run(hooks[0](redirect))
-        assert "X-API-Key" not in next_request.headers
-        assert "mcp-protocol-version" in next_request.headers
 
     def test_factory_injected_when_cert_set(self, patch_sse_client, tmp_path):
         """With client_cert set, an httpx_client_factory is injected that
@@ -579,3 +567,105 @@ class TestSSEClientCert:
 
         assert captured_client_kwargs["verify"] == str(ca_bundle)
         assert "cert" not in captured_client_kwargs
+
+
+# ---------------------------------------------------------------------------
+# Cross-origin secret-header scrubber — real httpx redirect lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestRedirectSecretScrubber:
+    """End-to-end coverage for ``_make_redirect_secret_scrubber``.
+
+    These drive httpx's real redirect-following machinery through a
+    ``MockTransport`` and observe the headers that are *actually sent* at each
+    hop, instead of hand-calling the hook with a synthetic ``next_request``.
+    Because httpx invokes ``response`` hooks before it builds the followed
+    redirect request (and only sets ``response.next_request`` in the
+    non-following branch), a response-hook implementation is a silent no-op
+    here; the scrubber must be a request hook to strip the followed hop.
+    """
+
+    def _drive(self, original_url, secret_keys, headers, redirect_to):
+        import httpx
+
+        from tools.mcp_tool import _make_redirect_secret_scrubber
+
+        sent = []  # headers actually seen by the transport, per hop
+
+        def handler(request: "httpx.Request") -> "httpx.Response":
+            sent.append((str(request.url), dict(request.headers)))
+            if str(request.url) == original_url:
+                return httpx.Response(302, headers={"location": redirect_to})
+            return httpx.Response(200, text="landed")
+
+        scrubber = _make_redirect_secret_scrubber(original_url, secret_keys)
+
+        async def run():
+            async with httpx.AsyncClient(
+                transport=httpx.MockTransport(handler),
+                follow_redirects=True,
+                event_hooks={"request": [scrubber]},
+                headers=headers,
+            ) as client:
+                resp = await client.get(original_url)
+                assert resp.status_code == 200
+
+        asyncio.run(run())
+        return sent
+
+    def test_strips_secret_on_followed_cross_origin_redirect(self):
+        sent = self._drive(
+            "https://example.com/mcp",
+            {"x-api-key"},
+            {"X-API-Key": "sekrit"},
+            "https://evil.example.net/landing",
+        )
+        # Two real hops: original request, then the followed redirect.
+        assert len(sent) == 2
+        first_url, first_headers = sent[0]
+        assert first_url == "https://example.com/mcp"
+        # Same origin -> secret preserved on the initial request.
+        assert first_headers.get("x-api-key") == "sekrit"
+        second_url, second_headers = sent[1]
+        assert second_url == "https://evil.example.net/landing"
+        # Foreign origin reached via a followed redirect -> secret stripped.
+        assert "x-api-key" not in second_headers
+
+    def test_strips_secret_on_same_host_different_port(self):
+        sent = self._drive(
+            "https://example.com/mcp",
+            {"x-api-key"},
+            {"X-API-Key": "sekrit"},
+            "https://example.com:8443/landing",
+        )
+        assert len(sent) == 2
+        second_url, second_headers = sent[1]
+        assert second_url == "https://example.com:8443/landing"
+        assert "x-api-key" not in second_headers
+
+    def test_preserves_secret_on_same_origin_redirect(self):
+        sent = self._drive(
+            "https://example.com/mcp",
+            {"x-api-key"},
+            {"X-API-Key": "sekrit"},
+            "https://example.com/mcp/v2",
+        )
+        assert len(sent) == 2
+        second_url, second_headers = sent[1]
+        assert second_url == "https://example.com/mcp/v2"
+        # Same origin (scheme, host, default port) -> secret must survive.
+        assert second_headers.get("x-api-key") == "sekrit"
+
+    def test_only_configured_keys_are_stripped(self):
+        sent = self._drive(
+            "https://example.com/mcp",
+            {"x-api-key"},
+            {"X-API-Key": "sekrit", "mcp-protocol-version": "2025-11-25"},
+            "https://evil.example.net/landing",
+        )
+        _, second_headers = sent[1]
+        assert "x-api-key" not in second_headers
+        # A non-secret protocol header that wasn't in the configured key set is
+        # left untouched.
+        assert second_headers.get("mcp-protocol-version") == "2025-11-25"

--- a/tests/tools/test_mcp_client_cert.py
+++ b/tests/tools/test_mcp_client_cert.py
@@ -425,6 +425,66 @@ class TestSSEClientCert:
         asyncio.run(drive())
         assert "httpx_client_factory" not in patch_sse_client
 
+    def test_factory_injected_when_secret_headers_set(self, patch_sse_client):
+        """With user-configured headers (potential secrets) and default TLS, a
+        factory IS injected so the redirect scrubber can strip them on a
+        cross-origin redirect. The auto-seeded mcp-protocol-version header
+        alone must NOT trigger this (covered by test_no_factory_when_defaults),
+        and the scrubber must only strip the configured keys."""
+        import httpx
+
+        from tools.mcp_tool import MCPServerTask
+
+        server = MCPServerTask("sse-test")
+        server._auth_type = ""
+        server._sampling = None
+
+        async def drive():
+            with patch.object(MCPServerTask, "_wait_for_lifecycle_event",
+                              new=AsyncMock(return_value="shutdown")), \
+                 patch.object(MCPServerTask, "_discover_tools", new=AsyncMock()):
+                try:
+                    await asyncio.wait_for(
+                        server._run_http({
+                            "url": "https://example.com/mcp/sse",
+                            "transport": "sse",
+                            "headers": {"X-API-Key": "sekrit"},
+                        }),
+                        timeout=2.0,
+                    )
+                except (asyncio.TimeoutError, StopAsyncIteration, Exception):
+                    pass
+
+        asyncio.run(drive())
+        factory = patch_sse_client.get("httpx_client_factory")
+        assert factory is not None, (
+            "expected httpx_client_factory when secret headers are configured"
+        )
+
+        # The factory's client must carry a response hook that scrubs the
+        # configured secret header on a cross-origin redirect but leaves the
+        # (non-secret) seeded protocol header alone.
+        client = factory(headers=None, timeout=None, auth=None)
+        hooks = client.event_hooks.get("response") or []
+        assert hooks, "expected a redirect-scrubbing response hook"
+
+        next_request = httpx.Request(
+            "GET", "https://evil.example.net/landing",
+            headers={
+                "X-API-Key": "sekrit",
+                "mcp-protocol-version": "2025-11-25",
+            },
+        )
+        redirect = httpx.Response(
+            302,
+            headers={"location": "https://evil.example.net/landing"},
+            request=httpx.Request("GET", "https://example.com/mcp/sse"),
+        )
+        redirect.next_request = next_request
+        asyncio.run(hooks[0](redirect))
+        assert "X-API-Key" not in next_request.headers
+        assert "mcp-protocol-version" in next_request.headers
+
     def test_factory_injected_when_cert_set(self, patch_sse_client, tmp_path):
         """With client_cert set, an httpx_client_factory is injected that
         applies the cert (and follow_redirects=True to match the SDK)."""

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2590,6 +2590,12 @@ class MCPServerTask:
 
         url = config["url"]
         headers = dict(config.get("headers") or {})
+        # Only user-configured headers can carry secrets (API keys, ${VAR}
+        # tokens). Snapshot their keys before seeding the protocol header
+        # below so the redirect scrubber targets exactly those — the seeded
+        # header is not a secret and must not, by itself, force the
+        # scrubbing machinery (client factories) onto default configs.
+        _secret_header_keys = frozenset(headers.keys())
         # Some MCP servers require MCP-Protocol-Version on the initial
         # initialize request and reject session-less POSTs otherwise.
         # Seed it as a client-level default, but treat user overrides as
@@ -2654,22 +2660,24 @@ class MCPServerTask:
                 # behind OAuth 2.1 PKCE work. Previously built but never
                 # forwarded — SSE OAuth would silently fail with 401s.
                 _sse_kwargs["auth"] = _oauth_auth
-            if headers or client_cert is not None or ssl_verify is not True:
+            if _secret_header_keys or client_cert is not None or ssl_verify is not True:
                 # SSE transport doesn't expose verify/cert (or a redirect hook)
                 # as kwargs, so route them through an httpx_client_factory that
                 # wraps the SDK's defaults (follow_redirects=True) and adds our
                 # TLS settings plus the cross-origin secret-header scrubber. The
                 # factory must be installed whenever secret headers are present
                 # too — otherwise the default-TLS SSE path has no redirect
-                # scrubbing and custom auth headers leak cross-origin. The SDK
-                # calls the factory with (headers, auth, timeout); we forward
-                # all of those and layer verify/cert/event_hooks on top.
+                # scrubbing and custom auth headers leak cross-origin. Gated on
+                # the user-configured header keys (not the seeded protocol
+                # header) so fully-default configs keep the SDK's own client.
+                # The SDK calls the factory with (headers, auth, timeout); we
+                # forward all of those and layer verify/cert/event_hooks on top.
                 import httpx as _httpx_mod
 
                 _cert_for_factory = client_cert
                 _verify_for_factory = ssl_verify
                 _sse_scrubber = _make_redirect_secret_scrubber(
-                    url, (headers or {}).keys()
+                    url, _secret_header_keys
                 )
 
                 def _mcp_http_client_factory(
@@ -2735,7 +2743,7 @@ class MCPServerTask:
                 "verify": ssl_verify,
                 "event_hooks": {
                     "response": [
-                        _make_redirect_secret_scrubber(url, (headers or {}).keys())
+                        _make_redirect_secret_scrubber(url, _secret_header_keys)
                     ]
                 },
             }
@@ -2786,16 +2794,22 @@ class MCPServerTask:
             # robustness — without it the deprecated client follows redirects
             # with the configured secret headers attached and no scrubbing).
             # When a factory is supplied the SDK builds the client itself, so
-            # verify/cert move into the factory.
+            # verify/cert move into the factory. Gated like the SSE path: a
+            # fully-default config (no secret headers, default TLS) keeps the
+            # SDK's own client.
             try:
                 import inspect as _inspect
                 import httpx as _httpx_dep
 
-                if "httpx_client_factory" in _inspect.signature(
+                if (
+                    _secret_header_keys
+                    or client_cert is not None
+                    or ssl_verify is not True
+                ) and "httpx_client_factory" in _inspect.signature(
                     streamablehttp_client
                 ).parameters:
                     _dep_scrubber = _make_redirect_secret_scrubber(
-                        url, (headers or {}).keys()
+                        url, _secret_header_keys
                     )
                     _dep_cert = client_cert
                     _dep_verify = ssl_verify

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1705,6 +1705,41 @@ class ElicitationHandler:
         return ElicitResult(action="decline")
 
 
+def _make_redirect_secret_scrubber(original_url, header_keys):
+    """Build an httpx ``response`` event hook that strips secret headers on a
+    cross-origin redirect.
+
+    httpx only auto-strips the standard ``Authorization`` header (and not even
+    that on an http->https same-host upgrade); it never strips custom auth
+    headers such as ``X-API-Key`` / vendor tokens, which operators configure
+    for remote MCP servers (often ``${VAR}``-resolved secrets). Without this, a
+    server URL that 30x-redirects to a foreign origin exfiltrates every
+    configured secret header. The hook removes ALL caller-supplied header keys
+    whenever the redirect target's (scheme, host, port) differs from the
+    original, so the same shared policy covers the Streamable-HTTP, SSE,
+    deprecated, and preflight-probe transports.
+    """
+    import httpx as _httpx
+
+    orig = original_url if isinstance(original_url, _httpx.URL) else _httpx.URL(original_url)
+    keys = {str(k).lower() for k in (header_keys or ())}
+
+    async def _scrub(response):
+        if not keys:
+            return
+        if response.is_redirect and response.next_request is not None:
+            target = response.next_request.url
+            if (target.scheme, target.host, target.port) != (
+                orig.scheme, orig.host, orig.port,
+            ):
+                hdrs = response.next_request.headers
+                for name in list(hdrs.keys()):
+                    if name.lower() in keys:
+                        del hdrs[name]
+
+    return _scrub
+
+
 # ---------------------------------------------------------------------------
 # Server task -- each MCP server lives in one long-lived asyncio Task
 # ---------------------------------------------------------------------------
@@ -2460,6 +2495,14 @@ class MCPServerTask:
             "verify": ssl_verify,
             "follow_redirects": True,
             "timeout": _httpx.Timeout(timeout),
+            # Strip configured secret headers if the probe is redirected to a
+            # foreign origin — this HEAD/GET is the earliest egress carrying
+            # the configured auth headers, before the SDK handshake.
+            "event_hooks": {
+                "response": [
+                    _make_redirect_secret_scrubber(url, (headers or {}).keys())
+                ]
+            },
         }
         if client_cert is not None:
             client_kwargs["cert"] = client_cert
@@ -2611,16 +2654,23 @@ class MCPServerTask:
                 # behind OAuth 2.1 PKCE work. Previously built but never
                 # forwarded — SSE OAuth would silently fail with 401s.
                 _sse_kwargs["auth"] = _oauth_auth
-            if client_cert is not None or ssl_verify is not True:
-                # SSE transport doesn't expose verify/cert as kwargs, so route
-                # them through an httpx_client_factory that wraps the SDK's
-                # defaults (follow_redirects=True) and adds our TLS settings.
-                # The SDK calls the factory with (headers, auth, timeout); we
-                # forward all of those and layer verify/cert on top.
+            if headers or client_cert is not None or ssl_verify is not True:
+                # SSE transport doesn't expose verify/cert (or a redirect hook)
+                # as kwargs, so route them through an httpx_client_factory that
+                # wraps the SDK's defaults (follow_redirects=True) and adds our
+                # TLS settings plus the cross-origin secret-header scrubber. The
+                # factory must be installed whenever secret headers are present
+                # too — otherwise the default-TLS SSE path has no redirect
+                # scrubbing and custom auth headers leak cross-origin. The SDK
+                # calls the factory with (headers, auth, timeout); we forward
+                # all of those and layer verify/cert/event_hooks on top.
                 import httpx as _httpx_mod
 
                 _cert_for_factory = client_cert
                 _verify_for_factory = ssl_verify
+                _sse_scrubber = _make_redirect_secret_scrubber(
+                    url, (headers or {}).keys()
+                )
 
                 def _mcp_http_client_factory(
                     headers=None, timeout=None, auth=None,
@@ -2628,6 +2678,7 @@ class MCPServerTask:
                     kwargs: dict = {
                         "follow_redirects": True,
                         "verify": _verify_for_factory,
+                        "event_hooks": {"response": [_sse_scrubber]},
                     }
                     if timeout is not None:
                         kwargs["timeout"] = timeout
@@ -2674,23 +2725,19 @@ class MCPServerTask:
             # matching the SDK's own create_mcp_http_client defaults.
             import httpx
 
-            _original_url = httpx.URL(url)
-
-            async def _strip_auth_on_cross_origin_redirect(response):
-                """Strip Authorization headers when redirected to a different origin."""
-                if response.is_redirect and response.next_request:
-                    target = response.next_request.url
-                    if (target.scheme, target.host, target.port) != (
-                        _original_url.scheme, _original_url.host, _original_url.port,
-                    ):
-                        response.next_request.headers.pop("authorization", None)
-                        response.next_request.headers.pop("Authorization", None)
-
+            # Strip ALL configured secret headers (not just Authorization) on a
+            # cross-origin redirect. httpx only auto-strips Authorization;
+            # custom auth headers (X-API-Key, vendor tokens, ${VAR} secrets)
+            # would otherwise be forwarded to the redirect target origin.
             client_kwargs: dict = {
                 "follow_redirects": True,
                 "timeout": httpx.Timeout(float(connect_timeout), read=300.0),
                 "verify": ssl_verify,
-                "event_hooks": {"response": [_strip_auth_on_cross_origin_redirect]},
+                "event_hooks": {
+                    "response": [
+                        _make_redirect_secret_scrubber(url, (headers or {}).keys())
+                    ]
+                },
             }
             if headers:
                 client_kwargs["headers"] = headers
@@ -2734,6 +2781,52 @@ class MCPServerTask:
             }
             if _oauth_auth is not None:
                 _http_kwargs["auth"] = _oauth_auth
+            # Install the cross-origin secret-header scrubber when this SDK
+            # build exposes httpx_client_factory (feature-detected for version
+            # robustness — without it the deprecated client follows redirects
+            # with the configured secret headers attached and no scrubbing).
+            # When a factory is supplied the SDK builds the client itself, so
+            # verify/cert move into the factory.
+            try:
+                import inspect as _inspect
+                import httpx as _httpx_dep
+
+                if "httpx_client_factory" in _inspect.signature(
+                    streamablehttp_client
+                ).parameters:
+                    _dep_scrubber = _make_redirect_secret_scrubber(
+                        url, (headers or {}).keys()
+                    )
+                    _dep_cert = client_cert
+                    _dep_verify = ssl_verify
+
+                    def _dep_factory(headers=None, timeout=None, auth=None):
+                        kwargs: dict = {
+                            "follow_redirects": True,
+                            "verify": _dep_verify,
+                            "event_hooks": {"response": [_dep_scrubber]},
+                        }
+                        kwargs["timeout"] = (
+                            timeout
+                            if timeout is not None
+                            else _httpx_dep.Timeout(float(connect_timeout), read=300.0)
+                        )
+                        if headers is not None:
+                            kwargs["headers"] = headers
+                        if auth is not None:
+                            kwargs["auth"] = auth
+                        if _dep_cert is not None:
+                            kwargs["cert"] = _dep_cert
+                        return _httpx_dep.AsyncClient(**kwargs)
+
+                    _http_kwargs["httpx_client_factory"] = _dep_factory
+                    _http_kwargs.pop("verify", None)  # factory owns verify now
+            except Exception:
+                logger.debug(
+                    "MCP '%s': could not install deprecated-path redirect scrubber",
+                    self.name,
+                    exc_info=True,
+                )
             async with streamablehttp_client(url, **_http_kwargs) as (
                 read_stream, write_stream, _get_session_id,
             ):

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1706,8 +1706,9 @@ class ElicitationHandler:
 
 
 def _make_redirect_secret_scrubber(original_url, header_keys):
-    """Build an httpx ``response`` event hook that strips secret headers on a
-    cross-origin redirect.
+    """Build an httpx ``request`` event hook that strips configured secret
+    headers from any outgoing request whose origin differs from the original
+    configured server URL.
 
     httpx only auto-strips the standard ``Authorization`` header (and not even
     that on an http->https same-host upgrade); it never strips custom auth
@@ -1715,27 +1716,33 @@ def _make_redirect_secret_scrubber(original_url, header_keys):
     for remote MCP servers (often ``${VAR}``-resolved secrets). Without this, a
     server URL that 30x-redirects to a foreign origin exfiltrates every
     configured secret header. The hook removes ALL caller-supplied header keys
-    whenever the redirect target's (scheme, host, port) differs from the
-    original, so the same shared policy covers the Streamable-HTTP, SSE,
-    deprecated, and preflight-probe transports.
+    whenever a request's (scheme, host, port) differs from the original, so the
+    same shared policy covers the Streamable-HTTP, SSE, deprecated, and
+    preflight-probe transports.
+
+    This MUST be a ``request`` hook, not a ``response`` hook. With
+    ``follow_redirects=True`` httpx builds and sends the followed redirect
+    request internally and never populates ``response.next_request`` (it sets
+    that only in the non-following branch), so a response hook cannot see — let
+    alone scrub — the request that is actually sent. A request hook runs for
+    every outgoing request, including each redirect hop, and can mutate its
+    headers in place before the request goes out.
     """
     import httpx as _httpx
 
     orig = original_url if isinstance(original_url, _httpx.URL) else _httpx.URL(original_url)
+    orig_origin = (orig.scheme, orig.host, orig.port)
     keys = {str(k).lower() for k in (header_keys or ())}
 
-    async def _scrub(response):
+    async def _scrub(request):
         if not keys:
             return
-        if response.is_redirect and response.next_request is not None:
-            target = response.next_request.url
-            if (target.scheme, target.host, target.port) != (
-                orig.scheme, orig.host, orig.port,
-            ):
-                hdrs = response.next_request.headers
-                for name in list(hdrs.keys()):
-                    if name.lower() in keys:
-                        del hdrs[name]
+        target = request.url
+        if (target.scheme, target.host, target.port) != orig_origin:
+            hdrs = request.headers
+            for name in list(hdrs.keys()):
+                if name.lower() in keys:
+                    del hdrs[name]
 
     return _scrub
 
@@ -2499,7 +2506,7 @@ class MCPServerTask:
             # foreign origin — this HEAD/GET is the earliest egress carrying
             # the configured auth headers, before the SDK handshake.
             "event_hooks": {
-                "response": [
+                "request": [
                     _make_redirect_secret_scrubber(url, (headers or {}).keys())
                 ]
             },
@@ -2686,7 +2693,7 @@ class MCPServerTask:
                     kwargs: dict = {
                         "follow_redirects": True,
                         "verify": _verify_for_factory,
-                        "event_hooks": {"response": [_sse_scrubber]},
+                        "event_hooks": {"request": [_sse_scrubber]},
                     }
                     if timeout is not None:
                         kwargs["timeout"] = timeout
@@ -2742,7 +2749,7 @@ class MCPServerTask:
                 "timeout": httpx.Timeout(float(connect_timeout), read=300.0),
                 "verify": ssl_verify,
                 "event_hooks": {
-                    "response": [
+                    "request": [
                         _make_redirect_secret_scrubber(url, _secret_header_keys)
                     ]
                 },
@@ -2818,7 +2825,7 @@ class MCPServerTask:
                         kwargs: dict = {
                             "follow_redirects": True,
                             "verify": _dep_verify,
-                            "event_hooks": {"response": [_dep_scrubber]},
+                            "event_hooks": {"request": [_dep_scrubber]},
                         }
                         kwargs["timeout"] = (
                             timeout


### PR DESCRIPTION
Remote MCP servers are configured with custom auth headers (X-API-Key, vendor
tokens, ${VAR} secrets). Every authenticated HTTP path followed redirects with
those headers attached, and the only scrubber stripped Authorization alone
(which httpx already strips) — custom secret headers leaked to a redirect target
origin. Three paths had no scrubbing at all: the preflight probe, the
default-TLS SSE client, and the deprecated streamablehttp client.

Add one shared _make_redirect_secret_scrubber (strips every caller-configured
header key when the redirect target origin differs) and wire it into all four
transports: Streamable-HTTP, SSE (now installed whenever headers are present,
not just for custom TLS), the deprecated path (feature-detected
httpx_client_factory), and the preflight probe.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
