### PR TITLE
fix(desktop): broken "Open setup guide" button for plugin platforms (Teams)

### DIFF
--- a/apps/desktop/src/app/messaging/index.test.tsx
+++ b/apps/desktop/src/app/messaging/index.test.tsx
@@ -1,0 +1,88 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { MessagingPlatformInfo } from '@/types/hermes'
+
+const getMessagingPlatforms = vi.fn()
+const updateMessagingPlatform = vi.fn()
+const openExternalLink = vi.fn()
+
+vi.mock('@/hermes', () => ({
+  getMessagingPlatforms: () => getMessagingPlatforms(),
+  updateMessagingPlatform: (id: string, body: unknown) => updateMessagingPlatform(id, body)
+}))
+
+vi.mock('@/lib/external-link', () => ({
+  openExternalLink: (href: string) => openExternalLink(href)
+}))
+
+vi.mock('@/store/notifications', () => ({
+  notify: vi.fn(),
+  notifyError: vi.fn()
+}))
+
+vi.mock('@/store/system-actions', () => ({
+  runGatewayRestart: vi.fn()
+}))
+
+function platform(patch: Partial<MessagingPlatformInfo> = {}): MessagingPlatformInfo {
+  return {
+    configured: false,
+    description: 'A platform.',
+    docs_url: '',
+    enabled: false,
+    env_vars: [],
+    gateway_running: true,
+    id: 'teams',
+    name: 'Microsoft Teams',
+    state: 'disabled',
+    ...patch
+  }
+}
+
+beforeEach(() => {
+  updateMessagingPlatform.mockResolvedValue({ ok: true, platform: 'teams' })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+async function renderMessaging() {
+  const { MessagingView } = await import('./index')
+
+  return render(
+    <MemoryRouter>
+      <MessagingView />
+    </MemoryRouter>
+  )
+}
+
+describe('MessagingView setup-guide link', () => {
+  it('hides the setup-guide button for a plugin platform with no docs URL', async () => {
+    // Teams (and other plugin platforms) ship an empty docs_url. Rendering an
+    // anchor with href="" let Electron resolve it to the app's own packaged
+    // index.html and fail with an OS "file not found" dialog. The button must
+    // simply not appear when there is no guide to open.
+    getMessagingPlatforms.mockResolvedValue({ platforms: [platform({ docs_url: '' })] })
+
+    await renderMessaging()
+
+    expect((await screen.findAllByText('Microsoft Teams')).length).toBeGreaterThan(0)
+    expect(screen.queryByText('Open setup guide')).toBeNull()
+  })
+
+  it('opens a real docs URL through the validated external opener', async () => {
+    const docsUrl = 'https://hermes-agent.nousresearch.com/docs/user-guide/messaging/teams'
+    getMessagingPlatforms.mockResolvedValue({ platforms: [platform({ docs_url: docsUrl })] })
+
+    await renderMessaging()
+
+    const link = await screen.findByText('Open setup guide')
+    fireEvent.click(link)
+
+    await waitFor(() => expect(openExternalLink).toHaveBeenCalledWith(docsUrl))
+  })
+})

--- a/apps/desktop/src/app/messaging/index.tsx
+++ b/apps/desktop/src/app/messaging/index.tsx
@@ -14,6 +14,7 @@ import {
   updateMessagingPlatform
 } from '@/hermes'
 import { type Translations, useI18n } from '@/i18n'
+import { openExternalLink } from '@/lib/external-link'
 import { AlertTriangle, ExternalLink, Save, Trash2 } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
@@ -401,14 +402,31 @@ function PlatformDetail({
             <p className="mt-1 text-[length:var(--conversation-caption-font-size)] leading-(--conversation-caption-line-height) text-(--ui-text-tertiary)">
               {introCopy(platform, m)}
             </p>
-            <div className="mt-3">
-              <Button asChild size="sm" variant="textStrong">
-                <a href={platform.docs_url} rel="noreferrer" target="_blank">
-                  {m.openSetupGuide}
-                  <ExternalLink className="size-3.5" />
-                </a>
-              </Button>
-            </div>
+            {platform.docs_url && (
+              <div className="mt-3">
+                <Button asChild size="sm" variant="textStrong">
+                  <a
+                    href={platform.docs_url}
+                    onClick={event => {
+                      // Route through the validated external opener instead of
+                      // letting Electron resolve the anchor. A packaged build's
+                      // empty/relative href resolves to the app's own
+                      // index.html file path, which shell.openPath then fails to
+                      // open ("file not found"). Plugin platforms (Teams, etc.)
+                      // ship no docs_url, so this guard + handler keeps the
+                      // button from ever pointing at a local bundle path.
+                      event.preventDefault()
+                      openExternalLink(platform.docs_url)
+                    }}
+                    rel="noreferrer"
+                    target="_blank"
+                  >
+                    {m.openSetupGuide}
+                    <ExternalLink className="size-3.5" />
+                  </a>
+                </Button>
+              </div>
+            )}
           </section>
 
           <section>

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4540,6 +4540,12 @@ _PLATFORM_OVERRIDES: dict[str, dict[str, Any]] = {
         "env_vars": ("QQ_APP_ID", "QQ_CLIENT_SECRET", "QQ_ALLOWED_USERS"),
         "required_env": ("QQ_APP_ID", "QQ_CLIENT_SECRET"),
     },
+    # Teams ships as a platform plugin, so its name/env vars come from the
+    # plugin registry. Only the docs link needs an override here so the
+    # Channels page can point at the Microsoft Teams setup guide.
+    "teams": {
+        "docs_url": "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/teams",
+    },
     "yuanbao": {
         "name": "Yuanbao (元宝)",
         "description": "Connect Hermes to Tencent Yuanbao.",

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1672,6 +1672,18 @@ class TestWebServerEndpoints:
             assert "QR login" in fields[key]["description"]
             assert "Official Account" not in fields[key]["description"]
 
+    def test_teams_messaging_metadata_links_setup_guide(self):
+        # Teams is a platform plugin, so the catalog entry is built from the
+        # plugin registry. The override must still supply a docs link so the
+        # Channels page renders a working "Open setup guide" button instead of
+        # an empty href (which resolves to the packaged app's own index.html).
+        from hermes_cli.web_server import _build_catalog_entry
+
+        teams = _build_catalog_entry("teams")
+        assert teams["docs_url"] == (
+            "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/teams"
+        )
+
     def test_messaging_catalog_covers_gateway_platforms(self):
         """Catalog is derived from the Platform enum, so every built-in shows up."""
         from gateway.config import Platform


### PR DESCRIPTION
## Summary

On the desktop **Channels / Messaging** page, the **Open setup guide** button was rendered as a bare `<a href={platform.docs_url} target="_blank">` with no guard. Plugin-provided platforms (Microsoft Teams, Line, Raft, Google Chat, Yuanbao, …) ship an **empty `docs_url`**, so the anchor's `href` was `""`.

In a packaged build, Electron resolves an empty `href` against the current document — the app's own `index.html` inside the asar bundle — and `shell.openPath` then fails with an OS *"file not found"* dialog. This is exactly the Windows error reported for **Messaging → Teams → Open guide** (German: *"…index.html konnte nicht gefunden werden"*), pointing at `…\win-unpacked\resources\app.asar.unpacked\dist\…\index.html`.

### Fix (2 commits)

1. **`fix(desktop)`** — Only render the "Open setup guide" button when `docs_url` is non-empty, and route clicks through `openExternalLink` so a relative/empty value can never be treated as a local bundle path. This fixes the whole class (every plugin platform), not just Teams.
2. **`fix(messaging)`** — Give the Teams platform plugin a real `docs_url` (Microsoft Teams setup guide) so its card shows a working button instead of nothing.

This is complementary to #48940 (which only added a `docs_url` for Google Chat): that narrow per-platform fix did not stop the broken button for platforms still missing a `docs_url`. Commit 1 here is the shared, whole-class guard.

## Test plan

- [x] `apps/desktop` — new `src/app/messaging/index.test.tsx`: button is hidden when `docs_url` is empty; a real URL opens via the validated external opener (does not navigate).
- [x] `apps/desktop` typecheck (`tsc --noEmit`) clean.
- [x] backend — new `test_teams_messaging_metadata_links_setup_guide`: the Teams catalog entry exposes the setup-guide `docs_url`.