### PR TITLE
fix(auxiliary): fall back on rate limits for explicit providers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5659,16 +5659,14 @@ def call_llm(
             or _is_rate_limit_error(first_err)
         )
         # Respect explicit provider choice for transient errors (auth, request
-        # validation, etc.) but allow fallback when the provider clearly cannot
-        # serve the request due to capacity: payment/quota exhaustion and
-        # connection failures are capacity problems, not request constraints.
-        # See #26803: daily token quota (429 + "too many tokens per day") must
-        # fall back just like a 402 credit error.
+        # validation, etc.) but fall back when the provider clearly cannot serve
+        # the request due to capacity. Every class in should_fallback above is
+        # such a capacity error — payment/quota exhaustion, connection failure,
+        # or a rate limit that outlived retries — so it falls back regardless of
+        # whether the provider was auto-detected or explicitly configured.
+        # See #26803 (daily token quota) and #52228 (rate limits, explicit providers).
         is_auto = resolved_provider in {"auto", "", None}
-        # Capacity errors bypass the explicit-provider gate: the provider
-        # literally cannot serve this request regardless of user intent.
-        is_capacity_error = _is_payment_error(first_err) or _is_connection_error(first_err)
-        if should_fallback and (is_auto or is_capacity_error):
+        if should_fallback:
             if _is_payment_error(first_err):
                 reason = "payment error"
                 # Resolve the actual provider label (resolved_provider may be
@@ -6110,12 +6108,12 @@ async def async_call_llm(
             or _is_connection_error(first_err)
             or _is_rate_limit_error(first_err)
         )
-        # Capacity errors (payment/quota/connection) bypass the explicit-provider
-        # gate — the provider cannot serve the request regardless of user intent.
-        # See #26803: daily token quota must fall back like a 402 credit error.
+        # Every class in should_fallback above is a capacity error — the provider
+        # cannot serve the request regardless of user intent — so it falls back
+        # whether the provider was auto-detected or explicitly configured.
+        # See #26803 (daily token quota) and #52228 (rate limits, explicit providers).
         is_auto = resolved_provider in {"auto", "", None}
-        is_capacity_error = _is_payment_error(first_err) or _is_connection_error(first_err)
-        if should_fallback and (is_auto or is_capacity_error):
+        if should_fallback:
             if _is_payment_error(first_err):
                 reason = "payment error"
                 _mark_provider_unhealthy(

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1870,6 +1870,36 @@ class TestAuxiliaryFallbackLayering:
 
         assert main_client.chat.completions.create.called
 
+    def test_explicit_provider_falls_back_on_rate_limit(self, monkeypatch):
+        """#52228: an explicit provider hit by a 429 must still fall back."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+
+        rate_err = Exception("Rate limit exceeded, try again in 60 seconds")
+        rate_err.status_code = 429
+
+        primary_client = MagicMock()
+        primary_client.chat.completions.create.side_effect = rate_err
+
+        main_client = MagicMock()
+        main_client.chat.completions.create.return_value = MagicMock(choices=[
+            MagicMock(message=MagicMock(content="from main agent after rate limit"))
+        ])
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary_client, "gpt-5.5")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("openai-codex", "gpt-5.5", None, None, None)), \
+             patch("agent.auxiliary_client._try_configured_fallback_chain",
+                   return_value=(None, None, "")), \
+             patch("agent.auxiliary_client._try_main_agent_model_fallback",
+                   return_value=(main_client, "claude-sonnet-4", "main-agent(openrouter)")):
+            call_llm(
+                task="kanban_decomposer",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+
+        assert main_client.chat.completions.create.called
+
     def test_warning_emitted_when_all_fallbacks_exhausted(self, monkeypatch, caplog):
         """When chain AND main model both fail, a user-visible warning fires before re-raise."""
         monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")


### PR DESCRIPTION
Auxiliary tasks with an explicit provider (e.g. `openai-codex`) don't fall back on a 429, so they just fail. Rate limits were in `should_fallback` but not `is_capacity_error`, so the gate `should_fallback and (is_auto or is_capacity_error)` was False for explicit providers and the `_is_rate_limit_error` branch below was dead.

`is_capacity_error` is a subset of `should_fallback`, so the condition collapses to `should_fallback`. Gate on that in the sync and async paths and drop the variable. Regression test added for explicit provider + 429.


Fixes #52228.