### PR TITLE
fix(slack): authorize bot/workflow senders before the no-user-id guard

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -275,6 +275,22 @@ class GatewayAuthorizationMixin:
                     if "*" in allowed_group_ids or source.chat_id in allowed_group_ids:
                         return True
 
+        # Bots admitted by {PLATFORM}_ALLOW_BOTS bypass the human allowlist (#4466).
+        # Checked before the no-user-id guard below: some platforms deliver
+        # bot/automation traffic with no user_id at all -- e.g. Slack Workflow
+        # Builder posts arrive as subtype=bot_message with user=None -- so
+        # deferring past the guard would reject them outright (the same reason
+        # the chat-scoped allowlist above runs early).
+        platform_allow_bots_map = {
+            Platform.DISCORD: "DISCORD_ALLOW_BOTS",
+            Platform.FEISHU: "FEISHU_ALLOW_BOTS",
+            Platform.SLACK: "SLACK_ALLOW_BOTS",
+        }
+        if getattr(source, "is_bot", False):
+            allow_bots_var = platform_allow_bots_map.get(source.platform)
+            if allow_bots_var and os.getenv(allow_bots_var, "none").lower().strip() in {"mentions", "all"}:
+                return True
+
         if not user_id:
             return False
 
@@ -325,11 +341,6 @@ class GatewayAuthorizationMixin:
             Platform.QQBOT: "QQ_ALLOW_ALL_USERS",
             Platform.YUANBAO: "YUANBAO_ALLOW_ALL_USERS",
         }
-        # Bots admitted by {PLATFORM}_ALLOW_BOTS bypass the human allowlist (#4466).
-        platform_allow_bots_map = {
-            Platform.DISCORD: "DISCORD_ALLOW_BOTS",
-            Platform.FEISHU: "FEISHU_ALLOW_BOTS",
-        }
 
         # Plugin platforms: check the registry for auth env var names
         if source.platform not in platform_env_map:
@@ -356,11 +367,6 @@ class GatewayAuthorizationMixin:
         # mock sources) does not auto-truthy through this gate (see pitfall #13).
         if getattr(source, "role_authorized", False) is True:
             return True
-
-        if getattr(source, "is_bot", False):
-            allow_bots_var = platform_allow_bots_map.get(source.platform)
-            if allow_bots_var and os.getenv(allow_bots_var, "none").lower().strip() in {"mentions", "all"}:
-                return True
 
         # Check pairing store (always checked, regardless of allowlists)
         platform_name = source.platform.value if source.platform else ""

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2922,6 +2922,11 @@ class SlackAdapter(BasePlatformAdapter):
             user_id=user_id,
             user_name=user_name,
             thread_id=thread_ts,
+            # Slack Workflow Builder / app posts arrive as
+            # subtype=bot_message with user=None; flag them so the
+            # gateway SLACK_ALLOW_BOTS bypass can authorize them
+            # (they carry no user_id to match against the allowlist).
+            is_bot=bool(event.get("bot_id")) or event.get("subtype") == "bot_message",
         )
 
         # Per-channel ephemeral prompt

--- a/tests/gateway/test_slack_bot_auth_bypass.py
+++ b/tests/gateway/test_slack_bot_auth_bypass.py
@@ -1,0 +1,92 @@
+"""Regression guard for Slack bot/workflow-sender authorization bypass.
+
+Mirrors tests/gateway/test_feishu_bot_auth_bypass.py for Platform.SLACK.
+
+Slack Workflow Builder posts (and other app/bot messages) arrive as
+``subtype=bot_message`` with ``user=None``, so the SessionSource carries
+``is_bot=True`` and ``user_id=None``. Without the #4466 bot bypass running
+*before* the no-user-id guard, these senders are rejected at
+``_is_user_authorized`` even when the operator enabled ``SLACK_ALLOW_BOTS`` --
+the bug that makes @mentioning the bot from a Slack workflow do nothing.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.session import Platform, SessionSource
+
+
+@pytest.fixture(autouse=True)
+def _isolate_slack_env(monkeypatch):
+    for var in (
+        "SLACK_ALLOW_BOTS",
+        "SLACK_ALLOWED_USERS",
+        "SLACK_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOWED_USERS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _make_bare_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.pairing_store = SimpleNamespace(is_approved=lambda *_a, **_kw: False)
+    return runner
+
+
+def _make_slack_bot_source():
+    # Workflow Builder / app posts: subtype=bot_message, user=None.
+    return SessionSource(
+        platform=Platform.SLACK,
+        chat_id="C0123",
+        chat_type="group",
+        user_id=None,
+        user_name="",
+        is_bot=True,
+    )
+
+
+def _make_slack_human_source(user_id="U_human"):
+    return SessionSource(
+        platform=Platform.SLACK,
+        chat_id="C0123",
+        chat_type="group",
+        user_id=user_id,
+        user_name="Human",
+        is_bot=False,
+    )
+
+
+def test_slack_bot_authorized_when_allow_bots_all(monkeypatch):
+    runner = _make_bare_runner()
+    monkeypatch.setenv("SLACK_ALLOW_BOTS", "all")
+    assert runner._is_user_authorized(_make_slack_bot_source()) is True
+
+
+def test_slack_bot_authorized_when_allow_bots_mentions(monkeypatch):
+    runner = _make_bare_runner()
+    monkeypatch.setenv("SLACK_ALLOW_BOTS", "mentions")
+    assert runner._is_user_authorized(_make_slack_bot_source()) is True
+
+
+def test_slack_bot_denied_when_allow_bots_unset(monkeypatch):
+    # No SLACK_ALLOW_BOTS + no user_id => denied (no bypass, hits guard).
+    runner = _make_bare_runner()
+    assert runner._is_user_authorized(_make_slack_bot_source()) is False
+
+
+def test_slack_bot_denied_when_allow_bots_none(monkeypatch):
+    runner = _make_bare_runner()
+    monkeypatch.setenv("SLACK_ALLOW_BOTS", "none")
+    assert runner._is_user_authorized(_make_slack_bot_source()) is False
+
+
+def test_slack_human_unaffected_by_bot_bypass(monkeypatch):
+    runner = _make_bare_runner()
+    monkeypatch.setenv("SLACK_ALLOW_ALL_USERS", "true")
+    assert runner._is_user_authorized(_make_slack_human_source()) is True


### PR DESCRIPTION
## What does this PR do?

Slack Workflow Builder posts (and other app/bot messages) arrive as `subtype=bot_message` with `user=None`. `_is_user_authorized` rejected them at the `if not user_id: return False` guard, which runs **before** the #4466 `{PLATFORM}_ALLOW_BOTS` bypass — so @mentioning the bot from a Slack workflow silently did nothing, even with `SLACK_ALLOW_BOTS` (or `SLACK_ALLOW_ALL_USERS`) set.

The chat-scoped allowlist for Telegram/QQ already runs *before* that guard for exactly this reason (channel broadcasts with no `from_user`). Slack was both missing from the bot-bypass map **and** had the bypass running too late to help senders that carry no `user_id`.

## Related Issue

No existing issue/PR found (searched open PRs/issues for `slack` / `allowed_channels` / `user_id` / `workflow` — only #46925 *ignored-channel gate*, which is unrelated). Symptom + root cause documented above.

Fixes # (none)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/authz_mixin.py`: move the `{PLATFORM}_ALLOW_BOTS` bypass ahead of the no-user-id guard and add `Platform.SLACK -> SLACK_ALLOW_BOTS` to it. Discord/Feishu behavior is unchanged — those bot senders carry a `user_id` and pass the guard regardless; the relocation only additionally covers platforms (Slack) whose bot/automation traffic has no `user_id`.
- `plugins/platforms/slack/adapter.py`: set `is_bot=True` on inbound `bot_message` events in `_handle_slack_message` so the gateway can identify workflow/app senders.
- `tests/gateway/test_slack_bot_auth_bypass.py`: new regression test (mirrors `test_feishu_bot_auth_bypass.py`).

## How to Test

1. Slack app with `SLACK_ALLOW_BOTS=all` (or `mentions`), bot invited to a channel.
2. Create a Workflow Builder flow that posts a message @mentioning the bot in that channel.
3. Trigger it → the bot now responds. Before this PR it was silently dropped (`Dropping message from unauthorized user: user=None ... platform=slack`).
4. `pytest tests/gateway/test_slack_bot_auth_bypass.py -q`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(slack):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the affected suites — new `test_slack_bot_auth_bypass.py` + existing Discord/Feishu bot-auth + gateway authz/gating tests: **146 passed**. (Did not run the entire `pytest tests/`; scoped to the affected area.)
- [x] I've added tests for my changes (5 new cases: allow_bots all/mentions authorize a no-user-id Slack bot; none/unset deny; humans unaffected)
- [x] I've tested on my platform: macOS (Darwin)

### Documentation & Housekeeping

- [x] Docs — N/A (semantics mirror the already-documented Discord/Feishu `*_ALLOW_BOTS` bypass; no new config key introduced)
- [x] `cli-config.yaml.example` — N/A (no new config keys)
- [x] Cross-platform impact considered — change is platform-routing logic, no OS-specific code
