### PR TITLE
fix(dashboard): drop _HERMES_GATEWAY when spawning hermes actions

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2374,12 +2374,20 @@ def _spawn_hermes_action(subcommand: List[str], name: str) -> subprocess.Popen:
 
     cmd = [sys.executable, "-m", "hermes_cli.main", *subcommand]
 
+    # The dashboard runs *inside* the gateway process, so os.environ carries
+    # _HERMES_GATEWAY=1. Inheriting it makes a spawned `hermes gateway restart`
+    # trip the in-process restart-loop guard and exit 1 — silently failing the
+    # dashboard's auto-restart paths. The gateway's own restart watcher already
+    # drops it (gateway/run.py); mirror that here (#52470).
+    action_env = {**os.environ, "HERMES_NONINTERACTIVE": "1"}
+    action_env.pop("_HERMES_GATEWAY", None)
+
     popen_kwargs: Dict[str, Any] = {
         "cwd": str(PROJECT_ROOT),
         "stdin": subprocess.DEVNULL,
         "stdout": log_file,
         "stderr": subprocess.STDOUT,
-        "env": {**os.environ, "HERMES_NONINTERACTIVE": "1"},
+        "env": action_env,
     }
     if sys.platform == "win32":
         popen_kwargs["creationflags"] = (

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -1083,3 +1083,35 @@ class TestToolsConfigEndpoints:
                 kwargs["json"] = payload
             r = fn(path, **kwargs)
             assert r.status_code == 401, f"{method} {path} not gated"
+
+
+# ---------------------------------------------------------------------------
+# _spawn_hermes_action env scrubbing (#52470)
+# ---------------------------------------------------------------------------
+
+def test_spawn_hermes_action_scrubs_gateway_loop_guard_env(monkeypatch, tmp_path):
+    """The dashboard runs inside the gateway, so os.environ has
+    _HERMES_GATEWAY=1. Spawned actions (e.g. `gateway restart`) must NOT inherit
+    it, or the in-process restart-loop guard rejects the restart and it silently
+    fails (#52470).
+    """
+    import hermes_cli.web_server as ws
+
+    monkeypatch.setenv("_HERMES_GATEWAY", "1")
+    monkeypatch.setattr(ws, "_ACTION_LOG_DIR", tmp_path)
+
+    captured = {}
+
+    class _FakeProc:
+        pid = 1234
+
+    def _fake_popen(cmd, **kwargs):
+        captured["env"] = kwargs.get("env")
+        return _FakeProc()
+
+    monkeypatch.setattr(ws.subprocess, "Popen", _fake_popen)
+
+    ws._spawn_hermes_action(["gateway", "restart"], "gateway-restart")
+
+    assert "_HERMES_GATEWAY" not in captured["env"]
+    assert captured["env"]["HERMES_NONINTERACTIVE"] == "1"


### PR DESCRIPTION
## Summary

Fixes #52470. The web dashboard runs *inside* the gateway process, so `os.environ` carries `_HERMES_GATEWAY=1` (set in `gateway/run.py`). `_spawn_hermes_action` built the subprocess env as `{**os.environ, "HERMES_NONINTERACTIVE": "1"}`, spreading that var through. A spawned `hermes gateway restart` (dashboard "Enable webhooks", Telegram QR onboarding apply) then tripped the in-process restart-loop guard:

```
✗ Refusing to restart the gateway from inside the gateway process.
```

…and exited 1. The gateway never restarted, but the dashboard returned `restart_started: true` because it only checks that the spawn succeeded — a silent failure.

## Fix

Scrub `_HERMES_GATEWAY` from the spawned action's env, mirroring what the gateway's own restart watcher already does (`gateway/run.py` does `watcher_env.pop("_HERMES_GATEWAY", None)`). Dropping it for all spawned `hermes <subcommand>` actions is safe — those are fresh CLI invocations, not the gateway process itself.

## Tests

Adds `test_spawn_hermes_action_scrubs_gateway_loop_guard_env`: with `_HERMES_GATEWAY=1` in the environment, the env passed to the spawned process omits `_HERMES_GATEWAY` and still sets `HERMES_NONINTERACTIVE=1`. Existing restart/webhook endpoint tests stay green.
