### PR TITLE
fix(agent): fallback to Anthropic-style token fields in normalize_usage

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -774,8 +774,16 @@ def normalize_usage(
         )
         input_tokens = max(0, input_total - cache_read_tokens - cache_write_tokens)
     else:
-        prompt_total = _to_int(getattr(response_usage, "prompt_tokens", 0))
-        output_tokens = _to_int(getattr(response_usage, "completion_tokens", 0))
+        # OpenAI-style names first; fall back to Anthropic-style
+        # (input_tokens/output_tokens). Local OpenAI-compatible servers like
+        # mlx_vlm.server emit the Anthropic names in chat_completions responses,
+        # and the OpenAI Python client preserves them as extra attributes.
+        prompt_total = _to_int(getattr(response_usage, "prompt_tokens", 0)) or _to_int(
+            getattr(response_usage, "input_tokens", 0)
+        )
+        output_tokens = _to_int(getattr(response_usage, "completion_tokens", 0)) or _to_int(
+            getattr(response_usage, "output_tokens", 0)
+        )
         details = getattr(response_usage, "prompt_tokens_details", None)
         # Primary: OpenAI-style prompt_tokens_details. Fallback: Anthropic-style
         # top-level fields that some OpenAI-compatible proxies (OpenRouter, Cline)


### PR DESCRIPTION
## Problem

Context progress bar stays at 0% with OpenAI-compatible local servers (mlx_vlm, etc.). The status line shows 0/131.1K forever, even after many turns. Auto-compression thresholds never trigger.

## Root Cause

Local OpenAI-compatible servers like mlx_vlm.server emit input_tokens/output_tokens in chat completion responses instead of prompt_tokens/completion_tokens. The OpenAI Python client preserves these as extra attributes, but normalize_usage() only looked at OpenAI-style field names, causing input_tokens to always be 0.

## Changes

agent/usage_pricing.py: add Anthropic-style fallback (input_tokens/output_tokens) in the default else-branch of normalize_usage, with OpenAI-style names taking priority.

## Verification

- pytest tests/agent/test_usage_pricing.py: 15/15 passed
- pytest tests/ -k usage: 146/146 passed
- Custom validation: OpenAI style, Anthropic style, mixed fields, mlx_vlm style, empty usage: all passed

Fixes #14686