### PR TITLE
fix(gateway): make /model status a read-only status path

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1184,6 +1184,23 @@ class GatewaySlashCommandsMixin:
             current_base_url = override.get("base_url", current_base_url)
             current_api_key = override.get("api_key", current_api_key)
 
+        # Intercept reserved status/info subcommands before switch_model() so
+        # `/model status` doesn't persist a literal model named "status" (#28489).
+        model_status_aliases = {"status", "info", "current", "show"}
+        if model_input.lower() in model_status_aliases and not explicit_provider:
+            provider_label = get_label(current_provider)
+            return "\n".join([
+                t(
+                    "gateway.model.current_label",
+                    model=current_model or "unknown",
+                    provider=provider_label,
+                ),
+                "",
+                t("gateway.model.usage_switch_model"),
+                t("gateway.model.usage_switch_provider"),
+                t("gateway.model.usage_persist"),
+            ])
+
         # No args: show interactive picker (Telegram/Discord) or text list
         if not model_input and not explicit_provider:
             # Try interactive picker if the platform supports it

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4962,6 +4962,12 @@ class DiscordAdapter(BasePlatformAdapter):
             except Exception:
                 provider_label = current_provider
 
+            content = (
+                "⚙ **Model Configuration**\n"
+                f"Current model: `{current_model or 'unknown'}`\n"
+                f"Provider: {provider_label}\n\n"
+                "Select a provider:"
+            )
             embed = discord.Embed(
                 title="⚙ Model Configuration",
                 description=(
@@ -4982,7 +4988,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 allowed_role_ids=self._allowed_role_ids,
             )
 
-            msg = await channel.send(embed=embed, view=view)
+            msg = await channel.send(content=content, embed=embed, view=view)
             view._message = msg  # store for on_timeout expiration editing
             return SendResult(success=True, message_id=str(msg.id))
 

--- a/tests/gateway/test_discord_model_picker_content.py
+++ b/tests/gateway/test_discord_model_picker_content.py
@@ -1,0 +1,57 @@
+"""Regression tests for visible Discord /model picker current-state content."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+
+def _capture_channel(adapter):
+    sent = {}
+
+    async def fake_send(**kwargs):
+        sent.update(kwargs)
+        return SimpleNamespace(id=1234)
+
+    channel = SimpleNamespace(send=AsyncMock(side_effect=fake_send))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+    return sent
+
+
+@pytest.mark.asyncio
+async def test_model_picker_sends_current_model_in_plain_content():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    sent = _capture_channel(adapter)
+
+    result = await adapter.send_model_picker(
+        chat_id="555",
+        providers=[
+            {
+                "slug": "openrouter",
+                "name": "OpenRouter",
+                "models": ["openai/gpt-5.5"],
+                "total_models": 1,
+                "is_current": True,
+            }
+        ],
+        current_model="openai/gpt-5.5",
+        current_provider="openrouter",
+        session_key="discord:555",
+        on_model_selected=AsyncMock(return_value="switched"),
+    )
+
+    assert result.success is True
+    assert sent["view"] is not None
+    assert sent["embed"] is not None
+
+    content = sent["content"]
+    assert "Model Configuration" in content
+    assert "Current model: `openai/gpt-5.5`" in content
+    assert "Provider: OpenRouter" in content
+    assert "Select a provider" in content

--- a/tests/gateway/test_model_status_subcommand.py
+++ b/tests/gateway/test_model_status_subcommand.py
@@ -1,0 +1,104 @@
+"""Regression tests: /model status/info should not switch to literal models.
+
+Adapted from closed PR #28498 after the gateway model handler moved from
+``gateway/run.py`` into ``gateway/slash_commands.py``.
+"""
+
+import yaml
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+def _make_runner():
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner._session_model_overrides = {}
+    runner._running_agents = {}
+    return runner
+
+
+def _make_event(text="/model status"):
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm"),
+    )
+
+
+@pytest.fixture
+def _isolated_home(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "model": {
+                    "default": "gemini-3.1-pro-preview",
+                    "provider": "custom",
+                    "base_url": "http://127.0.0.1:8317/v1",
+                },
+                "providers": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    return hermes_home
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("subcommand", ["status", "info", "current", "show"])
+async def test_model_status_alias_shows_info_instead_of_switching(
+    _isolated_home,
+    monkeypatch,
+    subcommand,
+):
+    """Info aliases should display the current model, not call switch_model()."""
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model",
+        lambda **_kwargs: pytest.fail(f"/model {subcommand} must not call switch_model"),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.list_picker_providers",
+        lambda **_kwargs: pytest.fail(f"/model {subcommand} must not open the picker"),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.list_authenticated_providers",
+        lambda **_kwargs: pytest.fail(f"/model {subcommand} must not list provider catalogs"),
+    )
+
+    runner = _make_runner()
+    result = await runner._handle_model_command(_make_event(f"/model {subcommand}"))
+
+    session_key = runner._session_key_for_source(
+        SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm")
+    )
+    override = runner._session_model_overrides.get(session_key, {})
+    assert override.get("model") != subcommand
+    assert result is not None
+    assert "Current: `gemini-3.1-pro-preview` on custom" in result
+    assert "`/model <name>`" in result
+
+
+@pytest.mark.asyncio
+async def test_model_status_uses_session_override(_isolated_home):
+    runner = _make_runner()
+    session_key = runner._session_key_for_source(_make_event("/model status").source)
+    runner._session_model_overrides[session_key] = {
+        "model": "anthropic/claude-sonnet-4",
+        "provider": "anthropic",
+    }
+
+    result = await runner._handle_model_command(_make_event("/model status"))
+
+    assert result is not None
+    assert "Current: `anthropic/claude-sonnet-4` on anthropic" in result


### PR DESCRIPTION
## Summary
- salvage closed PR #28498 by preserving the original author commit and adapting it to the current `gateway/slash_commands.py` handler location
- treat `/model status`, `/model info`, `/model current`, and `/model show` as read-only current-model queries instead of switching to literal model names
- include the current model/provider in plain Discord message content when opening the interactive `/model` picker, while preserving the existing embed and select view

## Related
- Fixes #28489
- Supersedes/adapts #28498 after the gateway model handler moved
- Related to #40730 and #47592, but this PR does not change picker catalog retention; it only adds the read-only status path plus visible Discord picker state

## Tests
- `python -m pytest tests/gateway/test_model_status_subcommand.py tests/gateway/test_discord_model_picker_content.py -q -o 'addopts='`
- `python -m pytest tests/gateway/test_model_status_subcommand.py tests/gateway/test_discord_model_picker_content.py tests/gateway/test_model_command_flat_string_config.py tests/gateway/test_model_command_async_offload.py tests/gateway/test_model_command_expensive_confirm.py tests/gateway/test_model_command_custom_providers.py tests/gateway/test_model_picker_persist.py tests/gateway/test_discord_model_picker.py -q -o 'addopts='`
