### PR TITLE
fix(gateway): allow Feishu websocket mode in multiplex profiles

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1381,6 +1381,24 @@ _PORT_BINDING_PLATFORM_VALUES = frozenset({
     "sms",
 })
 
+# Platforms whose port-binding status depends on connection mode.
+# Feishu in websocket mode (the default) uses an outbound WebSocket — no port
+# binding.  Only webhook/callback mode needs an HTTP listener.
+_PORT_BINDING_CONDITIONAL_MODES: dict[str, str] = {
+    "feishu": "webhook",  # only binds port when connection_mode == "webhook"
+}
+
+
+def _platform_binds_port(platform_value: str, extra: dict) -> bool:
+    """Return True if *platform_value* actually binds a port for *extra* config."""
+    if platform_value not in _PORT_BINDING_PLATFORM_VALUES:
+        return False
+    expected_mode = _PORT_BINDING_CONDITIONAL_MODES.get(platform_value)
+    if expected_mode is not None:
+        actual = str(extra.get("connection_mode", "websocket")).strip().lower()
+        return actual == expected_mode
+    return True
+
 
 class MultiplexConfigError(RuntimeError):
     """A profile multiplexer config is invalid (fail-fast at startup).
@@ -7251,7 +7269,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # default profile's listener already serves every profile via the
             # /p/<profile>/ prefix, so a second bind can only collide. This is a
             # config error, not a transient failure — fail fast and loud.
-            if platform.value in _PORT_BINDING_PLATFORM_VALUES:
+            if _platform_binds_port(platform.value, platform_config.extra):
                 raise MultiplexConfigError(
                     f"Profile '{profile_name}' enables the port-binding platform "
                     f"'{platform.value}', but gateway.multiplex_profiles is on. The "

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -134,3 +134,71 @@ class TestPortBindingHardError:
                   "wecom_callback", "bluebubbles", "sms"):
             assert p in _PORT_BINDING_PLATFORM_VALUES
 
+
+
+class TestFeishuPortBindingConditional:
+    """Feishu websocket mode does NOT bind a port; only webhook mode does (#52563)."""
+
+    @pytest.mark.asyncio
+    async def test_feishu_websocket_mode_not_rejected(self, monkeypatch):
+        """Feishu in websocket mode (the default) should NOT raise MultiplexConfigError."""
+        from gateway.run import MultiplexConfigError
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._profile_adapters = {}
+
+        reviewer_cfg = GatewayConfig(multiplex_profiles=True)
+        reviewer_cfg.platforms = {
+            Platform.FEISHU: PlatformConfig(
+                enabled=True,
+                extra={"app_id": "cli_xxx", "app_secret": "sec", "connection_mode": "websocket"},
+            ),
+        }
+        monkeypatch.setattr("gateway.config.load_gateway_config", lambda: reviewer_cfg)
+        monkeypatch.setattr(runner, "_create_adapter", lambda p, c: None)
+
+        connected = await runner._start_one_profile_adapters("reviewer", "/tmp/x", {})
+        assert connected == 0  # no error, just nothing connected
+
+    @pytest.mark.asyncio
+    async def test_feishu_webhook_mode_raises(self, monkeypatch):
+        """Feishu in webhook mode binds a port and should raise MultiplexConfigError."""
+        from gateway.run import MultiplexConfigError
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._profile_adapters = {}
+
+        reviewer_cfg = GatewayConfig(multiplex_profiles=True)
+        reviewer_cfg.platforms = {
+            Platform.FEISHU: PlatformConfig(
+                enabled=True,
+                extra={"app_id": "cli_xxx", "app_secret": "sec", "connection_mode": "webhook"},
+            ),
+        }
+        monkeypatch.setattr("gateway.config.load_gateway_config", lambda: reviewer_cfg)
+
+        with pytest.raises(MultiplexConfigError) as ei:
+            await runner._start_one_profile_adapters("reviewer", "/tmp/x", {})
+        assert "feishu" in str(ei.value)
+
+    def test_platform_binds_port_helper(self):
+        """Unit test for _platform_binds_port helper."""
+        from gateway.run import _platform_binds_port
+
+        # Non-port-binding platform
+        assert _platform_binds_port("telegram", {}) is False
+
+        # Unconditional port-binding platform
+        assert _platform_binds_port("webhook", {}) is True
+        assert _platform_binds_port("api_server", {}) is True
+
+        # Feishu: websocket = no port binding
+        assert _platform_binds_port("feishu", {"connection_mode": "websocket"}) is False
+        assert _platform_binds_port("feishu", {}) is False  # default is websocket
+
+        # Feishu: webhook = port binding
+        assert _platform_binds_port("feishu", {"connection_mode": "webhook"}) is True


### PR DESCRIPTION
## What does this PR do?

Feishu was unconditionally listed in `_PORT_BINDING_PLATFORM_VALUES`, causing the multiplexer to reject ALL Feishu secondary profiles with `MultiplexConfigError`. But Feishu in websocket mode (the default) uses an outbound WebSocket connection and does NOT bind an HTTP port — only webhook/callback mode needs a listener. This PR adds a `_platform_binds_port()` helper that checks connection-dependent platforms against their actual config before raising the error.

## Related Issue

Fixes #52563

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: Add `_PORT_BINDING_CONDITIONAL_MODES` dict and `_platform_binds_port()` helper. Replace the unconditional `platform.value in _PORT_BINDING_PLATFORM_VALUES` check with `_platform_binds_port(platform.value, platform_config.extra)` in `_start_one_profile_adapters`. Feishu websocket profiles are now allowed; Feishu webhook profiles still raise as before.
- `tests/gateway/test_multiplex_adapter_registry.py`: Add `TestFeishuPortBindingConditional` with 3 tests: (1) websocket mode not rejected, (2) webhook mode raises, (3) `_platform_binds_port` helper unit test.

## How to Test

1. Run `pytest tests/gateway/test_multiplex_adapter_registry.py -xvs` — all 12 tests should pass (9 existing + 3 new).
2. Verify that a Feishu profile with `connection_mode: websocket` (or no connection_mode, defaulting to websocket) does NOT raise `MultiplexConfigError` when `gateway.multiplex_profiles` is on.
3. Verify that a Feishu profile with `connection_mode: webhook` still raises `MultiplexConfigError`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/run.py:_PORT_BINDING_PLATFORM_VALUES`, `gateway/run.py:_start_one_profile_adapters`
- Blast radius: LOW — only affects multiplex profile startup; non-multiplex and non-Feishu paths unchanged
- Related patterns: Same-token conflict detection at line 7270+ already prevents duplicate bot polling; this fix removes the earlier blanket rejection for websocket-mode Feishu
