### PR TITLE
fix(verification): skip nudge for non-code file edits

### DIFF
--- a/agent/verification_stop.py
+++ b/agent/verification_stop.py
@@ -15,6 +15,37 @@ from typing import Any, Iterable
 
 _MAX_CHANGED_PATHS_IN_NUDGE = 8
 
+# File patterns that cannot affect code/test behaviour — editing these should
+# not trigger the verification nudge.  Kept deliberately narrow: only pure
+# documentation, license, VCS metadata, and CI workflow YAML.
+_NON_CODE_SUFFIXES = (".md", ".txt", ".rst", ".adoc", ".rdoc")
+_NON_CODE_FILENAMES = frozenset({
+    ".gitignore", ".gitattributes", ".gitmodules", ".gitkeep",
+    ".editorconfig", ".prettierrc",
+    "LICENSE", "LICENCE", "COPYING",
+    "CHANGELOG", "CHANGES", "AUTHORS", "CONTRIBUTORS",
+})
+# Directories whose contents are CI/workflow config — not runtime code.
+_NON_CODE_DIR_SEGMENTS = frozenset({".github"})
+
+
+def _is_non_code_path(raw: str) -> bool:
+    """Return *True* when *raw* cannot affect code/test behaviour."""
+    try:
+        p = Path(raw)
+    except Exception:
+        return False
+    name = p.name
+    if name in _NON_CODE_FILENAMES:
+        return True
+    if name.endswith(_NON_CODE_SUFFIXES):
+        return True
+    # Match files under .github/ (workflows, issue templates, CODEOWNERS, …)
+    parts = p.parts
+    if any(seg in _NON_CODE_DIR_SEGMENTS for seg in parts):
+        return True
+    return False
+
 
 def verify_on_stop_enabled(config: dict[str, Any] | None = None) -> bool:
     """Return whether edit -> verify-before-finish behavior is enabled."""
@@ -115,6 +146,8 @@ def build_verify_on_stop_nudge(
 ) -> str | None:
     """Return a synthetic follow-up when edited code lacks fresh verification."""
     paths = sorted({str(p) for p in changed_paths if p})
+    # Filter out non-code paths (docs, license, VCS metadata, CI config).
+    paths = [p for p in paths if not _is_non_code_path(p)]
     if not paths or attempts >= max_attempts:
         return None
 

--- a/tests/agent/test_verification_stop.py
+++ b/tests/agent/test_verification_stop.py
@@ -7,6 +7,7 @@ from agent.verification_evidence import (
     record_terminal_result,
 )
 from agent.verification_stop import (
+    _is_non_code_path,
     build_verify_on_stop_nudge,
     verify_on_stop_enabled,
 )
@@ -163,3 +164,82 @@ def test_nudge_attempts_are_bounded(tmp_path, monkeypatch):
         attempts=2,
         max_attempts=2,
     ) is None
+
+
+# --- Non-code path filtering (issue #52612) ---
+
+
+def test_no_nudge_when_only_non_code_paths(tmp_path, monkeypatch):
+    """Editing docs, gitignore, LICENSE etc. should NOT trigger the nudge."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+    mark_workspace_edited(
+        session_id="s1",
+        cwd=tmp_path,
+        paths=[
+            str(tmp_path / "README.md"),
+            str(tmp_path / ".gitignore"),
+            str(tmp_path / "LICENSE"),
+            str(tmp_path / ".github" / "workflows" / "ci.yml"),
+        ],
+    )
+
+    assert build_verify_on_stop_nudge(
+        session_id="s1",
+        changed_paths=[
+            str(tmp_path / "README.md"),
+            str(tmp_path / ".gitignore"),
+            str(tmp_path / "LICENSE"),
+            str(tmp_path / ".github" / "workflows" / "ci.yml"),
+        ],
+    ) is None
+
+
+def test_nudge_still_fires_for_mixed_code_and_non_code(tmp_path, monkeypatch):
+    """Editing code + docs together should still trigger the nudge."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+    code_path = str(tmp_path / "src" / "app.ts")
+    mark_workspace_edited(
+        session_id="s1", cwd=tmp_path, paths=[code_path],
+    )
+
+    nudge = build_verify_on_stop_nudge(
+        session_id="s1",
+        changed_paths=[code_path, str(tmp_path / "README.md")],
+    )
+
+    assert nudge is not None
+    assert "fresh passing verification evidence" in nudge
+
+
+def test_is_non_code_path_markdown():
+    assert _is_non_code_path("README.md") is True
+    assert _is_non_code_path("/repo/docs/architecture.rst") is True
+    assert _is_non_code_path("notes.txt") is True
+
+
+def test_is_non_code_path_git_metadata():
+    assert _is_non_code_path(".gitignore") is True
+    assert _is_non_code_path(".gitattributes") is True
+    assert _is_non_code_path(".gitmodules") is True
+
+
+def test_is_non_code_path_license():
+    assert _is_non_code_path("LICENSE") is True
+    assert _is_non_code_path("LICENCE") is True
+    assert _is_non_code_path("COPYING") is True
+
+
+def test_is_non_code_path_github_dir():
+    assert _is_non_code_path(".github/workflows/ci.yml") is True
+    assert _is_non_code_path(".github/ISSUE_TEMPLATE/bug.yml") is True
+    assert _is_non_code_path(".github/CODEOWNERS") is True
+
+
+def test_is_non_code_path_code_files_not_filtered():
+    assert _is_non_code_path("src/app.ts") is False
+    assert _is_non_code_path("agent/verification_stop.py") is False
+    assert _is_non_code_path("package.json") is False
+    assert _is_non_code_path("tsconfig.json") is False
+    assert _is_non_code_path("pyproject.toml") is False


### PR DESCRIPTION
## What does this PR do?

Skips the verify-on-stop nudge when all edited files are non-code (documentation, license, VCS metadata, CI workflow YAML). Previously, editing `.gitignore`, `README.md`, `LICENSE`, or `.github/workflows/ci.yml` would trigger the verification nudge, forcing the agent to write ad-hoc verification scripts for changes that cannot affect code/test behaviour.

## Related Issue

Fixes #52612

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/verification_stop.py`: Added `_is_non_code_path()` helper and path-based filtering in `build_verify_on_stop_nudge()`. Non-code suffixes (`.md`, `.txt`, `.rst`, `.adoc`, `.rdoc`), metadata filenames (`.gitignore`, `.gitattributes`, `LICENSE`, etc.), and `.github/` directory contents are excluded from triggering the nudge.
- `tests/agent/test_verification_stop.py`: Added 7 tests — `test_no_nudge_when_only_non_code_paths` (docs-only edit), `test_nudge_still_fires_for_mixed_code_and_non_code` (code+docs edit), and 5 unit tests for `_is_non_code_path` covering markdown, git metadata, license files, `.github/` directory, and code file passthrough.

## How to Test

1. Run `python -m pytest tests/agent/test_verification_stop.py -v` — all 17 tests should pass.
2. Verify the new tests specifically: `test_no_nudge_when_only_non_code_paths` confirms docs-only edits produce no nudge; `test_nudge_still_fires_for_mixed_code_and_non_code` confirms code edits still trigger verification.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/verification_stop.py` (`build_verify_on_stop_nudge` callers: 1 in `conversation_loop.py`)
- Blast radius: LOW — only affects the nudge trigger path; no change to verification evidence recording or workspace tracking
- Related patterns: Path-based filtering is a common guard pattern; kept deliberately narrow to avoid false negatives on legitimate code files
