### PR TITLE
fix(gateway): merge instead of overwrite agent.request_overrides

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20447,7 +20447,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             agent.event_callback = _event_callback_sync
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
-            agent.request_overrides = turn_route.get("request_overrides") or {}
+            request_overrides = dict(getattr(agent, "request_overrides", {}) or {})
+            previous_turn_overrides = dict(
+                getattr(agent, "_gateway_turn_request_overrides", {}) or {}
+            )
+            for key, value in previous_turn_overrides.items():
+                if request_overrides.get(key) == value:
+                    request_overrides.pop(key, None)
+            turn_request_overrides = dict(turn_route.get("request_overrides") or {})
+            request_overrides.update(turn_request_overrides)
+            agent.request_overrides = request_overrides
+            agent._gateway_turn_request_overrides = turn_request_overrides
             # Must-deliver notes for THIS turn ride the current user message
             # (api_content sidecar), never the system prompt: staged by
             # _handle_message_with_agent (auto-reset note, first-contact

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -10,6 +10,7 @@ import pytest
 import yaml
 
 import gateway.run as gateway_run
+from agent.agent_init import _merge_custom_provider_extra_body
 from gateway.config import Platform
 from gateway.platforms.base import MessageEvent
 from gateway.session import SessionSource
@@ -18,9 +19,15 @@ from gateway.session import SessionSource
 class _CapturingAgent:
     last_init = None
     last_run = None
+    custom_providers = []
 
     def __init__(self, *args, **kwargs):
         type(self).last_init = dict(kwargs)
+        self.model = kwargs["model"]
+        self.provider = kwargs.get("provider")
+        self.base_url = kwargs.get("base_url")
+        self.request_overrides = dict(kwargs.get("request_overrides") or {})
+        _merge_custom_provider_extra_body(self, type(self).custom_providers)
         self.tools = []
 
     def run_conversation(
@@ -37,6 +44,7 @@ class _CapturingAgent:
             "task_id": task_id,
             "persist_user_message": persist_user_message,
             "persist_user_timestamp": persist_user_timestamp,
+            "request_overrides": dict(self.request_overrides),
         }
         return {
             "final_response": "ok",
@@ -253,6 +261,78 @@ async def test_run_agent_passes_priority_processing_to_gateway_agent(monkeypatch
     assert result["final_response"] == "ok"
     assert _CapturingAgent.last_init["service_tier"] == "priority"
     assert _CapturingAgent.last_init["request_overrides"] == {"service_tier": "priority"}
+
+
+@pytest.mark.asyncio
+async def test_run_agent_preserves_custom_provider_extra_body_across_turn_refresh(
+    monkeypatch,
+    tmp_path,
+):
+    _install_fake_agent(monkeypatch)
+    runner = _make_runner()
+    runtime_config = {"agent": {"service_tier": "fast"}}
+
+    monkeypatch.setattr(
+        _CapturingAgent,
+        "custom_providers",
+        [
+            {
+                "name": "test-provider",
+                "base_url": "https://example.test/v1",
+                "model": "gpt-5.4",
+                "extra_body": {"content_filter": False},
+            }
+        ],
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_runtime_config",
+        lambda: runtime_config,
+    )
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "base_url": "https://example.test/v1",
+            "api_key": "***",
+        },
+    )
+
+    import hermes_cli.tools_config as tools_config
+    monkeypatch.setattr(tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"})
+
+    async def run_turn():
+        return await runner._run_agent(
+            message="hi",
+            context_prompt="",
+            history=[],
+            source=_make_source(),
+            session_id="session-1",
+            session_key="agent:main:telegram:dm:12345",
+        )
+
+    result = await run_turn()
+
+    assert result["final_response"] == "ok"
+    assert _CapturingAgent.last_run["request_overrides"] == {
+        "extra_body": {"content_filter": False},
+        "service_tier": "priority",
+    }
+
+    runtime_config.clear()
+    result = await run_turn()
+
+    assert result["final_response"] == "ok"
+    assert _CapturingAgent.last_run["request_overrides"] == {
+        "extra_body": {"content_filter": False},
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

After `init_agent()` merges `custom_providers` `extra_body` into
`agent.request_overrides`, the gateway runner's per-turn setup on
line 15856 unconditionally overwrites it:

```python
agent.request_overrides = turn_route.get(request_overrides) or {}
```

`turn_route.get(request_overrides)` is `{}` when no
`service_tier` is set (see `_make_turn_route` at line 3487), so
any `custom_providers` `extra_body` that was injected during
agent init is silently discarded.

## Fix

Merge instead of overwrite: preserve whatever the agent already
has in `request_overrides`, and only layer on `turn_route`
overrides when they are non-empty.

## Tested

- Confirmed `custom_providers` `extra_body` (e.g.
  `content_filter: false` for 360 provider) survives past the gateway
  per-turn setup when `service_tier` is not set.