### PR TITLE
fix(gateway): write restart-notification marker in launchd and systemd SIGTERM fallback paths

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5,6 +5,7 @@ Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
 """
 
 import asyncio
+import json
 import logging
 import os
 import shlex
@@ -3123,6 +3124,11 @@ def systemd_restart(system: bool = False):
             f"⚠ Graceful restart did not complete within {int(drain_timeout + 5)}s; "
             "forcing a service restart..."
         )
+        # SIGUSR1 drain timed out.  Write the planned-restart marker before
+        # the hard kill so the new gateway startup sends "♻️ Gateway online".
+        # (The marker would normally be written by the gateway on clean exit
+        # via the SIGUSR1 path; the force path skips that.)
+        _write_planned_restart_marker()
         _run_systemctl(
             ["reset-failed", svc],
             system=system,
@@ -3879,6 +3885,28 @@ def _wait_for_gateway_exit(
     return True
 
 
+def _write_planned_restart_marker() -> None:
+    """Write .restart_pending.json so the next gateway startup sends the
+    home-channel "♻️ Gateway online" notification.
+
+    Called from the SIGTERM/force-kill fallback paths on both launchd
+    (macOS) and systemd (Linux) where the SIGUSR1 graceful path is
+    unavailable.  The SIGUSR1 path writes this marker from inside the
+    gateway process (gateway/run.py); the external kill paths must write
+    it here before the process is terminated.
+    """
+    try:
+        marker = get_hermes_home() / ".restart_pending.json"
+        data = {
+            "requested_at": time.time(),
+            "via_service": True,
+            "detached": False,
+        }
+        marker.write_text(json.dumps(data), encoding="utf-8")
+    except Exception as e:  # pragma: no cover
+        print(f"⚠ Failed to write restart notification marker: {e}")
+
+
 def launchd_restart():
     label = get_launchd_label()
     target = f"{_launchd_domain()}/{label}"
@@ -3890,6 +3918,11 @@ def launchd_restart():
         if pid is not None and _request_gateway_self_restart(pid):
             print("✓ Service restart requested")
             return
+        # SIGUSR1 path failed (terminal is not a gateway child) or no PID
+        # found.  Write the planned-restart marker now so the next gateway
+        # startup sends "♻️ Gateway online" — mirroring what the graceful
+        # SIGUSR1 path does inside the gateway process (gateway/run.py).
+        _write_planned_restart_marker()
         if pid is not None:
             # Announce the drain BEFORE waiting on it. This wait can run for
             # the full drain budget (180s by default) while the old gateway

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1084,6 +1084,56 @@ class TestLaunchdServiceRecovery:
         assert "nohup hermes gateway run" in out
 
 
+    def test_launchd_restart_writes_marker_when_sigusr1_fails(self, monkeypatch, tmp_path):
+        """launchd_restart writes .restart_pending.json when SIGUSR1 path is unavailable.
+
+        When _request_gateway_self_restart returns False (terminal is not a
+        gateway child), launchd falls back to SIGTERM + kickstart.  The
+        planned-restart marker must be written before the kill so the new
+        gateway startup sends the home-channel notification.
+        """
+        import json
+
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 5.0)
+        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
+        monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True)
+        monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: None)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: tmp_path)
+
+        def fake_run(cmd, check=False, **kwargs):
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_restart()
+
+        marker = tmp_path / ".restart_pending.json"
+        assert marker.exists(), ".restart_pending.json must be written before kickstart"
+        data = json.loads(marker.read_text())
+        assert data["via_service"] is True
+
+    def test_launchd_restart_writes_marker_when_no_running_pid(self, monkeypatch, tmp_path):
+        """launchd_restart writes the marker even when no existing gateway is found."""
+        import json
+
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 5.0)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: tmp_path)
+
+        def fake_run(cmd, check=False, **kwargs):
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_restart()
+
+        marker = tmp_path / ".restart_pending.json"
+        assert marker.exists(), ".restart_pending.json must be written even without a running gateway"
+        data = json.loads(marker.read_text())
+        assert data["via_service"] is True
+
+
 class TestLaunchdDomainDetection:
     """Regression tests for _launchd_domain() probing (#40831).
 
@@ -1441,6 +1491,56 @@ class TestGatewaySystemServiceRouting:
         assert any(call[0] == "start" for call in calls)
         out = capsys.readouterr().out.lower()
         assert "restarted" in out
+
+    def test_systemd_restart_writes_marker_on_sigusr1_timeout(self, monkeypatch, tmp_path):
+        """systemd_restart writes .restart_pending.json when SIGUSR1 drain times out.
+
+        When _graceful_restart_via_sigusr1 returns False (SIGUSR1 unavailable or
+        drain timed out), systemd_restart forces a service restart via systemctl.
+        The planned-restart marker must be written before the force-restart so
+        the new gateway startup sends the home-channel notification.
+        """
+        import json
+
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
+        monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
+        monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
+        monkeypatch.setattr(gateway_cli, "_sync_hermes_home_from_systemd_unit", lambda system=False: None)
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 5.0)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 654)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_graceful_restart_via_sigusr1",
+            lambda pid, timeout: False,  # simulate timeout
+        )
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: tmp_path)
+
+        def fake_run_systemctl(args, system=False, check=False, timeout=None):
+            calls.append(args[0] if args else args)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli, "_run_systemctl", fake_run_systemctl)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_systemd_service_restart",
+            lambda system=False, previous_pid=None: True,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_systemd_service_is_start_limited",
+            lambda system=False: False,
+        )
+
+        gateway_cli.systemd_restart()
+
+        marker = tmp_path / ".restart_pending.json"
+        assert marker.exists(), ".restart_pending.json must be written before force restart"
+        data = json.loads(marker.read_text())
+        assert data["via_service"] is True
+        assert "restart" in calls
 
     def test_systemd_status_surfaces_planned_restart_failure(self, monkeypatch, capsys):
         unit = SimpleNamespace(exists=lambda: True)


### PR DESCRIPTION
## Summary

Generalises the launchd notification fix from PR #43199 to also cover the Linux/systemd SIGTERM fallback path, as identified in [#issuecomment-4801682177](https://github.com/NousResearch/hermes-agent/pull/43199#issuecomment-4801682177).

Fixes #52567. Related: #47179, #43199.

## Root Cause

`hermes gateway restart` silently skips "♻️ Gateway online" on both platforms when SIGUSR1 is unavailable:

| Platform | Trigger | Why no marker |
|----------|---------|---------------|
| macOS/launchd | `_request_gateway_self_restart()` returns False (terminal != gateway child) → SIGTERM fallback | marker only written inside gateway on SIGUSR1 exit |
| Linux/systemd | `_graceful_restart_via_sigusr1()` times out → force `systemctl restart` | same reason |

Both share the same root: the CLI kills the gateway externally, so `_restart_requested` is never set and the gateway's own shutdown path (gateway/run.py:7108) never writes `.restart_pending.json`.

## The Fix

Added `_write_planned_restart_marker()` — a single helper that writes `.restart_pending.json` with `{"via_service": true, "detached": false, "requested_at": <ts>}` — and calls it from both SIGTERM fallback paths **before** the kill:

- **`launchd_restart()`**: called after `_request_gateway_self_restart()`   returns False (covers the case in #43199 + the no-PID case)
- **`systemd_restart()`**: called after `_graceful_restart_via_sigusr1()`   returns False, before `systemctl restart`

The SIGUSR1 happy path is **unaffected** — the gateway writes the marker itself and `_write_planned_restart_marker()` is not called in that branch.

## Tests

Three new test cases added to `tests/hermes_cli/test_gateway_service.py`:

- `test_launchd_restart_writes_marker_when_sigusr1_fails` — SIGUSR1   unavailable (terminal restart case)
- `test_launchd_restart_writes_marker_when_no_running_pid` — no running   gateway found
- `test_systemd_restart_writes_marker_on_sigusr1_timeout` — drain timed out,   force restart triggered

All 166 existing tests in the file continue to pass.

## Relation to PR #43199

PR #43199 proposes the same fix for the launchd path only, via a `_write_planned_restart_marker()` helper using `marker.write_text()`. This PR:

1. Covers both platforms with one helper
2. Uses the same call site approach as #43199 for launchd
3. Adds the systemd fallback fix (new in this PR)
4. Adds test coverage for all three failure modes
