### PR TITLE
fix(discord): delete orphaned seed message when auto-thread creation fails

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4594,6 +4594,7 @@ class DiscordAdapter(BasePlatformAdapter):
         except Exception as direct_error:
             display_name = getattr(getattr(message, "author", None), "display_name", None) or "unknown user"
             reason = f"Auto-threaded from mention by {display_name}"
+            seed_msg = None
             try:
                 seed_msg = await message.channel.send(f"\U0001f9f5 Thread created by Hermes: **{thread_name}**")
                 thread = await seed_msg.create_thread(
@@ -4603,6 +4604,13 @@ class DiscordAdapter(BasePlatformAdapter):
                 )
                 return thread
             except Exception as fallback_error:
+                # Delete the seed message to avoid orphaned "Thread created"
+                # announcements when thread creation fails (e.g. rate-limit).
+                if seed_msg is not None:
+                    try:
+                        await seed_msg.delete()
+                    except Exception:
+                        pass
                 logger.warning(
                     "[%s] Auto-thread creation failed. Direct error: %s. Fallback error: %s",
                     self.name,


### PR DESCRIPTION
## Problem

When Discord auto-threading fallback path posts a 'Thread created by Hermes' announcement before `create_thread()`, and `create_thread()` then fails (e.g. 429 rate-limit), the announcement is left orphaned in the channel with no thread behind it.

```python
# Current — seed message posted BEFORE create_thread()
seed_msg = await message.channel.send("🧵 Thread created by Hermes: ...")
thread = await seed_msg.create_thread(...)  # ← can fail (429)
return thread
# If create_thread() fails, seed_msg is orphaned
```

## Fix

Delete the seed message in the fallback error handler:

```python
seed_msg = None
try:
    seed_msg = await message.channel.send(...)
    thread = await seed_msg.create_thread(...)
    return thread
except Exception:
    if seed_msg is not None:
        try:
            await seed_msg.delete()  # ← clean up orphaned announcement
        except Exception:
            pass
```

## Files changed

| File | Change |
|------|--------|
| `plugins/platforms/discord/adapter.py` | Delete orphaned seed message on fallback failure (+8 lines) |

Fixes #52422