### PR TITLE
fix(kanban): auto-sort done tasks by completed_at DESC, add completed-desc sort key

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -407,7 +407,8 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         "--sort",
         default=None,
         choices=sorted(kb.VALID_SORT_ORDERS.keys()),
-        help="Sort order for listed tasks (default: priority)",
+        help="Sort order for listed tasks (default: priority; "
+             "'completed-desc' when --status done and no --sort given)",
     )
     p_list.add_argument(
         "--workflow-template-id",

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2718,6 +2718,7 @@ VALID_SORT_ORDERS: dict[str, str] = {
     "assignee": "assignee ASC, created_at ASC",
     "title": "title ASC, id ASC",
     "updated": "started_at DESC NULLS LAST, created_at DESC",
+    "completed-desc": "completed_at DESC NULLS LAST, id DESC",
 }
 
 
@@ -2766,7 +2767,13 @@ def list_tasks(
             )
         query += f" ORDER BY {VALID_SORT_ORDERS[order_by]}"
     else:
-        query += " ORDER BY priority DESC, created_at ASC"
+        # When filtering by done status and no explicit sort is given,
+        # default to completed_at DESC so the most recently finished
+        # tasks surface at the top.
+        if status == "done":
+            query += f" ORDER BY {VALID_SORT_ORDERS['completed-desc']}"
+        else:
+            query += " ORDER BY priority DESC, created_at ASC"
     if limit:
         query += f" LIMIT {int(limit)}"
     rows = conn.execute(query, params).fetchall()

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1456,6 +1456,7 @@ VALID_SORT_ORDERS: dict[str, str] = {
     "assignee": "assignee ASC, created_at ASC",
     "title": "title ASC, id ASC",
     "updated": "started_at DESC NULLS LAST, created_at DESC",
+    "completed-desc": "completed_at DESC NULLS LAST, id DESC",
 }
 
 
@@ -1485,7 +1486,13 @@ def list_tasks(
             raise ValueError(f"order_by must be one of {sorted(VALID_SORT_ORDERS.keys())}")
         query += f" ORDER BY {VALID_SORT_ORDERS[order_by]}"
     else:
-        query += " ORDER BY priority DESC, created_at ASC"
+        # When filtering by done status and no explicit sort is given,
+        # default to completed_at DESC so the most recently finished
+        # tasks surface at the top.
+        if status == "done":
+            query += f" ORDER BY {VALID_SORT_ORDERS['completed-desc']}"
+        else:
+            query += " ORDER BY priority DESC, created_at ASC"
     if limit:
         query += f" LIMIT {int(limit)}"
     rows = conn.execute(query, params).fetchall()

--- a/hermes_cli/kanban_parser.py
+++ b/hermes_cli/kanban_parser.py
@@ -224,7 +224,7 @@ _SPECS = [
         _arg("--archived", action="store_true", help="Include archived tasks"),
         _json_flag(),
         _arg("--sort", choices=sorted(kb.VALID_SORT_ORDERS.keys()),
-             help="Sort order for listed tasks (default: priority)"),
+             help="Sort order for listed tasks (default: priority; 'completed-desc' when --status done and no --sort given)"),
         _arg("--workflow-template-id", metavar="ID", help="Restrict to tasks with this workflow_template_id"),
         _arg("--step-key", dest="current_step_key", metavar="KEY",
              help="Restrict to tasks with this current_step_key"),

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1562,6 +1562,53 @@ def test_list_tasks_order_by(kanban_home):
         except ValueError as e:
             assert "order_by must be one of" in str(e)
 
+def test_list_tasks_done_default_sort_is_completed_desc(kanban_home):
+    """done 狀態無明確 order_by 時，預設應按 completed_at DESC 排序"""
+    import time
+    with kb.connect() as conn:
+        t_a = kb.create_task(conn, title="first-done", priority=1)
+        t_b = kb.create_task(conn, title="second-done", priority=1)
+        t_c = kb.create_task(conn, title="third-done", priority=1)
+
+        # 依序完成，再手動覆寫 completed_at（complete_task 使用整數秒，
+        # 同一秒內無法區分），確保排序測試可靠
+        kb.complete_task(conn, t_a)
+        kb.complete_task(conn, t_b)
+        kb.complete_task(conn, t_c)
+
+        base_ts = int(time.time())
+        conn.execute("UPDATE tasks SET completed_at = ? WHERE id = ?", (base_ts - 2, t_a))
+        conn.execute("UPDATE tasks SET completed_at = ? WHERE id = ?", (base_ts - 1, t_b))
+        conn.execute("UPDATE tasks SET completed_at = ? WHERE id = ?", (base_ts, t_c))
+        conn.commit()
+
+        # 不傳 order_by，預設應是最新完成在最前
+        result = kb.list_tasks(conn, status="done")
+        ids = [t.id for t in result]
+        assert ids == [t_c, t_b, t_a], f"Expected newest-done first, got {ids}"
+
+
+def test_list_tasks_completed_desc_sort_key(kanban_home):
+    """`completed-desc` sort key 可被明確指定使用"""
+    import time
+    with kb.connect() as conn:
+        t_a = kb.create_task(conn, title="alpha-done", priority=2)
+        t_b = kb.create_task(conn, title="beta-done", priority=1)
+
+        kb.complete_task(conn, t_a)
+        kb.complete_task(conn, t_b)
+
+        # 手動覆寫 completed_at 確保 t_b 完成較晚
+        base_ts = int(time.time())
+        conn.execute("UPDATE tasks SET completed_at = ? WHERE id = ?", (base_ts - 1, t_a))
+        conn.execute("UPDATE tasks SET completed_at = ? WHERE id = ?", (base_ts, t_b))
+        conn.commit()
+
+        # t_b 完成較晚，應在最前
+        result = kb.list_tasks(conn, order_by="completed-desc")
+        assert result[0].id == t_b
+
+
 def test_delete_task_removes_task_and_cascades(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="to-delete", assignee="alice")

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -478,6 +478,53 @@ def test_delete_archived_task_removes_related_rows(kanban_home):
         assert conn.execute("SELECT COUNT(*) FROM kanban_notify_subs WHERE task_id = ?", (tid,)).fetchone()[0] == 0
 
 
+def test_list_tasks_done_default_sort_is_completed_desc(kanban_home):
+    """done 狀態無明確 order_by 時，預設應按 completed_at DESC 排序"""
+    import time
+    with kbc.connect() as conn:
+        t_a = kb.create_task(conn, title="first-done", priority=1)
+        t_b = kb.create_task(conn, title="second-done", priority=1)
+        t_c = kb.create_task(conn, title="third-done", priority=1)
+
+        # 依序完成，再手動覆寫 completed_at（complete_task 使用整數秒，
+        # 同一秒內無法區分），確保排序測試可靠
+        kb.complete_task(conn, t_a)
+        kb.complete_task(conn, t_b)
+        kb.complete_task(conn, t_c)
+
+        base_ts = int(time.time())
+        conn.execute("UPDATE tasks SET completed_at = ? WHERE id = ?", (base_ts - 2, t_a))
+        conn.execute("UPDATE tasks SET completed_at = ? WHERE id = ?", (base_ts - 1, t_b))
+        conn.execute("UPDATE tasks SET completed_at = ? WHERE id = ?", (base_ts, t_c))
+        conn.commit()
+
+        # 不傳 order_by，預設應是最新完成在最前
+        result = kb.list_tasks(conn, status="done")
+        ids = [t.id for t in result]
+        assert ids == [t_c, t_b, t_a], f"Expected newest-done first, got {ids}"
+
+
+def test_list_tasks_completed_desc_sort_key(kanban_home):
+    """`completed-desc` sort key 可被明確指定使用"""
+    import time
+    with kbc.connect() as conn:
+        t_a = kb.create_task(conn, title="alpha-done", priority=2)
+        t_b = kb.create_task(conn, title="beta-done", priority=1)
+
+        kb.complete_task(conn, t_a)
+        kb.complete_task(conn, t_b)
+
+        # 手動覆寫 completed_at 確保 t_b 完成較晚
+        base_ts = int(time.time())
+        conn.execute("UPDATE tasks SET completed_at = ? WHERE id = ?", (base_ts - 1, t_a))
+        conn.execute("UPDATE tasks SET completed_at = ? WHERE id = ?", (base_ts, t_b))
+        conn.commit()
+
+        # t_b 完成較晚，應在最前
+        result = kb.list_tasks(conn, order_by="completed-desc")
+        assert result[0].id == t_b
+
+
 def test_delete_task_removes_task_and_cascades(kanban_home):
     with kbc.connect() as conn:
         t = kb.create_task(conn, title="to-delete", assignee="alice")

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -627,7 +627,8 @@ hermes kanban create "<title>" [--body ...] [--assignee <profile>]
                                 [--json]
 hermes kanban list [--mine] [--assignee P] [--status S] [--tenant T] [--archived]
         [--workflow-template-id <id>] [--current-step-key <key>]
-        [--sort created|created-desc|priority|priority-desc|status|assignee|title|updated]
+        [--sort created|created-desc|priority|priority-desc|status|assignee|title|updated|completed-desc]
+        # default: priority; auto-switches to completed-desc when --status done and --sort is omitted
         [--json]
 hermes kanban show <id> [--json]
 hermes kanban assign <id> <profile>                    # or 'none' to unassign

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -796,7 +796,8 @@ hermes kanban create "<title>" [--body ...] [--assignee <profile>]
                                 [--json]
 hermes kanban list [--mine] [--assignee P] [--status S] [--tenant T] [--archived]
         [--workflow-template-id <id>] [--current-step-key <key>]
-        [--sort created|created-desc|priority|priority-desc|status|assignee|title|updated]
+        [--sort created|created-desc|priority|priority-desc|status|assignee|title|updated|completed-desc]
+        # default: priority; auto-switches to completed-desc when --status done and --sort is omitted
         [--json]
 hermes kanban show <id> [--json]
 hermes kanban assign <id> <profile>                    # or 'none' to unassign


### PR DESCRIPTION
## Summary

When listing tasks with `status=done` and no explicit `--sort` flag,
default to `completed_at DESC` (most recently finished at top).

This complements #44196 which fixes the general default sort — that PR
didn't cover the `done` status case where `completed_at` is the more
meaningful ordering axis.

## Changes

**`VALID_SORT_ORDERS`** — adds `"completed-desc"` key:
```python
"completed-desc": "completed_at DESC NULLS LAST, id DESC"
```

**`list_tasks()`** — when `status="done"` and `order_by` is `None`,
auto-selects `completed-desc` instead of the generic priority-based default.

## Behavior

```
# Before: done tasks sort by priority DESC, created_at ASC
hermes kanban list --filter status=done
# → oldest-completed first (confusing)

# After: done tasks sort by completed_at DESC
hermes kanban list --filter status=done
# → most recently finished first ✓

# Explicit override still works:
hermes kanban list --filter status=done --sort priority
```

## Tests

- `test_list_tasks_done_default_sort_is_completed_desc` — verifies auto-sort
- `test_list_tasks_completed_desc_sort_key` — verifies explicit `completed-desc` key

Related: #44196, #37472
