### PR TITLE
fix(cron): accept named months/weekdays in cron schedules

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -335,9 +335,13 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
     
     # Check for cron expression (5 or 6 space-separated fields)
     # Cron fields: minute hour day month weekday [year]
+    # Allow letters so named months/weekdays (JAN-DEC, MON-SUN, incl. ranges
+    # and lists like MON-FRI or MON,WED,FRI) are routed to croniter, which
+    # supports them. The previous digit-only pattern silently rejected these
+    # valid expressions as "Invalid schedule".
     parts = schedule.split()
     if len(parts) >= 5 and all(
-        re.match(r'^[\d\*\-,/]+$', p) for p in parts[:5]
+        re.match(r'^[A-Za-z\d\*\-,/]+$', p) for p in parts[:5]
     ):
         if not HAS_CRONITER:
             raise ValueError("Cron expressions require 'croniter' package. Install with: pip install croniter")

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -96,6 +96,25 @@ class TestParseSchedule:
         assert result["kind"] == "cron"
         assert result["expr"] == "0 9 * * *"
 
+    def test_cron_named_weekdays_and_months(self):
+        # Named months/weekdays (and ranges/lists) are valid cron and must
+        # route to croniter, not be rejected as "Invalid schedule".
+        pytest.importorskip("croniter")
+        for expr in (
+            "0 9 * * MON",
+            "*/15 9-17 * * MON-FRI",
+            "0 9 1 JAN *",
+            "0 9 * * MON,WED,FRI",
+        ):
+            result = parse_schedule(expr)
+            assert result["kind"] == "cron", expr
+            assert result["expr"] == expr
+
+    def test_invalid_named_cron_still_rejected(self):
+        pytest.importorskip("croniter")
+        with pytest.raises(ValueError):
+            parse_schedule("0 9 * * FUNDAY")
+
     def test_iso_timestamp(self):
         result = parse_schedule("2030-01-15T14:00:00")
         assert result["kind"] == "once"


### PR DESCRIPTION
## Summary

`parse_schedule()` (cron/jobs.py) detects a cron expression by requiring every field to match a **digit-only** pattern:

```python
if len(parts) >= 5 and all(re.match(r'^[\d\*\-,/]+$', p) for p in parts[:5]):
```

So any field using **named months or weekdays** fails detection and falls through to a generic `Invalid schedule '...'` error — even though they're standard cron and croniter supports them. Common, very ordinary schedules are rejected:

- `0 9 * * MON`
- `*/15 9-17 * * MON-FRI`  ← business-hours weekdays, extremely common
- `0 9 1 JAN *`
- `0 9 * * MON,WED,FRI`

(Reproduced before the fix: all four raise `Invalid schedule`, while `0 9 * * *` works.)

## Fix

Allow letters in the field pattern (`^[A-Za-z\d\*\-,/]+$`) so named-month/weekday expressions route to croniter, which is the authoritative validator (called right after). Behaviour is otherwise unchanged:

- Truly-invalid expressions still error via croniter — `0 9 * * FUNDAY`, `99 9 * * MON` → `Invalid cron expression`.
- Duration (`30m`), interval (`every 2h`), and ISO-timestamp parsing are untouched.

## Tests

`tests/cron/test_jobs.py`: named weekdays/months including ranges (`MON-FRI`) and lists (`MON,WED,FRI`) parse as `kind == "cron"`, and an invalid named field (`FUNDAY`) is still rejected.
