### PR TITLE
fix(gateway): return empty string instead of hardcoded model placeholder

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1680,7 +1680,11 @@ def _resolve_model() -> str:
         return str(m.get("default", "") or "").strip()
     if isinstance(m, str) and m:
         return m.strip()
-    return "anthropic/claude-sonnet-4"
+    # Return empty string instead of hardcoded placeholder — a placeholder
+    # like "anthropic/claude-sonnet-4" gets persisted into sessions and
+    # causes permanent 404s when the endpoint doesn't serve that model.
+    # An empty string lets the session use the config default on resume.
+    return ""
 
 
 def _config_model_target() -> tuple[str, str]:


### PR DESCRIPTION
## Problem

`_resolve_model()` in `tui_gateway/server.py` returns `"anthropic/claude-sonnet-4"` as a fallback when no model is configured. This placeholder gets persisted into sessions via `create_session()`, causing permanent `404: Model not found` errors when the endpoint doesn't serve that model. The sticky session binding survives config fixes and restarts.

```python
# Before — hardcoded placeholder persisted into sessions
return "anthropic/claude-sonnet-4"

# After — empty string lets session use config default on resume
return ""
```

## Files changed

| File | Change |
|------|--------|
| `tui_gateway/server.py` | Return empty string instead of hardcoded placeholder (+5/-1 lines) |

Fixes #52410