### PR TITLE
fix(ci): run CI on all PRs to anywhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
   push:
     branches: [main]
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,7 +16,6 @@ on:
   # reports a status (path-gated workflows leave checks "pending" forever
   # when no matching files change, which blocks merge).
   pull_request:
-    branches: [main]
 
   release:
     types: [published]


### PR DESCRIPTION

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->
fixes stacked PRs no-checks bug where
main < a < b
a merges into main
b is retargeted to main

but b doesn't run checks since it's not considered a new pr to main

now b will simply already have passing ci :)



## Related Issue

<img width="1084" height="872" alt="image" src="https://github.com/user-attachments/assets/fde1f02f-b253-4ad0-94d7-41add60b97cc" />
 ( proof that this works)
closes https://github.com/NousResearch/hermes-agent/pull/52553
## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- removed `branches: [main]` specifier on `pull_request:` for `ci.yml` and `docker-publish.yml`

## Checklist
proof it works here: https://github.com/NousResearch/hermes-agent/pull/52553
