### PR TITLE
fix(qqbot): authorize approval clicks for dm session keys

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1092,7 +1092,7 @@ class QQAdapter(BasePlatformAdapter):
 
         chat_type = parsed.get("chat_type", "")
         chat_id = parsed.get("chat_id", "")
-        if chat_type == "c2c":
+        if chat_type in {"c2c", "dm"}:
             return bool(chat_id) and operator == chat_id
 
         if chat_type in {"group", "guild"}:

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -1577,6 +1577,33 @@ class TestDefaultInteractionDispatch:
         assert resolve_calls == [("agent:main:qqbot:c2c:u-42", "once", False)]
 
     @pytest.mark.asyncio
+    async def test_approval_click_dm_session_authorizes_operator(self):
+        """Approval click with dm chat_type authorizes when operator matches."""
+        adapter = self._make_adapter()
+        resolve_calls = []
+
+        def fake_resolve(session_key, choice, resolve_all=False):
+            resolve_calls.append((session_key, choice, resolve_all))
+            return 1
+
+        import tools.approval
+        orig = tools.approval.resolve_gateway_approval
+        tools.approval.resolve_gateway_approval = fake_resolve
+        try:
+            from gateway.platforms.qqbot.keyboards import parse_interaction_event
+            event = parse_interaction_event({
+                "id": "i",
+                "chat_type": 2,
+                "user_openid": "u-42",
+                "data": {"resolved": {"button_data": "approve:agent:main:qqbot:dm:u-42:allow-once"}},
+            })
+            await adapter._default_interaction_dispatch(event)
+        finally:
+            tools.approval.resolve_gateway_approval = orig
+
+        assert resolve_calls == [("agent:main:qqbot:dm:u-42", "once", False)]
+
+    @pytest.mark.asyncio
     async def test_approval_click_always_maps_to_always(self):
         adapter = self._make_adapter()
         resolve_calls = []


### PR DESCRIPTION
## What does this PR do?

Fixes authorization of approval button clicks on QQ Bot for DM (direct message) sessions. The `_is_authorized_interaction_for_session` method only handled `"c2c"` chat type, but QQ Bot's c2c message handler creates session sources with `chat_type="dm"`, causing all DM approval clicks to be rejected as unauthorized.

## Related Issue

Fixes #52467

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/qqbot/adapter.py`: Add `"dm"` to the chat_type check in `_is_authorized_interaction_for_session` alongside `"c2c"` so DM approval buttons are authorized when the operator matches the chat ID.
- `tests/gateway/test_qqbot.py`: Add `test_approval_click_dm_session_authorizes_operator` test to verify DM session approval clicks work correctly.

## How to Test

1. Run `pytest tests/gateway/test_qqbot.py::TestDefaultInteractionDispatch -xvs` — all 12 tests should pass, including the new `test_approval_click_dm_session_authorizes_operator`.
2. On QQ Bot, send a dangerous command in a DM session and click "Allow" — the approval should succeed instead of being rejected as unauthorized.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/platforms/qqbot/adapter.py:_is_authorized_interaction_for_session` (line 1082-1105)
- Blast radius: LOW — single condition change in authorization check
- Related patterns: QQ Bot uses `chat_type="dm"` for c2c messages (line 1288), `chat_type="c2c"` stored in `_chat_type_map` (line 1283), `chat_type="dm"` for guild DMs (line 1498)
