### PR TITLE
fix(mem0): support custom_instructions in OSS mode backend

### DIFF
--- a/plugins/memory/mem0/_backend.py
+++ b/plugins/memory/mem0/_backend.py
@@ -123,6 +123,9 @@ class OSSBackend(Mem0Backend):
             "embedder": oss_config["embedder"],
             "version": "v1.1",
         }
+        # Pass custom_instructions if present in oss_config (set via mem0.json "oss.custom_instructions")
+        if oss_config.get("custom_instructions"):
+            config["custom_instructions"] = oss_config["custom_instructions"]
         self._memory = Memory.from_config(config)
 
     @staticmethod


### PR DESCRIPTION
## Summary

`OSSBackend.__init__()` in `_backend.py` ignores the `oss.custom_instructions` field from `mem0.json`. This means users who self-host mem0 in OSS mode cannot customize fact extraction behavior (e.g. language, tone, formatting).

## Changes

Added 3 lines to `plugins/memory/mem0/_backend.py` that pass `custom_instructions` from `oss_config` to `Memory.from_config()` when present.

## Why this matters

Without this fix, OSS mode users who set `custom_instructions` in `mem0.json` (e.g. to extract facts in Italian) find their setting silently ignored. The field is read from config but never forwarded to the Memory constructor.

## Testing

- Verified `custom_instructions` is now passed through
- No-op when field is absent (backward compatible)