### PR TITLE
feat: add DeerFlow and OpenMontage skills

### DIFF
--- a/skills/autonomous-ai-agents/deerflow/SKILL.md
+++ b/skills/autonomous-ai-agents/deerflow/SKILL.md
@@ -1,0 +1,272 @@
+---
+name: deerflow
+description: "Use when bootstrapping, running, or delegating work to ByteDance DeerFlow: an open-source super-agent harness for deep research, sub-agents, memory, sandboxed execution, skills, and messaging channels."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [DeerFlow, Agent-Harness, Research-Agent, LangGraph, Skills, Sandboxes]
+    related_skills: [hermes-agent, codex, claude-code, native-mcp]
+---
+
+# DeerFlow
+
+## Overview
+
+[DeerFlow](https://github.com/bytedance/deer-flow) is ByteDance's open-source super-agent harness. DeerFlow 2.0 orchestrates a lead agent, sub-agents, persistent memory, sandboxed filesystem/command execution, MCP servers, skills, and optional IM channels. Use it when the user wants a DeerFlow instance set up, evaluated, compared to Hermes, or used as a long-running research/build harness.
+
+Canonical upstream:
+
+- Repo: `https://github.com/bytedance/deer-flow`
+- Website: `https://deerflow.tech`
+- Install guide: `https://raw.githubusercontent.com/bytedance/deer-flow/main/Install.md`
+- Default UI endpoint after startup: `http://localhost:2026`
+
+## When to Use
+
+- The user explicitly mentions DeerFlow, `deer-flow`, or ByteDance's super-agent harness.
+- The task is a long-running deep research or multi-agent exploration where DeerFlow is the requested runtime.
+- The user asks to compare Hermes, OpenClaw, DeerFlow, LangGraph-based agent harnesses, or sandboxed agent execution systems.
+- The user wants to wire DeerFlow to Claude Code, Codex, Cursor, Windsurf, Copilot, MCP, or messaging channels.
+
+Do not use this skill just because a task involves research. Use Hermes' native web/search/delegation tools unless DeerFlow itself is part of the requested environment.
+
+## Prerequisites
+
+DeerFlow 2.0 expects current language runtimes:
+
+| Requirement | Baseline |
+|---|---|
+| Python | 3.12+ |
+| Node.js | 22+ |
+| Package tooling | `uv`, `pnpm` / repo-managed scripts |
+| Persistent server | Docker-capable Linux preferred |
+| Local evaluation | 4 vCPU / 8 GB RAM minimum; 8 vCPU / 16 GB recommended |
+
+Run prerequisite checks from the repo root, not from a parent directory.
+
+```bash
+git clone https://github.com/bytedance/deer-flow.git
+cd deer-flow
+make check
+```
+
+If Docker commands fail with `permission denied while trying to connect to the Docker daemon socket`, add the user to the `docker` group and re-login before retrying.
+
+## Fast Setup Path
+
+For an agentic setup handoff, use the upstream one-line instruction verbatim:
+
+```text
+Help me clone DeerFlow if needed, then bootstrap it for local development by following https://raw.githubusercontent.com/bytedance/deer-flow/main/Install.md
+```
+
+For direct setup:
+
+```bash
+git clone https://github.com/bytedance/deer-flow.git
+cd deer-flow
+make setup
+make doctor
+```
+
+`make setup` opens an interactive wizard for LLM provider, optional search provider, sandbox mode, bash access, and write-tool preferences. It creates `config.yaml` and writes credentials to `.env`.
+
+Manual config path:
+
+```bash
+make config          # copies the full config template
+$EDITOR config.yaml
+make doctor
+```
+
+## Running DeerFlow
+
+### Docker Development
+
+Use this for most local evaluation. It hot-reloads source and follows `config.yaml` sandbox settings.
+
+```bash
+make docker-init     # pull sandbox image, first run only or after image updates
+make docker-start    # start services
+```
+
+Stop/restart:
+
+```bash
+make docker-stop
+make docker-start
+```
+
+### Docker Production
+
+Use this for a persistent shared instance.
+
+```bash
+make up              # build images and start production services
+make down            # stop and remove containers
+```
+
+### Local Development
+
+Use this when Docker is unavailable or when debugging the Python/Node services directly.
+
+```bash
+make install
+make dev
+```
+
+Startup variants exposed by the repo:
+
+```bash
+./scripts/serve.sh --dev
+./scripts/serve.sh --dev --daemon
+./scripts/serve.sh --prod
+./scripts/serve.sh --stop
+./scripts/serve.sh --restart
+```
+
+Access the UI at `http://localhost:2026` unless the user configured a different endpoint.
+
+## Model Configuration Notes
+
+DeerFlow is model-agnostic and uses OpenAI-compatible / LangChain-compatible model entries in `config.yaml`.
+
+Common hosted model shape:
+
+```yaml
+models:
+  - name: gpt-4o
+    display_name: GPT-4o
+    use: langchain_openai:ChatOpenAI
+    model: gpt-4o
+    api_key: $OPENAI_API_KEY
+```
+
+OpenRouter / compatible gateways:
+
+```yaml
+models:
+  - name: openrouter-gemini-2.5-flash
+    display_name: Gemini 2.5 Flash (OpenRouter)
+    use: langchain_openai:ChatOpenAI
+    model: google/gemini-2.5-flash-preview
+    api_key: $OPENROUTER_API_KEY
+    base_url: https://openrouter.ai/api/v1
+```
+
+OpenAI Responses API:
+
+```yaml
+models:
+  - name: gpt-5-responses
+    display_name: GPT-5 (Responses API)
+    use: langchain_openai:ChatOpenAI
+    model: gpt-5
+    api_key: $OPENAI_API_KEY
+    use_responses_api: true
+    output_version: responses/v1
+```
+
+CLI-backed providers:
+
+```yaml
+models:
+  - name: gpt-5.4
+    display_name: GPT-5.4 (Codex CLI)
+    use: deerflow.models.openai_codex_provider:CodexChatModel
+    model: gpt-5.4
+    supports_thinking: true
+    supports_reasoning_effort: true
+
+  - name: claude-sonnet-4.6
+    display_name: Claude Sonnet 4.6 (Claude Code OAuth)
+    use: deerflow.models.claude_provider:ClaudeChatModel
+    model: claude-sonnet-4-6
+    max_tokens: 4096
+    supports_thinking: true
+```
+
+Credential locations from upstream docs:
+
+- Codex CLI reads `~/.codex/auth.json`.
+- Claude Code accepts `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_AUTH_TOKEN`, `CLAUDE_CODE_CREDENTIALS_PATH`, or `~/.claude/.credentials.json`.
+- ACP agent entries are separate from model provider entries.
+
+## Sandboxes and Security
+
+DeerFlow can run with local execution, Docker execution, or Docker/Kubernetes provisioner execution. Treat these as material security choices.
+
+- `AioSandboxProvider` runs shell execution inside isolated containers.
+- `LocalSandboxProvider` maps file tools to per-thread host directories, but host bash is disabled by default because it is not a secure isolation boundary.
+- Re-enable host bash only for trusted local workflows.
+- Do not expose DeerFlow publicly without authentication, IP allowlists, or a proper access gateway.
+
+The upstream security notice is explicit: DeerFlow has high-privilege capabilities including command execution, resource operations, and business logic invocation, and is designed by default for local trusted access.
+
+## MCP and Messaging Channels
+
+DeerFlow supports configurable MCP servers and optional IM channels.
+
+Relevant docs in the upstream repo:
+
+- `backend/docs/MCP_SERVER.md`
+- `backend/docs/IM_CHANNEL_CONNECTIONS.md`
+- `backend/docs/CONFIGURATION.md`
+
+Supported IM channels include Telegram, Slack, Feishu/Lark, DingTalk, WeChat, and WeCom. Channels call the Gateway API internally. In Docker Compose, do not point channel URLs at `localhost`; use service names such as:
+
+```yaml
+channels:
+  langgraph_url: http://gateway:8001/api
+  gateway_url: http://gateway:8001
+```
+
+## Claude Code Integration
+
+DeerFlow ships a `claude-to-deerflow` skill for controlling a running DeerFlow instance from Claude Code.
+
+```bash
+npx skills add https://github.com/bytedance/deer-flow --skill claude-to-deerflow
+```
+
+Then ensure DeerFlow is running and use the `/claude-to-deerflow` command from Claude Code. Optional endpoint variables:
+
+```bash
+DEERFLOW_URL=http://localhost:2026
+DEERFLOW_GATEWAY_URL=http://localhost:2026
+DEERFLOW_LANGGRAPH_URL=http://localhost:2026/api/langgraph
+```
+
+## Evaluation Workflow
+
+When asked to evaluate DeerFlow rather than merely install it:
+
+1. Clone a fresh copy or inspect the existing checkout.
+2. Read `README.md`, `Install.md`, `backend/docs/CONFIGURATION.md`, and any requested integration docs.
+3. Run `make check` and `make doctor` before attempting a full run.
+4. Start with Docker dev (`make docker-init && make docker-start`) unless the environment lacks Docker.
+5. Verify the UI/API responds at `http://localhost:2026`.
+6. Run a small research prompt and inspect generated workspace/output artifacts.
+7. Report exact commands, paths, endpoint, and blockers.
+
+## Common Pitfalls
+
+1. **Using DeerFlow v1 docs for DeerFlow 2.0.** DeerFlow 2.0 is a ground-up rewrite. The older deep-research framework lives on the `main-1.x` branch.
+2. **Under-sizing the host.** Two CPU cores and 4 GB RAM is usually not enough. Start at 4 vCPU / 8 GB for evaluation and 8 vCPU / 16 GB for real use.
+3. **Exposing the UI/API on a public interface without access control.** DeerFlow can execute commands and manipulate files.
+4. **Pointing Docker channels at `localhost`.** Inside Compose, `localhost` is the container itself; use `gateway` service URLs.
+5. **Treating CLI auth as API-key auth.** Codex/Claude Code provider entries can rely on their own CLI OAuth files instead of `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`.
+6. **Skipping `make doctor`.** It is the fastest way to get actionable setup fixes.
+
+## Verification Checklist
+
+- [ ] Repo is cloned from `https://github.com/bytedance/deer-flow`.
+- [ ] Runtime versions satisfy Python 3.12+ and Node 22+.
+- [ ] `make check` and `make doctor` have been run and quoted in the report.
+- [ ] `config.yaml` and `.env` exist without secrets being printed.
+- [ ] Selected startup mode is explicit: Docker dev, Docker prod, or local dev.
+- [ ] UI/API endpoint responds, usually `http://localhost:2026`.
+- [ ] If exposed beyond localhost, access control is documented.

--- a/skills/media/openmontage/SKILL.md
+++ b/skills/media/openmontage/SKILL.md
@@ -1,0 +1,279 @@
+---
+name: openmontage
+description: "Use when installing, running, or directing OpenMontage: an open-source agentic video production system that turns AI coding assistants into end-to-end video studios with pipelines, tools, skills, Remotion/HyperFrames, FFmpeg, and quality gates."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [OpenMontage, Video-Production, Remotion, FFmpeg, AI-Video, Agentic-Workflows]
+    related_skills: [youtube-content, manim-video, comfyui, songwriting-and-ai-music, codex]
+---
+
+# OpenMontage
+
+## Overview
+
+[OpenMontage](https://github.com/calesthio/OpenMontage) is an open-source, agentic video production system. It turns a coding assistant into the orchestrator for research, scripting, asset generation, editing, composition, subtitles, audio, and post-render review.
+
+Canonical upstream:
+
+- Repo: `https://github.com/calesthio/OpenMontage`
+- Agent guide: `AGENT_GUIDE.md`
+- Project context: `PROJECT_CONTEXT.md`
+- Providers guide: `docs/PROVIDERS.md`
+- Review guide: `docs/PR_REVIEW_GUIDE.md`
+
+OpenMontage is built around readable pipeline manifests, stage-director skills, Python tools, and renderers such as Remotion, HyperFrames, and FFmpeg. Treat it as a production workflow, not a single prompt-to-video API.
+
+## When to Use
+
+- The user explicitly mentions OpenMontage or wants an agentic video production stack.
+- The task is to create or evaluate explainer videos, documentary montages, cinematic trailers, shorts, podcast clips, talking-head edits, local video workflows, or production pipelines through OpenMontage.
+- The user wants to start from a reference video and derive a grounded production plan.
+- The user asks for free/open video workflows using real footage, Archive.org, NASA, Wikimedia, FFmpeg, Remotion, or local TTS.
+
+Do not use this skill for a quick one-off image generation or simple video summary unless the user specifically wants OpenMontage.
+
+## Prerequisites
+
+| Requirement | Baseline |
+|---|---|
+| Python | 3.10+ |
+| Node.js | 18+ for most workflows; Node 22+ recommended for HyperFrames |
+| FFmpeg | Required for post-production and encoding |
+| AI coding assistant | Claude Code, Cursor, Copilot, Windsurf, Codex, or Hermes with terminal/file tools |
+| Optional GPU | Required only for local video-generation models |
+
+Install FFmpeg first:
+
+```bash
+# Ubuntu/Debian
+sudo apt-get update && sudo apt-get install -y ffmpeg
+
+# macOS
+brew install ffmpeg
+```
+
+## Install
+
+Preferred setup:
+
+```bash
+git clone https://github.com/calesthio/OpenMontage.git
+cd OpenMontage
+make setup
+```
+
+Manual setup if `make` is unavailable:
+
+```bash
+pip install -r requirements.txt
+cd remotion-composer
+npm install
+cd ..
+pip install piper-tts
+cp .env.example .env
+```
+
+Windows npm pitfall from upstream docs:
+
+```bash
+# If npm install fails with ERR_INVALID_ARG_TYPE
+npx --yes npm install
+```
+
+## First Steps for an Agent
+
+OpenMontage is intentionally agent-operated. Before doing production work in the repo:
+
+1. Read `AGENT_GUIDE.md`.
+2. Read `PROJECT_CONTEXT.md`.
+3. Inspect the capability envelope and provider menu:
+
+```bash
+python -c "from tools.tool_registry import registry; import json; registry.discover(); print(json.dumps(registry.support_envelope(), indent=2))"
+python -c "from tools.tool_registry import registry; import json; registry.discover(); print(json.dumps(registry.provider_menu(), indent=2))"
+```
+
+4. Treat every request as a pipeline-selection problem.
+5. Read the selected pipeline manifest under `pipeline_defs/`.
+6. Read the matching stage-director skills under `skills/pipelines/`.
+7. Execute with checkpoints and review gates; do not improvise around the pipeline.
+
+## Request Patterns
+
+### Prompt from Scratch
+
+```text
+Make a 60-second animated explainer about how neural networks learn.
+```
+
+### Real-Footage Documentary Path
+
+```text
+Make a 75-second documentary montage about city life in the rain. Use real footage only, no narration, elegiac tone, with music.
+```
+
+### Reference-Driven Production
+
+```text
+Here's a YouTube Short I love. Make something like this, but about quantum computing.
+```
+
+For reference-driven work, inspect the source video first. Identify pacing, hook structure, scene rhythm, caption style, visual grammar, and audio treatment before proposing variants.
+
+## Pipeline Selection
+
+OpenMontage pipelines are complete production workflows. Start by selecting the right one, then follow its manifest.
+
+| Pipeline | Best For |
+|---|---|
+| `animated-explainer` | Educational explainers, tutorials, concept breakdowns |
+| `animation` | Motion graphics, kinetic typography, abstract sequences |
+| `avatar-spokesperson` | Presenter/avatar-driven videos |
+| `cinematic` | Trailers, teasers, cinematic brand clips |
+| `clip-factory` | Batch short-form clips from a long source |
+| `documentary-montage` | Real-footage edits from stock/open archives |
+| `hybrid` | Existing footage plus AI-generated support visuals |
+| `localization-dub` | Subtitles, dubbing, translation |
+| `podcast-repurpose` | Podcast highlights and audiograms |
+| `screen-demo` | Software walkthroughs and polished screen demos |
+| `talking-head` | Speaker footage, presentations, interviews |
+
+Default pipeline flow:
+
+```text
+research -> proposal -> script -> scene_plan -> assets -> edit -> compose
+```
+
+Do not skip proposal, cost, or approval checkpoints when the pipeline expects them.
+
+## Tool and Renderer Model
+
+OpenMontage has three layers:
+
+```text
+Layer 1: tools/ + pipeline_defs/     What exists: executable capabilities and orchestration contracts
+Layer 2: skills/                     How to use it: OpenMontage conventions and quality bars
+Layer 3: .agents/skills/             How it works: external technology knowledge packs
+```
+
+Renderer choices:
+
+| Renderer | Use For |
+|---|---|
+| Remotion | React-based video, animated explainers, data scenes, captions, image-based motion |
+| HyperFrames | HTML/CSS/GSAP motion graphics, kinetic typography, launch reels, custom web-to-video |
+| FFmpeg | Core assembly, encoding, subtitles, audio muxing, trimming, color work |
+
+`render_runtime` is selected at proposal time and locked through edit decisions. Silent swaps between Remotion and HyperFrames are governance violations.
+
+## Zero-Key and Low-Cost Paths
+
+OpenMontage can create useful outputs without paid video-generation APIs.
+
+Zero-key/free local stack:
+
+- Piper TTS for narration.
+- Archive.org, NASA, and Wikimedia Commons for open footage.
+- FFmpeg for assembly and encoding.
+- Built-in subtitle generation.
+- Remotion or HyperFrames for programmatic animation.
+
+Free-key stock media options:
+
+- Pexels API key.
+- Pixabay API key.
+- Unsplash access key.
+
+Cloud provider keys unlock higher-end image/video/audio generation but should be treated as optional. Do not ask the user to paste secrets into chat; point them to `.env` variable names or retrieve from the approved local secret store if this is Jason's environment.
+
+Common `.env` variables:
+
+```bash
+FAL_KEY=...
+PEXELS_API_KEY=...
+PIXABAY_API_KEY=...
+UNSPLASH_ACCESS_KEY=...
+SUNO_API_KEY=...
+ELEVENLABS_API_KEY=...
+OPENAI_API_KEY=...
+XAI_API_KEY=...
+GOOGLE_API_KEY=...
+HEYGEN_API_KEY=...
+RUNWAY_API_KEY=...
+```
+
+Local GPU unlock:
+
+```bash
+make install-gpu
+
+# .env
+VIDEO_GEN_LOCAL_ENABLED=true
+VIDEO_GEN_LOCAL_MODEL=wan2.1-1.3b
+```
+
+## Production Governance
+
+OpenMontage has quality gates. Preserve them.
+
+- Pre-compose validation checks delivery promises, slideshow risk, and renderer-family selection before render.
+- Post-render self-review uses ffprobe validation, frame sampling, audio level checks, delivery-promise verification, and subtitle checks.
+- Provider selection is scored across task fit, output quality, control features, reliability, cost efficiency, latency, and continuity.
+- Decision logs should record provider choices, style/playbook choices, music/voice selections, renderer decisions, fallback reasoning, and costs.
+- Budget controls estimate, reserve, reconcile, warn/cap, and pause above configured approval thresholds.
+
+Never present a final video if review gates fail. Fix the issue, re-render, and verify again.
+
+## Running Tests
+
+From the repo root:
+
+```bash
+make test-contracts
+make test
+```
+
+Use contract tests first when changing pipeline definitions, schemas, registry behavior, or tool signatures. Run a representative end-to-end render only after contract tests pass.
+
+## Deliverable Verification
+
+For any generated video, verify before handing it to the user:
+
+```bash
+ffprobe -v error -show_format -show_streams path/to/final.mp4
+ffmpeg -i path/to/final.mp4 -vf "fps=1/10" -frames:v 6 /tmp/openmontage-frame-%02d.jpg
+```
+
+Check:
+
+- File exists and has non-zero duration.
+- Video and audio streams match the expected delivery profile.
+- Frames are not black, broken, or duplicate slides unless intentionally static.
+- Captions/subtitles exist when promised.
+- Audio is not silent or clipping.
+- Final format matches the target platform: landscape, Shorts/Reels vertical, square, or cinematic.
+
+## Common Pitfalls
+
+1. **Treating OpenMontage as prompt-to-video.** It is a pipeline system. Select a pipeline and read the stage-director skills.
+2. **Skipping `AGENT_GUIDE.md`.** The repo's operating contract lives there.
+3. **Ignoring zero-key paths.** The system can produce real footage montages and image-based videos without paid video APIs.
+4. **Calling still-image animation “real footage.”** If the user asks for real footage only, use documentary montage / stock/open archives.
+5. **Changing render runtime midstream.** Lock `render_runtime` once the proposal is approved.
+6. **Presenting unverified renders.** Always run ffprobe/frame/audio/subtitle checks.
+7. **Leaking or requesting API keys in chat.** Use `.env` and approved secret retrieval workflows.
+8. **Skipping source-media inspection.** For user-supplied footage, inspect codec, resolution, duration, audio channels, scene boundaries, and actual visual content.
+
+## Verification Checklist
+
+- [ ] Repo is cloned from `https://github.com/calesthio/OpenMontage`.
+- [ ] `AGENT_GUIDE.md` and `PROJECT_CONTEXT.md` were read before production work.
+- [ ] Capability envelope and provider menu were inspected.
+- [ ] Pipeline manifest and stage skills were read.
+- [ ] Cost/provider decisions were recorded before spend.
+- [ ] Render output passed ffprobe, frame sampling, audio, delivery-promise, and subtitle checks.
+- [ ] Final artifact path and exact verification commands are included in the report.


### PR DESCRIPTION
## Summary
- Add a DeerFlow skill covering setup, runtime modes, model config, sandbox/security, MCP/messaging, and evaluation workflow
- Add an OpenMontage skill covering setup, pipeline selection, renderer/tool model, zero-key paths, governance, and deliverable verification

## Test Plan
- `python -m pytest tests/tools/test_skill_manager_tool.py tests/tools/test_skill_size_limits.py tests/scripts/test_build_skills_index_health.py -q -o 'addopts='`
