### PR TITLE
feat(session-search): add time window filters

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3473,6 +3473,8 @@ class SessionDB:
         offset: int = 0,
         sort: str = None,
         include_inactive: bool = False,
+        since: Optional[float] = None,
+        before: Optional[float] = None,
     ) -> List[Dict[str, Any]]:
         """
         Full-text search across session messages using FTS5.
@@ -3555,6 +3557,13 @@ class SessionDB:
             where_clauses.append(f"m.role IN ({role_placeholders})")
             params.extend(role_filter)
 
+        if since is not None:
+            where_clauses.append("m.timestamp >= ?")
+            params.append(since)
+        if before is not None:
+            where_clauses.append("m.timestamp < ?")
+            params.append(before)
+
         where_sql = " AND ".join(where_clauses)
         params.extend([limit, offset])
 
@@ -3630,6 +3639,12 @@ class SessionDB:
                 if role_filter:
                     tri_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
                     tri_params.extend(role_filter)
+                if since is not None:
+                    tri_where.append("m.timestamp >= ?")
+                    tri_params.append(since)
+                if before is not None:
+                    tri_where.append("m.timestamp < ?")
+                    tri_params.append(before)
                 tri_sql = f"""
                     SELECT
                         m.id,
@@ -3687,6 +3702,12 @@ class SessionDB:
                 if role_filter:
                     like_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
                     like_params.extend(role_filter)
+                if since is not None:
+                    like_where.append("m.timestamp >= ?")
+                    like_params.append(since)
+                if before is not None:
+                    like_where.append("m.timestamp < ?")
+                    like_params.append(before)
                 like_sql = f"""
                     SELECT m.id, m.session_id, m.role,
                            substr(m.content,

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -69,6 +69,8 @@ class TestSchema:
         assert "query" in params
         assert "limit" in params
         assert "sort" in params
+        assert "since" in params
+        assert "before" in params
         # Scroll shape
         assert "session_id" in params
         assert "around_message_id" in params
@@ -232,6 +234,68 @@ class TestDiscoverySort:
         # Should not error
         result = json.loads(session_search(query="modpack", sort="bogus", db=db))
         assert result["success"] is True
+
+
+class TestDiscoveryTimeWindow:
+    def _seed(self, db):
+        rows = [
+            ("s_old", 1000.0, "old"),
+            ("s_since_boundary", 2000.0, "since boundary"),
+            ("s_inside", 2500.0, "inside"),
+            ("s_before_boundary", 3000.0, "before boundary"),
+        ]
+        for sid, ts, label in rows:
+            db.create_session(sid, source="cli")
+            db._conn.execute(
+                "UPDATE sessions SET started_at = ?, title = ? WHERE id = ?",
+                (ts, label, sid),
+            )
+            db.append_message(
+                sid,
+                role="user",
+                content=f"timewindow needle {label}",
+                timestamp=ts,
+            )
+        db._conn.commit()
+
+    def _session_ids(self, db, **kwargs):
+        result = json.loads(
+            session_search(query="timewindow", limit=10, sort="oldest", db=db, **kwargs)
+        )
+        assert result["success"] is True
+        return [r["session_id"] for r in result["results"]]
+
+    def test_without_bounds_matches_existing_discovery(self, db):
+        self._seed(db)
+        assert self._session_ids(db) == [
+            "s_old",
+            "s_since_boundary",
+            "s_inside",
+            "s_before_boundary",
+        ]
+
+    def test_since_excludes_older_messages(self, db):
+        self._seed(db)
+        assert self._session_ids(db, since=2000.0) == [
+            "s_since_boundary",
+            "s_inside",
+            "s_before_boundary",
+        ]
+
+    def test_before_excludes_newer_messages(self, db):
+        self._seed(db)
+        assert self._session_ids(db, before=3000.0) == [
+            "s_old",
+            "s_since_boundary",
+            "s_inside",
+        ]
+
+    def test_since_before_use_half_open_interval(self, db):
+        self._seed(db)
+        assert self._session_ids(db, since=2000.0, before=3000.0) == [
+            "s_since_boundary",
+            "s_inside",
+        ]
 
 
 class TestRoleFilter:

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -31,6 +31,8 @@ support.
 
 import json
 import logging
+import math
+from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
 # Sources that are excluded from session browsing/searching by default.
@@ -63,6 +65,33 @@ def _format_timestamp(ts: Union[int, float, str, None]) -> str:
     except Exception as e:
         logging.debug("Unexpected error formatting timestamp %s: %s", ts, e, exc_info=True)
     return str(ts)
+
+
+def _parse_timestamp_bound(value: Any, name: str) -> Optional[float]:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be a Unix timestamp or ISO timestamp string")
+    if isinstance(value, (int, float)):
+        ts = float(value)
+    elif isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            ts = float(text)
+        except ValueError:
+            try:
+                ts = datetime.fromisoformat(text.replace("Z", "+00:00")).timestamp()
+            except ValueError as exc:
+                raise ValueError(
+                    f"{name} must be a Unix timestamp or ISO timestamp string"
+                ) from exc
+    else:
+        raise ValueError(f"{name} must be a Unix timestamp or ISO timestamp string")
+    if not math.isfinite(ts):
+        raise ValueError(f"{name} must be a finite timestamp")
+    return ts
 
 
 def _resolve_to_parent(db, session_id: str) -> str:
@@ -397,6 +426,8 @@ def _discover(
     role_filter: Optional[List[str]],
     limit: int,
     sort: Optional[str],
+    since: Optional[float] = None,
+    before: Optional[float] = None,
     current_session_id: str = None,
 ) -> str:
     """Discovery shape: FTS5 + anchored window + bookends per hit. Single call."""
@@ -410,6 +441,8 @@ def _discover(
             limit=50,  # widen so dedup-by-lineage can find distinct sessions
             offset=0,
             sort=sort,
+            since=since,
+            before=before,
         )
     except Exception as e:
         logging.error("FTS5 search failed: %s", e, exc_info=True)
@@ -504,6 +537,8 @@ def session_search(
     window: int = 5,
     # Discovery shape
     sort: str = None,
+    since: Any = None,
+    before: Any = None,
     # Cross-profile (any shape)
     profile: str = None,
 ) -> str:
@@ -606,12 +641,20 @@ def session_search(
         if candidate in ("newest", "oldest"):
             sort_norm = candidate
 
+    try:
+        since_ts = _parse_timestamp_bound(since, "since")
+        before_ts = _parse_timestamp_bound(before, "before")
+    except ValueError as e:
+        return tool_error(str(e), success=False)
+
     return _discover(
         db=db,
         query=query.strip(),
         role_filter=role_list,
         limit=limit,
         sort=sort_norm,
+        since=since_ts,
+        before=before_ts,
         current_session_id=current_session_id,
     )
 
@@ -724,6 +767,22 @@ SESSION_SEARCH_SCHEMA = {
                     "and browse shapes."
                 ),
             },
+            "since": {
+                "type": ["number", "string"],
+                "description": (
+                    "Discovery shape only. Optional inclusive lower bound on "
+                    "message timestamp: only match messages with timestamp >= since. "
+                    "Accepts a Unix timestamp number or ISO timestamp string."
+                ),
+            },
+            "before": {
+                "type": ["number", "string"],
+                "description": (
+                    "Discovery shape only. Optional exclusive upper bound on "
+                    "message timestamp: only match messages with timestamp < before. "
+                    "Accepts a Unix timestamp number or ISO timestamp string."
+                ),
+            },
             "session_id": {
                 "type": "string",
                 "description": (
@@ -788,6 +847,8 @@ registry.register(
         around_message_id=args.get("around_message_id"),
         window=args.get("window", 5),
         sort=args.get("sort"),
+        since=args.get("since"),
+        before=args.get("before"),
         profile=args.get("profile"),
         db=kw.get("db"),
         current_session_id=kw.get("current_session_id"),

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -393,6 +393,14 @@ Runs FTS5, dedupes hits by session lineage, returns the top N sessions. Each res
 
 Bookends + window together reconstruct goal → match → resolution without paying for the whole transcript. Typical wall time: 15–50ms on a real session DB.
 
+To narrow discovery to messages from a time window, pass Unix timestamps or ISO timestamps:
+
+```python
+session_search(query="auth refactor", since=1770249600, before="2026-02-06T00:00:00Z")
+```
+
+`since` is inclusive (`timestamp >= since`) and `before` is exclusive (`timestamp < before`).
+
 **2. Scroll — pass `session_id` + `around_message_id`:**
 
 ```python
@@ -428,6 +436,8 @@ The keyword mode supports standard FTS5 query syntax:
 ### Optional parameters
 
 - `sort` — `newest` or `oldest`, on top of FTS5 ranking. Omit for relevance-only ordering (the default; suitable for exploratory recall). Use `newest` for "where did we leave X" questions, `oldest` for "how did X start" questions.
+- `since` — discovery only. Inclusive lower bound on message timestamp (`timestamp >= since`). Accepts a Unix timestamp or ISO timestamp string.
+- `before` — discovery only. Exclusive upper bound on message timestamp (`timestamp < before`). Accepts a Unix timestamp or ISO timestamp string.
 - `role_filter` — comma-separated roles to include. Discovery defaults to `user,assistant` (tool output is usually noise). Pass `user,assistant,tool` to include tool output (debugging tool behaviour) or `tool` to search tool output only.
 
 ### When It's Used


### PR DESCRIPTION
## What does this PR do?

Adds optional time-window filters to the `session_search` discovery path so callers can search past session messages by both text and message timestamp.

The new `since` and `before` parameters filter against the existing message-level `messages.timestamp` column:

* `since`: inclusive lower bound, `m.timestamp >= since`
* `before`: exclusive upper bound, `m.timestamp < before`

The implementation keeps the change small and additive: existing `session_search` calls behave the same when the new parameters are omitted, no new dependencies are added, and the existing SQLite predicates/indexes are used instead of introducing new search infrastructure.

## Related Issue

N/A

## Type of Change

* [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
* [x] ✨ New feature (non-breaking change that adds functionality)
* [ ] 🔒 Security fix
* [x] 📝 Documentation update
* [x] ✅ Tests (adding or improving test coverage)
* [ ] ♻️ Refactor (no behavior change)
* [ ] 🎯 New skill (bundled or hub)

## Changes Made

* Added `since` and `before` parameters to the `session_search` tool schema in `tools/session_search_tool.py`.
* Added minimal timestamp-bound parsing for Unix timestamps, numeric strings, and ISO timestamp strings.
* Threaded `since` and `before` through `session_search()` and `_discover()`.
* Updated `SessionDB.search_messages(...)` in `hermes_state.py` to apply timestamp predicates across:

  * main FTS5 search path
  * CJK trigram FTS5 path
  * CJK LIKE fallback path
* Reused the existing message timestamp storage and existing `(session_id, timestamp)` index; no redundant index was added.
* Added discovery tests for no bounds, `since`, `before`, and combined half-open interval behavior in `tests/tools/test_session_search.py`.
* Updated `website/docs/user-guide/sessions.md` with parameter docs and a short time-window example.

## How to Test

1. Run the full test suite:

   ```bash
   uv run --extra dev python -m pytest tests/ -q
   ```

2. Run the focused session search tool tests:

   ```bash
   uv run --extra dev python -m pytest "tests/tools/test_session_search.py"
   ```

3. Run the FTS5 session DB tests:

   ```bash
   uv run --extra dev python -m pytest "tests/test_hermes_state.py::TestFTS5Search"
   ```

4. Run the CJK search fallback tests to cover trigram and LIKE paths:

   ```bash
   uv run --extra dev python -m pytest "tests/test_hermes_state.py::TestCJKSearchFallback"
   ```

Observed locally:

```text
tests/tools/test_session_search.py: 51 passed
tests/test_hermes_state.py::TestFTS5Search: 19 passed
tests/test_hermes_state.py::TestCJKSearchFallback: 18 passed
```

## Checklist

### Code

* [x] I've read the [[Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
* [x] My commit messages follow [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
* [x] I searched for [[existing PRs](https://github.com/NousResearch/hermes-agent/pulls)](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
* [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
* [ ] I've run `pytest tests/ -q` and all tests pass
* [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
* [x] I've tested on my platform: macOS / Darwin, Python 3.12.11 via uv

### Documentation & Housekeeping

* [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
* [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
* [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
* [x] I've considered cross-platform impact (Windows, macOS) per the [[compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
* [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted test output:

```text
$ uv run --extra dev python -m pytest "tests/tools/test_session_search.py"
51 passed in 1.74s

$ uv run --extra dev python -m pytest "tests/test_hermes_state.py::TestFTS5Search"
19 passed in 0.48s

$ uv run --extra dev python -m pytest "tests/test_hermes_state.py::TestCJKSearchFallback"
18 passed in 0.34s
```