### PR TITLE
refactor: Drop unnecessary sys.path.insert call to set python path

### DIFF
--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -33,7 +33,6 @@ import argparse
 import asyncio
 import logging
 import sys
-from pathlib import Path
 from hermes_constants import get_hermes_home
 
 
@@ -237,11 +236,6 @@ def main(argv: list[str] | None = None) -> None:
 
     logger = logging.getLogger(__name__)
     logger.info("Starting hermes-agent ACP adapter")
-
-    # Ensure the project root is on sys.path so ``from run_agent import AIAgent`` works
-    project_root = str(Path(__file__).resolve().parent.parent)
-    if project_root not in sys.path:
-        sys.path.insert(0, project_root)
 
     import acp
     from .server import HermesACPAgent

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -33,11 +33,6 @@ except ImportError:
 from pathlib import Path
 from typing import Any, List, Optional
 
-# Add parent directory to path for imports BEFORE repo-level imports.
-# Without this, standalone invocations (e.g. after `hermes update` reloads
-# the module) fail with ModuleNotFoundError for hermes_time et al.
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
 from hermes_constants import get_hermes_home
 from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.config import load_config, _expand_env_vars

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -487,9 +487,6 @@ from pathlib import Path
 from typing import Dict, List, Optional, Any, Callable, Awaitable, Tuple, Union
 from enum import Enum
 
-from pathlib import Path as _Path
-sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
-
 from gateway.config import Platform, PlatformConfig
 from gateway.session import SessionSource, build_session_key
 from hermes_constants import get_default_hermes_root, get_hermes_dir, get_hermes_home

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1295,9 +1295,6 @@ os.environ["_HERMES_GATEWAY"] = "1"
 
 _ensure_ssl_certs()
 
-# Add parent directory to path
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
 # Resolve Hermes home directory (respects HERMES_HOME override)
 from hermes_constants import get_hermes_home, get_hermes_home_override
 from utils import atomic_json_write, atomic_yaml_write, base_url_host_matches, is_truthy_value

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -10,9 +10,6 @@ import sys
 from pathlib import Path
 from typing import Iterable, List, Optional
 
-PROJECT_ROOT = Path(__file__).parent.parent.resolve()
-sys.path.insert(0, str(PROJECT_ROOT))
-
 from hermes_cli.colors import Colors, color
 
 # Gateway-lifecycle command detection lives in ``cron.lifecycle_guard`` so it

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2169,12 +2169,11 @@ def run_doctor(args):
     _section("Tool Availability")
     try:
         # Add project root to path for imports
-        sys.path.insert(0, str(PROJECT_ROOT))
         from model_tools import check_tool_availability, TOOLSET_REQUIREMENTS
-        
+
         available, unavailable = check_tool_availability()
         available, unavailable = _apply_doctor_tool_availability_overrides(available, unavailable)
-        
+
         for tid in available:
             info = TOOLSET_REQUIREMENTS.get(tid, {})
             check_ok(info.get("name", tid), _doctor_tool_availability_detail(tid))

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -325,7 +325,6 @@ def _require_tty(command_name: str) -> None:
 
 # Add project root to path
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
-sys.path.insert(0, str(PROJECT_ROOT))
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -49,8 +49,6 @@ from typing import Any, Dict, List, Optional, Tuple
 import yaml
 
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(PROJECT_ROOT))
 
 from hermes_cli import __version__, __release_date__
 from hermes_cli.config import (

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -100,9 +100,6 @@ except ImportError:
     Intents = Any
     commands = None
 
-import sys
-from pathlib import Path as _Path
-sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
 
 from gateway.config import Platform, PlatformConfig
 

--- a/plugins/platforms/raft/adapter.py
+++ b/plugins/platforms/raft/adapter.py
@@ -34,10 +34,6 @@ except ImportError:
     AIOHTTP_AVAILABLE = False
     web = None  # type: ignore[assignment]
 
-import sys
-from pathlib import Path as _Path
-sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
-
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -31,11 +31,6 @@ except ImportError:
     AsyncSocketModeHandler = Any
     AsyncWebClient = Any
 
-import sys
-from pathlib import Path as _Path
-
-sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
-
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.helpers import MessageDeduplicator
 from gateway.platforms.base import (

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -192,10 +192,6 @@ except ImportError:
         DEFAULT_TYPE = Any
     ContextTypes = _MockContextTypes
 
-import sys
-from pathlib import Path as _Path
-sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
-
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -259,9 +259,6 @@ def _terminate_bridge_process(proc, *, force: bool = False) -> None:
     except psutil.NoSuchProcess:
         return
 
-import sys
-sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
-
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.whatsapp_common import WhatsAppBehaviorMixin
 from gateway.whatsapp_identity import to_whatsapp_jid

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,21 @@
+import importlib.resources
+import os.path
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def load_module_from_file(rel_path: Path) -> ModuleType:
+    anchor = str(rel_path.parent).replace(os.sep, ".")
+    abs_module_file = str(importlib.resources.files(anchor).joinpath(rel_path.name))
+
+    assert os.path.exists(abs_module_file), f"Module file missing: {rel_path}"
+
+    spec = importlib.util.spec_from_file_location(
+        f"hermes_{anchor.replace('.', '_')}", abs_module_file,
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod

--- a/tests/agent/test_anthropic_output_field_leak.py
+++ b/tests/agent/test_anthropic_output_field_leak.py
@@ -10,8 +10,6 @@ Fix: whitelist input-permitted fields per block type at three points —
 normalize_response capture, _sanitize_replay_block (ordered-blocks replay), and
 _convert_content_part_to_anthropic (content-list replay).
 """
-import sys, os
-sys.path.insert(0, os.path.expanduser("~/.hermes/hermes-agent"))
 
 import pytest
 from agent.anthropic_adapter import (

--- a/tests/agent/test_auxiliary_config_bridge.py
+++ b/tests/agent/test_auxiliary_config_bridge.py
@@ -5,14 +5,10 @@ Also tests the vision_tools and browser_tool model override env vars.
 """
 
 import os
-import sys
 from pathlib import Path
 from unittest.mock import patch, MagicMock, AsyncMock
 
 import pytest
-
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
 
 def _run_auxiliary_bridge(config_dict, monkeypatch):

--- a/tests/agent/test_context_compressor_cross_session_guard.py
+++ b/tests/agent/test_context_compressor_cross_session_guard.py
@@ -14,11 +14,8 @@ handoff summary is found in the current messages.
 
 import sys
 import types
-from pathlib import Path
 from unittest.mock import patch
 
-# Ensure repo root is importable
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
 
 # Stub out optional heavy dependencies not installed in the test environment
 sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))

--- a/tests/agent/test_empty_tool_name_loop_dampening.py
+++ b/tests/agent/test_empty_tool_name_loop_dampening.py
@@ -31,11 +31,6 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import pytest
 
-# Repo root = three levels up from tests/agent/<file>.
-_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-if _REPO_ROOT not in sys.path:
-    sys.path.insert(0, _REPO_ROOT)
-
 
 class _MockHandler(BaseHTTPRequestHandler):
     # Set by the fixture before each request cycle.

--- a/tests/agent/test_minimax_auxiliary_url.py
+++ b/tests/agent/test_minimax_auxiliary_url.py
@@ -4,11 +4,6 @@ MiniMax and MiniMax-CN set inference_base_url to the /anthropic path.
 The auxiliary client uses the OpenAI SDK, which needs /v1 instead.
 """
 
-import sys
-import os
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
-
 from agent.auxiliary_client import _to_openai_base_url
 
 

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -4,13 +4,9 @@ get_model_context_length.
 All tests use synthetic inputs — no filesystem or live server required.
 """
 
-import sys
-import os
 from unittest.mock import MagicMock, patch
 
 import pytest
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 
 @pytest.fixture(autouse=True)

--- a/tests/agent/test_model_metadata_ssl.py
+++ b/tests/agent/test_model_metadata_ssl.py
@@ -9,11 +9,7 @@ No filesystem or network I/O required — we use tmp_path to create real
 CA bundle stand-in files and monkeypatch env vars.
 """
 
-import os
-import sys
 from pathlib import Path
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import pytest
 

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -6,8 +6,6 @@ import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-
 
 def _make_cli(env_overrides=None, config_overrides=None, **kwargs):
     """Create a HermesCLI instance with minimal mocking."""

--- a/tests/cli/test_cli_user_message_preview.py
+++ b/tests/cli/test_cli_user_message_preview.py
@@ -1,9 +1,6 @@
 import importlib
-import os
 import sys
 from unittest.mock import MagicMock, patch
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 
 _cli_mod = None

--- a/tests/cli/test_resume_display.py
+++ b/tests/cli/test_resume_display.py
@@ -5,14 +5,10 @@ Verifies that resuming a session shows a compact recap of the previous
 conversation with correct formatting, truncation, and config behavior.
 """
 
-import os
-import sys
 from io import StringIO
 from unittest.mock import MagicMock, patch
 
 import cli as cli_mod
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 
 def _make_cli(config_overrides=None, env_overrides=None, **kwargs):

--- a/tests/cli/test_stream_delta_think_tag.py
+++ b/tests/cli/test_stream_delta_think_tag.py
@@ -1,11 +1,7 @@
 """Tests for _stream_delta's handling of <think> tags in prose vs real reasoning blocks."""
-import sys
 import os
 
 import pytest
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
-
 
 
 def _make_cli_stub():

--- a/tests/cli/test_tool_progress_scrollback.py
+++ b/tests/cli/test_tool_progress_scrollback.py
@@ -5,12 +5,9 @@ persistent lines to scrollback on tool.completed, restoring the stacked
 tool history that was lost when the TUI switched to a single-line spinner.
 """
 
-import os
 import sys
 import importlib
 from unittest.mock import MagicMock, patch
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 # Module-level reference to the cli module (set by _make_cli on first call)
 _cli_mod = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,11 +26,6 @@ from pathlib import Path
 
 import pytest
 
-# Ensure project root is importable
-PROJECT_ROOT = Path(__file__).parent.parent
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(PROJECT_ROOT))
-
 
 # ── Per-file process isolation ──────────────────────────────────────────────
 # Tests run via ``scripts/run_tests_parallel.py``, which spawns a fresh

--- a/tests/cron/test_cron_context_from.py
+++ b/tests/cron/test_cron_context_from.py
@@ -1,12 +1,9 @@
 """Tests for cron job context_from feature (issue #5439 Option C)."""
 
 import logging
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 
 @pytest.fixture

--- a/tests/cron/test_cron_inactivity_timeout.py
+++ b/tests/cron/test_cron_inactivity_timeout.py
@@ -10,13 +10,7 @@ Tests cover:
 
 import concurrent.futures
 import os
-import sys
 import time
-from pathlib import Path
-
-
-# Ensure project root is importable
-sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 
 class FakeAgent:

--- a/tests/cron/test_cron_prompt_injection_skill.py
+++ b/tests/cron/test_cron_prompt_injection_skill.py
@@ -12,12 +12,9 @@ prompt + cron hint + skill content) through the same scanner and raises
 surfaces a clean "job blocked" delivery instead of running the agent.
 """
 
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 
 @pytest.fixture

--- a/tests/cron/test_cron_provider_pin.py
+++ b/tests/cron/test_cron_provider_pin.py
@@ -18,14 +18,7 @@ snapshot capture. They are load-bearing: without the guard, cases (b) call the
 agent and "succeed" instead of failing closed.
 """
 
-import sys
-from pathlib import Path
 from unittest.mock import MagicMock, patch
-
-import pytest
-
-# Ensure project root is importable.
-sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from cron.scheduler import run_job
 

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -12,12 +12,8 @@ import os
 import sys
 import textwrap
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 
 import pytest
-
-# Ensure project root is importable
-sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 
 @pytest.fixture

--- a/tests/cron/test_jobs_crossprocess_lock.py
+++ b/tests/cron/test_jobs_crossprocess_lock.py
@@ -24,10 +24,6 @@ import pytest
 from cron import jobs
 
 
-# Repo root (parent of the ``cron`` package) so the child process can import it.
-_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(jobs.__file__)))
-
-
 @pytest.mark.skipif(jobs.fcntl is None, reason="POSIX fcntl/flock required")
 def test_jobs_lock_excludes_another_process(tmp_path, monkeypatch):
     cron_dir = tmp_path / "cron"
@@ -45,7 +41,6 @@ def test_jobs_lock_excludes_another_process(tmp_path, monkeypatch):
         textwrap.dedent(
             f"""
             import sys, time, pathlib
-            sys.path.insert(0, {_REPO_ROOT!r})
             from cron import jobs
 
             jobs.CRON_DIR = pathlib.Path({str(cron_dir)!r})
@@ -69,7 +64,6 @@ def test_jobs_lock_excludes_another_process(tmp_path, monkeypatch):
         textwrap.dedent(
             f"""
             import sys, pathlib
-            sys.path.insert(0, {_REPO_ROOT!r})
             from cron import jobs
 
             jobs.CRON_DIR = pathlib.Path({str(cron_dir)!r})

--- a/tests/cron/test_rewrite_skill_refs.py
+++ b/tests/cron/test_rewrite_skill_refs.py
@@ -10,13 +10,7 @@ job runs without the instructions it was scheduled to follow.
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
 import pytest
-
-# Ensure project root is importable
-sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 
 @pytest.fixture

--- a/tests/e2e/matrix_xsign_bootstrap/test_bootstrap.py
+++ b/tests/e2e/matrix_xsign_bootstrap/test_bootstrap.py
@@ -41,9 +41,6 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
-sys.path.insert(0, str(REPO_ROOT))
-
 HS = os.environ.get("E2E_MATRIX_HS", "http://127.0.0.1:26167")
 COMPOSE_DIR = Path(__file__).parent
 CONTAINER_NAME = "matrix_xsign_bootstrap-homeserver-1"

--- a/tests/gateway/test_config_env_bridge_authority.py
+++ b/tests/gateway/test_config_env_bridge_authority.py
@@ -18,9 +18,6 @@ from pathlib import Path
 import pytest
 
 
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
-
-
 def _run_gateway_import(hermes_home: Path, initial_env: dict[str, str]) -> dict[str, str]:
     """Import gateway.run in a clean subprocess and return the post-import env.
 
@@ -32,7 +29,6 @@ def _run_gateway_import(hermes_home: Path, initial_env: dict[str, str]) -> dict[
     script = textwrap.dedent(
         f"""
         import os, sys
-        sys.path.insert(0, {str(PROJECT_ROOT)!r})
 
         try:
             from gateway import run  # noqa: F401  — module import triggers bridge

--- a/tests/gateway/test_discord_clarify_buttons.py
+++ b/tests/gateway/test_discord_clarify_buttons.py
@@ -11,17 +11,10 @@ dispatcher like Telegram — the auth + resolution path is the same:
   · already-resolved or unauthorized → ephemeral "this prompt..." reply
 """
 
-import sys
-from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-
-# Repo root importable
-_repo = str(Path(__file__).resolve().parents[2])
-if _repo not in sys.path:
-    sys.path.insert(0, _repo)
 
 # Triggers the shared discord mock from tests/gateway/conftest.py before
 # importing the production module.

--- a/tests/gateway/test_discord_voice_mixer.py
+++ b/tests/gateway/test_discord_voice_mixer.py
@@ -17,16 +17,7 @@ import pytest
 # math needs it, so skip this whole module when it isn't installed.
 np = pytest.importorskip("numpy")
 
-# voice_mixer lives inside the discord plugin package dir; import by path the
-# same way the adapter does.
-_DISCORD_DIR = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
-    "plugins", "platforms", "discord",
-)
-if _DISCORD_DIR not in sys.path:
-    sys.path.insert(0, _DISCORD_DIR)
-
-import voice_mixer as vm  # noqa: E402
+import plugins.platforms.discord.voice_mixer as vm  # noqa: E402
 
 
 # =====================================================================

--- a/tests/gateway/test_fallback_eviction.py
+++ b/tests/gateway/test_fallback_eviction.py
@@ -5,12 +5,6 @@ forces MCP reinit on the next message, creating a CPU-burning restart loop.
 Eviction should only happen on successful runs where fallback activated.
 """
 
-import sys
-from pathlib import Path
-
-
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
-
 
 class TestFallbackEvictionGating:
     """The fallback-eviction code path should skip eviction on failed runs."""

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -3,18 +3,10 @@
 import importlib.util
 import json
 import sys
-from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
-# ---------------------------------------------------------------------------
-# Ensure the repo root is importable
-# ---------------------------------------------------------------------------
-_repo = str(Path(__file__).resolve().parents[2])
-if _repo not in sys.path:
-    sys.path.insert(0, _repo)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_gateway_inactivity_timeout.py
+++ b/tests/gateway/test_gateway_inactivity_timeout.py
@@ -11,12 +11,7 @@ Tests cover:
 
 import concurrent.futures
 import os
-import sys
 import time
-from pathlib import Path
-
-
-sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 
 class FakeAgent:

--- a/tests/gateway/test_plugin_platform_interface.py
+++ b/tests/gateway/test_plugin_platform_interface.py
@@ -79,9 +79,6 @@ class _MockPluginContext:
 
 def _import_platform_module(name: str) -> ModuleType:
     """Import plugins.platforms.<name> in a test-safe way."""
-    # Make sure the project root is on sys.path so relative imports work
-    if str(PROJECT_ROOT) not in sys.path:
-        sys.path.insert(0, str(PROJECT_ROOT))
     module = importlib.import_module(f"plugins.platforms.{name}")
     return module
 

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -1,19 +1,10 @@
 """Tests for Slack Block Kit approval buttons and thread context fetching."""
 
-import asyncio
 import sys
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
-# ---------------------------------------------------------------------------
-# Ensure the repo root is importable
-# ---------------------------------------------------------------------------
-_repo = str(Path(__file__).resolve().parents[2])
-if _repo not in sys.path:
-    sys.path.insert(0, _repo)
-
 
 # ---------------------------------------------------------------------------
 # Minimal Slack SDK mock so SlackAdapter can be imported

--- a/tests/gateway/test_slack_plugin_action_handlers.py
+++ b/tests/gateway/test_slack_plugin_action_handlers.py
@@ -13,18 +13,9 @@ from __future__ import annotations
 import asyncio
 import os
 import sys
-from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
-
-# ---------------------------------------------------------------------------
-# Ensure the repo root is importable when this test runs directly
-# ---------------------------------------------------------------------------
-_repo = str(Path(__file__).resolve().parents[2])
-if _repo not in sys.path:
-    sys.path.insert(0, _repo)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -2,18 +2,10 @@
 
 import os
 import sys
-from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
-# ---------------------------------------------------------------------------
-# Ensure the repo root is importable
-# ---------------------------------------------------------------------------
-_repo = str(Path(__file__).resolve().parents[2])
-if _repo not in sys.path:
-    sys.path.insert(0, _repo)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_telegram_clarify_buttons.py
+++ b/tests/gateway/test_telegram_clarify_buttons.py
@@ -11,13 +11,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-# ---------------------------------------------------------------------------
-# Ensure the repo root is importable
-# ---------------------------------------------------------------------------
-_repo = str(Path(__file__).resolve().parents[2])
-if _repo not in sys.path:
-    sys.path.insert(0, _repo)
-
 
 # ---------------------------------------------------------------------------
 # Minimal Telegram mock so TelegramAdapter can be imported (mirrors

--- a/tests/gateway/test_telegram_slash_confirm.py
+++ b/tests/gateway/test_telegram_slash_confirm.py
@@ -1,15 +1,10 @@
 """Regression guard: send_slash_confirm must use format_message + MARKDOWN_V2."""
 
 import sys
-from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-
-_repo = str(Path(__file__).resolve().parents[2])
-if _repo not in sys.path:
-    sys.path.insert(0, _repo)
 
 
 def _ensure_telegram_mock():

--- a/tests/gateway/test_telegram_voice_v0_regressions.py
+++ b/tests/gateway/test_telegram_voice_v0_regressions.py
@@ -1,13 +1,6 @@
-import sys
-from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-
-
-ROOT = Path(__file__).resolve().parents[2]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
 
 from gateway.config import Platform
 from plugins.platforms.telegram.adapter import TelegramAdapter

--- a/tests/gateway/test_telegram_webhook_secret.py
+++ b/tests/gateway/test_telegram_webhook_secret.py
@@ -9,14 +9,8 @@ The fix refuses to start the adapter in webhook mode without the secret.
 
 from __future__ import annotations
 
+import importlib.resources
 import re
-import sys
-from pathlib import Path
-
-
-_repo = str(Path(__file__).resolve().parents[2])
-if _repo not in sys.path:
-    sys.path.insert(0, _repo)
 
 
 class TestTelegramWebhookSecretRequired:
@@ -31,8 +25,7 @@ class TestTelegramWebhookSecretRequired:
     """
 
     def _get_source(self) -> str:
-        path = Path(_repo) / "plugins" / "platforms" / "telegram" / "adapter.py"
-        return path.read_text(encoding="utf-8")
+        return importlib.resources.files("plugins.platforms.telegram").joinpath("adapter.py").read_text()
 
     def test_webhook_branch_checks_secret(self):
         """The webhook-mode branch of connect() must read

--- a/tests/hermes_cli/test_auth_ssl_macos.py
+++ b/tests/hermes_cli/test_auth_ssl_macos.py
@@ -19,8 +19,6 @@ from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-
 from hermes_cli.auth import _default_verify, _resolve_verify
 
 

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -23,11 +23,6 @@ from pathlib import Path
 
 import pytest
 
-# Ensure the worktree (not the stale global clone) is first on sys.path.
-_WORKTREE = Path(__file__).resolve().parents[2]
-if str(_WORKTREE) not in sys.path:
-    sys.path.insert(0, str(_WORKTREE))
-
 from hermes_cli import kanban_db as kb
 
 
@@ -470,15 +465,12 @@ class TestWorkerSpawnEnv:
 def _cli(args: list[str], env_extra: dict | None = None) -> subprocess.CompletedProcess:
     """Run ``hermes kanban …`` with PYTHONPATH pinned to the worktree."""
     env = dict(os.environ)
-    env["PYTHONPATH"] = str(_WORKTREE)
     if env_extra:
         env.update(env_extra)
     return subprocess.run(
         [sys.executable, "-m", "hermes_cli.main", "kanban"] + args,
-        env=env,
         capture_output=True,
         text=True,
-        cwd=str(_WORKTREE),
         timeout=30,
     )
 

--- a/tests/hermes_cli/test_voice_wrapper.py
+++ b/tests/hermes_cli/test_voice_wrapper.py
@@ -9,12 +9,7 @@ and ``speak_text`` tolerates empty input without touching the provider
 stack.
 """
 
-import os
-import sys
-
 import pytest
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 
 class TestPublicAPI:

--- a/tests/hermes_cli/test_web_server_host_header.py
+++ b/tests/hermes_cli/test_web_server_host_header.py
@@ -14,10 +14,6 @@ from pathlib import Path
 
 import pytest
 
-_repo = str(Path(__file__).resolve().parents[1])
-if _repo not in sys.path:
-    sys.path.insert(0, _repo)
-
 
 class TestHostHeaderValidator:
     """Unit test the _is_accepted_host helper directly — cheaper and

--- a/tests/integration/test_checkpoint_resumption.py
+++ b/tests/integration/test_checkpoint_resumption.py
@@ -29,9 +29,6 @@ from pathlib import Path
 from typing import List, Dict, Any
 import traceback
 
-# Add project root to path to import batch_runner
-sys.path.insert(0, str(Path(__file__).parent.parent.parent))
-
 
 def create_test_dataset(num_prompts: int = 20) -> Path:
     """Create a small test dataset for checkpoint testing."""

--- a/tests/integration/test_daytona_terminal.py
+++ b/tests/integration/test_daytona_terminal.py
@@ -21,7 +21,6 @@ if not os.getenv("DAYTONA_API_KEY"):
 import importlib.util
 
 parent_dir = Path(__file__).parent.parent.parent
-sys.path.insert(0, str(parent_dir))
 
 spec = importlib.util.spec_from_file_location(
     "terminal_tool", parent_dir / "tools" / "terminal_tool.py"

--- a/tests/integration/test_modal_terminal.py
+++ b/tests/integration/test_modal_terminal.py
@@ -12,6 +12,7 @@ Usage:
     # Or run directly (will use whatever TERMINAL_ENV is set in .env)
     python tests/test_modal_terminal.py
 """
+from tests import load_module_from_file
 
 import pytest
 pytestmark = pytest.mark.integration
@@ -38,16 +39,9 @@ except ImportError:
                     value = value.strip().strip('"').strip("'")
                     os.environ.setdefault(key.strip(), value)
 
-# Add project root to path for imports
-parent_dir = Path(__file__).parent.parent.parent
-sys.path.insert(0, str(parent_dir))
-
 # Import terminal_tool module directly using importlib to avoid tools/__init__.py
-import importlib.util
-terminal_tool_path = parent_dir / "tools" / "terminal_tool.py"
-spec = importlib.util.spec_from_file_location("terminal_tool", terminal_tool_path)
-terminal_module = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(terminal_module)
+module_file = Path("tools", "terminal_tool.py")
+terminal_module = load_module_from_file(module_file)
 
 terminal_tool = terminal_module.terminal_tool
 check_terminal_requirements = terminal_module.check_terminal_requirements

--- a/tests/plugins/test_retaindb_plugin.py
+++ b/tests/plugins/test_retaindb_plugin.py
@@ -53,12 +53,6 @@ def _cap_retaindb_sleeps(monkeypatch):
     monkeypatch.setattr(_retaindb, "time", fake_time)
 
 
-# We need the repo root on sys.path so the plugin can import agent.memory_provider
-import sys
-_repo_root = str(Path(__file__).resolve().parents[2])
-if _repo_root not in sys.path:
-    sys.path.insert(0, _repo_root)
-
 from plugins.memory.retaindb import (
     _Client,
     _WriteQueue,

--- a/tests/run_agent/repro_48013_image_shrink_brick.py
+++ b/tests/run_agent/repro_48013_image_shrink_brick.py
@@ -27,15 +27,9 @@ from __future__ import annotations
 
 import base64
 import io
-import sys
-from pathlib import Path
 
 import pytest
 
-# Make the repo root importable when run as a plain script.
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-if str(_REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(_REPO_ROOT))
 
 PIL = pytest.importorskip("PIL", reason="Pillow required for the real-resize proof")
 from PIL import Image, ImageDraw  # noqa: E402

--- a/tests/run_agent/test_interactive_interrupt.py
+++ b/tests/run_agent/test_interactive_interrupt.py
@@ -13,14 +13,11 @@ import queue
 import sys
 import threading
 import time
-import os
 
 # Force stderr logging so redirect_stdout doesn't swallow it
 logging.basicConfig(level=logging.DEBUG, stream=sys.stderr,
                     format="%(asctime)s [%(threadName)s] %(message)s")
 log = logging.getLogger("interrupt_test")
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 from unittest.mock import MagicMock, patch
 from run_agent import AIAgent, IterationBudget

--- a/tests/run_agent/test_session_id_env.py
+++ b/tests/run_agent/test_session_id_env.py
@@ -1,11 +1,8 @@
 """Test that HERMES_SESSION_ID is exposed as an env var and ContextVar."""
 
 import os
-import sys
 
 import pytest
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
 from run_agent import AIAgent
 

--- a/tests/run_agent/test_session_reset_fix.py
+++ b/tests/run_agent/test_session_reset_fix.py
@@ -8,11 +8,7 @@ therefore never cleared:
 """
 import sys
 import types
-from pathlib import Path
 
-
-# Ensure repo root is importable
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
 
 # Stub out optional heavy dependencies not installed in the test environment
 sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))

--- a/tests/run_interrupt_test.py
+++ b/tests/run_interrupt_test.py
@@ -7,9 +7,6 @@ Not a pytest test — runs directly as a script for live testing.
 import threading
 import time
 import sys
-import os
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from unittest.mock import MagicMock, patch
 from run_agent import AIAgent, IterationBudget

--- a/tests/skills/test_cloudflare_temporary_deploy_skill.py
+++ b/tests/skills/test_cloudflare_temporary_deploy_skill.py
@@ -1,4 +1,5 @@
 """Tests for optional-skills/web-development/cloudflare-temporary-deploy/scripts/parse_deploy_output.py"""
+from tests import load_module_from_file
 
 import json
 import sys
@@ -7,16 +8,14 @@ from unittest import mock
 
 import pytest
 
-SCRIPTS_DIR = (
-    Path(__file__).resolve().parents[2]
-    / "optional-skills"
-    / "web-development"
-    / "cloudflare-temporary-deploy"
-    / "scripts"
+module_file = Path(
+    "optional-skills",
+    "web-development",
+    "cloudflare-temporary-deploy",
+    "scripts",
+    "parse_deploy_output.py",
 )
-sys.path.insert(0, str(SCRIPTS_DIR))
-
-import parse_deploy_output as pdo
+pdo = load_module_from_file(module_file)
 
 
 CREATED = """\

--- a/tests/skills/test_fetch_transcript.py
+++ b/tests/skills/test_fetch_transcript.py
@@ -1,15 +1,14 @@
 """Tests for skills/media/youtube-content/scripts/fetch_transcript.py (issue #22243)."""
-
-import sys
 from pathlib import Path
+from typing import Final
 from unittest import mock
 
 import pytest
 
-SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "skills" / "media" / "youtube-content" / "scripts"
-sys.path.insert(0, str(SCRIPTS_DIR))
+from tests import load_module_from_file
 
-import fetch_transcript
+module_file: Final = Path("skills", "media", "youtube-content", "scripts", "fetch_transcript.py")
+fetch_transcript: Final = load_module_from_file(module_file)
 
 
 class TestExtractVideoId:

--- a/tests/skills/test_memento_cards.py
+++ b/tests/skills/test_memento_cards.py
@@ -2,19 +2,18 @@
 
 import csv
 import json
-import sys
 import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import Final
 from unittest import mock
 
 import pytest
 
-# Add the scripts dir so we can import the module directly
-SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "optional-skills" / "productivity" / "memento-flashcards" / "scripts"
-sys.path.insert(0, str(SCRIPTS_DIR))
+from tests import load_module_from_file
 
-import memento_cards
+module_file: Final = Path("optional-skills", "productivity", "memento-flashcards", "scripts", "memento_cards.py")
+memento_cards: Final = load_module_from_file(module_file)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/skills/test_youtube_quiz.py
+++ b/tests/skills/test_youtube_quiz.py
@@ -1,16 +1,15 @@
 """Tests for optional-skills/productivity/memento-flashcards/scripts/youtube_quiz.py"""
 
 import json
-import sys
 from pathlib import Path
 from unittest import mock
 
 import pytest
 
-SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "optional-skills" / "productivity" / "memento-flashcards" / "scripts"
-sys.path.insert(0, str(SCRIPTS_DIR))
+from tests import load_module_from_file
 
-import youtube_quiz
+module_file = Path("optional-skills", "productivity", "memento-flashcards", "scripts", "youtube_quiz.py")
+youtube_quiz = load_module_from_file(module_file)
 
 
 def _run(capsys, argv: list[str]) -> dict:

--- a/tests/stress/test_atypical_scenarios.py
+++ b/tests/stress/test_atypical_scenarios.py
@@ -30,7 +30,6 @@ from pathlib import Path
 
 # Resolve the worktree path robustly.
 _THIS = Path(__file__).resolve()
-WT = _THIS.parents[2] if _THIS.parent.name == "stress" else Path.cwd()
 
 FAILURES: list[str] = []
 SKIPS: list[str] = []
@@ -51,7 +50,6 @@ def scenario(name):
             for m in list(sys.modules.keys()):
                 if m.startswith(("hermes_cli", "plugins", "gateway")):
                     del sys.modules[m]
-            sys.path.insert(0, str(WT))
             from hermes_cli import kanban_db as kb  # noqa: F401
             print(f"\n═══ {name} ═══")
             try:
@@ -226,7 +224,7 @@ def _(home, kb):
     finally:
         conn.close()
 
-    env = {**os.environ, "PYTHONPATH": str(WT), "HERMES_HOME": home, "HOME": home}
+    env = {**os.environ, "HERMES_HOME": home, "HOME": home}
     bad_metas = [
         "not-json",
         "[1, 2, 3]",  # array not dict
@@ -690,7 +688,6 @@ def _idempotency_race_worker(hermes_home: str, key: str, result_file: str,
     """Subprocess body for the idempotency race test."""
     os.environ["HERMES_HOME"] = hermes_home
     os.environ["HOME"] = hermes_home
-    sys.path.insert(0, str(WT))
     from hermes_cli import kanban_db as kb
 
     # Spin until the barrier file exists (crude sync across processes)

--- a/tests/stress/test_benchmarks.py
+++ b/tests/stress/test_benchmarks.py
@@ -18,9 +18,6 @@ import random
 import sys
 import tempfile
 import time
-from pathlib import Path
-
-WT = str(Path(__file__).resolve().parents[2])
 
 
 def bench(label, fn, iterations=5):
@@ -57,7 +54,6 @@ def main():
     home = tempfile.mkdtemp(prefix="hermes_bench_")
     os.environ["HERMES_HOME"] = home
     os.environ["HOME"] = home
-    sys.path.insert(0, WT)
     from hermes_cli import kanban_db as kb
 
     kb.init_db()

--- a/tests/stress/test_concurrency.py
+++ b/tests/stress/test_concurrency.py
@@ -24,13 +24,11 @@ import sqlite3
 import sys
 import tempfile
 import time
-from pathlib import Path
 
 
 NUM_WORKERS = 5
 NUM_TASKS = 100
 WORKER_TIMEOUT_S = 60
-WT = str(Path(__file__).resolve().parents[2])
 
 
 def worker_loop(worker_id: int, hermes_home: str, result_file: str) -> None:
@@ -42,7 +40,6 @@ def worker_loop(worker_id: int, hermes_home: str, result_file: str) -> None:
     """
     os.environ["HERMES_HOME"] = hermes_home
     os.environ["HOME"] = hermes_home
-    sys.path.insert(0, WT)
 
     from hermes_cli import kanban_db as kb
 
@@ -123,7 +120,6 @@ def main():
     # Seed.
     os.environ["HERMES_HOME"] = home
     os.environ["HOME"] = home
-    sys.path.insert(0, WT)
     from hermes_cli import kanban_db as kb
 
     kb.init_db()

--- a/tests/stress/test_concurrency_mixed.py
+++ b/tests/stress/test_concurrency_mixed.py
@@ -22,18 +22,15 @@ import sqlite3
 import sys
 import tempfile
 import time
-from pathlib import Path
 
 NUM_WORKERS = 10
 NUM_TASKS = 500
 RUN_DURATION_S = 30
-WT = str(Path(__file__).resolve().parents[2])
 
 
 def worker_loop(worker_id: int, hermes_home: str, result_file: str) -> None:
     os.environ["HERMES_HOME"] = hermes_home
     os.environ["HOME"] = hermes_home
-    sys.path.insert(0, WT)
     from hermes_cli import kanban_db as kb
 
     events = []
@@ -145,7 +142,6 @@ def reclaimer_loop(hermes_home: str, result_file: str) -> None:
     """Background dispatcher-like loop that reclaims stale tasks."""
     os.environ["HERMES_HOME"] = hermes_home
     os.environ["HOME"] = hermes_home
-    sys.path.insert(0, WT)
     from hermes_cli import kanban_db as kb
 
     events = []
@@ -175,7 +171,6 @@ def main():
 
     os.environ["HERMES_HOME"] = home
     os.environ["HOME"] = home
-    sys.path.insert(0, WT)
     from hermes_cli import kanban_db as kb
 
     kb.init_db()

--- a/tests/stress/test_concurrency_parent_gate.py
+++ b/tests/stress/test_concurrency_parent_gate.py
@@ -24,10 +24,6 @@ import sys
 import tempfile
 import threading
 import time
-from pathlib import Path
-
-WT = str(Path(__file__).resolve().parents[2])
-sys.path.insert(0, WT)
 
 NUM_CREATE_ROUNDS = 200
 WORKERS_RUN_DURATION_S = 8

--- a/tests/stress/test_concurrency_reclaim_race.py
+++ b/tests/stress/test_concurrency_reclaim_race.py
@@ -29,19 +29,16 @@ import sqlite3
 import sys
 import tempfile
 import time
-from pathlib import Path
 
 NUM_WORKERS = 5
 NUM_TASKS = 50
 TTL = 1
 WORK_DURATION_S = 2.0  # longer than TTL => reclaimer wins
-WT = str(Path(__file__).resolve().parents[2])
 
 
 def worker_loop(worker_id: int, hermes_home: str, result_file: str) -> None:
     os.environ["HERMES_HOME"] = hermes_home
     os.environ["HOME"] = hermes_home
-    sys.path.insert(0, WT)
     from hermes_cli import kanban_db as kb
 
     events = []
@@ -98,7 +95,6 @@ def worker_loop(worker_id: int, hermes_home: str, result_file: str) -> None:
 def reclaimer_loop(hermes_home: str, result_file: str) -> None:
     os.environ["HERMES_HOME"] = hermes_home
     os.environ["HOME"] = hermes_home
-    sys.path.insert(0, WT)
     from hermes_cli import kanban_db as kb
 
     events = []
@@ -124,7 +120,6 @@ def main():
     home = tempfile.mkdtemp(prefix="hermes_reclaim_race_")
     os.environ["HERMES_HOME"] = home
     os.environ["HOME"] = home
-    sys.path.insert(0, WT)
     from hermes_cli import kanban_db as kb
 
     kb.init_db()

--- a/tests/stress/test_property_fuzzing.py
+++ b/tests/stress/test_property_fuzzing.py
@@ -29,7 +29,6 @@ import sys
 import tempfile
 from pathlib import Path
 
-WT = str(Path(__file__).resolve().parents[2])
 NUM_SEQUENCES = 500
 OPS_PER_SEQUENCE = 100
 TASK_POOL = 10
@@ -236,7 +235,6 @@ def main():
         home = tempfile.mkdtemp(prefix=f"hermes_fuzz_{seq_idx}_")
         os.environ["HERMES_HOME"] = home
         os.environ["HOME"] = home
-        sys.path.insert(0, WT)
 
         # Fresh module state per sequence to avoid cached init paths.
         for m in list(sys.modules.keys()):

--- a/tests/stress/test_subprocess_e2e.py
+++ b/tests/stress/test_subprocess_e2e.py
@@ -17,7 +17,6 @@ import sys
 import tempfile
 import time
 
-WT = str(Path(__file__).resolve().parents[2])
 FAKE_WORKER = str(Path(__file__).parent / "_fake_worker.py")
 PY = sys.executable
 
@@ -32,7 +31,6 @@ def make_spawn_fn(home: str):
             **os.environ,
             "HERMES_HOME": home,
             "HOME": home,
-            "PYTHONPATH": WT,
             "HERMES_KANBAN_TASK": task.id,
             "HERMES_KANBAN_WORKSPACE": workspace,
             "PATH": f"{os.path.dirname(PY)}:{os.environ.get('PATH','')}",
@@ -55,7 +53,6 @@ def main():
     home = tempfile.mkdtemp(prefix="hermes_e2e_")
     os.environ["HERMES_HOME"] = home
     os.environ["HOME"] = home
-    sys.path.insert(0, WT)
     from hermes_cli import kanban_db as kb
 
     # Point the `hermes` CLI child processes will run at the worktree

--- a/tests/test_atomic_replace_symlinks.py
+++ b/tests/test_atomic_replace_symlinks.py
@@ -15,16 +15,11 @@ from __future__ import annotations
 import errno
 import json
 import os
-import sys
 from pathlib import Path
 
 import pytest
 import yaml
 
-# Ensure the repo root is importable when running via `pytest tests/...`.
-_REPO_ROOT = Path(__file__).resolve().parent.parent
-if str(_REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(_REPO_ROOT))
 
 from utils import (
     atomic_json_write,

--- a/tests/test_batch_runner_checkpoint.py
+++ b/tests/test_batch_runner_checkpoint.py
@@ -1,14 +1,10 @@
 """Tests for batch_runner checkpoint behavior — incremental writes, resume, atomicity."""
 
 import json
-from pathlib import Path
 from threading import Lock
 
 import pytest
 
-# batch_runner uses relative imports, ensure project root is on path
-import sys
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from batch_runner import BatchRunner, _process_batch_worker
 

--- a/tests/test_bitwarden_secrets.py
+++ b/tests/test_bitwarden_secrets.py
@@ -23,11 +23,6 @@ from unittest import mock
 import pytest
 
 
-# Make the worktree importable without depending on the installed wheel.
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-
 from agent.secret_sources import bitwarden as bw  # noqa: E402
 
 

--- a/tests/test_ctx_halving_fix.py
+++ b/tests/test_ctx_halving_fix.py
@@ -23,12 +23,7 @@ These are different and the old code conflated them; the fix keeps them
 separate.
 """
 
-import sys
-import os
 from unittest.mock import MagicMock
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -13,10 +13,6 @@ from pathlib import Path
 import pytest
 
 
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-
 from hermes_cli import env_loader  # noqa: E402
 
 

--- a/tests/test_model_picker_scroll.py
+++ b/tests/test_model_picker_scroll.py
@@ -12,12 +12,6 @@ is always within the visible window.  These tests exercise that logic in
 isolation without requiring a real TTY.
 """
 
-import sys
-import os
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-
-
 # ---------------------------------------------------------------------------
 # Pure scroll-offset logic extracted from _curses_menu for unit testing
 # ---------------------------------------------------------------------------

--- a/tests/test_yuanbao_integration.py
+++ b/tests/test_yuanbao_integration.py
@@ -11,14 +11,6 @@ test_yuanbao_integration.py - Yuanbao 模块集成测试
   - Toolset 注册
 """
 
-import sys
-import os
-
-# 确保 hermes-agent 根目录在 sys.path 中
-_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if _REPO_ROOT not in sys.path:
-    sys.path.insert(0, _REPO_ROOT)
-
 import pytest
 from unittest.mock import MagicMock, patch
 from gateway.config import Platform, PlatformConfig, GatewayConfig

--- a/tests/test_yuanbao_markdown.py
+++ b/tests/test_yuanbao_markdown.py
@@ -9,12 +9,7 @@ Or with pytest if available:
     python3 -m pytest tests/test_yuanbao_markdown.py -v
 """
 
-import sys
-import os
 import unittest
-
-# Ensure project root is on the path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from gateway.platforms.yuanbao import MarkdownProcessor
 

--- a/tests/test_yuanbao_pipeline.py
+++ b/tests/test_yuanbao_pipeline.py
@@ -11,14 +11,8 @@ Tests cover:
 """
 
 import asyncio
-import sys
 import os
 import json
-
-# Ensure project root is on the path
-_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if _REPO_ROOT not in sys.path:
-    sys.path.insert(0, _REPO_ROOT)
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/tests/test_yuanbao_proto.py
+++ b/tests/test_yuanbao_proto.py
@@ -14,11 +14,6 @@ test_yuanbao_proto.py - yuanbao_proto 单元测试
 import sys
 import os
 
-# 确保 hermes-agent 根目录在 sys.path 中
-_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if _REPO_ROOT not in sys.path:
-    sys.path.insert(0, _REPO_ROOT)
-
 import pytest
 from gateway.platforms.yuanbao_proto import (
     # 基础工具

--- a/tests/test_yuanbao_shutdown.py
+++ b/tests/test_yuanbao_shutdown.py
@@ -13,13 +13,7 @@ is ``websockets``' responsibility (and harmless at shutdown, where the loop is
 tearing down regardless), so it is intentionally out of scope here.
 """
 
-import sys
-import os
 import asyncio
-
-_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if _REPO_ROOT not in sys.path:
-    sys.path.insert(0, _REPO_ROOT)
 
 import pytest
 from gateway.config import PlatformConfig

--- a/tests/tools/test_browser_console.py
+++ b/tests/tools/test_browser_console.py
@@ -2,12 +2,9 @@
 
 import json
 import os
-import sys
 from unittest.mock import patch, MagicMock
 
 import pytest
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
 
 # ── browser_console ──────────────────────────────────────────────────

--- a/tests/tools/test_file_tools_live.py
+++ b/tests/tools/test_file_tools_live.py
@@ -9,16 +9,8 @@ asserts zero contamination from shell noise via _assert_clean().
 """
 
 import pytest
-
-
-
-
 import os
-import sys
 from pathlib import Path
-
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from tools.environments.local import LocalEnvironment
 from tools.file_operations import ShellFileOperations

--- a/tests/tools/test_modal_sandbox_fixes.py
+++ b/tests/tools/test_modal_sandbox_fixes.py
@@ -11,13 +11,7 @@ Covers the bugs discovered while setting up TBLite evaluation:
 
 import os
 import sys
-from pathlib import Path
 import pytest
-
-# Ensure repo root is importable
-_repo_root = Path(__file__).resolve().parent.parent.parent
-if str(_repo_root) not in sys.path:
-    sys.path.insert(0, str(_repo_root))
 
 try:
     import tools.terminal_tool  # noqa: F401

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -8,16 +8,7 @@ guard that would have caught that specific failure mode.
 from __future__ import annotations
 
 import json
-import os
-import sys
-from typing import List, Dict, Any
-
-import pytest
-
-
-_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
-if _REPO_ROOT not in sys.path:
-    sys.path.insert(0, _REPO_ROOT)
+from typing import Dict, Any
 
 
 def _td(name: str, description: str = "", properties: Dict[str, Any] | None = None) -> Dict[str, Any]:

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -16,9 +16,6 @@ from hermes_constants import display_hermes_home
 
 logger = logging.getLogger(__name__)
 
-# Import from cron module (will be available when properly installed)
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
 from cron.jobs import (
     AmbiguousJobReference,
     claim_job_for_fire,


### PR DESCRIPTION
## What does this PR do?

This is the first attempt of moving to namespaced modules.

Setting python path by calling sys.path.insert with hardcoded project root directory is unnecessary to run tests and import current modules like hermes_cli.

This commit also includes some related changes:

* Add method load_module_from_file to load specific file-based modules from plugins and others from inside the hermes-agent distribution.
* PYTHONPATH env var and subprocess cwd are unset. hermes modules are accessible from sys.executable.

The next step is to not rely on manual project root construction, e.g. `Path(__file__).resolve().parent.parent`

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Relates to #21691 

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- Drop unnecessary `sys.path.insert` calls
- Add method load_module_from_file to load specific file-based modules from plugins and others from inside the hermes-agent distribution.
- PYTHONPATH env var and subprocess cwd are unset. hermes modules are accessible from sys.executable.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Pass tests by `./scripts/run_tests.sh`
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

