### PR TITLE
fix(session-db): persist post-flush /steer mutation to SQLite

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_cli.timeouts import get_provider_request_timeout
+from agent.persistence_markers import _DB_CONTENT_UPDATE_PENDING
 from agent.prompt_builder import format_steer_marker
 from agent.tool_dispatch_helpers import _trajectory_normalize_msg, make_tool_result_message
 from agent.trajectory import convert_scratchpad_to_think
@@ -3964,6 +3965,10 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
             messages[target_idx]["content"] = f"{existing_content}{marker}"
     else:
         messages[target_idx]["content"] = existing_content + marker
+    # The result may already have been incrementally flushed. Mark only this
+    # intentional mutation for an in-place durable update; generic content
+    # drift can also come from sequence repair and must not rewrite other rows.
+    messages[target_idx][_DB_CONTENT_UPDATE_PENDING] = True
     _ra().logger.info(
         "Delivered /steer to agent after tool batch (%d chars): %s",
         len(steer_text),

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -148,7 +148,11 @@ COMPRESSED_SUMMARY_HAS_USER_TURN_KEY = "_compressed_summary_has_user_turn"
 # micro markers: a batch marker's content is NOT contained in the micro
 # rolling summary, so dropping or rewriting one destroys history.
 MICRO_COMPACT_MARKER_KEY = "_micro_compact_marker"
-_DB_PERSISTED_MARKER = "_db_persisted"
+
+from agent.persistence_markers import (  # noqa: E402
+    _DB_PERSISTED_MARKER,
+    _DB_CONTENT_UPDATE_PENDING,
+)
 
 _NO_USER_TASK_SENTINEL = "None. This session contains no user-authored turns."
 COMPRESSION_CONTINUATION_USER_CONTENT = (
@@ -178,6 +182,7 @@ def _fresh_compaction_message_copy(msg: Dict[str, Any]) -> Dict[str, Any]:
     """
     fresh = msg.copy()
     fresh.pop(_DB_PERSISTED_MARKER, None)
+    fresh.pop(_DB_CONTENT_UPDATE_PENDING, None)
     return fresh
 
 
@@ -227,6 +232,7 @@ def _strip_persistence_markers(messages: List[Dict[str, Any]]) -> None:
     for msg in messages:
         if isinstance(msg, dict):
             msg.pop(_DB_PERSISTED_MARKER, None)
+            msg.pop(_DB_CONTENT_UPDATE_PENDING, None)
 
 
 # Appended to every standalone summary message (and to the merged-into-tail

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -73,6 +73,7 @@ from agent.model_metadata import (
     parse_available_output_tokens_from_error,
     save_context_length,
 )
+from agent.persistence_markers import _DB_CONTENT_UPDATE_PENDING
 from agent.process_bootstrap import _install_safe_stdio
 from agent.prompt_caching import (
     build_prompt_cache_plan,
@@ -1514,6 +1515,7 @@ def run_conversation(
                             _sm["content"] = blocks
                         except Exception:
                             pass
+                    _sm[_DB_CONTENT_UPDATE_PENDING] = True
                     _injected = True
                     logger.debug(
                         "Pre-API-call steer drain: injected into tool msg at index %d",

--- a/agent/persistence_markers.py
+++ b/agent/persistence_markers.py
@@ -1,0 +1,20 @@
+"""Private persistence metadata stamped on live message dicts.
+
+The incremental SessionDB flush (``AIAgent._flush_messages_to_session_db``)
+tracks durability directly on the message dicts it writes, so repeated
+flushes stay idempotent without positional slices or ``id()``-keyed sets.
+These keys are private wire metadata: the API payload build strips every
+top-level ``_``-prefixed key before a request leaves the process, and the
+JSON session snapshot / context compressor strip them before reusing a
+message. Define them ONCE here — every producer (steer injection), consumer
+(flush), and stripper (compressor, session log) must agree on the exact
+string or markers silently leak or stop being honoured.
+"""
+
+# Stamped by the flush on each message dict it has written to state.db.
+_DB_PERSISTED_MARKER = "_db_persisted"
+
+# Stamped by intentional post-INSERT content mutations (mid-turn /steer
+# appending its marker to an already-flushed tool result) so the next flush
+# updates the durable row in place instead of skipping the dict.
+_DB_CONTENT_UPDATE_PENDING = "_db_content_update_pending"

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3392,7 +3392,9 @@ class SessionStore:
             # would otherwise re-trigger the pre-request repair on every
             # request forever — heal it once at the restore boundary.
             return self._db.get_messages_as_conversation(
-                session_id, repair_alternation=True
+                session_id,
+                repair_alternation=True,
+                include_row_ids=True,
             )
         except Exception as e:
             logger.debug("Could not load messages from DB: %s", e)

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -405,7 +405,9 @@ class CLIAgentSetupMixin:
                 if resolved_meta:
                     session_meta = resolved_meta
             restored = self._session_db.get_messages_as_conversation(
-                self.session_id, repair_alternation=True
+                self.session_id,
+                repair_alternation=True,
+                include_row_ids=True,
             )
             if restored:
                 restored = [m for m in restored if m.get("role") != "session_meta"]

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6293,7 +6293,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         messages: List[Dict[str, Any]],
         compression_lock_holder: Optional[str] = None,
         chunk_rows: Optional[int] = None,
-    ) -> int:
+        return_row_ids: bool = False,
+    ) -> int | List[int]:
         """Append multiple messages atomically in ONE write transaction.
 
         ``messages`` is a list of dicts in the same shape
@@ -6319,12 +6320,28 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         the batch commits in chunks of at most that many rows — same
         recovery semantics as the old per-row loops (a mid-copy failure
         leaves a partial seed), just with bounded lock holds. A turn flush
-        never needs it. Returns the inserted row count.
+        never needs it.
+
+        Returns the inserted row count by default. ``return_row_ids=True``
+        returns the inserted ids in input order for live consumers that must
+        retain exact durable message identity.
         """
         if not messages:
-            return 0
+            return [] if return_row_ids else 0
 
         if chunk_rows is not None and len(messages) > chunk_rows:
+            if return_row_ids:
+                inserted_ids: List[int] = []
+                for start in range(0, len(messages), chunk_rows):
+                    inserted_ids.extend(
+                        self.append_messages_batch(
+                            session_id,
+                            messages[start:start + chunk_rows],
+                            compression_lock_holder=compression_lock_holder,
+                            return_row_ids=True,
+                        )
+                    )
+                return inserted_ids
             inserted_total = 0
             for start in range(0, len(messages), chunk_rows):
                 inserted_total += self.append_messages_batch(
@@ -6338,9 +6355,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             self._check_transcript_write_guards(
                 conn, session_id, compression_lock_holder
             )
-            inserted, tool_calls_total = self._insert_message_rows(
-                conn, session_id, messages
-            )
+            inserted_ids = [] if return_row_ids else None
+            if return_row_ids:
+                inserted, tool_calls_total = self._insert_message_rows(
+                    conn,
+                    session_id,
+                    messages,
+                    inserted_row_ids=inserted_ids,
+                )
+            else:
+                inserted, tool_calls_total = self._insert_message_rows(
+                    conn, session_id, messages
+                )
             # One aggregated counter update for the whole batch.
             if tool_calls_total > 0:
                 conn.execute(
@@ -6353,7 +6379,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     "UPDATE sessions SET message_count = message_count + ? WHERE id = ?",
                     (inserted, session_id),
                 )
-            return inserted
+            return inserted_ids if return_row_ids else inserted
 
         # Same criticality as append_message: this IS the turn's transcript.
         return self._execute_write(
@@ -6602,7 +6628,80 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         return row[0] if row else None
 
-    def _insert_message_rows(self, conn, session_id: str, messages: List[Dict[str, Any]]) -> tuple[int, int]:
+    def update_tool_message_content(
+        self,
+        message_row_id: Optional[int],
+        content: Any,
+        session_id: str,
+        *,
+        tool_call_id: Optional[str] = None,
+        compression_lock_holder: Optional[str] = None,
+    ) -> Optional[int]:
+        """Update an intentionally mutated active tool row and return its id.
+
+        ``message_row_id`` is exact for rows inserted by the live agent or
+        loaded for live replay. ``tool_call_id`` is a fallback for an atomic
+        transcript rewrite that replaced the SQLite row id, and is accepted
+        only when it resolves uniquely. FTS update triggers keep search indexes
+        in sync.
+        """
+        stored_content = self._encode_content(content)
+
+        def _do(conn):
+            self._check_transcript_write_guards(
+                conn, session_id, compression_lock_holder
+            )
+
+            row = None
+            if message_row_id is not None:
+                row = conn.execute(
+                    "SELECT id FROM messages "
+                    "WHERE id = ? AND session_id = ? "
+                    "AND role = 'tool' AND active = 1",
+                    (message_row_id, session_id),
+                ).fetchone()
+            if row is None and tool_call_id:
+                matches = conn.execute(
+                    "SELECT id FROM messages "
+                    "WHERE session_id = ? AND role = 'tool' "
+                    "AND tool_call_id = ? AND active = 1 "
+                    "ORDER BY id LIMIT 2",
+                    (session_id, tool_call_id),
+                ).fetchall()
+                # Durable transcripts may contain retry/crash duplicates that
+                # live replay repairs by keeping only the first. Never guess
+                # which duplicate a metadata-free message represents.
+                if len(matches) == 1:
+                    row = matches[0]
+            if row is None:
+                return None
+            resolved_row_id = int(row["id"])
+            conn.execute(
+                "UPDATE messages SET content = ? WHERE id = ?",
+                (stored_content, resolved_row_id),
+            )
+            return resolved_row_id
+
+        updated_row_id = self._execute_write(
+            _do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S
+        )
+        if updated_row_id is None:
+            logger.warning(
+                "update_tool_message_content matched no active row "
+                "(id=%s session_id=%s tool_call_id=%s)",
+                message_row_id,
+                session_id,
+                tool_call_id,
+            )
+        return updated_row_id
+
+    def _insert_message_rows(
+        self,
+        conn,
+        session_id: str,
+        messages: List[Dict[str, Any]],
+        inserted_row_ids: Optional[List[int]] = None,
+    ) -> tuple[int, int]:
         """Insert *messages* as fresh active rows for *session_id*.
 
         Shared by :meth:`replace_messages` (delete-then-insert) and
@@ -6661,7 +6760,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
             api_content = msg.get("api_content")
 
-            conn.execute(
+            cursor = conn.execute(
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
@@ -6691,6 +6790,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     self._encode_display_metadata(msg.get("display_metadata")),
                 ),
             )
+            if inserted_row_ids is not None:
+                inserted_row_ids.append(int(cursor.lastrowid))
             inserted += 1
             if tool_calls is not None:
                 tool_calls_total += (
@@ -7099,8 +7200,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         otherwise re-triggers the pre-request defensive repair on every
         single request for the rest of the session's life — the repair
         mutates only the per-request list, never the stored transcript.
-        Inspection/export consumers keep the default and see the transcript
-        verbatim.
+        ``include_row_ids=True`` adds the private SQLite row id needed by
+        consumers that address or intentionally mutate a durable message.
+        Inspection/export consumers keep the default transcript shape.
         """
         session_ids = [session_id]
         if include_ancestors:
@@ -7165,9 +7267,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 content = sanitize_context(content).strip()
             msg = {"role": row["role"], "content": content}
             # Durable per-message identity for surfaces that need to address a
-            # specific row later (desktop reactions). OPT-IN: only the gateway
-            # asks for it — every other consumer (ACP restore, export,
-            # inspection) gets the transcript in its historical shape.
+            # specific row later (desktop reactions and live post-flush
+            # mutations). OPT-IN: other consumers (ACP restore, export,
+            # inspection) keep the transcript's historical shape.
             # Underscore-prefixed so every transport's convert_messages()
             # strips it before the wire.
             if include_row_ids and row["id"] is not None:

--- a/run_agent.py
+++ b/run_agent.py
@@ -264,19 +264,34 @@ def _is_ephemeral_scaffolding(msg: Any) -> bool:
 
 _MAX_TOOL_WORKERS = 8
 
-# Intrinsic marker stamped on a message dict once it has been written to the
-# SQLite session store.  Used by ``_flush_messages_to_session_db`` to decide
-# what is already durable.  An object-identity (``id(msg)``) dedup set cannot be
-# trusted across turns: once a flushed message dict is dropped from the live
-# list (e.g. by scaffolding rewind or in-place compaction) and garbage-
-# collected, CPython is free to hand its address to a brand-new assistant/tool
-# message, whose ``id()`` then collides with the stale entry and the real turn
-# is silently never persisted.  A marker bound to the dict itself cannot be
-# aliased that way.  The ``_`` prefix is mandatory: the wire sanitizers
-# (agent/transports/chat_completions.py, agent/chat_completion_helpers.py) strip
-# every top-level ``_``-prefixed key before the request leaves the process, so
-# this never reaches a strict OpenAI-compatible gateway.
-_DB_PERSISTED_MARKER = "_db_persisted"
+# See agent/persistence_markers.py for why the marker must live on the dict
+# itself rather than in an id()-keyed set.  The ``_`` prefix is mandatory: the
+# wire sanitizers (agent/transports/chat_completions.py,
+# agent/chat_completion_helpers.py) strip every top-level ``_``-prefixed key
+# before the request leaves the process, so these never reach a strict
+# OpenAI-compatible gateway.
+from agent.persistence_markers import (  # noqa: E402
+    _DB_PERSISTED_MARKER,
+    _DB_CONTENT_UPDATE_PENDING,
+)
+
+
+def _db_normalized_content(content: Any) -> Any:
+    """Reduce message content to the scalar value written to state.db."""
+    if _is_multimodal_tool_result(content):
+        return _multimodal_text_summary(content)
+    if isinstance(content, list):
+        text_parts = []
+        for part in content:
+            if isinstance(part, dict) and part.get("type") == "text":
+                text_parts.append(str(part.get("text", "")))
+            elif (
+                isinstance(part, dict)
+                and part.get("type") in {"image", "image_url", "input_image"}
+            ):
+                text_parts.append("[screenshot]")
+        return "\n".join(text_parts) if text_parts else None
+    return content
 
 
 # Guard so the OpenRouter metadata pre-warm thread is only spawned once per
@@ -2008,10 +2023,10 @@ class AIAgent:
         ``_flushed_db_message_ids`` attribute is now only a one-shot seed
         (translated to markers, then cleared each flush), not a persisted set.
 
-        Note: the marker is stamped on the live/shared conversation dict, which
-        correctly makes re-persistence idempotent across turns. No code path
-        edits a persisted message's content/role in place expecting a re-write
-        (in-place compaction resets the seed and re-diffs by identity).
+        Intentional post-INSERT content mutations set
+        ``_DB_CONTENT_UPDATE_PENDING``. Those rows are updated in place using
+        the row id stamped on a message written by this process, or (for a
+        cold-resumed tool result) its protocol-level ``tool_call_id``.
         """
         # Persistence-isolated agents (e.g. the background skill/memory review
         # fork) must NEVER write into the canonical session store. The fork
@@ -2084,8 +2099,9 @@ class AIAgent:
             # skipped as ephemeral scaffolding / non-dict), and no code path
             # pops _DB_PERSISTED_MARKER from a live dict in place (compression
             # strips markers on fresh copies, which breaks identity here and
-            # forces a full re-scan). Identity match ⇒ identical skip decision,
-            # so starting after the matched prefix is behavior-preserving.
+            # forces a full re-scan). A post-INSERT content mutation is the one
+            # exception: it keeps object identity but sets an explicit pending
+            # flag, so the prefix walk must stop before that message.
             _scan_start = 0
             _prev_prefix = getattr(self, "_db_flush_scan_prefix", None)
             if isinstance(_prev_prefix, list):
@@ -2093,6 +2109,10 @@ class AIAgent:
                 while (
                     _scan_start < _limit
                     and messages[_scan_start] is _prev_prefix[_scan_start]
+                    and not (
+                        isinstance(messages[_scan_start], dict)
+                        and messages[_scan_start].get(_DB_CONTENT_UPDATE_PENDING)
+                    )
                 ):
                     _scan_start += 1
 
@@ -2115,13 +2135,33 @@ class AIAgent:
                 # the synthetic pair buried mid-list, not just at the tail.
                 if _is_ephemeral_scaffolding(msg):
                     continue
-                if msg.get(_DB_PERSISTED_MARKER):
-                    continue
                 # Already-durable messages: either carried over from the loaded
                 # history copy, or seeded by a caller. Stamp them so future
                 # flushes skip them without consulting any id() set again.
-                if id(msg) in history_ids or id(msg) in seed_ids:
+                already_persisted = bool(msg.get(_DB_PERSISTED_MARKER))
+                if not already_persisted and (
+                    id(msg) in history_ids or id(msg) in seed_ids
+                ):
                     msg[_DB_PERSISTED_MARKER] = True
+                    already_persisted = True
+                if already_persisted:
+                    if msg.get(_DB_CONTENT_UPDATE_PENDING):
+                        updated_row_id = self._session_db.update_tool_message_content(
+                            message_row_id=msg.get("_row_id"),
+                            content=_db_normalized_content(msg.get("content")),
+                            session_id=self.session_id,
+                            tool_call_id=msg.get("tool_call_id"),
+                            compression_lock_holder=getattr(
+                                self, "_active_compression_lock_holder", None
+                            ),
+                        )
+                        if updated_row_id is None:
+                            raise RuntimeError(
+                                "could not resolve durable row for pending "
+                                f"{msg.get('role', 'unknown')} content update"
+                            )
+                        msg["_row_id"] = updated_row_id
+                        msg.pop(_DB_CONTENT_UPDATE_PENDING, None)
                     continue
                 role = msg.get("role", "unknown")
                 content = msg.get("content")
@@ -2199,17 +2239,7 @@ class AIAgent:
                 # Persist multimodal tool results as their text summary only —
                 # base64 images would bloat the session DB and aren't useful
                 # for cross-session replay.
-                if _is_multimodal_tool_result(content):
-                    content = _multimodal_text_summary(content)
-                elif isinstance(content, list):
-                    # List of OpenAI-style content parts: strip images, keep text.
-                    _txt = []
-                    for p in content:
-                        if isinstance(p, dict) and p.get("type") == "text":
-                            _txt.append(str(p.get("text", "")))
-                        elif isinstance(p, dict) and p.get("type") in {"image", "image_url", "input_image"}:
-                            _txt.append("[screenshot]")
-                    content = "\n".join(_txt) if _txt else None
+                write_content = _db_normalized_content(content)
                 tool_calls_data = None
                 if hasattr(msg, "tool_calls") and isinstance(msg.tool_calls, list) and msg.tool_calls:
                     tool_calls_data = [
@@ -2220,7 +2250,7 @@ class AIAgent:
                     tool_calls_data = msg["tool_calls"]
                 _batch_rows.append({
                     "role": role,
-                    "content": content,
+                    "content": write_content,
                     "tool_name": msg.get("tool_name"),
                     "tool_calls": tool_calls_data,
                     "tool_call_id": msg.get("tool_call_id"),
@@ -2251,15 +2281,23 @@ class AIAgent:
             # re-writes the whole tail (same recovery contract as before,
             # minus the partial-prefix case that could double-pay counters).
             if _batch_rows:
-                self._session_db.append_messages_batch(
+                inserted_row_ids = self._session_db.append_messages_batch(
                     session_id=self.session_id,
                     messages=_batch_rows,
                     compression_lock_holder=getattr(
                         self, "_active_compression_lock_holder", None
                     ),
+                    return_row_ids=True,
                 )
-                for _written in _batch_msgs:
+                if len(inserted_row_ids) != len(_batch_msgs):
+                    raise RuntimeError(
+                        "session batch insert returned an unexpected row-id count"
+                    )
+                for _written, _row_id in zip(_batch_msgs, inserted_row_ids):
                     _written[_DB_PERSISTED_MARKER] = True
+                    if _written.get("role") == "tool":
+                        _written["_row_id"] = _row_id
+                    _written.pop(_DB_CONTENT_UPDATE_PENDING, None)
             # The intrinsic markers are now the sole source of truth. Reset the
             # one-shot seed so no id() outlives this flush to alias a message
             # allocated next turn at a recycled address.
@@ -2963,8 +3001,10 @@ class AIAgent:
                 # internal retry state, never durable transcript content.
                 if _is_ephemeral_scaffolding(msg):
                     continue
+                msg = dict(msg)
+                msg.pop(_DB_PERSISTED_MARKER, None)
+                msg.pop(_DB_CONTENT_UPDATE_PENDING, None)
                 if msg.get("role") == "assistant" and msg.get("content"):
-                    msg = dict(msg)
                     msg["content"] = self._clean_session_content(msg["content"])
                 # Defence-in-depth: redact credentials from every message
                 # content before persistence. Catches PATs / API keys / Bearer
@@ -2972,7 +3012,6 @@ class AIAgent:
                 # output, or user paste. Respects HERMES_REDACT_SECRETS via
                 # redact_sensitive_text — no-op when disabled. (#19798, #19845)
                 if "content" in msg:
-                    msg = dict(msg)
                     msg["content"] = self._redact_message_content(msg.get("content"))
                 cleaned.append(msg)
 

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -209,13 +209,19 @@ class TestCompress:
     def test_compress_strips_db_persisted_from_assembled_messages(self, compressor):
         """Regression for #57491: shallow copies must not carry flush markers."""
         msgs = [
-            {"role": "user" if i % 2 == 0 else "assistant", "content": f"m{i}", "_db_persisted": True}
+            {
+                "role": "user" if i % 2 == 0 else "assistant",
+                "content": f"m{i}",
+                "_db_persisted": True,
+                "_db_content_update_pending": True,
+            }
             for i in range(10)
         ]
         with patch("agent.context_compressor.call_llm", side_effect=RuntimeError("no provider")):
             result = compressor.compress(msgs)
         assert len(result) < len(msgs)
         assert all("_db_persisted" not in msg for msg in result)
+        assert all("_db_content_update_pending" not in msg for msg in result)
 
     def test_compress_terminal_sweep_strips_markers_even_if_a_copy_site_leaks(self, compressor):
         """Regression for #57491, structural: even if a copy site fails to strip
@@ -226,7 +232,12 @@ class TestCompress:
         import agent.context_compressor as _cc
 
         msgs = [
-            {"role": "user" if i % 2 == 0 else "assistant", "content": f"m{i}", "_db_persisted": True}
+            {
+                "role": "user" if i % 2 == 0 else "assistant",
+                "content": f"m{i}",
+                "_db_persisted": True,
+                "_db_content_update_pending": True,
+            }
             for i in range(10)
         ]
         # Make the per-site helper leak the marker (dict.copy keeps it).
@@ -237,6 +248,7 @@ class TestCompress:
         assert all("_db_persisted" not in msg for msg in result), (
             "terminal sweep must strip _db_persisted even when a copy site leaks"
         )
+        assert all("_db_content_update_pending" not in msg for msg in result)
 
     def test_protect_first_n_decays_after_first_compression(self):
         """Regression for #11996: protect_first_n must protect early turns on

--- a/tests/hermes_state/test_append_messages_batch.py
+++ b/tests/hermes_state/test_append_messages_batch.py
@@ -113,6 +113,14 @@ class TestAppendMessagesBatch:
     def test_returns_inserted_count(self, db):
         assert db.append_messages_batch("sess-batch", _turn_messages()) == 4
 
+    def test_optionally_returns_inserted_row_ids_in_input_order(self, db):
+        row_ids = db.append_messages_batch(
+            "sess-batch", _turn_messages(), return_row_ids=True
+        )
+
+        stored_ids = [row["id"] for row in db.get_messages("sess-batch")]
+        assert row_ids == stored_ids
+
     def test_empty_batch_is_noop(self, db):
         assert db.append_messages_batch("sess-batch", []) == 0
         row = db._conn.execute(

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -501,6 +501,26 @@ class TestSessionJsonSnapshotOptIn:
             "Opt-in writer must produce session_{sid}.json under logs_dir"
         )
 
+    def test_save_session_log_strips_internal_db_metadata(self, agent, tmp_path):
+        agent._session_json_enabled = True
+        agent.logs_dir = tmp_path
+        message = {
+            "role": "tool",
+            "content": "result",
+            "_db_persisted": True,
+            "_db_content_update_pending": True,
+        }
+
+        agent._save_session_log([message])
+
+        snapshot = json.loads(
+            (tmp_path / f"session_{agent.session_id}.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        stored = snapshot["messages"][0]
+        assert all(not key.startswith("_db_") for key in stored)
+
     def test_logs_dir_retained_for_request_dumps(self, agent):
         # logs_dir is kept unconditionally because
         # agent_runtime_helpers.dump_api_request_debug still writes
@@ -6050,4 +6070,3 @@ class TestMemoryContextSanitization:
         assert "memory-context" not in result.lower()
         assert "stale observation" not in result
         assert "how is the honcho working" in result
-

--- a/tests/run_agent/test_steer_sessiondb_persistence.py
+++ b/tests/run_agent/test_steer_sessiondb_persistence.py
@@ -1,0 +1,487 @@
+"""Regression coverage for durable mid-turn ``/steer`` mutations.
+
+Tool results are flushed to SQLite before a pending steer may append its marker
+to the live message. The later flush must update that row rather than skip it
+or insert a duplicate. The executor tests cover the mutation sites:
+concurrent/sequential batch-end drains (the only in-batch delivery — upstream
+deliberately keeps /steer pending until after aggregate budget enforcement)
+and the pre-API drain.
+"""
+
+from contextlib import ExitStack
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.prompt_builder import STEER_MARKER_OPEN
+from hermes_state import SessionDB
+from run_agent import AIAgent
+from tools.budget_config import BudgetConfig
+from tools.tool_result_storage import enforce_turn_budget
+
+STEER_TEXT = "please prefer the smaller fix"
+SESSION_ID = "steer-db-test"
+
+
+def _tool_call_data(call_id="c1"):
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": "web_search", "arguments": "{}"},
+    }
+
+
+def _make_tool_defs(*names: str) -> list:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _make_agent(session_db, hermes_home: Path, session_id=SESSION_ID):
+    (hermes_home / "logs").mkdir(parents=True, exist_ok=True)
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs("web_search"),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("run_agent._hermes_home", hermes_home),
+        patch("agent.model_metadata.fetch_model_metadata", return_value={}),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            session_db=session_db,
+            session_id=session_id,
+        )
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.tool_delay = 0
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    agent._ensure_db_session()
+    return agent
+
+
+@pytest.fixture
+def db(tmp_path):
+    session_db = SessionDB(db_path=tmp_path / "t.db")
+    try:
+        yield session_db
+    finally:
+        session_db.close()
+
+
+@pytest.fixture
+def agent(db, tmp_path):
+    return _make_agent(db, tmp_path / "hermes-home")
+
+
+def _mock_tool_call(call_id="c1"):
+    return SimpleNamespace(
+        id=call_id,
+        type="function",
+        function=SimpleNamespace(name="web_search", arguments="{}"),
+    )
+
+
+def _mock_response(content="", finish_reason="stop", tool_calls=None):
+    message = SimpleNamespace(content=content, tool_calls=tool_calls)
+    choice = SimpleNamespace(message=message, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+def _tool_rows(db, session_id=SESSION_ID):
+    return [
+        row for row in db.get_messages(session_id) if row.get("role") == "tool"
+    ]
+
+
+def _assert_single_steered_row(db, live_tool_msg):
+    rows = _tool_rows(db)
+    assert len(rows) == 1
+    assert STEER_MARKER_OPEN in rows[0]["content"]
+    assert STEER_TEXT in rows[0]["content"]
+    assert rows[0]["content"] == live_tool_msg["content"]
+
+
+def _execute_tool_batch(agent, messages, mode, *, budget_hook=None):
+    assistant = SimpleNamespace(
+        content="",
+        tool_calls=[_mock_tool_call()],
+    )
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                "agent.tool_executor.maybe_persist_tool_result",
+                side_effect=lambda **kwargs: kwargs["content"],
+            )
+        )
+        if budget_hook is not None:
+            stack.enter_context(
+                patch(
+                    "agent.tool_executor.enforce_turn_budget",
+                    side_effect=budget_hook,
+                )
+            )
+        if mode == "concurrent":
+            stack.enter_context(
+                patch.object(
+                    agent,
+                    "_invoke_tool",
+                    side_effect=lambda *_args, **_kwargs: "search result",
+                )
+            )
+            executor = agent._execute_tool_calls_concurrent
+        else:
+            stack.enter_context(
+                patch(
+                    "run_agent.handle_function_call",
+                    side_effect=lambda *_args, **_kwargs: "search result",
+                )
+            )
+            executor = agent._execute_tool_calls_sequential
+        executor(assistant, messages, "task-1")
+
+
+def _seed_tool_history(db, *tool_contents, final_answer=None):
+    db.create_session(SESSION_ID, source="cli")
+    db.append_message(
+        SESSION_ID,
+        "assistant",
+        "",
+        tool_calls=[_tool_call_data()],
+    )
+    for content in tool_contents:
+        db.append_message(
+            SESSION_ID,
+            "tool",
+            content,
+            tool_name="web_search",
+            tool_call_id="c1",
+        )
+    if final_answer is not None:
+        db.append_message(SESSION_ID, "assistant", final_answer)
+
+
+@pytest.mark.parametrize("mode", ["concurrent", "sequential"])
+def test_pre_batch_steer_persists(db, agent, mode):
+    """A steer queued before the batch is delivered at the batch-end drain
+    (after aggregate budget enforcement) and persisted in place."""
+    messages = []
+    agent.steer(STEER_TEXT)
+
+    _execute_tool_batch(agent, messages, mode)
+
+    assert STEER_MARKER_OPEN in messages[-1]["content"]
+    agent._flush_messages_to_session_db(messages)
+    _assert_single_steered_row(db, messages[-1])
+
+
+@pytest.mark.parametrize("mode", ["concurrent", "sequential"])
+def test_batch_end_drain_persists_steer(db, agent, mode):
+    messages = []
+
+    def _set_steer_at_budget(*_args, **_kwargs):
+        agent.steer(STEER_TEXT)
+
+    _execute_tool_batch(agent, messages, mode, budget_hook=_set_steer_at_budget)
+
+    assert STEER_MARKER_OPEN in messages[-1]["content"]
+    assert agent._pending_steer is None
+    agent._flush_messages_to_session_db(messages)
+    _assert_single_steered_row(db, messages[-1])
+
+
+@pytest.mark.parametrize("mode", ["concurrent", "sequential"])
+def test_batch_end_steer_lands_after_aggregate_budget(db, agent, mode):
+    """Upstream keeps /steer pending until after aggregate budget
+    enforcement, so the budget rewrite and the steer append are two
+    independent post-flush mutations. Both must reach the durable rows:
+    the budget-externalized content via its pending flag, and the steer
+    marker appended on top of the last (post-budget) tool result."""
+    messages = []
+    assistant = SimpleNamespace(
+        content="",
+        tool_calls=[_mock_tool_call("c1"), _mock_tool_call("c2")],
+    )
+    budget = BudgetConfig(
+        # High per-tool threshold keeps Layer-2 per-tool persistence out of
+        # the picture so only the Layer-3 aggregate budget mutates messages.
+        default_result_size=100_000,
+        turn_budget=1_500,
+        preview_size=100,
+    )
+    agent.steer(STEER_TEXT)
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch("agent.tool_executor._budget_for_agent", return_value=budget)
+        )
+        stack.enter_context(
+            patch("agent.tool_executor.get_active_env", return_value=None)
+        )
+        if mode == "concurrent":
+            stack.enter_context(
+                patch.object(agent, "_invoke_tool", return_value="x" * 900)
+            )
+            executor = agent._execute_tool_calls_concurrent
+        else:
+            stack.enter_context(
+                patch("run_agent.handle_function_call", return_value="x" * 900)
+            )
+            executor = agent._execute_tool_calls_sequential
+        executor(assistant, messages, "task-1")
+
+    assert len(messages) == 2
+    steered = next(msg for msg in messages if STEER_MARKER_OPEN in msg["content"])
+    assert STEER_TEXT in steered["content"]
+    # The steer marker is the final segment of the message — proof it was
+    # appended AFTER the aggregate budget pass, not protected through it.
+    assert STEER_TEXT in steered["content"].split(STEER_MARKER_OPEN)[-1]
+    assert steered["_db_content_update_pending"] is True
+    # Exactly one sibling was externalized by the aggregate budget AFTER the
+    # incremental flush — the second post-flush mutation.
+    budget_rewritten = [msg for msg in messages if "x" * 900 not in msg["content"]]
+    assert len(budget_rewritten) == 1
+    assert budget_rewritten[0]["_db_content_update_pending"] is True
+    assert agent._pending_steer is None
+
+    assert agent._flush_messages_to_session_db(messages) is True
+    rows = _tool_rows(db)
+    assert len(rows) == 2
+    assert [row["content"] for row in rows] == [msg["content"] for msg in messages]
+    assert any(STEER_MARKER_OPEN in row["content"] for row in rows)
+    assert all(
+        msg.get("_db_content_update_pending") is None for msg in messages
+    )
+
+
+def test_steer_update_reindexes_fts_search(db, agent):
+    if not db._fts_enabled:
+        pytest.skip("FTS5 unavailable in this sqlite build")
+
+    tool_msg = {
+        "role": "tool",
+        "content": "tool result",
+        "tool_call_id": "c1",
+        "tool_name": "web_search",
+    }
+    messages = [tool_msg]
+    agent._flush_messages_to_session_db(messages)
+    assert db.search_messages("smaller", role_filter=["tool"]) == []
+
+    agent.steer(STEER_TEXT)
+    agent._apply_pending_steer_to_tool_results(messages, 1)
+    agent._flush_messages_to_session_db(messages)
+
+    hits = db.search_messages("smaller", role_filter=["tool"])
+    assert len(hits) == 1
+    assert hits[0]["session_id"] == SESSION_ID
+    assert "smaller" in hits[0]["snippet"]
+    _assert_single_steered_row(db, tool_msg)
+
+
+def test_sequence_repair_does_not_rewrite_durable_rows(db, agent):
+    messages = [
+        {"role": "user", "content": "first"},
+        {"role": "user", "content": "second"},
+    ]
+    agent._flush_messages_to_session_db(messages)
+
+    assert agent._repair_message_sequence(messages) == 1
+    assert [message["content"] for message in messages] == ["first\n\nsecond"]
+    agent._flush_messages_to_session_db(messages)
+
+    assert [message["content"] for message in db.get_messages(SESSION_ID)] == [
+        "first",
+        "second",
+    ]
+
+
+def test_cold_resumed_pre_api_drain_updates_exact_tool_row(db, tmp_path):
+    _seed_tool_history(db, "old result", final_answer="old final answer")
+    loaded = db.get_messages_as_conversation(
+        SESSION_ID,
+        repair_alternation=True,
+        include_row_ids=True,
+    )
+    agent = _make_agent(db, tmp_path / "hermes-home")
+    requests = []
+
+    def _create(**kwargs):
+        requests.append(kwargs["messages"])
+        if len(requests) == 1:
+            agent.steer(STEER_TEXT)
+            return _mock_response(
+                content="<REASONING_SCRATCHPAD>still thinking",
+                finish_reason="stop",
+            )
+        return _mock_response(content="done", finish_reason="stop")
+
+    agent.client.chat.completions.create.side_effect = _create
+    with (
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+        patch.object(agent, "_spawn_background_review"),
+    ):
+        result = agent.run_conversation(
+            "new question",
+            conversation_history=loaded,
+        )
+
+    historical_tool = next(
+        message for message in loaded if message.get("role") == "tool"
+    )
+    assert result["final_response"] == "done"
+    assert len(requests) == 2
+    assert STEER_MARKER_OPEN in next(
+        message["content"]
+        for message in requests[1]
+        if message.get("role") == "tool"
+    )
+    _assert_single_steered_row(db, historical_tool)
+    assert historical_tool.get("_db_content_update_pending") is None
+    assert isinstance(historical_tool.get("_row_id"), int)
+
+
+def test_duplicate_tool_id_updates_exact_repaired_row(db, agent):
+    _seed_tool_history(db, "first result", "retry duplicate")
+    loaded = db.get_messages_as_conversation(
+        SESSION_ID,
+        repair_alternation=True,
+        include_row_ids=True,
+    )
+    live_tool = next(message for message in loaded if message.get("role") == "tool")
+    assert live_tool["content"] == "first result"
+    assert isinstance(live_tool.get("_row_id"), int)
+
+    agent.steer(STEER_TEXT)
+    agent._apply_pending_steer_to_tool_results(loaded, 1)
+    assert agent._flush_messages_to_session_db(
+        loaded,
+        conversation_history=loaded,
+    )
+
+    durable_tools = _tool_rows(db)
+    assert STEER_TEXT in durable_tools[0]["content"]
+    assert durable_tools[1]["content"] == "retry duplicate"
+    repaired_again = db.get_messages_as_conversation(
+        SESSION_ID,
+        repair_alternation=True,
+    )
+    assert STEER_TEXT in next(
+        message["content"]
+        for message in repaired_again
+        if message.get("role") == "tool"
+    )
+
+
+def test_duplicate_tool_id_without_row_metadata_fails_closed(db, agent):
+    _seed_tool_history(db, "first result", "retry duplicate")
+    loaded = db.get_messages_as_conversation(SESSION_ID)
+    assert agent._repair_message_sequence(loaded) == 1
+    live_tool = next(message for message in loaded if message.get("role") == "tool")
+    assert "_row_id" not in live_tool
+
+    agent.steer(STEER_TEXT)
+    agent._apply_pending_steer_to_tool_results(loaded, 1)
+    assert not agent._flush_messages_to_session_db(
+        loaded,
+        conversation_history=loaded,
+    )
+
+    assert [row["content"] for row in _tool_rows(db)] == [
+        "first result",
+        "retry duplicate",
+    ]
+    assert live_tool["_db_content_update_pending"] is True
+
+
+def test_rewritten_tool_row_falls_back_from_stale_row_id(db, agent):
+    tool_msg = {
+        "role": "tool",
+        "content": "old result",
+        "tool_call_id": "c1",
+        "tool_name": "web_search",
+    }
+    messages = [tool_msg]
+    agent._flush_messages_to_session_db(messages)
+    old_row_id = tool_msg["_row_id"]
+    db.replace_messages(SESSION_ID, messages)
+    assert _tool_rows(db)[0]["id"] != old_row_id
+
+    agent.steer(STEER_TEXT)
+    agent._apply_pending_steer_to_tool_results(messages, 1)
+    agent._flush_messages_to_session_db(messages)
+
+    _assert_single_steered_row(db, tool_msg)
+    assert tool_msg["_row_id"] == _tool_rows(db)[0]["id"]
+
+
+def test_aggregate_budget_rewrite_updates_durable_row(db, agent):
+    """Aggregate budget enforcement rewrites tool content AFTER the per-tool
+    flush (agent/tool_executor.py flushes each result, then enforce_turn_budget
+    externalizes oversized ones in place). The next flush must UPDATE the
+    durable row rather than leave the pre-budget content behind."""
+    original = "x" * 250_000
+    tool_msg = {
+        "role": "tool",
+        "content": original,
+        "tool_call_id": "c1",
+        "tool_name": "web_search",
+    }
+    messages = [tool_msg]
+    assert agent._flush_messages_to_session_db(messages) is True
+
+    enforce_turn_budget(messages, env=None, config=BudgetConfig(turn_budget=200_000))
+    assert tool_msg["content"] != original
+    assert tool_msg["_db_content_update_pending"] is True
+
+    assert agent._flush_messages_to_session_db(messages) is True
+    rows = _tool_rows(db)
+    assert len(rows) == 1
+    assert rows[0]["content"] == tool_msg["content"]
+    assert tool_msg.get("_db_content_update_pending") is None
+
+
+def test_steer_update_respects_compression_lease_and_retries(db, agent):
+    tool_msg = {
+        "role": "tool",
+        "content": "old result",
+        "tool_call_id": "c1",
+        "tool_name": "web_search",
+    }
+    messages = [tool_msg]
+    agent._flush_messages_to_session_db(messages)
+    agent.steer(STEER_TEXT)
+    agent._apply_pending_steer_to_tool_results(messages, 1)
+
+    assert db.try_acquire_compression_lock(
+        SESSION_ID,
+        "foreign-writer",
+        ttl_seconds=60,
+    )
+    assert agent._flush_messages_to_session_db(messages) is False
+    assert _tool_rows(db)[0]["content"] == "old result"
+    assert tool_msg["_db_content_update_pending"] is True
+
+    db.release_compression_lock(SESSION_ID, "foreign-writer")
+    assert agent._flush_messages_to_session_db(messages) is True
+    _assert_single_steered_row(db, tool_msg)
+    assert tool_msg.get("_db_content_update_pending") is None

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -11571,7 +11571,6 @@ def test_session_branch_installs_parent_profile_secret_scope(monkeypatch, tmp_pa
 
         def close(self):
             return None
-
     class FakeAgent:
         def __init__(self):
             self.model = "test-model"
@@ -11620,6 +11619,154 @@ def test_session_branch_installs_parent_profile_secret_scope(monkeypatch, tmp_pa
     finally:
         for k in list(server._sessions):
             server._sessions.pop(k, None)
+
+
+def test_session_branch_tool_metadata_survives_steer_flush(monkeypatch, tmp_path):
+    """Branch-copied tool messages must stay steer-updatable in the child."""
+    from hermes_state import SessionDB
+
+    db_path = tmp_path / "state.db"
+    seed = SessionDB(db_path=db_path)
+    seed.create_session("parent-key", source="tui")
+    seed.append_message(
+        "parent-key",
+        "assistant",
+        "",
+        tool_calls=[
+            {
+                "id": "c1",
+                "type": "function",
+                "function": {"name": "web_search", "arguments": "{}"},
+            }
+        ],
+    )
+    seed.append_message(
+        "parent-key",
+        "tool",
+        "old result",
+        tool_name="web_search",
+        tool_call_id="c1",
+    )
+    history = seed.get_messages_as_conversation(
+        "parent-key",
+        repair_alternation=True,
+        include_row_ids=True,
+    )
+    parent_row_id = next(
+        msg["_row_id"] for msg in history if msg["role"] == "tool"
+    )
+    for msg in history:
+        msg["_db_persisted"] = True
+    seed.close()
+
+    profile_home = tmp_path / "profiles" / "mlperf"
+    profile_home.mkdir(parents=True)
+
+    class _RealDB(SessionDB):
+        def __init__(self, db_path=None):
+            super().__init__(db_path=tmp_path / "state.db")
+
+    class FakeAgent:
+        def __init__(self):
+            self.model = "test-model"
+            self.session_id = None
+
+    parent = {
+        "session_key": "parent-key",
+        "history": history,
+        "history_lock": threading.Lock(),
+        "running": False,
+        "cols": 80,
+        "profile_home": str(profile_home),
+        "source": "tui",
+        "agent": FakeAgent(),
+        "created_at": 1.0,
+        "last_active": 1.0,
+        "cwd": str(tmp_path),
+    }
+    server._sessions["parent"] = parent
+    monkeypatch.setattr("hermes_state.SessionDB", _RealDB)
+    monkeypatch.setattr(
+        server, "_claim_active_session_slot", lambda *a, **k: (None, None)
+    )
+    monkeypatch.setattr(server, "_make_agent", lambda *a, **k: FakeAgent())
+    monkeypatch.setattr(server, "_set_session_context", lambda *a, **k: {})
+    monkeypatch.setattr(server, "_clear_session_context", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
+    monkeypatch.setattr(server, "_session_cwd", lambda s: str(tmp_path))
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_attach_worker", lambda *a, **k: None)
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.branch",
+                "params": {"session_id": "parent", "name": "forked"},
+            }
+        )
+        assert "result" in resp, resp
+        child_sid = resp["result"]["session_id"]
+        child_key = resp["result"]["stored_session_id"]
+        child_history = server._sessions[child_sid]["history"]
+
+        child_tool = next(msg for msg in child_history if msg["role"] == "tool")
+        assert child_tool["_row_id"] != parent_row_id
+
+        from run_agent import AIAgent
+
+        hermes_home = tmp_path / "hermes-home"
+        (hermes_home / "logs").mkdir(parents=True)
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch("run_agent._hermes_home", hermes_home),
+            patch("agent.model_metadata.fetch_model_metadata", return_value={}),
+        ):
+            agent = AIAgent(
+                api_key="test-key",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                session_db=SessionDB(db_path=db_path),
+                session_id=child_key,
+            )
+        agent._ensure_db_session()
+        agent.steer("prefer the smaller fix")
+        agent._apply_pending_steer_to_tool_results(child_history, 1)
+        assert agent._flush_messages_to_session_db(child_history) is True
+
+        check = SessionDB(db_path=db_path)
+        try:
+            child_rows = [
+                row
+                for row in check.get_messages(child_key)
+                if row["role"] == "tool"
+            ]
+            assert len(child_rows) == 1
+            assert child_rows[0]["tool_call_id"] == "c1"
+            assert child_rows[0]["tool_name"] == "web_search"
+            assert child_rows[0]["id"] == child_tool["_row_id"]
+            assert "prefer the smaller fix" in child_rows[0]["content"]
+            assert child_tool.get("_db_content_update_pending") is None
+            child_asst = [
+                row
+                for row in check.get_messages(child_key)
+                if row["role"] == "assistant"
+            ]
+            assert child_asst[0]["tool_calls"]
+            parent_rows = [
+                row
+                for row in check.get_messages("parent-key")
+                if row["role"] == "tool"
+            ]
+            assert parent_rows[0]["content"] == "old result"
+        finally:
+            check.close()
+    finally:
+        for key in list(server._sessions):
+            server._sessions.pop(key, None)
 
 
 def test_pending_title_finalizer_uses_session_profile_db(monkeypatch, tmp_path):

--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -3,6 +3,7 @@
 import pytest
 from unittest.mock import MagicMock, patch
 
+from agent.persistence_markers import _DB_CONTENT_UPDATE_PENDING
 from tools.budget_config import (
     DEFAULT_RESULT_SIZE_CHARS,
     DEFAULT_PREVIEW_SIZE_CHARS,
@@ -282,6 +283,25 @@ class TestEnforceTurnBudget:
             1 for m in msgs if PERSISTED_OUTPUT_TAG in m["content"]
         )
         assert persisted_count >= 2  # Need to shed at least ~52K
+
+
+    def test_replaced_content_flagged_for_durable_update(self):
+        """Budget rewrites run after the per-tool incremental flush, so a
+        replaced message must be flagged for an in-place durable update."""
+        msgs = [
+            {"role": "tool", "tool_call_id": "t1", "content": "small"},
+            {"role": "tool", "tool_call_id": "t2", "content": "x" * 250_000},
+        ]
+        enforce_turn_budget(msgs, env=None, config=BudgetConfig(turn_budget=200_000))
+        assert msgs[1]["content"] != "x" * 250_000
+        assert msgs[1][_DB_CONTENT_UPDATE_PENDING] is True
+        assert _DB_CONTENT_UPDATE_PENDING not in msgs[0]
+
+
+    def test_under_budget_sets_no_update_flag(self):
+        msgs = [{"role": "tool", "tool_call_id": "t1", "content": "small"}]
+        enforce_turn_budget(msgs, env=None, config=BudgetConfig(turn_budget=200_000))
+        assert _DB_CONTENT_UPDATE_PENDING not in msgs[0]
 
 
     def test_empty_messages(self):

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -29,6 +29,7 @@ import re
 import shlex
 import uuid
 
+from agent.persistence_markers import _DB_CONTENT_UPDATE_PENDING
 from tools.budget_config import (
     DEFAULT_PREVIEW_SIZE_CHARS,
     BudgetConfig,
@@ -246,6 +247,13 @@ def enforce_turn_budget(
             total_size -= size
             total_size += len(replacement)
             tool_messages[idx]["content"] = replacement
+            # The aggregate budget runs AFTER the per-tool incremental flush,
+            # so this in-place rewrite would otherwise leave the durable
+            # state.db row holding the pre-budget content while the model saw
+            # the replacement. Flag it for an in-place durable update (same
+            # contract as the /steer marker append; a no-op for messages the
+            # flush has not written yet).
+            tool_messages[idx][_DB_CONTENT_UPDATE_PENDING] = True
             logger.info(
                 "Budget enforcement: persisted tool result %s (%d chars)",
                 tool_use_id, size,

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -420,7 +420,11 @@ def _(rid, params: dict) -> dict:
             # history becomes the resumed session record's working conversation),
             # so heal a durable ``user;user`` violation once here instead of
             # re-firing the pre-request repair on every subsequent turn.
-            history = db.get_messages_as_conversation(target, repair_alternation=True)
+            history = db.get_messages_as_conversation(
+                target,
+                repair_alternation=True,
+                include_row_ids=True,
+            )
         except Exception as e:
             if lease is not None:
                 lease.release()
@@ -2652,12 +2656,17 @@ def _(rid, params: dict) -> dict:
             # Copy the whole parent history in bounded-chunk transactions —
             # a branch seed can be hundreds of rows, and per-row transactions
             # were the write-amplification pattern removed in #23254.
-            db.append_messages_batch(
+            child_row_ids = db.append_messages_batch(
                 new_key,
                 [
                     {
                         "role": msg.get("role", "user"),
                         "content": msg.get("content"),
+                        # Preserve assistant/tool pairing and retain the
+                        # protocol-level fallback for later durable updates.
+                        "tool_name": msg.get("tool_name") or msg.get("name"),
+                        "tool_calls": msg.get("tool_calls"),
+                        "tool_call_id": msg.get("tool_call_id"),
                         # Preserve the parent's original message timestamps —
                         # branch copies are history, not new activity (9d73006ad).
                         "timestamp": msg.get("timestamp"),
@@ -2665,7 +2674,14 @@ def _(rid, params: dict) -> dict:
                     for msg in history
                 ],
                 chunk_rows=500,
+                return_row_ids=True,
             )
+            if len(child_row_ids) != len(history):
+                raise RuntimeError("branch copy returned an unexpected row-id count")
+            # The shallow copies still point at parent rows. Re-stamp them with
+            # child ids for later mutations and desktop reactions.
+            for msg, row_id in zip(history, child_row_ids):
+                msg["_row_id"] = row_id
             db.set_session_title(new_key, title)
         except Exception as e:
             if lease is not None:

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -881,7 +881,11 @@ def _(rid, params: dict) -> dict:
         # lands on a durable user;user pair would otherwise re-fire the
         # pre-request repair on every request from here on.
         try:
-            active = db.get_messages_as_conversation(session_key, repair_alternation=True)
+            active = db.get_messages_as_conversation(
+                session_key,
+                repair_alternation=True,
+                include_row_ids=True,
+            )
         except Exception:
             active = []
         with session["history_lock"]:


### PR DESCRIPTION
## What does this PR do?

Fixes a durable-persistence bug where a mid-turn `/steer` is delivered to the live model but is not written back to SQLite `SessionDB` (`state.db`). A later resume, session API read, or search could therefore replay a transcript that differs from the content that actually produced the answer.

It also fixes the sibling post-flush mutation in aggregate tool-output budget enforcement: `enforce_turn_budget` can rewrite an already-flushed tool result in place, leaving the durable row with the pre-budget content while the model sees the replacement.

## Root cause

`AIAgent._flush_messages_to_session_db()` marks message dicts with `_db_persisted` after writing them. Later flushes skip those dicts, and the bounded identity-prefix scan can skip the entire already-seen prefix. `/steer` and aggregate budget enforcement intentionally mutate tool-result content after that first write, so the durable row remained stale.

## Approach on current `main`

This revision is rebased directly onto `9712b8f0c` and follows the current batched persistence design:

1. Steer injection and aggregate budget rewrites stamp `_db_content_update_pending` on the intentionally mutated tool message.
2. The bounded identity-prefix scan stops before a pending mutation.
3. The flush performs a scoped UPDATE of the active tool row, using its exact `_row_id` and falling back only to a unique `tool_call_id`.
4. UPDATEs reuse the current transcript-write guards and patience budget, so compression leases and compression-closed sessions remain protected.
5. New turn rows still land through one `append_messages_batch()` transaction. The batch API now returns row IDs only when `return_row_ids=True`; the live flush uses that opt-in to stamp freshly inserted tool messages without changing the default inserted-count contract.
6. TUI branch seeding keeps current main's bounded chunked batch writes, preserves assistant/tool pairing metadata, and re-stamps copied messages with child-session row IDs.

The original revision also re-added per-tool steer drains. Current main deliberately delivers `/steer` at the batch-end drain after aggregate budget enforcement, so this revision preserves that ordering and does not restore the old drain scheme.

## Changes made

- `agent/persistence_markers.py` centralizes `_db_persisted` and `_db_content_update_pending`.
- `run_agent.py` updates pending durable rows, integrates row-ID capture with batched inserts, stops the prefix fast path at pending mutations, and strips private persistence metadata from JSON snapshots.
- `hermes_state.py` adds fail-closed `update_tool_message_content(...)` and opt-in row-ID returns for batched inserts.
- `agent/agent_runtime_helpers.py`, `agent/conversation_loop.py`, and `tools/tool_result_storage.py` explicitly mark the three intentional mutation sites.
- CLI, gateway, and TUI live-resume paths opt into row IDs; inspection/export consumers retain the historical transcript shape.
- `tui_gateway/methods_session.py` preserves tool pairing and child-row identity without reverting current main's chunked batch-copy optimization.
- `agent/context_compressor.py` removes both persistence markers when re-baselining compacted messages.
- Regression coverage exercises real SQLite, FTS updates, compression leases, rewritten and duplicate row identities, TUI branching, concurrent/sequential steer drains, aggregate-budget rewrites, marker stripping, and the batched write contract.

## Validation

```text
6 focused files: 914 passed, 0 failed
ruff check: passed
git diff --check: passed
```

The focused run includes:

- `tests/run_agent/test_steer_sessiondb_persistence.py`
- `tests/hermes_state/test_append_messages_batch.py`
- `tests/tools/test_tool_result_storage.py`
- `tests/agent/test_context_compressor.py`
- `tests/run_agent/test_run_agent.py`
- `tests/test_tui_gateway_server.py`

## Scope / impact

Affected: incremental SQLite persistence for normal CLI, gateway, and TUI turns, plus TUI branch copies.

No model-tool schema, config key, system-prompt content, or user-facing command surface changes. Full-transcript rewrite paths remain unchanged, and current main's batch-end-only steer delivery remains intact.

## Checklist

- [x] Bug fix with real-path regression coverage
- [x] Single commit rebased directly onto latest `main`
- [x] Conventional commit title
- [x] Reuses the opt-in `_row_id` contract; no duplicate row-id metadata
- [x] Preserves batched turn flushes and bounded branch-copy transactions
- [x] No unrelated config, documentation, or tool-schema changes
- [x] Tested on Ubuntu / Python 3.11