### PR TITLE
Clarify /reload-mcp before agent init

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10273,7 +10273,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 except Exception:
                     pass  # Best-effort
 
-            print(f"  ✅ Agent updated — {len(self.agent.tools if self.agent else [])} tool(s) available")
+            if self.agent is not None:
+                print(f"  ✅ Agent updated — {len(self.agent.tools or [])} tool(s) available")
+            else:
+                print(
+                    f"  ✅ MCP registry updated — {len(new_tools)} MCP tool(s) available; "
+                    "agent will load tools on the next message"
+                )
 
         except Exception as e:
             print(f"  ❌ MCP reload failed: {e}")

--- a/tests/cli/test_cli_reload_mcp_output.py
+++ b/tests/cli/test_cli_reload_mcp_output.py
@@ -1,0 +1,43 @@
+"""Regression tests for classic CLI /reload-mcp status output."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def _make_cli_without_agent():
+    import cli as cli_mod
+
+    cli_obj = object.__new__(cli_mod.HermesCLI)
+    cli_obj._command_running = False
+    cli_obj.agent = None
+    cli_obj.enabled_toolsets = ["coding"]
+    cli_obj.conversation_history = []
+    return cli_obj
+
+
+def test_reload_mcp_before_first_message_does_not_claim_agent_updated(capsys):
+    """Before the first prompt, only the MCP registry exists; no agent was rebuilt."""
+    cli_obj = _make_cli_without_agent()
+    tools = [
+        "mcp_langchaindocs_search",
+        "mcp_langchaindocs_fetch",
+        "mcp_langchaindocs_list_resources",
+        "mcp_langchaindocs_read_resource",
+    ]
+
+    with (
+        patch("tools.mcp_tool.shutdown_mcp_servers"),
+        patch("tools.mcp_tool.discover_mcp_tools", return_value=tools),
+        patch.dict(
+            "tools.mcp_tool._servers",
+            {"langchaindocs": SimpleNamespace(_registered_tool_names=tools)},
+            clear=True,
+        ),
+    ):
+        cli_obj._reload_mcp()
+
+    output = capsys.readouterr().out
+    assert "🔧 4 tool(s) available from 1 server(s)" in output
+    assert "MCP registry updated — 4 MCP tool(s) available" in output
+    assert "agent will load tools on the next message" in output
+    assert "Agent updated — 0 tool(s) available" not in output


### PR DESCRIPTION
## Summary

- clarify classic CLI `/reload-mcp` output before the first agent is initialized
- report the MCP registry tool count in the pre-agent state instead of `Agent updated — 0 tool(s)`
- add a regression test for reloading MCP before the first user prompt

## Root Cause

Classic CLI lazily constructs `AIAgent` on the first real prompt. `/reload-mcp` can run before that point, so MCP discovery succeeds and registers tools, but there is no agent snapshot to refresh yet. The old final status line counted a missing agent as zero tools, making a successful MCP registry reload look like an empty agent toolset.

## Validation

- `/Users/bytedance/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_refresh_agent_mcp_tools.py tests/gateway/test_mcp_reload_refreshes_cached_agents.py tests/cli/test_cli_reload_mcp_output.py tests/cli/test_cli_loading_indicator.py tests/cli/test_cli_mcp_config_watch.py`
- `/Users/bytedance/.hermes/hermes-agent/venv/bin/python -m ruff check cli.py tests/cli/test_cli_reload_mcp_output.py`
- `git diff --check -- cli.py tests/cli/test_cli_reload_mcp_output.py`
