### PR TITLE
feat(router): add codex turn routing for model and effort presets

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -424,6 +424,13 @@ def load_cli_config() -> Dict[str, Any]:
             "prefill_messages_file": "",
             "reasoning_effort": "",
             "service_tier": "",
+            "request_router": {
+                "enabled": False,
+                "providers_allowlist": ["openai-codex"],
+                "default_preset": "high_standard",
+                "allow_auto_priority": False,
+                "log_decisions": False,
+            },
             "personalities": {
                 "helpful": "You are a helpful, friendly AI assistant.",
                 "concise": "You are a concise assistant. Keep responses brief and to the point.",
@@ -3602,6 +3609,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         )
         self.service_tier = _parse_service_tier_config(
             CLI_CONFIG["agent"].get("service_tier", "")
+        )
+        _request_router_config = CLI_CONFIG["agent"].get("request_router", {})
+        self.request_router_config = (
+            dict(_request_router_config) if isinstance(_request_router_config, dict) else {}
         )
         
         # OpenRouter provider routing preferences
@@ -11450,6 +11461,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             request_overrides=turn_route.get("request_overrides"),
         ):
             return None
+        if self.agent is not None:
+            # Per-turn router fields must update cached agents in place.
+            # Rebuilding is only required for model/runtime signature changes.
+            self.agent.reasoning_config = turn_route.get("reasoning_config")
+            self.agent.service_tier = turn_route.get("service_tier")
+            self.agent.request_overrides = turn_route.get("request_overrides") or {}
+        _router_message_override = turn_route.get("message_override")
         
         # Route image attachments based on the active model's vision capability.
         # "native" → pass pixels as OpenAI-style content parts (adapters
@@ -11655,7 +11673,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 except Exception:
                     reset_current_session_key = None  # type: ignore[assignment]
                     _approval_session_token = None
-                agent_message = _voice_prefix + message if _voice_prefix else message
+                _api_message = _router_message_override if isinstance(message, str) and _router_message_override is not None else message
+                agent_message = _voice_prefix + _api_message if _voice_prefix and isinstance(_api_message, str) else _api_message
                 # Prepend pending notes via _prepend_note_to_message, which
                 # handles both plain-string and multimodal content-parts list
                 # messages. Naive ``note + "\n\n" + agent_message`` crashed with
@@ -11678,7 +11697,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         conversation_history=self.conversation_history[:-1],  # Exclude the message we just added
                         stream_callback=stream_callback,
                         task_id=self.session_id,
-                        persist_user_message=message if _voice_prefix else None,
+                        persist_user_message=message if (_voice_prefix or _router_message_override is not None) else None,
                     )
                 except Exception as exc:
                     logging.error("run_conversation raised: %s", exc, exc_info=True)
@@ -15366,6 +15385,27 @@ def main(
                         runtime_override=turn_route["runtime"],
                         request_overrides=turn_route.get("request_overrides"),
                     ):
+                        cli.agent.reasoning_config = turn_route.get("reasoning_config")
+                        cli.agent.service_tier = turn_route.get("service_tier")
+                        cli.agent.request_overrides = turn_route.get("request_overrides") or {}
+                        _router_message_override = turn_route.get("message_override")
+                        _api_effective_query = effective_query
+                        if _router_message_override is not None:
+                            if isinstance(effective_query, str):
+                                _api_effective_query = _router_message_override
+                            elif isinstance(effective_query, list):
+                                _api_effective_query = []
+                                _replaced_text = False
+                                for _part in effective_query:
+                                    if (
+                                        not _replaced_text
+                                        and isinstance(_part, dict)
+                                        and _part.get("type") == "text"
+                                    ):
+                                        _part = dict(_part)
+                                        _part["text"] = _router_message_override
+                                        _replaced_text = True
+                                    _api_effective_query.append(_part)
                         cli.agent.quiet_mode = True
                         cli.agent.suppress_status_output = True
                         # Suppress streaming display callbacks so stdout stays
@@ -15374,9 +15414,11 @@ def main(
                         cli.agent.stream_delta_callback = None
                         cli.agent.tool_gen_callback = None
                         try:
+                            _persist_query = effective_query if _router_message_override is not None else None
                             result = cli.agent.run_conversation(
-                                user_message=effective_query,
+                                user_message=_api_effective_query,
                                 conversation_history=cli.conversation_history,
+                                persist_user_message=_persist_query,
                             )
                         except KeyboardInterrupt:
                             _emit_interrupted_session_end(cli, reason="keyboard_interrupt")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3449,15 +3449,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         return model, runtime_kwargs
 
-    def _resolve_turn_agent_config(self, user_message: str, model: str, runtime_kwargs: dict) -> dict:
+    def _resolve_turn_agent_config(
+        self,
+        user_message: str,
+        model: str,
+        runtime_kwargs: dict,
+        *,
+        explicit_model_override: bool = False,
+    ) -> dict:
         """Build the effective model/runtime config for a single turn.
 
-        Always uses the session's primary model/provider.  If `/fast` is
-        enabled and the model supports Priority Processing / Anthropic fast
-        mode, attach `request_overrides` so the API call is marked
-        accordingly.
+        Uses the session's primary model/provider by default. When
+        ``agent.request_router.enabled`` is true and the provider is allowlisted,
+        enriches the turn with deterministic model/reasoning/service-tier
+        settings without changing prompt, tools, or transcript history.
         """
         from hermes_cli.models import resolve_fast_mode_overrides
+        from hermes_cli.turn_router import route_turn
 
         runtime = {
             "api_key": runtime_kwargs.get("api_key"),
@@ -3480,11 +3488,44 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 runtime["command"],
                 tuple(runtime["args"]),
             ),
+            "reasoning_config": getattr(self, "_reasoning_config", None),
+            "service_tier": getattr(self, "_service_tier", None),
+            "request_overrides": {},
+            "router_decision": None,
+            "message_override": None,
         }
+
+        cfg = _load_gateway_runtime_config()
+        agent_cfg = cfg_get(cfg, "agent", default={})
+        router_cfg = agent_cfg.get("request_router", {}) if isinstance(agent_cfg, dict) else {}
+        router_decision = route_turn(
+            user_message,
+            router_config=router_cfg,
+            current_model=model,
+            provider=runtime["provider"],
+            explicit_reasoning_config=getattr(self, "_reasoning_config", None),
+            explicit_service_tier=getattr(self, "_service_tier", None),
+            explicit_model_override=explicit_model_override,
+        )
+        route["router_decision"] = router_decision
+        if router_decision.enabled:
+            route["model"] = router_decision.model or route["model"]
+            route["reasoning_config"] = router_decision.reasoning_config
+            route["service_tier"] = router_decision.service_tier
+            route["request_overrides"] = router_decision.request_overrides
+            route["message_override"] = router_decision.message_override
+            route["signature"] = (
+                route["model"],
+                runtime["provider"],
+                runtime["base_url"],
+                runtime["api_mode"],
+                runtime["command"],
+                tuple(runtime["args"]),
+            )
+            return route
 
         service_tier = getattr(self, "_service_tier", None)
         if not service_tier:
-            route["request_overrides"] = {}
             return route
 
         try:
@@ -11504,11 +11545,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             reasoning_config = self._resolve_session_reasoning_config(source=source)
             self._reasoning_config = reasoning_config
             self._service_tier = self._load_service_tier()
-            turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
+            try:
+                _background_session_key = self._session_key_for_source(source)
+            except Exception:
+                _background_session_key = None
+            turn_route = self._resolve_turn_agent_config(
+                prompt,
+                model,
+                runtime_kwargs,
+                explicit_model_override=bool(
+                    _background_session_key and _background_session_key in self._session_model_overrides
+                ),
+            )
 
             # Enrich the prompt with image descriptions so the background
             # agent can see user-attached images (same as the main flow).
-            enriched_prompt = prompt
+            enriched_prompt = turn_route.get("message_override") or prompt
             if media_urls:
                 image_paths = []
                 for i, path in enumerate(media_urls):
@@ -11518,7 +11570,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if image_paths:
                     try:
                         enriched_prompt = await self._enrich_message_with_vision(
-                            prompt, image_paths,
+                            enriched_prompt, image_paths,
                         )
                     except Exception as e:
                         logger.warning("Background task vision enrichment failed: %s", e)
@@ -11532,8 +11584,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     verbose_logging=False,
                     enabled_toolsets=enabled_toolsets,
                     disabled_toolsets=disabled_toolsets,
-                    reasoning_config=reasoning_config,
-                    service_tier=self._service_tier,
+                    reasoning_config=turn_route.get("reasoning_config"),
+                    service_tier=turn_route.get("service_tier"),
                     request_overrides=turn_route.get("request_overrides"),
                     providers_allowed=pr.get("only"),
                     providers_ignored=pr.get("ignore"),
@@ -15719,7 +15771,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     log_message="interim_assistant_callback scheduling error",
                 )
 
-            turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs)
+            _router_original_message = message
+            turn_route = self._resolve_turn_agent_config(
+                message,
+                model,
+                runtime_kwargs,
+                explicit_model_override=bool(session_key and session_key in self._session_model_overrides),
+            )
 
             # Check agent cache — reuse the AIAgent from the previous message
             # in this session to preserve the frozen system prompt and tool
@@ -15803,8 +15861,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     disabled_toolsets=disabled_toolsets,
                     ephemeral_system_prompt=combined_ephemeral or None,
                     prefill_messages=self._prefill_messages or None,
-                    reasoning_config=reasoning_config,
-                    service_tier=self._service_tier,
+                    reasoning_config=turn_route.get("reasoning_config"),
+                    service_tier=turn_route.get("service_tier"),
                     request_overrides=turn_route.get("request_overrides"),
                     providers_allowed=pr.get("only"),
                     providers_ignored=pr.get("ignore"),
@@ -15875,8 +15933,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             agent.notice_callback = _notice_callback_sync
             agent.notice_clear_callback = None
             agent.event_callback = _event_callback_sync
-            agent.reasoning_config = reasoning_config
-            agent.service_tier = self._service_tier
+            agent.reasoning_config = turn_route.get("reasoning_config")
+            agent.service_tier = turn_route.get("service_tier")
             agent.request_overrides = turn_route.get("request_overrides") or {}
 
             _bg_review_release = threading.Event()
@@ -16266,12 +16324,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # attachment, wrap the user turn as an OpenAI-style multimodal
                 # content list. Consume-and-clear so subsequent turns on the same
                 # runner instance don't re-attach stale images.
+                _api_message_text = message
+                _router_override = turn_route.get("message_override")
+                if _router_override is not None:
+                    if message == _router_original_message:
+                        _api_message_text = _router_override
+                    elif isinstance(message, str) and isinstance(_router_original_message, str) and message.endswith(_router_original_message):
+                        _api_message_text = message[: -len(_router_original_message)] + _router_override
+                    else:
+                        _api_message_text = _router_override
                 _native_imgs = self._consume_pending_native_image_paths(session_key)
                 if _native_imgs:
                     try:
                         from agent.image_routing import build_native_content_parts
                         _parts, _skipped = build_native_content_parts(
-                            message,
+                            _api_message_text,
                             _native_imgs,
                         )
                         if _skipped:
@@ -16283,15 +16350,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             _run_message: Any = _parts
                         else:
                             # All images failed to read — fall back to plain text.
-                            _run_message = message
+                            _run_message = _api_message_text
                     except Exception as _img_exc:
                         logger.warning(
                             "Native image attachment failed, falling back to text: %s",
                             _img_exc,
                         )
-                        _run_message = message
+                        _run_message = _api_message_text
                 else:
-                    _run_message = message
+                    _run_message = _api_message_text
 
                 _api_run_message = _wrap_current_message_with_observed_context(
                     _run_message,
@@ -16303,6 +16370,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 }
                 if _persist_user_message_override is not None:
                     _conversation_kwargs["persist_user_message"] = _persist_user_message_override
+                elif turn_route.get("message_override") is not None:
+                    _conversation_kwargs["persist_user_message"] = message
                 elif observed_group_context:
                     _conversation_kwargs["persist_user_message"] = message
                 if _persist_user_timestamp_override is not None:

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -174,12 +174,14 @@ class CLIAgentSetupMixin:
     def _resolve_turn_agent_config(self, user_message: str) -> dict:
         """Build the effective model/runtime config for a single user turn.
 
-        Always uses the session's primary model/provider.  If the user has
-        toggled `/fast` on and the current model supports Priority
-        Processing / Anthropic fast mode, attach `request_overrides` so the
-        API call is marked accordingly.
+        Uses the session's primary model/provider by default. When
+        ``agent.request_router.enabled`` is true and the active provider is
+        allowlisted, enriches the turn with model/reasoning/service-tier
+        settings from the deterministic router. No system prompt, tool schema,
+        or conversation history is mutated.
         """
         from hermes_cli.models import resolve_fast_mode_overrides
+        from hermes_cli.turn_router import route_turn
 
         runtime = {
             "api_key": self.api_key,
@@ -201,11 +203,40 @@ class CLIAgentSetupMixin:
                 runtime["command"],
                 tuple(runtime["args"]),
             ),
+            "reasoning_config": getattr(self, "reasoning_config", None),
+            "service_tier": getattr(self, "service_tier", None),
+            "request_overrides": None,
+            "router_decision": None,
+            "message_override": None,
         }
+
+        router_decision = route_turn(
+            user_message,
+            router_config=getattr(self, "request_router_config", {}) or {},
+            current_model=self.model,
+            provider=runtime["provider"],
+            explicit_reasoning_config=getattr(self, "reasoning_config", None),
+            explicit_service_tier=getattr(self, "service_tier", None),
+        )
+        route["router_decision"] = router_decision
+        if router_decision.enabled:
+            route["model"] = router_decision.model or route["model"]
+            route["reasoning_config"] = router_decision.reasoning_config
+            route["service_tier"] = router_decision.service_tier
+            route["request_overrides"] = router_decision.request_overrides
+            route["message_override"] = router_decision.message_override
+            route["signature"] = (
+                route["model"],
+                runtime["provider"],
+                runtime["base_url"],
+                runtime["api_mode"],
+                runtime["command"],
+                tuple(runtime["args"]),
+            )
+            return route
 
         service_tier = getattr(self, "service_tier", None)
         if not service_tier:
-            route["request_overrides"] = None
             return route
 
         try:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -928,6 +928,40 @@ DEFAULT_CONFIG = {
         # provider hiccups on a single provider.
         "api_max_retries": 3,
         "service_tier": "",
+        "request_router": {
+            "enabled": False,
+            "providers_allowlist": ["openai-codex"],
+            "default_preset": "high_standard",
+            "allow_auto_priority": False,
+            "log_decisions": False,
+            "presets": {
+                "low_standard": {
+                    "model": "gpt-5.5",
+                    "effort": "low",
+                    "service_tier": "standard",
+                },
+                "high_standard": {
+                    "model": "gpt-5.5",
+                    "effort": "high",
+                    "service_tier": "standard",
+                },
+                "xhigh_standard": {
+                    "model": "gpt-5.5",
+                    "effort": "xhigh",
+                    "service_tier": "standard",
+                },
+                "xhigh_fast": {
+                    "model": "gpt-5.4",
+                    "effort": "xhigh",
+                    "service_tier": "standard",
+                },
+                "high_priority": {
+                    "model": "gpt-5.5",
+                    "effort": "high",
+                    "service_tier": "priority",
+                },
+            },
+        },
         # Tool-use enforcement: injects system prompt guidance that tells the
         # model to actually call tools instead of describing intended actions.
         # Values: "auto" (default — applies to gpt/codex models), true/false

--- a/hermes_cli/turn_router.py
+++ b/hermes_cli/turn_router.py
@@ -1,0 +1,200 @@
+"""Deterministic per-turn request routing for Codex providers.
+
+The router is intentionally local and cheap: no LLM call, no prompt mutation,
+and no tool/schema/system-prompt changes. It returns request-time knobs that
+callers apply to the current turn only.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from hermes_constants import parse_reasoning_effort
+
+
+@dataclass(frozen=True)
+class RouterPreset:
+    """Concrete request settings for one routing preset."""
+
+    name: str
+    model: str
+    effort: str
+    service_tier: str = "standard"
+
+
+@dataclass(frozen=True)
+class RouterDecision:
+    """Result of routing a single user turn."""
+
+    enabled: bool
+    source: str
+    preset: str | None
+    model: str | None
+    reasoning_config: dict[str, Any] | None
+    service_tier: str | None
+    request_overrides: dict[str, Any]
+    message_override: str | None = None
+    reason: str = ""
+
+
+DEFAULT_PRESETS: dict[str, RouterPreset] = {
+    "low_standard": RouterPreset("low_standard", "gpt-5.5", "low", "standard"),
+    "high_standard": RouterPreset("high_standard", "gpt-5.5", "high", "standard"),
+    "xhigh_standard": RouterPreset("xhigh_standard", "gpt-5.5", "xhigh", "standard"),
+    "xhigh_fast": RouterPreset("xhigh_fast", "gpt-5.4", "xhigh", "standard"),
+    "high_priority": RouterPreset("high_priority", "gpt-5.5", "high", "priority"),
+}
+
+_PREFIX_PRESETS: dict[str, str] = {
+    "!low": "low_standard",
+    "!cheap": "low_standard",
+    "!standard": "high_standard",
+    "!deep": "xhigh_standard",
+    "!xhigh": "xhigh_standard",
+    "!fast": "xhigh_fast",
+    "!priority": "high_priority",
+}
+
+_LOW_RE = re.compile(r"\b(grammar|gramática|translate|tradu(?:z|ção)|format(?:ting)?|resum[eo]|summari[sz]e|typo|ortografia)\b", re.I)
+_FAST_RE = re.compile(r"\b(quick|rápido|rapido|barato|cheap|fast|low latency|baixo custo)\b", re.I)
+_XHIGH_RE = re.compile(r"\b(architecture|arquitetura|migration|migração|migracao|refactor|multi[- ]?file|múltiplos arquivos|multiplos arquivos|cached agent|gateway parity|prompt cache|race condition|root cause|obscur[eo]|complex[oa])\b", re.I)
+_HIGH_RE = re.compile(r"\b(debug|bug|fix|corrig|sql|join|python|test|integration|integração|dataverse|gateway|cli|api)\b", re.I)
+_EMERGENCY_RE = re.compile(r"\b(emergency|urgente|produção|producao|prod|incident|incidente|sev[ -]?1|hotfix)\b", re.I)
+_SLASH_RE = re.compile(r"^\s*/")
+
+
+def _as_bool(value: Any, *, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    if isinstance(value, (int, float)):
+        return bool(value)
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "on", "enable", "enabled"}:
+        return True
+    if text in {"0", "false", "no", "off", "disable", "disabled"}:
+        return False
+    return default
+
+
+def _str_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [p.strip() for p in value.split(",") if p.strip()]
+    if isinstance(value, (list, tuple, set)):
+        return [str(p).strip() for p in value if str(p).strip()]
+    return []
+
+
+def _load_presets(router_cfg: Mapping[str, Any]) -> dict[str, RouterPreset]:
+    presets = dict(DEFAULT_PRESETS)
+    raw_presets = router_cfg.get("presets") if isinstance(router_cfg, Mapping) else None
+    if not isinstance(raw_presets, Mapping):
+        return presets
+    for name, raw in raw_presets.items():
+        if not isinstance(raw, Mapping):
+            continue
+        key = str(name).strip()
+        model = str(raw.get("model") or "").strip()
+        effort = str(raw.get("effort") or raw.get("reasoning_effort") or "").strip().lower()
+        service_tier = str(raw.get("service_tier") or "standard").strip().lower()
+        if not key or not model or parse_reasoning_effort(effort) is None:
+            continue
+        if service_tier not in {"standard", "priority"}:
+            service_tier = "standard"
+        presets[key] = RouterPreset(key, model, effort, service_tier)
+    return presets
+
+
+def _provider_allowed(provider: str | None, allowlist: list[str]) -> bool:
+    # V1 is Codex-only. Missing/empty allowlist fails closed to the default
+    # Codex provider instead of becoming a wildcard for every provider.
+    effective_allowlist = allowlist or ["openai-codex"]
+    provider_text = (provider or "").strip().lower()
+    return any(item.lower() == provider_text for item in effective_allowlist)
+
+
+def _request_overrides_for_service_tier(service_tier: str | None) -> dict[str, Any]:
+    if service_tier == "priority":
+        return {"service_tier": "priority"}
+    return {}
+
+
+def _choose_preset(message: str, router_cfg: Mapping[str, Any]) -> tuple[str, str, str | None]:
+    stripped = message.lstrip()
+    first = stripped.split(maxsplit=1)[0].lower() if stripped else ""
+    if first in _PREFIX_PRESETS:
+        remaining = stripped[len(first):].lstrip()
+        return _PREFIX_PRESETS[first], "prefix", remaining
+
+    if _EMERGENCY_RE.search(message):
+        if _as_bool(router_cfg.get("allow_auto_priority"), default=False):
+            return "high_priority", "auto", None
+        return "xhigh_standard", "auto", None
+    if _FAST_RE.search(message):
+        return "xhigh_fast", "auto", None
+    if _XHIGH_RE.search(message):
+        return "xhigh_standard", "auto", None
+    if _LOW_RE.search(message):
+        return "low_standard", "auto", None
+    if _HIGH_RE.search(message):
+        return "high_standard", "auto", None
+    return str(router_cfg.get("default_preset") or "high_standard"), "default", None
+
+
+def route_turn(
+    user_message: Any,
+    *,
+    router_config: Mapping[str, Any] | None,
+    current_model: str,
+    provider: str | None,
+    explicit_reasoning_config: Mapping[str, Any] | None = None,
+    explicit_service_tier: str | None = None,
+    explicit_request_overrides: Mapping[str, Any] | None = None,
+    explicit_model_override: bool = False,
+) -> RouterDecision:
+    """Return per-turn routing knobs for ``user_message``.
+
+    Explicit reasoning/service/request overrides win. Slash commands and non-text
+    messages are no-ops. Disabled or non-allowlisted providers are also no-ops.
+    """
+
+    cfg: Mapping[str, Any] = router_config or {}
+    if not _as_bool(cfg.get("enabled"), default=False):
+        return RouterDecision(False, "disabled", None, None, None, None, {}, reason="router disabled")
+    if not isinstance(user_message, str) or not user_message.strip():
+        return RouterDecision(False, "no-op", None, None, None, None, {}, reason="non-text or empty message")
+    if _SLASH_RE.match(user_message):
+        return RouterDecision(False, "no-op", None, None, None, None, {}, reason="slash command")
+    if explicit_model_override or explicit_reasoning_config or explicit_service_tier or explicit_request_overrides:
+        return RouterDecision(False, "explicit", None, None, None, None, {}, reason="explicit override present")
+
+    allowlist = _str_list(cfg.get("providers_allowlist") or cfg.get("provider_allowlist"))
+    if not _provider_allowed(provider, allowlist):
+        return RouterDecision(False, "no-op", None, None, None, None, {}, reason="provider not allowlisted")
+
+    presets = _load_presets(cfg)
+    preset_name, source, message_override = _choose_preset(user_message, cfg)
+    preset = presets.get(preset_name) or presets["high_standard"]
+    if preset.service_tier == "priority" and not _as_bool(cfg.get("allow_auto_priority"), default=False) and source != "prefix":
+        preset = presets["xhigh_standard"]
+        preset_name = preset.name
+    reasoning_config = parse_reasoning_effort(preset.effort)
+    request_overrides = _request_overrides_for_service_tier(preset.service_tier)
+    service_tier = "priority" if preset.service_tier == "priority" else None
+    reason = f"{source}:{preset_name}"
+    return RouterDecision(
+        True,
+        source,
+        preset.name,
+        preset.model or current_model,
+        reasoning_config,
+        service_tier,
+        request_overrides,
+        message_override=message_override,
+        reason=reason,
+    )

--- a/tests/hermes_cli/test_turn_router.py
+++ b/tests/hermes_cli/test_turn_router.py
@@ -1,0 +1,166 @@
+from hermes_cli.turn_router import route_turn
+
+
+def _cfg(**overrides):
+    base = {
+        "enabled": True,
+        "providers_allowlist": ["openai-codex"],
+        "default_preset": "high_standard",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_router_disabled_is_noop():
+    decision = route_turn("debug this sql", router_config={"enabled": False}, current_model="gpt-5.5", provider="openai-codex")
+    assert not decision.enabled
+    assert decision.reasoning_config is None
+    assert decision.request_overrides == {}
+
+
+def test_provider_not_allowlisted_is_noop():
+    decision = route_turn("debug this sql", router_config=_cfg(), current_model="claude-sonnet-4", provider="anthropic")
+    assert not decision.enabled
+    assert decision.reason == "provider not allowlisted"
+
+
+def test_explicit_overrides_win():
+    decision = route_turn(
+        "please do a deep refactor",
+        router_config=_cfg(),
+        current_model="gpt-5.5",
+        provider="openai-codex",
+        explicit_reasoning_config={"enabled": True, "effort": "low"},
+    )
+    assert not decision.enabled
+    assert decision.source == "explicit"
+
+
+def test_grammar_routes_low_standard():
+    decision = route_turn("corrige a gramática deste texto", router_config=_cfg(), current_model="gpt-5.5", provider="openai-codex")
+    assert decision.enabled
+    assert decision.preset == "low_standard"
+    assert decision.reasoning_config == {"enabled": True, "effort": "low"}
+    assert decision.request_overrides == {}
+
+
+def test_sql_debug_routes_high_standard():
+    decision = route_turn("debug this SQL join and filter", router_config=_cfg(), current_model="gpt-5.5", provider="openai-codex")
+    assert decision.preset == "high_standard"
+    assert decision.reasoning_config == {"enabled": True, "effort": "high"}
+
+
+def test_architecture_routes_xhigh_standard():
+    decision = route_turn("analyze the architecture and cached agent gateway parity risk", router_config=_cfg(), current_model="gpt-5.5", provider="openai-codex")
+    assert decision.preset == "xhigh_standard"
+    assert decision.reasoning_config == {"enabled": True, "effort": "xhigh"}
+
+
+def test_quick_routes_xhigh_fast():
+    decision = route_turn("quick fix, preciso rápido e barato", router_config=_cfg(), current_model="gpt-5.5", provider="openai-codex")
+    assert decision.preset == "xhigh_fast"
+    assert decision.model == "gpt-5.4"
+
+
+def test_emergency_priority_requires_config_gate():
+    decision = route_turn("emergency production incident", router_config=_cfg(), current_model="gpt-5.5", provider="openai-codex")
+    assert decision.preset == "xhigh_standard"
+    assert decision.service_tier is None
+    priority = route_turn("emergency production incident", router_config=_cfg(allow_auto_priority=True), current_model="gpt-5.5", provider="openai-codex")
+    assert priority.preset == "high_priority"
+    assert priority.service_tier == "priority"
+    assert priority.request_overrides == {"service_tier": "priority"}
+
+
+def test_prefix_routes_and_strips_api_message():
+    decision = route_turn("!deep investigate this migration", router_config=_cfg(), current_model="gpt-5.5", provider="openai-codex")
+    assert decision.source == "prefix"
+    assert decision.preset == "xhigh_standard"
+    assert decision.message_override == "investigate this migration"
+
+
+def test_slash_commands_bypass_router():
+    decision = route_turn("/model gpt-5.5", router_config=_cfg(), current_model="gpt-5.5", provider="openai-codex")
+    assert not decision.enabled
+    assert decision.reason == "slash command"
+
+
+def test_cli_mixin_resolve_turn_route_enriches_codex_turn():
+    from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
+
+    class Dummy(CLIAgentSetupMixin):
+        pass
+
+    dummy = Dummy()
+    dummy.api_key = "key"
+    dummy.base_url = "https://example.invalid"
+    dummy.provider = "openai-codex"
+    dummy.api_mode = "responses"
+    dummy.acp_command = None
+    dummy.acp_args = []
+    dummy.model = "gpt-5.5"
+    dummy.reasoning_config = None
+    dummy.service_tier = None
+    dummy.request_router_config = _cfg()
+    route = dummy._resolve_turn_agent_config("quick fix, preciso rápido e barato")
+    assert route["model"] == "gpt-5.4"
+    assert route["signature"][0] == "gpt-5.4"
+    assert route["reasoning_config"] == {"enabled": True, "effort": "xhigh"}
+    assert route["router_decision"].preset == "xhigh_fast"
+
+
+def test_cli_mixin_resolve_turn_route_honors_explicit_reasoning_override():
+    from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
+
+    class Dummy(CLIAgentSetupMixin):
+        pass
+
+    dummy = Dummy()
+    dummy.api_key = "key"
+    dummy.base_url = "https://example.invalid"
+    dummy.provider = "openai-codex"
+    dummy.api_mode = "responses"
+    dummy.acp_command = None
+    dummy.acp_args = []
+    dummy.model = "gpt-5.5"
+    dummy.reasoning_config = {"enabled": True, "effort": "low"}
+    dummy.service_tier = None
+    dummy.request_router_config = _cfg()
+    route = dummy._resolve_turn_agent_config("please deeply refactor this architecture")
+    assert route["model"] == "gpt-5.5"
+    assert route["reasoning_config"] == {"enabled": True, "effort": "low"}
+    assert not route["router_decision"].enabled
+    assert route["router_decision"].source == "explicit"
+
+
+
+def test_empty_allowlist_still_codex_only():
+    allowed = route_turn(
+        "debug this SQL",
+        router_config={"enabled": True, "providers_allowlist": []},
+        current_model="gpt-5.5",
+        provider="openai-codex",
+    )
+    blocked = route_turn(
+        "debug this SQL",
+        router_config={"enabled": True, "providers_allowlist": []},
+        current_model="claude-sonnet-4",
+        provider="anthropic",
+    )
+
+    assert allowed.enabled
+    assert not blocked.enabled
+    assert blocked.reason == "provider not allowlisted"
+
+
+def test_explicit_model_override_wins():
+    decision = route_turn(
+        "quick fix, preciso rápido e barato",
+        router_config=_cfg(),
+        current_model="gpt-5.5",
+        provider="openai-codex",
+        explicit_model_override=True,
+    )
+
+    assert not decision.enabled
+    assert decision.source == "explicit"


### PR DESCRIPTION
## Summary
- add deterministic, local Codex-only turn router in `hermes_cli/turn_router.py`
- integrate routing in CLI and gateway flows (interactive, single-query, and background)
- apply per-turn knobs only for the current turn: `model`, `reasoning_config`, `service_tier`, and `request_overrides`
- preserve explicit `/model` and session overrides when present
- keep behavior unchanged when router is disabled or provider is not allowlisted

## Validation
- `python -m py_compile`
- `git diff --check`
- `scripts/run_validation.sh focused`
- `pytest tests/hermes_cli/test_turn_router.py tests/cli/test_fast_command.py tests/gateway/test_fast_command.py`
