### PR TITLE
fix(test): barrier eliminates race in compression fork test (#52526)

### DIFF
--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -101,6 +101,18 @@ def test_concurrent_compression_does_not_fork_session(tmp_path: Path) -> None:
     parent_sid = "PARENT_TEST_SESSION"
     db.create_session(parent_sid, source="discord")
 
+    # Barrier ensures both threads reach the compression lock acquisition
+    # before either proceeds — without it, the OS can serialize the threads
+    # so the first finishes before the second even attempts the lock.
+    # Patching try_acquire_compression_lock to synchronize at the exact
+    # contention point eliminates timing sensitivity.
+    lock_barrier = threading.Barrier(2)
+    _orig_try_lock = SessionDB.try_acquire_compression_lock
+
+    def _barrier_try_lock(self, session_id, holder):
+        lock_barrier.wait(timeout=5)
+        return _orig_try_lock(self, session_id, holder)
+
     # Two agents on the same session_id, both wired to the same db —
     # mirrors the parent-turn agent + the background-review fork right
     # after a turn ends.
@@ -115,12 +127,13 @@ def test_concurrent_compression_does_not_fork_session(tmp_path: Path) -> None:
             # Surface to the test if either raises — should not happen.
             raise
 
-    t_a = threading.Thread(target=run, args=(agent_a,), name="main_turn")
-    t_b = threading.Thread(target=run, args=(agent_b,), name="review_fork")
-    t_a.start()
-    t_b.start()
-    t_a.join(timeout=10)
-    t_b.join(timeout=10)
+    with patch.object(SessionDB, "try_acquire_compression_lock", _barrier_try_lock):
+        t_a = threading.Thread(target=run, args=(agent_a,), name="main_turn")
+        t_b = threading.Thread(target=run, args=(agent_b,), name="review_fork")
+        t_a.start()
+        t_b.start()
+        t_a.join(timeout=10)
+        t_b.join(timeout=10)
 
     # Exactly one canonical child — not two orphans.
     assert _count_children(db, parent_sid) == 1, (


### PR DESCRIPTION
## What does this PR do?

Fixes a flaky test (`test_concurrent_compression_does_not_fork_session`) that intermittently fails in CI due to a race condition in thread scheduling. The test verifies that the per-session compression lock prevents transcript forks when two paths compress the same session concurrently. Without deterministic synchronization, the OS can serialize the two threads so the first finishes before the second even attempts the lock acquisition, making the test non-reproducible.

## Related Issue

Fixes #52526

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tests/agent/test_compression_concurrent_fork.py`: Added a `threading.Barrier` that synchronizes both threads at the `try_acquire_compression_lock` entry point via `patch.object`. This ensures both threads contend for the lock simultaneously, eliminating timing sensitivity from OS thread scheduling. Ran the test 10 consecutive times with 10/10 passes (previously flaky at ~2/5 failure rate).

## How to Test

1. Run the test file: `python -m pytest tests/agent/test_compression_concurrent_fork.py -xvs`
2. All 4 tests should pass, including `test_concurrent_compression_does_not_fork_session`
3. Run the specific flaky test 10+ times: `for i in $(seq 10); do python -m pytest tests/agent/test_compression_concurrent_fork.py::test_concurrent_compression_does_not_fork_session -x --tb=short -q || break; done` — should pass all 10 times

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
