### PR TITLE
feat: scaffold profile distributions

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11027,6 +11027,55 @@ def cmd_profile(args):
                     print(f"      default: {er['default']}")
         print()
 
+    elif action == "validate":
+        from hermes_cli.profile_authoring import validate_distribution
+
+        result = validate_distribution(Path(getattr(args, "path", ".")))
+        if result.ok:
+            print(f"Hermes profile distribution validation passed: {result.root}")
+            if result.warnings:
+                for warning in result.warnings:
+                    print(f"WARNING: {warning}")
+            return
+        print("Hermes profile distribution validation failed")
+        for error in result.errors:
+            print(f"ERROR: {error}")
+        for warning in result.warnings:
+            print(f"WARNING: {warning}")
+        sys.exit(1)
+
+    elif action == "scaffold":
+        from hermes_cli.profile_authoring import scaffold_distribution, validate_distribution
+        from hermes_cli.profile_distribution import DistributionError
+
+        try:
+            output = scaffold_distribution(
+                Path(getattr(args, "output")),
+                name=getattr(args, "name", None),
+                description=getattr(args, "description", None),
+                display_name=getattr(args, "display_name", None),
+                author=getattr(args, "author", "Hermes profile author"),
+                params_file=(
+                    Path(getattr(args, "params")).expanduser()
+                    if getattr(args, "params", None)
+                    else None
+                ),
+                force=getattr(args, "force", False),
+            )
+            result = validate_distribution(output)
+            if not result.ok:
+                print(f"Created profile distribution with validation errors: {output}")
+                for error in result.errors:
+                    print(f"ERROR: {error}")
+                sys.exit(1)
+            print(f"Created Hermes profile distribution scaffold: {output}")
+            print("Next steps:")
+            print(f"  hermes profile validate {output}")
+            print(f"  hermes profile install {output} --name {output.name}-local --yes")
+        except (ValueError, FileExistsError, DistributionError) as e:
+            print(f"Error: {e}")
+            sys.exit(1)
+
 
 def _render_distribution_plan(plan) -> None:
     """Print a human-readable summary of a pending distribution install."""

--- a/hermes_cli/profile_authoring.py
+++ b/hermes_cli/profile_authoring.py
@@ -1,0 +1,365 @@
+"""Developer authoring helpers for Hermes profile distributions.
+
+This module is intentionally CLI-shaped rather than agent-tool-shaped. It helps
+profile authors produce and check installable distribution repositories without
+adding anything to the model tool schema.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from hermes_cli.profile_distribution import (
+    DEFAULT_DIST_OWNED,
+    DistributionError,
+    DistributionManifest,
+    MANIFEST_FILENAME,
+    USER_OWNED_EXCLUDE,
+    read_manifest,
+    write_manifest,
+)
+
+_PLACEHOLDER_RE = re.compile(r"{{[a-zA-Z0-9_]+}}")
+_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,62}$")
+_SECRET_PATTERNS = (
+    re.compile(r"ghp_[A-Za-z0-9_]{20,}"),
+    re.compile(r"gho_[A-Za-z0-9_]{20,}"),
+    re.compile(r"sk-[A-Za-z0-9]{20,}"),
+    re.compile(r"xox[baprs]-[A-Za-z0-9-]{20,}"),
+    re.compile(r"AKIA[0-9A-Z]{16}"),
+)
+_FORBIDDEN_DIR_NAMES = USER_OWNED_EXCLUDE | {
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+    "htmlcov",
+    "dist",
+    "build",
+}
+_FORBIDDEN_FILE_NAMES = {".coverage", "coverage.xml"}
+_BINARY_SUFFIXES = {".png", ".jpg", ".jpeg", ".gif", ".pdf", ".ico"}
+
+
+@dataclass
+class ValidationResult:
+    """Profile distribution validation outcome."""
+
+    root: Path
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+
+def slugify(value: str) -> str:
+    """Return a distribution-safe kebab-case slug."""
+    value = value.strip().lower()
+    value = re.sub(r"[^a-z0-9]+", "-", value)
+    value = re.sub(r"-+", "-", value).strip("-")
+    if not value:
+        raise ValueError("name must contain at least one alphanumeric character")
+    return value
+
+
+def _load_yaml(path: Path) -> Any:
+    try:
+        import yaml
+    except ImportError as exc:  # pragma: no cover
+        raise DistributionError("PyYAML is required for profile authoring") from exc
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _dump_yaml(data: Any) -> str:
+    import yaml
+    return yaml.safe_dump(data, sort_keys=False, default_flow_style=False)
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content.rstrip() + "\n", encoding="utf-8")
+
+
+def _as_list(value: Any, default: list[str] | None = None) -> list[str]:
+    if value is None:
+        return list(default or [])
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    text = str(value).strip()
+    return [text] if text else list(default or [])
+
+
+def _render_soul(display_name: str, description: str, params: dict[str, Any]) -> str:
+    principles = _as_list(params.get("principles"), [
+        "Use tools when they materially improve correctness.",
+        "Keep user data private and never expose secrets.",
+        "Verify important claims with evidence.",
+    ])
+    scope = _as_list(params.get("scope"), [description, "Produce clear, actionable outputs."])
+    lines = [
+        f"# {display_name}",
+        "",
+        f"You are {display_name}, a focused Hermes Agent profile.",
+        "",
+        "## Mission",
+        "",
+        description,
+        "",
+        "## First principles",
+        "",
+    ]
+    lines.extend(f"{idx}. {item}" for idx, item in enumerate(principles, 1))
+    lines.extend(["", "## Scope", ""])
+    lines.extend(f"- {item}" for item in scope)
+    lines.extend([
+        "",
+        "## Safety",
+        "",
+        "Refuse credential theft, hidden persistence, secret exposure, fabricated facts, and unsafe destructive actions without explicit user approval.",
+    ])
+    return "\n".join(lines)
+
+
+def _render_config(params: dict[str, Any]) -> str:
+    return _dump_yaml({
+        "model": {
+            "provider": str(params.get("model_provider") or "openrouter"),
+            "default": str(params.get("model_default") or "anthropic/claude-sonnet-4"),
+        },
+        "toolsets": _as_list(params.get("toolsets"), ["file", "terminal", "skills", "web"]),
+        "agent": {"max_turns": int(params.get("max_turns") or 90), "tool_use_enforcement": True},
+        "memory": {"memory_enabled": True, "user_profile_enabled": True},
+        "security": {"redact_secrets": True},
+        "approvals": {"mode": "manual"},
+    })
+
+
+def _render_env_example(params: dict[str, Any]) -> str:
+    lines = ["# Copy this file to .env and fill in real values.", "# Never commit .env.", ""]
+    env_requires = params.get("env_requires") or []
+    if not env_requires:
+        lines.append("# Add profile-specific environment variables here when needed.")
+    for item in env_requires:
+        if not isinstance(item, dict) or not item.get("name"):
+            raise ValueError("each env_requires item must be a mapping with name")
+        required = bool(item.get("required", True))
+        lines.append(f"# {item.get('description') or 'Required by this profile'}")
+        lines.append(f"# {'required' if required else 'optional'}")
+        prefix = "" if required else "# "
+        lines.append(f"{prefix}{item['name']}={item.get('default') or ''}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _render_readme(slug: str, display_name: str, description: str) -> str:
+    return f"""# {display_name}
+
+{description}
+
+This is a Hermes Agent profile distribution. It can be installed with `hermes profile install` and updated from git.
+
+## Install
+
+```bash
+hermes profile install github.com/YOUR_ORG/{slug} --alias
+hermes -p {slug} chat
+```
+
+## Local authoring checks
+
+```bash
+hermes profile validate .
+hermes profile install . --name {slug}-local --yes
+```
+
+## Safety
+
+Do not commit `.env`, credentials, memories, sessions, logs, runtime databases, or user data.
+"""
+
+
+def scaffold_distribution(
+    output: Path,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+    display_name: str | None = None,
+    author: str = "Hermes profile author",
+    params_file: Path | None = None,
+    force: bool = False,
+) -> Path:
+    """Create a starter profile distribution repository."""
+    params: dict[str, Any] = {}
+    if params_file is not None:
+        loaded = _load_yaml(params_file)
+        if not isinstance(loaded, dict):
+            raise ValueError("params file must contain a YAML mapping")
+        params.update(loaded)
+
+    raw_name = name or params.get("name")
+    if not raw_name:
+        raise ValueError("profile scaffold requires a name or params.name")
+    slug = slugify(str(raw_name))
+    desc = str(description or params.get("description") or "").strip()
+    if not desc:
+        raise ValueError("profile scaffold requires --description or params.description")
+    pretty = display_name or str(params.get("display_name") or slug.replace("-", " ").title())
+
+    if output.exists():
+        if not force:
+            raise FileExistsError(f"output exists. Pass --force to overwrite: {output}")
+        shutil.rmtree(output)
+    output.mkdir(parents=True)
+
+    manifest = DistributionManifest(
+        name=slug,
+        version=str(params.get("version") or "0.1.0"),
+        description=desc,
+        hermes_requires=str(params.get("hermes_requires") or ">=0.12.0"),
+        author=str(params.get("author") or author),
+        license=str(params.get("license") or "MIT"),
+        distribution_owned=list(DEFAULT_DIST_OWNED) + ["README.md", "AGENTS.md", "CONTRIBUTING.md", "SECURITY.md", ".env.EXAMPLE"],
+    )
+    env_requires = params.get("env_requires") or []
+    if env_requires:
+        from hermes_cli.profile_distribution import EnvRequirement
+        manifest.env_requires = [EnvRequirement.from_dict(item) for item in env_requires]
+
+    write_manifest(output, manifest)
+    _write(output / "SOUL.md", _render_soul(pretty, desc, params))
+    _write(output / "config.yaml", _render_config(params))
+    _write(output / "mcp.json", json.dumps({"mcpServers": {}}, indent=2))
+    _write(output / ".env.EXAMPLE", _render_env_example(params))
+    _write(output / "README.md", _render_readme(slug, pretty, desc))
+    _write(output / "AGENTS.md", "# Agent Instructions\n\nRun `hermes profile validate .` after substantive edits. Never commit secrets.")
+    _write(output / "CONTRIBUTING.md", "# Contributing\n\nRun `hermes profile validate .` and a local install smoke test before publishing changes.")
+    _write(output / "SECURITY.md", "# Security\n\nNever commit `.env`, `auth.json`, sessions, memories, logs, or runtime databases.")
+    _write(output / ".gitignore", ".env\nauth.json\nstate.db*\nsessions/\nmemories/\nlogs/\nworkspace/\nplans/\nlocal/\ncache/\n__pycache__/\n*.pyc\n.DS_Store\n")
+    _write(output / "skills" / "README.md", "# Bundled skills\n\nAdd profile-specific skills here. Each skill should live in a directory containing `SKILL.md`.")
+    _write(output / "cron" / "README.md", "# Cron jobs\n\nAdd distribution-owned scheduled job definitions here when this profile needs them.")
+    _write(output / "templates" / "profile.params.yaml", _dump_yaml({
+        "name": slug,
+        "display_name": pretty,
+        "description": desc,
+        "author": str(params.get("author") or author),
+        "version": manifest.version,
+        "license": manifest.license,
+        "model_provider": params.get("model_provider") or "openrouter",
+        "model_default": params.get("model_default") or "anthropic/claude-sonnet-4",
+        "toolsets": _as_list(params.get("toolsets"), ["file", "terminal", "skills", "web"]),
+        "env_requires": env_requires,
+    }))
+    return output
+
+
+def _iter_validation_files(root: Path) -> list[Path]:
+    return [path for path in root.rglob("*") if path.is_file() and ".git" not in path.parts]
+
+
+def validate_distribution(root: Path) -> ValidationResult:
+    """Validate a profile distribution authoring tree."""
+    root = root.resolve()
+    result = ValidationResult(root=root)
+    if not root.exists():
+        result.errors.append(f"path does not exist: {root}")
+        return result
+    if not root.is_dir():
+        result.errors.append(f"path is not a directory: {root}")
+        return result
+
+    try:
+        raw_manifest = (
+            _load_yaml(root / MANIFEST_FILENAME)
+            if (root / MANIFEST_FILENAME).exists()
+            else None
+        )
+        manifest = read_manifest(root)
+    except Exception as exc:
+        result.errors.append(f"invalid {MANIFEST_FILENAME}: {exc}")
+        raw_manifest = None
+        manifest = None
+    if manifest is None:
+        result.errors.append(f"missing required file: {MANIFEST_FILENAME}")
+    else:
+        if isinstance(raw_manifest, dict):
+            for key in ("name", "version", "description"):
+                if not str(raw_manifest.get(key) or "").strip():
+                    result.errors.append(f"distribution.yaml missing required field: {key}")
+        if not _NAME_RE.fullmatch(manifest.name):
+            result.errors.append("distribution.yaml name must be lowercase kebab case")
+        if not manifest.version.strip():
+            result.errors.append("distribution.yaml missing required field: version")
+        if not manifest.description.strip():
+            result.errors.append("distribution.yaml missing required field: description")
+        for rel in manifest.owned_paths():
+            if not (root / rel.rstrip("/")).exists():
+                result.errors.append(f"distribution_owned path does not exist: {rel}")
+        env_example = (root / ".env.EXAMPLE").read_text(encoding="utf-8") if (root / ".env.EXAMPLE").exists() else ""
+        for req in manifest.env_requires:
+            if req.name not in env_example:
+                result.errors.append(f"env var {req.name} is declared but missing from .env.EXAMPLE")
+
+    for required in ("SOUL.md", "README.md", "config.yaml", ".env.EXAMPLE"):
+        if not (root / required).is_file():
+            result.errors.append(f"missing recommended distribution file: {required}")
+
+    files = _iter_validation_files(root)
+    for path in files:
+        rel = path.relative_to(root)
+        for parent in rel.parents:
+            if str(parent) != "." and parent.name in _FORBIDDEN_DIR_NAMES:
+                result.errors.append(f"runtime or cache directory must not be committed: {parent}")
+        if path.name in _FORBIDDEN_FILE_NAMES or path.name in USER_OWNED_EXCLUDE:
+            result.errors.append(f"user-owned runtime file must not be committed: {rel}")
+        if path.suffix.lower() in {".json"}:
+            try:
+                json.loads(path.read_text(encoding="utf-8"))
+            except Exception as exc:
+                result.errors.append(f"invalid JSON in {rel}: {exc}")
+        if path.suffix.lower() in {".yaml", ".yml"} or path.name == MANIFEST_FILENAME:
+            try:
+                _load_yaml(path)
+            except Exception as exc:
+                result.errors.append(f"invalid YAML in {rel}: {exc}")
+        if path.suffix.lower() in _BINARY_SUFFIXES:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        if "templates" not in rel.parts and _PLACEHOLDER_RE.search(text):
+            result.errors.append(f"unresolved template placeholder in {rel}")
+        for pattern in _SECRET_PATTERNS:
+            if pattern.search(text):
+                result.errors.append(f"possible secret pattern in {rel}")
+
+    skills_dir = root / "skills"
+    if skills_dir.is_dir():
+        for skill_md in skills_dir.rglob("SKILL.md"):
+            rel = skill_md.relative_to(root)
+            text = skill_md.read_text(encoding="utf-8")
+            if not text.startswith("---\n"):
+                result.errors.append(f"skill missing YAML frontmatter: {rel}")
+                continue
+            parts = text.split("---", 2)
+            if len(parts) < 3:
+                result.errors.append(f"skill frontmatter not closed: {rel}")
+                continue
+            try:
+                import yaml
+                meta = yaml.safe_load(parts[1]) or {}
+            except Exception as exc:
+                result.errors.append(f"invalid skill frontmatter in {rel}: {exc}")
+                continue
+            if not meta.get("name"):
+                result.errors.append(f"skill {rel} missing frontmatter field: name")
+            if not meta.get("description"):
+                result.errors.append(f"skill {rel} missing frontmatter field: description")
+    return result

--- a/hermes_cli/subcommands/profile.py
+++ b/hermes_cli/subcommands/profile.py
@@ -200,4 +200,59 @@ def build_profile_parser(subparsers, *, cmd_profile: Callable) -> None:
     )
     profile_info.add_argument("profile_name", help="Profile to inspect")
 
+    profile_validate = profile_subparsers.add_parser(
+        "validate",
+        help="Validate a profile distribution authoring directory",
+        description=(
+            "Validate a profile distribution before publishing. PATH defaults "
+            "to the current directory and must contain distribution.yaml."
+        ),
+    )
+    profile_validate.add_argument(
+        "path",
+        nargs="?",
+        default=".",
+        help="Distribution directory to validate (default: current directory)",
+    )
+
+    profile_scaffold = profile_subparsers.add_parser(
+        "scaffold",
+        help="Create a starter profile distribution repository",
+        description=(
+            "Create a starter Hermes profile distribution repository for authors. "
+            "This is a proof-of-concept developer workflow, not a profile catalog."
+        ),
+    )
+    profile_scaffold.add_argument("name", nargs="?", help="Distribution profile name")
+    profile_scaffold.add_argument(
+        "--description",
+        default=None,
+        help="One-sentence description of the profile's purpose",
+    )
+    profile_scaffold.add_argument(
+        "--display-name",
+        default=None,
+        help="Human-readable profile name (default: title-cased name)",
+    )
+    profile_scaffold.add_argument(
+        "--author",
+        default="Hermes profile author",
+        help="Author name written to distribution.yaml",
+    )
+    profile_scaffold.add_argument(
+        "--params",
+        default=None,
+        help="YAML params file for deterministic scaffold generation",
+    )
+    profile_scaffold.add_argument(
+        "--output",
+        required=True,
+        help="Output directory for the scaffolded distribution",
+    )
+    profile_scaffold.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite output directory if it already exists",
+    )
+
     profile_parser.set_defaults(func=cmd_profile)

--- a/tests/hermes_cli/test_profile_authoring.py
+++ b/tests/hermes_cli/test_profile_authoring.py
@@ -1,0 +1,113 @@
+"""Tests for profile distribution authoring helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.profile_authoring import (
+    scaffold_distribution,
+    slugify,
+    validate_distribution,
+)
+from hermes_cli.profile_distribution import read_manifest
+
+
+@pytest.fixture()
+def profile_env(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    default_home = tmp_path / ".hermes"
+    default_home.mkdir(exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    return tmp_path
+
+
+class TestScaffoldDistribution:
+    def test_scaffold_creates_valid_distribution(self, profile_env):
+        out = profile_env / "sql-reviewer"
+        scaffold_distribution(
+            out,
+            name="SQL Reviewer",
+            description="Reviews SQL migrations and writes rollback checklists.",
+            author="Example Team",
+        )
+
+        manifest = read_manifest(out)
+        assert manifest is not None
+        assert manifest.name == "sql-reviewer"
+        assert manifest.description == "Reviews SQL migrations and writes rollback checklists."
+        assert (out / "SOUL.md").is_file()
+        assert (out / "config.yaml").is_file()
+        assert (out / "mcp.json").is_file()
+        assert (out / ".env.EXAMPLE").is_file()
+        assert (out / "templates" / "profile.params.yaml").is_file()
+        assert validate_distribution(out).ok
+
+    def test_scaffold_from_params_file(self, profile_env):
+        params = profile_env / "params.yaml"
+        params.write_text(
+            "name: migration-guard\n"
+            "display_name: Migration Guard\n"
+            "description: Flags destructive database migrations.\n"
+            "env_requires:\n"
+            "  - name: DATABASE_URL\n"
+            "    description: Optional database URL.\n"
+            "    required: false\n",
+            encoding="utf-8",
+        )
+        out = profile_env / "out"
+        scaffold_distribution(out, params_file=params)
+
+        manifest = read_manifest(out)
+        assert manifest is not None
+        assert manifest.name == "migration-guard"
+        assert manifest.env_requires[0].name == "DATABASE_URL"
+        assert "DATABASE_URL" in (out / ".env.EXAMPLE").read_text(encoding="utf-8")
+        assert validate_distribution(out).ok
+
+    def test_scaffold_refuses_existing_output_without_force(self, profile_env):
+        out = profile_env / "existing"
+        out.mkdir()
+        with pytest.raises(FileExistsError):
+            scaffold_distribution(out, name="x", description="desc")
+
+
+class TestValidateDistribution:
+    def test_validate_rejects_missing_manifest(self, tmp_path):
+        result = validate_distribution(tmp_path)
+        assert not result.ok
+        assert any("missing required file: distribution.yaml" in err for err in result.errors)
+
+    def test_validate_rejects_runtime_files(self, profile_env):
+        out = profile_env / "profile"
+        scaffold_distribution(out, name="runtime-test", description="Runtime test profile.")
+        (out / ".env").write_text("SECRET=1\n", encoding="utf-8")
+        (out / "sessions").mkdir()
+        (out / "sessions" / "session.json").write_text("{}\n", encoding="utf-8")
+
+        result = validate_distribution(out)
+        assert not result.ok
+        assert any(".env" in err for err in result.errors)
+        assert any("sessions" in err for err in result.errors)
+
+    def test_validate_rejects_skill_without_frontmatter(self, profile_env):
+        out = profile_env / "profile"
+        scaffold_distribution(out, name="skill-test", description="Skill test profile.")
+        skill = out / "skills" / "bad" / "SKILL.md"
+        skill.parent.mkdir(parents=True)
+        skill.write_text("# Missing frontmatter\n", encoding="utf-8")
+
+        result = validate_distribution(out)
+        assert not result.ok
+        assert any("frontmatter" in err for err in result.errors)
+
+
+class TestSlugify:
+    def test_slugify_normalizes_names(self):
+        assert slugify("SQL Migration Reviewer") == "sql-migration-reviewer"
+        assert slugify("  A__B  ") == "a-b"
+
+    def test_slugify_rejects_empty(self):
+        with pytest.raises(ValueError):
+            slugify("!!!")

--- a/website/docs/reference/profile-commands.md
+++ b/website/docs/reference/profile-commands.md
@@ -29,6 +29,8 @@ Top-level command for managing profiles. Running `hermes profile` without a subc
 | `install` | Install a profile distribution from a git URL or local directory. See [Profile Distributions](../user-guide/profile-distributions.md). |
 | `update` | Re-pull a distribution-managed profile and re-apply its bundle. |
 | `info` | Show distribution metadata for a profile (origin URL, commit, last update). |
+| `validate` | Validate a profile distribution authoring directory before publishing. |
+| `scaffold` | Create a starter profile distribution repository. |
 
 ## `hermes profile list`
 
@@ -442,8 +444,67 @@ Authoring a distribution is just a git push:
    GitLab / any host Hermes can clone from.
 3. Tell recipients to run `hermes profile install <your-repo-url>`.
 
-Use git tags for versioned releases — recipients who clone `HEAD` get your
+Use git tags for versioned releases. Recipients who clone `HEAD` get your
 latest state, and you can always bump `version:` in the manifest.
+
+### `hermes profile validate`
+
+```bash
+hermes profile validate [path]
+```
+
+Validates a profile distribution authoring directory before publishing it.
+`path` defaults to the current directory and must contain `distribution.yaml`.
+
+The validator checks for common authoring mistakes:
+
+- missing or invalid `distribution.yaml`
+- invalid YAML or JSON
+- missing recommended files such as `SOUL.md`, `README.md`, `config.yaml`, and `.env.EXAMPLE`
+- declared env vars that are missing from `.env.EXAMPLE`
+- `distribution_owned` paths that do not exist
+- committed runtime or user-owned files such as `.env`, `auth.json`, `state.db*`, `sessions/`, `memories/`, `logs/`, `workspace/`, `plans/`, and `local/`
+- bundled skills with missing or invalid `SKILL.md` frontmatter
+- unresolved `{{placeholder}}` tokens outside template directories
+
+Example:
+
+```bash
+cd ./my-profile-distribution
+hermes profile validate .
+```
+
+### `hermes profile scaffold`
+
+```bash
+hermes profile scaffold [name] --description "..." --output ./my-profile
+```
+
+Creates a starter profile distribution repository for developers who want to
+publish installable profiles faster. This is an authoring workflow, not a
+profile catalog or gallery.
+
+Examples:
+
+```bash
+hermes profile scaffold sql-migration-reviewer \
+  --description "Reviews SQL migrations and writes rollback checklists." \
+  --output ./sql-migration-reviewer
+
+hermes profile scaffold --params profile.params.yaml --output ./my-profile
+```
+
+Generated repositories include a starter `distribution.yaml`, `SOUL.md`,
+`config.yaml`, `mcp.json`, `.env.EXAMPLE`, README, contribution and security
+docs, safe `.gitignore`, a `skills/` directory, and a reusable
+`templates/profile.params.yaml` file.
+
+After scaffolding, run:
+
+```bash
+hermes profile validate ./sql-migration-reviewer
+hermes profile install ./sql-migration-reviewer --name sql-migration-reviewer-local --yes
+```
 
 ## `hermes -p` / `hermes --profile`
 


### PR DESCRIPTION
## Summary

Draft proof of concept for #52598.

This adds a first-party developer authoring workflow for profile distributions:

- `hermes profile scaffold [name] --description ... --output <dir>`
- `hermes profile scaffold --params profile.params.yaml --output <dir>`
- `hermes profile validate [path]`

The implementation is intentionally CLI-only. It does not add any model tools or prompt surface. It builds on the existing profile distribution runtime in `hermes_cli/profile_distribution.py`.

## What this includes

- New `hermes_cli/profile_authoring.py` module for scaffold and validate helpers.
- CLI parser wiring under `hermes profile`.
- `cmd_profile` handlers for scaffold and validate.
- Unit tests for scaffolding, params-driven generation, validation, runtime-file rejection, skill-frontmatter checks, and slug normalization.
- Profile command docs for the new authoring workflow.

## Why draft

This is a proof of concept to start the product/API discussion. The exact command naming, generated file set, validation strictness, and whether this should live in core versus an official starter repo are all open for maintainer direction.

## Validation

```text
python3 -m py_compile hermes_cli/profile_authoring.py hermes_cli/subcommands/profile.py hermes_cli/main.py tests/hermes_cli/test_profile_authoring.py
python3 -m pytest tests/hermes_cli/test_profile_authoring.py tests/hermes_cli/test_profile_distribution.py tests/hermes_cli/test_subcommands_profile_gateway.py -q -o 'addopts='
```

Result:

```text
83 passed, 31 warnings in 0.82s
```

Manual CLI smoke:

```text
HERMES_HOME="$tmp" python3 -m hermes_cli.main profile scaffold sql-reviewer --description 'Reviews SQL migrations and writes rollback checklists.' --output "$out"
HERMES_HOME="$tmp" python3 -m hermes_cli.main profile validate "$out"
HERMES_HOME="$tmp" python3 -m hermes_cli.main profile install "$out" --name sql-reviewer-local --yes
```

Result:

```text
Created Hermes profile distribution scaffold: /tmp/hermes-authoring-out.4bmkzk/sql-reviewer
Hermes profile distribution validation passed: /private/tmp/hermes-authoring-out.4bmkzk/sql-reviewer
Installed 'sql-reviewer-local' v0.1.0
```

Closes #52598 if accepted.
