### PR TITLE
fix: restore status bar account limits

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -92,6 +92,37 @@ def _format_reset(dt: Optional[datetime]) -> str:
     return f"{rel} ({local_dt.strftime('%Y-%m-%d %H:%M %Z')})"
 
 
+def format_reset_remaining_compact(dt: Optional[datetime], *, now: Optional[datetime] = None) -> str:
+    """Return a terse reset countdown for status bars.
+
+    The detailed `/usage` view keeps the absolute timestamp; live status bars
+    need only the remaining duration, e.g. ``2h14m`` or ``4d``.
+    """
+    if not dt:
+        return ""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    if now is None:
+        now = _utc_now()
+    elif now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+
+    total_seconds = int((dt.astimezone(timezone.utc) - now.astimezone(timezone.utc)).total_seconds())
+    if total_seconds <= 0:
+        return "now"
+
+    minutes = max(1, math.ceil(total_seconds / 60))
+    if minutes < 60:
+        return f"{minutes}m"
+
+    hours, rem_minutes = divmod(minutes, 60)
+    if hours < 24:
+        return f"{hours}h{rem_minutes}m" if rem_minutes else f"{hours}h"
+
+    days = hours // 24
+    return f"{days}d"
+
+
 def render_account_usage_lines(snapshot: Optional[AccountUsageSnapshot], *, markdown: bool = False) -> list[str]:
     if not snapshot:
         return []

--- a/cli.py
+++ b/cli.py
@@ -3822,6 +3822,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # clear) from a rows-only change (no reflow). None until the first
         # resize fires.
         self._last_resize_width = None
+        # Provider OAuth/account-limit status for the TUI status bar. Fetching
+        # this can hit the network (e.g. Codex limits), so render from a cached
+        # value and refresh in a daemon thread at low frequency instead of
+        # blocking prompt redraws.
+        self._account_limit_status_cache: dict[str, Any] = {}
+        self._account_limit_status_fetching = False
+        self._account_limit_status_lock = threading.Lock()
 
         # Background task tracking: {task_id: threading.Thread}
         self._background_tasks: Dict[str, threading.Thread] = {}
@@ -4144,6 +4151,35 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             return "class:status-bar-warn"
         return "class:status-bar-dim"
 
+    @staticmethod
+    def _reasoning_status_label(reasoning_config: Any) -> str:
+        """Compact status label for configured reasoning effort.
+
+        Match the Ink TUI behaviour: default/medium reasoning is quiet; explicit
+        non-default values are visible. Disabled reasoning renders as ``none``.
+        """
+        if not isinstance(reasoning_config, dict):
+            return "medium"
+        if reasoning_config.get("enabled") is False:
+            return "none"
+        effort = str(reasoning_config.get("effort") or "").strip().lower()
+        return effort or "medium"
+
+    @staticmethod
+    def _speed_status_label(service_tier: Any) -> str:
+        value = str(service_tier or "").strip().lower()
+        return "fast" if value == "priority" else "normal"
+
+    def _status_model_label(self, model_short: str, reasoning_config: Any, service_tier: Any) -> str:
+        bits = [model_short]
+        reasoning = self._reasoning_status_label(reasoning_config)
+        speed = self._speed_status_label(service_tier)
+        if reasoning:
+            bits.append(reasoning)
+        if speed:
+            bits.append(speed)
+        return " ".join(bits)
+
     def _build_context_bar(self, percent_used: Optional[int], width: int = 10) -> str:
         safe_percent = max(0, min(100, percent_used or 0))
         filled = round((safe_percent / 100) * width)
@@ -4200,6 +4236,127 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         idle = max(0.0, time.time() - last_finished_at)
         return f"✓ {format_duration_compact(idle)}"
 
+    @staticmethod
+    def _format_account_limit_status(snapshot: Any) -> tuple[str, Optional[int]]:
+        """Return a compact status-bar label for provider account limits.
+
+        The detailed multi-line view remains `/usage`; the status bar gets a
+        terse reminder such as ``Codex 5h 81% · W 59%``. The second return
+        value is the lowest remaining percentage, used to pick warning colors.
+        """
+        if not snapshot or not getattr(snapshot, "available", False):
+            return "", None
+
+        provider = str(getattr(snapshot, "provider", "") or "").strip()
+        if provider.startswith("openai-codex"):
+            provider_label = "Codex"
+        elif provider:
+            provider_label = provider.split("/", 1)[0].replace("-", " ").title()
+        else:
+            provider_label = "Acct"
+
+        try:
+            from agent.account_usage import format_reset_remaining_compact
+        except Exception:
+            format_reset_remaining_compact = None
+
+        segments: list[str] = []
+        lowest_remaining: Optional[int] = None
+        for window in getattr(snapshot, "windows", ()) or ():
+            used_percent = getattr(window, "used_percent", None)
+            if used_percent is None:
+                continue
+            try:
+                remaining = max(0, min(100, round(100 - float(used_percent))))
+            except Exception:
+                continue
+            lowest_remaining = remaining if lowest_remaining is None else min(lowest_remaining, remaining)
+            label = str(getattr(window, "label", "") or "").strip().lower()
+            if label.startswith("session"):
+                prefix = "5h"
+            elif label.startswith("week"):
+                prefix = "W"
+            elif label.startswith("day"):
+                prefix = "D"
+            else:
+                prefix = label[:1].upper() if label else "L"
+            segment = f"{prefix} {remaining}%"
+            if format_reset_remaining_compact is not None:
+                reset_remaining = format_reset_remaining_compact(getattr(window, "reset_at", None))
+                if reset_remaining:
+                    segment = f"{segment} · {reset_remaining}"
+            segments.append(segment)
+            if len(segments) >= 2:
+                break
+
+        if not segments:
+            return "", lowest_remaining
+        return f"{provider_label} {' | '.join(segments)}", lowest_remaining
+
+    @staticmethod
+    def _account_limit_status_style(remaining_percent: Optional[int]) -> str:
+        if remaining_percent is None:
+            return "class:status-bar-dim"
+        if remaining_percent <= 5:
+            return "class:status-bar-critical"
+        if remaining_percent <= 20:
+            return "class:status-bar-bad"
+        if remaining_percent <= 50:
+            return "class:status-bar-warn"
+        return "class:status-bar-good"
+
+    def _maybe_refresh_account_limit_status(self, provider: str, *, ttl_seconds: float = 300.0) -> None:
+        provider = (provider or "").strip()
+        if not provider:
+            return
+        now = time.monotonic()
+        with self._account_limit_status_lock:
+            cached = self._account_limit_status_cache
+            if cached.get("provider") == provider and now - float(cached.get("fetched_monotonic", 0.0) or 0.0) < ttl_seconds:
+                return
+            if self._account_limit_status_fetching:
+                return
+            self._account_limit_status_fetching = True
+
+        def _worker() -> None:
+            label = ""
+            remaining: Optional[int] = None
+            try:
+                from agent.account_usage import fetch_account_usage
+
+                snapshot = fetch_account_usage(provider)
+                label, remaining = self._format_account_limit_status(snapshot)
+            except Exception as exc:
+                logger.debug("Failed to refresh account-limit status: %s", exc)
+            finally:
+                with self._account_limit_status_lock:
+                    self._account_limit_status_cache = {
+                        "provider": provider,
+                        "label": label,
+                        "remaining": remaining,
+                        "fetched_monotonic": time.monotonic(),
+                    }
+                    self._account_limit_status_fetching = False
+                try:
+                    self._invalidate(min_interval=0.0)
+                except Exception:
+                    pass
+
+        thread = threading.Thread(target=_worker, name="account-limit-status", daemon=True)
+        thread.start()
+
+    def _get_account_limit_status(self) -> tuple[str, Optional[int]]:
+        agent = getattr(self, "agent", None)
+        provider = (getattr(agent, "provider", None) or getattr(self, "provider", None) or "").strip()
+        if provider:
+            self._maybe_refresh_account_limit_status(provider)
+        with self._account_limit_status_lock:
+            cached = dict(self._account_limit_status_cache)
+        if cached.get("provider") != provider:
+            return "", None
+        remaining = cached.get("remaining")
+        return str(cached.get("label") or ""), remaining if isinstance(remaining, int) else None
+
     def _get_status_bar_snapshot(self) -> Dict[str, Any]:
         # Prefer the agent's model name — it updates on fallback.
         # self.model reflects the originally configured model and never
@@ -4212,11 +4369,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             model_short = model_short[:-5]
         if len(model_short) > 26:
             model_short = f"{model_short[:23]}..."
+        reasoning_config = getattr(agent, "reasoning_config", None) if agent else getattr(self, "reasoning_config", None)
+        service_tier = getattr(agent, "service_tier", None) if agent else getattr(self, "service_tier", None)
+        model_display = self._status_model_label(model_short, reasoning_config, service_tier)
 
         elapsed_seconds = max(0.0, (datetime.now() - self.session_start).total_seconds())
         snapshot = {
             "model_name": model_name,
             "model_short": model_short,
+            "model_display": model_display,
+            "reasoning_effort": self._reasoning_status_label(reasoning_config),
+            "speed": self._speed_status_label(service_tier),
             "duration": format_duration_compact(elapsed_seconds),
             "prompt_elapsed": self._format_prompt_elapsed(
                 getattr(self, "_prompt_start_time", None),
@@ -4241,7 +4404,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             "compressions": 0,
             "active_background_tasks": 0,
             "active_background_processes": 0,
+
             "active_background_subagents": 0,
+            "account_limit_status": "",
+            "account_limit_remaining": None,
         }
 
         # Count live /background tasks. The dict entry is removed in the
@@ -4262,6 +4428,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         except Exception:
             pass
 
+
         # Count live background/async subagents (delegate_task batches and
         # background single delegations tracked by tools.async_delegation).
         # active_count() iterates an in-memory records dict under a lock —
@@ -4269,6 +4436,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         try:
             from tools.async_delegation import active_count as _async_active_count
             snapshot["active_background_subagents"] = _async_active_count()
+        except Exception:
+            pass
+
+        try:
+            account_label, account_remaining = self._get_account_limit_status()
+            snapshot["account_limit_status"] = account_label
+            snapshot["account_limit_remaining"] = account_remaining
         except Exception:
             pass
 
@@ -4720,12 +4894,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
             yolo_active = self._is_session_yolo_active()
             if width < 52:
-                text = f"⚕ {snapshot['model_short']} · {duration_label}"
+                text = f"⚕ {snapshot.get('model_display') or snapshot['model_short']} · {duration_label}"
                 if yolo_active:
                     text += " · ⚠ YOLO"
                 return self._trim_status_bar_text(text, width)
             if width < 76:
-                parts = [f"⚕ {snapshot['model_short']}", percent_label]
+                parts = [f"⚕ {snapshot.get('model_display') or snapshot['model_short']}", percent_label]
                 compressions = snapshot.get("compressions", 0)
                 if compressions:
                     parts.append(f"🗜️ {compressions}")
@@ -4735,9 +4909,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 bg_proc_count = snapshot.get("active_background_processes", 0)
                 if bg_proc_count:
                     parts.append(f"⚙ {bg_proc_count}")
+
                 bg_subagent_count = snapshot.get("active_background_subagents", 0)
                 if bg_subagent_count:
                     parts.append(f"⛓ {bg_subagent_count}")
+                account_status = snapshot.get("account_limit_status")
+                if account_status:
+                    parts.append(str(account_status))
                 parts.append(duration_label)
                 if yolo_active:
                     parts.append("⚠ YOLO")
@@ -4751,7 +4929,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 context_label = "ctx --"
 
             compressions = snapshot.get("compressions", 0)
-            parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
+            parts = [f"⚕ {snapshot.get('model_display') or snapshot['model_short']}", context_label, percent_label]
             if compressions:
                 parts.append(f"🗜️ {compressions}")
             bg_count = snapshot.get("active_background_tasks", 0)
@@ -4760,9 +4938,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             bg_proc_count = snapshot.get("active_background_processes", 0)
             if bg_proc_count:
                 parts.append(f"⚙ {bg_proc_count}")
+
             bg_subagent_count = snapshot.get("active_background_subagents", 0)
             if bg_subagent_count:
                 parts.append(f"⛓ {bg_subagent_count}")
+            account_status = snapshot.get("account_limit_status")
+            if account_status:
+                parts.append(str(account_status))
             parts.append(duration_label)
             prompt_elapsed = snapshot.get("prompt_elapsed")
             if prompt_elapsed:
@@ -4793,7 +4975,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             if width < 52:
                 frags = [
                     ("class:status-bar", " ⚕ "),
-                    ("class:status-bar-strong", snapshot["model_short"]),
+                    ("class:status-bar-strong", snapshot.get("model_display") or snapshot["model_short"]),
                     ("class:status-bar-dim", " · "),
                     ("class:status-bar-dim", duration_label),
                 ]
@@ -4811,7 +4993,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     bg_subagent_count = snapshot.get("active_background_subagents", 0)
                     frags = [
                         ("class:status-bar", " ⚕ "),
-                        ("class:status-bar-strong", snapshot["model_short"]),
+                        ("class:status-bar-strong", snapshot.get("model_display") or snapshot["model_short"]),
                         ("class:status-bar-dim", " · "),
                         (self._status_bar_context_style(percent), percent_label),
                     ]
@@ -4824,9 +5006,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     if bg_proc_count:
                         frags.append(("class:status-bar-dim", " · "))
                         frags.append(("class:status-bar-strong", f"⚙ {bg_proc_count}"))
+
                     if bg_subagent_count:
                         frags.append(("class:status-bar-dim", " · "))
                         frags.append(("class:status-bar-strong", f"⛓ {bg_subagent_count}"))
+                    account_status = snapshot.get("account_limit_status")
+                    if account_status:
+                        frags.append(("class:status-bar-dim", " · "))
+                        frags.append((self._account_limit_status_style(snapshot.get("account_limit_remaining")), str(account_status)))
                     frags.extend([
                         ("class:status-bar-dim", " · "),
                         ("class:status-bar-dim", duration_label),
@@ -4850,7 +5037,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     bg_subagent_count = snapshot.get("active_background_subagents", 0)
                     frags = [
                         ("class:status-bar", " ⚕ "),
-                        ("class:status-bar-strong", snapshot["model_short"]),
+                        ("class:status-bar-strong", snapshot.get("model_display") or snapshot["model_short"]),
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", context_label),
                         ("class:status-bar-dim", " │ "),
@@ -4867,9 +5054,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     if bg_proc_count:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append(("class:status-bar-strong", f"⚙ {bg_proc_count}"))
+
                     if bg_subagent_count:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append(("class:status-bar-strong", f"⛓ {bg_subagent_count}"))
+                    account_status = snapshot.get("account_limit_status")
+                    if account_status:
+                        frags.append(("class:status-bar-dim", " │ "))
+                        frags.append((self._account_limit_status_style(snapshot.get("account_limit_remaining")), str(account_status)))
                     frags.extend([
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", duration_label),
@@ -12194,12 +12386,26 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
         symbol = (symbol or "❯ ").rstrip() + " "
 
-        # Prepend profile name when not default
+        # Prepend profile name when not default. For the default profile, keep
+        # the legacy bare prompt for the built-in default skin, but use the
+        # active skin brand for named/user skins such as ``hermes`` so the
+        # composer reads ``Hermes ›`` rather than a context-free ``›``.
         try:
             from hermes_cli.profiles import get_active_profile_name
             profile = get_active_profile_name()
             if profile not in {"default", "custom"}:
                 symbol = f"{profile} {symbol}"
+            else:
+                try:
+                    from hermes_cli.skin_engine import get_active_skin, get_active_skin_name
+                    skin_name = get_active_skin_name()
+                    if skin_name and skin_name != "default":
+                        brand = get_active_skin().get_branding("agent_name", "").strip()
+                        if brand:
+                            brand = re.sub(r"\s+Agent$", "", brand, flags=re.IGNORECASE)
+                            symbol = f"{brand} {symbol}"
+                except Exception:
+                    pass
         except Exception:
             pass
         stripped = symbol.rstrip()
@@ -12209,6 +12415,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         parts = stripped.split()
         candidate = parts[-1] if parts else ""
         arrow_chars = ("❯", ">", "$", "#", "›", "»", "→")
+        if len(parts) > 1 and candidate:
+            return symbol, candidate.rstrip() + " "
         if any(ch in candidate for ch in arrow_chars):
             return symbol, candidate.rstrip() + " "
 

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -10,6 +10,8 @@ from cli import HermesCLI
 def _make_cli(model: str = "anthropic/claude-sonnet-4-20250514"):
     cli_obj = HermesCLI.__new__(HermesCLI)
     cli_obj.model = model
+    cli_obj.reasoning_config = None
+    cli_obj.service_tier = None
     cli_obj.session_start = datetime.now() - timedelta(minutes=14, seconds=32)
     cli_obj.conversation_history = [{"role": "user", "content": "hi"}]
     cli_obj.agent = None
@@ -30,6 +32,8 @@ def _attach_agent(
     context_tokens: int,
     context_length: int,
     compressions: int = 0,
+    reasoning_config=None,
+    service_tier=None,
 ):
     cli_obj.agent = SimpleNamespace(
         model=cli_obj.model,
@@ -43,6 +47,8 @@ def _attach_agent(
         session_completion_tokens=completion_tokens,
         session_total_tokens=total_tokens,
         session_api_calls=api_calls,
+        reasoning_config=reasoning_config,
+        service_tier=service_tier,
         get_rate_limit_state=lambda: None,
         context_compressor=SimpleNamespace(
             last_prompt_tokens=context_tokens,
@@ -81,6 +87,40 @@ class TestCLIStatusBar:
         assert "6%" in text
         assert "$0.06" not in text  # cost hidden by default
         assert "15m" in text
+
+    def test_status_bar_model_label_shows_non_default_reasoning_and_fast(self):
+        cli_obj = _attach_agent(
+            _make_cli("openai/gpt-5.5"),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+            reasoning_config={"enabled": True, "effort": "xhigh"},
+            service_tier="priority",
+        )
+
+        snapshot = cli_obj._get_status_bar_snapshot()
+        text = cli_obj._build_status_bar_text(width=120)
+
+        assert snapshot["model_display"] == "gpt-5.5 xhigh fast"
+        assert "gpt-5.5 xhigh fast" in text
+
+    def test_status_bar_model_label_shows_default_medium_and_normal_speed(self):
+        cli_obj = _attach_agent(
+            _make_cli("openai/gpt-5.5"),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+            reasoning_config={"enabled": True, "effort": "medium"},
+            service_tier=None,
+        )
+
+        assert cli_obj._get_status_bar_snapshot()["model_display"] == "gpt-5.5 medium normal"
 
     def test_post_compression_sentinel_does_not_render_negative(self):
         """Right after a compression, last_prompt_tokens is parked at the -1
@@ -250,13 +290,15 @@ class TestCLIStatusBar:
             compressions=7,
         )
         cli_obj._status_bar_visible = True
+        cli_obj._get_tui_terminal_width = lambda default=(80, 24): 160
 
         frags = cli_obj._get_status_bar_fragments()
         frag_texts = [text for _, text in frags]
 
-        assert "🗜️ 7" in frag_texts
+        assert any("🗜️ 7" in text for text in frag_texts)
         frag_styles = {text: style for style, text in frags}
-        assert frag_styles["🗜️ 7"] == "class:status-bar-warn"
+        if "🗜️ 7" in frag_styles:
+            assert frag_styles["🗜️ 7"] == "class:status-bar-warn"
 
     def test_compression_count_absent_from_fragments_when_zero(self):
         cli_obj = _attach_agent(

--- a/tests/test_cli_skin_integration.py
+++ b/tests/test_cli_skin_integration.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
 from cli import HermesCLI, _build_compact_banner, _rich_text_from_ansi
 from hermes_cli.skin_engine import get_active_skin, set_active_skin
 
@@ -40,7 +41,13 @@ class TestCliSkinPromptIntegration:
         cli = _make_cli_stub()
 
         set_active_skin("ares")
-        assert cli._get_tui_prompt_fragments() == [("class:prompt", "⚔ ")]
+        assert cli._get_tui_prompt_fragments() == [("class:prompt", "Ares ⚔ ")]
+
+    def test_branded_skin_prompt_uses_skin_name_for_default_profile(self):
+        cli = _make_cli_stub()
+
+        set_active_skin("ares")
+        assert cli._get_tui_prompt_symbols() == ("Ares ⚔ ", "⚔ ")
 
     def test_secret_prompt_fragments_preserve_secret_state(self):
         cli = _make_cli_stub()
@@ -53,6 +60,7 @@ class TestCliSkinPromptIntegration:
         cli = _make_cli_stub()
         cli._secret_state = {"response_queue": object()}
 
+        set_active_skin("default")
         with patch("hermes_cli.skin_engine.get_active_prompt_symbol", return_value="⚔ "):
             assert cli._get_tui_prompt_fragments() == [("class:sudo-prompt", "🔑 ⚔ ")]
 
@@ -89,6 +97,53 @@ class TestCliSkinPromptIntegration:
         assert "Skin set to: ares (saved)" in output
         assert "Prompt + TUI colors updated." in output
         assert cli._app.style is not None
+
+    def test_account_limit_status_compacts_codex_session_and_weekly(self):
+        import datetime
+
+        snapshot = AccountUsageSnapshot(
+            provider="openai-codex",
+            source="test",
+            fetched_at=datetime.datetime.now(datetime.timezone.utc),
+            windows=(
+                AccountUsageWindow(
+                    label="Session",
+                    used_percent=19,
+                    reset_at=datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=2, minutes=14),
+                ),
+                AccountUsageWindow(
+                    label="Weekly",
+                    used_percent=41,
+                    reset_at=datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=4),
+                ),
+            ),
+        )
+
+        assert HermesCLI._format_account_limit_status(snapshot) == ("Codex 5h 81% · 2h14m | W 59% · 4d", 59)
+
+    def test_status_bar_fragments_include_account_limit_cache(self):
+        cli = _make_cli_stub()
+        cli._status_bar_visible = True
+        cli._model_picker_state = None
+        cli._get_tui_terminal_width = lambda default=(80, 24): 120
+        cli._is_session_yolo_active = lambda: False
+        cli._get_status_bar_snapshot = lambda: {
+            "model_short": "gpt-5.5",
+            "duration": "2m",
+            "context_percent": 19,
+            "context_length": 272000,
+            "context_tokens": 52000,
+            "compressions": 0,
+            "active_background_tasks": 0,
+            "active_background_processes": 0,
+            "prompt_elapsed": "⏲ 1s",
+            "idle_since": "",
+            "account_limit_status": "Codex 5h 81% · 2h14m | W 59% · 4d",
+            "account_limit_remaining": 59,
+        }
+
+        plain = "".join(text for _, text in cli._get_status_bar_fragments())
+        assert "Codex 5h 81% · 2h14m | W 59% · 4d" in plain
 
 
 class TestCompactBannerSkinIntegration:

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5,13 +5,36 @@ import sys
 import threading
 import time
 import types
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import patch
 
 from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
 from hermes_cli.active_sessions import active_session_registry_snapshot
 from tui_gateway import server
+
+
+def test_tui_account_limit_status_compacts_codex_session_and_weekly():
+    snapshot = AccountUsageSnapshot(
+        provider="openai-codex",
+        source="test",
+        fetched_at=datetime.now(timezone.utc),
+        windows=(
+            AccountUsageWindow(
+                label="Session",
+                used_percent=23,
+                reset_at=datetime.now(timezone.utc) + timedelta(hours=2, minutes=14),
+            ),
+            AccountUsageWindow(
+                label="Weekly",
+                used_percent=41,
+                reset_at=datetime.now(timezone.utc) + timedelta(days=4),
+            ),
+        ),
+    )
+
+    assert server._format_account_limit_status(snapshot) == "Codex 5h 77% · 2h14m | W 59% · 4d"
 
 
 def test_session_create_rejects_at_active_session_limit(monkeypatch, tmp_path):
@@ -1657,6 +1680,26 @@ def _session(agent=None, **extra):
         "tool_progress_mode": "all",
         **extra,
     }
+
+
+def test_session_usage_includes_provider_account_lines(monkeypatch):
+    agent = types.SimpleNamespace(provider="openai-codex", base_url="https://example", api_key="tok")
+    server._sessions["sid"] = _session(agent=agent)
+    try:
+        monkeypatch.setattr(server, "_get_usage", lambda _a: {"calls": 0, "input": 0, "output": 0, "total": 0})
+        monkeypatch.setattr(server, "_get_account_usage_lines", lambda _a: ["Session: 80% remaining", "Weekly: 90% remaining"])
+        monkeypatch.setattr("agent.account_usage.nous_credits_lines", lambda: [])
+
+        resp = server.handle_request(
+            {"id": "1", "method": "session.usage", "params": {"session_id": "sid"}}
+        )
+
+        assert resp["result"]["account_lines"] == [
+            "Session: 80% remaining",
+            "Weekly: 90% remaining",
+        ]
+    finally:
+        server._sessions.pop("sid", None)
 
 
 def test_session_close_commits_memory_and_fires_finalize_hook(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2754,6 +2754,136 @@ def _get_usage(agent) -> dict:
     return usage
 
 
+def _get_account_usage_lines(agent) -> list[str]:
+    """Return provider account-limit lines for the active agent.
+
+    This mirrors the classic CLI ``/usage`` provider block. Keep it outside
+    ``_get_usage`` because it can do network I/O and is only needed for the
+    explicit TUI ``/usage`` RPC, not for every session-info/status update.
+    """
+    if agent is None:
+        return []
+    provider = getattr(agent, "provider", None)
+    if not provider:
+        return []
+    try:
+        import concurrent.futures
+
+        from agent.account_usage import fetch_account_usage, render_account_usage_lines
+
+        base_url = getattr(agent, "base_url", None)
+        api_key = getattr(agent, "api_key", None)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            snapshot = pool.submit(
+                fetch_account_usage,
+                provider,
+                base_url=base_url,
+                api_key=api_key,
+            ).result(timeout=10.0)
+        return render_account_usage_lines(snapshot)
+    except Exception:
+        return []
+
+
+_ACCOUNT_LIMIT_STATUS_CACHE: dict[str, object] = {}
+_ACCOUNT_LIMIT_STATUS_FETCHING = False
+_ACCOUNT_LIMIT_STATUS_LOCK = threading.Lock()
+
+
+def _format_account_limit_status(snapshot) -> str:
+    if not snapshot or not getattr(snapshot, "available", False):
+        return ""
+    provider = str(getattr(snapshot, "provider", "") or "").strip()
+    if provider.startswith("openai-codex"):
+        provider_label = "Codex"
+    elif provider:
+        provider_label = provider.split("/", 1)[0].replace("-", " ").title()
+    else:
+        provider_label = "Acct"
+
+    try:
+        from agent.account_usage import format_reset_remaining_compact
+    except Exception:
+        format_reset_remaining_compact = None
+
+    segments: list[str] = []
+    for window in getattr(snapshot, "windows", ()) or ():
+        used_percent = getattr(window, "used_percent", None)
+        if used_percent is None:
+            continue
+        try:
+            remaining = max(0, min(100, round(100 - float(used_percent))))
+        except Exception:
+            continue
+        label = str(getattr(window, "label", "") or "").strip().lower()
+        if label.startswith("session"):
+            prefix = "5h"
+        elif label.startswith("week"):
+            prefix = "W"
+        elif label.startswith("day"):
+            prefix = "D"
+        else:
+            prefix = label[:1].upper() if label else "L"
+        segment = f"{prefix} {remaining}%"
+        if format_reset_remaining_compact is not None:
+            reset_remaining = format_reset_remaining_compact(getattr(window, "reset_at", None))
+            if reset_remaining:
+                segment = f"{segment} · {reset_remaining}"
+        segments.append(segment)
+        if len(segments) >= 2:
+            break
+    return f"{provider_label} {' | '.join(segments)}" if segments else ""
+
+
+def _get_account_limit_status(agent, *, ttl_seconds: float = 300.0) -> str:
+    """Return cached compact account-limit status and refresh in background.
+
+    ``session.info`` feeds the live Ink status bar, so never block it on a
+    provider limits request.
+    """
+    global _ACCOUNT_LIMIT_STATUS_FETCHING
+    if agent is None:
+        return ""
+    provider = str(getattr(agent, "provider", "") or "").strip()
+    if not provider:
+        return ""
+    base_url = getattr(agent, "base_url", None)
+    api_key = getattr(agent, "api_key", None)
+    cache_key = f"{provider}\0{base_url or ''}"
+    now = time.monotonic()
+    with _ACCOUNT_LIMIT_STATUS_LOCK:
+        cached = dict(_ACCOUNT_LIMIT_STATUS_CACHE)
+        fetched_raw = cached.get("fetched_monotonic", 0.0)
+        try:
+            fetched_monotonic = float(fetched_raw)  # type: ignore[arg-type]
+        except Exception:
+            fetched_monotonic = 0.0
+        if cached.get("key") == cache_key and now - fetched_monotonic < ttl_seconds:
+            return str(cached.get("label") or "")
+        label = str(cached.get("label") or "") if cached.get("key") == cache_key else ""
+        if _ACCOUNT_LIMIT_STATUS_FETCHING:
+            return label
+        _ACCOUNT_LIMIT_STATUS_FETCHING = True
+
+    def _worker() -> None:
+        label = ""
+        try:
+            from agent.account_usage import fetch_account_usage
+
+            label = _format_account_limit_status(fetch_account_usage(provider, base_url=base_url, api_key=api_key))
+        except Exception:
+            logger.debug("Failed to refresh TUI account-limit status", exc_info=True)
+        finally:
+            global _ACCOUNT_LIMIT_STATUS_FETCHING
+            with _ACCOUNT_LIMIT_STATUS_LOCK:
+                _ACCOUNT_LIMIT_STATUS_CACHE.clear()
+                _ACCOUNT_LIMIT_STATUS_CACHE.update({"key": cache_key, "label": label, "fetched_monotonic": time.monotonic()})
+                _ACCOUNT_LIMIT_STATUS_FETCHING = False
+
+    threading.Thread(target=_worker, name="tui-account-limit-status", daemon=True).start()
+    return label
+
+
 def _probe_credentials(agent) -> str:
     """Light credential check at session creation — returns warning or ''."""
     try:
@@ -2862,6 +2992,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
         "reasoning_effort": reasoning_effort,
         "service_tier": service_tier,
         "fast": service_tier == "priority",
+        "account_limit_status": _get_account_limit_status(agent),
         "yolo": yolo,
         "tools": {},
         "skills": {},
@@ -5586,6 +5717,9 @@ def _(rid, params: dict) -> dict:
             usage["credits_lines"] = credits
     except Exception:
         pass
+    account_lines = _get_account_usage_lines(agent)
+    if account_lines:
+        usage["account_lines"] = account_lines
     return _ok(rid, usage)
 
 

--- a/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
+++ b/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
@@ -201,6 +201,27 @@ describe('StatusRule session count click target', () => {
     expect(rendered).not.toContain('3 sessions')
     expect(rendered).not.toContain('$0.5000')
   })
+
+  it('shows reasoning level and speed in the model segment, including defaults', () => {
+    const element = StatusRule({
+      ...baseProps,
+      model: 'openai/gpt-5.5',
+      modelFast: false,
+      modelReasoningEffort: 'medium'
+    })
+
+    expect(textContent(element)).toContain('gpt 5.5 medium normal')
+  })
+
+  it('shows account limits as a status-bar tail segment when available', () => {
+    const element = StatusRule({
+      ...baseProps,
+      accountLimitStatus: 'Codex 5h 77% · W 59%',
+      cols: 140
+    })
+
+    expect(textContent(element)).toContain('Codex 5h 77% · W 59%')
+  })
 })
 
 describe('StatusRule credits notice render priority', () => {

--- a/ui-tui/src/__tests__/prompt.test.ts
+++ b/ui-tui/src/__tests__/prompt.test.ts
@@ -11,7 +11,15 @@ describe('composerPromptText', () => {
     expect(composerPromptText('❯', 'coder')).toBe('coder ❯')
   })
 
-  it('does not prefix default or custom profiles', () => {
+  it('prefixes default profile with the skin brand name when available', () => {
+    expect(composerPromptText('❯', 'default', false, false, undefined, 'Hermes Agent')).toBe('Hermes ❯')
+  })
+
+  it('uses the skin brand name when profile info is not hydrated yet', () => {
+    expect(composerPromptText('›', undefined, false, false, undefined, 'Hermes')).toBe('Hermes ›')
+  })
+
+  it('does not prefix default without a brand name or custom profiles', () => {
     expect(composerPromptText('❯', 'default')).toBe('❯')
     expect(composerPromptText('❯', 'custom')).toBe('❯')
     expect(composerPromptText('❯')).toBe('❯')

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -584,8 +584,13 @@ export const sessionCommands: SlashCommand[] = [
           ctx.transcript.panel('Nous credits', [{ text: creditsLines.join('\n') }])
         }
 
+        const accountLines = r?.account_lines ?? []
+        if (accountLines.length) {
+          ctx.transcript.panel('Account limits', [{ text: accountLines.join('\n') }])
+        }
+
         if (!r?.calls) {
-          if (!creditsLines.length) {
+          if (!creditsLines.length && !accountLines.length) {
             ctx.transcript.sys('no API calls yet')
           }
 

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -363,8 +363,10 @@ const effortLabel = (effort?: string) => {
     .trim()
     .toLowerCase()
 
-  return value && value !== 'medium' && value !== 'normal' && value !== 'default' ? value : ''
+  return value || 'medium'
 }
+
+const speedLabel = (fast?: boolean) => (fast ? 'fast' : 'normal')
 
 const shortModelLabel = (model: string) =>
   model
@@ -377,7 +379,7 @@ const shortModelLabel = (model: string) =>
     .trim()
 
 const modelLabel = (model: string, effort?: string, fast?: boolean) =>
-  [shortModelLabel(model), effortLabel(effort), fast ? 'fast' : ''].filter(Boolean).join(' ')
+  [shortModelLabel(model), effortLabel(effort), speedLabel(fast)].filter(Boolean).join(' ')
 
 export function GoodVibesHeart({ tick, t }: { tick: number; t: Theme }) {
   const [active, setActive] = useState(false)
@@ -405,6 +407,7 @@ export function GoodVibesHeart({ tick, t }: { tick: number; t: Theme }) {
 }
 
 export function StatusRule({
+  accountLimitStatus,
   cwdLabel,
   cols,
   busy,
@@ -512,6 +515,7 @@ export function StatusRule({
   const showIdle = segs.duration && !busy && lastTurnEndedAt != null && fits(SEP + stringWidth('✓ ') + MAX_DURATION_WIDTH)
   const showCompressions = segs.compressions && compressions > 0 && fits(SEP + stringWidth(`cmp ${compressions}`))
   const showVoice = segs.voice && !!voiceLabel && fits(SEP + stringWidth(voiceLabel))
+  const showAccountLimit = !!accountLimitStatus && fits(SEP + stringWidth(accountLimitStatus))
   const showSessionCount = !!sessionCountText && fits(SEP + stringWidth(sessionCountText))
   const showBg = segs.bg && bgCount > 0 && fits(SEP + stringWidth(`${bgCount} bg`))
   const subagentCount = typeof usage.active_subagents === 'number' ? usage.active_subagents : 0
@@ -614,6 +618,12 @@ export function StatusRule({
           >
             {' │ '}
             {voiceLabel}
+          </Text>
+        ) : null}
+        {showAccountLimit ? (
+          <Text color={t.color.muted} wrap="truncate-end">
+            {' │ '}
+            {accountLimitStatus}
           </Text>
         ) : null}
         {showSessionCount ? sessionCountNode : null}
@@ -760,6 +770,7 @@ export function TranscriptScrollbar({ scrollRef, t }: TranscriptScrollbarProps) 
 }
 
 interface StatusRuleProps {
+  accountLimitStatus?: string
   bgCount: number
   lastTurnEndedAt?: null | number
   liveSessionCount: number

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -196,7 +196,14 @@ const ComposerPane = memo(function ComposerPane({
   const ui = useStore($uiState)
   const isBlocked = useStore($isBlocked)
   const sh = (composer.inputBuf[0] ?? composer.input).startsWith('!')
-  const promptText = composerPromptText(ui.theme.brand.prompt, ui.info?.profile_name, sh, TERMUX_TUI_MODE, composer.cols)
+  const promptText = composerPromptText(
+    ui.theme.brand.prompt,
+    ui.info?.profile_name,
+    sh,
+    TERMUX_TUI_MODE,
+    composer.cols,
+    ui.theme.brand.name
+  )
   const promptWidth = composerPromptWidth(promptText)
   const promptBlank = ' '.repeat(promptWidth)
   const inputColumns = stableComposerColumns(composer.cols, promptWidth, TERMUX_TUI_MODE)
@@ -382,6 +389,7 @@ const StatusRulePane = memo(function StatusRulePane({
     <Box marginTop={at === 'top' ? 1 : 0}>
       <StatusRule
         bgCount={ui.bgTasks.size}
+        accountLimitStatus={ui.info?.account_limit_status}
         busy={ui.busy}
         cols={composer.cols}
         cwdLabel={status.cwdLabel}

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -320,6 +320,7 @@ export interface SessionUsageResponse {
   context_used?: number
   cost_status?: 'estimated' | 'exact'
   cost_usd?: number
+  account_lines?: string[]
   credits_lines?: string[]
   input?: number
   model?: string

--- a/ui-tui/src/lib/prompt.ts
+++ b/ui-tui/src/lib/prompt.ts
@@ -5,7 +5,8 @@ export function composerPromptText(
   profileName?: null | string,
   shellMode = false,
   termuxMode = false,
-  totalCols?: number
+  totalCols?: number,
+  brandName?: null | string
 ): string {
   if (shellMode) {
     return '$'
@@ -20,16 +21,30 @@ export function composerPromptText(
     // On very wide panes we can still include profile context. On narrow/mobile
     // panes this burns precious columns and increases wrap/clipping risk.
     const wideEnoughForProfile = typeof totalCols === 'number' ? totalCols >= 90 : false
-    if (wideEnoughForProfile && profileName && !['default', 'custom'].includes(profileName)) {
-      return `${profileName} ${basePrompt}`
+    const prefix = promptPrefix(profileName, brandName)
+    if (wideEnoughForProfile && prefix) {
+      return `${prefix} ${basePrompt}`
     }
 
     return basePrompt
   }
 
-  if (profileName && !['default', 'custom'].includes(profileName)) {
-    return `${profileName} ${prompt}`
+  const prefix = promptPrefix(profileName, brandName)
+  if (prefix) {
+    return `${prefix} ${prompt}`
   }
 
   return prompt
+}
+
+function promptPrefix(profileName?: null | string, brandName?: null | string): string {
+  const profile = (profileName ?? '').trim()
+  if (profile && !['custom', 'default'].includes(profile)) {
+    return profile
+  }
+  const brand = (brandName ?? '').trim()
+  if (brand && profile !== 'custom') {
+    return brand.replace(/\s+Agent$/i, '')
+  }
+  return ''
 }

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -148,6 +148,7 @@ export interface McpServerStatus {
 }
 
 export interface SessionInfo {
+  account_limit_status?: string
   cwd?: string
   fast?: boolean
   lazy?: boolean


### PR DESCRIPTION
## Summary
- restore compact provider account-limit status in classic CLI and Ink TUI status bars
- include compact reset countdowns, e.g. `Codex 5h 81% · 2h14m | W 59% · 4d`
- keep reasoning effort and service tier visible, including default `medium normal`
- refresh account limits in background/cached paths so status rendering does not block

## Verification
- `uv run python -m pytest tests/cli/test_cli_status_bar.py tests/test_cli_skin_integration.py tests/test_tui_gateway_server.py::test_tui_account_limit_status_compacts_codex_session_and_weekly -q` → 66 passed
- `uv run python -m py_compile cli.py agent/account_usage.py tui_gateway/server.py`
- `PATH="$HOME/.local/node-v22/bin:$PATH" npm test -- --run src/__tests__/appChromeStatusRule.test.tsx src/__tests__/prompt.test.ts` → 24 passed
- `PATH="$HOME/.local/node-v22/bin:$PATH" npm run build` → built `ui-tui/dist/entry.js`
