### PR TITLE
perf(model): reuse auth store during provider listing

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1447,7 +1447,7 @@ def list_authenticated_providers(
         fetch_models_dev,
         get_provider_info as _mdev_pinfo,
     )
-    from hermes_cli.auth import PROVIDER_REGISTRY
+    from hermes_cli.auth import PROVIDER_REGISTRY, _load_auth_store
     from hermes_cli.models import (
         OPENROUTER_MODELS, _PROVIDER_MODELS,
         _MODELS_DEV_PREFERRED, _merge_with_models_dev, cached_provider_model_ids,
@@ -1478,6 +1478,22 @@ def list_authenticated_providers(
 
     def _norm_url(url: str) -> str:
         return str(url or "").strip().rstrip("/").lower()
+
+    _auth_store_loaded = False
+    _auth_store_snapshot: dict = {}
+
+    def _auth_store_for_listing() -> dict:
+        """Return one auth-store snapshot for this picker listing call."""
+        nonlocal _auth_store_loaded, _auth_store_snapshot
+        if not _auth_store_loaded:
+            try:
+                store = _load_auth_store()
+                _auth_store_snapshot = store if isinstance(store, dict) else {}
+            except Exception as exc:
+                logger.debug("Auth store check failed for model picker: %s", exc)
+                _auth_store_snapshot = {}
+            _auth_store_loaded = True
+        return _auth_store_snapshot
 
     def _record_builtin_endpoint(slug: str) -> None:
         """Record the effective base URL for a built-in provider row.
@@ -1630,13 +1646,9 @@ def list_authenticated_providers(
         # Check if any env var is set
         has_creds = any(os.environ.get(ev) for ev in env_vars)
         if not has_creds:
-            try:
-                from hermes_cli.auth import _load_auth_store
-                store = _load_auth_store()
-                if store and store.get("credential_pool", {}).get(hermes_id):
-                    has_creds = True
-            except Exception:
-                pass
+            store = _auth_store_for_listing()
+            if store and store.get("credential_pool", {}).get(hermes_id):
+                has_creds = True
         if not has_creds:
             continue
 
@@ -1671,7 +1683,7 @@ def list_authenticated_providers(
 
     # --- 2. Check Hermes-only providers (nous, openai-codex, copilot, opencode-go) ---
     from hermes_cli.providers import HERMES_OVERLAYS
-    from hermes_cli.auth import PROVIDER_REGISTRY as _auth_registry
+    _auth_registry = PROVIDER_REGISTRY
 
     # Build reverse mapping: models.dev ID → Hermes provider ID.
     # HERMES_OVERLAYS keys may be models.dev IDs (e.g. "github-copilot")
@@ -1706,14 +1718,10 @@ def list_authenticated_providers(
         # support OAuth (e.g. anthropic supports both API key and Claude Code
         # OAuth via external credential files).
         if not has_creds:
-            try:
-                from hermes_cli.auth import _load_auth_store
-                store = _load_auth_store()
-                providers_store = store.get("providers", {})
-                if store and (pid in providers_store or hermes_slug in providers_store):
-                    has_creds = True
-            except Exception as exc:
-                logger.debug("Auth store check failed for %s: %s", pid, exc)
+            store = _auth_store_for_listing()
+            providers_store = store.get("providers", {}) if store else {}
+            if store and (pid in providers_store or hermes_slug in providers_store):
+                has_creds = True
         # Fallback: check the credential pool with full auto-seeding.
         # This catches credentials that exist in external stores (e.g.
         # Codex CLI ~/.codex/auth.json) which _seed_from_singletons()
@@ -1848,14 +1856,10 @@ def list_authenticated_providers(
             _cp_has_creds = any(os.environ.get(ev) for ev in _cp_config.api_key_env_vars)
         # Also check auth store and credential pool
         if not _cp_has_creds:
-            try:
-                from hermes_cli.auth import _load_auth_store
-                _cp_store = _load_auth_store()
-                _cp_providers_store = _cp_store.get("providers", {})
-                if _cp_store and _cp.slug in _cp_providers_store:
-                    _cp_has_creds = True
-            except Exception:
-                pass
+            _cp_store = _auth_store_for_listing()
+            _cp_providers_store = _cp_store.get("providers", {}) if _cp_store else {}
+            if _cp_store and _cp.slug in _cp_providers_store:
+                _cp_has_creds = True
         if not _cp_has_creds:
             try:
                 from agent.credential_pool import load_pool

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -767,3 +767,35 @@ def test_list_authenticated_providers_refresh_busts_cache():
         model_switch.list_authenticated_providers(refresh=True)
         assert clear.call_count == 1
 
+
+def test_list_authenticated_providers_reuses_auth_store_snapshot(monkeypatch):
+    """One picker listing should not reread auth.json for every provider row."""
+    from hermes_cli import model_switch
+
+    calls = 0
+
+    def _load_store_once():
+        nonlocal calls
+        calls += 1
+        return {"providers": {}, "credential_pool": {}}
+
+    class _EmptyPool:
+        def has_credentials(self):
+            return False
+
+    monkeypatch.setattr("hermes_cli.auth._load_auth_store", _load_store_once)
+    monkeypatch.setattr("agent.credential_pool.load_pool", lambda _provider: _EmptyPool())
+    monkeypatch.setattr(
+        "agent.models_dev.fetch_models_dev",
+        lambda: {
+            "openrouter": {"env": ["HERMES_TEST_OPENROUTER_KEY"]},
+            "anthropic": {"env": ["HERMES_TEST_ANTHROPIC_KEY"]},
+        },
+    )
+    monkeypatch.setattr("hermes_cli.models.get_curated_nous_model_ids", lambda: [])
+    monkeypatch.setattr("hermes_cli.models.fetch_ollama_cloud_models", lambda: [])
+
+    model_switch.list_authenticated_providers(max_models=0)
+
+    assert calls == 1
+


### PR DESCRIPTION
## Summary
- load the auth store at most once per `list_authenticated_providers()` call instead of rereading auth.json in each provider loop
- keep the cache scoped to a single picker listing call, avoiding global auth-store caching or `_load_auth_store()` contract changes
- reuse the same snapshot for models.dev providers, Hermes overlays, and canonical provider fallback checks
- add a regression test that exercises repeated provider checks and asserts a single auth-store read

## Verification
- `git diff --check`
- `& 'C:\Program Files\Git\bin\bash.exe' -n scripts/run_tests.sh`
- `& 'C:\Program Files\Git\bin\bash.exe' scripts/run_tests.sh tests/hermes_cli/test_inventory.py`
  - currently blocked on upstream main's Windows venv lookup: `error: no virtualenv found ... .venv or ... venv`
  - covered separately by #52435
- `.\.venv\Scripts\python.exe -m pytest tests/hermes_cli/test_inventory.py -q`
  - `35 passed`
- `.\.venv\Scripts\python.exe -m pytest tests/hermes_cli/test_inventory.py tests/hermes_cli/test_overlay_slug_resolution.py tests/hermes_cli/test_bedrock_model_picker.py tests/hermes_cli/test_model_switch_custom_providers.py -q`
  - `88 passed`