### PR TITLE
fix: add default retention for cron output files to prevent disk fill (#52383)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1497,6 +1497,69 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
     return due
 
 
+def prune_job_outputs(job_id: str, keep: int = 50) -> int:
+    """Remove all but the *keep* most recent output files for a cron job.
+
+    Output files are named ``<timestamp>.md`` by ``save_job_output`` and
+    sorted by their embedded UTC timestamp (descending).  Files beyond the
+    *keep* limit are deleted.  Zero-size or malformed timestamps sort last
+    so they are pruned first.
+
+    Pass ``keep=0`` to disable pruning entirely (keep all output files).
+
+    Returns:
+        Number of files deleted.
+    """
+    if keep <= 0:
+        # 0 or negative = no pruning (preserves historical behaviour).
+        return 0
+
+    try:
+        output_dir = _job_output_dir(job_id)
+    except ValueError:
+        logger.warning("prune_job_outputs: invalid job_id %r - skipping", job_id)
+        return 0
+
+    if not output_dir.is_dir():
+        return 0
+
+    try:
+        entries = sorted(
+            (
+                p
+                for p in output_dir.iterdir()
+                if p.is_file() and p.suffix == ".md" and not p.name.startswith(".")
+            ),
+            # Sort by the ISO-ish timestamp in filenames like
+            # ``2026-06-25_07-38-06.md`` descending, so the newest files
+            # come first.  Any file whose name does not start with a digit
+            # sorts last (lexicographic fallback) and is thus pruned first.
+            key=lambda p: p.stem if p.stem and p.stem[0].isdigit() else "0",
+            reverse=True,
+        )
+    except OSError:
+        return 0
+
+    if len(entries) <= keep:
+        return 0
+
+    to_remove = entries[keep:]
+    deleted = 0
+    for p in to_remove:
+        try:
+            p.unlink()
+            deleted += 1
+        except OSError as exc:
+            logger.warning("Failed to remove stale cron output %s: %s", p, exc)
+
+    if deleted:
+        logger.info(
+            "Pruned %d stale output file(s) for cron job %s (keep=%d)",
+            deleted, job_id, keep,
+        )
+    return deleted
+
+
 def save_job_output(job_id: str, output: str):
     """Save job output to file."""
     ensure_dirs()

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -236,7 +236,7 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
-from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run
+from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run, prune_job_outputs
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
 # response with this marker to suppress delivery.  Output is still saved
@@ -2701,6 +2701,15 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         output_file = save_job_output(job["id"], output)
         if verbose:
             logger.info("Output saved to: %s", output_file)
+
+        # Prune old outputs.  Read keep from config (default 50), fall back
+        # to 50 if the config is missing or unavailable.
+        try:
+            cfg = load_config()
+            keep = (cfg.get("cron") or {}).get("keep_outputs", 50)
+        except Exception:
+            keep = 50
+        prune_job_outputs(job["id"], keep=keep)
 
         # Deliver the final response to the origin/target chat.
         # If the agent responded with [SILENT], skip delivery (but

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2412,6 +2412,10 @@ DEFAULT_CONFIG = {
         # 1 = serial (pre-v0.9 behaviour).
         # Also overridable via HERMES_CRON_MAX_PARALLEL env var.
         "max_parallel_jobs": None,
+        # Number of most recent output files to keep per cron job.
+        # Older files are automatically pruned after each run.
+        # Set to 0 to keep all (no pruning - historical behaviour).
+        "keep_outputs": 50,
     },
 
     # Kanban multi-agent coordination — controls the dispatcher loop that


### PR DESCRIPTION
Fixes #52383

## Description
Adds automatic retention-based pruning of cron job output files. Previously, every cron run created a new output file in `cron/output/<job_id>/` that was never deleted, causing the directory to grow unbounded over time and eventually filling the disk on long-running deploys.

Changes:
- New `prune_job_outputs(job_id, keep)` function in `cron/jobs.py` that keeps the N most recent `<timestamp>.md` files per job
- New `cron.keep_outputs` config key (default 50) exposed in `config.yaml`
- Pruning is called from `cron/scheduler.py` after each job run, so old outputs are cleaned up as new ones are written

The state-snapshots directory already had a built-in retention limit (`_QUICK_DEFAULT_KEEP = 20`), so this patch addresses the main unbounded-growth path reported in the issue.

## Verification
- `prune_job_outputs` passes 4 functional tests: keeps N most recent, returns 0 when already within limit, handles keep=0 (no-op, preserve all), rejects invalid job IDs
- All imports succeed (`cron.jobs`, `cron.scheduler`, `hermes_cli.config`)
- Config default verified in `DEFAULT_CONFIG`
- No secrets, no personal references, conventional commit format
- Only 3 files changed (77 insertions, 1 deletion) — focused on the fix

---
*Solidified via simplify-swarm + hermaguard before opening.*