### PR TITLE
fix(anthropic): preserve tool use cache markers

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1898,6 +1898,11 @@ def _convert_assistant_message(m: Dict[str, Any]) -> Dict[str, Any]:
             "name": fn.get("name", ""),
             "input": parsed_args,
         })
+    if isinstance(m.get("cache_control"), dict):
+        for block in reversed(blocks):
+            if isinstance(block, dict) and block.get("type") in {"text", "tool_use"}:
+                block.setdefault("cache_control", dict(m["cache_control"]))
+                break
     # Kimi's /coding endpoint (Anthropic protocol) requires assistant
     # tool-call messages to carry reasoning_content when thinking is
     # enabled server-side.  Preserve it as a thinking block so Kimi

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1819,6 +1819,18 @@ def _sanitize_replay_block(b: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     return None
 
 
+def _apply_assistant_cache_control_to_last_cacheable_block(
+    blocks: List[Dict[str, Any]],
+    cache_control: Any,
+) -> None:
+    if not isinstance(cache_control, dict):
+        return
+    for block in reversed(blocks):
+        if isinstance(block, dict) and block.get("type") in {"text", "tool_use"}:
+            block.setdefault("cache_control", dict(cache_control))
+            break
+
+
 def _convert_assistant_message(m: Dict[str, Any]) -> Dict[str, Any]:
     """Convert an assistant message to Anthropic content blocks.
 
@@ -1873,6 +1885,9 @@ def _convert_assistant_message(m: Dict[str, Any]) -> Dict[str, Any]:
                     clean["input"] = redacted
             replayed.append(clean)
         if replayed:
+            _apply_assistant_cache_control_to_last_cacheable_block(
+                replayed, m.get("cache_control")
+            )
             return {"role": "assistant", "content": replayed}
 
     blocks = _extract_preserved_thinking_blocks(m)
@@ -1898,11 +1913,9 @@ def _convert_assistant_message(m: Dict[str, Any]) -> Dict[str, Any]:
             "name": fn.get("name", ""),
             "input": parsed_args,
         })
-    if isinstance(m.get("cache_control"), dict):
-        for block in reversed(blocks):
-            if isinstance(block, dict) and block.get("type") in {"text", "tool_use"}:
-                block.setdefault("cache_control", dict(m["cache_control"]))
-                break
+    _apply_assistant_cache_control_to_last_cacheable_block(
+        blocks, m.get("cache_control")
+    )
     # Kimi's /coding endpoint (Anthropic protocol) requires assistant
     # tool-call messages to carry reasoning_content when thinking is
     # enabled server-side.  Preserve it as a thinking block so Kimi

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1002,6 +1002,28 @@ class TestConvertMessages:
         assert assistant_blocks[0]["text"] == "Hello from assistant"
         assert assistant_blocks[0]["cache_control"] == {"type": "ephemeral"}
 
+    def test_assistant_tool_use_cache_control_is_preserved(self):
+        messages = apply_anthropic_cache_control([
+            {"role": "system", "content": "System prompt"},
+            {"role": "user", "content": "Run the tool"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "tc_1", "function": {"name": "test_tool", "arguments": "{}"}},
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tc_1", "content": "result"},
+        ], native_anthropic=True)
+
+        _, result = convert_messages_to_anthropic(messages)
+        assistant_msg = [m for m in result if m["role"] == "assistant"][0]
+        tool_use = assistant_msg["content"][-1]
+
+        assert tool_use["type"] == "tool_use"
+        assert tool_use["id"] == "tc_1"
+        assert tool_use["cache_control"] == {"type": "ephemeral"}
+
     def test_tool_cache_control_is_preserved_on_tool_result_block(self):
         messages = apply_anthropic_cache_control([
             {"role": "system", "content": "System prompt"},

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1024,6 +1024,50 @@ class TestConvertMessages:
         assert tool_use["id"] == "tc_1"
         assert tool_use["cache_control"] == {"type": "ephemeral"}
 
+    def test_ordered_replay_tool_use_cache_control_is_preserved(self):
+        messages = apply_anthropic_cache_control([
+            {"role": "system", "content": "System prompt"},
+            {"role": "user", "content": "Run the tool"},
+            {
+                "role": "assistant",
+                "content": "",
+                "anthropic_content_blocks": [
+                    {
+                        "type": "thinking",
+                        "thinking": "Need a tool.",
+                        "signature": "sig_1",
+                    },
+                    {
+                        "type": "tool_use",
+                        "id": "tc_1",
+                        "name": "test_tool",
+                        "input": {"query": "raw"},
+                    },
+                ],
+                "tool_calls": [
+                    {
+                        "id": "tc_1",
+                        "function": {
+                            "name": "test_tool",
+                            "arguments": '{"query":"redacted"}',
+                        },
+                    },
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tc_1", "content": "result"},
+        ], native_anthropic=True)
+
+        _, result = convert_messages_to_anthropic(messages)
+        assistant_msg = [m for m in result if m["role"] == "assistant"][0]
+        thinking, tool_use = assistant_msg["content"]
+
+        assert thinking["type"] == "thinking"
+        assert "cache_control" not in thinking
+        assert tool_use["type"] == "tool_use"
+        assert tool_use["id"] == "tc_1"
+        assert tool_use["input"] == {"query": "redacted"}
+        assert tool_use["cache_control"] == {"type": "ephemeral"}
+
     def test_tool_cache_control_is_preserved_on_tool_result_block(self):
         messages = apply_anthropic_cache_control([
             {"role": "system", "content": "System prompt"},


### PR DESCRIPTION
## What does this PR do?

Preserves Anthropic prompt-cache markers when an assistant message with tool calls is converted to Anthropic `tool_use` content blocks.

Hermes applies Anthropic cache markers before provider-specific conversion. For assistant tool-call messages, the marker lived on the OpenAI-format assistant message, but `_convert_assistant_message()` rebuilt the Anthropic `tool_use` block without copying that marker. That meant Hermes could select an assistant tool-call turn as a cache breakpoint while the actual Anthropic request silently omitted it.

This change copies a top-level assistant `cache_control` marker onto the last generated text/tool_use block during Anthropic conversion, matching the existing preservation behavior for assistant text blocks and tool result blocks.

### Background / Root Cause

Hermes enables Anthropic prompt caching by applying `cache_control` before converting messages into the provider-specific Anthropic Messages format. The cache strategy marks the system prompt plus the last non-system messages in the OpenAI-style history.

That works for ordinary assistant text because `_convert_content_to_anthropic()` preserves `cache_control` on text blocks. It also works for tool results because `_convert_tool_message_to_result()` copies a tool message's top-level `cache_control` onto the generated Anthropic `tool_result` block.

The missing case was assistant tool calls:

1. `apply_anthropic_cache_control(..., native_anthropic=True)` can mark an assistant message shaped like:
   ```python
   {"role": "assistant", "content": "", "tool_calls": [...]}
   ```
2. `_convert_assistant_message()` converts that OpenAI-style `tool_calls` list into Anthropic `tool_use` content blocks.
3. Before this PR, that conversion did not copy the assistant message's top-level `cache_control` onto the generated `tool_use` block.

So the marker was present in Hermes's intermediate API message but absent from the actual Anthropic request payload.

### Verification Notes

I verified this in three layers:

1. **Unit-level reproduction**
   - Added `test_assistant_tool_use_cache_control_is_preserved`.
   - Without the production fix, the test fails because the converted Anthropic `tool_use` block has no `cache_control`.
   - With the fix, the `tool_use` block keeps `{"type": "ephemeral"}`.

2. **Adjacent behavior check**
   - Existing assistant text cache-control preservation still passes.
   - Existing tool result cache-control preservation still passes.
   - The full Anthropic adapter test file passes.

3. **Live probing performed during investigation**
   - A minimal Hermes SDK/stream request confirmed that the configured Anthropic-compatible endpoint reports normal cache write/read usage when driven through Hermes's real Anthropic SDK path.
   - A marker dump confirmed that simulating the old behavior removes the `tool_use` marker while leaving later `tool_result` markers intact.
   - Because that provider can also serve cache hits from other/implicit breakpoints in small synthetic prompts, the PR does **not** claim to fully explain every observed cache miss or guarantee a specific dollar savings. The narrowly proven bug is the lost `tool_use.cache_control` marker.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/anthropic_adapter.py`: preserve top-level assistant `cache_control` on the converted Anthropic `text` / `tool_use` block.
- `tests/agent/test_anthropic_adapter.py`: add a regression test for assistant tool-call messages selected by `apply_anthropic_cache_control()`.

## How to Test

1. Confirm the regression without the fix:
   - Revert the `agent/anthropic_adapter.py` change only.
   - Run:
     ```bash
     .venv/bin/python -m pytest tests/agent/test_anthropic_adapter.py -k assistant_tool_use_cache_control_is_preserved
     ```
   - Expected failure: the converted `tool_use` block lacks `cache_control`.
2. Run the focused Anthropic adapter tests on this branch:
   ```bash
   .venv/bin/python -m pytest tests/agent/test_anthropic_adapter.py
   ```
3. Verify the fixed branch passes:
   ```text
   167 passed
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL/Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Focused test run:

```text
$ .venv/bin/python -m pytest tests/agent/test_anthropic_adapter.py
167 passed
```

Regression proof:

```text
tests/agent/test_anthropic_adapter.py::TestConvertMessages::test_assistant_tool_use_cache_control_is_preserved
```

This test exercises:

```text
apply_anthropic_cache_control(...)
  -> assistant tool-call message receives top-level cache_control
convert_messages_to_anthropic(...)
  -> assistant tool_calls become Anthropic tool_use blocks
  -> cache_control must survive on the tool_use block
```
