### PR TITLE
feat(custom-provider): forward session_id as x-session-id HTTP header

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -727,7 +727,10 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
     # found, delegate fully; otherwise fall through to the legacy flag path.
     try:
         from providers import get_provider_profile
-        _profile = get_provider_profile(agent.provider)
+        _provider_for_profile = agent.provider
+        if _provider_for_profile and _provider_for_profile.startswith("custom:") and _provider_for_profile != "custom":
+            _provider_for_profile = "custom"
+        _profile = get_provider_profile(_provider_for_profile)
     except Exception:
         _profile = None
 

--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -20,9 +20,11 @@ class CustomProfile(ProviderProfile):
         *,
         reasoning_config: dict | None = None,
         ollama_num_ctx: int | None = None,
+        session_id: str | None = None,
         **ctx: Any,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         extra_body: dict[str, Any] = {}
+        top_level: dict[str, Any] = {}
 
         # Ollama context window
         if ollama_num_ctx:
@@ -37,7 +39,10 @@ class CustomProfile(ProviderProfile):
             if _effort == "none" or _enabled is False:
                 extra_body["think"] = False
 
-        return extra_body, {}
+        if session_id:
+            top_level["extra_headers"] = {"x-session-id": session_id}
+
+        return extra_body, top_level
 
     def fetch_models(
         self,

--- a/tests/plugins/model_providers/test_custom_profile.py
+++ b/tests/plugins/model_providers/test_custom_profile.py
@@ -1,0 +1,122 @@
+"""Unit tests for the Custom provider profile's wire-shape contracts.
+
+Covers the ``build_api_kwargs_extras`` return for Ollama num_ctx, reasoning
+disable, and the ``x-session-id`` header forwarding for self-hosted backends.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def custom_profile():
+    """Resolve the registered Custom profile via the provider registry."""
+    import model_tools  # noqa: F401
+    import providers
+
+    profile = providers.get_provider_profile("custom")
+    assert profile is not None, "custom provider profile must be registered"
+    return profile
+
+
+class TestCustomSessionIdHeader:
+    """session_id is forwarded as x-session-id HTTP header."""
+
+    def test_session_id_emits_header(self, custom_profile):
+        _, top_level = custom_profile.build_api_kwargs_extras(
+            session_id="abc-123"
+        )
+        assert top_level == {"extra_headers": {"x-session-id": "abc-123"}}
+
+    def test_no_session_id_omits_header(self, custom_profile):
+        _, top_level = custom_profile.build_api_kwargs_extras()
+        assert top_level == {}
+
+    def test_empty_session_id_omits_header(self, custom_profile):
+        _, top_level = custom_profile.build_api_kwargs_extras(
+            session_id=""
+        )
+        assert top_level == {}
+
+    def test_none_session_id_omits_header(self, custom_profile):
+        _, top_level = custom_profile.build_api_kwargs_extras(
+            session_id=None
+        )
+        assert top_level == {}
+
+
+class TestCustomOllamaNumCtx:
+    """Ollama num_ctx is forwarded via extra_body.options.num_ctx."""
+
+    def test_num_ctx_emitted(self, custom_profile):
+        extra_body, _ = custom_profile.build_api_kwargs_extras(
+            ollama_num_ctx=8192
+        )
+        assert extra_body == {"options": {"num_ctx": 8192}}
+
+    def test_no_num_ctx_omits_options(self, custom_profile):
+        extra_body, _ = custom_profile.build_api_kwargs_extras()
+        assert extra_body == {}
+
+
+class TestCustomReasoningDisable:
+    """reasoning_config disabled → extra_body.think = False."""
+
+    def test_disabled_emits_think_false(self, custom_profile):
+        extra_body, _ = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False}
+        )
+        assert extra_body == {"think": False}
+
+    def test_effort_none_emits_think_false(self, custom_profile):
+        extra_body, _ = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "none"}
+        )
+        assert extra_body == {"think": False}
+
+    def test_enabled_emits_no_think(self, custom_profile):
+        extra_body, _ = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"}
+        )
+        assert extra_body == {}
+
+
+class TestCustomCombinedOutput:
+    """session_id header + reasoning + num_ctx all work together."""
+
+    def test_all_three_present(self, custom_profile):
+        extra_body, top_level = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            ollama_num_ctx=4096,
+            session_id="sess-xyz",
+        )
+        assert extra_body == {"options": {"num_ctx": 4096}, "think": False}
+        assert top_level == {"extra_headers": {"x-session-id": "sess-xyz"}}
+
+
+class TestCustomFullKwargsIntegration:
+    """End-to-end: the transport produces x-session-id in api_kwargs."""
+
+    def test_full_kwargs_include_session_header(self, custom_profile):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="my-model",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=custom_profile,
+            session_id="conv-42",
+        )
+        assert kwargs["extra_headers"] == {"x-session-id": "conv-42"}
+
+    def test_full_kwargs_omit_header_without_session(self, custom_profile):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="my-model",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=custom_profile,
+        )
+        assert "extra_headers" not in kwargs


### PR DESCRIPTION
## What does this PR do?

The `custom` provider profile (used for self-hosted OpenAI-compatible backends like SGLang, vLLM, Ollama, llamacpp) did not accept `session_id` in `build_api_kwargs_extras`, so no session header was ever sent on any request through the custom provider.

This PR forwards `session_id` as an `x-session-id` HTTP header via `extra_headers`, enabling self-hosted backends to correlate requests by conversation in traffic logs.


## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

1. Forward session_id as x-session-id header (29a5bc7)

• plugins/model-providers/custom/__init__.py: build_api_kwargs_extras now accepts session_id parameter and forwards it astop_level["extra_headers"] = {"x-session-id": session_id} when present
• tests/plugins/model_providers/test_custom_profile.py: New test file with 12 tests covering session_id header emission, Ollamanum_ctx, reasoning disable, combined output, and full transport integration

2. Normalize custom:* provider slug for profile lookup (c4f77b7)

• agent/chat_completion_helpers.py: Normalize custom:* slugs (e.g. custom:glm-4.7) to "custom" before get_provider_profile()lookup

Why this is needed: When switching models via /model, Hermes stores the full provider slug (e.g. custom:glm-4.7) inagent.provider. However, get_provider_profile() only registers the bare "custom" key — so the lookup returns None, causing theagent to fall through to the legacy kwargs path which does not inject the x-session-id header. Without this fix, the session_idheader from commit 1 only works at session start (where init_agent resolves provider: "custom"), and breaks after any /modelswitch to a named custom provider.

## How to Test

1. `python -m pytest tests/plugins/model_providers/test_custom_profile.py -v --tb=short -o 'addopts=' -n 0`
2. Verify 12 tests pass
3. Optionally: configure a custom provider pointing to a self-hosted SGLang/vLLM endpoint, send a message, and confirm `x-session-id` header appears in the backend's traffic logs
4. Regression test for named custom providers: Switch models via /model to a named custom provider (e.g. custom:glm-4.7), thensend a message — confirm x-session-id header still appears in the backend's traffic logs (this would fail without commitc4f77b7)


## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
tests/plugins/model_providers/test_custom_profile.py::TestCustomSessionIdHeader::test_session_id_emits_header PASSED [  8%]
tests/plugins/model_providers/test_custom_profile.py::TestCustomSessionIdHeader::test_no_session_id_omits_header PASSED [ 16%]
tests/plugins/model_providers/test_custom_profile.py::TestCustomSessionIdHeader::test_empty_session_id_omits_header PASSED [ 25%]
tests/plugins/model_providers/test_custom_profile.py::TestCustomSessionIdHeader::test_none_session_id_omits_header PASSED [ 33%]
tests/plugins/model_providers/test_custom_profile.py::TestCustomOllamaNumCtx::test_num_ctx_emitted PASSED [ 41%]
tests/plugins/model_providers/test_custom_profile.py::TestCustomOllamaNumCtx::test_no_num_ctx_omits_options PASSED [ 50%]
tests/plugins/model_providers/test_custom_profile.py::TestCustomReasoningDisable::test_disabled_emits_think_false PASSED [ 58%]
tests/plugins/model_providers/test_custom_profile.py::TestCustomReasoningDisable::test_effort_none_emits_think_false PASSED [ 66%]
tests/plugins/model_providers/test_custom_profile.py::TestCustomReasoningDisable::test_enabled_emits_no_think PASSED [ 75%]
tests/plugins/model_providers/test_custom_profile.py::TestCustomCombinedOutput::test_all_three_present PASSED [ 83%]
tests/plugins/model_providers/test_custom_profile.py::TestCustomFullKwargsIntegration::test_full_kwargs_include_session_header PASSED [ 91%]
tests/plugins/model_providers/test_custom_profile.py::TestCustomFullKwargsIntegration::test_full_kwargs_omit_header_without_session PASSED [100%]

======================== 12 passed, 1 warning in 1.37s =========================
```