### PR TITLE
fix: persist non-NULL system prompt on fresh turn setup (#45499)

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -142,7 +142,13 @@ def build_turn_context(
     # Guard stdio against OSError from broken pipes (systemd/headless/daemon).
     install_safe_stdio()
 
-    agent._ensure_db_session()
+    # NOTE: the DB session row is created later, AFTER the system prompt is
+    # restored/built (see _ensure_db_session() below the system-prompt block).
+    # Creating it here — before _cached_system_prompt is populated — inserts a
+    # row with system_prompt=NULL on a fresh API/gateway agent that carries
+    # client-managed history, which then trips the "stored system prompt is
+    # null; rebuilding from scratch" warning and a needless first-turn prefix
+    # cache miss. (Issue #45499.)
 
     # Tell auxiliary_client what the live main provider/model are for this turn.
     try:
@@ -308,6 +314,11 @@ def build_turn_context(
         restore_or_build_system_prompt(agent, system_message, conversation_history)
 
     active_system_prompt = agent._cached_system_prompt
+
+    # Create the DB session row now that _cached_system_prompt is populated, so
+    # the persisted snapshot is written non-NULL on the first turn (Issue
+    # #45499). Idempotent: _ensure_db_session() no-ops once the row exists.
+    agent._ensure_db_session()
 
     # Crash-resilience: persist the inbound user turn as soon as the session row exists.
     try:

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -71,10 +71,13 @@ class _FakeAgent:
         self._invalid_tool_retries = -1
         self._vision_supported = None
         self._persist_calls = 0
+        # Records _cached_system_prompt at the moment _ensure_db_session()
+        # is called (regression guard for #45499 turn-setup ordering).
+        self._ensure_db_prompt_at_call = "<unset>"
 
     # --- methods the prologue calls ---
     def _ensure_db_session(self):
-        pass
+        self._ensure_db_prompt_at_call = self._cached_system_prompt
 
     def _restore_primary_runtime(self):
         pass
@@ -188,6 +191,29 @@ def test_no_review_when_memory_disabled():
     agent = _FakeAgent()
     ctx = _build(agent)
     assert ctx.should_review_memory is False
+
+
+def test_ensure_db_session_runs_after_system_prompt_restore():
+    """Regression for #45499.
+
+    On a fresh API/gateway agent (``_cached_system_prompt is None``) the DB
+    session row must be created AFTER the system prompt is restored/built, so
+    the persisted snapshot is written non-NULL. If ``_ensure_db_session()``
+    ran first it would insert ``system_prompt=NULL`` and trip the misleading
+    "stored system prompt is null; rebuilding" warning plus a first-turn
+    prefix cache miss.
+    """
+    agent = _FakeAgent()
+    agent._cached_system_prompt = None  # fresh agent, no cached prompt yet
+
+    def _restore(_agent, _system_message, _history):
+        _agent._cached_system_prompt = "REBUILT-SYSTEM"
+
+    _build(agent, restore_or_build_system_prompt=_restore)
+
+    # The prompt was populated before the DB row was created.
+    assert agent._ensure_db_prompt_at_call == "REBUILT-SYSTEM"
+    assert agent._cached_system_prompt == "REBUILT-SYSTEM"
 
 
 # ── Between-turns MCP refresh (cache-safe late-binding) ──────────────────────


### PR DESCRIPTION
## Summary
Keeps the per-conversation prefix cache warm on the first turn of a fresh API/gateway agent. `build_turn_context()` created the DB session row before the system prompt was built, so a fresh agent carrying client-managed history persisted a row with `system_prompt=NULL` — tripping a misleading "stored system prompt is null; rebuilding from scratch ... investigate the previous turn's write path" warning and a guaranteed first-turn cache miss.

Fixes #45499.

## Changes
- `agent/turn_context.py`: move `_ensure_db_session()` to **after** the system prompt is restored/built, so `create_session()` persists the real prompt snapshot instead of `NULL`. Idempotent — `_ensure_db_session()` no-ops once the row exists.
- `tests/agent/test_turn_context.py`: regression asserting `_ensure_db_session()` runs after `_cached_system_prompt` is populated.

## Root cause
`_ensure_db_session()` → `create_session(system_prompt=self._cached_system_prompt)` ran while `_cached_system_prompt` was still `None` (the restore/build happens ~160 lines later in the prologue). Reordering the row creation fixes it without touching the restore logic.

## Validation
- `scripts/run_tests.sh tests/agent/test_turn_context.py tests/agent/test_system_prompt_restore.py` → 22 passed.
- **Live (OpenRouter + claude-sonnet-4.5, real wire):** persistent-agent multi-turn run shows the prefix cache engaging correctly — turn 1 `cache_write=24411`, turn 2 `cache_read=24411` (full prefix hit), turn 3 `cache_read=24428`. Fresh-agent restore keeps the persisted `system_prompt` non-NULL and reuses it verbatim, so the cache stays warm across the gateway-style fresh-agent boundary.

> Note: an earlier revision of this branch also touched `_stored_prompt_matches_runtime` for #49462 (read-first-line). Live testing showed the canonical `Model:`/`Provider:` identity line is appended **last** in the volatile tier (after memory/USER blocks), so the existing read-last behavior is correct and #49462's premise doesn't hold against the real assembly order — that change was dropped. This PR is scoped to the #45499 ordering fix only.

## Infographic
![Prompt cache warm — fresh-turn NULL-snapshot fix](https://v3b.fal.media/files/b/0a9fbf0f/xMsVb3k5EzqbbVIWbmdtu_y8apg7EM.png)
