### PR TITLE
fix(cron): seed continuable-thread session on standalone-fallback delivery

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1445,6 +1445,18 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 continue
 
             logger.info("Job '%s': delivered to %s:%s", job["id"], platform_name, chat_id)
+            # Seed the thread session here too: the standalone fallback also
+            # delivered into the freshly-opened thread (thread_id == opened_thread_id),
+            # so this is a delivery-succeeded path and must seed exactly like the
+            # live-adapter branch above — otherwise an in-thread reply hits a
+            # session with no record of the brief.
+            if opened_thread_id and not thread_seeded:
+                _seed_cron_thread_session(
+                    job, runtime_adapter, platform_name, chat_id,
+                    opened_thread_id, mirror_text,
+                    chat_name=origin.get("chat_name"),
+                )
+                thread_seeded = True
             _maybe_mirror_cron_delivery(
                 job, platform_name, chat_id, mirror_text,
                 thread_id=thread_id, user_id=origin_user_id,

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -3869,3 +3869,76 @@ class TestCronDeliveryMirror:
             )
         store.get_or_create_session.assert_not_called()
         mirror_mock.assert_not_called()
+
+    def test_standalone_fallback_seeds_opened_thread_session(self):
+        """Regression: a continuable-cron delivery that opens a thread but
+        completes via the STANDALONE fallback (live send unconfirmed →
+        adapter_ok=False) must still seed the thread-keyed session, exactly
+        like the live-adapter success branch.
+
+        `b177d4ee4` deferred the seed to "delivery succeeded" but wired it into
+        the live branch only; the standalone fallback also delivers into the
+        freshly-opened thread (``thread_id == opened_thread_id``), so it is
+        equally a delivery-succeeded path. Without the seed, the user's first
+        in-thread reply resolves to a session with no record of the brief
+        ("what is Task #2?"). FAILS before the fix (seed never invoked on the
+        standalone path), PASSES after.
+        """
+        from gateway.config import Platform
+        from concurrent.futures import Future
+
+        adapter = MagicMock()
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+        mock_cfg.filter_silence_narration = False
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        # Force the live send to come back UNCONFIRMED so adapter_ok=False and
+        # delivery falls through to the standalone path (see _deliver_result).
+        def fake_schedule(coro, _loop):
+            try:
+                coro.close()
+            except Exception:
+                pass
+            fut = Future()
+            fut.set_result({"success": False, "error": "loop wedged"})
+            return fut
+
+        standalone_send = AsyncMock(return_value={"success": True})
+
+        job = {
+            "id": "continuable-standalone-job",
+            "name": "Daily Brief",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "123", "chat_name": "Ops"},
+            "attach_to_session": True,
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("cron.scheduler._open_continuable_cron_thread", return_value="9001"), \
+             patch("agent.async_utils.safe_schedule_threadsafe", side_effect=fake_schedule), \
+             patch("tools.send_message_tool._send_to_platform", new=standalone_send), \
+             patch("cron.scheduler._seed_cron_thread_session") as seed_mock:
+            result = _deliver_result(
+                job,
+                "Daily brief Task #2",
+                adapters={Platform.TELEGRAM: adapter},
+                loop=loop,
+            )
+
+        # Delivery completed via the standalone fallback.
+        assert result is None, f"standalone should have delivered, got: {result!r}"
+        standalone_send.assert_awaited_once()
+        # The opened thread's session MUST be seeded on this path too.
+        seed_mock.assert_called_once()
+        seed_args = seed_mock.call_args[0]
+        # _seed_cron_thread_session(job, adapter, platform_name, chat_id,
+        #                           thread_id, mirror_text, chat_name=...)
+        assert seed_args[4] == "9001", "seed must target the opened thread id"
+        assert "Task #2" in seed_args[5], "seed must carry the brief text"


### PR DESCRIPTION
## What does this PR do?

Seeds the continuable-cron thread session on the **standalone-fallback** delivery path, matching the live-adapter path.

`b177d4ee4` deferred the thread-session seed to "delivery succeeded," but only wired it into the live-adapter success branch (`if adapter_ok:`). The standalone fallback also delivers the brief into the freshly-opened thread (`thread_id == opened_thread_id`), so it is equally a delivery-succeeded path and must seed.

Without this, when the live send is unconfirmed (`adapter_ok=False`) and delivery completes via the standalone fallback, the thread-keyed session is never created: the user's first in-thread reply resolves to a session with no record of the brief ("what is Task #2?"), and the brief is absent from the transcript (the mirror no-ops against the unseeded thread).

The fix adds the same `if opened_thread_id and not thread_seeded: _seed_cron_thread_session(...)` guard before the standalone-path mirror call. `runtime_adapter` is guaranteed non-None there (a thread only opens under the same `runtime_adapter is not None` guard), and `_seed_cron_thread_session` is best-effort (its own try/except), so an already-succeeded delivery is never failed by seeding.

## Related Issue

No filed issue — author-found regression in a fresh module (`b177d4ee4`, merged today). Fixes a gap introduced by that commit's seed-deferral refactor.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py`: in `_deliver_result`, before the standalone-path `_maybe_mirror_cron_delivery(...)` call, add the same `if opened_thread_id and not thread_seeded: _seed_cron_thread_session(...)` guard the live-adapter branch already runs. This keeps the two delivery-succeeded paths consistent so they can't drift again.
- `tests/cron/test_scheduler.py`: new regression test `test_standalone_fallback_seeds_opened_thread_session`.

## How to Test

1. Configure a continuable cron job (`cron.mirror_delivery` / `attach_to_session`) whose origin is a thread-capable platform (Telegram/Discord/Slack).
2. Drive the path where the thread opens, the live send is unconfirmed (`adapter_ok=False`), and delivery completes via the standalone fallback.
3. Before the fix: the thread-keyed session is never created, so a reply in the new thread has no record of the brief. After the fix: the session is seeded with the brief, exactly as on the live-adapter path.

Automated: `test_standalone_fallback_seeds_opened_thread_session` drives the "thread opens → live send unconfirmed → standalone succeeds" path and asserts `_seed_cron_thread_session` is invoked once with the opened thread id and the brief text. **Fails before the fix** (seed never invoked on the standalone path), **passes after**. Full `tests/cron/test_scheduler.py` suite green (187 passed).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/cron/test_scheduler.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A (pure control-flow change, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A