### PR TITLE
feat(api-server): stream model reasoning as reasoning_content in chat completions

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1068,6 +1068,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_progress_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
+        reasoning_callback=None,
         gateway_session_key: Optional[str] = None,
     ) -> Any:
         """
@@ -1122,6 +1123,7 @@ class APIServerAdapter(BasePlatformAdapter):
             tool_progress_callback=tool_progress_callback,
             tool_start_callback=tool_start_callback,
             tool_complete_callback=tool_complete_callback,
+            reasoning_callback=reasoning_callback,
             session_db=self._ensure_session_db(),
             fallback_model=fallback_model,
             reasoning_config=reasoning_config,
@@ -1990,6 +1992,17 @@ class APIServerAdapter(BasePlatformAdapter):
                     "status": "completed",
                 }))
 
+            def _on_reasoning(text):
+                """Stream model reasoning as delta.reasoning_content.
+
+                Open WebUI (and other OpenAI-compatible frontends) render a
+                collapsing "thinking" block from reasoning_content deltas.  We
+                tag the queue item so _emit routes it to the reasoning field
+                instead of visible content; empty/None chunks are skipped.
+                """
+                if text:
+                    _stream_q.put(("__reasoning__", text))
+
             # Start agent in background.  agent_ref is a mutable container
             # so the SSE writer can interrupt the agent on client disconnect.
             #
@@ -2007,6 +2020,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 stream_delta_callback=_on_delta,
                 tool_start_callback=_on_tool_start,
                 tool_complete_callback=_on_tool_complete,
+                reasoning_callback=_on_reasoning,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
             ))
@@ -2189,6 +2203,13 @@ class APIServerAdapter(BasePlatformAdapter):
                     await response.write(
                         f"event: hermes.tool.progress\ndata: {event_data}\n\n".encode()
                     )
+                elif isinstance(item, tuple) and len(item) == 2 and item[0] == "__reasoning__":
+                    reasoning_chunk = {
+                        "id": completion_id, "object": "chat.completion.chunk",
+                        "created": created, "model": model,
+                        "choices": [{"index": 0, "delta": {"reasoning_content": item[1]}, "finish_reason": None}],
+                    }
+                    await response.write(f"data: {json.dumps(reasoning_chunk)}\n\n".encode())
                 else:
                     content_chunk = {
                         "id": completion_id, "object": "chat.completion.chunk",
@@ -3707,6 +3728,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_progress_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
+        reasoning_callback=None,
         agent_ref: Optional[list] = None,
         gateway_session_key: Optional[str] = None,
     ) -> tuple:
@@ -3739,6 +3761,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     tool_progress_callback=tool_progress_callback,
                     tool_start_callback=tool_start_callback,
                     tool_complete_callback=tool_complete_callback,
+                    reasoning_callback=reasoning_callback,
                     gateway_session_key=gateway_session_key,
                 )
                 if agent_ref is not None:


### PR DESCRIPTION
## Summary
The `/v1/chat/completions` streaming path wired `stream_delta_callback`, `tool_start_callback`, and `tool_complete_callback`, but **never `reasoning_callback`**. As a result, a model's reasoning stream (e.g. Claude extended thinking, `thinking_delta` → `agent._fire_reasoning_delta`) was silently dropped for OpenAI-compatible frontends.

Open WebUI (and other OpenAI-compatible UIs) render a collapsible "thinking" block from `delta.reasoning_content` chunks — but nothing on this path emitted them.

## Change
Thread `reasoning_callback` through the existing call chain and route reasoning deltas to a dedicated SSE chunk:

- `_create_agent` and `_run_agent` gain a `reasoning_callback` parameter, forwarded to `AIAgent` (which already accepts and fires it via `_fire_reasoning_delta`).
- In the streaming branch of `_handle_chat_completions`, a new `_on_reasoning(text)` enqueues a tagged `("__reasoning__", text)` item (mirroring the existing `("__tool_progress__", …)` pattern).
- `_emit` gains an `elif` that renders that tagged item as a `chat.completion.chunk` carrying `delta.reasoning_content`.

Visible `delta.content`, the `hermes.tool.progress` events, and the end-of-stream sentinel are all unchanged. Empty/None reasoning chunks are skipped.

## Real behavior / verification
- Module imports cleanly; both `_create_agent` and `_run_agent` signatures carry `reasoning_callback` (verified via `inspect.signature`).
- End-to-end chain confirmed in source: Anthropic streaming `thinking_delta` (chat_completion_helpers.py) → `agent._fire_reasoning_delta` → `self.reasoning_callback` (assigned in `agent_init.py`) → `_on_reasoning` → `_stream_q` → `_emit`.
- Deterministic unit-level reproduction of the `_emit` branch confirms a tagged reasoning item serializes to `{"delta": {"reasoning_content": "..."}}` while normal content still serializes to `{"delta": {"content": "..."}}`.

## Scope / safety
- No new model tools; agent loop and prompt caching untouched.
- Additive only (+23 lines, one file); content/tool-progress paths byte-identical when no reasoning is emitted.