### PR TITLE
fix(gateway): fall back for readonly desktop attachments

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -126,7 +126,7 @@ def preprocess_context_references(
     context_length: int,
     url_fetcher: Callable[[str], str | Awaitable[str]] | None = None,
     allowed_root: str | Path | None = None,
-    allowed_roots: Iterable[str | Path] | None = None,
+    extra_allowed_file_roots: Iterable[str | Path] | None = None,
 ) -> ContextReferenceResult:
     coro = preprocess_context_references_async(
         message,
@@ -134,7 +134,7 @@ def preprocess_context_references(
         context_length=context_length,
         url_fetcher=url_fetcher,
         allowed_root=allowed_root,
-        allowed_roots=allowed_roots,
+        extra_allowed_file_roots=extra_allowed_file_roots,
     )
     # Safe for both CLI (no loop) and gateway (loop already running).
     try:
@@ -155,7 +155,7 @@ async def preprocess_context_references_async(
     context_length: int,
     url_fetcher: Callable[[str], str | Awaitable[str]] | None = None,
     allowed_root: str | Path | None = None,
-    allowed_roots: Iterable[str | Path] | None = None,
+    extra_allowed_file_roots: Iterable[str | Path] | None = None,
 ) -> ContextReferenceResult:
     refs = parse_context_references(message)
     if not refs:
@@ -164,11 +164,10 @@ async def preprocess_context_references_async(
     cwd_path = Path(cwd).expanduser().resolve()
     # Default to the current working directory so @ references cannot escape
     # the active workspace unless a caller explicitly widens the root.
-    allowed_root_paths = _normalize_allowed_roots(
-        cwd_path,
-        allowed_root=allowed_root,
-        allowed_roots=allowed_roots,
+    allowed_root_path = (
+        Path(allowed_root).expanduser().resolve() if allowed_root is not None else cwd_path
     )
+    extra_file_root_paths = _normalize_extra_allowed_roots(extra_allowed_file_roots)
     warnings: list[str] = []
     blocks: list[str] = []
     injected_tokens = 0
@@ -185,7 +184,8 @@ async def preprocess_context_references_async(
                 ref,
                 cwd_path,
                 url_fetcher=url_fetcher,
-                allowed_roots=allowed_root_paths,
+                allowed_root=allowed_root_path,
+                extra_allowed_file_roots=extra_file_root_paths,
             )
             for ref in refs
         )
@@ -245,13 +245,18 @@ async def _expand_reference(
     cwd: Path,
     *,
     url_fetcher: Callable[[str], str | Awaitable[str]] | None = None,
-    allowed_roots: list[Path] | None = None,
+    allowed_root: Path | None = None,
+    extra_allowed_file_roots: list[Path] | None = None,
 ) -> tuple[str | None, str | None]:
     try:
         if ref.kind == "file":
-            return _expand_file_reference(ref, cwd, allowed_roots=allowed_roots)
+            file_roots = []
+            if allowed_root is not None:
+                file_roots.append(allowed_root)
+            file_roots.extend(extra_allowed_file_roots or [])
+            return _expand_file_reference(ref, cwd, allowed_roots=file_roots)
         if ref.kind == "folder":
-            return _expand_folder_reference(ref, cwd, allowed_roots=allowed_roots)
+            return _expand_folder_reference(ref, cwd, allowed_root=allowed_root)
         if ref.kind == "diff":
             return _expand_git_reference(ref, cwd, ["diff"], "git diff")
         if ref.kind == "staged":
@@ -308,9 +313,13 @@ def _expand_folder_reference(
     ref: ContextReference,
     cwd: Path,
     *,
-    allowed_roots: list[Path] | None = None,
+    allowed_root: Path | None = None,
 ) -> tuple[str | None, str | None]:
-    path = _resolve_path(cwd, ref.target, allowed_roots=allowed_roots)
+    path = _resolve_path(
+        cwd,
+        ref.target,
+        allowed_roots=[allowed_root] if allowed_root is not None else None,
+    )
     _ensure_reference_path_allowed(path)
     if not path.exists():
         return f"{ref.raw}: folder not found", None
@@ -373,19 +382,14 @@ async def _default_url_fetcher(url: str) -> str:
     return str(doc.get("content") or doc.get("raw_content") or "").strip()
 
 
-def _normalize_allowed_roots(
-    cwd: Path,
-    *,
-    allowed_root: str | Path | None = None,
-    allowed_roots: Iterable[str | Path] | None = None,
+def _normalize_extra_allowed_roots(
+    roots: Iterable[str | Path] | None = None,
 ) -> list[Path]:
-    roots = [Path(allowed_root).expanduser().resolve() if allowed_root is not None else cwd]
-    if allowed_roots is not None:
-        if isinstance(allowed_roots, (str, Path)):
-            roots.append(Path(allowed_roots).expanduser().resolve())
-        else:
-            roots.extend(Path(root).expanduser().resolve() for root in allowed_roots)
-    return roots
+    if roots is None:
+        return []
+    if isinstance(roots, (str, Path)):
+        return [Path(roots).expanduser().resolve()]
+    return [Path(root).expanduser().resolve() for root in roots]
 
 
 def _resolve_path(cwd: Path, target: str, *, allowed_roots: list[Path] | None = None) -> Path:

--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -289,8 +289,8 @@ def _expand_file_reference(
         return f"{ref.raw}: path is not a file", None
     if _is_binary_file(path):
         # A binary file can't be inlined as text, but it IS on disk (the agent's
-        # tools run where this resolves — the local cwd, or the staged copy in a
-        # remote session workspace). Returning a bare "not supported" warning
+        # tools run where this resolves — the local cwd, or the gateway's staged
+        # attachment storage). Returning a bare "not supported" warning
         # with no content was a dead end: the model saw a failure and gave up
         # (told the user the file type wasn't supported). Instead, hand it an
         # actionable block — the path, type, size, and a nudge to use its tools —

--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -9,7 +9,7 @@ import re
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Awaitable, Callable
+from typing import Awaitable, Callable, Iterable
 
 from agent.model_metadata import estimate_tokens_rough
 from hermes_cli._subprocess_compat import IS_WINDOWS, windows_hide_flags
@@ -126,6 +126,7 @@ def preprocess_context_references(
     context_length: int,
     url_fetcher: Callable[[str], str | Awaitable[str]] | None = None,
     allowed_root: str | Path | None = None,
+    allowed_roots: Iterable[str | Path] | None = None,
 ) -> ContextReferenceResult:
     coro = preprocess_context_references_async(
         message,
@@ -133,6 +134,7 @@ def preprocess_context_references(
         context_length=context_length,
         url_fetcher=url_fetcher,
         allowed_root=allowed_root,
+        allowed_roots=allowed_roots,
     )
     # Safe for both CLI (no loop) and gateway (loop already running).
     try:
@@ -153,6 +155,7 @@ async def preprocess_context_references_async(
     context_length: int,
     url_fetcher: Callable[[str], str | Awaitable[str]] | None = None,
     allowed_root: str | Path | None = None,
+    allowed_roots: Iterable[str | Path] | None = None,
 ) -> ContextReferenceResult:
     refs = parse_context_references(message)
     if not refs:
@@ -161,8 +164,10 @@ async def preprocess_context_references_async(
     cwd_path = Path(cwd).expanduser().resolve()
     # Default to the current working directory so @ references cannot escape
     # the active workspace unless a caller explicitly widens the root.
-    allowed_root_path = (
-        Path(allowed_root).expanduser().resolve() if allowed_root is not None else cwd_path
+    allowed_root_paths = _normalize_allowed_roots(
+        cwd_path,
+        allowed_root=allowed_root,
+        allowed_roots=allowed_roots,
     )
     warnings: list[str] = []
     blocks: list[str] = []
@@ -180,7 +185,7 @@ async def preprocess_context_references_async(
                 ref,
                 cwd_path,
                 url_fetcher=url_fetcher,
-                allowed_root=allowed_root_path,
+                allowed_roots=allowed_root_paths,
             )
             for ref in refs
         )
@@ -240,13 +245,13 @@ async def _expand_reference(
     cwd: Path,
     *,
     url_fetcher: Callable[[str], str | Awaitable[str]] | None = None,
-    allowed_root: Path | None = None,
+    allowed_roots: list[Path] | None = None,
 ) -> tuple[str | None, str | None]:
     try:
         if ref.kind == "file":
-            return _expand_file_reference(ref, cwd, allowed_root=allowed_root)
+            return _expand_file_reference(ref, cwd, allowed_roots=allowed_roots)
         if ref.kind == "folder":
-            return _expand_folder_reference(ref, cwd, allowed_root=allowed_root)
+            return _expand_folder_reference(ref, cwd, allowed_roots=allowed_roots)
         if ref.kind == "diff":
             return _expand_git_reference(ref, cwd, ["diff"], "git diff")
         if ref.kind == "staged":
@@ -269,9 +274,9 @@ def _expand_file_reference(
     ref: ContextReference,
     cwd: Path,
     *,
-    allowed_root: Path | None = None,
+    allowed_roots: list[Path] | None = None,
 ) -> tuple[str | None, str | None]:
-    path = _resolve_path(cwd, ref.target, allowed_root=allowed_root)
+    path = _resolve_path(cwd, ref.target, allowed_roots=allowed_roots)
     _ensure_reference_path_allowed(path)
     if not path.exists():
         return f"{ref.raw}: file not found", None
@@ -303,9 +308,9 @@ def _expand_folder_reference(
     ref: ContextReference,
     cwd: Path,
     *,
-    allowed_root: Path | None = None,
+    allowed_roots: list[Path] | None = None,
 ) -> tuple[str | None, str | None]:
-    path = _resolve_path(cwd, ref.target, allowed_root=allowed_root)
+    path = _resolve_path(cwd, ref.target, allowed_roots=allowed_roots)
     _ensure_reference_path_allowed(path)
     if not path.exists():
         return f"{ref.raw}: folder not found", None
@@ -368,17 +373,35 @@ async def _default_url_fetcher(url: str) -> str:
     return str(doc.get("content") or doc.get("raw_content") or "").strip()
 
 
-def _resolve_path(cwd: Path, target: str, *, allowed_root: Path | None = None) -> Path:
+def _normalize_allowed_roots(
+    cwd: Path,
+    *,
+    allowed_root: str | Path | None = None,
+    allowed_roots: Iterable[str | Path] | None = None,
+) -> list[Path]:
+    roots = [Path(allowed_root).expanduser().resolve() if allowed_root is not None else cwd]
+    if allowed_roots is not None:
+        if isinstance(allowed_roots, (str, Path)):
+            roots.append(Path(allowed_roots).expanduser().resolve())
+        else:
+            roots.extend(Path(root).expanduser().resolve() for root in allowed_roots)
+    return roots
+
+
+def _resolve_path(cwd: Path, target: str, *, allowed_roots: list[Path] | None = None) -> Path:
     path = Path(os.path.expanduser(target))
     if not path.is_absolute():
         path = cwd / path
     resolved = path.resolve()
-    if allowed_root is not None:
+    if allowed_roots is None:
+        return resolved
+    for allowed_root in allowed_roots:
         try:
             resolved.relative_to(allowed_root)
-        except ValueError as exc:
-            raise ValueError("path is outside the allowed workspace") from exc
-    return resolved
+            return resolved
+        except ValueError:
+            continue
+    raise ValueError("path is outside the allowed workspace")
 
 
 def _ensure_reference_path_allowed(path: Path) -> None:

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -33,11 +33,12 @@ export interface FileAttachResponse {
   message?: string
   // Gateway-side absolute path the file was staged to.
   path?: string
-  // Workspace-relative path used to build ref_text.
+  // Path used to build ref_text; normally workspace-relative, absolute for
+  // fallback staging.
   ref_path?: string
-  // Rewritten @file: ref that resolves on the gateway (workspace-relative).
+  // Rewritten @file: ref that resolves on the gateway.
   ref_text?: string
-  // True when bytes/host file were copied into the session workspace.
+  // True when bytes/host file were copied into session attachment storage.
   uploaded?: boolean
   name?: string
 }

--- a/tests/agent/test_context_references.py
+++ b/tests/agent/test_context_references.py
@@ -131,6 +131,49 @@ def test_missing_file_becomes_warning(sample_repo: Path):
 
 
 
+def test_allows_paths_in_additional_allowed_roots(tmp_path: Path):
+    from agent.context_references import preprocess_context_references
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    staging = tmp_path / "desktop-attachments"
+    staging.mkdir()
+    staged = staging / "report.txt"
+    staged.write_text("uploaded report\n", encoding="utf-8")
+    secret = tmp_path / "secret.txt"
+    secret.write_text("outside\n", encoding="utf-8")
+
+    result = preprocess_context_references(
+        f"read @file:{staged} and @file:{secret}",
+        cwd=workspace,
+        context_length=100_000,
+        allowed_root=workspace,
+        allowed_roots=[staging],
+    )
+
+    assert result.expanded
+    assert "uploaded report" in result.message
+    assert "```\noutside\n```" not in result.message
+    assert any("outside the allowed workspace" in warning for warning in result.warnings)
+
+
+def test_defaults_allowed_root_to_cwd(tmp_path: Path):
+    from agent.context_references import preprocess_context_references
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    secret = tmp_path / "secret.txt"
+    secret.write_text("outside\n", encoding="utf-8")
+
+    result = preprocess_context_references(
+        f"read @file:{secret}",
+        cwd=workspace,
+        context_length=100_000,
+    )
+
+    assert result.expanded
+    assert "```\noutside\n```" not in result.message
+    assert any("outside the allowed workspace" in warning for warning in result.warnings)
 
 
 

--- a/tests/agent/test_context_references.py
+++ b/tests/agent/test_context_references.py
@@ -131,7 +131,7 @@ def test_missing_file_becomes_warning(sample_repo: Path):
 
 
 
-def test_allows_paths_in_additional_allowed_roots(tmp_path: Path):
+def test_allows_file_paths_in_extra_allowed_file_roots(tmp_path: Path):
     from agent.context_references import preprocess_context_references
 
     workspace = tmp_path / "workspace"
@@ -148,12 +148,34 @@ def test_allows_paths_in_additional_allowed_roots(tmp_path: Path):
         cwd=workspace,
         context_length=100_000,
         allowed_root=workspace,
-        allowed_roots=[staging],
+        extra_allowed_file_roots=[staging],
     )
 
     assert result.expanded
     assert "uploaded report" in result.message
     assert "```\noutside\n```" not in result.message
+    assert any("outside the allowed workspace" in warning for warning in result.warnings)
+
+
+def test_extra_allowed_file_roots_do_not_widen_folder_refs(tmp_path: Path):
+    from agent.context_references import preprocess_context_references
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    staging = tmp_path / "desktop-attachments"
+    staging.mkdir()
+    (staging / "report.txt").write_text("uploaded\n", encoding="utf-8")
+
+    result = preprocess_context_references(
+        f"list @folder:{staging}",
+        cwd=workspace,
+        context_length=100_000,
+        allowed_root=workspace,
+        extra_allowed_file_roots=[staging],
+    )
+
+    assert result.expanded
+    assert "report.txt" not in result.message
     assert any("outside the allowed workspace" in warning for warning in result.warnings)
 
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8252,7 +8252,7 @@ def test_file_attach_fallback_ref_survives_session_key_and_cwd_change(monkeypatc
         provider = ""
 
         def run_conversation(
-            self, prompt, conversation_history=None, stream_callback=None
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
         ):
             captured["prompt"] = prompt
             return {

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7977,11 +7977,13 @@ def test_prompt_submit_expands_context_refs(monkeypatch, tmp_path):
     workspace.mkdir()
     hermes_home = tmp_path / "hermes-home"
     hermes_home.mkdir()
+    remembered_root = hermes_home / "desktop-attachments" / "remembered"
 
     server._sessions["sid"] = _session(
         agent=_Agent(),
         cwd=str(workspace),
         profile_home=str(hermes_home),
+        desktop_attachment_fallback_roots=[str(remembered_root)],
     )
     monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
@@ -8004,7 +8006,7 @@ def test_prompt_submit_expands_context_refs(monkeypatch, tmp_path):
     assert [
         Path(root).resolve() for root in context_kwargs["extra_allowed_file_roots"]
     ] == [
-        server._desktop_attachment_fallback_dir(server._sessions["sid"]).resolve()
+        remembered_root.resolve()
     ]
 
 
@@ -8171,9 +8173,9 @@ def test_file_attach_falls_back_to_hermes_home_when_workspace_is_read_only(monke
             resp["result"]["ref_text"],
             cwd=workspace,
             allowed_root=workspace,
-            extra_allowed_file_roots=[
-                server._desktop_attachment_fallback_dir(server._sessions["sid"])
-            ],
+            extra_allowed_file_roots=server._desktop_attachment_allowed_file_roots(
+                server._sessions["sid"]
+            ),
             context_length=100_000,
         )
         assert ctx.blocked is False
@@ -8182,7 +8184,7 @@ def test_file_attach_falls_back_to_hermes_home_when_workspace_is_read_only(monke
         server._sessions.pop("sid", None)
 
 
-def test_file_attach_fallback_ref_expands_during_prompt_submit(monkeypatch, tmp_path):
+def test_file_attach_fallback_ref_survives_session_key_and_cwd_change(monkeypatch, tmp_path):
     workspace = tmp_path / "readonly-workspace"
     workspace.mkdir()
     hermes_home = tmp_path / "hermes-home"
@@ -8256,6 +8258,10 @@ def test_file_attach_fallback_ref_expands_during_prompt_submit(monkeypatch, tmp_
                 },
             }
         )
+        next_workspace = tmp_path / "next-workspace"
+        next_workspace.mkdir()
+        server._sessions["sid"]["session_key"] = "new-session-key"
+        server._sessions["sid"]["cwd"] = str(next_workspace)
         server.handle_request(
             {
                 "id": "2",

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8001,9 +8001,26 @@ def test_prompt_submit_expands_context_refs(monkeypatch, tmp_path):
     assert captured["prompt"] == "expanded prompt"
     context_kwargs = captured["context_kwargs"]
     assert Path(context_kwargs["allowed_root"]).resolve() == workspace.resolve()
-    assert [Path(root).resolve() for root in context_kwargs["allowed_roots"]] == [
+    assert [
+        Path(root).resolve() for root in context_kwargs["extra_allowed_file_roots"]
+    ] == [
         server._desktop_attachment_fallback_dir(server._sessions["sid"]).resolve()
     ]
+
+
+def test_desktop_attachment_fallback_dir_is_session_scoped(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    monkeypatch.setattr(server, "_hermes_home", hermes_home)
+
+    first = _session(cwd=str(workspace), session_key="session-a")
+    second = _session(cwd=str(workspace), session_key="session-b")
+
+    first_dir = server._desktop_attachment_fallback_dir(first)
+    second_dir = server._desktop_attachment_fallback_dir(second)
+    assert first_dir != second_dir
 
 
 def test_image_attach_appends_local_image(monkeypatch):
@@ -8154,11 +8171,104 @@ def test_file_attach_falls_back_to_hermes_home_when_workspace_is_read_only(monke
             resp["result"]["ref_text"],
             cwd=workspace,
             allowed_root=workspace,
-            allowed_roots=[server._desktop_attachment_fallback_dir(server._sessions["sid"])],
+            extra_allowed_file_roots=[
+                server._desktop_attachment_fallback_dir(server._sessions["sid"])
+            ],
             context_length=100_000,
         )
         assert ctx.blocked is False
         assert "hello world" in ctx.message
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_file_attach_fallback_ref_expands_during_prompt_submit(monkeypatch, tmp_path):
+    workspace = tmp_path / "readonly-workspace"
+    workspace.mkdir()
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    blocked_root = workspace / ".hermes" / "desktop-attachments"
+    original_mkdir = Path.mkdir
+    captured = {}
+
+    def fake_mkdir(self, *args, **kwargs):
+        if self == blocked_root:
+            raise PermissionError("read-only workspace")
+        return original_mkdir(self, *args, **kwargs)
+
+    class _Agent:
+        model = "test/model"
+        base_url = ""
+        api_key = ""
+        provider = ""
+
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None
+        ):
+            captured["prompt"] = prompt
+            return {
+                "final_response": "ok",
+                "messages": [{"role": "assistant", "content": "ok"}],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    fake_cli = types.ModuleType("cli")
+    fake_cli._detect_file_drop = lambda raw: None
+    fake_cli._split_path_input = lambda raw: (raw, "")
+    fake_cli._resolve_attachment_path = lambda raw: None
+
+    import agent.model_metadata as model_metadata
+
+    server._sessions["sid"] = _session(
+        agent=_Agent(),
+        cwd=str(workspace),
+        profile_home=str(hermes_home),
+    )
+    monkeypatch.setattr(server, "_hermes_home", hermes_home)
+    monkeypatch.setattr(Path, "mkdir", fake_mkdir)
+    monkeypatch.setattr(
+        model_metadata,
+        "get_model_context_length",
+        lambda *args, **kwargs: 100_000,
+    )
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+    monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
+    monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+
+    try:
+        attach = server.handle_request(
+            {
+                "id": "1",
+                "method": "file.attach",
+                "params": {
+                    "session_id": "sid",
+                    "path": "/Users/alice/Downloads/report.txt",
+                    "name": "report.txt",
+                    "data_url": "data:text/plain;base64,aGVsbG8gd29ybGQ=",
+                },
+            }
+        )
+        server.handle_request(
+            {
+                "id": "2",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "sid",
+                    "text": f'{attach["result"]["ref_text"]}\n\nsummarize',
+                },
+            }
+        )
+
+        assert "hello world" in captured["prompt"]
+        assert "outside the allowed workspace" not in captured["prompt"]
     finally:
         server._sessions.pop("sid", None)
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1,3 +1,4 @@
+import errno
 import json
 import os
 import subprocess
@@ -8158,6 +8159,100 @@ def test_file_attach_falls_back_to_hermes_home_when_workspace_is_read_only(monke
         )
         assert ctx.blocked is False
         assert "hello world" in ctx.message
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_file_attach_falls_back_on_read_only_filesystem_oserror(monkeypatch, tmp_path):
+    workspace = tmp_path / "readonly-workspace"
+    workspace.mkdir()
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    blocked_root = workspace / ".hermes" / "desktop-attachments"
+    original_mkdir = Path.mkdir
+
+    def fake_mkdir(self, *args, **kwargs):
+        if self == blocked_root:
+            raise OSError(errno.EROFS, "Read-only file system", str(self))
+        return original_mkdir(self, *args, **kwargs)
+
+    fake_cli = types.ModuleType("cli")
+    fake_cli._detect_file_drop = lambda raw: None
+    fake_cli._split_path_input = lambda raw: (raw, "")
+    fake_cli._resolve_attachment_path = lambda raw: None
+
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    monkeypatch.setattr(server, "_hermes_home", hermes_home)
+    monkeypatch.setattr(Path, "mkdir", fake_mkdir)
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "file.attach",
+                "params": {
+                    "session_id": "sid",
+                    "path": "/Users/alice/Downloads/report.txt",
+                    "name": "report.txt",
+                    "data_url": "data:text/plain;base64,aGVsbG8=",
+                },
+            }
+        )
+
+        stored = Path(resp["result"]["path"])
+        assert resp["result"]["attached"] is True
+        assert stored.is_relative_to(hermes_home.resolve() / "desktop-attachments")
+        assert stored.read_text(encoding="utf-8") == "hello"
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_file_attach_falls_back_when_workspace_attachment_write_is_denied(monkeypatch, tmp_path):
+    workspace = tmp_path / "readonly-workspace"
+    workspace.mkdir()
+    blocked_root = workspace / ".hermes" / "desktop-attachments"
+    blocked_root.mkdir(parents=True)
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    original_write_bytes = Path.write_bytes
+
+    def fake_write_bytes(self, data):
+        try:
+            self.relative_to(blocked_root)
+        except ValueError:
+            return original_write_bytes(self, data)
+        raise PermissionError("workspace attachment dir is read-only")
+
+    fake_cli = types.ModuleType("cli")
+    fake_cli._detect_file_drop = lambda raw: None
+    fake_cli._split_path_input = lambda raw: (raw, "")
+    fake_cli._resolve_attachment_path = lambda raw: None
+
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    monkeypatch.setattr(server, "_hermes_home", hermes_home)
+    monkeypatch.setattr(Path, "write_bytes", fake_write_bytes)
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "file.attach",
+                "params": {
+                    "session_id": "sid",
+                    "path": "/Users/alice/Downloads/report.txt",
+                    "name": "report.txt",
+                    "data_url": "data:text/plain;base64,aGVsbG8=",
+                },
+            }
+        )
+
+        stored = Path(resp["result"]["path"])
+        assert resp["result"]["attached"] is True
+        assert stored.is_relative_to(hermes_home.resolve() / "desktop-attachments")
+        assert stored.read_text(encoding="utf-8") == "hello"
+        assert not (blocked_root / "report.txt").exists()
     finally:
         server._sessions.pop("sid", None)
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2802,8 +2802,10 @@ def test_session_resume_follows_compression_tip(monkeypatch, tmp_path):
     assert "post-compression reply" in texts
 
 
-def test_session_resume_passes_stored_runtime_to_agent(monkeypatch):
+def test_session_resume_passes_stored_runtime_to_agent(monkeypatch, tmp_path):
     captured = {}
+    hermes_home = tmp_path / "hermes-home"
+    fallback_root = hermes_home / "desktop-attachments" / "remembered"
 
     class FakeDB:
         def get_session(self, target):
@@ -2811,7 +2813,15 @@ def test_session_resume_passes_stored_runtime_to_agent(monkeypatch):
                 "id": target,
                 "model": "gpt-5.4",
                 "billing_provider": "openai-codex",
-                "model_config": '{"reasoning_config":{"enabled":true,"effort":"high"},"service_tier":"priority","base_url":"https://custom.example/v1","api_mode":"chat_completions"}',
+                "model_config": json.dumps(
+                    {
+                        "reasoning_config": {"enabled": True, "effort": "high"},
+                        "service_tier": "priority",
+                        "base_url": "https://custom.example/v1",
+                        "api_mode": "chat_completions",
+                        "_desktop_attachment_fallback_roots": [str(fallback_root)],
+                    }
+                ),
             }
 
         def reopen_session(self, target):
@@ -2834,13 +2844,17 @@ def test_session_resume_passes_stored_runtime_to_agent(monkeypatch):
         return types.SimpleNamespace(model="gpt-5.4", provider="openai-codex")
 
     monkeypatch.setattr(server, "_get_db", lambda: FakeDB())
+    monkeypatch.setattr(server, "_hermes_home", hermes_home)
     monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
     monkeypatch.setattr(server, "_set_session_context", lambda target: [])
     monkeypatch.setattr(server, "_clear_session_context", lambda tokens: None)
     monkeypatch.setattr(server, "_make_agent", fake_make_agent)
     monkeypatch.setattr(server, "_session_info", lambda agent, *a: {"model": agent.model, "provider": agent.provider})
 
-    def fake_init_session(sid, key, agent, history, cols=80, **_kwargs):
+    def fake_init_session(sid, key, agent, history, cols=80, **kwargs):
+        captured["desktop_attachment_fallback_roots"] = kwargs.get(
+            "desktop_attachment_fallback_roots"
+        )
         server._sessions[sid] = {"agent": agent, "session_key": key}
 
     monkeypatch.setattr(server, "_init_session", fake_init_session)
@@ -2862,6 +2876,7 @@ def test_session_resume_passes_stored_runtime_to_agent(monkeypatch):
     assert captured["provider_override"] == "openai-codex"
     assert captured["reasoning_config_override"] == {"enabled": True, "effort": "high"}
     assert captured["service_tier_override"] == "priority"
+    assert captured["desktop_attachment_fallback_roots"] == [str(fallback_root)]
     runtime_sid = resp["result"]["session_id"]
     assert server._sessions[runtime_sid]["model_override"] == captured["model_override"]
 
@@ -8023,6 +8038,38 @@ def test_desktop_attachment_fallback_dir_is_session_scoped(monkeypatch, tmp_path
     first_dir = server._desktop_attachment_fallback_dir(first)
     second_dir = server._desktop_attachment_fallback_dir(second)
     assert first_dir != second_dir
+
+
+def test_desktop_attachment_fallback_roots_persist_in_session_metadata(tmp_path):
+    hermes_home = tmp_path / "hermes-home"
+    root = hermes_home / "desktop-attachments" / "remembered"
+    calls = []
+
+    class _DB:
+        def get_session(self, session_key):
+            assert session_key == "session-key"
+            return {"model_config": '{"provider":"openai-codex"}'}
+
+        def update_session_meta(self, session_key, model_config, model):
+            calls.append((session_key, json.loads(model_config), model))
+
+    session = _session(
+        agent=types.SimpleNamespace(_session_db=_DB()),
+        profile_home=str(hermes_home),
+    )
+
+    server._remember_desktop_attachment_fallback_dir(session, root)
+
+    assert calls == [
+        (
+            "session-key",
+            {
+                "provider": "openai-codex",
+                "_desktop_attachment_fallback_roots": [str(root.resolve())],
+            },
+            None,
+        )
+    ]
 
 
 def test_image_attach_appends_local_image(monkeypatch):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7935,7 +7935,7 @@ def test_prompt_submit_sets_approval_session_key(monkeypatch):
     assert captured["session_key"] == "session-key"
 
 
-def test_prompt_submit_expands_context_refs(monkeypatch):
+def test_prompt_submit_expands_context_refs(monkeypatch, tmp_path):
     captured = {}
 
     class _Agent:
@@ -7957,20 +7957,31 @@ def test_prompt_submit_expands_context_refs(monkeypatch):
         def start(self):
             self._target()
 
-    fake_ctx = types.ModuleType("agent.context_references")
-    fake_ctx.preprocess_context_references = (
-        lambda message, **kwargs: types.SimpleNamespace(
+    def fake_preprocess_context_references(message, **kwargs):
+        captured["context_kwargs"] = kwargs
+        return types.SimpleNamespace(
             blocked=False,
             message="expanded prompt",
             warnings=[],
             references=[],
             injected_tokens=0,
         )
-    )
+
+    fake_ctx = types.ModuleType("agent.context_references")
+    fake_ctx.preprocess_context_references = fake_preprocess_context_references
     fake_meta = types.ModuleType("agent.model_metadata")
     fake_meta.get_model_context_length = lambda *args, **kwargs: 100000
 
-    server._sessions["sid"] = _session(agent=_Agent())
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+
+    server._sessions["sid"] = _session(
+        agent=_Agent(),
+        cwd=str(workspace),
+        profile_home=str(hermes_home),
+    )
     monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
     monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
@@ -7987,6 +7998,11 @@ def test_prompt_submit_expands_context_refs(monkeypatch):
     )
 
     assert captured["prompt"] == "expanded prompt"
+    context_kwargs = captured["context_kwargs"]
+    assert Path(context_kwargs["allowed_root"]).resolve() == workspace.resolve()
+    assert [Path(root).resolve() for root in context_kwargs["allowed_roots"]] == [
+        server._desktop_attachment_fallback_dir(server._sessions["sid"]).resolve()
+    ]
 
 
 def test_image_attach_appends_local_image(monkeypatch):
@@ -8130,6 +8146,18 @@ def test_file_attach_falls_back_to_hermes_home_when_workspace_is_read_only(monke
         assert resp["result"]["ref_text"] == f"@file:{stored}"
         assert stored.read_text(encoding="utf-8") == "hello world"
         assert not blocked_root.exists()
+
+        from agent.context_references import preprocess_context_references
+
+        ctx = preprocess_context_references(
+            resp["result"]["ref_text"],
+            cwd=workspace,
+            allowed_root=workspace,
+            allowed_roots=[server._desktop_attachment_fallback_dir(server._sessions["sid"])],
+            context_length=100_000,
+        )
+        assert ctx.blocked is False
+        assert "hello world" in ctx.message
     finally:
         server._sessions.pop("sid", None)
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8084,6 +8084,56 @@ def test_file_attach_uploads_remote_file_into_session_workspace(monkeypatch, tmp
         server._sessions.pop("sid", None)
 
 
+def test_file_attach_falls_back_to_hermes_home_when_workspace_is_read_only(monkeypatch, tmp_path):
+    """Remote gateway case: session cwd exists but cannot accept .hermes uploads."""
+    workspace = tmp_path / "readonly-workspace"
+    workspace.mkdir()
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    blocked_root = workspace / ".hermes" / "desktop-attachments"
+    original_mkdir = Path.mkdir
+
+    def fake_mkdir(self, *args, **kwargs):
+        if self == blocked_root:
+            raise PermissionError("read-only workspace")
+        return original_mkdir(self, *args, **kwargs)
+
+    fake_cli = types.ModuleType("cli")
+    fake_cli._detect_file_drop = lambda raw: None
+    fake_cli._split_path_input = lambda raw: (raw, "")
+    fake_cli._resolve_attachment_path = lambda raw: None
+
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    monkeypatch.setattr(server, "_hermes_home", hermes_home)
+    monkeypatch.setattr(Path, "mkdir", fake_mkdir)
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "file.attach",
+                "params": {
+                    "session_id": "sid",
+                    "path": "/Users/alice/Downloads/report.txt",
+                    "name": "report.txt",
+                    "data_url": "data:text/plain;base64,aGVsbG8gd29ybGQ=",
+                },
+            }
+        )
+
+        stored = Path(resp["result"]["path"])
+        assert resp["result"]["attached"] is True
+        assert resp["result"]["uploaded"] is True
+        assert stored.is_relative_to(hermes_home.resolve() / "desktop-attachments")
+        assert stored.name == "report.txt"
+        assert resp["result"]["ref_text"] == f"@file:{stored}"
+        assert stored.read_text(encoding="utf-8") == "hello world"
+        assert not blocked_root.exists()
+    finally:
+        server._sessions.pop("sid", None)
+
+
 def test_file_attach_copies_gateway_visible_file_outside_workspace(monkeypatch, tmp_path):
     """Local case: gateway can see the file but it's outside the workspace → copy in."""
     workspace = tmp_path / "workspace"

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -2757,6 +2757,14 @@ def _(rid, params: dict) -> dict:
         source = _session_source(session)
         lease = None  # claimed lazily on the first turn (_ensure_active_session_slot)
         branch_name = params.get("name", "")
+        inherited_attachment_roots = [
+            str(root) for root in _desktop_attachment_allowed_file_roots(session)
+        ]
+        branch_model_config = {"_branched_from": old_key}
+        if inherited_attachment_roots:
+            branch_model_config[_DESKTOP_ATTACHMENT_ROOTS_CONFIG_KEY] = (
+                inherited_attachment_roots
+            )
         try:
             if branch_name:
                 title = branch_name
@@ -2776,7 +2784,7 @@ def _(rid, params: dict) -> dict:
                 # the parent live (no end_reason='branched'), so the legacy
                 # end_reason heuristic never matches it — the marker is the only
                 # thing that surfaces TUI branches. See issue #20856.
-                model_config={"_branched_from": old_key},
+                model_config=branch_model_config,
                 parent_session_id=old_key,
                 cwd=_session_cwd(session),
                 # The branch stays on its parent's profile. Explicit stamp (not
@@ -2866,6 +2874,7 @@ def _(rid, params: dict) -> dict:
                 session_db=branch_db,
                 source=source,
                 profile_home=parent_home,
+                desktop_attachment_fallback_roots=inherited_attachment_roots,
             )
             # Ownership TRANSFER — the branched session's agent holds this
             # handle for its whole life and closes it on teardown. Drop is

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -382,6 +382,11 @@ def _(rid, params: dict) -> dict:
             profile_home
         )
 
+        stored_attachment_roots = _stored_desktop_attachment_fallback_roots(
+            found,
+            profile_home=profile_home,
+        )
+
         def _reuse_live_payload(sid: str, session: dict) -> dict:
             payload = _live_session_payload(
                 sid,
@@ -441,6 +446,7 @@ def _(rid, params: dict) -> dict:
                 close_on_disconnect=is_truthy_value(params.get("close_on_disconnect", False)),
                 profile_home=profile_home,
                 lazy=True,
+                desktop_attachment_fallback_roots=stored_attachment_roots,
             )
             if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
                 return _ok(rid, _reuse_live_payload(*live))
@@ -539,6 +545,7 @@ def _(rid, params: dict) -> dict:
                 profile_home=profile_home,
                 model_override=overrides.get("model_override"),
                 resume_runtime_overrides=overrides or None,
+                desktop_attachment_fallback_roots=stored_attachment_roots,
             )
             if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
                 return _ok(rid, _reuse_live_payload(*live))
@@ -683,6 +690,7 @@ def _(rid, params: dict) -> dict:
                         cwd=profile_resume_cwd,
                         session_db=db,
                         source=source,
+                        desktop_attachment_fallback_roots=stored_attachment_roots,
                     )
                     # Ownership TRANSFER — the registered session's agent now
                     # holds this handle for its whole life, and _init_session

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3,6 +3,7 @@ import concurrent.futures
 import contextlib
 import contextvars
 import copy
+import errno
 import hashlib
 import inspect
 import json
@@ -10496,7 +10497,9 @@ def _desktop_attachment_dir(session: dict) -> Path:
     try:
         root.mkdir(parents=True, exist_ok=True)
         return root
-    except PermissionError:
+    except OSError as exc:
+        if not _should_fallback_attachment_path(exc):
+            raise
         fallback = _desktop_attachment_fallback_dir(session, workspace=workspace)
         fallback.mkdir(parents=True, exist_ok=True)
         return fallback
@@ -10507,6 +10510,16 @@ def _desktop_attachment_fallback_dir(session: dict, *, workspace: Path | None = 
     profile_home = Path(str(session.get("profile_home") or _hermes_home)).resolve()
     digest = hashlib.sha256(str(workspace).encode("utf-8")).hexdigest()[:12]
     return profile_home / "desktop-attachments" / f"{workspace.name or 'workspace'}-{digest}"
+
+
+def _should_fallback_attachment_path(exc: OSError) -> bool:
+    return isinstance(exc, PermissionError) or exc.errno in {
+        errno.EACCES,
+        errno.EPERM,
+        errno.EROFS,
+        errno.ENOTDIR,
+        errno.EEXIST,
+    }
 
 
 def _sanitize_attachment_name(name: str) -> str:
@@ -10584,10 +10597,10 @@ def _stage_session_file_attachment(
       1. The path resolves to a file already INSIDE the session workspace — use
          it as-is (no copy, ``uploaded=False``).
       2. The path resolves to a gateway-visible file OUTSIDE the workspace — copy
-         it into ``.hermes/desktop-attachments/`` so the ``@file:`` ref resolves.
+         it into session attachment storage so the ``@file:`` ref resolves.
       3. The path doesn't exist on the gateway (the common remote case: it's a
          path on the CLIENT's disk) — decode the uploaded ``data_url`` bytes and
-         write them into ``.hermes/desktop-attachments/``.
+         write them into session attachment storage.
 
     Returns ``(stored_path, uploaded)``.
     """
@@ -10606,9 +10619,21 @@ def _stage_session_file_attachment(
         payload = _decode_attachment_data_url(data_url)
         filename = _sanitize_attachment_name(name or Path(str(raw_path or "")).name)
 
+    filename = _sanitize_attachment_name(filename)
     upload_dir = _desktop_attachment_dir(session)
-    target = _unique_attachment_path(upload_dir, _sanitize_attachment_name(filename))
-    target.write_bytes(payload)
+    target = _unique_attachment_path(upload_dir, filename)
+    try:
+        target.write_bytes(payload)
+    except OSError as exc:
+        fallback_dir = _desktop_attachment_fallback_dir(session, workspace=workspace)
+        if (
+            upload_dir.resolve() == fallback_dir.resolve()
+            or not _should_fallback_attachment_path(exc)
+        ):
+            raise
+        fallback_dir.mkdir(parents=True, exist_ok=True)
+        target = _unique_attachment_path(fallback_dir, filename)
+        target.write_bytes(payload)
     return target.resolve(), True
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6592,6 +6592,7 @@ def _init_session(
     session_db=None,
     source: str | None = None,
     profile_home: str | None = None,
+    desktop_attachment_fallback_roots: list[str] | None = None,
 ):
     now = time.time()
     with _sessions_lock:
@@ -6612,6 +6613,9 @@ def _init_session(
             "slash_worker": None,
             "show_reasoning": _load_show_reasoning(),
             "source": _resolve_session_source(source),
+            "desktop_attachment_fallback_roots": list(
+                desktop_attachment_fallback_roots or []
+            ),
             "tool_progress_mode": _load_tool_progress_mode(),
             "edit_snapshots": {},
             "tool_started_at": {},
@@ -7804,6 +7808,7 @@ def _deferred_session_record(
     lazy: bool = False,
     model_override=None,
     resume_runtime_overrides: dict | None = None,
+    desktop_attachment_fallback_roots: list[str] | None = None,
 ) -> dict:
     """A live-session record whose AIAgent is built later (lazy watch / cold
     resume) — _init_session's shape minus the agent."""
@@ -7819,6 +7824,9 @@ def _deferred_session_record(
         "created_at": now,
         "cwd": cwd,
         "display_history_prefix": display_history_prefix or [],
+        "desktop_attachment_fallback_roots": list(
+            desktop_attachment_fallback_roots or []
+        ),
         "edit_snapshots": {},
         "explicit_cwd": False,
         "history": history,
@@ -10517,18 +10525,93 @@ def _desktop_attachment_fallback_dir(session: dict, *, workspace: Path | None = 
     return profile_home / "desktop-attachments" / f"{name}-{workspace_digest}-{session_digest}"
 
 
+_DESKTOP_ATTACHMENT_ROOTS_CONFIG_KEY = "_desktop_attachment_fallback_roots"
+
+
+def _stored_desktop_attachment_fallback_roots(
+    row: dict | None,
+    *,
+    profile_home: str | Path | None = None,
+) -> list[str]:
+    if not row:
+        return []
+    raw_config = row.get("model_config")
+    if isinstance(raw_config, str):
+        try:
+            raw_config = json.loads(raw_config)
+        except (TypeError, ValueError):
+            return []
+    if not isinstance(raw_config, dict):
+        return []
+    roots = raw_config.get(_DESKTOP_ATTACHMENT_ROOTS_CONFIG_KEY)
+    if not isinstance(roots, list):
+        return []
+    return [
+        str(root)
+        for root in _validated_desktop_attachment_fallback_roots(
+            roots,
+            profile_home=profile_home,
+        )
+    ]
+
+
+def _validated_desktop_attachment_fallback_roots(
+    roots,
+    *,
+    profile_home: str | Path | None = None,
+) -> list[Path]:
+    base = Path(str(profile_home or _hermes_home)).resolve() / "desktop-attachments"
+    validated: list[Path] = []
+    for raw_root in roots or []:
+        try:
+            root = Path(str(raw_root)).resolve()
+            root.relative_to(base)
+        except (OSError, ValueError):
+            continue
+        if root not in validated:
+            validated.append(root)
+    return validated
+
+
+def _persist_desktop_attachment_fallback_roots(session: dict) -> None:
+    agent = session.get("agent")
+    db = getattr(agent, "_session_db", None)
+    session_key = str(session.get("session_key") or "").strip()
+    if db is None or not session_key or not hasattr(db, "update_session_meta"):
+        return
+    try:
+        row = db.get_session(session_key) or {}
+        raw_config = row.get("model_config")
+        if isinstance(raw_config, dict):
+            model_config = dict(raw_config)
+        elif isinstance(raw_config, str) and raw_config.strip():
+            parsed = json.loads(raw_config)
+            model_config = dict(parsed) if isinstance(parsed, dict) else {}
+        else:
+            model_config = {}
+        roots = _validated_desktop_attachment_fallback_roots(
+            session.get("desktop_attachment_fallback_roots", []),
+            profile_home=session.get("profile_home"),
+        )
+        model_config[_DESKTOP_ATTACHMENT_ROOTS_CONFIG_KEY] = [str(root) for root in roots]
+        db.update_session_meta(session_key, json.dumps(model_config), None)
+    except Exception:
+        logger.debug("failed to persist desktop attachment fallback roots", exc_info=True)
+
+
 def _remember_desktop_attachment_fallback_dir(session: dict, root: Path) -> None:
     roots = session.setdefault("desktop_attachment_fallback_roots", [])
     root_str = str(root.resolve())
     if root_str not in roots:
         roots.append(root_str)
+        _persist_desktop_attachment_fallback_roots(session)
 
 
 def _desktop_attachment_allowed_file_roots(session: dict) -> list[Path]:
-    return [
-        Path(root).resolve()
-        for root in session.get("desktop_attachment_fallback_roots", [])
-    ]
+    return _validated_desktop_attachment_fallback_roots(
+        session.get("desktop_attachment_fallback_roots", []),
+        profile_home=session.get("profile_home"),
+    )
 
 
 def _should_fallback_attachment_path(exc: OSError) -> bool:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9608,6 +9608,7 @@ def _run_prompt_submit(
                     prompt,
                     cwd=cwd,
                     allowed_root=cwd,
+                    allowed_roots=[_desktop_attachment_fallback_dir(session)],
                     context_length=ctx_len,
                 )
                 if ctx.blocked:
@@ -10496,11 +10497,16 @@ def _desktop_attachment_dir(session: dict) -> Path:
         root.mkdir(parents=True, exist_ok=True)
         return root
     except PermissionError:
-        profile_home = Path(str(session.get("profile_home") or _hermes_home)).resolve()
-        digest = hashlib.sha256(str(workspace).encode("utf-8")).hexdigest()[:12]
-        fallback = profile_home / "desktop-attachments" / f"{workspace.name or 'workspace'}-{digest}"
+        fallback = _desktop_attachment_fallback_dir(session, workspace=workspace)
         fallback.mkdir(parents=True, exist_ok=True)
         return fallback
+
+
+def _desktop_attachment_fallback_dir(session: dict, *, workspace: Path | None = None) -> Path:
+    workspace = (workspace or Path(_session_cwd(session))).resolve()
+    profile_home = Path(str(session.get("profile_home") or _hermes_home)).resolve()
+    digest = hashlib.sha256(str(workspace).encode("utf-8")).hexdigest()[:12]
+    return profile_home / "desktop-attachments" / f"{workspace.name or 'workspace'}-{digest}"
 
 
 def _sanitize_attachment_name(name: str) -> str:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9609,7 +9609,7 @@ def _run_prompt_submit(
                     prompt,
                     cwd=cwd,
                     allowed_root=cwd,
-                    allowed_roots=[_desktop_attachment_fallback_dir(session)],
+                    extra_allowed_file_roots=[_desktop_attachment_fallback_dir(session)],
                     context_length=ctx_len,
                 )
                 if ctx.blocked:
@@ -10508,8 +10508,12 @@ def _desktop_attachment_dir(session: dict) -> Path:
 def _desktop_attachment_fallback_dir(session: dict, *, workspace: Path | None = None) -> Path:
     workspace = (workspace or Path(_session_cwd(session))).resolve()
     profile_home = Path(str(session.get("profile_home") or _hermes_home)).resolve()
-    digest = hashlib.sha256(str(workspace).encode("utf-8")).hexdigest()[:12]
-    return profile_home / "desktop-attachments" / f"{workspace.name or 'workspace'}-{digest}"
+    workspace_digest = hashlib.sha256(str(workspace).encode("utf-8")).hexdigest()[:12]
+    session_digest = hashlib.sha256(
+        str(session.get("session_key") or "").encode("utf-8")
+    ).hexdigest()[:12]
+    name = workspace.name or "workspace"
+    return profile_home / "desktop-attachments" / f"{name}-{workspace_digest}-{session_digest}"
 
 
 def _should_fallback_attachment_path(exc: OSError) -> bool:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10490,9 +10490,17 @@ def _attachment_ref_path(session: dict, target: Path) -> str:
 
 
 def _desktop_attachment_dir(session: dict) -> Path:
-    root = Path(_session_cwd(session)).resolve() / ".hermes" / "desktop-attachments"
-    root.mkdir(parents=True, exist_ok=True)
-    return root
+    workspace = Path(_session_cwd(session)).resolve()
+    root = workspace / ".hermes" / "desktop-attachments"
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+        return root
+    except PermissionError:
+        profile_home = Path(str(session.get("profile_home") or _hermes_home)).resolve()
+        digest = hashlib.sha256(str(workspace).encode("utf-8")).hexdigest()[:12]
+        fallback = profile_home / "desktop-attachments" / f"{workspace.name or 'workspace'}-{digest}"
+        fallback.mkdir(parents=True, exist_ok=True)
+        return fallback
 
 
 def _sanitize_attachment_name(name: str) -> str:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9609,7 +9609,7 @@ def _run_prompt_submit(
                     prompt,
                     cwd=cwd,
                     allowed_root=cwd,
-                    extra_allowed_file_roots=[_desktop_attachment_fallback_dir(session)],
+                    extra_allowed_file_roots=_desktop_attachment_allowed_file_roots(session),
                     context_length=ctx_len,
                 )
                 if ctx.blocked:
@@ -10502,6 +10502,7 @@ def _desktop_attachment_dir(session: dict) -> Path:
             raise
         fallback = _desktop_attachment_fallback_dir(session, workspace=workspace)
         fallback.mkdir(parents=True, exist_ok=True)
+        _remember_desktop_attachment_fallback_dir(session, fallback)
         return fallback
 
 
@@ -10514,6 +10515,20 @@ def _desktop_attachment_fallback_dir(session: dict, *, workspace: Path | None = 
     ).hexdigest()[:12]
     name = workspace.name or "workspace"
     return profile_home / "desktop-attachments" / f"{name}-{workspace_digest}-{session_digest}"
+
+
+def _remember_desktop_attachment_fallback_dir(session: dict, root: Path) -> None:
+    roots = session.setdefault("desktop_attachment_fallback_roots", [])
+    root_str = str(root.resolve())
+    if root_str not in roots:
+        roots.append(root_str)
+
+
+def _desktop_attachment_allowed_file_roots(session: dict) -> list[Path]:
+    return [
+        Path(root).resolve()
+        for root in session.get("desktop_attachment_fallback_roots", [])
+    ]
 
 
 def _should_fallback_attachment_path(exc: OSError) -> bool:
@@ -10636,6 +10651,7 @@ def _stage_session_file_attachment(
         ):
             raise
         fallback_dir.mkdir(parents=True, exist_ok=True)
+        _remember_desktop_attachment_fallback_dir(session, fallback_dir)
         target = _unique_attachment_path(fallback_dir, filename)
         target.write_bytes(payload)
     return target.resolve(), True


### PR DESCRIPTION
## What does this PR do?

Fixes the desktop remote-gateway file upload path when the active session cwd cannot accept `.hermes/desktop-attachments` writes. The gateway now falls back to a profile-scoped desktop attachment directory, remembers the exact fallback roots used by the session, and allows only those remembered roots through `@file:` context expansion.

This keeps the normal writable-workspace behavior unchanged while making uploaded file refs survive read-only cwd errors, write-time permission errors, session-key rotation, and cwd changes before submit.

## Related Issue

Fixes #52556

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py`: fall back from workspace-local desktop attachment storage to a profile-scoped fallback directory on permission/read-only failures.
- `tui_gateway/server.py`: remember fallback roots actually used by `file.attach` and pass only those roots to context-reference expansion.
- `tui_gateway/server.py`: persist those exact roots in existing session metadata, restore them for lazy/cold/eager resumes, and inherit them across branches.
- `agent/context_references.py`: add `extra_allowed_file_roots` for file refs only, without widening folder refs.
- `apps/desktop/src/app/types.ts`: update file attachment response comments for fallback refs.
- Tests cover read-only mkdir failure, `EROFS`, write-time denial, prompt-submit expansion, session resume/branch persistence, session-key/cwd changes, and file-only root widening.

## How to Test

1. Duplicate checks:
   - `gh pr list --repo NousResearch/hermes-agent --state all --search "52556" --json number,title,state,isDraft,url,mergedAt,headRefName`
   - `gh pr list --repo NousResearch/hermes-agent --state all --search "desktop attachment read-only cwd EACCES _desktop_attachment_dir" --json number,title,state,isDraft,url,mergedAt,headRefName`
2. Local checks after rebasing onto current `main`:
   - `git diff --check origin/main...HEAD`
   - `scripts/run_tests.sh tests/agent/test_context_references.py tests/test_tui_gateway_server.py`
   - `.venv/bin/ruff check agent/context_references.py tui_gateway/server.py tests/agent/test_context_references.py tests/test_tui_gateway_server.py`
   - `.venv/bin/python scripts/check-windows-footguns.py agent/context_references.py tui_gateway/server.py tests/agent/test_context_references.py tests/test_tui_gateway_server.py`
3. Local result: 416/416 focused and protocol tests passed; Ruff and the Windows footgun scan passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## Screenshots / Logs

The user-owned series was rebased onto current `main` and pushed normally so the private pre-push review gate ran. Grogu identified that a real session rebuild could lose the in-memory fallback allowlist; the latest commit persists and restores the exact roots and adds regression proof for that path. GitHub CI is validating the refreshed head.
