### PR TITLE
fix(feishu): use get_secret() for credential env vars in multiplex mode

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1478,6 +1478,9 @@ class FeishuAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _load_settings(extra: Dict[str, Any]) -> FeishuAdapterSettings:
+        # Lazy import to avoid circular dependency — same pattern as gateway/run.py
+        from agent.secret_scope import get_secret
+
         # Parse per-group rules from config
         raw_group_rules = extra.get("group_rules", {})
         group_rules: Dict[str, FeishuGroupRule] = {}
@@ -1515,15 +1518,15 @@ class FeishuAdapter(BasePlatformAdapter):
             allow_bots = "none"
 
         return FeishuAdapterSettings(
-            app_id=str(extra.get("app_id") or os.getenv("FEISHU_APP_ID", "")).strip(),
-            app_secret=str(extra.get("app_secret") or os.getenv("FEISHU_APP_SECRET", "")).strip(),
+            app_id=str(extra.get("app_id") or get_secret("FEISHU_APP_ID", "")).strip(),
+            app_secret=str(extra.get("app_secret") or get_secret("FEISHU_APP_SECRET", "")).strip(),
             domain_name=str(extra.get("domain") or os.getenv("FEISHU_DOMAIN", "feishu")).strip().lower(),
             connection_mode=str(
                 extra.get("connection_mode") or os.getenv("FEISHU_CONNECTION_MODE", "websocket")
             ).strip().lower(),
-            encrypt_key=str(extra.get("encrypt_key") or os.getenv("FEISHU_ENCRYPT_KEY", "")).strip(),
+            encrypt_key=str(extra.get("encrypt_key") or get_secret("FEISHU_ENCRYPT_KEY", "")).strip(),
             verification_token=str(
-                extra.get("verification_token") or os.getenv("FEISHU_VERIFICATION_TOKEN", "")
+                extra.get("verification_token") or get_secret("FEISHU_VERIFICATION_TOKEN", "")
             ).strip(),
             group_policy=os.getenv("FEISHU_GROUP_POLICY", "allowlist").strip().lower(),
             allowed_group_users=frozenset(

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -4944,3 +4944,58 @@ class TestChatLockEviction(unittest.TestCase):
                 held.release()
 
         asyncio.run(_run())
+
+
+class TestLoadSettingsSecretScope(unittest.TestCase):
+    """Verify _load_settings uses get_secret() for credential env vars (#52564)."""
+
+    def test_credentials_read_via_get_secret_not_os_getenv(self):
+        """Credential vars must resolve through the profile secret scope."""
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        scope_secrets = {
+            "FEISHU_APP_ID": "scope_app_id",
+            "FEISHU_APP_SECRET": "scope_secret",
+            "FEISHU_ENCRYPT_KEY": "scope_encrypt",
+            "FEISHU_VERIFICATION_TOKEN": "scope_token",
+        }
+
+        with patch(
+            "agent.secret_scope.get_secret",
+            side_effect=lambda name, default="": scope_secrets.get(name, default),
+        ):
+            settings = FeishuAdapter._load_settings({})
+
+        self.assertEqual(settings.app_id, "scope_app_id")
+        self.assertEqual(settings.app_secret, "scope_secret")
+        self.assertEqual(settings.encrypt_key, "scope_encrypt")
+        self.assertEqual(settings.verification_token, "scope_token")
+
+    def test_extra_overrides_secret_scope(self):
+        """Explicit config.yaml values (extra) take precedence over scope."""
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        with patch(
+            "agent.secret_scope.get_secret",
+            side_effect=lambda name, default="": "scope_val",
+        ):
+            settings = FeishuAdapter._load_settings({
+                "app_id": "config_app_id",
+                "app_secret": "config_secret",
+            })
+
+        self.assertEqual(settings.app_id, "config_app_id")
+        self.assertEqual(settings.app_secret, "config_secret")
+
+    def test_non_credential_vars_still_use_os_getenv(self):
+        """Config vars (domain, connection_mode, group_policy) still use os.getenv."""
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        with patch.dict(os.environ, {
+            "FEISHU_DOMAIN": "lark",
+            "FEISHU_GROUP_POLICY": "open",
+        }, clear=False):
+            settings = FeishuAdapter._load_settings({})
+
+        self.assertEqual(settings.domain_name, "lark")
+        self.assertEqual(settings.group_policy, "open")


### PR DESCRIPTION
## What does this PR do?

Fixes the Feishu adapter's credential resolution in multiplex mode. When `gateway.multiplex_profiles` is on, per-profile credentials are installed via `set_secret_scope()` and readable through `get_secret()`, but `os.environ` is intentionally NOT modified (to prevent cross-profile leakage). The adapter's `_load_settings()` used `os.getenv()` as fallback for four credential variables, always reading the default profile's values regardless of which profile it was serving. This PR replaces those `os.getenv()` calls with `get_secret()`.

## Related Issue

Fixes #52564

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `plugins/platforms/feishu/adapter.py`: Replace `os.getenv()` with `get_secret()` for `FEISHU_APP_ID`, `FEISHU_APP_SECRET`, `FEISHU_ENCRYPT_KEY`, and `FEISHU_VERIFICATION_TOKEN` in `_load_settings()`. Uses lazy import (same pattern as `gateway/run.py`) to avoid circular dependency. Non-multiplex behavior is preserved: `get_secret()` falls through to `os.environ` when no scope is active.
- `tests/gateway/test_feishu.py`: Add `TestLoadSettingsSecretScope` with 3 tests verifying (1) credentials resolve through `get_secret`, (2) explicit `extra` config takes precedence, (3) non-credential vars still use `os.getenv`.

## How to Test

1. Run `pytest tests/gateway/test_feishu.py::TestLoadSettingsSecretScope -xvs` — all 3 tests should pass.
2. Run `pytest tests/gateway/test_feishu.py -x -q` — full Feishu test suite (208 tests) should pass with no regressions.
3. In non-multiplex mode, Feishu adapter behavior is unchanged: `get_secret()` without an active scope reads `os.environ`, identical to the prior `os.getenv()` path.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `plugins/platforms/feishu/adapter.py:_load_settings` (callers: 1 via `__init__`)
- Blast radius: LOW — only affects Feishu adapter credential resolution in multiplex mode; non-multiplex path is behaviour-preserving
- Related patterns: `gateway/run.py:_profile_runtime_scope` uses same `get_secret` / `set_secret_scope` seam; `agent/secret_scope.py:get_secret` falls through to `os.environ` when no scope active
