### PR TITLE
perf(profiles): allow lightweight profile listing

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2315,7 +2315,16 @@ def run_doctor(args):
         from hermes_cli.profiles import list_profiles, _get_wrapper_dir, profile_exists
         import re as _re
 
-        named_profiles = [p for p in list_profiles() if not p.is_default]
+        named_profiles = [
+            p for p in list_profiles(
+                include_distribution=False,
+                include_description=False,
+                include_skill_count=False,
+                include_alias=False,
+                include_env=False,
+            )
+            if not p.is_default
+        ]
         if named_profiles:
             _section("Profiles")
             check_ok(f"{len(named_profiles)} profile(s) found")

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -613,7 +613,15 @@ def find_profile_gateway_processes(
         return processes
 
     seen: set[int] = set()
-    for profile in list_profiles():
+    for profile in list_profiles(
+        include_model=False,
+        include_distribution=False,
+        include_description=False,
+        include_gateway_status=False,
+        include_skill_count=False,
+        include_alias=False,
+        include_env=False,
+    ):
         try:
             pid = get_running_pid(profile.path / "gateway.pid", cleanup_stale=False)
         except Exception:
@@ -1376,7 +1384,14 @@ def _gateway_list() -> None:
         print("Unable to list profiles.")
         return
 
-    profiles = list_profiles()
+    profiles = list_profiles(
+        include_model=False,
+        include_distribution=False,
+        include_description=False,
+        include_skill_count=False,
+        include_alias=False,
+        include_env=False,
+    )
     if not profiles:
         print("No profiles found.")
         return

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -224,7 +224,14 @@ def _build_roster() -> tuple[list[dict], set[str]]:
     roster: list[dict] = []
     valid: set[str] = set()
     try:
-        all_profiles = profiles_mod.list_profiles()
+        all_profiles = profiles_mod.list_profiles(
+            include_model=False,
+            include_distribution=False,
+            include_gateway_status=False,
+            include_skill_count=False,
+            include_alias=False,
+            include_env=False,
+        )
     except Exception as exc:
         logger.warning("decompose: failed to list profiles: %s", exc)
         return roster, valid

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9422,7 +9422,15 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 seed_profile_skills,
             )
 
-            all_profiles = list_profiles()
+            all_profiles = list_profiles(
+                include_model=False,
+                include_distribution=False,
+                include_description=False,
+                include_gateway_status=False,
+                include_skill_count=False,
+                include_alias=False,
+                include_env=False,
+            )
             if all_profiles:
                 print()
                 print("→ Syncing bundled skills to all profiles...")

--- a/hermes_cli/profile_describer.py
+++ b/hermes_cli/profile_describer.py
@@ -291,7 +291,14 @@ def list_describable_profiles(*, missing_only: bool = True) -> list[str]:
     description. ``missing_only=False`` returns every profile.
     """
     out: list[str] = []
-    for p in profiles_mod.list_profiles():
+    for p in profiles_mod.list_profiles(
+        include_model=False,
+        include_distribution=False,
+        include_gateway_status=False,
+        include_skill_count=False,
+        include_alias=False,
+        include_env=False,
+    ):
         if missing_only and (p.description or "").strip() and not p.description_auto:
             continue
         out.append(p.name)

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -737,26 +737,55 @@ def write_profile_meta(
 # CRUD operations
 # ---------------------------------------------------------------------------
 
-def list_profiles() -> List[ProfileInfo]:
-    """Return info for all profiles, including the default."""
+def list_profiles(
+    *,
+    include_model: bool = True,
+    include_distribution: bool = True,
+    include_description: bool = True,
+    include_gateway_status: bool = True,
+    include_skill_count: bool = True,
+    include_alias: bool = True,
+    include_env: bool = True,
+) -> List[ProfileInfo]:
+    """Return info for all profiles, including the default.
+
+    Callers that only need profile names and directories should disable the
+    optional fields. Some of them cross expensive boundaries per profile:
+    ``include_skill_count`` walks the whole skills tree, ``include_gateway_status``
+    reads gateway runtime state, and the metadata flags parse YAML files.
+    """
     profiles = []
     wrapper_dir = _get_wrapper_dir()
 
     # Default profile
     default_home = _get_default_hermes_home()
     if default_home.is_dir():
-        model, provider = _read_config_model(default_home)
-        dist_name, dist_version, dist_source = _read_distribution_meta(default_home)
-        meta = read_profile_meta(default_home)
+        model, provider = (
+            _read_config_model(default_home) if include_model else (None, None)
+        )
+        dist_name, dist_version, dist_source = (
+            _read_distribution_meta(default_home)
+            if include_distribution
+            else (None, None, None)
+        )
+        meta = (
+            read_profile_meta(default_home)
+            if include_description
+            else {"description": "", "description_auto": False}
+        )
         profiles.append(ProfileInfo(
             name="default",
             path=default_home,
             is_default=True,
-            gateway_running=_check_gateway_running(default_home),
+            gateway_running=(
+                _check_gateway_running(default_home)
+                if include_gateway_status
+                else False
+            ),
             model=model,
             provider=provider,
-            has_env=(default_home / ".env").exists(),
-            skill_count=_count_skills(default_home),
+            has_env=(default_home / ".env").exists() if include_env else False,
+            skill_count=_count_skills(default_home) if include_skill_count else 0,
             distribution_name=dist_name,
             distribution_version=dist_version,
             distribution_source=dist_source,
@@ -775,24 +804,36 @@ def list_profiles() -> List[ProfileInfo]:
                 continue  # already added as the built-in default above
             if not _PROFILE_ID_RE.match(name):
                 continue
-            model, provider = _read_config_model(entry)
-            alias_name = find_alias_for_profile(name)
+            model, provider = (
+                _read_config_model(entry) if include_model else (None, None)
+            )
+            alias_name = find_alias_for_profile(name) if include_alias else None
             if alias_name:
                 is_windows = sys.platform == "win32"
                 alias_path = wrapper_dir / (f"{alias_name}.bat" if is_windows else alias_name)
             else:
                 alias_path = None
-            dist_name, dist_version, dist_source = _read_distribution_meta(entry)
-            meta = read_profile_meta(entry)
+            dist_name, dist_version, dist_source = (
+                _read_distribution_meta(entry)
+                if include_distribution
+                else (None, None, None)
+            )
+            meta = (
+                read_profile_meta(entry)
+                if include_description
+                else {"description": "", "description_auto": False}
+            )
             profiles.append(ProfileInfo(
                 name=name,
                 path=entry,
                 is_default=False,
-                gateway_running=_check_gateway_running(entry),
+                gateway_running=(
+                    _check_gateway_running(entry) if include_gateway_status else False
+                ),
                 model=model,
                 provider=provider,
-                has_env=(entry / ".env").exists(),
-                skill_count=_count_skills(entry),
+                has_env=(entry / ".env").exists() if include_env else False,
+                skill_count=_count_skills(entry) if include_skill_count else 0,
                 alias_path=alias_path if (alias_path and alias_path.exists()) else None,
                 alias_name=alias_name,
                 distribution_name=dist_name,

--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -436,7 +436,16 @@ def _discover_named_profiles():
     except Exception:
         return []
     try:
-        return [p for p in list_profiles() if not getattr(p, "is_default", False)]
+        return [
+            p for p in list_profiles(
+                include_model=False,
+                include_distribution=False,
+                include_description=False,
+                include_skill_count=False,
+                include_env=False,
+            )
+            if not getattr(p, "is_default", False)
+        ]
     except Exception as e:
         log_warn(f"Could not enumerate profiles: {e}")
         return []

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3257,7 +3257,15 @@ async def get_profiles_sessions(
         targets.append((name, home))
     else:
         try:
-            infos = profiles_mod.list_profiles()
+            infos = profiles_mod.list_profiles(
+                include_model=False,
+                include_distribution=False,
+                include_description=False,
+                include_gateway_status=False,
+                include_skill_count=False,
+                include_alias=False,
+                include_env=False,
+            )
             targets = [(info.name, info.path) for info in infos]
         except Exception:
             _log.exception("GET /api/profiles/sessions: list_profiles failed")

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -2123,7 +2123,12 @@ def list_profile_roster():
     """
     try:
         from hermes_cli import profiles as profiles_mod
-        profiles = profiles_mod.list_profiles()
+        profiles = profiles_mod.list_profiles(
+            include_distribution=False,
+            include_gateway_status=False,
+            include_alias=False,
+            include_env=False,
+        )
     except Exception as exc:
         raise HTTPException(status_code=500, detail=f"failed to list profiles: {exc}")
     return {

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -166,7 +166,15 @@ def cmd_sync(args) -> None:
     """
     try:
         from hermes_cli.profiles import list_profiles
-        profiles = list_profiles()
+        profiles = list_profiles(
+            include_model=False,
+            include_distribution=False,
+            include_description=False,
+            include_gateway_status=False,
+            include_skill_count=False,
+            include_alias=False,
+            include_env=False,
+        )
     except Exception as e:
         print(f"  Could not list profiles: {e}\n")
         return
@@ -211,7 +219,15 @@ def sync_honcho_profiles_quiet() -> int:
     """
     try:
         from hermes_cli.profiles import list_profiles
-        profiles = list_profiles()
+        profiles = list_profiles(
+            include_model=False,
+            include_distribution=False,
+            include_description=False,
+            include_gateway_status=False,
+            include_skill_count=False,
+            include_alias=False,
+            include_env=False,
+        )
     except Exception:
         return 0
 
@@ -996,7 +1012,15 @@ def _all_profile_host_configs() -> list[tuple[str, str, dict]]:
     """
     try:
         from hermes_cli.profiles import list_profiles
-        profiles = list_profiles()
+        profiles = list_profiles(
+            include_model=False,
+            include_distribution=False,
+            include_description=False,
+            include_gateway_status=False,
+            include_skill_count=False,
+            include_alias=False,
+            include_env=False,
+        )
     except Exception:
         return [(_active_profile_name(), _host_key(), {})]
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -617,6 +617,45 @@ class TestListProfiles:
         assert profiles[0].name == "default"
         assert profiles[0].is_default is True
 
+    def test_can_skip_expensive_detail_fields(self, profile_env):
+        create_profile("alpha", no_alias=True)
+
+        with patch("hermes_cli.profiles._read_config_model") as read_config, \
+             patch("hermes_cli.profiles._read_distribution_meta") as read_dist, \
+             patch("hermes_cli.profiles.read_profile_meta") as read_meta, \
+             patch("hermes_cli.profiles._check_gateway_running") as check_gateway, \
+             patch("hermes_cli.profiles._count_skills") as count_skills, \
+             patch("hermes_cli.profiles.find_alias_for_profile") as find_alias:
+            profiles = list_profiles(
+                include_model=False,
+                include_distribution=False,
+                include_description=False,
+                include_gateway_status=False,
+                include_skill_count=False,
+                include_alias=False,
+                include_env=False,
+            )
+
+        names = [p.name for p in profiles]
+        assert names == ["default", "alpha"]
+        for profile in profiles:
+            assert profile.model is None
+            assert profile.provider is None
+            assert profile.has_env is False
+            assert profile.distribution_name is None
+            assert profile.description == ""
+            assert profile.description_auto is False
+            assert profile.gateway_running is False
+            assert profile.skill_count == 0
+            assert profile.alias_name is None
+            assert profile.alias_path is None
+        read_config.assert_not_called()
+        read_dist.assert_not_called()
+        read_meta.assert_not_called()
+        check_gateway.assert_not_called()
+        count_skills.assert_not_called()
+        find_alias.assert_not_called()
+
 
 # ===================================================================
 # TestActiveProfile

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -534,7 +534,11 @@ class TestCrossProfileRead:
         from hermes_cli import profiles as profiles_mod
         Info = namedtuple("Info", "name path")
         monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: tmp_path / "default_home")
-        monkeypatch.setattr(profiles_mod, "list_profiles", lambda: [Info("asdf", other_home)])
+        monkeypatch.setattr(
+            profiles_mod,
+            "list_profiles",
+            lambda **_kwargs: [Info("asdf", other_home)],
+        )
 
         # `db` (current profile) lacks s_far; no profile passed → scan finds it.
         result = json.loads(session_search(session_id="s_far", db=db))

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -150,7 +150,16 @@ def _locate_session_db(session_id: str):
 
     targets = [("default", profiles_mod.get_profile_dir("default"))]
     try:
-        targets += [(info.name, info.path) for info in profiles_mod.list_profiles()]
+        infos = profiles_mod.list_profiles(
+            include_model=False,
+            include_distribution=False,
+            include_description=False,
+            include_gateway_status=False,
+            include_skill_count=False,
+            include_alias=False,
+            include_env=False,
+        )
+        targets += [(info.name, info.path) for info in infos]
     except Exception:
         logging.debug("list_profiles failed during session locate", exc_info=True)
 


### PR DESCRIPTION
## What does this PR do?

Adds opt-in lightweight profile listing so callers that only need profile names and directories do not pay every per-profile detail cost.

`list_profiles()` still returns the same full `ProfileInfo` data by default. New keyword-only flags let hot paths skip specific expensive details:

- `include_model` skips `config.yaml` parsing
- `include_distribution` skips `distribution.yaml` parsing
- `include_description` skips `profile.yaml` parsing
- `include_gateway_status` skips gateway PID/runtime-state checks
- `include_skill_count` skips recursive `skills/**/SKILL.md` counting
- `include_alias` skips wrapper alias scanning
- `include_env` skips `.env` existence checks

This keeps detailed surfaces such as `hermes profile list` and `/api/profiles` unchanged, while cheaper routing/sync paths use minimal profile records.

## Related Issue

N/A. I searched open issues/PRs for `profile list skills count performance` and did not find a direct duplicate.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/profiles.py`
  - Adds keyword-only include flags to `list_profiles()` with all defaults preserving current behavior.
  - Skips optional I/O and recursive scans when callers request lightweight profile records.
- Updated lightweight call sites that only need `name`/`path` or a narrow subset of fields:
  - update bundled-skill sync
  - session search cross-profile lookup
  - dashboard profile-session aggregation
  - gateway process discovery and gateway list
  - doctor profile checks
  - uninstall named-profile discovery
  - kanban decomposition profile roster
  - profile description listing
  - Honcho profile sync/status helpers
  - kanban dashboard profile roster
- Tests:
  - Adds a `list_profiles()` test proving expensive helpers are not called when detail flags are disabled.
  - Updates a session-search test double to accept the new keyword-only call shape.

## How to Test

1. Focused profile listing tests:

   ```bash
   uv run --with pytest --with pytest-timeout --with pytest-xdist python -m pytest tests/hermes_cli/test_profiles.py::TestListProfiles -q
   ```

   Result: `5 passed`

2. Distribution metadata compatibility:

   ```bash
   uv run --with pytest --with pytest-timeout --with pytest-xdist python -m pytest tests/hermes_cli/test_profile_distribution.py -q
   ```

   Result: `69 passed`

3. Kanban roster behavior:

   ```bash
   uv run --with pytest --with pytest-timeout --with pytest-xdist python -m pytest tests/hermes_cli/test_kanban_decompose.py -q
   ```

   Result: `9 passed`

4. Dashboard profile/session paths:

   ```bash
   uv run --with pytest --with pytest-timeout --with pytest-xdist python -m pytest tests/hermes_cli/test_web_server.py -k "profiles_sessions or profiles_list" -q
   ```

   Result: `4 passed, 311 deselected`

5. Session search:

   ```bash
   uv run --with pytest --with pytest-timeout --with pytest-xdist python -m pytest tests/tools/test_session_search.py -q
   ```

   Result: `47 passed`

6. Update profile skill sync:

   ```bash
   uv run --with pytest --with pytest-timeout --with pytest-xdist python -m pytest tests/hermes_cli/test_cmd_update.py::TestCmdUpdateProfileSkillSync -q
   ```

   Result: `2 passed`

7. Syntax and whitespace checks:

   ```bash
   python -m py_compile hermes_cli/profiles.py hermes_cli/main.py hermes_cli/gateway.py hermes_cli/doctor.py hermes_cli/uninstall.py hermes_cli/kanban_decompose.py hermes_cli/profile_describer.py hermes_cli/web_server.py tools/session_search_tool.py plugins/memory/honcho/cli.py plugins/kanban/dashboard/plugin_api.py tests/hermes_cli/test_profiles.py tests/tools/test_session_search.py
   git diff --check
   ```

   Result: passed.

I also tried a broader direct pytest run for `tests/hermes_cli/test_profiles.py tests/hermes_cli/test_profile_distribution.py tests/hermes_cli/test_kanban_decompose.py`; the new/related tests passed, but 5 existing profile tests failed on this Windows direct-pytest environment because of existing `cp949` default decoding and Windows chmod mode behavior. I did not change those unrelated tests in this PR.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, internal API behavior documented in code
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A.

## Screenshots / Logs

N/A. This is an internal profile-listing performance path change.

AI assistance: this PR was prepared with Codex assistance; I reviewed the diff and ran the verification listed above.
