### PR TITLE
fix: refresh live session history

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -6,7 +6,12 @@ import { readActiveTerminal } from '@/app/right-sidebar/terminal/buffer'
 import { closeAgentTerminalByProc } from '@/app/right-sidebar/terminal/terminals'
 import { burstVibeHearts } from '@/components/chat/vibe-hearts'
 import { translateNow } from '@/i18n'
-import { type GatewayEventPayload, textPart } from '@/lib/chat-messages'
+import {
+  type GatewayEventPayload,
+  preserveLocalAssistantErrors,
+  textPart,
+  toChatMessages
+} from '@/lib/chat-messages'
 import { coerceGatewayText, coerceThinkingText, normalizePersonalityValue } from '@/lib/chat-runtime'
 import { playCompletionSound } from '@/lib/completion-sound'
 import { resolveGatewayEventSessionId } from '@/lib/gateway-events'
@@ -144,6 +149,24 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
       }
 
       if (event.type === 'gateway.ready') {
+        return
+      } else if (event.type === 'session.history.updated') {
+        if (!sessionId || !Array.isArray(payload?.messages)) {
+          return
+        }
+
+        const refreshedMessages = toChatMessages(payload.messages)
+        updateSessionState(sessionId, state => {
+          if (state.busy || state.awaitingResponse) {
+            return state
+          }
+
+          return {
+            ...state,
+            messages: preserveLocalAssistantErrors(refreshedMessages, state.messages)
+          }
+        })
+
         return
       } else if (event.type === 'session.info') {
         // Apply session-scoped fields when the event targets the active

--- a/apps/desktop/src/app/session/hooks/use-message-stream/history-refresh-event.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/history-refresh-event.test.tsx
@@ -1,0 +1,109 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { chatMessageText } from '@/lib/chat-messages'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import type { RpcEvent } from '@/types/hermes'
+
+import { useMessageStream } from './index'
+
+const SID = 'session-1'
+let handleEvent: ((event: RpcEvent) => void) | null = null
+let states = new Map<string, ClientSessionState>()
+
+function Harness() {
+  const activeSessionIdRef = useRef<string | null>(SID)
+  const sessionStateByRuntimeIdRef = useRef(states)
+  const queryClientRef = useRef(new QueryClient())
+
+  const stream = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession: vi.fn(async () => undefined),
+    queryClient: queryClientRef.current,
+    refreshHermesConfig: vi.fn(async () => undefined),
+    refreshSessions: vi.fn(async () => undefined),
+    sessionStateByRuntimeIdRef,
+    updateSessionState: (sessionId, updater) => {
+      const current = states.get(sessionId) ?? createClientSessionState()
+      const next = updater(current)
+
+      states.set(sessionId, next)
+
+      return next
+    }
+  })
+
+  useEffect(() => {
+    handleEvent = stream.handleGatewayEvent
+  }, [stream.handleGatewayEvent])
+
+  return null
+}
+
+async function mountStream() {
+  render(<Harness />)
+  await waitFor(() => expect(handleEvent).not.toBeNull())
+}
+
+describe('live durable history refresh', () => {
+  beforeEach(() => {
+    handleEvent = null
+    states = new Map()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('hydrates an idle session and preserves its local assistant error', async () => {
+    states.set(
+      SID,
+      createClientSessionState(null, [
+        { id: 'local-user', parts: [{ text: 'failed prompt', type: 'text' }], role: 'user' },
+        { error: 'provider failed', id: 'local-error', parts: [], role: 'assistant' }
+      ])
+    )
+    await mountStream()
+
+    act(() =>
+      handleEvent!({
+        payload: {
+          messages: [
+            { content: 'external prompt', role: 'user' },
+            { content: 'external reply', role: 'assistant' }
+          ]
+        },
+        session_id: SID,
+        type: 'session.history.updated'
+      })
+    )
+
+    const messages = states.get(SID)!.messages
+    expect(messages.slice(0, 2).map(chatMessageText)).toEqual(['external prompt', 'external reply'])
+    expect(messages.at(-1)?.error).toBe('provider failed')
+  })
+
+  it('does not replace a session while a turn is active', async () => {
+    const initial = createClientSessionState(null, [
+      { id: 'live', parts: [{ text: 'live turn', type: 'text' }], role: 'user' }
+    ])
+
+    initial.busy = true
+    states.set(SID, initial)
+    await mountStream()
+
+    act(() =>
+      handleEvent!({
+        payload: { messages: [{ content: 'stale durable row', role: 'user' }] },
+        session_id: SID,
+        type: 'session.history.updated'
+      })
+    )
+
+    expect(states.get(SID)!.messages).toBe(initial.messages)
+  })
+})

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -55,6 +55,8 @@ export type GatewayEventPayload = {
   install_warning?: string
   personality?: string
   usage?: Partial<UsageStats>
+  message_count?: number
+  messages?: SessionMessage[]
   // agent.terminal.output — live chunk for a read-only agent terminal tab
   process_id?: string
   chunk?: string

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -17,6 +17,95 @@ from hermes_cli.browser_connect import ChromeDebugLaunch
 from tui_gateway import server
 
 
+def test_history_refresh_emits_real_durable_extension(monkeypatch, tmp_path):
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("stored-session", source="tui")
+    db.append_message("stored-session", role="user", content="local prompt")
+    initial_history = db.get_messages_as_conversation("stored-session")
+    session = {
+        "agent": None,
+        "created_at": time.time(),
+        "display_history_prefix": [],
+        "history": initial_history,
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "session_key": "stored-session",
+    }
+    emitted = []
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, sid, payload=None: emitted.append((event, sid, payload)),
+    )
+
+    try:
+        db.append_message(
+            "stored-session",
+            role="assistant",
+            content="durable reply from another surface",
+        )
+        payload = server._poll_session_history_once("runtime-session", session)
+    finally:
+        db.close()
+
+    assert session["history_version"] == 1
+    assert payload is not None
+    assert payload["messages"][-1] == {
+        "role": "assistant",
+        "text": "durable reply from another surface",
+    }
+    assert emitted == [
+        ("session.history.updated", "runtime-session", payload)
+    ]
+
+
+def test_history_refresh_skips_running_session(monkeypatch):
+    def fail_session_db(_session):
+        raise AssertionError("running sessions must not read durable history")
+
+    monkeypatch.setattr(server, "_session_db", fail_session_db)
+    session = {
+        "history": [{"role": "user", "content": "live turn"}],
+        "history_lock": threading.Lock(),
+        "running": True,
+        "session_key": "stored-session",
+    }
+
+    assert server._refresh_session_history_from_db("runtime-session", session) is None
+
+
+def test_history_refresh_does_not_replace_longer_live_history(monkeypatch, tmp_path):
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("stored-session", source="tui")
+    db.append_message("stored-session", role="user", content="durable prompt")
+    durable_history = db.get_messages_as_conversation("stored-session")
+    live_history = [
+        *durable_history,
+        {"role": "assistant", "content": "not persisted yet"},
+    ]
+    session = {
+        "history": live_history,
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "session_key": "stored-session",
+    }
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+
+    try:
+        assert server._refresh_session_history_from_db("runtime-session", session) is None
+    finally:
+        db.close()
+
+    assert session["history"] == live_history
+
+
 def test_session_create_rejects_at_active_session_limit(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -165,6 +165,7 @@ except (ValueError, TypeError):
 _WS_ORPHAN_REAP_GRACE_S = max(0.0, _ws_orphan_reap_grace)
 _DETAIL_SECTION_NAMES = ("thinking", "tools", "subagents", "activity")
 _DETAIL_MODES = frozenset({"hidden", "collapsed", "expanded"})
+_SESSION_HISTORY_REFRESH_SECONDS = 2.0
 
 # ── Async RPC dispatch (#12546) ──────────────────────────────────────
 # A handful of handlers block the dispatcher loop in entry.py for seconds
@@ -558,6 +559,9 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
     stop_event = session.get("_notif_stop")
     if stop_event is not None:
         stop_event.set()
+    history_stop_event = session.get("_history_refresh_stop")
+    if history_stop_event is not None:
+        history_stop_event.set()
 
     agent = session.get("agent")
     lock = session.get("history_lock")
@@ -1447,6 +1451,9 @@ def _start_agent_build(sid: str, session: dict) -> None:
             with _sessions_lock:
                 if sid in _sessions:
                     _sessions[sid]["_notif_stop"] = _start_notification_poller(sid, _sessions[sid])
+                    _sessions[sid]["_history_refresh_stop"] = _start_history_refresh_poller(
+                        sid, _sessions[sid]
+                    )
             _notify_session_boundary("on_session_reset", key, _session_source(current))
 
             info = _session_info(agent, current)
@@ -4776,6 +4783,9 @@ def _init_session(
     with _sessions_lock:
         if sid in _sessions:
             _sessions[sid]["_notif_stop"] = _start_notification_poller(sid, _sessions[sid])
+            _sessions[sid]["_history_refresh_stop"] = _start_history_refresh_poller(
+                sid, _sessions[sid]
+            )
     _notify_session_boundary("on_session_reset", key, _session_source(_sessions.get(sid, {})))
     _emit("session.info", sid, _session_info(agent, _sessions.get(sid, {})))
     _schedule_mcp_late_refresh(sid, agent)
@@ -6108,6 +6118,89 @@ def _live_session_payload(
     if inflight:
         payload["inflight"] = inflight
     return payload
+
+
+def _refresh_session_history_from_db(sid: str, session: dict) -> dict | None:
+    """Refresh an idle live session after another surface durably extends it."""
+    key = str(session.get("session_key") or "")
+    lock = session.get("history_lock")
+    if not key or lock is None:
+        return None
+
+    with lock:
+        if session.get("running"):
+            return None
+        previous_history = list(session.get("history") or [])
+        previous_prefix = list(session.get("display_history_prefix") or [])
+
+    try:
+        with _session_db(session) as db:
+            if db is None:
+                return None
+            history = db.get_messages_as_conversation(key)
+            display_history = db.get_messages_as_conversation(
+                key,
+                include_ancestors=True,
+            )
+    except Exception:
+        logger.debug("failed to refresh live session history", exc_info=True)
+        return None
+
+    display_prefix = display_history[: max(0, len(display_history) - len(history))]
+    with lock:
+        if session.get("running"):
+            return None
+        if (
+            list(session.get("history") or []) != previous_history
+            or list(session.get("display_history_prefix") or []) != previous_prefix
+        ):
+            return None
+        if len(history) < len(previous_history):
+            return None
+        if len(history) == len(previous_history) and history != previous_history:
+            return None
+        if history == previous_history and display_prefix == previous_prefix:
+            return None
+
+        session["history"] = history
+        session["display_history_prefix"] = display_prefix
+        session["history_version"] = int(session.get("history_version", 0)) + 1
+        session["last_active"] = time.time()
+
+    messages = list(display_prefix) + list(history)
+    return {
+        "message_count": len(messages),
+        "messages": _history_to_messages(messages),
+        "running": False,
+        "session_key": _session_lookup_key(session, fallback=sid),
+        "status": _session_live_status(sid, session),
+        "updated_at": time.time(),
+    }
+
+
+def _poll_session_history_once(sid: str, session: dict) -> dict | None:
+    payload = _refresh_session_history_from_db(sid, session)
+    if payload is not None:
+        _emit("session.history.updated", sid, payload)
+    return payload
+
+
+def _history_refresh_loop(stop_event: threading.Event, sid: str, session: dict) -> None:
+    while not stop_event.wait(_SESSION_HISTORY_REFRESH_SECONDS):
+        if session.get("_finalized"):
+            return
+        _poll_session_history_once(sid, session)
+
+
+def _start_history_refresh_poller(sid: str, session: dict) -> threading.Event:
+    stop = threading.Event()
+    thread = threading.Thread(
+        target=_history_refresh_loop,
+        args=(stop, sid, session),
+        daemon=True,
+    )
+    thread.start()
+    return stop
 
 
 @method("session.active_list")

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -66,6 +66,43 @@ describe('createGatewayEventHandler', () => {
     patchUiState({ showReasoning: true })
   })
 
+  it('refreshes idle transcript history while preserving the intro row', () => {
+    const ctx = buildCtx([])
+    patchUiState({ busy: false, sid: 'runtime-session' })
+    createGatewayEventHandler(ctx)({
+      payload: {
+        messages: [
+          { role: 'user', text: 'external prompt' },
+          { role: 'assistant', text: 'external reply' }
+        ]
+      },
+      session_id: 'runtime-session',
+      type: 'session.history.updated'
+    } as any)
+
+    const update = ctx.transcript.setHistoryItems.mock.calls[0]?.[0]
+    const intro = { kind: 'intro', role: 'system', text: 'intro' }
+    const refreshed = update([intro])
+
+    expect(refreshed[0]).toBe(intro)
+    expect(refreshed.slice(1).map((row: Msg) => [row.role, row.text])).toEqual([
+      ['user', 'external prompt'],
+      ['assistant', 'external reply']
+    ])
+  })
+
+  it('does not refresh transcript history during a live turn', () => {
+    const ctx = buildCtx([])
+    patchUiState({ busy: true, sid: 'runtime-session' })
+    createGatewayEventHandler(ctx)({
+      payload: { messages: [{ role: 'user', text: 'stale row' }] },
+      session_id: 'runtime-session',
+      type: 'session.history.updated'
+    } as any)
+
+    expect(ctx.transcript.setHistoryItems).not.toHaveBeenCalled()
+  })
+
   it('archives incomplete todos into transcript flow at end of turn so they scroll up', () => {
     const appended: Msg[] = []
 

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -1,6 +1,7 @@
 import { STARTUP_IMAGE, STARTUP_QUERY } from '../config/env.js'
 import { STREAM_BATCH_MS } from '../config/timing.js'
 import { buildSetupRequiredSections, SETUP_REQUIRED_TITLE } from '../content/setup.js'
+import { toTranscriptMessages } from '../domain/messages.js'
 import type {
   CommandsCatalogResponse,
   ConfigFullResponse,
@@ -431,6 +432,21 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         }))
 
         setHistoryItems(prev => prev.map(m => (m.kind === 'intro' ? { ...m, info } : m)))
+
+        return
+      }
+
+      case 'session.history.updated': {
+        if (getUiState().busy) {
+          return
+        }
+
+        const rows = toTranscriptMessages(ev.payload?.messages ?? [])
+        setHistoryItems(prev => {
+          const intro = prev.find(item => item.kind === 'intro')
+
+          return intro ? [intro, ...rows] : rows
+        })
 
         return
       }

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -239,6 +239,15 @@ export interface SessionResumeResponse {
   status?: LiveSessionStatus
 }
 
+export interface SessionHistoryUpdatedPayload {
+  message_count?: number
+  messages: GatewayTranscriptMessage[]
+  running?: boolean
+  session_key?: string
+  status?: LiveSessionStatus
+  updated_at?: number
+}
+
 export type LiveSessionStatus = 'idle' | 'starting' | 'waiting' | 'working'
 
 export interface SessionActiveItem {
@@ -713,4 +722,5 @@ export type GatewayEvent =
       session_id?: string
       type: 'message.complete'
     }
+  | { payload: SessionHistoryUpdatedPayload; session_id?: string; type: 'session.history.updated' }
   | { payload?: { message?: string }; session_id?: string; type: 'error' }


### PR DESCRIPTION
Summary\n- Poll idle live sessions every two seconds for transcript additions persisted by another gateway surface.\n- Refresh only when durable history strictly extends unchanged live history, and never while the session is running.\n- Emit session.history.updated and update the desktop and Ink TUI without replacing local assistant error rows or the TUI intro row.\n- Stop the poller during gateway finalization and cover eager and deferred agent startup paths.\n\nValidation\n- 3 focused Python gateway tests\n- 2 desktop event-handler tests\n- 81 Ink TUI gateway-event tests\n- Ruff and ESLint on the changed files\n\nFixes #52308