### PR TITLE
feat(providers): support provider-scoped model headers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -469,45 +469,30 @@ _OR_HEADERS_BASE = {
 _TRUTHY_ENV_VALUES = frozenset({"1", "true", "yes", "on"})
 
 
-def _apply_user_default_headers(headers: dict | None) -> dict | None:
-    """Merge user-configured ``model.default_headers`` onto resolved headers.
+def _apply_user_default_headers(
+    headers: dict | None,
+    *,
+    provider: str | None = None,
+    base_url: str | None = None,
+) -> dict | None:
+    """Merge user-configured ``model`` headers onto resolved headers.
 
-    User values take precedence over provider/SDK defaults, mirroring the main
-    agent client (``AIAgent._apply_user_default_headers``). This lets a
-    ``custom`` OpenAI-compatible endpoint behind a gateway/WAF that rejects the
-    OpenAI SDK's identifying headers (``User-Agent: OpenAI/Python ...``,
-    ``X-Stainless-*``) override them for auxiliary calls too — otherwise the
-    main turn would succeed but title/compression/vision calls to the same
-    endpoint would still fail. (#40033)
-
-    Returns the merged dict, or the original ``headers`` (possibly ``None``)
-    when nothing is configured. No allocation when there are no overrides.
+    ``model.default_headers`` remains the backward-compatible global override.
+    ``model.provider_headers.<provider>`` applies provider-scoped headers (for
+    attribution/billing/proxy routing) only when the active provider or base URL
+    matches, so one OpenAI-compatible provider's metadata does not leak to
+    another.
     """
     try:
-        from hermes_cli.config import cfg_get, load_config
-        _cfg = load_config()
-        user_headers = cfg_get(_cfg, "model", "default_headers")
-        # ``model.extra_headers`` is an accepted alias (matches the
-        # per-provider ``extra_headers`` key on providers/custom_providers
-        # entries). When both are set they merge, with ``extra_headers``
-        # winning. SECURITY: values may carry credentials — never log them.
-        alias_headers = cfg_get(_cfg, "model", "extra_headers")
-        if isinstance(alias_headers, dict) and alias_headers:
-            merged_user: dict = {}
-            if isinstance(user_headers, dict):
-                merged_user.update(user_headers)
-            merged_user.update(alias_headers)
-            user_headers = merged_user
+        from hermes_cli.providers import merge_configured_provider_headers
+
+        return merge_configured_provider_headers(
+            headers,
+            provider=provider,
+            base_url=base_url,
+        )
     except Exception:
         return headers
-    if not isinstance(user_headers, dict) or not user_headers:
-        return headers
-    merged = dict(headers or {})
-    for key, value in user_headers.items():
-        if value is None:
-            continue
-        merged[str(key)] = str(value)
-    return merged or headers
 
 
 def build_or_headers(or_config: dict | None = None) -> dict:
@@ -1734,7 +1719,11 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
                         extra["default_headers"] = dict(_ph_aux.default_headers)
                 except Exception:
                     pass
-            _merged_aux = _apply_user_default_headers(extra.get("default_headers"))
+            _merged_aux = _apply_user_default_headers(
+                extra.get("default_headers"),
+                provider=provider_id,
+                base_url=base_url,
+            )
             if _merged_aux:
                 extra["default_headers"] = _merged_aux
             _client = _create_openai_client(api_key=api_key, base_url=base_url, **extra)
@@ -1774,7 +1763,11 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
                     extra["default_headers"] = dict(_ph_aux2.default_headers)
             except Exception:
                 pass
-        _merged_aux2 = _apply_user_default_headers(extra.get("default_headers"))
+        _merged_aux2 = _apply_user_default_headers(
+            extra.get("default_headers"),
+            provider=provider_id,
+            base_url=base_url,
+        )
         if _merged_aux2:
             extra["default_headers"] = _merged_aux2
         _client = _create_openai_client(api_key=api_key, base_url=base_url, **extra)
@@ -1794,9 +1787,17 @@ def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Op
         or_key = explicit_api_key or _pool_runtime_api_key(entry)
         if or_key:
             base_url = _pool_runtime_base_url(entry, OPENROUTER_BASE_URL) or OPENROUTER_BASE_URL
+            headers = _apply_user_default_headers(
+                build_or_headers(),
+                provider="openrouter",
+                base_url=base_url,
+            )
             logger.debug("Auxiliary client: OpenRouter via pool")
-            return _create_openai_client(api_key=or_key, base_url=base_url,
-                           default_headers=build_or_headers()), model or _OPENROUTER_MODEL
+            return _create_openai_client(
+                api_key=or_key,
+                base_url=base_url,
+                default_headers=headers,
+            ), model or _OPENROUTER_MODEL
         # Pool exists but is exhausted (no usable runtime key) — fall through to
         # the OPENROUTER_API_KEY env-var path rather than failing outright.
         logger.debug("Auxiliary client: OpenRouter pool exhausted, trying OPENROUTER_API_KEY")
@@ -1806,8 +1807,16 @@ def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Op
         _mark_provider_unhealthy("openrouter", ttl=60)
         return None, None
     logger.debug("Auxiliary client: OpenRouter")
-    return _create_openai_client(api_key=or_key, base_url=OPENROUTER_BASE_URL,
-                   default_headers=build_or_headers()), model or _OPENROUTER_MODEL
+    headers = _apply_user_default_headers(
+        build_or_headers(),
+        provider="openrouter",
+        base_url=OPENROUTER_BASE_URL,
+    )
+    return _create_openai_client(
+        api_key=or_key,
+        base_url=OPENROUTER_BASE_URL,
+        default_headers=headers,
+    ), model or _OPENROUTER_MODEL
 
 
 def _describe_openrouter_unavailable() -> str:
@@ -1898,10 +1907,19 @@ def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
             _mark_provider_unhealthy("nous", ttl=60)
             return None, None
         base_url = str((nous or {}).get("inference_base_url") or _nous_base_url()).rstrip("/")
+    headers = _apply_user_default_headers(
+        None,
+        provider="nous",
+        base_url=base_url,
+    )
+    extra = {}
+    if headers:
+        extra["default_headers"] = headers
     return (
         _create_openai_client(
             api_key=api_key,
             base_url=base_url,
+            **extra,
         ),
         model,
     )
@@ -2172,7 +2190,7 @@ def _try_custom_endpoint() -> Tuple[Optional[Any], Optional[str]]:
     # headers (User-Agent: OpenAI/Python ..., X-Stainless-*) on this custom
     # endpoint's auxiliary calls too — matching the main agent client so the
     # whole session reaches a gateway/WAF that rejects the SDK fingerprint. (#40033)
-    _custom_headers = _apply_user_default_headers(None)
+    _custom_headers = _apply_user_default_headers(None, provider="custom", base_url=_clean_base)
     if _custom_headers:
         _extra["default_headers"] = _custom_headers
     if custom_mode == "codex_responses":
@@ -3739,10 +3757,20 @@ def _resolve_single_provider(
     )
     return client
 
-def _resolve_auto(
+def _auto_provider_key(provider: str) -> str:
+    """Normalize logged fallback labels back to provider keys for header lookup."""
+    key = str(provider or "").strip().lower()
+    if key.endswith(")") and "(" in key:
+        key = key.rsplit("(", 1)[1][:-1].strip()
+    if key == "local/custom":
+        return "custom"
+    return key
+
+
+def _resolve_auto_with_provider(
     main_runtime: Optional[Dict[str, Any]] = None,
     task: Optional[str] = None,
-) -> Tuple[Optional[OpenAI], Optional[str]]:
+) -> Tuple[Optional[Any], Optional[str], str]:
     """Full auto-detection chain.
 
     Priority:
@@ -3869,7 +3897,7 @@ def _resolve_auto(
             if client is not None:
                 logger.info("Auxiliary auto-detect: using main provider %s (%s)",
                             main_provider, resolved or main_model)
-                return client, resolved or main_model
+                return client, resolved or main_model, _auto_provider_key(resolved_provider)
 
     # ── Step 2: user-configured fallback policy ─────────────────────────
     # In auto mode, respect the task-specific fallback chain first, then the
@@ -3880,11 +3908,11 @@ def _resolve_auto(
         fb_client, fb_model, _fb_label = _try_configured_fallback_chain(
             task, main_provider or "auto", reason="main provider unavailable")
         if fb_client is not None:
-            return fb_client, fb_model
+            return fb_client, fb_model, _auto_provider_key(_fb_label)
     fb_client, fb_model, _fb_label = _try_main_fallback_chain(
         task, main_provider or "auto", reason="main provider unavailable")
     if fb_client is not None:
-        return fb_client, fb_model
+        return fb_client, fb_model, _auto_provider_key(_fb_label)
 
     # ── Step 3: aggregator / fallback chain ──────────────────────────────
     tried = []
@@ -3900,13 +3928,22 @@ def _resolve_auto(
                             label, model or "default", ", ".join(tried))
             else:
                 logger.info("Auxiliary auto-detect: using %s (%s)", label, model or "default")
-            return client, model
+            return client, model, _auto_provider_key(label)
         tried.append(label)
     logger.warning("Auxiliary auto-detect: no provider available (tried: %s). "
                    "Compression, summarization, and memory flush will not work. "
                    "Set OPENROUTER_API_KEY or configure a local model in config.yaml.",
                    ", ".join(tried))
-    return None, None
+    return None, None, ""
+
+
+def _resolve_auto(
+    main_runtime: Optional[Dict[str, Any]] = None,
+    task: Optional[str] = None,
+) -> Tuple[Optional[Any], Optional[str]]:
+    """Backward-compatible two-value auto resolver."""
+    client, model, _provider = _resolve_auto_with_provider(main_runtime=main_runtime, task=task)
+    return client, model
 
 
 # ── Centralized Provider Router ─────────────────────────────────────────────
@@ -3920,7 +3957,12 @@ def _resolve_auto(
 # below — never look up auth env vars ad-hoc.
 
 
-def _to_async_client(sync_client, model: str, is_vision: bool = False):
+def _to_async_client(
+    sync_client,
+    model: str | None,
+    is_vision: bool = False,
+    provider: str | None = None,
+):
     """Convert a sync client to its async counterpart, preserving Codex routing.
 
     When ``is_vision=True`` and the underlying base URL is Copilot, the
@@ -3979,7 +4021,11 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
                     async_kwargs["default_headers"] = dict(_ph_async.default_headers)
         except Exception:
             pass
-    _merged_async = _apply_user_default_headers(async_kwargs.get("default_headers"))
+    _merged_async = _apply_user_default_headers(
+        async_kwargs.get("default_headers"),
+        provider=provider,
+        base_url=sync_base_url,
+    )
     if _merged_async:
         async_kwargs["default_headers"] = _merged_async
     async_kwargs = {
@@ -4135,7 +4181,10 @@ def resolve_provider_client(
 
     # ── Auto: try all providers in priority order ────────────────────
     if provider == "auto":
-        client, resolved = _resolve_auto(main_runtime=main_runtime, task=task)
+        client, resolved, auto_provider = _resolve_auto_with_provider(
+            main_runtime=main_runtime,
+            task=task,
+        )
         if client is None:
             return None, None
         # When auto-detection lands on a non-OpenRouter provider (e.g. a
@@ -4148,7 +4197,8 @@ def resolve_provider_client(
                 "auxiliary provider (using %r instead)", model, resolved)
             model = None
         final_model = model or resolved
-        return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+        auto_provider = auto_provider or provider
+        return (_to_async_client(client, final_model, is_vision=is_vision, provider=auto_provider) if async_mode
                 else (client, final_model))
 
     # ── OpenRouter ───────────────────────────────────────────
@@ -4161,7 +4211,7 @@ def resolve_provider_client(
             )
             return None, None
         final_model = _normalize_resolved_model(model or default, provider)
-        return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+        return (_to_async_client(client, final_model, is_vision=is_vision, provider=provider) if async_mode
                 else (client, final_model))
 
     # ── Nous Portal (OAuth) ──────────────────────────────────────────
@@ -4178,7 +4228,7 @@ def resolve_provider_client(
                            "but Nous Portal not configured (run: hermes auth)")
             return None, None
         final_model = _normalize_resolved_model(model or default, provider)
-        return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+        return (_to_async_client(client, final_model, is_vision=is_vision, provider=provider) if async_mode
                 else (client, final_model))
 
     # ── OpenAI Codex (OAuth → Responses API) ─────────────────────────
@@ -4212,7 +4262,7 @@ def resolve_provider_client(
                            "but no Codex OAuth token found (run: hermes model)")
             return None, None
         final_model = _normalize_resolved_model(model or default, provider)
-        return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+        return (_to_async_client(client, final_model, is_vision=is_vision, provider=provider) if async_mode
                 else (client, final_model))
 
     # ── xAI Grok OAuth (device code → Responses API) ───────────────
@@ -4232,7 +4282,7 @@ def resolve_provider_client(
             )
             return None, None
         final_model = _normalize_resolved_model(model or default, provider)
-        return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+        return (_to_async_client(client, final_model, is_vision=is_vision, provider=provider) if async_mode
                 else (client, final_model))
 
     # ── Custom endpoint (OPENAI_BASE_URL + OPENAI_API_KEY) ───────────
@@ -4277,12 +4327,16 @@ def resolve_provider_client(
                         extra["default_headers"] = dict(_ph_custom.default_headers)
                 except Exception:
                     pass
-            _merged_custom = _apply_user_default_headers(extra.get("default_headers"))
+            _merged_custom = _apply_user_default_headers(
+                extra.get("default_headers"),
+                provider="custom",
+                base_url=_clean_base,
+            )
             if _merged_custom:
                 extra["default_headers"] = _merged_custom
             client = _create_openai_client(api_key=custom_key, base_url=_clean_base, **extra)
             client = _wrap_if_needed(client, final_model, custom_base, custom_key)
-            return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+            return (_to_async_client(client, final_model, is_vision=is_vision, provider=provider) if async_mode
                     else (client, final_model))
         # Try custom first, then API-key providers (Codex excluded here:
         # falling through to Codex with no model is a stale-constant trap).
@@ -4297,7 +4351,7 @@ def resolve_provider_client(
                 _raw_ckey = getattr(client, "api_key", "")
                 _ckey = "" if (callable(_raw_ckey) and not isinstance(_raw_ckey, str)) else str(_raw_ckey or "")
                 client = _wrap_if_needed(client, final_model, _cbase, _ckey)
-                return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                return (_to_async_client(client, final_model, is_vision=is_vision, provider=provider) if async_mode
                         else (client, final_model))
         logger.warning("resolve_provider_client: custom/main requested "
                        "but no endpoint credentials found")
@@ -4356,7 +4410,11 @@ def resolve_provider_client(
                     raw_base_for_wrap = custom_base
                 _clean_base2, _dq2 = _extract_url_query_params(openai_base)
                 _extra2 = {"default_query": _dq2} if _dq2 else {}
-                _headers2 = _apply_user_default_headers(_extra2.get("default_headers"))
+                _headers2 = _apply_user_default_headers(
+                    _extra2.get("default_headers"),
+                    provider=provider,
+                    base_url=_clean_base2,
+                )
                 if _headers2:
                     _extra2["default_headers"] = _headers2
                 logger.debug(
@@ -4381,11 +4439,15 @@ def resolve_provider_client(
                         _fallback_base = _to_openai_base_url(custom_base)
                         _fb_clean, _fb_dq = _extract_url_query_params(_fallback_base)
                         _fb_extra = {"default_query": _fb_dq} if _fb_dq else {}
-                        _fb_headers = _apply_user_default_headers(_fb_extra.get("default_headers"))
+                        _fb_headers = _apply_user_default_headers(
+                            _fb_extra.get("default_headers"),
+                            provider=provider,
+                            base_url=_fb_clean,
+                        )
                         if _fb_headers:
                             _fb_extra["default_headers"] = _fb_headers
                         client = _create_openai_client(api_key=custom_key, base_url=_fb_clean, **_fb_extra)
-                        return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                        return (_to_async_client(client, final_model, is_vision=is_vision, provider=provider) if async_mode
                                 else (client, final_model))
                     sync_anthropic = AnthropicAuxiliaryClient(
                         real_client, final_model, custom_key, custom_base, is_oauth=False,
@@ -4404,7 +4466,7 @@ def resolve_provider_client(
                     client = CodexAuxiliaryClient(client, final_model)
                 else:
                     client = _wrap_if_needed(client, final_model, raw_base_for_wrap, custom_key)
-                return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                return (_to_async_client(client, final_model, is_vision=is_vision, provider=provider) if async_mode
                         else (client, final_model))
             logger.warning(
                 "resolve_provider_client: named custom provider %r has no base_url",
@@ -4444,7 +4506,7 @@ def resolve_provider_client(
             )
             return None, None
         final_model = _normalize_resolved_model(model or default_model, provider)
-        return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+        return (_to_async_client(client, final_model, is_vision=is_vision, provider=provider) if async_mode
                 else (client, final_model))
 
     # ── API-key providers from PROVIDER_REGISTRY ─────────────────────
@@ -4474,7 +4536,7 @@ def resolve_provider_client(
                 logger.warning("resolve_provider_client: anthropic requested but no Anthropic credentials found")
                 return None, None
             final_model = _normalize_resolved_model(model or default_model, provider)
-            return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode else (client, final_model))
+            return (_to_async_client(client, final_model, is_vision=is_vision, provider=provider) if async_mode else (client, final_model))
 
         creds = resolve_api_key_provider_credentials(provider)
         api_key = str(creds.get("api_key", "")).strip()
@@ -4510,7 +4572,7 @@ def resolve_provider_client(
             if is_native_gemini_base_url(base_url):
                 client = GeminiNativeClient(api_key=api_key, base_url=base_url)
                 logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
-                return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                return (_to_async_client(client, final_model, is_vision=is_vision, provider=provider) if async_mode
                         else (client, final_model))
 
         # Provider-specific headers
@@ -4536,7 +4598,11 @@ def resolve_provider_client(
                     headers.update(_ph_main.default_headers)
             except Exception:
                 pass
-        _merged_main = _apply_user_default_headers(headers)
+        _merged_main = _apply_user_default_headers(
+            headers,
+            provider=provider,
+            base_url=base_url,
+        )
         if _merged_main:
             headers = _merged_main
         client = _create_openai_client(api_key=api_key, base_url=base_url,
@@ -4567,7 +4633,7 @@ def resolve_provider_client(
         client = _wrap_if_needed(client, final_model, raw_base_url, api_key)
 
         logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
-        return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+        return (_to_async_client(client, final_model, is_vision=is_vision, provider=provider) if async_mode
                 else (client, final_model))
 
     if pconfig.auth_type == "external_process":
@@ -4604,7 +4670,7 @@ def resolve_provider_client(
                 args=args,
             )
             logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
-            return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+            return (_to_async_client(client, final_model, is_vision=is_vision, provider=provider) if async_mode
                     else (client, final_model))
         if provider not in _LOGGED_UNSUPPORTED_EXTPROC_KEYS:
             _LOGGED_UNSUPPORTED_EXTPROC_KEYS.add(provider)
@@ -4678,7 +4744,7 @@ def resolve_provider_client(
             base_url=f"https://bedrock-runtime.{region}.amazonaws.com",
         )
         logger.debug("resolve_provider_client: bedrock (%s, %s)", final_model, region)
-        return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+        return (_to_async_client(client, final_model, is_vision=is_vision, provider=provider) if async_mode
                 else (client, final_model))
 
     elif pconfig.auth_type in {"oauth_device_code", "oauth_external"}:
@@ -4871,7 +4937,12 @@ def resolve_vision_provider_client(
             return resolved_provider, None, None
         final_model = resolved_model or default_model
         if async_mode:
-            async_client, async_model = _to_async_client(sync_client, final_model, is_vision=True)
+            async_client, async_model = _to_async_client(
+                sync_client,
+                final_model,
+                is_vision=True,
+                provider=resolved_provider,
+            )
             return resolved_provider, async_client, async_model
         return resolved_provider, sync_client, final_model
 
@@ -5173,7 +5244,12 @@ def _refresh_nous_auxiliary_client(
             current_loop = _aio.get_event_loop()
         except RuntimeError:
             pass
-        client, final_model = _to_async_client(sync_client, final_model or "", is_vision=is_vision)
+        client, final_model = _to_async_client(
+            sync_client,
+            final_model or "",
+            is_vision=is_vision,
+            provider="nous",
+        )
     else:
         client = sync_client
 
@@ -6965,7 +7041,10 @@ async def async_call_llm(
                     base_url=str(getattr(fb_client, "base_url", "") or ""))
                 # Convert sync fallback client to async
                 async_fb, async_fb_model = _to_async_client(
-                    fb_client, fb_model or "", is_vision=(task == "vision")
+                    fb_client,
+                    fb_model or "",
+                    is_vision=(task == "vision"),
+                    provider=_auto_provider_key(fb_label or ""),
                 )
                 if async_fb_model and async_fb_model != fb_kwargs.get("model"):
                     fb_kwargs["model"] = async_fb_model

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -7,6 +7,7 @@ Add, remove, or reorder entries here — both `hermes setup` and
 
 from __future__ import annotations
 
+import inspect
 import json
 import os
 import urllib.parse
@@ -2325,7 +2326,11 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             api_key = str(creds.get("api_key") or "").strip()
             base_url = str(creds.get("base_url") or "").strip()
             if api_key and base_url:
-                live = fetch_api_models(api_key, base_url)
+                live = _fetch_api_models_with_headers(
+                    api_key,
+                    base_url,
+                    headers=_configured_model_headers(provider="stepfun", base_url=base_url),
+                )
                 if live:
                     return live
         except Exception:
@@ -2381,7 +2386,11 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
                 "https://api.openai.com",
             )
             try:
-                live = fetch_api_models(api_key, base)
+                live = _fetch_api_models_with_headers(
+                    api_key,
+                    base,
+                    headers=_configured_model_headers(provider=normalized, base_url=base),
+                )
                 if live:
                     if is_default_openai:
                         live_lower = {m.lower() for m in live}
@@ -2406,7 +2415,11 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             api_key = str(creds.get("api_key") or "").strip()
             base_url = str(creds.get("base_url") or "").strip()
             if api_key and base_url:
-                live = fetch_api_models(api_key, base_url)
+                live = _fetch_api_models_with_headers(
+                    api_key,
+                    base_url,
+                    headers=_configured_model_headers(provider="gmi", base_url=base_url),
+                )
                 if live:
                     return live
         except Exception:
@@ -2423,7 +2436,12 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
                 or os.getenv("OPENROUTER_API_KEY", "")
             )
             api_mode = "anthropic_messages" if _base_url_looks_like_anthropic_messages(base_url) else None
-            live = fetch_api_models(api_key, base_url, api_mode=api_mode)
+            live = _fetch_api_models_with_headers(
+                api_key,
+                base_url,
+                api_mode=api_mode,
+                headers=_configured_model_headers(provider="custom", base_url=base_url),
+            )
             if live:
                 return live
     # Bedrock uses live discovery keyed by the resolved AWS region so that
@@ -2457,7 +2475,17 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             if not base_url:
                 base_url = _p.base_url
             if api_key:
-                live = _p.fetch_models(api_key=api_key, base_url=base_url or None)
+                headers = _configured_model_headers(
+                    dict(_p.default_headers),
+                    provider=normalized,
+                    base_url=base_url or _p.base_url,
+                )
+                live = _fetch_profile_models(
+                    _p,
+                    api_key=api_key,
+                    base_url=base_url or "",
+                    headers=headers,
+                )
                 if live:
                     # Merge static curated list with live API results so
                     # models that the live endpoint omits (stale cache,
@@ -2506,9 +2534,10 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
 #
 # Cache strategy:
 #   - One JSON file at $HERMES_HOME/provider_models_cache.json
-#   - Per-provider entries keyed by (provider, credential fingerprint)
-#   - Credential fingerprint = sha256 of env-var values that the provider
-#     normally reads. Swap your OPENAI_API_KEY and the entry invalidates.
+#   - Per-provider entries keyed by (provider, credential/header fingerprint)
+#   - Credential/header fingerprint = hash of env-var values that the provider
+#     normally reads plus configured model request headers. Swap your
+#     OPENAI_API_KEY or a provider-scoped tenant header and the entry invalidates.
 #   - 1h TTL by default. `force_refresh=True` skips the cache entirely
 #     and overwrites it on success.
 #   - Only NON-EMPTY results are cached. An empty/None response from a
@@ -2525,17 +2554,17 @@ def _provider_models_cache_path() -> Path:
 
 
 def _credential_fingerprint(provider: str) -> str:
-    """Return a short hash representing the credentials that
+    """Return a short hash representing the request context that
     ``provider_model_ids(provider)`` would see right now.
 
-    Rotating any of the relevant env vars invalidates the cached entry
-    for that provider. We hash AT LEAST the api-key + base-url env vars
-    declared in ``PROVIDER_REGISTRY``. For OAuth-backed providers
-    (codex, copilot, anthropic-via-claude-code, nous portal), the
-    relevant tokens live in ``$HERMES_HOME/auth.json`` and external
-    credential files. Rather than parse every shape, we additionally
-    fold the mtime of those files into the fingerprint so refreshes
-    after re-auth bust the cache.
+    Rotating any of the relevant env vars or configured request headers
+    invalidates the cached entry for that provider. We hash AT LEAST the
+    api-key + base-url env vars declared in ``PROVIDER_REGISTRY``. For
+    OAuth-backed providers (codex, copilot, anthropic-via-claude-code,
+    nous portal), the relevant tokens live in ``$HERMES_HOME/auth.json``
+    and external credential files. Rather than parse every shape, we
+    additionally fold the mtime of those files into the fingerprint so
+    refreshes after re-auth bust the cache.
     """
     import hashlib
     import os as _os
@@ -2552,6 +2581,28 @@ def _credential_fingerprint(provider: str) -> str:
             bev = getattr(pcfg, "base_url_env_var", "") or ""
             if bev:
                 parts.append(f"{bev}={_os.environ.get(bev, '')}")
+    except Exception:
+        pass
+
+    # User-configured request headers can affect provider model listings
+    # (project/tenant attribution, billing routes, proxy routing headers).
+    # They are hashed into the cache key, never persisted in cache entries.
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        model_cfg = cfg.get("model") if isinstance(cfg, dict) else {}
+        if isinstance(model_cfg, dict):
+            header_cfg: dict[str, Any] = {}
+            for key in ("default_headers", "extra_headers", "provider_headers"):
+                value = model_cfg.get(key)
+                if isinstance(value, dict) and value:
+                    header_cfg[key] = value
+            if header_cfg:
+                parts.append(
+                    "model_headers="
+                    + json.dumps(header_cfg, sort_keys=True, default=str)
+                )
     except Exception:
         pass
 
@@ -3555,6 +3606,10 @@ def probe_api_models(
 
     tried: list[str] = []
     headers: dict[str, str] = {"User-Agent": _HERMES_USER_AGENT}
+    if request_headers:
+        for key, value in request_headers.items():
+            if value is not None:
+                headers[str(key)] = str(value)
     if api_key and api_mode == "anthropic_messages":
         headers["x-api-key"] = api_key
         headers["anthropic-version"] = "2023-06-01"
@@ -3616,6 +3671,85 @@ def fetch_api_models(
     ).get("models")
 
 
+def _configured_model_headers(
+    headers: Optional[dict[str, str]] = None,
+    *,
+    provider: Optional[str] = None,
+    base_url: Optional[str] = None,
+) -> Optional[dict[str, str]]:
+    try:
+        providers_mod = __import__(
+            "hermes_cli.providers",
+            fromlist=["merge_configured_provider_headers"],
+        )
+        merge_configured_provider_headers = getattr(
+            providers_mod,
+            "merge_configured_provider_headers",
+        )
+        return merge_configured_provider_headers(
+            headers,
+            provider=provider,
+            base_url=base_url,
+        )
+    except Exception:
+        return headers
+
+
+def _fetch_api_models_with_headers(
+    api_key: Optional[str],
+    base_url: Optional[str],
+    *,
+    timeout: Optional[float] = None,
+    api_mode: Optional[str] = None,
+    headers: Optional[dict[str, str]] = None,
+) -> Optional[list[str]]:
+    kwargs: dict[str, Any] = {}
+    optional_kwargs: dict[str, Any] = {
+        "timeout": timeout,
+        "api_mode": api_mode,
+        "headers": headers,
+    }
+    try:
+        signature = inspect.signature(fetch_api_models)
+        parameters = signature.parameters.values()
+        accepts_var_kwargs = any(p.kind is inspect.Parameter.VAR_KEYWORD for p in parameters)
+        for key, value in optional_kwargs.items():
+            if value is not None and (key in signature.parameters or accepts_var_kwargs):
+                kwargs[key] = value
+    except (TypeError, ValueError):
+        # Built-in fetch_api_models accepts these keywords. If a replacement
+        # callable does not expose a signature, keep the historical two-arg
+        # call rather than risking an unexpected-keyword failure.
+        pass
+    return fetch_api_models(api_key, base_url, **kwargs)
+
+
+def _fetch_profile_models(
+    profile: Any,
+    *,
+    api_key: str,
+    base_url: str,
+    headers: Optional[dict[str, str]],
+) -> Optional[list[str]]:
+    kwargs: dict[str, Any] = {
+        "api_key": api_key,
+        "base_url": base_url or None,
+    }
+    try:
+        signature = inspect.signature(profile.fetch_models)
+        parameters = signature.parameters.values()
+        if "headers" in signature.parameters or any(
+            p.kind is inspect.Parameter.VAR_KEYWORD for p in parameters
+        ):
+            kwargs["headers"] = headers
+    except (TypeError, ValueError):
+        # Some callables do not expose signatures. Preserve the historical
+        # ProviderProfile.fetch_models(api_key=..., base_url=...) ABI rather
+        # than risking an unexpected-keyword failure in out-of-tree plugins.
+        pass
+    return profile.fetch_models(**kwargs)
+
+
 # ---------------------------------------------------------------------------
 # Ollama Cloud — merged model discovery with disk cache
 # ---------------------------------------------------------------------------
@@ -3644,11 +3778,17 @@ def _ollama_cloud_cache_path() -> Path:
     return get_hermes_home() / "ollama_cloud_models_cache.json"
 
 
-def _load_ollama_cloud_cache(*, ignore_ttl: bool = False) -> Optional[dict]:
+def _load_ollama_cloud_cache(
+    *,
+    ignore_ttl: bool = False,
+    fingerprint: Optional[str] = None,
+) -> Optional[dict]:
     """Load cached Ollama Cloud models from disk.
 
     Args:
         ignore_ttl: If True, return data even if the TTL has expired (stale fallback).
+        fingerprint: Optional request-context fingerprint that must match the
+            cached entry.
     """
     try:
         cache_path = _ollama_cloud_cache_path()
@@ -3661,6 +3801,8 @@ def _load_ollama_cloud_cache(*, ignore_ttl: bool = False) -> Optional[dict]:
         models = data.get("models")
         if not (isinstance(models, list) and models):
             return None
+        if fingerprint is not None and data.get("fp") != fingerprint:
+            return None
         if not ignore_ttl:
             cached_at = data.get("cached_at", 0)
             if (time.time() - cached_at) > _OLLAMA_CLOUD_CACHE_TTL:
@@ -3671,13 +3813,20 @@ def _load_ollama_cloud_cache(*, ignore_ttl: bool = False) -> Optional[dict]:
     return None
 
 
-def _save_ollama_cloud_cache(models: list[str]) -> None:
+def _save_ollama_cloud_cache(
+    models: list[str],
+    *,
+    fingerprint: Optional[str] = None,
+) -> None:
     """Persist the merged Ollama Cloud model list to disk."""
     try:
         from utils import atomic_json_write
         cache_path = _ollama_cloud_cache_path()
         cache_path.parent.mkdir(parents=True, exist_ok=True)
-        atomic_json_write(cache_path, {"models": models, "cached_at": time.time()}, indent=None)
+        if fingerprint is None:
+            fingerprint = _credential_fingerprint("ollama-cloud")
+        payload = {"models": models, "cached_at": time.time(), "fp": fingerprint}
+        atomic_json_write(cache_path, payload, indent=None)
     except Exception:
         pass
 
@@ -3698,9 +3847,11 @@ def fetch_ollama_cloud_models(
 
     Returns a list of model IDs (never None — empty list on total failure).
     """
+    cache_fp = _credential_fingerprint("ollama-cloud")
+
     # 1. Check disk cache
     if not force_refresh:
-        cached = _load_ollama_cloud_cache()
+        cached = _load_ollama_cloud_cache(fingerprint=cache_fp)
         if cached is not None:
             return cached["models"]
 
@@ -3712,7 +3863,12 @@ def fetch_ollama_cloud_models(
 
     live_models: list[str] = []
     if api_key:
-        result = fetch_api_models(api_key, base_url, timeout=8.0)
+        result = _fetch_api_models_with_headers(
+            api_key,
+            base_url,
+            timeout=8.0,
+            headers=_configured_model_headers(provider="ollama-cloud", base_url=base_url),
+        )
         if result:
             live_models = result
 
@@ -3738,11 +3894,11 @@ def fetch_ollama_cloud_models(
                 seen.add(normalized)
                 merged.append(normalized)
         if merged:
-            _save_ollama_cloud_cache(merged)
+            _save_ollama_cloud_cache(merged, fingerprint=cache_fp)
             return merged
 
     # Total failure — return stale cache if available (ignore TTL)
-    stale = _load_ollama_cloud_cache(ignore_ttl=True)
+    stale = _load_ollama_cloud_cache(ignore_ttl=True, fingerprint=cache_fp)
     if stale is not None:
         return stale["models"]
 
@@ -3850,10 +4006,16 @@ def validate_requested_model(
 
     if normalized == "custom" or normalized.startswith("custom:"):
         # Try probing with correct auth for the api_mode.
+        request_headers = _configured_model_headers(provider=normalized, base_url=base_url)
         if api_mode == "anthropic_messages":
-            probe = probe_api_models(api_key, base_url, api_mode=api_mode)
+            probe = probe_api_models(
+                api_key,
+                base_url,
+                api_mode=api_mode,
+                request_headers=request_headers,
+            )
         else:
-            probe = probe_api_models(api_key, base_url)
+            probe = probe_api_models(api_key, base_url, request_headers=request_headers)
         api_models = probe.get("models")
         if api_models is not None:
             if requested_for_lookup in set(api_models):
@@ -4084,7 +4246,12 @@ def validate_requested_model(
     # Anthropic Messages API: many proxies don't implement /v1/models.
     # Try probing with correct auth; if it fails, accept with a warning.
     if api_mode == "anthropic_messages":
-        api_models = fetch_api_models(api_key, base_url, api_mode=api_mode)
+        api_models = _fetch_api_models_with_headers(
+            api_key,
+            base_url,
+            api_mode=api_mode,
+            headers=_configured_model_headers(provider=normalized, base_url=base_url),
+        )
         if api_models is not None:
             if requested_for_lookup in set(api_models):
                 return {
@@ -4117,7 +4284,11 @@ def validate_requested_model(
         }
 
     # Probe the live API to check if the model actually exists
-    api_models = fetch_api_models(api_key, base_url)
+    api_models = _fetch_api_models_with_headers(
+        api_key,
+        base_url,
+        headers=_configured_model_headers(provider=normalized, base_url=base_url),
+    )
 
     if api_models is not None:
         # Gemini's OpenAI-compat /v1beta/openai/models endpoint returns IDs

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
 
 from utils import base_url_host_matches, base_url_hostname
 
@@ -396,6 +397,118 @@ def normalize_provider(name: str) -> str:
     """
     key = name.strip().lower()
     return ALIASES.get(key, key)
+
+
+def _url_path_segments(value: str) -> tuple[str, ...]:
+    path = urlparse((value or "").strip()).path.rstrip("/")
+    return tuple(segment for segment in path.split("/") if segment)
+
+
+def _profile_base_url_match_length(base_url: str, profile_base_url: str) -> int:
+    """Return a path-specific match score for base_url against profile_base_url."""
+    if not base_url or not profile_base_url:
+        return -1
+    if base_url_hostname(base_url) != base_url_hostname(profile_base_url):
+        return -1
+    actual_segments = _url_path_segments(base_url)
+    profile_segments = _url_path_segments(profile_base_url)
+    if not profile_segments:
+        return 0
+    if len(actual_segments) < len(profile_segments):
+        return -1
+    if actual_segments[: len(profile_segments)] != profile_segments:
+        return -1
+    return len(profile_segments)
+
+
+def infer_provider_from_base_url(base_url: Optional[str]) -> Optional[str]:
+    """Infer the best ProviderProfile provider id from an OpenAI-compatible base URL."""
+    if not base_url:
+        return None
+    try:
+        import providers as provider_registry
+
+        list_profiles = getattr(provider_registry, "list_providers", None)
+        if list_profiles:
+            best_name = ""
+            best_score = -1
+            for profile in list_profiles():
+                profile_base = str(getattr(profile, "base_url", "") or "")
+                score = _profile_base_url_match_length(str(base_url), profile_base)
+                if score > best_score:
+                    best_name = str(getattr(profile, "name", "") or "")
+                    best_score = score
+            if best_score >= 0 and best_name:
+                return best_name
+    except Exception:
+        pass
+    return None
+
+
+def merge_configured_provider_headers(
+    headers: Optional[Dict[str, str]] = None,
+    *,
+    provider: Optional[str] = None,
+    base_url: Optional[str] = None,
+    config: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, str]]:
+    """Merge global and provider-scoped ``model`` headers from config.yaml.
+
+    ``model.default_headers`` remains the backward-compatible global override;
+    ``model.extra_headers`` is accepted as an alias and wins over
+    ``default_headers`` when both are set.
+    ``model.provider_headers.<provider>`` adds scoped headers for one provider
+    without leaking them to unrelated OpenAI-compatible providers.
+    """
+    try:
+        config_mod = __import__("hermes_cli.config", fromlist=["cfg_get", "load_config"])
+        cfg_get = getattr(config_mod, "cfg_get")
+        load_config = getattr(config_mod, "load_config")
+
+        cfg = config if isinstance(config, dict) else load_config()
+        global_headers = cfg_get(cfg, "model", "default_headers")
+        alias_headers = cfg_get(cfg, "model", "extra_headers")
+        provider_headers = cfg_get(cfg, "model", "provider_headers")
+    except Exception:
+        return headers
+
+    layers: List[Dict[str, Any]] = []
+    if isinstance(global_headers, dict) and global_headers:
+        layers.append(global_headers)
+    if isinstance(alias_headers, dict) and alias_headers:
+        layers.append(alias_headers)
+
+    if isinstance(provider_headers, dict) and provider_headers:
+        candidates: List[str] = []
+        raw_provider = str(provider or "").strip().lower()
+        if raw_provider and raw_provider != "auto":
+            candidates.append(raw_provider)
+        try:
+            normalized = normalize_provider(raw_provider)
+            if normalized and normalized != "auto" and normalized not in candidates:
+                candidates.append(normalized)
+        except Exception:
+            pass
+        if base_url:
+            inferred = infer_provider_from_base_url(base_url)
+            if inferred and inferred not in candidates:
+                candidates.append(inferred)
+        for candidate in candidates:
+            scoped_headers = provider_headers.get(candidate)
+            if isinstance(scoped_headers, dict) and scoped_headers:
+                layers.append(scoped_headers)
+                break
+
+    if not layers:
+        return headers
+
+    merged = dict(headers or {})
+    for layer in layers:
+        for key, value in layer.items():
+            if value is None:
+                continue
+            merged[str(key)] = str(value)
+    return merged or headers
 
 
 def get_provider(name: str) -> Optional[ProviderDef]:

--- a/providers/base.py
+++ b/providers/base.py
@@ -165,6 +165,7 @@ class ProviderProfile:
         api_key: str | None = None,
         base_url: str | None = None,
         timeout: float = 8.0,
+        headers: dict[str, str] | None = None,
     ) -> list[str] | None:
         """Fetch the live model list from the provider's models endpoint.
 
@@ -204,7 +205,8 @@ class ProviderProfile:
         # the default ``Python-urllib/<ver>`` User-Agent.  Set a generic
         # hermes-cli UA so the catalog endpoint is reachable.
         req.add_header("User-Agent", _profile_user_agent())
-        for k, v in self.default_headers.items():
+        effective_headers = headers if headers is not None else self.default_headers
+        for k, v in effective_headers.items():
             req.add_header(k, v)
 
         try:

--- a/run_agent.py
+++ b/run_agent.py
@@ -4454,8 +4454,9 @@ class AIAgent:
     def _apply_user_default_headers(self) -> None:
         """Merge user-configured request headers onto the OpenAI client.
 
-        Reads ``model.default_headers`` from config.yaml and merges it onto
-        ``self._client_kwargs["default_headers"]``, with user values taking
+        Reads ``model.default_headers`` plus provider-scoped
+        ``model.provider_headers.<provider>`` from config.yaml and merges them
+        onto ``self._client_kwargs["default_headers"]``, with user values taking
         precedence over provider- and SDK-supplied defaults.
 
         This exists for ``custom`` OpenAI-compatible endpoints sitting behind
@@ -4477,9 +4478,15 @@ class AIAgent:
         from agent.auxiliary_client import (
             _apply_user_default_headers as _merge_user_headers,
         )
-        merged = _merge_user_headers(self._client_kwargs.get("default_headers"))
+        client_kwargs = getattr(self, "_client_kwargs", {})
+        merged = _merge_user_headers(
+            client_kwargs.get("default_headers"),
+            provider=getattr(self, "provider", None),
+            base_url=str(getattr(self, "base_url", "") or ""),
+        )
         if merged:
-            self._client_kwargs["default_headers"] = merged
+            client_kwargs["default_headers"] = merged
+            setattr(self, "_client_kwargs", client_kwargs)
 
     def _swap_credential(self, entry) -> None:
         runtime_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")

--- a/tests/agent/test_auxiliary_user_default_headers.py
+++ b/tests/agent/test_auxiliary_user_default_headers.py
@@ -10,6 +10,7 @@ same endpoint still fail with an opaque 4xx/502. (#40033)
 """
 
 from unittest.mock import patch, MagicMock
+from types import SimpleNamespace
 
 import pytest
 
@@ -68,6 +69,87 @@ class TestApplyUserDefaultHeadersHelper:
         merged = _apply_user_default_headers({})
         assert merged == {"User-Agent": "curl/8.7.1"}
         assert "X-Drop" not in merged
+
+    def test_provider_headers_apply_only_to_matching_provider(self, tmp_path):
+        _write_config(tmp_path, {
+            "model": {
+                "default": "m",
+                "default_headers": {"X-Global": "global"},
+                "provider_headers": {
+                    "gmi": {"X-Provider": "gmi", "X-Global": "gmi"},
+                },
+            },
+        })
+        from agent.auxiliary_client import _apply_user_default_headers
+
+        matched = _apply_user_default_headers({"User-Agent": "HermesAgent/test"}, provider="gmi")
+        assert matched is not None
+        assert matched["User-Agent"] == "HermesAgent/test"
+        assert matched["X-Global"] == "gmi"
+        assert matched["X-Provider"] == "gmi"
+
+        other = _apply_user_default_headers({}, provider="openrouter")
+        assert other == {"X-Global": "global"}
+
+    def test_provider_headers_can_match_by_base_url_for_auto_async(self, tmp_path):
+        _write_config(tmp_path, {
+            "model": {
+                "default": "m",
+                "provider_headers": {
+                    "gmi": {"X-Provider": "gmi"},
+                },
+            },
+        })
+        from agent.auxiliary_client import _apply_user_default_headers
+
+        merged = _apply_user_default_headers(
+            {},
+            provider="auto",
+            base_url="https://api.gmi-serving.com/v1",
+        )
+        assert merged == {"X-Provider": "gmi"}
+
+    def test_provider_headers_can_match_custom_provider_by_base_url(self, tmp_path):
+        _write_config(tmp_path, {
+            "model": {
+                "default": "m",
+                "provider_headers": {
+                    "gmi": {"X-Provider": "gmi"},
+                },
+            },
+        })
+        from agent.auxiliary_client import _apply_user_default_headers
+
+        merged = _apply_user_default_headers(
+            {},
+            provider="custom",
+            base_url="https://api.gmi-serving.com/v1",
+        )
+        assert merged == {"X-Provider": "gmi"}
+
+    def test_base_url_inference_prefers_most_specific_profile_path(self, tmp_path, monkeypatch):
+        _write_config(tmp_path, {
+            "model": {
+                "default": "m",
+                "provider_headers": {
+                    "wide": {"X-Billing": "wide"},
+                    "specific": {"X-Billing": "specific"},
+                },
+            },
+        })
+        profiles = [
+            SimpleNamespace(name="wide", base_url="https://example.test/root/v1"),
+            SimpleNamespace(name="specific", base_url="https://example.test/root/specific/v1"),
+        ]
+        monkeypatch.setattr("providers.list_providers", lambda: profiles)
+        from agent.auxiliary_client import _apply_user_default_headers
+
+        merged = _apply_user_default_headers(
+            {},
+            provider="auto",
+            base_url="https://example.test/root/specific/v1",
+        )
+        assert merged == {"X-Billing": "specific"}
 
 
 class TestAuxClientHonorsUserDefaultHeaders:
@@ -135,3 +217,209 @@ class TestAuxClientHonorsUserDefaultHeaders:
         assert client is not None
         headers = mock_openai.call_args.kwargs.get("default_headers", {}) or {}
         assert headers.get("User-Agent") == "curl/8.7.1"
+
+    def test_provider_scoped_header_reaches_api_key_aux_client(self, tmp_path):
+        """Provider-scoped headers apply to matching API-key auxiliary clients only."""
+        _write_config(tmp_path, {
+            "model": {
+                "default": "gmi-test-model",
+                "provider_headers": {
+                    "gmi": {"X-Provider": "gmi"},
+                },
+            },
+        })
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client
+            client, model = resolve_provider_client(
+                "gmi",
+                "gmi-test-model",
+                explicit_api_key="gmi-test-key",
+                explicit_base_url="https://api.gmi-serving.com/v1",
+            )
+
+        assert client is not None
+        assert model == "gmi-test-model"
+        headers = mock_openai.call_args.kwargs.get("default_headers", {}) or {}
+        assert headers.get("X-Provider") == "gmi"
+
+    def test_auto_resolution_remembers_concrete_main_provider(self, tmp_path, monkeypatch):
+        """_resolve_auto keeps the provider identity without changing its two-tuple API."""
+        from agent import auxiliary_client as aux
+
+        sync_client = SimpleNamespace(
+            api_key="gmi-test-key",
+            base_url="https://unregistered-gmi-gateway.example/v1",
+        )
+
+        def fake_resolve_provider_client(provider, model, **_kwargs):
+            assert provider == "gmi"
+            assert model == "gmi-test-model"
+            return sync_client, model
+
+        monkeypatch.setattr(aux, "resolve_provider_client", fake_resolve_provider_client)
+        client, model, provider = aux._resolve_auto_with_provider(
+            main_runtime={
+                "provider": "gmi",
+                "model": "gmi-test-model",
+                "base_url": "https://unregistered-gmi-gateway.example/v1",
+                "api_key": "gmi-test-key",
+            },
+        )
+
+        assert client is sync_client
+        assert model == "gmi-test-model"
+        assert provider == "gmi"
+
+    def test_auto_async_infers_provider_for_scoped_headers(self, tmp_path):
+        """Auto-routed async clients must keep the resolved provider's scoped headers."""
+        _write_config(tmp_path, {
+            "model": {
+                "default": "gmi-test-model",
+                "provider_headers": {
+                    "gmi": {"X-Provider": "gmi"},
+                },
+            },
+        })
+        sync_client = SimpleNamespace(
+            api_key="gmi-test-key",
+            base_url="https://unregistered-gmi-gateway.example/v1",
+        )
+
+        def fake_resolve_auto_with_provider(*_args, **_kwargs):
+            return sync_client, "gmi-test-model", "gmi"
+
+        with patch("agent.auxiliary_client._resolve_auto_with_provider", side_effect=fake_resolve_auto_with_provider), \
+             patch("openai.AsyncOpenAI") as mock_async_openai:
+            mock_async_openai.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client
+            client, model = resolve_provider_client("auto", async_mode=True)
+
+        assert client is not None
+        assert model == "gmi-test-model"
+        headers = mock_async_openai.call_args.kwargs.get("default_headers", {}) or {}
+        assert headers.get("X-Provider") == "gmi"
+
+    def test_openrouter_aux_client_honors_provider_scoped_headers(self, tmp_path, monkeypatch):
+        """Direct OpenRouter aux fallback clients should merge scoped headers too."""
+        _write_config(tmp_path, {
+            "model": {
+                "provider_headers": {
+                    "openrouter": {"X-Provider": "openrouter"},
+                },
+            },
+        })
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import _try_openrouter
+            client, model = _try_openrouter()
+
+        assert client is not None
+        headers = mock_openai.call_args.kwargs.get("default_headers", {}) or {}
+        assert headers.get("X-Provider") == "openrouter"
+
+    def test_nous_aux_client_honors_provider_scoped_headers(self, tmp_path):
+        """Direct Nous aux fallback clients should merge scoped headers too."""
+        _write_config(tmp_path, {
+            "model": {
+                "provider_headers": {
+                    "nous": {"X-Provider": "nous"},
+                },
+            },
+        })
+
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai, \
+             patch("agent.auxiliary_client._read_nous_auth", return_value={}), \
+             patch(
+                 "agent.auxiliary_client._resolve_nous_runtime_api",
+                 return_value=("nous-test-key", "https://inference-api.nousresearch.com/v1"),
+             ), \
+             patch("hermes_cli.models.get_nous_recommended_aux_model", return_value="nous-test-model"):
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import _try_nous
+            client, model = _try_nous()
+
+        assert client is not None
+        assert model == "nous-test-model"
+        headers = mock_openai.call_args.kwargs.get("default_headers", {}) or {}
+        assert headers.get("X-Provider") == "nous"
+
+    def test_auto_vision_async_finalize_keeps_resolved_provider_headers(self, tmp_path, monkeypatch):
+        """Vision auto async conversion must preserve the provider selected by auto."""
+        _write_config(tmp_path, {
+            "model": {
+                "provider_headers": {
+                    "gmi": {"X-Provider": "gmi"},
+                },
+            },
+        })
+        import agent.auxiliary_client as aux
+
+        sync_client = SimpleNamespace(
+            api_key="gmi-key",
+            base_url="https://unregistered-gmi-gateway.example/v1",
+        )
+        monkeypatch.setattr(
+            aux,
+            "_resolve_task_provider_model",
+            lambda *_args, **_kwargs: ("auto", "gmi-vision", None, None, None),
+        )
+        monkeypatch.setattr(aux, "_read_main_provider", lambda: "gmi")
+        monkeypatch.setattr(aux, "_read_main_model", lambda: "gmi-vision")
+        monkeypatch.setattr(aux, "_main_model_supports_vision", lambda provider, model: True)
+        monkeypatch.setattr(
+            aux,
+            "resolve_provider_client",
+            lambda provider, model, **_kwargs: (sync_client, model),
+        )
+
+        with patch("openai.AsyncOpenAI") as mock_async_openai:
+            mock_async_openai.return_value = MagicMock()
+            provider, client, model = aux.resolve_vision_provider_client(
+                "auto",
+                "gmi-vision",
+                async_mode=True,
+            )
+
+        assert provider == "gmi"
+        assert client is not None
+        assert model == "gmi-vision"
+        headers = mock_async_openai.call_args.kwargs.get("default_headers", {}) or {}
+        assert headers.get("X-Provider") == "gmi"
+
+    def test_nous_runtime_refresh_async_keeps_provider_scoped_headers(self, tmp_path, monkeypatch):
+        """Refreshing Nous async clients must preserve Nous-scoped headers."""
+        _write_config(tmp_path, {
+            "model": {
+                "provider_headers": {
+                    "nous": {"X-Provider": "nous"},
+                },
+            },
+        })
+        import agent.auxiliary_client as aux
+
+        sync_client = SimpleNamespace(
+            api_key="nous-key",
+            base_url="https://inference-api.nousresearch.com/v1",
+        )
+        monkeypatch.setattr(
+            aux,
+            "_resolve_nous_runtime_api",
+            lambda force_refresh=False: ("nous-key", "https://inference-api.nousresearch.com/v1"),
+        )
+
+        with patch("agent.auxiliary_client.OpenAI", return_value=sync_client), \
+             patch("openai.AsyncOpenAI") as mock_async_openai:
+            mock_async_openai.return_value = MagicMock()
+            client, model = aux._refresh_nous_auxiliary_client(
+                cache_provider="nous",
+                model="nous-model",
+                async_mode=True,
+            )
+
+        assert client is not None
+        assert model == "nous-model"
+        headers = mock_async_openai.call_args.kwargs.get("default_headers", {}) or {}
+        assert headers.get("X-Provider") == "nous"

--- a/tests/hermes_cli/test_provider_scoped_model_headers.py
+++ b/tests/hermes_cli/test_provider_scoped_model_headers.py
@@ -1,0 +1,145 @@
+"""Provider-scoped header regression tests for OpenAI-compatible providers."""
+
+from providers.base import ProviderProfile
+
+
+def _install_unit_test_provider_profile(monkeypatch) -> ProviderProfile:
+    profile = ProviderProfile(
+        name="unit-test-profile-provider",
+        aliases=("unit-test-profile", "utpp"),
+        display_name="Unit Test Profile Provider",
+        description="ProviderProfile-only provider used by header tests.",
+        signup_url="https://unit-test-provider.example/signup",
+        env_vars=("UTPP_API_KEY", "UTPP_BASE_URL"),
+        base_url="https://unit-test-provider.example/v1",
+        api_mode="anthropic_messages",
+        fallback_models=("unit-profile-model",),
+    )
+
+    def fake_get_provider_profile(name):
+        if name in {profile.name, *profile.aliases}:
+            return profile
+        return None
+
+    import providers as provider_registry
+
+    monkeypatch.setattr(provider_registry, "get_provider_profile", fake_get_provider_profile)
+    return profile
+
+
+def test_provider_profile_catalog_fetch_receives_provider_scoped_headers(monkeypatch, tmp_path):
+    """Live profile catalog fetches should receive matching provider headers."""
+    profile = _install_unit_test_provider_profile(monkeypatch)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_api_key_provider_credentials",
+        lambda provider: {"api_key": "profile-key", "base_url": profile.base_url},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": {"provider_headers": {profile.name: {"X-Provider": "profile"}}}},
+    )
+    captured = {}
+
+    def fake_fetch_models(*, api_key=None, base_url=None, timeout=8.0, headers=None):
+        captured["api_key"] = api_key
+        captured["base_url"] = base_url
+        captured["headers"] = headers
+        return ["unit-profile-model"]
+
+    monkeypatch.setattr(profile, "fetch_models", fake_fetch_models)
+
+    from hermes_cli.models import provider_model_ids
+
+    assert provider_model_ids(profile.name, force_refresh=True) == ["unit-profile-model"]
+    assert captured["api_key"] == "profile-key"
+    assert captured["base_url"] == profile.base_url
+    assert captured["headers"]["X-Provider"] == "profile"
+
+
+def test_provider_profile_catalog_fetch_keeps_legacy_fetch_models_signature(monkeypatch, tmp_path):
+    """Out-of-tree ProviderProfile.fetch_models overrides need not accept headers."""
+    profile = _install_unit_test_provider_profile(monkeypatch)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_api_key_provider_credentials",
+        lambda provider: {"api_key": "profile-key", "base_url": profile.base_url},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": {"provider_headers": {profile.name: {"X-Provider": "profile"}}}},
+    )
+    captured = {}
+
+    def legacy_fetch_models(*, api_key=None, base_url=None, timeout=8.0):
+        captured["api_key"] = api_key
+        captured["base_url"] = base_url
+        return ["legacy-live-model"]
+
+    monkeypatch.setattr(profile, "fetch_models", legacy_fetch_models)
+
+    from hermes_cli.models import provider_model_ids
+
+    assert provider_model_ids(profile.name, force_refresh=True) == ["legacy-live-model"]
+    assert captured == {"api_key": "profile-key", "base_url": profile.base_url}
+
+
+def test_custom_validation_probe_receives_base_url_inferred_scoped_headers(monkeypatch):
+    """Custom endpoint validation should pass provider-scoped headers to /models probes."""
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": {"provider_headers": {"gmi": {"X-Provider": "gmi"}}}},
+    )
+    captured = {}
+
+    def fake_probe(api_key, base_url, timeout=5.0, api_mode=None, request_headers=None):
+        captured["api_key"] = api_key
+        captured["base_url"] = base_url
+        captured["api_mode"] = api_mode
+        captured["request_headers"] = request_headers
+        return {"models": ["demo-model"], "probed_url": base_url.rstrip("/") + "/models"}
+
+    monkeypatch.setattr("hermes_cli.models.probe_api_models", fake_probe)
+    from hermes_cli.models import validate_requested_model
+
+    result = validate_requested_model(
+        "demo-model",
+        "custom",
+        api_key="test-key",
+        base_url="https://api.gmi-serving.com/v1",
+    )
+
+    assert result["accepted"] is True
+    assert captured["request_headers"] == {"X-Provider": "gmi"}
+
+
+def test_provider_model_cache_invalidates_when_configured_headers_change(monkeypatch, tmp_path):
+    """Header-dependent /models caches must refresh when tenant headers change."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = {"model": {"provider_headers": {"gmi": {"X-Tenant": "tenant-a"}}}}
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_api_key_provider_credentials",
+        lambda provider: {"api_key": "test-key", "base_url": "https://api.gmi-serving.com/v1"},
+    )
+    captured_headers = []
+
+    def fake_probe(api_key, base_url, timeout=5.0, api_mode=None, request_headers=None):
+        headers = dict(request_headers or {})
+        captured_headers.append(headers)
+        return {
+            "models": [f"{headers.get('X-Tenant')}-model"],
+            "probed_url": base_url.rstrip("/") + "/models",
+        }
+
+    monkeypatch.setattr("hermes_cli.models.probe_api_models", fake_probe)
+    from hermes_cli.models import cached_provider_model_ids
+
+    assert cached_provider_model_ids("gmi") == ["tenant-a-model"]
+
+    config["model"]["provider_headers"]["gmi"]["X-Tenant"] = "tenant-b"
+    assert cached_provider_model_ids("gmi") == ["tenant-b-model"]
+    assert captured_headers == [
+        {"X-Tenant": "tenant-a"},
+        {"X-Tenant": "tenant-b"},
+    ]

--- a/tests/run_agent/test_provider_attribution_headers.py
+++ b/tests/run_agent/test_provider_attribution_headers.py
@@ -275,6 +275,39 @@ def test_no_user_default_headers_leaves_provider_defaults_untouched(mock_openai)
 
 
 @patch("run_agent.OpenAI")
+def test_provider_scoped_headers_apply_to_matching_main_client_only(mock_openai):
+    """Provider-scoped headers should not leak between OpenAI-compatible providers."""
+    mock_openai.return_value = MagicMock()
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://api.gmi-serving.com/v1",
+        model="gmi-test-model",
+        provider="gmi",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    setattr(agent, "_client_kwargs", {})
+
+    with patch("hermes_cli.config.load_config", return_value={
+        "model": {"provider_headers": {"gmi": {"X-Provider": "gmi"}}},
+    }):
+        agent._apply_user_default_headers()
+
+    assert getattr(agent, "_client_kwargs")["default_headers"]["X-Provider"] == "gmi"
+
+    setattr(agent, "_client_kwargs", {})
+    setattr(agent, "provider", "openrouter")
+    agent.base_url = "https://openrouter.ai/api/v1"
+    with patch("hermes_cli.config.load_config", return_value={
+        "model": {"provider_headers": {"gmi": {"X-Provider": "gmi"}}},
+    }):
+        agent._apply_user_default_headers()
+
+    assert "default_headers" not in getattr(agent, "_client_kwargs")
+
+
+@patch("run_agent.OpenAI")
 def test_user_default_headers_skipped_for_anthropic_mode(mock_openai):
     """Anthropic/Bedrock modes don't use the OpenAI client — never touched."""
     mock_openai.return_value = MagicMock()


### PR DESCRIPTION
## Summary

While testing the CoreWeave/W&B `openai-project` attribution header needed by #44250, I found that `model.default_headers` is too broad for provider/project-scoped routing or billing headers: it is global, so a provider-specific header can leak to unrelated OpenAI-compatible providers and catalog probes.

This PR adds a generic provider-scoped header layer:

```yaml
model:
  provider_headers:
    coreweave:
      openai-project: team/project
```

- Keep `model.default_headers` as the backward-compatible global layer.
- Add `model.provider_headers.<provider>` and merge it only for matching providers.
- Apply scoped headers consistently to main clients, auxiliary clients, async auxiliary conversion, live model catalog fetches, custom validation probes, and generic `/v1/models` requests.
- Preserve the concrete provider selected by auto auxiliary routing through `_resolve_auto_with_provider()` so async conversion can apply scoped headers even when the base URL cannot be reverse-mapped to a registered profile.
- Infer provider-scoped headers from ProviderProfile base URLs for `auto`/`custom` paths without substring host matching.
- Preserve legacy `ProviderProfile.fetch_models()` overrides that do not accept a `headers` keyword.

## Test plan

- `PYTHONDONTWRITEBYTECODE=1 HERMES_HOME=$(mktemp -d) python -m pytest -q -p no:cacheprovider tests/hermes_cli/test_model_validation.py tests/hermes_cli/test_gmi_provider.py tests/agent/test_auxiliary_user_default_headers.py tests/run_agent/test_provider_attribution_headers.py tests/hermes_cli/test_provider_scoped_model_headers.py`
  - `135 passed, 9 warnings`
- `git diff --check upstream/main...HEAD`
- Merge simulation after the ProviderProfile resolver PR: clean

## Notes

Motivated by #44250, but implemented as generic header hygiene for any OpenAI-compatible provider that needs provider/project/billing headers without leaking them globally.
