### PR TITLE
fix(cron-test): isolate claim_job_for_fire store from the real jobs.json

### DIFF
--- a/tests/cron/test_claim_job_for_fire.py
+++ b/tests/cron/test_claim_job_for_fire.py
@@ -12,9 +12,20 @@ import pytest
 
 @pytest.fixture
 def temp_home(tmp_path, monkeypatch):
-    """Isolated HERMES_HOME so jobs.json doesn't touch the real store."""
+    """Isolated cron store so jobs.json doesn't touch the real one.
+
+    cron.jobs resolves HERMES_HOME ONCE at import (JOBS_FILE/CRON_DIR are
+    module-level constants — see cron/jobs.py:59-61). By the time this fixture
+    runs, the module is already imported with the real HERMES_HOME, so merely
+    setenv-ing HERMES_HOME is too late and create_job() would write to the REAL
+    ~/.hermes/cron/jobs.json (this leaked junk t/o/p/s/c jobs into production
+    when the suite ran on the live host). Patch the frozen module constants
+    directly — the same isolation pattern sibling tests use (test_jobs.py /
+    test_cron_workdir.py tmp_cron_dir). setenv is kept for any live reads."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    # cron.jobs caches no home at import; get_hermes_home() reads the env live.
+    monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
     yield tmp_path
 
 


### PR DESCRIPTION
## Problem

`tests/cron/test_claim_job_for_fire.py` writes recurring junk jobs (`t`, `o`,
`p`, `s`, `c` — `prompt="x"`, `schedule="every 5m"`) into the **real**
`~/.hermes/cron/jobs.json` when the suite runs on a host that has a live cron
store. After a run, those jobs persist and start firing every 5 minutes.

## Root cause

`cron/jobs.py` resolves the store path **once at import** as module-level
constants:

```python
# cron/jobs.py
HERMES_DIR = get_hermes_home().resolve()
CRON_DIR   = HERMES_DIR / "cron"
JOBS_FILE  = CRON_DIR / "jobs.json"
```

The `temp_home` fixture only did `monkeypatch.setenv("HERMES_HOME", ...)`, with
a comment asserting *"cron.jobs caches no home at import; get_hermes_home()
reads the env live."* That premise is false: by the time the fixture runs,
`cron.jobs` is already imported (another test triggers it first) and `JOBS_FILE`
is frozen against the real `HERMES_HOME`. So `create_job(...)` in these tests
writes to the production store, not the temp dir.

This surfaced after #51116 (revert cron storage to per-profile) reintroduced the
module-level constant pattern; before that the path resolved per-call and the
fixture happened to work.

## Fix

Patch the frozen module constants directly — the exact isolation pattern the
sibling fixtures already use (`tests/cron/test_jobs.py` and
`test_cron_workdir.py` `tmp_cron_dir`):

```python
monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
```

Test-only change; no production code touched.

## Verification

- `pytest tests/cron/test_claim_job_for_fire.py` → 6 passed.
- Full `tests/cron/` suite (543 passed) now leaks **zero** jobs into the real
  store. Before the fix, running the suite on a live host added 5 junk jobs to
  `~/.hermes/cron/jobs.json`.
