### PR TITLE
feat(setup): Z.AI endpoint picker for Global/China/Coding Plan selection

### DIFF
--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -2275,7 +2275,7 @@ def _select_zai_endpoint(current_base: str) -> str:
             return current_base
         return override.rstrip("/")
 
-    return options[selected][1]
+    return options[selected][1].rstrip("/")
 
 
 def _model_flow_api_key_provider(config, provider_id, current_model=""):
@@ -2400,7 +2400,7 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
         chosen_base = _select_zai_endpoint(effective_base)
         if chosen_base and chosen_base != effective_base and base_url_env:
             save_env_value(base_url_env, chosen_base)
-        effective_base = chosen_base or effective_base
+        effective_base = chosen_base
     else:
         try:
             override = input(f"Base URL [{effective_base}]: ").strip()

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -2392,19 +2392,29 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
             pass
     effective_base = current_base or pconfig.inference_base_url
 
-    try:
-        override = input(f"Base URL [{effective_base}]: ").strip()
-    except (KeyboardInterrupt, EOFError):
-        print()
-        override = ""
-    if override and base_url_env:
-        if not override.startswith(("http://", "https://")):
-            print(
-                "  Invalid URL — must start with http:// or https://. Keeping current value."
-            )
-        else:
-            save_env_value(base_url_env, override)
-            effective_base = override
+    if provider_id == "zai":
+        # Z.AI has four official endpoints (Global, China, Coding Plan
+        # Global, Coding Plan China) with separate billing paths.  Present
+        # a picker instead of a plain text input so users can explicitly
+        # choose the endpoint that matches their key type.
+        chosen_base = _select_zai_endpoint(effective_base)
+        if chosen_base and chosen_base != effective_base and base_url_env:
+            save_env_value(base_url_env, chosen_base)
+        effective_base = chosen_base or effective_base
+    else:
+        try:
+            override = input(f"Base URL [{effective_base}]: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            print()
+            override = ""
+        if override and base_url_env:
+            if not override.startswith(("http://", "https://")):
+                print(
+                    "  Invalid URL — must start with http:// or https://. Keeping current value."
+                )
+            else:
+                save_env_value(base_url_env, override)
+                effective_base = override
 
     # Model selection — resolution order:
     #   1. models.dev registry (cached, filtered for agentic/tool-capable models)

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -2220,6 +2220,64 @@ def _model_flow_bedrock(config, current_model=""):
     else:
         print("  No change.")
 
+def _select_zai_endpoint(current_base: str) -> str:
+    """Present a picker for Z.AI endpoint selection during setup.
+
+    Offers the four official Z.AI endpoints (Global, China, Coding Plan
+    Global, Coding Plan China) plus a custom-proxy option.  The list is
+    sourced from ``ZAI_ENDPOINTS`` in ``hermes_cli.auth`` so it stays in
+    sync with the probe list.
+
+    Returns the selected base URL.  Falls back to *current_base* on cancel
+    or error.
+    """
+    from hermes_cli.main import _prompt_provider_choice
+    from hermes_cli.auth import ZAI_ENDPOINTS
+
+    # Build label + URL pairs from the shared endpoint list.
+    options = [(label, url) for _, url, _, label in ZAI_ENDPOINTS]
+    normalized_current = (current_base or "").strip().rstrip("/")
+
+    # Default to the currently-active option if it matches one of the
+    # known endpoints; otherwise default to the first (Global).
+    default_idx = 0
+    for idx, (_, url) in enumerate(options):
+        if normalized_current == url.rstrip("/"):
+            default_idx = idx
+            break
+    else:
+        if normalized_current:
+            # A custom URL is active — offer "Custom proxy" as the default.
+            default_idx = len(options)
+
+    choices = [f"{label} ({url})" for label, url in options]
+    choices.append("Custom proxy URL")
+
+    selected = _prompt_provider_choice(
+        choices,
+        default=default_idx,
+        title="Select Z.AI / GLM endpoint:",
+    )
+    if selected is None:
+        return current_base
+
+    if selected == len(options):
+        # Custom proxy URL
+        try:
+            override = input(f"Custom base URL [{current_base}]: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            print()
+            return current_base
+        if not override:
+            return current_base
+        if not override.startswith(("http://", "https://")):
+            print("  Invalid URL — must start with http:// or https://. Keeping current value.")
+            return current_base
+        return override.rstrip("/")
+
+    return options[selected][1]
+
+
 def _model_flow_api_key_provider(config, provider_id, current_model=""):
     """Generic flow for API-key providers (z.ai, MiniMax, OpenCode, etc.)."""
     from hermes_cli.main import _prompt_api_key

--- a/tests/hermes_cli/test_model_provider_persistence.py
+++ b/tests/hermes_cli/test_model_provider_persistence.py
@@ -319,31 +319,37 @@ class TestProviderPersistsAfterModelSave:
 
 
 class TestBaseUrlValidation:
-    """Reject non-URL values in the base URL prompt (e.g. shell commands)."""
+    """Reject non-URL values in the base URL prompt (e.g. shell commands).
+
+    Uses MiniMax instead of Z.AI because Z.AI now uses a curses-based
+    endpoint picker (_select_zai_endpoint) rather than the plain text
+    input() prompt. Z.AI picker behavior is covered in
+    TestZaiEndpointPicker below.
+    """
 
     def test_invalid_base_url_rejected(self, config_home, monkeypatch, capsys):
         """Typing a non-URL string should not be saved as the base URL."""
         from hermes_cli.auth import PROVIDER_REGISTRY
 
-        pconfig = PROVIDER_REGISTRY.get("zai")
+        pconfig = PROVIDER_REGISTRY.get("minimax")
         if not pconfig:
-            pytest.skip("zai not in PROVIDER_REGISTRY")
+            pytest.skip("minimax not in PROVIDER_REGISTRY")
 
-        monkeypatch.setenv("GLM_API_KEY", "test-key")
+        monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
 
         from hermes_cli.main import _model_flow_api_key_provider
         from hermes_cli.config import load_config, get_env_value
 
         # User types a shell command instead of a URL at the base URL prompt
-        with patch("hermes_cli.auth._prompt_model_selection", return_value="glm-5"), \
+        with patch("hermes_cli.auth._prompt_model_selection", return_value="MiniMax-M2"), \
              patch("hermes_cli.auth.deactivate_provider"), \
              patch("builtins.input", return_value="nano ~/.hermes/.env"):
-            _model_flow_api_key_provider(load_config(), "zai", "old-model")
+            _model_flow_api_key_provider(load_config(), "minimax", "old-model")
 
         # The garbage value should NOT have been saved
-        saved = get_env_value("GLM_BASE_URL") or ""
+        saved = get_env_value("MINIMAX_BASE_URL") or ""
         assert not saved or saved.startswith(("http://", "https://")), \
-            f"Non-URL value was saved as GLM_BASE_URL: {saved}"
+            f"Non-URL value was saved as MINIMAX_BASE_URL: {saved}"
         captured = capsys.readouterr()
         assert "Invalid URL" in captured.out
 
@@ -351,42 +357,199 @@ class TestBaseUrlValidation:
         """A proper URL should be saved normally."""
         from hermes_cli.auth import PROVIDER_REGISTRY
 
-        pconfig = PROVIDER_REGISTRY.get("zai")
+        pconfig = PROVIDER_REGISTRY.get("minimax")
         if not pconfig:
-            pytest.skip("zai not in PROVIDER_REGISTRY")
+            pytest.skip("minimax not in PROVIDER_REGISTRY")
 
-        monkeypatch.setenv("GLM_API_KEY", "test-key")
+        monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
 
         from hermes_cli.main import _model_flow_api_key_provider
         from hermes_cli.config import load_config, get_env_value
 
-        with patch("hermes_cli.auth._prompt_model_selection", return_value="glm-5"), \
+        with patch("hermes_cli.auth._prompt_model_selection", return_value="MiniMax-M2"), \
              patch("hermes_cli.auth.deactivate_provider"), \
-             patch("builtins.input", return_value="https://custom.z.ai/api/paas/v4"):
-            _model_flow_api_key_provider(load_config(), "zai", "old-model")
+             patch("builtins.input", return_value="https://custom.minimax.example/v1"):
+            _model_flow_api_key_provider(load_config(), "minimax", "old-model")
 
-        saved = get_env_value("GLM_BASE_URL") or ""
-        assert saved == "https://custom.z.ai/api/paas/v4"
+        saved = get_env_value("MINIMAX_BASE_URL") or ""
+        assert saved == "https://custom.minimax.example/v1"
 
     def test_empty_base_url_keeps_default(self, config_home, monkeypatch):
         """Pressing Enter (empty) should not change the base URL."""
         from hermes_cli.auth import PROVIDER_REGISTRY
 
-        pconfig = PROVIDER_REGISTRY.get("zai")
+        pconfig = PROVIDER_REGISTRY.get("minimax")
         if not pconfig:
-            pytest.skip("zai not in PROVIDER_REGISTRY")
+            pytest.skip("minimax not in PROVIDER_REGISTRY")
 
-        monkeypatch.setenv("GLM_API_KEY", "test-key")
-        monkeypatch.delenv("GLM_BASE_URL", raising=False)
+        monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+        monkeypatch.delenv("MINIMAX_BASE_URL", raising=False)
 
         from hermes_cli.main import _model_flow_api_key_provider
         from hermes_cli.config import load_config, get_env_value
 
-        with patch("hermes_cli.auth._prompt_model_selection", return_value="glm-5"), \
+        with patch("hermes_cli.auth._prompt_model_selection", return_value="MiniMax-M2"), \
+             patch("hermes_cli.auth.deactivate_provider"), \
+             patch("builtins.input", return_value=""):
+            _model_flow_api_key_provider(load_config(), "minimax", "old-model")
+
+        saved = get_env_value("MINIMAX_BASE_URL") or ""
+        assert saved == "", "Empty input should not save a base URL"
+
+
+class TestZaiEndpointPicker:
+    """Z.AI setup should present a curses picker for endpoint selection."""
+
+    def test_select_global_endpoint(self, config_home, monkeypatch):
+        """Selecting Global should save the direct API base URL."""
+        from hermes_cli.auth import ZAI_ENDPOINTS
+        from hermes_cli.main import _model_flow_api_key_provider
+        from hermes_cli.config import load_config
+
+        global_url = ZAI_ENDPOINTS[0][1]  # "https://api.z.ai/api/paas/v4"
+        monkeypatch.setenv("GLM_API_KEY", "test-key")
+
+        with patch("hermes_cli.main._prompt_provider_choice", return_value=0), \
+             patch("hermes_cli.auth._prompt_model_selection", return_value="glm-5"), \
              patch("hermes_cli.auth.deactivate_provider"), \
              patch("builtins.input", return_value=""):
             _model_flow_api_key_provider(load_config(), "zai", "old-model")
 
+        model = load_config()["model"]
+        assert model["base_url"] == global_url
+
+    def test_select_coding_plan_global_endpoint(self, config_home, monkeypatch):
+        """Selecting Coding Plan Global should save the coding base URL."""
+        from hermes_cli.auth import ZAI_ENDPOINTS
+        from hermes_cli.main import _model_flow_api_key_provider
+        from hermes_cli.config import load_config
+
+        coding_url = ZAI_ENDPOINTS[2][1]  # coding-global
+        monkeypatch.setenv("GLM_API_KEY", "test-key")
+
+        # Index 2 = Coding Plan Global in ZAI_ENDPOINTS
+        with patch("hermes_cli.main._prompt_provider_choice", return_value=2), \
+             patch("hermes_cli.auth._prompt_model_selection", return_value="glm-5.2"), \
+             patch("hermes_cli.auth.deactivate_provider"), \
+             patch("builtins.input", return_value=""):
+            _model_flow_api_key_provider(load_config(), "zai", "old-model")
+
+        model = load_config()["model"]
+        assert model["base_url"] == coding_url
+
+    def test_select_china_endpoint(self, config_home, monkeypatch):
+        """Selecting China should save the bigmodel.cn base URL."""
+        from hermes_cli.auth import ZAI_ENDPOINTS
+        from hermes_cli.main import _model_flow_api_key_provider
+        from hermes_cli.config import load_config
+
+        cn_url = ZAI_ENDPOINTS[1][1]  # "https://open.bigmodel.cn/api/paas/v4"
+        monkeypatch.setenv("GLM_API_KEY", "test-key")
+
+        with patch("hermes_cli.main._prompt_provider_choice", return_value=1), \
+             patch("hermes_cli.auth._prompt_model_selection", return_value="glm-5"), \
+             patch("hermes_cli.auth.deactivate_provider"), \
+             patch("builtins.input", return_value=""):
+            _model_flow_api_key_provider(load_config(), "zai", "old-model")
+
+        model = load_config()["model"]
+        assert model["base_url"] == cn_url
+
+    def test_select_custom_proxy_url(self, config_home, monkeypatch):
+        """Selecting Custom proxy should prompt for a URL and save it."""
+        from hermes_cli.main import _model_flow_api_key_provider
+        from hermes_cli.config import load_config, get_env_value
+
+        monkeypatch.setenv("GLM_API_KEY", "test-key")
+
+        # Last option index = custom proxy
+        with patch("hermes_cli.main._prompt_provider_choice", return_value=4), \
+             patch("hermes_cli.auth._prompt_model_selection", return_value="glm-5"), \
+             patch("hermes_cli.auth.deactivate_provider"), \
+             patch("builtins.input", return_value="https://proxy.example.com/glm/v4"):
+            _model_flow_api_key_provider(load_config(), "zai", "old-model")
+
         saved = get_env_value("GLM_BASE_URL") or ""
-        assert saved == "", "Empty input should not save a base URL"
+        assert saved == "https://proxy.example.com/glm/v4"
+
+    def test_custom_proxy_rejects_invalid_url(self, config_home, monkeypatch, capsys):
+        """Custom proxy must start with http:// or https://."""
+        from hermes_cli.main import _model_flow_api_key_provider
+        from hermes_cli.config import load_config
+
+        monkeypatch.setenv("GLM_API_KEY", "test-key")
+        monkeypatch.delenv("GLM_BASE_URL", raising=False)
+
+        with patch("hermes_cli.main._prompt_provider_choice", return_value=4), \
+             patch("hermes_cli.auth._prompt_model_selection", return_value="glm-5"), \
+             patch("hermes_cli.auth.deactivate_provider"), \
+             patch("builtins.input", return_value="not-a-url"):
+            _model_flow_api_key_provider(load_config(), "zai", "old-model")
+
+        # The invalid URL should not have been saved as base_url
+        model = load_config()["model"]
+        assert model["base_url"] != "not-a-url"
+        captured = capsys.readouterr()
+        assert "Invalid URL" in captured.out
+
+    def test_cancel_keeps_existing_base_url(self, config_home, monkeypatch):
+        """Cancelling the picker should not change the base URL."""
+        from hermes_cli.main import _model_flow_api_key_provider
+        from hermes_cli.config import load_config, get_env_value
+
+        monkeypatch.setenv("GLM_API_KEY", "test-key")
+        monkeypatch.setenv("GLM_BASE_URL", "https://existing.example/v4")
+
+        # _prompt_provider_choice returns None on cancel
+        with patch("hermes_cli.main._prompt_provider_choice", return_value=None), \
+             patch("hermes_cli.auth._prompt_model_selection", return_value="glm-5"), \
+             patch("hermes_cli.auth.deactivate_provider"), \
+             patch("builtins.input", return_value=""):
+            _model_flow_api_key_provider(load_config(), "zai", "old-model")
+
+        # env var is preserved (not overwritten on cancel)
+        saved = get_env_value("GLM_BASE_URL") or ""
+        assert saved == "https://existing.example/v4"
+
+    def test_current_endpoint_is_default_choice(self, config_home, monkeypatch):
+        """When a known endpoint is already active, it should be the default."""
+        from hermes_cli.auth import ZAI_ENDPOINTS
+        from hermes_cli.model_setup_flows import _select_zai_endpoint
+
+        coding_url = ZAI_ENDPOINTS[2][1]  # coding-global
+
+        captured = {}
+
+        def fake_choice(choices, *, default=0, title=""):
+            captured["default"] = default
+            captured["choices"] = choices
+            return default
+
+        with patch("hermes_cli.main._prompt_provider_choice", side_effect=fake_choice):
+            result = _select_zai_endpoint(coding_url)
+
+        # Default should point at index 2 (coding-global)
+        assert captured["default"] == 2
+        assert result == coding_url
+
+    def test_custom_url_active_defaults_to_custom_option(self, config_home, monkeypatch):
+        """When a non-standard URL is active, Custom proxy should be default."""
+        from hermes_cli.auth import ZAI_ENDPOINTS
+        from hermes_cli.model_setup_flows import _select_zai_endpoint
+
+        custom_url = "https://my-proxy.example.com/v4"
+        # 4 official endpoints → custom is index 4
+        expected_default = len(ZAI_ENDPOINTS)
+
+        captured = {}
+
+        def fake_choice(choices, *, default=0, title=""):
+            captured["default"] = default
+            return default
+
+        with patch("hermes_cli.main._prompt_provider_choice", side_effect=fake_choice), \
+             patch("builtins.input", return_value=""):
+            _select_zai_endpoint(custom_url)
+
+        assert captured["default"] == expected_default
 

--- a/tests/hermes_cli/test_model_provider_persistence.py
+++ b/tests/hermes_cli/test_model_provider_persistence.py
@@ -462,8 +462,9 @@ class TestZaiEndpointPicker:
 
         monkeypatch.setenv("GLM_API_KEY", "test-key")
 
-        # Last option index = custom proxy
-        with patch("hermes_cli.main._prompt_provider_choice", return_value=4), \
+        from hermes_cli.auth import ZAI_ENDPOINTS
+        custom_idx = len(ZAI_ENDPOINTS)  # last option = custom proxy
+        with patch("hermes_cli.main._prompt_provider_choice", return_value=custom_idx), \
              patch("hermes_cli.auth._prompt_model_selection", return_value="glm-5"), \
              patch("hermes_cli.auth.deactivate_provider"), \
              patch("builtins.input", return_value="https://proxy.example.com/glm/v4"):
@@ -479,8 +480,10 @@ class TestZaiEndpointPicker:
 
         monkeypatch.setenv("GLM_API_KEY", "test-key")
         monkeypatch.delenv("GLM_BASE_URL", raising=False)
+        from hermes_cli.auth import ZAI_ENDPOINTS
+        custom_idx = len(ZAI_ENDPOINTS)
 
-        with patch("hermes_cli.main._prompt_provider_choice", return_value=4), \
+        with patch("hermes_cli.main._prompt_provider_choice", return_value=custom_idx), \
              patch("hermes_cli.auth._prompt_model_selection", return_value="glm-5"), \
              patch("hermes_cli.auth.deactivate_provider"), \
              patch("builtins.input", return_value="not-a-url"):


### PR DESCRIPTION
## Summary
Z.AI setup now presents a curses-based endpoint picker instead of a plain text input, letting users explicitly choose between Global, China, Coding Plan Global, Coding Plan China, or a custom proxy URL.

## Changes
- `hermes_cli/model_setup_flows.py`: Add `_select_zai_endpoint()` helper that presents a `_prompt_provider_choice` picker sourced from `ZAI_ENDPOINTS` in `auth.py` (stays in sync with the probe list). Wire it into `_model_flow_api_key_provider` for `provider_id == "zai"`; other API-key providers keep the text input.
- `tests/hermes_cli/test_model_provider_persistence.py`: Migrate `TestBaseUrlValidation` from `zai` to `minimax` (zai no longer uses `input()` for base URL). Add `TestZaiEndpointPicker` covering each endpoint selection, custom proxy (valid + invalid), cancel, default selection, and custom-URL default behavior.

## Validation
| | Before | After |
|---|---|---|
| Z.AI base URL selection | Plain text `input()` prompt | Curses picker with 4 official endpoints + custom |
| Tests | 12 passed (TestBaseUrlValidation with zai) | 20 passed (TestBaseUrlValidation with minimax + TestZaiEndpointPicker) |

3 commits:
1. `feat(setup): add _select_zai_endpoint helper for Z.AI endpoint picker`
2. `feat(setup): wire Z.AI endpoint picker into _model_flow_api_key_provider`
3. `test(setup): add ZAI endpoint picker tests, move base-URL tests to MiniMax`
