### PR TITLE
fix(feishu): align card approval auth with interactive sessions

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2574,15 +2574,24 @@ class FeishuAdapter(BasePlatformAdapter):
         future.add_done_callback(self._log_background_failure)
         return True
 
-    def _is_interactive_operator_authorized(self, open_id: str) -> bool:
-        """Return whether this card-action operator may answer gated prompts."""
-        normalized = str(open_id or "").strip()
-        if not normalized:
+    def _is_interactive_operator_authorized(self, open_id: str, user_id: str = "") -> bool:
+        """Return whether this card-action operator may answer gated prompts.
+
+        Interactive card callbacks already come from a chat where Hermes sent a
+        gated prompt. When an explicit Feishu allowlist/admin list exists we
+        still enforce it, but without one we should not reject the same user who
+        could already approve via plain-text ``/approve``.
+        """
+        sender_ids = {
+            str(open_id or "").strip(),
+            str(user_id or "").strip(),
+        } - {""}
+        if not sender_ids:
             return False
         allowed_ids = set(self._admins) | set(self._allowed_group_users)
         if not allowed_ids:
             return True
-        return "*" in allowed_ids or normalized in allowed_ids
+        return "*" in allowed_ids or bool(sender_ids & allowed_ids)
 
     def _handle_approval_card_action(self, *, event: Any, action_value: Dict[str, Any], loop: Any) -> Any:
         """Schedule approval resolution and build the synchronous callback response."""
@@ -2598,8 +2607,8 @@ class FeishuAdapter(BasePlatformAdapter):
 
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
-        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
-        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+        user_id = str(getattr(operator, "user_id", "") or "")
+        if not self._is_interactive_operator_authorized(open_id, user_id):
             logger.warning("[Feishu] Unauthorized approval click by %s", open_id or "<unknown>")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 
@@ -2625,6 +2634,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 choice=choice,
                 user_name=user_name,
                 open_id=open_id,
+                user_id=user_id,
                 chat_id=chat_id,
             ),
         ):
@@ -2658,8 +2668,8 @@ class FeishuAdapter(BasePlatformAdapter):
 
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
-        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
-        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+        user_id = str(getattr(operator, "user_id", "") or "")
+        if not self._is_interactive_operator_authorized(open_id, user_id):
             logger.warning("[Feishu] Unauthorized update prompt click by %s", open_id or "<unknown>")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 
@@ -2682,6 +2692,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 answer,
                 user_name,
                 open_id=open_id,
+                user_id=user_id,
                 chat_id=callback_chat_id,
             ),
         ):
@@ -2704,6 +2715,7 @@ class FeishuAdapter(BasePlatformAdapter):
         user_name: str,
         *,
         open_id: str = "",
+        user_id: str = "",
         chat_id: str = "",
     ) -> None:
         """Pop approval state and unblock the waiting agent thread."""
@@ -2711,7 +2723,7 @@ class FeishuAdapter(BasePlatformAdapter):
         if not state:
             logger.debug("[Feishu] Approval %s already resolved or unknown", approval_id)
             return
-        if not self._is_interactive_operator_authorized(open_id):
+        if not self._is_interactive_operator_authorized(open_id, user_id):
             logger.warning("[Feishu] Unauthorized approval click by %s for approval %s", open_id or "<unknown>", approval_id)
             return
         expected_chat_id = str(state.get("chat_id", "") or "")
@@ -2742,6 +2754,7 @@ class FeishuAdapter(BasePlatformAdapter):
         user_name: str,
         *,
         open_id: str = "",
+        user_id: str = "",
         chat_id: str = "",
     ) -> None:
         """Persist an update prompt answer for the detached update process."""
@@ -2749,11 +2762,9 @@ class FeishuAdapter(BasePlatformAdapter):
         if not state:
             logger.debug("[Feishu] Update prompt %s already resolved or unknown", prompt_id)
             return
-        if open_id:
-            sender_id = SimpleNamespace(open_id=open_id, user_id="")
-            if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
-                logger.warning("[Feishu] Unauthorized update prompt click by %s for prompt %s", open_id, prompt_id)
-                return
+        if open_id and not self._is_interactive_operator_authorized(open_id, user_id):
+            logger.warning("[Feishu] Unauthorized update prompt click by %s for prompt %s", open_id, prompt_id)
+            return
         expected_chat_id = str(state.get("chat_id", "") or "")
         if expected_chat_id and chat_id and expected_chat_id != chat_id:
             logger.warning(

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -58,6 +58,7 @@ def _make_card_action_data(
     action_value: dict,
     chat_id: str = "oc_12345",
     open_id: str = "ou_user1",
+    user_id: str = "",
     token: str = "tok_abc",
 ) -> SimpleNamespace:
     """Create a mock Feishu card action callback data object."""
@@ -65,7 +66,7 @@ def _make_card_action_data(
         event=SimpleNamespace(
             token=token,
             context=SimpleNamespace(open_chat_id=chat_id),
-            operator=SimpleNamespace(open_id=open_id),
+            operator=SimpleNamespace(open_id=open_id, user_id=user_id),
             action=SimpleNamespace(
                 tag="button",
                 value=action_value,
@@ -393,6 +394,29 @@ class TestResolveApproval:
         assert 5 in adapter._approval_state
 
     @pytest.mark.asyncio
+    async def test_user_id_allowlist_authorizes_click(self):
+        adapter = _make_adapter()
+        adapter._allowed_group_users = {"u_allowed"}
+        adapter._approval_state[55] = {
+            "session_key": "sess-55",
+            "message_id": "msg_055",
+            "chat_id": "oc_12345",
+        }
+
+        with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+            await adapter._resolve_approval(
+                55,
+                "once",
+                "Norbert",
+                open_id="ou_unknown",
+                user_id="u_allowed",
+                chat_id="oc_12345",
+            )
+
+        mock_resolve.assert_called_once_with("sess-55", "once")
+        assert 55 not in adapter._approval_state
+
+    @pytest.mark.asyncio
     async def test_chat_mismatch_does_not_resolve(self):
         adapter = _make_adapter()
         adapter._approval_state[6] = {
@@ -501,6 +525,30 @@ class TestCardActionCallbackResponse:
         assert card["header"]["template"] == "green"
         assert "Approved once" in card["header"]["title"]["content"]
         assert "Bob" in card["elements"][0]["content"]
+
+    def test_returns_card_without_explicit_feishu_allowlist(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._admins = set()
+        adapter._allowed_group_users = set()
+        adapter._approval_state[11] = {
+            "session_key": "sess-11",
+            "message_id": "msg-11",
+            "chat_id": "oc_12345",
+        }
+        data = _make_card_action_data(
+            {"hermes_action": "approve_once", "approval_id": 11},
+            open_id="ou_user1",
+        )
+        adapter._sender_name_cache["ou_user1"] = ("User One", 9999999999)
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is not None
+        assert response.card.type == "raw"
 
     def test_returns_card_for_deny_action(self, _patch_callback_card_types):
         adapter = _make_adapter()
@@ -757,7 +805,7 @@ class TestCardActionCallbackResponse:
         assert response.card is None
         mock_submit.assert_not_called()
 
-    def test_update_prompt_empty_allowlists_fail_closed(self, _patch_callback_card_types):
+    def test_update_prompt_without_explicit_feishu_allowlist(self, _patch_callback_card_types):
         adapter = _make_adapter()
         adapter._loop = MagicMock()
         adapter._loop.is_closed = MagicMock(return_value=False)
@@ -770,14 +818,14 @@ class TestCardActionCallbackResponse:
             {"hermes_update_prompt_action": "y", "update_prompt_id": 7},
             open_id="ou_intruder",
         )
+        adapter._sender_name_cache["ou_intruder"] = ("Intruder", 9999999999)
 
-        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
             response = adapter._on_card_action_trigger(data)
 
         assert response is not None
-        assert response.card is None
-        assert 7 in adapter._update_prompt_state
-        mock_submit.assert_not_called()
+        assert response.card is not None
+        assert response.card.type == "raw"
 
     def test_update_prompt_chat_mismatch_returns_no_card(self, _patch_callback_card_types):
         adapter = _make_adapter()


### PR DESCRIPTION
## Summary
- align Feishu interactive card approvals with the same authorization semantics users already get in DM sessions
- authorize card operators by either `open_id` or `user_id` when an explicit Feishu allowlist/admin list exists
- add regression coverage for approval/update-prompt card callbacks without explicit Feishu allowlists

## Problem
Feishu users could send DM messages and approve a pending command via plain-text `/approve`, but clicking the interactive approval card button failed with:

- `Unauthorized approval click by <open_id>`

The card callback path was checking `_allow_group_message()` first, which is stricter than the interactive session behavior and did not reuse the dedicated interactive-operator authorization semantics.

## Fix
- route approval/update-prompt card callbacks through `_is_interactive_operator_authorized(...)`
- make that helper accept both `open_id` and `user_id`
- preserve explicit Feishu admin/allowlist enforcement when configured, but stop fail-closing card callbacks solely because no Feishu-specific allowlist is set

## Testing
- `./venv/bin/pytest tests/gateway/test_feishu_approval_buttons.py -q`
