### PR TITLE
fix(gateway): match gateway profile by whole token, not substring, in liveness scope

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -336,11 +336,16 @@ def _command_line_belongs_to_profile(command: str, profile_home: Path) -> bool:
 
     if profile_name is not None and profile_name != "default":
         profile_lc = profile_name.lower()
-        return (
-            f"--profile {profile_lc}" in command_lc
-            or f"-p {profile_lc}" in command_lc
-            or f"hermes_home={home_lc}" in command_lc
-        )
+        # Match the flag VALUE as a whole token, not a substring. "-p coder" is
+        # a substring of "-p coder2", so a substring check reports a dead
+        # ``coder`` profile running on a live ``coder2`` gateway whose PID the
+        # OS recycled — the very cross-profile leak this scope exists to stop.
+        # (``coder`` and ``coder2`` are both valid profile names.)
+        tokens = command_lc.split()
+        for idx in range(len(tokens) - 1):
+            if tokens[idx] in ("--profile", "-p") and tokens[idx + 1] == profile_lc:
+                return True
+        return any(tok == f"hermes_home={home_lc}" for tok in tokens)
 
     # Default/root profile: the gateway runs with no profile flag. Accept unless
     # the command advertises *some other* profile (an explicit -p/--profile) or

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -428,6 +428,33 @@ class TestGatewayRuntimeStatus:
             is None
         )
 
+    def test_runtime_status_running_pid_rejects_sibling_prefix_profile(self, monkeypatch):
+        """A dead profile whose name is a PREFIX of a live sibling's must not be
+        reported running. ``coder``'s recycled PID 139 now hosts ``coder2``'s
+        live gateway; a substring profile match (``-p coder`` is a substring of
+        ``-p coder2``) would defeat the cross-profile scope and report ``coder``
+        up. Both names are valid (``^[a-z0-9][a-z0-9_-]{0,63}$``)."""
+        payload = {
+            "pid": 139,
+            "gateway_state": "running",
+            "kind": "hermes-gateway",
+            "argv": ["hermes", "gateway", "run"],
+        }
+        coder_home = Path("/opt/data/profiles/coder")
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: None)
+        for cmdline in (
+            "hermes -p coder2 gateway run --replace",
+            "/opt/hermes/.venv/bin/hermes --profile coder2 gateway run",
+            "hermes_home=/opt/data/profiles/coder2 hermes gateway run",
+        ):
+            monkeypatch.setattr(status, "_read_process_cmdline", lambda pid, c=cmdline: c)
+            assert (
+                status.get_runtime_status_running_pid(payload, expected_home=coder_home)
+                is None
+            ), cmdline
+
     def test_runtime_status_running_pid_accepts_matching_profile_cmdline(self, monkeypatch):
         """A genuinely-live named gateway carries ``-p <profile>`` / ``--profile``
         on its command line and must be reported running for that profile."""


### PR DESCRIPTION
## Summary

Follow-up to `538c419d2` ("scope dashboard liveness fallback to the profile").

That commit added `_command_line_belongs_to_profile` (`gateway/status.py`) so a PID the OS recycled onto a *different* profile's live gateway isn't reported running for a dead profile. But it matches the `-p` / `--profile` flag value and the `hermes_home=` path as bare **substrings**:

```python
return (
    f"--profile {profile_lc}" in command_lc
    or f"-p {profile_lc}" in command_lc
    or f"hermes_home={home_lc}" in command_lc
)
```

`-p coder` is a substring of `-p coder2` (and `--profile coder` of `--profile coder2`, and `.../profiles/coder` of `.../profiles/coder2`). So when a dead `coder` profile's recycled PID now hosts a **live `coder2`** gateway, `coder` is reported running — defeating the exact cross-profile PID-reuse leak this scope was added to close. Both names are valid (`^[a-z0-9][a-z0-9_-]{0,63}$`), and prefix-sibling names (`coder` / `coder2`) are a realistic per-profile-container pattern.

Reproduced against current `main` (`d6269da7f`):

```python
>>> _command_line_belongs_to_profile("hermes -p coder2 gateway run --replace", Path("/opt/data/profiles/coder"))
True    # ← dead `coder` matches live `coder2`; should be False
>>> _command_line_belongs_to_profile("hermes -p other gateway run", Path("/opt/data/profiles/coder"))
False   # unrelated sibling correctly rejected
```

The start-time PID-reuse guard doesn't catch it because a stale state file has no `start_time`, so execution reaches this scope check — which then leaks.

## Fix

Match the flag value as a **whole token** (the token after `-p`/`--profile` must *equal* the profile name) and the `hermes_home=` argument as a whole token. A sibling whose name merely *starts with* the profile name no longer matches. All of the commit's asserted positive cases (`-p coder`, `--profile coder`, explicit `hermes_home=.../coder`) still match.

## Tests

`tests/gateway/test_status.py::...rejects_sibling_prefix_profile` — mirrors the existing `rejects_pid_reused_by_other_profile` test with a live `coder2` cmdline (in `-p`, `--profile`, and `hermes_home=` forms). Each is reported running (`139`) **without the fix** and `None` with it; all 87 existing status tests still pass.