### PR TITLE
fix(web): preserve named custom providers in main model assignment

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -858,25 +858,48 @@ def _normalize_main_model_assignment(provider: str, model: str) -> tuple[str, st
        ``normalize_model_for_provider`` (e.g. ``anthropic/claude-opus-4.6``
        on native anthropic → ``claude-opus-4-6``).
     """
+    from hermes_cli.config import get_compatible_custom_providers, load_config
     from hermes_cli.models import _KNOWN_PROVIDER_NAMES, normalize_provider
     from hermes_cli.model_normalize import normalize_model_for_provider
+    from hermes_cli.providers import custom_provider_slug, resolve_custom_provider
 
     prov_in = (provider or "").strip()
     model_in = (model or "").strip()
     canonical = normalize_provider(prov_in)
 
+    try:
+        cfg = load_config()
+    except Exception:
+        cfg = {}
+
+    custom_provider = resolve_custom_provider(
+        prov_in,
+        get_compatible_custom_providers(cfg),
+    )
+    if custom_provider is not None:
+        prov_in = custom_provider.id
+        canonical = custom_provider.id
+
     if canonical not in _KNOWN_PROVIDER_NAMES and "/" in model_in:
+        if canonical.startswith("custom:"):
+            return canonical, model_in
+
+        custom_slug = custom_provider_slug(prov_in) if prov_in else ""
+        custom_provider = resolve_custom_provider(
+            custom_slug,
+            get_compatible_custom_providers(cfg),
+        )
+        if custom_provider is not None:
+            return custom_provider.id, model_in
+
         # Vendor prefix posing as a provider (analytics fallback). Resolve
         # against the user's current provider when it's an aggregator that
         # serves vendor-prefixed slugs; otherwise default to openrouter.
-        try:
-            cur_cfg = load_config().get("model", {})
-            cur_provider = (
-                str(cur_cfg.get("provider", "") or "").strip().lower()
-                if isinstance(cur_cfg, dict) else ""
-            )
-        except Exception:
-            cur_provider = ""
+        cur_cfg = cfg.get("model", {})
+        cur_provider = (
+            str(cur_cfg.get("provider", "") or "").strip().lower()
+            if isinstance(cur_cfg, dict) else ""
+        )
         from hermes_cli.models import _AGGREGATOR_PROVIDERS
         if cur_provider and normalize_provider(cur_provider) in _AGGREGATOR_PROVIDERS:
             canonical = normalize_provider(cur_provider)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1483,6 +1483,83 @@ class TestWebServerEndpoints:
         assert data["provider"] == "openrouter"
         assert data["model"] == "moonshotai/kimi-k2.6"
 
+    def test_model_set_keeps_named_custom_provider_slug(self, monkeypatch):
+        """A named custom provider slug from the dashboard must survive
+        `/api/model/set` unchanged instead of falling into the unknown-provider
+        OpenRouter fallback."""
+        monkeypatch.setattr(
+            "hermes_cli.model_cost_guard.expensive_model_warning",
+            lambda *_args, **_kwargs: None,
+        )
+        from hermes_cli.config import load_config, save_config
+        cfg = load_config()
+        cfg["model"] = {"provider": "openrouter", "default": "openai/gpt-5.5"}
+        cfg["custom_providers"] = [
+            {
+                "name": "US Azure",
+                "base_url": "http://127.0.0.1:18025/v1",
+                "api_key": "x",
+                "models": ["us/azure/openai/gpt-5.5"],
+            }
+        ]
+        save_config(cfg)
+
+        resp = self.client.post(
+            "/api/model/set",
+            json={
+                "scope": "main",
+                "provider": "custom:us-azure",
+                "model": "us/azure/openai/gpt-5.5",
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["provider"] == "custom:us-azure"
+        assert data["model"] == "us/azure/openai/gpt-5.5"
+
+        cfg = load_config()
+        assert cfg["model"]["provider"] == "custom:us-azure"
+        assert cfg["model"]["default"] == "us/azure/openai/gpt-5.5"
+
+    def test_model_set_resolves_named_custom_provider_display_name(self, monkeypatch):
+        """A bare named custom provider from UI state should canonicalize to
+        the stored `custom:<name>` slug so runtime resolution stays routable."""
+        monkeypatch.setattr(
+            "hermes_cli.model_cost_guard.expensive_model_warning",
+            lambda *_args, **_kwargs: None,
+        )
+        from hermes_cli.config import load_config, save_config
+        cfg = load_config()
+        cfg["model"] = {"provider": "openrouter", "default": "openai/gpt-5.5"}
+        cfg["custom_providers"] = [
+            {
+                "name": "US Azure",
+                "base_url": "http://127.0.0.1:18025/v1",
+                "api_key": "x",
+                "models": ["us/azure/openai/gpt-5.5"],
+            }
+        ]
+        save_config(cfg)
+
+        resp = self.client.post(
+            "/api/model/set",
+            json={
+                "scope": "main",
+                "provider": "us-azure",
+                "model": "us/azure/openai/gpt-5.5",
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["provider"] == "custom:us-azure"
+        assert data["model"] == "us/azure/openai/gpt-5.5"
+
+        cfg = load_config()
+        assert cfg["model"]["provider"] == "custom:us-azure"
+        assert cfg["model"]["default"] == "us/azure/openai/gpt-5.5"
+
     def test_model_set_keeps_aggregator_slug_unchanged(self, monkeypatch):
         """The happy path (picker → openrouter + vendor/model) is untouched."""
         monkeypatch.setattr(


### PR DESCRIPTION
## What does this PR do?

Fixes a dashboard regression where `POST /api/model/set` rewrote named custom providers to `openrouter` when the selected model id contained a slash.

The save path now resolves configured `custom_providers` before the unknown-vendor fallback, so both `custom:us-azure` and bare `us-azure` persist as the routable `custom:us-azure` slug. Truly unknown vendor prefixes still keep the existing aggregator fallback behavior.

## Related Issue

Fixes #52496

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Preserve configured named custom providers in `_normalize_main_model_assignment()` instead of routing them through the unknown-provider OpenRouter fallback.
- Canonicalize bare custom provider display names like `us-azure` back to `custom:us-azure` before persisting the main model assignment.
- Add regression tests for named custom provider slug preservation and bare-name canonicalization, while keeping existing native-provider and aggregator fallback coverage.

## How to Test

1. Run `pytest -q tests/hermes_cli/test_web_server.py -k 'model_set_normalizes_vendor_slug_for_native_provider or model_set_maps_unknown_vendor_to_aggregator or model_set_keeps_named_custom_provider_slug or model_set_resolves_named_custom_provider_display_name or model_set_keeps_aggregator_slug_unchanged'`.
2. Verify the new named-custom-provider cases persist `custom:us-azure` instead of rewriting to `openrouter`.
3. Confirm the unknown vendor case still falls back to `openrouter`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (local numbered upstream worktree)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
