### PR TITLE
feat(kanban): AP-4033 verified-dispatch + AP-4031/AP-4032 close-side gate (hermes-agent surgical merge)

### DIFF
--- a/tools/kanban_dispatch_gate.py
+++ b/tools/kanban_dispatch_gate.py
@@ -1,0 +1,262 @@
+"""kanban_dispatch_gate.py — AP-4033 verified-dispatch on kanban-create.
+
+Symmetric mirror of kanban_gate.py (AP-4031+AP-4032) applied to the
+dispatch side of the kanban DB. Every kanban_create must either be
+performed by an allowed dispatcher (HERMES_PROFILE in
+HERMES_KANBAN_DISPATCHERS, default ['operator']) OR carry a verified
+kind=dispatch metadata field backed by a prior kind=dispatch evidence
+entry signed by an allowed dispatcher.
+
+Ships disabled (HERMES_KANBAN_DISPATCH_GATE=0 default per BC-9). Operators
+opt-in per the 14-day observation window documented in
+docs/migration-notes/ap-4033-kanban-dispatch-2026-06-24.md.
+
+Trust-boundary mirror of AP-4032 (kanban_gate.py): the verifier and
+the evidence-chain write path on the dispatch side require either
+HERMES_PROFILE in HERMES_KANBAN_DISPATCHERS (for dispatch /
+dispatch_override / spawn_refused kinds) OR HERMES_PROFILE=wags (for
+dispatch_override_authorisation kind). Same actor-spoof defense.
+
+Extracted from AP-4033 commit 643646054 (totum-src main) for surgical
+merge to hermes-agent main without conflict on _handle_create.
+Imported by tools/kanban_tools.py::_handle_create.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sys
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ── Constants ───────────────────────────────────────────────────────────
+
+# AP-4033: when HERMES_KANBAN_DISPATCH_GATE=1, _handle_create refuses
+# unless the caller is an allowed dispatcher (per the env-var list)
+# or the card carries a verified dispatch entry. Default is 0 (off)
+# for one release cycle per BC-9.
+DISPATCH_GATE_ENV = "HERMES_KANBAN_DISPATCH_GATE"
+
+# Allowed dispatcher profiles for the write-side gate. Default is
+# ["operator"] only — Wags is excluded because including them in the
+# dispatcher list would make their identity forgeable via the dispatch
+# path, defeating the close-side HERMES_PROFILE=wags trust boundary.
+# Configurable via HERMES_KANBAN_DISPATCHERS env var (comma-separated).
+DISPATCHERS_ENV = "HERMES_KANBAN_DISPATCHERS"
+DEFAULT_DISPATCHERS = ["operator"]
+
+# Allowed approver profiles for the auto-rule approval check (separate
+# from DISPATCHERS so operators dispatch while wags approves auto-rules).
+# Configurable via HERMES_KANBAN_DISPATCH_APPROVERS env var.
+APPROVERS_ENV = "HERMES_KANBAN_DISPATCH_APPROVERS"
+DEFAULT_APPROVERS = ["wags"]
+
+# Default location of the dispatch_gap_detection helper.
+DISPATCH_GAP_DETECTION_HELPER_ENV = "HERMES_DISPATCH_GAP_DETECTION_PY"
+
+# Default location of the dispatch_verifier helper.
+DISPATCH_VERIFIER_HELPER_ENV = "HERMES_DISPATCH_VERIFIER_PY"
+
+# Subprocess timeout for the gate check. 2s is generous (target p99
+# 200ms); cap protects kanban_create from a wedged subprocess.
+_GATE_CHECK_TIMEOUT_S = 2.0
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────
+
+
+def dispatch_gate_required() -> bool:
+    """True iff the env-var dispatch gate is on for this process."""
+    raw = os.environ.get(DISPATCH_GATE_ENV, "").strip()
+    if not raw:
+        return False
+    return raw not in ("0", "false", "False", "no", "off")
+
+
+def _allowed_dispatchers() -> list[str]:
+    """Return the configured list of allowed dispatcher profiles.
+
+    Reads HERMES_KANBAN_DISPATCHERS env var (comma-separated). Falls back
+    to ["operator"] per ADR §3.1 operator revisions (WAGS pre-build
+    review 2026-06-25).
+    """
+    raw = os.environ.get(DISPATCHERS_ENV, "").strip()
+    if raw:
+        return [s.strip() for s in raw.split(",") if s.strip()]
+    return list(DEFAULT_DISPATCHERS)
+
+
+def _allowed_approvers() -> list[str]:
+    """Return the configured list of allowed approver profiles.
+
+    Reads HERMES_KANBAN_DISPATCH_APPROVERS env var (comma-separated).
+    Falls back to ["wags"] — approvers approve auto-rules (different
+    role from dispatchers who actually create cards).
+    """
+    raw = os.environ.get(APPROVERS_ENV, "").strip()
+    if raw:
+        return [s.strip() for s in raw.split(",") if s.strip()]
+    return list(DEFAULT_APPROVERS)
+
+
+def _dispatch_gap_detection_helper() -> str:
+    """Locate scripts/dispatch_gap_detection.py for the subprocess gate check.
+
+    Lookup order:
+      1. HERMES_DISPATCH_GAP_DETECTION_PY env var (explicit override)
+      2. AOS_WORKSPACE/scripts/dispatch_gap_detection.py (workspace copy)
+      3. <hermes-agent-root>/../scripts/dispatch_gap_detection.py (sibling
+         repo fallback — totum-src lives one directory up from hermes-agent)
+    """
+    explicit = os.environ.get(DISPATCH_GAP_DETECTION_HELPER_ENV, "").strip()
+    if explicit and os.path.isfile(explicit):
+        return explicit
+    ws = os.environ.get("AOS_WORKSPACE", "").strip()
+    if ws:
+        candidate = os.path.join(ws, "scripts", "dispatch_gap_detection.py")
+        if os.path.isfile(candidate):
+            return candidate
+    here = os.path.dirname(os.path.abspath(__file__))
+    sibling = os.path.abspath(
+        os.path.join(here, "..", "..", "scripts", "dispatch_gap_detection.py")
+    )
+    if os.path.isfile(sibling):
+        return sibling
+    return ""
+
+
+def _dispatch_verifier_helper() -> str:
+    """Locate scripts/dispatch_verifier.py (AP-4033 override path)."""
+    explicit = os.environ.get(DISPATCH_VERIFIER_HELPER_ENV, "").strip()
+    if explicit and os.path.isfile(explicit):
+        return explicit
+    ws = os.environ.get("AOS_WORKSPACE", "").strip()
+    if ws:
+        candidate = os.path.join(ws, "scripts", "dispatch_verifier.py")
+        if os.path.isfile(candidate):
+            return candidate
+    here = os.path.dirname(os.path.abspath(__file__))
+    sibling = os.path.abspath(
+        os.path.join(here, "..", "..", "scripts", "dispatch_verifier.py")
+    )
+    if os.path.isfile(sibling):
+        return sibling
+    return ""
+
+
+# ── Gate pre-check ─────────────────────────────────────────────────────
+
+
+def dispatch_gate_pre_check(
+    card_metadata: dict,
+    caller_profile: Optional[str],
+    has_dispatch_entry: bool,
+) -> Optional[str]:
+    """Run the AP-4033 dispatch gate pre-check.
+
+    Decision tree (per ADR §3.4):
+      - HERMES_KANBAN_DISPATCH_GATE=0 → pass (backward compatible).
+      - caller_profile in HERMES_KANBAN_DISPATCHERS → pass (caller IS
+        the dispatcher; the dispatch entry will be written post-create).
+      - card_metadata.dispatched_by matches a verified dispatch entry
+        → pass.
+      - card_metadata has dispatch_override field with actor + reason
+        → run the 3-branch verifier; pass iff accepted.
+      - else → refuse with the prescribed error message.
+
+    Returns None on pass, error-message string on refusal.
+
+    `has_dispatch_entry` is the caller-supplied check: did the kanban
+    DB row (or its prior entries) carry a verified dispatch evidence
+    entry? Passed in to keep this module free of internal DB imports.
+    """
+    if not dispatch_gate_required():
+        return None
+    # Caller IS the dispatcher → pass; the dispatch entry will be
+    # appended by the caller immediately after create_task.
+    if caller_profile and caller_profile in _allowed_dispatchers():
+        return None
+    # Card metadata carries a dispatch_override → run the 3-branch verifier.
+    override = (card_metadata or {}).get("dispatch_override")
+    if override and isinstance(override, dict):
+        return _dispatch_override_check(override)
+    # Card has a prior verified dispatch entry → pass.
+    if has_dispatch_entry:
+        return None
+    return (
+        "AP-4033 dispatch gate: no verified dispatch entry for this card. "
+        "Either (a) the caller's HERMES_PROFILE must be in "
+        "HERMES_KANBAN_DISPATCHERS (default ['operator']), (b) the card "
+        "metadata must carry a dispatch_override field for the 3-branch "
+        "verifier, or (c) a kind=dispatch evidence entry must already "
+        "exist for this card_id. See docs/migration-notes/"
+        "ap-4033-kanban-dispatch-2026-06-24.md."
+    )
+
+
+def _dispatch_override_check(override: dict) -> Optional[str]:
+    """AP-4033 dispatch-side 3-branch override verification.
+
+    Mirrors kanban_gate.py::_gate_skip_check. Spawns
+    scripts/dispatch_verifier.py check with the override metadata.
+    On accept, the verifier appends a kind=dispatch_override evidence
+    entry to the chain (audit trail per ADR §3.4).
+    """
+    helper = _dispatch_verifier_helper()
+    if not helper:
+        return (
+            "AP-4033 dispatch_override check requires "
+            "scripts/dispatch_verifier.py (set "
+            "HERMES_DISPATCH_VERIFIER_PY to override); see AP-4033"
+        )
+    actor = (override.get("actor") or "").strip()
+    reason = (override.get("reason") or "").strip()
+    card_id = (override.get("card_id") or "").strip()
+    cmd = [
+        sys.executable, helper, "check",
+        "--card-id", card_id,
+        "--reason", reason,
+        "--actor", actor or "operator",
+    ]
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True,
+            timeout=_GATE_CHECK_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        return (
+            f"AP-4033 dispatch_override verifier timed out after "
+            f"{_GATE_CHECK_TIMEOUT_S}s; refusing rather than bypassing"
+        )
+    except Exception as e:
+        logger.exception("kanban_create: dispatch_override verifier subprocess failed")
+        return (
+            f"AP-4033 dispatch_override verifier subprocess error ({e}); "
+            f"refusing rather than bypassing"
+        )
+    if proc.returncode not in (0, 1):
+        return (
+            f"AP-4033 dispatch_override verifier error "
+            f"(exit {proc.returncode}): "
+            f"{proc.stderr.strip() or proc.stdout.strip()}"
+        )
+    verdict: dict[str, Any] = {}
+    try:
+        out = proc.stdout.strip()
+        if out:
+            verdict = json.loads(out.splitlines()[-1])
+    except (json.JSONDecodeError, IndexError):
+        verdict = {}
+    accepted = bool(verdict.get("accepted"))
+    if proc.returncode == 0:
+        accepted = True
+    if not accepted:
+        reason_str = verdict.get("refusal_reason") or (
+            f"AP-4033 dispatch_override verifier refused (exit {proc.returncode})"
+        )
+        return f"AP-4033 dispatch_override refused: {reason_str}"
+    return None

--- a/tools/kanban_gate.py
+++ b/tools/kanban_gate.py
@@ -1,0 +1,348 @@
+"""kanban_gate.py — AP-4031 + AP-4032 mechanical kanban-complete gate.
+
+Houses the gate logic lifted from feat/ap-4032-gate-skip-verifier
+(hermes-agent commit 2000c99a5) and refactored out of tools/kanban_tools.py
+for surgical merge to main without conflict on the larger _handle_complete
+function. Imported by tools/kanban_tools.py::_handle_complete.
+
+Ships disabled (HERMES_KANBAN_GATE_REQUIRED=0 default per BC-9). Operators
+opt-in per the 14-day observation window documented in
+docs/migration-notes/ap-4031-kanban-gate-2026-06-24.md.
+
+Trust-boundary fix (WAGS post-build review, 2026-06-24): the verifier and
+the evidence-chain write path both require HERMES_PROFILE=wags before any
+gate_skip_authorisation entry is trusted. See ADR section 10 risk row
+"sev-2 actor-spoof".
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sys
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ── Constants ───────────────────────────────────────────────────────────
+
+# AP-4031: when HERMES_KANBAN_GATE_REQUIRED=1, _handle_complete refuses
+# to close any non-wags card unless a gate_signature evidence entry exists
+# in the evidence chain. Default is 0 (off) for one release cycle per
+# the BC-9 additivity rules in the ADR.
+GATE_REQUIRED_ENV = "HERMES_KANBAN_GATE_REQUIRED"
+GATE_BYPASS_SIGNER = "wags"
+
+# Default location of the gap_detection helper. Overridable via env so
+# tests and hermes-agent-installed venvs can point at the right copy.
+GAP_DETECTION_HELPER_ENV = "HERMES_GAP_DETECTION_PY"
+
+# AP-4032: gate_skip_verifier.py implements the 3-branch verification
+# path that closes the bypass on AP-4031's permissive gate_skip_reason
+# short-circuit. Located the same way as gap_detection.py so workers
+# running in totum-src's AOS_WORKSPACE pick up the workspace copy.
+GATE_SKIP_VERIFIER_ENV = "HERMES_GATE_SKIP_VERIFIER_PY"
+
+# Subprocess timeout for the gate check. 2s is generous (target p99
+# 200ms per ADR §3.4); cap protects kanban_complete from a wedged
+# subprocess wedging the worker.
+_GATE_CHECK_TIMEOUT_S = 2.0
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────
+
+
+def _gap_detection_helper() -> str:
+    """Locate scripts/gap_detection.py for the subprocess gate check.
+
+    Lookup order:
+      1. HERMES_GAP_DETECTION_PY env var (explicit override)
+      2. AOS_WORKSPACE/scripts/gap_detection.py (the workspace the
+         dispatcher spawned us in)
+      3. <hermes-agent-root>/../scripts/gap_detection.py (sibling
+         repo fallback for the standard workspace layout — totum-src
+         lives one directory up from hermes-agent)
+    """
+    explicit = os.environ.get(GAP_DETECTION_HELPER_ENV, "").strip()
+    if explicit and os.path.isfile(explicit):
+        return explicit
+    ws = os.environ.get("AOS_WORKSPACE", "").strip()
+    if ws:
+        candidate = os.path.join(ws, "scripts", "gap_detection.py")
+        if os.path.isfile(candidate):
+            return candidate
+    here = os.path.dirname(os.path.abspath(__file__))
+    sibling = os.path.abspath(
+        os.path.join(here, "..", "..", "scripts", "gap_detection.py")
+    )
+    if os.path.isfile(sibling):
+        return sibling
+    return ""
+
+
+def _gate_skip_verifier_helper() -> str:
+    """Locate scripts/gate_skip_verifier.py (AP-4032). Same lookup order
+    as _gap_detection_helper()."""
+    explicit = os.environ.get(GATE_SKIP_VERIFIER_ENV, "").strip()
+    if explicit and os.path.isfile(explicit):
+        return explicit
+    ws = os.environ.get("AOS_WORKSPACE", "").strip()
+    if ws:
+        candidate = os.path.join(ws, "scripts", "gate_skip_verifier.py")
+        if os.path.isfile(candidate):
+            return candidate
+    here = os.path.dirname(os.path.abspath(__file__))
+    sibling = os.path.abspath(
+        os.path.join(here, "..", "..", "scripts", "gate_skip_verifier.py")
+    )
+    if os.path.isfile(sibling):
+        return sibling
+    return ""
+
+
+def gate_required() -> bool:
+    """True iff the env-var gate is on for this process."""
+    raw = os.environ.get(GATE_REQUIRED_ENV, "").strip()
+    if not raw:
+        return False
+    return raw not in ("0", "false", "False", "no", "off")
+
+
+# ── Gate pre-check ─────────────────────────────────────────────────────
+
+
+def gate_pre_check(task_id: str, metadata: dict, get_task_fn) -> Optional[str]:
+    """Run the AP-4031 mechanical gate, returning an error message on
+    refusal or None on pass.
+
+    Decision tree (per ADR §3.3 + AP-4032 §3.2):
+      - HERMES_KANBAN_GATE_REQUIRED=0 → pass (backward compatible).
+      - assignee == 'wags' → pass (wags signs his own cards).
+      - metadata.gate_skip_reason non-empty → run the AP-4032 3-branch
+        verifier (operator | wags | auto). Pass iff verifier accepts;
+        refuse otherwise. The verifier's verdict replaces the previous
+        permissive short-circuit (the bypass AP-4032 closes).
+      - else: run gap_detection.py check-card-completeness. Exit 0
+        passes; non-zero refuses with the prescribed error message.
+
+    The check is intentionally lock-free and side-effect-free (it only
+    reads the evidence chain and the kanban DB). Failures from the
+    subprocess (timeout, missing helper, exception) DEGRADE OPEN — the
+    gate refuses rather than silently passing — because a silent pass
+    would defeat the purpose of the gate.
+
+    `get_task_fn` is the caller-supplied task lookup; passed in to avoid
+    a circular import on hermes_cli.kanban_db (kept inside tools/kanban_tools).
+    """
+    if not gate_required():
+        return None
+    if not task_id:
+        return None
+    try:
+        task = get_task_fn(task_id)
+    except Exception as e:
+        logger.exception("kanban_complete: gate pre-check db lookup failed")
+        return (
+            f"cannot complete {task_id}: AP-4031 gate pre-check could not "
+            f"read task row ({e}); refusing rather than bypassing"
+        )
+    if task is None:
+        # Unknown id — let kb.complete_task surface its own error.
+        return None
+    if (getattr(task, "assignee", "") or "").strip() == GATE_BYPASS_SIGNER:
+        return None
+    skip_reason = (metadata or {}).get("gate_skip_reason") or ""
+    skip_reason = str(skip_reason).strip()
+    if skip_reason:
+        # AP-4032: instead of short-circuiting on the bare field, run the
+        # 3-branch verifier. This closes the bypass that AP-4031 left open
+        # by treating any non-empty gate_skip_reason as a pass.
+        return _gate_skip_check(task_id, task, metadata or {}, skip_reason)
+    helper = _gap_detection_helper()
+    if not helper:
+        return (
+            f"cannot complete {task_id}: AP-4031 gate required but "
+            f"scripts/gap_detection.py not found (set "
+            f"HERMES_GAP_DETECTION_PY to override); see AP-4031"
+        )
+    try:
+        proc = subprocess.run(
+            [sys.executable, helper, "check-card-completeness", task_id],
+            capture_output=True,
+            text=True,
+            timeout=_GATE_CHECK_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        return (
+            f"cannot complete {task_id}: AP-4031 gate check timed out "
+            f"after {_GATE_CHECK_TIMEOUT_S}s; refusing rather than bypassing"
+        )
+    except Exception as e:
+        logger.exception("kanban_complete: gate subprocess failed")
+        return (
+            f"cannot complete {task_id}: AP-4031 gate subprocess error ({e}); "
+            f"refusing rather than bypassing"
+        )
+    if proc.returncode == 0:
+        return None
+    if proc.returncode == 1:
+        return (
+            f"cannot complete {task_id}: no gate_signature evidence entry; "
+            f"see AP-4031 for the gate pattern; operator override via "
+            f"gate_skip_reason + gate_skip_actor fields in metadata (AP-4032)"
+        )
+    return (
+        f"cannot complete {task_id}: gate check error (exit "
+        f"{proc.returncode}): {proc.stderr.strip() or proc.stdout.strip()}"
+    )
+
+
+def _gate_skip_check(
+    task_id: str, task: Any, metadata: dict, skip_reason: str
+) -> Optional[str]:
+    """AP-4032 3-branch gate-skip verifier dispatch.
+
+    Spawns scripts/gate_skip_verifier.py check with the card's role + the
+    skip metadata. On accept, appends a kind=gate_skip evidence entry to
+    the chain (audit trail per ADR §3.2 step 6). The verifier itself
+    does NOT write evidence; the caller invokes _emit_gate_skip_evidence
+    after a positive verdict.
+    """
+    helper = _gate_skip_verifier_helper()
+    if not helper:
+        return (
+            f"cannot complete {task_id}: AP-4032 gate_skip verifier "
+            f"(scripts/gate_skip_verifier.py) not found (set "
+            f"HERMES_GATE_SKIP_VERIFIER_PY to override); see AP-4032"
+        )
+    actor = (metadata.get("gate_skip_actor") or "").strip()
+    cmd = [
+        sys.executable, helper, "check",
+        "--card-id", task_id,
+        "--reason", skip_reason,
+        "--actor", actor or "operator",
+        "--card-role", (getattr(task, "assignee", "") or "").strip(),
+    ]
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True,
+            timeout=_GATE_CHECK_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        return (
+            f"cannot complete {task_id}: AP-4032 gate_skip verifier timed "
+            f"out after {_GATE_CHECK_TIMEOUT_S}s; refusing rather than bypassing"
+        )
+    except Exception as e:
+        logger.exception("kanban_complete: gate_skip verifier subprocess failed")
+        return (
+            f"cannot complete {task_id}: AP-4032 gate_skip verifier "
+            f"subprocess error ({e}); refusing rather than bypassing"
+        )
+    if proc.returncode not in (0, 1):
+        return (
+            f"cannot complete {task_id}: AP-4032 gate_skip verifier error "
+            f"(exit {proc.returncode}): "
+            f"{proc.stderr.strip() or proc.stdout.strip()}"
+        )
+    verdict: dict[str, Any] = {}
+    try:
+        out = proc.stdout.strip()
+        if out:
+            verdict = json.loads(out.splitlines()[-1])
+    except (json.JSONDecodeError, IndexError):
+        verdict = {}
+    accepted = bool(verdict.get("accepted"))
+    if proc.returncode == 0:
+        accepted = True
+    if not accepted:
+        reason = verdict.get("refusal_reason") or (
+            f"AP-4032 gate_skip verifier refused (exit {proc.returncode})"
+        )
+        return (
+            f"cannot complete {task_id}: {reason}"
+        )
+    # Accepted. Emit the audit-trail evidence entry per ADR §3.2 step 6.
+    soft_pass = bool(verdict.get("soft_pass"))
+    rule_id = verdict.get("rule_id")
+    emit_err = _emit_gate_skip_evidence(
+        task_id=task_id,
+        actor=actor or "operator",
+        reason=skip_reason,
+        soft_pass=soft_pass,
+        rule_id=rule_id,
+    )
+    if emit_err:
+        # Audit trail emission failure → degrade open (refuse). Without
+        # the audit entry the skip is invisible to Wags's weekly CNS
+        # review, which is the whole point of AP-4032.
+        return (
+            f"cannot complete {task_id}: AP-4032 gate_skip accepted but "
+            f"audit-trail evidence entry failed to write ({emit_err}); "
+            f"refusing rather than bypassing"
+        )
+    return None
+
+
+def _emit_gate_skip_evidence(
+    *,
+    task_id: str,
+    actor: str,
+    reason: str,
+    soft_pass: bool,
+    rule_id: Optional[str],
+) -> Optional[str]:
+    """Append a kind=gate_skip entry to the evidence chain (audit trail
+    per ADR §3.2 step 6). Returns None on success, or an error message
+    on failure.
+
+    Uses the same evidence_chain.py helper as everything else. The
+    summary includes the soft-pass / rule_id markers so downstream
+    auditors (Wags weekly CNS review) can see at a glance which skip
+    path authorised this close.
+    """
+    ws = os.environ.get("AOS_WORKSPACE", "").strip()
+    candidates: list[str] = []
+    if ws:
+        candidates.append(os.path.join(ws, "scripts", "evidence_chain.py"))
+    here = os.path.dirname(os.path.abspath(__file__))
+    candidates.append(
+        os.path.abspath(
+            os.path.join(here, "..", "..", "scripts", "evidence_chain.py")
+        )
+    )
+    ev_helper = next((c for c in candidates if os.path.isfile(c)), "")
+    if not ev_helper:
+        return "scripts/evidence_chain.py not found in workspace or sibling path"
+    summary_parts = [f"gate_skip accepted for {task_id}"]
+    if soft_pass:
+        summary_parts.append("[operator soft-pass: AP-NNNN-A not yet shipped]")
+    if rule_id:
+        summary_parts.append(f"[rule_id={rule_id}]")
+    summary = " ".join(summary_parts)
+    cmd = [
+        sys.executable, ev_helper, "append",
+        "--kind", "gate_skip",
+        "--actor", actor,
+        "--gate-skip-reason", reason,
+        "--gate-skip-actor", actor,
+        "--card-id", task_id,
+        "--summary", summary[:400],
+    ]
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True,
+            timeout=_GATE_CHECK_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        return f"evidence_chain.py append timed out after {_GATE_CHECK_TIMEOUT_S}s"
+    except Exception as e:
+        return f"evidence_chain.py append subprocess error: {e}"
+    if proc.returncode != 0:
+        return (
+            f"evidence_chain.py append failed (exit {proc.returncode}): "
+            f"{proc.stderr.strip() or proc.stdout.strip()}"
+        )
+    return None

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -36,6 +36,8 @@ from typing import Any, Optional
 from agent.redact import redact_sensitive_text
 from tools.registry import registry, tool_error
 from hermes_cli.config import cfg_get, load_config
+from tools.kanban_gate import gate_pre_check  # AP-4031+AP-4032
+from tools.kanban_dispatch_gate import dispatch_gate_pre_check  # AP-4033
 
 logger = logging.getLogger(__name__)
 
@@ -129,6 +131,20 @@ def _stamp_worker_session_metadata(
     stamped = dict(metadata or {})
     stamped["worker_session_id"] = session_id
     return stamped
+
+
+def _lookup_task_for_gate(tid: str):
+    """AP-4031: task lookup used by the gate pre-check. Returns the
+    task row (with .assignee attribute) or None. Implemented as a thin
+    wrapper over _connect + kb.get_task so the gate module does not
+    import hermes_cli.kanban_db directly (keeps tools/kanban_gate.py
+    free of internal dependencies).
+    """
+    kb, conn = _connect()
+    try:
+        return kb.get_task(conn, tid)
+    finally:
+        conn.close()
 
 
 def _enforce_worker_task_ownership(tid: str) -> Optional[str]:
@@ -562,6 +578,16 @@ def _handle_complete(args: dict, **kw) -> str:
             f"metadata must be an object/dict, got {type(metadata).__name__}"
         )
     metadata = _stamp_worker_session_metadata(tid, metadata)
+    # AP-4031+AP-4032: mechanical kanban-complete gate. Ships disabled
+    # (HERMES_KANBAN_GATE_REQUIRED=0 default per BC-9); when enabled,
+    # refuses non-wags cards without a gate_signature evidence entry.
+    # Operator override via gate_skip_reason + gate_skip_actor metadata.
+    # See docs/migration-notes/ap-4031-kanban-gate-2026-06-24.md.
+    gate_err = gate_pre_check(
+        tid, metadata or {}, lambda t: _lookup_task_for_gate(t)
+    )
+    if gate_err:
+        return tool_error(gate_err)
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
@@ -807,6 +833,20 @@ def _handle_create(args: dict, **kw) -> str:
                     if _self_task is not None and _self_task.workspace_kind:
                         workspace_kind = _self_task.workspace_kind
                         workspace_path = _self_task.workspace_path
+            # AP-4033: mechanical kanban-create dispatch gate. Ships
+            # disabled (HERMES_KANBAN_DISPATCH_GATE=0 default per BC-9);
+            # when enabled, refuses unless the caller's HERMES_PROFILE
+            # is in HERMES_KANBAN_DISPATCHERS (default ['operator']) or
+            # the card metadata carries a dispatch_override + reason for
+            # the 3-branch verifier. See docs/migration-notes/
+            # ap-4033-kanban-dispatch-2026-06-24.md.
+            dispatch_gate_err = dispatch_gate_pre_check(
+                card_metadata=args.get("metadata") or {},
+                caller_profile=os.environ.get("HERMES_PROFILE", "").strip() or None,
+                has_dispatch_entry=False,  # new card; no prior entry exists
+            )
+            if dispatch_gate_err:
+                return tool_error(dispatch_gate_err)
             new_tid = kb.create_task(
                 conn,
                 title=str(title).strip(),


### PR DESCRIPTION
## Summary

Carries commit `5cb3e9e7d` from `suckfish21/hermes-agent-1` (fork) to NousResearch/hermes-agent `main`. Combined surgical merge of:

- **AP-4033** — verified-dispatch on kanban-create (dispatch-side mirror of the close-side gate)
- **AP-4031 + AP-4032** — mechanical kanban-complete gate (close-side, plus 3-branch gate-skip verifier)

Both APs already shipped to totum-src main:
- AP-4031+AP-4032 at `46ecfa711`
- AP-4033 at `262965595`

Production already live via `pipx install --force` (operator MacBook-Pro) — see ADR/migration note below.

## What's in the merge

3 files / +650 LOC. BC-9 additive — both gates ship **disabled by default** (`HERMES_KANBAN_GATE_REQUIRED=0`, `HERMES_KANBAN_DISPATCH_GATE=0`). Existing fleet behaviour is unchanged until the operator explicitly opts in per the 14-day observation window.

### `tools/kanban_gate.py` (NEW, 348 LOC)
- `_gap_detection_helper` / `_gate_skip_verifier_helper` subprocess lookup with `AOS_WORKSPACE` + sibling-repo fallback
- `gate_pre_check` — close-side gate, called from `_handle_complete` after metadata stamping and before `kb.complete_task`
- `_gate_skip_check` + `_emit_gate_skip_evidence` — AP-4032 3-branch verifier dispatch + audit-trail evidence emission
- **Trust-boundary fix**: `HERMES_PROFILE=wags` write-side gate on `gate_skip_authorisation` + function-local read-side check in verifier (mirrors the F-1 fix from totum-src commit `ca2f72105`)

### `tools/kanban_dispatch_gate.py` (NEW, 262 LOC)
- Symmetric mirror of `kanban_gate.py` for the dispatch side
- `DISPATCHERS_ENV` defaults to `['operator']`; `APPROVERS_ENV` defaults to `['wags']` (separate from dispatchers — operators dispatch, wags approves auto-rules)
- `dispatch_gate_pre_check` — called from `_handle_create` before the create transaction
- `_dispatch_override_check` — AP-4033 3-branch verifier

### `tools/kanban_tools.py` (+40 LOC)
- Import both gate modules
- Add `_lookup_task_for_gate` helper so the gate modules stay free of internal imports
- Wire `gate_pre_check` into `_handle_complete`, `dispatch_gate_pre_check` into `_handle_create`

## Trust boundary (per WAGS post-build review)

- Close-side: only `HERMES_PROFILE=wags` may emit `gate_skip_authorisation` evidence. Function-local env-var lookup defeats test-fixture staleness.
- Dispatch-side: `HERMES_KANBAN_DISPATCHERS` env-gates `dispatch`, `dispatch_override`, `spawn_refused` writes (default `['operator']`). `dispatch_override_authorisation` requires `HERMES_PROFILE=wags`.
- WAGS intentionally excluded from dispatchers list (reviewer/auditor role; including them would defeat the close-side `HERMES_PROFILE=wags` trust boundary).

## Why surgical merge onto current main tip

The original hermes-agent feature branches (`feat/ap-4032-gate-skip-verifier` + the surgical merge attempt at `74b308edd`) could not be pushed to NousResearch/hermes-agent — operator GitHub account `suckfish21` lacks write access on the upstream repo. This commit re-applies the same code on the current main tip (`88e01d92e`) in the same surgical-split pattern. Operator fork `suckfish21/hermes-agent-1` is ADMIN-permissioned and carries the branch.

## Tests

- 90/90 hermes-agent kanban tools green
- 150/150 totum-src evidence-chain + dispatch-gate + close-side regression tests green (referenced in WAGS post-build review)
- ADR §6 deviations accepted by WAGS: F-num corrected 26→52 (F26 already taken); `HERMES_KANBAN_DISPATCH_APPROVERS` split from `DISPATCHERS` (clean refinement); hermes-agent integration deferred per ADR §6 (same surgical-split pattern)

## Migration

BC-9 migration note on branch (commit `5cb3e9e7d` message body) covers the 14-day observation window before flipping either gate flag. `scripts/audit_grandfathered_dispatches.py` + `scripts/backfill_dispatch_entries.py --dry-run` are operator-signed pre-flip tools.

## References

- ADR: `totum-src/architect/proposals/AP-4033_verified_dispatch_on_kanban_create.md`
- Migration note: `totum-src/docs/migration-notes/ap-4033-kanban-dispatch-2026-06-24.md`
- Carrier commit (totum-src AP-4033 main merge): `262965595`
- Carrier commit (totum-src AP-4031+AP-4032 main merge): `46ecfa711`

## Operator sign-off

2026-06-25 — proceed on hermes-agent surgical merge.