### PR TITLE
fix: disable redirect following in MCP preflight content-type check

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1914,7 +1914,7 @@ class MCPServerTask:
 
         client_kwargs: dict = {
             "verify": ssl_verify,
-            "follow_redirects": True,
+            "follow_redirects": False,
             "timeout": _httpx.Timeout(timeout),
         }
         if client_cert is not None:


### PR DESCRIPTION
OAuth-protected Streamable HTTP MCP servers (e.g. Qonto) return 301 redirects on unauthenticated GET requests. The preflight check with `follow_redirects=True` followed the redirect to an HTML page, triggering `NonMcpEndpointError` before the OAuth flow could start.

Fix: set `follow_redirects=False` so 3xx responses are caught by the status-code check and handled gracefully.

Closes #52460