### PR TITLE
fix(tirith): allow safe private LAN health probes

### DIFF
--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -1407,6 +1407,119 @@ class TestAppTldSuppression:
         assert result["action"] == "allow"
 
 
+class TestPrivateLanRawIpSuppression:
+    """Raw private-IP warnings are suppressed only for read-only status probes."""
+
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    def test_private_lan_health_probe_warn_downgraded_to_allow(self, mock_cfg, mock_run):
+        mock_cfg.return_value = _CFG
+        findings = [
+            {
+                "rule_id": "raw_ip_url",
+                "message": "URL uses raw IP address: URL points to IP address 192.168.1.86 instead of a domain name",
+            },
+            {
+                "rule_id": "plain_http_execution",
+                "message": "URL uses unencrypted HTTP in execution context",
+            },
+            {
+                "rule_id": "private_network_access",
+                "message": "Command accesses private network address 192.168.1.86",
+            },
+        ]
+        mock_run.return_value = _mock_run(2, _json_stdout(findings, "raw IP"))
+        result = check_command_security("curl -fsS http://192.168.1.86:11434/api/tags")
+        assert result["action"] == "allow"
+        assert result["findings"] == []
+        assert result["summary"] == ""
+
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    def test_public_raw_ip_warning_preserved(self, mock_cfg, mock_run):
+        mock_cfg.return_value = _CFG
+        findings = [{"rule_id": "raw_ip_url", "message": "URL uses raw IP address"}]
+        mock_run.return_value = _mock_run(2, _json_stdout(findings, "raw IP"))
+        result = check_command_security("curl -fsS http://93.184.216.34/health")
+        assert result["action"] == "warn"
+        assert len(result["findings"]) == 1
+
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    def test_private_raw_ip_post_preserved(self, mock_cfg, mock_run):
+        mock_cfg.return_value = _CFG
+        findings = [{"rule_id": "raw_ip_url", "message": "URL uses raw IP address"}]
+        mock_run.return_value = _mock_run(2, _json_stdout(findings, "raw IP"))
+        result = check_command_security("curl -fsS -X POST http://192.168.1.86:11434/api/tags")
+        assert result["action"] == "warn"
+        assert len(result["findings"]) == 1
+
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    def test_private_raw_ip_with_pipe_preserved(self, mock_cfg, mock_run):
+        mock_cfg.return_value = _CFG
+        findings = [{"rule_id": "raw_ip_url", "message": "URL uses raw IP address"}]
+        mock_run.return_value = _mock_run(2, _json_stdout(findings, "raw IP"))
+        result = check_command_security("curl -fsS http://192.168.1.86:11434/api/tags | python3")
+        assert result["action"] == "warn"
+        assert len(result["findings"]) == 1
+
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    def test_private_raw_ip_with_credentials_preserved(self, mock_cfg, mock_run):
+        mock_cfg.return_value = _CFG
+        findings = [{"rule_id": "raw_ip_url", "message": "URL uses raw IP address"}]
+        mock_run.return_value = _mock_run(2, _json_stdout(findings, "raw IP"))
+        result = check_command_security("curl -fsS -u user:pass http://192.168.1.86:11434/api/tags")
+        assert result["action"] == "warn"
+        assert len(result["findings"]) == 1
+
+    @pytest.mark.parametrize("command", [
+        "curl --config probe.conf http://192.168.1.86/health",
+        "curl --location http://192.168.1.86/health",
+        "curl --header=Authorization:secret http://192.168.1.86/health",
+        "curl -HAuthorization:secret http://192.168.1.86/health",
+        "curl --cookie session=secret http://192.168.1.86/health",
+        "curl http://user:pass@192.168.1.86/health",
+        "curl http://192.0.2.1/health",
+        "curl http://198.51.100.1/health",
+    ])
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    def test_bypass_forms_and_reserved_ranges_preserve_warn(
+        self, mock_cfg, mock_run, command
+    ):
+        mock_cfg.return_value = _CFG
+        findings = [{"rule_id": "raw_ip_url", "message": "URL uses raw IP address"}]
+        mock_run.return_value = _mock_run(2, _json_stdout(findings, "raw IP"))
+        result = check_command_security(command)
+        assert result["action"] == "warn"
+        assert len(result["findings"]) == 1
+
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    def test_private_raw_ip_non_curl_preserved(self, mock_cfg, mock_run):
+        mock_cfg.return_value = _CFG
+        findings = [{"rule_id": "raw_ip_url", "message": "URL uses raw IP address"}]
+        mock_run.return_value = _mock_run(2, _json_stdout(findings, "raw IP"))
+        result = check_command_security("wget -qO- http://192.168.1.86:11434/api/tags")
+        assert result["action"] == "warn"
+        assert len(result["findings"]) == 1
+
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    def test_private_raw_ip_mixed_findings_preserve_warn(self, mock_cfg, mock_run):
+        mock_cfg.return_value = _CFG
+        findings = [
+            {"rule_id": "raw_ip_url", "message": "URL uses raw IP address"},
+            {"rule_id": "shortened_url", "severity": "medium"},
+        ]
+        mock_run.return_value = _mock_run(2, _json_stdout(findings, "mixed"))
+        result = check_command_security("curl -fsS http://192.168.1.86:11434/api/tags")
+        assert result["action"] == "warn"
+        assert len(result["findings"]) == 2
+
+
 class TestIsAppTldFinding:
     """Unit tests for the _is_app_tld_finding helper."""
 

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -21,11 +21,14 @@ never blocks.
 """
 
 import hashlib
+import ipaddress
 import json
 import logging
 import os
 import platform
+import re
 import shutil
+import shlex
 import stat
 import subprocess
 import tarfile
@@ -33,6 +36,7 @@ import tempfile
 import threading
 import time
 import urllib.request
+from urllib.parse import urlparse
 
 from hermes_constants import get_hermes_home
 
@@ -851,6 +855,23 @@ def check_command_security(command: str) -> dict:
             findings = []
             summary = ""
 
+    # LAN health/status probes are normal in local-first Hermes/Niko setups.
+    # Tirith's raw-IP/private-network/plain-HTTP heuristics are useful for
+    # public IPs, opaque network fetches, SSRF, and execution chains; but
+    # prompting on a read-only GET/HEAD to an RFC1918/link-local health/status
+    # endpoint creates noise and trains operators to bypass blockers. Downgrade
+    # only the narrow case where every finding is one of these LAN-probe
+    # context warnings and the command shape is an inspect-only private-LAN
+    # status probe. Anything mixed with another finding, mutating HTTP
+    # method/data, credentials, redirects to execution, or shell chaining
+    # remains a warning/block.
+    if action == "warn" and findings:
+        non_suppressible = [f for f in findings if not _is_safe_lan_probe_context_finding(f)]
+        if not non_suppressible and _is_private_lan_readonly_probe(command):
+            action = "allow"
+            findings = []
+            summary = ""
+
     return {"action": action, "findings": findings, "summary": summary}
 
 
@@ -869,3 +890,131 @@ def _is_app_tld_finding(finding: dict) -> bool:
         if val is not None and ".app" in str(val).lower():
             return True
     return False
+
+
+_URL_RE = re.compile(r"https?://[^\s'\"<>]+", re.IGNORECASE)
+_SHELL_CHAIN_RE = re.compile(r"\||&&|\|\||;|`|\$\(|>|<")
+_READONLY_PROBE_PATHS = (
+    "/",
+    "/health",
+    "/healthz",
+    "/status",
+    "/version",
+    "/metrics",
+    "/api/tags",
+    "/api/version",
+)
+_SAFE_CURL_SHORT_FLAGS = frozenset("fsSI")
+_SAFE_CURL_LONG_FLAGS = {"--fail", "--silent", "--show-error", "--head"}
+_SAFE_CURL_VALUE_FLAGS = {"-m", "--max-time", "--connect-timeout"}
+_PRIVATE_PROBE_NETWORKS = tuple(
+    ipaddress.ip_network(network)
+    for network in (
+        "10.0.0.0/8",
+        "172.16.0.0/12",
+        "192.168.0.0/16",
+        "127.0.0.0/8",
+        "169.254.0.0/16",
+        "::1/128",
+        "fe80::/10",
+    )
+)
+
+
+def _is_safe_lan_probe_context_finding(finding: dict) -> bool:
+    """Return True for findings tolerated only on safe private-LAN probes."""
+    if not isinstance(finding, dict):
+        return False
+    text = _finding_text(finding)
+    human_text = text.replace("_", " ")
+    return (
+        "raw_ip" in text
+        or "ip_address_url" in text
+        or "private_network" in text
+        or "private network access" in human_text
+        or "plain_http" in text
+        or "plain http" in human_text
+        or "unencrypted http" in human_text
+        or "url uses raw ip address" in human_text
+        or "url points to ip address" in human_text
+    )
+
+
+def _finding_text(finding: dict) -> str:
+    return " ".join(
+        str(finding.get(field, "") or "")
+        for field in ("rule_id", "id", "name", "title", "detail", "description", "message", "summary")
+    ).lower().replace("-", "_")
+
+
+def _is_private_lan_readonly_probe(command: str) -> bool:
+    """Return True for narrowly-scoped private-LAN read-only health probes."""
+    if not command or _SHELL_CHAIN_RE.search(command):
+        return False
+
+    urls = _URL_RE.findall(command)
+    if not urls or not all(_is_private_http_probe_url(url) for url in urls):
+        return False
+
+    try:
+        tokens = shlex.split(command, posix=True)
+    except ValueError:
+        return False
+    if not tokens:
+        return False
+
+    executable = os.path.basename(tokens[0])
+    if executable != "curl":
+        return False
+
+    index = 1
+    seen_urls = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token in urls:
+            seen_urls += 1
+        elif token in _SAFE_CURL_LONG_FLAGS:
+            pass
+        elif token in _SAFE_CURL_VALUE_FLAGS:
+            index += 1
+            if index >= len(tokens):
+                return False
+            try:
+                if float(tokens[index]) <= 0:
+                    return False
+            except ValueError:
+                return False
+        elif any(token.startswith(flag + "=") for flag in _SAFE_CURL_VALUE_FLAGS if flag.startswith("--")):
+            try:
+                if float(token.split("=", 1)[1]) <= 0:
+                    return False
+            except ValueError:
+                return False
+        elif token.startswith("-") and not token.startswith("--"):
+            if token.startswith("-m") and len(token) > 2:
+                try:
+                    if float(token[2:]) <= 0:
+                        return False
+                except ValueError:
+                    return False
+            elif not token[1:] or not set(token[1:]) <= _SAFE_CURL_SHORT_FLAGS:
+                return False
+        else:
+            return False
+        index += 1
+    return seen_urls == len(urls)
+
+
+def _is_private_http_probe_url(url: str) -> bool:
+    try:
+        parsed = urlparse(url)
+        if parsed.username is not None or parsed.password is not None:
+            return False
+        host = (parsed.hostname or "").strip("[]")
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    if not any(ip in network for network in _PRIVATE_PROBE_NETWORKS):
+        return False
+    path = parsed.path or "/"
+    return any(path == allowed or path.startswith(allowed + "/") for allowed in _READONLY_PROBE_PATHS)


### PR DESCRIPTION
## What does this PR do?

Allows only a narrow class of local, read-only RFC1918/link-local/loopback health probes to bypass repetitive Tirith warnings.

```bash
curl -fsS http://192.168.1.86:11434/api/tags
```

The suppression is fail-closed: only `curl`, explicit private/loopback/link-local ranges, known health/status paths, and a minimal set of harmless flags are accepted. Unknown options remain warnings.

## Related Issue

N/A. No matching issue or PR found for Tirith raw private-IP health probes.

A broad egress/security PR exists (#30179), but this is not a duplicate: this is a small Tirith warning-suppression rule for local read-only health checks only.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- Replaces curl-option denylisting with a strict allowlist.
- Accepts only `curl`, safe short flags (`-f`, `-s`, `-S`, `-I`), safe timeout flags, known health/status paths, and explicit RFC1918/loopback/link-local networks.
- Rejects config files, redirects, headers, cookies, credentials, request bodies/uploads, mutating or explicit methods, unknown options, shell chains, non-curl commands, URL userinfo, public IPs, and reserved/documentation ranges.
- Adds regression coverage for the allowed probe and the rejected bypass forms, including `--config`, `--location`, attached headers, cookies, URL credentials, and TEST-NET addresses.

## Validation

```bash
uv run --with pytest --with pytest-asyncio pytest -q tests/tools/test_tirith_security.py
# 110 passed

uv run --with pytest --with pytest-asyncio pytest -q \
  tests/tools/test_tirith_security.py \
  tests/tools/test_approval.py \
  tests/tools/test_yolo_mode.py
# 441 passed

uv run --with ruff ruff check tools/tirith_security.py tests/tools/test_tirith_security.py
# All checks passed

python3 -m py_compile tools/tirith_security.py tests/tools/test_tirith_security.py
git diff --check upstream/main..HEAD
```

An independent read-only review also exercised 64 bypass cases and 17 edge cases; no blocking findings remained.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on Linux

### Documentation & Housekeeping

- [x] Documentation changes are N/A
- [x] Config changes are N/A
- [x] Architecture/workflow documentation changes are N/A
- [x] Cross-platform impact considered; parsing remains conservative and stdlib-only
- [x] Tool schema changes are N/A

## Screenshots / Logs

N/A — behavior is covered by tests.
