### PR TITLE
fix(gateway): clamp stale ordinal in checkpoint restore instead of erroring (#52514)

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8152,3 +8152,157 @@ def test_persist_model_switch_clears_stale_base_url(tmp_path, monkeypatch):
     assert saved["model"]["provider"] == "anthropic"
     # Stale custom base_url must be cleared (null coalesces to absent on read).
     assert not saved["model"].get("base_url"), saved["model"].get("base_url")
+
+
+def test_prompt_submit_clamps_stale_ordinal_after_compression(monkeypatch):
+    """When context compression shrinks history, a stale ordinal should clamp
+    to the last user message instead of erroring (issue #52514)."""
+
+    seen = {}
+
+    class _Agent:
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None
+        ):
+            seen["prompt"] = prompt
+            seen["history"] = conversation_history
+            return {
+                "final_response": "restored",
+                "messages": [
+                    *(conversation_history or []),
+                    {"role": "user", "content": prompt},
+                    {"role": "assistant", "content": "restored"},
+                ],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    # Simulate post-compression history: summary + one user/assistant pair.
+    # The frontend computed ordinal=3 (from a longer pre-compression list).
+    compressed_history = [
+        {"role": "assistant", "content": "summary of earlier conversation"},
+        {"role": "user", "content": "recent question"},
+        {"role": "assistant", "content": "recent answer"},
+    ]
+    server._sessions["sid"] = _session(agent=_Agent(), history=compressed_history)
+
+    class _StubDb:
+        def __init__(self):
+            self.replaced = []
+
+        def replace_messages(self, session_id, messages):
+            self.replaced.append((session_id, list(messages)))
+
+    stub_db = _StubDb()
+
+    try:
+        monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+        monkeypatch.setattr(server, "_get_usage", lambda _a: {})
+        monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
+        monkeypatch.setattr(server, "_emit", lambda *a: None)
+        monkeypatch.setattr(server, "_get_db", lambda: stub_db)
+
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "sid",
+                    "text": "restore this",
+                    "truncate_before_user_ordinal": 3,  # stale, only 1 user msg
+                },
+            }
+        )
+        # Should succeed (clamped) instead of returning error 4018
+        assert resp.get("result"), f"got error: {resp.get('error')}"
+
+        # Clamped to last user index → history[:1] = [summary]
+        assert seen["prompt"] == "restore this"
+        assert seen["history"] == compressed_history[:1]
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_prompt_submit_rejects_negative_ordinal(monkeypatch):
+    """Negative truncate_before_user_ordinal should be rejected."""
+
+    server._sessions["sid"] = _session(
+        history=[{"role": "user", "content": "hello"}]
+    )
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "sid",
+                    "text": "test",
+                    "truncate_before_user_ordinal": -1,
+                },
+            }
+        )
+        assert "error" in resp
+        assert resp["error"]["code"] == 4004
+        assert "non-negative" in resp["error"]["message"]
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_prompt_submit_empty_history_with_ordinal(monkeypatch):
+    """When history has no user messages, truncation should clear history."""
+
+    seen = {}
+
+    class _Agent:
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None
+        ):
+            seen["prompt"] = prompt
+            seen["history"] = conversation_history
+            return {
+                "final_response": "ok",
+                "messages": [
+                    {"role": "user", "content": prompt},
+                    {"role": "assistant", "content": "ok"},
+                ],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    server._sessions["sid"] = _session(
+        agent=_Agent(),
+        history=[{"role": "assistant", "content": "orphan"}],
+    )
+    try:
+        monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+        monkeypatch.setattr(server, "_get_usage", lambda _a: {})
+        monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
+        monkeypatch.setattr(server, "_emit", lambda *a: None)
+        monkeypatch.setattr(server, "_get_db", lambda: None)
+
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "sid",
+                    "text": "fresh start",
+                    "truncate_before_user_ordinal": 0,
+                },
+            }
+        )
+        assert resp.get("result"), f"got error: {resp.get('error')}"
+        assert seen["prompt"] == "fresh start"
+        assert seen["history"] == []
+    finally:
+        server._sessions.pop("sid", None)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7469,11 +7469,20 @@ def _(rid, params: dict) -> dict:
                 ordinal = int(truncate_user_ordinal)
             except (TypeError, ValueError):
                 return _err(rid, 4004, "truncate_before_user_ordinal must be an integer")
+            if ordinal < 0:
+                return _err(rid, 4004, "truncate_before_user_ordinal must be non-negative")
             history = session.get("history", [])
             user_indices = [i for i, m in enumerate(history) if m.get("role") == "user"]
-            if ordinal >= len(user_indices):
-                return _err(rid, 4018, "target user message is no longer in session history")
-            truncated = history[: user_indices[ordinal]]
+            if not user_indices:
+                truncated = []
+            elif ordinal >= len(user_indices):
+                # The requested ordinal exceeds available user messages —
+                # context compression may have shrunk the history since the
+                # frontend computed the ordinal.  Clamp to the last user
+                # message so the restore still produces a usable turn.
+                truncated = history[: user_indices[-1]]
+            else:
+                truncated = history[: user_indices[ordinal]]
             session["history"] = truncated
             session["history_version"] = int(session.get("history_version", 0)) + 1
             if (db := _get_db()) is not None:


### PR DESCRIPTION
## What does this PR do?

Clamps a stale `truncate_before_user_ordinal` to the last available user message instead of returning error 4018 when the ordinal exceeds the backend's user message count. This prevents checkpoint restore from failing after context compression has shrunk session history.

## Related Issue

Fixes #52514

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`: Replace hard error (4018) with ordinal clamping when `truncate_before_user_ordinal >= len(user_indices)`. Also adds negative ordinal rejection (4004) and empty-history handling.
- `tests/test_tui_gateway_server.py`: Three new tests — stale ordinal clamps to last user message, negative ordinal rejected, empty history clears cleanly.

## How to Test

1. `python -m pytest tests/test_tui_gateway_server.py::test_prompt_submit_clamps_stale_ordinal_after_compression tests/test_tui_gateway_server.py::test_prompt_submit_rejects_negative_ordinal tests/test_tui_gateway_server.py::test_prompt_submit_empty_history_with_ordinal -v` — all 3 should pass.
2. `python -m pytest tests/test_tui_gateway_server.py::test_prompt_submit_can_truncate_before_user_ordinal -v` — existing test still passes (normal ordinal path unchanged).
3. Reproduce in Desktop: start a long session, trigger `/compress`, then click "Restore to this checkpoint?" on an older message — should restore instead of showing error 4018.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tui_gateway/server.py` prompt.submit handler (lines 7467–7483)
- Blast radius: LOW — only affects the `truncate_before_user_ordinal` branch of `prompt.submit`; normal edit/restore path unchanged
- Related patterns: context compression replaces `session["history"]` (line 2600), frontend computes ordinal from `$messages` which may be stale after compression
