### PR TITLE
fix(cli): prune retired messaging toolset from config

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2908,7 +2908,7 @@ DEFAULT_CONFIG = {
 
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 30,
+    "_config_version": 31,
 }
 
 # =============================================================================
@@ -2925,6 +2925,38 @@ ENV_VARS_BY_VERSION: Dict[int, List[str]] = {
     10: ["TAVILY_API_KEY"],
     11: ["TERMINAL_MODAL_MODE"],
 }
+
+_REMOVED_BUILTIN_TOOLSETS: frozenset[str] = frozenset({"messaging"})
+
+
+def _drop_removed_builtin_toolsets(config: Dict[str, Any]) -> List[str]:
+    """Remove built-in toolset names that were intentionally retired."""
+    removed_locations: List[str] = []
+
+    def _prune(values: Any) -> Tuple[Any, bool]:
+        if not isinstance(values, list):
+            return values, False
+        pruned = [value for value in values if value not in _REMOVED_BUILTIN_TOOLSETS]
+        return pruned, pruned != values
+
+    platform_toolsets = config.get("platform_toolsets")
+    if isinstance(platform_toolsets, dict):
+        for platform_name, values in list(platform_toolsets.items()):
+            pruned, changed = _prune(values)
+            if changed:
+                platform_toolsets[platform_name] = pruned
+                removed_locations.append(f"platform_toolsets.{platform_name}")
+        config["platform_toolsets"] = platform_toolsets
+
+    agent_cfg = config.get("agent")
+    if isinstance(agent_cfg, dict):
+        pruned, changed = _prune(agent_cfg.get("enabled_toolsets"))
+        if changed:
+            agent_cfg["enabled_toolsets"] = pruned
+            config["agent"] = agent_cfg
+            removed_locations.append("agent.enabled_toolsets")
+
+    return removed_locations
 
 # Required environment variables with metadata for migration prompts.
 # LLM provider is required but handled in the setup wizard's provider
@@ -5228,6 +5260,30 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                 print(
                     "  ✓ Seeded curator.consolidate: false "
                     "(LLM consolidation is now opt-in; pruning stays on)"
+                )
+
+    # ── Version 30 → 31: remove the retired messaging toolset from configs ──
+    # PR #47856 removed the agent-callable `messaging` toolset. Older configs
+    # can still have it persisted under platform_toolsets.* or
+    # agent.enabled_toolsets, which makes every CLI startup warn about an
+    # unknown toolset even though the user's config is otherwise healthy.
+    #
+    # Keep this targeted to known retired built-ins: a generic "remove any
+    # invalid toolset" pass would risk deleting user/plugin toolsets before
+    # their registry entries have been loaded during early config migration.
+    if current_ver < 31:
+        config = read_raw_config()
+        removed_locations = _drop_removed_builtin_toolsets(config)
+        if removed_locations:
+            save_config(config)
+            locations = ", ".join(removed_locations)
+            results["config_added"].append(
+                f"removed retired messaging toolset from {locations}"
+            )
+            if not quiet:
+                print(
+                    "  ✓ Removed retired messaging toolset from config: "
+                    f"{locations}"
                 )
 
     # ── Post-migration: disable exfiltration-shaped MCP stdio entries ──

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1197,3 +1197,58 @@ class TestWriteApprovalMigration:
             # gate ends up off and there's no leftover write_mode key.
             assert raw["memory"].get("write_approval", False) is False
             assert "write_mode" not in raw.get("memory", {})
+
+
+class TestRemovedToolsetMigration:
+    """Version 30→31 removes the retired messaging toolset from user config."""
+
+    def _write(self, tmp_path, body: dict):
+        (tmp_path / "config.yaml").write_text(yaml.safe_dump(body), encoding="utf-8")
+
+    def test_prunes_retired_messaging_toolset_from_persisted_surfaces(self, tmp_path):
+        self._write(
+            tmp_path,
+            {
+                "_config_version": 30,
+                "platform_toolsets": {
+                    "cli": ["file", "messaging", "terminal"],
+                    "telegram": ["messaging", "telegram"],
+                },
+                "agent": {"enabled_toolsets": ["web", "messaging"]},
+            },
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            results = migrate_config(interactive=False, quiet=True)
+
+        raw = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+        assert raw["platform_toolsets"]["cli"] == ["file", "terminal"]
+        assert raw["platform_toolsets"]["telegram"] == ["telegram"]
+        assert raw["agent"]["enabled_toolsets"] == ["web"]
+        assert raw["_config_version"] == DEFAULT_CONFIG["_config_version"]
+        assert any(
+            "removed retired messaging toolset" in entry
+            for entry in results["config_added"]
+        )
+
+    def test_preserves_non_retired_custom_and_mcp_toolset_names(self, tmp_path):
+        self._write(
+            tmp_path,
+            {
+                "_config_version": 30,
+                "mcp_servers": {"mcp-docs": {"url": "https://example.com/mcp"}},
+                "platform_toolsets": {
+                    "cli": ["mcp-docs", "plugin-search", "messaging"],
+                },
+                "agent": {
+                    "enabled_toolsets": ["plugin-search", "messaging", "file"],
+                },
+            },
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            migrate_config(interactive=False, quiet=True)
+
+        raw = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+        assert raw["platform_toolsets"]["cli"] == ["mcp-docs", "plugin-search"]
+        assert raw["agent"]["enabled_toolsets"] == ["plugin-search", "file"]


### PR DESCRIPTION
## What does this PR do?

Prunes the retired `messaging` toolset from persisted user config during the v30 -> v31 config migration.

PR #47856 removed the agent-callable `messaging` toolset, but older configs can still contain it under `platform_toolsets.*` or `agent.enabled_toolsets`. Since `HermesCLI` validates those lists at startup, upgraded users see `Warning: Unknown toolsets: messaging` every launch even though the stale entry is harmless.

This keeps the migration intentionally targeted to the known retired built-in instead of deleting every currently invalid name, so user/plugin toolsets that are not registered yet during early config migration are preserved.

## Related Issue

Fixes #52382

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Bumped config schema version to 31.
- Added a v30 -> v31 migration that removes `messaging` from `platform_toolsets.*` and `agent.enabled_toolsets`.
- Added regression tests proving the retired toolset is removed while non-retired MCP/plugin-like names are preserved.

## How to Test

1. Reproduce on current main behavior with a temp config containing `messaging` in `platform_toolsets.cli` and `agent.enabled_toolsets`: `validate_toolset("messaging")` is false, but `migrate_config()` leaves both stale entries in place.
2. Apply this PR and rerun the same harness: `messaging` is pruned from both persisted locations.
3. Run the focused test proof below.

## Duplicate Work Check

Searched before implementation:

- `gh search prs --repo NousResearch/hermes-agent --state open "52382 messaging toolset config migration unknown toolsets"`
- `gh search prs --repo NousResearch/hermes-agent --state closed "52382 messaging toolset config migration unknown toolsets"`
- `gh search prs --repo NousResearch/hermes-agent --state open "Unknown toolsets messaging platform_toolsets"`
- `gh search prs --repo NousResearch/hermes-agent --state closed "Unknown toolsets messaging platform_toolsets"`

No open or closed PR owner was found for this issue/root-cause cluster.

## Proof

- `scripts/run_tests.sh tests/hermes_cli/test_config.py` -> 105 passed
- `scripts/run_tests.sh tests/hermes_cli/test_config.py tests/hermes_cli/test_tools_config.py` -> 202 passed
- `git diff --check` -> passed

Normal push ran the private pre-push review hook. The hook gated in both reviewers, but no actionable report was produced: grogu failed local auth with `401 Invalid authentication credentials`, and mario produced no final report/consensus artifact.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A
