### PR TITLE
fix(desktop): sudo password prompt UX (command context + needs-input badge)

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -69,6 +69,7 @@ import {
   getRecentlySettledSessionIds,
   mergeSessionPage,
   MESSAGING_SECTION_LIMIT,
+  $blockingPromptResolvedRuntimeId,
   sessionPinId,
   setAwaitingResponse,
   setBusy,
@@ -266,6 +267,20 @@ export function DesktopController() {
     setBusy,
     setMessages
   })
+
+  // Sudo/secret overlays resolve before tool.complete — drop needsInput right
+  // away so the sidebar badge and retry flow do not look stuck.
+  useEffect(
+    () =>
+      $blockingPromptResolvedRuntimeId.listen(runtimeSessionId => {
+        if (runtimeSessionId) {
+          updateSessionState(runtimeSessionId, state =>
+            state.needsInput ? { ...state, needsInput: false } : state
+          )
+        }
+      }),
+    [updateSessionState]
+  )
 
   const { connectionRef, gatewayRef, requestGateway } = useGatewayRequest()
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -1049,7 +1049,13 @@ export function useMessageStream({
         const requestId = typeof payload?.request_id === 'string' ? payload.request_id : ''
 
         if (requestId) {
-          setSudoRequest({ requestId, sessionId: sessionId ?? null })
+          const command = typeof payload?.command === 'string' ? payload.command : ''
+
+          setSudoRequest({
+            command: command || undefined,
+            requestId,
+            sessionId: sessionId ?? null
+          })
 
           if (sessionId) {
             updateSessionState(sessionId, state => ({ ...state, needsInput: true }))

--- a/apps/desktop/src/components/prompt-overlays.tsx
+++ b/apps/desktop/src/components/prompt-overlays.tsx
@@ -19,6 +19,7 @@ import { triggerHaptic } from '@/lib/haptics'
 import { KeyRound, Loader2, Lock } from '@/lib/icons'
 import { $gateway } from '@/store/gateway'
 import { notifyError } from '@/store/notifications'
+import { notifyBlockingPromptResolved } from '@/store/session'
 import { $secretRequest, $sudoRequest, clearSecretRequest, clearSudoRequest } from '@/store/prompts'
 
 // Renders the modal mid-turn prompts the gateway raises and waits on: sudo
@@ -68,6 +69,7 @@ function SudoDialog() {
         })
         triggerHaptic('submit')
         clearSudoRequest(request.sessionId, request.requestId)
+        notifyBlockingPromptResolved(request.sessionId)
       } catch (error) {
         notifyError(error, copy.sudoSendFailed)
         setSubmitting(false)
@@ -171,6 +173,7 @@ function SecretDialog() {
         })
         triggerHaptic('submit')
         clearSecretRequest(request.sessionId, request.requestId)
+        notifyBlockingPromptResolved(request.sessionId)
       } catch (error) {
         notifyError(error, copy.secretSendFailed)
         setSubmitting(false)

--- a/apps/desktop/src/components/prompt-overlays.tsx
+++ b/apps/desktop/src/components/prompt-overlays.tsx
@@ -104,7 +104,14 @@ function SudoDialog() {
       <DialogContent showCloseButton={false}>
         <DialogHeader>
           <DialogTitle icon={Lock}>{copy.sudoTitle}</DialogTitle>
-          <DialogDescription>{copy.sudoDesc}</DialogDescription>
+          <DialogDescription>
+            {copy.sudoDesc}
+            {request.command ? (
+              <code className="mt-2 block max-h-24 overflow-y-auto rounded-md bg-muted/60 px-2 py-1.5 font-mono text-[length:var(--conversation-tool-font-size)] text-foreground break-all">
+                {request.command}
+              </code>
+            ) : null}
+          </DialogDescription>
         </DialogHeader>
 
         <form className="grid gap-3" onSubmit={onSubmit}>

--- a/apps/desktop/src/store/prompts.ts
+++ b/apps/desktop/src/store/prompts.ts
@@ -75,6 +75,7 @@ export interface ApprovalRequest extends KeyedPrompt {
 }
 
 export interface SudoRequest extends KeyedPrompt {
+  command?: string
   requestId: string
 }
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -466,6 +466,17 @@ export function setSessionAttention(sessionId: string | null | undefined, needsI
   }
 }
 
+// Blocking mid-turn prompts (sudo/secret) set needsInput on the runtime session.
+// When the overlay resolves — submit or backdrop cancel — clear it immediately
+// so the sidebar badge does not linger until the next tool.complete.
+export const $blockingPromptResolvedRuntimeId = atom<string | null>(null)
+
+export function notifyBlockingPromptResolved(runtimeSessionId: string | null | undefined) {
+  if (runtimeSessionId) {
+    $blockingPromptResolvedRuntimeId.set(runtimeSessionId)
+  }
+}
+
 export function setSessionWorking(sessionId: string | null | undefined, working: boolean) {
   if (!sessionId) {
     return

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -122,6 +122,26 @@ def test_registered_sudo_callback_is_used_without_interactive_env(monkeypatch):
     assert sudo_stdin == "callback-pass\n"
 
 
+def test_sudo_callback_receives_command_when_supported(monkeypatch):
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    monkeypatch.setattr(terminal_tool, "_sudo_nopasswd_works", lambda: False)
+
+    received = []
+
+    def sudo_callback(command=""):
+        received.append(command)
+        return "callback-pass"
+
+    terminal_tool.set_sudo_password_callback(sudo_callback)
+    try:
+        terminal_tool._transform_sudo_command("sudo apt install fprintd")
+    finally:
+        terminal_tool.set_sudo_password_callback(None)
+
+    assert received == ["sudo apt install fprintd"]
+
+
 def test_cached_sudo_password_isolated_by_session_key(monkeypatch):
     monkeypatch.delenv("SUDO_PASSWORD", raising=False)
     monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -318,7 +318,28 @@ def _handle_sudo_failure(output: str, env_type: str) -> str:
     return output
 
 
-def _prompt_for_sudo_password(timeout_seconds: int = 45) -> str:
+def _invoke_sudo_password_callback(command: str | None = None) -> str:
+    """Call the registered sudo password callback, passing *command* when supported."""
+    _sudo_cb = _get_sudo_password_callback()
+    if _sudo_cb is None:
+        return ""
+    try:
+        import inspect
+
+        params = list(inspect.signature(_sudo_cb).parameters.values())
+        if params and params[0].kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        ):
+            return _sudo_cb(command or "") or ""
+        return _sudo_cb() or ""
+    except Exception:
+        return ""
+
+
+def _prompt_for_sudo_password(
+    timeout_seconds: int = 45, command: str | None = None
+) -> str:
     """
     Prompt user for sudo password with timeout.
     
@@ -335,12 +356,8 @@ def _prompt_for_sudo_password(timeout_seconds: int = 45) -> str:
     import sys
     
     # Use the registered callback when available (prompt_toolkit-compatible)
-    _sudo_cb = _get_sudo_password_callback()
-    if _sudo_cb is not None:
-        try:
-            return _sudo_cb() or ""
-        except Exception:
-            return ""
+    if _get_sudo_password_callback() is not None:
+        return _invoke_sudo_password_callback(command)
 
     result = {"password": None, "done": False}
     
@@ -811,7 +828,9 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
         env_var_enabled("HERMES_INTERACTIVE") or has_sudo_prompt_callback
     )
     if not has_configured_password and not sudo_password and should_prompt_for_sudo:
-        sudo_password = _prompt_for_sudo_password(timeout_seconds=45)
+        sudo_password = _prompt_for_sudo_password(
+            timeout_seconds=45, command=command
+        )
         if sudo_password:
             _set_cached_sudo_password(sudo_password)
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3378,7 +3378,14 @@ def _wire_callbacks(sid: str):
     from tools.terminal_tool import set_sudo_password_callback
     from tools.skills_tool import set_secret_capture_callback
 
-    set_sudo_password_callback(lambda: _block("sudo.request", sid, {}, timeout=120))
+    set_sudo_password_callback(
+        lambda command="": _block(
+            "sudo.request",
+            sid,
+            {"command": command} if command else {},
+            timeout=120,
+        )
+    )
 
     def secret_cb(env_var, prompt, metadata=None):
         pl = {"prompt": prompt, "env_var": env_var}


### PR DESCRIPTION
## Summary
- Show the privileged shell command inside the desktop sudo password dialog so users know what they are approving (the modal no longer blocks the chat with zero context).
- Clear the sidebar "needs your input" badge immediately when a sudo/secret overlay is submitted or dismissed, instead of waiting for the next `tool.complete` event.

**Context:** Debug logs from the reporter show `sudo: A terminal is required to authenticate` after ~8s — consistent with closing the password dialog without entering a password (intentional refusal). Notification-click navigation to the right chat was already fixed on `main` after their 0.17.0 build (`d6269da7`); rebuilding from current `main` addresses that part.

## Test plan
- [x] `scripts/run_tests.sh tests/tools/test_terminal_tool.py`
- [x] `npm run typecheck` in `apps/desktop`
- [ ] Desktop: trigger a `sudo` terminal command, confirm the dialog shows the command text
- [ ] Dismiss the dialog and confirm the sidebar badge clears immediately
- [ ] Rebuild desktop from `main` and confirm notification click opens the correct chat
