### PR TITLE
fix(windows-install): stop exporting venv Scripts on PATH

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1857,28 +1857,55 @@ except Exception:
 
 function Set-PathVariable {
     Write-Info "Setting up hermes command..."
-    
+
     if ($NoVenv) {
-        $hermesBin = "$InstallDir"
+        $pathEntry = "$InstallDir"
     } else {
-        $hermesBin = "$InstallDir\venv\Scripts"
+        $venvScriptsDir = "$InstallDir\venv\Scripts"
+        $pathEntry = Join-Path $HermesHome "bin"
+        $shimPath = Join-Path $pathEntry "hermes.cmd"
+        $shimBody = @(
+            "@echo off",
+            "set `"PYTHONPATH=`"",
+            "set `"PYTHONHOME=`"",
+            "set `"HERMES_HOME=$HermesHome`"",
+            "`"$InstallDir\venv\Scripts\hermes.exe`" %*"
+        ) -join "`r`n"
+
+        New-Item -ItemType Directory -Path $pathEntry -Force | Out-Null
+        Set-Content -Path $shimPath -Value $shimBody -Encoding ASCII
     }
-    
-    # Add the venv Scripts dir to user PATH so hermes is globally available
-    # On Windows, the hermes.exe in venv\Scripts\ has the venv Python baked in
+
+    # Keep Hermes launchers globally available without exposing the whole venv
+    # Scripts dir, which also shadows bare python/pip for unrelated projects.
     $currentPath = [Environment]::GetEnvironmentVariable("Path", "User")
-    
-    if ($currentPath -notlike "*$hermesBin*") {
-        [Environment]::SetEnvironmentVariable(
-            "Path",
-            "$hermesBin;$currentPath",
-            "User"
-        )
-        Write-Success "Added to user PATH: $hermesBin"
+    $pathItems = if ($currentPath) { $currentPath -split ";" } else { @() }
+    $changed = $false
+
+    if (-not $NoVenv) {
+        $filtered = @()
+        foreach ($entry in $pathItems) {
+            if ($entry -eq $venvScriptsDir) {
+                $changed = $true
+                continue
+            }
+            $filtered += $entry
+        }
+        $pathItems = $filtered
+    }
+
+    if ($pathItems -notcontains $pathEntry) {
+        $pathItems = @($pathEntry) + $pathItems
+        $changed = $true
+    }
+
+    if ($changed) {
+        [Environment]::SetEnvironmentVariable("Path", ($pathItems -join ";"), "User")
+        Write-Success "Added to user PATH: $pathEntry"
     } else {
         Write-Info "PATH already configured"
     }
-    
+
     # Set HERMES_HOME so the Python code finds config/data in the right place.
     # Only needed on Windows where we install to %LOCALAPPDATA%\hermes instead
     # of the Unix default ~/.hermes
@@ -1888,10 +1915,15 @@ function Set-PathVariable {
         Write-Success "Set HERMES_HOME=$HermesHome"
     }
     $env:HERMES_HOME = $HermesHome
-    
+
     # Update current session
-    $env:Path = "$hermesBin;$env:Path"
-    
+    $sessionPathItems = if ($env:Path) { $env:Path -split ";" } else { @() }
+    if (-not $NoVenv) {
+        $sessionPathItems = @($sessionPathItems | Where-Object { $_ -and $_ -ne $venvScriptsDir })
+    }
+    $sessionPathItems = @($pathEntry) + @($sessionPathItems | Where-Object { $_ -and $_ -ne $pathEntry })
+    $env:Path = $sessionPathItems -join ";"
+
     Write-Success "hermes command ready"
 }
 

--- a/tests/test_install_ps1_no_venv_path_shadow.py
+++ b/tests/test_install_ps1_no_venv_path_shadow.py
@@ -1,0 +1,73 @@
+"""Regression: Windows install must not persist the whole venv Scripts dir.
+
+A follow-up on issue #22054 showed the packaged Windows/Desktop install was
+writing ``%LOCALAPPDATA%\\hermes\\hermes-agent\\venv\\Scripts`` into the user
+PATH. That made bare ``python`` / ``pip`` resolve to Hermes's bundled 3.11
+instead of the user's system Python.
+
+The installer still needs a global ``hermes`` command, but that must come from
+a dedicated shim directory (``$HermesHome\\bin``), not from the venv itself.
+These tests lock that source-level contract.
+"""
+
+from pathlib import Path
+
+import pytest
+
+_INSTALL_PS1 = Path(__file__).resolve().parents[1] / "scripts" / "install.ps1"
+
+
+@pytest.fixture(scope="module")
+def source() -> str:
+    return _INSTALL_PS1.read_text(encoding="utf-8")
+
+
+def _function_body(source: str, name: str) -> str:
+    start = source.index(f"function {name}")
+    brace = source.index("{", start)
+    depth = 0
+    for i in range(brace, len(source)):
+        if source[i] == "{":
+            depth += 1
+        elif source[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[brace : i + 1]
+    raise AssertionError(f"unterminated function body for {name}")
+
+
+def test_set_path_variable_uses_hermes_bin_shim_dir(source: str):
+    body = _function_body(source, "Set-PathVariable")
+    assert 'Join-Path $HermesHome "bin"' in body, (
+        "Set-PathVariable must publish a Hermes-managed shim directory, not the "
+        "venv Scripts directory itself"
+    )
+    assert 'Join-Path $pathEntry "hermes.cmd"' in body, (
+        "expected a dedicated hermes.cmd launcher under the Hermes-managed bin dir"
+    )
+
+
+def test_set_path_variable_removes_old_venv_scripts_entry(source: str):
+    body = _function_body(source, "Set-PathVariable")
+    assert "$entry -eq $venvScriptsDir" in body, (
+        "Set-PathVariable must filter any persisted venv Scripts entry out of "
+        "the user PATH during install/update"
+    )
+    assert 'Where-Object { $_ -and $_ -ne $venvScriptsDir }' in body, (
+        "the current installer session must also drop the venv Scripts entry so "
+        "bare python/pip stop resolving to Hermes immediately"
+    )
+
+
+def test_hermes_cmd_clears_python_env_before_exec(source: str):
+    body = _function_body(source, "Set-PathVariable")
+    assert 'set `"PYTHONPATH=`"' in body, (
+        "the Windows hermes.cmd shim must clear PYTHONPATH before execing the venv launcher"
+    )
+    assert 'set `"PYTHONHOME=`"' in body, (
+        "the Windows hermes.cmd shim must clear PYTHONHOME before execing the venv launcher"
+    )
+    assert '`"$InstallDir\\venv\\Scripts\\hermes.exe`" %*' in body, (
+        "the shim should delegate directly to the venv hermes.exe without publishing "
+        "the rest of venv Scripts on PATH"
+    )


### PR DESCRIPTION
What changed and why

The follow-up on #22054 narrowed the repro to the Windows/Desktop install path: `scripts/install.ps1` was prepending `%LOCALAPPDATA%\hermes\hermes-agent\venv\Scripts` to the user `PATH`. That made bare `python` / `pip` resolve to Hermes's bundled 3.11 interpreter instead of the user's system Python.

This change stops persisting the whole venv `Scripts` directory to user `PATH`. Instead, the installer now writes a dedicated `hermes.cmd` launcher into the Hermes-managed `bin` directory, adds that shim directory to `PATH`, and removes any stale venv `Scripts` entry during install/update. The shim clears `PYTHONPATH` and `PYTHONHOME` before delegating to the venv `hermes.exe`, so Hermes still launches globally without exposing the bundled Python toolchain to unrelated shells and projects.

I also added source-level regression tests for the Windows installer contract so future edits cannot silently reintroduce the venv PATH shadowing.

How to test

1. Run `pytest tests/test_install_ps1_python_fallback_venv.py tests/test_install_ps1_no_venv_path_shadow.py -q --timeout=60`.
2. On a Windows machine, run the installer or desktop bootstrap path that invokes `scripts/install.ps1`.
3. Verify user `PATH` contains the Hermes-managed `bin` directory but not `%LOCALAPPDATA%\hermes\hermes-agent\venv\Scripts`.
4. Verify `hermes` still launches, while bare `python` / `pip` continue resolving to the system installation rather than Hermes's bundled interpreter.

What platforms tested on

- Linux host for source-level PowerShell installer regression tests

Fixes #22054

<!-- autocontrib:worker-id=issue-followup-0036763c kind=pr-open -->