### PR TITLE
fix(pets): stop leaking intermediate images in cache/images

### DIFF
--- a/agent/pet/generate/orchestrate.py
+++ b/agent/pet/generate/orchestrate.py
@@ -246,6 +246,7 @@ def hatch_pet(
             if cancelled():
                 return state, None
             strict = attempt < _ROW_GEN_ATTEMPTS - 1
+            strips: list[Path] = []
             try:
                 strips = imagegen.generate(
                     prompts.build_row_prompt(state, count, label, style=style),
@@ -274,6 +275,18 @@ def hatch_pet(
                     "pet hatch %r: row %r attempt %d/%d failed: %s",
                     slug, state, attempt + 1, _ROW_GEN_ATTEMPTS, exc,
                 )
+            finally:
+                # The strip is an intermediate. extract_strip_frames has already
+                # decoded its frames into memory, so drop the row image after
+                # every attempt (success or failure). Nothing prunes
+                # cache/images outside the gateway housekeeping loop, so a CLI
+                # or desktop hatch would otherwise leave each strip behind for
+                # good and grow the cache without bound.
+                for strip in strips:
+                    try:
+                        Path(strip).unlink(missing_ok=True)
+                    except OSError:
+                        pass
         logger.warning(
             "pet hatch %r: row %r gave up after %.1fs: %s",
             slug, state, time.monotonic() - t0, last_exc,

--- a/agent/pet/generate/orchestrate.py
+++ b/agent/pet/generate/orchestrate.py
@@ -71,8 +71,24 @@ def _harden_transparency(path: Path) -> Path:
         # Zero the RGB of any leftover semi-transparent edge pixels so a keyed
         # draft has no colored halo when composited on the dark UI.
         keyed = atlas._clear_transparent_rgb(keyed)
-        out = path.with_suffix(".png")
+        # PNG inputs are hardened in place, including mixed-case suffixes like
+        # .PNG. with_suffix(".png") would name a different Path string that still
+        # resolves to the same file on case-insensitive filesystems (macOS APFS,
+        # Windows), and unlinking path after save would delete the hardened output.
+        if path.suffix.lower() == ".png":
+            out = path
+        else:
+            out = path.with_suffix(".png")
         keyed.save(out, format="PNG")
+        if out != path:
+            # The hardened PNG stands in for the draft. When the provider handed
+            # back a non-PNG file (webp, jpg, gif), out is a different path, so
+            # remove the original instead of leaving it behind in cache/images
+            # (nothing prunes that directory outside the gateway loop).
+            try:
+                path.unlink(missing_ok=True)
+            except OSError:
+                pass
         return out
     except Exception as exc:  # noqa: BLE001 - cosmetic; fall back to the raw image
         logger.debug("base draft transparency hardening failed for %s: %s", path, exc)

--- a/tests/agent/test_pet_generate.py
+++ b/tests/agent/test_pet_generate.py
@@ -8,6 +8,7 @@ exercised hermetically.
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import pytest
 
@@ -460,6 +461,74 @@ def test_hatch_pet_end_to_end(monkeypatch, tmp_path):
     assert ("compose", "") in events
     # The pet is on disk and adoptable.
     assert store.load_pet("mocky").exists
+
+
+def test_hatch_pet_removes_row_strips_after_extraction(monkeypatch, tmp_path):
+    """Row strips are intermediates. Once their frames are decoded, the strip
+    files are removed so the image cache does not grow on every hatch (nothing
+    prunes cache/images outside the gateway housekeeping loop)."""
+    from agent.pet.generate import atlas as atlas_mod
+    from agent.pet.generate import imagegen, orchestrate
+
+    base = tmp_path / "base.png"
+    _strip(1).save(base)
+
+    produced: list = []
+
+    def fake_generate(prompt, *, n=1, reference_images=None, provider=None, prefix="pet", aspect_ratio="square"):
+        state = prefix.replace("pet_row_", "")
+        count = atlas_mod.FRAME_COUNTS.get(state, 6)
+        p = tmp_path / f"{prefix}.png"
+        _strip(count).save(p)
+        produced.append(p)
+        return [p]
+
+    monkeypatch.setattr(imagegen, "resolve_provider", lambda **_: object())
+    monkeypatch.setattr(imagegen, "generate", fake_generate)
+
+    orchestrate.hatch_pet(base_image=base, slug="cleanup", concept="a fox")
+
+    assert produced, "expected row strips to be generated"
+    leftover = [p for p in produced if p.exists()]
+    assert leftover == [], f"row strips left in cache: {leftover}"
+
+
+def test_hatch_pet_removes_row_strips_after_failed_attempt(monkeypatch, tmp_path):
+    from agent.pet.generate import atlas as atlas_mod
+    from agent.pet.generate import imagegen, orchestrate
+
+    base = tmp_path / "base.png"
+    _strip(1).save(base)
+
+    attempts: dict[str, int] = {}
+
+    def fake_generate(prompt, *, n=1, reference_images=None, provider=None, prefix="pet", aspect_ratio="square"):
+        attempts[prefix] = attempts.get(prefix, 0) + 1
+        state = prefix.replace("pet_row_", "")
+        count = atlas_mod.FRAME_COUNTS.get(state, 6)
+        path = tmp_path / f"{prefix}_{attempts[prefix]}.png"
+        _strip(count).save(path)
+        return [path]
+
+    extract_strip_frames = atlas_mod.extract_strip_frames
+    failed_once = False
+
+    def flaky_extract(strip, count, *args, **kwargs):
+        nonlocal failed_once
+        if Path(strip).name.startswith("pet_row_idle_") and not failed_once:
+            failed_once = True
+            raise ValueError("retry idle row")
+        return extract_strip_frames(strip, count, *args, **kwargs)
+
+    monkeypatch.setattr(imagegen, "resolve_provider", lambda **_: object())
+    monkeypatch.setattr(imagegen, "generate", fake_generate)
+    monkeypatch.setattr(atlas_mod, "extract_strip_frames", flaky_extract)
+
+    orchestrate.hatch_pet(base_image=base, slug="retry-cleanup", concept="a fox")
+
+    assert failed_once
+    assert attempts["pet_row_idle"] == 2
+    assert not list(tmp_path.glob("pet_row_*"))
 
 
 def test_hatch_pet_idle_fallback_when_row_fails(monkeypatch, tmp_path):

--- a/tests/agent/test_pet_generate.py
+++ b/tests/agent/test_pet_generate.py
@@ -426,6 +426,55 @@ def test_generate_base_drafts_hardens_opaque_background(monkeypatch, tmp_path):
     assert rgba.getpixel((rgba.width // 2, rgba.height // 2))[3] > 0
 
 
+def test_harden_transparency_removes_non_png_original(tmp_path):
+    """A non-PNG base draft is replaced by a hardened PNG, and the original
+    draft file is not left behind in the image cache."""
+    from agent.pet.generate import orchestrate
+
+    src = tmp_path / "pet_base_sample.webp"
+    _strip(1).save(src, format="WEBP")
+
+    out = orchestrate._harden_transparency(src)
+
+    assert out.suffix == ".png"
+    assert out.exists()
+    assert not src.exists()
+
+
+def test_harden_transparency_keeps_png_input_in_place(tmp_path):
+    """A PNG base draft is hardened in place, so the returned path is the input
+    path and there is no separate original to remove."""
+    from agent.pet.generate import orchestrate
+
+    src = tmp_path / "pet_base_sample.png"
+    _strip(1).save(src, format="PNG")
+
+    out = orchestrate._harden_transparency(src)
+
+    assert out == src
+    assert out.exists()
+
+
+def test_harden_transparency_keeps_mixed_case_png_in_place(tmp_path):
+    """A PNG path with a mixed-case suffix is hardened in place.
+
+    path.with_suffix('.png') yields a different Path string than 'pet.PNG', but
+    on case-insensitive filesystems (macOS APFS, Windows) both resolve to the
+    same file. Unlinking the input after save would delete the hardened output.
+    """
+    from agent.pet.generate import orchestrate
+
+    src = tmp_path / "pet_base_sample.PNG"
+    _strip(1).save(src, format="PNG")
+
+    out = orchestrate._harden_transparency(src)
+
+    assert out == src
+    assert out.suffix == ".PNG"
+    assert out.exists()
+    assert src.exists()
+
+
 def test_hatch_pet_end_to_end(monkeypatch, tmp_path):
     from agent.pet import store
     from agent.pet.generate import atlas as atlas_mod


### PR DESCRIPTION
## What does this PR do?

Pet generation writes intermediate images into `$HERMES_HOME/cache/images/` and never removes them, so on the CLI, the desktop app, and cron the directory grows without bound. The only pruning for that directory is `cleanup_image_cache` in `gateway/platforms/base.py`, called only from the gateway housekeeping loop in `gateway/run.py`, which none of those surfaces run. That cleanup is also age-gated at 24 hours, so even a running gateway would not remove fresh intermediates.

There are two independent leak sources in `agent/pet/generate/orchestrate.py`, fixed in one commit each so either can be cherry-picked on its own:

1. `_gen_row` generates one row strip per animation state, extracts the frames from it, and returns, but never deletes the strip. This leaks on every hatch regardless of provider or image format, and failed or retried attempts leak their strips too. The fix drops the strip after every attempt once `extract_strip_frames` has decoded its frames into memory.
2. `_harden_transparency` saves a hardened `.png` for each base draft. When the provider returned a non-PNG file (webp, jpg, or gif), the hardened PNG lands on a new path and the original draft is left behind. The fix removes the original after a successful hardening when the output path differs from the input, so a PNG input is still hardened in place with nothing to delete.

Both fixes only delete a file after its pixels are already in memory, so nothing downstream in the hatch is affected.

**Scope note:** the *unchosen* base drafts (the hardened PNGs from `generate_base_drafts`) still accumulate in `cache/images/` after the user picks one. That is deliberate: the drafts have to stay on disk until the user has picked between them, and this layer has no hook at pick time, so cleaning them up belongs to the surface that owns the pick flow. This PR covers the per-hatch intermediates that are provably dead the moment their pixels are decoded.

## Related Issue

Fixes #52602

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/pet/generate/orchestrate.py`: in `_gen_row`, remove the row strip after every attempt once its frames are extracted (covers success, failure, and retry).
- `agent/pet/generate/orchestrate.py`: in `_harden_transparency`, remove the original base draft after hardening when the hardened PNG path differs from the input path.
- `tests/agent/test_pet_generate.py`: add `test_hatch_pet_removes_row_strips_after_extraction` (row strips are gone after a hatch), `test_harden_transparency_removes_non_png_original` (a webp original is removed), and `test_harden_transparency_keeps_png_input_in_place` (a PNG input is hardened in place and kept).

## How to Test

The pet generation suite is opt-in (image processing), so set `HERMES_RUN_SLOW_PET_TESTS=1`:

1. `HERMES_RUN_SLOW_PET_TESTS=1 python -m pytest tests/agent/test_pet_generate.py -q` - 39 passed
2. Proof the new tests exercise the leaks: with the `_gen_row` change reverted, `test_hatch_pet_removes_row_strips_after_extraction` fails (8 strip files left behind). With the `_harden_transparency` change reverted, `test_harden_transparency_removes_non_png_original` fails (the webp original is still on disk) while the PNG control still passes.
3. `HERMES_RUN_SLOW_PET_TESTS=1 python -m pytest tests/tui_gateway/test_pet_generate_rpc.py -q` - 12 passed (no regressions in the RPC layer)
4. `ruff check agent/pet/generate/orchestrate.py tests/agent/test_pet_generate.py` - clean

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/agent/test_pet_generate.py -q` and all tests pass (pet generation suite, opt-in via `HERMES_RUN_SLOW_PET_TESTS=1`; the change is isolated to pet generation)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (filesystem cleanup, platform-independent)


