### PR TITLE
fix(gateway): stop typing before final delivery

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4536,6 +4536,19 @@ class BasePlatformAdapter(ABC):
 
             # Call the handler (this can take a while with tool calls)
             response = await self._message_handler(event)
+
+            # The agent/command handler has finished and the next visible action
+            # is final response delivery (or silence/queue handoff).  Stop the
+            # typing refresh *before* sending the final message, not only in the
+            # finally cleanup after delivery.  Platforms such as Discord have no
+            # explicit "typing stop" endpoint; a late refresh that lands just
+            # before the final send can leave the client showing "bot is typing"
+            # for the platform TTL after the answer has already appeared.  This
+            # boundary also closes the race where a handler-level stop_typing()
+            # (GatewayRunner does one after _run_agent()) is immediately undone
+            # by the still-running base refresh loop before _send_with_retry().
+            await _stop_typing_task()
+
             is_ephemeral_response = isinstance(response, EphemeralReply)
 
             # Slash-command handlers may return an EphemeralReply sentinel to

--- a/tests/gateway/test_typing_stop_before_delivery.py
+++ b/tests/gateway/test_typing_stop_before_delivery.py
@@ -1,0 +1,85 @@
+"""Regression tests for typing indicator shutdown around final delivery."""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType
+from gateway.session import SessionSource, build_session_key
+
+
+class _TypingOrderAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="t"), Platform.DISCORD)
+        self.events: list[str] = []
+        self._stop_seen = asyncio.Event()
+
+    async def connect(self):
+        pass
+
+    async def disconnect(self):
+        pass
+
+    async def send(self, chat_id, text, **kwargs):
+        return None
+
+    async def stop_typing(self, chat_id: str) -> None:
+        self.events.append("stop_typing")
+        self._stop_seen.set()
+
+    async def get_chat_info(self, chat_id):
+        return {}
+
+
+def _make_event(text="hi", chat_id="42"):
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(platform=Platform.DISCORD, chat_id=chat_id, chat_type="dm"),
+    )
+
+
+def _session_key(chat_id="42"):
+    return build_session_key(
+        SessionSource(platform=Platform.DISCORD, chat_id=chat_id, chat_type="dm")
+    )
+
+
+@pytest.mark.asyncio
+async def test_typing_refresh_stops_before_final_response_delivery():
+    """Final delivery must not race with a still-running typing refresh.
+
+    Discord has no explicit "typing stop" endpoint.  A typing event sent just
+    before the final answer can keep "bot is typing" visible for Discord's TTL
+    after the answer appears.  The base gateway therefore stops the refresh task
+    before it calls the platform send path, not only in the finally cleanup.
+    """
+    adapter = _TypingOrderAdapter()
+
+    async def handler(event):
+        adapter.events.append("handler_done")
+        return "final answer"
+
+    async def send_with_retry(*args, **kwargs):
+        adapter.events.append("send")
+        assert adapter._stop_seen.is_set(), (
+            "typing refresh was still active when final response delivery began"
+        )
+        return None
+
+    adapter._message_handler = handler
+    adapter._send_with_retry = AsyncMock(side_effect=send_with_retry)
+
+    await adapter.handle_message(_make_event())
+
+    for _ in range(50):
+        if _session_key() not in adapter._active_sessions:
+            break
+        await asyncio.sleep(0.01)
+
+    await adapter.cancel_background_tasks()
+
+    assert "send" in adapter.events
+    assert adapter.events.index("stop_typing") < adapter.events.index("send")


### PR DESCRIPTION
## What does this PR do?

Stops the gateway typing refresh before final response delivery starts.

`GatewayRunner._run_agent()` already calls `adapter.stop_typing()` after the agent returns, but `BasePlatformAdapter._keep_typing()` can still be alive until `_process_message_background()` reaches its later cleanup path. On Discord, a late `_keep_typing()` tick can re-enter `send_typing()` after that handler-level stop and just before `_send_with_retry()` delivers the final answer. Because Discord has no explicit "typing stop" endpoint, that last typing pulse can leave the client showing "bot is typing" after the final response has already appeared.

This patch stops the base typing refresh immediately after the message handler returns and before the final send/media delivery path begins. The existing finally-block cleanup is kept as a fallback.

## Related issues / PRs

- Fixes #49290
- Related to #29172, which has the same lifecycle-boundary direction but is currently conflicted/stale against `main`.
- Related to #26854 / #43691, which address the Discord adapter's nested typing-loop race from another angle.
- Follow-up to the post-delivery typing cleanup work mentioned around #37556: this covers the remaining pre-final-delivery race observed on current `main`.

## Changes made

- `gateway/platforms/base.py`
  - Calls `_stop_typing_task()` immediately after `_message_handler(event)` returns and before final response delivery.
  - Documents why this boundary matters for Discord's TTL-based typing indicator.
- `tests/gateway/test_typing_stop_before_delivery.py`
  - Adds a regression test asserting that final response send does not begin until `stop_typing()` has fired.

## Verification

Run on macOS from this checkout:

```bash
venv/bin/python -m pytest tests/gateway/test_typing_stop_before_delivery.py -q -o 'addopts='
# 1 passed in 0.48s

venv/bin/python -m pytest \
  tests/gateway/test_pending_drain_race.py \
  tests/gateway/test_pending_drain_no_recursion.py \
  tests/gateway/test_typing_stop_before_delivery.py \
  -q -o 'addopts='
# 9 passed in 5.52s

venv/bin/python -m pytest \
  tests/gateway/test_discord_send.py \
  tests/gateway/test_discord_imports.py \
  tests/gateway/test_typing_stop_before_delivery.py \
  -q -o 'addopts='
# 20 passed in 1.38s

git diff --check
python -m py_compile gateway/platforms/base.py tests/gateway/test_typing_stop_before_delivery.py
# clean
```

Manual verification: reproduced in a Discord DM on current `main` after a long turn (`time=199.0s api_calls=16`), applied this patch, restarted the gateway, and confirmed the "Atropos is typing" indicator no longer lingers after the final response.

## Notes

This is intentionally a small lifecycle-ordering fix. It does not remove or redesign Discord's adapter-level typing behavior; PR #43691 may still be a better long-term fix for orphaned Discord typing loops. This patch closes the remaining race where the base refresh loop can issue a final typing pulse after the agent has returned but before final response delivery begins.
