### PR TITLE
fix: improve gateway footer and Feishu image follow-ups

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14378,7 +14378,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     model=agent_result.get("model"),
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
-                    cwd=os.environ.get("TERMINAL_CWD", ""),
+                    cwd=os.environ.get("TERMINAL_CWD") or os.getcwd(),
+                    duration=_response_time,
                 )
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -88,18 +88,34 @@ def resolve_footer_config(
     return resolved
 
 
+def _format_duration(seconds: Optional[float]) -> str:
+    """Render a duration in a human-readable short form.
+
+    ``3.4s`` → ``3.4s``; ``72.1s`` → ``1m12s``; ``125s`` → ``2m5s``.
+    """
+    if seconds is None or seconds < 0:
+        return ""
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    mins, secs = divmod(int(seconds), 60)
+    return f"{mins}m{secs}s"
+
+
 def format_runtime_footer(
     *,
     model: Optional[str],
     context_tokens: int,
     context_length: Optional[int],
     cwd: Optional[str] = None,
+    duration: Optional[float] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
 ) -> str:
     """Render the footer line, or return "" if no fields have data.
 
     Fields are skipped silently when their underlying data is missing — a
     partially-populated footer is better than a line with ``?%`` or empty slots.
+
+    Supported fields: ``model``, ``context_pct``, ``cwd``, ``duration``.
     """
     parts: list[str] = []
     for field in fields:
@@ -107,14 +123,18 @@ def format_runtime_footer(
             m = _model_short(model)
             if m:
                 parts.append(m)
-        elif field == "context_pct":
+        elif field in {"context_pct", "ctx"}:
             if context_length and context_length > 0 and context_tokens >= 0:
                 pct = max(0, min(100, round((context_tokens / context_length) * 100)))
-                parts.append(f"{pct}%")
-        elif field == "cwd":
+                parts.append(f"ctx {pct}%" if field == "ctx" else f"{pct}%")
+        elif field in {"cwd", "cwd_label"}:
             rel = _home_relative_cwd(cwd or os.environ.get("TERMINAL_CWD", ""))
             if rel:
-                parts.append(rel)
+                parts.append(f"cwd {rel}" if field == "cwd_label" else rel)
+        elif field == "duration":
+            d = _format_duration(duration)
+            if d:
+                parts.append(d)
         # Unknown field names are silently ignored.
 
     if not parts:
@@ -130,6 +150,7 @@ def build_footer_line(
     context_tokens: int,
     context_length: Optional[int],
     cwd: Optional[str] = None,
+    duration: Optional[float] = None,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
 
@@ -145,5 +166,6 @@ def build_footer_line(
         context_tokens=context_tokens,
         context_length=context_length,
         cwd=cwd,
+        duration=duration,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
     )

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -1,6 +1,7 @@
 """Gateway runtime-metadata footer.
 
-Renders a compact footer showing runtime state (model, context %, cwd) and
+Renders a compact footer showing runtime state (model, duration, context %,
+cwd) and
 appends it to the FINAL message of an agent turn when enabled.  Off by default
 to keep replies minimal.
 
@@ -9,7 +10,7 @@ Config (``~/.hermes/config.yaml``)::
     display:
       runtime_footer:
         enabled: true                       # off by default
-        fields: [model, context_pct, cwd]   # order shown; drop any to hide
+        fields: [model, duration, context_pct, cwd]  # order shown; drop any to hide
 
 Per-platform overrides live under ``display.platforms.<platform>.runtime_footer``.
 Users can toggle the global setting with ``/footer on|off`` from both the CLI
@@ -115,7 +116,8 @@ def format_runtime_footer(
     Fields are skipped silently when their underlying data is missing — a
     partially-populated footer is better than a line with ``?%`` or empty slots.
 
-    Supported fields: ``model``, ``context_pct``, ``cwd``, ``duration``.
+    Supported fields: ``model``, ``duration``, ``context_pct`` (or labeled
+    alias ``ctx``), and ``cwd`` (or labeled alias ``cwd_label``).
     """
     parts: list[str] = []
     for field in fields:

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -345,7 +345,7 @@ TIPS = [
     '/copy [N] copies the last assistant response to your clipboard, or the Nth-from-last with a number.',
     '/redraw forces a full UI repaint, fixing terminal drift after tmux resize or mouse selection artifacts.',
     '/agents (alias /tasks) shows active agents and running background tasks across the current session.',
-    '/footer toggles the gateway footer on final replies showing model, context %, and cwd.',
+    '/footer toggles the gateway footer on final replies showing model, response duration, context %, and cwd.',
     '/busy queue|steer|interrupt controls what pressing Enter does while Hermes is working.',
     '/topic in Telegram DMs enables user-managed multi-session topic mode — /topic <id> restores past sessions inline.',
     '/approve session|always runs a pending dangerous command with your chosen trust scope; /deny rejects it.',

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -228,6 +228,9 @@ _FEISHU_WEBHOOK_BODY_TIMEOUT_SECONDS = 30          # max seconds to read request
 _FEISHU_WEBHOOK_ANOMALY_THRESHOLD = 25             # consecutive error responses before WARNING log
 _FEISHU_WEBHOOK_ANOMALY_TTL_SECONDS = 6 * 60 * 60  # anomaly tracker TTL (6 hours) — matches openclaw
 _FEISHU_CARD_ACTION_DEDUP_TTL_SECONDS = 15 * 60    # card action token dedup window (15 min)
+_FEISHU_RECENT_MEDIA_TTL_SECONDS = 30 * 60         # allow text follow-ups to refer to a just-sent image
+_FEISHU_RECENT_MEDIA_MAX_CHATS = 256
+_FEISHU_RECENT_MEDIA_MAX_ITEMS_PER_CHAT = 4
 
 _APPROVAL_CHOICE_MAP: Dict[str, str] = {
     "approve_once": "once",
@@ -256,6 +259,11 @@ async def _read_limited_feishu_webhook_body(request: Any, max_bytes: int) -> byt
 
 _FEISHU_BOT_MSG_TRACK_SIZE = 512                   # LRU size for tracking sent message IDs
 _FEISHU_REPLY_FALLBACK_CODES = frozenset({230011, 231003})  # reply target withdrawn/missing → create fallback
+
+_RECENT_IMAGE_REFERENCE_RE = re.compile(
+    r"(图片|照片|截图|这张图|那张图|上一张图|上张图|刚发.{0,8}图|图里|图中|看得到图|看得到图片|看得到照片|看得到截图|image|photo|screenshot)",
+    re.IGNORECASE,
+)
 
 # Feishu reactions render as prominent badges, unlike Discord/Telegram's
 # small footer emoji — a success badge on every message would add noise, so
@@ -1494,6 +1502,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._sent_message_id_order: List[str] = []  # LRU order for _sent_message_ids_to_chat
         self._chat_info_cache: Dict[str, Dict[str, Any]] = {}
         self._message_text_cache: "OrderedDict[str, Optional[str]]" = OrderedDict()
+        self._recent_media_by_context: "OrderedDict[str, List[Dict[str, Any]]]" = OrderedDict()
         self._app_lock_identity: Optional[str] = None
         self._text_batch_state = FeishuBatchState()
         self._pending_text_batches = self._text_batch_state.events
@@ -3300,6 +3309,30 @@ class FeishuAdapter(BasePlatformAdapter):
             or getattr(message, "root_id", None)
             or None
         )
+
+        chat_id = getattr(message, "chat_id", "") or ""
+        if media_urls:
+            self._remember_recent_media(
+                chat_id=chat_id,
+                thread_id=thread_id,
+                message_id=message_id,
+                media_urls=media_urls,
+                media_types=media_types,
+            )
+        elif self._text_references_recent_image(text):
+            recent_urls, recent_types = self._recent_media_for_context(
+                chat_id=chat_id,
+                thread_id=thread_id,
+            )
+            if recent_urls:
+                media_urls.extend(recent_urls)
+                media_types.extend(recent_types)
+                logger.info(
+                    "[Feishu] Attached %d recent image(s) to text follow-up id=%s",
+                    len(recent_urls),
+                    message_id,
+                )
+
         reply_to_text = await self._fetch_message_text(reply_to_message_id) if reply_to_message_id else None
 
         sender_primary = (
@@ -3320,7 +3353,6 @@ class FeishuAdapter(BasePlatformAdapter):
             len(media_urls),
         )
 
-        chat_id = getattr(message, "chat_id", "") or ""
         chat_info = await self.get_chat_info(chat_id)
         sender_profile = await self._resolve_sender_profile(sender_id, is_bot=is_bot)
         source = self.build_source(
@@ -3434,6 +3466,89 @@ class FeishuAdapter(BasePlatformAdapter):
             len(event.media_urls),
         )
         await self._handle_message_with_guards(event)
+
+    @staticmethod
+    def _recent_media_context_key(chat_id: str, thread_id: Optional[str]) -> str:
+        return f"{chat_id or ''}:{thread_id or ''}"
+
+    @staticmethod
+    def _text_references_recent_image(text: str) -> bool:
+        if not text:
+            return False
+        return bool(_RECENT_IMAGE_REFERENCE_RE.search(text))
+
+    def _prune_recent_media_cache(self, now: Optional[float] = None) -> None:
+        now = time.time() if now is None else now
+        expired_keys: List[str] = []
+        for key, items in list(self._recent_media_by_context.items()):
+            kept = [item for item in items if now - float(item.get("ts", 0.0)) <= _FEISHU_RECENT_MEDIA_TTL_SECONDS]
+            if kept:
+                self._recent_media_by_context[key] = kept[-_FEISHU_RECENT_MEDIA_MAX_ITEMS_PER_CHAT:]
+            else:
+                expired_keys.append(key)
+        for key in expired_keys:
+            self._recent_media_by_context.pop(key, None)
+        while len(self._recent_media_by_context) > _FEISHU_RECENT_MEDIA_MAX_CHATS:
+            self._recent_media_by_context.popitem(last=False)
+
+    def _remember_recent_media(
+        self,
+        *,
+        chat_id: str,
+        thread_id: Optional[str],
+        message_id: str,
+        media_urls: List[str],
+        media_types: List[str],
+    ) -> None:
+        image_urls: List[str] = []
+        image_types: List[str] = []
+        for i, url in enumerate(media_urls):
+            media_type = media_types[i] if i < len(media_types) else ""
+            if media_type.startswith("image/"):
+                image_urls.append(url)
+                image_types.append(media_type)
+        if not image_urls:
+            return
+
+        self._prune_recent_media_cache()
+        now = time.time()
+        for key in {
+            self._recent_media_context_key(chat_id, thread_id),
+            self._recent_media_context_key(chat_id, None),
+        }:
+            items = self._recent_media_by_context.setdefault(key, [])
+            items.append(
+                {
+                    "ts": now,
+                    "message_id": message_id,
+                    "media_urls": list(image_urls),
+                    "media_types": list(image_types),
+                }
+            )
+            self._recent_media_by_context.move_to_end(key)
+            del items[:-_FEISHU_RECENT_MEDIA_MAX_ITEMS_PER_CHAT]
+
+    def _recent_media_for_context(
+        self,
+        *,
+        chat_id: str,
+        thread_id: Optional[str],
+    ) -> tuple[List[str], List[str]]:
+        self._prune_recent_media_cache()
+        for key in (
+            self._recent_media_context_key(chat_id, thread_id),
+            self._recent_media_context_key(chat_id, None),
+        ):
+            items = self._recent_media_by_context.get(key) or []
+            if not items:
+                continue
+            latest = items[-1]
+            urls = list(latest.get("media_urls") or [])
+            types = list(latest.get("media_types") or [])
+            if urls:
+                self._recent_media_by_context.move_to_end(key)
+                return urls, types
+        return [], []
 
     async def _download_remote_image(self, image_url: str) -> str:
         ext = self._guess_remote_extension(image_url, default=".jpg")

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1497,7 +1497,8 @@ class FeishuAdapter(BasePlatformAdapter):
         self._pending_inbound_lock = threading.Lock()
         self._pending_drain_scheduled = False
         self._pending_inbound_max_depth = 1000  # cap queue; drop oldest beyond
-        self._chat_locks: "collections.OrderedDict[str, asyncio.Lock]" = collections.OrderedDict()  # chat_id → lock (per-chat serial processing, LRU-bounded)
+        self._chat_locks: "collections.OrderedDict[str, asyncio.Lock]" = collections.OrderedDict()  # chat_id → lock (per-chat agent dispatch, LRU-bounded)
+        self._inbound_intake_locks: "collections.OrderedDict[str, asyncio.Lock]" = collections.OrderedDict()  # chat_id → lock (media extraction/cache ordering, LRU-bounded)
         self._sent_message_ids_to_chat: Dict[str, str] = {}  # message_id → chat_id (for reaction routing)
         self._sent_message_id_order: List[str] = []  # LRU order for _sent_message_ids_to_chat
         self._chat_info_cache: Dict[str, Dict[str, Any]] = {}
@@ -3070,6 +3071,34 @@ class FeishuAdapter(BasePlatformAdapter):
     # Per-chat serialization and typing indicator
     # =========================================================================
 
+    def _get_inbound_intake_lock(self, chat_id: str) -> asyncio.Lock:
+        """Return the per-chat lock that preserves inbound cache ordering.
+
+        Feishu SDK callbacks are submitted to the event loop independently.  A
+        media event may therefore still be downloading when a following text
+        event starts.  This lock serializes extraction, recent-media cache
+        mutation/lookups, and normalization in callback arrival order, before
+        the separate agent-dispatch lock is involved.
+        """
+        lock_map = getattr(self, "_inbound_intake_locks", None)
+        if lock_map is None:
+            lock_map = collections.OrderedDict()
+            self._inbound_intake_locks = lock_map
+        lock = lock_map.get(chat_id)
+        if lock is not None:
+            lock_map.move_to_end(chat_id)
+            return lock
+        if len(lock_map) >= self.CHAT_LOCK_MAX_SIZE:
+            for key in list(lock_map):
+                if not lock_map[key].locked():
+                    lock_map.pop(key)
+                    break
+            # If every lock is active, grow temporarily rather than evicting a
+            # live lock and allowing two intake paths for the same chat.
+        lock = asyncio.Lock()
+        lock_map[chat_id] = lock
+        return lock
+
     def _get_chat_lock(self, chat_id: str) -> asyncio.Lock:
         """Return (creating if needed) the per-chat asyncio.Lock for serial message processing.
 
@@ -3285,6 +3314,36 @@ class FeishuAdapter(BasePlatformAdapter):
         message_id: str,
         is_bot: bool = False,
     ) -> None:
+        """Process one inbound callback in per-chat arrival order.
+
+        The lock starts before media extraction so a text follow-up cannot read
+        recent-media state while an earlier image callback is still downloading.
+        Agent dispatch has its own lock and may continue asynchronously after
+        this intake phase.
+        """
+        chat_id = getattr(message, "chat_id", "") or ""
+        async with self._get_inbound_intake_lock(chat_id):
+            normalized = await self._normalize_inbound_message_serialized(
+                data=data,
+                message=message,
+                sender_id=sender_id,
+                chat_type=chat_type,
+                message_id=message_id,
+                is_bot=is_bot,
+            )
+        if normalized is not None:
+            await self._dispatch_inbound_event(normalized)
+
+    async def _normalize_inbound_message_serialized(
+        self,
+        *,
+        data: Any,
+        message: Any,
+        sender_id: Any,
+        chat_type: str,
+        message_id: str,
+        is_bot: bool = False,
+    ) -> Optional[MessageEvent]:
         text, inbound_type, media_urls, media_types, mentions = await self._extract_message_content(message)
 
         if inbound_type == MessageType.TEXT:
@@ -3378,7 +3437,7 @@ class FeishuAdapter(BasePlatformAdapter):
             channel_prompt=self._resolve_channel_prompt(chat_id, thread_id or None),
             timestamp=datetime.now(),
         )
-        await self._dispatch_inbound_event(normalized)
+        return normalized
 
     async def _dispatch_inbound_event(self, event: MessageEvent) -> None:
         """Apply Feishu-specific burst protection before entering the base adapter."""

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1538,6 +1538,82 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(follow_up_event.media_types, ["image/png"])
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_concurrent_image_then_text_preserves_recent_media_order(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        async def scenario():
+            adapter = FeishuAdapter(PlatformConfig())
+            download_started = asyncio.Event()
+            allow_download = asyncio.Event()
+
+            async def delayed_download(*, message_id, image_key):
+                self.assertEqual((message_id, image_key), ("om_image", "img_123"))
+                download_started.set()
+                await allow_download.wait()
+                return "/tmp/feishu-image.png", "image/png"
+
+            adapter._download_feishu_image = AsyncMock(side_effect=delayed_download)
+            adapter._dispatch_inbound_event = AsyncMock()
+            adapter.get_chat_info = AsyncMock(return_value={"name": "TileTrace 项目", "type": "group"})
+            adapter._resolve_sender_profile = AsyncMock(
+                return_value={
+                    "user_id": "ou_user",
+                    "user_name": "韩泽北",
+                    "user_id_alt": None,
+                }
+            )
+            sender_id = SimpleNamespace(open_id="ou_user", user_id=None, union_id=None)
+
+            def message(message_type, content, message_id):
+                return SimpleNamespace(
+                    message_type=message_type,
+                    content=content,
+                    message_id=message_id,
+                    chat_id="oc_chat",
+                    thread_id=None,
+                    root_id=None,
+                    parent_id=None,
+                    upper_message_id=None,
+                    mentions=[],
+                )
+
+            image_task = asyncio.create_task(
+                adapter._process_inbound_message(
+                    data={},
+                    message=message("image", '{"image_key":"img_123"}', "om_image"),
+                    sender_id=sender_id,
+                    chat_type="group",
+                    message_id="om_image",
+                )
+            )
+            await download_started.wait()
+
+            text_task = asyncio.create_task(
+                adapter._process_inbound_message(
+                    data={},
+                    message=message("text", '{"text":"你看得到图片内容吗"}', "om_text"),
+                    sender_id=sender_id,
+                    chat_type="group",
+                    message_id="om_text",
+                )
+            )
+            await asyncio.sleep(0)
+
+            self.assertFalse(text_task.done())
+            adapter._dispatch_inbound_event.assert_not_awaited()
+
+            allow_download.set()
+            await asyncio.gather(image_task, text_task)
+
+            dispatched = [call.args[0] for call in adapter._dispatch_inbound_event.await_args_list]
+            self.assertEqual([event.message_id for event in dispatched], ["om_image", "om_text"])
+            self.assertEqual(dispatched[1].media_urls, ["/tmp/feishu-image.png"])
+            self.assertEqual(dispatched[1].media_types, ["image/png"])
+
+        asyncio.run(scenario())
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_extract_audio_message_downloads_and_caches(self):
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1473,6 +1473,71 @@ class TestAdapterBehavior(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_text_follow_up_can_reference_recent_image(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._download_feishu_image = AsyncMock(return_value=("/tmp/feishu-image.png", "image/png"))
+        adapter._dispatch_inbound_event = AsyncMock()
+        adapter.get_chat_info = AsyncMock(return_value={"name": "TileTrace 项目", "type": "group"})
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={
+                "user_id": "ou_user",
+                "user_name": "韩泽北",
+                "user_id_alt": None,
+            }
+        )
+        sender_id = SimpleNamespace(open_id="ou_user", user_id=None, union_id=None)
+
+        image_message = SimpleNamespace(
+            message_type="image",
+            content='{"image_key":"img_123"}',
+            message_id="om_image",
+            chat_id="oc_chat",
+            thread_id=None,
+            root_id=None,
+            parent_id=None,
+            upper_message_id=None,
+            mentions=[],
+        )
+        asyncio.run(
+            adapter._process_inbound_message(
+                data={},
+                message=image_message,
+                sender_id=sender_id,
+                chat_type="group",
+                message_id="om_image",
+            )
+        )
+
+        text_message = SimpleNamespace(
+            message_type="text",
+            content='{"text":"你看得到图片内容吗"}',
+            message_id="om_text",
+            chat_id="oc_chat",
+            thread_id=None,
+            root_id=None,
+            parent_id=None,
+            upper_message_id=None,
+            mentions=[],
+        )
+        asyncio.run(
+            adapter._process_inbound_message(
+                data={},
+                message=text_message,
+                sender_id=sender_id,
+                chat_type="group",
+                message_id="om_text",
+            )
+        )
+
+        follow_up_event = adapter._dispatch_inbound_event.await_args_list[-1].args[0]
+        self.assertEqual(follow_up_event.text, "你看得到图片内容吗")
+        self.assertEqual(follow_up_event.media_urls, ["/tmp/feishu-image.png"])
+        self.assertEqual(follow_up_event.media_types, ["image/png"])
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_extract_audio_message_downloads_and_caches(self):
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -137,6 +137,73 @@ def test_format_footer_custom_field_order():
     assert out == "50% · gpt-5.4"
 
 
+# ---------------------------------------------------------------------------
+# duration field
+# ---------------------------------------------------------------------------
+
+def test_format_footer_duration_seconds():
+    out = format_runtime_footer(
+        model="m", context_tokens=0, context_length=100,
+        cwd="", duration=3.4,
+        fields=("duration",),
+    )
+    assert out == "3.4s"
+
+
+def test_format_footer_duration_minutes():
+    out = format_runtime_footer(
+        model="m", context_tokens=0, context_length=100,
+        cwd="", duration=72.3,
+        fields=("duration",),
+    )
+    assert out == "1m12s"
+
+
+def test_format_footer_duration_none_skipped():
+    out = format_runtime_footer(
+        model="m", context_tokens=0, context_length=100,
+        cwd="", duration=None,
+        fields=("duration",),
+    )
+    assert out == ""
+
+
+def test_format_footer_model_and_duration():
+    out = format_runtime_footer(
+        model="openai/gpt-5.4",
+        context_tokens=0, context_length=100,
+        cwd="", duration=5.2,
+        fields=("model", "duration"),
+    )
+    assert out == "gpt-5.4 · 5.2s"
+
+
+def test_format_footer_labeled_ctx_and_cwd(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    out = format_runtime_footer(
+        model="openai/gpt-5.4",
+        context_tokens=25, context_length=100,
+        cwd=str(proj), duration=5.2,
+        fields=("ctx", "cwd_label"),
+    )
+    assert out == "ctx 25% · cwd ~/proj"
+
+
+def test_build_footer_includes_duration():
+    out = build_footer_line(
+        user_config={"display": {"runtime_footer": {"enabled": True, "fields": ["model", "duration"]}}},
+        platform_key="feishu",
+        model="openai/gpt-5.4",
+        context_tokens=0, context_length=100,
+        cwd="/tmp",
+        duration=8.7,
+    )
+    assert "gpt-5.4" in out
+    assert "8.7s" in out
+
+
 def test_format_footer_unknown_field_silently_ignored():
     out = format_runtime_footer(
         model="openai/gpt-5.4",

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -82,7 +82,7 @@ Type `/` in the CLI to open the autocomplete menu. Built-in commands are case-in
 | `/battery [on\|off\|status]` | Toggle a color-coded battery read-out as the first status-bar element (off by default; no-op without a battery). |
 | `/voice [on\|off\|tts\|status]` | Toggle CLI voice mode and spoken playback. Recording uses `voice.record_key` (default: `Ctrl+B`). |
 | `/yolo` | Toggle YOLO mode — skip all dangerous command approval prompts. |
-| `/footer [on\|off\|status]` | Toggle the gateway runtime-metadata footer on final replies (shows model, context %, and cwd). |
+| `/footer [on\|off\|status]` | Toggle the gateway runtime-metadata footer on final replies (supports model, response duration, context %, and cwd). |
 | `/busy [queue\|steer\|interrupt\|status]` | CLI-only: control what pressing Enter does while Hermes is working — queue the new message, steer mid-turn, or interrupt immediately. |
 | `/indicator [kaomoji\|emoji\|unicode\|ascii]` | CLI-only: pick the TUI busy-indicator style. |
 | `/timestamps [on\|off\|status]` | CLI-only: toggle `[HH:MM]` timestamps on messages and in `/history`. |
@@ -239,7 +239,7 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 | `/queue <prompt>` (alias: `/q`) | Queue a prompt for the next turn without interrupting the current one. |
 | `/steer <prompt>` | Inject a message after the next tool call without interrupting — the model picks it up on its next iteration rather than as a new turn. |
 | `/goal <text>` | Set a standing goal Hermes works toward across turns — our take on the Ralph loop. A judge model checks after each turn; if not done, Hermes auto-continues until it is, you pause/clear it, or the turn budget (default 20) is hit. Subcommands: `/goal status`, `/goal pause`, `/goal resume`, `/goal clear`. Safe to run mid-agent for status/pause/clear; setting a new goal requires `/stop` first. See [Persistent Goals](/user-guide/features/goals). |
-| `/footer [on\|off\|status]` | Toggle the runtime-metadata footer on final replies (shows model, context %, and cwd). |
+| `/footer [on\|off\|status]` | Toggle the runtime-metadata footer on final replies (supports model, response duration, context %, and cwd). |
 | `/curator [status\|run\|pin\|archive]` | Background skill maintenance controls. |
 | `/suggestions [accept\|dismiss N\|catalog\|clear]` | Review suggested automations right in chat. `/suggestions` lists pending suggestions, `catalog` adds curated starter automations, and `clear` prunes resolved suggestion records. Accepted suggestions keep this chat/thread as the job delivery origin. |
 | `/blueprint [name] [slot=value ...]` | Browse cron blueprints, start a guided slot-filling conversation, or create a blueprint job directly. Directly created jobs deliver back to the current chat/thread. |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1529,7 +1529,7 @@ display:
   spinner_token_flow: true # CLI only: append live cumulative turn tokens to the spinner timer
   runtime_footer:         # Gateway: append a runtime-context footer to final replies
     enabled: false
-    fields: ["model", "context_pct", "cwd"]
+    fields: ["model", "duration", "context_pct", "cwd"]
   file_mutation_verifier: true    # Append an advisory footer when write_file/patch calls failed this turn
   credits_notices: true   # Nous credits status-bar notices (usage bands, grant-spent, depleted). false = silence them; /usage still works
   language: en            # UI language for static messages (approval prompts, some gateway replies). en | zh | zh-hant | ja | de | es | fr | tr | uk | af | ko | it | ga | pt | ru | hu
@@ -1631,21 +1631,26 @@ Focus view is **display-only**. It never edits conversation history, the system 
 
 ### Runtime-metadata footer (gateway only)
 
-When `display.runtime_footer.enabled: true`, Hermes appends a small runtime-context footer to the **final** message of each gateway turn. The current footer can show the model, context-window percentage, and current working directory. Off by default; opt in per-gateway if your team wants every reply to include this provenance.
+When `display.runtime_footer.enabled: true`, Hermes appends a small runtime-context footer to the **final** message of each gateway turn. The footer can show the model, response duration, context-window percentage, and current working directory. Off by default; opt in per-gateway if your team wants every reply to include this provenance.
 
 ```yaml
 display:
   runtime_footer:
     enabled: true
-    fields: ["model", "context_pct", "cwd"]   # supported fields: model, context_pct, cwd
+    fields: ["model", "duration", "ctx", "cwd_label"]
 ```
+
+Supported fields are `model`, `duration`, `context_pct`, and `cwd`. Use `ctx`
+instead of `context_pct` to render a labeled value such as `ctx 68%`; use
+`cwd_label` instead of `cwd` to render `cwd ~/project`. Unknown fields and
+fields whose runtime value is unavailable are skipped.
 
 The `/footer` slash command toggles this at runtime in any session.
 
-Example footer appended to a Telegram/Discord/Slack reply:
+Example footer appended to a gateway reply:
 
 ```
-— claude-opus-4.7 · 12 tool calls · 2m 14s · $0.042
+claude-opus-4.7 · 2m14s · ctx 68% · cwd ~/project
 ```
 
 Only the **final** message of a turn gets the footer; interim updates stay clean.


### PR DESCRIPTION
## Summary

- add `duration` support to the gateway runtime footer and pass measured response time from the gateway send path
- make footer `cwd` fallback to `os.getcwd()` when `TERMINAL_CWD` is unset
- attach recently uploaded Feishu images to text follow-ups that refer to the image (e.g. “can you see the screenshot?”)

## Motivation

Two gateway UX gaps showed up in real Feishu usage:

1. Runtime footers could show model/context/cwd, but not the actual turn duration.
2. In Feishu group chats, a user often sends an image first and then asks about “this image” in a separate text message. The second message has no media payload, so the agent cannot see the image unless the adapter carries recent image context forward.

## Implementation

- `gateway/runtime_footer.py`
  - adds duration formatting (`3.4s`, `1m12s`)
  - supports `duration`, plus labeled aliases `ctx` and `cwd_label`
- `gateway/run.py`
  - passes `_response_time` into the runtime footer builder
  - falls back to `os.getcwd()` for `cwd`
- `plugins/platforms/feishu/adapter.py`
  - caches recent image media per chat/thread for 30 minutes
  - attaches the latest recent image when a follow-up text references images/screenshots
  - caps cache size to avoid unbounded growth

## Tests

- `uv run --with pytest python -m pytest tests/gateway/test_runtime_footer.py -q -o 'addopts='`
  - `31 passed`
- `uv run --with pytest --with aiohttp python -m pytest tests/gateway/test_feishu.py -q -o 'addopts='`
  - `161 passed, 45 skipped`
