### PR TITLE
fix(gateway): prefer systemd snapshot in systemd containers

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1165,6 +1165,12 @@ def get_gateway_runtime_snapshot(system: bool = False) -> GatewayRuntimeSnapshot
         # Phase 4: report s6 supervision when running under our /init.
         # Other container runtimes (or containers built before Phase 2)
         # still get the original "docker (foreground)" label.
+        #
+        # Some Linux environments expose container markers while still running
+        # a real systemd as PID 1 (systemd-nspawn, systemd-bearing dev
+        # containers, and VLM-style hosts with an overlay/containerd rootfs).
+        # In those cases systemd is the authoritative supervisor for the
+        # gateway, so do not stop at the generic "docker foreground" label.
         try:
             from hermes_cli.service_manager import detect_service_manager, get_service_manager
             if detect_service_manager() == "s6":
@@ -1192,11 +1198,12 @@ def get_gateway_runtime_snapshot(system: bool = False) -> GatewayRuntimeSnapshot
                     service_scope="s6",
                 )
         except Exception:
-            pass  # Fall through to the legacy label on any detection error.
-        return GatewayRuntimeSnapshot(
-            manager="docker (foreground)",
-            gateway_pids=gateway_pids,
-        )
+            pass  # Fall through to systemd or the legacy label below.
+        if not _container_systemd_operational():
+            return GatewayRuntimeSnapshot(
+                manager="docker (foreground)",
+                gateway_pids=gateway_pids,
+            )
 
     if supports_systemd_services():
         selected_system, service_running = _probe_systemd_service_running(system=system)

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -280,6 +280,31 @@ def test_s6_runtime_snapshot_reports_supervised_service(monkeypatch, tmp_path):
     assert snapshot.gateway_pids == (123,)
 
 
+def test_container_with_operational_systemd_snapshot_reports_systemd(monkeypatch):
+    monkeypatch.setattr(gateway, "is_linux", lambda: True)
+    monkeypatch.setattr("hermes_constants.is_container", lambda: True)
+    monkeypatch.setattr("hermes_cli.service_manager.detect_service_manager", lambda: "none")
+    monkeypatch.setattr(gateway, "_container_systemd_operational", lambda: True)
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: True)
+    monkeypatch.setattr(gateway, "_select_systemd_scope", lambda system=False: False)
+    monkeypatch.setattr(gateway, "_service_scope_label", lambda system=False: "user")
+    monkeypatch.setattr(gateway, "_probe_systemd_service_running", lambda system=False: (False, True))
+    monkeypatch.setattr(
+        gateway,
+        "get_systemd_unit_path",
+        lambda system=False: SimpleNamespace(exists=lambda: True),
+    )
+    monkeypatch.setattr(gateway, "find_gateway_pids", lambda: [456])
+
+    snapshot = gateway.get_gateway_runtime_snapshot()
+
+    assert snapshot.manager == "systemd (user)"
+    assert snapshot.service_installed is True
+    assert snapshot.service_running is True
+    assert snapshot.service_scope == "user"
+    assert snapshot.gateway_pids == (456,)
+
+
 def test_running_under_gateway_supervisor_markers(monkeypatch):
     _clear_supervisor_markers(monkeypatch)
     assert gateway._running_under_gateway_supervisor() is False


### PR DESCRIPTION
## What does this PR do?

Makes `hermes gateway status` prefer the systemd runtime snapshot when Hermes is running in a Linux environment that has container markers but also has operational systemd supervision.

Current `main` returns `manager="docker (foreground)"` as soon as `is_container()` is true and the gateway is not s6-supervised. That is wrong for systemd-nspawn/dev containers and other systemd-bearing environments: systemd is the authoritative gateway supervisor, so the status surface should report `systemd (user)` instead of the generic Docker foreground label.

This keeps the existing non-systemd container fallback unchanged.

## Related Issue

Related to #46848, but not a duplicate:

- #46848 handles the opposite sibling case: non-container Firecracker/Fly environments that are actually s6-supervised.
- This PR handles container-marked Linux environments that are actually systemd-supervised.

Both improve `get_gateway_runtime_snapshot()` so the gateway status reports the real supervisor instead of an environment-label fallback.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/gateway.py`
  - After the s6 check inside the container branch, falls through to the existing systemd probing path when `_container_systemd_operational()` is true.
  - Preserves `manager="docker (foreground)"` for containers without operational systemd.
- `tests/hermes_cli/test_gateway.py`
  - Adds regression coverage for container-marked environments where systemd is operational and should be reported as the supervisor.

## How to Test

1. Confirm the regression on current `main` by checking out only the new test:
   ```bash
   git checkout 41bea6b80 -- tests/hermes_cli/test_gateway.py
   /home/krishna/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_gateway.py::test_container_with_operational_systemd_snapshot_reports_systemd -q
   # 1 failed: expected systemd (user), got docker (foreground)
   ```

2. Run the focused test after the fix:
   ```bash
   /home/krishna/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_gateway.py::test_container_with_operational_systemd_snapshot_reports_systemd -q
   # 1 passed in 0.36s
   ```

3. Run the gateway CLI test module:
   ```bash
   /home/krishna/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_gateway.py -q
   # 49 passed in 0.57s
   ```

4. Static checks:
   ```bash
   /home/krishna/.hermes/hermes-agent/venv/bin/python -m py_compile hermes_cli/gateway.py
   git diff --check upstream/main..HEAD
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Linux runtime detection only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — gateway runtime snapshot behavior covered by tests.
