### PR TITLE
fix(tools): don't trip MCP circuit breaker during reconnect window

### DIFF
--- a/tests/tools/test_mcp_reconnect_breaker.py
+++ b/tests/tools/test_mcp_reconnect_breaker.py
@@ -1,0 +1,138 @@
+"""Regression tests: a keepalive-triggered reconnect must not trip the breaker.
+
+When a server-side connection idles out, ``MCPServerTask``'s keepalive probe
+fails and the run loop tears down and rebuilds the transport, setting
+``session = None`` for a few hundred milliseconds. Tool handlers that observed
+that transient ``None`` previously returned ``"not connected"`` *and* bumped
+the circuit-breaker counter. ``_CIRCUIT_BREAKER_THRESHOLD`` such bumps opened
+the breaker for the full cooldown, so a perfectly healthy server looked
+unreachable for ~60s even though the only thing wrong was that a call landed
+inside the reconnect gap.
+
+These tests lock in the fix: while the background ``run()`` task is still
+alive (reconnecting), handlers report a transient ``"reconnecting"`` status and
+do NOT bump the breaker; only a genuinely dead server (task finished or never
+started) is counted as a failure, preserving the original fast-fail behavior.
+"""
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+
+pytest.importorskip("mcp.client.auth.oauth2")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _install_server(mcp_tool_module, name, *, session, task_done):
+    """Install a fake server whose ``session`` and background-task state we
+    control precisely.
+
+    ``task_done`` drives ``_server_is_reconnecting``: ``False`` models a live
+    ``run()`` task rebuilding the transport (reconnecting); ``True`` models a
+    server whose task has exited (genuinely dead).
+    """
+    server = MagicMock()
+    server.name = name
+    server.session = session
+    task = MagicMock()
+    task.done.return_value = task_done
+    server._task = task
+
+    mcp_tool_module._servers[name] = server
+    mcp_tool_module._server_error_counts.pop(name, None)
+    mcp_tool_module._server_breaker_opened_at.pop(name, None)
+    return server
+
+
+def _cleanup(mcp_tool_module, name):
+    mcp_tool_module._servers.pop(name, None)
+    mcp_tool_module._server_error_counts.pop(name, None)
+    mcp_tool_module._server_breaker_opened_at.pop(name, None)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_reconnect_window_does_not_trip_breaker(monkeypatch, tmp_path):
+    """session=None while the run() task is still alive == reconnecting.
+
+    Every call in that window must report a transient "reconnecting" status
+    and must NOT bump the breaker, so the breaker can never open on a healthy
+    server that is merely rebuilding its transport.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    _install_server(mcp_tool, "srv", session=None, task_done=False)
+    try:
+        handler = _make_tool_handler("srv", "tool1", 10.0)
+
+        # More calls than the threshold: a pre-fix build would have opened
+        # the breaker by now.
+        for _ in range(mcp_tool._CIRCUIT_BREAKER_THRESHOLD + 2):
+            parsed = json.loads(handler({}))
+            assert "reconnecting" in parsed.get("error", "").lower(), parsed
+
+        assert mcp_tool._server_error_counts.get("srv", 0) == 0, (
+            "reconnect window must not bump the breaker counter"
+        )
+        assert "srv" not in mcp_tool._server_breaker_opened_at, (
+            "breaker must not open during a reconnect"
+        )
+    finally:
+        _cleanup(mcp_tool, "srv")
+
+
+def test_dead_server_still_trips_breaker(monkeypatch, tmp_path):
+    """session=None and the run() task finished == genuinely dead.
+
+    The original fast-fail + breaker behavior must be preserved: each call
+    bumps the counter, and once the threshold is reached the breaker opens
+    and short-circuits subsequent calls.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    _install_server(mcp_tool, "srv", session=None, task_done=True)
+    try:
+        handler = _make_tool_handler("srv", "tool1", 10.0)
+
+        for i in range(1, mcp_tool._CIRCUIT_BREAKER_THRESHOLD + 1):
+            parsed = json.loads(handler({}))
+            assert "not connected" in parsed.get("error", ""), parsed
+            assert mcp_tool._server_error_counts["srv"] == i
+
+        # Threshold reached → breaker open → next call short-circuits.
+        assert "srv" in mcp_tool._server_breaker_opened_at
+        parsed = json.loads(handler({}))
+        assert "unreachable" in parsed.get("error", "").lower(), parsed
+    finally:
+        _cleanup(mcp_tool, "srv")
+
+
+def test_resource_handler_reports_reconnecting(monkeypatch, tmp_path):
+    """Non-tool handlers (which never bumped the breaker) should still report
+    the transient reconnect state rather than a bare "not connected"."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_list_resources_handler
+
+    _install_server(mcp_tool, "srv", session=None, task_done=False)
+    try:
+        handler = _make_list_resources_handler("srv", 10.0)
+        parsed = json.loads(handler({}))
+        assert "reconnecting" in parsed.get("error", "").lower(), parsed
+    finally:
+        _cleanup(mcp_tool, "srv")

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2466,6 +2466,23 @@ def _reset_server_error(server_name: str) -> None:
     _server_error_counts[server_name] = 0
     _server_breaker_opened_at.pop(server_name, None)
 
+
+def _server_is_reconnecting(server) -> bool:
+    """Return True when a server's background task is mid-reconnect.
+
+    A keepalive-triggered reconnect (#17003 path) makes the run loop set
+    ``session = None`` for a few hundred milliseconds while it tears down
+    and rebuilds the transport. During that window ``server.session`` is
+    None even though the server is healthy and its background ``run()``
+    task is still alive.
+
+    Handlers use this to tell that transient gap apart from a genuinely
+    dead server (task finished or never started), so they can avoid
+    counting the reconnect window as a circuit-breaker failure.
+    """
+    task = getattr(server, "_task", None)
+    return task is not None and not task.done()
+
 # ---------------------------------------------------------------------------
 # Auth-failure detection helpers (Task 6 of MCP OAuth consolidation)
 # ---------------------------------------------------------------------------
@@ -3152,6 +3169,19 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
         with _lock:
             server = _servers.get(server_name)
         if not server or not server.session:
+            # A keepalive-triggered reconnect sets session=None for a few
+            # hundred ms while the run loop rebuilds the transport. Counting
+            # that transient gap as a failure bumps the circuit breaker and,
+            # after _CIRCUIT_BREAKER_THRESHOLD such bumps, opens it for the
+            # full cooldown on an otherwise-healthy server. Only bump when the
+            # server is genuinely gone (task finished or never started).
+            if server is not None and _server_is_reconnecting(server):
+                return json.dumps({
+                    "error": (
+                        f"MCP server '{server_name}' is reconnecting; "
+                        f"retry shortly."
+                    )
+                }, ensure_ascii=False)
             _bump_server_error(server_name)
             return json.dumps({
                 "error": f"MCP server '{server_name}' is not connected"
@@ -3274,6 +3304,13 @@ def _make_list_resources_handler(server_name: str, tool_timeout: float):
         with _lock:
             server = _servers.get(server_name)
         if not server or not server.session:
+            if server is not None and _server_is_reconnecting(server):
+                return json.dumps({
+                    "error": (
+                        f"MCP server '{server_name}' is reconnecting; "
+                        f"retry shortly."
+                    )
+                }, ensure_ascii=False)
             return json.dumps({
                 "error": f"MCP server '{server_name}' is not connected"
             }, ensure_ascii=False)
@@ -3334,6 +3371,13 @@ def _make_read_resource_handler(server_name: str, tool_timeout: float):
         with _lock:
             server = _servers.get(server_name)
         if not server or not server.session:
+            if server is not None and _server_is_reconnecting(server):
+                return json.dumps({
+                    "error": (
+                        f"MCP server '{server_name}' is reconnecting; "
+                        f"retry shortly."
+                    )
+                }, ensure_ascii=False)
             return json.dumps({
                 "error": f"MCP server '{server_name}' is not connected"
             }, ensure_ascii=False)
@@ -3392,6 +3436,13 @@ def _make_list_prompts_handler(server_name: str, tool_timeout: float):
         with _lock:
             server = _servers.get(server_name)
         if not server or not server.session:
+            if server is not None and _server_is_reconnecting(server):
+                return json.dumps({
+                    "error": (
+                        f"MCP server '{server_name}' is reconnecting; "
+                        f"retry shortly."
+                    )
+                }, ensure_ascii=False)
             return json.dumps({
                 "error": f"MCP server '{server_name}' is not connected"
             }, ensure_ascii=False)
@@ -3457,6 +3508,13 @@ def _make_get_prompt_handler(server_name: str, tool_timeout: float):
         with _lock:
             server = _servers.get(server_name)
         if not server or not server.session:
+            if server is not None and _server_is_reconnecting(server):
+                return json.dumps({
+                    "error": (
+                        f"MCP server '{server_name}' is reconnecting; "
+                        f"retry shortly."
+                    )
+                }, ensure_ascii=False)
             return json.dumps({
                 "error": f"MCP server '{server_name}' is not connected"
             }, ensure_ascii=False)


### PR DESCRIPTION
## What & why

After a server-side idle timeout, `MCPServerTask`'s keepalive probe fails and
the run loop tears down and rebuilds the transport (the #17003 keepalive path).
During that rebuild it sets `self.session = None` for a few hundred milliseconds.

Every tool/resource/prompt handler guards with:

```python
if not server or not server.session:
    _bump_server_error(server_name)   # tool handler only
    return {"error": "MCP server '...' is not connected"}
```

A call that lands in the reconnect window therefore returns "not connected"
and (in the tool handler) bumps the circuit breaker. After
`_CIRCUIT_BREAKER_THRESHOLD` such bumps the breaker opens for the full
`_CIRCUIT_BREAKER_COOLDOWN_SEC`, so a healthy server is reported unreachable
until the cooldown's half-open probe succeeds — even though the only thing
wrong was that a call raced the reconnect.

This is not covered by `_handle_session_expired_and_retry` (#13383): that
recovery runs in the `except` branch *after* `session.call_tool()` raises, but
here the pre-check returns before any call is made, so the session-expired
retry never executes.

## Fix

Distinguish a live, reconnecting background task from a genuinely dead one. A
new helper `_server_is_reconnecting(server)` returns True when `server._task`
exists and isn't done — i.e. the run loop is still rebuilding the transport.
When `session is None` but the task is alive, handlers return a transient
"reconnecting; retry shortly" status and skip the breaker bump. A genuinely
dead server (task finished or never started) still fast-fails and bumps exactly
as before, so the breaker keeps protecting against real outages (#10447).

This does not block the in-flight call waiting for the new session; it surfaces
a transient status and lets the caller retry once the (sub-second) reconnect
completes. The point is that the reconnect window no longer poisons the breaker.

## How to test

New regression test `tests/tools/test_mcp_reconnect_breaker.py`:

- reconnect window (session=None, task alive) → "reconnecting", no bump, breaker never opens
- dead server (session=None, task done) → bumps, breaker opens after threshold
- resource handler reports the transient reconnect state

```
pytest tests/tools/test_mcp_reconnect_breaker.py tests/tools/test_mcp_circuit_breaker.py -v
```

All pass, including the existing circuit-breaker tests (no behavior change for
the dead-server path).

## Platforms

Tested on macOS, Python 3.12. Pure-Python change, no platform-specific code.


## Lineage / related

This addresses a side effect of the keepalive-triggered reconnect added in
#49221: that path sets `session = None` while rebuilding the transport, and the
handler's pre-check counted that transient window as a connection failure.

Part of the broader MCP-reliability cluster (#38488, #50170, #47851, #38193);
it fixes one specific sub-case — the false circuit-breaker trip during the
reconnect window — not the whole cluster.
