### PR TITLE
security(matrix): authorize media download, cap real bytes, gate auto-join

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2456,6 +2456,21 @@ class MatrixAdapter(BasePlatformAdapter):
             )
             return False
 
+    @staticmethod
+    def _adapter_allow_all_users() -> bool:
+        """True when either the Matrix-specific or the global allow-all env is set.
+
+        The gateway authorization layer honors both ``MATRIX_ALLOW_ALL_USERS``
+        (the adapter's registered ``allow_all_env``) and the cross-platform
+        ``GATEWAY_ALLOW_ALL_USERS``; the adapter's own pre-auth gates must honor
+        the same pair, or an operator who set only ``MATRIX_ALLOW_ALL_USERS``
+        would find media downloads and invite auto-joins silently blocked.
+        """
+        return any(
+            os.getenv(var, "").lower() in {"true", "1", "yes"}
+            for var in ("MATRIX_ALLOW_ALL_USERS", "GATEWAY_ALLOW_ALL_USERS")
+        )
+
     def _is_media_download_authorized(self, sender: str) -> bool:
         """Whether to fetch+cache attacker-supplied media bytes for *sender*.
 
@@ -2463,12 +2478,12 @@ class MatrixAdapter(BasePlatformAdapter):
         BEFORE the gateway's pairing/allowlist runs. Open by default (no
         ``MATRIX_ALLOWED_USERS`` configured) to preserve the adapter's existing
         intake posture where the gateway handles pairing downstream; when an
-        operator sets an allowlist (or ``GATEWAY_ALLOW_ALL_USERS``) it is
-        honored here too so unauthorized senders can't drive pre-auth
-        downloads. Unauthorized senders still reach the gateway via the
-        HTTP-fallback envelope, so pairing/denial is unchanged.
+        operator sets an allowlist (or an allow-all env) it is honored here too
+        so unauthorized senders can't drive pre-auth downloads. Unauthorized
+        senders still reach the gateway via the HTTP-fallback envelope, so
+        pairing/denial is unchanged.
         """
-        if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
+        if self._adapter_allow_all_users():
             return True
         if not self._allowed_user_ids:
             return True
@@ -3023,21 +3038,23 @@ class MatrixAdapter(BasePlatformAdapter):
         await self.handle_message(msg_event)
 
     def _invite_auto_join_allowed(self, room_id: str, inviter: str) -> bool:
-        """Whether to auto-join an invite given the configured allowlists.
+        """Whether to auto-join a *pending* invite during the reconcile sweep.
 
-        Open by default (no allowlist configured) to preserve existing
-        behavior. When ``MATRIX_ALLOWED_ROOMS`` or ``MATRIX_ALLOWED_USERS`` is
-        set (and ``GATEWAY_ALLOW_ALL_USERS`` is not), only auto-join rooms or
-        inviters the operator allowlisted — otherwise an arbitrary external
-        user could DM-invite the bot, get auto-joined, and (because DMs are
-        exempt from the room allowlist) manufacture an authorized-looking
-        context for later message/media processing.
+        Open by default (no allowlist configured) to preserve the adapter's
+        existing reconcile behavior. When an allowlist is configured, require an
+        explicitly authorized *inviter*.
+
+        A ``MATRIX_ALLOWED_ROOMS`` match is deliberately NOT sufficient on its
+        own: the inviter is any federated user / room member and is unverified,
+        and DMs are exempt from the room allowlist, so honoring a room-only
+        match would let an unauthorized inviter manufacture an
+        authorized-looking context for later message/media processing.
+        ``MATRIX_ALLOWED_ROOMS`` still constrains which rooms the bot operates
+        in elsewhere; it just can't, by itself, authorize an auto-join.
         """
-        if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
+        if self._adapter_allow_all_users():
             return True
         if not self._allowed_user_ids and not self._allowed_room_ids:
-            return True
-        if room_id and room_id in self._allowed_room_ids:
             return True
         return bool(inviter) and inviter in self._allowed_user_ids
 
@@ -3063,31 +3080,19 @@ class MatrixAdapter(BasePlatformAdapter):
         is_direct = bool(getattr(content, "is_direct", False))
         inviter = str(getattr(event, "sender", "") or "")
 
-        if not self._invite_auto_join_allowed(room_id, inviter):
-            logger.info(
-                "Matrix: declining invite to %s from unauthorized inviter %s "
-                "(not in MATRIX_ALLOWED_ROOMS / MATRIX_ALLOWED_USERS)",
-                room_id,
-                inviter or "<unknown>",
-            )
-            return
-
-        # Only auto-join when the inviter is authorized. Without this, any
+        # Only auto-join when the inviter is authorized (fail-closed: with no
+        # allowlist configured, live invites are rejected). Without this, any
         # federated Matrix user could invite the bot into arbitrary rooms,
-        # exposing its presence and metadata. Mirrors the allow-list gate
-        # used on the message/reaction paths.
-        allow_all = os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {
-            "true",
-            "1",
-            "yes",
-        }
-        if not allow_all and not (
+        # exposing its presence and metadata. Mirrors the allow-list gate used
+        # on the message/reaction paths. The pending-invite reconcile sweep
+        # applies its own (open-by-default) gate via _invite_auto_join_allowed.
+        if not self._adapter_allow_all_users() and not (
             self._allowed_user_ids and inviter in self._allowed_user_ids
         ):
             logger.warning(
                 "Matrix: rejecting invite to %s from unauthorized user %s",
                 room_id,
-                inviter,
+                inviter or "<unknown>",
             )
             return
 

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2456,6 +2456,24 @@ class MatrixAdapter(BasePlatformAdapter):
             )
             return False
 
+    def _is_media_download_authorized(self, sender: str) -> bool:
+        """Whether to fetch+cache attacker-supplied media bytes for *sender*.
+
+        Gates the network fetch and host cache write that currently happen
+        BEFORE the gateway's pairing/allowlist runs. Open by default (no
+        ``MATRIX_ALLOWED_USERS`` configured) to preserve the adapter's existing
+        intake posture where the gateway handles pairing downstream; when an
+        operator sets an allowlist (or ``GATEWAY_ALLOW_ALL_USERS``) it is
+        honored here too so unauthorized senders can't drive pre-auth
+        downloads. Unauthorized senders still reach the gateway via the
+        HTTP-fallback envelope, so pairing/denial is unchanged.
+        """
+        if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
+            return True
+        if not self._allowed_user_ids:
+            return True
+        return bool(sender) and sender in self._allowed_user_ids
+
     async def _on_room_message(self, event: Any) -> None:
         """Handle incoming room message events (text, media)."""
         room_id = str(getattr(event, "room_id", ""))
@@ -2873,9 +2891,22 @@ class MatrixAdapter(BasePlatformAdapter):
         should_cache_locally = msg_type in {
             MessageType.PHOTO, MessageType.AUDIO, MessageType.VIDEO, MessageType.DOCUMENT,
         } or is_voice_message or is_encrypted_media
-        if should_cache_locally and url:
+        if should_cache_locally and url and self._is_media_download_authorized(sender):
             try:
                 file_bytes = await self._client.download_media(ContentURI(url))
+                if file_bytes is not None and len(file_bytes) > self._max_media_bytes:
+                    # The pre-download check trusts the attacker-declared
+                    # content_info.size; enforce the cap against the REAL
+                    # downloaded length too so a lying/absent size can't smuggle
+                    # an oversized payload into memory/cache.
+                    logger.warning(
+                        "[Matrix] Discarding inbound media %s: real size %d "
+                        "exceeds limit %d bytes",
+                        event_id,
+                        len(file_bytes),
+                        self._max_media_bytes,
+                    )
+                    file_bytes = None
                 if file_bytes is not None:
                     if is_encrypted_media:
                         from mautrix.crypto.attachments import decrypt_attachment
@@ -2991,13 +3022,55 @@ class MatrixAdapter(BasePlatformAdapter):
 
         await self.handle_message(msg_event)
 
+    def _invite_auto_join_allowed(self, room_id: str, inviter: str) -> bool:
+        """Whether to auto-join an invite given the configured allowlists.
+
+        Open by default (no allowlist configured) to preserve existing
+        behavior. When ``MATRIX_ALLOWED_ROOMS`` or ``MATRIX_ALLOWED_USERS`` is
+        set (and ``GATEWAY_ALLOW_ALL_USERS`` is not), only auto-join rooms or
+        inviters the operator allowlisted — otherwise an arbitrary external
+        user could DM-invite the bot, get auto-joined, and (because DMs are
+        exempt from the room allowlist) manufacture an authorized-looking
+        context for later message/media processing.
+        """
+        if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
+            return True
+        if not self._allowed_user_ids and not self._allowed_room_ids:
+            return True
+        if room_id and room_id in self._allowed_room_ids:
+            return True
+        return bool(inviter) and inviter in self._allowed_user_ids
+
+    @staticmethod
+    def _invite_state_sender(invite_entry: Any) -> str:
+        """Best-effort extraction of the inviter from a sync invite entry."""
+        try:
+            events = (invite_entry or {}).get("invite_state", {}).get("events", [])
+            for ev in events:
+                if ev.get("type") == "m.room.member" and (
+                    ev.get("content") or {}
+                ).get("membership") == "invite":
+                    return str(ev.get("sender", "") or "")
+        except Exception:
+            pass
+        return ""
+
     async def _on_invite(self, event: Any) -> None:
         """Auto-join rooms when invited, recording DM rooms in m.direct."""
 
         room_id = str(getattr(event, "room_id", ""))
         content = getattr(event, "content", None)
         is_direct = bool(getattr(content, "is_direct", False))
-        inviter = str(getattr(event, "sender", ""))
+        inviter = str(getattr(event, "sender", "") or "")
+
+        if not self._invite_auto_join_allowed(room_id, inviter):
+            logger.info(
+                "Matrix: declining invite to %s from unauthorized inviter %s "
+                "(not in MATRIX_ALLOWED_ROOMS / MATRIX_ALLOWED_USERS)",
+                room_id,
+                inviter or "<unknown>",
+            )
+            return
 
         # Only auto-join when the inviter is authorized. Without this, any
         # federated Matrix user could invite the bot into arbitrary rooms,
@@ -3102,6 +3175,15 @@ class MatrixAdapter(BasePlatformAdapter):
             return
         for room_id in invites:
             if room_id in self._joined_rooms:
+                continue
+            inviter = self._invite_state_sender(invites.get(room_id))
+            if not self._invite_auto_join_allowed(str(room_id), inviter):
+                logger.info(
+                    "Matrix: declining pending invite to %s from unauthorized "
+                    "inviter %s",
+                    room_id,
+                    inviter or "<unknown>",
+                )
                 continue
             logger.info("Matrix: reconciling pending invite for %s", room_id)
             self._schedule_invite_join(str(room_id))

--- a/tests/gateway/test_matrix_media_invite_preauth.py
+++ b/tests/gateway/test_matrix_media_invite_preauth.py
@@ -1,0 +1,118 @@
+"""Pre-auth gates on the Matrix adapter (PR #52354).
+
+Covers two gates that run BEFORE the gateway's pairing/allowlist:
+
+* ``_is_media_download_authorized`` — whether to fetch + cache attacker-supplied
+  media bytes. Open by default, tightened when an allowlist / allow-all env is
+  configured.
+* ``_invite_auto_join_allowed`` — whether to auto-join an invite. Fail-closed and
+  inviter-based, shared by the live invite event and the pending-invite
+  reconciliation sweep so both apply the same policy.
+"""
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _make_adapter():
+    from plugins.platforms.matrix.adapter import MatrixAdapter
+
+    config = PlatformConfig(
+        enabled=True,
+        token="syt_test_token",
+        extra={
+            "homeserver": "https://matrix.example.org",
+            "user_id": "@hermes:example.org",
+        },
+    )
+    adapter = MatrixAdapter(config)
+    adapter._allowed_user_ids = set()
+    adapter._allowed_room_ids = set()
+    return adapter
+
+
+@pytest.fixture(autouse=True)
+def _clear_allow_all(monkeypatch):
+    # These gates read allow-all envs; ensure a clean slate per test.
+    monkeypatch.delenv("MATRIX_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+
+
+class TestMediaDownloadAuthorized:
+    def test_open_by_default_without_allowlist(self):
+        adapter = _make_adapter()
+        assert adapter._is_media_download_authorized("@anyone:example.org") is True
+
+    def test_allowlisted_sender_authorized(self):
+        adapter = _make_adapter()
+        adapter._allowed_user_ids = {"@alice:example.org"}
+        assert adapter._is_media_download_authorized("@alice:example.org") is True
+
+    def test_unauthorized_sender_blocked_when_allowlist_set(self):
+        adapter = _make_adapter()
+        adapter._allowed_user_ids = {"@alice:example.org"}
+        assert adapter._is_media_download_authorized("@mallory:evil.org") is False
+
+    def test_empty_sender_blocked_when_allowlist_set(self):
+        adapter = _make_adapter()
+        adapter._allowed_user_ids = {"@alice:example.org"}
+        assert adapter._is_media_download_authorized("") is False
+
+    @pytest.mark.parametrize("env", ["MATRIX_ALLOW_ALL_USERS", "GATEWAY_ALLOW_ALL_USERS"])
+    def test_allow_all_env_overrides_allowlist(self, monkeypatch, env):
+        # Both the Matrix-specific and the global allow-all env must be honored,
+        # matching the gateway authorization layer. Previously only
+        # GATEWAY_ALLOW_ALL_USERS was checked, so an operator who set only
+        # MATRIX_ALLOW_ALL_USERS had media silently blocked.
+        adapter = _make_adapter()
+        adapter._allowed_user_ids = {"@alice:example.org"}
+        monkeypatch.setenv(env, "true")
+        assert adapter._is_media_download_authorized("@mallory:evil.org") is True
+
+
+class TestInviteAutoJoinAllowed:
+    def test_open_by_default_without_allowlist(self):
+        # The reconcile sweep preserves the adapter's existing open-by-default
+        # posture when no allowlist is configured.
+        adapter = _make_adapter()
+        assert adapter._invite_auto_join_allowed("!room:example.org", "@alice:example.org") is True
+
+    def test_allowlisted_inviter_allowed(self):
+        adapter = _make_adapter()
+        adapter._allowed_user_ids = {"@alice:example.org"}
+        assert adapter._invite_auto_join_allowed("!room:example.org", "@alice:example.org") is True
+
+    def test_unauthorized_inviter_blocked(self):
+        adapter = _make_adapter()
+        adapter._allowed_user_ids = {"@alice:example.org"}
+        assert adapter._invite_auto_join_allowed("!room:example.org", "@mallory:evil.org") is False
+
+    def test_room_allowlist_alone_does_not_authorize(self):
+        # Regression guard: a room-allowlist match must NOT authorize an
+        # auto-join from an unauthorized inviter. The inviter is unverified and
+        # DMs are exempt from the room allowlist, so a room-only match would let
+        # an attacker manufacture an authorized-looking context.
+        adapter = _make_adapter()
+        adapter._allowed_room_ids = {"!listed:example.org"}
+        adapter._allowed_user_ids = {"@alice:example.org"}
+        assert adapter._invite_auto_join_allowed("!listed:example.org", "@mallory:evil.org") is False
+
+    def test_room_allowlist_only_still_requires_authorized_inviter(self):
+        # With ONLY a room allowlist configured (no user allowlist), an invite
+        # to an allowlisted room from an unverified inviter is still declined —
+        # the room match alone does not authorize the join.
+        adapter = _make_adapter()
+        adapter._allowed_room_ids = {"!listed:example.org"}
+        assert adapter._invite_auto_join_allowed("!listed:example.org", "@mallory:evil.org") is False
+
+    def test_empty_inviter_blocked(self):
+        adapter = _make_adapter()
+        adapter._allowed_user_ids = {"@alice:example.org"}
+        assert adapter._invite_auto_join_allowed("!room:example.org", "") is False
+
+    @pytest.mark.parametrize("env", ["MATRIX_ALLOW_ALL_USERS", "GATEWAY_ALLOW_ALL_USERS"])
+    def test_allow_all_env_permits_join(self, monkeypatch, env):
+        adapter = _make_adapter()
+        monkeypatch.setenv(env, "true")
+        assert adapter._invite_auto_join_allowed("!room:example.org", "@mallory:evil.org") is True


### PR DESCRIPTION
Inbound Matrix media was downloaded into memory and cached to disk before the
gateway's per-user authorization ran (DMs are exempt from the room allowlist),
the pre-download size check trusted the attacker-declared content_info.size, and
_on_invite auto-joined any inviter — letting an external user manufacture the DM
context that the room-allowlist exemption then waves through.

- Gate the media download/cache on the sender allowlist (open by default;
  honored when MATRIX_ALLOWED_USERS / GATEWAY_ALLOW_ALL_USERS is set).
- Re-check the real downloaded length against the media cap.
- Only auto-join invites from allowlisted rooms/inviters when an allowlist is
  configured.

Pairs with the shared document-cache size cap, which bounds on-disk writes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
