### PR TITLE
Fix: MCP Streamable HTTP servers fail preflight check when GET redirects

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1914,7 +1914,7 @@ class MCPServerTask:
 
         client_kwargs: dict = {
             "verify": ssl_verify,
-            "follow_redirects": True,
+            "follow_redirects": False,
             "timeout": _httpx.Timeout(timeout),
         }
         if client_cert is not None:


### PR DESCRIPTION
### Describe the bug
When attempting to add an OAuth-protected Streamable HTTP MCP server (such as Qonto's official MCP server at `https://mcp.qonto.com/mcp`) using `hermes mcp add qonto --url https://mcp.qonto.com/mcp --auth oauth`, the command fails with a `NonMcpEndpointError`. 

The error message states:
`Failed to connect: MCP server 'qonto' at https://mcp.qonto.com/mcp returned Content-Type 'text/html', not an MCP response (expected one of: application/json, text/event-stream). The URL most likely points at a web page rather than an MCP endpoint`

### Root Cause
This occurs because `tools/mcp_tool.py` performs a preflight HTTP GET/HEAD request (`_preflight_content_type`) using an `httpx.AsyncClient` that has `follow_redirects=True`. 

Since the Qonto MCP server requires authentication (via POST and OAuth), any unauthenticated `GET` request to the endpoint returns a `301 Moved Permanently` redirecting to their marketing webpage (`https://qonto.com/en/ai/mcp`). Because `follow_redirects` is true, the preflight check automatically follows the redirect, lands on the HTML page, and sees a `text/html` content type. This triggers the strict `_MCP_CONTENT_TYPES` check and throws `NonMcpEndpointError` before the actual Streamable HTTP (POST) connection or OAuth flow even has a chance to start.

### Suggested Fix
In `tools/mcp_tool.py`, within `_preflight_content_type`, change `follow_redirects` to `False` in the `client_kwargs`:

```python
        client_kwargs: dict = {
            "verify": ssl_verify,
            "follow_redirects": False,
            "timeout": _httpx.Timeout(timeout),
        }
```

By disabling automatic redirects in the preflight check, the 301 response is caught by the `not (200 <= resp.status_code < 300)` condition, which silently returns and allows the real connection (and OAuth flow) to proceed gracefully.

### Steps to Reproduce
1. Run `hermes mcp add qonto --url https://mcp.qonto.com/mcp --auth oauth`
2. Observe the `Failed to connect` error due to `Content-Type 'text/html'`.

### Expected Behavior
Hermes should skip the preflight failure for 3xx responses and proceed to the actual OAuth initialization and Streamable HTTP POST connection.
