### PR TITLE
feat(plugins): add profile tasks dashboard

### DIFF
--- a/plugins/profile-tasks/dashboard/dist/index.js
+++ b/plugins/profile-tasks/dashboard/dist/index.js
@@ -1,0 +1,175 @@
+(function () {
+  "use strict";
+
+  const SDK = window.__HERMES_PLUGIN_SDK__;
+  const REG = window.__HERMES_PLUGINS__;
+  if (!SDK || !REG) return;
+
+  const { React } = SDK;
+  const h = React.createElement;
+  const { useCallback, useEffect, useMemo, useState } = SDK.hooks;
+  const C = SDK.components || {};
+  const Card = C.Card || "div";
+  const CardContent = C.CardContent || "div";
+  const Button = C.Button || "button";
+  const Badge = C.Badge || "span";
+  const Label = C.Label || "label";
+  const Select = C.Select || "select";
+  const SelectOption = C.SelectOption || "option";
+  const cn = (SDK.utils && SDK.utils.cn) || function () { return Array.prototype.slice.call(arguments).filter(Boolean).join(" "); };
+
+  const API = "/api/plugins/profile-tasks";
+  const COLUMNS = [
+    ["running", "Running"],
+    ["blocked", "Blocked"],
+    ["review", "Review"],
+    ["recent_done", "Recent done"],
+    ["ready", "Ready"],
+  ];
+
+  function selectChangeHandler(setter) {
+    return {
+      onValueChange: function (v) { setter(v); },
+      onChange: function (e) { setter(e && e.target ? e.target.value : e); },
+    };
+  }
+
+  function apiError(err) {
+    const raw = err && err.message ? String(err.message) : String(err || "Unknown error");
+    const m = raw.match(/^(\d{3}):\s*(.*)$/s);
+    if (!m) return raw;
+    try {
+      const parsed = JSON.parse(m[2]);
+      return parsed.detail || raw;
+    } catch (_) {
+      return m[2] || raw;
+    }
+  }
+
+  function TaskCard(props) {
+    const t = props.task;
+    const warningCount = (t.warnings || []).length;
+    return h("div", { className: "pt-card" },
+      h("div", { className: "pt-card-title" }, t.title || t.id),
+      h("div", { className: "pt-card-meta" },
+        h(Badge, { className: "pt-badge" }, t.id),
+        t.priority ? h(Badge, { className: "pt-badge" }, "P" + t.priority) : null,
+        t.tenant ? h(Badge, { className: "pt-badge" }, t.tenant) : null,
+        warningCount ? h(Badge, { className: "pt-badge pt-warning" }, warningCount + " warning" + (warningCount === 1 ? "" : "s")) : null
+      ),
+      t.summary_preview ? h("p", { className: "pt-summary" }, t.summary_preview) : null,
+      t.latest_run ? h("div", { className: "pt-run" }, "Latest run: ", t.latest_run.status || "unknown", t.latest_run.outcome ? " / " + t.latest_run.outcome : "") : null,
+      warningCount ? h("ul", { className: "pt-warnings" }, (t.warnings || []).map(function (w) {
+        return h("li", { key: w.kind }, w.message || w.kind);
+      })) : null
+    );
+  }
+
+  function Column(props) {
+    const tasks = props.tasks || [];
+    return h("section", { className: "pt-column" },
+      h("div", { className: "pt-column-head" },
+        h("h3", null, props.label),
+        h(Badge, { className: "pt-badge" }, String(tasks.length))
+      ),
+      tasks.length ? tasks.map(function (task) {
+        return h(TaskCard, { key: task.id, task: task });
+      }) : h("div", { className: "pt-empty" }, "No tasks")
+    );
+  }
+
+  function ProfileTasks() {
+    const [profiles, setProfiles] = useState([]);
+    const [boards, setBoards] = useState([]);
+    const [profile, setProfile] = useState("");
+    const [board, setBoard] = useState("default");
+    const [includeReady, setIncludeReady] = useState(false);
+    const [data, setData] = useState(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+
+    const loadMetadata = useCallback(function () {
+      return Promise.all([
+        SDK.fetchJSON(API + "/profiles"),
+        SDK.fetchJSON(API + "/boards"),
+      ]).then(function (results) {
+        const ps = results[0].profiles || [];
+        const bs = results[1].boards || [];
+        setProfiles(ps);
+        setBoards(bs);
+        setProfile(function (current) { return current || (ps[0] && ps[0].name) || ""; });
+        setBoard(function (current) { return current || (bs[0] && bs[0].slug) || "default"; });
+      });
+    }, []);
+
+    const loadTasks = useCallback(function () {
+      if (!profile) return Promise.resolve();
+      setLoading(true);
+      setError(null);
+      const qs = new URLSearchParams({ profile: profile, board: board || "default", include_ready: includeReady ? "true" : "false" });
+      return SDK.fetchJSON(API + "/tasks?" + qs.toString())
+        .then(function (payload) { setData(payload); })
+        .catch(function (err) { setError(apiError(err)); })
+        .finally(function () { setLoading(false); });
+    }, [profile, board, includeReady]);
+
+    useEffect(function () {
+      loadMetadata().catch(function (err) { setError(apiError(err)); });
+    }, [loadMetadata]);
+
+    useEffect(function () {
+      loadTasks();
+      const timer = window.setInterval(loadTasks, 15000);
+      return function () { window.clearInterval(timer); };
+    }, [loadTasks]);
+
+    const activeProfile = useMemo(function () {
+      return profiles.find(function (p) { return p.name === profile; }) || null;
+    }, [profiles, profile]);
+
+    return h("div", { className: "pt-root" },
+      h("div", { className: "pt-header" },
+        h("div", null,
+          h("h1", null, "Profile Tasks"),
+          h("p", null, "Read-only Kanban-by-profile view. Refreshes every 15 seconds; no task mutations are available here.")
+        ),
+        h(Button, { onClick: loadTasks, disabled: loading || !profile }, loading ? "Refreshing…" : "Refresh")
+      ),
+      h(Card, { className: "pt-controls" },
+        h(CardContent, { className: "pt-controls-inner" },
+          h("div", { className: "pt-field" },
+            h(Label, null, "Profile"),
+            h(Select, Object.assign({ value: profile, className: "pt-select" }, selectChangeHandler(setProfile)),
+              profiles.map(function (p) { return h(SelectOption, { key: p.name, value: p.name }, p.name); })
+            )
+          ),
+          h("div", { className: "pt-field" },
+            h(Label, null, "Board"),
+            h(Select, Object.assign({ value: board, className: "pt-select" }, selectChangeHandler(setBoard)),
+              boards.map(function (b) { return h(SelectOption, { key: b.slug, value: b.slug }, b.name || b.slug); })
+            )
+          ),
+          h("label", { className: "pt-check" },
+            h("input", { type: "checkbox", checked: includeReady, onChange: function (e) { setIncludeReady(e.target.checked); } }),
+            " Include assigned ready tasks"
+          )
+        )
+      ),
+      activeProfile ? h("div", { className: "pt-profile-meta" },
+        h(Badge, { className: "pt-badge" }, activeProfile.gateway_running ? "gateway running" : "gateway stopped"),
+        activeProfile.model ? h(Badge, { className: "pt-badge" }, activeProfile.provider ? activeProfile.provider + ":" + activeProfile.model : activeProfile.model) : null,
+        h(Badge, { className: "pt-badge" }, (activeProfile.skill_count || 0) + " skills"),
+        activeProfile.description ? h("span", null, activeProfile.description) : null
+      ) : null,
+      error ? h("div", { className: "pt-error" }, error) : null,
+      data && data.warnings && data.warnings.length ? h("div", { className: "pt-warning-box" }, data.warnings.map(function (w) { return h("div", { key: w.kind }, w.message || w.kind); })) : null,
+      h("div", { className: cn("pt-board", includeReady && "pt-board-ready") },
+        COLUMNS.filter(function (pair) { return pair[0] !== "ready" || includeReady; }).map(function (pair) {
+          return h(Column, { key: pair[0], label: pair[1], tasks: data && data.columns ? data.columns[pair[0]] : [] });
+        })
+      )
+    );
+  }
+
+  REG.register("profile-tasks", ProfileTasks);
+})();

--- a/plugins/profile-tasks/dashboard/dist/style.css
+++ b/plugins/profile-tasks/dashboard/dist/style.css
@@ -1,0 +1,176 @@
+.pt-root {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.pt-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.pt-header h1 {
+  margin: 0;
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+.pt-header p,
+.pt-summary,
+.pt-run,
+.pt-empty {
+  color: hsl(var(--muted-foreground, 215 16% 47%));
+}
+
+.pt-controls-inner {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: end;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.pt-field {
+  display: flex;
+  min-width: 12rem;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.pt-select {
+  min-height: 2.25rem;
+}
+
+.pt-check {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-height: 2.25rem;
+  font-size: 0.9rem;
+}
+
+.pt-profile-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.pt-error,
+.pt-warning-box {
+  border-radius: 0.5rem;
+  padding: 0.75rem 1rem;
+}
+
+.pt-error {
+  border: 1px solid hsl(var(--destructive, 0 84% 60%));
+  background: hsl(var(--destructive, 0 84% 60%) / 0.08);
+}
+
+.pt-warning-box {
+  border: 1px solid hsl(38 92% 50% / 0.5);
+  background: hsl(38 92% 50% / 0.12);
+}
+
+.pt-board {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(13rem, 1fr));
+  gap: 1rem;
+}
+
+.pt-board-ready {
+  grid-template-columns: repeat(5, minmax(13rem, 1fr));
+}
+
+.pt-column {
+  min-height: 12rem;
+  border: 1px solid hsl(var(--border, 214 32% 91%));
+  border-radius: 0.75rem;
+  background: hsl(var(--muted, 210 40% 96%) / 0.35);
+  padding: 0.75rem;
+}
+
+.pt-column-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.pt-column-head h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 650;
+}
+
+.pt-card {
+  margin-bottom: 0.65rem;
+  border: 1px solid hsl(var(--border, 214 32% 91%));
+  border-radius: 0.65rem;
+  background: hsl(var(--card, 0 0% 100%));
+  padding: 0.75rem;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 0.04);
+}
+
+.pt-card-title {
+  font-weight: 650;
+  line-height: 1.25;
+}
+
+.pt-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.5rem;
+}
+
+.pt-badge {
+  font-size: 0.72rem;
+}
+
+.pt-warning {
+  background: hsl(38 92% 50% / 0.18);
+}
+
+.pt-summary {
+  margin: 0.6rem 0 0;
+  font-size: 0.85rem;
+}
+
+.pt-run {
+  margin-top: 0.5rem;
+  font-size: 0.78rem;
+}
+
+.pt-warnings {
+  margin: 0.5rem 0 0;
+  padding-left: 1.1rem;
+  color: hsl(38 92% 35%);
+  font-size: 0.78rem;
+}
+
+.pt-empty {
+  border: 1px dashed hsl(var(--border, 214 32% 91%));
+  border-radius: 0.5rem;
+  padding: 1rem;
+  text-align: center;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 1100px) {
+  .pt-board,
+  .pt-board-ready {
+    grid-template-columns: repeat(2, minmax(13rem, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .pt-board,
+  .pt-board-ready {
+    grid-template-columns: 1fr;
+  }
+}

--- a/plugins/profile-tasks/dashboard/manifest.json
+++ b/plugins/profile-tasks/dashboard/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "profile-tasks",
+  "label": "Profile Tasks",
+  "description": "Read-only Kanban task dashboard grouped by local Hermes profile",
+  "icon": "Activity",
+  "version": "0.1.0",
+  "tab": {
+    "path": "/profile-tasks",
+    "position": "after:kanban"
+  },
+  "entry": "dist/index.js",
+  "css": "dist/style.css",
+  "api": "plugin_api.py"
+}

--- a/plugins/profile-tasks/dashboard/plugin_api.py
+++ b/plugins/profile-tasks/dashboard/plugin_api.py
@@ -1,0 +1,318 @@
+"""Profile Tasks dashboard plugin — read-only backend API.
+
+Mounted by the dashboard plugin system at ``/api/plugins/profile-tasks``.
+This module intentionally exposes a narrow, read-only view over local Hermes
+profiles and Kanban boards for a profile-scoped task dashboard.  It never calls
+Kanban mutation helpers and opens board databases with SQLite ``mode=ro`` plus
+``PRAGMA query_only=ON``.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator
+
+from fastapi import APIRouter, HTTPException, Query
+
+from hermes_cli import kanban_db
+from hermes_cli import profiles as profile_mod
+
+router = APIRouter()
+
+_ACTIVE_COLUMNS = ("running", "blocked", "review")
+_RECENT_DONE_LIMIT = 10
+_SUMMARY_PREVIEW_CHARS = 240
+_STALE_HEARTBEAT_SECONDS = 15 * 60
+
+
+def _safe_preview(value: Any, limit: int = _SUMMARY_PREVIEW_CHARS) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    text = " ".join(text.split())
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 1)].rstrip() + "…"
+
+
+def _profile_dict(info: Any) -> dict[str, Any]:
+    """Return non-secret profile metadata suitable for the dashboard."""
+    return {
+        "name": info.name,
+        "is_default": bool(info.is_default),
+        "gateway_running": bool(info.gateway_running),
+        "model": info.model,
+        "provider": info.provider,
+        "has_env": bool(info.has_env),
+        "skill_count": int(info.skill_count or 0),
+        "description": info.description or "",
+        "description_auto": bool(info.description_auto),
+        "distribution_name": info.distribution_name,
+        "distribution_version": info.distribution_version,
+        "alias_name": info.alias_name,
+    }
+
+
+def _profiles_by_name() -> dict[str, Any]:
+    return {p.name: p for p in profile_mod.list_profiles()}
+
+
+def _normalize_existing_profile(profile: str) -> str:
+    try:
+        name = profile_mod.normalize_profile_name(profile)
+        profile_mod.validate_profile_name(name)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    # Use list_profiles() as the local-profile source of truth, as requested.
+    if name not in _profiles_by_name():
+        raise HTTPException(status_code=404, detail=f"profile not found: {name}")
+    return name
+
+
+def _board_dict(meta: dict[str, Any]) -> dict[str, Any]:
+    # Do not expose absolute db_path/default_workdir in the API response.
+    return {
+        "slug": meta.get("slug"),
+        "name": meta.get("name") or meta.get("slug"),
+        "description": meta.get("description") or "",
+        "icon": meta.get("icon") or "",
+        "color": meta.get("color") or "",
+        "archived": bool(meta.get("archived", False)),
+        "created_at": meta.get("created_at"),
+        "db_exists": Path(str(meta.get("db_path", ""))).is_file(),
+    }
+
+
+def _board_slugs() -> set[str]:
+    return {str(b.get("slug")) for b in kanban_db.list_boards(include_archived=True)}
+
+
+def _normalize_board(board: str | None) -> str:
+    slug = (board or kanban_db.DEFAULT_BOARD).strip() or kanban_db.DEFAULT_BOARD
+    if slug not in _board_slugs():
+        raise HTTPException(status_code=404, detail=f"board not found: {slug}")
+    return slug
+
+
+@contextmanager
+def _open_board_readonly(board: str) -> Iterator[sqlite3.Connection]:
+    db_path = kanban_db.kanban_db_path(board)
+    if not db_path.is_file():
+        raise FileNotFoundError(str(db_path))
+    uri = f"file:{db_path}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True, timeout=5)
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.execute("PRAGMA query_only=ON")
+        yield conn
+    finally:
+        conn.close()
+
+
+def _json_or_none(value: Any) -> Any:
+    if value in (None, ""):
+        return None
+    try:
+        return json.loads(value)
+    except Exception:
+        return None
+
+
+def _latest_runs(conn: sqlite3.Connection, task_ids: list[str]) -> dict[str, sqlite3.Row]:
+    if not task_ids:
+        return {}
+    placeholders = ",".join("?" for _ in task_ids)
+    rows = conn.execute(
+        f"""
+        SELECT r.*
+        FROM task_runs r
+        JOIN (
+          SELECT task_id, MAX(id) AS max_id
+          FROM task_runs
+          WHERE task_id IN ({placeholders})
+          GROUP BY task_id
+        ) latest ON latest.max_id = r.id
+        """,
+        task_ids,
+    ).fetchall()
+    return {str(r["task_id"]): r for r in rows}
+
+
+def _task_warnings(row: sqlite3.Row, latest_run: sqlite3.Row | None, now: int) -> list[dict[str, Any]]:
+    warnings: list[dict[str, Any]] = []
+    if row["status"] == "running":
+        claim_expires = row["claim_expires"]
+        if claim_expires is not None and int(claim_expires) < now:
+            warnings.append({"kind": "stale_claim", "message": "Running claim has expired."})
+        heartbeat = row["last_heartbeat_at"]
+        if heartbeat is not None and int(heartbeat) < now - _STALE_HEARTBEAT_SECONDS:
+            warnings.append({"kind": "stale_heartbeat", "message": "Worker heartbeat is stale."})
+    if row["consecutive_failures"] and int(row["consecutive_failures"]) > 0:
+        warnings.append({
+            "kind": "recent_failures",
+            "message": f"{int(row['consecutive_failures'])} consecutive failure(s).",
+        })
+    if latest_run is not None and latest_run["outcome"] in {"crashed", "timed_out", "spawn_failed", "gave_up"}:
+        warnings.append({"kind": "last_run_failed", "message": "Latest run did not complete successfully."})
+    return warnings
+
+
+def _task_dict(row: sqlite3.Row, latest_run: sqlite3.Row | None, now: int) -> dict[str, Any]:
+    skills = _json_or_none(row["skills"])
+    if not isinstance(skills, list):
+        skills = []
+    summary_source = latest_run["summary"] if latest_run is not None and latest_run["summary"] else row["result"]
+    safe: dict[str, Any] = {
+        "id": row["id"],
+        "title": row["title"],
+        "status": row["status"],
+        "assignee": row["assignee"],
+        "priority": row["priority"] or 0,
+        "created_by": row["created_by"],
+        "created_at": row["created_at"],
+        "started_at": row["started_at"],
+        "completed_at": row["completed_at"],
+        "tenant": row["tenant"],
+        "workspace_kind": row["workspace_kind"],
+        "branch_name": row["branch_name"],
+        "claim_expires": row["claim_expires"],
+        "last_heartbeat_at": row["last_heartbeat_at"],
+        "current_run_id": row["current_run_id"],
+        "consecutive_failures": row["consecutive_failures"] or 0,
+        "workflow_template_id": row["workflow_template_id"],
+        "current_step_key": row["current_step_key"],
+        "skills_count": len(skills),
+        "summary_preview": _safe_preview(summary_source),
+        "warnings": [],
+        "latest_run": None,
+    }
+    if latest_run is not None:
+        safe["latest_run"] = {
+            "id": latest_run["id"],
+            "task_id": latest_run["task_id"],
+            "profile": latest_run["profile"],
+            "step_key": latest_run["step_key"],
+            "status": latest_run["status"],
+            "started_at": latest_run["started_at"],
+            "ended_at": latest_run["ended_at"],
+            "outcome": latest_run["outcome"],
+            "summary_preview": _safe_preview(latest_run["summary"]),
+        }
+    safe["warnings"] = _task_warnings(row, latest_run, now)
+    return safe
+
+
+def _fetch_tasks_for_profile(
+    conn: sqlite3.Connection,
+    profile: str,
+    *,
+    include_ready: bool,
+) -> dict[str, list[dict[str, Any]]]:
+    statuses = list(_ACTIVE_COLUMNS) + ["done"]
+    if include_ready:
+        statuses.append("ready")
+    placeholders = ",".join("?" for _ in statuses)
+    rows = conn.execute(
+        f"""
+        SELECT * FROM tasks
+        WHERE assignee = ? AND status IN ({placeholders})
+        ORDER BY
+          CASE status
+            WHEN 'running' THEN 0
+            WHEN 'blocked' THEN 1
+            WHEN 'review' THEN 2
+            WHEN 'ready' THEN 3
+            WHEN 'done' THEN 4
+            ELSE 5
+          END,
+          COALESCE(completed_at, started_at, created_at) DESC,
+          priority DESC,
+          created_at DESC
+        """,
+        [profile, *statuses],
+    ).fetchall()
+    latest_by_task = _latest_runs(conn, [r["id"] for r in rows])
+    now = int(time.time())
+    columns: dict[str, list[dict[str, Any]]] = {name: [] for name in _ACTIVE_COLUMNS}
+    columns["recent_done"] = []
+    if include_ready:
+        columns["ready"] = []
+    for row in rows:
+        task = _task_dict(row, latest_by_task.get(row["id"]), now)
+        status = str(row["status"])
+        if status == "done":
+            if len(columns["recent_done"]) < _RECENT_DONE_LIMIT:
+                columns["recent_done"].append(task)
+        elif status == "ready":
+            if include_ready:
+                columns["ready"].append(task)
+        elif status in columns:
+            columns[status].append(task)
+    return columns
+
+
+@router.get("/profiles")
+def list_profiles() -> dict[str, Any]:
+    profiles = [_profile_dict(p) for p in profile_mod.list_profiles()]
+    return {"profiles": profiles, "count": len(profiles)}
+
+
+@router.get("/boards")
+def list_boards() -> dict[str, Any]:
+    boards = [_board_dict(b) for b in kanban_db.list_boards(include_archived=True)]
+    return {"boards": boards, "count": len(boards)}
+
+
+@router.get("/tasks")
+def tasks_for_profile(
+    profile: str = Query(..., description="Local Hermes profile name"),
+    board: str | None = Query(None, description="Kanban board slug"),
+    include_ready: bool = Query(False, description="Include assigned ready tasks"),
+) -> dict[str, Any]:
+    profile_name = _normalize_existing_profile(profile)
+    board_slug = _normalize_board(board)
+    board_meta = next((b for b in kanban_db.list_boards(include_archived=True) if b.get("slug") == board_slug), None) or {"slug": board_slug}
+    warnings: list[dict[str, Any]] = []
+    try:
+        with _open_board_readonly(board_slug) as conn:
+            columns = _fetch_tasks_for_profile(conn, profile_name, include_ready=include_ready)
+    except FileNotFoundError:
+        columns = {name: [] for name in _ACTIVE_COLUMNS}
+        columns["recent_done"] = []
+        if include_ready:
+            columns["ready"] = []
+        warnings.append({"kind": "missing_board_db", "message": "Kanban database does not exist yet."})
+    except sqlite3.DatabaseError as exc:
+        raise HTTPException(status_code=500, detail=f"could not read kanban board: {exc}") from exc
+
+    return {
+        "profile": profile_name,
+        "board": _board_dict(board_meta),
+        "include_ready": include_ready,
+        "columns": columns,
+        "warnings": warnings,
+        "read_only": True,
+        "generated_at": int(time.time()),
+    }
+
+
+@router.get("/overview")
+def overview(
+    profile: str = Query(..., description="Local Hermes profile name"),
+    board: str | None = Query(None, description="Kanban board slug"),
+    include_ready: bool = Query(False, description="Include assigned ready tasks"),
+) -> dict[str, Any]:
+    profile_name = _normalize_existing_profile(profile)
+    info = _profiles_by_name()[profile_name]
+    tasks = tasks_for_profile(profile=profile_name, board=board, include_ready=include_ready)
+    return {
+        "profile": _profile_dict(info),
+        "tasks": tasks,
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -329,6 +329,7 @@ hermes_cli = ["web_dist/**/*", "tui_dist/**/*", "scripts/install.sh", "scripts/i
 gateway = ["assets/**/*"]
 plugins = [
   "*/dashboard/manifest.json",
+  "*/dashboard/plugin_api.py",
   "*/dashboard/dist/*",
   "*/dashboard/dist/**/*",
   # Plugin discovery (hermes_cli/plugins.py) reads a plugin.yaml/plugin.yml

--- a/tests/plugins/test_profile_tasks_dashboard_plugin.py
+++ b/tests/plugins/test_profile_tasks_dashboard_plugin.py
@@ -1,0 +1,196 @@
+"""Tests for the Profile Tasks dashboard plugin backend."""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hermes_cli import kanban_db as kb
+
+
+def _load_plugin_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    plugin_file = repo_root / "plugins" / "profile-tasks" / "dashboard" / "plugin_api.py"
+    assert plugin_file.exists(), f"plugin file missing: {plugin_file}"
+    spec = importlib.util.spec_from_file_location(
+        "hermes_dashboard_plugin_profile_tasks_test", plugin_file,
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def profile_tasks_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "profiles" / "worker").mkdir(parents=True)
+    (home / "profiles" / "reviewer").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def plugin_mod(profile_tasks_home):
+    return _load_plugin_module()
+
+
+@pytest.fixture
+def client(plugin_mod):
+    app = FastAPI()
+    app.include_router(plugin_mod.router, prefix="/api/plugins/profile-tasks")
+    return TestClient(app)
+
+
+def test_profiles_and_boards_contract(client):
+    r = client.get("/api/plugins/profile-tasks/profiles")
+    assert r.status_code == 200, r.text
+    data = r.json()
+    names = {p["name"] for p in data["profiles"]}
+    assert {"default", "worker", "reviewer"}.issubset(names)
+    # Safe metadata only: do not leak local profile paths or env contents.
+    assert all("path" not in p for p in data["profiles"])
+    assert all("env" not in p for p in data["profiles"])
+
+    r = client.get("/api/plugins/profile-tasks/boards")
+    assert r.status_code == 200, r.text
+    boards = r.json()["boards"]
+    assert boards[0]["slug"] == "default"
+    assert "db_path" not in boards[0]
+    assert boards[0]["db_exists"] is True
+
+
+def test_tasks_filter_by_profile_status_and_recent_done(client):
+    conn = kb.connect()
+    try:
+        running = kb.create_task(conn, title="worker running", assignee="worker")
+        blocked = kb.create_task(conn, title="worker blocked", assignee="worker")
+        review = kb.create_task(conn, title="worker review", assignee="worker")
+        done = kb.create_task(conn, title="worker done", assignee="worker")
+        ready = kb.create_task(conn, title="worker ready", assignee="worker")
+        other = kb.create_task(conn, title="reviewer running", assignee="reviewer")
+        now = int(time.time())
+        conn.execute(
+            "UPDATE tasks SET status='running', started_at=?, claim_expires=?, last_heartbeat_at=? WHERE id=?",
+            (now - 3600, now - 30, now - 2000, running),
+        )
+        conn.execute("UPDATE tasks SET status='blocked' WHERE id=?", (blocked,))
+        conn.execute("UPDATE tasks SET status='review' WHERE id=?", (review,))
+        conn.execute("UPDATE tasks SET status='done', completed_at=? WHERE id=?", (now - 5, done))
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (ready,))
+        conn.execute("UPDATE tasks SET status='running' WHERE id=?", (other,))
+        conn.commit()
+    finally:
+        conn.close()
+
+    r = client.get("/api/plugins/profile-tasks/tasks", params={"profile": "worker"})
+    assert r.status_code == 200, r.text
+    cols = r.json()["columns"]
+    assert {t["id"] for t in cols["running"]} == {running}
+    assert {t["id"] for t in cols["blocked"]} == {blocked}
+    assert {t["id"] for t in cols["review"]} == {review}
+    assert {t["id"] for t in cols["recent_done"]} == {done}
+    assert "ready" not in cols
+    assert other not in {t["id"] for tasks in cols.values() for t in tasks}
+    assert {w["kind"] for w in cols["running"][0]["warnings"]} >= {"stale_claim", "stale_heartbeat"}
+
+    r = client.get(
+        "/api/plugins/profile-tasks/tasks",
+        params={"profile": "worker", "include_ready": "true"},
+    )
+    assert r.status_code == 200, r.text
+    assert {t["id"] for t in r.json()["columns"]["ready"]} == {ready}
+
+
+def test_tasks_response_excludes_sensitive_kanban_fields(client):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="secret task",
+            body="FULL PRIVATE BODY",
+            assignee="worker",
+        )
+        conn.execute(
+            "UPDATE tasks SET status='done', result=?, completed_at=? WHERE id=?",
+            ("FULL PRIVATE RESULT " * 40, int(time.time()), tid),
+        )
+        conn.execute(
+            "INSERT INTO task_runs (task_id, profile, status, started_at, ended_at, outcome, summary, metadata, error) "
+            "VALUES (?, 'worker', 'done', ?, ?, 'completed', ?, ?, ?)",
+            (tid, int(time.time()) - 10, int(time.time()), "SAFE SUMMARY", '{"secret":"metadata"}', "RAW ERROR"),
+        )
+        conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) VALUES (?, 'user', 'PRIVATE COMMENT', ?)",
+            (tid, int(time.time())),
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) VALUES (?, 'x', ?, ?)",
+            (tid, '{"private":"payload"}', int(time.time())),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    r = client.get("/api/plugins/profile-tasks/tasks", params={"profile": "worker"})
+    assert r.status_code == 200, r.text
+    task = r.json()["columns"]["recent_done"][0]
+    forbidden = {"body", "result", "last_failure_error", "workspace_path", "claim_lock", "worker_pid", "model_override"}
+    assert forbidden.isdisjoint(task.keys())
+    assert "comments" not in task
+    assert "events" not in task
+    assert task["summary_preview"] == "SAFE SUMMARY"
+    assert set(task["latest_run"]) == {
+        "id", "task_id", "profile", "step_key", "status", "started_at", "ended_at", "outcome", "summary_preview",
+    }
+    assert "metadata" not in task["latest_run"]
+    assert "error" not in task["latest_run"]
+
+
+def test_invalid_profile_and_missing_board_db(client, profile_tasks_home):
+    assert client.get("/api/plugins/profile-tasks/tasks", params={"profile": "missing"}).status_code == 404
+
+    db_path = profile_tasks_home / "kanban.db"
+    db_path.unlink()
+    r = client.get("/api/plugins/profile-tasks/tasks", params={"profile": "worker"})
+    assert r.status_code == 200, r.text
+    assert r.json()["warnings"][0]["kind"] == "missing_board_db"
+
+
+def test_readonly_connection_rejects_writes(plugin_mod, profile_tasks_home):
+    with plugin_mod._open_board_readonly("default") as conn:
+        with pytest.raises(sqlite3.OperationalError):
+            conn.execute(
+                "INSERT INTO tasks (id, title, status, created_at) VALUES ('t_ro', 'nope', 'ready', ?)",
+                (int(time.time()),),
+            )
+
+    # Confirm the failed write did not leave a row behind via a normal read.
+    conn = kb.connect()
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM tasks WHERE id='t_ro'").fetchone()[0] == 0
+    finally:
+        conn.close()
+
+
+def test_dashboard_bundle_registers_plugin_and_polls():
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle = (repo_root / "plugins" / "profile-tasks" / "dashboard" / "dist" / "index.js").read_text()
+    manifest = (repo_root / "plugins" / "profile-tasks" / "dashboard" / "manifest.json").read_text()
+
+    assert 'REG.register("profile-tasks", ProfileTasks)' in bundle
+    assert 'window.setInterval(loadTasks, 15000)' in bundle
+    assert 'selectChangeHandler(setProfile)' in bundle
+    assert '"path": "/profile-tasks"' in manifest
+    assert '"api": "plugin_api.py"' in manifest

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -239,6 +239,7 @@ def test_dashboard_plugin_manifests_and_assets_are_packaged():
     plugin_data = package_data["plugins"]
 
     assert "*/dashboard/manifest.json" in plugin_data
+    assert "*/dashboard/plugin_api.py" in plugin_data
     assert "*/dashboard/dist/*" in plugin_data
     assert "*/dashboard/dist/**/*" in plugin_data
 


### PR DESCRIPTION
## Summary
- add the Profile Tasks dashboard plugin backend and frontend bundle
- expose read-only profile/board/task APIs with sensitive-field redaction and stale/failure warnings
- package dashboard plugin API files and add focused backend tests

## QA
- Manual FastAPI TestClient QA passed in a temporary HERMES_HOME using venv python
- Syntax checks passed for plugin_api.py and manifest.json

Note: pytest was unavailable in the local environment, so the focused test logic was executed manually.