### PR TITLE
fix(ollama): preserve cloud model suffixes in picker

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3604,14 +3604,15 @@ def fetch_ollama_cloud_models(
         seen: set[str] = set()
         merged: list[str] = []
         for m in live_models:
-            if m and m not in seen:
-                seen.add(m)
+            normalized = _strip_ollama_cloud_suffix(m)
+            if normalized and normalized not in seen:
+                seen.add(normalized)
                 merged.append(m)
         for m in mdev_models:
             normalized = _strip_ollama_cloud_suffix(m)
             if normalized and normalized not in seen:
                 seen.add(normalized)
-                merged.append(normalized)
+                merged.append(m)
         if merged:
             _save_ollama_cloud_cache(merged)
             return merged

--- a/tests/hermes_cli/test_ollama_cloud_provider.py
+++ b/tests/hermes_cli/test_ollama_cloud_provider.py
@@ -266,10 +266,10 @@ class TestOllamaCloudMergedDiscovery:
         # Make the cache appear stale by backdating it
         import json
         cache_path = tmp_path / "ollama_cloud_models_cache.json"
-        with open(cache_path) as f:
+        with open(cache_path, encoding="utf-8") as f:
             data = json.load(f)
         data["cached_at"] = 0  # epoch = very stale
-        with open(cache_path, "w") as f:
+        with open(cache_path, "w", encoding="utf-8") as f:
             json.dump(data, f)
 
         with patch("hermes_cli.models.fetch_api_models", return_value=None), \
@@ -400,17 +400,17 @@ class TestOllamaCloudProvidersNew:
         assert pdef.transport == "openai_chat"
 
 
-# ── Cloud Suffix Stripping ──
+# ── Cloud Suffix Deduplication ──
 
-class TestOllamaCloudSuffixStripping:
-    """models.dev appends :cloud / -cloud suffixes that the live API omits.
+class TestOllamaCloudSuffixDeduplication:
+    """models.dev may include :cloud / -cloud suffixes for Ollama Cloud IDs.
 
-    fetch_ollama_cloud_models() must normalise these before the dedup merge so
-    users never see broken IDs like 'kimi-k2.6:cloud' in the model picker.
+    fetch_ollama_cloud_models() uses normalized IDs only for deduplication so
+    the picker keeps the actual cloud model ID when models.dev is the source.
     """
 
-    def test_strips_colon_cloud_suffix(self, tmp_path, monkeypatch):
-        """:cloud suffix from models.dev is stripped before merge."""
+    def test_preserves_colon_cloud_suffix_from_models_dev(self, tmp_path, monkeypatch):
+        """:cloud suffix from models.dev is preserved in picker output."""
         from hermes_cli.models import fetch_ollama_cloud_models
 
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -424,11 +424,11 @@ class TestOllamaCloudSuffixStripping:
         with patch("agent.models_dev.fetch_models_dev", return_value=mock_mdev):
             result = fetch_ollama_cloud_models(force_refresh=True)
 
-        assert "kimi-k2.6" in result
-        assert "kimi-k2.6:cloud" not in result
+        assert "kimi-k2.6:cloud" in result
+        assert "kimi-k2.6" not in result
 
-    def test_strips_dash_cloud_suffix(self, tmp_path, monkeypatch):
-        """-cloud suffix from models.dev is stripped before merge."""
+    def test_preserves_dash_cloud_suffix_from_models_dev(self, tmp_path, monkeypatch):
+        """-cloud suffix from models.dev is preserved in picker output."""
         from hermes_cli.models import fetch_ollama_cloud_models
 
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -442,8 +442,8 @@ class TestOllamaCloudSuffixStripping:
         with patch("agent.models_dev.fetch_models_dev", return_value=mock_mdev):
             result = fetch_ollama_cloud_models(force_refresh=True)
 
-        assert "qwen3-coder:480b" in result
-        assert "qwen3-coder:480b-cloud" not in result
+        assert "qwen3-coder:480b-cloud" in result
+        assert "qwen3-coder:480b" not in result
 
     def test_no_duplicate_when_live_clean_and_mdev_suffixed(self, tmp_path, monkeypatch):
         """Live API returns clean ID; mdev has :cloud variant — result has exactly one entry."""
@@ -468,6 +468,25 @@ class TestOllamaCloudSuffixStripping:
         assert result.count("glm-5.1") == 1
         assert "kimi-k2.6:cloud" not in result
         assert "glm-5.1:cloud" not in result
+
+    def test_no_duplicate_when_live_suffixed_and_mdev_clean(self, tmp_path, monkeypatch):
+        """Live API may return a cloud ID; a clean mdev variant must not duplicate it."""
+        from hermes_cli.models import fetch_ollama_cloud_models
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("OLLAMA_API_KEY", "test-key")
+
+        mock_mdev = {
+            "ollama-cloud": {
+                "models": {"qwen3-coder:480b": {"tool_call": True}}
+            }
+        }
+        with patch("hermes_cli.models.fetch_api_models", return_value=["qwen3-coder:480b-cloud"]), \
+             patch("agent.models_dev.fetch_models_dev", return_value=mock_mdev):
+            result = fetch_ollama_cloud_models(force_refresh=True)
+
+        assert result.count("qwen3-coder:480b-cloud") == 1
+        assert "qwen3-coder:480b" not in result
 
     def test_unsuffixed_model_id_unchanged(self, tmp_path, monkeypatch):
         """Model IDs without :cloud / -cloud suffix are passed through unchanged."""


### PR DESCRIPTION
## What does this PR do?

Preserves Ollama Cloud model IDs from models.dev in the model picker output while still using suffix-stripped IDs only for deduplication. This prevents cloud-only IDs such as `qwen3-coder:480b-cloud` from being shown as local-looking IDs like `qwen3-coder:480b`.

## Related Issue

Fixes #52599

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- `hermes_cli/models.py`: keep the original Ollama Cloud model ID when adding merged entries, but dedupe by the normalized suffix-stripped key.
- `tests/hermes_cli/test_ollama_cloud_provider.py`: update suffix tests to assert cloud IDs are preserved when models.dev is the source, and add coverage for live/API dedupe with suffixed IDs.
- `tests/hermes_cli/test_ollama_cloud_provider.py`: add explicit UTF-8 encodings in cache test file I/O to satisfy the Windows compatibility checker.

## How to Test

1. Run `uv run --extra dev pytest tests/hermes_cli/test_ollama_cloud_provider.py tests/hermes_cli/test_setup_ollama_cloud_force_refresh.py -q`.
2. Run `uv run python scripts/check-windows-footguns.py --diff upstream/main`.
3. Run `git diff --check`.

## Checklist

### Code

- [x] I read the contributing guide.
- [x] Commit message follows Conventional Commits: `fix(ollama): preserve cloud model suffixes in picker`.
- [x] I searched existing issues/PRs before opening this PR.
- [x] PR is focused on one logical bug fix.
- [x] Added/updated regression tests for the bug.
- [x] Platform tested: macOS, focused Python test suite.

### Documentation & Housekeeping

- [x] Documentation update: N/A, no user-facing docs changed.
- [x] `cli-config.yaml.example`: N/A, no config keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A, no architecture/workflow changed.
- [x] Cross-platform impact considered; `scripts/check-windows-footguns.py --diff upstream/main` passes.
- [x] Tool descriptions/schemas: N/A, no tool schema changed.

## Screenshots / Logs

```text
46 passed in 11.59s
✓ No Windows footguns found (2 file(s) scanned).
```