### PR TITLE
fix(codex): remove dead gpt-5.3-codex from curated fallback list (#52492)

### DIFF
--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -15,7 +15,6 @@ DEFAULT_CODEX_MODELS: List[str] = [
     "gpt-5.5",
     "gpt-5.4-mini",
     "gpt-5.4",
-    "gpt-5.3-codex",
     # gpt-5.3-codex-spark is in research preview and is exposed *only* via
     # the Codex CLI / OAuth backend (chatgpt.com/backend-api/codex/models)
     # for ChatGPT Pro subscribers. It is NOT available in the public OpenAI
@@ -29,12 +28,13 @@ DEFAULT_CODEX_MODELS: List[str] = [
     # curated fallback so Pro users still see Spark in `/model` when live
     # discovery is unavailable (offline first run, transient API failure).
     "gpt-5.3-codex-spark",
-    # NOTE: gpt-5.2-codex / gpt-5.1-codex-max / gpt-5.1-codex-mini were
-    # previously listed here but the chatgpt.com Codex backend returns
-    # HTTP 400 "The '<model>' model is not supported when using Codex with
-    # a ChatGPT account." for all three on every ChatGPT Pro account we've
-    # tested (verified live 2026-05-27). Keeping them in the fallback list
-    # leaked dead slugs into /model when live discovery was unavailable
+    # NOTE: gpt-5.3-codex / gpt-5.2-codex / gpt-5.1-codex-max /
+    # gpt-5.1-codex-mini were previously listed here but the chatgpt.com
+    # Codex backend returns HTTP 400 "The '<model>' model is not supported
+    # when using Codex with a ChatGPT account." for all of them on every
+    # ChatGPT Pro account tested (gpt-5.2/5.1 verified 2026-05-27,
+    # gpt-5.3-codex verified 2026-06-25 per issue #52492). Keeping them in
+    # the fallback list leaked dead slugs into /model when live discovery was unavailable
     # (transient API failure, first-run before refresh) and surfaced HTTP 400
     # crashes on selection. The Codex CLI public catalog still references
     # these slugs, which is why they survived previously — but those entries
@@ -44,14 +44,12 @@ DEFAULT_CODEX_MODELS: List[str] = [
 ]
 
 _FORWARD_COMPAT_TEMPLATE_MODELS: List[tuple[str, tuple[str, ...]]] = [
-    ("gpt-5.5", ("gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex")),
-    ("gpt-5.4-mini", ("gpt-5.3-codex",)),
-    ("gpt-5.4", ("gpt-5.3-codex",)),
+    ("gpt-5.5", ("gpt-5.4", "gpt-5.4-mini")),
     # Surface Spark whenever any compatible Codex template is present so
     # accounts hitting the live endpoint with an older lineup still see
     # Spark in the picker. Backend gates real availability by ChatGPT Pro
     # entitlement; Hermes does not.
-    ("gpt-5.3-codex-spark", ("gpt-5.3-codex",)),
+    ("gpt-5.3-codex-spark", ("gpt-5.4", "gpt-5.5")),
 ]
 
 

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -60,19 +60,15 @@ def test_get_codex_model_ids_falls_back_to_curated_defaults(tmp_path, monkeypatc
 def test_get_codex_model_ids_adds_forward_compat_models_from_templates(monkeypatch):
     monkeypatch.setattr(
         "hermes_cli.codex_models._fetch_models_from_api",
-        lambda access_token: ["gpt-5.3-codex"],
+        lambda access_token: ["gpt-5.5"],
     )
 
     models = get_codex_model_ids(access_token="codex-access-token")
 
-    # When live discovery only returns gpt-5.3-codex, forward-compat synthesis
-    # should surface gpt-5.5, gpt-5.4, gpt-5.4-mini, and gpt-5.3-codex-spark
-    # (each is templated off gpt-5.3-codex).
+    # When live discovery only returns gpt-5.5, forward-compat synthesis
+    # should surface gpt-5.3-codex-spark (templated off gpt-5.5).
     assert models == [
-        "gpt-5.3-codex",
         "gpt-5.5",
-        "gpt-5.4-mini",
-        "gpt-5.4",
         "gpt-5.3-codex-spark",
     ]
 

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -253,7 +253,7 @@ class TestDetectProviderForModel:
 
     def test_current_provider_model_returns_none(self):
         """Models belonging to the current provider should not trigger a switch."""
-        assert detect_provider_for_model("gpt-5.3-codex", "openai-codex") is None
+        assert detect_provider_for_model("gpt-5.3-codex-spark", "openai-codex") is None
 
     def test_short_alias_resolves_to_static_model(self):
         """Short aliases (e.g. sonnet) should resolve without network lookups."""


### PR DESCRIPTION
## What does this PR do?

Removes the dead `gpt-5.3-codex` model from the curated Codex fallback list and forward-compat templates. The chatgpt.com Codex backend now returns HTTP 400 for this model on ChatGPT Pro accounts, matching the same pattern that previously killed `gpt-5.2-codex`, `gpt-5.1-codex-max`, and `gpt-5.1-codex-mini`. Without this fix, users who are offline or hit a transient API failure see `gpt-5.3-codex` in `/model`, select it, and get a 400 crash.

## Related Issue

Fixes #52492

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/codex_models.py`: Remove `gpt-5.3-codex` from `DEFAULT_CODEX_MODELS`; update the removal comment to include it alongside the previously removed models; update `_FORWARD_COMPAT_TEMPLATE_MODELS` to remove `gpt-5.3-codex` as a forward-compat trigger and re-anchor `gpt-5.3-codex-spark` on `gpt-5.4`/`gpt-5.5` templates instead.
- `tests/hermes_cli/test_codex_models.py`: Update `test_get_codex_model_ids_adds_forward_compat_models_from_templates` to use `gpt-5.5` as the trigger model (since `gpt-5.3-codex` is no longer a template anchor) and adjust expected output.

## How to Test

1. Run `python -m pytest tests/hermes_cli/test_codex_models.py -q` — all 19 tests should pass.
2. Run `python -m pytest tests/test_empty_model_fallback.py -q` — all 14 tests should pass.
3. Verify `gpt-5.3-codex` is no longer in `DEFAULT_CODEX_MODELS` by inspecting `hermes_cli/codex_models.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_cli/codex_models.py` (callers: `models.py`, `model_setup_flows.py`, `test_codex_models.py`)
- Blast radius: LOW — data-only change in curated fallback list; live discovery path unaffected
- Related patterns: Same removal pattern as `gpt-5.2-codex` / `gpt-5.1-codex-max` / `gpt-5.1-codex-mini` (2026-05-27)
