### PR TITLE
feat(discord): add forum tag support to discord tool

### DIFF
--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -569,6 +569,20 @@ class TestCreateThread:
         assert "type" not in body                       # not a text thread
 
     @patch("tools.discord_tool._discord_request")
+    def test_create_media_post_uses_message_body(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.side_effect = [
+            {"id": "56", "type": 16},
+            {"id": "911", "name": "Media post"},
+        ]
+
+        discord_core(action="create_thread", channel_id="56", name="Media post")
+
+        body = mock_req.call_args_list[1].kwargs["body"]
+        assert body["message"] == {"content": "Media post"}
+        assert "type" not in body
+
+    @patch("tools.discord_tool._discord_request")
     def test_create_forum_post_defaults_content_to_name(self, mock_req, monkeypatch):
         """Forum post with tags but no content → content falls back to name."""
         monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")

--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -481,21 +481,37 @@ class TestPinUnpinDelete:
 # ---------------------------------------------------------------------------
 
 class TestCreateThread:
+    """create_thread discriminates forum vs text by CHANNEL TYPE.
+
+    For a non-anchored create_thread the handler first GETs the channel to
+    learn its type (15 == GUILD_FORUM), then POSTs the appropriate body. So
+    these tests drive ``_discord_request`` with a two-call side_effect:
+    [channel object, created thread].
+    """
+
     @patch("tools.discord_tool._discord_request")
     def test_create_standalone_thread(self, mock_req, monkeypatch):
+        """Non-forum channel (type 0) → text-thread path (type 11, no message)."""
         monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
-        mock_req.return_value = {"id": "800", "name": "New Thread"}
+        mock_req.side_effect = [
+            {"id": "11", "type": 0},               # GET channel
+            {"id": "800", "name": "New Thread"},   # POST thread
+        ]
         result = json.loads(discord_core(action="create_thread", channel_id="11", name="New Thread"))
         assert result["success"] is True
         assert result["thread_id"] == "800"
-        # Verify the API call
-        mock_req.assert_called_once_with(
-            "POST", "/channels/11/threads", "test-token",
-            body={"name": "New Thread", "auto_archive_duration": 1440, "type": 11},
-        )
+        # First call inspects the channel type.
+        assert mock_req.call_args_list[0].args == ("GET", "/channels/11", "test-token")
+        # Second call creates the text thread.
+        post_call = mock_req.call_args_list[1]
+        assert post_call.args == ("POST", "/channels/11/threads", "test-token")
+        assert post_call.kwargs["body"] == {
+            "name": "New Thread", "auto_archive_duration": 1440, "type": 11,
+        }
 
     @patch("tools.discord_tool._discord_request")
     def test_create_thread_from_message(self, mock_req, monkeypatch):
+        """Anchored create (message_id) is unambiguous — no channel pre-fetch."""
         monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
         mock_req.return_value = {"id": "801", "name": "Discussion"}
         result = json.loads(discord_core(
@@ -506,6 +522,162 @@ class TestCreateThread:
             "POST", "/channels/11/messages/1001/threads", "test-token",
             body={"name": "Discussion", "auto_archive_duration": 1440},
         )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_forum_post_with_applied_tags(self, mock_req, monkeypatch):
+        """Forum channel (type 15) with tags → message-object body + applied_tags,
+        and NO type:11 field."""
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.side_effect = [
+            {"id": "55", "type": 15},              # GET channel → forum
+            {"id": "900", "name": "Bug report"},   # POST thread
+        ]
+        result = json.loads(discord_core(
+            action="create_thread", channel_id="55", name="Bug report",
+            applied_tags=["111", "222"], content="It broke",
+        ))
+        assert result["success"] is True
+        assert result["thread_id"] == "900"
+        post_call = mock_req.call_args_list[1]
+        assert post_call.args == ("POST", "/channels/55/threads", "test-token")
+        assert post_call.kwargs["body"] == {
+            "name": "Bug report",
+            "auto_archive_duration": 1440,
+            "message": {"content": "It broke"},
+            "applied_tags": ["111", "222"],
+        }
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_forum_post_without_tags(self, mock_req, monkeypatch):
+        """Regression: a TAGLESS forum post (type 15, no applied_tags) must
+        still use the message-object endpoint — a forum REJECTS the text-style
+        'Start Thread' call, so this is the previously-broken case. Content
+        falls back to the thread name; no applied_tags key, no type:11."""
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.side_effect = [
+            {"id": "55", "type": 15},          # GET channel → forum
+            {"id": "910", "name": "Topic"},    # POST thread
+        ]
+        result = json.loads(discord_core(
+            action="create_thread", channel_id="55", name="Topic",
+        ))
+        assert result["success"] is True
+        assert result["thread_id"] == "910"
+        body = mock_req.call_args_list[1].kwargs["body"]
+        assert body["message"] == {"content": "Topic"}   # defaulted to name
+        assert "applied_tags" not in body               # tags optional, none given
+        assert "type" not in body                       # not a text thread
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_forum_post_defaults_content_to_name(self, mock_req, monkeypatch):
+        """Forum post with tags but no content → content falls back to name."""
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.side_effect = [
+            {"id": "55", "type": 15},          # GET channel → forum
+            {"id": "901", "name": "Topic"},    # POST thread
+        ]
+        discord_core(
+            action="create_thread", channel_id="55", name="Topic",
+            applied_tags=["111"],
+        )
+        body = mock_req.call_args_list[1].kwargs["body"]
+        assert body["message"] == {"content": "Topic"}
+        assert body["applied_tags"] == ["111"]
+        assert "type" not in body
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_thread_text_channel_ignores_tags(self, mock_req, monkeypatch):
+        """Regression guard: a non-forum channel (type 0) always takes the text
+        path (type 11, no message object) — even if applied_tags is passed."""
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.side_effect = [
+            {"id": "11", "type": 0},           # GET channel → text
+            {"id": "802", "name": "Plain"},    # POST thread
+        ]
+        discord_core(action="create_thread", channel_id="11", name="Plain")
+        post_call = mock_req.call_args_list[1]
+        assert post_call.args == ("POST", "/channels/11/threads", "test-token")
+        body = post_call.kwargs["body"]
+        assert body == {"name": "Plain", "auto_archive_duration": 1440, "type": 11}
+        assert "message" not in body
+        assert "applied_tags" not in body
+
+
+# ---------------------------------------------------------------------------
+# Action: list_forum_tags
+# ---------------------------------------------------------------------------
+
+class TestListForumTags:
+    @patch("tools.discord_tool._discord_request")
+    def test_list_forum_tags(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {
+            "id": "55",
+            "type": 15,
+            "available_tags": [
+                {"id": "111", "name": "bug", "moderated": False, "emoji_id": None, "emoji_name": "🐛"},
+                {"id": "222", "name": "staff-only", "moderated": True, "emoji_id": "999", "emoji_name": None},
+            ],
+        }
+        result = json.loads(discord_core(action="list_forum_tags", channel_id="55"))
+        assert result["success"] is True
+        assert result["channel_id"] == "55"
+        assert result["available_tags"] == [
+            {"id": "111", "name": "bug", "emoji": "🐛", "moderated": False},
+            {"id": "222", "name": "staff-only", "emoji": "999", "moderated": True},
+        ]
+        mock_req.assert_called_once_with("GET", "/channels/55", "test-token")
+
+    @patch("tools.discord_tool._discord_request")
+    def test_list_forum_tags_no_tags(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {"id": "55", "type": 15}  # available_tags absent
+        result = json.loads(discord_core(action="list_forum_tags", channel_id="55"))
+        assert result["available_tags"] == []
+
+
+# ---------------------------------------------------------------------------
+# Action: set_thread_tags
+# ---------------------------------------------------------------------------
+
+class TestSetThreadTags:
+    @patch("tools.discord_tool._discord_request")
+    def test_set_thread_tags(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {"id": "900", "applied_tags": ["111", "222"]}
+        result = json.loads(discord_admin_handler(
+            action="set_thread_tags", channel_id="900", applied_tags=["111", "222"],
+        ))
+        assert result["success"] is True
+        assert result["thread_id"] == "900"
+        assert result["applied_tags"] == ["111", "222"]
+        mock_req.assert_called_once_with(
+            "PATCH", "/channels/900", "test-token",
+            body={"applied_tags": ["111", "222"]},
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_set_thread_tags_empty_clears(self, mock_req, monkeypatch):
+        """An empty applied_tags list is a valid 'clear all tags' request and
+        must not be rejected as a missing param."""
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {"id": "900", "applied_tags": []}
+        result = json.loads(discord_admin_handler(
+            action="set_thread_tags", channel_id="900", applied_tags=[],
+        ))
+        assert "error" not in result
+        assert result["applied_tags"] == []
+        mock_req.assert_called_once_with(
+            "PATCH", "/channels/900", "test-token", body={"applied_tags": []},
+        )
+
+    def test_set_thread_tags_requires_channel_id(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        result = json.loads(discord_admin_handler(
+            action="set_thread_tags", applied_tags=["1"],
+        ))
+        assert "error" in result
+        assert "channel_id" in result["error"]
 
 
 # ---------------------------------------------------------------------------
@@ -593,15 +765,19 @@ class TestRegistration:
         from tools.registry import registry
         entry = registry._tools["discord"]
         actions = set(entry.schema["parameters"]["properties"]["action"]["enum"])
-        assert actions == {"fetch_messages", "search_members", "create_thread"}
+        assert actions == {
+            "fetch_messages", "search_members", "create_thread", "list_forum_tags",
+        }
+        assert actions == set(_CORE_ACTIONS.keys())
 
     def test_admin_schema_actions(self):
         """Admin static schema should list only admin actions."""
         from tools.registry import registry
         entry = registry._tools["discord_admin"]
         actions = set(entry.schema["parameters"]["properties"]["action"]["enum"])
-        expected_admin = set(_ACTIONS.keys()) - {"fetch_messages", "search_members", "create_thread"}
+        expected_admin = set(_ACTIONS.keys()) - set(_CORE_ACTIONS.keys())
         assert actions == expected_admin
+        assert "set_thread_tags" in actions
 
     def test_all_actions_covered(self):
         """Core + admin actions should cover all known actions."""
@@ -646,6 +822,28 @@ class TestRegistration:
         assert callable(entry.handler)
         entry_admin = registry._tools["discord_admin"]
         assert callable(entry_admin.handler)
+
+    def test_forum_tag_actions_in_correct_schemas(self):
+        """list_forum_tags is read-only → CORE; set_thread_tags mutates → ADMIN."""
+        from tools.registry import registry
+        core_actions = set(
+            registry._tools["discord"].schema["parameters"]["properties"]["action"]["enum"]
+        )
+        admin_actions = set(
+            registry._tools["discord_admin"].schema["parameters"]["properties"]["action"]["enum"]
+        )
+        assert "list_forum_tags" in core_actions
+        assert "list_forum_tags" not in admin_actions
+        assert "set_thread_tags" in admin_actions
+        assert "set_thread_tags" not in core_actions
+
+    def test_applied_tags_and_content_properties_present(self):
+        from tools.registry import registry
+        for tool_name in ("discord", "discord_admin"):
+            props = registry._tools[tool_name].schema["parameters"]["properties"]
+            assert props["applied_tags"]["type"] == "array"
+            assert props["applied_tags"]["items"] == {"type": "string"}
+            assert props["content"]["type"] == "string"
 
 
 # ---------------------------------------------------------------------------

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -588,19 +588,61 @@ def _create_thread(
     token: str, channel_id: str, name: str,
     message_id: Optional[str] = None,
     auto_archive_duration: int = 1440,
+    applied_tags: Optional[List[str]] = None,
+    content: str = "",
     **_kwargs: Any,
 ) -> str:
-    """Create a thread in a channel."""
+    """Create a thread in a channel.
+
+    Three shapes:
+
+    - ``message_id`` given → thread anchored to an existing message
+      (text/announcement channel). No message body, no type field, and no
+      channel pre-fetch (the anchor endpoint is unambiguous).
+    - target is a GUILD_FORUM channel (``type == 15``) → a FORUM post. Forum
+      (and media) channels REQUIRE the message-object endpoint
+      (``POST /channels/{forum_id}/threads`` with a ``message`` object) and
+      REJECT the text-style "Start Thread" call — so we must detect the forum
+      by channel type, NOT by whether tags were supplied. ``applied_tags`` is
+      purely OPTIONAL here: a tagless forum post is normal. Discord rejects an
+      empty message, so ``content`` falls back to the thread ``name`` (and
+      finally a single space) when not supplied.
+    - otherwise → a standalone PUBLIC_THREAD (``type: 11``) in a text channel,
+      the original behavior (no message body).
+
+    Detection costs one extra ``GET /channels/{channel_id}`` per non-anchored
+    create_thread, which is acceptable for a thread-create.
+    """
     if message_id:
-        # Create thread from an existing message
+        # Create thread from an existing message — no pre-fetch needed.
         path = f"/channels/{channel_id}/messages/{message_id}/threads"
         body: Dict[str, Any] = {
             "name": name,
             "auto_archive_duration": auto_archive_duration,
         }
+        thread = _discord_request("POST", path, token, body=body)
+        return json.dumps({
+            "success": True,
+            "thread_id": thread["id"],
+            "name": thread.get("name"),
+        })
+
+    # Discriminate forum vs text on the actual channel type (type 15 ==
+    # GUILD_FORUM). Tag presence is NOT a reliable signal — tagless forum
+    # posts are normal and still require the message-object endpoint.
+    channel = _discord_request("GET", f"/channels/{channel_id}", token)
+    path = f"/channels/{channel_id}/threads"
+    if channel.get("type") == 15:
+        # Forum post: required message object; tags optional.
+        body = {
+            "name": name,
+            "auto_archive_duration": auto_archive_duration,
+            "message": {"content": content or name or " "},
+        }
+        if applied_tags:
+            body["applied_tags"] = list(applied_tags)
     else:
-        # Create a standalone thread
-        path = f"/channels/{channel_id}/threads"
+        # Standalone text-channel thread (original behavior).
         body = {
             "name": name,
             "auto_archive_duration": auto_archive_duration,
@@ -611,6 +653,53 @@ def _create_thread(
         "success": True,
         "thread_id": thread["id"],
         "name": thread.get("name"),
+    })
+
+
+def _list_forum_tags(token: str, channel_id: str, **_kwargs: Any) -> str:
+    """List the tags configured on a forum channel (its ``available_tags``).
+
+    Read-only — GET the channel and surface the tag set a forum post can draw
+    from. ``channel_id`` is the GUILD_FORUM channel ID.
+    """
+    ch = _discord_request("GET", f"/channels/{channel_id}", token)
+    tags = []
+    for t in ch.get("available_tags") or []:
+        tags.append({
+            "id": t.get("id"),
+            "name": t.get("name"),
+            # Either a unicode emoji name or a custom emoji id may be set.
+            "emoji": t.get("emoji_name") or t.get("emoji_id"),
+            "moderated": t.get("moderated", False),
+        })
+    return json.dumps({
+        "success": True,
+        "channel_id": channel_id,
+        "available_tags": tags,
+    })
+
+
+def _set_thread_tags(
+    token: str, channel_id: str,
+    applied_tags: Optional[List[str]] = None,
+    **_kwargs: Any,
+) -> str:
+    """Re-tag a forum post by PATCHing its ``applied_tags``.
+
+    ``channel_id`` is the forum POST/thread ID. ``applied_tags`` is the FULL
+    desired list of tag IDs — Discord replaces (does not merge) the set, so an
+    empty list intentionally CLEARS all tags. We therefore deliberately do not
+    gate on truthiness; ``[]`` is a valid request, not a missing param.
+    """
+    tags = list(applied_tags or [])
+    thread = _discord_request(
+        "PATCH", f"/channels/{channel_id}", token, body={"applied_tags": tags},
+    )
+    thread = thread or {}
+    return json.dumps({
+        "success": True,
+        "thread_id": thread.get("id", channel_id),
+        "applied_tags": thread.get("applied_tags", tags),
     })
 
 
@@ -644,11 +733,15 @@ _ACTIONS = {
     "unpin_message": _unpin_message,
     "delete_message": _delete_message,
     "create_thread": _create_thread,
+    "set_thread_tags": _set_thread_tags,
+    "list_forum_tags": _list_forum_tags,
     "add_role": _add_role,
     "remove_role": _remove_role,
 }
 
-_CORE_ACTION_NAMES = frozenset({"fetch_messages", "search_members", "create_thread"})
+_CORE_ACTION_NAMES = frozenset({
+    "fetch_messages", "search_members", "create_thread", "list_forum_tags",
+})
 _ADMIN_ACTION_NAMES = frozenset(_ACTIONS.keys()) - _CORE_ACTION_NAMES
 
 _CORE_ACTIONS = {k: v for k, v in _ACTIONS.items() if k in _CORE_ACTION_NAMES}
@@ -670,7 +763,9 @@ _ACTION_MANIFEST: List[Tuple[str, str, str]] = [
     ("pin_message", "(channel_id, message_id)", "pin a message"),
     ("unpin_message", "(channel_id, message_id)", "unpin a message"),
     ("delete_message", "(channel_id, message_id)", "delete a message"),
-    ("create_thread", "(channel_id, name)", "create a public thread; optional message_id anchor"),
+    ("create_thread", "(channel_id, name)", "create a thread; forum channels become forum posts (optional applied_tags/content); optional message_id anchor"),
+    ("set_thread_tags", "(channel_id, applied_tags)", "set forum tags on a forum post (thread); empty list clears"),
+    ("list_forum_tags", "(channel_id)", "list a forum channel's available tags"),
     ("add_role", "(guild_id, user_id, role_id)", "assign a role"),
     ("remove_role", "(guild_id, user_id, role_id)", "remove a role"),
 ]
@@ -692,6 +787,10 @@ _REQUIRED_PARAMS: Dict[str, List[str]] = {
     "unpin_message": ["channel_id", "message_id"],
     "delete_message": ["channel_id", "message_id"],
     "create_thread": ["channel_id", "name"],
+    # set_thread_tags: only the thread id is required — an empty applied_tags
+    # list is a valid "clear all tags" request, so it is NOT required here.
+    "set_thread_tags": ["channel_id"],
+    "list_forum_tags": ["channel_id"],
     "add_role": ["guild_id", "user_id", "role_id"],
     "remove_role": ["guild_id", "user_id", "role_id"],
 }
@@ -872,6 +971,23 @@ def _build_schema(
             "enum": [60, 1440, 4320, 10080],
             "description": "Thread archive duration in minutes (create_thread, default 1440).",
         },
+        "applied_tags": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": (
+                "Forum tag IDs. Required for set_thread_tags (the full desired "
+                "set; an empty list clears all tags). Optional for create_thread "
+                "when the target is a forum channel (tags are not required to "
+                "post)."
+            ),
+        },
+        "content": {
+            "type": "string",
+            "description": (
+                "Initial message body for a forum post (create_thread on a forum "
+                "channel). Defaults to the thread name if omitted."
+            ),
+        },
     }
 
     return {
@@ -932,6 +1048,13 @@ _ACTION_403_HINT = {
     ),
     "create_thread": (
         "Bot lacks CREATE_PUBLIC_THREADS in this channel, or cannot view it."
+    ),
+    "set_thread_tags": (
+        "Bot lacks MANAGE_THREADS in this forum (or is not the thread owner). "
+        "Editing applied_tags on someone else's post requires MANAGE_THREADS."
+    ),
+    "list_forum_tags": (
+        "Bot cannot view this forum channel (missing VIEW_CHANNEL)."
     ),
     "add_role": (
         "Either the bot lacks MANAGE_ROLES, or the target role sits higher "
@@ -999,6 +1122,8 @@ def _run_discord_action(
     before: str = "",
     after: str = "",
     auto_archive_duration: int = 1440,
+    applied_tags: Optional[List[str]] = None,
+    content: str = "",
 ) -> str:
     """Shared handler logic for both discord tools."""
     token = _get_bot_token()
@@ -1054,6 +1179,8 @@ def _run_discord_action(
             before=before,
             after=after,
             auto_archive_duration=auto_archive_duration,
+            applied_tags=applied_tags,
+            content=content,
         )
     except DiscordAPIError as e:
         logger.warning("Discord API error in %s action '%s': %s", tool_label, action, e)
@@ -1066,7 +1193,7 @@ def _run_discord_action(
 
 
 def discord_core(action: str, **kwargs) -> str:
-    """Execute a core Discord action (fetch_messages, search_members, create_thread)."""
+    """Execute a core Discord action (fetch_messages, search_members, create_thread, list_forum_tags)."""
     return _run_discord_action(action, _CORE_ACTIONS, "discord", **kwargs)
 
 
@@ -1083,6 +1210,7 @@ _HANDLER_DEFAULTS = {
     "action": "", "guild_id": "", "channel_id": "", "user_id": "",
     "role_id": "", "message_id": "", "query": "", "name": "",
     "limit": 50, "before": "", "after": "", "auto_archive_duration": 1440,
+    "applied_tags": None, "content": "",
 }
 
 

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -599,8 +599,8 @@ def _create_thread(
     - ``message_id`` given → thread anchored to an existing message
       (text/announcement channel). No message body, no type field, and no
       channel pre-fetch (the anchor endpoint is unambiguous).
-    - target is a GUILD_FORUM channel (``type == 15``) → a FORUM post. Forum
-      (and media) channels REQUIRE the message-object endpoint
+    - target is a GUILD_FORUM or GUILD_MEDIA channel (``type`` 15 or 16) → a
+      post. Forum and media channels REQUIRE the message-object endpoint
       (``POST /channels/{forum_id}/threads`` with a ``message`` object) and
       REJECT the text-style "Start Thread" call — so we must detect the forum
       by channel type, NOT by whether tags were supplied. ``applied_tags`` is
@@ -627,13 +627,12 @@ def _create_thread(
             "name": thread.get("name"),
         })
 
-    # Discriminate forum vs text on the actual channel type (type 15 ==
-    # GUILD_FORUM). Tag presence is NOT a reliable signal — tagless forum
-    # posts are normal and still require the message-object endpoint.
+    # Tag presence is not a reliable discriminator: tagless forum/media posts
+    # still require the message-object endpoint.
     channel = _discord_request("GET", f"/channels/{channel_id}", token)
     path = f"/channels/{channel_id}/threads"
-    if channel.get("type") == 15:
-        # Forum post: required message object; tags optional.
+    if channel.get("type") in (15, 16):
+        # Forum/media post: required message object; tags optional.
         body = {
             "name": name,
             "auto_archive_duration": auto_archive_duration,


### PR DESCRIPTION
## Summary

Discord forum and media channels organize posts with tags (`available_tags` on the parent channel and `applied_tags` on each post). This extends the existing service-gated Discord tool rather than adding core tool surface.

### New / changed actions

- **`list_forum_tags`** (core, read-only): read a forum/media channel's available tags
- **`set_thread_tags`** (admin): replace a post's applied tags; an empty list clears them
- **`create_thread`**: detect `GUILD_FORUM` (15) and `GUILD_MEDIA` (16) and create posts through Discord's required message-object body; text channels retain `type: 11`

Forum/media detection uses the channel type rather than tag presence, so tagless posts still take the valid endpoint shape. Message-anchored thread creation remains unchanged and avoids the channel prefetch.

The actions are wired through the existing Discord action manifest, schema, validation, defaults, handler passthrough, privilege split, and 403 hints.

## Test Plan

- [x] `uv run --with pytest --with pytest-asyncio --python ~/.hermes/hermes-agent/venv/bin/python python -m pytest tests/tools/test_discord_tool.py -q` — 111 passed
- [x] Forum type 15 with/without tags uses the message-object body
- [x] Media type 16 uses the message-object body and omits `type: 11`
- [x] Text channels retain `type: 11`
- [x] `git diff --check`
