### PR TITLE
feat(gateway): optional model.allowlist to restrict /model targets

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -46,6 +46,22 @@ model:
   # api_key: "your-key-here"  # Uncomment to set here instead of .env
   base_url: "https://openrouter.ai/api/v1"
 
+  # ── Model allowlist (optional) ────────────────────────────────────────────
+  # Restrict which models the in-session `/model` command may switch to. When
+  # set, `/model` only offers these in its picker/list and refuses a switch to
+  # anything else (typed name, alias, or --provider auto-detect — checked on the
+  # resolved model). Leave unset/empty for no restriction (the default).
+  # Useful for a shared/hosted bot where an operator wants hires to switch only
+  # between a curated, tool-capable set. Entries must be the EXACT catalog model
+  # id that `/model` shows (not a short alias), matched case-insensitively; an
+  # alias entry is still refused on typed input but won't surface in the picker.
+  # This does NOT change `default` above, and it governs the in-session `/model`
+  # command (local operator surfaces are out of scope).
+  #
+  # allowlist:
+  #   - "anthropic/claude-opus-4.6"
+  #   - "google/gemini-2.5-flash-lite"
+
   # Azure Foundry keyless auth example:
   # provider: "azure-foundry"
   # base_url: "https://<resource>.openai.azure.com/openai/v1"

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -56,7 +56,8 @@ model:
   # id that `/model` shows (not a short alias), matched case-insensitively; an
   # alias entry is still refused on typed input but won't surface in the picker.
   # This does NOT change `default` above, and it governs the in-session `/model`
-  # command (local operator surfaces are out of scope).
+  # command (local operator surfaces are out of scope). Also editable from the
+  # dashboard Config page ("Model Allowlist", next to the Model field).
   #
   # allowlist:
   #   - "anthropic/claude-opus-4.6"

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -85,6 +85,58 @@ def _model_switch_skew_guard() -> Optional[str]:
     )
 
 
+def _normalize_model_allowlist(raw: Any) -> frozenset[str]:
+    """Normalize ``model.allowlist`` config into a set of lowercased model ids.
+
+    The allowlist restricts which models ``/model`` may switch to. Missing,
+    empty, or malformed config yields an EMPTY set, which the callers treat as
+    "no restriction" — so the feature is opt-in and the default behaviour is
+    unchanged.
+    """
+    if not isinstance(raw, (list, tuple)):
+        return frozenset()
+    return frozenset(
+        item.strip().lower()
+        for item in raw
+        if isinstance(item, str) and item.strip()
+    )
+
+
+def _model_blocked_by_allowlist(model: str, allowlist: frozenset[str]) -> bool:
+    """True when an allowlist is configured AND ``model`` is not in it.
+
+    An empty allowlist means unrestricted, so this never blocks then.
+    """
+    if not allowlist:
+        return False
+    return (model or "").strip().lower() not in allowlist
+
+
+def _filter_providers_to_allowlist(providers: list, allowlist: frozenset[str]) -> list:
+    """Return ``providers`` with each provider's ``models`` filtered to the
+    allowlist, dropping providers left with no allowed models.
+
+    Used to shape the ``/model`` picker + text list so a user only ever sees
+    models they're permitted to switch to. A no-op when the allowlist is empty.
+    """
+    if not allowlist:
+        return providers
+    filtered = []
+    for p in providers:
+        models = [
+            m for m in (p.get("models") or [])
+            if (m or "").strip().lower() in allowlist
+        ]
+        if not models:
+            continue
+        q = dict(p)
+        q["models"] = models
+        if "total_models" in q:
+            q["total_models"] = len(models)
+        filtered.append(q)
+    return filtered
+
+
 class GatewaySlashCommandsMixin:
     """In-session slash-command handlers for GatewayRunner."""
 
@@ -1497,6 +1549,9 @@ class GatewaySlashCommandsMixin:
         user_provs = None
         custom_provs = None
         excluded_provs = []
+        # Operator-configured allowlist of models /model may switch to. Empty =
+        # unrestricted (the default), so this feature is fully opt-in.
+        model_allowlist: frozenset[str] = frozenset()
         config_path = (_command_profile_home or _hermes_home) / "config.yaml"
         try:
             cfg = _load_gateway_config()
@@ -1506,6 +1561,7 @@ class GatewaySlashCommandsMixin:
                     current_model = model_cfg.get("default", "")
                     current_provider = model_cfg.get("provider", current_provider)
                     current_base_url = model_cfg.get("base_url", "")
+                    model_allowlist = _normalize_model_allowlist(model_cfg.get("allowlist"))
                 user_provs = cfg.get("providers")
                 try:
                     from hermes_cli.config import get_compatible_custom_providers
@@ -1556,12 +1612,19 @@ class GatewaySlashCommandsMixin:
                         current_model=current_model,
                         user_providers=user_provs,
                         custom_providers=custom_provs,
-                        max_models=50,
+                        # When an allowlist is active, don't pre-truncate: filter
+                        # the FULL catalog to the allowlist instead, so an allowed
+                        # model ranked outside the top-N isn't silently dropped.
+                        max_models=None if model_allowlist else 50,
                         include_moa=True,
                         excluded_providers=excluded_provs,
                     )
                 except Exception:
                     providers = []
+
+                # Shape the picker to the operator's allowlist so the user only
+                # sees models they're allowed to switch to (no-op when unset).
+                providers = _filter_providers_to_allowlist(providers, model_allowlist)
 
                 if providers:
                     # Build a callback closure for when the user picks a model.
@@ -1599,6 +1662,17 @@ class GatewaySlashCommandsMixin:
                         )
                         if not result.success:
                             return t("gateway.model.error_prefix", error=result.error_message)
+                        # Allowlist gate (defense in depth — the picker is already
+                        # filtered). Checked on the RESOLVED model so an alias or
+                        # provider auto-detect can't slip past the set, and BEFORE
+                        # any commit step (agent swap, session DB, override
+                        # write-through) so a blocked switch is a pure no-op.
+                        if _model_blocked_by_allowlist(result.new_model, model_allowlist):
+                            return t(
+                                "gateway.model.not_allowed",
+                                model=result.new_model,
+                                allowed=", ".join(sorted(model_allowlist)),
+                            )
 
                         try:
                             from hermes_cli.context_switch_guard import (
@@ -1837,9 +1911,15 @@ class GatewaySlashCommandsMixin:
                     current_model=current_model,
                     user_providers=user_provs,
                     custom_providers=custom_provs,
-                    max_models=5,
+                    # See the picker path: skip the top-N truncation when an
+                    # allowlist is active so a low-ranked allowed model still
+                    # shows (and the "+N more" hint stays truthful post-filter).
+                    max_models=None if model_allowlist else 5,
                     excluded_providers=excluded_provs,
                 )
+                # Restrict the listed models to the operator's allowlist (no-op
+                # when unset) so the text fallback matches the picker.
+                providers = _filter_providers_to_allowlist(providers, model_allowlist)
                 for p in providers:
                     tag = t("gateway.model.current_tag") if p["is_current"] else ""
                     lines.append(f"**{p['name']}** `--provider {p['slug']}`{tag}:")
@@ -1881,6 +1961,18 @@ class GatewaySlashCommandsMixin:
 
         if not result.success:
             return t("gateway.model.error_prefix", error=result.error_message)
+
+        # Allowlist gate for the typed path. Checked on the RESOLVED model (after
+        # alias expansion / --provider auto-detect) and BEFORE the expensive-model
+        # confirm and _finish_switch, so a disallowed switch is refused outright —
+        # no cost prompt, no session-DB persist, no override write-through, no
+        # config write. Empty allowlist = unrestricted.
+        if _model_blocked_by_allowlist(result.new_model, model_allowlist):
+            return t(
+                "gateway.model.not_allowed",
+                model=result.new_model,
+                allowed=", ".join(sorted(model_allowlist)),
+            )
 
         try:
             from hermes_cli.context_switch_guard import (

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -91,15 +91,29 @@ def _normalize_model_allowlist(raw: Any) -> frozenset[str]:
     The allowlist restricts which models ``/model`` may switch to. Missing,
     empty, or malformed config yields an EMPTY set, which the callers treat as
     "no restriction" — so the feature is opt-in and the default behaviour is
-    unchanged.
+    unchanged. Malformed shapes are logged so an operator who hand-edited
+    config.yaml (e.g. ``allowlist: some-model`` — a scalar, not a list) isn't
+    left believing a restriction is active when it isn't.
     """
-    if not isinstance(raw, (list, tuple)):
+    if raw is None:
         return frozenset()
-    return frozenset(
+    if not isinstance(raw, (list, tuple)):
+        logger.warning(
+            "model.allowlist is %s, expected a list of model ids — "
+            "treating as unrestricted",
+            type(raw).__name__,
+        )
+        return frozenset()
+    normalized = frozenset(
         item.strip().lower()
         for item in raw
         if isinstance(item, str) and item.strip()
     )
+    if raw and not normalized:
+        logger.warning(
+            "model.allowlist has no usable entries — treating as unrestricted"
+        )
+    return normalized
 
 
 def _model_blocked_by_allowlist(model: str, allowlist: frozenset[str]) -> bool:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -996,6 +996,13 @@ def _ensure_hermes_home_managed(home: Path):
 # =============================================================================
 
 DEFAULT_CONFIG = {
+    # ``model`` is intentionally a scalar here (the dashboard schema builder
+    # renders it as a flat string field). On disk it may also be a dict —
+    # ``model: {default, provider, base_url, context_length, allowlist}``.
+    # Dict-only subkeys are surfaced to the dashboard as virtual top-level
+    # fields (``model_context_length``, ``model_allowlist``) via the
+    # normalize/denormalize cycle in hermes_cli/web_server.py; their no-op
+    # defaults (0 = auto-detect, [] = no /model restriction) live there.
     "model": "",
     "providers": {},
     "fallback_providers": [],

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6762,7 +6762,16 @@ async def update_config(body: ConfigUpdate, profile: Optional[str] = None):
             # frontend can only overwrite what it explicitly sends.
             existing = read_raw_config()
             incoming = _denormalize_config_from_web(body.config)
-            save_config(_deep_merge(existing, incoming))
+            merged = _deep_merge(existing, incoming)
+            # _denormalize_config_from_web reconstructs the FULL ``model``
+            # section from the on-disk config (every subkey recovered) and
+            # intentionally pops keys the user just cleared (context_length
+            # back to auto, allowlist emptied). Deep-merging that dict over
+            # the raw disk section would resurrect exactly those popped keys,
+            # so replace the section wholesale instead.
+            if isinstance(incoming.get("model"), dict):
+                merged["model"] = incoming["model"]
+            save_config(merged)
         return {"ok": True}
     except HTTPException:
         raise

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -655,6 +655,14 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "description": "Context window override (0 = auto-detect from model metadata)",
         "category": "general",
     },
+    "model_allowlist": {
+        "type": "list",
+        "description": (
+            "Models the in-session /model command may switch to (exact catalog "
+            "ids, e.g. anthropic/claude-sonnet-4.6). Empty = no restriction."
+        ),
+        "category": "general",
+    },
     "terminal.backend": {
         "type": "select",
         "description": "Terminal execution backend",
@@ -856,14 +864,17 @@ def _build_schema_from_config(
 CONFIG_SCHEMA = _build_schema_from_config(DEFAULT_CONFIG)
 
 # Inject virtual fields that don't live in DEFAULT_CONFIG but are surfaced
-# by the normalize/denormalize cycle.  Insert model_context_length right after
-# the "model" key so it renders adjacent in the frontend.
+# by the normalize/denormalize cycle.  Insert model_context_length and
+# model_allowlist right after the "model" key so they render adjacent in the
+# frontend (all three edit the same on-disk ``model:`` section).
 _mcl_entry = _SCHEMA_OVERRIDES["model_context_length"]
+_mal_entry = _SCHEMA_OVERRIDES["model_allowlist"]
 _ordered_schema: Dict[str, Dict[str, Any]] = {}
 for _k, _v in CONFIG_SCHEMA.items():
     _ordered_schema[_k] = _v
     if _k == "model":
         _ordered_schema["model_context_length"] = _mcl_entry
+        _ordered_schema["model_allowlist"] = _mal_entry
 CONFIG_SCHEMA = _ordered_schema
 
 
@@ -4739,19 +4750,44 @@ def _normalize_config_for_web(config: Dict[str, Any]) -> Dict[str, Any]:
     from DEFAULT_CONFIG where ``model`` is a string, but user configs often have the
     dict form.  Normalize to the string form so the frontend schema matches.
 
-    Also surfaces ``model_context_length`` as a top-level field so the web UI can
-    display and edit it.  A value of 0 means "auto-detect".
+    Also surfaces ``model_context_length`` and ``model_allowlist`` as top-level
+    fields so the web UI can display and edit them.  A context length of 0
+    means "auto-detect"; an empty allowlist means "no restriction" (both are
+    the explicit no-op defaults, emitted even when the subkey is absent so the
+    dashboard always renders the fields).
     """
     config = dict(config)  # shallow copy
     model_val = config.get("model")
     if isinstance(model_val, dict):
-        # Extract context_length before flattening the dict
+        # Extract context_length + allowlist before flattening the dict
         ctx_len = model_val.get("context_length", 0)
+        raw_allow = model_val.get("allowlist")
         config["model"] = model_val.get("default", model_val.get("name", ""))
         config["model_context_length"] = ctx_len if isinstance(ctx_len, int) else 0
+        config["model_allowlist"] = _sanitize_model_allowlist(raw_allow)
     else:
         config["model_context_length"] = 0
+        config["model_allowlist"] = []
     return config
+
+
+def _sanitize_model_allowlist(raw: Any) -> List[str]:
+    """Coerce a ``model.allowlist`` value into a clean list of model ids.
+
+    Keeps non-empty strings (trimmed, order-preserving, de-duplicated); a
+    missing or malformed value yields ``[]`` — the no-op "no restriction"
+    default the gateway's ``/model`` gate also uses.
+    """
+    if not isinstance(raw, (list, tuple)):
+        return []
+    out: List[str] = []
+    for item in raw:
+        if not isinstance(item, str):
+            continue
+        item = item.strip()
+        if item and item not in out:
+            out.append(item)
+    return out
 
 
 # ── Memory provider config: one generic GET/PUT pair, dispatching on storage ──
@@ -6629,6 +6665,11 @@ def _denormalize_config_from_web(config: Dict[str, Any]) -> Dict[str, Any]:
     Also handles ``model_context_length`` — writes it back into the model dict
     as ``context_length``.  A value of 0 or absent means "auto-detect" (omitted
     from the dict so get_model_context_length() uses its normal resolution).
+
+    ``model_allowlist`` gets the same treatment — written back into the model
+    dict as ``allowlist``; an empty list means "no restriction" (key removed).
+    A payload that omits the field entirely (older frontend) leaves the
+    on-disk allowlist untouched.
     """
     config = dict(config)
     # Remove any _model_meta that might have leaked in (shouldn't happen
@@ -6642,6 +6683,11 @@ def _denormalize_config_from_web(config: Dict[str, Any]) -> Dict[str, Any]:
             ctx_override = int(ctx_override)
         except (TypeError, ValueError):
             ctx_override = 0
+
+    # Extract and remove model_allowlist before processing model. "Present
+    # but empty" clears the on-disk allowlist; "absent" preserves it.
+    allow_present = "model_allowlist" in config
+    allow_override = _sanitize_model_allowlist(config.pop("model_allowlist", None))
 
     model_val = config.get("model")
     if isinstance(model_val, str) and model_val:
@@ -6682,14 +6728,23 @@ def _denormalize_config_from_web(config: Dict[str, Any]) -> Dict[str, Any]:
                     disk_model["context_length"] = ctx_override
                 else:
                     disk_model.pop("context_length", None)
+                # Write allowlist into the model dict (empty = remove — the
+                # explicit "no restriction" default); absent = leave as-is.
+                if allow_present:
+                    if allow_override:
+                        disk_model["allowlist"] = allow_override
+                    else:
+                        disk_model.pop("allowlist", None)
                 config["model"] = disk_model
-            # Model was previously a bare string — upgrade to dict if
-            # user is setting a context_length override
-            elif ctx_override > 0:
-                config["model"] = {
-                    "default": model_val,
-                    "context_length": ctx_override,
-                }
+            # Model was previously a bare string — upgrade to dict if the
+            # user is setting a context_length or allowlist override
+            elif ctx_override > 0 or (allow_present and allow_override):
+                new_model: Dict[str, Any] = {"default": model_val}
+                if ctx_override > 0:
+                    new_model["context_length"] = ctx_override
+                if allow_present and allow_override:
+                    new_model["allowlist"] = allow_override
+                config["model"] = new_model
         except Exception:
             pass  # can't read disk config — just use the string form
     return config

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -37,6 +37,7 @@ gateway:
     capabilities_label:     "Vermoëns: {capabilities}"
     prompt_caching_enabled: "Prompt-kasing: geaktiveer"
     warning_prefix:         "Waarskuwing: {warning}"
+    not_allowed:            "`{model}` is nie op hierdie bot se lys van toegelate modelle nie. Toegelaat: {allowed}"
     saved_global:           "Gestoor in config.yaml (`--global`)"
     session_only_hint:      "_(slegs sessie — voeg `--global` by om permanent te stoor)_"
     current_label:          "Huidig: `{model}` op {provider}"

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -37,6 +37,7 @@ gateway:
     capabilities_label:     "Fähigkeiten: {capabilities}"
     prompt_caching_enabled: "Prompt-Caching: aktiviert"
     warning_prefix:         "Warnung: {warning}"
+    not_allowed:            "`{model}` steht nicht auf der Liste der erlaubten Modelle dieses Bots. Erlaubt: {allowed}"
     saved_global:           "In config.yaml gespeichert (`--global`)"
     session_only_hint:      "_(nur für diese Sitzung — `--global` ergänzen, um zu speichern)_"
     current_label:          "Aktuell: `{model}` bei {provider}"

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -52,6 +52,7 @@ gateway:
     capabilities_label:     "Capabilities: {capabilities}"
     prompt_caching_enabled: "Prompt caching: enabled"
     warning_prefix:         "Warning: {warning}"
+    not_allowed:            "`{model}` is not in this bot's allowed model list. Allowed: {allowed}"
     saved_global:           "Saved to config.yaml (`--global`)"
     session_only_hint:      "_(session only — add `--global` to persist)_"
     current_label:          "Current: `{model}` on {provider}"

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -37,6 +37,7 @@ gateway:
     capabilities_label:     "Capacidades: {capabilities}"
     prompt_caching_enabled: "Caché de prompts: activado"
     warning_prefix:         "Advertencia: {warning}"
+    not_allowed:            "`{model}` no está en la lista de modelos permitidos de este bot. Permitidos: {allowed}"
     saved_global:           "Guardado en config.yaml (`--global`)"
     session_only_hint:      "_(solo para esta sesión — añade `--global` para guardarlo)_"
     current_label:          "Actual: `{model}` en {provider}"

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -37,6 +37,7 @@ gateway:
     capabilities_label:     "Capacités : {capabilities}"
     prompt_caching_enabled: "Cache de prompts : activé"
     warning_prefix:         "Avertissement : {warning}"
+    not_allowed:            "`{model}` ne figure pas dans la liste des modèles autorisés de ce bot. Autorisés : {allowed}"
     saved_global:           "Enregistré dans config.yaml (`--global`)"
     session_only_hint:      "_(session uniquement — ajoutez `--global` pour conserver)_"
     current_label:          "Actuel : `{model}` chez {provider}"

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -41,6 +41,7 @@ gateway:
     capabilities_label:     "Cumais: {capabilities}"
     prompt_caching_enabled: "Taisceadh leid: cumasaithe"
     warning_prefix:         "Rabhadh: {warning}"
+    not_allowed:            "Níl `{model}` ar liosta na múnlaí ceadaithe don bhota seo. Ceadaithe: {allowed}"
     saved_global:           "Sábháilte i config.yaml (`--global`)"
     session_only_hint:      "_(seisiún amháin — cuir `--global` leis chun é a choinneáil)_"
     current_label:          "Reatha: `{model}` ar {provider}"

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -37,6 +37,7 @@ gateway:
     capabilities_label:     "Képességek: {capabilities}"
     prompt_caching_enabled: "Prompt-gyorsítótárazás: bekapcsolva"
     warning_prefix:         "Figyelmeztetés: {warning}"
+    not_allowed:            "`{model}` nincs rajta ennek a botnak az engedélyezett modelljei listáján. Engedélyezett: {allowed}"
     saved_global:           "Mentve a config.yaml fájlba (`--global`)"
     session_only_hint:      "_(csak ehhez a munkamenethez — add hozzá a `--global` opciót a megőrzéshez)_"
     current_label:          "Aktuális: `{model}` ezen: {provider}"

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -37,6 +37,7 @@ gateway:
     capabilities_label:     "Capacità: {capabilities}"
     prompt_caching_enabled: "Caching dei prompt: attivo"
     warning_prefix:         "Avviso: {warning}"
+    not_allowed:            "`{model}` non è nell'elenco dei modelli consentiti di questo bot. Consentiti: {allowed}"
     saved_global:           "Salvato in config.yaml (`--global`)"
     session_only_hint:      "_(solo per questa sessione — aggiungi `--global` per renderlo permanente)_"
     current_label:          "Attuale: `{model}` su {provider}"

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -37,6 +37,7 @@ gateway:
     capabilities_label:     "機能: {capabilities}"
     prompt_caching_enabled: "プロンプトキャッシュ: 有効"
     warning_prefix:         "警告: {warning}"
+    not_allowed:            "`{model}` はこのボットの許可モデル一覧にありません。許可されているモデル：{allowed}"
     saved_global:           "config.yaml に保存しました (`--global`)"
     session_only_hint:      "_(このセッションのみ — 永続化するには `--global` を追加)_"
     current_label:          "現在: `{model}` ({provider})"

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -37,6 +37,7 @@ gateway:
     capabilities_label:     "기능: {capabilities}"
     prompt_caching_enabled: "프롬프트 캐싱: 활성화됨"
     warning_prefix:         "경고: {warning}"
+    not_allowed:            "`{model}`은(는) 이 봇에서 허용된 모델 목록에 없습니다. 허용된 모델: {allowed}"
     saved_global:           "config.yaml에 저장됨 (`--global`)"
     session_only_hint:      "_(세션 한정 — 영구 저장하려면 `--global`을 추가하세요)_"
     current_label:          "현재: `{model}` ({provider})"

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -37,6 +37,7 @@ gateway:
     capabilities_label:     "Capacidades: {capabilities}"
     prompt_caching_enabled: "Cache de prompts: ativado"
     warning_prefix:         "Aviso: {warning}"
+    not_allowed:            "`{model}` não está na lista de modelos permitidos deste bot. Permitidos: {allowed}"
     saved_global:           "Guardado em config.yaml (`--global`)"
     session_only_hint:      "_(apenas para esta sessão — adiciona `--global` para tornar permanente)_"
     current_label:          "Atual: `{model}` em {provider}"

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -37,6 +37,7 @@ gateway:
     capabilities_label:     "Возможности: {capabilities}"
     prompt_caching_enabled: "Кеширование промптов: включено"
     warning_prefix:         "Предупреждение: {warning}"
+    not_allowed:            "`{model}` отсутствует в списке разрешённых моделей этого бота. Разрешённые: {allowed}"
     saved_global:           "Сохранено в config.yaml (`--global`)"
     session_only_hint:      "_(только для этого сеанса — добавьте `--global`, чтобы сохранить)_"
     current_label:          "Текущая: `{model}` на {provider}"

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -37,6 +37,7 @@ gateway:
     capabilities_label:     "Yetenekler: {capabilities}"
     prompt_caching_enabled: "Prompt önbelleği: etkin"
     warning_prefix:         "Uyarı: {warning}"
+    not_allowed:            "`{model}` bu botun izin verilen model listesinde yok. İzin verilenler: {allowed}"
     saved_global:           "config.yaml'a kaydedildi (`--global`)"
     session_only_hint:      "_(yalnızca bu oturum — kalıcı yapmak için `--global` ekleyin)_"
     current_label:          "Geçerli: `{model}` ({provider})"

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -37,6 +37,7 @@ gateway:
     capabilities_label:     "Можливості: {capabilities}"
     prompt_caching_enabled: "Кешування промптів: увімкнено"
     warning_prefix:         "Попередження: {warning}"
+    not_allowed:            "`{model}` немає у списку дозволених моделей цього бота. Дозволені: {allowed}"
     saved_global:           "Збережено в config.yaml (`--global`)"
     session_only_hint:      "_(лише для цього сеансу — додайте `--global`, щоб зберегти)_"
     current_label:          "Поточна: `{model}` на {provider}"

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -37,6 +37,7 @@ gateway:
     capabilities_label:     "能力：{capabilities}"
     prompt_caching_enabled: "提示快取：已啟用"
     warning_prefix:         "警告：{warning}"
+    not_allowed:            "`{model}` 不在此機器人的允許模型清單中。允許的模型：{allowed}"
     saved_global:           "已儲存到 config.yaml（`--global`）"
     session_only_hint:      "_（僅本次工作階段有效 — 加上 `--global` 可永久儲存）_"
     current_label:          "目前：`{model}`（{provider}）"

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -37,6 +37,7 @@ gateway:
     capabilities_label:     "能力：{capabilities}"
     prompt_caching_enabled: "提示词缓存：已启用"
     warning_prefix:         "警告：{warning}"
+    not_allowed:            "`{model}` 不在此机器人的允许模型列表中。允许的模型：{allowed}"
     saved_global:           "已保存到 config.yaml（`--global`）"
     session_only_hint:      "_（仅本次会话有效 — 添加 `--global` 可永久保存）_"
     current_label:          "当前：`{model}`（{provider}）"

--- a/tests/gateway/test_model_command_allowlist.py
+++ b/tests/gateway/test_model_command_allowlist.py
@@ -1,0 +1,263 @@
+"""Gateway ``/model`` must honour an operator-configured ``model.allowlist``.
+
+When ``model.allowlist`` is set in config.yaml, ``/model`` may only switch to a
+model in that set; a disallowed target (typed name, alias, or ``--provider``
+auto-detect, checked on the RESOLVED model) is refused and nothing is applied.
+An empty / unset allowlist means no restriction (the default), preserving the
+prior behaviour. The picker + text list are also filtered to the allowlist.
+"""
+
+import types
+
+import pytest
+import yaml
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+from gateway.slash_commands import (
+    _filter_providers_to_allowlist,
+    _model_blocked_by_allowlist,
+    _normalize_model_allowlist,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure-helper unit tests (no event loop, no config)
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_allowlist_handles_missing_and_malformed():
+    assert _normalize_model_allowlist(None) == frozenset()
+    assert _normalize_model_allowlist("not-a-list") == frozenset()
+    assert _normalize_model_allowlist([]) == frozenset()
+    # lowercases, trims, drops blanks + non-strings
+    assert _normalize_model_allowlist(["A/B", " c/d ", "", 5, None]) == frozenset(
+        {"a/b", "c/d"}
+    )
+
+
+def test_blocked_by_allowlist_semantics():
+    allow = frozenset({"a/b", "c/d"})
+    # an empty allowlist never blocks (unrestricted default)
+    assert _model_blocked_by_allowlist("anything", frozenset()) is False
+    # membership is case- and whitespace-insensitive
+    assert _model_blocked_by_allowlist("A/B", allow) is False
+    assert _model_blocked_by_allowlist("  c/d ", allow) is False
+    # anything outside the set is blocked, including empty
+    assert _model_blocked_by_allowlist("e/f", allow) is True
+    assert _model_blocked_by_allowlist("", allow) is True
+
+
+def test_filter_providers_drops_disallowed_models_and_empty_providers():
+    allow = frozenset({"a/b"})
+    providers = [
+        {"name": "P1", "slug": "p1", "models": ["a/b", "x/y"], "total_models": 2},
+        {"name": "P2", "slug": "p2", "models": ["x/y"], "total_models": 1},
+    ]
+    out = _filter_providers_to_allowlist(providers, allow)
+    assert len(out) == 1
+    assert out[0]["slug"] == "p1"
+    assert out[0]["models"] == ["a/b"]
+    assert out[0]["total_models"] == 1
+    # no-op (same object) when the allowlist is empty
+    assert _filter_providers_to_allowlist(providers, frozenset()) is providers
+
+
+# ---------------------------------------------------------------------------
+# Handler gate tests (mirror tests/gateway/test_model_command_expensive_confirm)
+# ---------------------------------------------------------------------------
+
+
+def _make_runner():
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner._session_model_overrides = {}
+    runner._running_agents = {}
+    runner._evict_cached_agent = lambda session_key: None
+    return runner
+
+
+def _make_event(text):
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm"),
+    )
+
+
+def _setup_home(tmp_path, monkeypatch, *, allowlist):
+    """Isolated HERMES_HOME whose config carries (or omits) model.allowlist.
+
+    ``switch_model`` is stubbed to ECHO the requested model as ``new_model`` so
+    the allowlist gate (which checks the resolved model) is driven by the input.
+    The expensive-model warning is stubbed off so an allowed switch applies
+    immediately rather than routing through the confirm gate.
+    """
+    import gateway.run as gateway_run
+    from hermes_cli.model_switch import ModelSwitchResult
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    model_cfg = {"default": "old-model", "provider": "openrouter"}
+    if allowlist is not None:
+        model_cfg["allowlist"] = allowlist
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"model": model_cfg, "providers": {}}), encoding="utf-8"
+    )
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: hermes_home)
+    monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: hermes_home)
+    monkeypatch.setattr(
+        "hermes_cli.model_cost_guard.expensive_model_warning",
+        lambda *a, **kw: None,
+    )
+
+    def _fake_switch(**kw):
+        return ModelSwitchResult(
+            success=True,
+            new_model=kw["raw_input"],
+            target_provider="openrouter",
+            provider_changed=False,
+            api_key="sk-test",
+            base_url="https://openrouter.ai/api/v1",
+            api_mode="chat_completions",
+            provider_label="OpenRouter",
+        )
+
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", _fake_switch)
+
+
+@pytest.mark.asyncio
+async def test_disallowed_model_is_refused(tmp_path, monkeypatch):
+    """A typed model outside the allowlist is refused; nothing is applied."""
+    _setup_home(tmp_path, monkeypatch, allowlist=["allowed/one", "allowed/two"])
+    runner = _make_runner()
+
+    result = await runner._handle_model_command(_make_event("/model evil/model"))
+
+    assert result is not None
+    assert "not in this bot's allowed model list" in result
+    assert runner._session_model_overrides == {}
+
+
+@pytest.mark.asyncio
+async def test_allowed_model_switches(tmp_path, monkeypatch):
+    """A model in the allowlist switches normally."""
+    _setup_home(tmp_path, monkeypatch, allowlist=["allowed/one", "allowed/two"])
+    runner = _make_runner()
+
+    result = await runner._handle_model_command(_make_event("/model allowed/two"))
+
+    assert result is not None
+    overrides = list(runner._session_model_overrides.values())
+    assert len(overrides) == 1
+    assert overrides[0]["model"] == "allowed/two"
+
+
+@pytest.mark.asyncio
+async def test_allowlist_membership_is_case_insensitive(tmp_path, monkeypatch):
+    """Allowlist matching ignores case, so a differently-cased id still passes."""
+    _setup_home(tmp_path, monkeypatch, allowlist=["Allowed/One"])
+    runner = _make_runner()
+
+    result = await runner._handle_model_command(_make_event("/model allowed/one"))
+
+    overrides = list(runner._session_model_overrides.values())
+    assert len(overrides) == 1
+    assert overrides[0]["model"] == "allowed/one"
+
+
+@pytest.mark.asyncio
+async def test_no_allowlist_allows_any_model(tmp_path, monkeypatch):
+    """With no allowlist configured, any model switches (back-compat)."""
+    _setup_home(tmp_path, monkeypatch, allowlist=None)
+    runner = _make_runner()
+
+    result = await runner._handle_model_command(_make_event("/model any/model"))
+
+    assert result is not None
+    overrides = list(runner._session_model_overrides.values())
+    assert len(overrides) == 1
+    assert overrides[0]["model"] == "any/model"
+
+
+@pytest.mark.asyncio
+async def test_gate_checks_resolved_model_not_typed_string(tmp_path, monkeypatch):
+    """The gate must check the RESOLVED model, not the typed string.
+
+    Mutation guard: the typed token "allowed/one" IS in the allowlist, but the
+    resolver maps it to "resolved/blocked" (simulating an alias / --provider
+    auto-detect). A gate that checked the typed string would wrongly allow it; a
+    correct gate checks result.new_model and refuses. This pins the choice and
+    fails if someone "simplifies" the check to use model_input.
+    """
+    _setup_home(tmp_path, monkeypatch, allowlist=["allowed/one"])
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model",
+        lambda **kw: __import__("hermes_cli.model_switch", fromlist=["ModelSwitchResult"]).ModelSwitchResult(
+            success=True,
+            new_model="resolved/blocked",  # resolves to something NOT allowlisted
+            target_provider="openrouter",
+            provider_changed=False,
+            api_key="sk-test",
+            base_url="https://openrouter.ai/api/v1",
+            api_mode="chat_completions",
+            provider_label="OpenRouter",
+        ),
+    )
+    runner = _make_runner()
+
+    result = await runner._handle_model_command(_make_event("/model allowed/one"))
+
+    assert result is not None
+    assert "not in this bot's allowed model list" in result
+    assert "resolved/blocked" in result  # message names the resolved id
+    assert runner._session_model_overrides == {}
+
+
+class _FakePickerAdapter:
+    """Picker-capable adapter that captures the on_model_selected closure.
+
+    _handle_model_command gates the picker path on
+    ``getattr(type(adapter), "send_model_picker", None) is not None``, so the
+    method must exist on the class. Mirrors tests/gateway/test_model_picker_persist.
+    """
+
+    def __init__(self):
+        self.captured_callback = None
+
+    async def send_model_picker(self, *, on_model_selected, **kwargs):
+        self.captured_callback = on_model_selected
+        return types.SimpleNamespace(success=True)
+
+
+@pytest.mark.asyncio
+async def test_picker_callback_refuses_disallowed_model(tmp_path, monkeypatch):
+    """The interactive-picker callback enforces the allowlist too (defense in
+    depth — the picker is already filtered, but a tap on a disallowed id, e.g.
+    from a stale keyboard, must still be refused with no side effect)."""
+    _setup_home(tmp_path, monkeypatch, allowlist=["allowed/one"])
+    # The picker setup path lists providers; return one allowed model so the
+    # picker is shown and the callback is captured.
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.list_picker_providers",
+        lambda **kw: [{"slug": "openrouter", "name": "OpenRouter", "models": ["allowed/one"]}],
+    )
+    adapter = _FakePickerAdapter()
+    runner = _make_runner()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+
+    # Bare /model sends the picker (returns None) and wires the callback.
+    sent = await runner._handle_model_command(_make_event("/model"))
+    assert sent is None
+    assert adapter.captured_callback is not None, "picker callback was not wired"
+
+    # Fire a tap on a disallowed model id — must be refused, nothing applied.
+    reply = await adapter.captured_callback("12345", "evil/model", "openrouter")
+    assert "not in this bot's allowed model list" in reply
+    assert runner._session_model_overrides == {}

--- a/tests/gateway/test_model_command_allowlist.py
+++ b/tests/gateway/test_model_command_allowlist.py
@@ -230,9 +230,11 @@ class _FakePickerAdapter:
 
     def __init__(self):
         self.captured_callback = None
+        self.captured_providers = None
 
     async def send_model_picker(self, *, on_model_selected, **kwargs):
         self.captured_callback = on_model_selected
+        self.captured_providers = kwargs.get("providers")
         return types.SimpleNamespace(success=True)
 
 
@@ -261,3 +263,118 @@ async def test_picker_callback_refuses_disallowed_model(tmp_path, monkeypatch):
     reply = await adapter.captured_callback("12345", "evil/model", "openrouter")
     assert "not in this bot's allowed model list" in reply
     assert runner._session_model_overrides == {}
+
+
+@pytest.mark.asyncio
+async def test_picker_payload_is_filtered_and_uncapped(tmp_path, monkeypatch):
+    """The providers actually SENT to send_model_picker are pre-filtered to
+    the allowlist, and the catalog fetch is uncapped (max_models=None) so an
+    allowed model ranked outside the default top-N still surfaces.
+
+    Mutation guard: deleting the _filter_providers_to_allowlist call on the
+    picker path would pass every other test in this file — the picker test
+    above only exercises the callback."""
+    _setup_home(tmp_path, monkeypatch, allowlist=["allowed/one"])
+    captured_kwargs = {}
+
+    def _fake_list(**kw):
+        captured_kwargs.update(kw)
+        return [
+            {"slug": "openrouter", "name": "OpenRouter",
+             "models": ["allowed/one", "evil/model"], "total_models": 2},
+            {"slug": "other", "name": "Other",
+             "models": ["evil/model2"], "total_models": 1},
+        ]
+
+    monkeypatch.setattr("hermes_cli.model_switch.list_picker_providers", _fake_list)
+    adapter = _FakePickerAdapter()
+    runner = _make_runner()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+
+    sent = await runner._handle_model_command(_make_event("/model"))
+
+    assert sent is None
+    assert captured_kwargs.get("max_models") is None, (
+        "an active allowlist must uncap the catalog fetch so allowed models "
+        "outside the default top-N aren't silently dropped"
+    )
+    provs = adapter.captured_providers
+    assert provs is not None
+    assert [p["slug"] for p in provs] == ["openrouter"]  # empty provider dropped
+    assert provs[0]["models"] == ["allowed/one"]
+    assert provs[0]["total_models"] == 1  # "+N more" hint stays truthful
+
+
+@pytest.mark.asyncio
+async def test_blocked_model_never_reaches_expensive_confirm(tmp_path, monkeypatch):
+    """Gate ordering pin: a blocked switch is refused OUTRIGHT — the
+    expensive-model confirm prompt must not fire first. Moving the gate below
+    the cost confirm would go undetected by every other test here (they all
+    stub the warning off)."""
+    _setup_home(tmp_path, monkeypatch, allowlist=["allowed/one"])
+    monkeypatch.setattr(
+        "hermes_cli.model_cost_guard.expensive_model_warning",
+        lambda *a, **kw: types.SimpleNamespace(message="!!! EXPENSIVE MODEL WARNING !!!"),
+    )
+    runner = _make_runner()
+    confirm_calls = []
+
+    async def _fake_confirm(**kwargs):
+        confirm_calls.append(kwargs)
+        return kwargs.get("message")
+
+    runner._request_slash_confirm = _fake_confirm
+
+    result = await runner._handle_model_command(_make_event("/model evil/model"))
+
+    assert "not in this bot's allowed model list" in result
+    assert confirm_calls == [], "blocked model must never see the cost prompt"
+    assert runner._session_model_overrides == {}
+
+
+@pytest.mark.asyncio
+async def test_allowed_expensive_model_still_prompts(tmp_path, monkeypatch):
+    """Companion to the ordering pin above (proves the empty confirm_calls
+    there isn't vacuous): an ALLOWED expensive model does route through the
+    confirm gate."""
+    _setup_home(tmp_path, monkeypatch, allowlist=["allowed/one"])
+    monkeypatch.setattr(
+        "hermes_cli.model_cost_guard.expensive_model_warning",
+        lambda *a, **kw: types.SimpleNamespace(message="!!! EXPENSIVE MODEL WARNING !!!"),
+    )
+    runner = _make_runner()
+    confirm_calls = []
+
+    async def _fake_confirm(**kwargs):
+        confirm_calls.append(kwargs)
+        return kwargs.get("message")
+
+    runner._request_slash_confirm = _fake_confirm
+
+    result = await runner._handle_model_command(_make_event("/model allowed/one"))
+
+    assert len(confirm_calls) == 1
+    assert "EXPENSIVE MODEL WARNING" in result
+    # Prompted, not yet applied
+    assert runner._session_model_overrides == {}
+
+
+@pytest.mark.asyncio
+async def test_text_list_fallback_is_filtered(tmp_path, monkeypatch):
+    """Without a picker-capable adapter, bare /model falls back to the text
+    list — which must be filtered to the allowlist just like the picker."""
+    _setup_home(tmp_path, monkeypatch, allowlist=["allowed/one"])
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.list_authenticated_providers",
+        lambda **kw: [
+            {"slug": "openrouter", "name": "OpenRouter", "is_current": True,
+             "models": ["allowed/one", "evil/model"], "total_models": 2},
+        ],
+    )
+    runner = _make_runner()  # no adapters → text fallback
+
+    result = await runner._handle_model_command(_make_event("/model"))
+
+    assert result is not None
+    assert "allowed/one" in result
+    assert "evil/model" not in result

--- a/tests/hermes_cli/test_web_config_model_allowlist.py
+++ b/tests/hermes_cli/test_web_config_model_allowlist.py
@@ -153,3 +153,72 @@ def test_normalize_denormalize_roundtrip_is_stable(monkeypatch):
     assert out["model"]["allowlist"] == ["x/y"]
     assert out["model"]["default"] == "a/b"
     assert out["model"]["provider"] == "openrouter"
+
+
+# ---------------------------------------------------------------------------
+# Endpoint-level round-trip (PUT /api/config)
+# ---------------------------------------------------------------------------
+
+
+class TestAllowlistEndpointRoundTrip:
+    """Set AND clear must survive the real endpoint, not just the pure
+    denormalize function. update_config deep-merges the denormalized payload
+    over the raw disk config — which would silently resurrect a popped
+    ``allowlist`` key — so the ``model`` section is replaced wholesale there;
+    these tests pin that behavior end-to-end."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+        self.client = TestClient(app)
+        self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+
+    def _seed(self, allowlist=None):
+        from hermes_cli.config import save_config
+
+        model = {"default": "a/b", "provider": "openrouter"}
+        if allowlist:
+            model["allowlist"] = allowlist
+        save_config({"model": model})
+
+    def test_put_sets_allowlist_on_disk(self):
+        from hermes_cli.config import load_config
+
+        self._seed()
+        web_config = self.client.get("/api/config").json()
+        assert web_config["model_allowlist"] == []
+
+        web_config["model_allowlist"] = ["x/y", "z/w"]
+        resp = self.client.put("/api/config", json={"config": web_config})
+        assert resp.status_code == 200
+
+        after = load_config()
+        assert after["model"]["allowlist"] == ["x/y", "z/w"]
+        # sibling subkeys survive the write
+        assert after["model"]["provider"] == "openrouter"
+        assert after["model"]["default"] == "a/b"
+
+    def test_put_clear_removes_allowlist_from_disk(self):
+        from hermes_cli.config import load_config
+
+        self._seed(allowlist=["x/y"])
+        web_config = self.client.get("/api/config").json()
+        assert web_config["model_allowlist"] == ["x/y"]
+
+        web_config["model_allowlist"] = []
+        resp = self.client.put("/api/config", json={"config": web_config})
+        assert resp.status_code == 200
+
+        after = load_config()
+        assert "allowlist" not in (after.get("model") or {}), (
+            "clearing the dashboard field must clear the restriction on disk "
+            "— the endpoint's deep-merge must not resurrect the popped key"
+        )
+        # ...without collateral damage to the rest of the model section
+        assert after["model"]["default"] == "a/b"
+        assert after["model"]["provider"] == "openrouter"

--- a/tests/hermes_cli/test_web_config_model_allowlist.py
+++ b/tests/hermes_cli/test_web_config_model_allowlist.py
@@ -1,0 +1,155 @@
+"""Dashboard config surface for ``model.allowlist`` (the /model switch gate).
+
+The dashboard's editable schema is built from ``DEFAULT_CONFIG``, where
+``model`` is deliberately a flat string — so dict-only model subkeys are
+surfaced as virtual top-level fields through the normalize/denormalize cycle
+(the same mechanism as ``model_context_length``). These tests pin:
+
+  - ``model_allowlist`` is registered in CONFIG_SCHEMA (list field, rendered
+    adjacent to ``model``), so the supported dashboard config UI can edit it
+  - the explicit no-op default: a config without ``model.allowlist`` (dict or
+    bare-string ``model``) normalizes to ``[]``, meaning "no restriction"
+  - GET normalization surfaces ``model.allowlist`` → ``model_allowlist``
+  - PUT denormalization writes it back into the ``model`` dict, clears it on
+    empty, preserves it when the payload omits the field, upgrades a
+    bare-string ``model`` to the dict form, and never drops sibling subkeys
+"""
+
+import pytest
+
+from hermes_cli.web_server import (
+    CONFIG_SCHEMA,
+    _denormalize_config_from_web,
+    _normalize_config_for_web,
+    _sanitize_model_allowlist,
+)
+
+
+# ---------------------------------------------------------------------------
+# Schema registration
+# ---------------------------------------------------------------------------
+
+
+def test_model_allowlist_registered_in_config_schema():
+    """The dashboard schema must expose model_allowlist as an editable list."""
+    entry = CONFIG_SCHEMA.get("model_allowlist")
+    assert entry is not None, "model_allowlist missing from CONFIG_SCHEMA"
+    assert entry["type"] == "list"
+    assert entry["category"] == "general"
+
+
+def test_model_allowlist_renders_adjacent_to_model():
+    """Virtual model fields sit right after ``model`` so the frontend groups
+    the three fields that edit the same on-disk ``model:`` section."""
+    keys = list(CONFIG_SCHEMA.keys())
+    i_model = keys.index("model")
+    assert keys[i_model + 1] == "model_context_length"
+    assert keys[i_model + 2] == "model_allowlist"
+
+
+# ---------------------------------------------------------------------------
+# Sanitizer + the explicit no-op default
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_model_allowlist_defaults_and_malformed():
+    assert _sanitize_model_allowlist(None) == []
+    assert _sanitize_model_allowlist("not-a-list") == []
+    assert _sanitize_model_allowlist([]) == []
+    # trims, drops blanks + non-strings, de-dupes, preserves order + case
+    assert _sanitize_model_allowlist([" a/b ", "", 5, None, "c/d", "a/b"]) == [
+        "a/b",
+        "c/d",
+    ]
+
+
+def test_normalize_defaults_to_empty_allowlist_for_dict_model():
+    """No ``model.allowlist`` on disk → the field still renders, as [] (no
+    restriction) — the explicit no-op default."""
+    out = _normalize_config_for_web(
+        {"model": {"default": "a/b", "provider": "openrouter"}}
+    )
+    assert out["model"] == "a/b"
+    assert out["model_allowlist"] == []
+
+
+def test_normalize_defaults_to_empty_allowlist_for_string_model():
+    out = _normalize_config_for_web({"model": "a/b"})
+    assert out["model"] == "a/b"
+    assert out["model_allowlist"] == []
+
+
+def test_normalize_surfaces_allowlist_from_model_dict():
+    out = _normalize_config_for_web(
+        {"model": {"default": "a/b", "allowlist": ["x/y", " z/w "]}}
+    )
+    assert out["model"] == "a/b"
+    assert out["model_allowlist"] == ["x/y", "z/w"]
+
+
+# ---------------------------------------------------------------------------
+# Denormalization (PUT /api/config write-back)
+# ---------------------------------------------------------------------------
+
+
+def _with_disk_config(monkeypatch, disk_config):
+    monkeypatch.setattr(
+        "hermes_cli.web_server.load_config", lambda: dict(disk_config)
+    )
+
+
+def test_denormalize_writes_allowlist_into_model_dict(monkeypatch):
+    _with_disk_config(
+        monkeypatch,
+        {"model": {"default": "a/b", "provider": "openrouter", "base_url": "https://x"}},
+    )
+    out = _denormalize_config_from_web(
+        {"model": "a/b", "model_allowlist": ["x/y", "z/w"]}
+    )
+    model = out["model"]
+    assert isinstance(model, dict)
+    assert model["allowlist"] == ["x/y", "z/w"]
+    # sibling subkeys recovered from disk survive the round-trip
+    assert model["provider"] == "openrouter"
+    assert model["base_url"] == "https://x"
+    # the virtual field never reaches config.yaml
+    assert "model_allowlist" not in out
+
+
+def test_denormalize_empty_allowlist_clears_disk_value(monkeypatch):
+    """Present-but-empty means the user cleared the field → key removed (back
+    to the unrestricted default)."""
+    _with_disk_config(
+        monkeypatch, {"model": {"default": "a/b", "allowlist": ["x/y"]}}
+    )
+    out = _denormalize_config_from_web({"model": "a/b", "model_allowlist": []})
+    assert "allowlist" not in out["model"]
+
+
+def test_denormalize_absent_allowlist_preserves_disk_value(monkeypatch):
+    """A payload that omits the field (older frontend) must not clobber a
+    hand-written allowlist."""
+    _with_disk_config(
+        monkeypatch, {"model": {"default": "a/b", "allowlist": ["x/y"]}}
+    )
+    out = _denormalize_config_from_web({"model": "a/b"})
+    assert out["model"]["allowlist"] == ["x/y"]
+
+
+def test_denormalize_upgrades_bare_string_model(monkeypatch):
+    """Disk config with flat ``model: "a/b"`` upgrades to the dict form when
+    an allowlist is set — mirroring the context_length upgrade path."""
+    _with_disk_config(monkeypatch, {"model": "a/b"})
+    out = _denormalize_config_from_web(
+        {"model": "a/b", "model_allowlist": ["x/y"]}
+    )
+    assert out["model"] == {"default": "a/b", "allowlist": ["x/y"]}
+
+
+def test_normalize_denormalize_roundtrip_is_stable(monkeypatch):
+    disk = {"model": {"default": "a/b", "provider": "openrouter", "allowlist": ["x/y"]}}
+    _with_disk_config(monkeypatch, disk)
+    out = _denormalize_config_from_web(_normalize_config_for_web(dict(disk)))
+    assert out["model"]["allowlist"] == ["x/y"]
+    assert out["model"]["default"] == "a/b"
+    assert out["model"]["provider"] == "openrouter"


### PR DESCRIPTION
## What does this PR do?

Adds an **opt-in** `model.allowlist` config key under `model:`. When set, the in-session `/model` command may only switch to a model in that set:

- the interactive picker and the text fallback list are **filtered** to the allowlist (and skip the top-N truncation when an allowlist is active, so an allowed-but-low-ranked model isn't dropped before filtering), and
- a switch to anything outside it (typed name, alias, or `--provider` auto-detect) is **refused on the resolved model**, before any expensive-model confirm or apply.

Empty/unset means no restriction, so existing behaviour is unchanged.

On a shared/hosted bot an operator often wants hires to switch only between a curated, tool-capable set. `/model` otherwise accepts any provider model (the picker lists ~50; a typed/aliased name is accepted with a warning), so a hire can land on a model that doesn't support tool calls and break the agent until a reset. Command-level slash gating (`user_allowed_commands` / `allow_admin_from`) can't help — it allows/denies `/model` wholesale, not its argument. This adds the missing **argument-level** guard without removing the command.

## Related Issue

Implements #16608 (Model allowlist for `/model`).

**Prior art / overlap (not a silent duplicate):** #27025 also proposes a `model_allowlist`, but as a *discovery-list filter for dynamic-discovery providers* — it hides models from the list. This PR is complementary/stronger: it's a **switch-time gate** that actually *refuses* a disallowed switch (typed, aliased, or `--provider` auto-detected), and filters the picker/list as a side effect. I've used the nested `model.allowlist` key (consistent with the existing `model:` block) rather than a top-level `model_allowlist`; happy to reconcile naming with #27025 if maintainers prefer one shape.

Fixes #16608

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix (prevents a hire on a shared bot from switching to a non-tool model / off the curated set)

## Changes Made

- `gateway/slash_commands.py`: `_normalize_model_allowlist`, `_model_blocked_by_allowlist`, `_filter_providers_to_allowlist`; read `model.allowlist` in `_handle_model_command`; filter the picker + text list (skipping top-N truncation when an allowlist is active); gate both the picker callback and the typed path on the **resolved** model.
- `locales/*.yaml`: `gateway.model.not_allowed` added and **translated across all 16 locales** (the `{model}` / `{allowed}` placeholders preserved and verified against the i18n parity tests).
- `cli-config.yaml.example`: document the new key under `model:`.
- `tests/gateway/test_model_command_allowlist.py`: pure-helper unit tests + gate tests for the typed path, the resolved-model (alias) mutation guard, the picker callback, case-insensitivity, and the unset=unrestricted back-compat case.

## How to Test

1. In `config.yaml`, set:
   ```yaml
   model:
     default: "anthropic/claude-opus-4.6"
     allowlist:
       - "anthropic/claude-opus-4.6"
       - "google/gemini-2.5-flash-lite"
   ```
2. `/model openai/gpt-5.5` → refused: "`openai/gpt-5.5` is not in this bot's allowed model list. Allowed: ...".
3. `/model google/gemini-2.5-flash-lite` → switches normally. `/model` (bare) → picker/list shows only the two allowed models.
4. Remove `allowlist` → `/model` switches to anything again (unchanged behaviour).
5. `pytest tests/gateway/test_model_command_allowlist.py -q` and `pytest tests/agent/test_i18n.py -q`.

## Checklist

- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits (`feat(gateway):`)
- [x] I searched existing PRs/issues (found #16608, #27025 — addressed above)
- [x] PR contains only changes related to this feature
- [x] I've added tests
- [x] cli-config.yaml.example updated for the new config key
- [x] All 16 locales updated with the new key (translated, placeholders preserved)
- [ ] Full `pytest tests/ -q` run by CI (I validated syntax, YAML, and i18n key+placeholder parity across all 16 locales locally; the repo's deps install via uv in CI)

## Notes

Backward compatible: no `allowlist` key ⇒ no behaviour change. Matching is exact catalog model id, case-insensitive. The gate covers the gateway `/model` command; local operator surfaces (CLI/TUI/dashboard) are out of scope and could be unified later. The 15 non-English `not_allowed` strings are translations (corrections welcome from native speakers).