### PR TITLE
fix(telegram): render pipe tables natively when Topics enabled

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1156,6 +1156,34 @@ class TelegramAdapter(BasePlatformAdapter):
             return True
         return False
 
+    def _content_is_pipe_table_primary(self, content: str) -> bool:
+        """True when pipe tables are the only rich construct in *content*.
+
+        Tables are auto-routed to ``sendRichMessage`` even when the full
+        ``rich_messages`` opt-in is off — MarkdownV2 has no table syntax and
+        the legacy path rewrites them into bullet lists, which reads like a
+        regression when users enable Telegram Topics and expect native tables.
+        Task lists, ``<details>``, and block math still require the full opt-in.
+        """
+        if not content or not any(
+            _TABLE_SEPARATOR_RE.match(line) for line in content.splitlines()
+        ):
+            return False
+        if re.search(r"(?m)^\s*[-*]\s+\[[ xX]\]\s+", content):
+            return False
+        if re.search(r"(?m)^<details\b|^</details>|^<summary\b|^</summary>", content):
+            return False
+        if "$$" in content:
+            return False
+        return True
+
+    def _rich_delivery_enabled(self, content: str) -> bool:
+        """Whether rich delivery is allowed for this payload."""
+        return bool(
+            getattr(self, "_rich_messages_enabled", True)
+            or self._content_is_pipe_table_primary(content)
+        )
+
     def _rich_eligible(self, content: str) -> bool:
         """Capability/content eligibility for rich, ignoring ``expect_edits``.
 
@@ -1166,7 +1194,7 @@ class TelegramAdapter(BasePlatformAdapter):
         FINAL edit should still upgrade to rich when the content warrants it.
         """
         return bool(
-            getattr(self, "_rich_messages_enabled", True)
+            self._rich_delivery_enabled(content)
             and not getattr(self, "_rich_send_disabled", False)
             and content
             and content.strip()
@@ -1303,10 +1331,6 @@ class TelegramAdapter(BasePlatformAdapter):
         else:
             should_thread = self._should_thread_reply(reply_to_source, 0)
         reply_to_id = int(reply_to_source) if should_thread and reply_to_source else None
-        if private_dm_topic_send and reply_to_id is None and not dm_topic_reply_to_off:
-            # Refusing to send outside the requested DM topic — defer to the
-            # legacy path, which returns the canonical fail-loud SendResult.
-            return None
         thread_kwargs = self._thread_kwargs_for_send(
             chat_id,
             thread_id,
@@ -1314,6 +1338,13 @@ class TelegramAdapter(BasePlatformAdapter):
             reply_to_message_id=reply_to_id,
             reply_to_mode=self._reply_to_mode,
         )
+        if private_dm_topic_send and reply_to_id is None and not dm_topic_reply_to_off:
+            # Refusing to send outside the requested DM topic — defer to the
+            # legacy path, which returns the canonical fail-loud SendResult.
+            # Exception: synthetic/resumed topic sends that route via
+            # ``direct_messages_topic_id`` do not need a reply anchor.
+            if not thread_kwargs.get("direct_messages_topic_id"):
+                return None
         return reply_to_id, thread_kwargs
 
     async def _try_send_rich(
@@ -1427,6 +1458,7 @@ class TelegramAdapter(BasePlatformAdapter):
         chat_id: str,
         message_id: str,
         content: str,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> Optional[SendResult]:
         """Edit an existing message in place as a rich message (Bot API 10.1).
 
@@ -1446,6 +1478,15 @@ class TelegramAdapter(BasePlatformAdapter):
             "message_id": int(message_id),
             "rich_message": self._rich_message_payload(content),
         }
+        thread_id = self._metadata_thread_id(metadata)
+        thread_kwargs = self._thread_kwargs_for_send(
+            chat_id,
+            thread_id,
+            metadata,
+            reply_to_message_id=None,
+            reply_to_mode=self._reply_to_mode,
+        )
+        payload.update({k: v for k, v in thread_kwargs.items() if v is not None})
         if getattr(self, "_disable_link_previews", False):
             payload["link_preview_options"] = {"is_disabled": True}
         try:
@@ -2985,7 +3026,9 @@ class TelegramAdapter(BasePlatformAdapter):
         # chunks.  Falls back to the legacy edit path (overflow split included)
         # on capability/permanent rejection.
         if finalize and self._rich_eligible(content):
-            rich_result = await self._try_edit_rich(chat_id, message_id, content)
+            rich_result = await self._try_edit_rich(
+                chat_id, message_id, content, metadata=metadata,
+            )
             if rich_result is not None:
                 return rich_result
 

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -26,6 +26,12 @@ from telegram.error import BadRequest, NetworkError, TimedOut
 RICH_CONTENT = "## Results\n\n| Case | Status |\n|---|---|\n| rich | ✅ |\n\n- [x] table renders"
 CJK_RICH_CONTENT = "## 持仓\n\n| 项目 | 状态 |\n|---|---|\n| 早盘 | 正常 |"
 ASTRAL_CJK_RICH_CONTENT = "## Rare Han\n\n| glyph | status |\n|---|---|\n| \U00030000 | ok |"
+TABLE_ONLY_CONTENT = (
+    "| Team | W | L | GB |\n"
+    "|---|---|---|---|\n"
+    "| Red Sox | 36 | 34 | 6.0 |\n"
+    "| Dodgers | 40 | 30 | 2.0 |"
+)
 DANGEROUS_DETAILS_MATH = (
     "<details><summary>Complex proof</summary>\n\n"
     "$$\\sum_{i=1}^{n} i = \\frac{n(n+1)}{2}$$\n\n"
@@ -525,6 +531,77 @@ async def test_notification_opt_in_drops_disable_flag():
 
     api_kwargs = _rich_api_kwargs(adapter)
     assert "disable_notification" not in api_kwargs
+
+
+@pytest.mark.asyncio
+async def test_table_only_uses_rich_when_rich_messages_opt_out():
+    """Pipe tables auto-route to sendRichMessage even without the full opt-in."""
+    adapter = _make_adapter(extra={"rich_messages": False})
+
+    result = await adapter.send("12345", TABLE_ONLY_CONTENT)
+
+    assert result.success is True
+    api_kwargs = _rich_api_kwargs(adapter)
+    assert api_kwargs["rich_message"]["markdown"] == TABLE_ONLY_CONTENT
+    adapter._bot.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_table_only_uses_rich_with_default_config():
+    """Default config keeps task lists on legacy but upgrades bare tables."""
+    config = PlatformConfig(enabled=True, token="fake-token")
+    adapter = TelegramAdapter(config)
+    bot = MagicMock()
+    bot.do_api_request = AsyncMock(return_value=SimpleNamespace(message_id=123))
+    bot.send_message = AsyncMock(return_value=MagicMock(message_id=1))
+    bot.send_chat_action = AsyncMock()
+    adapter._bot = bot
+
+    result = await adapter.send("12345", TABLE_ONLY_CONTENT)
+
+    assert result.success is True
+    bot.do_api_request.assert_awaited_once()
+    bot.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dm_topic_resumed_send_uses_rich_for_table_without_reply_anchor():
+    """Resumed/synthetic DM-topic sends route tables via direct_messages_topic_id."""
+    adapter = _make_adapter(extra={"rich_messages": False})
+
+    result = await adapter.send(
+        "123",
+        TABLE_ONLY_CONTENT,
+        metadata={
+            "thread_id": "20189",
+            "telegram_dm_topic_reply_fallback": True,
+            "direct_messages_topic_id": "20189",
+        },
+    )
+
+    assert result.success is True
+    api_kwargs = _rich_api_kwargs(adapter)
+    assert api_kwargs["direct_messages_topic_id"] == 20189
+    assert "reply_parameters" not in api_kwargs
+    assert api_kwargs["rich_message"]["markdown"] == TABLE_ONLY_CONTENT
+
+
+@pytest.mark.asyncio
+async def test_finalize_edit_rich_includes_forum_topic_routing():
+    adapter = _make_adapter(extra={"rich_messages": False})
+
+    result = await adapter.edit_message(
+        "-100123",
+        "555",
+        TABLE_ONLY_CONTENT,
+        finalize=True,
+        metadata={"thread_id": "5"},
+    )
+
+    assert result.success is True
+    api_kwargs = _rich_edit_kwargs(adapter)
+    assert api_kwargs["message_thread_id"] == 5
+    assert api_kwargs["rich_message"]["markdown"] == TABLE_ONLY_CONTENT
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Auto-route **pipe-only** markdown tables through `sendRichMessage` even when `platforms.telegram.extra.rich_messages` is off (default). The legacy MarkdownV2 path rewrites GFM tables into bullet lists, which looked like a regression after enabling Telegram Topics.
- Allow rich sends for resumed/synthetic DM-topic deliveries that route via `direct_messages_topic_id` without a reply anchor.
- Forward forum/DM topic routing kwargs on rich `editMessageText` finalize edits.

## Test plan

- [x] `tests/gateway/test_telegram_rich_messages.py` — table auto-rich under default/opt-out config, DM-topic resumed routing, rich finalize topic metadata
- [ ] Manual: enable Telegram Topics, send a pipe-table reply without `rich_messages: true` — table should render natively, not as a bullet list


Made with [Cursor](https://cursor.com)