### PR TITLE
fix(gateway): add missing /compress case to command.dispatch in TUI

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10422,6 +10422,14 @@ def _(rid, params: dict) -> dict:
                 },
             )
 
+    if name == "compress":
+        if not session:
+            return _err(rid, 4001, "no active session to compress")
+        warning = _mirror_slash_side_effects(
+            params.get("session_id", ""), session, f"/{name} {arg}".strip()
+        )
+        return _ok(rid, {"type": "exec", "output": warning or "✓ Compression complete."})
+
     return _err(rid, 4018, f"not a quick/plugin/skill command: {name}")
 
 


### PR DESCRIPTION
## Summary

The /compress slash command was unavailable in the TUI because command.dispatch lacked a compress case.

## Fix

Added compress case routing to _mirror_slash_side_effects.

## Verification

Syntax check passed. 9 related tests pass.