### PR TITLE
fix(agent): remove OS username from system prompt to prevent privacy leak

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -957,8 +957,8 @@ def _probe_remote_backend(env_type: str) -> str | None:
     os_bits = " ".join(x for x in (parsed.get("os"), parsed.get("kernel")) if x and x != "unknown")
     if os_bits:
         pieces.append(f"OS: {os_bits}")
-    if parsed.get("user") and parsed["user"] != "unknown":
-        pieces.append(f"User: {parsed['user']}")
+    # Do NOT include the OS username in the system prompt — it leaks into
+    # auto-generated fields like skill author without the user's consent.
     if parsed.get("home"):
         pieces.append(f"Home: {parsed['home']}")
     if parsed.get("cwd"):


### PR DESCRIPTION
## Problem

The backend probe in `agent/prompt_builder.py` includes `whoami` output in the system prompt as a `User:` field. This causes the model to auto-fill the `author` field in skill frontmatter with the host OS username, which is a privacy leak.

Skills are meant to be shared and published to the skills hub. The user never chose to include their OS username — it happens silently because the model sees the username in the system prompt and uses it to fill the `author` field.

```yaml
# Current — OS username leaked into skill frontmatter
---
name: hermes-fallback-providers
author: johndoe  # ← OS username, never opted into
---
```

## Fix

Remove the `User:` field from the system prompt environment summary. The OS, home directory, and working directory fields are kept as they are useful for the agent's operation.

```python
# Before
if parsed.get("user") and parsed["user"] != "unknown":
    pieces.append(f"User: {parsed['user']}")

# After — removed (privacy leak)
```

## Files changed

| File | Change |
|------|--------|
| `agent/prompt_builder.py` | Remove User: field from system prompt (-2/+2 lines) |

Fixes #52368