### PR TITLE
fix(cli): surface provider errors in -z oneshot instead of swallowing them

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -21,6 +21,7 @@ Env var fallbacks (used when the corresponding arg is not passed):
 
 from __future__ import annotations
 
+import io
 import logging
 import os
 import sys
@@ -122,6 +123,26 @@ def _validate_explicit_toolsets(toolsets: object = None) -> tuple[list[str] | No
     return valid, None
 
 
+def _output_tail(text: str, *, max_lines: int = 12, max_chars: int = 2000) -> str:
+    """Return the last few non-empty lines of captured output, bounded.
+
+    Surfaces a real provider/auth error (e.g. an Anthropic 401 or a billing
+    400) that the provider adapter prints — to stdout, in practice — before the
+    agent loop returns an empty response. Without it, ``hermes -z`` fails with
+    only the generic "no final response" message. See #45155.
+    """
+    lines = [line.rstrip() for line in text.splitlines() if line.strip()]
+    if not lines:
+        return ""
+    tail = "\n".join(lines[-max_lines:])
+    if len(tail) > max_chars:
+        tail = tail[-max_chars:]
+        # Start on a clean line boundary so the snippet doesn't begin mid-line.
+        newline = tail.find("\n")
+        tail = "…" + (tail[newline + 1 :] if newline != -1 else tail)
+    return tail
+
+
 def run_oneshot(
     prompt: str,
     model: Optional[str] = None,
@@ -171,38 +192,38 @@ def run_oneshot(
     os.environ["HERMES_YOLO_MODE"] = "1"
     os.environ["HERMES_ACCEPT_HOOKS"] = "1"
 
-    # Redirect stderr AND stdout to devnull for the entire call tree.
-    # We'll print the final response to the real stdout at the end.
+    # Capture stdout+stderr during the run so a real provider/auth error can be
+    # surfaced if the agent yields no response. The final response is returned
+    # by _run_agent (not printed), so buffering the streams is safe. Previously
+    # both went to devnull, so a 401/400/billing error printed by the provider
+    # adapter — which goes to stdout in practice — was discarded and the user
+    # saw only the generic "no final response" message. See #45155.
     real_stdout = sys.stdout
     real_stderr = sys.stderr
-    devnull = open(os.devnull, "w", encoding="utf-8")
+    captured_output = io.StringIO()
 
     response: Optional[str] = None
     failure: BaseException | None = None
-    try:
-        with redirect_stdout(devnull), redirect_stderr(devnull):
-            try:
-                response = _run_agent(
-                    prompt,
-                    model=model,
-                    provider=provider,
-                    toolsets=explicit_toolsets,
-                    use_config_toolsets=use_config_toolsets,
-                )
-            except BaseException as exc:  # noqa: BLE001
-                # Capture anything that escapes the agent (including OSError
-                # from prompt_toolkit/Vt100 when stdout is a non-TTY pipe,
-                # KeyboardInterrupt, SystemExit, etc.) so we can surface it on
-                # the real stderr instead of crashing past the redirect with a
-                # traceback that the caller never sees. A silent exit in a
-                # cron / SSH / subprocess context is the worst failure mode.
-                # See #30623.
-                failure = exc
-    finally:
+    with redirect_stdout(captured_output), redirect_stderr(captured_output):
         try:
-            devnull.close()
-        except Exception:
-            pass
+            response = _run_agent(
+                prompt,
+                model=model,
+                provider=provider,
+                toolsets=explicit_toolsets,
+                use_config_toolsets=use_config_toolsets,
+            )
+        except BaseException as exc:  # noqa: BLE001
+            # Capture anything that escapes the agent (including OSError
+            # from prompt_toolkit/Vt100 when stdout is a non-TTY pipe,
+            # KeyboardInterrupt, SystemExit, etc.) so we can surface it on
+            # the real stderr instead of crashing past the redirect with a
+            # traceback that the caller never sees. A silent exit in a
+            # cron / SSH / subprocess context is the worst failure mode.
+            # See #30623.
+            failure = exc
+
+    captured_tail = _output_tail(captured_output.getvalue())
 
     if failure is not None:
         # Re-raise control-flow exceptions so the parent handles them as usual
@@ -210,11 +231,19 @@ def run_oneshot(
         if isinstance(failure, (KeyboardInterrupt, SystemExit)):
             raise failure
         real_stderr.write(f"hermes -z: agent failed: {failure}\n")
+        if captured_tail:
+            real_stderr.write(captured_tail + "\n")
         real_stderr.flush()
         return 1
 
     if not (response or "").strip():
-        real_stderr.write("hermes -z: no final response was produced; treating the run as failed.\n")
+        real_stderr.write(
+            "hermes -z: no final response was produced; treating the run as failed.\n"
+        )
+        if captured_tail:
+            real_stderr.write(
+                "hermes -z: the provider/agent reported:\n" + captured_tail + "\n"
+            )
         real_stderr.flush()
         return 1
 

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -650,6 +650,28 @@ def test_oneshot_fails_closed_on_empty_final_response(monkeypatch, capsys):
     assert "no final response" in captured.err
 
 
+def test_oneshot_surfaces_provider_error_on_empty_response(monkeypatch, capsys):
+    _stub_plugin_discovery(monkeypatch)
+    import hermes_cli.oneshot as oneshot_mod
+
+    def _fake_run_agent(*_args, **_kwargs):
+        # Provider adapters print auth/billing errors to stdout (verified
+        # against the real Anthropic adapter) and the agent loop then returns an
+        # empty response instead of raising (#45155). run_oneshot must capture
+        # that output and surface it rather than discard it.
+        print("Anthropic 401 — authentication failed.")
+        return ""
+
+    monkeypatch.setattr(oneshot_mod, "_run_agent", _fake_run_agent)
+
+    assert oneshot_mod.run_oneshot("hello") == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "no final response" in captured.err
+    # The real provider error is now surfaced, not swallowed.
+    assert "401" in captured.err
+
+
 def test_oneshot_prints_nonempty_final_response(monkeypatch, capsys):
     _stub_plugin_discovery(monkeypatch)
     import hermes_cli.oneshot as oneshot_mod


### PR DESCRIPTION
## What & why

`hermes -z` redirected **both** stdout and stderr to `/dev/null` for the duration of the agent run. When a model call failed (e.g. an Anthropic 401, or the billing 400 in #45155), the provider adapter's error — which is printed to **stdout** in practice — was discarded, and the user saw only:

```
hermes -z: no final response was produced; treating the run as failed.
```

with no indication of the real cause. `hermes doctor` reporting the key as OK made this especially confusing.

This captures stdout+stderr into an in-memory buffer during the run and, on the empty-response path (and the exception path), surfaces the tail of that captured output beneath the failure message. The final response is returned by `_run_agent` (not printed), so buffering the streams is safe; output is bounded to the last ~12 lines / 2000 chars.

## How to test

With an Anthropic credential that authenticates but can't complete a call (or just force a bad model so the API errors):

```
hermes -m claude-bogus-model-xyz --provider anthropic -z "hi"
```

- **Before:** only `hermes -z: no final response was produced`.
- **After:** the real provider error is printed under `hermes -z: the provider/agent reported:`.

Unit test added — `test_oneshot_surfaces_provider_error_on_empty_response`:

```
pytest tests/hermes_cli/test_tui_resume_flow.py -k oneshot
```

(47 tests in that file pass; verified the patched `oneshot.py` against a live `hermes -z` invocation surfacing a real 401 banner.)

## Platforms tested

macOS (arm64, Python 3.11).

## Scope / notes

- Kept focused on the oneshot error-surfacing. The issue also suggests `hermes doctor` should distinguish "key exists / endpoint reachable" from "a real invocation succeeds" — that's a separate, larger change and a good follow-up PR.
- Capture is at the Python `sys.stdout`/`sys.stderr` level (verified the real Anthropic adapter writes the error to stdout). Errors emitted directly at fd level by a child process would not be captured; out of scope here.

Fixes #45155

