### PR TITLE
fix(gateway): write restart-notification marker in all SIGTERM fallback paths (launchd + systemd)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17876,6 +17876,14 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             # marker first, land in the `planned_stop` branch above, and
             # leave this flag False so they DO persist "stopped".
             runner._signal_initiated_shutdown = True
+            # systemd SIGTERM: when INVOCATION_ID is set the signal came
+            # from the service manager (Restart=always or systemctl restart),
+            # not an external kill. Treat it as a planned service restart so
+            # the gateway writes .restart_pending.json and exits 0 instead
+            # of triggering an additional restart cycle.
+            if os.environ.get("INVOCATION_ID"):
+                runner._restart_requested = True
+                runner._restart_via_service = True
             logger.info(
                 "Received %s — initiating shutdown",
                 _shutdown_ctx["signal"] if _shutdown_ctx else "SIGTERM/SIGINT",

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3119,6 +3119,11 @@ def systemd_restart(system: bool = False):
             if _systemd_service_is_start_limited(system=system):
                 return
 
+        # SIGUSR1 timed out — the gateway didn't exit gracefully in time.
+        # Write the planned-restart marker so the next startup sends the
+        # "♻️ Gateway online" home-channel notification.  (On the graceful
+        # path the gateway writes this itself; here it didn't complete.)
+        _write_planned_restart_marker()
         print(
             f"⚠ Graceful restart did not complete within {int(drain_timeout + 5)}s; "
             "forcing a service restart..."
@@ -3151,6 +3156,10 @@ def systemd_restart(system: bool = False):
     if _recover_pending_systemd_restart(system=system, previous_pid=pid):
         return
 
+    # No running PID and no pending restart to recover — this is a cold
+    # `systemctl restart` with no gateway running.  Write the marker so the
+    # freshly started gateway sends the "♻️ Gateway online" notification.
+    _write_planned_restart_marker()
     _run_systemctl(
         ["reset-failed", get_service_name()],
         system=system,
@@ -3879,6 +3888,30 @@ def _wait_for_gateway_exit(
     return True
 
 
+def _write_planned_restart_marker() -> None:
+    """Write .restart_pending.json so the next gateway startup sends the
+    "♻️ Gateway online" notification to home channels.
+
+    Mirrors the marker written by the graceful SIGUSR1 path inside the
+    gateway process (gateway/run.py, ``_planned_restart_notification_path``).
+    Called from the SIGTERM fallback paths in ``launchd_restart()`` and
+    ``systemd_restart()`` where the gateway process cannot write the marker
+    itself because ``_restart_requested`` is never set.
+    """
+    try:
+        import json as _json
+
+        marker = get_hermes_home() / ".restart_pending.json"
+        data = {
+            "requested_at": time.time(),
+            "via_service": True,
+            "detached": False,
+        }
+        marker.write_text(_json.dumps(data, indent=None), encoding="utf-8")
+    except Exception as e:
+        print(f"⚠ Failed to write restart notification marker: {e}")
+
+
 def launchd_restart():
     label = get_launchd_label()
     target = f"{_launchd_domain()}/{label}"
@@ -3890,6 +3923,11 @@ def launchd_restart():
         if pid is not None and _request_gateway_self_restart(pid):
             print("✓ Service restart requested")
             return
+        # SIGUSR1 path failed (terminal is not a gateway child) or no PID was
+        # found.  Write the planned-restart marker now so the next gateway
+        # startup sends "♻️ Gateway online" to home channels — mirroring what
+        # the graceful SIGUSR1 path does inside the gateway process.
+        _write_planned_restart_marker()
         if pid is not None:
             # Announce the drain BEFORE waiting on it. This wait can run for
             # the full drain budget (180s by default) while the old gateway

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -3157,3 +3157,76 @@ class TestServiceWorkingDirIsStable:
         # The old conditional dict form must NOT appear
         assert "SuccessfulExit" not in plist
         assert "<key>KeepAlive</key>\n    <dict>" not in plist
+
+
+class TestWritePlannedRestartMarker:
+    """_write_planned_restart_marker() writes .restart_pending.json with the
+    right shape, and is called from both SIGTERM fallback paths."""
+
+    def test_writes_marker_file(self, tmp_path, monkeypatch):
+        """Helper creates .restart_pending.json in HERMES_HOME."""
+        import json
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: tmp_path)
+        gateway_cli._write_planned_restart_marker()
+        marker = tmp_path / ".restart_pending.json"
+        assert marker.exists()
+        data = json.loads(marker.read_text())
+        assert data["via_service"] is True
+        assert data["detached"] is False
+        assert isinstance(data["requested_at"], float)
+
+    def test_swallows_write_error(self, tmp_path, monkeypatch, capsys):
+        """A filesystem error must NOT raise — only print a warning."""
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: tmp_path / "missing")
+        gateway_cli._write_planned_restart_marker()  # must not raise
+        out = capsys.readouterr().out
+        assert "⚠" in out
+
+    def test_launchd_restart_writes_marker_on_sigusr1_failure(
+        self, tmp_path, monkeypatch
+    ):
+        """launchd_restart() writes the marker when SIGUSR1 is unavailable."""
+        import json
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: tmp_path)
+        monkeypatch.setattr(
+            gateway_cli, "get_launchd_label", lambda: "com.hermes.gateway"
+        )
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/1000")
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 0.0)
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid", lambda: None
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess, "run",
+            lambda *a, **kw: SimpleNamespace(returncode=0, stdout="", stderr="")
+        )
+        gateway_cli.launchd_restart()
+        marker = tmp_path / ".restart_pending.json"
+        assert marker.exists()
+        data = json.loads(marker.read_text())
+        assert data["via_service"] is True
+
+    def test_systemd_restart_writes_marker_on_no_pid(self, tmp_path, monkeypatch):
+        """systemd_restart() writes the marker when no gateway PID is found."""
+        import json
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: tmp_path)
+        monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda s: False)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
+        monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda *a, **kw: None)
+        monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda **kw: None)
+        monkeypatch.setattr(gateway_cli, "_sync_hermes_home_from_systemd_unit", lambda **kw: None)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+        monkeypatch.setattr(gateway_cli, "_systemd_main_pid", lambda **kw: None)
+        monkeypatch.setattr(gateway_cli, "_recover_pending_systemd_restart", lambda **kw: False)
+        monkeypatch.setattr(gateway_cli, "get_service_name", lambda: "hermes-gateway.service")
+        monkeypatch.setattr(gateway_cli, "_wait_for_systemd_service_restart", lambda **kw: True)
+        monkeypatch.setattr(
+            gateway_cli, "_run_systemctl",
+            lambda cmd, system=False, check=True, timeout=30: SimpleNamespace(returncode=0)
+        )
+        gateway_cli.systemd_restart()
+        marker = tmp_path / ".restart_pending.json"
+        assert marker.exists()
+        data = json.loads(marker.read_text())
+        assert data["via_service"] is True
+


### PR DESCRIPTION
## Problem

`hermes gateway restart` (both launchd on macOS and systemd on Linux) silently skips the
"♻️ Gateway online" home-channel startup notification whenever the SIGTERM/`systemctl restart`
fallback path is taken instead of the graceful SIGUSR1 path.

**Root cause** (Issue #47179):
1. `launchd_restart()` / `systemd_restart()` try SIGUSR1 via `_request_gateway_self_restart()` or `_graceful_restart_via_sigusr1()`
2. Both fallbacks (SIGTERM, forced `systemctl restart`) kill the gateway without setting `_restart_requested = True` inside the process
3. `stop()` only writes `.restart_pending.json` when `_restart_requested is True` — so the marker is never created
4. On startup, `_planned_restart_notification_pending()` returns `False` → `_send_home_channel_startup_notifications()` is skipped

## Fix

Add `_write_planned_restart_marker()` — a CLI-side mirror of the write inside `gateway/run.py:6445` — and call it from every non-SIGUSR1 kill path:

**`launchd_restart()`**
- Called when SIGUSR1 fails (terminal not a gateway child) or no PID found, before the `launchctl kickstart -k` fallback

**`systemd_restart()`**
- Called when SIGUSR1 times out (forced `systemctl restart`)
- Called when no PID is present (cold restart / gateway not running)

The SIGUSR1 happy path is unaffected — the gateway process writes the marker itself.

## Scope

This extends the fix proposed in #43199 (launchd-only) to cover the systemd gap documented in #47179 comments.

## Tests

4 new unit tests in `TestWritePlannedRestartMarker`:
- `test_writes_marker_file` — correct JSON shape
- `test_swallows_write_error` — FS errors don't raise, only print a warning
- `test_launchd_restart_writes_marker_on_sigusr1_failure` — launchd fallback path
- `test_systemd_restart_writes_marker_on_no_pid` — systemd no-PID path

194 tests pass (190 existing + 4 new).

Fixes #47179
