### PR TITLE
fix(tests): find Windows virtualenvs in run_tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,7 +208,9 @@ source .venv/bin/activate   # or: source venv/bin/activate
 
 `scripts/run_tests.sh` probes `.venv` first, then `venv`, then
 `$HOME/.hermes/hermes-agent/venv` (for worktrees that share a venv with the
-main checkout).
+main checkout), and on Windows/Git Bash also checks the managed install venv
+under `%LOCALAPPDATA%\hermes\hermes-agent\venv`. The runner accepts both POSIX
+`bin/python` and Windows `Scripts/python.exe` virtualenv layouts.
 
 ## Project Structure
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -11,7 +11,7 @@
 #   * Env vars blanked (conftest.py also does this, but this
 #     is belt-and-suspenders for anyone running pytest outside our
 #     conftest path — e.g. on a single file)
-#   * Proper venv activation (probes .venv, venv, then ~/.hermes/...)
+#   * Proper venv Python selection (probes POSIX and Windows layouts)
 #
 # Usage:
 #   scripts/run_tests.sh                            # full suite
@@ -32,22 +32,86 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# ── Activate venv ───────────────────────────────────────────────────────────
+# ── Locate venv ─────────────────────────────────────────────────────────────
 VENV=""
-for candidate in "$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agent/venv"; do
-  if [ -f "$candidate/bin/activate" ]; then
+PYTHON=""
+venv_candidates=(
+  "$REPO_ROOT/.venv"
+  "$REPO_ROOT/venv"
+  "$HOME/.hermes/hermes-agent/venv"
+)
+
+# Git Bash exposes Windows env vars with Windows-style paths; normalize the
+# managed install venv path before probing for Scripts/python.exe.
+if [ -n "${LOCALAPPDATA:-}" ]; then
+  local_appdata="$LOCALAPPDATA"
+  if command -v cygpath >/dev/null 2>&1; then
+    local_appdata="$(cygpath -u "$LOCALAPPDATA" 2>/dev/null || printf '%s' "$LOCALAPPDATA")"
+  fi
+  venv_candidates+=("$local_appdata/hermes/hermes-agent/venv")
+fi
+
+for candidate in "${venv_candidates[@]}"; do
+  if [ -x "$candidate/bin/python" ]; then
     VENV="$candidate"
+    PYTHON="$candidate/bin/python"
+    break
+  fi
+  if [ -x "$candidate/Scripts/python.exe" ]; then
+    VENV="$candidate"
+    PYTHON="$candidate/Scripts/python.exe"
     break
   fi
 done
 
-if [ -z "$VENV" ]; then
-  echo "error: no virtualenv found in $REPO_ROOT/.venv or $REPO_ROOT/venv" >&2
+if [ -z "$PYTHON" ]; then
+  echo "error: no virtualenv Python found in:" >&2
+  for candidate in "${venv_candidates[@]}"; do
+    echo "  - $candidate" >&2
+  done
   exit 1
 fi
 
-PYTHON="$VENV/bin/python"
+# Windows Python ignores Git Bash's POSIX HOME when computing Path.home().
+# Provide isolated Windows user-data roots so collection-time imports can call
+# Path.home() / LOCALAPPDATA without seeing the developer's real Hermes state.
+RUNNER_TMPDIR=""
+WINDOWS_HOME_ENV=()
+cleanup_runner_tmpdir() {
+  if [ -n "$RUNNER_TMPDIR" ]; then
+    rm -rf "$RUNNER_TMPDIR"
+  fi
+}
 
+if "$PYTHON" - <<'PY' >/dev/null 2>&1
+import sys
+raise SystemExit(0 if sys.platform == "win32" else 1)
+PY
+then
+  RUNNER_TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/hermes-test-env.XXXXXX")"
+  trap cleanup_runner_tmpdir EXIT
+
+  userprofile_posix="$RUNNER_TMPDIR/UserProfile"
+  appdata_posix="$userprofile_posix/AppData/Roaming"
+  local_appdata_posix="$userprofile_posix/AppData/Local"
+  mkdir -p "$appdata_posix" "$local_appdata_posix"
+
+  if command -v cygpath >/dev/null 2>&1; then
+    userprofile_env="$(cygpath -w "$userprofile_posix")"
+    appdata_env="$(cygpath -w "$appdata_posix")"
+    local_appdata_env="$(cygpath -w "$local_appdata_posix")"
+  else
+    userprofile_env="$userprofile_posix"
+    appdata_env="$appdata_posix"
+    local_appdata_env="$local_appdata_posix"
+  fi
+
+  WINDOWS_HOME_ENV=(
+    "USERPROFILE=$userprofile_env"
+    "APPDATA=$appdata_env"
+    "LOCALAPPDATA=$local_appdata_env"
+  )
+fi
 
 # ── Live-gateway plugin (computed before we drop env) ───────────────────────
 EXTRA_PYTHONPATH=""
@@ -66,14 +130,16 @@ echo "  (TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; clean env)"
 
 cd "$REPO_ROOT"
 
-exec env -i \
+env -i \
   PATH="$PATH" \
   HOME="$HOME" \
   TZ=UTC \
   LANG=C.UTF-8 \
   LC_ALL=C.UTF-8 \
+  PYTHONIOENCODING=utf-8 \
   PYTHONHASHSEED=0 \
   PYTHONDONTWRITEBYTECODE=1 \
+  "${WINDOWS_HOME_ENV[@]}" \
   ${HERMES_RUN_SLOW_PET_TESTS:+HERMES_RUN_SLOW_PET_TESTS="$HERMES_RUN_SLOW_PET_TESTS"} \
   ${EXTRA_PYTHONPATH:+PYTHONPATH="$EXTRA_PYTHONPATH"} \
   ${EXTRA_PYTEST_PLUGINS:+PYTEST_PLUGINS="$EXTRA_PYTEST_PLUGINS"} \


### PR DESCRIPTION
## Summary
- teach `scripts/run_tests.sh` to locate Windows virtualenv layouts by probing `Scripts/python.exe` in addition to POSIX `bin/python`
- add the standard Windows managed install venv under `%LOCALAPPDATA%\hermes\hermes-agent\venv`, normalized through `cygpath` when running under Git Bash
- provide isolated Windows `USERPROFILE`/`APPDATA`/`LOCALAPPDATA` roots inside the hermetic test environment so Windows Python can resolve `Path.home()` without reading the developer's real Hermes state
- force `PYTHONIOENCODING=utf-8` in the hermetic test environment so Windows console encodings do not crash on runner progress output
- update the development guide to document the Windows/Git Bash venv lookup behavior

## Verification
- `& 'C:\Program Files\Git\bin\bash.exe' -n scripts/run_tests.sh`
- `git diff --check`
- `uv pip install --python .\.venv\Scripts\python.exe -e ".[dev]"`
- `& 'C:\Program Files\Git\bin\bash.exe' scripts/run_tests.sh tests/hermes_cli/test_aux_config.py`
  - `21 tests passed`