### PR TITLE
fix: prune retired messaging toolset config

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3346,7 +3346,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 33,
+    "_config_version": 34,
 }
 
 # =============================================================================
@@ -3369,6 +3369,12 @@ ENV_VARS_BY_VERSION: Dict[int, List[str]] = {
 # selection step (Nous Portal / OpenRouter / Custom endpoint), so this
 # dict is intentionally empty — no single env var is universally required.
 REQUIRED_ENV_VARS = {}
+
+_RETIRED_TOOLSET_NAMES = frozenset({
+    # Removed with the agent-callable send_message toolset cleanup; older
+    # configs can still persist it under platform_toolsets.*.
+    "messaging",
+})
 
 # Optional environment variables that enhance functionality
 OPTIONAL_ENV_VARS = {
@@ -5532,6 +5538,65 @@ def _persist_migration(config: Dict[str, Any]) -> None:
     save_config(config)
 
 
+def _prune_retired_toolset_names(config: Dict[str, Any]) -> List[str]:
+    """Remove retired built-in toolset names from persisted selections."""
+    try:
+        from toolsets import validate_toolset
+    except Exception:
+        validate_toolset = None
+
+    mcp_cfg = config.get("mcp_servers")
+    mcp_names = {str(name) for name in mcp_cfg} if isinstance(mcp_cfg, dict) else set()
+    preserved_invalid = mcp_names | {"no_mcp"}
+    removed: List[str] = []
+
+    def _is_retired(name: str) -> bool:
+        if name not in _RETIRED_TOOLSET_NAMES:
+            return False
+        if name in preserved_invalid:
+            return False
+        if validate_toolset is not None and validate_toolset(name):
+            return False
+        return True
+
+    platform_toolsets = config.get("platform_toolsets")
+    if isinstance(platform_toolsets, dict):
+        for platform_name, raw_toolsets in list(platform_toolsets.items()):
+            if not isinstance(raw_toolsets, list):
+                continue
+            kept = []
+            changed = False
+            for raw_name in raw_toolsets:
+                name = str(raw_name)
+                if _is_retired(name):
+                    removed.append(f"platform_toolsets.{platform_name}.{name}")
+                    changed = True
+                    continue
+                kept.append(raw_name)
+            if changed:
+                platform_toolsets[platform_name] = kept
+        config["platform_toolsets"] = platform_toolsets
+
+    agent_cfg = config.get("agent")
+    if isinstance(agent_cfg, dict):
+        enabled_toolsets = agent_cfg.get("enabled_toolsets")
+        if isinstance(enabled_toolsets, list):
+            kept = []
+            changed = False
+            for raw_name in enabled_toolsets:
+                name = str(raw_name)
+                if _is_retired(name):
+                    removed.append(f"agent.enabled_toolsets.{name}")
+                    changed = True
+                    continue
+                kept.append(raw_name)
+            if changed:
+                agent_cfg["enabled_toolsets"] = kept
+                config["agent"] = agent_cfg
+
+    return removed
+
+
 def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, Any]:
     """
     Migrate config to latest version, prompting for new required fields.
@@ -6104,6 +6169,26 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                     "  ✓ Removed deprecated delegation.max_async_children — "
                     "delegation.max_concurrent_children now caps background "
                     "delegations too."
+                )
+
+    # ── Version 33 → 34: prune retired persisted toolset names ──
+    # The old messaging toolset was removed with the agent-callable
+    # send_message cleanup. Configs that saved it under platform_toolsets.* or
+    # agent.enabled_toolsets now produce "Unknown toolsets: messaging" on every
+    # CLI start. Remove only retired built-in names; preserve MCP server names
+    # and custom/plugin entries that may resolve after plugin discovery.
+    if current_ver < 34:
+        config = read_raw_config()
+        removed_toolsets = _prune_retired_toolset_names(config)
+        if removed_toolsets:
+            _persist_migration(config)
+            results["config_added"].append(
+                f"pruned retired toolsets ({len(removed_toolsets)})"
+            )
+            if not quiet:
+                print(
+                    "  ✓ Removed retired toolset entries from config.yaml: "
+                    f"{', '.join(removed_toolsets)}"
                 )
 
     # ── Post-migration: disable exfiltration-shaped MCP stdio entries ──

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1928,3 +1928,71 @@ class TestCodexAppServerAutoConfig:
             assert raw["compression"]["codex_app_server_auto"] == "hermes"
 
 
+class TestRetiredToolsetMigration:
+    """Version 33→34 prunes toolset names retired from built-in toolsets."""
+
+    def _write(self, tmp_path, data):
+        (tmp_path / "config.yaml").write_text(yaml.safe_dump(data), encoding="utf-8")
+
+    @pytest.mark.parametrize("start_version", [31, 32, 33])
+    def test_prunes_messaging_from_platform_and_agent_enabled(
+        self, tmp_path, start_version
+    ):
+        self._write(
+            tmp_path,
+            {
+                "_config_version": start_version,
+                "agent": {"enabled_toolsets": ["terminal", "messaging"]},
+                "platform_toolsets": {
+                    "cli": ["web", "messaging", "terminal"],
+                    "telegram": ["messaging", "web"],
+                },
+            },
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            migrate_config(interactive=False, quiet=True)
+            raw = yaml.safe_load((tmp_path / "config.yaml").read_text())
+
+        assert raw["_config_version"] == DEFAULT_CONFIG["_config_version"]
+        assert raw["agent"]["enabled_toolsets"] == ["terminal"]
+        assert raw["platform_toolsets"]["cli"] == ["web", "terminal"]
+        assert raw["platform_toolsets"]["telegram"] == ["web"]
+
+    def test_preserves_mcp_sentinel_and_custom_toolset_names(self, tmp_path):
+        self._write(
+            tmp_path,
+            {
+                "_config_version": 33,
+                "mcp_servers": {"local-mcp": {"url": "http://127.0.0.1/mcp"}},
+                "platform_toolsets": {
+                    "cli": ["messaging", "local-mcp", "custom-plugin", "no_mcp"],
+                },
+            },
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            migrate_config(interactive=False, quiet=True)
+            raw = yaml.safe_load((tmp_path / "config.yaml").read_text())
+
+        assert raw["platform_toolsets"]["cli"] == [
+            "local-mcp",
+            "custom-plugin",
+            "no_mcp",
+        ]
+
+    def test_preserves_mcp_server_named_messaging(self, tmp_path):
+        self._write(
+            tmp_path,
+            {
+                "_config_version": 33,
+                "mcp_servers": {"messaging": {"url": "http://127.0.0.1/mcp"}},
+                "platform_toolsets": {"cli": ["messaging"]},
+            },
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            migrate_config(interactive=False, quiet=True)
+            raw = yaml.safe_load((tmp_path / "config.yaml").read_text())
+
+        assert raw["platform_toolsets"]["cli"] == ["messaging"]


### PR DESCRIPTION
Summary\n- Bump the config schema to v34 and migrate v33 configs through the standard persistence path.\n- Remove the retired messaging entry from platform_toolsets.* and agent.enabled_toolsets.\n- Preserve configured MCP server names, no_mcp, and custom/plugin toolset names.\n- Cover configs starting at v31, v32, and v33, including an MCP server named messaging.\n\nProblem\nThe messaging toolset was removed, but existing user configs could still have it persisted. After upgrading, CLI startup validation kept printing Warning: Unknown toolsets: messaging on every launch.\n\nFix\nThe v34 migration prunes the retired built-in name only where it represents a stale toolset. It leaves unrelated custom entries and configured MCP servers untouched.\n\nValidation\n- 21 focused config migration tests\n- Ruff on the changed config and test files\n- git diff --check\n\nCloses #52382