### PR TITLE
fix(gateway): enforce non-empty allowlists for config-driven platform policies

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -195,6 +195,66 @@ class GatewayAuthorizationMixin:
             return any(str(item).strip() for item in sender_allow)
         return False
 
+    def _adapter_has_dm_allowlist(self, platform: Optional[Platform]) -> bool:
+        """Whether the own-policy adapter has a non-empty DM caller allowlist.
+        
+        This prevents failing open when allowlist policy is active but no allowlist
+        is configured.
+        """
+        if not platform:
+            return False
+        adapters = getattr(self, "adapters", None) or {}
+        adapter = adapters.get(platform)
+        if adapter is not None:
+            allow_from = getattr(adapter, "_allow_from", None) or getattr(adapter, "dm_allow_from", None)
+            if allow_from and any(str(item).strip() for item in allow_from):
+                return True
+        config = getattr(self, "config", None)
+        platform_cfg = (
+            config.platforms.get(platform)
+            if config is not None and hasattr(config, "platforms")
+            else None
+        )
+        extra = getattr(platform_cfg, "extra", None) if platform_cfg else None
+        if isinstance(extra, dict):
+            for key in ("allow_from", "allowFrom", "dm_allow_from", "dmAllowFrom"):
+                val = extra.get(key)
+                if isinstance(val, str) and val.strip():
+                    return True
+                if isinstance(val, (list, tuple, set)) and any(str(item).strip() for item in val):
+                    return True
+        return False
+
+    def _adapter_has_group_allowlist(self, platform: Optional[Platform]) -> bool:
+        """Whether the own-policy adapter has a non-empty group caller allowlist.
+        
+        This prevents failing open when allowlist policy is active but no allowlist
+        is configured.
+        """
+        if not platform:
+            return False
+        adapters = getattr(self, "adapters", None) or {}
+        adapter = adapters.get(platform)
+        if adapter is not None:
+            allow_from = getattr(adapter, "_group_allow_from", None) or getattr(adapter, "group_allow_from", None)
+            if allow_from and any(str(item).strip() for item in allow_from):
+                return True
+        config = getattr(self, "config", None)
+        platform_cfg = (
+            config.platforms.get(platform)
+            if config is not None and hasattr(config, "platforms")
+            else None
+        )
+        extra = getattr(platform_cfg, "extra", None) if platform_cfg else None
+        if isinstance(extra, dict):
+            for key in ("group_allow_from", "groupAllowFrom"):
+                val = extra.get(key)
+                if isinstance(val, str) and val.strip():
+                    return True
+                if isinstance(val, (list, tuple, set)) and any(str(item).strip() for item in val):
+                    return True
+        return False
+
     def _is_user_authorized(self, source: SessionSource) -> bool:
         """
         Check if a user is authorized to use the bot.
@@ -408,11 +468,13 @@ class GatewayAuthorizationMixin:
                         source.chat_id,
                     ):
                         return True
+                    if effective_policy == "allowlist" and self._adapter_has_group_allowlist(source.platform):
+                        return True
                 else:
                     effective_policy = self._adapter_dm_policy(source.platform)
-                if effective_policy == "allowlist":
-                    return True
-            # No allowlists configured -- check global allow-all flag
+                    if effective_policy == "allowlist" and self._adapter_has_dm_allowlist(source.platform):
+                        return True
+            # No allowlists configured - check global allow-all flag
             return os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
 
         # Telegram can optionally authorize group traffic by chat ID.

--- a/tests/gateway/test_config_driven_access_policy.py
+++ b/tests/gateway/test_config_driven_access_policy.py
@@ -142,7 +142,7 @@ def test_own_policy_allowlist_authorized_without_env_allowlist(monkeypatch, plat
     """
     _clear_auth_env(monkeypatch)
     config = GatewayConfig(
-        platforms={platform: PlatformConfig(enabled=True, extra={"dm_policy": "allowlist"})}
+        platforms={platform: PlatformConfig(enabled=True, extra={"dm_policy": "allowlist", "allow_from": ["some-user"]})}
     )
     runner, _adapter = _make_runner(platform, config, enforces=True)
 
@@ -188,7 +188,7 @@ def test_own_policy_allowlist_authorized_for_group_chat(monkeypatch, platform):
     """A config-only ``group_policy: allowlist`` is trusted for group traffic."""
     _clear_auth_env(monkeypatch)
     config = GatewayConfig(
-        platforms={platform: PlatformConfig(enabled=True, extra={"group_policy": "allowlist"})}
+        platforms={platform: PlatformConfig(enabled=True, extra={"group_policy": "allowlist", "group_allow_from": ["some-chat"]})}
     )
     runner, _adapter = _make_runner(platform, config, enforces=True)
 
@@ -363,7 +363,7 @@ def test_pairing_dm_policy_group_chat_still_trusted(monkeypatch):
     config = GatewayConfig(
         platforms={
             Platform.WECOM: PlatformConfig(
-                enabled=True, extra={"dm_policy": "pairing", "group_policy": "allowlist"}
+                enabled=True, extra={"dm_policy": "pairing", "group_policy": "allowlist", "group_allow_from": ["some-chat"]}
             )
         }
     )
@@ -406,3 +406,16 @@ def test_unauthorized_dm_behavior_open_policy_keeps_default(monkeypatch):
 
     # No allowlist + no restrictive policy → open-gateway pairing default.
     assert runner._get_unauthorized_dm_behavior(Platform.WECOM) == "pair"
+
+
+@pytest.mark.parametrize("platform", _OWN_POLICY_PLATFORMS)
+def test_empty_allowlist_fails_closed(monkeypatch, platform):
+    """An empty or absent allowlist under allowlist policy fails closed (denies access)."""
+    _clear_auth_env(monkeypatch)
+    config = GatewayConfig(
+        platforms={platform: PlatformConfig(enabled=True, extra={"dm_policy": "allowlist"})}
+    )
+    runner, _adapter = _make_runner(platform, config, enforces=True)
+
+    # Since no allow_from/allowlist is configured, _is_user_authorized must deny.
+    assert runner._is_user_authorized(_source(platform)) is False


### PR DESCRIPTION
Fixes #38638

## What changed and why

When config-driven platforms (like QQBot, WeCom, Weixin, Yuanbao, or WhatsApp) are enabled, the gateway runner's authorization check is bypassed under the assumption that the platform adapter has already evaluated caller authorization at intake. However, if the operator selects the allowlist policy but provides an empty or absent user allowlist, the gateway runner incorrectly returns True (authorized), bypassing default-deny security boundaries.

To resolve this, the gateway runner now checks that config-driven adapters configured for the allowlist policy actually provide a non-empty caller allowlist. If the allowlist is empty or absent, the gateway runner correctly defaults to denying access.

## Fix

### `gateway/authz_mixin.py`
- Added helper methods `_adapter_has_dm_allowlist` and `_adapter_has_group_allowlist` to check both live adapter instances and config files for non-empty allowlists.
- Updated `_is_user_authorized` to require `_adapter_has_dm_allowlist` / `_adapter_has_group_allowlist` to return True before trusting config-driven `"allowlist"` policy checks.

## What this does NOT change

- Does not change default pairing behaviors when no allowlists or restrictive policies are set.
- Does not alter env-based allowlist resolution, global allowlists, or per-platform override flags.

## How to test

Ran the test suite:
```bash
.venv/bin/pytest tests/gateway/test_config_driven_access_policy.py
```

## Platforms tested

Linux (pure Python fix).