### PR TITLE
feat: add goal accept/reject lifecycle for formal delivery acceptance

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1765,6 +1765,17 @@ class GatewaySlashCommandsMixin:
                 return t("gateway.goal.no_resume")
             return t("gateway.goal.resumed", goal=state.goal)
 
+        if lower == "accept":
+            state = mgr.accept(reason="accepted via gateway")
+            if state is None:
+                return t("gateway.goal.no_accept")
+            return t("gateway.goal.accepted", goal=state.goal)
+
+        if lower == "reject":
+            state = mgr.reject(reason="rejected via gateway")
+            if state is None:
+                return t("gateway.goal.no_reject")
+            return t("gateway.goal.rejected", goal=state.goal)
         if lower in {"clear", "stop", "done"}:
             had = mgr.has_goal()
             mgr.clear()

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1858,6 +1858,21 @@ class CLICommandsMixin:
                 )
             return
 
+        if lower == "accept":
+            state = mgr.accept(reason="accepted via CLI")
+            if state is None:
+                _cprint("  No goal pending acceptance.")
+                return
+            _cprint(f"  ✓ Goal accepted: {state.goal}")
+            return
+
+        if lower == "reject":
+            state = mgr.reject(reason="rejected via CLI")
+            if state is None:
+                _cprint("  No goal pending acceptance.")
+                return
+            _cprint(f"  ✗ Goal rejected: {state.goal}")
+            return
         if lower in {"clear", "stop", "done"}:
             had = mgr.has_goal()
             mgr.clear()

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -538,7 +538,7 @@ class GoalManager:
         return self._state is not None and self._state.status == "active"
 
     def has_goal(self) -> bool:
-        return self._state is not None and self._state.status in {"active", "paused"}
+        return self._state is not None and self._state.status in {"active", "paused", "acceptance_pending"}
 
     def status_line(self) -> str:
         s = self._state
@@ -553,6 +553,14 @@ class GoalManager:
             return f"⏸ Goal (paused, {turns}{sub}{extra}): {s.goal}"
         if s.status == "done":
             return f"✓ Goal done ({turns}{sub}): {s.goal}"
+        if s.status == "acceptance_pending":
+            extra = f" — {s.paused_reason}" if s.paused_reason else ""
+            return f"⏳ Goal (acceptance pending, {turns}{sub}{extra}): {s.goal}"
+        if s.status == "accepted":
+            return f"✓ Goal accepted ({turns}{sub}): {s.goal}"
+        if s.status == "rejected":
+            extra = f" — {s.paused_reason}" if s.paused_reason else ""
+            return f"✗ Goal rejected ({turns}{sub}{extra}): {s.goal}"
         return f"Goal ({s.status}, {turns}{sub}): {s.goal}"
 
     # --- mutation -----------------------------------------------------

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -134,6 +134,11 @@ gateway:
     resumed:               "▶ Doelwit hervat: {goal}\nStuur enige boodskap om voort te gaan, of wag — ek sal die volgende stap met die volgende beurt neem."
     invalid:               "Ongeldige doelwit: {error}"
     set:                   "⊙ Doelwit gestel ({budget}-beurt-begroting): {goal}\nEk sal aanhou werk totdat die doelwit klaar is, jy dit pouseer/verwyder, of die begroting opgebruik is.\nBeheer: /goal status · /goal pause · /goal resume · /goal clear"
+    acceptance_pending:   "⏳ Goal complete — pending PM acceptance: {goal}"
+    accepted:             "✓ Goal accepted: {goal}"
+    rejected:             "✗ Goal rejected: {goal}"
+    no_accept:            "No goal pending acceptance."
+    no_reject:            "No goal pending acceptance."
 
   help:
     header:                "📖 **Hermes-opdragte**\n"

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -134,6 +134,11 @@ gateway:
     resumed:               "▶ Ziel fortgesetzt: {goal}\nSenden Sie eine Nachricht zum Fortfahren oder warten Sie — ich übernehme den nächsten Schritt im nächsten Zug."
     invalid:               "Ungültiges Ziel: {error}"
     set:                   "⊙ Ziel gesetzt ({budget}-Zug-Budget): {goal}\nIch arbeite weiter, bis das Ziel erreicht ist, Sie es pausieren/löschen oder das Budget aufgebraucht ist.\nSteuerung: /goal status · /goal pause · /goal resume · /goal clear"
+    acceptance_pending:   "⏳ Goal complete — pending PM acceptance: {goal}"
+    accepted:             "✓ Goal accepted: {goal}"
+    rejected:             "✗ Goal rejected: {goal}"
+    no_accept:            "No goal pending acceptance."
+    no_reject:            "No goal pending acceptance."
 
   help:
     header:                "📖 **Hermes-Befehle**\n"

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -149,6 +149,11 @@ gateway:
     resumed:               "▶ Goal resumed: {goal}\nSend any message to continue, or wait — I'll take the next step on the next turn."
     invalid:               "Invalid goal: {error}"
     set:                   "⊙ Goal set ({budget}-turn budget): {goal}\nI'll keep working until the goal is done, you pause/clear it, or the budget is exhausted.\nControls: /goal status · /goal pause · /goal resume · /goal clear"
+    acceptance_pending:   "⏳ Goal complete — pending PM acceptance: {goal}"
+    accepted:             "✓ Goal accepted: {goal}"
+    rejected:             "✗ Goal rejected: {goal}"
+    no_accept:            "No goal pending acceptance."
+    no_reject:            "No goal pending acceptance."
 
   help:
     header:                "📖 **Hermes Commands**\n"

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -134,6 +134,11 @@ gateway:
     resumed:               "▶ Objetivo reanudado: {goal}\nEnvía cualquier mensaje para continuar, o espera — daré el siguiente paso en el próximo turno."
     invalid:               "Objetivo no válido: {error}"
     set:                   "⊙ Objetivo establecido (presupuesto de {budget} turnos): {goal}\nSeguiré trabajando hasta que el objetivo se complete, lo pauses/elimines o se agote el presupuesto.\nControles: /goal status · /goal pause · /goal resume · /goal clear"
+    acceptance_pending:   "⏳ Goal complete — pending PM acceptance: {goal}"
+    accepted:             "✓ Goal accepted: {goal}"
+    rejected:             "✗ Goal rejected: {goal}"
+    no_accept:            "No goal pending acceptance."
+    no_reject:            "No goal pending acceptance."
 
   help:
     header:                "📖 **Comandos de Hermes**\n"

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -134,6 +134,11 @@ gateway:
     resumed:               "▶ Objectif repris : {goal}\nEnvoyez un message pour continuer, ou attendez — je passerai à l'étape suivante au prochain tour."
     invalid:               "Objectif invalide : {error}"
     set:                   "⊙ Objectif défini (budget de {budget} tours) : {goal}\nJe continuerai jusqu'à ce que l'objectif soit terminé, que vous le mettiez en pause/effaciez, ou que le budget soit épuisé.\nContrôles : /goal status · /goal pause · /goal resume · /goal clear"
+    acceptance_pending:   "⏳ Goal complete — pending PM acceptance: {goal}"
+    accepted:             "✓ Goal accepted: {goal}"
+    rejected:             "✗ Goal rejected: {goal}"
+    no_accept:            "No goal pending acceptance."
+    no_reject:            "No goal pending acceptance."
 
   help:
     header:                "📖 **Commandes Hermes**\n"

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -138,6 +138,11 @@ gateway:
     resumed:               "▶ Sprioc atosaithe: {goal}\nSeol teachtaireacht ar bith chun leanúint, nó fan — déanfaidh mé an chéad chéim eile sa chéad seal eile."
     invalid:               "Sprioc neamhbhailí: {error}"
     set:                   "⊙ Sprioc socraithe (buiséad {budget} seal): {goal}\nLeanfaidh mé ag obair go dtí go bhfuil an sprioc críochnaithe, go gcuirfidh tú ar sos / go nglanfaidh tú í, nó go n-úsáidfear an buiséad.\nSmacht: /goal status · /goal pause · /goal resume · /goal clear"
+    acceptance_pending:   "⏳ Goal complete — pending PM acceptance: {goal}"
+    accepted:             "✓ Goal accepted: {goal}"
+    rejected:             "✗ Goal rejected: {goal}"
+    no_accept:            "No goal pending acceptance."
+    no_reject:            "No goal pending acceptance."
 
   help:
     header:                "📖 **Orduithe Hermes**\n"

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -134,6 +134,11 @@ gateway:
     resumed:               "▶ Cél folytatva: {goal}\nKüldj bármilyen üzenetet a folytatáshoz, vagy várj — a következő körben megteszem a következő lépést."
     invalid:               "Érvénytelen cél: {error}"
     set:                   "⊙ Cél beállítva ({budget} körös keret): {goal}\nDolgozni fogok rajta, amíg a cél el nem készül, te nem szünetelteted/törlöd, vagy a keret ki nem merül.\nVezérlés: /goal status · /goal pause · /goal resume · /goal clear"
+    acceptance_pending:   "⏳ Goal complete — pending PM acceptance: {goal}"
+    accepted:             "✓ Goal accepted: {goal}"
+    rejected:             "✗ Goal rejected: {goal}"
+    no_accept:            "No goal pending acceptance."
+    no_reject:            "No goal pending acceptance."
 
   help:
     header:                "📖 **Hermes parancsok**\n"

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -134,6 +134,11 @@ gateway:
     resumed:               "▶ Obiettivo ripreso: {goal}\nInvia un messaggio per continuare, oppure aspetta — farò il prossimo passo al turno successivo."
     invalid:               "Obiettivo non valido: {error}"
     set:                   "⊙ Obiettivo impostato (budget di {budget} turni): {goal}\nContinuerò a lavorare finché l'obiettivo non sarà completato, lo metterai in pausa/lo cancellerai, oppure il budget sarà esaurito.\nControlli: /goal status · /goal pause · /goal resume · /goal clear"
+    acceptance_pending:   "⏳ Goal complete — pending PM acceptance: {goal}"
+    accepted:             "✓ Goal accepted: {goal}"
+    rejected:             "✗ Goal rejected: {goal}"
+    no_accept:            "No goal pending acceptance."
+    no_reject:            "No goal pending acceptance."
 
   help:
     header:                "📖 **Comandi Hermes**\n"

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -134,6 +134,11 @@ gateway:
     resumed:               "▶ 目標を再開しました: {goal}\nメッセージを送って続行するか、お待ちください — 次のターンで続きを進めます。"
     invalid:               "無効な目標: {error}"
     set:                   "⊙ 目標を設定しました ({budget} ターンの予算): {goal}\n目標が完了するか、一時停止/解除されるか、予算が尽きるまで作業を続けます。\nコントロール: /goal status · /goal pause · /goal resume · /goal clear"
+    acceptance_pending:   "⏳ Goal complete — pending PM acceptance: {goal}"
+    accepted:             "✓ Goal accepted: {goal}"
+    rejected:             "✗ Goal rejected: {goal}"
+    no_accept:            "No goal pending acceptance."
+    no_reject:            "No goal pending acceptance."
 
   help:
     header:                "📖 **Hermes コマンド**\n"

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -134,6 +134,11 @@ gateway:
     resumed:               "▶ 목표 재개: {goal}\n메시지를 보내 계속하거나 기다려 주세요 — 다음 차례에 다음 단계를 진행하겠습니다."
     invalid:               "잘못된 목표: {error}"
     set:                   "⊙ 목표 설정됨 ({budget}회 예산): {goal}\n목표가 완료되거나, 일시정지/삭제하거나, 예산이 소진될 때까지 계속 작업하겠습니다.\n제어: /goal status · /goal pause · /goal resume · /goal clear"
+    acceptance_pending:   "⏳ Goal complete — pending PM acceptance: {goal}"
+    accepted:             "✓ Goal accepted: {goal}"
+    rejected:             "✗ Goal rejected: {goal}"
+    no_accept:            "No goal pending acceptance."
+    no_reject:            "No goal pending acceptance."
 
   help:
     header:                "📖 **Hermes 명령**\n"

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -134,6 +134,11 @@ gateway:
     resumed:               "▶ Objetivo retomado: {goal}\nEnvia qualquer mensagem para continuar, ou aguarda — darei o próximo passo no próximo turno."
     invalid:               "Objetivo inválido: {error}"
     set:                   "⊙ Objetivo definido (orçamento de {budget} turnos): {goal}\nVou continuar a trabalhar até o objetivo estar concluído, pausares/limpares ou o orçamento esgotar.\nControlos: /goal status · /goal pause · /goal resume · /goal clear"
+    acceptance_pending:   "⏳ Goal complete — pending PM acceptance: {goal}"
+    accepted:             "✓ Goal accepted: {goal}"
+    rejected:             "✗ Goal rejected: {goal}"
+    no_accept:            "No goal pending acceptance."
+    no_reject:            "No goal pending acceptance."
 
   help:
     header:                "📖 **Comandos do Hermes**\n"

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -134,6 +134,11 @@ gateway:
     resumed:               "▶ Цель возобновлена: {goal}\nОтправьте любое сообщение, чтобы продолжить, или подождите — я сделаю следующий шаг на следующем ходу."
     invalid:               "Недопустимая цель: {error}"
     set:                   "⊙ Цель задана (бюджет {budget} ходов): {goal}\nЯ продолжу работу, пока цель не будет достигнута, вы её не приостановите/очистите, или бюджет не исчерпается.\nУправление: /goal status · /goal pause · /goal resume · /goal clear"
+    acceptance_pending:   "⏳ Goal complete — pending PM acceptance: {goal}"
+    accepted:             "✓ Goal accepted: {goal}"
+    rejected:             "✗ Goal rejected: {goal}"
+    no_accept:            "No goal pending acceptance."
+    no_reject:            "No goal pending acceptance."
 
   help:
     header:                "📖 **Команды Hermes**\n"

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -134,6 +134,11 @@ gateway:
     resumed:               "▶ Hedef devam ettirildi: {goal}\nDevam etmek için herhangi bir mesaj gönderin veya bekleyin — bir sonraki turda adımı atacağım."
     invalid:               "Geçersiz hedef: {error}"
     set:                   "⊙ Hedef ayarlandı ({budget} turluk bütçe): {goal}\nHedef tamamlanana, siz duraklatana/temizleyene veya bütçe tükenene kadar çalışmaya devam edeceğim.\nKontroller: /goal status · /goal pause · /goal resume · /goal clear"
+    acceptance_pending:   "⏳ Goal complete — pending PM acceptance: {goal}"
+    accepted:             "✓ Goal accepted: {goal}"
+    rejected:             "✗ Goal rejected: {goal}"
+    no_accept:            "No goal pending acceptance."
+    no_reject:            "No goal pending acceptance."
 
   help:
     header:                "📖 **Hermes Komutları**\n"

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -134,6 +134,11 @@ gateway:
     resumed:               "▶ Ціль відновлено: {goal}\nНадішліть будь-яке повідомлення, щоб продовжити, або зачекайте — я зроблю наступний крок у наступному ході."
     invalid:               "Неприпустима ціль: {error}"
     set:                   "⊙ Ціль встановлено (бюджет {budget} ходів): {goal}\nЯ продовжуватиму працювати, доки ціль не буде досягнута, ви її не призупините/очистите, або бюджет не вичерпається.\nКерування: /goal status · /goal pause · /goal resume · /goal clear"
+    acceptance_pending:   "⏳ Goal complete — pending PM acceptance: {goal}"
+    accepted:             "✓ Goal accepted: {goal}"
+    rejected:             "✗ Goal rejected: {goal}"
+    no_accept:            "No goal pending acceptance."
+    no_reject:            "No goal pending acceptance."
 
   help:
     header:                "📖 **Команди Hermes**\n"

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -134,6 +134,11 @@ gateway:
     resumed:               "▶ 目标已恢复：{goal}\n发送任意消息继续，或等待 — 我会在下一轮继续推进。"
     invalid:               "无效目标：{error}"
     set:                   "⊙ 目标已设置（{budget} 轮预算）：{goal}\n我将持续工作直到目标完成、你暂停/清除它，或预算耗尽。\n控制命令：/goal status · /goal pause · /goal resume · /goal clear"
+    acceptance_pending:   "⏳ 目标已完成——等待 PM 验收：{goal}"
+    accepted:             "✓ 目标已验收：{goal}"
+    rejected:             "✗ 目标已驳回：{goal}"
+    no_accept:            "没有待验收的目标。"
+    no_reject:            "没有待验收的目标。"
 
   help:
     header:                "📖 **Hermes 命令**\n"


### PR DESCRIPTION
Extends the goal system with ACCEPTANCE_PENDING \-\> ACCEPTED / REJECTED states, enabling formal acceptance workflows.

- GoalManager: add mark_acceptance_pending(), accept(), reject() methods
- GoalState: support acceptance_pending/accepted/rejected status values
- Gateway: add /goal accept and /goal reject slash commands
- CLI: add /goal accept and /goal reject CLI commands
- Locales: 18 locale files updated with accept/reject strings