### PR TITLE
fix(tui): add newline delimiter to WebSocket JSON-RPC frames

### DIFF
--- a/tui_gateway/event_publisher.py
+++ b/tui_gateway/event_publisher.py
@@ -91,7 +91,7 @@ class WsPublisherTransport:
         if self._dead or self._ws is None or self._worker is None:
             return False
 
-        line = json.dumps(obj, ensure_ascii=False)
+        line = json.dumps(obj, ensure_ascii=False) + "\n"
 
         try:
             self._q.put_nowait(line)

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -119,7 +119,7 @@ class WSTransport:
         if self._closed:
             return False
 
-        line = json.dumps(obj, ensure_ascii=False)
+        line = json.dumps(obj, ensure_ascii=False) + "\n"
 
         try:
             on_loop = asyncio.get_running_loop() is self._loop
@@ -221,7 +221,7 @@ class WSTransport:
         with self._token_lock:
             batch = self._pending_tokens
             self._pending_tokens = []
-            batch.append(json.dumps(obj, ensure_ascii=False))
+            batch.append(json.dumps(obj, ensure_ascii=False) + "\n")
         await self._safe_send_many(batch)
         return not self._closed
 


### PR DESCRIPTION
Fixes #52244

## Description
Match StdioTransport framing by appending newline to each JSON-RPC frame in WSTransport and WsPublisherTransport. This prevents potential UTF-8 multi-byte character splitting on Windows when ASGI WebSocket text frames interact with non-UTF-8 system locales.

The StdioTransport (used by CLI, which is unaffected) already includes the trailing newline in every JSON frame. The WSTransport and WsPublisherTransport (used by the Desktop WebSocket path) were missing this delimiter, which could cause frame-boundary ambiguity on Windows where the ASGI server may coalesce or fragment WebSocket sends differently.

## Verification
- Compilation: both modified files compile clean
- Tests: tests/test_tui_gateway_ws.py — 3 passed
- Secrets: clean
- Personal refs: clean
- Branch: current with origin/main