### PR TITLE
Panel width fixed (HD) + Overlay size fix (also HD)

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -1127,13 +1127,24 @@ export function DesktopController() {
   const sidebarSide = panesFlipped ? 'right' : 'left'
   const railSide = panesFlipped ? 'left' : 'right'
 
+  // The system titlebar cluster (haptics/keybinds/settings/right-sidebar) is
+  // pinned over the window's right edge, past the OS window-control overlay.
+  // A pane on the right must stay at least this wide or its leftmost icon (the
+  // haptics "speaker") spills past the pane onto the main area. Expressed in CSS
+  // so it tracks the live OS overlay width (--titlebar-tools-right) and zoom
+  // (--titlebar-control-size); resolved to px by PaneShell for drag clamping.
+  const rightEdgeToolsMin =
+    'calc(var(--titlebar-tools-right, 0.75rem) + 4 * (var(--titlebar-control-size, 1.25rem) + 0.25rem))'
+  const minWidthForSide = (side: 'left' | 'right', declared: string) =>
+    side === 'right' ? `max(${declared}, ${rightEdgeToolsMin})` : declared
+
   const previewPane = (
     <Pane
       disabled={!chatOpen || (!previewTarget && !filePreviewTarget)}
       id={PREVIEW_PANE_ID}
       key="preview"
       maxWidth={PREVIEW_RAIL_MAX_WIDTH}
-      minWidth={PREVIEW_RAIL_MIN_WIDTH}
+      minWidth={minWidthForSide(railSide, PREVIEW_RAIL_MIN_WIDTH)}
       resizable
       side={railSide}
       width={PREVIEW_RAIL_PANE_WIDTH}
@@ -1153,7 +1164,7 @@ export function DesktopController() {
       id="file-browser"
       key="file-browser"
       maxWidth={FILE_BROWSER_MAX_WIDTH}
-      minWidth={FILE_BROWSER_MIN_WIDTH}
+      minWidth={minWidthForSide(railSide, FILE_BROWSER_MIN_WIDTH)}
       resizable
       side={railSide}
       width={FILE_BROWSER_DEFAULT_WIDTH}
@@ -1174,7 +1185,7 @@ export function DesktopController() {
       id="terminal-sidebar"
       key="terminal-sidebar"
       maxWidth="80vw"
-      minWidth="22vw"
+      minWidth={minWidthForSide(railSide, '22vw')}
       resizable
       side={railSide}
       width="42vw"
@@ -1203,7 +1214,7 @@ export function DesktopController() {
           hoverReveal
           id="chat-sidebar"
           maxWidth={SIDEBAR_MAX_WIDTH}
-          minWidth={SIDEBAR_DEFAULT_WIDTH}
+          minWidth={minWidthForSide(sidebarSide, `${SIDEBAR_DEFAULT_WIDTH}px`)}
           onOverlayActiveChange={setSidebarOverlayMounted}
           resizable
           side={sidebarSide}

--- a/apps/desktop/src/app/overlays/overlay-view.tsx
+++ b/apps/desktop/src/app/overlays/overlay-view.tsx
@@ -49,7 +49,7 @@ export function OverlayView({
 
   return (
     <div
-      className="fixed inset-0 z-50 bg-black/22 p-3 backdrop-blur-[0.125rem] sm:p-6"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/22 p-3 backdrop-blur-[0.125rem] sm:p-6"
       onClick={event => {
         if (event.target === event.currentTarget) {
           closeOverlay()
@@ -59,7 +59,7 @@ export function OverlayView({
     >
       <div
         className={cn(
-          'relative flex h-full min-h-0 flex-col overflow-hidden rounded-xl border border-(--ui-stroke-secondary) bg-(--ui-chat-surface-background) shadow-md',
+          'relative flex h-[90%] max-h-full w-[90%] max-w-full min-h-0 flex-col overflow-hidden rounded-xl border border-(--ui-stroke-secondary) bg-(--ui-chat-surface-background) shadow-md',
           rootClassName
         )}
       >

--- a/apps/desktop/src/components/pane-shell/pane-shell.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.tsx
@@ -64,6 +64,7 @@ interface CollectedPane {
   disabled: boolean
   forceCollapsed: boolean
   id: string
+  minWidth?: string
   resizable: boolean
   side: PaneSide
   width: string
@@ -94,6 +95,9 @@ export const PANE_TOGGLE_REVEAL_EVENT = 'hermes:pane-toggle-reveal'
 const widthToCss = (value: WidthValue | undefined, fallback: string) =>
   value === undefined ? fallback : typeof value === 'number' ? `${value}px` : value
 
+const lengthToCss = (value: WidthValue | undefined) =>
+  value === undefined ? undefined : typeof value === 'number' ? `${value}px` : value
+
 const remPx = () =>
   typeof window === 'undefined'
     ? 16
@@ -103,31 +107,48 @@ const viewportPx = () => (typeof window === 'undefined' ? 1280 : window.innerWid
 
 // Resolves PaneProps.minWidth/maxWidth (number | "Npx" | "Nrem" | "Nvw" | "N%") to
 // pixels for drag clamping. Viewport units resolve against the current window width.
-function widthToPx(value: WidthValue | undefined) {
+// Anything more complex (calc()/min()/max()/var()) is resolved by measuring a probe
+// element inside `contextEl`'s cascade, so CSS variables resolve at the pane's scope.
+function widthToPx(value: WidthValue | undefined, contextEl?: HTMLElement | null) {
   if (typeof value === 'number') {
     return Number.isFinite(value) ? value : undefined
   }
 
-  const match = value?.trim().match(/^(-?\d*\.?\d+)(px|rem|vw|%)?$/)
-
-  if (!match) {
+  if (value === undefined) {
     return undefined
   }
 
-  const n = Number.parseFloat(match[1])
+  const match = value.trim().match(/^(-?\d*\.?\d+)(px|rem|vw|%)?$/)
 
-  switch (match[2]) {
-    case 'rem':
-      return n * remPx()
+  if (match) {
+    const n = Number.parseFloat(match[1])
 
-    case 'vw':
+    switch (match[2]) {
+      case 'rem':
+        return n * remPx()
 
-    case '%':
-      return (n * viewportPx()) / 100
+      case 'vw':
 
-    default:
-      return n
+      case '%':
+        return (n * viewportPx()) / 100
+
+      default:
+        return n
+    }
   }
+
+  if (typeof document === 'undefined' || !contextEl) {
+    return undefined
+  }
+
+  const probe = document.createElement('div')
+  probe.style.cssText = 'position:absolute;visibility:hidden;height:0;pointer-events:none'
+  probe.style.width = value
+  contextEl.appendChild(probe)
+  const px = probe.getBoundingClientRect().width
+  probe.remove()
+
+  return Number.isFinite(px) && px > 0 ? px : undefined
 }
 
 function isRole(child: unknown, role: 'pane' | 'main'): child is ReactElement {
@@ -157,6 +178,7 @@ function collectPanes(children: ReactNode) {
       disabled: props.disabled ?? false,
       forceCollapsed: props.forceCollapsed ?? false,
       id: props.id,
+      minWidth: lengthToCss(props.minWidth),
       resizable: props.resizable ?? false,
       side: props.side,
       width: widthToCss(props.width, DEFAULT_WIDTH)
@@ -177,8 +199,12 @@ function trackForPane(pane: CollectedPane, states: Record<string, { open: boolea
   }
 
   const override = pane.resizable ? states[pane.id]?.widthOverride : undefined
+  const base = override !== undefined ? `${override}px` : pane.width
 
-  return { open: true, track: override !== undefined ? `${override}px` : pane.width }
+  // Never render narrower than the declared minimum — the stored override or
+  // default width can both fall below it (e.g. a min that grows to clear the
+  // floating titlebar tool cluster). CSS resolves the max() at the pane's scope.
+  return { open: true, track: pane.minWidth ? `max(${base}, ${pane.minWidth})` : base }
 }
 
 export function PaneShell({ children, className, style }: PaneShellProps) {
@@ -300,8 +326,6 @@ export function Pane({
   }, [onOverlayActiveChange, overlayActive])
 
   const canResize = open && resizable
-  const lo = widthToPx(minWidth) ?? DEFAULT_RESIZE_MIN_WIDTH
-  const hi = widthToPx(maxWidth) ?? Number.POSITIVE_INFINITY
 
   const startResize = useCallback(
     (event: ReactPointerEvent<HTMLDivElement>) => {
@@ -312,6 +336,9 @@ export function Pane({
       }
 
       event.preventDefault()
+
+      const lo = widthToPx(minWidth, paneRef.current) ?? DEFAULT_RESIZE_MIN_WIDTH
+      const hi = widthToPx(maxWidth, paneRef.current) ?? Number.POSITIVE_INFINITY
 
       const handle = event.currentTarget
       const { pointerId, clientX: startX } = event
@@ -343,7 +370,7 @@ export function Pane({
       window.addEventListener('pointercancel', cleanup, true)
       window.addEventListener('blur', cleanup)
     },
-    [canResize, hi, id, lo, side]
+    [canResize, id, maxWidth, minWidth, side]
   )
 
   if (!ctx) {


### PR DESCRIPTION
## What does this PR do?

It improves overlay window size and sidebar minimum width (so it doesn't collide with buttons).



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<img width="245" height="521" alt="image" src="https://github.com/user-attachments/assets/71ee699a-bfe4-4ea0-be27-cf99dfdd8468" />

<img width="263" height="588" alt="image" src="https://github.com/user-attachments/assets/999b2b59-1c5c-41d0-aeaa-5eaa8646d3fe" />

<img width="1919" height="1031" alt="image" src="https://github.com/user-attachments/assets/abea1d9d-dcc8-49a1-9e21-4a599b14884f" />


<img width="1919" height="1032" alt="image" src="https://github.com/user-attachments/assets/fc81f52a-8b3f-4eae-a689-ee883cbbe102" />

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1.  Open the sidebar, try to move the width.
2.  Open settings, the size is correct.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs
<img width="1919" height="1032" alt="image" src="https://github.com/user-attachments/assets/fc81f52a-8b3f-4eae-a689-ee883cbbe102" />

<img width="263" height="588" alt="image" src="https://github.com/user-attachments/assets/999b2b59-1c5c-41d0-aeaa-5eaa8646d3fe" />


<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

