### PR TITLE
fix(anthropic): support Z.AI (Zhipu GLM) anthropic-compatible endpoints

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -569,6 +569,34 @@ def _is_minimax_anthropic_endpoint(base_url: str | None) -> bool:
     )
 
 
+def _is_zai_anthropic_endpoint(base_url: str | None) -> bool:
+    """Return True for Z.AI (Zhipu GLM) Anthropic-compatible endpoints.
+
+    Z.AI serves GLM models (glm-5.2, etc.) behind an Anthropic wire relay at
+    ``api.z.ai/api/anthropic`` (global) and ``open.bigmodel.cn/api/anthropic``
+    (China). The relay deterministically rejects Claude-specific
+    ``anthropic-beta`` headers with HTTP 429 ``rate_limit_error`` code 1302:
+    an A/B test of 5 alternating calls (same key, payload, time window) got
+    5/5 success without the betas and 0/5 with them, all rejections returning
+    in <0.5s. ``_common_betas_for_base_url`` uses this to strip ALL betas for
+    Z.AI so traffic matches the bare SDK calls that native clients send.
+
+    The relay also rejects system prompts larger than ~2 KB with
+    ``overloaded_error`` code 1305 (5/5 success at <1 KB, 0/5 at 104 KB);
+    ``build_anthropic_kwargs`` folds large system prompts into the first user
+    message for Z.AI to work around this (message content has no such limit).
+    """
+    normalized = _normalize_base_url_text(base_url)
+    if not normalized:
+        return False
+    normalized = normalized.rstrip("/").lower()
+    return (
+        "api.z.ai/api/anthropic" in normalized
+        or "bigmodel.cn/api/anthropic" in normalized
+        or "z.ai/api/anthropic" in normalized
+    )
+
+
 def _is_azure_anthropic_endpoint(base_url: str | None) -> bool:
     """Return True for Azure-hosted Anthropic Messages endpoints.
 
@@ -619,6 +647,16 @@ def _common_betas_for_base_url(
     if _is_minimax_anthropic_endpoint(base_url):
         _stripped = {_TOOL_STREAMING_BETA, _CONTEXT_1M_BETA}
         return [b for b in betas if b not in _stripped]
+    if _is_zai_anthropic_endpoint(base_url):
+        # Z.AI (Zhipu GLM) serves GLM models behind an Anthropic-compatible
+        # relay. The relay rejects requests carrying Claude-specific betas
+        # (``interleaved-thinking``, ``fine-grained-tool-streaming``) with
+        # HTTP 429 ``rate_limit_error`` code 1302 — empirically verified
+        # against api.z.ai/api/anthropic: identical payloads succeed without
+        # the betas (200, ~2s) and fail with them (429, <1s). Strip ALL
+        # Claude-specific betas so Z.AI traffic matches the bare SDK calls
+        # that native clients (ZCode) send successfully.
+        return []
     if drop_context_1m_beta:
         return [b for b in betas if b != _CONTEXT_1M_BETA]
     return betas
@@ -2469,7 +2507,39 @@ def build_anthropic_kwargs(
     }
 
     if system:
-        kwargs["system"] = system
+        # Z.AI's Anthropic-compatible relay rejects system prompts larger
+        # than ~2-4 KB with ``overloaded_error`` code 1305 (verified
+        # empirically: 0/5 success at 104 KB, 5/5 at <1 KB). Message
+        # content has no such limit (420 K tokens of user content works),
+        # so for Z.AI we fold the system prompt into the first user message
+        # as a leading content block. Native Anthropic and other relays
+        # keep the system field (correct for caching/identity).
+        _system_str = system if isinstance(system, str) else str(system)
+        if (
+            _is_zai_anthropic_endpoint(base_url)
+            and len(_system_str) > 2000
+        ):
+            _system_block = (
+                f"<system>\n{_system_str}\n</system>\n\n"
+                if isinstance(system, str)
+                else f"<system>\n{json.dumps(system)}\n</system>\n\n"
+            )
+            if anthropic_messages and anthropic_messages[0].get("role") == "user":
+                _first = anthropic_messages[0]
+                _first_content = _first.get("content")
+                if isinstance(_first_content, str):
+                    _first["content"] = _system_block + _first_content
+                elif isinstance(_first_content, list):
+                    _first["content"] = [{"type": "text", "text": _system_block}] + _first_content
+                else:
+                    _first["content"] = _system_block + str(_first_content or "")
+            else:
+                anthropic_messages.insert(0, {"role": "user", "content": _system_block.rstrip()})
+                if not anthropic_messages or anthropic_messages[-1].get("role") != "assistant":
+                    anthropic_messages.append({"role": "assistant", "content": "Understood."})
+            # system is now in the messages — do not send the system field
+        else:
+            kwargs["system"] = system
 
     if anthropic_tools:
         kwargs["tools"] = anthropic_tools

--- a/tests/agent/test_zai_anthropic_compat.py
+++ b/tests/agent/test_zai_anthropic_compat.py
@@ -1,0 +1,217 @@
+"""Tests for Z.AI (Zhipu GLM) Anthropic-compatible endpoint compatibility.
+
+Z.AI serves GLM models behind an Anthropic wire relay at ``api.z.ai/api/anthropic``
+and ``open.bigmodel.cn/api/anthropic``. The relay has two quirks that Hermes'
+adapter must work around:
+
+1. **Beta rejection (1302):** requests carrying Claude-specific
+   ``anthropic-beta`` headers are rejected with HTTP 429 ``rate_limit_error``
+   code 1302. An A/B test (5 alternating calls, same key/payload/window)
+   showed 5/5 success without the betas and 0/5 with them, all rejections
+   returning in <0.5s — deterministic, not rate-limit noise. The adapter
+   strips ALL betas for Z.AI endpoints.
+
+2. **System prompt size limit (1305):** system prompts larger than ~2 KB are
+   rejected with ``overloaded_error`` code 1305 (5/5 success at <1 KB, 0/5 at
+   104 KB). Message content has no such limit (420 K tokens of user content
+   works), so the adapter folds large system prompts into the first user
+   message for Z.AI. Native Anthropic and other relays are unaffected.
+"""
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Endpoint detection
+# ---------------------------------------------------------------------------
+
+class TestIsZaiAnthropicEndpoint:
+    def _f(self, url):
+        from agent.anthropic_adapter import _is_zai_anthropic_endpoint
+        return _is_zai_anthropic_endpoint(url)
+
+    def test_zai_global_endpoint(self):
+        assert self._f("https://api.z.ai/api/anthropic")
+
+    def test_zai_global_with_trailing_slash(self):
+        assert self._f("https://api.z.ai/api/anthropic/")
+
+    def test_zai_bigmodel_cn_endpoint(self):
+        assert self._f("https://open.bigmodel.cn/api/anthropic")
+
+    def test_zai_mixed_case(self):
+        assert self._f("https://API.Z.AI/api/Anthropic")
+
+    def test_none_url(self):
+        assert not self._f(None)
+
+    def test_empty_url(self):
+        assert not self._f("")
+
+    def test_native_anthropic_not_matched(self):
+        assert not self._f("https://api.anthropic.com")
+
+    def test_minimax_not_matched(self):
+        assert not self._f("https://api.minimax.io/anthropic")
+
+    def test_kimi_not_matched(self):
+        assert not self._f("https://api.moonshot.cn/anthropic")
+
+    def test_openai_compat_not_matched(self):
+        assert not self._f("https://api.z.ai/api/coding/paas/v4")
+
+    def test_unrelated_zai_not_matched(self):
+        # The OpenAI-compat Z.AI endpoints must not trigger the anthropic fix.
+        assert not self._f("https://api.z.ai/api/paas/v4")
+
+
+# ---------------------------------------------------------------------------
+# Beta stripping
+# ---------------------------------------------------------------------------
+
+class TestZaiBetaStripping:
+    def test_zai_strips_all_betas(self):
+        from agent.anthropic_adapter import (
+            _common_betas_for_base_url,
+            _COMMON_BETAS,
+            _TOOL_STREAMING_BETA,
+        )
+        # Sanity: _COMMON_BETAS is non-empty and includes the Claude betas.
+        assert _COMMON_BETAS
+        assert _TOOL_STREAMING_BETA in _COMMON_BETAS
+        # Z.AI must strip ALL of them (not just a subset like MiniMax).
+        result = _common_betas_for_base_url("https://api.z.ai/api/anthropic")
+        assert result == []
+
+    def test_zai_bigmodel_cn_strips_all_betas(self):
+        from agent.anthropic_adapter import _common_betas_for_base_url
+        assert _common_betas_for_base_url("https://open.bigmodel.cn/api/anthropic") == []
+
+    def test_native_anthropic_keeps_betas(self):
+        """Native Anthropic endpoints must keep ALL betas (caching/thinking)."""
+        from agent.anthropic_adapter import (
+            _common_betas_for_base_url,
+            _COMMON_BETAS,
+            _TOOL_STREAMING_BETA,
+        )
+        result = _common_betas_for_base_url("https://api.anthropic.com")
+        assert _TOOL_STREAMING_BETA in result
+        assert result == _COMMON_BETAS
+
+    def test_minimax_still_strips_only_specific_betas(self):
+        """MiniMax behaviour must be unchanged by the Z.AI branch."""
+        from agent.anthropic_adapter import (
+            _common_betas_for_base_url,
+            _TOOL_STREAMING_BETA,
+        )
+        result = _common_betas_for_base_url("https://api.minimax.io/anthropic")
+        assert _TOOL_STREAMING_BETA not in result
+        assert len(result) > 0  # MiniMax keeps some betas; Z.AI strips all
+
+
+# ---------------------------------------------------------------------------
+# System prompt folding
+# ---------------------------------------------------------------------------
+
+def _build_kwargs(base_url, system=None, messages=None, **extra):
+    """Thin wrapper around build_anthropic_kwargs with sensible defaults."""
+    from agent.anthropic_adapter import build_anthropic_kwargs
+    kwargs = dict(
+        model="glm-5.2",
+        messages=messages if messages is not None else [{"role": "user", "content": "hi"}],
+        tools=None,
+        max_tokens=128,
+        reasoning_config=None,
+        base_url=base_url,
+        context_length=1000000,
+    )
+    if system is not None:
+        # build_anthropic_kwargs extracts system from a leading system-role message
+        kwargs["messages"] = [{"role": "system", "content": system}] + kwargs["messages"]
+    kwargs.update(extra)
+    return build_anthropic_kwargs(**kwargs)
+
+
+class TestZaiSystemPromptFolding:
+    BIG_SYSTEM = "You are Zephyr. " + ("Important rule. " * 5000)  # ~60 KB
+
+    def test_zai_large_system_folded_into_messages(self):
+        """Large system prompt on Z.AI must move into the first user message."""
+        kw = _build_kwargs(
+            base_url="https://api.z.ai/api/anthropic",
+            system=self.BIG_SYSTEM,
+            messages=[{"role": "user", "content": "hello"}],
+        )
+        # system field must NOT be present (folded instead)
+        assert "system" not in kw
+        # the system content must appear in the message stream, wrapped in <system>
+        msg_blob = str(kw["messages"])
+        assert "<system>" in msg_blob
+        assert "Important rule" in msg_blob
+        # the original user message content must still be present
+        assert "hello" in msg_blob
+
+    def test_zai_small_system_kept_as_system_field(self):
+        """Small system prompt (< 2 KB) stays in the system field for Z.AI."""
+        kw = _build_kwargs(
+            base_url="https://api.z.ai/api/anthropic",
+            system="You are helpful.",  # ~17 chars, well under 2 KB
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert kw.get("system") == "You are helpful."
+
+    def test_native_anthropic_large_system_unchanged(self):
+        """Native Anthropic must keep the large system in the system field."""
+        kw = _build_kwargs(
+            base_url="https://api.anthropic.com",
+            system=self.BIG_SYSTEM,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert kw.get("system") == self.BIG_SYSTEM
+        # must NOT be folded into messages
+        assert "<system>" not in str(kw["messages"])
+
+    def test_zai_fold_preserves_content_block_list(self):
+        """When the first user message has a content-block list, the system
+        block is prepended as a new text block without clobbering the list."""
+        kw = _build_kwargs(
+            base_url="https://api.z.ai/api/anthropic",
+            system=self.BIG_SYSTEM,
+            messages=[{"role": "user", "content": [
+                {"type": "text", "text": "image follows"},
+                {"type": "image", "source": {"data": "..."}},
+            ]}],
+        )
+        assert "system" not in kw
+        first = kw["messages"][0]
+        assert first["role"] == "user"
+        content = first["content"]
+        assert isinstance(content, list)
+        # prepended system block is first
+        assert content[0]["type"] == "text"
+        assert "<system>" in content[0]["text"]
+        # original blocks preserved after it
+        assert content[1]["text"] == "image follows"
+        assert content[2]["type"] == "image"
+
+
+# ---------------------------------------------------------------------------
+# Regression: native paths untouched
+# ---------------------------------------------------------------------------
+
+class TestNativePathsUnaffected:
+    def test_native_endpoint_keeps_betas_and_system(self):
+        """The whole Z.AI guard must be a no-op for native Anthropic."""
+        big_system = "x " * 5000
+        kw = _build_kwargs(
+            base_url="https://api.anthropic.com",
+            system=big_system,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert kw.get("system") == big_system
+        assert "<system>" not in str(kw["messages"])
+
+    def test_openai_compat_url_unchanged(self):
+        """Z.AI's OpenAI-compat endpoints are not Anthropic wire — must be
+        untouched by the anthropic-only fixes."""
+        from agent.anthropic_adapter import _is_zai_anthropic_endpoint
+        assert not _is_zai_anthropic_endpoint("https://api.z.ai/api/coding/paas/v4")


### PR DESCRIPTION
## Summary

Z.AI serves GLM models (glm-5.2, etc.) behind an Anthropic-compatible relay at `api.z.ai/api/anthropic` (global) and `open.bigmodel.cn/api/anthropic` (China). Native clients (e.g. ZCode) work fine against it, but **Hermes is unusable on this endpoint** — every GLM turn fails and Hermes loops on retries. This PR fixes two adapter quirks that cause the failures.

## Fix 1 — Strip Claude-specific beta headers (`HTTP 429 code 1302`)

Hermes sends `interleaved-thinking-2025-05-14` and `fine-grained-tool-streaming-2025-05-14` on every anthropic request. Z.AI's relay **deterministically rejects** requests carrying these betas with `rate_limit_error` code 1302.

**Verification** — A/B test, 5 alternating calls (same key, payload, time window):

| | Success |
|---|---|
| No betas | **5/5 (100%)** |
| With betas | **0/5 (0%)** — all `1302`, all <0.5s |

`_common_betas_for_base_url` now returns `[]` for Z.AI endpoints (same idea as the existing MiniMax handling, but strips all betas rather than a subset, since Z.AI rejects the full Claude beta set).

## Fix 2 — Fold large system prompts into messages (`HTTP 429 code 1305`)

Z.AI's relay rejects **system prompts larger than ~2 KB** with `overloaded_error` code 1305. Message content has no such limit (420 K tokens of user content works fine). Hermes' default system prompt is ~104 KB (26 K tokens of persona + tools + skills), so every turn trips the limit.

**Verification**:

| System prompt size | Result |
|---|---|
| 104 KB | 0/5 success |
| <1 KB | 5/5 success |

`build_anthropic_kwargs` now folds system prompts >2 KB into the first user message as a `<system>…</system>` text block for Z.AI only. Small system prompts and all non-Z.AI endpoints keep the `system` field unchanged.

## Scope / safety

Both fixes are guarded by `_is_zai_anthropic_endpoint(base_url)`, matching only the Z.AI anthropic hostnames. **Native Anthropic, Azure, MiniMax, Kimi, and all OpenAI-compat traffic are completely unaffected** — verified by the regression tests and the existing suite.

## Testing

- **21 new tests** in `tests/agent/test_zai_anthropic_compat.py`: endpoint detection (11 cases), beta stripping (Z.AI strips all / MiniMax unchanged / native keeps all), system-prompt folding (large→messages / small→system field / content-block-list preserved / native unchanged), and a native-path regression guard.
- Tests **fail without the fix** (16/21) and **pass with it** (21/21) — genuine regression coverage.
- **213 existing** anthropic + MiniMax tests pass unchanged (no regressions).

## Observed in production

A ~1.3k-message GLM-5.2 session on the Z.AI anthropic endpoint failed every turn with `1305`/`1302` and retried for hours. After this fix, turns complete in ~10-30s with prefix caching.