### PR TITLE
fix(agent): enforce child_timeout_seconds via force-kill on terminal subprocess (#52185)

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1574,6 +1574,29 @@ def _run_single_child(
             except Exception:
                 pass
 
+            # Force-kill any terminal subprocess the child may have left
+            # running.  The cooperative child.interrupt() only sets a
+            # thread-level flag; in edge cases (thread-mapping races,
+            # late arrival) the subprocess never sees it.  This hard stop
+            # guarantees no orphan process outlives the timeout.
+            #
+            # All children of a single parent share one terminal
+            # environment (collapsed to "default" by
+            # _resolve_container_task_id()), so iterating every active
+            # environment in _active_environments covers every in-flight
+            # subprocess.  The parent is blocked here on
+            # _child_future.result(), so it cannot be running terminal
+            # commands itself; the force-kill targets the child's
+            # session only.  (Bug #52185)
+            try:
+                from tools.terminal_tool import _active_environments
+                from tools.environments.base import BaseEnvironment
+                for _env in _active_environments.values():
+                    if isinstance(_env, BaseEnvironment):
+                        _env.kill_running_process()
+            except Exception:
+                pass
+
             is_timeout = isinstance(_timeout_exc, (FuturesTimeoutError, TimeoutError))
             duration = round(time.monotonic() - child_start, 2)
             logger.warning(

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -319,6 +319,19 @@ class BaseEnvironment(ABC):
         self._cwd_file = f"{temp_dir}/hermes-cwd-{self._session_id}.txt"
         self._cwd_marker = _cwd_marker(self._session_id)
         self._snapshot_ready = False
+        # Track the currently running subprocess so delegate_tool's timeout
+        # handler can force-kill a child's terminal command even when
+        # cooperative interrupt propagation fails (Bug #52185).
+        #
+        # Cross-thread contract: delegate_tool's parent thread reads and
+        # clears this attribute (via kill_running_process()) while the
+        # child's worker thread is busy inside _wait_for_process.  We
+        # don't take a lock because the GIL makes individual attribute
+        # reads and writes atomic, and a stale read is harmless — at
+        # worst we miss a kill (the cooperative child.interrupt() path
+        # catches the orphan) or double-kill (caught by _kill_process
+        # error handling).
+        self._current_proc: ProcessHandle | None = None
 
     # ------------------------------------------------------------------
     # Abstract methods
@@ -498,6 +511,11 @@ class BaseEnvironment(ABC):
         """
         output_chunks: list[str] = []
 
+        # Track this proc so delegate_tool's timeout handler can force-kill
+        # a child's terminal command even when cooperative interrupt
+        # propagation fails (Bug #52185).  Cleared at every exit point below.
+        self._current_proc = proc
+
         # Non-blocking drain via select().
         #
         # The old pattern — ``for line in proc.stdout`` — blocks on
@@ -663,6 +681,7 @@ class BaseEnvironment(ABC):
                         )
                     self._kill_process(proc)
                     drain_thread.join(timeout=2)
+                    self._current_proc = None
                     return {
                         "output": "".join(output_chunks) + "\n[Command interrupted]",
                         "returncode": 130,
@@ -678,6 +697,7 @@ class BaseEnvironment(ABC):
                     drain_thread.join(timeout=2)
                     partial = "".join(output_chunks)
                     timeout_msg = f"\n[Command timed out after {timeout}s]"
+                    self._current_proc = None
                     return {
                         "output": partial + timeout_msg
                         if partial
@@ -736,6 +756,7 @@ class BaseEnvironment(ABC):
                 drain_thread.join(timeout=2)
             except Exception:
                 pass  # cleanup is best-effort
+            self._current_proc = None
             raise
 
         # Drain thread now exits promptly after bash does (~300ms idle
@@ -757,6 +778,7 @@ class BaseEnvironment(ABC):
                 proc.returncode,
             )
 
+        self._current_proc = None
         return {"output": "".join(output_chunks), "returncode": proc.returncode}
 
     def _kill_process(self, proc: ProcessHandle):
@@ -765,6 +787,50 @@ class BaseEnvironment(ABC):
             proc.kill()
         except (ProcessLookupError, PermissionError, OSError):
             pass
+
+    def kill_running_process(self):
+        """Force-kill the currently running subprocess (if any).
+
+        Belt-and-suspenders companion to ``child.interrupt()`` (Bug #52185).
+
+        ``child.interrupt()`` only sets a thread-level flag, so the
+        terminal-tool's ``_wait_for_process`` poll loop *should* see the
+        flag on its next iteration and tear the process group down
+        itself.  In edge cases -- thread-mapping races, late arrival of
+        the interrupt, an SDK adapter whose thread is mid-blocking
+        ``exec_fn()`` -- the flag never reaches the wait loop and the
+        subprocess would outlive the timeout as an orphan.  This method
+        is the hard stop that guarantees no orphan process survives a
+        ``child_timeout`` deadline.
+
+        **Caller contract.**  Called from a different thread (the
+        parent delegate) than the one running the proc (the child
+        subagent).  The parent is blocked inside
+        ``_child_future.result(timeout=...)`` and cannot be issuing
+        tool calls, so it is safe to reach into a shared environment
+        and kill the running subprocess -- all of which are owned by
+        the child's terminal session.
+
+        **Shared environment.**  All children of a single parent share
+        one terminal environment (collapsed to ``"default"`` by
+        ``_resolve_container_task_id()``), so iterating
+        ``_active_environments`` from the timeout handler naturally
+        covers every in-flight subprocess.
+
+        **Cross-thread safety.**  No lock.  ``_current_proc`` is read
+        and written by different threads; the GIL makes individual
+        attribute access atomic, and a stale read is harmless -- at
+        worst we miss a kill (cooperative interrupt catches the
+        orphan) or double-kill (``_kill_process`` already swallows
+        ``ProcessLookupError``).
+
+        **Windows compat.**  ``_kill_process`` dispatches to
+        ``subprocess.Popen.terminate()`` on Windows, which is
+        handled by the existing ``_IS_WINDOWS`` guard.
+        """
+        if self._current_proc is not None and self._current_proc.poll() is None:
+            self._kill_process(self._current_proc)
+            self._current_proc = None
 
     # ------------------------------------------------------------------
     # CWD extraction
@@ -869,6 +935,7 @@ class BaseEnvironment(ABC):
         proc = self._run_bash(
             wrapped, login=login, timeout=effective_timeout, stdin_data=effective_stdin
         )
+        self._current_proc = proc
         result = self._wait_for_process(proc, timeout=effective_timeout)
         self._update_cwd(result)
 


### PR DESCRIPTION
## Summary

Fixes #52185 — delegated child can exceed `child_timeout_seconds` when running a blocking terminal command.

## Root Cause

When the parents `Future.result(timeout=child_timeout)` fires, `child.interrupt()` sets a cooperative thread-level flag via `_set_interrupt()` and fans out to tool worker threads. The terminal tools `_wait_for_process()` poll loop checks `is_interrupted()` every 5-50ms and should tear the subprocess down. However, in edge cases (thread-mapping races, late arrival after poll cycle, SDK adapter threads in mid-blocking exec_fn), the flag never reaches the wait loop and the subprocess continues running past the deadline.

## Fix

Belt-and-suspenders approach — the cooperative `child.interrupt()` is primary, a hard force-kill is the safety net:

**`tools/environments/base.py`:**
- `BaseEnvironment.__init__()`: Added `self._current_proc: ProcessHandle | None = None` — tracks the currently running subprocess
- `_wait_for_process()`: Sets `self._current_proc = proc` at entry, clears at all 4 exit points (interrupt-kill, timeout-kill, exception re-raise, normal completion)
- New `kill_running_process()` method: Checks if `_current_proc` is alive via `poll()` and calls `_kill_process()` (SIGTERM→SIGKILL to process group on POSIX, `proc.terminate()` on Windows)

**`tools/delegate_tool.py`:**
- In `_run_single_child()` timeout handler: After `child.interrupt()` (cooperative), added a force-kill fallback that iterates the terminal tools `_active_environments` and calls `kill_running_process()` on each `BaseEnvironment`

## Design Notes

- **Shared environment**: All children share one terminal environment (collapsed to `"default"` by `_resolve_container_task_id()`). The parent is blocked in `_child_future.result()` during the timeout and cannot be issuing terminal calls, so killing the shared environments subprocess is safe.
- **Cross-thread safety**: Lock-free by design. GIL makes individual attribute ops atomic. Worst case: double-kill (caught by `_kill_process` error handling) or missed kill (cooperative interrupt catches the orphan).
- **Windows compat**: `_kill_process` dispatches to `proc.terminate()` on Windows via existing `_IS_WINDOWS` guard.

## Test Results

\`\`\`
57 passed in 9.62s
\`\`\`

All delegate timeout diagnostic tests, terminal tool tests, and related test suites pass with zero regressions.

## Review

Code critic: **APPROVE** — No CRITICAL/HIGH findings. 2 MEDIUM notes (shared-environment scope, lock-free design) documented as intentional tradeoffs.