### PR TITLE
fix(desktop): make user messages selectable for copying

### DIFF
--- a/apps/desktop/src/components/assistant-ui/user-message-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/user-message-text.tsx
@@ -99,7 +99,7 @@ export const UserMessageText: FC<UserMessageTextProps> = ({ className, text }) =
   const top = useMemo(() => splitFences(text), [text])
 
   return (
-    <span className={cn('block', className)} data-slot="aui_user-message-text">
+    <span className={cn('block', className)} data-selectable-text="true" data-slot="aui_user-message-text">
       {top.map((segment, segmentIndex) => {
         if (segment.kind === 'fence') {
           return (


### PR DESCRIPTION
User messages in the desktop app had no `data-selectable-text` attribute, so the CSS `user-select: none` from parent elements prevented text selection. Added `data-selectable-text="true"` to the user message span, matching the existing pattern used by assistant messages.

Closes #52457