### PR TITLE
fix(agent): gate verify-on-stop nudge off for messaging surfaces

### DIFF
--- a/agent/verification_stop.py
+++ b/agent/verification_stop.py
@@ -15,9 +15,77 @@ from typing import Any, Iterable
 
 _MAX_CHANGED_PATHS_IN_NUDGE = 8
 
+# Session identities (platform or source) that are NOT human conversational
+# messaging surfaces: interactive coding surfaces (CLI, TUI, desktop, codex,
+# local, gateway) and programmatic callers (API server, webhooks, tools).
+# Verify-on-stop stays ON by default for these. Any other resolved gateway
+# platform is a conversational messaging surface (Telegram, Discord, WhatsApp,
+# Signal, Slack, etc.) where the verification narrative would reach a human as
+# chat noise, so it defaults OFF. Mirrors LOCAL_SESSION_SOURCE_IDS in
+# apps/desktop/src/lib/session-source.ts; keep roughly in sync when adding a
+# local or programmatic surface. Default-deny by design: an unrecognized
+# identity is treated as messaging (OFF) so a new chat platform never leaks the
+# verification receipt before this set is updated.
+_NON_MESSAGING_SESSION_SURFACES = frozenset(
+    {
+        "",
+        "cli",
+        "codex",
+        "desktop",
+        "gateway",
+        "local",
+        "tui",
+        "tool",
+        "api_server",
+        "webhook",
+        "msgraph_webhook",
+    }
+)
+
+
+def _session_is_messaging_surface() -> bool:
+    """Return whether this turn is delivered over a human messaging channel.
+
+    The gateway binds the platform value (e.g. ``telegram``) to
+    ``HERMES_SESSION_PLATFORM``; the CLI and TUI set ``HERMES_SESSION_SOURCE``
+    (e.g. ``cli``, ``tui``) instead. Both are consulted via the session-context
+    helper (with an ``os.environ`` fallback), alongside the ``HERMES_PLATFORM``
+    override, matching the sibling platform resolution in
+    ``agent/skill_commands.py`` and ``agent/prompt_builder.py``. A turn is a
+    messaging surface when a resolved identity is present and is not a known
+    non-messaging surface.
+    """
+    try:
+        from gateway.session_context import get_session_env
+
+        platform = (
+            os.getenv("HERMES_PLATFORM")
+            or get_session_env("HERMES_SESSION_PLATFORM", "")
+        )
+        source = get_session_env("HERMES_SESSION_SOURCE", "")
+    except Exception:
+        platform = os.getenv("HERMES_PLATFORM", "") or os.environ.get(
+            "HERMES_SESSION_PLATFORM", ""
+        )
+        source = os.environ.get("HERMES_SESSION_SOURCE", "")
+    for identity in (platform, source):
+        identity = str(identity or "").strip().lower()
+        if identity and identity not in _NON_MESSAGING_SESSION_SURFACES:
+            return True
+    return False
+
 
 def verify_on_stop_enabled(config: dict[str, Any] | None = None) -> bool:
-    """Return whether edit -> verify-before-finish behavior is enabled."""
+    """Return whether edit -> verify-before-finish behavior is enabled.
+
+    Precedence: an explicit ``HERMES_VERIFY_ON_STOP`` env var wins, then an
+    explicit boolean ``agent.verify_on_stop`` config value, then a surface-aware
+    default. The config default is the sentinel ``"auto"`` (see
+    ``DEFAULT_CONFIG``), which resolves to ON for interactive coding surfaces
+    (CLI, TUI, desktop) and programmatic callers, and OFF for conversational
+    messaging surfaces (Telegram, Discord, etc.) where the verification
+    narrative would otherwise reach a human as chat noise.
+    """
     env = os.environ.get("HERMES_VERIFY_ON_STOP")
     if env is not None:
         return env.strip().lower() not in {"0", "false", "no", "off"}
@@ -29,9 +97,17 @@ def verify_on_stop_enabled(config: dict[str, Any] | None = None) -> bool:
         except Exception:
             config = {}
     agent_cfg = (config or {}).get("agent") if isinstance(config, dict) else None
-    if isinstance(agent_cfg, dict) and "verify_on_stop" in agent_cfg:
-        return bool(agent_cfg.get("verify_on_stop"))
-    return True
+    cfg_val = agent_cfg.get("verify_on_stop") if isinstance(agent_cfg, dict) else None
+    if isinstance(cfg_val, bool):
+        return cfg_val
+    if isinstance(cfg_val, str):
+        token = cfg_val.strip().lower()
+        if token in {"1", "true", "yes", "on"}:
+            return True
+        if token in {"0", "false", "no", "off"}:
+            return False
+    # "auto", missing, or any other value -> surface-aware default.
+    return not _session_is_messaging_surface()
 
 
 def _candidate_cwds(paths: Iterable[str]) -> list[Path]:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -637,7 +637,15 @@ agent:
   # primaries (default 3). The OpenAI SDK does its own low-level retries
   # underneath this wrapper — this is the Hermes-level loop.
   # api_max_retries: 3
-  
+
+  # After the agent edits code without fresh passing verification, nudge it to
+  # verify before finishing. The default "auto" enables it on interactive
+  # coding surfaces (CLI, TUI, desktop) and programmatic callers, and disables
+  # it on conversational messaging surfaces (Telegram, Discord, etc.) where the
+  # verification summary would reach a human as chat noise. Set true or false to
+  # force it on or off; the HERMES_VERIFY_ON_STOP env var (1/0) takes precedence.
+  # verify_on_stop: auto
+
   # Enable verbose logging
   verbose: false
   

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -982,8 +982,12 @@ DEFAULT_CONFIG = {
         # Verification closure: after the agent edits files in a code workspace,
         # do not accept a final answer until fresh verification evidence exists
         # or the agent explains why it cannot run checks. The loop is bounded
-        # and uses the passive verification ledger. Set false to disable.
-        "verify_on_stop": True,
+        # and uses the passive verification ledger. The default "auto" enables
+        # it on interactive coding surfaces (CLI, TUI, desktop) and programmatic
+        # callers, and disables it on conversational messaging surfaces
+        # (Telegram, Discord, etc.) where the verification summary would reach a
+        # human as chat noise. Set true or false to force it on or off.
+        "verify_on_stop": "auto",
         # Staged inactivity warning: send a warning to the user at this
         # threshold before escalating to a full timeout.  The warning fires
         # once per run and does not interrupt the agent.  0 = disable warning.

--- a/tests/agent/test_verification_stop.py
+++ b/tests/agent/test_verification_stop.py
@@ -2,6 +2,8 @@ import json
 import tempfile
 from pathlib import Path
 
+import pytest
+
 from agent.verification_evidence import (
     mark_workspace_edited,
     record_terminal_result,
@@ -25,19 +27,115 @@ def _make_project(root: Path) -> None:
     _node_project(root)
 
 
-def test_verify_on_stop_default_is_on(monkeypatch):
-    monkeypatch.delenv("HERMES_VERIFY_ON_STOP", raising=False)
+@pytest.fixture
+def clear_verify_env(monkeypatch):
+    """Clear every env signal verify_on_stop_enabled consults.
+
+    Tests then set only the variable they exercise, mirroring how the CLI/TUI
+    set HERMES_SESSION_SOURCE and the gateway sets HERMES_SESSION_PLATFORM.
+    """
+    for var in (
+        "HERMES_VERIFY_ON_STOP",
+        "HERMES_PLATFORM",
+        "HERMES_SESSION_PLATFORM",
+        "HERMES_SESSION_SOURCE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    return monkeypatch
+
+
+def test_verify_on_stop_default_is_on(clear_verify_env):
+    # No env, no messaging identity, no explicit config -> default ON.
     assert verify_on_stop_enabled({"agent": {}}) is True
 
 
-def test_verify_on_stop_env_can_disable(monkeypatch):
-    monkeypatch.setenv("HERMES_VERIFY_ON_STOP", "0")
+def test_verify_on_stop_auto_sentinel_resolves_to_surface_default(clear_verify_env):
+    # The DEFAULT_CONFIG sentinel must fall through to the surface-aware default,
+    # not be coerced to a truthy string.
+    assert verify_on_stop_enabled({"agent": {"verify_on_stop": "auto"}}) is True
+    clear_verify_env.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    assert verify_on_stop_enabled({"agent": {"verify_on_stop": "auto"}}) is False
+
+
+def test_verify_on_stop_env_can_disable(clear_verify_env):
+    clear_verify_env.setenv("HERMES_VERIFY_ON_STOP", "0")
     assert verify_on_stop_enabled({"agent": {"verify_on_stop": True}}) is False
 
 
-def test_verify_on_stop_config_can_disable(monkeypatch):
-    monkeypatch.delenv("HERMES_VERIFY_ON_STOP", raising=False)
+def test_verify_on_stop_config_can_disable(clear_verify_env):
     assert verify_on_stop_enabled({"agent": {"verify_on_stop": False}}) is False
+
+
+def test_verify_on_stop_off_on_gateway_messaging_platform(clear_verify_env):
+    # The gateway binds the platform value to HERMES_SESSION_PLATFORM and leaves
+    # HERMES_SESSION_SOURCE empty, so a real Telegram turn must default OFF.
+    clear_verify_env.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    assert verify_on_stop_enabled({"agent": {}}) is False
+
+
+@pytest.mark.parametrize(
+    "platform",
+    ["discord", "whatsapp_cloud", "signal", "slack", "matrix", "email", "sms"],
+)
+def test_verify_on_stop_off_for_each_messaging_platform(clear_verify_env, platform):
+    clear_verify_env.setenv("HERMES_SESSION_PLATFORM", platform)
+    assert verify_on_stop_enabled({"agent": {}}) is False
+
+
+def test_verify_on_stop_messaging_platform_is_case_insensitive(clear_verify_env):
+    clear_verify_env.setenv("HERMES_SESSION_PLATFORM", "  Telegram  ")
+    assert verify_on_stop_enabled({"agent": {}}) is False
+
+
+def test_verify_on_stop_uses_hermes_platform_override(clear_verify_env):
+    # HERMES_PLATFORM mirrors the sibling platform resolution and also flags a
+    # messaging surface.
+    clear_verify_env.setenv("HERMES_PLATFORM", "discord")
+    assert verify_on_stop_enabled({"agent": {}}) is False
+
+
+@pytest.mark.parametrize("source", ["cli", "tui", "desktop", "codex", "local"])
+def test_verify_on_stop_on_for_interactive_surfaces(clear_verify_env, source):
+    # CLI/TUI/desktop set HERMES_SESSION_SOURCE; these are coding surfaces -> ON.
+    clear_verify_env.setenv("HERMES_SESSION_SOURCE", source)
+    assert verify_on_stop_enabled({"agent": {}}) is True
+
+
+@pytest.mark.parametrize("platform", ["api_server", "webhook", "msgraph_webhook"])
+def test_verify_on_stop_on_for_programmatic_surfaces(clear_verify_env, platform):
+    clear_verify_env.setenv("HERMES_SESSION_PLATFORM", platform)
+    assert verify_on_stop_enabled({"agent": {}}) is True
+
+
+def test_env_forces_verify_on_stop_on_for_messaging(clear_verify_env):
+    clear_verify_env.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    clear_verify_env.setenv("HERMES_VERIFY_ON_STOP", "1")
+    assert verify_on_stop_enabled({"agent": {}}) is True
+
+
+def test_config_forces_verify_on_stop_on_for_messaging(clear_verify_env):
+    clear_verify_env.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    assert verify_on_stop_enabled({"agent": {"verify_on_stop": True}}) is True
+
+
+def test_verify_on_stop_default_path_through_load_config(tmp_path, clear_verify_env):
+    # E2E: the sole production caller passes no config, so verify_on_stop_enabled
+    # resolves through load_config() + DEFAULT_CONFIG. The "auto" sentinel must
+    # reach the surface-aware default rather than being shadowed by a static
+    # True. This is the path the unit-level tests above cannot exercise.
+    clear_verify_env.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+    from hermes_cli.config import load_config
+
+    merged = load_config()
+    assert merged["agent"]["verify_on_stop"] == "auto"
+
+    # Interactive (no messaging identity) resolves ON through the real loader.
+    assert verify_on_stop_enabled() is True
+
+    # A messaging platform resolves OFF, proving the sentinel flows through.
+    clear_verify_env.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    assert verify_on_stop_enabled() is False
 
 
 def test_no_nudge_after_fresh_pass(tmp_path, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Makes the verify-on-stop guard (added in #52296 / #52297) surface-aware so it stops leaking internal verification machinery into user-facing chat replies on messaging surfaces.

On a gateway messaging session (Telegram, Discord, etc.), after an agent edits local files in a workspace with no canonical test command, the harness injects the edit -> verify nudge, which tells the model to write a `/tmp/hermes-verify-*.py` script, run it, and "summarize it explicitly as ad-hoc verification." The model complies, and that ad-hoc verification receipt becomes the final turn response the gateway delivers to the human user as chat noise:

```
Ad-hoc verification rerun for the changed files.
Temporary script: /tmp/hermes-verify-4hupyoi1.py
Result: PASS ... cleanup=removed
This is ad-hoc verification, not a canonical full suite green.
```

The guard is valuable in a coding CLI session; on a chat surface it is internal machinery the user should never see.

This PR resolves a surface-aware default instead of a hardcoded one. `agent.verify_on_stop` now defaults to the sentinel `"auto"`, which `verify_on_stop_enabled()` resolves to:

- ON for interactive coding surfaces (CLI, TUI, desktop) and programmatic callers (API server, webhooks).
- OFF for conversational messaging surfaces (Telegram, Discord, Slack, Signal, WhatsApp, etc.).

The surface is read from `HERMES_SESSION_PLATFORM` (what the gateway actually binds), with `HERMES_SESSION_SOURCE` and `HERMES_PLATFORM` as fallbacks, mirroring the sibling platform resolution in `agent/skill_commands.py` and `agent/prompt_builder.py`. An explicit `HERMES_VERIFY_ON_STOP` env var or a boolean `agent.verify_on_stop` config still overrides in either direction. The passive verification ledger and the call site are untouched.

## Related Issue

Fixes #52411

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/verification_stop.py`: `verify_on_stop_enabled()` resolves a surface-aware default when no explicit env/config is set; honors an explicit boolean config or recognized string tokens; new `_session_is_messaging_surface()` reads `HERMES_SESSION_PLATFORM` + `HERMES_SESSION_SOURCE` + `HERMES_PLATFORM` and classifies against `_NON_MESSAGING_SESSION_SURFACES` (the local/programmatic surfaces, mirroring `apps/desktop/src/lib/session-source.ts` `LOCAL_SESSION_SOURCE_IDS`).
- `hermes_cli/config.py`: `DEFAULT_CONFIG` `agent.verify_on_stop` changes from `True` to the sentinel `"auto"` so the surface-aware default is actually reachable through `load_config()`.
- `cli-config.yaml.example`: documents `agent.verify_on_stop` and the `"auto"` default.
- `tests/agent/test_verification_stop.py`: surface-aware coverage including messaging-platform OFF, interactive/programmatic ON (CLI, TUI, desktop, codex, api_server, webhook), env/config override both directions, the `"auto"` sentinel, and an end-to-end test that drives `verify_on_stop_enabled()` through the real `load_config()` to prove the sentinel reaches the surface branch.

## How to Test

1. `pytest tests/agent/test_verification_stop.py -q` (32 passing).
2. Reproduction of the original bug and proof of the fix:

```python
import os
from agent.verification_stop import verify_on_stop_enabled, _session_is_messaging_surface

os.environ["HERMES_SESSION_PLATFORM"] = "telegram"   # what the gateway binds for a Telegram turn
assert _session_is_messaging_surface() is True
assert verify_on_stop_enabled() is False             # messaging surface -> nudge OFF, no leak

os.environ["HERMES_SESSION_PLATFORM"] = ""
os.environ["HERMES_SESSION_SOURCE"] = "cli"
assert verify_on_stop_enabled() is True              # CLI coding surface -> nudge ON (unchanged)

os.environ["HERMES_SESSION_SOURCE"] = "tui"
assert verify_on_stop_enabled() is True              # TUI/desktop coding surface -> nudge ON
```

3. Override still works: `HERMES_VERIFY_ON_STOP=1` forces ON on a messaging surface; `agent.verify_on_stop: false` forces OFF on a coding surface.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(agent):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` on the affected suites and all tests pass (verification + full config suite: 213 passing)
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`cli-config.yaml.example`, docstrings)
- [x] I've updated `cli-config.yaml.example` since I changed a config key default
- [x] N/A architecture/workflow docs
- [x] I've considered cross-platform impact (pure Python stdlib, env/contextvar reads; no platform-specific code)
- [x] N/A tool descriptions/schemas

## Screenshots / Logs

<img width="583" height="1098" alt="image" src="https://github.com/user-attachments/assets/3a1c83c6-3afd-4878-81df-1c976f048d51" />
