### PR TITLE
fix: prevent TypeError in _summarize_tool_result when tool args contain non-string values

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -487,6 +487,21 @@ def _strip_historical_media(messages: List[Dict[str, Any]]) -> List[Dict[str, An
     return result if changed else messages
 
 
+def _str_arg(args: dict, key: str, default: str = "") -> str:
+    """Safely get a string argument from parsed tool args.
+
+    LLMs sometimes return non-string parameter values (e.g. bool, int) for
+    tool calls.  Calling ``len()`` / ``.count()`` / slicing on those causes
+    ``TypeError`` / ``AttributeError`` which crashes context compression.
+    This helper coerces any value to ``str`` so downstream code can assume
+    a string is always returned.
+    """
+    val = args.get(key, default)
+    if isinstance(val, str):
+        return val
+    return str(val) if val is not None else default
+
+
 def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) -> str:
     """Create an informative 1-line summary of a tool call + result.
 
@@ -510,7 +525,7 @@ def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) ->
     line_count = content.count("\n") + 1 if content.strip() else 0
 
     if tool_name == "terminal":
-        cmd = args.get("command", "")
+        cmd = _str_arg(args, "command")
         if len(cmd) > 80:
             cmd = cmd[:77] + "..."
         exit_match = re.search(r'"exit_code"\s*:\s*(-?\d+)', content)
@@ -524,7 +539,7 @@ def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) ->
 
     if tool_name == "write_file":
         path = args.get("path", "?")
-        written_lines = args.get("content", "").count("\n") + 1 if args.get("content") else "?"
+        written_lines = _str_arg(args, "content").count("\n") + 1 if args.get("content") else "?"
         return f"[write_file] wrote to {path} ({written_lines} lines)"
 
     if tool_name == "search_files":
@@ -559,14 +574,15 @@ def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) ->
         return f"[web_extract] {url_desc} ({content_len:,} chars)"
 
     if tool_name == "delegate_task":
-        goal = args.get("goal", "")
+        goal = _str_arg(args, "goal")
         if len(goal) > 60:
             goal = goal[:57] + "..."
         return f"[delegate_task] '{goal}' ({content_len:,} chars result)"
 
     if tool_name == "execute_code":
-        code_preview = (args.get("code") or "")[:60].replace("\n", " ")
-        if len(args.get("code", "")) > 60:
+        code_str = _str_arg(args, "code")
+        code_preview = code_str[:60].replace("\n", " ")
+        if len(code_str) > 60:
             code_preview += "..."
         return f"[execute_code] `{code_preview}` ({line_count} lines output)"
 
@@ -575,7 +591,7 @@ def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) ->
         return f"[{tool_name}] name={name} ({content_len:,} chars)"
 
     if tool_name == "vision_analyze":
-        question = args.get("question", "")[:50]
+        question = _str_arg(args, "question")[:50]
         return f"[vision_analyze] '{question}' ({content_len:,} chars)"
 
     if tool_name == "memory":

--- a/tests/agent/test_summarize_tool_result_type_safety.py
+++ b/tests/agent/test_summarize_tool_result_type_safety.py
@@ -1,0 +1,207 @@
+"""Type safety tests for _summarize_tool_result.
+
+When LLMs return non-string parameter values (e.g. bool, int, None) in tool
+call arguments, _summarize_tool_result() must not crash with TypeError or
+AttributeError. This caused an infinite TUI crash loop in production.
+"""
+import json
+import pytest
+from agent.context_compressor import _summarize_tool_result
+
+
+class TestTypeSafety:
+    """Non-string tool arguments must not crash _summarize_tool_result."""
+
+    def test_terminal_command_bool(self):
+        """bool value for 'command' should not raise TypeError."""
+        args = json.dumps({"command": True})
+        result = _summarize_tool_result("terminal", args, '{"exit_code": 0}')
+        assert "terminal" in result
+        assert "True" in result or "exit" in result
+
+    def test_terminal_command_int(self):
+        """int value for 'command' should not raise TypeError."""
+        args = json.dumps({"command": 42})
+        result = _summarize_tool_result("terminal", args, '{"exit_code": 0}')
+        assert "terminal" in result
+        assert "42" in result
+
+    def test_terminal_command_none(self):
+        """None value for 'command' should not raise TypeError."""
+        args = json.dumps({"command": None})
+        result = _summarize_tool_result("terminal", args, '{"exit_code": 0}')
+        assert "terminal" in result
+
+    def test_write_file_content_bool(self):
+        """bool value for 'content' should not raise AttributeError."""
+        args = json.dumps({"path": "test.txt", "content": False})
+        result = _summarize_tool_result("write_file", args, "OK")
+        assert "write_file" in result
+        assert "test.txt" in result
+
+    def test_write_file_content_int(self):
+        """int value for 'content' should not raise AttributeError."""
+        args = json.dumps({"path": "test.txt", "content": 123})
+        result = _summarize_tool_result("write_file", args, "OK")
+        assert "write_file" in result
+
+    def test_delegate_task_goal_bool(self):
+        """bool value for 'goal' should not raise TypeError."""
+        args = json.dumps({"goal": False})
+        result = _summarize_tool_result("delegate_task", args, "result")
+        assert "delegate_task" in result
+        assert "False" in result
+
+    def test_delegate_task_goal_int(self):
+        """int value for 'goal' should not raise TypeError."""
+        args = json.dumps({"goal": 999})
+        result = _summarize_tool_result("delegate_task", args, "result")
+        assert "delegate_task" in result
+        assert "999" in result
+
+    def test_execute_code_code_bool(self):
+        """bool value for 'code' should not raise TypeError."""
+        args = json.dumps({"code": True})
+        result = _summarize_tool_result("execute_code", args, "output")
+        assert "execute_code" in result
+        assert "True" in result
+
+    def test_execute_code_code_int(self):
+        """int value for 'code' should not raise TypeError."""
+        args = json.dumps({"code": 0})
+        result = _summarize_tool_result("execute_code", args, "output")
+        assert "execute_code" in result
+
+    def test_vision_analyze_question_bool(self):
+        """bool value for 'question' should not raise TypeError."""
+        args = json.dumps({"question": True})
+        result = _summarize_tool_result("vision_analyze", args, "analysis")
+        assert "vision_analyze" in result
+        assert "True" in result
+
+    def test_vision_analyze_question_int(self):
+        """int value for 'question' should not raise TypeError."""
+        args = json.dumps({"question": 123})
+        result = _summarize_tool_result("vision_analyze", args, "analysis")
+        assert "vision_analyze" in result
+        assert "123" in result
+
+    def test_vision_analyze_question_list(self):
+        """list value for 'question' should not raise TypeError."""
+        args = json.dumps({"question": ["a", "b"]})
+        result = _summarize_tool_result("vision_analyze", args, "analysis")
+        assert "vision_analyze" in result
+
+    def test_vision_analyze_question_dict(self):
+        """dict value for 'question' should not raise TypeError."""
+        args = json.dumps({"question": {"key": "value"}})
+        result = _summarize_tool_result("vision_analyze", args, "analysis")
+        assert "vision_analyze" in result
+
+
+class TestNormalStringArguments:
+    """Normal string arguments should continue to work as before."""
+
+    def test_terminal_normal_command(self):
+        """Normal string command should be summarized correctly."""
+        args = json.dumps({"command": "ls -la"})
+        result = _summarize_tool_result("terminal", args, '{"exit_code": 0}')
+        assert "terminal" in result
+        assert "ls -la" in result
+        assert "exit 0" in result
+
+    def test_terminal_long_command_truncated(self):
+        """Long commands should be truncated."""
+        long_cmd = "a" * 100
+        args = json.dumps({"command": long_cmd})
+        result = _summarize_tool_result("terminal", args, '{"exit_code": 0}')
+        assert "..." in result
+        assert len(result) < 150
+
+    def test_write_file_normal_content(self):
+        """Normal string content should count lines correctly."""
+        args = json.dumps({"path": "test.py", "content": "line1\nline2\nline3"})
+        result = _summarize_tool_result("write_file", args, "OK")
+        assert "write_file" in result
+        assert "test.py" in result
+        assert "3 lines" in result
+
+    def test_delegate_task_normal_goal(self):
+        """Normal string goal should be summarized correctly."""
+        args = json.dumps({"goal": "Fix the bug"})
+        result = _summarize_tool_result("delegate_task", args, "done")
+        assert "delegate_task" in result
+        assert "Fix the bug" in result
+
+    def test_delegate_task_long_goal_truncated(self):
+        """Long goals should be truncated."""
+        long_goal = "x" * 100
+        args = json.dumps({"goal": long_goal})
+        result = _summarize_tool_result("delegate_task", args, "done")
+        assert "..." in result
+
+    def test_execute_code_normal_code(self):
+        """Normal code should be previewed correctly."""
+        args = json.dumps({"code": "print('hello')"})
+        result = _summarize_tool_result("execute_code", args, "hello")
+        assert "execute_code" in result
+        assert "print" in result
+
+    def test_execute_code_long_code_truncated(self):
+        """Long code should be truncated."""
+        long_code = "a = 1\n" * 20
+        args = json.dumps({"code": long_code})
+        result = _summarize_tool_result("execute_code", args, "output")
+        assert "..." in result
+
+    def test_vision_analyze_normal_question(self):
+        """Normal question should be included."""
+        args = json.dumps({"question": "What is this?"})
+        result = _summarize_tool_result("vision_analyze", args, "It's a cat")
+        assert "vision_analyze" in result
+        assert "What is this?" in result
+
+    def test_vision_analyze_long_question_truncated(self):
+        """Long questions should be truncated."""
+        long_q = "?" * 100
+        args = json.dumps({"question": long_q})
+        result = _summarize_tool_result("vision_analyze", args, "answer")
+        assert len(result) < 150
+
+
+class TestEdgeCases:
+    """Edge cases and boundary conditions."""
+
+    def test_empty_args(self):
+        """Empty JSON object should not crash."""
+        result = _summarize_tool_result("terminal", "{}", "output")
+        assert "terminal" in result
+
+    def test_invalid_json(self):
+        """Invalid JSON should not crash."""
+        result = _summarize_tool_result("terminal", "not json", "output")
+        assert "terminal" in result
+
+    def test_null_args(self):
+        """None/null args should not crash."""
+        result = _summarize_tool_result("terminal", None, "output")
+        assert "terminal" in result
+
+    def test_unknown_tool_name(self):
+        """Unknown tool name should return generic summary."""
+        args = json.dumps({"foo": "bar"})
+        result = _summarize_tool_result("unknown_tool", args, "output")
+        # Should return some fallback, not crash
+        assert isinstance(result, str)
+
+    def test_mixed_types_in_args(self):
+        """Args with mixed types should not crash."""
+        args = json.dumps({
+            "command": "ls",
+            "background": True,
+            "timeout": 30,
+            "extra": None
+        })
+        result = _summarize_tool_result("terminal", args, '{"exit_code": 0}')
+        assert "terminal" in result
+        assert "ls" in result


### PR DESCRIPTION
## Problem

`_summarize_tool_result()` in `agent/context_compressor.py` crashes with `TypeError: object of type 'bool' has no len()` (or similar `AttributeError`) when LLMs return non-string parameter values in tool call arguments.

This causes an **infinite crash loop in the TUI** — context compression triggers on session resume, which crashes, which restarts, which triggers compression again.

## Root Cause

`json.loads()` on tool args can produce dicts where values are `bool`, `int`, etc. The code calls `len()`, `.count()`, and string slicing directly on `args.get()` return values without type checking.

5 vulnerable call sites:

| Line | Code | Error |
|---|---|---|
| `len(cmd)` | `args.get("command", "")` | `TypeError: object of type 'bool' has no len()` |
| `.count()` | `args.get("content", "").count()` | `AttributeError` |
| `len(goal)` | `args.get("goal", "")` | `TypeError` |
| `len(code)` | `args.get("code", "")` | `TypeError` |
| `[:50]` | `args.get("question", "")[:50]` | `TypeError: 'bool' not subscriptable` |

## Fix

Add a `_str_arg(args, key, default="")` helper that safely coerces any value to `str`, and replace all 5 vulnerable `args.get()` calls with it.

Minimal, surgical change — no behavior change for normal (string) args.

## Tests

Added 27 new tests in `tests/agent/test_summarize_tool_result_type_safety.py`:

- **13 type safety tests**: Non-string args (bool, int, None, list, dict) for all 5 vulnerable call sites
- **9 regression tests**: Normal string args continue to work correctly
- **5 edge case tests**: Empty args, invalid JSON, null args, unknown tool, mixed types

All 27 new tests pass ✅
All 73 existing compressor tests pass ✅ (no regression)

```
27 passed in 4.61s
73 passed in 8.57s
```