### PR TITLE
fix(agent): bound concurrent tool execution with a wall-clock deadline

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -68,6 +68,15 @@ def _budget_for_agent(agent) -> BudgetConfig:
 # Mirrors the constant in ``run_agent`` for tests/imports that look here.
 _MAX_TOOL_WORKERS = 8
 
+# Hard wall-clock deadline for a single concurrent tool batch. A tool with no
+# internal timeout (e.g. read_file shelling out to a wedged terminal backend)
+# can otherwise hang the whole agent run indefinitely: the batch heartbeat keeps
+# resetting the gateway's idle clock, so the idle-based inactivity monitor never
+# fires. This deadline is measured from batch start and is independent of idle,
+# so it cannot be defeated by the heartbeat. Set HERMES_TOOL_BATCH_TIMEOUT=0 to
+# disable (not recommended).
+_TOOL_BATCH_TIMEOUT_S = float(os.environ.get("HERMES_TOOL_BATCH_TIMEOUT", "600"))
+
 
 def _flush_session_db_after_tool_progress(
     agent,
@@ -606,9 +615,16 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             if block_result is None
         ]
         futures = []
+        _batch_timed_out = False
         if runnable_calls:
             max_workers = min(len(runnable_calls), _MAX_TOOL_WORKERS)
-            with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            # Manage the executor manually (not via ``with``) so we can shut it
+            # down WITHOUT waiting when we abandon a wedged worker. The ``with``
+            # form calls shutdown(wait=True) on exit, which would join the hung
+            # thread and re-introduce the indefinite block we are fixing.
+            executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
+            _hung_workers = False
+            try:
                 for submit_index, (i, tc, name, args) in enumerate(runnable_calls):
                     # Propagate the agent turn's ContextVars (e.g.
                     # _approval_session_key) AND thread-local approval/sudo
@@ -674,12 +690,42 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                             )
                         for f in not_done:
                             f.cancel()
+                        # An already-running tool may not be cancellable; record
+                        # that we are abandoning workers so the executor is shut
+                        # down without joining them.
+                        _hung_workers = True
                         # Give already-running tools a moment to notice the
                         # per-thread interrupt signal and exit gracefully.
                         concurrent.futures.wait(not_done, timeout=3.0)
                         break
 
                     _conc_elapsed = int(time.time() - _conc_start)
+
+                    # Hard wall-clock deadline, measured from batch start and
+                    # independent of the idle clock, so the heartbeat below
+                    # cannot keep a wedged tool alive forever. Abandon the
+                    # unfinished workers; the post-execution loop fills a timeout
+                    # result for each so the turn can proceed.
+                    if _TOOL_BATCH_TIMEOUT_S > 0 and _conc_elapsed >= _TOOL_BATCH_TIMEOUT_S:
+                        _still_running = [
+                            parsed_calls[futures.index(f)][1]
+                            for f in not_done
+                            if f in futures
+                        ]
+                        logger.error(
+                            "Concurrent tool batch exceeded %ss wall-clock deadline; "
+                            "abandoning %d unfinished tool(s): %s",
+                            _TOOL_BATCH_TIMEOUT_S,
+                            len(not_done),
+                            ", ".join(_still_running[:3]),
+                        )
+                        for f in not_done:
+                            f.cancel()
+                        _batch_timed_out = True
+                        _hung_workers = True
+                        concurrent.futures.wait(not_done, timeout=3.0)
+                        break
+
                     # Heartbeat every ~30s (6 × 5s poll intervals)
                     if _conc_elapsed > 0 and _conc_elapsed % 30 < 6:
                         _still_running = [
@@ -691,6 +737,12 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                             f"concurrent tools running ({_conc_elapsed}s, "
                             f"{len(not_done)} remaining: {', '.join(_still_running[:3])})"
                         )
+            finally:
+                # If we abandoned not-done workers (interrupt or deadline), shut
+                # down WITHOUT waiting so a wedged thread cannot block the turn;
+                # cancel_futures drops any that never started. Otherwise join
+                # cleanly so completed workers are reaped.
+                executor.shutdown(wait=not _hung_workers, cancel_futures=True)
     finally:
         if spinner:
             # Build a summary message for the spinner stop
@@ -716,6 +768,23 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     status="cancelled",
                     error_type="keyboard_interrupt",
                     error_message="Tool execution cancelled by user interrupt",
+                    middleware_trace=list(middleware_trace),
+                )
+            elif _batch_timed_out:
+                function_result = (
+                    f"Error executing tool '{name}': exceeded the "
+                    f"{_TOOL_BATCH_TIMEOUT_S:.0f}s tool execution deadline and was abandoned"
+                )
+                _emit_terminal_post_tool_call(
+                    agent,
+                    function_name=name,
+                    function_args=args,
+                    result=function_result,
+                    effective_task_id=effective_task_id,
+                    tool_call_id=getattr(tc, "id", "") or "",
+                    status="error",
+                    error_type="tool_timeout",
+                    error_message=function_result,
                     middleware_trace=list(middleware_trace),
                 )
             else:

--- a/tests/run_agent/test_concurrent_interrupt.py
+++ b/tests/run_agent/test_concurrent_interrupt.py
@@ -143,3 +143,49 @@ def test_clear_interrupt_clears_worker_tids(monkeypatch):
         "worker tid — stale interrupt can leak into the next turn"
     )
 
+
+def test_concurrent_tool_batch_hard_deadline_abandons_wedged_tool(monkeypatch):
+    """A tool with no internal timeout (e.g. read_file shelling out to a wedged
+    backend) must not hang the whole batch forever. The wall-clock deadline
+    abandons the unfinished worker and the turn proceeds with a timeout result,
+    instead of blocking on the executor join (the ~11h production hang)."""
+    import agent.tool_executor as te
+
+    agent = _make_agent(monkeypatch)
+    # This test runs a tool through the full executor path (the other tests
+    # short-circuit at the preflight interrupt), so stub the guardrail gate to
+    # permit execution.
+    agent._tool_guardrails = MagicMock()
+    agent._tool_guardrails.before_call.return_value = MagicMock(allows_execution=True)
+    agent._tool_result_content_for_active_model = lambda name, content, *a, **kw: content
+    agent._subdirectory_hints.check_tool_call.return_value = ""  # no extra hint appended
+    # Short deadline so the test is fast (the 5s poll is the real granularity).
+    monkeypatch.setattr(te, "_TOOL_BATCH_TIMEOUT_S", 1.0)
+
+    started = threading.Event()
+    release = threading.Event()  # never set during the assert → tool stays wedged
+
+    def _wedged_tool(*args, **kwargs):
+        started.set()
+        release.wait(timeout=30)  # would block the batch ~30s without the deadline
+        return '{"ok": true}'
+
+    agent._invoke_tool = MagicMock(side_effect=_wedged_tool)
+
+    msg = _FakeAssistantMsg([_FakeToolCall("slow_tool", call_id="tc_slow")])
+    messages = []
+
+    t0 = time.time()
+    try:
+        agent._execute_tool_calls_concurrent(msg, messages, "test_task")
+        elapsed = time.time() - t0
+
+        # Must return promptly (deadline + ~3s grace + one 5s poll), NOT ~30s,
+        # and crucially must not block joining the still-wedged worker.
+        assert elapsed < 12, f"batch did not honor the deadline (took {elapsed:.1f}s)"
+        assert started.is_set(), "the tool never actually started"
+        assert len(messages) == 1
+        assert "deadline" in messages[0]["content"].lower(), messages[0]["content"]
+    finally:
+        release.set()  # let the abandoned worker unwind so the test process is clean
+


### PR DESCRIPTION
## Problem

A tool call with no internal timeout can hang an entire agent run indefinitely. We hit this in production: a `read_file` ran for ~11 hours and wedged a gateway session.

Three compounding defects:

1. **No deadline in the concurrent executor.** `execute_tool_calls_concurrent`'s wait loop (`agent/tool_executor.py`) polls every 5s but only exits when the batch finishes or `_interrupt_requested` is set — there is no wall-clock bound.
2. **The batch heartbeat masks the hang.** Every ~30s the loop calls `agent._touch_activity("concurrent tools running …")`, which resets the gateway's idle clock. Both inactivity monitors are idle-based, so a continuously-"running" wedged tool never trips the 1800s timeout. Production logs showed `idle: 6s` against `timeout: 1800s` while `age` reached `39888s`.
3. **Cancellation can't escape it.** Even when finally cancelled, exiting the `with ThreadPoolExecutor() as executor:` block calls `shutdown(wait=True)`, which joins the wedged worker and blocks.

(The specific tool, `read_file`, hangs because `ShellFileOperations._exec` drops the `timeout` when it is `None`, so the backend `wc`/`head`/`sed` subprocess runs unbounded — see follow-ups.)

## Fix

Add a hard wall-clock deadline per concurrent tool batch (`HERMES_TOOL_BATCH_TIMEOUT`, default 600s), measured from batch start and **independent of the idle clock**, so the heartbeat cannot defeat it. On the deadline (and on interrupt), unfinished workers are abandoned and the executor is shut down with `wait=False` (and `cancel_futures=True`) so a hung thread can never block the turn. Each abandoned tool gets a clear timeout result so the model can proceed.

The executor is now managed manually rather than via `with`, specifically so we can choose `shutdown(wait=False)` when abandoning workers; the normal completion path still joins cleanly.

## Test

`tests/run_agent/test_concurrent_interrupt.py::test_concurrent_tool_batch_hard_deadline_abandons_wedged_tool` registers a tool that blocks ~30s, sets a 1s deadline, and asserts the batch returns promptly (not ~30s) with a timeout result. The existing interrupt tests still pass — the abandon-without-join change also hardens the interrupt path, which had the same `shutdown(wait=True)` join problem.

## Scope / follow-ups (intentionally out of this PR)

- Forward a default timeout in `ShellFileOperations._exec` so file-op subprocesses are bounded at the source (this also means an abandoned worker stops lingering once its subprocess is killed).
- Give the gateway's in-run inactivity monitor a wall-clock ceiling in addition to the idle check.

This PR fixes the general "a tool with no timeout hangs the whole run" defect at the one place that bounds every tool. The related restart-relaunch regression from the same incident is already addressed by #50204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
