### PR TITLE
Emit runtime notice after fallback responses

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1863,6 +1863,7 @@ _RUNTIME_MAIN_MODEL: str = ""
 _RUNTIME_MAIN_BASE_URL: str = ""
 _RUNTIME_MAIN_API_KEY: str = ""
 _RUNTIME_MAIN_API_MODE: str = ""
+_RUNTIME_STATUS_CALLBACK: Any = None
 
 
 def set_runtime_main(
@@ -1872,6 +1873,7 @@ def set_runtime_main(
     base_url: str = "",
     api_key: str = "",
     api_mode: str = "",
+    status_callback: Any = None,
 ) -> None:
     """Record the live runtime provider/model/credentials for the current AIAgent.
 
@@ -1884,24 +1886,26 @@ def set_runtime_main(
     recorded so that ``_resolve_auto`` can construct a valid client in
     Step 1 instead of falling through to the aggregator chain.
     """
-    global _RUNTIME_MAIN_PROVIDER, _RUNTIME_MAIN_MODEL
+    global _RUNTIME_MAIN_PROVIDER, _RUNTIME_MAIN_MODEL, _RUNTIME_STATUS_CALLBACK
     global _RUNTIME_MAIN_BASE_URL, _RUNTIME_MAIN_API_KEY, _RUNTIME_MAIN_API_MODE
     _RUNTIME_MAIN_PROVIDER = (provider or "").strip().lower()
     _RUNTIME_MAIN_MODEL = (model or "").strip()
     _RUNTIME_MAIN_BASE_URL = (base_url or "").strip()
     _RUNTIME_MAIN_API_KEY = api_key.strip() if isinstance(api_key, str) else ""
     _RUNTIME_MAIN_API_MODE = (api_mode or "").strip()
+    _RUNTIME_STATUS_CALLBACK = status_callback
 
 
 def clear_runtime_main() -> None:
     """Clear the runtime override (e.g. on session end)."""
-    global _RUNTIME_MAIN_PROVIDER, _RUNTIME_MAIN_MODEL
+    global _RUNTIME_MAIN_PROVIDER, _RUNTIME_MAIN_MODEL, _RUNTIME_STATUS_CALLBACK
     global _RUNTIME_MAIN_BASE_URL, _RUNTIME_MAIN_API_KEY, _RUNTIME_MAIN_API_MODE
     _RUNTIME_MAIN_PROVIDER = ""
     _RUNTIME_MAIN_MODEL = ""
     _RUNTIME_MAIN_BASE_URL = ""
     _RUNTIME_MAIN_API_KEY = ""
     _RUNTIME_MAIN_API_MODE = ""
+    _RUNTIME_STATUS_CALLBACK = None
 
 
 def _resolve_custom_runtime() -> Tuple[Optional[str], Optional[str], Optional[str]]:
@@ -3096,6 +3100,51 @@ def _try_payment_fallback(
         task or "call", reason, failed_provider, ", ".join(tried),
     )
     return None, None, ""
+
+
+def _extract_response_model_name(response: Any) -> Optional[str]:
+    """Best-effort model extraction from OpenAI-compatible response objects."""
+    if response is None:
+        return None
+    try:
+        model = getattr(response, "model", None)
+        if model:
+            return str(model)
+    except Exception:
+        pass
+    if isinstance(response, dict):
+        model = response.get("model")
+        return str(model) if model else None
+    try:
+        dump = response.model_dump()
+        if isinstance(dump, dict) and dump.get("model"):
+            return str(dump["model"])
+    except Exception:
+        pass
+    return None
+
+
+def _emit_aux_fallback_status(
+    task: Optional[str],
+    reason: str,
+    provider: str,
+    model: Optional[str],
+    actual_model: Optional[str] = None,
+) -> None:
+    """Emit a runtime fallback notice without adding anything to prompts."""
+    cb = _RUNTIME_STATUS_CALLBACK
+    if not cb:
+        return
+    label = task or "auxiliary"
+    actual = (actual_model or "").strip()
+    try:
+        cb(
+            f"Auxiliary {label}: {reason}; fallback activated: "
+            f"{model or ''} via {provider or 'unknown'}; "
+            f"actual response model: {actual}"
+        )
+    except Exception:
+        logger.debug("Auxiliary fallback status callback failed", exc_info=True)
 
 
 def _try_main_agent_model_fallback(
@@ -5714,8 +5763,12 @@ def call_llm(
                     tools=tools, timeout=effective_timeout,
                     extra_body=effective_extra_body,
                     base_url=str(getattr(fb_client, "base_url", "") or ""))
-                return _validate_llm_response(
-                    fb_client.chat.completions.create(**fb_kwargs), task)
+                fb_response = fb_client.chat.completions.create(**fb_kwargs)
+                validated = _validate_llm_response(fb_response, task)
+                _emit_aux_fallback_status(
+                    task, reason, fb_label, fb_model,
+                    _extract_response_model_name(fb_response))
+                return validated
             # All fallback layers exhausted — emit a single user-visible
             # warning so the operator knows aux task is about to fail.
             # (#26882) The error itself is re-raised below.
@@ -6163,8 +6216,12 @@ async def async_call_llm(
                 )
                 if async_fb_model and async_fb_model != fb_kwargs.get("model"):
                     fb_kwargs["model"] = async_fb_model
-                return _validate_llm_response(
-                    await async_fb.chat.completions.create(**fb_kwargs), task)
+                fb_response = await async_fb.chat.completions.create(**fb_kwargs)
+                validated = _validate_llm_response(fb_response, task)
+                _emit_aux_fallback_status(
+                    task, reason, fb_label, fb_kwargs.get("model") or fb_model,
+                    _extract_response_model_name(fb_response))
+                return validated
             # All fallback layers exhausted — warn before re-raising. (#26882)
             logger.warning(
                 "Auxiliary %s (async): %s on %s and all fallbacks exhausted "

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -548,7 +548,10 @@ def interruptible_api_call(agent, api_kwargs: dict):
             raise InterruptedError("Agent interrupted during API call")
     if result["error"] is not None:
         raise result["error"]
-    return result["response"]
+    response = result["response"]
+    _maybe_buffer_fallback_status(
+        agent, _extract_response_model_name(response), allow_empty=True)
+    return response
 
 
 
@@ -1071,6 +1074,67 @@ def rewrite_prompt_model_identity(agent, model: str, provider: str) -> None:
     agent._cached_system_prompt = sp
 
 
+def _extract_response_model_name(response: Any) -> Optional[str]:
+    """Best-effort model extraction from OpenAI-compatible response objects."""
+    if response is None:
+        return None
+    try:
+        model = getattr(response, "model", None)
+        if model:
+            return str(model)
+    except Exception:
+        pass
+    if isinstance(response, dict):
+        model = response.get("model")
+        return str(model) if model else None
+    try:
+        dump = response.model_dump()
+        if isinstance(dump, dict) and dump.get("model"):
+            return str(dump["model"])
+    except Exception:
+        pass
+    return None
+
+
+def _set_fallback_notice_pending(agent, provider: str, model: str) -> None:
+    agent._fallback_notice_pending = {
+        "provider": provider or "unknown",
+        "model": model or "",
+    }
+
+
+def _maybe_buffer_fallback_status(
+    agent, actual_model: Optional[str], *, allow_empty: bool = False
+) -> bool:
+    """Emit one runtime fallback notice after a fallback response exists."""
+    pending = getattr(agent, "_fallback_notice_pending", None)
+    if not pending:
+        return False
+    actual = (actual_model or "").strip()
+    if not actual and not allow_empty:
+        return False
+    provider = pending.get("provider") or "unknown"
+    model = pending.get("model") or ""
+    current_provider = (getattr(agent, "provider", "") or "").strip().lower()
+    current_model = (getattr(agent, "model", "") or "").strip()
+    if (
+        (provider or "").strip().lower() != current_provider
+        or (model or "").strip() != current_model
+    ):
+        agent._fallback_notice_pending = None
+        return False
+    try:
+        agent._buffer_status(
+            f"Fallback activated: {model} via {provider}; "
+            f"actual response model: {actual}"
+        )
+    except Exception:
+        logger.debug("Fallback status callback failed", exc_info=True)
+    finally:
+        agent._fallback_notice_pending = None
+    return True
+
+
 def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool:
     """Switch to the next fallback model/provider in the chain.
 
@@ -1320,10 +1384,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # answering, so "what model are you?" doesn't report the primary.
         rewrite_prompt_model_identity(agent, fb_model, fb_provider)
 
-        agent._buffer_status(
-            f"🔄 Primary model failed — switching to fallback: "
-            f"{fb_model} via {fb_provider}"
-        )
+        _set_fallback_notice_pending(agent, fb_provider, fb_model)
         logger.info(
             "Fallback activated: %s → %s (%s)",
             old_model, fb_model, fb_provider,
@@ -1718,7 +1779,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 raise InterruptedError("Agent interrupted during Bedrock API call")
         if result["error"] is not None:
             raise result["error"]
-        return result["response"]
+        response = result["response"]
+        _maybe_buffer_fallback_status(
+            agent, _extract_response_model_name(response), allow_empty=True)
+        return response
 
     result = {"response": None, "error": None, "partial_tool_names": []}
     request_client_holder = {"client": None, "diag": None, "owner_tid": None}
@@ -1918,6 +1982,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             if not chunk.choices:
                 if hasattr(chunk, "model") and chunk.model:
                     model_name = chunk.model
+                    _maybe_buffer_fallback_status(agent, model_name)
                 # Usage comes in the final chunk with empty choices
                 if hasattr(chunk, "usage") and chunk.usage:
                     usage_obj = chunk.usage
@@ -1926,6 +1991,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             delta = chunk.choices[0].delta
             if hasattr(chunk, "model") and chunk.model:
                 model_name = chunk.model
+                _maybe_buffer_fallback_status(agent, model_name)
 
             # Accumulate reasoning content
             reasoning_text = getattr(delta, "reasoning_content", None) or getattr(delta, "reasoning", None)
@@ -2698,7 +2764,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 _dropped_tool_names=_partial_names or None,
             )
         raise result["error"]
-    return result["response"]
+    response = result["response"]
+    _maybe_buffer_fallback_status(
+        agent, _extract_response_model_name(response), allow_empty=True)
+    return response
 
 # ── Provider fallback ──────────────────────────────────────────────────
 

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -153,6 +153,7 @@ def build_turn_context(
             base_url=getattr(agent, "base_url", "") or "",
             api_key=getattr(agent, "api_key", "") or "",
             api_mode=getattr(agent, "api_mode", "") or "",
+            status_callback=getattr(agent, "_emit_status", None),
         )
     except Exception:
         pass

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1896,6 +1896,94 @@ class TestAuxiliaryFallbackLayering:
             "all fallbacks exhausted" in r.message for r in caplog.records
         ), f"Expected exhaustion warning, got: {[r.message for r in caplog.records]}"
 
+    def test_fallback_success_emits_runtime_status_with_actual_model(self, monkeypatch):
+        """Fallback status is emitted only after the fallback response succeeds."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+
+        primary_client = MagicMock()
+        primary_client.chat.completions.create.side_effect = self._make_payment_err()
+
+        fallback_response = MagicMock(
+            model="provider/routed-model",
+            choices=[MagicMock(message=MagicMock(content="from fallback"))],
+        )
+        fallback_client = MagicMock()
+        fallback_client.chat.completions.create.return_value = fallback_response
+
+        statuses = []
+        import agent.auxiliary_client as aux_mod
+
+        aux_mod._RUNTIME_STATUS_CALLBACK = statuses.append
+        try:
+            with (
+                patch(
+                    "agent.auxiliary_client._get_cached_client",
+                    return_value=(primary_client, "glm-4v-flash"),
+                ),
+                patch(
+                    "agent.auxiliary_client._resolve_task_provider_model",
+                    return_value=("glm", "glm-4v-flash", None, None, None),
+                ),
+                patch(
+                    "agent.auxiliary_client._try_configured_fallback_chain",
+                    return_value=(
+                        fallback_client,
+                        "fallback/model",
+                        "fallback_chain[0](openrouter)",
+                    ),
+                ),
+                patch(
+                    "agent.auxiliary_client._try_main_agent_model_fallback",
+                    return_value=(None, None, ""),
+                ),
+            ):
+                result = call_llm(
+                    task="vision",
+                    messages=[{"role": "user", "content": "hello"}],
+                )
+        finally:
+            aux_mod._RUNTIME_STATUS_CALLBACK = None
+
+        assert result is fallback_response
+        assert statuses == [
+            "Auxiliary vision: payment error; fallback activated: "
+            "fallback/model via fallback_chain[0](openrouter); "
+            "actual response model: provider/routed-model"
+        ]
+
+    def test_primary_success_does_not_emit_runtime_fallback_status(self):
+        primary_response = MagicMock(
+            model="primary/model",
+            choices=[MagicMock(message=MagicMock(content="from primary"))],
+        )
+        primary_client = MagicMock()
+        primary_client.chat.completions.create.return_value = primary_response
+
+        statuses = []
+        import agent.auxiliary_client as aux_mod
+
+        aux_mod._RUNTIME_STATUS_CALLBACK = statuses.append
+        try:
+            with (
+                patch(
+                    "agent.auxiliary_client._get_cached_client",
+                    return_value=(primary_client, "primary/model"),
+                ),
+                patch(
+                    "agent.auxiliary_client._resolve_task_provider_model",
+                    return_value=("openrouter", "primary/model", None, None, None),
+                ),
+            ):
+                result = call_llm(
+                    task="title_generation",
+                    messages=[{"role": "user", "content": "hello"}],
+                )
+        finally:
+            aux_mod._RUNTIME_STATUS_CALLBACK = None
+
+        assert result is primary_response
+        assert statuses == []
+
 
 class TestTryMainAgentModelFallback:
     """_try_main_agent_model_fallback resolves the user's main provider+model as a safety net."""

--- a/tests/agent/test_set_runtime_main_custom_provider.py
+++ b/tests/agent/test_set_runtime_main_custom_provider.py
@@ -15,6 +15,7 @@ def _get_globals(mod):
         "base_url": mod._RUNTIME_MAIN_BASE_URL,
         "cred": mod._RUNTIME_MAIN_API_KEY,  # renamed to avoid redaction
         "api_mode": mod._RUNTIME_MAIN_API_MODE,
+        "status_callback": mod._RUNTIME_STATUS_CALLBACK,
     }
 
 
@@ -55,8 +56,9 @@ class TestSetRuntimeMainCustomProvider:
         )
         mod.clear_runtime_main()
         g = _get_globals(mod)
-        for v in g.values():
-            assert v == "", f"Expected empty, got {v!r}"
+        for key, value in g.items():
+            expected = None if key == "status_callback" else ""
+            assert value == expected, f"Expected {expected!r}, got {value!r}"
 
     def test_resolve_auto_uses_globals_for_custom_provider(self):
         """_resolve_auto reads base_url/api_key from globals when main_runtime is None."""
@@ -125,6 +127,21 @@ class TestSetRuntimeMainCustomProvider:
             assert g["base_url"] == ""
             assert g["cred"] == ""
             assert g["api_mode"] == ""
+            assert g["status_callback"] is None
+        finally:
+            mod.clear_runtime_main()
+
+    def test_status_callback_is_stored_and_cleared(self):
+        """set_runtime_main can carry the active agent's runtime status emitter."""
+        import agent.auxiliary_client as mod
+
+        callback = lambda msg: None
+        mod.clear_runtime_main()
+        try:
+            mod.set_runtime_main("openrouter", "gpt-4o", status_callback=callback)
+            assert mod._RUNTIME_STATUS_CALLBACK is callback
+            mod.clear_runtime_main()
+            assert mod._RUNTIME_STATUS_CALLBACK is None
         finally:
             mod.clear_runtime_main()
 

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -305,3 +305,68 @@ class TestFallbackChainDedup:
 
         assert ok is False
         mock_resolve.assert_not_called()
+
+
+class TestFallbackRuntimeNotice:
+    def test_activation_defers_status_until_response_model_is_known(self):
+        fb = {"provider": "openrouter", "model": "openrouter/auto"}
+        agent = _make_agent(fallback_model=[fb])
+        statuses = []
+        agent._buffer_status = statuses.append
+
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(_mock_client(), "openrouter/auto"),
+            ),
+            patch(
+                "hermes_cli.model_normalize.normalize_model_for_provider",
+                side_effect=lambda m, p: m,
+            ),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert statuses == []
+        assert agent._fallback_notice_pending == {
+            "provider": "openrouter",
+            "model": "openrouter/auto",
+        }
+
+    def test_fallback_status_includes_actual_response_model_once(self):
+        from agent.chat_completion_helpers import _maybe_buffer_fallback_status
+
+        agent = _make_agent(fallback_model=None)
+        statuses = []
+        agent._buffer_status = statuses.append
+        agent.provider = "openrouter"
+        agent.model = "openrouter/auto"
+        agent._fallback_notice_pending = {
+            "provider": "openrouter",
+            "model": "openrouter/auto",
+        }
+
+        assert _maybe_buffer_fallback_status(agent, "meta/llama-3.1") is True
+        assert _maybe_buffer_fallback_status(agent, "ignored") is False
+        assert statuses == [
+            "Fallback activated: openrouter/auto via openrouter; "
+            "actual response model: meta/llama-3.1"
+        ]
+
+    def test_fallback_status_allows_empty_actual_model_after_response(self):
+        from agent.chat_completion_helpers import _maybe_buffer_fallback_status
+
+        agent = _make_agent(fallback_model=None)
+        statuses = []
+        agent._buffer_status = statuses.append
+        agent.provider = "openrouter"
+        agent.model = "openrouter/auto"
+        agent._fallback_notice_pending = {
+            "provider": "openrouter",
+            "model": "openrouter/auto",
+        }
+
+        assert _maybe_buffer_fallback_status(agent, None, allow_empty=True) is True
+        assert statuses == [
+            "Fallback activated: openrouter/auto via openrouter; "
+            "actual response model: "
+        ]


### PR DESCRIPTION
## Summary
- defer main-model fallback status until a fallback response exists
- include the actual response model when providers expose it, or leave it blank when unavailable
- emit equivalent runtime status for auxiliary fallback successes through the active agent status callback

## Tests
- `.\.venv\Scripts\python -m py_compile agent\chat_completion_helpers.py agent\auxiliary_client.py agent\turn_context.py`
- `.\.venv\Scripts\python -m pytest tests\run_agent\test_provider_fallback.py tests\agent\test_auxiliary_client.py::TestAuxiliaryFallbackLayering tests\agent\test_set_runtime_main_custom_provider.py`