### PR TITLE
fix(mem0): restore self-hosted support dropped by v3 refactor

### DIFF
--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -80,6 +80,7 @@ def _load_config() -> dict:
     config = {
         "mode": os.environ.get("MEM0_MODE", "platform"),
         "api_key": os.environ.get("MEM0_API_KEY", ""),
+        "host": os.environ.get("MEM0_HOST", ""),
         "agent_id": os.environ.get("MEM0_AGENT_ID", "hermes"),
         "oss": {},
     }
@@ -217,7 +218,7 @@ class Mem0MemoryProvider(MemoryProvider):
         mode = cfg.get("mode", "platform")
         if mode == "oss":
             return bool(cfg.get("oss", {}).get("vector_store"))
-        return bool(cfg.get("api_key"))
+        return bool(cfg.get("api_key") or cfg.get("host"))
 
     def save_config(self, values, hermes_home):
         """Write config to $HERMES_HOME/mem0.json."""
@@ -240,6 +241,7 @@ class Mem0MemoryProvider(MemoryProvider):
         api_key_required = mode != "oss"
         return [
             {"key": "api_key", "description": "Mem0 Platform API key", "secret": True, "required": api_key_required, "env_var": "MEM0_API_KEY", "url": "https://app.mem0.ai"},
+            {"key": "host", "description": "Self-hosted Mem0 URL (e.g. http://localhost:8888)", "default": "", "env_var": "MEM0_HOST"},
             {"key": "user_id", "description": "User identifier", "default": "hermes-user"},
             {"key": "agent_id", "description": "Agent identifier", "default": "hermes"},
             {"key": "rerank", "description": "Enable reranking for recall", "default": "true", "choices": ["true", "false"]},
@@ -254,6 +256,9 @@ class Mem0MemoryProvider(MemoryProvider):
             if self._mode == "oss":
                 from ._backend import OSSBackend
                 return OSSBackend(self._config.get("oss", {}))
+            if self._host:
+                from ._backend import SelfHostedBackend
+                return SelfHostedBackend(self._api_key, self._host)
             from ._backend import PlatformBackend
             return PlatformBackend(self._api_key)
         except Exception as e:
@@ -308,6 +313,7 @@ class Mem0MemoryProvider(MemoryProvider):
         self._config = _load_config()
         self._mode = self._config.get("mode", "platform")
         self._api_key = self._config.get("api_key", "")
+        self._host = self._config.get("host", "")
         # Resolution order for user_id:
         #   1. Operator-configured MEM0_USER_ID (env or $HERMES_HOME/mem0.json) —
         #      the canonical principal, applied across every gateway so the same
@@ -344,7 +350,12 @@ class Mem0MemoryProvider(MemoryProvider):
         return {"channel": self._channel} if self._channel else {}
 
     def system_prompt_block(self) -> str:
-        mode_label = "platform (cloud API)" if self._mode == "platform" else "OSS (self-hosted)"
+        if getattr(self, "_host", ""):
+            mode_label = f"self-hosted ({self._host})"
+        elif self._mode == "platform":
+            mode_label = "platform (cloud API)"
+        else:
+            mode_label = "OSS (self-hosted)"
         rerank_note = " Rerank is available on search." if self._mode == "platform" else ""
         return (
             "# Mem0 Memory\n"

--- a/plugins/memory/mem0/_backend.py
+++ b/plugins/memory/mem0/_backend.py
@@ -90,6 +90,93 @@ class PlatformBackend(Mem0Backend):
         return {"result": "Memory deleted.", "memory_id": memory_id}
 
 
+class SelfHostedBackend(Mem0Backend):
+    """Direct HTTP backend for self-hosted Mem0 (FastAPI server via httpx).
+
+    Bypasses MemoryClient entirely — the SDK's ``_validate_api_key`` calls
+    ``GET /v1/ping/`` which the self-hosted server does not expose.
+    Uses ``X-API-Key`` header instead of ``Authorization: Token``.
+    """
+
+    def __init__(self, api_key: str, host: str):
+        import httpx
+
+        self._host = host.rstrip("/")
+        headers: dict[str, str] = {"Content-Type": "application/json"}
+        if api_key:
+            headers["X-API-Key"] = api_key
+        self._client = httpx.Client(
+            base_url=self._host, headers=headers, timeout=30,
+        )
+
+    def _unwrap(self, response) -> list:
+        if response.status_code >= 400:
+            return []
+        data = response.json()
+        if isinstance(data, dict):
+            return data.get("results", data.get("data", []))
+        if isinstance(data, list):
+            return data
+        return []
+
+    def search(self, query: str, *, filters: dict, top_k: int = 10, rerank: bool = True) -> list[dict]:
+        body: dict[str, Any] = {"query": query, "top_k": top_k}
+        if filters:
+            body["filters"] = filters
+        resp = self._client.post("/search", json=body)
+        return self._unwrap(resp)
+
+    def get_all(self, *, filters: dict, page: int = 1, page_size: int = 100) -> dict:
+        params: dict[str, Any] = {}
+        if filters:
+            params["user_id"] = filters.get("user_id", "")
+        resp = self._client.get("/memories", params=params)
+        results = self._unwrap(resp)
+        total = len(results)
+        start = (page - 1) * page_size
+        return {"results": results[start : start + page_size], "count": total}
+
+    def add(
+        self,
+        messages: list,
+        *,
+        user_id: str,
+        agent_id: str,
+        infer: bool = False,
+        metadata: dict | None = None,
+    ) -> dict:
+        body: dict[str, Any] = {
+            "messages": messages,
+            "user_id": user_id,
+            "agent_id": agent_id,
+            "infer": infer,
+        }
+        if metadata:
+            body["metadata"] = metadata
+        resp = self._client.post("/memories", json=body)
+        if resp.status_code >= 400:
+            return {"error": resp.text}
+        return resp.json()
+
+    def update(self, memory_id: str, text: str) -> dict:
+        resp = self._client.patch(f"/memories/{memory_id}", json={"text": text})
+        if resp.status_code >= 400:
+            return {"error": resp.text}
+        return {"result": "Memory updated.", "memory_id": memory_id}
+
+    def delete(self, memory_id: str) -> dict:
+        resp = self._client.delete(f"/memories/{memory_id}")
+        if resp.status_code >= 400:
+            return {"error": resp.text}
+        return {"result": "Memory deleted.", "memory_id": memory_id}
+
+    def close(self) -> None:
+        try:
+            self._client.close()
+        except Exception:
+            pass
+
+
 class OSSBackend(Mem0Backend):
     """Wraps mem0.Memory for self-hosted (OSS) mode."""
 

--- a/tests/plugins/memory/test_mem0_backend.py
+++ b/tests/plugins/memory/test_mem0_backend.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from plugins.memory.mem0._backend import Mem0Backend, PlatformBackend, OSSBackend
+from plugins.memory.mem0._backend import Mem0Backend, PlatformBackend, OSSBackend, SelfHostedBackend
 
 
 class FakePlatformClient:
@@ -207,3 +207,150 @@ class TestOSSBackend:
         backend, _ = self._make()
         result = backend.delete("m1")
         assert result == {"result": "Memory deleted.", "memory_id": "m1"}
+
+
+class TestSelfHostedBackend:
+    """Tests for SelfHostedBackend — direct HTTP to self-hosted Mem0 server."""
+
+    def _make(self, api_key="test-key", host="http://localhost:8888"):
+        backend = SelfHostedBackend.__new__(SelfHostedBackend)
+        backend._host = host.rstrip("/")
+
+        class MockClient:
+            def __init__(self):
+                self.calls = []
+                self.base_url = host
+                self.headers = {}
+
+            def post(self, path, json=None, **kw):
+                self.calls.append(("POST", path, json))
+                if path == "/search":
+                    return MockResponse(200, {"results": [{"id": "m1", "memory": "fact1", "score": 0.9}]})
+                if path == "/memories":
+                    return MockResponse(200, {"event_id": "evt-1", "status": "ok"})
+                return MockResponse(404, {})
+
+            def get(self, path, params=None, **kw):
+                self.calls.append(("GET", path, params))
+                return MockResponse(200, {"results": [{"id": "m1", "memory": "fact1"}]})
+
+            def patch(self, path, json=None, **kw):
+                self.calls.append(("PATCH", path, json))
+                return MockResponse(200, {"id": "m1"})
+
+            def delete(self, path, **kw):
+                self.calls.append(("DELETE", path))
+                return MockResponse(200, {})
+
+            def close(self):
+                pass
+
+        class MockResponse:
+            def __init__(self, status, data):
+                self.status_code = status
+                self._data = data
+
+            def json(self):
+                return self._data
+
+        backend._client = MockClient()
+        return backend
+
+    def test_search_forwards_params(self):
+        backend = self._make()
+        result = backend.search("test query", filters={"user_id": "u1"}, top_k=5)
+        call = backend._client.calls[0]
+        assert call[0] == "POST"
+        assert call[1] == "/search"
+        assert call[2]["query"] == "test query"
+        assert call[2]["top_k"] == 5
+        assert call[2]["filters"] == {"user_id": "u1"}
+
+    def test_search_returns_list(self):
+        backend = self._make()
+        result = backend.search("q", filters={})
+        assert isinstance(result, list)
+        assert result[0]["id"] == "m1"
+
+    def test_search_empty_filters_omits_key(self):
+        backend = self._make()
+        backend.search("q", filters={})
+        call = backend._client.calls[0]
+        assert "filters" not in call[2]
+
+    def test_get_all_forwards_user_id(self):
+        backend = self._make()
+        result = backend.get_all(filters={"user_id": "u1"}, page=1, page_size=50)
+        call = backend._client.calls[0]
+        assert call[0] == "GET"
+        assert call[1] == "/memories"
+        assert call[2]["user_id"] == "u1"
+        assert "results" in result
+        assert "count" in result
+
+    def test_get_all_pagination(self):
+        backend = self._make()
+        result = backend.get_all(filters={"user_id": "u1"}, page=1, page_size=1)
+        assert len(result["results"]) <= 1
+
+    def test_add_forwards_kwargs(self):
+        backend = self._make()
+        msgs = [{"role": "user", "content": "hi"}]
+        result = backend.add(msgs, user_id="u1", agent_id="hermes", infer=False)
+        call = backend._client.calls[0]
+        assert call[0] == "POST"
+        assert call[1] == "/memories"
+        assert call[2]["messages"] == msgs
+        assert call[2]["user_id"] == "u1"
+        assert call[2]["infer"] is False
+
+    def test_add_forwards_metadata(self):
+        backend = self._make()
+        msgs = [{"role": "user", "content": "hi"}]
+        backend.add(msgs, user_id="u1", agent_id="hermes", infer=True, metadata={"channel": "telegram"})
+        call = backend._client.calls[0]
+        assert call[2]["metadata"] == {"channel": "telegram"}
+
+    def test_add_omits_empty_metadata(self):
+        backend = self._make()
+        msgs = [{"role": "user", "content": "hi"}]
+        backend.add(msgs, user_id="u1", agent_id="hermes", infer=False)
+        call = backend._client.calls[0]
+        assert "metadata" not in call[2]
+
+    def test_update_forwards(self):
+        backend = self._make()
+        result = backend.update("m1", "new text")
+        call = backend._client.calls[0]
+        assert call[0] == "PATCH"
+        assert call[1] == "/memories/m1"
+        assert call[2] == {"text": "new text"}
+        assert result["result"] == "Memory updated."
+
+    def test_delete_forwards(self):
+        backend = self._make()
+        result = backend.delete("m1")
+        call = backend._client.calls[0]
+        assert call[0] == "DELETE"
+        assert call[1] == "/memories/m1"
+        assert result["result"] == "Memory deleted."
+
+    def test_init_sets_headers(self):
+        backend = SelfHostedBackend("my-key", "http://localhost:8888")
+        assert backend._client.headers.get("X-API-Key") == "my-key"
+        assert "Authorization" not in backend._client.headers
+        backend.close()
+
+    def test_init_strips_trailing_slash(self):
+        backend = SelfHostedBackend("key", "http://localhost:8888/")
+        assert backend._host == "http://localhost:8888"
+        backend.close()
+
+    def test_init_no_api_key(self):
+        backend = SelfHostedBackend("", "http://localhost:8888")
+        assert "X-API-Key" not in backend._client.headers
+        backend.close()
+
+    def test_close(self):
+        backend = self._make()
+        backend.close()

--- a/tests/plugins/memory/test_mem0_v3.py
+++ b/tests/plugins/memory/test_mem0_v3.py
@@ -461,3 +461,63 @@ class TestMem0WriteMetadata:
         adds = [c for c in provider._backend.captured if c[0] == "add"]
         assert adds, "expected an add call from sync_turn"
         assert adds[-1][2]["metadata"] == {"channel": "discord"}
+
+
+class TestCreateBackendRouting:
+    """Test _create_backend() routes to the correct backend based on config."""
+
+    def test_host_routes_to_self_hosted(self):
+        from plugins.memory.mem0._backend import SelfHostedBackend
+        provider = Mem0MemoryProvider()
+        provider._config = {"host": "http://localhost:8888", "api_key": "key", "mode": "platform"}
+        provider._mode = "platform"
+        provider._api_key = "key"
+        provider._host = "http://localhost:8888"
+        backend = provider._create_backend()
+        assert isinstance(backend, SelfHostedBackend)
+        backend.close()
+
+    def test_no_host_routes_to_platform(self, monkeypatch):
+        from plugins.memory.mem0._backend import PlatformBackend
+        class FakeMemoryClient:
+            def __init__(self, api_key=None, host=None):
+                pass
+        original_init = PlatformBackend.__init__
+        def patched_init(self, api_key):
+            self._client = FakeMemoryClient(api_key=api_key)
+        monkeypatch.setattr(PlatformBackend, "__init__", patched_init)
+        provider = Mem0MemoryProvider()
+        provider._config = {"api_key": "key", "mode": "platform"}
+        provider._mode = "platform"
+        provider._api_key = "key"
+        provider._host = ""
+        backend = provider._create_backend()
+        assert isinstance(backend, PlatformBackend)
+
+    def test_oss_mode_routes_to_oss(self):
+        from plugins.memory.mem0._backend import OSSBackend
+        provider = Mem0MemoryProvider()
+        provider._config = {"mode": "oss", "oss": {"vector_store": {"provider": "qdrant", "config": {"path": "/tmp/test"}}}}
+        provider._mode = "oss"
+        provider._api_key = ""
+        provider._host = ""
+        original_oss_init = OSSBackend.__init__
+        def fake_oss_init(self, oss_config):
+            self._memory = None
+        OSSBackend.__init__ = fake_oss_init
+        try:
+            backend = provider._create_backend()
+            assert isinstance(backend, OSSBackend)
+        finally:
+            OSSBackend.__init__ = original_oss_init
+
+    def test_host_with_empty_api_key(self):
+        from plugins.memory.mem0._backend import SelfHostedBackend
+        provider = Mem0MemoryProvider()
+        provider._config = {"host": "http://localhost:8888", "mode": "platform"}
+        provider._mode = "platform"
+        provider._api_key = ""
+        provider._host = "http://localhost:8888"
+        backend = provider._create_backend()
+        assert isinstance(backend, SelfHostedBackend)
+        backend.close()


### PR DESCRIPTION
## What does this PR do?

Restores self-hosted Mem0 support that was dropped during the v3 refactor (#15624). When `host` is set in `mem0.json` (or `MEM0_HOST` env var), the plugin now routes to a new `SelfHostedBackend` that communicates directly with the self-hosted Mem0 FastAPI server via httpx, bypassing `MemoryClient` (whose `_validate_api_key()` calls `GET /v1/ping/` — an endpoint the self-hosted server does not expose).

## Related Issue

Fixes #52478

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/mem0/_backend.py`: Added `SelfHostedBackend` class — direct HTTP client for self-hosted Mem0 FastAPI server using `X-API-Key` auth and `/memories`/`/search` endpoints.
- `plugins/memory/mem0/__init__.py`: Route to `SelfHostedBackend` when `host` is configured; read `MEM0_HOST` env var; accept `host` as alternative to `api_key` in `is_available()`; add `host` field to config schema; show self-hosted URL in system prompt.
- `tests/plugins/memory/test_mem0_backend.py`: Added `TestSelfHostedBackend` (14 tests) covering search, get_all, add, update, delete, header setup, trailing-slash normalization, and no-api-key handling.
- `tests/plugins/memory/test_mem0_v3.py`: Added `TestCreateBackendRouting` (4 tests) verifying `_create_backend()` routes to the correct backend class based on config.

## How to Test

1. Set up a self-hosted Mem0 Docker instance (FastAPI + pgvector)
2. Create `~/.hermes/mem0.json` with `"host": "http://localhost:8888"` and the ADMIN_API_KEY
3. Start a new Hermes session (`/reset`)
4. Call `mem0_list` or `mem0_search` — should connect to the self-hosted server without errors
5. Run `pytest tests/plugins/memory/test_mem0_backend.py tests/plugins/memory/test_mem0_v3.py -q` — should pass 80 tests

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `plugins/memory/mem0/_backend.py` (PlatformBackend, OSSBackend, SelfHostedBackend), `plugins/memory/mem0/__init__.py` (_create_backend, is_available, _load_config)
- Blast radius: LOW — isolated to mem0 plugin, no core changes
- Related patterns: Commit `b6d2ac176` originally added `host` support via `MemoryClient(host=...)`; PR #15624 refactor dropped it. This PR restores the capability with a dedicated backend that avoids `MemoryClient._validate_api_key()`.
