### PR TITLE
fix(tools): preserve word-boundary space in whitespace-normalized edits

### DIFF
--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -44,6 +44,27 @@ class TestWhitespaceDifference:
         assert "bar" in new
 
 
+class TestWhitespaceBoundaryPreservation:
+    """Regression for #52491: the whitespace_normalized strategy must not
+    swallow the word-boundary space that separates the match from the token
+    that follows it."""
+
+    def test_boundary_space_preserved_minimal(self):
+        new, count, _, err = fuzzy_find_and_replace("foo   bar baz", "foo bar", "XY")
+        assert err is None
+        assert count == 1
+        assert new == "XY baz"
+
+    def test_boundary_space_preserved_realistic(self):
+        content = "result = compute(a,  b) + tail"
+        new, count, _, err = fuzzy_find_and_replace(
+            content, "compute(a, b)", "compute(a, b, c)"
+        )
+        assert err is None
+        assert count == 1
+        assert new == "result = compute(a, b, c) + tail"
+
+
 class TestIndentDifference:
     def test_different_indentation(self):
         content = "    def foo():\n        pass"

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -768,9 +768,13 @@ def _map_normalized_positions(original: str, normalized: str,
         else:
             orig_end = orig_start + (norm_end - norm_start)
         
-        # Expand to include trailing whitespace that was normalized
-        while orig_end < len(original) and original[orig_end] in ' \t':
-            orig_end += 1
+        # Expand to include trailing whitespace that was collapsed *inside*
+        # the match — but only when the match itself ended on whitespace.
+        # Otherwise we'd swallow the word-boundary space that separates the
+        # match from the following token, silently corrupting the edit (#52491).
+        if orig_end > orig_start and original[orig_end - 1] in ' \t':
+            while orig_end < len(original) and original[orig_end] in ' \t':
+                orig_end += 1
         
         original_matches.append((orig_start, min(orig_end, len(original))))
     


### PR DESCRIPTION
## What does this PR do?

The fuzzy file-editing matcher used by `str_replace` / patch apply silently deleted the space between a matched region and the token that follows it, corrupting the file while still reporting success (`match_count=1`, `error=None`).

When an exact match fails, the editor falls back to the `whitespace_normalized` strategy, which collapses runs of spaces/tabs so an `old_string` with single spaces can match a file that has extra spaces. In `_map_normalized_positions`, after the normalized match was mapped back to original offsets, the code unconditionally extended the match end over any trailing whitespace. That expansion is only meant to recover whitespace collapsed *inside* the pattern — but with no guard it also consumed the word-boundary space separating the match from the next token, which was never part of the pattern, so the replacement deleted it.

The fix gates that expansion on whether the match actually ended on a whitespace character. If the last matched character is non-whitespace, the following space is a boundary separator and is left untouched; patterns that genuinely end in whitespace still get their collapsed run recovered. This is a minimal, behavior-preserving change for every existing case.

## Related Issue

Fixes #52491

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/fuzzy_match.py` — in `_map_normalized_positions`, guard the trailing-whitespace expansion so it only runs when the matched region itself ends on whitespace (`if orig_end > orig_start and original[orig_end - 1] in ' \t'`), instead of unconditionally consuming following whitespace.
- `tests/tools/test_fuzzy_match.py` — add `TestWhitespaceBoundaryPreservation` with a minimal case and a realistic code-edit case asserting the boundary space is preserved.

## How to Test

1. Run the fuzzy-match suite: `pytest tests/tools/test_fuzzy_match.py -q` — 49 pass (47 existing + 2 new). The 2 new tests fail on `main` and pass with this change.
2. Minimal proof — `fuzzy_find_and_replace("foo   bar baz", "foo bar", "XY")` returns `('XYbaz', ...)` before the fix and `('XY baz', ...)` after.
3. Realistic proof — replacing `compute(a, b)` with `compute(a, b, c)` in `result = compute(a,  b) + tail` produced `result = compute(a, b, c)+ tail` before (space before `+` lost) and `result = compute(a, b, c) + tail` after.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.0 (Tahoe)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python string logic, platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs