### PR TITLE
Reliability fixes: auto-IPv4 on dead IPv6, local-endpoint billing, silent worker-config warning

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -6,8 +6,17 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any, Dict, Literal, Optional
 
-from agent.model_metadata import fetch_endpoint_model_metadata, fetch_model_metadata
+from agent.model_metadata import (
+    fetch_endpoint_model_metadata,
+    fetch_model_metadata,
+    is_local_endpoint,
+)
 from utils import base_url_host_matches
+
+# Provider ids that always denote a self-hosted/local model server (no per-token
+# cost), regardless of base_url. Loopback/LAN/Tailscale base_urls are detected
+# separately via is_local_endpoint().
+_LOCAL_PROVIDERS = frozenset({"custom", "local", "lmstudio", "ollama", "vllm", "llamacpp"})
 
 DEFAULT_PRICING = {"input": 0.0, "output": 0.0}
 
@@ -611,7 +620,7 @@ def resolve_billing_route(
     # the OpenAI-compat endpoint requires so the pricing key matches.
     if provider_name == "vertex" or base_url_host_matches(base_url or "", "aiplatform.googleapis.com"):
         return BillingRoute(provider="gemini", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
-    if provider_name in {"custom", "local"} or (base and "localhost" in base):
+    if provider_name in _LOCAL_PROVIDERS or (base_url and is_local_endpoint(base_url)):
         return BillingRoute(provider=provider_name or "custom", model=model, base_url=base_url or "", billing_mode="unknown")
     return BillingRoute(provider=provider_name or "unknown", model=model.split("/")[-1] if model else "", base_url=base_url or "", billing_mode="unknown")
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2757,12 +2757,14 @@ def run_job(
                 "default with `hermes model <name>`."
             )
 
-        # Apply IPv4 preference if configured.
+        # Apply IPv4 preference. force=True when network.force_ipv4 is set;
+        # otherwise the helper auto-enables only when IPv6 is dead (the probe
+        # result is cached per-process, so this per-job call is cheap).
         try:
             from hermes_constants import apply_ipv4_preference
             _net_cfg = _cfg.get("network", {})
-            if isinstance(_net_cfg, dict) and _net_cfg.get("force_ipv4"):
-                apply_ipv4_preference(force=True)
+            _force_ipv4 = bool(isinstance(_net_cfg, dict) and _net_cfg.get("force_ipv4"))
+            apply_ipv4_preference(force=_force_ipv4)
         except Exception:
             pass
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1681,12 +1681,14 @@ if _config_path.exists():
             file=sys.stderr,
         )
 
-# Apply IPv4 preference if configured (before any HTTP clients are created).
+# Apply IPv4 preference (before any HTTP clients are created). force=True when
+# network.force_ipv4 is set; otherwise the helper auto-enables only when this
+# host's IPv6 route is dead (no-op on healthy dual-stack hosts).
 try:
     from hermes_constants import apply_ipv4_preference
     _network_cfg = (_cfg if '_cfg' in dir() else {}).get("network", {})
-    if isinstance(_network_cfg, dict) and _network_cfg.get("force_ipv4"):
-        apply_ipv4_preference(force=True)
+    _force_ipv4 = bool(isinstance(_network_cfg, dict) and _network_cfg.get("force_ipv4"))
+    apply_ipv4_preference(force=_force_ipv4)
 except Exception as _bootstrap_exc:
     print(f"  Warning: IPv4 preference application failed: {_bootstrap_exc}", file=sys.stderr)
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -581,15 +581,15 @@ except Exception:
     pass  # best-effort — don't crash the CLI if logging setup fails
 
 # Apply IPv4 preference early, before any HTTP clients are created.
-# We already determined whether to force IPv4 from the raw yaml read above —
-# this just calls the toggle without a redundant load_config() round trip.
-if _FORCE_IPV4_EARLY:
-    try:
-        from hermes_constants import apply_ipv4_preference as _apply_ipv4
+# force=True when network.force_ipv4 is set (from the raw yaml read above);
+# otherwise the helper auto-enables IPv4 preference only when this host's IPv6
+# route is dead (no-op on healthy dual-stack hosts).
+try:
+    from hermes_constants import apply_ipv4_preference as _apply_ipv4
 
-        _apply_ipv4(force=True)
-    except Exception:
-        pass  # best-effort — don't crash if hermes_constants not importable yet
+    _apply_ipv4(force=_FORCE_IPV4_EARLY)
+except Exception:
+    pass  # best-effort — don't crash if hermes_constants not importable yet
 
 import logging
 import threading

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -974,6 +974,18 @@ def _resolve_named_custom_runtime(
         or custom_provider.get("base_url", "")
     ).rstrip("/")
     if not base_url:
+        # A named custom/local provider was configured but has no endpoint.
+        # This is the #1 silent kanban-worker footgun: with no base_url we
+        # return None and the caller falls back to default (OpenRouter)
+        # resolution — which produces nothing if no other credentials exist,
+        # and previously left ZERO trace of why. Surface it instead.
+        logger.warning(
+            "Custom provider %r is configured but has no base_url — set its "
+            "base_url (or LM_BASE_URL in this profile's .env). Falling back to "
+            "default provider resolution, which will fail if no other "
+            "credentials are configured.",
+            custom_provider.get("name") or requested_provider,
+        )
         return None
 
     # Check if a credential pool exists for this custom endpoint

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -934,6 +934,44 @@ def get_env_path() -> Path:
 # ─── Network Preferences ─────────────────────────────────────────────────────
 
 
+# Cached result of the per-process IPv6 reachability probe (None = not run yet).
+_IPV6_ROUTE_ALIVE = None  # Optional[bool]
+
+
+def ipv6_route_alive() -> bool:
+    """Return True if the host has a usable global IPv6 route.
+
+    Performs a UDP ``connect()`` to a global IPv6 address. For UDP this only
+    selects a route and source address — *no packet is sent* — so it is instant
+    and reliably distinguishes "IPv6 works" from the broken-but-configured case
+    (a v6 address with no working route, which makes AAAA-first name resolution
+    hang for the full TCP connect timeout). The result is cached for the life
+    of the process.
+    """
+    global _IPV6_ROUTE_ALIVE
+    if _IPV6_ROUTE_ALIVE is not None:
+        return _IPV6_ROUTE_ALIVE
+
+    import socket
+
+    alive = False
+    if getattr(socket, "has_ipv6", False):
+        try:
+            probe = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+            try:
+                probe.settimeout(0.5)
+                # 2001:4860:4860::8888 = Google Public DNS (a stable global addr)
+                probe.connect(("2001:4860:4860::8888", 53))
+                alive = True
+            finally:
+                probe.close()
+        except OSError:
+            alive = False
+
+    _IPV6_ROUTE_ALIVE = alive
+    return alive
+
+
 def apply_ipv4_preference(force: bool = False) -> None:
     """Monkey-patch ``socket.getaddrinfo`` to prefer IPv4 connections.
 
@@ -948,12 +986,24 @@ def apply_ipv4_preference(force: bool = False) -> None:
     original unfiltered resolution so pure-IPv6 hosts still work.
 
     Safe to call multiple times — only patches once.
-    Set ``network.force_ipv4: true`` in ``config.yaml`` to enable.
-    """
-    if not force:
-        return
 
+    With *force* False, the patch is applied automatically only when the host's
+    IPv6 route is dead (see ``ipv6_route_alive``); a healthy IPv6 stack is left
+    untouched. Set ``network.force_ipv4: true`` in ``config.yaml`` to force it
+    on unconditionally (and skip the probe).
+    """
     import socket
+    import logging
+
+    if not force:
+        # No explicit force: auto-enable only when IPv6 is configured-but-dead.
+        if ipv6_route_alive():
+            return
+        logging.getLogger(__name__).warning(
+            "IPv6 route appears dead — enabling IPv4-preferred DNS resolution "
+            "to avoid connection hangs. Set network.force_ipv4 in config.yaml "
+            "to make this explicit (and skip the probe)."
+        )
 
     # Guard against double-patching
     if getattr(socket.getaddrinfo, "_hermes_ipv4_patched", False):

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1023,6 +1023,9 @@ def apply_ipv4_preference(force: bool = False) -> None:
         return _original_getaddrinfo(host, port, family, type, proto, flags)
 
     _ipv4_getaddrinfo._hermes_ipv4_patched = True  # type: ignore[attr-defined]
+    # Keep a handle to the pristine resolver so the patch is reversible (used by
+    # tests to restore a clean global after an import-time auto-apply).
+    _ipv4_getaddrinfo._hermes_original = _original_getaddrinfo  # type: ignore[attr-defined]
     socket.getaddrinfo = _ipv4_getaddrinfo  # type: ignore[assignment]
 
 

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -995,6 +995,12 @@ def apply_ipv4_preference(force: bool = False) -> None:
     import socket
     import logging
 
+    # Guard against double-patching. Return before probing/logging so the
+    # dead-route warning fires only on the patch transition — not on every
+    # (cached) call, e.g. once per cron job.
+    if getattr(socket.getaddrinfo, "_hermes_ipv4_patched", False):
+        return
+
     if not force:
         # No explicit force: auto-enable only when IPv6 is configured-but-dead.
         if ipv6_route_alive():
@@ -1004,10 +1010,6 @@ def apply_ipv4_preference(force: bool = False) -> None:
             "to avoid connection hangs. Set network.force_ipv4 in config.yaml "
             "to make this explicit (and skip the probe)."
         )
-
-    # Guard against double-patching
-    if getattr(socket.getaddrinfo, "_hermes_ipv4_patched", False):
-        return
 
     _original_getaddrinfo = socket.getaddrinfo
 

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -5,7 +5,30 @@ from agent.usage_pricing import (
     estimate_usage_cost,
     get_pricing_entry,
     normalize_usage,
+    resolve_billing_route,
 )
+
+
+def test_resolve_billing_route_recognises_local_endpoints():
+    """Self-hosted model servers route to the local branch regardless of how
+    they're addressed — loopback IP, LAN/Tailscale IP, or a local provider id —
+    not just the literal 'localhost' / 'custom'. (LM Studio defaults to
+    http://127.0.0.1:1234, which previously fell through to the generic route.)"""
+    local_cases = [
+        ("lmstudio", "http://127.0.0.1:1234/v1"),
+        ("lmstudio", "http://localhost:1234/v1"),
+        ("", "http://127.0.0.1:1234/v1"),
+        ("ollama", "http://192.168.1.50:11434/v1"),
+        ("vllm", "http://[::1]:8000/v1"),
+        ("custom", ""),
+    ]
+    for provider, base_url in local_cases:
+        route = resolve_billing_route("some-model", provider, base_url)
+        assert route.provider in {"custom", provider}, (provider, base_url, route)
+
+    # Cloud providers must NOT be misclassified as local.
+    assert resolve_billing_route("gpt-4o", "openai", "https://api.openai.com/v1").billing_mode == "official_docs_snapshot"
+    assert resolve_billing_route("hermes-4", "nous", "").billing_mode == "official_models_api"
 
 
 def test_normalize_usage_anthropic_keeps_cache_buckets_separate():

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1424,6 +1424,29 @@ def test_custom_provider_keeps_configured_non_responses_api_mode(monkeypatch):
     assert resolved["api_mode"] == "anthropic_messages"
 
 
+def test_named_custom_provider_without_base_url_warns(monkeypatch, caplog):
+    """A named custom/local provider with no base_url must not fail silently.
+
+    Regression for the kanban-worker footgun: an empty base_url returned None
+    and the caller silently fell back to OpenRouter (no key -> produces nothing,
+    no diagnostic). We now log a warning naming the provider so the per-task log
+    explains *why* a worker did nothing.
+    """
+    monkeypatch.setattr(
+        rp, "_get_named_custom_provider",
+        lambda p: {"name": "mylocal"},  # configured, but no base_url
+    )
+
+    with caplog.at_level("WARNING", logger=rp.logger.name):
+        result = rp._resolve_named_custom_runtime(requested_provider="mylocal")
+
+    assert result is None
+    assert any(
+        "base_url" in r.getMessage() and "mylocal" in r.getMessage()
+        for r in caplog.records
+    ), [r.getMessage() for r in caplog.records]
+
+
 def test_named_custom_provider_api_mode(monkeypatch):
     """custom_providers entries with api_mode should use it."""
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "my-server")

--- a/tests/test_ipv4_preference.py
+++ b/tests/test_ipv4_preference.py
@@ -16,19 +16,54 @@ class TestApplyIPv4Preference:
     """Tests for apply_ipv4_preference()."""
 
     def setup_method(self):
-        """Save the original getaddrinfo before each test."""
+        """Save the original getaddrinfo + reset the IPv6 probe cache."""
+        import hermes_constants
         self._original = socket.getaddrinfo
+        hermes_constants._IPV6_ROUTE_ALIVE = None
 
     def teardown_method(self):
-        """Restore the original getaddrinfo after each test."""
+        """Restore the original getaddrinfo + reset the IPv6 probe cache."""
+        import hermes_constants
         socket.getaddrinfo = self._original
+        hermes_constants._IPV6_ROUTE_ALIVE = None
 
-    def test_noop_when_force_false(self):
-        """No patch when force=False."""
-        from hermes_constants import apply_ipv4_preference
+    def test_noop_when_force_false_and_ipv6_alive(self, monkeypatch):
+        """No patch when force=False and the host's IPv6 route is healthy."""
+        import hermes_constants
+        monkeypatch.setattr(hermes_constants, "ipv6_route_alive", lambda: True)
         original = socket.getaddrinfo
-        apply_ipv4_preference(force=False)
+        hermes_constants.apply_ipv4_preference(force=False)
         assert socket.getaddrinfo is original
+
+    def test_auto_enables_when_ipv6_dead(self, monkeypatch, caplog):
+        """force=False auto-patches AND warns when the IPv6 route is dead."""
+        import hermes_constants
+        monkeypatch.setattr(hermes_constants, "ipv6_route_alive", lambda: False)
+        original = socket.getaddrinfo
+        with caplog.at_level("WARNING", logger="hermes_constants"):
+            hermes_constants.apply_ipv4_preference(force=False)
+        assert socket.getaddrinfo is not original
+        assert getattr(socket.getaddrinfo, "_hermes_ipv4_patched", False) is True
+        assert any("IPv6 route appears dead" in r.getMessage() for r in caplog.records)
+
+    def test_force_true_skips_the_probe(self, monkeypatch):
+        """force=True patches unconditionally, without probing IPv6."""
+        import hermes_constants
+
+        def _boom():
+            raise AssertionError("ipv6_route_alive must not run when force=True")
+
+        monkeypatch.setattr(hermes_constants, "ipv6_route_alive", _boom)
+        hermes_constants.apply_ipv4_preference(force=True)
+        assert getattr(socket.getaddrinfo, "_hermes_ipv4_patched", False) is True
+
+    def test_ipv6_route_alive_returns_bool_and_caches(self):
+        """The probe returns a bool and caches its result for the process."""
+        import hermes_constants
+        hermes_constants._IPV6_ROUTE_ALIVE = None
+        result = hermes_constants.ipv6_route_alive()
+        assert isinstance(result, bool)
+        assert hermes_constants._IPV6_ROUTE_ALIVE is result
 
     def test_patches_getaddrinfo_when_forced(self):
         """Patches socket.getaddrinfo when force=True."""

--- a/tests/test_ipv4_preference.py
+++ b/tests/test_ipv4_preference.py
@@ -16,8 +16,17 @@ class TestApplyIPv4Preference:
     """Tests for apply_ipv4_preference()."""
 
     def setup_method(self):
-        """Save the original getaddrinfo + reset the IPv6 probe cache."""
+        """Start each test from a pristine getaddrinfo + reset the probe cache.
+
+        Importing an entrypoint (e.g. hermes_cli.main) auto-applies IPv4
+        preference at import time on a host whose IPv6 route is dead, which can
+        leave socket.getaddrinfo patched before these tests run. Unwrap it so
+        each test sees a clean global regardless of import/test ordering.
+        """
         import hermes_constants
+        current = socket.getaddrinfo
+        if getattr(current, "_hermes_ipv4_patched", False):
+            socket.getaddrinfo = getattr(current, "_hermes_original", current)
         self._original = socket.getaddrinfo
         hermes_constants._IPV6_ROUTE_ALIVE = None
 

--- a/tests/test_ipv4_preference.py
+++ b/tests/test_ipv4_preference.py
@@ -55,6 +55,36 @@ class TestApplyIPv4Preference:
         assert getattr(socket.getaddrinfo, "_hermes_ipv4_patched", False) is True
         assert any("IPv6 route appears dead" in r.getMessage() for r in caplog.records)
 
+    def test_second_call_does_not_re_warn(self, monkeypatch, caplog):
+        """Once patched, a repeat force=False call is a no-op — no second warning.
+
+        The dead-route warning must fire only on the patch transition. Callers
+        like the cron scheduler invoke apply_ipv4_preference() per job, so a
+        warning on every (already-patched) call would spam the logs. The
+        double-patch guard returns before the probe/log block to prevent this.
+        """
+        import hermes_constants
+        monkeypatch.setattr(hermes_constants, "ipv6_route_alive", lambda: False)
+
+        # First call patches and warns.
+        with caplog.at_level("WARNING", logger="hermes_constants"):
+            hermes_constants.apply_ipv4_preference(force=False)
+        patched = socket.getaddrinfo
+        assert getattr(patched, "_hermes_ipv4_patched", False) is True
+        first_warnings = [
+            r for r in caplog.records if "IPv6 route appears dead" in r.getMessage()
+        ]
+        assert len(first_warnings) == 1
+
+        # Second call: already patched → early return, no new warning, no re-wrap.
+        caplog.clear()
+        with caplog.at_level("WARNING", logger="hermes_constants"):
+            hermes_constants.apply_ipv4_preference(force=False)
+        assert socket.getaddrinfo is patched
+        assert not any(
+            "IPv6 route appears dead" in r.getMessage() for r in caplog.records
+        )
+
     def test_force_true_skips_the_probe(self, monkeypatch):
         """force=True patches unconditionally, without probing IPv6."""
         import hermes_constants

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2002,10 +2002,14 @@ Connectivity workarounds for outbound HTTP:
 
 ```yaml
 network:
-  force_ipv4: false   # Force IPv4 for outbound connections (default: false)
+  force_ipv4: false   # Explicitly force IPv4 for outbound connections (default: false)
 ```
 
-`force_ipv4` — on servers with broken or unreachable IPv6, Python resolves AAAA records first and can hang for the full TCP timeout before falling back to IPv4. Set this to `true` to skip IPv6 entirely and connect over IPv4 directly.
+On servers with broken or unreachable IPv6, Python resolves AAAA records first and can hang for the full TCP timeout before falling back to IPv4 — this affects httpx, requests, urllib, the OpenAI SDK, and anything else that uses `socket.getaddrinfo`.
+
+**Automatic fallback (default).** Hermes probes the host's IPv6 route at startup. If IPv6 is configured but dead, it automatically enables IPv4-preferred DNS resolution and logs a one-time warning; a healthy IPv6 stack is left untouched. You don't need to set anything for this to work.
+
+`force_ipv4` — set this to `true` to enable IPv4-preferred resolution unconditionally, skipping the route probe. Use it when the automatic detection is wrong for your environment (for example, an IPv6 route that probes as "alive" but can't actually carry traffic), or when you simply want to pin the behavior on and avoid the probe cost. Leaving it `false` keeps the automatic-on-dead-IPv6 default.
 
 ## Onboarding
 


### PR DESCRIPTION
Three small, independent reliability fixes, each with regression tests. Happy to split into separate PRs if you'd prefer.

## 1. `fix(network)`: auto-enable IPv4 preference when the IPv6 route is dead
`apply_ipv4_preference` was a no-op unless `network.force_ipv4` was set, so a host with a configured-but-dead IPv6 stack (a v6 address with no route) kept hanging on AAAA-first DNS for the full TCP timeout. Adds `ipv6_route_alive()` — an instant, packet-free UDP-`connect()` probe, cached per process. The patch now auto-enables when IPv6 is dead and logs a one-line self-check warning that rides every entrypoint (dashboard / gateway / cron). Healthy dual-stack hosts probe "alive" and are left untouched; `force_ipv4: true` still forces it on and skips the probe. The patch is also made reversible (`_hermes_original`) so the import-time auto-apply can't break test isolation across files.

## 2. `fix(billing)`: recognise loopback / LAN / local-provider endpoints in `resolve_billing_route`
It matched provider `custom`/`local` or a base_url containing the literal `localhost`, so LM Studio's default `http://127.0.0.1:1234` and LAN/Tailscale-hosted models fell through to the generic route. Now uses the existing `is_local_endpoint()` helper (loopback, RFC-1918, Tailscale) plus a `_LOCAL_PROVIDERS` set (`custom/local/lmstudio/ollama/vllm/llamacpp`), so self-hosted servers classify consistently regardless of how they're addressed.

## 3. `fix(provider)`: warn instead of failing silently when a named custom provider has no `base_url`
`_resolve_named_custom_runtime` returned `None` when a configured named custom/local provider had no `base_url`, and the caller silently fell back to default (OpenRouter) resolution — producing nothing when no other credentials exist, with zero trace of why. Now logs a WARNING naming the provider (and pointing at `LM_BASE_URL`). Fires only on a genuine misconfig, so no false positives.

## Tests
```
pytest tests/agent/test_usage_pricing.py \
       tests/hermes_cli/test_runtime_provider_resolution.py \
       tests/test_ipv4_preference.py
# 159 passed
```
New regression tests cover each fix (loopback/LAN/provider-id billing classification + cloud-not-misclassified; the no-base_url warning; auto-enable-on-dead-IPv6, force-skips-probe, and the reversibility/isolation behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
