### PR TITLE
fix(browser): send Camofox auth headers

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -233,6 +233,9 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
     "TERMINAL_DOCKER_RUN_AS_HOST_USER",
     "BROWSER_CDP_URL",
     "CAMOFOX_URL",
+    "CAMOFOX_ADOPT_EXISTING_TAB",
+    "CAMOFOX_REWRITE_LOOPBACK_URLS",
+    "CAMOFOX_LOOPBACK_HOST_ALIAS",
     # Platform allowlists — not credentials, but if set from any source
     # (user shell, earlier leaky test, CI env), they change gateway auth
     # behavior and flake button-authorization tests.

--- a/tests/tools/test_browser_camofox.py
+++ b/tests/tools/test_browser_camofox.py
@@ -18,6 +18,7 @@ from tools.browser_camofox import (
     camofox_vision,
     check_camofox_available,
     is_camofox_mode,
+    _auth_headers,
     _rewrite_loopback_url_for_camofox,
 )
 
@@ -69,6 +70,36 @@ def _mock_response(status=200, json_data=None):
     resp.content = b"\x89PNG\r\n\x1a\nfake"
     resp.raise_for_status = MagicMock()
     return resp
+
+
+# ---------------------------------------------------------------------------
+# Authentication
+# ---------------------------------------------------------------------------
+
+
+class TestCamofoxAuth:
+    def test_auth_headers_empty_when_unset(self, monkeypatch):
+        monkeypatch.delenv("CAMOFOX_ACCESS_KEY", raising=False)
+        monkeypatch.delenv("CAMOFOX_API_KEY", raising=False)
+
+        assert _auth_headers() == {}
+
+    def test_access_key_preferred_over_api_key(self, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_ACCESS_KEY", "access-token")
+        monkeypatch.setenv("CAMOFOX_API_KEY", "api-token")
+
+        assert _auth_headers() == {"Authorization": "Bearer access-token"}
+
+    @patch("tools.browser_camofox.requests.post")
+    def test_create_tab_includes_auth_header_when_configured(self, mock_post, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        monkeypatch.setenv("CAMOFOX_ACCESS_KEY", "secret-token")
+        mock_post.return_value = _mock_response(json_data={"tabId": "tab-auth", "url": "https://example.com"})
+
+        result = json.loads(camofox_navigate("https://example.com", task_id="auth-task"))
+
+        assert result["success"] is True
+        assert mock_post.call_args.kwargs["headers"] == {"Authorization": "Bearer secret-token"}
 
 
 # ---------------------------------------------------------------------------

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -57,6 +57,43 @@ def get_camofox_url() -> str:
     return os.getenv("CAMOFOX_URL", "").rstrip("/")
 
 
+def _auth_headers() -> Dict[str, str]:
+    """Return Authorization headers for Camofox, if a token is configured.
+
+    Upstream camofox-browser gates sensitive routes such as JS evaluation, and
+    can optionally gate every route with ``CAMOFOX_ACCESS_KEY``.  Keep secrets in
+    Hermes' environment/.env rather than config.yaml; if both are present, the
+    access key wins because it satisfies both the global and per-route gates.
+    """
+    token = os.getenv("CAMOFOX_ACCESS_KEY", "").strip() or os.getenv("CAMOFOX_API_KEY", "").strip()
+    if not token:
+        return {}
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _request_kwargs(**kwargs: Any) -> Dict[str, Any]:
+    """Attach optional Camofox auth headers to a requests call."""
+    headers = _auth_headers()
+    if headers:
+        kwargs["headers"] = headers
+    return kwargs
+
+
+def _raise_for_status(resp: requests.Response) -> None:
+    """Raise for HTTP errors, with an actionable auth hint for Camofox."""
+    try:
+        resp.raise_for_status()
+    except requests.HTTPError as exc:
+        status = getattr(resp, "status_code", None)
+        if status in (401, 403):
+            raise RuntimeError(
+                f"Camofox API authentication failed (HTTP {status}). "
+                "Set CAMOFOX_ACCESS_KEY (preferred) or CAMOFOX_API_KEY in Hermes .env "
+                "to match the Camofox server."
+            ) from exc
+        raise
+
+
 def is_camofox_mode() -> bool:
     """True when Camofox backend is configured and no CDP override is active.
 
@@ -343,14 +380,13 @@ def _ensure_tab(task_id: Optional[str], url: str = "about:blank") -> Dict[str, A
     base = get_camofox_url()
     resp = requests.post(
         f"{base}/tabs",
-        json={
+        **_request_kwargs(json={
             "userId": session["user_id"],
             "sessionKey": session["session_key"],
             "url": url,
-        },
-        timeout=_DEFAULT_TIMEOUT,
+        }, timeout=_DEFAULT_TIMEOUT),
     )
-    resp.raise_for_status()
+    _raise_for_status(resp)
     data = resp.json()
     session["tab_id"] = data.get("tabId")
     return session
@@ -387,32 +423,32 @@ def camofox_soft_cleanup(task_id: Optional[str] = None) -> bool:
 def _post(path: str, body: dict, timeout: int = _DEFAULT_TIMEOUT) -> dict:
     """POST JSON to camofox and return parsed response."""
     url = f"{get_camofox_url()}{path}"
-    resp = requests.post(url, json=body, timeout=timeout)
-    resp.raise_for_status()
+    resp = requests.post(url, **_request_kwargs(json=body, timeout=timeout))
+    _raise_for_status(resp)
     return resp.json()
 
 
 def _get(path: str, params: dict = None, timeout: int = _DEFAULT_TIMEOUT) -> dict:
     """GET from camofox and return parsed response."""
     url = f"{get_camofox_url()}{path}"
-    resp = requests.get(url, params=params, timeout=timeout)
-    resp.raise_for_status()
+    resp = requests.get(url, **_request_kwargs(params=params, timeout=timeout))
+    _raise_for_status(resp)
     return resp.json()
 
 
 def _get_raw(path: str, params: dict = None, timeout: int = _DEFAULT_TIMEOUT) -> requests.Response:
     """GET from camofox and return raw response (for binary data)."""
     url = f"{get_camofox_url()}{path}"
-    resp = requests.get(url, params=params, timeout=timeout)
-    resp.raise_for_status()
+    resp = requests.get(url, **_request_kwargs(params=params, timeout=timeout))
+    _raise_for_status(resp)
     return resp
 
 
 def _delete(path: str, body: dict = None, timeout: int = _DEFAULT_TIMEOUT) -> dict:
     """DELETE to camofox and return parsed response."""
     url = f"{get_camofox_url()}{path}"
-    resp = requests.delete(url, json=body, timeout=timeout)
-    resp.raise_for_status()
+    resp = requests.delete(url, **_request_kwargs(json=body, timeout=timeout))
+    _raise_for_status(resp)
     return resp.json()
 
 


### PR DESCRIPTION
## Summary
- send Bearer auth headers from the Camofox backend when CAMOFOX_ACCESS_KEY or CAMOFOX_API_KEY is configured
- surface an actionable auth hint for 401/403 Camofox API responses
- harden Camofox tests against local Camofox env leakage

## Tests
- python3 -m pytest tests/tools/test_browser_camofox.py tests/tools/test_browser_camofox_persistence.py -q -o 'addopts='