### PR TITLE
fix(tools): enforce 60-char description limit for skills

### DIFF
--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -109,7 +109,7 @@ HERMES_HOME = get_hermes_home()
 SKILLS_DIR = HERMES_HOME / "skills"
 
 MAX_NAME_LENGTH = 64
-MAX_DESCRIPTION_LENGTH = 1024
+MAX_DESCRIPTION_LENGTH = 60
 
 
 def _containing_skills_root(skill_path: Path) -> Path:

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -95,7 +95,7 @@ SKILLS_DIR = HERMES_HOME / "skills"
 
 # Anthropic-recommended limits for progressive disclosure efficiency
 MAX_NAME_LENGTH = 64
-MAX_DESCRIPTION_LENGTH = 1024
+MAX_DESCRIPTION_LENGTH = 60
 
 # Platform identifiers for the 'platforms' frontmatter field.
 # Maps user-friendly names to sys.platform prefixes.


### PR DESCRIPTION
## Problem

`MAX_DESCRIPTION_LENGTH` was set to 1024, but the documented skill-authoring standard specifies ≤60 characters. The `/learn` command generates descriptions up to 202 chars because the validation allows 1024. The system-prompt skill index already truncates to 60 chars, so over-length descriptions lose their routing signal past char 60.

```python
# Before — allows descriptions up to 1024 chars
MAX_DESCRIPTION_LENGTH = 1024

# After — matches documented ≤60 char standard
MAX_DESCRIPTION_LENGTH = 60
```

## Files changed

| File | Change |
|------|--------|
| `tools/skills_tool.py` | Lower MAX_DESCRIPTION_LENGTH from 1024 to 60 |
| `tools/skill_manager_tool.py` | Lower MAX_DESCRIPTION_LENGTH from 1024 to 60 |

Fixes #52367