### PR TITLE
fix(gateway): read multiplex_profiles from nested gateway config section

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -854,6 +854,12 @@ def load_gateway_config() -> GatewayConfig:
             # other session-scope flags above).
             if "multiplex_profiles" in yaml_cfg:
                 gw_data["multiplex_profiles"] = yaml_cfg["multiplex_profiles"]
+            elif "multiplex_profiles" not in gw_data:
+                # Also honor gateway.multiplex_profiles written by
+                # ``hermes config set gateway.multiplex_profiles true``.
+                _gw_section = yaml_cfg.get("gateway")
+                if isinstance(_gw_section, dict) and "multiplex_profiles" in _gw_section:
+                    gw_data["multiplex_profiles"] = _gw_section["multiplex_profiles"]
 
             gateway_section = yaml_cfg.get("gateway")
             if isinstance(gateway_section, dict) and "max_concurrent_sessions" in gateway_section:

--- a/tests/test_gateway_multiplex_profiles_nested_config.py
+++ b/tests/test_gateway_multiplex_profiles_nested_config.py
@@ -1,0 +1,52 @@
+"""Regression test for #52562 — nested gateway.multiplex_profiles config must be loaded."""
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+
+def _load_with_yaml_dict(yaml_dict: dict):
+    """Patch filesystem so load_gateway_config() sees *yaml_dict* as config.yaml."""
+    from gateway.config import load_gateway_config
+
+    fake_home = Path("/tmp/fake_hermes_home_52562")
+
+    def fake_exists(self):
+        return str(self).endswith("config.yaml")
+
+    with patch("gateway.config.get_hermes_home", return_value=fake_home), \
+         patch.object(Path, "exists", fake_exists), \
+         patch("builtins.open", create=True) as mock_file:
+        mock_file.return_value.__enter__ = lambda s: s
+        mock_file.return_value.__exit__ = MagicMock(return_value=False)
+        with patch("yaml.safe_load", return_value=yaml_dict):
+            return load_gateway_config()
+
+
+class TestMultiplexProfilesNestedConfig:
+    def test_top_level_multiplex_profiles(self):
+        """Top-level multiplex_profiles key is loaded directly."""
+        cfg = _load_with_yaml_dict({"multiplex_profiles": True})
+        assert cfg.multiplex_profiles is True
+
+    def test_nested_gateway_multiplex_profiles(self):
+        """Regression for #52562: gateway.multiplex_profiles written by
+        ``hermes config set gateway.multiplex_profiles true`` must be loaded."""
+        cfg = _load_with_yaml_dict({"gateway": {"multiplex_profiles": True}})
+        assert cfg.multiplex_profiles is True
+
+    def test_top_level_takes_precedence(self):
+        """Top-level key wins over nested gateway section."""
+        cfg = _load_with_yaml_dict({
+            "multiplex_profiles": False,
+            "gateway": {"multiplex_profiles": True},
+        })
+        assert cfg.multiplex_profiles is False
+
+    def test_default_is_false(self):
+        """When neither key is present, default is False."""
+        cfg = _load_with_yaml_dict({})
+        assert cfg.multiplex_profiles is False
+
+    def test_nested_gateway_section_not_dict(self):
+        """When gateway section is not a dict, no crash."""
+        cfg = _load_with_yaml_dict({"gateway": "invalid"})
+        assert cfg.multiplex_profiles is False


### PR DESCRIPTION
## What does this PR do?

Fixes `load_gateway_config()` ignoring `multiplex_profiles` when set via `hermes config set gateway.multiplex_profiles true`. The command writes the key under the nested `gateway:` section in config.yaml, but the loader only checked the top-level key, silently leaving multiplexing disabled.

## Related Issue

Fixes #52562

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/config.py`: Add fallback in `load_gateway_config()` to also read `multiplex_profiles` from the nested `gateway:` section when the top-level key is absent. Follows the same pattern used for `max_concurrent_sessions` and `streaming`.
- `tests/test_gateway_multiplex_profiles_nested_config.py`: 5 regression tests covering top-level key, nested key, precedence, default, and non-dict gateway section.

## How to Test

1. Set multiplex_profiles via the nested path: `hermes config set gateway.multiplex_profiles true`
2. Verify the config is written under `gateway:` in `~/.hermes/config.yaml`
3. Start the gateway — it should now detect multiplexing is enabled
4. Run `python -m pytest tests/test_gateway_multiplex_profiles_nested_config.py -v` — all 5 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/config.py:load_gateway_config()` (config loading path for multiplex_profiles)
- Blast radius: LOW — only affects the config reading path for `multiplex_profiles`, no behavioral change when key is absent
- Related patterns: Same nested-fallback pattern used for `max_concurrent_sessions` (line 858-860) and `streaming` (line 865-871)
