### PR TITLE
feat(gateway/telegram): inline action-menu buttons for agent/scheduled messages

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3758,6 +3758,66 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.warning("[%s] send_clarify failed: %s", self.name, e)
             return SendResult(success=False, error=str(e))
 
+    async def send_action_menu(
+        self,
+        chat_id: str,
+        text: str,
+        actions: list,
+        session_key: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Render a message with inline action buttons (one per follow-up action).
+
+        ``actions`` is a list of dicts/``Action`` (see ``tools.action_gateway``). Each
+        renders as a button labelled by the action's human description; a tap is routed
+        by the ``ca:`` branch in ``_handle_callback_query``. Distinct actions never
+        render as identical buttons — labels are de-duplicated in the registry (the
+        duplicate-button bug from #52252). A trailing "Skip" button dismisses the set,
+        and plain-text replies remain a valid fallback.
+        """
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            from tools import action_gateway
+
+            entry = action_gateway.register(actions, session_key=session_key)
+            thread_id = self._metadata_thread_id(metadata)
+
+            kwargs: Dict[str, Any] = {
+                "chat_id": int(chat_id),
+                "text": text,
+                **self._link_preview_kwargs(),
+            }
+            # Caller controls formatting; pass a parse_mode through metadata if set.
+            parse_mode = (metadata or {}).get("parse_mode")
+            if parse_mode:
+                kwargs["parse_mode"] = parse_mode
+
+            rows = [
+                [InlineKeyboardButton(label, callback_data=cb) for (label, cb) in row]
+                for row in action_gateway.build_keyboard_rows(entry.set_id)
+            ]
+            if rows:
+                kwargs["reply_markup"] = InlineKeyboardMarkup(rows)
+
+            reply_to_id = self._reply_to_message_id_for_send(None, metadata)
+            kwargs["reply_to_message_id"] = reply_to_id
+            kwargs.update(
+                self._thread_kwargs_for_send(
+                    chat_id,
+                    thread_id,
+                    metadata,
+                    reply_to_message_id=reply_to_id,
+                )
+            )
+
+            msg = await self._send_message_with_thread_fallback(**kwargs)
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            logger.warning("[%s] send_action_menu failed: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
     async def send_model_picker(
         self,
         chat_id: str,
@@ -4425,6 +4485,61 @@ class TelegramAdapter(BasePlatformAdapter):
                         await self._send_message_with_thread_fallback(**send_kwargs)
                 except Exception as exc:
                     logger.error("[%s] slash-confirm callback failed: %s", self.name, exc, exc_info=True)
+            return
+
+        # --- Action-menu callbacks (ca:set_id:token) — tools.action_gateway / #52252 ---
+        if data.startswith("ca:"):
+            from tools import action_gateway
+
+            parsed = action_gateway.parse_callback(data)
+            if not parsed:
+                await query.answer(text="Invalid action data.")
+                return
+            set_id, token = parsed
+
+            caller_id = str(getattr(query.from_user, "id", ""))
+            if not self._is_callback_user_authorized(
+                caller_id,
+                chat_id=query_chat_id,
+                chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                user_name=query_user_name,
+            ):
+                await query.answer(text="⛔ You are not authorized to act on this.")
+                return
+
+            chosen = action_gateway.resolve(set_id, token)
+
+            if chosen is None:
+                # skip / already-resolved / unknown — clear the buttons and stop.
+                await query.answer(text="Dismissed.")
+                try:
+                    await query.edit_message_reply_markup(reply_markup=None)
+                except Exception:
+                    pass
+                return
+
+            await query.answer(text=f"✓ {chosen.label[:60]}")
+            try:
+                await query.edit_message_reply_markup(reply_markup=None)
+            except Exception:
+                pass
+
+            # Hand the chosen action back to the agent. This dispatch hook is the
+            # integration seam under discussion in #52252; until the gateway registers
+            # one, log so the tap is observable rather than silently dropped.
+            dispatch = action_gateway.get_dispatch(None)
+            if dispatch is not None:
+                try:
+                    dispatch(set_id, chosen)
+                except Exception as exc:
+                    logger.error("[%s] action dispatch failed: %s", self.name, exc)
+            else:
+                logger.info(
+                    "Telegram action button tapped, no dispatch wired "
+                    "(set=%s, action=%r, op=%s) — see #52252",
+                    set_id, chosen.label, chosen.op,
+                )
             return
 
         # --- Clarify callbacks (cl:clarify_id:idx | cl:clarify_id:other) ---

--- a/tests/gateway/test_telegram_action_buttons.py
+++ b/tests/gateway/test_telegram_action_buttons.py
@@ -1,0 +1,84 @@
+"""Unit tests for the inline action-menu registry (``tools.action_gateway``).
+
+Pure-Python: no Telegram client required. Covers registration, label de-duplication
+(the duplicate-button bug that motivated #52252), keyboard-row shaping, the 64-byte
+``callback_data`` budget, foreign-callback rejection, and resolve()/skip semantics.
+
+The adapter render + callback-dispatch path (``send_action_menu`` / the ``ca:`` branch
+in ``_handle_callback_query``) is exercised under CI with the Telegram mocks used by
+``test_telegram_approval_buttons.py``; the outbound-delivery wiring seam is tracked in
+#52252.
+"""
+import pytest
+
+from tools import action_gateway as ag
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    ag._sets.clear()
+    ag._dispatch_cbs.clear()
+    yield
+    ag._sets.clear()
+    ag._dispatch_cbs.clear()
+
+
+def test_register_and_resolve():
+    s = ag.register([
+        {"id": 1, "label": "Prep 2pm meeting"},
+        {"id": 2, "label": "Open the lost-permissions thread"},
+    ])
+    assert len(s.actions) == 2
+    chosen = ag.resolve(s.set_id, "1")
+    assert chosen is not None and chosen.label == "Prep 2pm meeting"
+
+
+def test_distinct_actions_never_render_identical_buttons():
+    # Same verb, different object — the case that previously surfaced as two
+    # identical "investigate" buttons (#52252).
+    s = ag.register([
+        {"verb": "investigate", "object": "oh-my-pi v16.1.16 impact"},
+        {"verb": "investigate", "object": "context-mode change"},
+    ])
+    labels = [a.label for a in s.actions]
+    assert labels[0] != labels[1]
+    # And if labels genuinely collide, they are disambiguated:
+    s2 = ag.register([{"label": "Open thread"}, {"label": "Open thread"}])
+    assert s2.actions[0].label != s2.actions[1].label
+
+
+def test_keyboard_rows_shape_and_skip():
+    s = ag.register([{"id": 1, "label": "a"}, {"id": 2, "label": "b"}])
+    rows = ag.build_keyboard_rows(s.set_id)
+    assert [r[0][0] for r in rows] == ["a", "b", "Skip"]
+
+
+def test_callback_data_within_64_byte_cap():
+    s = ag.register([{"id": 1, "label": "x" * 300}])  # huge label
+    rows = ag.build_keyboard_rows(s.set_id)
+    for row in rows:
+        for label, cb in row:
+            assert len(cb.encode("utf-8")) <= ag.CALLBACK_MAX_BYTES
+            assert len(label) <= ag.LABEL_MAX_CHARS + 1  # truncation applied
+
+
+def test_parse_callback():
+    s = ag.register([{"id": 1, "label": "a"}])
+    assert ag.parse_callback(f"ca:{s.set_id}:1") == (s.set_id, "1")
+    assert ag.parse_callback("ca:abc:skip") == ("abc", "skip")
+    # Foreign prefixes (approval / clarify) are not ours:
+    assert ag.parse_callback("ea:once:5") is None
+    assert ag.parse_callback("cl:abc:0") is None
+
+
+def test_skip_and_single_resolution():
+    s = ag.register([{"id": 1, "label": "a"}, {"id": 2, "label": "b"}])
+    assert ag.resolve(s.set_id, "skip") is None
+    # A skipped/resolved set cannot fire again (stale button safety):
+    assert ag.resolve(s.set_id, "1") is None
+
+
+def test_resolve_unknown_token():
+    s = ag.register([{"id": 1, "label": "a"}])
+    assert ag.resolve(s.set_id, "nope") is None
+    assert ag.resolve("no-such-set", "1") is None

--- a/tools/action_gateway.py
+++ b/tools/action_gateway.py
@@ -1,0 +1,189 @@
+"""Gateway-side action-menu registry for inline action buttons on messages.
+
+Mirrors :mod:`tools.clarify_gateway`, but for **fire-and-forget action menus**
+rather than a blocking clarify prompt. A message (e.g. a scheduled digest) declares
+one or more follow-up actions; the Telegram adapter renders them as inline buttons; a
+later tap resolves the chosen action and hands it to a registered dispatch callback.
+
+Design notes
+------------
+* **No platform imports.** This module is pure data + a small callback registry, so it
+  is unit-testable without a live Telegram client (see
+  ``tests/gateway/test_telegram_action_buttons.py``).
+* **Callback budget.** Telegram caps ``callback_data`` at 64 bytes. We never inline the
+  action text into the callback; instead we key a short ``set_id`` + integer action id
+  (``ca:<set_id>:<action_id>``) and keep the human label server-side here — the same
+  short-id indirection the clarify/approval flows already use.
+* **Label de-duplication.** Two distinct actions must never render as identical buttons
+  (the bug that motivated #52252): if labels collide we disambiguate them.
+
+The remaining integration seam — *where* outbound scheduled/agent messages call
+``send_action_menu`` and what a tap dispatches back into the agent — is intentionally
+left to the gateway and tracked in #52252; this module provides the mechanism.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+import uuid
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+CALLBACK_PREFIX = "ca"
+CALLBACK_MAX_BYTES = 64  # Telegram callback_data hard cap
+LABEL_MAX_CHARS = 40     # button labels truncate for display (mirrors model picker)
+
+
+@dataclass
+class Action:
+    """One tappable follow-up action attached to a message."""
+
+    id: int
+    label: str            # human description shown on the button
+    op: str = "do"        # do | details | skip | retry | <custom>
+    payload: Optional[str] = None  # opaque; the dispatch handler interprets it
+
+
+@dataclass
+class _ActionSet:
+    set_id: str
+    actions: List[Action]
+    session_key: Optional[str] = None
+    resolved: bool = False
+
+
+_lock = threading.RLock()
+# set_id → _ActionSet (primary lookup for button callbacks)
+_sets: Dict[str, _ActionSet] = {}
+# session_key (or "*") → dispatch callback registered by the gateway (the seam)
+_dispatch_cbs: Dict[str, Callable[[str, Action], None]] = {}
+
+
+def _new_set_id() -> str:
+    return uuid.uuid4().hex[:10]
+
+
+# =========================================================================
+# Registration
+# =========================================================================
+
+def register(
+    actions: Iterable,
+    session_key: Optional[str] = None,
+    set_id: Optional[str] = None,
+) -> _ActionSet:
+    """Register an action set and return it.
+
+    ``actions`` is an iterable of :class:`Action` or dicts. Dict keys accepted:
+    ``id``, ``label`` (falls back to ``object`` then ``verb``), ``op``, ``payload``.
+    Visible labels are de-duplicated so two distinct actions never render as the
+    same button.
+    """
+    norm: List[Action] = []
+    seen: Dict[str, int] = {}
+    for i, a in enumerate(actions):
+        if isinstance(a, dict):
+            label = str(a.get("label") or a.get("object") or a.get("verb") or f"action {i + 1}").strip()
+            a = Action(
+                id=int(a.get("id", i + 1)),
+                label=label or f"action {i + 1}",
+                op=str(a.get("op", "do")),
+                payload=a.get("payload"),
+            )
+        count = seen.get(a.label, 0)
+        if count:
+            a = Action(id=a.id, label=f"{a.label} ({count + 1})", op=a.op, payload=a.payload)
+        seen[a.label] = count + 1
+        norm.append(a)
+
+    sid = set_id or _new_set_id()
+    entry = _ActionSet(set_id=sid, actions=norm, session_key=session_key)
+    with _lock:
+        _sets[sid] = entry
+    return entry
+
+
+# =========================================================================
+# Rendering helpers (adapter side)
+# =========================================================================
+
+def build_keyboard_rows(set_id: str, include_skip: bool = True) -> List[List[Tuple[str, str]]]:
+    """Return rows of ``(button_label, callback_data)`` for the adapter to render.
+
+    Each ``callback_data`` is ``ca:<set_id>:<action_id>`` and is guaranteed to fit
+    inside Telegram's 64-byte cap. Labels are truncated for display only.
+    """
+    with _lock:
+        entry = _sets.get(set_id)
+    if not entry:
+        return []
+    rows: List[List[Tuple[str, str]]] = []
+    for a in entry.actions:
+        cb = f"{CALLBACK_PREFIX}:{set_id}:{a.id}"
+        if len(cb.encode("utf-8")) > CALLBACK_MAX_BYTES:
+            logger.warning("action callback_data over 64 bytes, skipping: %s", cb)
+            continue
+        label = a.label if len(a.label) <= LABEL_MAX_CHARS else a.label[: LABEL_MAX_CHARS - 1] + "…"
+        rows.append([(label, cb)])
+    if include_skip and rows:
+        rows.append([("Skip", f"{CALLBACK_PREFIX}:{set_id}:skip")])
+    return rows
+
+
+def parse_callback(data: str) -> Optional[Tuple[str, str]]:
+    """Parse ``ca:<set_id>:<token>`` → ``(set_id, token)``; ``None`` if not ours."""
+    parts = data.split(":", 2)
+    if len(parts) != 3 or parts[0] != CALLBACK_PREFIX:
+        return None
+    return parts[1], parts[2]
+
+
+# =========================================================================
+# Resolution (callback side)
+# =========================================================================
+
+def resolve(set_id: str, token: str) -> Optional[Action]:
+    """Resolve a tapped ``token`` to its :class:`Action`.
+
+    Returns the chosen Action, or ``None`` for ``skip`` / unknown / already-resolved.
+    Marks the set resolved so a stale button cannot fire twice.
+    """
+    with _lock:
+        entry = _sets.get(set_id)
+        if not entry or entry.resolved:
+            return None
+        if token == "skip":
+            entry.resolved = True
+            return None
+        try:
+            aid = int(token)
+        except (TypeError, ValueError):
+            return None
+        for a in entry.actions:
+            if a.id == aid:
+                entry.resolved = True
+                return a
+    return None
+
+
+def clear(set_id: str) -> None:
+    with _lock:
+        _sets.pop(set_id, None)
+
+
+# =========================================================================
+# Dispatch seam (gateway → agent). Tracked in #52252.
+# =========================================================================
+
+def register_dispatch(key: str, cb: Callable[[str, Action], None]) -> None:
+    """Register a callback invoked when an action is tapped. ``key`` is a session_key
+    or ``"*"`` for a global default."""
+    with _lock:
+        _dispatch_cbs[key] = cb
+
+
+def get_dispatch(session_key: Optional[str]) -> Optional[Callable[[str, Action], None]]:
+    with _lock:
+        return _dispatch_cbs.get(session_key or "") or _dispatch_cbs.get("*")


### PR DESCRIPTION
**Draft — implements the mechanism for #52252; the outbound-delivery seam is the open question (see below).**

## What

Adds a generic way for agent / scheduled (cron) messages to attach **tappable inline action buttons**, with taps routed through the existing Telegram callback dispatcher — the same shape as the in-tree Gmail-triage (`gt:`) and clarify (`cl:`) flows.

Motivation, prior art, and design discussion live in #52252.

## Changes

- **`tools/action_gateway.py`** (new) — pure-Python action-set registry + keyboard-spec builder + `ca:` callback parse/resolve. Mirrors `tools/clarify_gateway.py`. Key properties:
  - **Label de-duplication** — two distinct actions never render as identical buttons (the duplicate-button problem that motivated the issue: same verb / different object).
  - **64-byte callback budget** — `callback_data` is `ca:<set_id>:<action_id>` with a short `set_id`; the human label is held server-side (the same short-id indirection clarify/approval use), never inlined.
  - **Single-resolution** — a resolved/skipped set can't fire twice (stale-button safety).
  - **No platform imports** → unit-testable without a live client.
- **`plugins/platforms/telegram/adapter.py`**
  - `send_action_menu()` — mirrors `send_clarify()`: registers the set, builds `InlineKeyboardMarkup`, sends with the usual thread / link-preview kwargs.
  - new `ca:` branch in `_handle_callback_query` — auth-gated via `_is_callback_user_authorized` (same gate as `cl:`/`update_prompt:`), resolves the tap, edits the markup off, and hands the chosen action to a dispatch hook.
- **`tests/gateway/test_telegram_action_buttons.py`** (new) — 7 unit tests covering registration, label de-dup, keyboard shape + Skip, the 64-byte cap, foreign-callback rejection, and skip/single-resolution. **All passing** (`pytest tests/gateway/test_telegram_action_buttons.py` → 7 passed).

## Open question (why this is a draft)

The one piece I deliberately did **not** wire is the **outbound-delivery seam** — *where* scheduled/agent messages should call `send_action_menu`, and *what* a tap should dispatch back into the agent (re-enter the agent with the action vs. a per-feature handler). The `ca:` branch currently routes to a registered dispatch callback (`action_gateway.register_dispatch`) and logs when none is wired, so taps are observable rather than dropped. I'd like maintainer guidance on the preferred seam before wiring it — that's the question raised in #52252.

## Not done here

- The adapter render + callback path is covered by the unit tests at the registry level; an adapter-level render/callback test (mirroring `test_telegram_approval_buttons.py`'s Telegram mocks) should be added once the seam is agreed. I couldn't run the full gateway Telegram harness in my environment, so I've kept the verified surface to the pure registry + a `py_compile` of the adapter.

Happy to iterate on the seam and add the adapter-level test. Refs #52252.
