### PR TITLE
feat(gateway): add gateway_restart_notification_channels config

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -251,7 +251,8 @@ class HomeChannel:
     chat_id: str
     name: str  # Human-readable name for display
     thread_id: Optional[str] = None
-    
+    chat_type: Optional[str] = None  # "dm", "group", "channel", etc.
+
     def to_dict(self) -> Dict[str, Any]:
         result = {
             "platform": self.platform.value,
@@ -260,8 +261,10 @@ class HomeChannel:
         }
         if self.thread_id:
             result["thread_id"] = self.thread_id
+        if self.chat_type:
+            result["chat_type"] = self.chat_type
         return result
-    
+
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "HomeChannel":
         return cls(
@@ -269,6 +272,7 @@ class HomeChannel:
             chat_id=str(data["chat_id"]),
             name=data.get("name", "Home"),
             thread_id=str(data["thread_id"]) if data.get("thread_id") else None,
+            chat_type=str(data["chat_type"]) if data.get("chat_type") else None,
         )
 
 
@@ -336,6 +340,11 @@ class PlatformConfig:
     # noise; keep True for back-channels where the operator wants them.
     gateway_restart_notification: bool = True
 
+    # If False, suppress gateway restart/shutdown notifications in bare
+    # channels/groups. Notifications still go to DMs and to active threads
+    # within channels. Default True preserves prior behavior.
+    gateway_restart_notification_channels: bool = True
+
     # Platform-specific settings
     extra: Dict[str, Any] = field(default_factory=dict)
 
@@ -345,6 +354,7 @@ class PlatformConfig:
             "extra": self.extra,
             "reply_to_mode": self.reply_to_mode,
             "gateway_restart_notification": self.gateway_restart_notification,
+            "gateway_restart_notification_channels": self.gateway_restart_notification_channels,
         }
         if self.token:
             result["token"] = self.token
@@ -368,6 +378,10 @@ class PlatformConfig:
         if _grn is None:
             _grn = data.get("extra", {}).get("gateway_restart_notification")
 
+        _grnc = data.get("gateway_restart_notification_channels")
+        if _grnc is None:
+            _grnc = data.get("extra", {}).get("gateway_restart_notification_channels")
+
         return cls(
             enabled=_coerce_bool(data.get("enabled"), False),
             token=data.get("token"),
@@ -375,6 +389,7 @@ class PlatformConfig:
             home_channel=home_channel,
             reply_to_mode=data.get("reply_to_mode", "first"),
             gateway_restart_notification=_coerce_bool(_grn, True),
+            gateway_restart_notification_channels=_coerce_bool(_grnc, True),
             extra=data.get("extra", {}),
         )
 
@@ -1023,6 +1038,8 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = channel_prompts
                 if "gateway_restart_notification" in platform_cfg:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
+                if "gateway_restart_notification_channels" in platform_cfg:
+                    bridged["gateway_restart_notification_channels"] = platform_cfg["gateway_restart_notification_channels"]
                 enabled_was_explicit = _cfg_toplevel and "enabled" in platform_cfg
                 if not bridged and not enabled_was_explicit:
                     continue

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -331,6 +331,49 @@ def _gateway_provider_error_reply(text: str) -> str:
     )
 
 
+# Mirror the DM-ish set used by gateway/slash_access.py and gateway/authz_mixin.py.
+# Anything that is not a DM/private/direct message and is not part of an active
+# thread is treated as a public/channel-like surface for lifecycle pings.
+_DM_CHAT_TYPES: frozenset[str] = frozenset({"dm", "direct", "private", ""})
+
+
+def _is_bare_channel(
+    chat_type: Optional[str],
+    thread_id: Optional[str],
+    *,
+    unknown_is_bare: bool = False,
+) -> bool:
+    """Return True for a non-DM chat that is not an active thread.
+
+    When ``chat_type`` is unknown (None), the result is controlled by
+    ``unknown_is_bare``. Home channels default to treating unknown chat
+    types as bare (legacy homes lack a stored chat_type), while active
+    sessions default to not suppressing when the origin is missing.
+    """
+    if chat_type is None:
+        return unknown_is_bare and not thread_id
+    return chat_type.lower() not in _DM_CHAT_TYPES and not thread_id
+
+
+def _lifecycle_suppression_reason(
+    platform_cfg: Optional[Any],
+    chat_type: Optional[str],
+    thread_id: Optional[str],
+    *,
+    unknown_is_bare: bool = False,
+) -> Optional[str]:
+    """Return a short reason if a gateway lifecycle notification should be suppressed."""
+    if platform_cfg is None:
+        return None
+    if not platform_cfg.gateway_restart_notification:
+        return "gateway_restart_notification=false"
+    if not platform_cfg.gateway_restart_notification_channels and _is_bare_channel(
+        chat_type, thread_id, unknown_is_bare=unknown_is_bare
+    ):
+        return f"gateway_restart_notification_channels=false and chat_type={chat_type} (no thread)"
+    return None
+
+
 _GATEWAY_PROVIDER_ERROR_SHAPE_RE = re.compile(
     r"^\s*(\W*\s*)?("
     r"api\s+(?:call\s+)?failed"
@@ -4764,15 +4807,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 platform_str = source.platform.value
                 chat_id = str(source.chat_id)
                 thread_id = source.thread_id
+                chat_type = source.chat_type
             else:
                 # Fall back to parsing the session key when no persisted
-                # origin is available (legacy sessions/tests).
+                # origin is available (legacy sessions/tests).  We cannot
+                # reliably tell whether a group/forum session key carries a
+                # thread_id (see _parse_session_key), so we only apply the
+                # global opt-out and preserve pre-feature behavior otherwise.
                 _parsed = _parse_session_key(session_key)
                 if not _parsed:
                     continue
                 platform_str = _parsed["platform"]
                 chat_id = _parsed["chat_id"]
                 thread_id = _parsed.get("thread_id")
+                chat_type = None
 
             # Deduplicate only identical delivery targets. Thread/topic-aware
             # platforms can share a parent chat while still routing to distinct
@@ -4787,11 +4835,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if not adapter:
                     continue
 
-                platform_cfg = self.config.platforms.get(platform)
-                if platform_cfg is not None and not platform_cfg.gateway_restart_notification:
+                reason = _lifecycle_suppression_reason(
+                    self.config.platforms.get(platform),
+                    chat_type,
+                    thread_id,
+                )
+                if reason:
                     logger.info(
-                        "Shutdown notification suppressed for active session: %s has gateway_restart_notification=false",
+                        "Shutdown notification suppressed for active session: %s has %s",
                         platform_str,
+                        reason,
                     )
                     continue
 
@@ -4850,11 +4903,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if not home or not home.chat_id:
                 continue
 
-            platform_cfg = self.config.platforms.get(platform)
-            if platform_cfg is not None and not platform_cfg.gateway_restart_notification:
+            reason = _lifecycle_suppression_reason(
+                self.config.platforms.get(platform),
+                getattr(home, "chat_type", None),
+                home.thread_id,
+                unknown_is_bare=True,
+            )
+            if reason:
                 logger.info(
-                    "Shutdown notification suppressed for home channel: %s has gateway_restart_notification=false",
+                    "Shutdown notification suppressed for home channel: %s has %s",
                     platform.value,
+                    reason,
                 )
                 continue
 
@@ -12901,11 +12960,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 return None
 
-            platform_cfg = self.config.platforms.get(platform)
-            if platform_cfg is not None and not platform_cfg.gateway_restart_notification:
+            reason = _lifecycle_suppression_reason(
+                self.config.platforms.get(platform),
+                chat_type,
+                thread_id,
+            )
+            if reason:
                 logger.info(
-                    "Restart notification suppressed: %s has gateway_restart_notification=false",
+                    "Restart notification suppressed: %s has %s",
                     platform_str,
+                    reason,
                 )
                 return None
 
@@ -12967,11 +13031,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if not home or not home.chat_id:
                 continue
 
-            platform_cfg = self.config.platforms.get(platform)
-            if platform_cfg is not None and not platform_cfg.gateway_restart_notification:
+            reason = _lifecycle_suppression_reason(
+                self.config.platforms.get(platform),
+                getattr(home, "chat_type", None),
+                home.thread_id,
+                unknown_is_bare=True,
+            )
+            if reason:
                 logger.info(
-                    "Home-channel startup notification suppressed: %s has gateway_restart_notification=false",
+                    "Home-channel startup notification suppressed: %s has %s",
                     platform.value,
+                    reason,
                 )
                 continue
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2122,6 +2122,7 @@ class GatewaySlashCommandsMixin:
                 chat_id=str(chat_id),
                 name=chat_name,
                 thread_id=str(thread_id) if thread_id else None,
+                chat_type=source.chat_type,
             )
 
         return t("gateway.set_home.success", name=chat_name, chat_id=chat_id)

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -26,6 +26,13 @@ class TestHomeChannelRoundtrip:
         assert restored.chat_id == "999"
         assert restored.name == "general"
 
+    def test_to_dict_from_dict_preserves_chat_type(self):
+        hc = HomeChannel(platform=Platform.SLACK, chat_id="C123", name="ops", chat_type="group")
+        d = hc.to_dict()
+        restored = HomeChannel.from_dict(d)
+
+        assert restored.chat_type == "group"
+
 
 class TestPlatformConfigRoundtrip:
     def test_to_dict_from_dict(self):
@@ -70,6 +77,23 @@ class TestPlatformConfigRoundtrip:
     def test_gateway_restart_notification_coerces_quoted_false(self):
         restored = PlatformConfig.from_dict({"gateway_restart_notification": "false"})
         assert restored.gateway_restart_notification is False
+
+    def test_gateway_restart_notification_channels_defaults_true(self):
+        assert PlatformConfig().gateway_restart_notification_channels is True
+        assert PlatformConfig.from_dict({}).gateway_restart_notification_channels is True
+
+    def test_gateway_restart_notification_channels_roundtrip_false(self):
+        pc = PlatformConfig(enabled=True, gateway_restart_notification_channels=False)
+        restored = PlatformConfig.from_dict(pc.to_dict())
+        assert restored.gateway_restart_notification_channels is False
+
+    def test_gateway_restart_notification_channels_coerces_quoted_false(self):
+        restored = PlatformConfig.from_dict({"gateway_restart_notification_channels": "false"})
+        assert restored.gateway_restart_notification_channels is False
+
+    def test_gateway_restart_notification_channels_reads_from_extra(self):
+        restored = PlatformConfig.from_dict({"extra": {"gateway_restart_notification_channels": False}})
+        assert restored.gateway_restart_notification_channels is False
 
 
 class TestGetConnectedPlatforms:

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -688,3 +688,242 @@ async def test_restart_shutdown_notification_anchors_telegram_dm_topic():
         "direct_messages_topic_id": "20197",
         "telegram_reply_to_message_id": "462",
     }
+
+
+# ── gateway_restart_notification_channels granularity ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_shutdown_notification_suppressed_in_bare_channel_when_channels_flag_false():
+    """With gateway_restart_notification_channels=False, bare channels are muted."""
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification_channels = False
+    source = make_restart_source(chat_id="chan-42", chat_type="group", thread_id=None)
+    session_key = build_session_key(source)
+
+    runner._running_agents[session_key] = object()
+    runner.session_store._entries[session_key] = MagicMock(origin=source)
+    adapter.send = AsyncMock(return_value=SendResult(success=True))
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_notification_suppressed_for_forum_and_webhook_when_channels_flag_false():
+    """Telegram forums and webhook-triggered sessions are also treated as bare channels."""
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification_channels = False
+
+    for chat_type in ("forum", "webhook"):
+        source = make_restart_source(chat_id=f"chan-{chat_type}", chat_type=chat_type, thread_id=None)
+        session_key = build_session_key(source)
+        runner._running_agents[session_key] = object()
+        runner.session_store._entries[session_key] = MagicMock(origin=source)
+
+    adapter.send = AsyncMock(return_value=SendResult(success=True))
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    assert adapter.send.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_shutdown_notification_kept_for_uppercase_dm_chat_type():
+    """DM suppression is case-insensitive, so uppercase 'DM' is still treated as a DM."""
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification_channels = False
+    source = make_restart_source(chat_id="42", chat_type="DM", thread_id=None)
+    session_key = build_session_key(source)
+
+    runner._running_agents[session_key] = object()
+    runner.session_store._entries[session_key] = MagicMock(origin=source)
+    adapter.send = AsyncMock(return_value=SendResult(success=True))
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    adapter.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_notification_still_sent_in_active_thread_when_channels_flag_false():
+    """Threads inside channels still get shutdown notifications."""
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification_channels = False
+    source = make_restart_source(chat_id="chan-42", chat_type="group", thread_id="t-7")
+    session_key = build_session_key(source)
+
+    runner._running_agents[session_key] = object()
+    runner.session_store._entries[session_key] = MagicMock(origin=source)
+    adapter.send = AsyncMock(return_value=SendResult(success=True))
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    adapter.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_notification_kept_for_legacy_session_without_source():
+    """Legacy sessions without origin cannot be confirmed as bare channels, so we send."""
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification_channels = False
+    session_key = "agent:main:telegram:group:chan-42"
+
+    runner._running_agents[session_key] = object()
+    runner.session_store._entries[session_key] = MagicMock(origin=None)
+    adapter.send = AsyncMock(return_value=SendResult(success=True))
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    adapter.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_notification_kept_for_legacy_dm_session_without_source():
+    """Legacy DM sessions without origin still receive shutdown notifications."""
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification_channels = False
+    session_key = "agent:main:telegram:dm:42"
+
+    runner._running_agents[session_key] = object()
+    runner.session_store._entries[session_key] = MagicMock(origin=None)
+    adapter.send = AsyncMock(return_value=SendResult(success=True))
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    adapter.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_suppressed_in_bare_channel_when_channels_flag_false(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps({
+        "platform": "telegram",
+        "chat_id": "chan-42",
+        "chat_type": "group",
+    }))
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification_channels = False
+    adapter.send = AsyncMock()
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target is None
+    adapter.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_still_sent_in_dm_when_channels_flag_false(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps({
+        "platform": "telegram",
+        "chat_id": "42",
+        "chat_type": "dm",
+    }))
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification_channels = False
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="m-1"))
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target == ("telegram", "42", None)
+    adapter.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_send_home_channel_startup_notification_suppressed_when_channels_flag_disabled(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification_channels = False
+    adapter.send = AsyncMock()
+
+    delivered = await runner._send_home_channel_startup_notifications()
+
+    assert delivered == set()
+    adapter.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_home_channel_startup_notification_kept_when_threaded_and_channels_flag_disabled(
+    tmp_path, monkeypatch
+):
+    """Threaded home channels still receive startup pings even when bare channels are muted."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+        thread_id="t-99",
+    )
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification_channels = False
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="m-1"))
+
+    delivered = await runner._send_home_channel_startup_notifications()
+
+    assert delivered == {("telegram", "home-42", "t-99")}
+    adapter.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_send_home_channel_startup_notification_kept_for_dm_when_channels_flag_disabled(
+    tmp_path, monkeypatch
+):
+    """DM home channels are never muted by the channels-only flag."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="dm-42",
+        name="Ops Home",
+        chat_type="dm",
+    )
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification_channels = False
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="m-1"))
+
+    delivered = await runner._send_home_channel_startup_notifications()
+
+    assert delivered == {("telegram", "dm-42", None)}
+    adapter.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_ack_suppressed_in_bare_channel_when_channels_flag_false(
+    tmp_path, monkeypatch
+):
+    """Explicit /restart ack is also muted in bare channels when the flag is off."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps({
+        "platform": "telegram",
+        "chat_id": "chan-42",
+        "chat_type": "group",
+    }))
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification_channels = False
+    adapter.send = AsyncMock()
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target is None
+    adapter.send.assert_not_called()


### PR DESCRIPTION
Adds per-platform `gateway_restart_notification_channels` (default `true`) to suppress gateway lifecycle notifications in bare channels/groups while keeping DMs and active threads.

**Scope:** 5 files only — config bridge, `_is_bare_channel` / `_lifecycle_suppression_reason`, HomeChannel stores `chat_type` on `/sethome`, tests (114 passing in gateway config + restart notification).

**Example (Monvanti Slack):**
```yaml
slack:
  gateway_restart_notification: true
  gateway_restart_notification_channels: false
```

**Notes:** Legacy active sessions without persisted origin fail-open (still notify). Unknown home-channel chat types without thread are treated as bare when the flag is off.